### PR TITLE
Media JSON API: restrict the edit endpoints to attachments

### DIFF
--- a/projects/plugins/jetpack/changelog/jetpack-2092-restrict-media-endpoints-to-attachments
+++ b/projects/plugins/jetpack/changelog/jetpack-2092-restrict-media-endpoints-to-attachments
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Media API: restrict the media edit endpoints to attachments, so they no longer accept ordinary post IDs.
+Media API: restrict the edit endpoints to attachments, so they no longer accept ordinary post IDs.

--- a/projects/plugins/jetpack/changelog/jetpack-2092-restrict-media-endpoints-to-attachments
+++ b/projects/plugins/jetpack/changelog/jetpack-2092-restrict-media-endpoints-to-attachments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Media API: restrict the media edit endpoints to attachments, so they no longer accept ordinary post IDs.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-endpoint.php
@@ -67,6 +67,11 @@ class WPCOM_JSON_API_Update_Media_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * the endpoint's own 404 rather than a 403. A userless request gets no exemption:
 	 * `edit_post` fails closed for user 0 like any other caller.
 	 *
+	 * Non-attachments are refused outright. `get_post()` resolves any post type, so
+	 * without this test a media endpoint edits ordinary posts, pages and revisions.
+	 * The post-type test must stay below the missing-post passthrough: that branch
+	 * returns true, so testing there would skip `edit_post` for ordinary posts.
+	 *
 	 * Do not move this into a trait: this file instantiates the endpoint above the
 	 * class declaration, and `use Trait;` disables PHP early binding, which makes the
 	 * file fatal with "Class not found".
@@ -79,8 +84,14 @@ class WPCOM_JSON_API_Update_Media_Endpoint extends WPCOM_JSON_API_Endpoint {
 			return false;
 		}
 
-		if ( ! get_post( $media_id ) ) {
+		$post = get_post( $media_id );
+
+		if ( ! $post ) {
 			return true;
+		}
+
+		if ( 'attachment' !== $post->post_type ) {
+			return false;
 		}
 
 		return current_user_can( 'edit_post', $media_id );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-endpoint.php
@@ -72,6 +72,10 @@ class WPCOM_JSON_API_Update_Media_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * The post-type test must stay below the missing-post passthrough: that branch
 	 * returns true, so testing there would skip `edit_post` for ordinary posts.
 	 *
+	 * A non-attachment yields 403, not the 404 a missing item gets. This is a boolean
+	 * gate, and `get_media_item*()` resolves any post type, so a passthrough would
+	 * return 200 rather than 404. Revisit if clients conflate it with an auth failure.
+	 *
 	 * Do not move this into a trait: this file instantiates the endpoint above the
 	 * class declaration, and `use Trait;` disables PHP early binding, which makes the
 	 * file fatal with "Class not found".

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
@@ -97,6 +97,10 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 	 * The post-type test must stay below the missing-post passthrough: that branch
 	 * returns true, so testing there would skip `edit_post` for ordinary posts.
 	 *
+	 * A non-attachment yields 403, not the 404 a missing item gets. This is a boolean
+	 * gate, and `get_media_item*()` resolves any post type, so a passthrough would
+	 * return 200 rather than 404. Revisit if clients conflate it with an auth failure.
+	 *
 	 * Do not move this into a trait: this file instantiates the endpoint above the
 	 * class declaration, and `use Trait;` disables PHP early binding, which makes the
 	 * file fatal with "Class not found".

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
@@ -92,6 +92,11 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 	 * the endpoint's own 404 rather than a 403. A userless request gets no exemption:
 	 * `edit_post` fails closed for user 0 like any other caller.
 	 *
+	 * Non-attachments are refused outright. `get_post()` resolves any post type, so
+	 * without this test a media endpoint edits ordinary posts, pages and revisions.
+	 * The post-type test must stay below the missing-post passthrough: that branch
+	 * returns true, so testing there would skip `edit_post` for ordinary posts.
+	 *
 	 * Do not move this into a trait: this file instantiates the endpoint above the
 	 * class declaration, and `use Trait;` disables PHP early binding, which makes the
 	 * file fatal with "Class not found".
@@ -104,8 +109,14 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 			return false;
 		}
 
-		if ( ! get_post( $media_id ) ) {
+		$post = get_post( $media_id );
+
+		if ( ! $post ) {
 			return true;
+		}
+
+		if ( 'attachment' !== $post->post_type ) {
+			return false;
 		}
 
 		return current_user_can( 'edit_post', $media_id );

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Media_Endpoints_Authorization_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Media_Endpoints_Authorization_Test.php
@@ -710,6 +710,7 @@ class WPCOM_JSON_API_Media_Endpoints_Authorization_Test extends WP_UnitTestCase 
 
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'unauthorized', $response->get_error_code() );
+		$this->assertSame( 403, $response->get_error_data() );
 		$this->assertSame( 'Original post title', get_post( $post_id )->post_title );
 	}
 

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Media_Endpoints_Authorization_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Media_Endpoints_Authorization_Test.php
@@ -630,6 +630,90 @@ class WPCOM_JSON_API_Media_Endpoints_Authorization_Test extends WP_UnitTestCase 
 	}
 
 	/**
+	 * An ordinary post is not media, so the media endpoints must refuse it even when the
+	 * caller may edit it. `get_post()` resolves any post type, and `get_media_item()` only
+	 * 404s on a *missing* post, so the post-type test is the only thing standing between
+	 * these endpoints and the whole posts table.
+	 *
+	 * The `edit_post` assertion is what gives this test its teeth: the caller passes every
+	 * other arm of the gate, so a failure here can only mean the post-type test is gone.
+	 *
+	 * @param string $class Endpoint class name.
+	 *
+	 * @dataProvider media_endpoint_classes
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	#[DataProvider( 'media_endpoint_classes' )]
+	public function test_ordinary_post_is_not_editable_as_media( $class ) {
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$owner_id ) );
+		wp_set_current_user( self::$owner_id );
+
+		$this->assertTrue( current_user_can( 'upload_files' ) );
+		$this->assertTrue( current_user_can( 'edit_post', $post_id ), 'The caller must otherwise pass the gate.' );
+
+		$this->assertFalse( $this->invoke_can_edit( $this->make_endpoint( $class ), $post_id ) );
+	}
+
+	/**
+	 * A revision is not media either, and it is the sharper case: `map_meta_cap` maps
+	 * `edit_post` on a revision to its parent, so a caller who may edit the parent passes
+	 * the capability arm. Only the post-type test rejects it.
+	 *
+	 * @param string $class Endpoint class name.
+	 *
+	 * @dataProvider media_endpoint_classes
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	#[DataProvider( 'media_endpoint_classes' )]
+	public function test_revision_is_not_editable_as_media( $class ) {
+		$post_id     = self::factory()->post->create( array( 'post_author' => self::$owner_id ) );
+		$revision_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'revision',
+				'post_status' => 'inherit',
+				'post_parent' => $post_id,
+				'post_author' => self::$owner_id,
+			)
+		);
+
+		wp_set_current_user( self::$owner_id );
+
+		$this->assertTrue( current_user_can( 'edit_post', $revision_id ), 'edit_post on a revision maps to its parent.' );
+
+		$this->assertFalse( $this->invoke_can_edit( $this->make_endpoint( $class ), $revision_id ) );
+	}
+
+	/**
+	 * V1.1 end to end: an ordinary post comes back 403 and is left untouched, rather than
+	 * being renamed through a media endpoint.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_v1_1_callback_rejects_an_ordinary_post() {
+		global $blog_id;
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => self::$owner_id,
+				'post_title'  => 'Original post title',
+			)
+		);
+		wp_set_current_user( self::$owner_id );
+
+		$endpoint = $this->make_endpoint( WPCOM_JSON_API_Update_Media_v1_1_Endpoint::class );
+		$this->set_input( array( 'title' => 'Renamed through the media endpoint' ) );
+
+		$response = $endpoint->callback( sprintf( '/sites/%d/media/%d', $blog_id, $post_id ), $blog_id, $post_id );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'unauthorized', $response->get_error_code() );
+		$this->assertSame( 'Original post title', get_post( $post_id )->post_title );
+	}
+
+	/**
 	 * V1.1: editors can still rename media uploaded by someone else.
 	 *
 	 * @group json-api


### PR DESCRIPTION
## Proposed changes

The media edit endpoints resolve `{media_id}` with `get_post()`, which is truthy for any post type, and `get_media_item()` only 404s on a *missing* post. So they accept ordinary posts and pages.

* Reject any post whose type is not `attachment`, in `WPCOM_JSON_API_Update_Media_Endpoint` and `WPCOM_JSON_API_Update_Media_v1_1_Endpoint`. `WPCOM_JSON_API_Edit_Media_v1_2_Endpoint` extends v1.1 and inherits it.
* The post-type test sits below the missing-post passthrough. That branch returns `true`, so testing there would skip the `edit_post` check for ordinary posts.

**Behaviour change:** editing your own ordinary post through these endpoints returns 200 today and now returns 403. Callers checked — wp-calypso passes IDs from `getMediaLibrarySelectedItems()` at all four production call sites, and the wpcom caller takes its ID from `wp_insert_attachment()`. Third-party OAuth clients and the npm `wpcom` SDK cannot be checked.

## Related product discussion/links

* JETPACK-2092

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

`jetpack docker phpunit jetpack -- --filter=WPCOM_JSON_API_Media_Endpoints_Authorization_Test` — 41 tests pass.

To see the new tests bite, remove the `'attachment' !== $post->post_type` block from both endpoint files and re-run: 7 failures. That run also surfaces `basename(): Passing null to parameter #1 ($path) of type string is deprecated` at `class.json-api-endpoints.php:1676` — `get_media_item_v1_1()` calling `get_attached_file()` on a non-attachment, getting `false`. Direct evidence that non-attachments were reaching code written for attachments. It stops firing with the guard in place.

Manually, as an Author with a post you own:

* `POST /wp-json/.../sites/$site/media/$post_id` with `{"title":"x"}` where `$post_id` is an ordinary post → 403 `unauthorized`, post unchanged. Was 200 and renamed the post.
* The same call with an attachment you own → still 200.

