### PR TITLE
Premium Analytics: match the dashboard's tightened Card padding on the detail routes

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-pa-detail-card-padding
+++ b/projects/packages/premium-analytics/changelog/add-pa-detail-card-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Detail pages: match the dashboard's tightened widget Card padding.

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -24,6 +24,24 @@
 	// Inherited by the @wordpress/grid surfaces (grid, masonry, edit overlay),
 	// which otherwise fall back to the wider `--wpds-dimension-gap-xl`.
 	--wp-grid-gap: var(--wpds-dimension-gap-lg);
+
+	// Match the dashboard's tightened widget Card padding (#51101): the detail
+	// routes render the same widget Cards, and the roomier default otherwise
+	// clips content-sized widgets like the traffic activity heatmap
+	// (WOOA7S-1905). TODO with #51101: consider fixing upstream in Card.
+	section:first-of-type {
+		--wp-ui-card-padding: var(--wpds-dimension-padding-lg);
+		--wp-ui-card-header-content-margin: var(--wpds-dimension-padding-lg);
+
+		> div {
+			margin-block-start: 0;
+		}
+	}
+
+	// Overlay WidgetHeader re-declares padding to 2xl; match the Card tweak.
+	[class*="__widget-header"][class*="__overlay"] {
+		--wp-ui-card-padding: var(--wpds-dimension-padding-lg);
+	}
 }
 
 .header {

--- a/projects/packages/premium-analytics/routes/video-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.module.scss
@@ -26,6 +26,24 @@
 	// Inherited by the @wordpress/grid surfaces (grid, masonry, edit overlay),
 	// which otherwise fall back to the wider `--wpds-dimension-gap-xl`.
 	--wp-grid-gap: var(--wpds-dimension-gap-lg);
+
+	// Match the dashboard's tightened widget Card padding (#51101): the detail
+	// routes render the same widget Cards, and the roomier default otherwise
+	// clips content-sized widgets like the traffic activity heatmap
+	// (WOOA7S-1905). TODO with #51101: consider fixing upstream in Card.
+	section:first-of-type {
+		--wp-ui-card-padding: var(--wpds-dimension-padding-lg);
+		--wp-ui-card-header-content-margin: var(--wpds-dimension-padding-lg);
+
+		> div {
+			margin-block-start: 0;
+		}
+	}
+
+	// Overlay WidgetHeader re-declares padding to 2xl; match the Card tweak.
+	[class*="__widget-header"][class*="__overlay"] {
+		--wp-ui-card-padding: var(--wpds-dimension-padding-lg);
+	}
 }
 
 .header {


### PR DESCRIPTION
Part of WOOA7S-1905 (the padding half of item 2).

## Proposed changes

* Apply the dashboard's tightened widget Card padding (#51101) to the post and video detail routes: the same `--wp-ui-card-padding` / `--wp-ui-card-header-content-margin` override (the `lg` token instead of the Card default), scoped to the routes' widget grids, plus the same overlay widget-header match.
* The detail routes render the same widget Cards as the dashboard, so this is the #51101 decision catching up rather than a new one. It also gives content-sized widgets ~16px of height back — the traffic activity heatmap's top/bottom clipping (WOOA7S-1905 item 2) mostly disappears at the current tile preset, though the height-aware cell sizing tracked there remains the real fix.

## Related product discussion/links

* #51101 established the value on the dashboard route.
* WOOA7S-1905 records the heatmap clipping this mitigates.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build `packages/premium-analytics` + `plugins/premium-analytics` and open a post detail and a video detail page.
* Widget cards use the same padding as the dashboard tabs (16px, not 24px) — compare any card against the Traffic tab.
* The Traffic activity heatmap's month labels and bottom weekday row are no longer clipped at the default two-row tile.
* Dashboard tabs are untouched (already had the override).
