### PR TITLE
Premium Analytics: isolate Storybook forced-state stories via the query cache

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -526,15 +526,9 @@ autodocs page (`tags: [ '!autodocs' ]`, since the override is keyed by path and 
 force the sibling stories into the same state). See `widgets/search-terms/stories/` for the
 reference.
 
-Setting or clearing a forced state evicts the shared query cache, so a forced-state story always
-refetches under its own state — you do not have to make its query key unique to keep it from
-reading a sibling story's cached response. Widgets still render each state on its own date preset
-(or `max`, or `post_id`) so the states read as separate periods rather than the same one four
-times; keep doing that, but treat it as presentation, not isolation. It was isolation once, and it
-silently failed: the query key is built from the computed `from`/`to`, not the preset id, and
-`last-365-days` and `last-12-months` resolve to the same range except in the year following a
-leap February — so six widgets' `ErrorRetryable` stories served their `Empty` story's cached rows
-for most of every four years (WOOA7S-1899).
+Setting or clearing a forced state evicts the shared query cache, so unique query keys are not
+required for isolation. Different presets or parameters can still help distinguish stories, but
+do not rely on them: distinct preset IDs may compute the same date range (WOOA7S-1899).
 
 `error` mocks a permission-gated 403 and `error-retryable` the proxy's `no_connection` 403. A
 widget that maps its error through `describeError` renders a Retry action only for the latter, so

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -523,9 +523,18 @@ To review a widget's loading / error / empty state directly, force it with
 `setReportMockState( '<endpoint>', 'loading' | 'error' | 'error-retryable' | 'empty' )` in the
 story's `beforeEach`, clearing it in the returned cleanup. Keep such stories off the shared
 autodocs page (`tags: [ '!autodocs' ]`, since the override is keyed by path and would otherwise
-force the sibling stories into the same state) and give each one a date preset distinct from the
-other stories so it hits the mock fresh instead of reading their cached success. See
-`widgets/search-terms/stories/` for the reference.
+force the sibling stories into the same state). See `widgets/search-terms/stories/` for the
+reference.
+
+Setting or clearing a forced state evicts the shared query cache, so a forced-state story always
+refetches under its own state — you do not have to make its query key unique to keep it from
+reading a sibling story's cached response. Widgets still render each state on its own date preset
+(or `max`, or `post_id`) so the states read as separate periods rather than the same one four
+times; keep doing that, but treat it as presentation, not isolation. It was isolation once, and it
+silently failed: the query key is built from the computed `from`/`to`, not the preset id, and
+`last-365-days` and `last-12-months` resolve to the same range except in the year following a
+leap February — so six widgets' `ErrorRetryable` stories served their `Empty` story's cached rows
+for most of every four years (WOOA7S-1899).
 
 `error` mocks a permission-gated 403 and `error-retryable` the proxy's `no_connection` 403. A
 widget that maps its error through `describeError` renders a Retry action only for the latter, so

--- a/projects/packages/premium-analytics/changelog/change-wooa7s-1899-forced-state-cache
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-1899-forced-state-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Storybook: keep a widget's forced loading, error, and empty stories from serving each other's cached data.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -174,24 +174,10 @@ type ReportMockState = 'error' | 'error-retryable' | 'loading' | 'empty';
 const mockStateOverrides = new Map< string, ReportMockState >();
 
 /**
- * Drops every entry from the shared query cache, so the story whose forced state
- * was just set or cleared refetches instead of reading a sibling story's result.
+ * Clear cached queries after a forced mock override changes.
  *
- * Storybook keeps one `queryClient` for the whole session, and a report response
- * stays fresh in it for `DEFAULT_STALE_TIME`. Without this, a forced-state story
- * only renders its own state when its query key happens to differ from every
- * story shown before it — which is why widgets have variously reached for a
- * distinct date preset, `max`, or `post_id`. Those axes are easy to get wrong
- * (`last-365-days` and `last-12-months` compute the same range outside a leap
- * window, so an `Empty` story silently served its cached rows to the
- * `ErrorRetryable` one) and some endpoints offer no axis at all. Evicting on both
- * edges makes the isolation unconditional: nothing a story does to its query key
- * can bring the bleed back.
- *
- * Clearing everything rather than one key is deliberate — forced-state stories
- * are scoped out of the autodocs page, so no sibling widget is on screen to lose
- * a useful cache entry, and a per-key list would have to be kept in step with
- * each widget's queries by hand.
+ * Forced-state stories are excluded from autodocs, so clearing the shared cache
+ * is safe and avoids coupling mocks to widget query keys.
  */
 export function resetForcedStateQueries(): void {
 	queryClient.clear();
@@ -203,8 +189,6 @@ export function resetForcedStateQueries(): void {
  * (set on enter, clear on cleanup). Because the override is keyed by path, scope
  * stories that use it out of the shared autodocs page (`tags: [ '!autodocs' ]`)
  * so it cannot bleed into sibling stories rendered alongside it.
- *
- * Both edges evict the shared query cache — see `resetForcedStateQueries()`.
  *
  * @param pathFragment - Substring matched against the request path (e.g. `stats/search-terms`).
  * @param state        - The forced state, or `null` to clear.
@@ -282,7 +266,6 @@ const mockResponseOverrides = new Map< string, unknown >();
  * over-limit reading, a specific row shape) the default fixture doesn't cover.
  * Same scoping caveat: keyed by path, so scope such stories out of the shared
  * autodocs page (`tags: [ '!autodocs' ]`) and clear the override on cleanup.
- * Both edges evict the shared query cache — see `resetForcedStateQueries()`.
  *
  * @param pathFragment - Substring matched against the request path.
  * @param response     - The response body to resolve with, or `null` to clear.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -174,11 +174,37 @@ type ReportMockState = 'error' | 'error-retryable' | 'loading' | 'empty';
 const mockStateOverrides = new Map< string, ReportMockState >();
 
 /**
+ * Drops every entry from the shared query cache, so the story whose forced state
+ * was just set or cleared refetches instead of reading a sibling story's result.
+ *
+ * Storybook keeps one `queryClient` for the whole session, and a report response
+ * stays fresh in it for `DEFAULT_STALE_TIME`. Without this, a forced-state story
+ * only renders its own state when its query key happens to differ from every
+ * story shown before it — which is why widgets have variously reached for a
+ * distinct date preset, `max`, or `post_id`. Those axes are easy to get wrong
+ * (`last-365-days` and `last-12-months` compute the same range outside a leap
+ * window, so an `Empty` story silently served its cached rows to the
+ * `ErrorRetryable` one) and some endpoints offer no axis at all. Evicting on both
+ * edges makes the isolation unconditional: nothing a story does to its query key
+ * can bring the bleed back.
+ *
+ * Clearing everything rather than one key is deliberate — forced-state stories
+ * are scoped out of the autodocs page, so no sibling widget is on screen to lose
+ * a useful cache entry, and a per-key list would have to be kept in step with
+ * each widget's queries by hand.
+ */
+export function resetForcedStateQueries(): void {
+	queryClient.clear();
+}
+
+/**
  * Force every request whose path contains `pathFragment` into a loading or error
  * state, or clear the override with `null`. Intended for a story's `beforeEach`
  * (set on enter, clear on cleanup). Because the override is keyed by path, scope
  * stories that use it out of the shared autodocs page (`tags: [ '!autodocs' ]`)
  * so it cannot bleed into sibling stories rendered alongside it.
+ *
+ * Both edges evict the shared query cache — see `resetForcedStateQueries()`.
  *
  * @param pathFragment - Substring matched against the request path (e.g. `stats/search-terms`).
  * @param state        - The forced state, or `null` to clear.
@@ -189,6 +215,7 @@ export function setReportMockState( pathFragment: string, state: ReportMockState
 	} else {
 		mockStateOverrides.set( pathFragment, state );
 	}
+	resetForcedStateQueries();
 }
 
 /**
@@ -255,6 +282,7 @@ const mockResponseOverrides = new Map< string, unknown >();
  * over-limit reading, a specific row shape) the default fixture doesn't cover.
  * Same scoping caveat: keyed by path, so scope such stories out of the shared
  * autodocs page (`tags: [ '!autodocs' ]`) and clear the override on cleanup.
+ * Both edges evict the shared query cache — see `resetForcedStateQueries()`.
  *
  * @param pathFragment - Substring matched against the request path.
  * @param response     - The response body to resolve with, or `null` to clear.
@@ -265,6 +293,7 @@ export function setReportMockResponse( pathFragment: string, response: unknown |
 	} else {
 		mockResponseOverrides.set( pathFragment, response );
 	}
+	resetForcedStateQueries();
 }
 
 /**

--- a/projects/packages/premium-analytics/widgets/devices/stories/devices-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/devices/stories/devices-widget.stories.tsx
@@ -153,7 +153,7 @@ export const ErrorRetryable: StoryObj< DevicesStoryControls > = {
  * glyph and "No device data in this period.").
  */
 export const Empty: StoryObj< DevicesStoryControls > = {
-	render: () => renderDevicesOnPreset( 'last-365-days' ),
+	render: () => renderDevicesOnPreset( 'last-year' ),
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/popular-days/stories/popular-days-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-days/stories/popular-days-widget.stories.tsx
@@ -128,8 +128,8 @@ export const ErrorRetryable: Story = {
  */
 export const Empty: Story = {
 	// A calendar year, not a rolling window: `last-365-days` and `last-12-months`
-	// resolve to the same dates most years, which would share ErrorRetryable's
-	// query key and serve this story's cached empty result there instead.
+	// resolve to the same dates most years, so the two would read as the same
+	// period side by side.
 	render: () => renderPopularDaysOnPreset( 'last-year' ),
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],

--- a/projects/packages/premium-analytics/widgets/popular-days/stories/popular-days-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-days/stories/popular-days-widget.stories.tsx
@@ -127,9 +127,7 @@ export const ErrorRetryable: Story = {
  * Resolved with no buckets: the widget shows its empty state.
  */
 export const Empty: Story = {
-	// A calendar year, not a rolling window: `last-365-days` and `last-12-months`
-	// resolve to the same dates most years, so the two would read as the same
-	// period side by side.
+	// Avoid presenting the same date range as ErrorRetryable in most years.
 	render: () => renderPopularDaysOnPreset( 'last-year' ),
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],

--- a/projects/packages/premium-analytics/widgets/popular-post/stories/popular-post-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-post/stories/popular-post-widget.stories.tsx
@@ -124,9 +124,7 @@ export const ErrorRetryable: Story = {
  * Resolved with no rows: the widget shows its empty state.
  */
 export const Empty: Story = {
-	// A calendar year, not a rolling window: `last-365-days` and `last-12-months`
-	// resolve to the same dates most years, so the two would read as the same
-	// period side by side.
+	// Avoid presenting the same date range as ErrorRetryable in most years.
 	render: () => renderPopularPostOnPreset( 'last-year' ),
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas, withStoryRouter ],

--- a/projects/packages/premium-analytics/widgets/popular-post/stories/popular-post-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-post/stories/popular-post-widget.stories.tsx
@@ -125,8 +125,8 @@ export const ErrorRetryable: Story = {
  */
 export const Empty: Story = {
 	// A calendar year, not a rolling window: `last-365-days` and `last-12-months`
-	// resolve to the same dates most years, which would share ErrorRetryable's
-	// query key and serve this story's cached empty result there instead.
+	// resolve to the same dates most years, so the two would read as the same
+	// period side by side.
 	render: () => renderPopularPostOnPreset( 'last-year' ),
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas, withStoryRouter ],

--- a/projects/packages/premium-analytics/widgets/search-terms/stories/search-terms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/search-terms/stories/search-terms-widget.stories.tsx
@@ -135,7 +135,7 @@ export const ErrorRetryable: Story = {
  * glyph and "No search terms in this period.").
  */
 export const Empty: Story = {
-	render: () => renderSearchTermsOnPreset( 'last-365-days' ),
+	render: () => renderSearchTermsOnPreset( 'last-year' ),
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/stories/force-stats-mock-state.ts
+++ b/projects/packages/premium-analytics/widgets/stories/force-stats-mock-state.ts
@@ -2,6 +2,10 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import { resetForcedStateQueries } from '../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
 
 type ForcedMockState = 'error' | 'error-retryable' | 'loading' | 'empty';
@@ -69,13 +73,13 @@ const forcedStateMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
  * comments point here rather than repeating the rationale in every widget file):
  * - Tag them `!autodocs`. The override is keyed by path, so on the shared
  *   autodocs page it would force every sibling story into the same state.
- * - Render each on a date preset distinct from the widget's other stories. The
- *   query key derives from the date range, so a unique preset gives the story
- *   its own cache entry and it hits the mock fresh instead of reading another
- *   story's cached success from the shared query client. When a widget's query
- *   key carries no date params, a distinct preset can't isolate it — evict the
- *   query from the shared client on enter and cleanup instead (see the
- *   `latest-post` stories).
+ * - Correctness does not depend on the story's query key being unique: both
+ *   edges evict the shared query cache, so a forced-state story always refetches
+ *   under its own state. Widgets still render each state on its own date preset
+ *   (or `max`, or `post_id`) so the states read as separate periods rather than
+ *   the same one four times — keep that up, but do not rely on it for isolation.
+ *   It is easy to get wrong: `last-365-days` and `last-12-months` compute the
+ *   same range outside a leap window.
  * - `'error'` mocks a permission-gated 403 and `'error-retryable'` the proxy's
  *   `no_connection` 403. Widgets on `describeError` render a Retry action only
  *   for the latter, so give those widgets a story for each.
@@ -90,4 +94,5 @@ export function forceStatsMockState( pathFragment: string, state: ForcedMockStat
 		apiFetch.use( forcedStateMiddleware );
 		stateOverrides.set( pathFragment, state );
 	}
+	resetForcedStateQueries();
 }

--- a/projects/packages/premium-analytics/widgets/stories/force-stats-mock-state.ts
+++ b/projects/packages/premium-analytics/widgets/stories/force-stats-mock-state.ts
@@ -53,36 +53,13 @@ const forcedStateMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 };
 
 /**
- * Story-side counterpart of `setReportMockState` for endpoints owned by
- * story-local or legacy stats mocks, e.g. `stats/clicks`, `stats/referrers`,
- * `reports/products`, or `latest-post`.
+ * Force a state for requests handled by story-local or legacy mocks.
  *
- * The shared override in `register-report-mocks.ts` can miss those requests:
- * the last-registered `apiFetch` middleware runs first, so legacy stats mocks or
- * story-local endpoint mocks can answer before the shared override loop sees
- * the request. Storybook can lazy-load more story modules later, so this helper
- * re-registers its shared middleware whenever a forced state is set. The
- * duplicate registrations are intentional: they share the same override map and
- * keep the forced-state middleware ahead of any later endpoint-specific
- * middleware.
+ * Re-register the middleware when setting a state because the most recently
+ * registered `apiFetch` middleware runs first and stories load lazily.
  *
- * Same contract as `setReportMockState`: call it in a story's `beforeEach` and
- * clear the override with `null` in the returned cleanup.
- *
- * Conventions for the forced-state stories that drive this helper (the per-story
- * comments point here rather than repeating the rationale in every widget file):
- * - Tag them `!autodocs`. The override is keyed by path, so on the shared
- *   autodocs page it would force every sibling story into the same state.
- * - Correctness does not depend on the story's query key being unique: both
- *   edges evict the shared query cache, so a forced-state story always refetches
- *   under its own state. Widgets still render each state on its own date preset
- *   (or `max`, or `post_id`) so the states read as separate periods rather than
- *   the same one four times — keep that up, but do not rely on it for isolation.
- *   It is easy to get wrong: `last-365-days` and `last-12-months` compute the
- *   same range outside a leap window.
- * - `'error'` mocks a permission-gated 403 and `'error-retryable'` the proxy's
- *   `no_connection` 403. Widgets on `describeError` render a Retry action only
- *   for the latter, so give those widgets a story for each.
+ * Use in `beforeEach`, clear on cleanup, and exclude the story from autodocs
+ * because overrides are keyed by path. Cache isolation is automatic.
  *
  * @param pathFragment - Substring matched against the request path (e.g. `stats/clicks`).
  * @param state        - The forced state, or `null` to clear.

--- a/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
@@ -184,7 +184,7 @@ export const ErrorRetryable: StoryObj< TopPlatformsStoryControls > = {
  * glyph and "No platform data in this period.").
  */
 export const Empty: StoryObj< TopPlatformsStoryControls > = {
-	render: () => renderTopPlatformsOnPreset( 'last-365-days' ),
+	render: () => renderTopPlatformsOnPreset( 'last-year' ),
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/total-views/stories/total-views-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-views/stories/total-views-widget.stories.tsx
@@ -127,7 +127,7 @@ export const ErrorRetryable: Story = {
  * Resolved with no buckets: the widget shows its empty state.
  */
 export const Empty: Story = {
-	render: () => renderTotalViewsOnPreset( 'last-365-days' ),
+	render: () => renderTotalViewsOnPreset( 'last-year' ),
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/total-visitors/stories/total-visitors-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-visitors/stories/total-visitors-widget.stories.tsx
@@ -127,7 +127,7 @@ export const ErrorRetryable: Story = {
  * Resolved with no buckets: the widget shows its empty state.
  */
 export const Empty: Story = {
-	render: () => renderTotalVisitorsOnPreset( 'last-365-days' ),
+	render: () => renderTotalVisitorsOnPreset( 'last-year' ),
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/utm-insights/stories/utm-insights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/stories/utm-insights-widget.stories.tsx
@@ -150,7 +150,7 @@ export const ErrorRetryable: Story = {
  * glyph and "No UTM data in this period.").
  */
 export const Empty: Story = {
-	render: () => renderUtmInsightsOnPreset( 'last-365-days' ),
+	render: () => renderUtmInsightsOnPreset( 'last-year' ),
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {


### PR DESCRIPTION
Fixes WOOA7S-1899

## Proposed changes

Storybook's forced loading, error, and empty stories share one query client. They previously relied on distinct query keys for isolation, but different date presets can compute the same range and reuse a sibling story's cached response.

- Clear the shared query cache whenever a forced state or response is set or removed.
- Use `last-year` for six `Empty` stories that otherwise present the same range as `last-12-months` in most years.
- Update the Storybook guidance to clarify that distinct presets are for presentation, not cache isolation.

## Related product discussion/links

- WOOA7S-1899

## Does this pull request change what data or activity we track or use?

No. These changes only affect Storybook.

## Testing instructions

1. Run Storybook with `pnpm --filter @automattic/jetpack-storybook storybook:dev`.
2. Open **Packages / Premium Analytics / Widgets / SearchTerms**.
3. Select **Empty**, then select **ErrorRetryable** without reloading.
4. Confirm **ErrorRetryable** shows an error and **Retry** button instead of the cached empty state.
5. Repeat for Devices, TopPlatforms, TotalViews, TotalVisitors, and UtmInsights.
6. Confirm switching from `Loading` or `Error` back to `Default` restores populated data.


https://github.com/user-attachments/assets/5fcb13dc-e944-48ff-b677-38f737820a3c

