### PR TITLE
Forms: let themes override the grouped field legend padding

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-legend-label-padding
+++ b/projects/packages/forms/changelog/fix-forms-legend-label-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Grouped field labels: lower the legend padding reset so themes and global styles can override it.

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -133,8 +133,11 @@
 	font-weight: 700;
 }
 
-.contact-form :where(legend.grunion-field-label) {
-	padding: 0;
+/* Browsers give <legend> 2px of inline padding that <label> does not get, so a
+ * grouped field's label would sit indented from every other field's. Neutralise
+ * just that, at zero specificity so themes and global styles still win. */
+:where(.contact-form legend.grunion-field-label) {
+	padding-inline: 0;
 }
 
 .contact-form :where(label.consent) {


### PR DESCRIPTION
Fixes #

## Proposed changes

Grouped fields (radio, checkbox-multiple, rating) render their label as a `<legend>`, and browsers give `<legend>` 2px of inline padding that `<label>` does not get. Forms neutralises that so a grouped field's label lines up with every other field's:

```scss
.contact-form :where(legend.grunion-field-label) {
	padding: 0;
}
```

That rule reaches further than it needs to, in two ways:

* **It is not actually low specificity.** `.contact-form` sits *outside* the `:where()`, so the rule still weighs `(0,1,0)`. A theme's `legend { padding: … }` is `(0,0,1)` and loses. The `:where()` was added in `3d84a00d77` with the commit message "Tweak default style specificity so global styles can apply" — wrapping only the second half of the selector did not achieve that.
* **`padding` is the shorthand.** Only the *inline* 2px ever needed neutralising, but the shorthand also zeroes `padding-block`, so vertical padding a theme sets on labels is silently dropped for grouped fields only.

This moves `.contact-form` inside the `:where()` so the rule carries no specificity at all, and narrows it to `padding-inline`:

```scss
:where(.contact-form legend.grunion-field-label) {
	padding-inline: 0;
}
```

The browser default it was written for is still neutralised on themes that do not opt in, and any theme or global-styles rule now wins.

For reference, the rule dates back to #34147, which converted grouped fields from a `<label>` to a `<fieldset>` + `<legend>` for accessibility. It was originally scoped to radio and checkbox-multiple legends, and was widened to every `legend.grunion-field-label` in #43634.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Add a **Form** block to a page with a **Radio** field, a **Checkbox multiple** field and a **Rating** field — all three render their label as a `<legend>`.
* Add a **Name** field as a control; it renders a `<label>`, and its alignment must not change.
* On a theme that does **not** style `legend` padding, confirm the grouped labels still line up with the Name field's label and with their own inputs — i.e. no 2px indent.
* On a theme that **does** set `legend` padding (or via a theme.json global style), confirm the theme's padding now applies where before it was overridden to `0`.
* Check under the **Default**, **Outlined**, **Animated** and **Below** form styles. Outlined and Animated apply their own higher-specificity legend padding for radio and checkbox-multiple, which is unchanged.

## Trade-off worth reviewing

Lowering the specificity is what makes theme rules apply, and that is the point — but it also means a theme with a blanket `legend { padding: … }` will now indent grouped field labels relative to the other fields in the same form. That is the cascade behaving correctly, and it is what lets themes style these labels at all, but it is a visible behaviour change on such themes rather than a pure bug fix.

If we would rather guarantee alignment over theme control, the alternative is to keep the current specificity and change only the shorthand:

```scss
.contact-form :where(legend.grunion-field-label) {
	padding-inline: 0;
}
```

That fixes the `padding-block` over-reach without handing legend padding back to themes. Happy to switch to that if it is preferred.
