### PR TITLE
Stats: pass false, not null, to stats_get_daily_history

### DIFF
--- a/projects/packages/stats/changelog/fix-wpcom-stats-daily-history-false-arg
+++ b/projects/packages/stats/changelog/fix-wpcom-stats-daily-history-false-arg
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Pass a valid first argument to the WordPress.com Simple daily history lookup.

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -598,7 +598,7 @@ class WPCOM_Stats {
 	 * @return array
 	 */
 	protected function fetch_stats_on_wpcom_simple( $end_date, $number_of_days, $escaped_post_ids ) {
-		return stats_get_daily_history( null, get_current_blog_id(), 'postviews', 'post_id', $end_date, $number_of_days, " AND post_id IN ($escaped_post_ids)", 0, true );
+		return stats_get_daily_history( false, get_current_blog_id(), 'postviews', 'post_id', $end_date, $number_of_days, " AND post_id IN ($escaped_post_ids)", 0, true );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes

* `WPCOM_Stats::fetch_stats_on_wpcom_simple()` passed `null` as the first argument to `stats_get_daily_history()`. The WordPress.com implementation types that parameter as `false|int`, so `null` is not a valid value — the sibling call site in the Top Posts widget (`projects/plugins/jetpack/modules/widgets/top-posts.php`) already passes `false`. This changes the one remaining `null` to `false`.

Both `null` and `false` are falsy, so behavior on WordPress.com Simple is unchanged; this is purely a type-correctness fix. It is needed so the [wpcom stubs PR](https://github.com/Automattic/jetpack/pull/51132) can land — with the real signature stubbed, Phan flags the `null` argument ([failing job](https://github.com/Automattic/jetpack/actions/runs/31286158456/job/93175302657?pr=51132)).

## Related product discussion/links

* Requested in review on #42218: https://github.com/Automattic/jetpack/pull/42218#discussion_r3755652969
* Blocks: #51132

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a one-token type fix on a code path that only runs on WordPress.com Simple, so there is nothing user-visible to click through.

* Confirm CI is green here (PHP lint, PHPCS, and `packages/stats` PHPUnit all pass locally).
* The real verification is #51132: once this lands and that PR is rebased on trunk, the `PhanTypeMismatchArgumentNullable` failure on `projects/packages/stats/src/class-wpcom-stats.php` should be gone.
* Optionally, on a WordPress.com Simple site, load a view that hits `WPCOM_Stats::fetch_stats_on_wpcom_simple()` (post views for a set of post IDs) and confirm the stats still come back as before — `null` and `false` are both falsy for the "current blog" argument, so results should be identical.
