### PR TITLE
Premium Analytics: resolve the site timezone once and anchor date-only values to it

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1820-site-timezone
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1820-site-timezone
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix report dates shifting by a day, and briefly using the visitor's timezone on load, for sites west of UTC.
+Fix report dates shifting by a day on sites west of UTC, and stop the date picker briefly using the visitor's timezone on load.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1820-site-timezone
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1820-site-timezone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix report dates shifting by a day, and briefly using the visitor's timezone on load, for sites west of UTC.

--- a/projects/packages/premium-analytics/packages/data/README.md
+++ b/projects/packages/premium-analytics/packages/data/README.md
@@ -398,30 +398,19 @@ const withTZ = dateToISOStringWithLocalTZ( new Date() );
 
 **Returns:** `string` - ISO string with timezone offset
 
-### `getSiteTimezone()`
-
-Returns the WordPress site's configured timezone string.
-
-```typescript
-const timezone = getSiteTimezone();
-// Returns: "America/New_York" or "+05:30" (offset format)
-```
-
-**Returns:** `string` - Site timezone from WordPress settings
-
-**Note:** This function will throw an error if called before core settings
-are loaded. Use `ensureCoreSettingsReady()` in route loaders to prevent
-this.
+**Note:** The site timezone comes from `siteTimeZone()` in
+`@jetpack-premium-analytics/datetime`, which reads the WordPress date
+settings that ship with the page. It needs no await.
 
 ### `ensureCoreSettingsReady()`
 
-Ensures WordPress core settings (site and general settings) are loaded
-before accessing timezone-dependent functions.
+Ensures the WordPress core `site` and `general settings` records are
+resolved, so components reading them (e.g. `useSiteHomeUrl`) render with a
+warm cache.
 
 ```typescript
 // In route loaders or beforeLoad hooks
 await ensureCoreSettingsReady();
-// Now getSiteTimezone() can be safely called
 ```
 
 **Returns:** `Promise<void>` - Resolves when settings are loaded
@@ -463,8 +452,7 @@ This package exports the following public API:
 
 - `localTZDate` - Create timezone-aware dates
 - `dateToISOStringWithLocalTZ` - Convert to ISO with timezone
-- `getSiteTimezone` - Get WordPress site timezone
-- `ensureCoreSettingsReady` - Ensure settings are loaded
+- `ensureCoreSettingsReady` - Ensure core settings records are resolved
 
 ### Constants
 

--- a/projects/packages/premium-analytics/packages/data/src/defaults/__tests__/get-default-preset.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/defaults/__tests__/get-default-preset.test.ts
@@ -1,25 +1,21 @@
-/**
- * Mock WordPress dependencies so date.ts can load. The select mock
- * returns site settings with timezone: 'UTC' so getSiteTimezone()
- * returns UTC, making localTZDate create UTC-aware TZDates.
- */
-jest.mock( '@wordpress/core-data', () => ( {
-	store: 'core',
-} ) );
-
-jest.mock( '@wordpress/data', () => ( {
-	select: jest.fn( () => ( {
-		getEntityRecord: jest.fn( () => ( { timezone: 'UTC' } ) ),
-	} ) ),
-} ) );
-
 jest.mock( '../../utils/ensure-core-settings', () => ( {
 	ensureCoreSettingsReady: jest.fn( () => Promise.resolve() ),
 } ) );
 /**
+ * External dependencies
+ */
+import { getSettings, setSettings } from '@wordpress/date';
+/**
  * Internal dependencies
  */
 import { getDefaultPreset, getDefaultQueryParams } from '../reports';
+
+// `localTZDate()` defaults to the site zone, so pin it rather than letting the
+// machine timezone decide which calendar day the presets resolve to.
+setSettings( {
+	...getSettings(),
+	timezone: { string: 'UTC', offset: 0, offsetFormatted: '0', abbr: 'UTC' },
+} );
 
 describe( 'getDefaultQueryParams - preset override', () => {
 	beforeEach( () => {

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -234,8 +234,6 @@ export {
 export {
 	dateToISOStringWithLocalTZ,
 	ensureCoreSettingsReady,
-	getSiteTimezone,
-	getSiteGmtOffset,
 	localTZDate,
 	hasProductFilters,
 	isSelectablePreset,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/chart-buckets.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/chart-buckets.ts
@@ -38,8 +38,8 @@ export function getStatsChartBucketKey( date: string, period: StatsChartBucketPe
  * The caller maps each data point to its chart metrics, including the required
  * headline `value`. Metrics are summed when daily points share a chart bucket.
  * Each bucket's `date_start` combines the bucket-key date with the first daily
- * point's time and offset. This keeps `localTZDate()` anchored to the bucket-key
- * calendar date; a bare `YYYY-MM-DD` would instead be parsed as a UTC instant.
+ * point's time and offset, so the bucket carries the offset its payload stated
+ * rather than being re-anchored to whatever zone the site is on now.
  *
  * @param report          - The normalized daily Stats report.
  * @param period          - The chart bucket period.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/chart-buckets.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/chart-buckets.ts
@@ -37,9 +37,7 @@ export function getStatsChartBucketKey( date: string, period: StatsChartBucketPe
  *
  * The caller maps each data point to its chart metrics, including the required
  * headline `value`. Metrics are summed when daily points share a chart bucket.
- * Each bucket's `date_start` combines the bucket-key date with the first daily
- * point's time and offset, so the bucket carries the offset its payload stated
- * rather than being re-anchored to whatever zone the site is on now.
+ * Each bucket preserves the first daily point's time and offset.
  *
  * @param report          - The normalized daily Stats report.
  * @param period          - The chart bucket period.

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -1,24 +1,8 @@
 /**
- * Mock WordPress dependencies so date.ts can load. The select mock returns
- * site settings with timezone: 'UTC' so getSiteTimezone() returns UTC,
- * making localTZDate's default (site-timezone) calls deterministic
- * regardless of the machine running the test (e.g. the WordAds "yesterday"
- * clamp in stats-wordads-query.ts).
- */
-jest.mock( '@wordpress/core-data', () => ( {
-	store: 'core',
-} ) );
-
-jest.mock( '@wordpress/data', () => ( {
-	select: jest.fn( () => ( {
-		getEntityRecord: jest.fn( () => ( { timezone: 'UTC' } ) ),
-	} ) ),
-} ) );
-
-/**
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { getSettings, setSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
@@ -70,6 +54,14 @@ import { statsWordAdsEarningsQuery, statsWordAdsStatsQuery } from '../stats-word
 import type { StatsReportParams } from '../stats-query';
 
 jest.mock( '@wordpress/api-fetch' );
+
+// `localTZDate()` defaults to the site zone, so pin it rather than letting the
+// machine timezone decide the WordAds "yesterday" clamp in
+// stats-wordads-query.ts.
+setSettings( {
+	...getSettings(),
+	timezone: { string: 'UTC', offset: 0, offsetFormatted: '0', abbr: 'UTC' },
+} );
 
 const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
 

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/compute-date-range-from-preset.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/compute-date-range-from-preset.test.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { tz } from '@date-fns/tz';
+import { getSettings, setSettings } from '@wordpress/date';
 import {
 	startOfDay,
 	endOfDay,
@@ -17,22 +18,24 @@ import {
 	endOfYear,
 } from 'date-fns';
 /**
- * Mocks – getSiteTimezone and dateToISOStringWithLocalTZ
- * depend on WordPress core store.
- * We mock them to remove that dependency.
- *
- * dateToISOStringWithLocalTZ normalizes to UTC Z-format
- * (matching native Date.toISOString) since the mock timezone
- * is +00:00 and all dates are UTC.
+ * Mocks – `dateToISOStringWithLocalTZ` normalizes to UTC Z-format (matching
+ * native Date.toISOString) so the expectations below can be plain UTC instants.
+ * The site zone itself is pinned through `setSettings` after the imports.
  */
 jest.mock( '../date', () => ( {
-	getSiteTimezone: jest.fn( () => '+00:00' ),
 	dateToISOStringWithLocalTZ: jest.fn( ( date: Date ) => new Date( date.getTime() ).toISOString() ),
 } ) );
 /**
  * Internal dependencies
  */
 import { computeDateRangeFromPreset } from '../preset-date-range';
+
+// `computePrimaryRange` resolves its day bounds in the site zone, so pin it
+// rather than letting the machine timezone decide.
+setSettings( {
+	...getSettings(),
+	timezone: { string: 'UTC', offset: 0, offsetFormatted: '0', abbr: 'UTC' },
+} );
 
 /*
  * Pin "now" to 2026-02-19 12:00:00 UTC for deterministic results.

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/date.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/date.test.ts
@@ -1,30 +1,67 @@
-const mockGetEntityRecord = jest.fn();
-
-jest.mock( '@wordpress/core-data', () => ( {
-	store: 'core',
-} ) );
-
-jest.mock( '@wordpress/data', () => ( {
-	select: jest.fn( () => ( {
-		getEntityRecord: mockGetEntityRecord,
-	} ) ),
-} ) );
-
+/**
+ * External dependencies
+ */
+import { getSettings, setSettings } from '@wordpress/date';
+import { format } from 'date-fns';
 /**
  * Internal dependencies
  */
-import { getSiteTimezone } from '../date';
+import { dateToISOStringWithLocalTZ, formatToTimezoneNaiveString, localTZDate } from '../date';
 
-describe( 'getSiteTimezone', () => {
-	it( 'returns UTC for a site with an empty timezone string and zero offset', () => {
-		mockGetEntityRecord.mockReturnValue( { timezone: '', gmt_offset: 0 } );
+const DEFAULTS = getSettings();
 
-		expect( getSiteTimezone() ).toBe( '+00:00' );
+/**
+ * Put the site on a timezone, the way WordPress does at page load.
+ *
+ * @param string - IANA zone name, empty for offset-configured sites.
+ * @param offset - Offset in hours.
+ */
+const siteOn = ( string: string, offset: number ) =>
+	setSettings( {
+		...DEFAULTS,
+		timezone: { string, offset, offsetFormatted: String( offset ), abbr: '' },
 	} );
 
-	it( 'formats a fractional manual offset', () => {
-		mockGetEntityRecord.mockReturnValue( { timezone: '', gmt_offset: 5.5 } );
+/** The calendar day and clock time the value resolves to in its own zone. */
+const wallTime = ( date: Date ) => format( date, "yyyy-MM-dd'T'HH:mm:ss.SSS" );
 
-		expect( getSiteTimezone() ).toBe( '+05:30' );
+describe( 'localTZDate', () => {
+	// These helpers read the site zone straight from the `@wordpress/date`
+	// settings WordPress installs synchronously, so there is no core-data entity
+	// to await and no window in which they answer in the visitor's zone.
+	it( 'reads a date-only value as site midnight, west of Greenwich', () => {
+		siteOn( 'America/New_York', -4 );
+
+		expect( wallTime( localTZDate( '2026-06-29' ) ) ).toBe( '2026-06-29T00:00:00.000' );
+	} );
+
+	it( 'reads a date-only value as site midnight, east of Greenwich', () => {
+		siteOn( 'Europe/Amsterdam', 2 );
+
+		expect( wallTime( localTZDate( '2026-06-29' ) ) ).toBe( '2026-06-29T00:00:00.000' );
+	} );
+
+	it( 'honours a site configured with a manual offset', () => {
+		siteOn( '', 5.5 );
+
+		expect( dateToISOStringWithLocalTZ( localTZDate( '2026-06-29' ) ) ).toBe(
+			'2026-06-29T00:00:00.000+05:30'
+		);
+	} );
+
+	it( 'lets an explicit timezone override the site', () => {
+		siteOn( 'America/New_York', -4 );
+
+		expect( localTZDate( '2026-06-29', '+00:00' ).toISOString() ).toBe(
+			'2026-06-29T00:00:00.000Z'
+		);
+	} );
+
+	it( 'formats a naive string in the site zone', () => {
+		siteOn( 'America/New_York', -4 );
+
+		expect( formatToTimezoneNaiveString( localTZDate( '2026-06-29T13:30:00Z' ) ) ).toBe(
+			'2026-06-29T09:30:00.000'
+		);
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/date.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/date.test.ts
@@ -10,25 +10,15 @@ import { dateToISOStringWithLocalTZ, formatToTimezoneNaiveString, localTZDate } 
 
 const DEFAULTS = getSettings();
 
-/**
- * Put the site on a timezone, the way WordPress does at page load.
- *
- * @param string - IANA zone name, empty for offset-configured sites.
- * @param offset - Offset in hours.
- */
 const siteOn = ( string: string, offset: number ) =>
 	setSettings( {
 		...DEFAULTS,
 		timezone: { string, offset, offsetFormatted: String( offset ), abbr: '' },
 	} );
 
-/** The calendar day and clock time the value resolves to in its own zone. */
 const wallTime = ( date: Date ) => format( date, "yyyy-MM-dd'T'HH:mm:ss.SSS" );
 
 describe( 'localTZDate', () => {
-	// These helpers read the site zone straight from the `@wordpress/date`
-	// settings WordPress installs synchronously, so there is no core-data entity
-	// to await and no window in which they answer in the visitor's zone.
 	it( 'reads a date-only value as site midnight, west of Greenwich', () => {
 		siteOn( 'America/New_York', -4 );
 

--- a/projects/packages/premium-analytics/packages/data/src/utils/date.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/date.ts
@@ -4,76 +4,24 @@
 import { type TZDate } from '@date-fns/tz';
 import {
 	toLocalTZ,
+	siteTimeZone,
 	formatToTimezoneNaiveString as _formatNaive,
 	dateToISOStringWithTZ as _toISOWithTZ,
 } from '@jetpack-premium-analytics/datetime';
-import { store as coreStore, type Settings } from '@wordpress/core-data';
-import { select } from '@wordpress/data';
-
-type FullSettings = Settings & {
-	gmt_offset: number;
-};
-
-let DEFAULT_TIME_ZONE: string;
-try {
-	DEFAULT_TIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone ?? '+00:00';
-} catch {
-	DEFAULT_TIME_ZONE = '+00:00';
-}
-
-function formatGmtOffset( offset: number | undefined ): string {
-	if ( offset === undefined ) {
-		return DEFAULT_TIME_ZONE;
-	}
-
-	const sign = offset >= 0 ? '+' : '-';
-	const abs = Math.abs( offset );
-	const hours = Math.floor( abs );
-	const minutes = Math.floor( ( abs - hours ) * 60 + 1e-6 );
-	return `${ sign }${ String( hours ).padStart( 2, '0' ) }:${ String( minutes ).padStart(
-		2,
-		'0'
-	) }`;
-}
-
-/*
- * Falls back to the GMT offset when the site has no named timezone, and to the
- * browser's timezone when it has neither.
- */
-export function getSiteTimezone() {
-	const siteSettings = select( coreStore ).getEntityRecord( 'root', 'site' ) as FullSettings;
-
-	if ( ! siteSettings ) {
-		return DEFAULT_TIME_ZONE;
-	}
-
-	return siteSettings?.timezone?.length
-		? siteSettings?.timezone
-		: formatGmtOffset( siteSettings?.gmt_offset ) || DEFAULT_TIME_ZONE;
-}
-
-/** The site's GMT offset as a string (e.g. "+05:30", "-08:00"). Throws until settings load. */
-export function getSiteGmtOffset(): string {
-	const siteSettings = select( coreStore ).getEntityRecord( 'root', 'site' ) as FullSettings;
-	if ( ! siteSettings ) {
-		throw new Error( 'getSiteGmtOffset() called before core settings are ready' );
-	}
-	return formatGmtOffset( siteSettings?.gmt_offset ) || DEFAULT_TIME_ZONE;
-}
 
 export function localTZDate( value?: number | string | Date, timezone?: string ): TZDate {
-	const tz = timezone ?? getSiteTimezone();
+	const tz = timezone ?? siteTimeZone();
 	return toLocalTZ( value, tz );
 }
 
 /** TZ-aware Date -> timezone-naive `YYYY-MM-DDTHH:mm:ss.SSS`. */
 export function formatToTimezoneNaiveString( date: Date, timezone?: string ): string {
-	const tz = timezone ?? getSiteTimezone();
+	const tz = timezone ?? siteTimeZone();
 	return _formatNaive( date, tz );
 }
 
 /** TZ-aware Date -> ISO with offset `YYYY-MM-DDTHH:mm:ss.SSSxxx`. */
 export function dateToISOStringWithLocalTZ( date: Date, timezone?: string ): string {
-	const tz = timezone ?? getSiteTimezone();
+	const tz = timezone ?? siteTimeZone();
 	return _toISOWithTZ( date, tz );
 }

--- a/projects/packages/premium-analytics/packages/data/src/utils/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/index.ts
@@ -1,10 +1,4 @@
-export {
-	localTZDate,
-	dateToISOStringWithLocalTZ,
-	formatToTimezoneNaiveString,
-	getSiteTimezone,
-	getSiteGmtOffset,
-} from './date';
+export { localTZDate, dateToISOStringWithLocalTZ, formatToTimezoneNaiveString } from './date';
 export { getApiErrorCode, getApiErrorStatus, shouldRetryApiError } from './api-error';
 export { ensureCoreSettingsReady } from './ensure-core-settings';
 export { getDefaultIntervalForPeriod } from './interval';

--- a/projects/packages/premium-analytics/packages/data/src/utils/preset-date-range.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/preset-date-range.ts
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { computePrimaryRange } from '@jetpack-premium-analytics/datetime';
-import { getSiteTimezone, dateToISOStringWithLocalTZ } from './date';
+import { computePrimaryRange, siteTimeZone } from '@jetpack-premium-analytics/datetime';
+import { dateToISOStringWithLocalTZ } from './date';
 import type { ComputablePresetId } from '@jetpack-premium-analytics/datetime';
 
 /**
@@ -13,7 +13,7 @@ import type { ComputablePresetId } from '@jetpack-premium-analytics/datetime';
 export function computeDateRangeFromPreset(
 	presetId: ComputablePresetId
 ): { from: string; to: string } | undefined {
-	const range = computePrimaryRange( presetId, getSiteTimezone() );
+	const range = computePrimaryRange( presetId, siteTimeZone() );
 	if ( ! range?.from || ! range?.to ) {
 		return undefined;
 	}

--- a/projects/packages/premium-analytics/packages/datetime/README.md
+++ b/projects/packages/premium-analytics/packages/datetime/README.md
@@ -46,13 +46,16 @@ Creates a timezone-aware date in the specified timezone.
 A string that states no offset — `YYYY-MM-DD`, or a `T`- or space-separated
 datetime — is read as **wall time** in that timezone. Values that already
 identify an instant (offset-bearing strings, timestamps, `Date`s) keep their
-instant. A calendar date that does not exist yields an invalid date rather
-than rolling over to the next month.
+instant. Surrounding whitespace is ignored, and a clock time or calendar date
+that does not exist yields an invalid date rather than rolling over — whether
+or not the value states an offset. `parseSiteDateTime` accepts exactly the same
+values, so the two cannot disagree on what is parseable.
 
 ```typescript
 const date = toLocalTZ( '2024-01-15', 'America/New_York' ); // Jan 15 00:00 in New York
 const now = toLocalTZ( undefined, '+05:30' ); // Current time in +05:30
 toLocalTZ( '2024-02-31', 'America/New_York' ); // Invalid Date
+toLocalTZ( '2024-02-31T00:00:00Z', 'America/New_York' ); // Invalid Date
 ```
 
 **Parameters:**

--- a/projects/packages/premium-analytics/packages/datetime/README.md
+++ b/projects/packages/premium-analytics/packages/datetime/README.md
@@ -28,19 +28,37 @@ const date = createTZDateFromParts( [ 2025, 9, 9 ], 'America/New_York' );
 
 **Returns:** `TZDate` - Timezone-aware date object
 
+#### `siteTimeZone()`
+
+The site's timezone, as an identifier `Intl` accepts. Reads the WordPress
+date settings that ship with the page, so it needs no await.
+
+```typescript
+siteTimeZone(); // 'America/New_York', or '+05:30' on an offset-configured site
+```
+
+**Returns:** `string` - An IANA zone name, or a `±HH:MM` offset
+
 #### `toLocalTZ( value?, timezone? )`
 
 Creates a timezone-aware date in the specified timezone.
 
+A string that states no offset — `YYYY-MM-DD`, or a `T`- or space-separated
+datetime — is read as **wall time** in that timezone. Values that already
+identify an instant (offset-bearing strings, timestamps, `Date`s) keep their
+instant. A calendar date that does not exist yields an invalid date rather
+than rolling over to the next month.
+
 ```typescript
-const date = toLocalTZ( '2024-01-15', 'America/New_York' );
+const date = toLocalTZ( '2024-01-15', 'America/New_York' ); // Jan 15 00:00 in New York
 const now = toLocalTZ( undefined, '+05:30' ); // Current time in +05:30
+toLocalTZ( '2024-02-31', 'America/New_York' ); // Invalid Date
 ```
 
 **Parameters:**
 
 - `value` (optional): `number | string | Date` - Date value to convert
-- `timezone` (optional): `string` - Target timezone
+- `timezone` (optional): `string` - Target timezone, default is UTC
 
 **Returns:** `TZDate` - Timezone-aware date object
 

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/site-time-zone.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/site-time-zone.test.ts
@@ -1,12 +1,18 @@
 /**
  * External dependencies
  */
-import { setSettings } from '@wordpress/date';
+import { getSettings, setSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
-import { EN_US_SETTINGS } from '../__fixtures__/wp-date-settings';
 import { siteTimeZone } from '../site-time-zone';
+
+/**
+ * The package's own defaults, captured before any test installs settings over
+ * them, so the "no settings installed" case asserts against what
+ * `@wordpress/date` actually ships rather than a restated copy of it.
+ */
+const DEFAULTS = getSettings();
 
 /**
  * Install settings carrying a specific timezone.
@@ -17,7 +23,7 @@ import { siteTimeZone } from '../site-time-zone';
  */
 const withTimezone = ( timezone: { offset: number; string: string } ) =>
 	setSettings( {
-		...EN_US_SETTINGS,
+		...DEFAULTS,
 		timezone: { ...timezone, offsetFormatted: String( timezone.offset ), abbr: '' },
 	} );
 
@@ -56,6 +62,14 @@ describe( 'siteTimeZone', () => {
 
 	it( 'formats a zero offset', () => {
 		withTimezone( { offset: 0, string: '' } );
+
+		expect( siteTimeZone() ).toBe( '+00:00' );
+	} );
+
+	// The visitor's zone is never the right answer for a site-scoped value, so
+	// the no-settings path has to land on UTC for everyone alike.
+	it( 'resolves to UTC when WordPress installed no settings', () => {
+		setSettings( DEFAULTS );
 
 		expect( siteTimeZone() ).toBe( '+00:00' );
 	} );

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/site-time-zone.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/site-time-zone.test.ts
@@ -7,11 +7,7 @@ import { getSettings, setSettings } from '@wordpress/date';
  */
 import { siteTimeZone } from '../site-time-zone';
 
-/**
- * The package's own defaults, captured before any test installs settings over
- * them, so the "no settings installed" case asserts against what
- * `@wordpress/date` actually ships rather than a restated copy of it.
- */
+/** The package defaults before tests override them. */
 const DEFAULTS = getSettings();
 
 /**
@@ -34,8 +30,6 @@ describe( 'siteTimeZone', () => {
 		expect( siteTimeZone() ).toBe( 'Europe/Amsterdam' );
 	} );
 
-	// A site set to a manual UTC offset rather than a city has no timezone
-	// string at all, so the offset is the only thing left to go on.
 	it( 'falls back to the offset when there is no named timezone', () => {
 		withTimezone( { offset: 8, string: '' } );
 
@@ -66,8 +60,6 @@ describe( 'siteTimeZone', () => {
 		expect( siteTimeZone() ).toBe( '+00:00' );
 	} );
 
-	// The visitor's zone is never the right answer for a site-scoped value, so
-	// the no-settings path has to land on UTC for everyone alike.
 	it( 'resolves to UTC when WordPress installed no settings', () => {
 		setSettings( DEFAULTS );
 

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/site-timestamp.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/site-timestamp.test.ts
@@ -44,6 +44,20 @@ describe( 'readSiteTimestamp', () => {
 	it( 'accepts a leap day', () => {
 		expect( readSiteTimestamp( '2024-02-29' )?.isValid ).toBe( true );
 	} );
+
+	it.each( [
+		'2026-06-29T00:00:00+24:00',
+		'2026-06-29T00:00:00-24:00',
+		'2026-06-29T00:00:00+23:60',
+		'2026-06-29T00:00:00+2360',
+	] )( 'marks the out-of-range offset in %s invalid', value => {
+		expect( readSiteTimestamp( value )?.isValid ).toBe( false );
+	} );
+
+	it( 'accepts an offset at the edge of the range', () => {
+		expect( readSiteTimestamp( '2026-06-29T00:00:00+23:59' )?.isValid ).toBe( true );
+		expect( readSiteTimestamp( '2026-06-29T00:00:00-2359' )?.isValid ).toBe( true );
+	} );
 } );
 
 // Both entry points decide what is parseable from `readSiteTimestamp`, so a
@@ -64,6 +78,12 @@ describe( 'parity between toLocalTZ and parseSiteDateTime', () => {
 		[ '2026-13-45 00:00:00', false ],
 		[ '2026-06-29T12:60:00', false ],
 		[ '2026-06-29T24:00:00Z', false ],
+		[ '2026/06/29', false ],
+		[ '06/29/2026', false ],
+		[ 'June 29, 2026', false ],
+		[ '2026-6-9', false ],
+		[ '2026-06-29T00:00:00+24:00', false ],
+		[ '2026-06-29T00:00:00+23:60', false ],
 	] )( 'both %s treat as parseable: %s', ( value, isParseable ) => {
 		expect( ! isNaN( toLocalTZ( value as string, '+00:00' ).getTime() ) ).toBe( isParseable );
 		expect( parseSiteDateTime( value ) !== undefined ).toBe( isParseable );

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/site-timestamp.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/site-timestamp.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Internal dependencies
+ */
+import { parseSiteDateTime } from '../site-datetime';
+import { readSiteTimestamp } from '../site-timestamp';
+import { toLocalTZ } from '../tz';
+
+describe( 'readSiteTimestamp', () => {
+	it( 'reads the parts of a date-only value', () => {
+		expect( readSiteTimestamp( '2026-06-29' ) ).toEqual( {
+			value: '2026-06-29',
+			parts: [ 2026, 5, 29, 0, 0, 0, 0 ],
+			offset: undefined,
+			isValid: true,
+		} );
+	} );
+
+	it( 'trims surrounding whitespace', () => {
+		expect( readSiteTimestamp( ' 2026-06-29 ' )?.value ).toBe( '2026-06-29' );
+	} );
+
+	it( 'reports the stated offset', () => {
+		expect( readSiteTimestamp( '2026-06-29T00:00:00.000+02:00' )?.offset ).toBe( '+02:00' );
+		expect( readSiteTimestamp( '2026-06-29T00:00:00Z' )?.offset ).toBe( 'Z' );
+	} );
+
+	it( 'pads a truncated millisecond field and truncates a longer one', () => {
+		expect( readSiteTimestamp( '2026-06-29T00:00:00.5' )?.parts[ 6 ] ).toBe( 500 );
+		expect( readSiteTimestamp( '2026-06-29T00:00:00.123456' )?.parts[ 6 ] ).toBe( 123 );
+	} );
+
+	it( 'returns null for a value in another format', () => {
+		expect( readSiteTimestamp( 'not a date' ) ).toBeNull();
+		expect( readSiteTimestamp( '' ) ).toBeNull();
+	} );
+
+	it.each( [ '2026-02-31', '2026-02-31T00:00:00Z', '2026-13-01', '2026-06-29T24:00:00Z' ] )(
+		'marks %s invalid whether or not it states an offset',
+		value => {
+			expect( readSiteTimestamp( value )?.isValid ).toBe( false );
+		}
+	);
+
+	it( 'accepts a leap day', () => {
+		expect( readSiteTimestamp( '2024-02-29' )?.isValid ).toBe( true );
+	} );
+} );
+
+// Both entry points decide what is parseable from `readSiteTimestamp`, so a
+// value accepted by one can never be rejected by the other.
+describe( 'parity between toLocalTZ and parseSiteDateTime', () => {
+	it.each( [
+		[ '2026-06-29', true ],
+		[ ' 2026-06-29 ', true ],
+		[ '2026-07-09 09:42:57', true ],
+		[ '2026-07-09T09:42:57.123', true ],
+		[ '2026-06-29T00:00:00Z', true ],
+		[ '2026-06-29T00:00:00.000+02:00', true ],
+		[ '2024-02-29', true ],
+		[ '', false ],
+		[ 'not a date', false ],
+		[ '2026-02-31', false ],
+		[ '2026-02-31T00:00:00Z', false ],
+		[ '2026-13-45 00:00:00', false ],
+		[ '2026-06-29T12:60:00', false ],
+		[ '2026-06-29T24:00:00Z', false ],
+	] )( 'both %s treat as parseable: %s', ( value, isParseable ) => {
+		expect( ! isNaN( toLocalTZ( value as string, '+00:00' ).getTime() ) ).toBe( isParseable );
+		expect( parseSiteDateTime( value ) !== undefined ).toBe( isParseable );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import { format } from 'date-fns';
+/**
+ * Internal dependencies
+ */
+import { toLocalTZ } from '../tz';
+
+/**
+ * The calendar day and clock time the value resolves to in its own zone.
+ * @param date
+ */
+const wallTime = ( date: Date ) => format( date, "yyyy-MM-dd'T'HH:mm:ss.SSS" );
+
+describe( 'toLocalTZ', () => {
+	describe( 'offset-less values are read as wall time in the target zone', () => {
+		// The regression this guards: `new Date( '2026-06-29' )` is UTC midnight,
+		// which every zone west of Greenwich renders as June 28.
+		it.each( [ 'Europe/Amsterdam', 'America/New_York', 'Pacific/Kiritimati', '+00:00' ] )(
+			'keeps a date-only value on its own calendar day in %s',
+			timeZone => {
+				expect( wallTime( toLocalTZ( '2026-06-29', timeZone ) ) ).toBe( '2026-06-29T00:00:00.000' );
+			}
+		);
+
+		it( 'reads a MySQL datetime as site wall time', () => {
+			expect( wallTime( toLocalTZ( '2026-07-09 09:42:57', 'America/New_York' ) ) ).toBe(
+				'2026-07-09T09:42:57.000'
+			);
+		} );
+
+		it( 'reads a `T`-separated datetime as site wall time', () => {
+			expect( wallTime( toLocalTZ( '2026-07-09T09:42:57.123', 'America/New_York' ) ) ).toBe(
+				'2026-07-09T09:42:57.123'
+			);
+		} );
+
+		it( 'pads a truncated millisecond field', () => {
+			expect( wallTime( toLocalTZ( '2026-07-09T09:42:57.5', 'America/New_York' ) ) ).toBe(
+				'2026-07-09T09:42:57.500'
+			);
+		} );
+
+		it( 'anchors to UTC when no timezone is given', () => {
+			expect( toLocalTZ( '2026-06-29' ).toISOString() ).toBe( '2026-06-29T00:00:00.000Z' );
+		} );
+	} );
+
+	describe( 'values that already identify an instant are left alone', () => {
+		it( 'preserves the instant of an offset-bearing value', () => {
+			// Midnight in Amsterdam is 18:00 the previous day in New York, and
+			// re-anchoring would wrongly move it to New York midnight.
+			expect( wallTime( toLocalTZ( '2026-06-29T00:00:00.000+02:00', 'America/New_York' ) ) ).toBe(
+				'2026-06-28T18:00:00.000'
+			);
+		} );
+
+		it( 'preserves the instant of a `Z`-suffixed value', () => {
+			expect( toLocalTZ( '2026-06-29T00:00:00Z', '+00:00' ).toISOString() ).toBe(
+				'2026-06-29T00:00:00.000Z'
+			);
+		} );
+
+		it( 'preserves the instant of a timestamp', () => {
+			const instant = Date.UTC( 2026, 5, 29, 3, 0, 0 );
+
+			expect( toLocalTZ( instant, 'America/New_York' ).getTime() ).toBe( instant );
+		} );
+
+		it( 'preserves the instant of a Date', () => {
+			const instant = new Date( Date.UTC( 2026, 5, 29, 3, 0, 0 ) );
+
+			expect( toLocalTZ( instant, 'America/New_York' ).getTime() ).toBe( instant.getTime() );
+		} );
+	} );
+
+	describe( 'malformed values', () => {
+		// The constructor rolls impossible dates over, so without the round-trip
+		// check these would silently become real dates instead of invalid ones.
+		it.each( [ '2026-02-31', '2026-13-01', '2026-06-00' ] )(
+			'rejects the impossible date %s',
+			value => {
+				expect( toLocalTZ( value, 'America/New_York' ).getTime() ).toBeNaN();
+			}
+		);
+
+		it( 'rejects a non-date string', () => {
+			expect( toLocalTZ( 'not a date', 'America/New_York' ).getTime() ).toBeNaN();
+		} );
+	} );
+
+	it( 'returns the current instant in the zone when no value is given', () => {
+		const before = Date.now();
+		const now = toLocalTZ( undefined, 'America/New_York' ).getTime();
+
+		expect( now ).toBeGreaterThanOrEqual( before );
+		expect( now ).toBeLessThanOrEqual( Date.now() );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
@@ -48,6 +48,13 @@ describe( 'toLocalTZ', () => {
 			);
 		} );
 
+		// Untrimmed values reach `Date`, which reads them in the browser's zone.
+		it( 'ignores surrounding whitespace', () => {
+			expect( wallTime( toLocalTZ( ' 2026-06-29 ', 'America/New_York' ) ) ).toBe(
+				'2026-06-29T00:00:00.000'
+			);
+		} );
+
 		it( 'anchors to UTC when no timezone is given', () => {
 			expect( toLocalTZ( '2026-06-29' ).toISOString() ).toBe( '2026-06-29T00:00:00.000Z' );
 		} );
@@ -126,6 +133,17 @@ describe( 'toLocalTZ', () => {
 				expect( toLocalTZ( value, 'America/New_York' ).getTime() ).toBeNaN();
 			}
 		);
+
+		// An offset says which instant a wall time names, not that the wall time
+		// exists. `Date` rolls these over, so they are checked before it sees them.
+		it.each( [
+			'2026-02-31T00:00:00Z',
+			'2026-02-31T00:00:00+02:00',
+			'2026-06-29T24:00:00Z',
+			' 2026-13-01T00:00:00Z ',
+		] )( 'rejects the offset-bearing value %s', value => {
+			expect( toLocalTZ( value, 'America/New_York' ).getTime() ).toBeNaN();
+		} );
 	} );
 
 	it( 'returns the current instant in the zone when no value is given', () => {

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
@@ -40,8 +40,43 @@ describe( 'toLocalTZ', () => {
 			);
 		} );
 
+		// Sub-millisecond precision must not drop the value through to `Date`,
+		// which would read it in the browser's zone instead of the site's.
+		it( 'truncates a sub-millisecond field rather than rejecting it', () => {
+			expect( wallTime( toLocalTZ( '2026-07-09T09:42:57.123456', 'America/New_York' ) ) ).toBe(
+				'2026-07-09T09:42:57.123'
+			);
+		} );
+
 		it( 'anchors to UTC when no timezone is given', () => {
 			expect( toLocalTZ( '2026-06-29' ).toISOString() ).toBe( '2026-06-29T00:00:00.000Z' );
+		} );
+	} );
+
+	describe( 'daylight-saving wall times', () => {
+		// Where DST starts at midnight, a date-only value names a wall time that
+		// does not exist. It normalizes forward to 01:00, and the round-trip
+		// guard has to accept that rather than read it as an impossible date.
+		it.each( [
+			[ 'America/Santiago', '2026-09-06' ],
+			[ 'America/Havana', '2026-03-08' ],
+		] )( 'keeps a date-only value on its day when %s has no midnight', ( timeZone, value ) => {
+			const date = toLocalTZ( value, timeZone );
+
+			expect( date.getTime() ).not.toBeNaN();
+			expect( format( date, 'yyyy-MM-dd' ) ).toBe( value );
+		} );
+
+		it( 'normalizes a wall time skipped by a spring-forward jump', () => {
+			expect( wallTime( toLocalTZ( '2026-03-08 02:30:00', 'America/New_York' ) ) ).toBe(
+				'2026-03-08T03:30:00.000'
+			);
+		} );
+
+		it( 'takes the first occurrence of an ambiguous fall-back wall time', () => {
+			expect( toLocalTZ( '2026-11-01 01:30:00', 'America/New_York' ).toISOString() ).toBe(
+				'2026-11-01T05:30:00.000Z'
+			);
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
@@ -15,8 +15,6 @@ const wallTime = ( date: Date ) => format( date, "yyyy-MM-dd'T'HH:mm:ss.SSS" );
 
 describe( 'toLocalTZ', () => {
 	describe( 'offset-less values are read as wall time in the target zone', () => {
-		// The regression this guards: `new Date( '2026-06-29' )` is UTC midnight,
-		// which every zone west of Greenwich renders as June 28.
 		it.each( [ 'Europe/Amsterdam', 'America/New_York', 'Pacific/Kiritimati', '+00:00' ] )(
 			'keeps a date-only value on its own calendar day in %s',
 			timeZone => {
@@ -76,8 +74,6 @@ describe( 'toLocalTZ', () => {
 	} );
 
 	describe( 'malformed values', () => {
-		// The constructor rolls impossible dates over, so without the round-trip
-		// check these would silently become real dates instead of invalid ones.
 		it.each( [ '2026-02-31', '2026-13-01', '2026-06-00' ] )(
 			'rejects the impossible date %s',
 			value => {

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
@@ -119,6 +119,13 @@ describe( 'toLocalTZ', () => {
 		it( 'rejects a non-date string', () => {
 			expect( toLocalTZ( 'not a date', 'America/New_York' ).getTime() ).toBeNaN();
 		} );
+
+		it.each( [ '2026-06-29T24:00:00', '2026-06-29T12:60:00', '2026-06-29T12:30:60' ] )(
+			'rejects the invalid wall time %s',
+			value => {
+				expect( toLocalTZ( value, 'America/New_York' ).getTime() ).toBeNaN();
+			}
+		);
 	} );
 
 	it( 'returns the current instant in the zone when no value is given', () => {

--- a/projects/packages/premium-analytics/packages/datetime/src/index.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/index.ts
@@ -24,6 +24,8 @@ export { stepDateRange, canStepForward, type StepDirection } from './step-date-r
 
 export { parseSiteDateTime } from './site-datetime';
 
+export { siteTimeZone } from './site-time-zone';
+
 export {
 	formatDatePartWithTime,
 	getDateIntervalDateParts,

--- a/projects/packages/premium-analytics/packages/datetime/src/site-datetime.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/site-datetime.ts
@@ -2,16 +2,18 @@
  * External dependencies
  */
 import { getDate } from '@wordpress/date';
-
-/** Date-only, MySQL datetime, or ISO datetime values used by Stats and report params. */
-const SITE_DATE_TIME =
-	/^\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
+/**
+ * Internal dependencies
+ */
+import { readSiteTimestamp } from './site-timestamp';
 
 /**
  * Parse a timestamp in the WordPress site timezone.
  *
  * `getDate` anchors offset-less Stats API values to the timezone configured in
  * WordPress while preserving the instant identified by offset-bearing values.
+ * It shares `toLocalTZ`'s reading of which values are timestamps and which of
+ * those are valid, so the two cannot disagree.
  *
  * @param value - The raw timestamp, or a `Date`.
  * @return The instant, or `undefined` when the value is missing or malformed.
@@ -25,13 +27,13 @@ export function parseSiteDateTime( value: unknown ): Date | undefined {
 		return undefined;
 	}
 
-	const raw = value.trim();
+	const timestamp = readSiteTimestamp( value );
 
-	if ( ! SITE_DATE_TIME.test( raw ) ) {
+	if ( ! timestamp?.isValid ) {
 		return undefined;
 	}
 
-	const parsed = getDate( raw );
+	const parsed = getDate( timestamp.value );
 
 	return isNaN( parsed.getTime() ) ? undefined : parsed;
 }

--- a/projects/packages/premium-analytics/packages/datetime/src/site-time-zone.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/site-time-zone.ts
@@ -6,17 +6,17 @@ import { getSettings } from '@wordpress/date';
 /**
  * The site's timezone, as an identifier `Intl` accepts.
  *
+ * This is the only accessor for the site zone. It reads the settings WordPress
+ * installs synchronously at page load — the same ones every formatter renders
+ * in — so date maths and rendered labels agree on the calendar day from the
+ * first paint, with no entity fetch to wait on.
+ *
  * Sites configured with a manual UTC offset instead of a city have no
  * `timezone_string` at all, so WordPress sends an empty string and carries the
  * zone in `offset` alone. `Intl` rejects `''` as a `timeZone`, so the offset is
- * rendered as a fixed `±HH:MM` identifier instead.
- *
- * This reads the same settings `formatDate` renders in, so a range built here
- * and a single date formatted there agree on the calendar day. Note that
- * `getSiteTimezone()` in `@jetpack-premium-analytics/data` answers the same
- * question from a different source — the core-data `root/site` entity, falling
- * back to the *browser* zone before it loads — so it cannot replace this
- * settings-backed accessor.
+ * rendered as a fixed `±HH:MM` identifier instead. Absent settings entirely,
+ * `@wordpress/date`'s own defaults yield `+00:00`: never the visitor's zone,
+ * which is never the right answer for a site-scoped value.
  *
  * @return An IANA zone name, or a `±HH:MM` offset.
  */

--- a/projects/packages/premium-analytics/packages/datetime/src/site-time-zone.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/site-time-zone.ts
@@ -4,19 +4,10 @@
 import { getSettings } from '@wordpress/date';
 
 /**
- * The site's timezone, as an identifier `Intl` accepts.
+ * Get the site's timezone from WordPress date settings.
  *
- * This is the only accessor for the site zone. It reads the settings WordPress
- * installs synchronously at page load — the same ones every formatter renders
- * in — so date maths and rendered labels agree on the calendar day from the
- * first paint, with no entity fetch to wait on.
- *
- * Sites configured with a manual UTC offset instead of a city have no
- * `timezone_string` at all, so WordPress sends an empty string and carries the
- * zone in `offset` alone. `Intl` rejects `''` as a `timeZone`, so the offset is
- * rendered as a fixed `±HH:MM` identifier instead. Absent settings entirely,
- * `@wordpress/date`'s own defaults yield `+00:00`: never the visitor's zone,
- * which is never the right answer for a site-scoped value.
+ * Sites configured with a UTC offset have no timezone name, so format their
+ * offset as an identifier accepted by `Intl`.
  *
  * @return An IANA zone name, or a `±HH:MM` offset.
  */

--- a/projects/packages/premium-analytics/packages/datetime/src/site-timestamp.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/site-timestamp.ts
@@ -9,6 +9,9 @@
 const SITE_TIMESTAMP =
 	/^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?(Z|[+-]\d{2}:?\d{2})?)?$/;
 
+/** The hours and minutes of a numeric offset. */
+const OFFSET_PARTS = /^[+-](\d{2}):?(\d{2})$/;
+
 /** Wall-clock parts in the same order as the native `Date` constructor. */
 export type TimestampParts = [ number, number, number, number, number, number, number ];
 
@@ -19,7 +22,7 @@ export type SiteTimestamp = {
 	parts: TimestampParts;
 	/** The stated offset, or undefined when the value names a wall time. */
 	offset?: string;
-	/** Whether it names a clock time and a calendar day that exist. */
+	/** Whether it names a clock time, calendar day, and offset that exist. */
 	isValid: boolean;
 };
 
@@ -37,6 +40,22 @@ function isRealCalendarDate( year: number, month: number, day: number ): boolean
 	return (
 		probe.getUTCFullYear() === year && probe.getUTCMonth() === month && probe.getUTCDate() === day
 	);
+}
+
+/**
+ * Whether a stated offset names a real distance from UTC.
+ *
+ * @param offset - The offset as written, or undefined for a wall time.
+ * @return Whether it is absent, `Z`, or within ±23:59.
+ */
+function isRealOffset( offset?: string ): boolean {
+	if ( offset === undefined || offset === 'Z' ) {
+		return true;
+	}
+
+	const match = OFFSET_PARTS.exec( offset );
+
+	return !! match && Number( match[ 1 ] ) <= 23 && Number( match[ 2 ] ) <= 59;
 }
 
 /**
@@ -70,6 +89,7 @@ export function readSiteTimestamp( value: string ): SiteTimestamp | null {
 		parts[ 3 ] <= 23 &&
 		parts[ 4 ] <= 59 &&
 		parts[ 5 ] <= 59 &&
+		isRealOffset( offset ) &&
 		isRealCalendarDate( parts[ 0 ], parts[ 1 ], parts[ 2 ] );
 
 	return { value: trimmed, parts, offset, isValid };

--- a/projects/packages/premium-analytics/packages/datetime/src/site-timestamp.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/site-timestamp.ts
@@ -1,0 +1,76 @@
+/**
+ * Date-only, MySQL datetime, or ISO datetime values used by Stats and report
+ * params.
+ *
+ * The fractional second is matched at any length, and truncated below. Capping
+ * it here would drop a value like `.123456` through to `Date`, which reads an
+ * offset-less string in the *browser's* zone — the shift this package avoids.
+ */
+const SITE_TIMESTAMP =
+	/^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+
+/** Wall-clock parts in the same order as the native `Date` constructor. */
+export type TimestampParts = [ number, number, number, number, number, number, number ];
+
+export type SiteTimestamp = {
+	/** The value with surrounding whitespace removed. */
+	value: string;
+	/** The wall-clock parts it names. */
+	parts: TimestampParts;
+	/** The stated offset, or undefined when the value names a wall time. */
+	offset?: string;
+	/** Whether it names a clock time and a calendar day that exist. */
+	isValid: boolean;
+};
+
+/**
+ * Whether a year, month and day name a day that exists.
+ *
+ * @param year  - The full year.
+ * @param month - The month index, 0–11.
+ * @param day   - The day of the month.
+ * @return Whether the date survives a round trip through `Date`.
+ */
+function isRealCalendarDate( year: number, month: number, day: number ): boolean {
+	const probe = new Date( Date.UTC( year, month, day ) );
+
+	return (
+		probe.getUTCFullYear() === year && probe.getUTCMonth() === month && probe.getUTCDate() === day
+	);
+}
+
+/**
+ * Read a timestamp string in one of the formats this package accepts.
+ *
+ * Every entry point that turns a string into a date goes through here, so they
+ * agree on which values are timestamps at all and which of those are valid.
+ *
+ * @param value - The raw timestamp.
+ * @return The timestamp, or null when the value has another format.
+ */
+export function readSiteTimestamp( value: string ): SiteTimestamp | null {
+	const trimmed = value.trim();
+	const match = SITE_TIMESTAMP.exec( trimmed );
+
+	if ( ! match ) {
+		return null;
+	}
+
+	const [ , year, month, day, hours, minutes, seconds, milliseconds, offset ] = match;
+	const parts: TimestampParts = [
+		Number( year ),
+		Number( month ) - 1,
+		Number( day ),
+		Number( hours ?? 0 ),
+		Number( minutes ?? 0 ),
+		Number( seconds ?? 0 ),
+		Number( ( milliseconds ?? '' ).slice( 0, 3 ).padEnd( 3, '0' ) ),
+	];
+	const isValid =
+		parts[ 3 ] <= 23 &&
+		parts[ 4 ] <= 59 &&
+		parts[ 5 ] <= 59 &&
+		isRealCalendarDate( parts[ 0 ], parts[ 1 ], parts[ 2 ] );
+
+	return { value: trimmed, parts, offset, isValid };
+}

--- a/projects/packages/premium-analytics/packages/datetime/src/tz.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/tz.ts
@@ -60,22 +60,15 @@ export function createTZDateFromParts(
 	return new TZDateMini( ...datePartsTrimmed, tzid );
 }
 
-/**
- * Offset-less `YYYY-MM-DD`, optionally with a `T`- or space-separated time.
- *
- * Values carrying their own offset are deliberately excluded: they already
- * identify an instant, so re-anchoring them would move it.
- */
 const OFFSETLESS_TIMESTAMP =
 	/^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?)?$/;
 
 /**
- * Read an offset-less timestamp as wall time in the given timezone.
+ * Read an offset-less timestamp as wall time in a timezone.
  *
  * @param value    - The timestamp.
  * @param timeZone - The timezone the wall time belongs to.
- * @return The instant, an invalid date when the calendar date does not exist,
- * or null when the value is not an offset-less timestamp at all.
+ * @return The zoned date, or null when the value has another format.
  */
 function offsetlessToTZDate( value: string, timeZone: string ): TZDate | null {
 	const match = OFFSETLESS_TIMESTAMP.exec( value );
@@ -97,11 +90,8 @@ function offsetlessToTZDate( value: string, timeZone: string ): TZDate | null {
 
 	const date = createTZDateFromParts( parts, timeZone );
 
-	// The constructor rolls impossible dates over rather than rejecting them, so
-	// `2026-02-31` would silently become March 3 — and callers that guard a URL
-	// param with `isValid()` would accept it. Report a date that didn't survive
-	// the round trip as invalid instead. A wall time skipped by a DST jump still
-	// lands on the same calendar day, so this doesn't reject those.
+	// Reject calendar dates normalized by the constructor. Compare only date
+	// parts so DST-normalized wall times remain valid.
 	const survivedRoundTrip =
 		date.getFullYear() === parts[ 0 ] &&
 		date.getMonth() === parts[ 1 ] &&
@@ -111,13 +101,7 @@ function offsetlessToTZDate( value: string, timeZone: string ): TZDate | null {
 }
 
 /**
- * Create a TZDate in the provided timezone.
- * Defaults to UTC when no timezone is given.
- *
- * A value that states no offset is read as wall time in `timeZone`. Left to
- * `Date`, a bare `YYYY-MM-DD` resolves to UTC midnight instead, and `TZDate`
- * only re-renders that instant — so every zone west of Greenwich would show the
- * previous day.
+ * Create a TZDate, reading offset-less strings as wall time in the timezone.
  *
  * @param value
  * @param timeZone

--- a/projects/packages/premium-analytics/packages/datetime/src/tz.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/tz.ts
@@ -61,18 +61,83 @@ export function createTZDateFromParts(
 }
 
 /**
+ * Offset-less `YYYY-MM-DD`, optionally with a `T`- or space-separated time.
+ *
+ * Values carrying their own offset are deliberately excluded: they already
+ * identify an instant, so re-anchoring them would move it.
+ */
+const OFFSETLESS_TIMESTAMP =
+	/^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?)?$/;
+
+/**
+ * Read an offset-less timestamp as wall time in the given timezone.
+ *
+ * @param value    - The timestamp.
+ * @param timeZone - The timezone the wall time belongs to.
+ * @return The instant, an invalid date when the calendar date does not exist,
+ * or null when the value is not an offset-less timestamp at all.
+ */
+function offsetlessToTZDate( value: string, timeZone: string ): TZDate | null {
+	const match = OFFSETLESS_TIMESTAMP.exec( value );
+
+	if ( ! match ) {
+		return null;
+	}
+
+	const [ , year, month, day, hours, minutes, seconds, milliseconds ] = match;
+	const parts: DateParts = [
+		Number( year ),
+		Number( month ) - 1,
+		Number( day ),
+		Number( hours ?? 0 ),
+		Number( minutes ?? 0 ),
+		Number( seconds ?? 0 ),
+		Number( ( milliseconds ?? '' ).padEnd( 3, '0' ) ),
+	];
+
+	const date = createTZDateFromParts( parts, timeZone );
+
+	// The constructor rolls impossible dates over rather than rejecting them, so
+	// `2026-02-31` would silently become March 3 — and callers that guard a URL
+	// param with `isValid()` would accept it. Report a date that didn't survive
+	// the round trip as invalid instead. A wall time skipped by a DST jump still
+	// lands on the same calendar day, so this doesn't reject those.
+	const survivedRoundTrip =
+		date.getFullYear() === parts[ 0 ] &&
+		date.getMonth() === parts[ 1 ] &&
+		date.getDate() === parts[ 2 ];
+
+	return survivedRoundTrip ? date : new TZDateMini( NaN, timeZone );
+}
+
+/**
  * Create a TZDate in the provided timezone.
  * Defaults to UTC when no timezone is given.
+ *
+ * A value that states no offset is read as wall time in `timeZone`. Left to
+ * `Date`, a bare `YYYY-MM-DD` resolves to UTC midnight instead, and `TZDate`
+ * only re-renders that instant — so every zone west of Greenwich would show the
+ * previous day.
+ *
  * @param value
  * @param timeZone
  */
 export function toLocalTZ( value?: number | string | Date, timeZone?: string ): TZDate {
 	const tzid = timeZone ?? '+00:00';
-	if ( value !== undefined ) {
-		return new TZDateMini( value as number, tzid );
+
+	if ( value === undefined ) {
+		return TZDateMini.tz( tzid );
 	}
 
-	return TZDateMini.tz( tzid );
+	if ( typeof value === 'string' ) {
+		const anchored = offsetlessToTZDate( value, tzid );
+
+		if ( anchored ) {
+			return anchored;
+		}
+	}
+
+	return new TZDateMini( value as number, tzid );
 }
 
 /**

--- a/projects/packages/premium-analytics/packages/datetime/src/tz.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/tz.ts
@@ -60,15 +60,19 @@ export function createTZDateFromParts(
 	return new TZDateMini( ...datePartsTrimmed, tzid );
 }
 
+// The fractional second is matched at any length, and truncated below. Capping
+// it here would drop a value like `.123456` through to `Date`, which reads an
+// offset-less string in the *browser's* zone — the shift this module avoids.
 const OFFSETLESS_TIMESTAMP =
-	/^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?)?$/;
+	/^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?)?$/;
 
 /**
  * Read an offset-less timestamp as wall time in a timezone.
  *
  * @param value    - The timestamp.
  * @param timeZone - The timezone the wall time belongs to.
- * @return The zoned date, or null when the value has another format.
+ * @return The zoned date, an invalid date when the calendar date does not
+ * exist, or null when the value has another format.
  */
 function offsetlessToTZDate( value: string, timeZone: string ): TZDate | null {
 	const match = OFFSETLESS_TIMESTAMP.exec( value );
@@ -85,7 +89,7 @@ function offsetlessToTZDate( value: string, timeZone: string ): TZDate | null {
 		Number( hours ?? 0 ),
 		Number( minutes ?? 0 ),
 		Number( seconds ?? 0 ),
-		Number( ( milliseconds ?? '' ).padEnd( 3, '0' ) ),
+		Number( ( milliseconds ?? '' ).slice( 0, 3 ).padEnd( 3, '0' ) ),
 	];
 
 	const date = createTZDateFromParts( parts, timeZone );

--- a/projects/packages/premium-analytics/packages/datetime/src/tz.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/tz.ts
@@ -101,17 +101,19 @@ export function toLocalTZ( value?: number | string | Date, timeZone?: string ): 
 	if ( typeof value === 'string' ) {
 		const timestamp = readSiteTimestamp( value );
 
-		if ( timestamp ) {
-			if ( ! timestamp.isValid ) {
-				return new TZDateMini( NaN, tzid );
-			}
-
-			// An offset already identifies an instant, so only wall times are
-			// anchored to the timezone.
-			return timestamp.offset
-				? new TZDateMini( timestamp.value as unknown as number, tzid )
-				: wallTimeToTZDate( timestamp.parts, tzid );
+		// A shape this package does not read reaches `Date` otherwise, which
+		// resolves an offset-less string in the *browser's* zone — the shift this
+		// module avoids — and leaves `parseSiteDateTime` rejecting a value this
+		// accepts.
+		if ( ! timestamp?.isValid ) {
+			return new TZDateMini( NaN, tzid );
 		}
+
+		// An offset already identifies an instant, so only wall times are
+		// anchored to the timezone.
+		return timestamp.offset
+			? new TZDateMini( timestamp.value as unknown as number, tzid )
+			: wallTimeToTZDate( timestamp.parts, tzid );
 	}
 
 	return new TZDateMini( value as number, tzid );

--- a/projects/packages/premium-analytics/packages/datetime/src/tz.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/tz.ts
@@ -3,6 +3,10 @@
  */
 import { tz, TZDate, TZDateMini } from '@date-fns/tz';
 import { format, isValid, startOfDay, endOfDay } from 'date-fns';
+/**
+ * Internal dependencies
+ */
+import { readSiteTimestamp, type TimestampParts } from './site-timestamp';
 
 type GrowTuple< T extends unknown[], Max extends number > = T[ 'length' ] extends Max
 	? T
@@ -60,53 +64,19 @@ export function createTZDateFromParts(
 	return new TZDateMini( ...datePartsTrimmed, tzid );
 }
 
-// The fractional second is matched at any length, and truncated below. Capping
-// it here would drop a value like `.123456` through to `Date`, which reads an
-// offset-less string in the *browser's* zone — the shift this module avoids.
-const OFFSETLESS_TIMESTAMP =
-	/^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?)?$/;
-
 /**
- * Read an offset-less timestamp as wall time in a timezone.
+ * Anchor wall-clock parts to a timezone.
  *
- * @param value    - The timestamp.
+ * @param parts    - The wall-clock parts.
  * @param timeZone - The timezone the wall time belongs to.
- * @return The zoned date, an invalid date when the calendar date does not
- * exist, or null when the value has another format.
+ * @return The zoned date, or an invalid date when the timezone has no such day.
  */
-function offsetlessToTZDate( value: string, timeZone: string ): TZDate | null {
-	const match = OFFSETLESS_TIMESTAMP.exec( value );
-
-	if ( ! match ) {
-		return null;
-	}
-
-	const [ , year, month, day, hours, minutes, seconds, milliseconds ] = match;
-	const parts: DateParts = [
-		Number( year ),
-		Number( month ) - 1,
-		Number( day ),
-		Number( hours ?? 0 ),
-		Number( minutes ?? 0 ),
-		Number( seconds ?? 0 ),
-		Number( ( milliseconds ?? '' ).slice( 0, 3 ).padEnd( 3, '0' ) ),
-	];
-	const hasValidTime =
-		parts[ 3 ] >= 0 &&
-		parts[ 3 ] <= 23 &&
-		parts[ 4 ] >= 0 &&
-		parts[ 4 ] <= 59 &&
-		parts[ 5 ] >= 0 &&
-		parts[ 5 ] <= 59;
-
-	if ( ! hasValidTime ) {
-		return new TZDateMini( NaN, timeZone );
-	}
-
+function wallTimeToTZDate( parts: TimestampParts, timeZone: string ): TZDate {
 	const date = createTZDateFromParts( parts, timeZone );
 
-	// Reject calendar dates normalized by the constructor. Compare only date
-	// parts so DST-normalized wall times remain valid.
+	// A zone that skips a whole day, as Pacific/Apia did on 2011-12-30, moves
+	// the wall time onto the next one. Compare only the date parts, so a wall
+	// time normalized by a DST jump stays valid.
 	const survivedRoundTrip =
 		date.getFullYear() === parts[ 0 ] &&
 		date.getMonth() === parts[ 1 ] &&
@@ -129,10 +99,18 @@ export function toLocalTZ( value?: number | string | Date, timeZone?: string ): 
 	}
 
 	if ( typeof value === 'string' ) {
-		const anchored = offsetlessToTZDate( value, tzid );
+		const timestamp = readSiteTimestamp( value );
 
-		if ( anchored ) {
-			return anchored;
+		if ( timestamp ) {
+			if ( ! timestamp.isValid ) {
+				return new TZDateMini( NaN, tzid );
+			}
+
+			// An offset already identifies an instant, so only wall times are
+			// anchored to the timezone.
+			return timestamp.offset
+				? new TZDateMini( timestamp.value as unknown as number, tzid )
+				: wallTimeToTZDate( timestamp.parts, tzid );
 		}
 	}
 

--- a/projects/packages/premium-analytics/packages/datetime/src/tz.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/tz.ts
@@ -91,6 +91,17 @@ function offsetlessToTZDate( value: string, timeZone: string ): TZDate | null {
 		Number( seconds ?? 0 ),
 		Number( ( milliseconds ?? '' ).slice( 0, 3 ).padEnd( 3, '0' ) ),
 	];
+	const hasValidTime =
+		parts[ 3 ] >= 0 &&
+		parts[ 3 ] <= 23 &&
+		parts[ 4 ] >= 0 &&
+		parts[ 4 ] <= 59 &&
+		parts[ 5 ] >= 0 &&
+		parts[ 5 ] <= 59;
+
+	if ( ! hasValidTime ) {
+		return new TZDateMini( NaN, timeZone );
+	}
 
 	const date = createTZDateFromParts( parts, timeZone );
 

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
@@ -5,11 +5,11 @@ import {
 	getDefaultPreset,
 	normalizeReportParams,
 	localTZDate,
-	getSiteTimezone,
 } from '@jetpack-premium-analytics/data';
 import {
 	type ComparisonPresetId,
 	isPrimaryPreset,
+	siteTimeZone,
 	type DateRange,
 } from '@jetpack-premium-analytics/datetime';
 import { Stack } from '@jetpack-premium-analytics/externals';
@@ -130,7 +130,7 @@ export function ReportParamsField( {
 				onApply={ commit }
 				canApply={ isDateRangeDirty }
 				onCancel={ clear }
-				timeZone={ getSiteTimezone() }
+				timeZone={ siteTimeZone() }
 			/>
 		</Stack>
 	);

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
@@ -15,7 +15,7 @@ import {
 import { Stack } from '@jetpack-premium-analytics/externals';
 import { deriveComparisonRange, encodeDateToSearchParam } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
-import { endOfDay } from 'date-fns';
+import { endOfDay, isValid } from 'date-fns';
 import { useCallback, useMemo, useState } from 'react';
 import { getStoreInfo } from '../helpers/store-info';
 import type { DataFormControlProps } from '@jetpack-premium-analytics/externals';
@@ -35,6 +35,26 @@ export type ReportParamsFieldAttributes = {
 	reportParams: ReportParams;
 };
 
+/**
+ * Parse a stored report-param date for the picker.
+ *
+ * `normalizeReportParams` passes `from`/`to` through untouched, so a malformed
+ * value reaches this far. The picker renders an invalid date through
+ * `formatToTimezoneNaiveString`, which throws, so drop it instead.
+ *
+ * @param value - The stored `from` or `to`.
+ * @return The parsed date, or undefined when it is missing or malformed.
+ */
+function toPickerDate( value?: string ) {
+	if ( ! value ) {
+		return undefined;
+	}
+
+	const date = localTZDate( value );
+
+	return isValid( date ) ? date : undefined;
+}
+
 export function ReportParamsField( {
 	data: attributes,
 	onChange,
@@ -49,8 +69,8 @@ export function ReportParamsField( {
 	const reportParams = normalizeReportParams( stagedReportParams, defaultPreset );
 
 	const range = {
-		from: localTZDate( reportParams.from ),
-		to: localTZDate( reportParams.to ),
+		from: toPickerDate( reportParams.from ),
+		to: toPickerDate( reportParams.to ),
 	};
 
 	const stageDateRange = useCallback(

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	getDefaultPreset,
-	normalizeReportParams,
-	localTZDate,
-} from '@jetpack-premium-analytics/data';
+import { getDefaultPreset, normalizeReportParams } from '@jetpack-premium-analytics/data';
 import {
 	type ComparisonPresetId,
 	isPrimaryPreset,
@@ -13,9 +9,13 @@ import {
 	type DateRange,
 } from '@jetpack-premium-analytics/datetime';
 import { Stack } from '@jetpack-premium-analytics/externals';
-import { deriveComparisonRange, encodeDateToSearchParam } from '@jetpack-premium-analytics/routing';
+import {
+	decodeDateSearchParam,
+	deriveComparisonRange,
+	encodeDateToSearchParam,
+} from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
-import { endOfDay, isValid } from 'date-fns';
+import { endOfDay } from 'date-fns';
 import { useCallback, useMemo, useState } from 'react';
 import { getStoreInfo } from '../helpers/store-info';
 import type { DataFormControlProps } from '@jetpack-premium-analytics/externals';
@@ -35,26 +35,6 @@ export type ReportParamsFieldAttributes = {
 	reportParams: ReportParams;
 };
 
-/**
- * Parse a stored report-param date for the picker.
- *
- * `normalizeReportParams` passes `from`/`to` through untouched, so a malformed
- * value reaches this far. The picker renders an invalid date through
- * `formatToTimezoneNaiveString`, which throws, so drop it instead.
- *
- * @param value - The stored `from` or `to`.
- * @return The parsed date, or undefined when it is missing or malformed.
- */
-function toPickerDate( value?: string ) {
-	if ( ! value ) {
-		return undefined;
-	}
-
-	const date = localTZDate( value );
-
-	return isValid( date ) ? date : undefined;
-}
-
 export function ReportParamsField( {
 	data: attributes,
 	onChange,
@@ -69,8 +49,8 @@ export function ReportParamsField( {
 	const reportParams = normalizeReportParams( stagedReportParams, defaultPreset );
 
 	const range = {
-		from: toPickerDate( reportParams.from ),
-		to: toPickerDate( reportParams.to ),
+		from: decodeDateSearchParam( reportParams.from ),
+		to: decodeDateSearchParam( reportParams.to ),
 	};
 
 	const stageDateRange = useCallback(

--- a/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
+import { siteTimeZone } from '@jetpack-premium-analytics/datetime';
 import { getSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
 import { formatDate } from './format-date';
-import { siteTimeZone } from './site-time-zone';
 
 /**
  * Forms a range can be elided in. Both name the month, so the elision rules

--- a/projects/packages/premium-analytics/packages/routing/README.md
+++ b/projects/packages/premium-analytics/packages/routing/README.md
@@ -104,6 +104,18 @@ Writes comparison parameters to the URL for period-over-period analysis.
 - `compare_preset` – Preset identifier
 - `comp` – '1' when comparison enabled, undefined when disabled
 
+### `decodeDateSearchParam( value?, timezone? )`
+
+Parses a stored report date for the date picker, returning undefined when the
+value is missing or malformed.
+
+**Parameters:**
+
+- **`value?`** – Date string to decode
+- **`timezone?`** – Timezone in which to read an offset-less value
+
+**Returns:** A timezone-aware Date or undefined
+
 ### `encodeDateToSearchParam( date?, timezone? )`
 
 Low-level function to convert a Date to an ISO string with timezone.

--- a/projects/packages/premium-analytics/packages/routing/package.json
+++ b/projects/packages/premium-analytics/packages/routing/package.json
@@ -9,6 +9,7 @@
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "workspace:*",
 		"@jetpack-premium-analytics/datetime": "workspace:*",
+		"@wordpress/date": "5.51.0",
 		"@wordpress/route": "0.18.0",
 		"date-fns": "4.1.0",
 		"react": "18.3.1"

--- a/projects/packages/premium-analytics/packages/routing/package.json
+++ b/projects/packages/premium-analytics/packages/routing/package.json
@@ -9,8 +9,6 @@
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "workspace:*",
 		"@jetpack-premium-analytics/datetime": "workspace:*",
-		"@wordpress/core-data": "7.51.0",
-		"@wordpress/data": "10.51.0",
 		"@wordpress/route": "0.18.0",
 		"date-fns": "4.1.0",
 		"react": "18.3.1"

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/build-range-patch.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/build-range-patch.test.ts
@@ -3,7 +3,7 @@
  * of the machine timezone running the tests.
  */
 jest.mock( '@jetpack-premium-analytics/data', () => {
-	const { TZDateMini } = jest.requireActual( '@date-fns/tz' );
+	const { toLocalTZ } = jest.requireActual( '@jetpack-premium-analytics/datetime' );
 
 	/*
 	 * Only the timezone reads are stubbed. `resolveIntervalForRange` stays
@@ -12,10 +12,9 @@ jest.mock( '@jetpack-premium-analytics/data', () => {
 	 */
 	return {
 		...jest.requireActual( '@jetpack-premium-analytics/data' ),
-		getSiteTimezone: () => '+00:00',
 		dateToISOStringWithLocalTZ: ( date: Date ) => new Date( date.getTime() ).toISOString(),
-		localTZDate: ( value: number | Date ) =>
-			new TZDateMini( typeof value === 'number' ? value : value.getTime(), '+00:00' ),
+		localTZDate: ( value?: number | string | Date, timezone?: string ) =>
+			toLocalTZ( value, timezone ?? '+00:00' ),
 	};
 } );
 /**

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
@@ -3,28 +3,13 @@
  * of the machine timezone running the tests.
  */
 jest.mock( '@jetpack-premium-analytics/data', () => {
-	const { TZDateMini } = jest.requireActual( '@date-fns/tz' );
+	const { toLocalTZ } = jest.requireActual( '@jetpack-premium-analytics/datetime' );
 
 	return {
 		...jest.requireActual( '@jetpack-premium-analytics/data' ),
-		getSiteTimezone: () => '+00:00',
 		dateToISOStringWithLocalTZ: ( date: Date ) => new Date( date.getTime() ).toISOString(),
-		localTZDate: ( value: number | string | Date, timeZone = '+00:00' ) => {
-			const time = value instanceof Date ? value.getTime() : new Date( value ).getTime();
-			return new TZDateMini( time, timeZone );
-		},
-	};
-} );
-
-jest.mock( '@wordpress/core-data', () => ( { store: 'core' } ) );
-
-jest.mock( '@wordpress/data', () => {
-	const getEntityRecord = () => undefined;
-
-	return {
-		useSelect: ( selector: ( select: () => { getEntityRecord: () => unknown } ) => unknown ) =>
-			selector( () => ( { getEntityRecord } ) ),
-		select: () => ( { getEntityRecord } ),
+		localTZDate: ( value?: number | string | Date, timeZone?: string ) =>
+			toLocalTZ( value, timeZone ?? '+00:00' ),
 	};
 } );
 
@@ -45,10 +30,18 @@ jest.mock( '@wordpress/route', () => ( {
  * External dependencies
  */
 import { act, renderHook } from '@testing-library/react';
+import { getSettings, setSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
 import { useReportDateFilters } from '../use-report-date-filters';
+
+// The hook reads the site zone from the WordPress date settings, so pin those
+// rather than leaving the pin to the mocked helpers alone.
+setSettings( {
+	...getSettings(),
+	timezone: { string: 'UTC', offset: 0, offsetFormatted: '0', abbr: 'UTC' },
+} );
 
 function renderDateFilters( search: Record< string, unknown > = {} ) {
 	mockSearch = search;

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
@@ -3,14 +3,11 @@
  */
 import {
 	getAllowedIntervalsForPreset,
-	getSiteTimezone,
 	hasComparisonEnabled,
 	localTZDate,
 	resolveIntervalForRange,
 } from '@jetpack-premium-analytics/data';
-import { PRESET_CUSTOM, stepDateRange } from '@jetpack-premium-analytics/datetime';
-import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { PRESET_CUSTOM, siteTimeZone, stepDateRange } from '@jetpack-premium-analytics/datetime';
 import { isValid } from 'date-fns';
 import { useCallback, useMemo } from 'react';
 /**
@@ -130,20 +127,7 @@ export function useReportDateFilters< TFrom extends string >( from: TFrom ): Rep
 		TFrom
 	>( { from } );
 
-	/*
-	 * Read the site timezone reactively. A fully-specified deep link skips the
-	 * seed's `ensureCoreSettingsReady()` await, so core `site` settings may not
-	 * be loaded on first paint. Rebuild picker dates when the real timezone
-	 * resolves instead of leaving them anchored to the browser fallback.
-	 */
-	const timeZone = useSelect( select => {
-		void (
-			select( coreStore ) as unknown as {
-				getEntityRecord: ( kind: string, name: string ) => unknown;
-			}
-		 ).getEntityRecord( 'root', 'site' );
-		return getSiteTimezone();
-	}, [] );
+	const timeZone = siteTimeZone();
 
 	const presetId = useMemo( () => effective.preset ?? undefined, [ effective.preset ] );
 	const range = useMemo(

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
@@ -4,16 +4,14 @@
 import {
 	getAllowedIntervalsForPreset,
 	hasComparisonEnabled,
-	localTZDate,
 	resolveIntervalForRange,
 } from '@jetpack-premium-analytics/data';
 import { PRESET_CUSTOM, siteTimeZone, stepDateRange } from '@jetpack-premium-analytics/datetime';
-import { isValid } from 'date-fns';
 import { useCallback, useMemo } from 'react';
 /**
  * Internal dependencies
  */
-import { encodeDateToSearchParam } from '../../search/date-range';
+import { decodeDateSearchParam, encodeDateToSearchParam } from '../../search/date-range';
 import { useStagedSearch } from '../use-staged-search';
 import { buildRangePatch, type ReportQuerySearchParams } from './build-range-patch';
 import type {
@@ -95,17 +93,9 @@ export type ReportDateFilters = {
  * @return The parsed range, with invalid endpoints as `undefined`.
  */
 function toPickerRange( from: string | undefined, to: string | undefined, timeZone: string ) {
-	const parse = ( value?: string ) => {
-		if ( ! value ) {
-			return undefined;
-		}
-		const date = localTZDate( value, timeZone );
-		return isValid( date ) ? date : undefined;
-	};
-
 	return {
-		from: parse( from ),
-		to: parse( to ),
+		from: decodeDateSearchParam( from, timeZone ),
+		to: decodeDateSearchParam( to, timeZone ),
 	};
 }
 

--- a/projects/packages/premium-analytics/packages/routing/src/index.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/index.ts
@@ -1,4 +1,5 @@
 export {
+	decodeDateSearchParam,
 	encodeDateToSearchParam,
 	writeDateRangeToSearch,
 	writeComparisonToSearch,

--- a/projects/packages/premium-analytics/packages/routing/src/search/comparison/__tests__/derive-comparison-range.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/comparison/__tests__/derive-comparison-range.test.ts
@@ -1,23 +1,41 @@
 /**
- * Mocks: the data package reads the site timezone from the WordPress core
- * store. Pin the timezone to UTC so day-bound math is deterministic
- * regardless of the machine timezone running the tests.
+ * Mocks: stub the data barrel so this unit test doesn't pull in its React Query
+ * and api-fetch surface. The date helpers delegate to the real datetime package,
+ * so the anchoring under test is the production one.
  */
 jest.mock( '@jetpack-premium-analytics/data', () => {
-	const { TZDateMini } = jest.requireActual( '@date-fns/tz' );
+	const { toLocalTZ, dateToISOStringWithTZ, siteTimeZone } = jest.requireActual(
+		'@jetpack-premium-analytics/datetime'
+	);
 	return {
-		getSiteTimezone: () => '+00:00',
-		dateToISOStringWithLocalTZ: ( date: Date ) => new Date( date.getTime() ).toISOString(),
-		localTZDate: ( value: number ) => new TZDateMini( value, '+00:00' ),
+		localTZDate: ( value?: number | string | Date, timezone?: string ) =>
+			toLocalTZ( value, timezone ?? siteTimeZone() ),
+		dateToISOStringWithLocalTZ: ( date: Date, timezone?: string ) =>
+			dateToISOStringWithTZ( date, timezone ?? siteTimeZone() ),
 	};
 } );
+/**
+ * External dependencies
+ */
+import { getSettings, setSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
 import { deriveComparisonRange } from '../derive-comparison-range';
 import type { ComparisonPresetId } from '@jetpack-premium-analytics/datetime';
 
+const DEFAULTS = getSettings();
+
+const siteOn = ( string: string, offset: number ) =>
+	setSettings( {
+		...DEFAULTS,
+		timezone: { string, offset, offsetFormatted: String( offset ), abbr: '' },
+	} );
+
 describe( 'deriveComparisonRange', () => {
+	// Day-bound math has to be deterministic regardless of the machine timezone
+	// running the tests, so pin the site rather than leaning on the defaults.
+	beforeEach( () => siteOn( 'UTC', 0 ) );
 	it( 'returns undefined when comparison is disabled or the preset is missing', () => {
 		const range = { from: '2026-06-01T00:00:00.000Z', to: '2026-06-07T23:59:59.999Z' };
 
@@ -36,8 +54,8 @@ describe( 'deriveComparisonRange', () => {
 				compare_preset: 'previous-period',
 			} )
 		).toEqual( {
-			compare_from: '2026-05-25T00:00:00.000Z',
-			compare_to: '2026-05-31T23:59:59.999Z',
+			compare_from: '2026-05-25T00:00:00.000+00:00',
+			compare_to: '2026-05-31T23:59:59.999+00:00',
 		} );
 	} );
 
@@ -50,8 +68,28 @@ describe( 'deriveComparisonRange', () => {
 				compare_preset: 'previous-period',
 			} )
 		).toEqual( {
-			compare_from: '2026-07-08T14:30:00.000Z',
-			compare_to: '2026-07-09T14:30:00.000Z',
+			compare_from: '2026-07-08T14:30:00.000+00:00',
+			compare_to: '2026-07-09T14:30:00.000+00:00',
+		} );
+	} );
+
+	// A hand-typed deep link carries no offset. Reading it as a UTC instant would
+	// put a site west of Greenwich on the previous calendar day and, because the
+	// range would no longer sit on day boundaries, derive a rolling window
+	// instead of the previous period the picker shows.
+	it( 'anchors an offset-less range to the site zone', () => {
+		siteOn( 'America/New_York', -4 );
+
+		expect(
+			deriveComparisonRange( {
+				from: '2026-06-29',
+				to: '2026-06-30T23:59:59.999',
+				comp: '1',
+				compare_preset: 'previous-period',
+			} )
+		).toEqual( {
+			compare_from: '2026-06-27T00:00:00.000-04:00',
+			compare_to: '2026-06-28T23:59:59.999-04:00',
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/packages/routing/src/search/comparison/derive-comparison-range.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/comparison/derive-comparison-range.ts
@@ -4,11 +4,11 @@
 import {
 	normalizeReportParams,
 	dateToISOStringWithLocalTZ,
-	getSiteTimezone,
 	localTZDate,
 } from '@jetpack-premium-analytics/data';
 import {
 	getComparisonRangeFromPreset,
+	siteTimeZone,
 	type ComparisonPresetId,
 } from '@jetpack-premium-analytics/datetime';
 
@@ -76,7 +76,7 @@ export function deriveComparisonRange( opts: ReportParams ):
 	 * site-locally. Day-aligned ranges keep day-aligned comparisons; rolling
 	 * windows (e.g. last-24-hours) mirror the exact window.
 	 */
-	const timezone = getSiteTimezone();
+	const timezone = siteTimeZone();
 	const reference = {
 		from: localTZDate( fromInstant.getTime(), timezone ),
 		to: localTZDate( toInstant.getTime(), timezone ),

--- a/projects/packages/premium-analytics/packages/routing/src/search/comparison/derive-comparison-range.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/comparison/derive-comparison-range.ts
@@ -64,23 +64,24 @@ export function deriveComparisonRange( opts: ReportParams ):
 		return undefined;
 	}
 
-	// Parse URL params (ISO+offset) to instants
-	const fromInstant = new Date( opts.from );
-	const toInstant = new Date( opts.to );
-	if ( isNaN( fromInstant.getTime() ) || isNaN( toInstant.getTime() ) ) {
-		return undefined;
-	}
-
 	/*
-	 * Interpret the instants in the site timezone so day boundaries resolve
-	 * site-locally. Day-aligned ranges keep day-aligned comparisons; rolling
-	 * windows (e.g. last-24-hours) mirror the exact window.
+	 * Parse the URL params through the same reader the picker uses, so an
+	 * offset-less `from`/`to` anchors to the site zone here too. Parsing them as
+	 * raw instants would put a date-only deep link on UTC midnight, which is a
+	 * different calendar day — and a different alignment — than the picker shows.
+	 * Day boundaries then resolve site-locally: day-aligned ranges keep
+	 * day-aligned comparisons; rolling windows (e.g. last-24-hours) mirror the
+	 * exact window.
 	 */
 	const timezone = siteTimeZone();
 	const reference = {
-		from: localTZDate( fromInstant.getTime(), timezone ),
-		to: localTZDate( toInstant.getTime(), timezone ),
+		from: localTZDate( opts.from, timezone ),
+		to: localTZDate( opts.to, timezone ),
 	};
+
+	if ( isNaN( reference.from.getTime() ) || isNaN( reference.to.getTime() ) ) {
+		return undefined;
+	}
 
 	const cmp = getComparisonRangeFromPreset( reference, presetId );
 	if ( ! cmp?.from || ! cmp?.to ) {

--- a/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.test.ts
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { getSettings, setSettings } from '@wordpress/date';
+/**
+ * Internal dependencies
+ */
+import { decodeDateSearchParam } from './date-range';
+
+const DEFAULTS = getSettings();
+
+describe( 'decodeDateSearchParam', () => {
+	beforeEach( () => {
+		setSettings( {
+			...DEFAULTS,
+			timezone: {
+				offset: -4,
+				offsetFormatted: '-4',
+				string: 'America/New_York',
+				abbr: 'EDT',
+			},
+		} );
+	} );
+
+	it( 'returns undefined for a missing value', () => {
+		expect( decodeDateSearchParam() ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for a malformed value', () => {
+		expect( decodeDateSearchParam( '2026-06-29T12:60:00' ) ).toBeUndefined();
+	} );
+
+	it( 'anchors an offset-less value to the requested timezone', () => {
+		const date = decodeDateSearchParam( '2026-06-29', 'Pacific/Honolulu' );
+
+		expect( date?.toISOString() ).toBe( '2026-06-29T10:00:00.000Z' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.ts
@@ -2,7 +2,25 @@
  * External dependencies
  */
 import { localTZDate, dateToISOStringWithLocalTZ } from '@jetpack-premium-analytics/data';
+import { isValid } from 'date-fns';
 import type { DateRange } from '@jetpack-premium-analytics/datetime';
+
+/**
+ * Parse a stored report-param date for the picker.
+ *
+ * @param value    - The stored `from` or `to`.
+ * @param timezone - The timezone used by the picker.
+ * @return The parsed date, or undefined when it is missing or malformed.
+ */
+export function decodeDateSearchParam( value?: string, timezone?: string ): Date | undefined {
+	if ( ! value ) {
+		return undefined;
+	}
+
+	const date = localTZDate( value, timezone );
+
+	return isValid( date ) ? date : undefined;
+}
 
 /**
  * Serializes a Date into an ISO string with the site's timezone

--- a/projects/packages/premium-analytics/packages/routing/src/search/date-range/index.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/date-range/index.ts
@@ -1,4 +1,5 @@
 export {
+	decodeDateSearchParam,
 	encodeDateToSearchParam,
 	writeDateRangeToSearch,
 	writeComparisonToSearch,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/date-report-params-field/date-report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/date-report-params-field/date-report-params-field.tsx
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	getDefaultPreset,
-	normalizeReportParams,
-	localTZDate,
-} from '@jetpack-premium-analytics/data';
+import { getDefaultPreset, normalizeReportParams } from '@jetpack-premium-analytics/data';
 import {
 	type ComparisonPresetId,
 	isPrimaryPreset,
@@ -13,9 +9,13 @@ import {
 	type DateRange,
 } from '@jetpack-premium-analytics/datetime';
 import { Stack, type DataFormControlProps } from '@jetpack-premium-analytics/externals';
-import { deriveComparisonRange, encodeDateToSearchParam } from '@jetpack-premium-analytics/routing';
+import {
+	decodeDateSearchParam,
+	deriveComparisonRange,
+	encodeDateToSearchParam,
+} from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
-import { endOfDay, isValid } from 'date-fns';
+import { endOfDay } from 'date-fns';
 import { useCallback, useMemo, useState } from 'react';
 import { getStoreInfo } from '../../helpers/store-info';
 
@@ -27,26 +27,6 @@ type ReportParams = NonNullable< Parameters< typeof normalizeReportParams >[ 0 ]
 export type ReportParamsFieldAttributes = {
 	reportParams: ReportParams;
 };
-
-/**
- * Parse a stored report-param date for the picker.
- *
- * `normalizeReportParams` passes `from`/`to` through untouched, so a malformed
- * value reaches this far. The picker renders an invalid date through
- * `formatToTimezoneNaiveString`, which throws, so drop it instead.
- *
- * @param value - The stored `from` or `to`.
- * @return The parsed date, or undefined when it is missing or malformed.
- */
-function toPickerDate( value?: string ) {
-	if ( ! value ) {
-		return undefined;
-	}
-
-	const date = localTZDate( value );
-
-	return isValid( date ) ? date : undefined;
-}
 
 export function ReportParamsField( {
 	data: attributes,
@@ -62,8 +42,8 @@ export function ReportParamsField( {
 	const reportParams = normalizeReportParams( stagedReportParams, defaultPreset );
 
 	const range = {
-		from: toPickerDate( reportParams.from ),
-		to: toPickerDate( reportParams.to ),
+		from: decodeDateSearchParam( reportParams.from ),
+		to: decodeDateSearchParam( reportParams.to ),
 	};
 
 	const stageDateRange = useCallback(

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/date-report-params-field/date-report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/date-report-params-field/date-report-params-field.tsx
@@ -5,11 +5,11 @@ import {
 	getDefaultPreset,
 	normalizeReportParams,
 	localTZDate,
-	getSiteTimezone,
 } from '@jetpack-premium-analytics/data';
 import {
 	type ComparisonPresetId,
 	isPrimaryPreset,
+	siteTimeZone,
 	type DateRange,
 } from '@jetpack-premium-analytics/datetime';
 import { Stack, type DataFormControlProps } from '@jetpack-premium-analytics/externals';
@@ -127,7 +127,7 @@ export function ReportParamsField( {
 				onApply={ commit }
 				canApply={ isDateRangeDirty }
 				onCancel={ clear }
-				timeZone={ getSiteTimezone() }
+				timeZone={ siteTimeZone() }
 			/>
 		</Stack>
 	);

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/date-report-params-field/date-report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/date-report-params-field/date-report-params-field.tsx
@@ -15,7 +15,7 @@ import {
 import { Stack, type DataFormControlProps } from '@jetpack-premium-analytics/externals';
 import { deriveComparisonRange, encodeDateToSearchParam } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
-import { endOfDay } from 'date-fns';
+import { endOfDay, isValid } from 'date-fns';
 import { useCallback, useMemo, useState } from 'react';
 import { getStoreInfo } from '../../helpers/store-info';
 
@@ -27,6 +27,26 @@ type ReportParams = NonNullable< Parameters< typeof normalizeReportParams >[ 0 ]
 export type ReportParamsFieldAttributes = {
 	reportParams: ReportParams;
 };
+
+/**
+ * Parse a stored report-param date for the picker.
+ *
+ * `normalizeReportParams` passes `from`/`to` through untouched, so a malformed
+ * value reaches this far. The picker renders an invalid date through
+ * `formatToTimezoneNaiveString`, which throws, so drop it instead.
+ *
+ * @param value - The stored `from` or `to`.
+ * @return The parsed date, or undefined when it is missing or malformed.
+ */
+function toPickerDate( value?: string ) {
+	if ( ! value ) {
+		return undefined;
+	}
+
+	const date = localTZDate( value );
+
+	return isValid( date ) ? date : undefined;
+}
 
 export function ReportParamsField( {
 	data: attributes,
@@ -42,8 +62,8 @@ export function ReportParamsField( {
 	const reportParams = normalizeReportParams( stagedReportParams, defaultPreset );
 
 	const range = {
-		from: localTZDate( reportParams.from ),
-		to: localTZDate( reportParams.to ),
+		from: toPickerDate( reportParams.from ),
+		to: toPickerDate( reportParams.to ),
 	};
 
 	const stageDateRange = useCallback(

--- a/projects/packages/premium-analytics/routes/dashboard/route.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.ts
@@ -29,11 +29,10 @@ type DashboardSearch = Record< string, string | undefined >;
  * and the widgets share a populated search state. Defaults to the last 30 days
  * with a previous-period comparison, resolved from the shared analytics
  * defaults (`getDefaultQueryParams`). Also re-seeds when `interval` is missing
- * or not allowed for the active range. The seed runs after
- * `ensureCoreSettingsReady()` so the dates are encoded in the site timezone;
- * otherwise `getDefaultQueryParams` would fall back to the browser timezone
- * (core `site` settings not loaded yet) and the seeded `to` boundary would land
- * on a different instant than a later Apply writes.
+ * or not allowed for the active range. The seed itself needs nothing async —
+ * the site timezone comes from the WordPress date settings that ship with the
+ * page — but it still awaits `ensureCoreSettingsReady()` to warm the core
+ * `site` record that `useSiteHomeUrl()` reads once the stage renders.
  *
  * Then register the widget-modules discovery entity before the stage renders,
  * so the stage's `getEntityRecords` read resolves and feeds the records to
@@ -64,11 +63,11 @@ export const route = {
 		const params = ( search ?? {} ) as DashboardSearch;
 		if ( needsReportDateParamsSeed( params ) ) {
 			/*
-			 * Seed dates in the site timezone, not the browser's, by waiting for
-			 * core `site` settings. A rejection here (network/auth) shouldn't
-			 * error the whole page, so fall back to the default seed — matching
-			 * upstream's loader behavior. The only cost is the timezone briefly
-			 * falling back to the browser's until settings resolve.
+			 * Warm the core `site` record before the stage renders, so
+			 * `useSiteHomeUrl()` has it. A rejection here (network/auth)
+			 * shouldn't error the whole page, so fall through to the seed —
+			 * matching upstream's loader behavior. The seed's own dates do not
+			 * depend on this; they resolve from the WordPress date settings.
 			 */
 			try {
 				await ensureCoreSettingsReady();

--- a/projects/packages/premium-analytics/routes/post-detail/route.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/route.ts
@@ -78,9 +78,10 @@ export const route = {
 
 		if ( needsDateSeed || needsPostSeed || needsSectionSeed ) {
 			/*
-			 * Seed dates in the site timezone, not the browser's, by waiting for
-			 * core `site` settings. A rejection here shouldn't error the whole
-			 * page, so fall back to the default seed.
+			 * Warm the core `site` record before the stage renders, so
+			 * `useSiteHomeUrl()` has it. A rejection here shouldn't error the
+			 * whole page, so fall through to the seed. The seed's own dates do
+			 * not depend on this; they resolve from the WordPress date settings.
 			 */
 			try {
 				await ensureCoreSettingsReady();

--- a/projects/packages/premium-analytics/routes/reports/route.ts
+++ b/projects/packages/premium-analytics/routes/reports/route.ts
@@ -85,9 +85,10 @@ export const route = {
 
 		if ( needsDateSeed || needsSectionSeed ) {
 			/*
-			 * Seed dates in the site timezone, not the browser's, by waiting for
-			 * core `site` settings. A rejection here shouldn't error the whole
-			 * page, so fall back to the default seed.
+			 * Warm the core `site` record before the stage renders, so
+			 * `useSiteHomeUrl()` has it. A rejection here shouldn't error the
+			 * whole page, so fall through to the seed. The seed's own dates do
+			 * not depend on this; they resolve from the WordPress date settings.
 			 */
 			try {
 				await ensureCoreSettingsReady();

--- a/projects/packages/premium-analytics/routes/video-detail/route.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/route.ts
@@ -60,9 +60,10 @@ export const route = {
 
 		if ( needsDateSeed || needsPostSeed ) {
 			/*
-			 * Seed dates in the site timezone, not the browser's, by waiting for
-			 * core `site` settings. A rejection here shouldn't error the whole
-			 * page, so fall back to the default seed.
+			 * Warm the core `site` record before the stage renders, so
+			 * `useSiteHomeUrl()` has it. A rejection here shouldn't error the
+			 * whole page, so fall through to the seed. The seed's own dates do
+			 * not depend on this; they resolve from the WordPress date settings.
 			 */
 			try {
 				await ensureCoreSettingsReady();

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -225,7 +225,7 @@ class Analytics {
 
 	/**
 	 * Prefers `timezone_string` over `gmt_offset`, matching the dashboard's own
-	 * `getSiteTimezone()`: analytics links point at past dates, so they cross
+	 * `siteTimeZone()`: analytics links point at past dates, so they cross
 	 * daylight-saving boundaries routinely, and a fixed offset applied to the far
 	 * side of a transition shifts the day.
 	 *

--- a/projects/packages/premium-analytics/widgets/post-views/use-post-views.ts
+++ b/projects/packages/premium-analytics/widgets/post-views/use-post-views.ts
@@ -150,12 +150,9 @@ function bucketDays( days: StatsPostDay[], buckets: BucketWindow[] ): PostViewsP
 	// The endpoint's day keys are plain site-local calendar dates, so each
 	// point's instant must be that day's site-local midnight. `parseSiteDateTime`
 	// anchors the offset-less key in the site timezone; the chart's `formatDate`
-	// labels render in the same zone, so the calendar day round-trips without a
-	// TZ-induced day shift (a date-only string fed to `localTZDate` would parse
-	// as UTC midnight and read as the previous day on negative-offset sites).
+	// labels render in the same zone, so the calendar day round-trips.
 	// `bucket.date` comes from `format( start, 'yyyy-MM-dd' )`, so the parse
-	// cannot fail in practice; if it ever does, drop the point rather than
-	// fall back to a browser-local instant that reintroduces the day shift.
+	// cannot fail in practice; drop the point rather than guess if it ever does.
 	return buckets.flatMap( bucket => {
 		const date = parseSiteDateTime( bucket.date );
 		return date ? [ { date, value: totals.get( bucket.date ) ?? 0 } ] : [];

--- a/projects/packages/premium-analytics/widgets/video-detail-views-performance/use-video-views.ts
+++ b/projects/packages/premium-analytics/widgets/video-detail-views-performance/use-video-views.ts
@@ -141,9 +141,7 @@ function bucketDays(
 	// The endpoint's bucket keys are plain site-local calendar dates, so each
 	// point's instant must be that day's site-local midnight. `parseSiteDateTime`
 	// anchors the offset-less key in the site timezone; the chart's `formatDate`
-	// labels render in the same zone, so the calendar day round-trips without a
-	// TZ-induced day shift (a date-only string fed to `localTZDate` would parse
-	// as UTC midnight and read as the previous day on negative-offset sites).
+	// labels render in the same zone, so the calendar day round-trips.
 	return buckets.map( bucket => ( {
 		date: parseSiteDateTime( bucket.date ) ?? parseISO( bucket.date ),
 		value: totals.get( bucket.date ) ?? 0,


### PR DESCRIPTION
Fixes WOOA7S-1820

## Proposed changes

Premium Analytics treated date-only values as UTC before displaying them in the site's timezone. Sites west of UTC therefore saw some report dates shift to the previous day. The data layer could also briefly use the visitor's timezone while site data loaded.

- Read date-only and other offset-less values as wall time in the site timezone.
- Use WordPress date settings as the single source for the site timezone.
- Remove the redundant core-data timezone accessor and loading subscription.
- Reject invalid calendar dates instead of allowing them to roll over.

## Related product discussion/links

- WOOA7S-1820
- WOOA7S-1766
- WOOA7S-1655

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

From `projects/packages/premium-analytics`, run:

```sh
pnpm exec jest --config=tests/jest.config.cjs
```

To reproduce manually you need a site west of UTC _and_ a date that states no
offset. The presets build their range from the current instant, so **Last 30
days** renders identically with and without this change — it never goes through
the path being fixed.

1. Under **Settings → General**, set the timezone to `Honolulu` (UTC-10).
2. Open Premium Analytics with a bare `from`/`to` in the report URL — any dates
   work:

   ```
   /wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin&p=%2F%3Ffrom%3D2026-07-01%26to%3D2026-07-31%26interval%3Dday%26preset%3Dcustom
   ```

3. Confirm the subtitle reads **Wednesday, July 1 – Friday, July 31**. On trunk
   it reads _June 30 – July 30_: the bare dates are parsed as UTC midnight and
   then rendered in the site zone, landing a day back.
4. Reload and confirm the range is right on first paint. The zone now comes from
   the date settings WordPress installs synchronously, so no entity fetch has to
   resolve before dates are correct.
5. Repeat with `Amsterdam` (east of UTC), which should be unaffected, and once
   with a manual **UTC-10** offset instead of a city, which exercises the
   offset-only path.

Storybook uses the UTC defaults from `@wordpress/date`, so its date-related
snapshots may update to be timezone-independent.
