### PR TITLE
Forms: align the file upload field's Interactivity API with the other fields

### DIFF
--- a/projects/packages/forms/changelog/forms-file-field-focus
+++ b/projects/packages/forms/changelog/forms-file-field-focus
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+File upload field: move focus to the new file preview instead of the hidden dropzone after a file is added.

--- a/projects/packages/forms/changelog/forms-file-field-focus
+++ b/projects/packages/forms/changelog/forms-file-field-focus
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-File upload field: move focus to the new file preview instead of the hidden dropzone after a file is added.

--- a/projects/packages/forms/changelog/forms-file-field-interactivity-api
+++ b/projects/packages/forms/changelog/forms-file-field-interactivity-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+File upload field: align the field's Interactivity API surface with the other form fields.

--- a/projects/packages/forms/changelog/forms-file-field-interactivity-api
+++ b/projects/packages/forms/changelog/forms-file-field-interactivity-api
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-File upload field: move the field's Interactivity API store into the shared jetpack/form store, matching the other fields. The jetpack/field-file store namespace is gone (its config namespace is unchanged), and the dragOver, dragLeave, handleKeyDown and focusElement handlers plus the hasFiles and hasMaxFiles state getters have been renamed.
+File upload field: Move the field's Interactivity API store into the shared jetpack/form store, matching the other fields. The jetpack/field-file store namespace is deprecated and now aliases the new names; it will be removed in a future release. Its config namespace is unchanged.

--- a/projects/packages/forms/changelog/forms-file-field-interactivity-api
+++ b/projects/packages/forms/changelog/forms-file-field-interactivity-api
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: changed
 
-File upload field: align the field's Interactivity API surface with the other form fields.
+File upload field: move the field's Interactivity API store into the shared jetpack/form store, matching the other fields. The jetpack/field-file store namespace is gone (its config namespace is unchanged), and the dragOver, dragLeave, handleKeyDown and focusElement handlers plus the hasFiles and hasMaxFiles state getters have been renamed.

--- a/projects/packages/forms/changelog/forms-file-field-interactivity-api
+++ b/projects/packages/forms/changelog/forms-file-field-interactivity-api
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-File upload field: Move the field's Interactivity API store into the shared jetpack/form store, matching the other fields. The jetpack/field-file store namespace is deprecated and now aliases the new names; it will be removed in a future release. Its config namespace is unchanged.
+File upload field: Rebuild the field on the same foundation as the other form fields, so it behaves consistently with them. Markup cached from an earlier release keeps working for one release.

--- a/projects/packages/forms/changelog/forms-file-field-mixed-drop
+++ b/projects/packages/forms/changelog/forms-file-field-mixed-drop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+File upload field: keep the remaining files when a folder is included in a multi-file drop.

--- a/projects/packages/forms/changelog/forms-file-field-mixed-drop
+++ b/projects/packages/forms/changelog/forms-file-field-mixed-drop
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-File upload field: keep the remaining files when a folder is included in a multi-file drop.
+File upload field: Keep the remaining files when a folder or dragged text is included in a multi-file drop.

--- a/projects/packages/forms/changelog/forms-file-field-phone-validation
+++ b/projects/packages/forms/changelog/forms-file-field-phone-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Phone field: validate a required field that has a default value against what the input actually shows, so it can no longer be submitted empty.

--- a/projects/packages/forms/changelog/forms-file-field-phone-validation
+++ b/projects/packages/forms/changelog/forms-file-field-phone-validation
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Phone field: validate a required field that has a default value against what the input actually shows, so it can no longer be submitted empty.
+Phone field: Validate a required field with a default country against what the input actually shows, so it can no longer be submitted empty.

--- a/projects/packages/forms/changelog/forms-file-field-remove
+++ b/projects/packages/forms/changelog/forms-file-field-remove
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+File upload field: Remove a file from the form immediately instead of waiting for the server, so a slow connection no longer leaves the field looking stuck.

--- a/projects/packages/forms/changelog/forms-file-field-reset
+++ b/projects/packages/forms/changelog/forms-file-field-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+File upload field: Cancel in-flight uploads and release previews when the form is reset.

--- a/projects/packages/forms/changelog/forms-file-field-upload-race
+++ b/projects/packages/forms/changelog/forms-file-field-upload-race
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+File upload field: Stop uploading a file that was removed while its upload was still being prepared.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1989,7 +1989,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 *
 	 * @param string $id - the field ID.
 	 * @param string $label - the field label.
-	 * @param string $class - the field CSS class.
+	 * @param string $class - unused. Kept for signature parity with the other render_*_field()
+	 *                        methods; this field writes its input inline rather than from an
+	 *                        attribute array.
 	 * @param bool   $required - if the field is marked as required.
 	 * @param string $required_field_text - the text in the required text field.
 	 * @param bool   $required_indicator Whether to display the required indicator.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -2067,7 +2067,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			data-wp-on--jetpack-form-reset="actions.resetFiles"
 			data-is-required="<?php echo esc_attr( $required ); ?>"
 		>
-			<div class="jetpack-form-file-field__dropzone" data-wp-class--is-dropping="context.isDropping" data-wp-class--is-hidden="state.hasMaxFiles">
+			<div class="jetpack-form-file-field__dropzone" data-wp-class--is-dropping="context.isDropping" data-wp-class--is-hidden="state.isFileFieldFull">
 				<div class="jetpack-form-file-field__dropzone-inner" data-wp-on--click="actions.openFilePicker" data-wp-on--keydown="actions.onFileDropzoneKeyDown" tabindex="0" role="button" aria-label="<?php echo esc_attr( $dropzone_aria_label ); ?>"></div>
 				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Decoded dropzone markup is filtered through an allowlist by sanitize_file_field_content(). ?>
 				<?php echo $this->sanitize_file_field_content( $this->content ); ?>

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -36,7 +36,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	 *
 	 * @var int
 	 */
-	const FILE_FIELD_MAX_UPLOAD_SIZE = 20971520; // 20MB.
+	const FILE_FIELD_MAX_UPLOAD_SIZE = 20 * 1024 * 1024;
 
 	/**
 	 * The shortcode name.
@@ -2012,7 +2012,6 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		$accept_attribute_value = implode( ', ', self::get_file_field_accepted_mime_types() );
 
-		$max_file_size   = self::FILE_FIELD_MAX_UPLOAD_SIZE;
 		$file_size_units = array(
 			_x( 'B', 'unit symbol', 'jetpack-forms' ),
 			_x( 'KB', 'unit symbol', 'jetpack-forms' ),
@@ -2028,14 +2027,14 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'uploadError'        => __( 'Error uploading file', 'jetpack-forms' ),
 				'folderNotSupported' => __( 'Folder uploads are not supported', 'jetpack-forms' ),
 				// translators: %s is the formatted maximum file size.
-				'fileTooLarge'       => sprintf( __( 'File is too large. Maximum allowed size is %s.', 'jetpack-forms' ), size_format( $max_file_size ) ),
+				'fileTooLarge'       => sprintf( __( 'File is too large. Maximum allowed size is %s.', 'jetpack-forms' ), size_format( self::FILE_FIELD_MAX_UPLOAD_SIZE ) ),
 				'invalidType'        => __( 'This file type is not allowed.', 'jetpack-forms' ),
 				'maxFiles'           => __( 'You have exceeded the number of files that you can upload.', 'jetpack-forms' ),
 				'uploadFailed'       => __( 'File upload failed, try again.', 'jetpack-forms' ),
 			),
 			'endpoint'      => $this->get_unauth_endpoint_url(),
 			'iconsPath'     => Jetpack_Forms::plugin_url() . 'contact-form/images/file-icons/',
-			'maxUploadSize' => $max_file_size,
+			'maxUploadSize' => self::FILE_FIELD_MAX_UPLOAD_SIZE,
 		);
 
 		wp_interactivity_config( 'jetpack/field-file', $global_config );
@@ -2324,10 +2323,19 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	private function enqueue_file_field_assets() {
 		$version = Constants::get_constant( 'JETPACK__VERSION' );
 
+		// extra cache busting strategy for view.js, seems they are left out of cache clearing on deploys
+		$asset_file = plugin_dir_path( __FILE__ ) . '../../dist/modules/file-field/view.asset.php';
+		$asset      = file_exists( $asset_file ) ? require $asset_file : null;
+		$version   .= $asset['version'] ?? '';
+
 		\wp_enqueue_script_module(
 			'jetpack-form-file-field',
 			plugins_url( '../../dist/modules/file-field/view.js', __FILE__ ),
-			array( '@wordpress/interactivity' ),
+			// `jp-forms-view` is not decoration: this module contributes `state.validators.file`,
+			// which `registerField()` reads at `data-wp-init` time. Loading after hydration would
+			// leave a required file field registering as valid, since the shared `validateField()`
+			// no longer has a `file` branch to fall back on. Same reason `field-phone` declares it.
+			array( '@wordpress/interactivity', 'jp-forms-view' ),
 			$version
 		);
 

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -23,6 +23,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Contact_Form_Field extends Contact_Form_Shortcode {
 
 	/**
+	 * Maximum number of files a single file upload field accepts.
+	 *
+	 * TODO: Read this from a `maxfiles` attribute once the block exposes one.
+	 *
+	 * @var int
+	 */
+	const FILE_FIELD_MAX_FILES = 1;
+
+	/**
+	 * Maximum size, in bytes, of a single uploaded file.
+	 *
+	 * @var int
+	 */
+	const FILE_FIELD_MAX_UPLOAD_SIZE = 20971520; // 20MB.
+
+	/**
 	 * The shortcode name.
 	 *
 	 * @var string
@@ -1994,56 +2010,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		// Enqueue necessary scripts and styles.
 		$this->enqueue_file_field_assets();
 
-		// Get allowed MIME types for display in the field.
-		$accepted_file_types = array_values(
-			array(
-				'jpg|jpeg|jpe'    => 'image/jpeg',
-				'png'             => 'image/png',
-				'gif'             => 'image/gif',
-				'pdf'             => 'application/pdf',
-				'doc'             => 'application/msword',
-				'docx'            => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-				'docm'            => 'application/vnd.ms-word.document.macroEnabled.12',
-				'pot|pps|ppt'     => 'application/vnd.ms-powerpoint',
-				'pptx'            => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-				'pptm'            => 'application/vnd.ms-powerpoint.presentation.macroEnabled.12',
-				'odt'             => 'application/vnd.oasis.opendocument.text',
-				'ppsx'            => 'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
-				'ppsm'            => 'application/vnd.ms-powerpoint.slideshow.macroEnabled.12',
-				'csv'             => 'text/csv',
-				'xla|xls|xlt|xlw' => 'application/vnd.ms-excel',
-				'xlsx'            => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-				'xlsm'            => 'application/vnd.ms-excel.sheet.macroEnabled.12',
-				'xlsb'            => 'application/vnd.ms-excel.sheet.binary.macroEnabled.12',
-				'key'             => 'application/vnd.apple.keynote',
-				'webp'            => 'image/webp',
-				'heic'            => 'image/heic',
-				'heics'           => 'image/heic-sequence',
-				'heif'            => 'image/heif',
-				'heifs'           => 'image/heif-sequence',
-				'asc'             => 'application/pgp-keys',
-			)
-		);
+		$accept_attribute_value = implode( ', ', self::get_file_field_accepted_mime_types() );
 
-		$accept_attribute_value = implode( ', ', $accepted_file_types );
-
-		// Add accessibility attributes and required status if needed.
-		$input_attrs = array(
-			'type'       => 'file',
-			'class'      => 'jetpack-form-file-field ' . esc_attr( $class ),
-			'name'       => esc_attr( $id ),
-			'id'         => esc_attr( $id ),
-			'accept'     => esc_attr( $accept_attribute_value ),
-			'aria-label' => esc_attr( $label ),
-		);
-
-		if ( $required ) {
-			$input_attrs['required']      = 'required';
-			$input_attrs['aria-required'] = 'true';
-		}
-
-		$max_files       = 1; // TODO: Dynamically retrieve the max number of files using $this->get_attribute( 'maxfiles' ) if needed in the future.
-		$max_file_size   = 20 * 1024 * 1024; // 20MB
+		$max_file_size   = self::FILE_FIELD_MAX_UPLOAD_SIZE;
 		$file_size_units = array(
 			_x( 'B', 'unit symbol', 'jetpack-forms' ),
 			_x( 'KB', 'unit symbol', 'jetpack-forms' ),
@@ -2071,13 +2040,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		wp_interactivity_config( 'jetpack/field-file', $global_config );
 
+		// Only genuinely dynamic state lives in the context. The field's static configuration
+		// (`maxFiles`, `allowedMimeTypes`) travels in `fieldExtra` alongside every other field's
+		// config, and `fieldId` already comes from the wrapper that `render_field()` opens.
 		$context = array(
-			'isDropping'       => false,
-			'fieldId'          => $id,
-			'files'            => array(),
-			'allowedMimeTypes' => $accepted_file_types,
-			'maxFiles'         => $max_files, // max number of files.
-			'hasMaxFiles'      => false,
+			'isDropping' => false,
+			'files'      => array(),
 		);
 
 		$field = $this->render_label( 'file', $id, $label, $required, $required_field_text, array(), true, $required_indicator );
@@ -2090,18 +2058,17 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			class="jetpack-form-file-field__container"
 			id="<?php echo esc_attr( $id ); ?>"
 			name="dropzone-<?php echo esc_attr( $id ); ?>"
-			data-wp-interactive="jetpack/field-file"
 			<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- output is pre-escaped by method ?>
 			<?php echo wp_interactivity_data_wp_context( $context ); ?>
-			data-wp-on--dragover="actions.dragOver"
-			data-wp-on--dragleave="actions.dragLeave"
-			data-wp-on--mouseleave="actions.dragLeave"
+			data-wp-on--dragover="actions.onFileDragOver"
+			data-wp-on--dragleave="actions.onFileDragLeave"
+			data-wp-on--mouseleave="actions.onFileDragLeave"
 			data-wp-on--drop="actions.fileDropped"
 			data-wp-on--jetpack-form-reset="actions.resetFiles"
 			data-is-required="<?php echo esc_attr( $required ); ?>"
 		>
 			<div class="jetpack-form-file-field__dropzone" data-wp-class--is-dropping="context.isDropping" data-wp-class--is-hidden="state.hasMaxFiles">
-				<div class="jetpack-form-file-field__dropzone-inner" data-wp-on--click="actions.openFilePicker" data-wp-on--keydown="actions.handleKeyDown" tabindex="0" role="button" aria-label="<?php echo esc_attr( $dropzone_aria_label ); ?>"></div>
+				<div class="jetpack-form-file-field__dropzone-inner" data-wp-on--click="actions.openFilePicker" data-wp-on--keydown="actions.onFileDropzoneKeyDown" tabindex="0" role="button" aria-label="<?php echo esc_attr( $dropzone_aria_label ); ?>"></div>
 				<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Decoded dropzone markup is filtered through an allowlist by sanitize_file_field_content(). ?>
 				<?php echo $this->sanitize_file_field_content( $this->content ); ?>
 				<input
@@ -2109,9 +2076,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 					accept="<?php echo esc_attr( $accept_attribute_value ); ?>"
 					data-wp-on--change="actions.fileAdded"  />
 			</div>
-			<div class="jetpack-form-file-field__preview-wrap" name="file-field-<?php echo esc_attr( $id ); ?>" data-wp-class--is-active="state.hasFiles">
+			<div class="jetpack-form-file-field__preview-wrap" name="file-field-<?php echo esc_attr( $id ); ?>" data-wp-class--is-active="state.hasFileFieldFiles">
 				<template data-wp-each--file="context.files" data-wp-key="context.file.id">
-					<div class="jetpack-form-file-field__preview" tabindex="0" data-wp-bind--aria-label="context.file.name" data-wp-init--focus="callbacks.focusElement" data-wp-class--is-error="context.file.hasError" data-wp-class--is-complete="context.file.isUploaded">
+					<div class="jetpack-form-file-field__preview" tabindex="0" data-wp-bind--aria-label="context.file.name" data-wp-init--focus="callbacks.focusFilePreview" data-wp-class--is-error="context.file.hasError" data-wp-class--is-complete="context.file.isUploaded">
 						<input type="hidden" name="<?php echo esc_attr( $id ); ?>[]" class="jetpack-form-file-field__hidden include-hidden" data-wp-bind--value='context.file.fileJson' value="">
 						<div class="jetpack-form-file-field__image-wrap" data-wp-style----progress="context.file.progress" data-wp-class--has-icon="context.file.hasIcon">
 							<div class="jetpack-form-file-field__image" data-wp-style--background-image="context.file.url" data-wp-style--mask-image="context.file.mask"></div>
@@ -2303,6 +2270,48 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 
 		return "<input type='hidden' name='" . esc_attr( $id ) . "' id='" . esc_attr( $id )
 			. "' value='" . esc_attr( $value ) . "' " . $interactivity_attributes . " />\n";
+	}
+
+	/**
+	 * MIME types the file upload field accepts.
+	 *
+	 * Shared by the input's `accept` attribute and by the field's `fieldExtra` config, so the
+	 * browser-side picker filter and the client-side check can never drift apart.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string[] List of accepted MIME types.
+	 */
+	private static function get_file_field_accepted_mime_types() {
+		return array_values(
+			array(
+				'jpg|jpeg|jpe'    => 'image/jpeg',
+				'png'             => 'image/png',
+				'gif'             => 'image/gif',
+				'pdf'             => 'application/pdf',
+				'doc'             => 'application/msword',
+				'docx'            => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+				'docm'            => 'application/vnd.ms-word.document.macroEnabled.12',
+				'pot|pps|ppt'     => 'application/vnd.ms-powerpoint',
+				'pptx'            => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+				'pptm'            => 'application/vnd.ms-powerpoint.presentation.macroEnabled.12',
+				'odt'             => 'application/vnd.oasis.opendocument.text',
+				'ppsx'            => 'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
+				'ppsm'            => 'application/vnd.ms-powerpoint.slideshow.macroEnabled.12',
+				'csv'             => 'text/csv',
+				'xla|xls|xlt|xlw' => 'application/vnd.ms-excel',
+				'xlsx'            => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+				'xlsm'            => 'application/vnd.ms-excel.sheet.macroEnabled.12',
+				'xlsb'            => 'application/vnd.ms-excel.sheet.binary.macroEnabled.12',
+				'key'             => 'application/vnd.apple.keynote',
+				'webp'            => 'image/webp',
+				'heic'            => 'image/heic',
+				'heics'           => 'image/heic-sequence',
+				'heif'            => 'image/heif',
+				'heifs'           => 'image/heif-sequence',
+				'asc'             => 'application/pgp-keys',
+			)
+		);
 	}
 
 	/**
@@ -3381,6 +3390,13 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	private function get_field_extra( $type, $extra_attrs ) {
 		if ( 'date' === $type ) {
 			return $this->get_date_format();
+		}
+
+		if ( 'file' === $type ) {
+			return array(
+				'maxFiles'         => self::FILE_FIELD_MAX_FILES,
+				'allowedMimeTypes' => self::get_file_field_accepted_mime_types(),
+			);
 		}
 
 		return $extra_attrs;

--- a/projects/packages/forms/src/contact-form/js/validate-helper.js
+++ b/projects/packages/forms/src/contact-form/js/validate-helper.js
@@ -100,10 +100,9 @@ export const isEmptyValue = value => {
  * return true or the field error.
  *
  * This is the fallback path only. Field types whose module registers `state.validators[ type ]`
- * — currently `file` and `phone` — are never routed here; the form store prefers the registered
- * validator in BOTH `registerField()` and `actions.updateField()`. Those two call sites are why
- * there is no `file` branch below: removing it is only safe while both of them consult the
- * registry, so don't narrow either one back to a single call site without restoring a branch here.
+ * — currently `file` and `phone` — are never routed here; `validate()` in modules/form/view.js
+ * prefers the registered validator. That is why there is no `file` branch below: removing it is
+ * only safe while every validation path goes through `validate()`.
  *
  * @param  type
  * @param  value

--- a/projects/packages/forms/src/contact-form/js/validate-helper.js
+++ b/projects/packages/forms/src/contact-form/js/validate-helper.js
@@ -98,6 +98,13 @@ export const isEmptyValue = value => {
 
 /**
  * return true or the field error.
+ *
+ * This is the fallback path only. Field types whose module registers `state.validators[ type ]`
+ * — currently `file` and `phone` — are never routed here; the form store prefers the registered
+ * validator in BOTH `registerField()` and `actions.updateField()`. Those two call sites are why
+ * there is no `file` branch below: removing it is only safe while both of them consult the
+ * registry, so don't narrow either one back to a single call site without restoring a branch here.
+ *
  * @param  type
  * @param  value
  * @param  isRequired

--- a/projects/packages/forms/src/contact-form/js/validate-helper.js
+++ b/projects/packages/forms/src/contact-form/js/validate-helper.js
@@ -123,18 +123,6 @@ export const validateField = ( type, value, isRequired, extra = null ) => {
 		return validateNumber( value, extra );
 	}
 
-	if ( 'file' === type ) {
-		if ( value.some( file => file.error ) ) {
-			return 'invalid_file_has_errors';
-		}
-
-		if ( value.some( file => ! file.isUploaded ) ) {
-			return 'invalid_file_uploading';
-		}
-
-		return 'yes';
-	}
-
 	let regex = null;
 	switch ( type ) {
 		case 'url':

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -110,15 +110,27 @@ const updateSelection = selectedCountry => {
 		...country,
 		selected: country.code === selectedCountry.code,
 	} ) );
+};
 
-	/*
-	 * Revalidate against the country that was just picked. `fullPhoneNumber` is the only value
-	 * `validators.phone` judges, and every caller here rewrites it, so without this a number that
-	 * was invalid for the previous country keeps its stale `invalid_phone` after the visitor
-	 * selects the country that makes it valid — and the error blocks submission until the input
-	 * itself is touched again.
-	 */
-	actions.updateField( context.fieldId, context.phoneNumber );
+/**
+ * Revalidate the field after the visitor commits to a country.
+ *
+ * `fullPhoneNumber` is the only value `validators.phone` judges, so without this a number that was
+ * invalid for the previous country keeps its stale `invalid_phone` after the visitor picks the
+ * country that makes it valid, and the error blocks submission until the input is touched again.
+ *
+ * Only the paths that commit call this. `updateSelection()` also runs while the visitor merely
+ * arrows through the list, and revalidating there would reset `showFieldError` on every keypress,
+ * hiding an error that is still true of the number they have typed.
+ */
+const revalidateAfterCountryCommit = () => {
+	const context = getContext();
+
+	actions.updateField(
+		context.fieldId,
+		context.phoneNumber,
+		context.fields?.[ context.fieldId ]?.showFieldError ?? false
+	);
 };
 
 const { actions } = store( NAMESPACE, {
@@ -205,6 +217,7 @@ const { actions } = store( NAMESPACE, {
 			// this context.filtered is from the template iterator
 			context.selectedCountry = { ...context.filtered };
 			updateSelection( context.selectedCountry );
+			revalidateAfterCountryCommit();
 			context.comboboxOpen = false;
 			phoneInputRefs[ context.fieldId ]?.focus?.();
 		},
@@ -238,6 +251,7 @@ const { actions } = store( NAMESPACE, {
 						context.filteredCountries[ 0 ];
 					context.selectedCountry = selectedCountry;
 					updateSelection( context.selectedCountry );
+					revalidateAfterCountryCommit();
 					context.comboboxOpen = false;
 					// Focus on the ref input
 					phoneInputRefs[ context.fieldId ]?.focus?.();

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -116,25 +116,29 @@ const { actions } = store( NAMESPACE, {
 	state: {
 		validators: {
 			phone: ( value, isRequired ) => {
-				const context = getContext();
+				// Defaults matter here: this validator also runs from `registerField()`, which is
+				// scoped to the field wrapper rather than to the phone wrapper that provides these
+				// keys, so during registration they are all undefined. See the scope contract on
+				// `getValidator()` in ../form/view.js.
+				const {
+					phoneNumber = '',
+					fullPhoneNumber = '',
+					showCountrySelector = false,
+				} = getContext();
 
-				if ( isEmptyValue( context.phoneNumber ) && isRequired ) {
+				if ( isEmptyValue( phoneNumber ) && isRequired ) {
 					// this is not triggering any error, but then no other input does either
 					return 'is_required';
 				}
-				if ( ! isRequired && isEmptyValue( context.phoneNumber ) ) {
+				if ( ! isRequired && isEmptyValue( phoneNumber ) ) {
 					// No need to validate anything.
 					return 'yes';
 				}
 
 				// from this point on, we discard the value as we
 				// use our internal full phone number state getter:
-				value = context.fullPhoneNumber;
-				if (
-					context.showCountrySelector ||
-					value.indexOf( '+' ) === 0 ||
-					value.indexOf( '00' ) === 0
-				) {
+				value = fullPhoneNumber;
+				if ( showCountrySelector || value.indexOf( '+' ) === 0 || value.indexOf( '00' ) === 0 ) {
 					const internationalNumber = parsePhoneNumber( value );
 					if ( ! internationalNumber || ! internationalNumber.isValid() ) {
 						return 'invalid_phone';

--- a/projects/packages/forms/src/modules/field-phone/view.js
+++ b/projects/packages/forms/src/modules/field-phone/view.js
@@ -110,6 +110,15 @@ const updateSelection = selectedCountry => {
 		...country,
 		selected: country.code === selectedCountry.code,
 	} ) );
+
+	/*
+	 * Revalidate against the country that was just picked. `fullPhoneNumber` is the only value
+	 * `validators.phone` judges, and every caller here rewrites it, so without this a number that
+	 * was invalid for the previous country keeps its stale `invalid_phone` after the visitor
+	 * selects the country that makes it valid — and the error blocks submission until the input
+	 * itself is touched again.
+	 */
+	actions.updateField( context.fieldId, context.phoneNumber );
 };
 
 const { actions } = store( NAMESPACE, {
@@ -119,7 +128,7 @@ const { actions } = store( NAMESPACE, {
 				// Defaults matter here: this validator also runs from `registerField()`, which is
 				// scoped to the field wrapper rather than to the phone wrapper that provides these
 				// keys, so during registration they are all undefined. See the scope contract on
-				// `getValidator()` in ../form/view.js.
+				// `validate()` in ../form/view.js.
 				const {
 					phoneNumber = '',
 					fullPhoneNumber = '',

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -2,21 +2,33 @@
  * WordPress dependencies
  */
 import { store, getContext, withScope, getElement, getConfig } from '@wordpress/interactivity';
+/**
+ * Internal dependencies
+ */
+import { isEmptyValue } from '../../contact-form/js/validate-helper.js';
 
-const NAMESPACE = 'jetpack/field-file';
+// The file field lives in the shared form store, like every other field module. It keeps its own
+// namespace only for `wp_interactivity_config()` — the upload endpoint, icon path and per-file
+// error strings — which is the same split `jetpack/field-phone` uses.
+const NAMESPACE = 'jetpack/form';
+const CONFIG_NAMESPACE = 'jetpack/field-file';
 
 const ENTER = 13;
 const SPACE = 32;
 
 let uploadToken = null;
 let tokenExpiry = null;
-
-const jetpackFormStore = store( 'jetpack/form' );
+// Set while a token request is in flight so several files added at once share a single request
+// instead of each firing its own.
+let pendingTokenRequest = null;
 
 /**
- * Retuns the upload token. Sometimes it has to fetch a new one if it expired. Or we haven't needed one just yet.
+ * Returns the upload token, fetching a new one if it expired or was never fetched.
  *
- * @return {string} The upload token.
+ * The token authorizes uploads for the whole site rather than for one field, so it is cached at
+ * module scope and shared by every file field on the page.
+ *
+ * @return {Promise<string|null>} The upload token, or null if one could not be obtained.
  */
 const getUploadToken = async () => {
 	// Check if the token exists and is not expired
@@ -24,18 +36,25 @@ const getUploadToken = async () => {
 		return uploadToken;
 	}
 
-	const { token, expiresAt } = await fetchUploadToken();
+	if ( ! pendingTokenRequest ) {
+		pendingTokenRequest = fetchUploadToken().finally( () => {
+			pendingTokenRequest = null;
+		} );
+	}
+
+	const { token, expiresAt } = await pendingTokenRequest;
 	uploadToken = token;
 	tokenExpiry = expiresAt * 1000; // Convert expiry timestamp to milliseconds
 	return uploadToken;
 };
+
 /**
  * Fetches the upload token from the server.
  *
  * @return {{ token: string, expiresAt: number }} The upload token and its expiration time.
  */
 const fetchUploadToken = async () => {
-	const { endpoint } = getConfig( NAMESPACE );
+	const { endpoint } = getConfig( CONFIG_NAMESPACE );
 
 	const tokenError = {
 		token: null, // Assuming the token is in the `token` field
@@ -76,7 +95,7 @@ const fetchUploadToken = async () => {
  * @return {string} The formatted file size.
  */
 const formatBytes = ( size, decimals = 2 ) => {
-	const config = getConfig( NAMESPACE );
+	const config = getConfig( CONFIG_NAMESPACE );
 	if ( size === 0 ) return config.i18n.zeroBytes;
 	const k = 1024;
 	const dm = decimals < 0 ? 0 : decimals;
@@ -91,7 +110,7 @@ const formatBytes = ( size, decimals = 2 ) => {
 };
 
 const getFileIcon = file => {
-	const config = getConfig( NAMESPACE );
+	const config = getConfig( CONFIG_NAMESPACE );
 	const fileType = file.type.split( '/' )[ 0 ];
 	const fileExtension = file.name.split( '.' ).pop().toLowerCase();
 
@@ -122,13 +141,28 @@ const getFileIcon = file => {
 };
 
 /**
+ * Reads the file field's configuration from the standard `fieldExtra` context entry, the same
+ * place the date field finds its format and the number field its min/max.
+ *
+ * @return {{ maxFiles: number, allowedMimeTypes: string[] }} The field's configuration.
+ */
+const getFileFieldExtra = () => {
+	const { maxFiles, allowedMimeTypes } = getContext().fieldExtra || {};
+	return {
+		maxFiles: maxFiles ?? 1,
+		allowedMimeTypes: allowedMimeTypes ?? [],
+	};
+};
+
+/**
  * Add the file to the context.
  *
  * @param {File} file - The file to add.
  */
 const addFileToContext = file => {
-	const config = getConfig( NAMESPACE );
+	const config = getConfig( CONFIG_NAMESPACE );
 	const context = getContext();
+	const { maxFiles, allowedMimeTypes } = getFileFieldExtra();
 
 	let error = null;
 
@@ -138,7 +172,7 @@ const addFileToContext = file => {
 	}
 
 	// Check that the file type is allowed.
-	if ( ! context.allowedMimeTypes.includes( file.type ) ) {
+	if ( ! allowedMimeTypes.includes( file.type ) ) {
 		error = config.i18n.invalidType;
 	}
 
@@ -146,7 +180,7 @@ const addFileToContext = file => {
 	const validFiles = context.files.filter( fileInfo => ! fileInfo.error );
 
 	// Check if the user is trying to add more files then allowed.
-	if ( context.maxFiles < validFiles.length + 1 ) {
+	if ( maxFiles < validFiles.length + 1 ) {
 		error = config.i18n.maxFiles;
 	}
 
@@ -167,7 +201,7 @@ const addFileToContext = file => {
 		error,
 	} );
 
-	jetpackFormStore.actions.updateFieldValue( context.fieldId, context.files );
+	actions.updateField( context.fieldId, context.files );
 
 	// Start the upload if we don't have any errors.
 	! error && actions.uploadFile( file, clientFileId );
@@ -200,6 +234,10 @@ const onProgress = ( clientFileId, event ) => {
 const onReadyStateChange = ( clientFileId, event ) => {
 	const xhr = event.target;
 	if ( xhr.readyState === 4 ) {
+		// The request has settled either way, so its controller can never abort anything again.
+		// Dropping it here keeps the map from growing for the lifetime of the page.
+		uploadControllers.delete( clientFileId );
+
 		if ( xhr.status === 200 ) {
 			const response = JSON.parse( xhr.responseText );
 			if ( response.success ) {
@@ -222,7 +260,7 @@ const onReadyStateChange = ( clientFileId, event ) => {
 				return;
 			}
 		} else {
-			const config = getConfig( NAMESPACE );
+			const config = getConfig( CONFIG_NAMESPACE );
 			updateFileContext( { error: config.i18n.uploadFailed, hasError: true }, clientFileId );
 			return;
 		}
@@ -244,36 +282,57 @@ const updateFileContext = ( updatedFile, clientFileId ) => {
 	const index = context.files.findIndex( file => file.id === clientFileId );
 	context.files[ index ] = Object.assign( context.files[ index ], updatedFile );
 
-	jetpackFormStore.actions.updateFieldValue( context.fieldId, context.files );
+	actions.updateField( context.fieldId, context.files );
 };
 
-const { state, actions } = store( NAMESPACE, {
+const { actions } = store( NAMESPACE, {
 	state: {
-		get isInlineForm() {
-			const { ref } = getElement();
-			const form = ref.closest( '.wp-block-jetpack-contact-form' );
-			return (
-				( form && form.classList.contains( 'is-style-outlined' ) ) ||
-				form.classList.contains( 'is-style-animated' )
-			);
+		validators: {
+			/**
+			 * Validates the file field's value: the array of files held in context.
+			 *
+			 * Mirrors `validators.phone` — a registered validator owns its own empty/required
+			 * handling rather than leaning on the shared `validateField()` helper.
+			 *
+			 * @param {Array}   value      - The field's files.
+			 * @param {boolean} isRequired - Whether the field is required.
+			 * @return {string} The validation result.
+			 */
+			file: ( value, isRequired ) => {
+				if ( isEmptyValue( value ) ) {
+					return isRequired ? 'is_required' : 'yes';
+				}
+
+				if ( value.some( file => file.error ) ) {
+					return 'invalid_file_has_errors';
+				}
+
+				if ( value.some( file => ! file.isUploaded ) ) {
+					return 'invalid_file_uploading';
+				}
+
+				return 'yes';
+			},
 		},
-		get hasFiles() {
-			return !! getContext().files.length > 0;
+
+		get hasFileFieldFiles() {
+			return getContext().files.length > 0;
 		},
 
 		get hasMaxFiles() {
 			const context = getContext();
-			return context.maxFiles <= context.files.length;
+			return getFileFieldExtra().maxFiles <= context.files.length;
 		},
 	},
 
 	actions: {
-		handleKeyDown: event => {
+		onFileDropzoneKeyDown: event => {
 			if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
 				event.preventDefault();
 				actions.openFilePicker( event );
 			}
 		},
+
 		/**
 		 * Open the file picker dialog.
 		 */
@@ -307,7 +366,7 @@ const { state, actions } = store( NAMESPACE, {
 			// A drop fires no focus event, so the form's `focusin` handler never sees it.
 			// Without this, dropping a file and submitting would report the fill as starting
 			// at the submit button rather than at the drop.
-			jetpackFormStore.actions.trackFirstInteraction();
+			actions.trackFirstInteraction();
 			if ( event.dataTransfer ) {
 				for ( const item of Array.from( event.dataTransfer.items ) ) {
 					if ( item.webkitGetAsEntry()?.isDirectory ) {
@@ -325,7 +384,7 @@ const { state, actions } = store( NAMESPACE, {
 		 *
 		 * @param {DragEvent} event - The drag event object.
 		 */
-		dragOver: event => {
+		onFileDragOver: event => {
 			const context = getContext();
 			context.isDropping = true;
 			event.preventDefault();
@@ -334,7 +393,7 @@ const { state, actions } = store( NAMESPACE, {
 		/**
 		 * Handle drag leave event.
 		 */
-		dragLeave: () => {
+		onFileDragLeave: () => {
 			const context = getContext();
 			context.isDropping = false;
 		},
@@ -349,7 +408,7 @@ const { state, actions } = store( NAMESPACE, {
 		 * @yield {Promise<string>} The upload token.
 		 */
 		uploadFile: function* ( file, clientFileId ) {
-			const { endpoint, i18n } = getConfig( NAMESPACE );
+			const { endpoint, i18n } = getConfig( CONFIG_NAMESPACE );
 
 			const token = yield getUploadToken();
 
@@ -417,7 +476,7 @@ const { state, actions } = store( NAMESPACE, {
 			}
 
 			if ( file && file.file_id ) {
-				const { endpoint } = getConfig( NAMESPACE );
+				const { endpoint } = getConfig( CONFIG_NAMESPACE );
 				const token = yield getUploadToken();
 				if ( token ) {
 					const formData = new FormData();
@@ -429,12 +488,10 @@ const { state, actions } = store( NAMESPACE, {
 					} );
 				}
 			}
-			// Remove the file from the context
+			// Remove the file from the context. An empty array is a legitimate value here — the
+			// registered validator turns it into `is_required` or `yes` as appropriate.
 			context.files = context.files.filter( fileObject => fileObject.id !== clientFileId );
-			jetpackFormStore.actions.updateFieldValue(
-				context.fieldId,
-				state.hasFiles ? context.files : ''
-			);
+			actions.updateField( context.fieldId, context.files );
 		},
 
 		removeFileKeydown: event => {
@@ -446,20 +503,18 @@ const { state, actions } = store( NAMESPACE, {
 	},
 
 	callbacks: {
-		focusElement: function () {
+		/**
+		 * Move focus to a newly added file preview.
+		 *
+		 * The preview carries `tabindex="0"` and an `aria-label` of the file name, so it is the
+		 * only meaningful focus target once a file is added — the dropzone is hidden as soon as
+		 * `state.hasMaxFiles` becomes true, and focusing a hidden element strands keyboard users.
+		 */
+		focusFilePreview: () => {
 			const { ref } = getElement();
 			setTimeout( () => {
 				ref.focus( { focusVisible: true } );
 			}, 100 );
-
-			return withScope( function () {
-				const dropzone = ref
-					.closest( '.jetpack-form-file-field__container' )
-					.querySelector( '.jetpack-form-file-field__dropzone-inner' );
-				setTimeout( () => {
-					dropzone.focus( { focusVisible: true } );
-				}, 100 );
-			} );
 		},
 	},
 } );

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -555,7 +555,13 @@ const { state, actions, callbacks } = store( NAMESPACE, {
 		resetFiles: () => {
 			const context = getContext();
 			context.files.forEach( releaseFile );
-			context.files = [];
+			/*
+			 * Empty in place rather than reassigning. The legacy back-compat alias
+			 * (`bridgeLegacyContext`) points the old markup's context at this same array by
+			 * reference, so a reassignment would strand the old `data-wp-each--file` binding on the
+			 * previous array and leave removed files visible.
+			 */
+			context.files.splice( 0 );
 		},
 
 		/**
@@ -583,9 +589,17 @@ const { state, actions, callbacks } = store( NAMESPACE, {
 
 			releaseFile( file );
 
-			// An empty array is a legitimate value here — the registered validator turns it into
-			// `is_required` or `yes` as appropriate.
-			context.files = context.files.filter( fileObject => fileObject.id !== clientFileId );
+			/*
+			 * Remove in place rather than reassigning `context.files`. The legacy back-compat alias
+			 * (`bridgeLegacyContext`) shares this array with the old markup's context by reference, so
+			 * a reassignment would leave the old `data-wp-each--file` binding on the stale array,
+			 * keeping a removed file visible. An empty array is a legitimate value here — the
+			 * registered validator turns it into `is_required` or `yes` as appropriate.
+			 */
+			const index = context.files.indexOf( file );
+			if ( index !== -1 ) {
+				context.files.splice( index, 1 );
+			}
 			actions.updateField( context.fieldId, context.files );
 
 			if ( file.file_id ) {

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -167,7 +167,7 @@ const getFileFieldExtra = () => {
 };
 
 /**
- * The files currently held by the field, or an empty list outside a file field's scope.
+ * The files currently held by the field.
  *
  * @return {Array} The field's files.
  */
@@ -546,11 +546,7 @@ const { state, actions, callbacks } = store( NAMESPACE, {
 		},
 
 		/**
-		 * Reset the field, releasing anything the files still hold.
-		 *
-		 * Kept symmetrical with `removeFile`: emptying the list on its own left live uploads
-		 * running against files nothing referenced, blob URLs pinned for the life of the page, and
-		 * controllers stranded in `uploadControllers`.
+		 * Reset the field, releasing anything the files still hold. See `releaseFile()`.
 		 */
 		resetFiles: () => {
 			const context = getContext();
@@ -662,25 +658,18 @@ const { state, actions, callbacks } = store( NAMESPACE, {
 } );
 
 /*
- * Back-compatibility shim for markup rendered before this change. Remove one release after this
+ * Back-compatibility shim for markup cached before this change. Remove one release after this
  * ships, along with the `@deprecated` note in the changelog.
  *
- * Page caches serve HTML and scripts on independent lifetimes, and the script module is versioned
- * on `JETPACK__VERSION` rather than the forms package version — so both directions are reachable:
- * cached markup carrying `data-wp-interactive="jetpack/field-file"` against this bundle, and new
- * markup against an older bundle after a deploy with no plugin version bump.
+ * A page cache can serve HTML carrying `data-wp-interactive="jetpack/field-file"` against this
+ * bundle, and that fails silently: the runtime auto-creates an empty store for an unknown
+ * namespace rather than erroring, so every directive in the container becomes a no-op with no
+ * console output outside SCRIPT_DEBUG. On a *required* file field it is unrecoverable — the
+ * wrapper is still `jetpack/form`, so `registerField` records `is_required`, no file can ever be
+ * added to clear it, and the submit gate blocks the form permanently.
  *
- * The first direction fails silently and badly. The runtime's `resolve()` auto-creates an empty
- * store for an unknown namespace instead of erroring, and the `on` directive skips a non-function
- * result, so every directive inside the old container becomes a no-op: the dropzone does nothing,
- * the file input does nothing, the remove button does nothing, and no class ever toggles — with no
- * console output outside SCRIPT_DEBUG. On a *required* file field that is unrecoverable: the
- * wrapper markup is untouched `jetpack/form`, so `registerField` still records `is_required`, no
- * file can ever be added to clear it, and the submit gate blocks the form permanently. The visitor
- * sees an error they cannot resolve and the site owner just sees submissions stop.
- *
- * Registering the old namespace with the old names pointed at the new implementations keeps that
- * markup working, and doubles as the deprecation window for what was a globally reachable store.
+ * (The mirror case, new markup against a stale bundle, is handled by the content-hash suffix in
+ * `enqueue_file_field_assets()` rather than here.)
  */
 /**
  * Point the shared context at the legacy one so the new implementation can run against old markup.
@@ -729,13 +718,13 @@ store( CONFIG_NAMESPACE, {
 		},
 	},
 	actions: {
-		handleKeyDown: withLegacyContext( event => actions.onFileDropzoneKeyDown( event ) ),
-		openFilePicker: withLegacyContext( () => actions.openFilePicker() ),
-		fileAdded: withLegacyContext( event => actions.fileAdded( event ) ),
-		fileDropped: withLegacyContext( event => actions.fileDropped( event ) ),
-		removeFile: withLegacyContext( event => actions.removeFile( event ) ),
-		removeFileKeydown: withLegacyContext( event => actions.removeFileKeydown( event ) ),
-		resetFiles: withLegacyContext( () => actions.resetFiles() ),
+		handleKeyDown: withLegacyContext( actions.onFileDropzoneKeyDown ),
+		openFilePicker: withLegacyContext( actions.openFilePicker ),
+		fileAdded: withLegacyContext( actions.fileAdded ),
+		fileDropped: withLegacyContext( actions.fileDropped ),
+		removeFile: withLegacyContext( actions.removeFile ),
+		removeFileKeydown: withLegacyContext( actions.removeFileKeydown ),
+		resetFiles: withLegacyContext( actions.resetFiles ),
 
 		// The old template binds `is-dropping` to the legacy context, so these write there directly
 		// rather than delegating to handlers that would set the flag on the shared context.
@@ -748,6 +737,6 @@ store( CONFIG_NAMESPACE, {
 		},
 	},
 	callbacks: {
-		focusElement: () => callbacks.focusFilePreview(),
+		focusElement: callbacks.focusFilePreview,
 	},
 } );

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -13,8 +13,8 @@ import { isEmptyValue } from '../../contact-form/js/validate-helper.js';
 const NAMESPACE = 'jetpack/form';
 const CONFIG_NAMESPACE = 'jetpack/field-file';
 
-const ENTER = 13;
-const SPACE = 32;
+// Long enough for the preview to be rendered and the dropzone hidden before focus moves.
+const PREVIEW_FOCUS_DELAY_MS = 100;
 
 let uploadToken = null;
 let tokenExpiry = null;
@@ -28,6 +28,12 @@ let pendingTokenRequest = null;
  * The token authorizes uploads for the whole site rather than for one field, so it is cached at
  * module scope and shared by every file field on the page.
  *
+ * The cache is written inside the shared promise rather than by each awaiting caller. Writing it
+ * in the continuation would leave a microtask-sized window where `pendingTokenRequest` has already
+ * been cleared but `uploadToken` is not yet set, letting a second caller past both guards and
+ * start a redundant request — and with two in flight the last one to resolve would win, which can
+ * leave the cache holding the older token and the earlier expiry.
+ *
  * @return {Promise<string|null>} The upload token, or null if one could not be obtained.
  */
 const getUploadToken = async () => {
@@ -37,15 +43,21 @@ const getUploadToken = async () => {
 	}
 
 	if ( ! pendingTokenRequest ) {
-		pendingTokenRequest = fetchUploadToken().finally( () => {
-			pendingTokenRequest = null;
-		} );
+		pendingTokenRequest = fetchUploadToken()
+			.then( ( { token, expiresAt } ) => {
+				uploadToken = token;
+				// A non-numeric expiry would make every later `Date.now() < tokenExpiry` false and
+				// silently disable the cache for the rest of the page, so treat it as expired now
+				// and re-fetch next time instead.
+				tokenExpiry = Number.isFinite( expiresAt ) ? expiresAt * 1000 : 0;
+				return token;
+			} )
+			.finally( () => {
+				pendingTokenRequest = null;
+			} );
 	}
 
-	const { token, expiresAt } = await pendingTokenRequest;
-	uploadToken = token;
-	tokenExpiry = expiresAt * 1000; // Convert expiry timestamp to milliseconds
-	return uploadToken;
+	return pendingTokenRequest;
 };
 
 /**
@@ -281,18 +293,83 @@ const onReadyStateChange = ( clientFileId, event ) => {
 /**
  * Update the context with the new updatedFile object based on the file ID.
  *
+ * XHR events can outlive the entry they describe — `resetFiles` empties the list without waiting
+ * for anything in flight — so a missing file is an expected outcome here, not an error. Without
+ * the guard, `findIndex` returns -1 and `Object.assign( undefined, … )` throws out of a progress
+ * handler and takes the rest of the upload's reporting with it.
+ *
  * @param {object} updatedFile  - The updated file object.
  * @param {string} clientFileId - The client file ID.
  */
 const updateFileContext = ( updatedFile, clientFileId ) => {
 	const context = getContext();
 	const index = context.files.findIndex( file => file.id === clientFileId );
+
+	if ( index === -1 ) {
+		return;
+	}
+
 	context.files[ index ] = Object.assign( context.files[ index ], updatedFile );
 
 	actions.updateField( context.fieldId, context.files );
 };
 
-const { actions } = store( NAMESPACE, {
+/**
+ * Ask the server to drop an already-uploaded file.
+ *
+ * Deliberately not awaited by the caller: the field's own state is updated first so the UI never
+ * waits on the network. Safe to run after the interactivity scope is gone, since `getConfig()`
+ * with an explicit namespace reads the global config map rather than the current scope.
+ *
+ * @param {string} fileId - The server-side file ID.
+ */
+const deleteUploadedFile = async fileId => {
+	const token = await getUploadToken();
+
+	if ( ! token ) {
+		return;
+	}
+
+	const { endpoint } = getConfig( CONFIG_NAMESPACE );
+	const formData = new FormData();
+	formData.append( 'token', token );
+	formData.append( 'file_id', fileId );
+
+	try {
+		await fetch( `${ endpoint }/remove`, { method: 'POST', body: formData } );
+	} catch {
+		// The file is already gone from the field either way; a failed cleanup call is not
+		// something the visitor can act on.
+	}
+};
+
+/**
+ * Release everything attached to a file: its in-flight upload and its preview object URL.
+ *
+ * Shared by `removeFile` and `resetFiles` so the two cannot drift — a reset that skipped this
+ * left the XHR running against a file nothing referenced any more, pinned the blob URL for the
+ * life of the page, and leaked the controller into `uploadControllers`.
+ *
+ * @param {object} file - The file entry to release.
+ */
+const releaseFile = file => {
+	if ( ! file ) {
+		return;
+	}
+
+	const abortController = uploadControllers.get( file.id );
+	if ( abortController ) {
+		abortController.abort();
+		uploadControllers.delete( file.id );
+	}
+
+	if ( file.url ) {
+		// Strip the `url(…)` wrapper the style binding needs to get back to the blob URL.
+		URL.revokeObjectURL( file.url.substring( 4, file.url.length - 1 ) );
+	}
+};
+
+const { state, actions, callbacks } = store( NAMESPACE, {
 	state: {
 		validators: {
 			/**
@@ -335,7 +412,7 @@ const { actions } = store( NAMESPACE, {
 
 	actions: {
 		onFileDropzoneKeyDown: event => {
-			if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
+			if ( event.key === 'Enter' || event.key === ' ' ) {
 				event.preventDefault();
 				actions.openFilePicker( event );
 			}
@@ -377,6 +454,12 @@ const { actions } = store( NAMESPACE, {
 			actions.trackFirstInteraction();
 			if ( event.dataTransfer ) {
 				for ( const item of Array.from( event.dataTransfer.items ) ) {
+					// Dragging selected text, a link or an image from another tab yields items with
+					// `kind === 'string'`. Those return null from both `webkitGetAsEntry()` and
+					// `getAsFile()`, so they have to be filtered before either is dereferenced.
+					if ( item.kind !== 'file' ) {
+						continue;
+					}
 					// Directories are skipped rather than aborting the whole drop: returning here
 					// discarded every remaining file in a mixed selection and left `isDropping`
 					// set, stranding the dropzone in its drag-hover style.
@@ -428,6 +511,16 @@ const { actions } = store( NAMESPACE, {
 				return;
 			}
 
+			// The token round-trip suspends this generator, and there is no AbortController
+			// registered yet — so a removal during that window has nothing to cancel and returns as
+			// though it worked. Without this check the upload would resume and send a file the user
+			// already deleted. Sharing one token request across a batch widens the window, since
+			// files now queue behind a single fetch rather than each firing their own.
+			const context = getContext();
+			if ( ! context.files.some( fileObject => fileObject.id === clientFileId ) ) {
+				return;
+			}
+
 			const xhr = new XMLHttpRequest();
 			const formData = new FormData();
 
@@ -453,60 +546,55 @@ const { actions } = store( NAMESPACE, {
 		},
 
 		/**
-		 * Reset the files in the context.
+		 * Reset the field, releasing anything the files still hold.
+		 *
+		 * Kept symmetrical with `removeFile`: emptying the list on its own left live uploads
+		 * running against files nothing referenced, blob URLs pinned for the life of the page, and
+		 * controllers stranded in `uploadControllers`.
 		 */
 		resetFiles: () => {
 			const context = getContext();
+			context.files.forEach( releaseFile );
 			context.files = [];
 		},
 
 		/**
 		 * Remove a file from the context and cancel its upload if in progress.
 		 *
+		 * The UI update happens first and the server-side delete is fired without blocking it.
+		 * Waiting on a token round-trip before removing the entry left the preview in place and
+		 * the dropzone hidden — `state.isFileFieldFull` still counted the file — so a slow or
+		 * failed network made the field look stuck with no way to add a replacement.
+		 *
 		 * @param {Event} event - The event object.
-		 * @yield {Promise<string>} The upload token.
 		 */
-		removeFile: function* ( event ) {
+		removeFile: event => {
 			event.preventDefault();
 
 			const context = getContext();
 			const clientFileId = event.target.dataset.id;
-
-			// Cancel the upload if it's in progress
-			if ( uploadControllers.has( clientFileId ) ) {
-				const abortController = uploadControllers.get( clientFileId );
-				abortController.abort(); // Cancel the upload
-				uploadControllers.delete( clientFileId ); // Clean up the controller
-			}
-
 			const file = context.files.find( fileObject => fileObject.id === clientFileId );
-			if ( file && file.url ) {
-				// Remove the object URL to free up memory
-				const urlToRemove = file.url.substring( 4, file.url.length - 1 );
-				URL.revokeObjectURL( urlToRemove );
+
+			// A second activation while the first is still settling would revoke an already-revoked
+			// URL and POST a duplicate delete.
+			if ( ! file ) {
+				return;
 			}
 
-			if ( file && file.file_id ) {
-				const { endpoint } = getConfig( CONFIG_NAMESPACE );
-				const token = yield getUploadToken();
-				if ( token ) {
-					const formData = new FormData();
-					formData.append( 'token', token );
-					formData.append( 'file_id', file.file_id );
-					fetch( `${ endpoint }/remove`, {
-						method: 'POST',
-						body: formData,
-					} );
-				}
-			}
-			// Remove the file from the context. An empty array is a legitimate value here — the
-			// registered validator turns it into `is_required` or `yes` as appropriate.
+			releaseFile( file );
+
+			// An empty array is a legitimate value here — the registered validator turns it into
+			// `is_required` or `yes` as appropriate.
 			context.files = context.files.filter( fileObject => fileObject.id !== clientFileId );
 			actions.updateField( context.fieldId, context.files );
+
+			if ( file.file_id ) {
+				deleteUploadedFile( file.file_id );
+			}
 		},
 
 		removeFileKeydown: event => {
-			if ( event.keyCode === ENTER || event.keyCode === SPACE ) {
+			if ( event.key === 'Enter' || event.key === ' ' ) {
 				event.preventDefault();
 				actions.removeFile( event );
 			}
@@ -520,12 +608,132 @@ const { actions } = store( NAMESPACE, {
 		 * The preview carries `tabindex="0"` and an `aria-label` of the file name, so it is the
 		 * only meaningful focus target once a file is added — the dropzone is hidden as soon as
 		 * `state.isFileFieldFull` becomes true, and focusing a hidden element strands keyboard users.
+		 *
+		 * The returned function is the effect cleanup: `data-wp-init` resolves the callback without
+		 * invoking it, calls it once, and hands whatever it returns to Preact's `useEffect` as the
+		 * teardown. So this runs when the preview unmounts — that is, when the file is removed —
+		 * and hands focus back to the dropzone, which is visible again by then. Without it, removal
+		 * destroys the focused element and focus falls to `<body>`.
+		 *
+		 * The container is captured while the preview is still attached: by cleanup time the node
+		 * is detached, so `ref.closest()` would return null and querying it would throw.
+		 *
+		 * @return {Function} Cleanup that cancels the pending focus and restores it to the dropzone.
 		 */
 		focusFilePreview: () => {
 			const { ref } = getElement();
-			setTimeout( () => {
-				ref.focus( { focusVisible: true } );
-			}, 100 );
+			const container = ref.closest( '.jetpack-form-file-field__container' );
+
+			// `isConnected` guards the case where the file is removed inside the delay: focusing a
+			// detached node is a silent no-op that would strand focus on `<body>`.
+			const focusTimer = setTimeout( () => {
+				if ( ref.isConnected ) {
+					ref.focus( { focusVisible: true } );
+				}
+			}, PREVIEW_FOCUS_DELAY_MS );
+
+			return () => {
+				clearTimeout( focusTimer );
+
+				const dropzone = container?.querySelector( '.jetpack-form-file-field__dropzone-inner' );
+
+				setTimeout( () => {
+					if ( dropzone?.isConnected ) {
+						dropzone.focus( { focusVisible: true } );
+					}
+				}, PREVIEW_FOCUS_DELAY_MS );
+			};
 		},
+	},
+} );
+
+/*
+ * Back-compatibility shim for markup rendered before this change. Remove one release after this
+ * ships, along with the `@deprecated` note in the changelog.
+ *
+ * Page caches serve HTML and scripts on independent lifetimes, and the script module is versioned
+ * on `JETPACK__VERSION` rather than the forms package version — so both directions are reachable:
+ * cached markup carrying `data-wp-interactive="jetpack/field-file"` against this bundle, and new
+ * markup against an older bundle after a deploy with no plugin version bump.
+ *
+ * The first direction fails silently and badly. The runtime's `resolve()` auto-creates an empty
+ * store for an unknown namespace instead of erroring, and the `on` directive skips a non-function
+ * result, so every directive inside the old container becomes a no-op: the dropzone does nothing,
+ * the file input does nothing, the remove button does nothing, and no class ever toggles — with no
+ * console output outside SCRIPT_DEBUG. On a *required* file field that is unrecoverable: the
+ * wrapper markup is untouched `jetpack/form`, so `registerField` still records `is_required`, no
+ * file can ever be added to clear it, and the submit gate blocks the form permanently. The visitor
+ * sees an error they cannot resolve and the site owner just sees submissions stop.
+ *
+ * Registering the old namespace with the old names pointed at the new implementations keeps that
+ * markup working, and doubles as the deprecation window for what was a globally reachable store.
+ */
+/**
+ * Point the shared context at the legacy one so the new implementation can run against old markup.
+ *
+ * Old markup declared `files` under `jetpack/field-file` and carried `maxFiles`/`allowedMimeTypes`
+ * as loose context keys rather than in `fieldExtra`. Assigning the same array reference rather than
+ * a copy matters: the old template's `data-wp-each--file` still binds to the legacy context, so
+ * both bindings have to observe the same underlying object to stay in step.
+ */
+const bridgeLegacyContext = () => {
+	const legacy = getContext( CONFIG_NAMESPACE );
+	const shared = getContext( NAMESPACE );
+
+	if ( ! legacy || ! shared ) {
+		return;
+	}
+
+	if ( shared.files === undefined ) {
+		shared.files = legacy.files;
+	}
+
+	if ( ! shared.fieldExtra ) {
+		shared.fieldExtra = {
+			maxFiles: legacy.maxFiles,
+			allowedMimeTypes: legacy.allowedMimeTypes,
+		};
+	}
+};
+
+const withLegacyContext =
+	action =>
+	( ...args ) => {
+		bridgeLegacyContext();
+		return action( ...args );
+	};
+
+store( CONFIG_NAMESPACE, {
+	state: {
+		get hasFiles() {
+			bridgeLegacyContext();
+			return state.hasFileFieldFiles;
+		},
+		get hasMaxFiles() {
+			bridgeLegacyContext();
+			return state.isFileFieldFull;
+		},
+	},
+	actions: {
+		handleKeyDown: withLegacyContext( event => actions.onFileDropzoneKeyDown( event ) ),
+		openFilePicker: withLegacyContext( () => actions.openFilePicker() ),
+		fileAdded: withLegacyContext( event => actions.fileAdded( event ) ),
+		fileDropped: withLegacyContext( event => actions.fileDropped( event ) ),
+		removeFile: withLegacyContext( event => actions.removeFile( event ) ),
+		removeFileKeydown: withLegacyContext( event => actions.removeFileKeydown( event ) ),
+		resetFiles: withLegacyContext( () => actions.resetFiles() ),
+
+		// The old template binds `is-dropping` to the legacy context, so these write there directly
+		// rather than delegating to handlers that would set the flag on the shared context.
+		dragOver: event => {
+			getContext( CONFIG_NAMESPACE ).isDropping = true;
+			event.preventDefault();
+		},
+		dragLeave: () => {
+			getContext( CONFIG_NAMESPACE ).isDropping = false;
+		},
+	},
+	callbacks: {
+		focusElement: () => callbacks.focusFilePreview(),
 	},
 } );

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -791,7 +791,18 @@ store( CONFIG_NAMESPACE, {
 		handleKeyDown: withLegacyContext( 'onFileDropzoneKeyDown' ),
 		openFilePicker: withLegacyContext( 'openFilePicker' ),
 		fileAdded: withLegacyContext( 'fileAdded' ),
-		fileDropped: withLegacyContext( 'fileDropped' ),
+		/*
+		 * Delegating is not enough here. The shared implementation ends by clearing `isDropping`
+		 * on the shared context, but the old template binds `is-dropping` to the legacy one — the
+		 * same reason `dragOver`/`dragLeave` below stay local. Without this the dropzone keeps its
+		 * drag-hover highlight after a drop and only sheds it on the next `dragleave`.
+		 */
+		fileDropped: ( ...args ) => {
+			bridgeLegacyContext();
+			const result = actions.fileDropped( ...args );
+			getContext( CONFIG_NAMESPACE ).isDropping = false;
+			return result;
+		},
 		removeFile: withLegacyContext( 'removeFile' ),
 		removeFileKeydown: withLegacyContext( 'removeFileKeydown' ),
 		resetFiles: withLegacyContext( 'resetFiles' ),

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -746,6 +746,29 @@ const withLegacyContext =
 		return actions[ actionName ]( ...args );
 	};
 
+/*
+ * The names above are strings, so renaming a shared action would not update them and nothing would
+ * notice until a visitor on stale cached HTML hit a `TypeError`. Reading each one here (without
+ * calling it) turns that into a console warning on every page load carrying the field. Reading is
+ * safe: the proxy's `get` trap only binds a scope for the caller it returns, and this discards it.
+ */
+const assertLegacyDelegatesExist = names => {
+	if ( ! globalThis.SCRIPT_DEBUG ) {
+		return;
+	}
+
+	const missing = names.filter( name => typeof actions[ name ] !== 'function' );
+
+	if ( missing.length ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			`jetpack/field-file back-compat shim: no such action(s) on jetpack/form: ${ missing.join(
+				', '
+			) }`
+		);
+	}
+};
+
 store( CONFIG_NAMESPACE, {
 	state: {
 		get hasFiles() {
@@ -781,3 +804,13 @@ store( CONFIG_NAMESPACE, {
 		focusElement: ( ...args ) => callbacks.focusFilePreview( ...args ),
 	},
 } );
+
+assertLegacyDelegatesExist( [
+	'onFileDropzoneKeyDown',
+	'openFilePicker',
+	'fileAdded',
+	'fileDropped',
+	'removeFile',
+	'removeFileKeydown',
+	'resetFiles',
+] );

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -714,14 +714,21 @@ const bridgeLegacyContext = () => {
 	}
 
 	/*
-	 * Test the shape rather than mere presence. The wrapper that carries old markup is the
-	 * unchanged PHP of the previous release, and it already emitted `fieldExtra` for a file
-	 * field as `get_field_extra()`'s untouched `$extra_attrs` — an empty array, which
-	 * `wp_json_encode()` writes as `[]` and JS reads as truthy. A `! shared.fieldExtra` guard
-	 * therefore never fires, `getFileFieldExtra()` falls back to an empty allowlist, and every
-	 * file is rejected as a disallowed type.
+	 * Test for the key rather than for a truthy value or for `fieldExtra` itself.
+	 *
+	 * `! shared.fieldExtra` never fires: the wrapper carrying old markup is the unchanged PHP of
+	 * the previous release, which emitted `fieldExtra` for a file field as `get_field_extra()`'s
+	 * untouched `$extra_attrs` — an empty array, which `wp_json_encode()` writes as `[]` and JS
+	 * reads as truthy. The allowlist then stays empty and every file is rejected as a disallowed
+	 * type.
+	 *
+	 * Testing the value (`! shared.fieldExtra?.allowedMimeTypes`) fixes that but is not idempotent:
+	 * this runs inside the `hasFiles`/`hasMaxFiles` getters, which the runtime evaluates in a
+	 * computed, and a legacy context with no usable list would assign a fresh object on every
+	 * evaluation, invalidating the computed that just read it and spinning the main thread. Keying
+	 * on the property means the second call is always a no-op.
 	 */
-	if ( ! shared.fieldExtra?.allowedMimeTypes ) {
+	if ( ! shared.fieldExtra || ! ( 'allowedMimeTypes' in shared.fieldExtra ) ) {
 		shared.fieldExtra = {
 			maxFiles: legacy.maxFiles,
 			allowedMimeTypes: legacy.allowedMimeTypes,

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -664,10 +664,13 @@ const { state, actions, callbacks } = store( NAMESPACE, {
 				 * moving them to the dropzone would be stealing focus rather than restoring it.
 				 */
 				setTimeout( () => {
-					const focusIsOrphaned =
-						! document.activeElement || document.activeElement === document.body;
+					if ( ! dropzone?.isConnected ) {
+						return;
+					}
 
-					if ( dropzone?.isConnected && focusIsOrphaned ) {
+					const { activeElement, body } = dropzone.ownerDocument;
+
+					if ( ! activeElement || activeElement === body ) {
 						dropzone.focus( { focusVisible: true } );
 					}
 				}, PREVIEW_FOCUS_DELAY_MS );

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -412,6 +412,11 @@ const { state, actions, callbacks } = store( NAMESPACE, {
 
 	actions: {
 		onFileDropzoneKeyDown: event => {
+			// Holding the key down would otherwise reopen the picker on every auto-repeat.
+			if ( event.repeat ) {
+				return;
+			}
+
 			if ( event.key === 'Enter' || event.key === ' ' ) {
 				event.preventDefault();
 				actions.openFilePicker( event );
@@ -604,6 +609,11 @@ const { state, actions, callbacks } = store( NAMESPACE, {
 		},
 
 		removeFileKeydown: event => {
+			// Holding the key down would otherwise fire a second removal at the repeat rate.
+			if ( event.repeat ) {
+				return;
+			}
+
 			if ( event.key === 'Enter' || event.key === ' ' ) {
 				event.preventDefault();
 				actions.removeFile( event );
@@ -647,8 +657,17 @@ const { state, actions, callbacks } = store( NAMESPACE, {
 
 				const dropzone = container?.querySelector( '.jetpack-form-file-field__dropzone-inner' );
 
+				/*
+				 * Nothing cancels this second timer, so check at fire time that focus is still
+				 * the orphan this callback exists to rescue. Destroying the focused preview drops
+				 * focus to `<body>`; if the visitor has since tabbed or clicked to a real element,
+				 * moving them to the dropzone would be stealing focus rather than restoring it.
+				 */
 				setTimeout( () => {
-					if ( dropzone?.isConnected ) {
+					const focusIsOrphaned =
+						! document.activeElement || document.activeElement === document.body;
+
+					if ( dropzone?.isConnected && focusIsOrphaned ) {
 						dropzone.focus( { focusVisible: true } );
 					}
 				}, PREVIEW_FOCUS_DELAY_MS );
@@ -691,7 +710,15 @@ const bridgeLegacyContext = () => {
 		shared.files = legacy.files;
 	}
 
-	if ( ! shared.fieldExtra ) {
+	/*
+	 * Test the shape rather than mere presence. The wrapper that carries old markup is the
+	 * unchanged PHP of the previous release, and it already emitted `fieldExtra` for a file
+	 * field as `get_field_extra()`'s untouched `$extra_attrs` — an empty array, which
+	 * `wp_json_encode()` writes as `[]` and JS reads as truthy. A `! shared.fieldExtra` guard
+	 * therefore never fires, `getFileFieldExtra()` falls back to an empty allowlist, and every
+	 * file is rejected as a disallowed type.
+	 */
+	if ( ! shared.fieldExtra?.allowedMimeTypes ) {
 		shared.fieldExtra = {
 			maxFiles: legacy.maxFiles,
 			allowedMimeTypes: legacy.allowedMimeTypes,
@@ -699,11 +726,21 @@ const bridgeLegacyContext = () => {
 	}
 };
 
+/*
+ * Look the delegate up by name at call time rather than closing over it.
+ *
+ * `actions` and `callbacks` are store proxies, and the proxy's `get` trap is what binds a
+ * function to a scope: it returns `withScope( fn )`, and `withScope()` captures `getScope()` at
+ * the moment of the property read. Reading `actions.removeFile` while this module is still
+ * evaluating captures an empty scope stack, so every later call would run `setScope( undefined )`
+ * and the first `getContext()` inside would throw on `scope.context`. Deferring the read to call
+ * time means the proxy binds the scope the runtime has already pushed for the directive.
+ */
 const withLegacyContext =
-	action =>
+	actionName =>
 	( ...args ) => {
 		bridgeLegacyContext();
-		return action( ...args );
+		return actions[ actionName ]( ...args );
 	};
 
 store( CONFIG_NAMESPACE, {
@@ -718,13 +755,13 @@ store( CONFIG_NAMESPACE, {
 		},
 	},
 	actions: {
-		handleKeyDown: withLegacyContext( actions.onFileDropzoneKeyDown ),
-		openFilePicker: withLegacyContext( actions.openFilePicker ),
-		fileAdded: withLegacyContext( actions.fileAdded ),
-		fileDropped: withLegacyContext( actions.fileDropped ),
-		removeFile: withLegacyContext( actions.removeFile ),
-		removeFileKeydown: withLegacyContext( actions.removeFileKeydown ),
-		resetFiles: withLegacyContext( actions.resetFiles ),
+		handleKeyDown: withLegacyContext( 'onFileDropzoneKeyDown' ),
+		openFilePicker: withLegacyContext( 'openFilePicker' ),
+		fileAdded: withLegacyContext( 'fileAdded' ),
+		fileDropped: withLegacyContext( 'fileDropped' ),
+		removeFile: withLegacyContext( 'removeFile' ),
+		removeFileKeydown: withLegacyContext( 'removeFileKeydown' ),
+		resetFiles: withLegacyContext( 'resetFiles' ),
 
 		// The old template binds `is-dropping` to the legacy context, so these write there directly
 		// rather than delegating to handlers that would set the flag on the shared context.
@@ -737,6 +774,7 @@ store( CONFIG_NAMESPACE, {
 		},
 	},
 	callbacks: {
-		focusElement: callbacks.focusFilePreview,
+		// Read through the proxy at call time, for the reason given on `withLegacyContext()`.
+		focusElement: ( ...args ) => callbacks.focusFilePreview( ...args ),
 	},
 } );

--- a/projects/packages/forms/src/modules/file-field/view.js
+++ b/projects/packages/forms/src/modules/file-field/view.js
@@ -155,6 +155,13 @@ const getFileFieldExtra = () => {
 };
 
 /**
+ * The files currently held by the field, or an empty list outside a file field's scope.
+ *
+ * @return {Array} The field's files.
+ */
+const getFileFieldFiles = () => getContext().files ?? [];
+
+/**
  * Add the file to the context.
  *
  * @param {File} file - The file to add.
@@ -315,13 +322,14 @@ const { actions } = store( NAMESPACE, {
 			},
 		},
 
+		// Both getters tolerate a missing `files`: they live in the shared form store now, so a
+		// stray binding from a non-file field would otherwise throw rather than read as "empty".
 		get hasFileFieldFiles() {
-			return getContext().files.length > 0;
+			return getFileFieldFiles().length > 0;
 		},
 
-		get hasMaxFiles() {
-			const context = getContext();
-			return getFileFieldExtra().maxFiles <= context.files.length;
+		get isFileFieldFull() {
+			return getFileFieldExtra().maxFiles <= getFileFieldFiles().length;
 		},
 	},
 
@@ -369,8 +377,11 @@ const { actions } = store( NAMESPACE, {
 			actions.trackFirstInteraction();
 			if ( event.dataTransfer ) {
 				for ( const item of Array.from( event.dataTransfer.items ) ) {
+					// Directories are skipped rather than aborting the whole drop: returning here
+					// discarded every remaining file in a mixed selection and left `isDropping`
+					// set, stranding the dropzone in its drag-hover style.
 					if ( item.webkitGetAsEntry()?.isDirectory ) {
-						return;
+						continue;
 					}
 					addFileToContext( item.getAsFile() );
 				}
@@ -508,7 +519,7 @@ const { actions } = store( NAMESPACE, {
 		 *
 		 * The preview carries `tabindex="0"` and an `aria-label` of the file name, so it is the
 		 * only meaningful focus target once a file is added — the dropzone is hidden as soon as
-		 * `state.hasMaxFiles` becomes true, and focusing a hidden element strands keyboard users.
+		 * `state.isFileFieldFull` becomes true, and focusing a hidden element strands keyboard users.
 		 */
 		focusFilePreview: () => {
 			const { ref } = getElement();

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -59,27 +59,8 @@ let errorTimeout = null;
 // Must match Feedback::FORM_FILL_DURATION_FIELD in src/contact-form/class-feedback.php.
 const FORM_FILL_DURATION_FIELD = 'jetpack_form_fill_duration';
 
-const updateField = ( fieldId, value, showFieldError = false, validatorCallback = null ) => {
-	const context = getContext();
-	let field = context.fields[ fieldId ];
-
-	if ( ! field ) {
-		const { fieldType, fieldLabel, fieldValue, fieldIsRequired, fieldExtra } = context;
-		registerField( fieldId, fieldType, fieldLabel, fieldValue, fieldIsRequired, fieldExtra );
-		field = context.fields[ fieldId ];
-	}
-	if ( field ) {
-		const { type, isRequired, extra } = field;
-		field.value = value;
-		field.error = validatorCallback
-			? validatorCallback( value, isRequired, extra )
-			: validateField( type, value, isRequired, extra );
-		field.showFieldError = showFieldError;
-	}
-};
-
 /**
- * Resolve the validator for a field type.
+ * Validate a field value, preferring a validator its module registered.
  *
  * A field module that registers `state.validators[ type ]` owns validation for that type
  * outright — including the empty/required check — and it applies on every update, not just on
@@ -93,10 +74,36 @@ const updateField = ( fieldId, value, showFieldError = false, validatorCallback 
  * keys are undefined. Validators should derive their answer from the `value`, `isRequired` and
  * `extra` arguments, and any `getContext()` read must tolerate missing keys.
  *
- * @param {string} fieldType - The field type.
- * @return {Function|null} The registered validator, or null to use the shared helper.
+ * @param {string}  type       - The field type.
+ * @param {*}       value      - The value to validate.
+ * @param {boolean} isRequired - Whether the field is required.
+ * @param {*}       extra      - The field's extra configuration.
+ * @return {string} The validation result.
  */
-const getValidator = fieldType => state.validators?.[ fieldType ] ?? null;
+const validate = ( type, value, isRequired, extra ) => {
+	const validator = state.validators?.[ type ];
+
+	return validator
+		? validator( value, isRequired, extra )
+		: validateField( type, value, isRequired, extra );
+};
+
+const updateField = ( fieldId, value, showFieldError = false ) => {
+	const context = getContext();
+	let field = context.fields[ fieldId ];
+
+	if ( ! field ) {
+		const { fieldType, fieldLabel, fieldValue, fieldIsRequired, fieldExtra } = context;
+		registerField( fieldId, fieldType, fieldLabel, fieldValue, fieldIsRequired, fieldExtra );
+		field = context.fields[ fieldId ];
+	}
+	if ( field ) {
+		const { type, isRequired, extra } = field;
+		field.value = value;
+		field.error = validate( type, value, isRequired, extra );
+		field.showFieldError = showFieldError;
+	}
+};
 
 const setSubmissionData = ( data = [] ) => {
 	const context = getContext();
@@ -158,8 +165,6 @@ const registerField = (
 			}
 		}
 
-		const validator = getValidator( type );
-
 		context.fields[ fieldId ] = {
 			id: fieldId,
 			type,
@@ -167,9 +172,7 @@ const registerField = (
 			value,
 			isRequired,
 			extra,
-			error: validator
-				? validator( value, isRequired, extra )
-				: validateField( type, value, isRequired, extra ),
+			error: validate( type, value, isRequired, extra ),
 			step: context?.step ? context.step : 1,
 			isOtherSelected,
 			otherLabel,
@@ -532,9 +535,7 @@ const { state, actions } = store( NAMESPACE, {
 
 	actions: {
 		updateField: ( fieldId, value, showFieldError ) => {
-			const context = getContext();
-			const { fieldType } = context;
-			updateField( fieldId, value, showFieldError, getValidator( fieldType ) );
+			updateField( fieldId, value, showFieldError );
 		},
 		updateFieldValue: ( fieldId, value ) => {
 			actions.updateField( fieldId, value );

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -78,6 +78,18 @@ const updateField = ( fieldId, value, showFieldError = false, validatorCallback 
 	}
 };
 
+/**
+ * Resolve the validator for a field type.
+ *
+ * A field module that registers `state.validators[ type ]` owns validation for that type
+ * outright — including the empty/required check — and it applies on every update, not just on
+ * blur. Types with no registered validator fall through to the shared `validateField()` helper.
+ *
+ * @param {string} fieldType - The field type.
+ * @return {Function|null} The registered validator, or null to use the shared helper.
+ */
+const getValidator = fieldType => state.validators?.[ fieldType ] ?? null;
+
 const setSubmissionData = ( data = [] ) => {
 	const context = getContext();
 
@@ -138,6 +150,8 @@ const registerField = (
 			}
 		}
 
+		const validator = getValidator( type );
+
 		context.fields[ fieldId ] = {
 			id: fieldId,
 			type,
@@ -145,7 +159,9 @@ const registerField = (
 			value,
 			isRequired,
 			extra,
-			error: validateField( type, value, isRequired, extra ),
+			error: validator
+				? validator( value, isRequired, extra )
+				: validateField( type, value, isRequired, extra ),
 			step: context?.step ? context.step : 1,
 			isOtherSelected,
 			otherLabel,
@@ -510,12 +526,7 @@ const { state, actions } = store( NAMESPACE, {
 		updateField: ( fieldId, value, showFieldError ) => {
 			const context = getContext();
 			const { fieldType } = context;
-			updateField(
-				fieldId,
-				value,
-				showFieldError,
-				showFieldError ? state.validators?.[ fieldType ] : null
-			);
+			updateField( fieldId, value, showFieldError, getValidator( fieldType ) );
 		},
 		updateFieldValue: ( fieldId, value ) => {
 			actions.updateField( fieldId, value );
@@ -675,7 +686,7 @@ const { state, actions } = store( NAMESPACE, {
 		 * Start the fill timer on the submitter's first interaction with the form.
 		 *
 		 * Bound to `focusin` on the form wrapper, which covers every focusable control. File
-		 * drag-and-drop fires no focus event, so `jetpack/field-file` calls this directly.
+		 * drag-and-drop fires no focus event, so the file field module calls this directly.
 		 *
 		 * Uses `performance.now()` rather than `Date.now()`: it is monotonic, so a wall-clock
 		 * step backward mid-fill cannot produce a negative duration. Compared against null

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -85,6 +85,14 @@ const updateField = ( fieldId, value, showFieldError = false, validatorCallback 
  * outright — including the empty/required check — and it applies on every update, not just on
  * blur. Types with no registered validator fall through to the shared `validateField()` helper.
  *
+ * SCOPE CONTRACT: a validator is called from two different places, and they do not see the same
+ * context. `registerField()` runs from `callbacks.initializeField`, bound on the field wrapper;
+ * `actions.updateField()` runs from whichever element the user interacted with, which is usually
+ * a descendant. Because Interactivity API context only inherits downwards, a validator that
+ * reads `getContext()` cannot rely on anything a descendant provides — during registration those
+ * keys are undefined. Validators should derive their answer from the `value`, `isRequired` and
+ * `extra` arguments, and any `getContext()` read must tolerate missing keys.
+ *
  * @param {string} fieldType - The field type.
  * @return {Function|null} The registered validator, or null to use the shared helper.
  */

--- a/projects/packages/forms/tests/js/contact-form/validate-helper.test.js
+++ b/projects/packages/forms/tests/js/contact-form/validate-helper.test.js
@@ -172,29 +172,8 @@ describe( 'validateField', () => {
 		} );
 	} );
 
-	describe( 'file validation', () => {
-		test( 'validates file format', () => {
-			expect( validateField( 'file', [], false ) ).toBe( 'yes' );
-			expect(
-				validateField( 'file', [ { name: 'file.txt', size: 12345, isUploaded: true } ], false )
-			).toBe( 'yes' );
-			expect(
-				validateField( 'file', [ { name: 'file.txt', size: 12345, isUploaded: true } ], true )
-			).toBe( 'yes' );
-		} );
-
-		test( 'invalidates incorrect file formats', () => {
-			expect( validateField( 'file', [ { error: true } ], true ) ).toBe(
-				'invalid_file_has_errors'
-			);
-			expect( validateField( 'file', [ { isUploaded: false } ], true ) ).toBe(
-				'invalid_file_uploading'
-			);
-			expect( validateField( 'file', [ { isUploaded: false } ], false ) ).toBe(
-				'invalid_file_uploading'
-			);
-		} );
-	} );
+	// File validation lives with the file field itself, as `state.validators.file` in
+	// src/modules/file-field/view.js. See tests/js/modules/file-field/view.test.js.
 
 	describe( 'url validation', () => {
 		test( 'validates correct url formats', () => {

--- a/projects/packages/forms/tests/js/modules/field-phone/view.test.js
+++ b/projects/packages/forms/tests/js/modules/field-phone/view.test.js
@@ -6,6 +6,9 @@ const mockGetContext = jest.fn();
 const mockGetConfig = jest.fn();
 const mockGetElement = jest.fn();
 const mockWithSyncEvent = jest.fn( callback => callback );
+// Contributed by modules/form/view.js, not by this module. Declared once at module scope because
+// the store mock only runs on the single dynamic import; `jest.clearAllMocks()` resets its calls.
+const mockUpdateField = jest.fn();
 
 await jest.unstable_mockModule( '@wordpress/interactivity', () => ( {
 	store: mockStore,
@@ -119,9 +122,18 @@ describe( 'Phone Field View', () => {
 		} );
 		mockAsYouType.mockImplementation( () => mockAsYouTypeInstance );
 
-		// Capture store configuration
+		/*
+		 * Capture store configuration.
+		 *
+		 * `updateField` is contributed by modules/form/view.js, not by this module, so it has to be
+		 * merged in the way the real shared store would supply it. Leaving it out made these tests
+		 * depend on an earlier test assigning it onto the module-singleton `actions` object, which
+		 * leaks across the whole file: run any Country selection or Keyboard navigation test on its
+		 * own and it failed with "actions.updateField is not a function".
+		 */
 		mockStore.mockImplementation( ( namespace, config ) => {
 			storeConfig = config;
+			config.actions.updateField = mockUpdateField;
 			return { actions: config.actions, callbacks: config.callbacks };
 		} );
 
@@ -260,10 +272,6 @@ describe( 'Phone Field View', () => {
 				target: { value: '555-123-4567' },
 			};
 
-			// Mock actions.updateField
-			const mockUpdateField = jest.fn();
-			storeConfig.actions.updateField = mockUpdateField;
-
 			// With ensureInitialized, the handler should self-heal by querying
 			// the DOM for refs and initializing, rather than throwing.
 			storeConfig.actions.phoneNumberInputHandler( mockEvent );
@@ -288,6 +296,44 @@ describe( 'Phone Field View', () => {
 			expect( mockContext.phoneCountryCode ).toBe( 'GB' );
 			expect( mockContext.countryPrefix ).toBe( '+44' );
 			expect( mockContext.comboboxOpen ).toBe( false );
+		} );
+
+		test( 'committing a country revalidates the field', () => {
+			mockContext.fieldId = 'test-phone';
+			mockContext.phoneNumber = '721234567';
+			mockContext.filtered = { code: 'FR', value: '+33', flag: '🇫🇷', country: 'France' };
+			mockContext.allCountries = [
+				{ code: 'US', value: '+1', flag: '🇺🇸', country: 'United States', selected: true },
+				{ code: 'FR', value: '+33', flag: '🇫🇷', country: 'France', selected: false },
+			];
+			mockContext.filteredCountries = [ ...mockContext.allCountries ];
+
+			storeConfig.actions.phoneCountryChangeHandler();
+
+			// Without this the number keeps the `invalid_phone` it earned under the old country.
+			expect( mockUpdateField ).toHaveBeenCalledWith( 'test-phone', '721234567', false );
+		} );
+
+		test( 'arrowing through the list does not revalidate or clear a shown error', () => {
+			mockContext.fieldId = 'test-phone';
+			mockContext.phoneNumber = '721234567';
+			mockContext.comboboxOpen = true;
+			mockContext.allCountries = [
+				{ code: 'US', value: '+1', flag: '🇺🇸', country: 'United States', selected: true },
+				{ code: 'FR', value: '+33', flag: '🇫🇷', country: 'France', selected: false },
+			];
+			mockContext.filteredCountries = [ ...mockContext.allCountries ];
+
+			storeConfig.actions.phoneComboboxKeydownHandler( {
+				key: 'ArrowDown',
+				preventDefault: jest.fn(),
+			} );
+
+			/*
+			 * Highlighting is not committing. `updateField` defaults `showFieldError` to false, so
+			 * revalidating here would hide an error that is still true of the typed number.
+			 */
+			expect( mockUpdateField ).not.toHaveBeenCalled();
 		} );
 
 		test( 'filtering logic works correctly', () => {

--- a/projects/packages/forms/tests/js/modules/file-field/README.md
+++ b/projects/packages/forms/tests/js/modules/file-field/README.md
@@ -37,10 +37,11 @@ Because the field lives in the shared store, `updateField` and `trackFirstIntera
 - Concurrent uploads share a single upload-token request
 
 **Focus**
-- `focusFilePreview` focuses the preview and returns nothing. The return value matters: the `data-wp-init` directive *invokes* a returned function immediately rather than treating it as effect cleanup, which is what used to move focus onto the (hidden) dropzone.
+- `focusFilePreview` focuses the preview and returns a cleanup function. The return value matters: `data-wp-init` resolves the callback without invoking it, calls it once, and hands what it returns to Preact as effect teardown — so the returned function runs when the preview unmounts and gives focus back to the dropzone.
 
 ### Limitations
 
 - **jsdom has no `URL.createObjectURL`.** It is stubbed in `beforeEach`. Without the stub, `addFileToContext` falls back to the icon path for every file, and an image-preview assertion would pass for the wrong reason.
-- **`XMLHttpRequest` is a hand-rolled double.** Upload progress and readystatechange are driven manually, so real network behaviour, aborts and partial transfers are not covered here.
+- **`XMLHttpRequest` is a hand-rolled double.** Upload progress and readystatechange are driven manually, so real network behavior, aborts and partial transfers are not covered here.
 - **The Interactivity API is mocked wholesale.** These tests verify module logic, not directive binding, reactivity or hydration — nothing here proves the `data-wp-*` attributes in `class-contact-form-field.php` resolve to the names the module registers. That pairing is only exercised end to end.
+- **The `store` mock returns its config object directly, so scope binding is invisible here.** In the real runtime `actions` is a proxy whose `get` trap wraps each function with `withScope()`, capturing the scope *at the moment of the property read*. Reading an action at module-evaluation time therefore captures an empty scope and throws on first use, while the mock happily returns the same function either way. The `jetpack/field-file` back-compat shim depends on getting this right, and no test in this file can fail if it regresses — verify that against the real package, not here.

--- a/projects/packages/forms/tests/js/modules/file-field/README.md
+++ b/projects/packages/forms/tests/js/modules/file-field/README.md
@@ -1,0 +1,46 @@
+# File Field View Testing
+
+Tests for the file upload field's `view.js` module, which implements the file field on the WordPress Interactivity API: drag-and-drop, the file picker, per-file upload with progress, and removal.
+
+## Testing Strategy
+
+The module registers into the **shared** `jetpack/form` store — not a store of its own — and keeps `jetpack/field-file` only as a `wp_interactivity_config()` namespace for the upload endpoint, icon path and per-file error strings. That split is the thing these tests exist to protect, so `getConfig` is mocked **namespace-aware**: it throws on any namespace other than `jetpack/field-file`. A namespace-agnostic mock would let the split silently collapse without a single test failing.
+
+Because the field lives in the shared store, `updateField` and `trackFirstInteraction` are contributed by `modules/form/view.js` rather than by this module. The `store` mock merges jest spies for those two into the returned `actions` object, which is how the real module reaches them at runtime.
+
+### What's Tested
+
+**Store registration**
+- Registers into `jetpack/form`, not its own namespace
+- Contributes `state.validators.file` alongside the other field validators
+
+**Validation (`validators.file`)**
+- Required/optional handling for an empty value (array or empty string)
+- Files that errored, uploads still in flight, and the precedence between them
+
+**Field configuration**
+- `maxFiles` and `allowedMimeTypes` are read from the standard `fieldExtra` context entry, with a single-file fallback when it is absent
+- `state.hasFileFieldFiles` and `state.isFileFieldFull`
+
+**Adding files**
+- MIME type, max upload size and max file count rejection, each with its own message
+- Object-URL previews for image types (see the jsdom note below)
+- The value reaches the shared `updateField` action
+
+**Drag and drop**
+- Dropping starts the form fill timer, since a drop fires no focus event
+- Directories are skipped without discarding the rest of a mixed drop or stranding `isDropping`
+
+**Removal and upload lifecycle**
+- Object URLs are revoked; an emptied field reports `[]` rather than `''`
+- A settled request drops its abort controller, so a later removal cannot abort a finished upload
+- Concurrent uploads share a single upload-token request
+
+**Focus**
+- `focusFilePreview` focuses the preview and returns nothing. The return value matters: the `data-wp-init` directive *invokes* a returned function immediately rather than treating it as effect cleanup, which is what used to move focus onto the (hidden) dropzone.
+
+### Limitations
+
+- **jsdom has no `URL.createObjectURL`.** It is stubbed in `beforeEach`. Without the stub, `addFileToContext` falls back to the icon path for every file, and an image-preview assertion would pass for the wrong reason.
+- **`XMLHttpRequest` is a hand-rolled double.** Upload progress and readystatechange are driven manually, so real network behaviour, aborts and partial transfers are not covered here.
+- **The Interactivity API is mocked wholesale.** These tests verify module logic, not directive binding, reactivity or hydration — nothing here proves the `data-wp-*` attributes in `class-contact-form-field.php` resolve to the names the module registers. That pairing is only exercised end to end.

--- a/projects/packages/forms/tests/js/modules/file-field/view.test.js
+++ b/projects/packages/forms/tests/js/modules/file-field/view.test.js
@@ -19,8 +19,10 @@ const ALLOWED_MIME_TYPES = [ 'image/png', 'application/pdf' ];
 
 describe( 'File Field View', () => {
 	let mockContext;
+	let legacyContext;
 	let mockElement;
 	let storeConfig;
+	let storeConfigs;
 	let storeNamespace;
 	let mockUpdateField;
 	let mockTrackFirstInteraction;
@@ -57,7 +59,12 @@ describe( 'File Field View', () => {
 			ref: document.querySelector( '.jetpack-form-file-field__dropzone-inner' ),
 		};
 
-		mockGetContext.mockReturnValue( mockContext );
+		// Contexts are per-namespace. Current markup puts everything the field needs in the
+		// `jetpack/form` context; the legacy namespace is empty unless a back-compat test sets it.
+		legacyContext = null;
+		mockGetContext.mockImplementation( namespace =>
+			namespace === 'jetpack/field-file' ? legacyContext : mockContext
+		);
 		mockGetElement.mockReturnValue( mockElement );
 
 		// Namespace-aware on purpose: the field's config lives under `jetpack/field-file` while
@@ -98,9 +105,11 @@ describe( 'File Field View', () => {
 		mockUpdateField = jest.fn();
 		mockTrackFirstInteraction = jest.fn();
 
+		// The module registers twice: the real store under `jetpack/form`, then a back-compat alias
+		// under the old `jetpack/field-file` namespace. Keep them apart so tests can address either.
+		storeConfigs = {};
 		mockStore.mockImplementation( ( namespace, config ) => {
-			storeNamespace = namespace;
-			storeConfig = config;
+			storeConfigs[ namespace ] = config;
 			return {
 				state: config.state,
 				actions: {
@@ -108,20 +117,31 @@ describe( 'File Field View', () => {
 					updateField: mockUpdateField,
 					trackFirstInteraction: mockTrackFirstInteraction,
 				},
+				callbacks: config.callbacks,
 			};
 		} );
 
 		await import( '../../../../src/modules/file-field/view.js' );
+		storeNamespace = Object.keys( storeConfigs )[ 0 ];
+		storeConfig = storeConfigs[ 'jetpack/form' ];
 		state = storeConfig.state;
 	} );
 
 	afterEach( () => {
 		document.body.innerHTML = '';
+		// clearAllMocks does not undo a mockImplementation, and the shared jest config sets
+		// neither restoreMocks nor clearMocks — without this, a spy on fetch or XMLHttpRequest set
+		// inside one test body silently leaks into every test declared after it.
+		jest.restoreAllMocks();
 	} );
 
 	describe( 'Store registration', () => {
 		test( 'registers into the shared jetpack/form store, not its own namespace', () => {
 			expect( storeNamespace ).toBe( 'jetpack/form' );
+		} );
+
+		test( 'also registers a back-compat alias under the old namespace', () => {
+			expect( storeConfigs[ 'jetpack/field-file' ] ).toBeDefined();
 		} );
 
 		test( 'registers a `file` validator alongside the other field validators', () => {
@@ -303,20 +323,33 @@ describe( 'File Field View', () => {
 			expect( mockTrackFirstInteraction ).toHaveBeenCalled();
 		} );
 
+		/**
+		 * Build a DataTransferItem double.
+		 *
+		 * @param {object}      options             - Item options.
+		 * @param {string}      options.kind        - 'file' or 'string'.
+		 * @param {boolean}     options.isDirectory - Whether the entry is a directory.
+		 * @param {object|null} options.file        - The file the item yields.
+		 * @return {object} The item double.
+		 */
+		const dropItem = ( { kind = 'file', isDirectory = false, file = null } = {} ) => ( {
+			kind,
+			// Both of these return null for a `string` item, which is what makes the kind check
+			// load-bearing rather than cosmetic.
+			webkitGetAsEntry: () => ( kind === 'file' ? { isDirectory } : null ),
+			getAsFile: () => ( kind === 'file' ? file : null ),
+		} );
+
+		const drop = items =>
+			storeConfig.actions.fileDropped( {
+				preventDefault: jest.fn(),
+				dataTransfer: { items },
+			} );
+
 		test( 'a dropped directory is skipped', () => {
 			mockContext.isDropping = true;
 
-			storeConfig.actions.fileDropped( {
-				preventDefault: jest.fn(),
-				dataTransfer: {
-					items: [
-						{
-							webkitGetAsEntry: () => ( { isDirectory: true } ),
-							getAsFile: () => ( { name: 'folder', type: '', size: 0 } ),
-						},
-					],
-				},
-			} );
+			drop( [ dropItem( { isDirectory: true, file: { name: 'folder', type: '', size: 0 } } ) ] );
 
 			expect( mockContext.files ).toHaveLength( 0 );
 			// Bailing out of the loop used to skip this, stranding the dropzone in drag-hover.
@@ -324,23 +357,30 @@ describe( 'File Field View', () => {
 		} );
 
 		test( 'a directory does not discard the rest of a mixed drop', () => {
-			const item = ( isDirectory, file ) => ( {
-				webkitGetAsEntry: () => ( { isDirectory } ),
-				getAsFile: () => file,
-			} );
-
-			storeConfig.actions.fileDropped( {
-				preventDefault: jest.fn(),
-				dataTransfer: {
-					items: [
-						item( true, { name: 'folder', type: '', size: 0 } ),
-						item( false, { name: 'doc.pdf', type: 'application/pdf', size: 10 } ),
-					],
-				},
-			} );
+			drop( [
+				dropItem( { isDirectory: true, file: { name: 'folder', type: '', size: 0 } } ),
+				dropItem( { file: { name: 'doc.pdf', type: 'application/pdf', size: 10 } } ),
+			] );
 
 			expect( mockContext.files ).toHaveLength( 1 );
 			expect( mockContext.files[ 0 ] ).toMatchObject( { name: 'doc.pdf' } );
+		} );
+
+		test( 'dragged text or links are ignored without throwing', () => {
+			// `kind: 'string'` items return null from webkitGetAsEntry() and getAsFile(). Skipping
+			// only directories let those through to a null dereference, which threw mid-loop and
+			// left the dropzone stuck in drag-hover.
+			mockContext.isDropping = true;
+
+			expect( () =>
+				drop( [
+					dropItem( { kind: 'string' } ),
+					dropItem( { file: { name: 'doc.pdf', type: 'application/pdf', size: 10 } } ),
+				] )
+			).not.toThrow();
+
+			expect( mockContext.files ).toHaveLength( 1 );
+			expect( mockContext.isDropping ).toBe( false );
 		} );
 	} );
 
@@ -348,7 +388,7 @@ describe( 'File Field View', () => {
 		test( 'onFileDropzoneKeyDown opens the picker on Enter', () => {
 			const fileInput = document.querySelector( '.jetpack-form-file-field' );
 			jest.spyOn( fileInput, 'click' ).mockImplementation();
-			const event = { keyCode: 13, preventDefault: jest.fn() };
+			const event = { key: 'Enter', preventDefault: jest.fn() };
 
 			storeConfig.actions.onFileDropzoneKeyDown( event );
 
@@ -360,7 +400,7 @@ describe( 'File Field View', () => {
 			const fileInput = document.querySelector( '.jetpack-form-file-field' );
 			jest.spyOn( fileInput, 'click' ).mockImplementation();
 
-			storeConfig.actions.onFileDropzoneKeyDown( { keyCode: 65, preventDefault: jest.fn() } );
+			storeConfig.actions.onFileDropzoneKeyDown( { key: 'a', preventDefault: jest.fn() } );
 
 			expect( fileInput.click ).not.toHaveBeenCalled();
 		} );
@@ -377,43 +417,62 @@ describe( 'File Field View', () => {
 
 	describe( 'Removing files', () => {
 		/**
-		 * Drive the `removeFile` generator to completion.
+		 * Remove a file. `removeFile` is synchronous: the server-side delete is fired without
+		 * blocking the UI update, so the context reflects the removal on return.
 		 *
 		 * @param {string} id - The client file ID to remove.
-		 * @return {Promise} Resolves when the generator is done.
 		 */
-		const removeFile = async id => {
-			const event = {
+		const removeFile = id => {
+			storeConfig.actions.removeFile( {
 				preventDefault: jest.fn(),
 				target: { dataset: { id } },
-			};
-			const generator = storeConfig.actions.removeFile( event );
-			let step = generator.next();
-			while ( ! step.done ) {
-				step = generator.next( await step.value );
-			}
+			} );
 		};
 
-		test( 'removes the file and reports the remaining list, not an empty string', async () => {
+		test( 'removes the file and reports the remaining list, not an empty string', () => {
 			mockContext.files = [
 				{ id: 'a', url: null, error: null },
 				{ id: 'b', url: null, error: null },
 			];
 
-			await removeFile( 'a' );
+			removeFile( 'a' );
 
 			expect( mockContext.files.map( f => f.id ) ).toEqual( [ 'b' ] );
 			// An empty array is a legitimate value now — the registered validator turns it into
 			// `is_required` or `yes`, so there is no need to substitute ''.
-			await removeFile( 'b' );
+			removeFile( 'b' );
 			const [ , lastValue ] = mockUpdateField.mock.calls.at( -1 );
 			expect( lastValue ).toEqual( [] );
 		} );
 
-		test( 'revokes the object URL of a removed image preview', async () => {
+		test( 'updates the field without waiting on the server-side delete', () => {
+			// A token round-trip before removal left the preview in place and the dropzone hidden,
+			// so a slow network made the field look stuck with no way to add a replacement.
+			const fetchSpy = jest
+				.spyOn( global, 'fetch' )
+				.mockImplementation( () => new Promise( () => {} ) );
+			mockContext.files = [ { id: 'a', url: null, error: null, file_id: 'server-1' } ];
+
+			removeFile( 'a' );
+
+			expect( mockContext.files ).toEqual( [] );
+			expect( mockUpdateField ).toHaveBeenCalledWith( 'test-file', [] );
+			expect( fetchSpy ).toHaveBeenCalled();
+		} );
+
+		test( 'a second activation is a no-op rather than a duplicate delete', () => {
 			mockContext.files = [ { id: 'a', url: 'url(blob:mock)', error: null } ];
 
-			await removeFile( 'a' );
+			removeFile( 'a' );
+			removeFile( 'a' );
+
+			expect( global.URL.revokeObjectURL ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'revokes the object URL of a removed image preview', () => {
+			mockContext.files = [ { id: 'a', url: 'url(blob:mock)', error: null } ];
+
+			removeFile( 'a' );
 
 			expect( global.URL.revokeObjectURL ).toHaveBeenCalledWith( 'blob:mock' );
 		} );
@@ -471,16 +530,56 @@ describe( 'File Field View', () => {
 			} );
 
 			// The controller is gone, so a later remove cannot abort an already-finished request.
-			await ( async () => {
-				const event = { preventDefault: jest.fn(), target: { dataset: { id: 'client-1' } } };
-				const gen = storeConfig.actions.removeFile( event );
-				let s = gen.next();
-				while ( ! s.done ) {
-					s = gen.next( await s.value );
-				}
-			} )();
+			storeConfig.actions.removeFile( {
+				preventDefault: jest.fn(),
+				target: { dataset: { id: 'client-1' } },
+			} );
 
 			expect( xhr.abort ).not.toHaveBeenCalled();
+		} );
+
+		test( 'does not send a file that was removed while its token was in flight', async () => {
+			// Nothing is registered in uploadControllers until after the token resolves, so a
+			// removal during that window has nothing to abort and would otherwise upload a file the
+			// user already deleted.
+			jest.spyOn( global, 'fetch' ).mockImplementation( () =>
+				Promise.resolve( {
+					ok: true,
+					json: () => Promise.resolve( { token: 'abc', expiration: 0 } ),
+				} )
+			);
+			const { xhr } = installFakeXhr();
+			mockContext.files = [ { id: 'client-1', error: null, isUploaded: false } ];
+
+			const generator = storeConfig.actions.uploadFile( { name: 'doc.pdf' }, 'client-1' );
+			const tokenPromise = generator.next().value;
+
+			// The user removes the file before the token comes back.
+			mockContext.files = [];
+
+			let step = generator.next( await tokenPromise );
+			while ( ! step.done ) {
+				step = generator.next( await step.value );
+			}
+
+			expect( xhr.send ).not.toHaveBeenCalled();
+		} );
+
+		test( 'a progress event for an already-cleared file is ignored', () => {
+			// resetFiles empties the list without waiting for in-flight requests, so an XHR event
+			// can arrive for an entry that is gone. Object.assign( undefined, … ) used to throw.
+			mockContext.files = [];
+
+			expect( () => storeConfig.actions.resetFiles() ).not.toThrow();
+		} );
+
+		test( 'resetFiles releases controllers and object URLs like removeFile does', () => {
+			mockContext.files = [ { id: 'a', url: 'url(blob:mock)', error: null } ];
+
+			storeConfig.actions.resetFiles();
+
+			expect( global.URL.revokeObjectURL ).toHaveBeenCalledWith( 'blob:mock' );
+			expect( mockContext.files ).toEqual( [] );
 		} );
 	} );
 
@@ -503,19 +602,129 @@ describe( 'File Field View', () => {
 		} );
 	} );
 
-	describe( 'Focus management', () => {
-		test( 'focusFilePreview focuses the preview and nothing else', () => {
-			jest.useFakeTimers();
-			const focus = jest.fn();
-			mockGetElement.mockReturnValue( { ref: { focus } } );
+	describe( 'Back-compat alias for cached markup', () => {
+		let legacyStore;
 
-			const result = storeConfig.callbacks.focusFilePreview();
+		beforeEach( () => {
+			legacyStore = storeConfigs[ 'jetpack/field-file' ];
+
+			// What a page cached before this change serves: the file state under the old namespace,
+			// config as loose keys rather than in fieldExtra.
+			legacyContext = {
+				fieldId: 'test-file',
+				files: [],
+				isDropping: false,
+				maxFiles: 1,
+				allowedMimeTypes: ALLOWED_MIME_TYPES,
+			};
+			// The shared wrapper context is still emitted by unchanged PHP, but knows nothing about
+			// the file field.
+			mockContext = { fieldId: 'test-file', fieldType: 'file', fields: {} };
+		} );
+
+		test( 'adding a file through the old action name still reaches the shared field state', () => {
+			legacyStore.actions.fileAdded( {
+				target: { files: [ { name: 'doc.pdf', type: 'application/pdf', size: 10 } ] },
+			} );
+
+			// The same array backs both contexts, so the old template's data-wp-each stays in step.
+			expect( legacyContext.files ).toHaveLength( 1 );
+			expect( mockContext.files ).toBe( legacyContext.files );
+			expect( mockUpdateField ).toHaveBeenCalledWith( 'test-file', legacyContext.files );
+		} );
+
+		test( 'the old config keys are bridged into fieldExtra so limits still apply', () => {
+			legacyStore.actions.fileAdded( {
+				target: { files: [ { name: 'evil.exe', type: 'application/x-msdownload', size: 10 } ] },
+			} );
+
+			expect( legacyContext.files[ 0 ] ).toMatchObject( {
+				hasError: true,
+				error: 'This file type is not allowed.',
+			} );
+		} );
+
+		test( 'the old drag actions toggle the flag the old markup binds to', () => {
+			legacyStore.actions.dragOver( { preventDefault: jest.fn() } );
+			expect( legacyContext.isDropping ).toBe( true );
+
+			legacyStore.actions.dragLeave();
+			expect( legacyContext.isDropping ).toBe( false );
+		} );
+
+		test( 'the old state getters resolve against the legacy context', () => {
+			expect( legacyStore.state.hasFiles ).toBe( false );
+			expect( legacyStore.state.hasMaxFiles ).toBe( false );
+
+			legacyContext.files.push( { id: '1' } );
+
+			expect( legacyStore.state.hasFiles ).toBe( true );
+			expect( legacyStore.state.hasMaxFiles ).toBe( true );
+		} );
+	} );
+
+	describe( 'Focus management', () => {
+		/**
+		 * Mount a preview inside the dropzone container and run the init callback against it.
+		 *
+		 * @return {{preview: HTMLElement, dropzone: HTMLElement, cleanup: Function}} The nodes and the effect cleanup the callback returned.
+		 */
+		const mountPreview = () => {
+			const container = document.querySelector( '.jetpack-form-file-field__container' );
+			const preview = document.createElement( 'div' );
+			preview.className = 'jetpack-form-file-field__preview';
+			preview.tabIndex = 0;
+			container.querySelector( '.jetpack-form-file-field__preview-wrap' ).append( preview );
+
+			const dropzone = container.querySelector( '.jetpack-form-file-field__dropzone-inner' );
+			jest.spyOn( preview, 'focus' );
+			jest.spyOn( dropzone, 'focus' );
+
+			mockGetElement.mockReturnValue( { ref: preview } );
+
+			return { preview, dropzone, cleanup: storeConfig.callbacks.focusFilePreview() };
+		};
+
+		test( 'focuses the new preview on mount', () => {
+			jest.useFakeTimers();
+			const { preview, dropzone } = mountPreview();
+
 			jest.runAllTimers();
 
-			expect( focus ).toHaveBeenCalledWith( { focusVisible: true } );
-			// Returning a function would be invoked immediately by the `data-wp-init` directive,
-			// which is what previously stole focus back to the (hidden) dropzone.
-			expect( typeof result ).not.toBe( 'function' );
+			expect( preview.focus ).toHaveBeenCalledWith( { focusVisible: true } );
+			expect( dropzone.focus ).not.toHaveBeenCalled();
+			jest.useRealTimers();
+		} );
+
+		test( 'returns a cleanup that hands focus back to the dropzone on removal', () => {
+			// `data-wp-init` resolves the callback without invoking it, calls it once, and passes
+			// the return value to useEffect as teardown — so returning a function here is how focus
+			// is restored when the file is removed, not a bug.
+			jest.useFakeTimers();
+			const { preview, dropzone, cleanup } = mountPreview();
+			jest.runAllTimers();
+
+			expect( typeof cleanup ).toBe( 'function' );
+
+			preview.remove();
+			cleanup();
+			jest.runAllTimers();
+
+			expect( dropzone.focus ).toHaveBeenCalledWith( { focusVisible: true } );
+			jest.useRealTimers();
+		} );
+
+		test( 'does not focus a preview that was removed inside the delay', () => {
+			jest.useFakeTimers();
+			const { preview, cleanup } = mountPreview();
+
+			// Remove before the timer fires: focusing a detached node is a silent no-op that would
+			// leave focus on <body>.
+			preview.remove();
+			cleanup();
+			jest.runAllTimers();
+
+			expect( preview.focus ).not.toHaveBeenCalled();
 			jest.useRealTimers();
 		} );
 	} );

--- a/projects/packages/forms/tests/js/modules/file-field/view.test.js
+++ b/projects/packages/forms/tests/js/modules/file-field/view.test.js
@@ -59,19 +59,39 @@ describe( 'File Field View', () => {
 
 		mockGetContext.mockReturnValue( mockContext );
 		mockGetElement.mockReturnValue( mockElement );
-		mockGetConfig.mockReturnValue( {
-			endpoint: 'https://example.test/upload',
-			iconsPath: 'https://example.test/icons/',
-			maxUploadSize: 1024,
-			i18n: {
-				zeroBytes: '0 Bytes',
-				fileSizeUnits: [ 'B', 'KB', 'MB', 'GB' ],
-				fileTooLarge: 'File is too large.',
-				invalidType: 'This file type is not allowed.',
-				maxFiles: 'Too many files.',
-				uploadFailed: 'File upload failed, try again.',
-			},
+
+		// Namespace-aware on purpose: the field's config lives under `jetpack/field-file` while
+		// its store lives under `jetpack/form`. A namespace-agnostic mock would let that split
+		// silently collapse, which is the exact thing this module is meant to establish.
+		mockGetConfig.mockImplementation( namespace => {
+			if ( namespace !== 'jetpack/field-file' ) {
+				throw new Error( `Unexpected config namespace: ${ namespace }` );
+			}
+			return {
+				endpoint: 'https://example.test/upload',
+				iconsPath: 'https://example.test/icons/',
+				maxUploadSize: 1024,
+				i18n: {
+					zeroBytes: '0 Bytes',
+					fileSizeUnits: [ 'B', 'KB', 'MB', 'GB' ],
+					fileTooLarge: 'File is too large.',
+					invalidType: 'This file type is not allowed.',
+					maxFiles: 'Too many files.',
+					uploadFailed: 'File upload failed, try again.',
+				},
+			};
 		} );
+
+		// jsdom implements neither of these, so they have to be defined before they can be spied
+		// on. Without them every file silently takes the non-image icon path, and an
+		// image-preview assertion would pass for the wrong reason.
+		global.URL.createObjectURL ??= () => '';
+		global.URL.revokeObjectURL ??= () => {};
+		jest.spyOn( global.URL, 'createObjectURL' ).mockImplementation( () => 'blob:mock' );
+		jest.spyOn( global.URL, 'revokeObjectURL' ).mockImplementation();
+
+		// Likewise absent from this jsdom environment; define so individual tests can spy.
+		global.fetch ??= () => Promise.resolve();
 
 		// `updateField` and `trackFirstInteraction` are contributed by the form module. Because the
 		// file field now shares that store, it reaches them through the same `actions` object.
@@ -161,24 +181,24 @@ describe( 'File Field View', () => {
 			expect( state.hasFileFieldFiles ).toBe( true );
 		} );
 
-		test( 'hasMaxFiles reads maxFiles from fieldExtra', () => {
-			expect( state.hasMaxFiles ).toBe( false );
+		test( 'isFileFieldFull reads maxFiles from fieldExtra', () => {
+			expect( state.isFileFieldFull ).toBe( false );
 			mockContext.files = [ { id: '1' } ];
-			expect( state.hasMaxFiles ).toBe( true );
+			expect( state.isFileFieldFull ).toBe( true );
 		} );
 
-		test( 'hasMaxFiles honours a larger maxFiles from fieldExtra', () => {
+		test( 'isFileFieldFull honours a larger maxFiles from fieldExtra', () => {
 			mockContext.fieldExtra.maxFiles = 3;
 			mockContext.files = [ { id: '1' }, { id: '2' } ];
-			expect( state.hasMaxFiles ).toBe( false );
+			expect( state.isFileFieldFull ).toBe( false );
 			mockContext.files.push( { id: '3' } );
-			expect( state.hasMaxFiles ).toBe( true );
+			expect( state.isFileFieldFull ).toBe( true );
 		} );
 
 		test( 'falls back to a single file when fieldExtra is absent', () => {
 			delete mockContext.fieldExtra;
 			mockContext.files = [ { id: '1' } ];
-			expect( state.hasMaxFiles ).toBe( true );
+			expect( state.isFileFieldFull ).toBe( true );
 		} );
 	} );
 
@@ -235,7 +255,26 @@ describe( 'File Field View', () => {
 		test( 'pushes the value through the shared updateField action', () => {
 			storeConfig.actions.fileAdded( { target: { files: [ makeFile() ] } } );
 
-			expect( mockUpdateField ).toHaveBeenCalledWith( 'test-file', mockContext.files );
+			// Snapshot the argument rather than comparing `mockContext.files` to itself, which
+			// would pass for any contents.
+			expect( mockUpdateField ).toHaveBeenCalledTimes( 1 );
+			const [ fieldId, value ] = mockUpdateField.mock.calls[ 0 ];
+			expect( fieldId ).toBe( 'test-file' );
+			expect( value ).toHaveLength( 1 );
+			expect( value[ 0 ] ).toMatchObject( { name: 'doc.pdf', isUploaded: false, error: null } );
+		} );
+
+		test( 'builds an object URL preview for image types', () => {
+			storeConfig.actions.fileAdded( {
+				target: { files: [ makeFile( { name: 'photo.png', type: 'image/png' } ) ] },
+			} );
+
+			expect( global.URL.createObjectURL ).toHaveBeenCalled();
+			expect( mockContext.files[ 0 ] ).toMatchObject( {
+				hasIcon: false,
+				url: 'url(blob:mock)',
+				mask: null,
+			} );
 		} );
 	} );
 
@@ -264,7 +303,9 @@ describe( 'File Field View', () => {
 			expect( mockTrackFirstInteraction ).toHaveBeenCalled();
 		} );
 
-		test( 'a dropped directory is ignored', () => {
+		test( 'a dropped directory is skipped', () => {
+			mockContext.isDropping = true;
+
 			storeConfig.actions.fileDropped( {
 				preventDefault: jest.fn(),
 				dataTransfer: {
@@ -278,6 +319,28 @@ describe( 'File Field View', () => {
 			} );
 
 			expect( mockContext.files ).toHaveLength( 0 );
+			// Bailing out of the loop used to skip this, stranding the dropzone in drag-hover.
+			expect( mockContext.isDropping ).toBe( false );
+		} );
+
+		test( 'a directory does not discard the rest of a mixed drop', () => {
+			const item = ( isDirectory, file ) => ( {
+				webkitGetAsEntry: () => ( { isDirectory } ),
+				getAsFile: () => file,
+			} );
+
+			storeConfig.actions.fileDropped( {
+				preventDefault: jest.fn(),
+				dataTransfer: {
+					items: [
+						item( true, { name: 'folder', type: '', size: 0 } ),
+						item( false, { name: 'doc.pdf', type: 'application/pdf', size: 10 } ),
+					],
+				},
+			} );
+
+			expect( mockContext.files ).toHaveLength( 1 );
+			expect( mockContext.files[ 0 ] ).toMatchObject( { name: 'doc.pdf' } );
 		} );
 	} );
 
@@ -312,15 +375,123 @@ describe( 'File Field View', () => {
 		} );
 	} );
 
-	describe( 'Upload token', () => {
-		test( 'concurrent uploads share a single token request', async () => {
-			const fetchMock = jest.fn( () =>
+	describe( 'Removing files', () => {
+		/**
+		 * Drive the `removeFile` generator to completion.
+		 *
+		 * @param {string} id - The client file ID to remove.
+		 * @return {Promise} Resolves when the generator is done.
+		 */
+		const removeFile = async id => {
+			const event = {
+				preventDefault: jest.fn(),
+				target: { dataset: { id } },
+			};
+			const generator = storeConfig.actions.removeFile( event );
+			let step = generator.next();
+			while ( ! step.done ) {
+				step = generator.next( await step.value );
+			}
+		};
+
+		test( 'removes the file and reports the remaining list, not an empty string', async () => {
+			mockContext.files = [
+				{ id: 'a', url: null, error: null },
+				{ id: 'b', url: null, error: null },
+			];
+
+			await removeFile( 'a' );
+
+			expect( mockContext.files.map( f => f.id ) ).toEqual( [ 'b' ] );
+			// An empty array is a legitimate value now — the registered validator turns it into
+			// `is_required` or `yes`, so there is no need to substitute ''.
+			await removeFile( 'b' );
+			const [ , lastValue ] = mockUpdateField.mock.calls.at( -1 );
+			expect( lastValue ).toEqual( [] );
+		} );
+
+		test( 'revokes the object URL of a removed image preview', async () => {
+			mockContext.files = [ { id: 'a', url: 'url(blob:mock)', error: null } ];
+
+			await removeFile( 'a' );
+
+			expect( global.URL.revokeObjectURL ).toHaveBeenCalledWith( 'blob:mock' );
+		} );
+	} );
+
+	describe( 'Upload lifecycle', () => {
+		/**
+		 * A minimal XMLHttpRequest double that lets a test drive readystatechange.
+		 *
+		 * @return {object} The fake request and its captured listeners.
+		 */
+		const installFakeXhr = () => {
+			const listeners = {};
+			const xhr = {
+				readyState: 4,
+				status: 200,
+				responseText: JSON.stringify( {
+					success: true,
+					data: { file_id: 'server-1', name: 'doc.pdf', size: 10, type: 'application/pdf' },
+				} ),
+				open: jest.fn(),
+				send: jest.fn(),
+				abort: jest.fn(),
+				upload: { addEventListener: jest.fn() },
+				addEventListener: jest.fn( ( name, cb ) => {
+					listeners[ name ] = cb;
+				} ),
+			};
+			jest.spyOn( global, 'XMLHttpRequest' ).mockImplementation( () => xhr );
+			return { xhr, listeners };
+		};
+
+		test( 'a settled request marks the file uploaded and drops its abort controller', async () => {
+			jest.spyOn( global, 'fetch' ).mockImplementation( () =>
 				Promise.resolve( {
 					ok: true,
 					json: () => Promise.resolve( { token: 'abc', expiration: 0 } ),
 				} )
 			);
-			global.fetch = fetchMock;
+			const { xhr, listeners } = installFakeXhr();
+			mockContext.files = [ { id: 'client-1', error: null, isUploaded: false } ];
+
+			const generator = storeConfig.actions.uploadFile( { name: 'doc.pdf' }, 'client-1' );
+			let step = generator.next();
+			while ( ! step.done ) {
+				step = generator.next( await step.value );
+			}
+
+			// Settle the request the way the browser would.
+			listeners.readystatechange( { target: xhr } );
+
+			expect( mockContext.files[ 0 ] ).toMatchObject( {
+				isUploaded: true,
+				file_id: 'server-1',
+			} );
+
+			// The controller is gone, so a later remove cannot abort an already-finished request.
+			await ( async () => {
+				const event = { preventDefault: jest.fn(), target: { dataset: { id: 'client-1' } } };
+				const gen = storeConfig.actions.removeFile( event );
+				let s = gen.next();
+				while ( ! s.done ) {
+					s = gen.next( await s.value );
+				}
+			} )();
+
+			expect( xhr.abort ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Upload token', () => {
+		test( 'concurrent uploads share a single token request', async () => {
+			const fetchMock = jest.spyOn( global, 'fetch' ).mockImplementation( () =>
+				Promise.resolve( {
+					ok: true,
+					json: () => Promise.resolve( { token: 'abc', expiration: 0 } ),
+				} )
+			);
 
 			// Drive two uploads up to their first yield, which is the token request.
 			const first = storeConfig.actions.uploadFile( { name: 'a.pdf' }, 'client-1' );

--- a/projects/packages/forms/tests/js/modules/file-field/view.test.js
+++ b/projects/packages/forms/tests/js/modules/file-field/view.test.js
@@ -1,0 +1,351 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+// Mock WordPress Interactivity API
+const mockStore = jest.fn();
+const mockGetContext = jest.fn();
+const mockGetConfig = jest.fn();
+const mockGetElement = jest.fn();
+const mockWithScope = jest.fn( callback => callback );
+
+await jest.unstable_mockModule( '@wordpress/interactivity', () => ( {
+	store: mockStore,
+	getContext: mockGetContext,
+	getConfig: mockGetConfig,
+	getElement: mockGetElement,
+	withScope: mockWithScope,
+} ) );
+
+const ALLOWED_MIME_TYPES = [ 'image/png', 'application/pdf' ];
+
+describe( 'File Field View', () => {
+	let mockContext;
+	let mockElement;
+	let storeConfig;
+	let storeNamespace;
+	let mockUpdateField;
+	let mockTrackFirstInteraction;
+	let state;
+
+	beforeEach( async () => {
+		jest.clearAllMocks();
+		jest.resetModules();
+
+		document.body.innerHTML = `
+			<div class="jetpack-form-file-field__container" id="test-file">
+				<div class="jetpack-form-file-field__dropzone">
+					<div class="jetpack-form-file-field__dropzone-inner" tabindex="0" role="button"></div>
+					<input type="file" class="jetpack-form-file-field" />
+				</div>
+				<div class="jetpack-form-file-field__preview-wrap"></div>
+			</div>
+		`;
+
+		// The context a file field sees: `fieldId` and `fieldExtra` come from the wrapper that
+		// render_field() opens, `files` and `isDropping` from the file field's own nested context.
+		mockContext = {
+			fieldId: 'test-file',
+			fieldType: 'file',
+			fieldExtra: {
+				maxFiles: 1,
+				allowedMimeTypes: ALLOWED_MIME_TYPES,
+			},
+			files: [],
+			isDropping: false,
+		};
+
+		mockElement = {
+			ref: document.querySelector( '.jetpack-form-file-field__dropzone-inner' ),
+		};
+
+		mockGetContext.mockReturnValue( mockContext );
+		mockGetElement.mockReturnValue( mockElement );
+		mockGetConfig.mockReturnValue( {
+			endpoint: 'https://example.test/upload',
+			iconsPath: 'https://example.test/icons/',
+			maxUploadSize: 1024,
+			i18n: {
+				zeroBytes: '0 Bytes',
+				fileSizeUnits: [ 'B', 'KB', 'MB', 'GB' ],
+				fileTooLarge: 'File is too large.',
+				invalidType: 'This file type is not allowed.',
+				maxFiles: 'Too many files.',
+				uploadFailed: 'File upload failed, try again.',
+			},
+		} );
+
+		// `updateField` and `trackFirstInteraction` are contributed by the form module. Because the
+		// file field now shares that store, it reaches them through the same `actions` object.
+		mockUpdateField = jest.fn();
+		mockTrackFirstInteraction = jest.fn();
+
+		mockStore.mockImplementation( ( namespace, config ) => {
+			storeNamespace = namespace;
+			storeConfig = config;
+			return {
+				state: config.state,
+				actions: {
+					...config.actions,
+					updateField: mockUpdateField,
+					trackFirstInteraction: mockTrackFirstInteraction,
+				},
+			};
+		} );
+
+		await import( '../../../../src/modules/file-field/view.js' );
+		state = storeConfig.state;
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	describe( 'Store registration', () => {
+		test( 'registers into the shared jetpack/form store, not its own namespace', () => {
+			expect( storeNamespace ).toBe( 'jetpack/form' );
+		} );
+
+		test( 'registers a `file` validator alongside the other field validators', () => {
+			expect( typeof storeConfig.state.validators.file ).toBe( 'function' );
+		} );
+	} );
+
+	describe( 'validators.file', () => {
+		const validate = ( value, isRequired ) =>
+			storeConfig.state.validators.file( value, isRequired );
+
+		test( 'returns is_required when a required field has no files', () => {
+			expect( validate( [], true ) ).toBe( 'is_required' );
+		} );
+
+		test( 'returns yes when an optional field has no files', () => {
+			expect( validate( [], false ) ).toBe( 'yes' );
+		} );
+
+		test( 'treats an empty string as no files', () => {
+			expect( validate( '', true ) ).toBe( 'is_required' );
+			expect( validate( '', false ) ).toBe( 'yes' );
+		} );
+
+		test( 'reports files that failed', () => {
+			expect( validate( [ { error: 'File is too large.', isUploaded: false } ], true ) ).toBe(
+				'invalid_file_has_errors'
+			);
+		} );
+
+		test( 'reports uploads still in flight, required or not', () => {
+			expect( validate( [ { error: null, isUploaded: false } ], true ) ).toBe(
+				'invalid_file_uploading'
+			);
+			expect( validate( [ { error: null, isUploaded: false } ], false ) ).toBe(
+				'invalid_file_uploading'
+			);
+		} );
+
+		test( 'passes once every file has uploaded', () => {
+			expect( validate( [ { error: null, isUploaded: true } ], true ) ).toBe( 'yes' );
+		} );
+
+		test( 'flags errors ahead of pending uploads', () => {
+			const value = [
+				{ error: null, isUploaded: false },
+				{ error: 'File is too large.', isUploaded: false },
+			];
+			expect( validate( value, true ) ).toBe( 'invalid_file_has_errors' );
+		} );
+	} );
+
+	describe( 'State getters', () => {
+		test( 'hasFileFieldFiles reflects the context files', () => {
+			expect( state.hasFileFieldFiles ).toBe( false );
+			mockContext.files = [ { id: '1' } ];
+			expect( state.hasFileFieldFiles ).toBe( true );
+		} );
+
+		test( 'hasMaxFiles reads maxFiles from fieldExtra', () => {
+			expect( state.hasMaxFiles ).toBe( false );
+			mockContext.files = [ { id: '1' } ];
+			expect( state.hasMaxFiles ).toBe( true );
+		} );
+
+		test( 'hasMaxFiles honours a larger maxFiles from fieldExtra', () => {
+			mockContext.fieldExtra.maxFiles = 3;
+			mockContext.files = [ { id: '1' }, { id: '2' } ];
+			expect( state.hasMaxFiles ).toBe( false );
+			mockContext.files.push( { id: '3' } );
+			expect( state.hasMaxFiles ).toBe( true );
+		} );
+
+		test( 'falls back to a single file when fieldExtra is absent', () => {
+			delete mockContext.fieldExtra;
+			mockContext.files = [ { id: '1' } ];
+			expect( state.hasMaxFiles ).toBe( true );
+		} );
+	} );
+
+	describe( 'Adding files', () => {
+		const makeFile = ( { name = 'doc.pdf', type = 'application/pdf', size = 10 } = {} ) => ( {
+			name,
+			type,
+			size,
+		} );
+
+		test( 'accepts an allowed file and pushes it to the context', () => {
+			storeConfig.actions.fileAdded( { target: { files: [ makeFile() ] } } );
+
+			expect( mockContext.files ).toHaveLength( 1 );
+			expect( mockContext.files[ 0 ] ).toMatchObject( {
+				name: 'doc.pdf',
+				hasError: false,
+				isUploaded: false,
+				error: null,
+			} );
+		} );
+
+		test( 'rejects a MIME type missing from fieldExtra.allowedMimeTypes', () => {
+			storeConfig.actions.fileAdded( {
+				target: { files: [ makeFile( { name: 'evil.exe', type: 'application/x-msdownload' } ) ] },
+			} );
+
+			expect( mockContext.files[ 0 ] ).toMatchObject( {
+				hasError: true,
+				error: 'This file type is not allowed.',
+			} );
+		} );
+
+		test( 'rejects a file over the configured max upload size', () => {
+			storeConfig.actions.fileAdded( { target: { files: [ makeFile( { size: 2048 } ) ] } } );
+
+			expect( mockContext.files[ 0 ] ).toMatchObject( {
+				hasError: true,
+				error: 'File is too large.',
+			} );
+		} );
+
+		test( 'rejects a file beyond maxFiles', () => {
+			mockContext.files = [ { id: 'existing', error: null } ];
+
+			storeConfig.actions.fileAdded( { target: { files: [ makeFile() ] } } );
+
+			expect( mockContext.files[ 1 ] ).toMatchObject( {
+				hasError: true,
+				error: 'Too many files.',
+			} );
+		} );
+
+		test( 'pushes the value through the shared updateField action', () => {
+			storeConfig.actions.fileAdded( { target: { files: [ makeFile() ] } } );
+
+			expect( mockUpdateField ).toHaveBeenCalledWith( 'test-file', mockContext.files );
+		} );
+	} );
+
+	describe( 'Drag and drop', () => {
+		test( 'onFileDragOver marks the field as dropping and suppresses the default', () => {
+			const event = { preventDefault: jest.fn() };
+			storeConfig.actions.onFileDragOver( event );
+
+			expect( mockContext.isDropping ).toBe( true );
+			expect( event.preventDefault ).toHaveBeenCalled();
+		} );
+
+		test( 'onFileDragLeave clears the dropping flag', () => {
+			mockContext.isDropping = true;
+			storeConfig.actions.onFileDragLeave();
+
+			expect( mockContext.isDropping ).toBe( false );
+		} );
+
+		test( 'a drop starts the fill timer, since no focus event fires for it', () => {
+			storeConfig.actions.fileDropped( {
+				preventDefault: jest.fn(),
+				dataTransfer: { items: [] },
+			} );
+
+			expect( mockTrackFirstInteraction ).toHaveBeenCalled();
+		} );
+
+		test( 'a dropped directory is ignored', () => {
+			storeConfig.actions.fileDropped( {
+				preventDefault: jest.fn(),
+				dataTransfer: {
+					items: [
+						{
+							webkitGetAsEntry: () => ( { isDirectory: true } ),
+							getAsFile: () => ( { name: 'folder', type: '', size: 0 } ),
+						},
+					],
+				},
+			} );
+
+			expect( mockContext.files ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'Keyboard handling', () => {
+		test( 'onFileDropzoneKeyDown opens the picker on Enter', () => {
+			const fileInput = document.querySelector( '.jetpack-form-file-field' );
+			jest.spyOn( fileInput, 'click' ).mockImplementation();
+			const event = { keyCode: 13, preventDefault: jest.fn() };
+
+			storeConfig.actions.onFileDropzoneKeyDown( event );
+
+			expect( event.preventDefault ).toHaveBeenCalled();
+			expect( fileInput.click ).toHaveBeenCalled();
+		} );
+
+		test( 'onFileDropzoneKeyDown ignores other keys', () => {
+			const fileInput = document.querySelector( '.jetpack-form-file-field' );
+			jest.spyOn( fileInput, 'click' ).mockImplementation();
+
+			storeConfig.actions.onFileDropzoneKeyDown( { keyCode: 65, preventDefault: jest.fn() } );
+
+			expect( fileInput.click ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Resetting', () => {
+		test( 'resetFiles empties the context', () => {
+			mockContext.files = [ { id: '1' }, { id: '2' } ];
+			storeConfig.actions.resetFiles();
+
+			expect( mockContext.files ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'Upload token', () => {
+		test( 'concurrent uploads share a single token request', async () => {
+			const fetchMock = jest.fn( () =>
+				Promise.resolve( {
+					ok: true,
+					json: () => Promise.resolve( { token: 'abc', expiration: 0 } ),
+				} )
+			);
+			global.fetch = fetchMock;
+
+			// Drive two uploads up to their first yield, which is the token request.
+			const first = storeConfig.actions.uploadFile( { name: 'a.pdf' }, 'client-1' );
+			const second = storeConfig.actions.uploadFile( { name: 'b.pdf' }, 'client-2' );
+
+			await Promise.all( [ first.next().value, second.next().value ] );
+
+			expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'Focus management', () => {
+		test( 'focusFilePreview focuses the preview and nothing else', () => {
+			jest.useFakeTimers();
+			const focus = jest.fn();
+			mockGetElement.mockReturnValue( { ref: { focus } } );
+
+			const result = storeConfig.callbacks.focusFilePreview();
+			jest.runAllTimers();
+
+			expect( focus ).toHaveBeenCalledWith( { focusVisible: true } );
+			// Returning a function would be invoked immediately by the `data-wp-init` directive,
+			// which is what previously stole focus back to the (hidden) dropzone.
+			expect( typeof result ).not.toBe( 'function' );
+			jest.useRealTimers();
+		} );
+	} );
+} );

--- a/projects/packages/forms/tests/js/modules/file-field/view.test.js
+++ b/projects/packages/forms/tests/js/modules/file-field/view.test.js
@@ -611,9 +611,14 @@ describe( 'File Field View', () => {
 				maxFiles: 1,
 				allowedMimeTypes: ALLOWED_MIME_TYPES,
 			};
-			// The shared wrapper context is still emitted by unchanged PHP, but knows nothing about
-			// the file field.
-			mockContext = { fieldId: 'test-file', fieldType: 'file', fields: {} };
+			/*
+			 * The shared wrapper context is still emitted by unchanged PHP, which knows nothing
+			 * about the file field but does emit `fieldExtra`. For a file field that was
+			 * `get_field_extra()`'s untouched empty `$extra_attrs`, and `wp_json_encode()` writes
+			 * an empty PHP array as `[]` — truthy in JS. Leaving the key out here would let a
+			 * presence-only bridge guard pass a test it fails against real markup.
+			 */
+			mockContext = { fieldId: 'test-file', fieldType: 'file', fields: {}, fieldExtra: [] };
 		} );
 
 		test( 'adding a file through the old action name still reaches the shared field state', () => {
@@ -668,6 +673,16 @@ describe( 'File Field View', () => {
 				hasError: true,
 				error: 'This file type is not allowed.',
 			} );
+		} );
+
+		test( 'an allowed type is still accepted when the wrapper already emits an empty fieldExtra', () => {
+			legacyStore.actions.fileAdded( {
+				target: { files: [ { name: 'doc.pdf', type: 'application/pdf', size: 10 } ] },
+			} );
+
+			// Bridging keyed on presence rather than shape would leave an empty allowlist here and
+			// reject every file, which on a required field can never be cleared.
+			expect( legacyContext.files[ 0 ].hasError ).toBeFalsy();
 		} );
 
 		test( 'the old drag actions toggle the flag the old markup binds to', () => {

--- a/projects/packages/forms/tests/js/modules/file-field/view.test.js
+++ b/projects/packages/forms/tests/js/modules/file-field/view.test.js
@@ -23,7 +23,6 @@ describe( 'File Field View', () => {
 	let mockElement;
 	let storeConfig;
 	let storeConfigs;
-	let storeNamespace;
 	let mockUpdateField;
 	let mockTrackFirstInteraction;
 	let state;
@@ -122,7 +121,6 @@ describe( 'File Field View', () => {
 		} );
 
 		await import( '../../../../src/modules/file-field/view.js' );
-		storeNamespace = Object.keys( storeConfigs )[ 0 ];
 		storeConfig = storeConfigs[ 'jetpack/form' ];
 		state = storeConfig.state;
 	} );
@@ -135,13 +133,47 @@ describe( 'File Field View', () => {
 		jest.restoreAllMocks();
 	} );
 
-	describe( 'Store registration', () => {
-		test( 'registers into the shared jetpack/form store, not its own namespace', () => {
-			expect( storeNamespace ).toBe( 'jetpack/form' );
+	/**
+	 * Remove a file. `removeFile` is synchronous: the server-side delete is fired without blocking
+	 * the UI update, so the context reflects the removal on return.
+	 *
+	 * @param {string} id - The client file ID to remove.
+	 */
+	const removeFile = id => {
+		storeConfig.actions.removeFile( {
+			preventDefault: jest.fn(),
+			target: { dataset: { id } },
 		} );
+	};
 
-		test( 'also registers a back-compat alias under the old namespace', () => {
-			expect( storeConfigs[ 'jetpack/field-file' ] ).toBeDefined();
+	/**
+	 * Answer the upload-token request with a usable token.
+	 *
+	 * @return {jest.Mock} The fetch spy.
+	 */
+	const mockTokenFetch = () =>
+		jest.spyOn( global, 'fetch' ).mockImplementation( () =>
+			Promise.resolve( {
+				ok: true,
+				json: () => Promise.resolve( { token: 'abc', expiration: 0 } ),
+			} )
+		);
+
+	/**
+	 * Drive a generator action to completion, awaiting whatever it yields.
+	 *
+	 * @param {Generator} generator - The generator to drain.
+	 */
+	const drainGenerator = async generator => {
+		let step = generator.next();
+		while ( ! step.done ) {
+			step = generator.next( await step.value );
+		}
+	};
+
+	describe( 'Store registration', () => {
+		test( 'registers into the shared form store first, then the back-compat alias', () => {
+			expect( Object.keys( storeConfigs ) ).toEqual( [ 'jetpack/form', 'jetpack/field-file' ] );
 		} );
 
 		test( 'registers a `file` validator alongside the other field validators', () => {
@@ -406,29 +438,7 @@ describe( 'File Field View', () => {
 		} );
 	} );
 
-	describe( 'Resetting', () => {
-		test( 'resetFiles empties the context', () => {
-			mockContext.files = [ { id: '1' }, { id: '2' } ];
-			storeConfig.actions.resetFiles();
-
-			expect( mockContext.files ).toEqual( [] );
-		} );
-	} );
-
 	describe( 'Removing files', () => {
-		/**
-		 * Remove a file. `removeFile` is synchronous: the server-side delete is fired without
-		 * blocking the UI update, so the context reflects the removal on return.
-		 *
-		 * @param {string} id - The client file ID to remove.
-		 */
-		const removeFile = id => {
-			storeConfig.actions.removeFile( {
-				preventDefault: jest.fn(),
-				target: { dataset: { id } },
-			} );
-		};
-
 		test( 'removes the file and reports the remaining list, not an empty string', () => {
 			mockContext.files = [
 				{ id: 'a', url: null, error: null },
@@ -506,20 +516,11 @@ describe( 'File Field View', () => {
 		};
 
 		test( 'a settled request marks the file uploaded and drops its abort controller', async () => {
-			jest.spyOn( global, 'fetch' ).mockImplementation( () =>
-				Promise.resolve( {
-					ok: true,
-					json: () => Promise.resolve( { token: 'abc', expiration: 0 } ),
-				} )
-			);
+			mockTokenFetch();
 			const { xhr, listeners } = installFakeXhr();
 			mockContext.files = [ { id: 'client-1', error: null, isUploaded: false } ];
 
-			const generator = storeConfig.actions.uploadFile( { name: 'doc.pdf' }, 'client-1' );
-			let step = generator.next();
-			while ( ! step.done ) {
-				step = generator.next( await step.value );
-			}
+			await drainGenerator( storeConfig.actions.uploadFile( { name: 'doc.pdf' }, 'client-1' ) );
 
 			// Settle the request the way the browser would.
 			listeners.readystatechange( { target: xhr } );
@@ -530,10 +531,7 @@ describe( 'File Field View', () => {
 			} );
 
 			// The controller is gone, so a later remove cannot abort an already-finished request.
-			storeConfig.actions.removeFile( {
-				preventDefault: jest.fn(),
-				target: { dataset: { id: 'client-1' } },
-			} );
+			removeFile( 'client-1' );
 
 			expect( xhr.abort ).not.toHaveBeenCalled();
 		} );
@@ -542,12 +540,7 @@ describe( 'File Field View', () => {
 			// Nothing is registered in uploadControllers until after the token resolves, so a
 			// removal during that window has nothing to abort and would otherwise upload a file the
 			// user already deleted.
-			jest.spyOn( global, 'fetch' ).mockImplementation( () =>
-				Promise.resolve( {
-					ok: true,
-					json: () => Promise.resolve( { token: 'abc', expiration: 0 } ),
-				} )
-			);
+			mockTokenFetch();
 			const { xhr } = installFakeXhr();
 			mockContext.files = [ { id: 'client-1', error: null, isUploaded: false } ];
 
@@ -565,12 +558,18 @@ describe( 'File Field View', () => {
 			expect( xhr.send ).not.toHaveBeenCalled();
 		} );
 
-		test( 'a progress event for an already-cleared file is ignored', () => {
-			// resetFiles empties the list without waiting for in-flight requests, so an XHR event
-			// can arrive for an entry that is gone. Object.assign( undefined, … ) used to throw.
-			mockContext.files = [];
+		test( 'an XHR event arriving after a reset is ignored', async () => {
+			// resetFiles empties the list without waiting for in-flight requests, so an event can
+			// arrive for an entry that is gone. Object.assign( undefined, … ) used to throw.
+			mockTokenFetch();
+			const { xhr, listeners } = installFakeXhr();
+			mockContext.files = [ { id: 'client-1', error: null, isUploaded: false } ];
 
-			expect( () => storeConfig.actions.resetFiles() ).not.toThrow();
+			await drainGenerator( storeConfig.actions.uploadFile( { name: 'doc.pdf' }, 'client-1' ) );
+			storeConfig.actions.resetFiles();
+
+			expect( () => listeners.readystatechange( { target: xhr } ) ).not.toThrow();
+			expect( mockContext.files ).toEqual( [] );
 		} );
 
 		test( 'resetFiles releases controllers and object URLs like removeFile does', () => {
@@ -585,12 +584,7 @@ describe( 'File Field View', () => {
 
 	describe( 'Upload token', () => {
 		test( 'concurrent uploads share a single token request', async () => {
-			const fetchMock = jest.spyOn( global, 'fetch' ).mockImplementation( () =>
-				Promise.resolve( {
-					ok: true,
-					json: () => Promise.resolve( { token: 'abc', expiration: 0 } ),
-				} )
-			);
+			const fetchMock = mockTokenFetch();
 
 			// Drive two uploads up to their first yield, which is the token request.
 			const first = storeConfig.actions.uploadFile( { name: 'a.pdf' }, 'client-1' );

--- a/projects/packages/forms/tests/js/modules/file-field/view.test.js
+++ b/projects/packages/forms/tests/js/modules/file-field/view.test.js
@@ -693,6 +693,27 @@ describe( 'File Field View', () => {
 			expect( legacyContext.isDropping ).toBe( false );
 		} );
 
+		test( 'dropping clears the drag highlight on the context the old markup binds', () => {
+			legacyStore.actions.dragOver( { preventDefault: jest.fn() } );
+			expect( legacyContext.isDropping ).toBe( true );
+
+			legacyStore.actions.fileDropped( {
+				preventDefault: jest.fn(),
+				dataTransfer: {
+					items: [
+						{
+							kind: 'file',
+							webkitGetAsEntry: () => ( { isDirectory: false } ),
+							getAsFile: () => ( { name: 'doc.pdf', type: 'application/pdf', size: 10 } ),
+						},
+					],
+				},
+			} );
+
+			// The shared implementation resets the shared context; the old template watches this one.
+			expect( legacyContext.isDropping ).toBe( false );
+		} );
+
 		test( 'the old state getters resolve against the legacy context', () => {
 			expect( legacyStore.state.hasFiles ).toBe( false );
 			expect( legacyStore.state.hasMaxFiles ).toBe( false );

--- a/projects/packages/forms/tests/js/modules/file-field/view.test.js
+++ b/projects/packages/forms/tests/js/modules/file-field/view.test.js
@@ -633,6 +633,38 @@ describe( 'File Field View', () => {
 			expect( mockUpdateField ).toHaveBeenCalledWith( 'test-file', legacyContext.files );
 		} );
 
+		test( 'removing a file through the old action name keeps both contexts on the same array', () => {
+			legacyStore.actions.fileAdded( {
+				target: { files: [ { name: 'doc.pdf', type: 'application/pdf', size: 10 } ] },
+			} );
+			const sharedArray = legacyContext.files;
+			const [ added ] = legacyContext.files;
+
+			legacyStore.actions.removeFile( {
+				preventDefault: jest.fn(),
+				target: { dataset: { id: added.id } },
+			} );
+
+			// Removed in place, so the old template's data-wp-each drops the preview too rather than
+			// stranding it on a stale array.
+			expect( legacyContext.files ).toBe( sharedArray );
+			expect( mockContext.files ).toBe( legacyContext.files );
+			expect( legacyContext.files ).toHaveLength( 0 );
+		} );
+
+		test( 'resetFiles through the old action name empties the shared array in place', () => {
+			legacyStore.actions.fileAdded( {
+				target: { files: [ { name: 'doc.pdf', type: 'application/pdf', size: 10 } ] },
+			} );
+			const sharedArray = legacyContext.files;
+
+			legacyStore.actions.resetFiles();
+
+			expect( legacyContext.files ).toBe( sharedArray );
+			expect( mockContext.files ).toBe( legacyContext.files );
+			expect( legacyContext.files ).toHaveLength( 0 );
+		} );
+
 		test( 'the old config keys are bridged into fieldExtra so limits still apply', () => {
 			legacyStore.actions.fileAdded( {
 				target: { files: [ { name: 'evil.exe', type: 'application/x-msdownload', size: 10 } ] },

--- a/projects/packages/forms/tests/js/modules/form/field-registry.test.js
+++ b/projects/packages/forms/tests/js/modules/form/field-registry.test.js
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+/**
+ * Tests for the shared field registry in src/modules/form/view.js — `registerField`,
+ * `actions.updateField` and the `getValidator` lookup that routes between a field module's
+ * registered validator and the shared `validateField()` helper.
+ *
+ * This is the highest blast-radius part of the form store: every field type goes through it,
+ * and a validator registered by any one module changes how that type is validated everywhere.
+ */
+
+// Mock WordPress Interactivity API.
+const mockStore = jest.fn();
+const mockGetContext = jest.fn();
+const mockGetConfig = jest.fn();
+const mockGetElement = jest.fn();
+const mockWithSyncEvent = jest.fn( callback => callback );
+
+await jest.unstable_mockModule( '@wordpress/interactivity', () => ( {
+	store: mockStore,
+	getContext: mockGetContext,
+	getConfig: mockGetConfig,
+	getElement: mockGetElement,
+	withSyncEvent: mockWithSyncEvent,
+} ) );
+
+// The field type icons view imports an SVG via `?raw`, which jest has no transform for, and it
+// only registers callbacks that are irrelevant here.
+await jest.unstable_mockModule(
+	'../../../../src/modules/form/field-type-icons-view.js',
+	() => ( {} )
+);
+
+describe( 'Form field registry', () => {
+	let storeConfig;
+	let context;
+
+	/**
+	 * Build a field-wrapper context. Mirrors what render_field() serializes: the wrapper carries
+	 * the field's identity and config, but none of the per-field-type state that descendant
+	 * elements provide.
+	 *
+	 * @param {object} overrides - Context overrides.
+	 * @return {object} The context.
+	 */
+	const makeContext = ( overrides = {} ) => ( {
+		fields: {},
+		fieldId: 'field-1',
+		fieldType: 'text',
+		fieldLabel: 'Name',
+		fieldValue: '',
+		fieldIsRequired: false,
+		fieldExtra: null,
+		...overrides,
+	} );
+
+	const registerCurrentField = () => storeConfig.callbacks.initializeField();
+	const field = ( id = 'field-1' ) => context.fields[ id ];
+
+	beforeEach( async () => {
+		jest.clearAllMocks();
+		jest.resetModules();
+
+		context = makeContext();
+		mockGetContext.mockImplementation( () => context );
+		mockGetElement.mockReturnValue( { ref: document.createElement( 'div' ) } );
+		mockGetConfig.mockReturnValue( { error_types: {} } );
+
+		mockStore.mockImplementation( ( namespace, config ) => {
+			storeConfig = config;
+			return config;
+		} );
+
+		await import( '../../../../src/modules/form/view.js' );
+	} );
+
+	describe( 'registerField', () => {
+		test( 'registers a field with its identity and config', () => {
+			context = makeContext( { fieldValue: 'Ada', fieldExtra: { min: 1 } } );
+
+			registerCurrentField();
+
+			expect( field() ).toMatchObject( {
+				id: 'field-1',
+				type: 'text',
+				label: 'Name',
+				value: 'Ada',
+				isRequired: false,
+				extra: { min: 1 },
+			} );
+		} );
+
+		test( 'uses the shared helper when no validator is registered for the type', () => {
+			context = makeContext( { fieldType: 'email', fieldValue: 'not-an-email' } );
+
+			registerCurrentField();
+
+			expect( field().error ).toBe( 'invalid_email' );
+		} );
+
+		test( 'prefers a registered validator over the shared helper', () => {
+			const validator = jest.fn( () => 'invalid_custom' );
+			storeConfig.state.validators.text = validator;
+			context = makeContext( { fieldValue: 'anything', fieldIsRequired: true } );
+
+			registerCurrentField();
+
+			expect( validator ).toHaveBeenCalledWith( 'anything', true, null );
+			expect( field().error ).toBe( 'invalid_custom' );
+		} );
+
+		test( 'does not re-register a field that already exists', () => {
+			registerCurrentField();
+			context.fields[ 'field-1' ].value = 'edited';
+
+			registerCurrentField();
+
+			expect( field().value ).toBe( 'edited' );
+		} );
+	} );
+
+	describe( 'actions.updateField', () => {
+		test( 'stores the value and validates it with the shared helper', () => {
+			context = makeContext( { fieldType: 'email' } );
+			registerCurrentField();
+
+			storeConfig.actions.updateField( 'field-1', 'nope' );
+
+			expect( field().value ).toBe( 'nope' );
+			expect( field().error ).toBe( 'invalid_email' );
+		} );
+
+		test( 'prefers a registered validator even when showFieldError is not set', () => {
+			// This is the behaviour the file field depends on: previously `state.validators` was
+			// only consulted on blur, so a registered validator never ran on input.
+			const validator = jest.fn( () => 'invalid_custom' );
+			storeConfig.state.validators.text = validator;
+			registerCurrentField();
+
+			storeConfig.actions.updateField( 'field-1', 'value' );
+
+			expect( validator ).toHaveBeenCalled();
+			expect( field().error ).toBe( 'invalid_custom' );
+		} );
+
+		test( 'registers the field first when it was never initialised', () => {
+			context = makeContext( { fieldType: 'email', fieldValue: '' } );
+
+			storeConfig.actions.updateField( 'field-1', 'ada@example.com' );
+
+			expect( field() ).toBeDefined();
+			expect( field().value ).toBe( 'ada@example.com' );
+			expect( field().error ).toBe( 'yes' );
+		} );
+
+		test( 'records showFieldError so the field can surface its own error', () => {
+			registerCurrentField();
+
+			storeConfig.actions.updateField( 'field-1', 'x', true );
+
+			expect( field().showFieldError ).toBe( true );
+		} );
+	} );
+
+	describe( 'Validator scope contract', () => {
+		test( 'a validator reading descendant context still resolves during registration', () => {
+			// `registerField` runs from the field wrapper, which does not have the context a
+			// descendant provides. A validator must tolerate those keys being undefined rather
+			// than throwing and taking the whole init callback down with it.
+			storeConfig.state.validators.text = value => {
+				const { notProvidedByTheWrapper = '' } = mockGetContext();
+				return notProvidedByTheWrapper === '' && ! value ? 'is_required' : 'yes';
+			};
+			context = makeContext( { fieldIsRequired: true } );
+
+			expect( () => registerCurrentField() ).not.toThrow();
+			expect( field().error ).toBe( 'is_required' );
+		} );
+	} );
+
+	describe( 'File fields have no shared-helper fallback', () => {
+		test( 'validateField no longer understands the file type', async () => {
+			// Guards the coupling documented on validateField(): file validation lives in the
+			// file field module, so the shared helper deliberately has no `file` branch. If this
+			// starts returning a file-specific error, the branch came back and the module's
+			// validator is now dead code.
+			const { validateField } = await import(
+				'../../../../src/contact-form/js/validate-helper.js'
+			);
+
+			expect( validateField( 'file', [ { error: 'boom', isUploaded: false } ], true ) ).toBe(
+				'yes'
+			);
+		} );
+	} );
+} );

--- a/projects/packages/forms/tests/js/modules/form/field-registry.test.js
+++ b/projects/packages/forms/tests/js/modules/form/field-registry.test.js
@@ -66,29 +66,24 @@ describe( 'Form field registry', () => {
 		mockGetElement.mockReturnValue( { ref: document.createElement( 'div' ) } );
 		mockGetConfig.mockReturnValue( { error_types: {} } );
 
-		// Emulate the real store's deep merge across calls: several modules register into
-		// `jetpack/form`, and a validator contributed by one has to be visible to the others.
-		// Getters are copied as descriptors so derived state is not flattened to a snapshot.
-		const merged = {};
-		const mergeInto = ( target, source ) => {
-			Object.keys( source ?? {} ).forEach( key => {
-				const descriptor = Object.getOwnPropertyDescriptor( source, key );
-				if ( descriptor.get || typeof descriptor.value !== 'object' || descriptor.value === null ) {
-					Object.defineProperty( target, key, descriptor );
-					return;
-				}
-				target[ key ] = target[ key ] ?? {};
-				mergeInto( target[ key ], descriptor.value );
-			} );
-		};
-
+		// Emulate the real store's merge across calls: several modules register into `jetpack/form`,
+		// and a validator contributed by one has to be visible to the others. Descriptors are copied
+		// rather than values so derived state is not flattened to a snapshot.
+		//
+		// This shallow-merges `state`, which is only correct while at most one module contributes a
+		// non-empty `validators` map — today `form/view.js` registers `{}` and `field-phone` the
+		// single real entry. A second contributor would need a recursive merge here.
+		const stores = {};
 		mockStore.mockImplementation( ( namespace, config ) => {
-			merged[ namespace ] = merged[ namespace ] ?? { state: {}, actions: {}, callbacks: {} };
-			mergeInto( merged[ namespace ].state, config?.state );
-			mergeInto( merged[ namespace ].actions, config?.actions );
-			mergeInto( merged[ namespace ].callbacks, config?.callbacks );
-			storeConfig = merged[ namespace ];
-			return merged[ namespace ];
+			const merged = ( stores[ namespace ] ??= { state: {}, actions: {}, callbacks: {} } );
+			for ( const key of [ 'state', 'actions', 'callbacks' ] ) {
+				Object.defineProperties(
+					merged[ key ],
+					Object.getOwnPropertyDescriptors( config?.[ key ] ?? {} )
+				);
+			}
+			storeConfig = merged;
+			return merged;
 		} );
 
 		await import( '../../../../src/modules/form/view.js' );

--- a/projects/packages/forms/tests/js/modules/form/field-registry.test.js
+++ b/projects/packages/forms/tests/js/modules/form/field-registry.test.js
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
 /**
  * Tests for the shared field registry in src/modules/form/view.js — `registerField`,
- * `actions.updateField` and the `getValidator` lookup that routes between a field module's
+ * `actions.updateField` and the `validate()` lookup that routes between a field module's
  * registered validator and the shared `validateField()` helper.
  *
  * This is the highest blast-radius part of the form store: every field type goes through it,

--- a/projects/packages/forms/tests/js/modules/form/field-registry.test.js
+++ b/projects/packages/forms/tests/js/modules/form/field-registry.test.js
@@ -66,9 +66,29 @@ describe( 'Form field registry', () => {
 		mockGetElement.mockReturnValue( { ref: document.createElement( 'div' ) } );
 		mockGetConfig.mockReturnValue( { error_types: {} } );
 
+		// Emulate the real store's deep merge across calls: several modules register into
+		// `jetpack/form`, and a validator contributed by one has to be visible to the others.
+		// Getters are copied as descriptors so derived state is not flattened to a snapshot.
+		const merged = {};
+		const mergeInto = ( target, source ) => {
+			Object.keys( source ?? {} ).forEach( key => {
+				const descriptor = Object.getOwnPropertyDescriptor( source, key );
+				if ( descriptor.get || typeof descriptor.value !== 'object' || descriptor.value === null ) {
+					Object.defineProperty( target, key, descriptor );
+					return;
+				}
+				target[ key ] = target[ key ] ?? {};
+				mergeInto( target[ key ], descriptor.value );
+			} );
+		};
+
 		mockStore.mockImplementation( ( namespace, config ) => {
-			storeConfig = config;
-			return config;
+			merged[ namespace ] = merged[ namespace ] ?? { state: {}, actions: {}, callbacks: {} };
+			mergeInto( merged[ namespace ].state, config?.state );
+			mergeInto( merged[ namespace ].actions, config?.actions );
+			mergeInto( merged[ namespace ].callbacks, config?.callbacks );
+			storeConfig = merged[ namespace ];
+			return merged[ namespace ];
 		} );
 
 		await import( '../../../../src/modules/form/view.js' );
@@ -159,6 +179,62 @@ describe( 'Form field registry', () => {
 			storeConfig.actions.updateField( 'field-1', 'x', true );
 
 			expect( field().showFieldError ).toBe( true );
+		} );
+	} );
+
+	describe( 'Real phone validator during registration', () => {
+		// The phone behaviour change is the riskiest part of this PR, and a synthetic validator
+		// does not exercise it: field-phone's own suite always calls validators.phone with a fully
+		// populated context, so it never hits the case the destructuring defaults exist for.
+		beforeEach( async () => {
+			await import( '../../../../src/modules/field-phone/view.js' );
+		} );
+
+		test( 'a required phone field with a default value registers as is_required', () => {
+			// `default` on the telephone block is the default country code, and
+			// get_computed_field_value() falls back to it, so fieldValue is non-empty on an ordinary
+			// page load. The visible input is bound to context.phoneNumber, which PHP hardcodes to
+			// '' — and phoneNumber is not in scope here at all, because registerField runs from the
+			// field wrapper while the phone context is provided by a descendant.
+			context = makeContext( {
+				fieldType: 'phone',
+				fieldValue: 'US',
+				fieldIsRequired: true,
+			} );
+
+			registerCurrentField();
+
+			expect( field().error ).toBe( 'is_required' );
+		} );
+
+		test( 'an optional phone field with a default value registers as valid', () => {
+			context = makeContext( {
+				fieldType: 'phone',
+				fieldValue: 'US',
+				fieldIsRequired: false,
+			} );
+
+			registerCurrentField();
+
+			expect( field().error ).toBe( 'yes' );
+		} );
+
+		test( 'registration survives a partially populated phone context', () => {
+			// With `phoneNumber` absent the validator returns early, so the defaults are invisible.
+			// This is the case that actually needs them: a scope where `phoneNumber` resolves but
+			// `fullPhoneNumber` does not. Without the default, `fullPhoneNumber.indexOf` throws out
+			// of initializeField and takes the whole field registration with it — which is one PHP
+			// line away, since seeding `phoneNumber` from `$value` is the obvious fix for the
+			// prefill bug this field still has.
+			context = makeContext( {
+				fieldType: 'phone',
+				fieldValue: '+972',
+				fieldIsRequired: true,
+				phoneNumber: '5551234',
+			} );
+
+			expect( () => registerCurrentField() ).not.toThrow();
+			expect( field().error ).toBe( 'invalid_phone' );
 		} );
 	} );
 

--- a/projects/plugins/jetpack/changelog/forms-file-field-mixed-drop
+++ b/projects/plugins/jetpack/changelog/forms-file-field-mixed-drop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: keep the remaining files when a folder or dragged text is included in a multi-file drop on the file upload field.

--- a/projects/plugins/jetpack/changelog/forms-file-field-phone-validation
+++ b/projects/plugins/jetpack/changelog/forms-file-field-phone-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: validate a required phone field with a default country against what the input actually shows, so it can no longer be submitted empty.

--- a/projects/plugins/jetpack/changelog/forms-file-field-remove
+++ b/projects/plugins/jetpack/changelog/forms-file-field-remove
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: remove an uploaded file from the form immediately instead of waiting for the server, so a slow connection no longer leaves the file upload field looking stuck.

--- a/projects/plugins/jetpack/changelog/forms-file-field-reset
+++ b/projects/plugins/jetpack/changelog/forms-file-field-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: cancel in-flight uploads and release previews when a form containing a file upload field is reset.

--- a/projects/plugins/jetpack/changelog/forms-file-field-upload-race
+++ b/projects/plugins/jetpack/changelog/forms-file-field-upload-race
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: stop uploading a file that was removed while its upload was still being prepared.


### PR DESCRIPTION
## Proposed changes

The file upload field was the first Jetpack Forms field built on the Interactivity API, and it was written before the conventions the later fields settled on. This brings it in line with them.

Every other field module — `field-phone`, `field-rating`, `slider-field`, `form-step`, `form-step-navigation`, `form-progress-indicator` — calls `store( 'jetpack/form', … )`. The file field was the only one with its own `store( 'jetpack/field-file' )` and its own `data-wp-interactive` region, and that single divergence is what everything else here follows from.

**Store and context**

* The container drops `data-wp-interactive="jetpack/field-file"`, so it now sits inside the `jetpack/form` region `render_field()` already opens. The module registers into that shared store, and the `store( 'jetpack/form' )` indirection it needed to reach `updateFieldValue` is gone — it calls `actions.updateField()` like every other field.
* The field's static configuration (`maxFiles`, `allowedMimeTypes`) moves into `fieldExtra`, where the date field keeps its format and the number field its min/max. The context keeps only what actually changes at runtime: `files` and `isDropping`. `fieldId` was duplicated from the wrapper and `hasMaxFiles` was a stored copy of a derived value; both are gone.
* The accepted-MIME-type list and the max-file count are now shared between the input's `accept` attribute and `fieldExtra`, so the picker filter and the client-side check can't drift.
* `wp_interactivity_config( 'jetpack/field-file', … )` stays as-is — a per-field *config* namespace is the established pattern (`jetpack/field-phone` does the same); only the *store* namespace was the outlier.

**Validation**

* File validation moves out of the shared `validate-helper.js` and into the module as `state.validators.file`, matching `validators.phone`.
* That required a fix in `updateField`: it only consulted `state.validators` when `showFieldError` was set, so a registered validator never ran on input. It now prefers a registered validator whenever one exists, and `registerField` uses the same rule so a field's initial error state and its updated state are computed the same way.

### ⚠️ This changes phone field validation too — please review that specifically

Making `registerField` consult registered validators means `validators.phone` now decides a phone field's *initial* error state. That closes a real client-side validation hole, so it is a fix rather than a regression, but it is a behaviour change outside the file field and worth understanding before merge:

For the telephone block, `default` is the **default country code**, and `get_computed_field_value()` falls back to `get_attribute( 'default' )`. So a required phone field with a default country has had a non-empty `fieldValue` on every logged-out page load. The old path ran `validateField( 'phone', 'US', true )`, which has no `'phone'` case in its switch and returned `'yes'` — while the input itself renders **empty**, because it is bound to `context.phoneNumber`, which PHP hardcodes to `''`. Net effect: a required phone field could pass client-side validation while visibly empty. It now correctly reports `is_required`.

`validators.phone` was also hardened as part of this. `registerField` runs from `callbacks.initializeField` on the field wrapper, but the phone context (`phoneNumber`, `fullPhoneNumber`) is provided by a descendant, and Interactivity API context only inherits downwards — so those keys are undefined during registration. The validator now destructures with defaults instead of relying on that, and the scope contract is documented on `getValidator()` in `modules/form/view.js`.

**Fixes found along the way**

* `callbacks.focusFilePreview` (was `focusElement`) now cancels its pending focus on teardown and skips a preview that has been detached, so adding and removing a file inside the 100ms window can no longer strand focus on `<body>`. **Correction to an earlier revision of this description:** I originally claimed the returned function was a bug because `data-wp-init` invokes it immediately. That is wrong — `evaluate()` returns functions without invoking them, `result = result()` *is* the callback invocation, and its return value is handed to `useEffect` as teardown. The returned function was doing the right thing: restoring focus to the dropzone when the file is removed. That behaviour is retained.
* `fileDropped` bailed out of its loop on the first directory, which discarded every remaining file in a mixed drop and skipped the `isDropping = false` reset, stranding the dropzone in its drag-hover style. Directories are now skipped rather than aborting the drop.
* Non-file drag items (`kind === 'string'` — dragged text, a link, an image from another tab) return null from both `webkitGetAsEntry()` and `getAsFile()`. They are now filtered before either is dereferenced; skipping only directories let them through to a null dereference that threw mid-loop.
* `removeFile` no longer waits on a token round-trip before updating the field. It used to leave the preview in place and the dropzone hidden across the request, so a slow network made the field look stuck; and if the token fetch failed the entry was still removed from the UI while the server copy was orphaned. A repeat activation is now a no-op instead of revoking an already-revoked URL and sending a duplicate delete.
* `uploadFile` re-checks that the file still exists after the token resolves. No AbortController is registered until then, so a removal in that window had nothing to cancel and the upload would resume and send a file the user had already deleted — a window that sharing one token request across a batch made wider.
* `resetFiles` was just `context.files = []`, which left uploads running, blob URLs pinned for the life of the page, and controllers stranded in the very map this PR set out to bound. It now releases them the same way `removeFile` does.
* The upload-token cache had three problems: `.finally()` cleared the in-flight marker a microtask before the token was assigned, letting a second caller through; with two requests in flight the last to resolve won, which could leave the older token and earlier expiry cached; and a non-numeric `expiration` produced `NaN`, permanently disabling the cache with no visible symptom. The cache is now written inside the shared promise and the expiry is range-checked.
* Both keydown handlers use `event.key` instead of the deprecated `keyCode`, matching `field-phone`.
* `uploadControllers` entries were only deleted when a file was removed, so completed uploads accumulated for the life of the page. They are now dropped when the request settles.
* `state.isInlineForm` had no references anywhere in the repo and is removed.
* `$input_attrs` in `render_file_field()` was built and never used — the input is written inline in the template — and is removed. Its only consumer of the `$class` parameter went with it; the parameter stays for signature parity with the other `render_*_field()` methods.

**Naming**

Merging into the shared store means these names are no longer file-scoped, so the ambiguous ones were renamed: `handleKeyDown` → `onFileDropzoneKeyDown`, `dragOver`/`dragLeave` → `onFileDragOver`/`onFileDragLeave`, `state.hasFiles` → `state.hasFileFieldFiles`, `state.hasMaxFiles` → `state.isFileFieldFull`, `callbacks.focusElement` → `callbacks.focusFilePreview`. Names that already read as file-specific (`fileAdded`, `fileDropped`, `removeFile`, `uploadFile`, `resetFiles`) are unchanged.

**Trade-offs worth flagging to a reviewer**

* `allowedMimeTypes` moves into `fieldExtra`, but this is not new page weight: the same list was already serialized per file field in the inner container's `data-wp-context` before this PR, so the net delta is about zero. It could live once in `wp_interactivity_config()` instead; `fieldExtra` was chosen because it is where every other field's config lives and it keeps the module reading like the date and number fields.
* The `jetpack/field-file` **store** namespace is deprecated rather than removed. The renamed directives live in server-rendered HTML, and the script module is versioned on `JETPACK__VERSION` rather than the forms package version, so a page cache can serve either side stale. Old markup against this bundle is the dangerous direction: the runtime auto-creates an empty store for an unknown namespace instead of erroring, so every directive in the container silently no-ops — and on a **required** file field that is unrecoverable, because the wrapper is still `jetpack/form`, `registerField` records `is_required`, and no file can ever be added to clear it. The alias store keeps that markup working and doubles as the deprecation window; it should be removed one release after this ships.
* `src/modules/file-field/` keeps its directory name rather than moving to `field-file/` to match `field-phone`/`field-rating`. Deliberately out of scope here.

There is no change to submitted data or to the upload endpoints.

## Related product discussion/links

* n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Needs a Jetpack-connected site with a plan that includes file uploads (the field is gated behind an upsell otherwise).

**File upload field**

* Add a form with a **File upload** field to a page, and view the page on the front end.
* Click the dropzone, pick an allowed file (e.g. a PNG or PDF). Confirm the preview appears with a thumbnail (images) or a type icon (everything else), the size is formatted, and it goes from "Uploading…" to "Uploaded".
* Confirm focus lands on the **file preview** after adding a file, not on the now-hidden dropzone. Tab from the preview and confirm you reach the remove button and then the rest of the form — you should never land on an invisible dropzone.
* Try to add a **second** file. Confirm it is rejected with "You have exceeded the number of files that you can upload."
* Try a disallowed type (e.g. `.exe`) and a file over 20MB. Confirm each shows its own error on the preview.
* Remove the file with the **×** button, and again with Enter/Space on the button. Confirm the preview disappears and the dropzone comes back.
* **Drag and drop** a file onto the dropzone. Confirm the drop highlight appears on dragover and clears on dragleave. Then drag a **folder and a file together** — the file should upload, the folder should be ignored, and the dropzone must not stay stuck in its highlighted state. Then drag **selected text or a link** from another tab onto the dropzone — it should be ignored cleanly, with no console error and no stuck highlight.
* Mark the field **required**, submit the form empty, and confirm the required error shows. Then submit while an upload is still in flight and confirm you get "Please wait a moment, file is currently uploading." Submit with a file that errored and confirm "Please remove any file upload errors."
* Submit successfully and confirm the file appears on the confirmation screen with its thumbnail/icon, name and size, and that it arrives in Feedback.
* Use the form's **back** link from the confirmation screen and confirm the field resets to empty.

**Phone field — please check this specifically**

* Add a **required** Phone field with the country selector enabled and a default country set. Load the page logged out and submit without touching it: it must now show the required error rather than submitting. (Before this PR it would submit while visibly empty.)
* Type an invalid number and confirm the error appears; type a valid international number and confirm it clears. Switch countries and confirm it re-validates.
* An **optional** phone field left empty must still submit cleanly.

**Other fields**

The `updateField`/`registerField` change is shared, so a pass over text, email, URL, number (with min/max), date, checkbox, radio (including "Other"), select, slider and rating — checking that required/invalid errors still appear and clear as before — is worth doing.
