### PR TITLE
Stats: register the dashboard before the site is connected

### DIFF
--- a/projects/packages/stats-admin/changelog/stats-345-not-connected-error
+++ b/projects/packages/stats-admin/changelog/stats-345-not-connected-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Return a clear error instead of a server error when a stats request is made before the site is connected to WordPress.com.

--- a/projects/packages/stats-admin/changelog/stats-345-pre-connection-dashboard
+++ b/projects/packages/stats-admin/changelog/stats-345-pre-connection-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Show the Stats dashboard before the site is connected to WordPress.com, so a plan can be picked and the site connected from there.

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -92,16 +92,27 @@ class Dashboard {
 	 * @return string
 	 */
 	protected function get_capability() {
-		return ( new Manager( 'jetpack' ) )->is_connected() ? 'view_stats' : 'manage_options';
+		return $this->is_site_connected() ? 'view_stats' : 'manage_options';
+	}
+
+	/**
+	 * Whether the site is connected to WordPress.com.
+	 *
+	 * @return bool
+	 */
+	protected function is_site_connected() {
+		return ( new Manager( 'jetpack' ) )->is_connected();
 	}
 
 	/**
 	 * Override render funtion
 	 */
 	public function render() {
-		// Record the number of views of the stats dashboard on the initial several loads for the purpose of showing feedback notice.
+		// Record the number of views of the stats dashboard on the initial several loads for the
+		// purpose of showing feedback notice. Views before the site is connected show the plan
+		// choice rather than the dashboard, and there is nothing to give feedback on yet.
 		$views = intval( Stats_Options::get_option( 'views' ) ) + 1;
-		if ( $views <= Notices::VIEWS_TO_SHOW_FEEDBACK ) {
+		if ( $views <= Notices::VIEWS_TO_SHOW_FEEDBACK && $this->is_site_connected() ) {
 			Stats_Options::set_option( 'views', $views );
 		}
 

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Stats_Admin;
 
+use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
 
 /**
@@ -68,7 +70,7 @@ class Dashboard {
 		$page_suffix = add_menu_page(
 			__( 'Stats', 'jetpack-stats-admin' ),
 			_x( 'Stats', 'product name shown in menu', 'jetpack-stats-admin' ),
-			'view_stats',
+			$this->get_capability(),
 			'stats',
 			array( $this, 'render' ),
 			'dashicons-chart-bar',
@@ -78,6 +80,19 @@ class Dashboard {
 		if ( $page_suffix ) {
 			add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
 		}
+	}
+
+	/**
+	 * Capability a user needs to reach the dashboard.
+	 *
+	 * Until the site is connected the page exists to pick a plan and connect, which only a user
+	 * who can manage the connection can act on. Once connected it is a reporting page, open to
+	 * everyone allowed to view stats.
+	 *
+	 * @return string
+	 */
+	protected function get_capability() {
+		return ( new Manager( 'jetpack' ) )->is_connected() ? 'view_stats' : 'manage_options';
 	}
 
 	/**
@@ -138,5 +153,10 @@ class Dashboard {
 	 */
 	public function load_admin_scripts() {
 		( new Odyssey_Assets() )->load_admin_scripts( 'jp-stats-dashboard', 'build.min', array( 'config_variable_name' => 'jetpackStatsOdysseyAppConfigData' ) );
+
+		// The app is served from our CDN and so cannot bundle the connection package. Print the
+		// state Search and Protect print on their own pages, so it can read the connection status
+		// and register the site through the connection REST API itself.
+		Connection_Initial_State::render_script( 'jp-stats-dashboard' );
 	}
 }

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -88,10 +88,14 @@ class Dashboard {
 	 * who can manage the connection can act on. Once connected it is a reporting page, open to
 	 * everyone allowed to view stats.
 	 *
+	 * Pre-connection that is `jetpack_connect`: it maps to `manage_options` on a normal site,
+	 * but is `do_not_allow` in offline mode and honours the same multisite/filter rules as the
+	 * register endpoint, so the menu is not offered where the connection cannot be completed.
+	 *
 	 * @return string
 	 */
 	protected function get_capability() {
-		return Main::is_site_connected() ? 'view_stats' : 'manage_options';
+		return Main::is_site_connected() ? 'view_stats' : 'jetpack_connect';
 	}
 
 	/**
@@ -157,7 +161,11 @@ class Dashboard {
 
 		// The app is served from our CDN and so cannot bundle the connection package. Print the
 		// state Search and Protect print on their own pages, so it can read the connection status
-		// and register the site through the connection REST API itself.
-		Connection_Initial_State::render_script( 'jp-stats-dashboard' );
+		// and register the site through the connection REST API itself. Connected sites fetch
+		// `jetpack/v4/connection` over REST instead, and must not receive registrationNonce and
+		// the connected-plugin list on a page that `view_stats` users can open.
+		if ( ! Main::is_site_connected() ) {
+			Connection_Initial_State::render_script( 'jp-stats-dashboard' );
+		}
 	}
 }

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
-use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
 
 /**
@@ -92,16 +91,7 @@ class Dashboard {
 	 * @return string
 	 */
 	protected function get_capability() {
-		return $this->is_site_connected() ? 'view_stats' : 'manage_options';
-	}
-
-	/**
-	 * Whether the site is connected to WordPress.com.
-	 *
-	 * @return bool
-	 */
-	protected function is_site_connected() {
-		return ( new Manager( 'jetpack' ) )->is_connected();
+		return Main::is_site_connected() ? 'view_stats' : 'manage_options';
 	}
 
 	/**
@@ -112,7 +102,7 @@ class Dashboard {
 		// purpose of showing feedback notice. Views before the site is connected show the plan
 		// choice rather than the dashboard, and there is nothing to give feedback on yet.
 		$views = intval( Stats_Options::get_option( 'views' ) ) + 1;
-		if ( $views <= Notices::VIEWS_TO_SHOW_FEEDBACK && $this->is_site_connected() ) {
+		if ( $views <= Notices::VIEWS_TO_SHOW_FEEDBACK && Main::is_site_connected() ) {
 			Stats_Options::set_option( 'views', $views );
 		}
 

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -76,6 +76,17 @@ class Main {
 	}
 
 	/**
+	 * Whether the site can talk to WordPress.com.
+	 *
+	 * Simple sites always can, and hold no Jetpack blog token to check.
+	 *
+	 * @return bool
+	 */
+	public static function is_site_connected() {
+		return ( new Host() )->is_wpcom_simple() || ( new Manager( 'jetpack' ) )->is_connected();
+	}
+
+	/**
 	 * Whether Stats has to register its own dashboard because nothing else will.
 	 *
 	 * The Jetpack plugin registers the Stats menu from its stats module, and modules are not
@@ -85,12 +96,7 @@ class Main {
 	 * @return bool
 	 */
 	private static function needs_own_dashboard() {
-		// Simple sites are always connected, and register the menu from a subclass of Dashboard.
-		if ( ( new Host() )->is_wpcom_simple() ) {
-			return false;
-		}
-
-		return ! ( new Manager( 'jetpack' ) )->is_connected();
+		return ! self::is_site_connected();
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
+use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Tracking;
 
 /**
@@ -68,6 +69,28 @@ class Main {
 
 		// Register stats-admin transient prefix for cleanup by the stats package.
 		add_filter( 'jetpack_stats_transient_cleanup_prefixes', array( $this, 'register_transient_cleanup_prefix' ) );
+
+		if ( self::needs_own_dashboard() ) {
+			Dashboard::init();
+		}
+	}
+
+	/**
+	 * Whether Stats has to register its own dashboard because nothing else will.
+	 *
+	 * The Jetpack plugin registers the Stats menu from its stats module, and modules are not
+	 * loaded until the site is connected. Registering the dashboard here keeps Stats reachable
+	 * before that happens, where the app offers a plan and drives the connection itself.
+	 *
+	 * @return bool
+	 */
+	private static function needs_own_dashboard() {
+		// Simple sites are always connected, and register the menu from a subclass of Dashboard.
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return false;
+		}
+
+		return ! ( new Manager( 'jetpack' ) )->is_connected();
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -37,19 +37,34 @@ class Odyssey_Config_Data {
 	 * Return the config for the app.
 	 */
 	public function get_data() {
-		$blog_id = (int) Jetpack_Options::get_option( 'id' );
+		$blog_id = $this->get_connected_blog_id();
 		$data    = $this->get_site_agnostic_data( $blog_id );
 
 		/*
-		 * A site with no WordPress.com connection has no record to seed the app's store with.
-		 * Emitting one anyway would key every entry on a blog ID of 0 and make each lookup miss,
-		 * so leave it out and let the app fall back to the screens it shows without a site.
+		 * A site the app cannot reach has no record to seed its store with. Emitting one anyway
+		 * would key every entry on a blog ID of 0 and make each lookup miss, so leave it out and
+		 * let the app fall back to the screens it shows without a site.
 		 */
 		if ( $blog_id ) {
 			$data['intial_state'] = $this->get_initial_state( $blog_id );
 		}
 
 		return $data;
+	}
+
+	/**
+	 * The WordPress.com blog ID the app can talk to, or 0 when there is none.
+	 *
+	 * A site keeps its blog ID when it disconnects, but every request the app would make with it
+	 * has to be signed with a token the site no longer holds. Such a site has no more to offer
+	 * the app than one that was never connected.
+	 *
+	 * @return int
+	 */
+	protected function get_connected_blog_id() {
+		$blog_id = (int) Jetpack_Options::get_option( 'id' );
+
+		return Main::is_site_connected() ? $blog_id : 0;
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -37,17 +37,34 @@ class Odyssey_Config_Data {
 	 * Return the config for the app.
 	 */
 	public function get_data() {
+		$blog_id = (int) Jetpack_Options::get_option( 'id' );
+		$data    = $this->get_site_agnostic_data( $blog_id );
+
+		/*
+		 * A site with no WordPress.com connection has no record to seed the app's store with.
+		 * Emitting one anyway would key every entry on a blog ID of 0 and make each lookup miss,
+		 * so leave it out and let the app fall back to the screens it shows without a site.
+		 */
+		if ( $blog_id ) {
+			$data['intial_state'] = $this->get_initial_state( $blog_id );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Config the app can rely on with or without a WordPress.com connection.
+	 *
+	 * @param int $blog_id The WordPress.com blog ID, 0 when the site is not connected.
+	 * @return array
+	 */
+	protected function get_site_agnostic_data( $blog_id ) {
 		global $wp_version;
-
-		$blog_id = Jetpack_Options::get_option( 'id' );
-		$host    = new Host();
-
-		$can_blaze = class_exists( 'Automattic\Jetpack\Blaze' ) && Blaze::should_initialize()['can_init'];
 
 		return array(
 			'admin_page_base'                => $this->get_admin_path(),
 			'api_root'                       => esc_url_raw( rest_url() ),
-			'blog_id'                        => Jetpack_Options::get_option( 'id' ),
+			'blog_id'                        => $blog_id,
 			'enable_all_sections'            => false,
 			'env_id'                         => 'production',
 			'google_analytics_key'           => 'UA-10673494-15',
@@ -62,50 +79,69 @@ class Odyssey_Config_Data {
 			'sections'                       => array(),
 			// Features are inlined @see https://github.com/Automattic/wp-calypso/pull/70122
 			'features'                       => array(
-				'is_running_in_jetpack_site' => ! $host->is_wpcom_simple(),
+				'is_running_in_jetpack_site' => ! ( new Host() )->is_wpcom_simple(),
 			),
 			// Intended for apps that do not use redux.
 			'gmt_offset'                     => $this->get_gmt_offset(),
 			'odyssey_stats_base_url'         => admin_url( 'admin.php?page=stats' ),
-			'intial_state'                   => array(
-				'currentUser' => array(
-					'id'           => 1000,
-					'user'         => array(
-						'ID'       => 1000,
-						'username' => 'no-user',
-					),
-					'capabilities' => array(
-						"$blog_id" => $this->get_current_user_capabilities(),
-					),
+			// Repeated in the site record below, which a site without a connection never gets.
+			'jetpack_version'                => defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '',
+			'stats_admin_version'            => Main::VERSION,
+			'software_version'               => $wp_version,
+		);
+	}
+
+	/**
+	 * The Redux state the app boots with.
+	 *
+	 * @param int $blog_id The WordPress.com blog ID.
+	 * @return array
+	 */
+	protected function get_initial_state( $blog_id ) {
+		global $wp_version;
+
+		$host         = new Host();
+		$capabilities = $this->get_current_user_capabilities();
+		$can_blaze    = class_exists( 'Automattic\Jetpack\Blaze' ) && Blaze::should_initialize()['can_init'];
+
+		return array(
+			'currentUser' => array(
+				'id'           => 1000,
+				'user'         => array(
+					'ID'       => 1000,
+					'username' => 'no-user',
 				),
-				'sites'       => array(
-					'items'    => array(
-						"$blog_id" => array(
-							'ID'           => $blog_id,
-							'URL'          => site_url(),
-							// Atomic and jetpack sites should return true.
-							'jetpack'      => ! $host->is_wpcom_simple(),
-							'visible'      => true,
-							'capabilities' => $this->get_current_user_capabilities(),
-							'products'     => Jetpack_Plan::get_products(),
-							'plan'         => $this->get_plan(),
-							'options'      => array(
-								'wordads'               => ( new Modules() )->is_active( 'wordads' ),
-								'admin_url'             => admin_url(),
-								'gmt_offset'            => $this->get_gmt_offset(),
-								'is_automated_transfer' => $this->is_automated_transfer( $blog_id ),
-								'is_wpcom_atomic'       => $host->is_woa_site(),
-								'is_wpcom_simple'       => $host->is_wpcom_simple(),
-								'is_vip'                => $host->is_vip_site(),
-								'jetpack_version'       => defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '',
-								'stats_admin_version'   => Main::VERSION,
-								'software_version'      => $wp_version,
-								'can_blaze'             => $can_blaze,
-							),
+				'capabilities' => array(
+					"$blog_id" => $capabilities,
+				),
+			),
+			'sites'       => array(
+				'items'    => array(
+					"$blog_id" => array(
+						'ID'           => $blog_id,
+						'URL'          => site_url(),
+						// Atomic and jetpack sites should return true.
+						'jetpack'      => ! $host->is_wpcom_simple(),
+						'visible'      => true,
+						'capabilities' => $capabilities,
+						'products'     => Jetpack_Plan::get_products(),
+						'plan'         => $this->get_plan(),
+						'options'      => array(
+							'wordads'               => ( new Modules() )->is_active( 'wordads' ),
+							'admin_url'             => admin_url(),
+							'gmt_offset'            => $this->get_gmt_offset(),
+							'is_automated_transfer' => $this->is_automated_transfer( $blog_id ),
+							'is_wpcom_atomic'       => $host->is_woa_site(),
+							'is_wpcom_simple'       => $host->is_wpcom_simple(),
+							'is_vip'                => $host->is_vip_site(),
+							'jetpack_version'       => defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '',
+							'stats_admin_version'   => Main::VERSION,
+							'software_version'      => $wp_version,
+							'can_blaze'             => $can_blaze,
 						),
 					),
-					'features' => array( "$blog_id" => array( 'data' => $this->get_plan_features() ) ),
 				),
+				'features' => array( "$blog_id" => array( 'data' => $this->get_plan_features() ) ),
 			),
 		);
 	}

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -100,6 +100,7 @@ class Odyssey_Config_Data {
 			'gmt_offset'                     => $this->get_gmt_offset(),
 			'odyssey_stats_base_url'         => admin_url( 'admin.php?page=stats' ),
 			// Repeated in the site record below, which a site without a connection never gets.
+			'admin_url'                      => admin_url(),
 			'jetpack_version'                => defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '',
 			'stats_admin_version'            => Main::VERSION,
 			'software_version'               => $wp_version,

--- a/projects/packages/stats-admin/src/class-wpcom-client.php
+++ b/projects/packages/stats-admin/src/class-wpcom-client.php
@@ -83,8 +83,9 @@ class WPCOM_Client {
 		if ( is_wp_error( $response ) ) {
 			// `Client` fails before sending anything when the site holds no blog token, and that
 			// error carries no status, which the REST API renders as a 500. Say what actually
-			// happened so callers can tell an unconnected site from a broken one.
-			if ( 'missing_token' === $response->get_error_code() ) {
+			// happened so callers can tell an unconnected site from a broken one. Newer connection
+			// packages name the reason (`no_possible_tokens`); older ones return `missing_token`.
+			if ( in_array( $response->get_error_code(), array( 'missing_token', 'no_possible_tokens' ), true ) ) {
 				return new WP_Error(
 					'site_not_connected',
 					__( 'This site is not connected to WordPress.com.', 'jetpack-stats-admin' ),

--- a/projects/packages/stats-admin/src/class-wpcom-client.php
+++ b/projects/packages/stats-admin/src/class-wpcom-client.php
@@ -81,6 +81,17 @@ class WPCOM_Client {
 		);
 
 		if ( is_wp_error( $response ) ) {
+			// `Client` fails before sending anything when the site holds no blog token, and that
+			// error carries no status, which the REST API renders as a 500. Say what actually
+			// happened so callers can tell an unconnected site from a broken one.
+			if ( 'missing_token' === $response->get_error_code() ) {
+				return new WP_Error(
+					'site_not_connected',
+					__( 'This site is not connected to WordPress.com.', 'jetpack-stats-admin' ),
+					array( 'status' => 400 )
+				);
+			}
+
 			return $response;
 		}
 

--- a/projects/packages/stats-admin/tests/php/Dashboard_Test.php
+++ b/projects/packages/stats-admin/tests/php/Dashboard_Test.php
@@ -60,11 +60,24 @@ class Dashboard_Test extends Stats_TestCase {
 	 * site through the connection REST API using the state printed alongside it.
 	 */
 	public function test_load_admin_scripts_prints_the_connection_state() {
+		$this->disconnect_site();
+
 		( new Dashboard() )->load_admin_scripts();
 
 		$inline_scripts = implode( '', (array) wp_scripts()->get_data( 'jp-stats-dashboard', 'before' ) );
 
 		$this->assertStringContainsString( 'JP_CONNECTION_INITIAL_STATE', $inline_scripts );
+	}
+
+	/**
+	 * A connected site reads connection status over REST, so the blob is not printed there.
+	 */
+	public function test_load_admin_scripts_does_not_print_the_connection_state_when_connected() {
+		( new Dashboard() )->load_admin_scripts();
+
+		$inline_scripts = implode( '', (array) wp_scripts()->get_data( 'jp-stats-dashboard', 'before' ) );
+
+		$this->assertStringNotContainsString( 'JP_CONNECTION_INITIAL_STATE', $inline_scripts );
 	}
 
 	/**
@@ -75,12 +88,13 @@ class Dashboard_Test extends Stats_TestCase {
 	}
 
 	/**
-	 * Before that it offers a plan and connects the site, which only an administrator can act on.
+	 * Before that it offers a plan and connects the site, which only a user who can manage the
+	 * connection can act on.
 	 */
 	public function test_capability_when_not_connected() {
 		$this->disconnect_site();
 
-		$this->assertSame( 'manage_options', $this->get_capability() );
+		$this->assertSame( 'jetpack_connect', $this->get_capability() );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/Dashboard_Test.php
+++ b/projects/packages/stats-admin/tests/php/Dashboard_Test.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\Jetpack\Stats_Admin;
 
+use Automattic\Jetpack\Stats\Options as Stats_Options;
 use Automattic\Jetpack\Stats_Admin\TestCase as Stats_TestCase;
 use ReflectionProperty;
 
@@ -39,6 +40,19 @@ class Dashboard_Test extends Stats_TestCase {
 	public function test_render() {
 		$this->expectOutputRegex( '/<div id="wpcom" class="jp-stats-dashboard".*>/i' );
 		( new Dashboard() )->render();
+	}
+
+	/**
+	 * The view count decides when to ask what the user makes of the dashboard, so a page that
+	 * only offered them a plan must not count towards it.
+	 */
+	public function test_render_does_not_count_views_before_the_site_is_connected() {
+		$this->disconnect_site();
+
+		$this->expectOutputRegex( '/<div id="wpcom"/i' );
+		( new Dashboard() )->render();
+
+		$this->assertSame( 0, intval( Stats_Options::get_option( 'views' ) ) );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/Dashboard_Test.php
+++ b/projects/packages/stats-admin/tests/php/Dashboard_Test.php
@@ -11,6 +11,15 @@ use ReflectionProperty;
  */
 class Dashboard_Test extends Stats_TestCase {
 	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		wp_dequeue_script( 'jp-stats-dashboard' );
+		wp_deregister_script( 'jp-stats-dashboard' );
+		parent::tearDown();
+	}
+
+	/**
 	 * Test that init sets $initialized.
 	 */
 	public function test_init_sets_initialized() {
@@ -30,5 +39,49 @@ class Dashboard_Test extends Stats_TestCase {
 	public function test_render() {
 		$this->expectOutputRegex( '/<div id="wpcom" class="jp-stats-dashboard".*>/i' );
 		( new Dashboard() )->render();
+	}
+
+	/**
+	 * The app is served from our CDN and cannot bundle the connection package, so it registers the
+	 * site through the connection REST API using the state printed alongside it.
+	 */
+	public function test_load_admin_scripts_prints_the_connection_state() {
+		( new Dashboard() )->load_admin_scripts();
+
+		$inline_scripts = implode( '', (array) wp_scripts()->get_data( 'jp-stats-dashboard', 'before' ) );
+
+		$this->assertStringContainsString( 'JP_CONNECTION_INITIAL_STATE', $inline_scripts );
+	}
+
+	/**
+	 * Once connected the dashboard is a reporting page, open to anyone allowed to see stats.
+	 */
+	public function test_capability_when_connected() {
+		$this->assertSame( 'view_stats', $this->get_capability() );
+	}
+
+	/**
+	 * Before that it offers a plan and connects the site, which only an administrator can act on.
+	 */
+	public function test_capability_when_not_connected() {
+		$this->disconnect_site();
+
+		$this->assertSame( 'manage_options', $this->get_capability() );
+	}
+
+	/**
+	 * Read the capability the dashboard menu is registered with.
+	 *
+	 * @return string
+	 */
+	private function get_capability() {
+		$dashboard = new Dashboard();
+		$method    = new \ReflectionMethod( $dashboard, 'get_capability' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		return $method->invoke( $dashboard );
 	}
 }

--- a/projects/packages/stats-admin/tests/php/Main_Test.php
+++ b/projects/packages/stats-admin/tests/php/Main_Test.php
@@ -1,0 +1,74 @@
+<?php
+namespace Automattic\Jetpack\Stats_Admin;
+
+use Automattic\Jetpack\Stats_Admin\TestCase as Stats_TestCase;
+use ReflectionProperty;
+
+/**
+ * Unit tests for the Main class.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+class Main_Test extends Stats_TestCase {
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->reset_dashboard_registration();
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		$this->reset_dashboard_registration();
+		parent::tearDown();
+	}
+
+	/**
+	 * A connected site gets its Stats menu from the Jetpack plugin's stats module.
+	 */
+	public function test_leaves_the_dashboard_alone_when_connected() {
+		Main::init();
+
+		$this->assertFalse( has_action( 'admin_menu' ) );
+	}
+
+	/**
+	 * Modules do not load before the site is connected, so nothing else would register the menu.
+	 */
+	public function test_registers_the_dashboard_when_not_connected() {
+		$this->disconnect_site();
+
+		Main::init();
+
+		$this->assertTrue( has_action( 'admin_menu' ) );
+	}
+
+	/**
+	 * `Main` and `Dashboard` both hold static state, and hooks an earlier test added survive in
+	 * `$wp_filter`, so a test only sees what it registered itself if the run starts clean.
+	 */
+	private function reset_dashboard_registration() {
+		remove_all_actions( 'admin_menu' );
+		$this->set_static_property( Main::class, 'instance', null );
+		$this->set_static_property( Dashboard::class, 'initialized', false );
+	}
+
+	/**
+	 * Set a private static property.
+	 *
+	 * @param string $class_name The class holding the property.
+	 * @param string $name       The property name.
+	 * @param mixed  $value      The value to set.
+	 */
+	private function set_static_property( $class_name, $name, $value ) {
+		$property = new ReflectionProperty( $class_name, $name );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, $value );
+	}
+}

--- a/projects/packages/stats-admin/tests/php/Odyssey_Config_Data_Test.php
+++ b/projects/packages/stats-admin/tests/php/Odyssey_Config_Data_Test.php
@@ -44,4 +44,36 @@ class Odyssey_Config_Data_Test extends Stats_TestCase {
 		$this->assertArrayHasKey( 'intial_state', $data );
 		$this->assertArrayHasKey( 'is_running_in_jetpack_site', $data['features'] );
 	}
+
+	/**
+	 * The app reads the versions from the site record when there is one, so they have to be
+	 * available on their own for the site that has none.
+	 */
+	public function test_config_data_carries_versions_outside_the_site_record() {
+		$data = ( new Odyssey_Config_Data() )->get_data();
+
+		$this->assertArrayHasKey( 'jetpack_version', $data );
+		$this->assertArrayHasKey( 'stats_admin_version', $data );
+		$this->assertArrayHasKey( 'software_version', $data );
+		$this->assertSame(
+			$data['intial_state']['sites']['items']['999']['options']['stats_admin_version'],
+			$data['stats_admin_version']
+		);
+	}
+
+	/**
+	 * Without a connection there is no site to describe, and a record keyed on a blog ID of 0
+	 * would only make every lookup in the app miss.
+	 */
+	public function test_config_data_without_a_connection() {
+		$this->disconnect_site();
+
+		$data = ( new Odyssey_Config_Data() )->get_data();
+
+		$this->assertSame( 0, $data['blog_id'] );
+		$this->assertArrayNotHasKey( 'intial_state', $data );
+		$this->assertArrayHasKey( 'api_root', $data );
+		$this->assertArrayHasKey( 'nonce', $data );
+		$this->assertArrayHasKey( 'stats_admin_version', $data );
+	}
 }

--- a/projects/packages/stats-admin/tests/php/Odyssey_Config_Data_Test.php
+++ b/projects/packages/stats-admin/tests/php/Odyssey_Config_Data_Test.php
@@ -56,6 +56,10 @@ class Odyssey_Config_Data_Test extends Stats_TestCase {
 		$this->assertArrayHasKey( 'stats_admin_version', $data );
 		$this->assertArrayHasKey( 'software_version', $data );
 		$this->assertSame(
+			$data['intial_state']['sites']['items']['999']['options']['admin_url'],
+			$data['admin_url']
+		);
+		$this->assertSame(
 			$data['intial_state']['sites']['items']['999']['options']['stats_admin_version'],
 			$data['stats_admin_version']
 		);
@@ -87,6 +91,7 @@ class Odyssey_Config_Data_Test extends Stats_TestCase {
 		$this->assertArrayNotHasKey( 'intial_state', $data );
 		$this->assertArrayHasKey( 'api_root', $data );
 		$this->assertArrayHasKey( 'nonce', $data );
+		$this->assertArrayHasKey( 'admin_url', $data );
 		$this->assertArrayHasKey( 'stats_admin_version', $data );
 	}
 }

--- a/projects/packages/stats-admin/tests/php/Odyssey_Config_Data_Test.php
+++ b/projects/packages/stats-admin/tests/php/Odyssey_Config_Data_Test.php
@@ -62,6 +62,19 @@ class Odyssey_Config_Data_Test extends Stats_TestCase {
 	}
 
 	/**
+	 * A site that disconnects keeps its blog ID, but the app cannot sign a single request with
+	 * it, so it has to be told there is no site rather than handed one that does not work.
+	 */
+	public function test_config_data_when_a_connected_site_disconnects() {
+		$this->disconnect_site_keeping_blog_id();
+
+		$data = ( new Odyssey_Config_Data() )->get_data();
+
+		$this->assertSame( 0, $data['blog_id'] );
+		$this->assertArrayNotHasKey( 'intial_state', $data );
+	}
+
+	/**
 	 * Without a connection there is no site to describe, and a record keyed on a blog ID of 0
 	 * would only make every lookup in the app miss.
 	 */

--- a/projects/packages/stats-admin/tests/php/WPCOM_Client_Test.php
+++ b/projects/packages/stats-admin/tests/php/WPCOM_Client_Test.php
@@ -1,0 +1,26 @@
+<?php
+namespace Automattic\Jetpack\Stats_Admin;
+
+use Automattic\Jetpack\Stats_Admin\TestCase as Stats_TestCase;
+use WP_Error;
+
+/**
+ * Unit tests for the WPCOM_Client class.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+class WPCOM_Client_Test extends Stats_TestCase {
+	/**
+	 * Without a blog token the request never leaves the site. The error says so, and carries a
+	 * status, so the REST API does not report it as a server fault.
+	 */
+	public function test_request_as_blog_without_a_connection() {
+		$this->disconnect_site();
+
+		$response = WPCOM_Client::request_as_blog( '/sites/0/stats' );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'site_not_connected', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
+	}
+}

--- a/projects/packages/stats-admin/tests/php/class-testcase.php
+++ b/projects/packages/stats-admin/tests/php/class-testcase.php
@@ -8,7 +8,9 @@
 namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Stats\Options as Stats_Options;
 use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
+use ReflectionProperty;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Posts as WorDBless_Posts;
 use WorDBless\Users as WorDBless_Users;
@@ -62,8 +64,22 @@ abstract class TestCase extends PHPUnit_TestCase {
 		add_filter( 'pre_http_request', array( $this, 'plan_http_response_fixture' ), 10, 3 );
 		delete_option( Odyssey_Assets::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY );
 
-		// The connection status is memoized in a static, so it outlives the mocked options.
+		// The connection status and the stats options are both memoized in statics, so they
+		// outlive the mocked options and the cleared database.
 		( new Connection_Manager() )->reset_connection_status();
+		$this->reset_stats_options();
+	}
+
+	/**
+	 * Drop the stats options `Stats\Options` holds on to between calls.
+	 */
+	private function reset_stats_options() {
+		$options = new ReflectionProperty( Stats_Options::class, 'options' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$options->setAccessible( true );
+		}
+		$options->setValue( null, array() );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/class-testcase.php
+++ b/projects/packages/stats-admin/tests/php/class-testcase.php
@@ -107,6 +107,21 @@ abstract class TestCase extends PHPUnit_TestCase {
 	}
 
 	/**
+	 * Drop the mocked tokens but keep the blog ID, as disconnecting a site actually leaves it.
+	 */
+	protected function disconnect_site_keeping_blog_id() {
+		$this->disconnect_site();
+		add_filter(
+			'jetpack_options',
+			static function ( $value, $name ) {
+				return 'id' === $name ? '999' : $value;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
 	 * Intercept the `Jetpack_Options` call and mock the values.
 	 * Site-level connection set-up.
 	 *

--- a/projects/packages/stats-admin/tests/php/class-testcase.php
+++ b/projects/packages/stats-admin/tests/php/class-testcase.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Stats_Admin;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Posts as WorDBless_Posts;
@@ -60,6 +61,9 @@ abstract class TestCase extends PHPUnit_TestCase {
 		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10, 2 );
 		add_filter( 'pre_http_request', array( $this, 'plan_http_response_fixture' ), 10, 3 );
 		delete_option( Odyssey_Assets::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY );
+
+		// The connection status is memoized in a static, so it outlives the mocked options.
+		( new Connection_Manager() )->reset_connection_status();
 	}
 
 	/**
@@ -76,6 +80,14 @@ abstract class TestCase extends PHPUnit_TestCase {
 		remove_filter( 'pre_http_request', array( $this, 'plan_http_response_fixture' ) );
 		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ) );
 		delete_option( Odyssey_Assets::ODYSSEY_STATS_CACHE_BUSTER_CACHE_KEY );
+	}
+
+	/**
+	 * Drop the mocked tokens, leaving a site that was never connected to WordPress.com.
+	 */
+	protected function disconnect_site() {
+		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_site_connection_options' ), 10 );
+		( new Connection_Manager() )->reset_connection_status();
 	}
 
 	/**

--- a/projects/packages/stats/changelog/stats-345-do-not-cache-missing-token
+++ b/projects/packages/stats/changelog/stats-345-do-not-cache-missing-token
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop caching the failure a request makes when the site has no WordPress.com connection, so a site that has just connected sees its stats straight away.

--- a/projects/packages/stats/changelog/stats-345-honour-cache-bypass
+++ b/projects/packages/stats/changelog/stats-345-honour-cache-bypass
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Let a Stats page load asking for fresh data bypass the cached copy, so a site that has just connected or bought a plan is not shown what it saw before.

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -584,9 +584,17 @@ class WPCOM_Stats {
 	 * The dashboard asks for its data over REST, and those requests carry none of the page's
 	 * query, so the marker has to be read from the page that sent them as well.
 	 *
+	 * Limited to users who can view stats: `fetch_stats()` also serves public widgets and
+	 * blocks, and those must not skip the cache because a visitor supplied a query arg or a
+	 * Referer that happens to contain one of the markers.
+	 *
 	 * @return bool
 	 */
 	protected function should_bypass_cache() {
+		if ( ! current_user_can( 'view_stats' ) ) {
+			return false;
+		}
+
 		foreach ( array( 'force_refresh', 'statsPurchaseSuccess' ) as $marker ) {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			if ( isset( $_GET[ $marker ] ) ) {

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -462,6 +462,15 @@ class WPCOM_Stats {
 
 		$wpcom_stats = $this->fetch_remote_stats( $endpoint, $args );
 
+		/*
+		 * A site with no connection fails before a request leaves it, so remembering that failure
+		 * saves no remote call -- and the answer stops being true the moment the site connects.
+		 * Caching it left a freshly connected site staring at an empty dashboard until it expired.
+		 */
+		if ( is_wp_error( $wpcom_stats ) && 'missing_token' === $wpcom_stats->get_error_code() ) {
+			return $wpcom_stats;
+		}
+
 		// To reduce size in storage: store with time as key, store JSON encoded data.
 		$cached_value = is_wp_error( $wpcom_stats ) ? $wpcom_stats : wp_json_encode( $wpcom_stats, JSON_UNESCAPED_SLASHES );
 

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -447,7 +447,7 @@ class WPCOM_Stats {
 		$api_version    = self::STATS_REST_API_VERSION;
 		$cache_key      = md5( implode( '|', array( $endpoint, $api_version, wp_json_encode( $args, JSON_UNESCAPED_SLASHES ) ) ) );
 		$transient_name = self::STATS_CACHE_TRANSIENT_PREFIX . $cache_key;
-		$stats_cache    = get_transient( $transient_name );
+		$stats_cache    = $this->should_bypass_cache() ? false : get_transient( $transient_name );
 
 		if ( $stats_cache ) {
 			$time = key( $stats_cache );
@@ -572,6 +572,34 @@ class WPCOM_Stats {
 		update_post_meta( $post_id, $meta_name, array( time() => $wpcom_stats ) );
 
 		return $wpcom_stats;
+	}
+
+	/**
+	 * Whether the caller has asked for an answer newer than the cached one.
+	 *
+	 * A site that has just connected, or just bought a plan, carries answers from before it did
+	 * -- including failures, which are cached like any other answer. Both markers are the ones
+	 * `Stats_Admin\WPCOM_Client` already honours, so a page load clears every layer or none.
+	 *
+	 * The dashboard asks for its data over REST, and those requests carry none of the page's
+	 * query, so the marker has to be read from the page that sent them as well.
+	 *
+	 * @return bool
+	 */
+	protected function should_bypass_cache() {
+		foreach ( array( 'force_refresh', 'statsPurchaseSuccess' ) as $marker ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( isset( $_GET[ $marker ] ) ) {
+				return true;
+			}
+
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( isset( $_SERVER['HTTP_REFERER'] ) && false !== strpos( (string) $_SERVER['HTTP_REFERER'], $marker ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -466,8 +466,11 @@ class WPCOM_Stats {
 		 * A site with no connection fails before a request leaves it, so remembering that failure
 		 * saves no remote call -- and the answer stops being true the moment the site connects.
 		 * Caching it left a freshly connected site staring at an empty dashboard until it expired.
+		 *
+		 * `no_possible_tokens` is what the connection package reports for a missing blog token
+		 * since it started naming the reason; `missing_token` is what older versions still return.
 		 */
-		if ( is_wp_error( $wpcom_stats ) && 'missing_token' === $wpcom_stats->get_error_code() ) {
+		if ( is_wp_error( $wpcom_stats ) && in_array( $wpcom_stats->get_error_code(), array( 'missing_token', 'no_possible_tokens' ), true ) ) {
 			return $wpcom_stats;
 		}
 

--- a/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
+++ b/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
@@ -865,6 +865,23 @@ class WPCOM_Stats_Test extends StatsBaseTestCase {
 	}
 
 	/**
+	 * Newer connection packages name the missing blog token `no_possible_tokens`; that failure is
+	 * left uncached for the same reason as `missing_token`.
+	 */
+	public function test_get_stats_does_not_cache_a_missing_blog_token() {
+		$expected_error = new WP_Error( 'no_possible_tokens' );
+
+		$this->wpcom_stats
+			->expects( $this->exactly( 2 ) )
+			->method( 'fetch_remote_stats' )
+			->willReturn( $expected_error );
+
+		$this->assertSame( $expected_error, $this->wpcom_stats->get_stats() );
+		$this->assertFalse( self::get_stats_transient( '/sites/1234/stats/' ) );
+		$this->assertSame( $expected_error, $this->wpcom_stats->get_stats() );
+	}
+
+	/**
 	 * A site returning through the connection or checkout flow carries answers from before it
 	 * had one, failures included, and has to be able to ask again.
 	 */

--- a/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
+++ b/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
@@ -844,6 +844,25 @@ class WPCOM_Stats_Test extends StatsBaseTestCase {
 	}
 
 	/**
+	 * A site with no connection fails before a request leaves it, so there is no remote call to
+	 * spare by remembering the failure -- and it stops being true the moment the site connects.
+	 */
+	public function test_get_stats_does_not_cache_a_missing_token() {
+		$expected_error = new WP_Error( 'missing_token' );
+
+		$this->wpcom_stats
+			->expects( $this->exactly( 2 ) )
+			->method( 'fetch_remote_stats' )
+			->willReturn( $expected_error );
+
+		$this->assertSame( $expected_error, $this->wpcom_stats->get_stats() );
+		$this->assertFalse( self::get_stats_transient( '/sites/1234/stats/' ) );
+
+		// A second call asks again rather than serving what the first one saw.
+		$this->assertSame( $expected_error, $this->wpcom_stats->get_stats() );
+	}
+
+	/**
 	 * Test get_stats with arguments.
 	 */
 	public function test_get_stats_with_arguments() {

--- a/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
+++ b/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
@@ -30,6 +30,8 @@ class WPCOM_Stats_Test extends StatsBaseTestCase {
 	protected function set_up() {
 		parent::set_up();
 
+		wp_set_current_user( 0 );
+
 		$this->wpcom_stats = $this->getMockBuilder( 'Automattic\Jetpack\Stats\WPCOM_Stats' )
 			->onlyMethods( array( 'fetch_remote_stats', 'fetch_stats_on_wpcom_simple' ) )
 			->getMock();
@@ -867,6 +869,8 @@ class WPCOM_Stats_Test extends StatsBaseTestCase {
 	 * had one, failures included, and has to be able to ask again.
 	 */
 	public function test_get_stats_ignores_the_cache_when_asked_to_refresh() {
+		$this->grant_view_stats();
+
 		$this->wpcom_stats
 			->expects( $this->exactly( 2 ) )
 			->method( 'fetch_remote_stats' )
@@ -887,6 +891,8 @@ class WPCOM_Stats_Test extends StatsBaseTestCase {
 	 * page was loaded with, so the marker has to be read from the page that sent them.
 	 */
 	public function test_get_stats_ignores_the_cache_when_the_page_asked_to_refresh() {
+		$this->grant_view_stats();
+
 		$this->wpcom_stats
 			->expects( $this->exactly( 2 ) )
 			->method( 'fetch_remote_stats' )
@@ -899,6 +905,41 @@ class WPCOM_Stats_Test extends StatsBaseTestCase {
 		unset( $_SERVER['HTTP_REFERER'] );
 
 		$this->assertArrayNotHasKey( 'cached_at', $stats );
+	}
+
+	/**
+	 * Widgets and blocks fetch stats for anonymous visitors. A public URL that happens to
+	 * carry the dashboard's refresh marker must not skip the cache.
+	 */
+	public function test_get_stats_keeps_the_cache_when_a_visitor_asks_to_refresh() {
+		$this->wpcom_stats
+			->expects( $this->once() )
+			->method( 'fetch_remote_stats' )
+			->willReturn( array( 'dummy' => 'test' ) );
+
+		$this->wpcom_stats->get_stats();
+
+		$_GET['force_refresh'] = '1';
+		$stats                 = $this->wpcom_stats->get_stats();
+		unset( $_GET['force_refresh'] );
+
+		$this->assertArrayHasKey( 'cached_at', $stats );
+	}
+
+	/**
+	 * Grant the current user the capability the dashboard uses, so cache-bypass tests exercise
+	 * the authenticated path rather than the public widgets.
+	 */
+	private function grant_view_stats() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'stats_viewer',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		get_userdata( $user_id )->add_cap( 'view_stats' );
+		wp_set_current_user( $user_id );
 	}
 
 	/**

--- a/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
+++ b/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
@@ -875,11 +875,8 @@ class WPCOM_Stats_Test extends StatsBaseTestCase {
 		$this->wpcom_stats->get_stats();
 
 		$_GET['force_refresh'] = '1';
-		try {
-			$stats = $this->wpcom_stats->get_stats();
-		} finally {
-			unset( $_GET['force_refresh'] );
-		}
+		$stats                 = $this->wpcom_stats->get_stats();
+		unset( $_GET['force_refresh'] );
 
 		$this->assertArrayHasKey( 'dummy', $stats );
 		$this->assertArrayNotHasKey( 'cached_at', $stats );
@@ -898,11 +895,8 @@ class WPCOM_Stats_Test extends StatsBaseTestCase {
 		$this->wpcom_stats->get_stats();
 
 		$_SERVER['HTTP_REFERER'] = 'https://example.com/wp-admin/admin.php?page=stats&force_refresh=1';
-		try {
-			$stats = $this->wpcom_stats->get_stats();
-		} finally {
-			unset( $_SERVER['HTTP_REFERER'] );
-		}
+		$stats                   = $this->wpcom_stats->get_stats();
+		unset( $_SERVER['HTTP_REFERER'] );
 
 		$this->assertArrayNotHasKey( 'cached_at', $stats );
 	}

--- a/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
+++ b/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
@@ -863,6 +863,51 @@ class WPCOM_Stats_Test extends StatsBaseTestCase {
 	}
 
 	/**
+	 * A site returning through the connection or checkout flow carries answers from before it
+	 * had one, failures included, and has to be able to ask again.
+	 */
+	public function test_get_stats_ignores_the_cache_when_asked_to_refresh() {
+		$this->wpcom_stats
+			->expects( $this->exactly( 2 ) )
+			->method( 'fetch_remote_stats' )
+			->willReturn( array( 'dummy' => 'test' ) );
+
+		$this->wpcom_stats->get_stats();
+
+		$_GET['force_refresh'] = '1';
+		try {
+			$stats = $this->wpcom_stats->get_stats();
+		} finally {
+			unset( $_GET['force_refresh'] );
+		}
+
+		$this->assertArrayHasKey( 'dummy', $stats );
+		$this->assertArrayNotHasKey( 'cached_at', $stats );
+	}
+
+	/**
+	 * The dashboard asks for its data over REST, and those requests carry none of the query the
+	 * page was loaded with, so the marker has to be read from the page that sent them.
+	 */
+	public function test_get_stats_ignores_the_cache_when_the_page_asked_to_refresh() {
+		$this->wpcom_stats
+			->expects( $this->exactly( 2 ) )
+			->method( 'fetch_remote_stats' )
+			->willReturn( array( 'dummy' => 'test' ) );
+
+		$this->wpcom_stats->get_stats();
+
+		$_SERVER['HTTP_REFERER'] = 'https://example.com/wp-admin/admin.php?page=stats&force_refresh=1';
+		try {
+			$stats = $this->wpcom_stats->get_stats();
+		} finally {
+			unset( $_SERVER['HTTP_REFERER'] );
+		}
+
+		$this->assertArrayNotHasKey( 'cached_at', $stats );
+	}
+
+	/**
 	 * Test get_stats with arguments.
 	 */
 	public function test_get_stats_with_arguments() {

--- a/projects/plugins/jetpack/changelog/stats-345-pre-connection-dashboard
+++ b/projects/plugins/jetpack/changelog/stats-345-pre-connection-dashboard
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Stats: Show the Stats dashboard before the site is connected to WordPress.com, so a plan can be picked and the site connected from there.


### PR DESCRIPTION
Part of [STATS-345](https://linear.app/a8c/issue/STATS-345)

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Register the Stats dashboard before the site is connected to WordPress.com. The Jetpack plugin registers the Stats menu from its stats module, and modules are not loaded until the site is connected, so Stats was unreachable on a site that never connected. `Stats_Admin\Main` now registers it when nothing else will, which both the Jetpack plugin and the standalone Stats plugin pick up from `Config::ensure( 'stats_admin' )` — no plugin-side wiring, and the connected path is untouched.
* Print the connection state beside the app. Odyssey ships from our CDN and cannot bundle the connection package, so it reads `JP_CONNECTION_INITIAL_STATE` and calls `jetpack/v4/connection/register` itself. Jetpack Search and Protect already print the same blob on their own pages.
* Stop describing a site the app cannot reach. A site keeps its blog ID when it disconnects, so the config was handing the app a full site record for a site whose every request would go unsigned; it now reports blog ID `0` and no `intial_state`, exactly as a site that never connected. The versions and admin URL the app read out of that record are carried at the top level instead.
* Pre-connection the menu takes `manage_options`, since the page exists to connect the site, which only a user who can manage the connection can do. Once connected it is a reporting page on `view_stats`, as before.
* Return `site_not_connected` with a status instead of letting a statusless `WP_Error` render as a 500, and stop caching what an unconnected site could not fetch — see below.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* [STATS-345](https://linear.app/a8c/issue/STATS-345) — Give the standalone plugin a Search-style activation & pricing screen
* Companion, ships the screen itself: Automattic/wp-calypso#113497
* Supersedes #51182, which solved the same issue with a second Odyssey bundle

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->

No. No new tracking, and no data leaves the site that did not before. The connection state now printed on the Stats page is the same blob Search and Protect already print on theirs.

## Two bugs this turned up

Both were found taking a real site through the new screen, and both are the reason a freshly connected site used to land on an empty dashboard:

* **`WPCOM_Stats` did not honour the cache bypass.** `Stats_Admin\WPCOM_Client` lets `force_refresh` and `statsPurchaseSuccess` skip its cache, but the dashboard's own data comes through `WPCOM_Stats`, which honoured neither — so a page asking for fresh data still got the old answers on the requests that matter most. Both markers ride on the page URL while the dashboard fetches over REST with a query of its own, so the referer is read as well, which is what `WPCOM_Client` already does.
* **Failures were cached for five minutes like any other answer.** A site with no connection fails before a request leaves it, so caching that saves no remote call and stops being true the moment the site connects.

## Testing instructions

The companion pull request has to be deployed first — this plugin loads the bundle from the CDN. To test both together, point a local Jetpack at the Calypso branch using the Field Guide's Odyssey Stats *Option 1*:

```
cd apps/odyssey-stats
STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin \
NODE_ENV=production BROWSERSLIST_ENV=wpcom \
yarn workspace @automattic/odyssey-stats run build:stats
```

Then, on a self-hosted site with **no** Jetpack connection — tunnelled, or it lands in offline mode:

1. Confirm the **Stats** menu appears at all. On trunk it does not exist until the site connects.
2. Open it. Expect the plan comparison with real prices. `window.jetpackStatsOdysseyAppConfigData` should carry `blog_id: 0`, no `intial_state`, and top-level `admin_url` / `stats_admin_version`; `window.JP_CONNECTION_INITIAL_STATE` should be present with a `registrationNonce`.
3. **Start for free** → the site registers, you authorize, and you come back to a dashboard with data on the **first** load — no reload needed.
4. Disconnect and try **Get Paid Stats** → the views-tier slider → checkout, which should be siteless and `unlinked=1`.
5. Disconnect a site that was previously connected — so it keeps its blog ID — and confirm it gets the plan choice rather than a dashboard it cannot fetch.
6. Regression, connected: the Stats menu still comes from the module, still respects `enable_odyssey_stats`, and the dashboard is unchanged.

### Verified on a live self-hosted site

Captured against a local docker WordPress over a Jurassic Tube tunnel, running this branch and its companion.

**Free plan — plan choice → registration → authorization → dashboard with data**

![Free plan, from the plan choice through to a dashboard with data](https://github.com/user-attachments/assets/8b5f44c6-7bf7-40c7-ad08-4b8808cc06fd)

**Paid plan — plan choice → feature comparison → views tier → siteless, unlinked checkout**

![Paid plan, from the plan choice through to a siteless, unlinked checkout](https://github.com/user-attachments/assets/6645e81e-d7fb-46e3-9b51-b206df1001b3)

Automated: `jp test php packages/stats-admin` (47 tests) and `jp test php packages/stats` (169 tests) both pass; `phpcs` is clean. `jp phan` crashes locally while parsing `wordpress-stubs.php` on PHP 8.5, identically on packages this branch does not touch, so it is left to CI.
