### PR TITLE
POC: Themes API: Bring theme updates to parity with plugin update

### DIFF
--- a/projects/plugins/jetpack/changelog/update-themes-endpoint-parity
+++ b/projects/plugins/jetpack/changelog/update-themes-endpoint-parity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Themes API: bring theme updates to parity with plugin updates — skip themes with no pending update, add upgrade locking, surface upgrade errors, honor core auto-update settings, and add a dedicated update route.

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-themes-modify-endpoint.php
@@ -8,6 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Themes modify endpoint class.
  * POST  /sites/%s/themes/%s
  * POST  /sites/%s/themes
+ * POST  /sites/%s/themes/%s/update
  *
  * @phan-constructor-used-for-side-effects
  */
@@ -61,20 +62,35 @@ class Jetpack_JSON_API_Themes_Modify_Endpoint extends Jetpack_JSON_API_Themes_En
 
 	/**
 	 * Turn autoupdate on.
+	 *
+	 * Writes both WP core's `auto_update_themes` site option, so wp-admin's native
+	 * auto-update UI stays in sync, and the legacy Jetpack option, which is still
+	 * read by format_theme() and Jetpack_Autoupdate.
 	 */
 	public function autoupdate_on() {
 		$autoupdate_themes = Jetpack_Options::get_option( 'autoupdate_themes', array() );
 		$autoupdate_themes = array_unique( array_merge( $autoupdate_themes, $this->themes ) );
 		Jetpack_Options::update_option( 'autoupdate_themes', $autoupdate_themes );
+
+		$core_autoupdate_themes = (array) get_site_option( 'auto_update_themes', array() );
+		$core_autoupdate_themes = array_unique( array_merge( $core_autoupdate_themes, $this->themes ) );
+		update_site_option( 'auto_update_themes', $core_autoupdate_themes );
 	}
 
 	/**
 	 * Turn autoupdate off.
+	 *
+	 * Clears the themes from both WP core's `auto_update_themes` site option and
+	 * the legacy Jetpack option; see autoupdate_on().
 	 */
 	public function autoupdate_off() {
 		$autoupdate_themes = Jetpack_Options::get_option( 'autoupdate_themes', array() );
 		$autoupdate_themes = array_diff( $autoupdate_themes, $this->themes );
 		Jetpack_Options::update_option( 'autoupdate_themes', $autoupdate_themes );
+
+		$core_autoupdate_themes = (array) get_site_option( 'auto_update_themes', array() );
+		$core_autoupdate_themes = array_values( array_diff( $core_autoupdate_themes, $this->themes ) );
+		update_site_option( 'auto_update_themes', $core_autoupdate_themes );
 	}
 
 	/**
@@ -101,13 +117,57 @@ class Jetpack_JSON_API_Themes_Modify_Endpoint extends Jetpack_JSON_API_Themes_En
 	 * @return bool|WP_Error True on success, WP_Error on failure.
 	 */
 	public function update() {
+		$query_args = $this->query_args();
+
+		$is_automatic_update = ! empty( $query_args['autoupdate'] );
+
+		wp_clean_themes_cache( false );
+		ob_start();
+		wp_update_themes(); // Check for Theme updates
+		ob_end_clean();
+
+		$update_themes = get_site_transient( 'update_themes' );
+
+		if ( isset( $update_themes->response ) ) {
+			$theme_updates_needed = array_keys( $update_themes->response );
+		} else {
+			$theme_updates_needed = array();
+		}
+
+		$update_attempted = false;
+
 		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
-		// Clear the cache.
-		wp_update_themes();
+		// unhook this functions that output things before we send our response header.
+		remove_action( 'upgrader_process_complete', array( 'Language_Pack_Upgrader', 'async_upgrade' ), 20 );
+		remove_action( 'upgrader_process_complete', 'wp_version_check' );
+		remove_action( 'upgrader_process_complete', 'wp_update_plugins' );
 
-		$result = null;
+		// Early return if unable to obtain auto_updater lock.
+		// @see https://github.com/WordPress/wordpress-develop/blob/66469efa99e7978c8824e287834135aa9842e84f/src/wp-admin/includes/class-wp-automatic-updater.php#L453.
+		if ( $is_automatic_update && ! WP_Upgrader::create_lock( 'auto_updater' ) ) {
+			return new WP_Error( 'update_fail', __( 'Updates are already in progress.', 'jetpack' ), 400 );
+		}
+
+		$result = false;
+
 		foreach ( $this->themes as $theme ) {
+
+			if ( ! in_array( $theme, $theme_updates_needed, true ) ) {
+				$this->log[ $theme ][] = __( 'No update needed', 'jetpack' );
+				continue;
+			}
+
+			// Rely on WP_Automatic_Updater class to check if a theme item should be updated if it is a Jetpack autoupdate request.
+			if ( $is_automatic_update && ! ( new WP_Automatic_Updater() )->should_update( 'theme', (object) $update_themes->response[ $theme ], get_theme_root( $theme ) ) ) {
+				continue;
+			}
+
+			// Establish per theme lock.
+			if ( ! WP_Upgrader::create_lock( 'jetpack_theme_' . $theme ) ) {
+				continue;
+			}
+
 			/**
 			 * Pre-upgrade action
 			 *
@@ -117,19 +177,39 @@ class Jetpack_JSON_API_Themes_Modify_Endpoint extends Jetpack_JSON_API_Themes_En
 			 * @param array $themes Array of theme objects
 			 */
 			do_action( 'jetpack_pre_theme_upgrade', $theme, $this->themes );
+
+			$update_attempted = true;
+
 			// Objects created inside the for loop to clean the messages for each theme
-			$skin     = new Automatic_Upgrader_Skin();
+			$skin     = new WP_Ajax_Upgrader_Skin();
 			$upgrader = new Theme_Upgrader( $skin );
 			$upgrader->init();
-			$result                = $upgrader->upgrade( $theme );
-			$this->log[ $theme ][] = $upgrader->skin->get_upgrade_messages();
+			// Using bulk upgrade puts the site into maintenance mode when the active theme is being updated.
+			$result              = $upgrader->bulk_upgrade( array( $theme ) );
+			$errors              = $skin->get_errors();
+			$this->log[ $theme ] = $skin->get_upgrade_messages();
+
+			// release individual theme lock.
+			WP_Upgrader::release_lock( 'jetpack_theme_' . $theme );
+
+			if ( is_wp_error( $errors ) && $errors->get_error_code() ) {
+				if ( $is_automatic_update ) {
+					WP_Upgrader::release_lock( 'auto_updater' );
+				}
+				return $errors;
+			}
 		}
 
-		if ( ! $this->bulk && ! $result ) {
+		// release auto_updater lock.
+		if ( $is_automatic_update ) {
+			WP_Upgrader::release_lock( 'auto_updater' );
+		}
+
+		if ( ! $this->bulk && ! $result && $update_attempted ) {
 			return new WP_Error( 'update_fail', __( 'There was an error updating your theme', 'jetpack' ), 400 );
 		}
 
-		return true;
+		return $this->default_action();
 	}
 
 	/**
@@ -141,7 +221,10 @@ class Jetpack_JSON_API_Themes_Modify_Endpoint extends Jetpack_JSON_API_Themes_En
 		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
 		// Clear the cache.
-		wp_update_themes();
+		wp_clean_themes_cache( false );
+		ob_start();
+		wp_update_themes(); // Check for Theme updates
+		ob_end_clean();
 
 		$available_themes_updates = get_site_transient( 'update_themes' );
 

--- a/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -157,6 +157,9 @@ new Jetpack_JSON_API_Themes_Modify_Endpoint(
 			'action'     => '(string) Only possible value is \'update\'. More to follow.',
 			'autoupdate' => '(bool) Whether or not to automatically update the theme.',
 		),
+		'query_parameters'        => array(
+			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
+		),
 		'response_format'         => Jetpack_JSON_API_Themes_Endpoint::$_response_format,
 		'allow_jetpack_site_auth' => true,
 		'example_request_data'    => array(
@@ -186,6 +189,9 @@ new Jetpack_JSON_API_Themes_Modify_Endpoint(
 			'autoupdate' => '(bool) Whether or not to automatically update the theme.',
 			'themes'     => '(array) A list of theme slugs',
 		),
+		'query_parameters'        => array(
+			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
+		),
 		'response_format'         => array(
 			'themes' => '(array:theme) A list of theme objects',
 		),
@@ -203,6 +209,32 @@ new Jetpack_JSON_API_Themes_Modify_Endpoint(
 			),
 		),
 		'example_request'         => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/themes',
+	)
+);
+
+// POST /sites/%s/themes/%s/update
+new Jetpack_JSON_API_Themes_Modify_Endpoint(
+	array(
+		'description'             => 'Update a theme on a jetpack blog',
+		'group'                   => '__do_not_document',
+		'stat'                    => 'themes:1:update',
+		'method'                  => 'POST',
+		'path'                    => '/sites/%s/themes/%s/update/',
+		'path_labels'             => array(
+			'$site'  => '(int|string) The site ID, The site domain',
+			'$theme' => '(string) The theme slug',
+		),
+		'query_parameters'        => array(
+			'autoupdate' => '(bool=false) If the update is happening as a result of autoupdate event',
+		),
+		'response_format'         => Jetpack_JSON_API_Themes_Endpoint::$_response_format,
+		'allow_jetpack_site_auth' => true,
+		'example_request_data'    => array(
+			'headers' => array(
+				'authorization' => 'Bearer YOUR_API_TOKEN',
+			),
+		),
+		'example_request'         => 'https://public-api.wordpress.com/rest/v1/sites/example.wordpress.org/themes/twentyfourteen/update',
 	)
 );
 


### PR DESCRIPTION
## Proposed changes
The theme update endpoint (`Jetpack_JSON_API_Themes_Modify_Endpoint`) has long lagged behind its plugins counterpart in robustness. This brings it to parity:
- Skip themes with no pending update - `update()` now checks the `update_themes` transient and logs "No update needed" instead of blindly invoking the upgrader (matching plugin behavior).
- Upgrade locking - takes the core `auto_updater` lock for autoupdate-driven requests and a per-theme lock, preventing concurrent upgrader collisions (half-written theme directories, stuck maintenance mode). Unlike the plugins version, locks are also released before error returns.
- Real error reporting - switched from `Automatic_Upgrader_Skin` to `WP_Ajax_Upgrader_Skin`; upgrade failures now return the skin's errors instead of a generic message.
- Autoupdate policy respected - `?autoupdate=1` requests defer to `WP_Automatic_Updater::should_update( 'theme', … )`, so site-owner auto-update filters apply.
- Core option sync - the autoupdate toggle now writes core's auto_update_themes site option alongside the legacy Jetpack option, so wp-admin's native auto-update UI stays in sync.
- Cache/output hygiene - `wp_clean_themes_cache()`, output-buffered update checks, and unhooking of output-producing `upgrader_process_complete` callbacks (stray output corrupts the signed XML-RPC response envelope).
- Maintenance mode - uses `bulk_upgrade()` so core puts the site into maintenance mode when the active theme is updated.
- New route - registers `POST /sites/%s/themes/%s/update/`, the theme analogue of the plugins update route, and documents the autoupdate query parameter on the existing modify routes.

The existing bulk route (`POST /sites/%s/themes` with `action=update`) benefits from all of the above immediately. The new single-theme /update/ route additionally requires a WordPress.com-side route registration to be reachable from public-api.wordpress.com; until that ships, it is inert. Scheduled-update support (which plugins have) is intentionally out of scope.

## Testing instructions

1. Set up a Jetpack-connected test site (Jurassic Ninja or local with a tunnel) running this branch.
2. Install a wp.org theme and make an update available - easiest is editing the theme's style.css and lowering Version: (e.g. to 0.1), then visiting wp-admin > Dashboard > Updates so the site notices.
3. Trigger an update through the API (bulk route, works without any WordPress.com changes):
`curl -X POST "https://public-api.wordpress.com/rest/v1.1/sites/<SITE_ID>/themes" -H "Authorization: Bearer <TOKEN>" --data "action=update" --data "themes[]=<THEME_SLUG>"`
3. The theme updates, and the response's log contains the upgrade messages.
4. Repeat the same request. The theme is not re-installed; the log reports "No update needed".
5. Request an update for a theme that doesn't exist on the site. A unknown_theme error is returned.
6. Toggle autoupdates: send `--data "autoupdate=true" --data "themes[]=<THEME_SLUG>"` (no action). `wp option get auto_update_themes` now includes the slug, and wp-admin > Appearance > Themes shows "Auto-updates enabled" for it. Sending `autoupdate=false` removes it from both.
7. Regression check: update a plugin via `POST /sites/%s/plugins/%s/update` and switch themes via `POST /sites/%s/themes/mine`. Both behave as before.