### PR TITLE
Forms: send email open Tracks site ID as blog_id

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-742-blog-id-prop
+++ b/projects/packages/forms/changelog/fix-forms-742-blog-id-prop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Send the site ID as `blog_id` on the email open Tracks event so it lands in the blogid column.

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -622,11 +622,13 @@ class Feedback_Email_Renderer {
 			'jetpack_version' => JETPACK__VERSION,
 		);
 
-		// Only send the site ID when the site is connected. Sending an empty value would have Tracks
-		// record `blogid` as a string, which makes the property unusable for analysis.
+		// Tracks promotes `blog_id` to the top-level `blogid` column; sending it as `blogid` leaves it
+		// as an ordinary event property and the column stays empty. Only send the site ID when the site
+		// is connected: an empty value would have Tracks record the property as a string, which makes it
+		// unusable for analysis.
 		$blog_id = Manager::get_site_id( true );
 		if ( $blog_id ) {
-			$event_props['blogid'] = $blog_id;
+			$event_props['blog_id'] = $blog_id;
 		}
 
 		$event = new Jetpack_Tracks_Event( (object) $event_props );


### PR DESCRIPTION
Fixes FORMS-742

## Proposed changes

* Follow-up to #51102, which added the site ID to the `jetpack_forms_email_open` Tracks event under the wrong property name.
* The site ID was sent as `blogid`. Tracks promotes `blog_id` to the top-level `blogid` column — under the name without the underscore it stays an ordinary event property, so the column remains empty. This renames the property to `blog_id`.
* No data is lost from the events already fired: the ~26.8k rows recorded so far still carry the value in the event payload, just not in the column that site joins and coverage checks read.
* `jetpack_version` was already correct and is unchanged.

## Related product discussion/links

* FORMS-742
* Previous PR: #51102

## Does this pull request change what data or activity we track or use?

No new data is collected. This corrects the property name of a site ID that is already being sent on the `jetpack_forms_email_open` event, so it lands in the `blogid` column instead of an arbitrary event property. As before, the site ID is only sent when the site is connected.

## Testing instructions

* Set up a site connected to WordPress.com with a Jetpack form on a page.
* Submit the form so a response notification email is sent to the admin.
* Open the email (or view its source) and find the 1x1 tracking pixel `<img>` pointing at `pixel.wp.com/t.gif`.
* Confirm the pixel URL query string contains `blog_id=<your site ID>` and no longer contains `blogid=`.
* Confirm `_en=jetpack_forms_email_open` and `jetpack_version` are still present.
* On a site that is *not* connected, confirm no `blog_id` parameter is present at all (rather than an empty one).
