### PR TITLE
Heartbeat: restore IDC reporting in the WP-CLI status command

### DIFF
--- a/projects/plugins/jetpack/changelog/deprecate-jetpack-stat-data
+++ b/projects/plugins/jetpack/changelog/deprecate-jetpack-stat-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Deprecate Jetpack::get_stat_data() and Jetpack::check_identity_crisis() in favor of their Connection package equivalents.

--- a/projects/plugins/jetpack/changelog/fix-heartbeat-idc-diagnostic
+++ b/projects/plugins/jetpack/changelog/fix-heartbeat-idc-diagnostic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Heartbeat: restore identity crisis reporting in the WP-CLI status command.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3618,12 +3618,21 @@ p {
 	/**
 	 * Return stat data for WPCOM sync.
 	 *
+	 * The Sync stats module was this method's last caller and moved to the Connection package's
+	 * `Heartbeat::generate_stats_array()`, which assembles the heartbeat data through the
+	 * `jetpack_heartbeat_stats_array` filter. Note the package method does not include the extended
+	 * data from `get_additional_stat_data()`, so callers relying on `$extended` need to add it themselves.
+	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @param bool $encode JSON encode the result.
 	 * @param bool $extended Adds additional stats data.
 	 *
 	 * @return array|string Stats data. Array if $encode is false. JSON-encoded string is $encode is true.
 	 */
 	public static function get_stat_data( $encode = true, $extended = true ) {
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Heartbeat::generate_stats_array' );
+
 		// Site environment stats now live in the Connection package; merge them with the Jetpack-specific stats.
 		$data = array_merge( Jetpack_Heartbeat::generate_stats_array(), Heartbeat::get_environment_stats() );
 
@@ -5588,13 +5597,18 @@ endif;
 	/**
 	 * Checks if the site is currently in an identity crisis.
 	 *
+	 * Now delegates to the Connection package so this matches what the heartbeat itself reports.
+	 * Note the package guards on `Connection\Manager::is_connected()` where this used to guard on
+	 * `Jetpack::is_connection_ready()`, so the `jetpack_is_connection_ready` filter no longer applies.
+	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @return array|bool Array of options that are in a crisis, or false if everything is OK.
 	 */
 	public static function check_identity_crisis() {
-		if ( ! self::is_connection_ready() || ( new Status() )->is_offline_mode() || ! Identity_Crisis::validate_sync_error_idc_option() ) {
-			return false;
-		}
-		return Jetpack_Options::get_option( 'sync_error_idc' );
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', 'Automattic\\Jetpack\\Identity_Crisis::check_identity_crisis' );
+
+		return Identity_Crisis::check_identity_crisis();
 	}
 
 	/**
@@ -6126,8 +6140,18 @@ endif;
 	 * $return array $filtered_data
 	 */
 	public static function jetpack_check_heartbeat_data() {
-		// Site environment stats (incl. wp-version/php-version checked below) now live in the Connection package.
-		$raw_data = array_merge( Jetpack_Heartbeat::generate_stats_array(), Heartbeat::get_environment_stats() );
+		/*
+		 * Site environment stats (incl. wp-version/php-version checked below) now live in the Connection package,
+		 * and the IDC stat is contributed by the Connection package's `jetpack_heartbeat_stats_array` filter
+		 * callback. We rebuild the stat here rather than running that filter: the filter's callbacks have side
+		 * effects (Connection\Manager::add_stats_to_heartbeat() consumes and deletes the `xmlrpc_errors` option)
+		 * and return non-scalar values, neither of which is appropriate for this read-only diagnostic.
+		 */
+		$raw_data = array_merge(
+			Jetpack_Heartbeat::generate_stats_array(),
+			Heartbeat::get_environment_stats(),
+			array( 'identitycrisis' => Identity_Crisis::check_identity_crisis() ? 'yes' : 'no' )
+		);
 
 		$good    = array();
 		$caution = array();

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Heartbeat_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Heartbeat_Test.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Status\Cache as StatusCache;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
@@ -48,7 +49,11 @@ class Jetpack_Heartbeat_Test extends WP_UnitTestCase {
 			'Plugin-specific and environment heartbeat stats must not share keys.'
 		);
 
-		// This is exactly the array `get_stat_data()`/`jetpack_check_heartbeat_data()` build.
+		/*
+		 * This is the array `get_stat_data()` builds. `jetpack_check_heartbeat_data()` merges the
+		 * `identitycrisis` stat on top of it as well -- see
+		 * `test_check_heartbeat_data_flags_identity_crisis_as_bad()` below.
+		 */
 		$merged = array_merge( $plugin_stats, $env_stats );
 
 		// Golden list of keys the plugin emitted before the environment stats moved to the package.
@@ -91,6 +96,71 @@ class Jetpack_Heartbeat_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected_keys, $actual_keys );
 
 		delete_transient( 'jetpack_https_test' );
+	}
+
+	/**
+	 * The IDC stat moved to the Connection package's `jetpack_heartbeat_stats_array` filter callback,
+	 * which `Jetpack::jetpack_check_heartbeat_data()` does not run. It must still rebuild the stat so
+	 * `wp jetpack status full` keeps reporting identity crises.
+	 */
+	public function test_check_heartbeat_data_includes_identity_crisis_stat() {
+		// Avoid a network request for the `ssl` environment stat.
+		set_transient( 'jetpack_https_test', 1 );
+
+		try {
+			$stats = Jetpack::jetpack_check_heartbeat_data();
+
+			$all_stats = array_merge( $stats['good'], $stats['caution'], $stats['bad'] );
+			$this->assertArrayHasKey( 'identitycrisis', $all_stats );
+
+			// Disconnected site, so there is no crisis to report and the stat is unremarkable.
+			$this->assertSame( 'no', $stats['good']['identitycrisis'] );
+		} finally {
+			delete_transient( 'jetpack_https_test' );
+		}
+	}
+
+	/**
+	 * A site in an identity crisis must land in the `bad` bucket, which is what the WP-CLI status
+	 * command prints in red.
+	 */
+	public function test_check_heartbeat_data_flags_identity_crisis_as_bad() {
+		set_transient( 'jetpack_https_test', 1 );
+
+		// Mock a connection so `Identity_Crisis::check_identity_crisis()` gets past its connection guard.
+		Jetpack_Options::update_option( 'id', 1234 );
+		Jetpack_Options::update_option( 'blog_token', 'asd.asd.1' );
+
+		/*
+		 * Deliberately does not match the local home/siteurl, so `validate_sync_error_idc_option()`
+		 * cannot reach its remote-validation branch. Validity comes from the filter below instead,
+		 * which keeps the test free of HTTP requests.
+		 */
+		Jetpack_Options::update_option(
+			'sync_error_idc',
+			array(
+				'home'    => 'http://example.com',
+				'siteurl' => 'http://example.com',
+			)
+		);
+
+		add_filter( 'jetpack_offline_mode', '__return_false', 1000 );
+		add_filter( 'jetpack_sync_error_idc_validation', '__return_true', 1000 );
+		StatusCache::clear();
+
+		try {
+			$stats = Jetpack::jetpack_check_heartbeat_data();
+
+			// The IDC stat is the only one the check can route to `bad`.
+			$this->assertSame( array( 'identitycrisis' => 'yes' ), $stats['bad'] );
+			$this->assertArrayNotHasKey( 'identitycrisis', $stats['good'] );
+		} finally {
+			remove_filter( 'jetpack_offline_mode', '__return_false', 1000 );
+			remove_filter( 'jetpack_sync_error_idc_validation', '__return_true', 1000 );
+			Jetpack_Options::delete_option( array( 'id', 'blog_token', 'sync_error_idc' ) );
+			StatusCache::clear();
+			delete_transient( 'jetpack_https_test' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes JETPACK-1465

## Proposed changes

PR 46967 moved the `identitycrisis` heartbeat stat out of `Jetpack_Heartbeat::generate_stats_array()` and into the Connection package's `Manager::add_stats_to_heartbeat()`, which is hooked to the `jetpack_heartbeat_stats_array` filter.

The heartbeat WP.com receives was unaffected — that path runs the filter, and it was manually verified on the original PR. What broke is the local diagnostic: `Jetpack::jetpack_check_heartbeat_data()` does not run the filter, it builds its own array from `Jetpack_Heartbeat::generate_stats_array()` + `Heartbeat::get_environment_stats()`. Neither contains `identitycrisis` anymore, so the `'identitycrisis' === $stat` branch became dead code and `wp jetpack status full` silently stopped flagging sites in an identity crisis.

* Rebuild the `identitycrisis` stat inside `jetpack_check_heartbeat_data()`, calling the same `Identity_Crisis::check_identity_crisis()` the Connection package calls so the CLI and the real heartbeat cannot drift.
* Deprecate `Jetpack::get_stat_data()` in favor of `Automattic\Jetpack\Heartbeat::generate_stats_array()`. The Sync stats module was its last caller and moved to the package method; nothing in the monorepo calls it now. Behavior is unchanged — the deprecation notice is additive.
* Deprecate `Jetpack::check_identity_crisis()` in favor of `Automattic\Jetpack\Identity_Crisis::check_identity_crisis()`. It is an uncalled duplicate of the package method.
* Add regression coverage for both the presence of the stat and its routing into the `bad` bucket.

### Why not just run the filter

Calling `apply_filters( 'jetpack_heartbeat_stats_array', … )` from the diagnostic looks tidier but is wrong here:

* `Manager::add_stats_to_heartbeat()` reads and then **deletes** the `xmlrpc_errors` option. Running the filter from a read-only status command would consume those pending errors, so the next real heartbeat would under-report them.
* The filter returns non-scalar values (`jetpack_package_versions`, `combined-connection`/`standalone-connection`). The CLI formats every value with `sprintf( '%s', … )`, which would emit "Array to string conversion" warnings.
* `Connection\Site_Health` already documents that this filter fires in synchronous contexts including WP-CLI, and deliberately avoids hanging work off it.

### Note for reviewers

The `check_identity_crisis()` shim now delegates to the package, which guards on `Connection\Manager::is_connected()` where the plugin version guarded on `Jetpack::is_connection_ready()`. The latter additionally applies the `jetpack_is_connection_ready` filter, so behavior can differ on hosts that filter it (e.g. Atomic). This is called out in the docblock. Happy to keep the original body verbatim instead if you would rather the deprecation be strictly behavior-preserving.

## Related product discussion/links

* JETPACK-1465
* Regression introduced in PR 46967 (CONNECT-133)

## Does this pull request change what data or activity we track or use?

No. The heartbeat sent to WP.com is unchanged — this only restores a stat in the local WP-CLI diagnostic, which is computed on demand and not transmitted.

## Testing instructions

Requires a Jetpack-connected site with WP-CLI.

* On `trunk`, run `wp jetpack status full` and note the output. There is no `identitycrisis` line at all.
* Check out this branch and run `wp jetpack status full` again. An `identitycrisis` line now appears, reading `no` on a healthy site.
* To see the red flag, put the site into a simulated identity crisis — e.g. `wp option patch insert jetpack_sync_error_idc home 'http://example.com'` plus `siteurl`, or change the site URL so it no longer matches what WP.com has — and re-run. `identitycrisis yes` should print in red, in the "red flags first" block ahead of the cautions.

Automated coverage: `jp docker phpunit jetpack -- --filter Jetpack_Heartbeat_Test`.
