### PR TITLE
Write: keep indented list items when serializing to blocks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-rsm-4762-nested-list-serialization
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-rsm-4762-nested-list-serialization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write: Keep indented list items when saving, so nested lists survive save, preview, and opening in the block editor.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1287,7 +1287,12 @@ function serializeList( listEl ) {
 							child.remove();
 						}
 					}
-					// Strip the lone <br> placeholder contentEditable leaves in empty items.
+					// Strip the lone <br> placeholder contentEditable leaves in an
+					// otherwise empty item, matching what the paragraph, heading
+					// and quote branches below already do.  Needed here because
+					// indenting an empty item leaves the <li> holding just a <br>
+					// plus its sublist, which would otherwise serialize a stray
+					// line break ahead of the nested list.
 					const text = clone.innerHTML.trim().replace( /^<br\s*\/?>$/, '' );
 					// Nested sublists sit inside the <li> so they come first in
 					// document order; sibling ones follow the <li> entirely.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -1237,6 +1237,73 @@ function sanitizePasteNode( el ) {
 }
 
 /**
+ * Serialize a <ul>/<ol> as core/list block markup, recursing into sublists.
+ *
+ * contentEditable produces two shapes for the same indented item, and both have
+ * to round-trip. Nested, where the sublist sits inside its parent <li>:
+ * `<ul><li>Parent<ul><li>Child</li></ul></li></ul>`. Sibling, where it follows
+ * the <li>: `<ul><li>Parent</li><ul><li>Child</li></ul></ul>`. The sibling shape
+ * is what document.execCommand( 'indent' ) and most pasted HTML produce; it
+ * renders identically, so a serializer that only walks direct-child <li>
+ * elements drops those items with nothing to show the writer.
+ *
+ * Sublists are emitted as nested core/list inner blocks, matching what
+ * `@wordpress/blocks` serialize() produces for the equivalent block tree, so the
+ * block editor reopens the list without an invalid-content warning.
+ *
+ * @param {Element} listEl - A <ul> or <ol> element.
+ * @return {string} Serialized core/list block markup.
+ */
+function serializeList( listEl ) {
+	// Group children into items, attaching each sibling-shaped sublist to the
+	// <li> it follows. A sublist with no <li> before it has no owner, and
+	// core/list cannot express an inner list without a parent core/list-item,
+	// so its items are pulled up to this level rather than inventing an empty
+	// bullet the writer never typed: one level of indent is lost, no content is.
+	const items = [];
+	const collect = el => {
+		for ( const child of el.children ) {
+			const childTag = child.tagName.toLowerCase();
+			if ( childTag === 'li' ) {
+				items.push( { li: child, sublists: [] } );
+			} else if ( childTag === 'ul' || childTag === 'ol' ) {
+				if ( items.length ) items[ items.length - 1 ].sublists.push( child );
+				else collect( child );
+			}
+		}
+	};
+	collect( listEl );
+
+	const listItems = items.length
+		? items
+				.map( ( { li, sublists } ) => {
+					// Clone so lifting nested lists out doesn't disturb the editor DOM.
+					const clone = li.cloneNode( true );
+					const nested = [];
+					for ( const child of Array.from( clone.children ) ) {
+						const childTag = child.tagName.toLowerCase();
+						if ( childTag === 'ul' || childTag === 'ol' ) {
+							nested.push( child );
+							child.remove();
+						}
+					}
+					// Strip the lone <br> placeholder contentEditable leaves in empty items.
+					const text = clone.innerHTML.trim().replace( /^<br\s*\/?>$/, '' );
+					// Nested sublists sit inside the <li> so they come first in
+					// document order; sibling ones follow the <li> entirely.
+					const inner = [ ...nested, ...sublists ].map( serializeList ).join( '' );
+					return `<!-- wp:list-item -->\n<li>${ text }${ inner }</li>\n<!-- /wp:list-item -->`;
+				} )
+				.join( '\n\n' )
+		: '<!-- wp:list-item -->\n<li></li>\n<!-- /wp:list-item -->';
+
+	const ordered = listEl.tagName.toLowerCase() === 'ol';
+	const listTag = ordered ? 'ol' : 'ul';
+	const attrs = ordered ? ' {"ordered":true}' : '';
+	return `<!-- wp:list${ attrs } -->\n<${ listTag } class="wp-block-list">${ listItems }</${ listTag }>\n<!-- /wp:list -->`;
+}
+
+/**
  * Convert contentEditable HTML into WordPress block markup.
  *
  * @param {string} html - The innerHTML from the contenteditable area.
@@ -1441,21 +1508,7 @@ function convertToBlocks( html ) {
 				`<!-- wp:quote${ jsonAttr } -->\n<blockquote class="wp-block-quote"${ quoteAlignAttr }>${ quoteInner }${ citeHtml }</blockquote>\n<!-- /wp:quote -->`
 			);
 		} else if ( tag === 'ul' || tag === 'ol' ) {
-			// Wrap each <li> in wp:list-item block comments.
-			const liNodes = Array.from( node.querySelectorAll( ':scope > li' ) );
-			const listItems = liNodes.length
-				? liNodes
-						.map(
-							li =>
-								`<!-- wp:list-item -->\n<li>${ li.innerHTML.trim() }</li>\n<!-- /wp:list-item -->`
-						)
-						.join( '\n' )
-				: '<!-- wp:list-item -->\n<li></li>\n<!-- /wp:list-item -->';
-			const listTag = tag === 'ol' ? 'ol' : 'ul';
-			const attrs = tag === 'ol' ? ' {"ordered":true}' : '';
-			blocks.push(
-				`<!-- wp:list${ attrs } -->\n<${ listTag } class="wp-block-list">${ listItems }</${ listTag }>\n<!-- /wp:list -->`
-			);
+			blocks.push( serializeList( node ) );
 		} else if ( tag === 'hr' ) {
 			blocks.push(
 				'<!-- wp:separator -->\n<hr class="wp-block-separator has-alpha-channel-opacity"/>\n<!-- /wp:separator -->'

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1330,13 +1330,20 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$view_js      = file_get_contents( $view_js_path );
 		$this->assertNotEmpty( $view_js, 'Could not read view.js at ' . $view_js_path );
 
-		$fn_start = strpos( $view_js, 'function serializeList(' );
-		$this->assertNotFalse( $fn_start, 'serializeList() not found in view.js' );
+		// Scan from serializeList(), the list serializer convertToBlocks()
+		// delegates to, through the end of convertToBlocks() itself -- which is
+		// its closing `return blocks.join(...)`.  Bounding the scan on that
+		// statement rather than a character count keeps unrelated code further
+		// down the file from being mistaken for block types the serializer
+		// emits, and keeps the region correct as either function grows.
+		$this->assertStringContainsString( 'function serializeList(', $view_js );
 		$this->assertStringContainsString( 'function convertToBlocks(', $view_js );
-		// Read enough of both function bodies to capture all block types.
-		// If they grow past this, the assertion below will catch missing
-		// types. Increase as needed.
-		$fn_body = substr( $view_js, $fn_start, 14000 );
+		$this->assertStringContainsString( 'return blocks.join', $view_js );
+
+		$fn_start = strpos( $view_js, 'function serializeList(' );
+		$fn_end   = strpos( $view_js, 'return blocks.join', $fn_start );
+		$this->assertGreaterThan( $fn_start, $fn_end, 'convertToBlocks() should follow serializeList() in view.js' );
+		$fn_body = substr( $view_js, $fn_start, $fn_end - $fn_start );
 
 		// Match opening block comments only (negative lookbehind skips closing <!-- /wp:... -->).
 		preg_match_all( '/<!-- (?!\/)wp:([a-z][a-z0-9-]*)/', $fn_body, $matches );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -1314,7 +1314,9 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	 *
 	 * Block types are extracted directly from the `<!-- wp:type -->` comment
 	 * literals that convertToBlocks() emits, so no manual annotations are
-	 * needed for that axis.
+	 * needed for that axis.  The scan starts at serializeList(), the list
+	 * serializer convertToBlocks() delegates to, which sits immediately above
+	 * it, so that both functions' literals are covered.
 	 *
 	 * Attribute-level sync uses a hardcoded map of what convertToBlocks()
 	 * outputs per block type.  When you add attribute support in view.js,
@@ -1328,12 +1330,13 @@ class Write_Test extends \WorDBless\BaseTestCase {
 		$view_js      = file_get_contents( $view_js_path );
 		$this->assertNotEmpty( $view_js, 'Could not read view.js at ' . $view_js_path );
 
-		$fn_start = strpos( $view_js, 'function convertToBlocks(' );
-		$this->assertNotFalse( $fn_start, 'convertToBlocks() not found in view.js' );
-		// Read enough of the function body to capture all block types.
-		// If convertToBlocks() grows past this, the assertion below will
-		// catch missing types. Increase as needed.
-		$fn_body = substr( $view_js, $fn_start, 10000 );
+		$fn_start = strpos( $view_js, 'function serializeList(' );
+		$this->assertNotFalse( $fn_start, 'serializeList() not found in view.js' );
+		$this->assertStringContainsString( 'function convertToBlocks(', $view_js );
+		// Read enough of both function bodies to capture all block types.
+		// If they grow past this, the assertion below will catch missing
+		// types. Increase as needed.
+		$fn_body = substr( $view_js, $fn_start, 14000 );
 
 		// Match opening block comments only (negative lookbehind skips closing <!-- /wp:... -->).
 		preg_match_all( '/<!-- (?!\/)wp:([a-z][a-z0-9-]*)/', $fn_body, $matches );


### PR DESCRIPTION
Fixes RSM-4762

## Proposed changes

Indented list items typed in the Write editor rendered fine while typing, then disappeared on save, on preview, and when opening the post in the block editor.

There were two distinct defects, both in how `convertToBlocks()` serialized `<ul>`/`<ol>`:

* **Silent data loss.** List items were enumerated with `:scope > li`, which only matches direct-child `<li>` elements. `document.execCommand( 'indent' )` and most pasted HTML produce a sublist that is a *sibling* of the `<li>` rather than a child of it, so the sublist was never visited and its items never reached the saved `post_content`. Both shapes render identically in the browser, so the loss was invisible until the writer reloaded the post.
* **Corrupted block-editor handoff.** For the nested shape (which the Tab key produces), the sublist did survive the save, but was written as raw HTML inside the `core/list-item` instead of as a nested `core/list` inner block. The block editor parsed it as part of the item's rich-text content and rendered the sublist inside the textbox; pressing Enter at the end of the parent item then relocated the whole sublist into a sibling list item.

`convertToBlocks()`'s list branch is now recursive: a sibling-shaped sublist is attached to the item it follows, and every sublist is emitted as a nested `core/list` inner block matching what `@wordpress/blocks` `serialize()` produces for the equivalent block tree.

One behavior change beyond the reported bug: a list item holding only contentEditable's placeholder `<br>` now serializes as an empty `<li>` rather than `<li><br></li>`. The paragraph, heading and quote branches already did this; the list branch did not. It's needed here because indenting an empty item leaves the `<li>` holding just that `<br>` plus its sublist, which would otherwise emit a stray line break ahead of the nested list.

Storage, `the_content`, `wp_kses_post()` and the editor's reload path were each checked and already preserved nested lists, so serialization was the only lossy hop. No PHP allowlist change was needed — `list` and `list-item` were already allowed. `Write_Test.php`'s JS/PHP sync check scrapes `wp:` literals out of a window of `view.js`; the window now starts at the new `serializeList()` helper so it still covers both functions.

## Related product discussion/links

* RSM-4762

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Nested lists in the Write editor, via both shapes the editor can produce.

**Tab-indent (nested shape):**

* Go to `/wp-admin/admin.php?page=write`.
* Give the post a title, then in the body type `- Parent item` and press Enter.
* Press Tab to indent, type `Child A`, press Enter, type `Child B`.
* Click **Save draft**.
* Reload the editor on that post — all three items should still be there, with the children indented.
* Open the same post in the block editor. The list should render with real nesting and no "this block contains unexpected or invalid content" warning. Click into the parent item: the sublist should *not* appear inside its text box.

**Paste (sibling shape — this is the one that lost content):**

* Open a new Write post and paste a nested list from another page (or any source that emits `<ul><li>Parent</li><ul><li>Child</li></ul></ul>`).
* Click **Save draft**, then reload.
* Before this change the child items were gone from the saved post. They should now persist and be indented.

**Also worth checking:** ordered lists and mixed `ul`/`ol` nesting, an empty list, and that re-saving an already-saved post doesn't change the stored markup.

There are no unit tests for the serializer: `view.js` calls `store()` at module scope, so it can't be imported in a Node test, and adding a DOM-capable test dependency would touch the root lockfile — which makes CI treat the monorepo as changed and fan out from 3 projects to 142. The behavior was verified manually against both shapes, at the stored-`post_content` level, plus the block editor and the front end.
