### PR TITLE
Premium Analytics: reorder traffic metric tiles and clarify the email view selector

### DIFF
--- a/projects/packages/premium-analytics/changelog/change-wooa7s-1911-widget-copy
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-1911-widget-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Widgets: Order the traffic metric tiles Views, Visitors, Comments, Likes, and name the Latest emails sent view selector "By open rate" and "By click rate".

--- a/projects/packages/premium-analytics/widgets/emails/widget.ts
+++ b/projects/packages/premium-analytics/widgets/emails/widget.ts
@@ -56,11 +56,11 @@ export default {
 			Edit: SelectField,
 			elements: [
 				{
-					label: __( 'Open rate', 'jetpack-premium-analytics-pkg' ),
+					label: __( 'By open rate', 'jetpack-premium-analytics-pkg' ),
 					value: 'opens',
 				},
 				{
-					label: __( 'Click rate', 'jetpack-premium-analytics-pkg' ),
+					label: __( 'By click rate', 'jetpack-premium-analytics-pkg' ),
 					value: 'clicks',
 				},
 			],

--- a/projects/packages/premium-analytics/widgets/site-overview/widget.ts
+++ b/projects/packages/premium-analytics/widgets/site-overview/widget.ts
@@ -36,8 +36,8 @@ export type SiteOverviewAttributes = {
 export const SITE_OVERVIEW_METRICS: { id: SiteOverviewMetricId; label: string }[] = [
 	{ id: 'views', label: __( 'Views', 'jetpack-premium-analytics-pkg' ) },
 	{ id: 'visitors', label: __( 'Visitors', 'jetpack-premium-analytics-pkg' ) },
-	{ id: 'likes', label: __( 'Likes', 'jetpack-premium-analytics-pkg' ) },
 	{ id: 'comments', label: __( 'Comments', 'jetpack-premium-analytics-pkg' ) },
+	{ id: 'likes', label: __( 'Likes', 'jetpack-premium-analytics-pkg' ) },
 ];
 
 /**

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/use-traffic-chart.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/use-traffic-chart.test.tsx
@@ -108,8 +108,8 @@ describe( 'useTrafficChart', () => {
 		expect( metrics.map( metric => metric.key ) ).toEqual( [
 			'views',
 			'visitors',
-			'likes',
 			'comments',
+			'likes',
 		] );
 		// This only proves `value` is each metric's correct total (not a
 		// hardcoded or swapped field) — sanitizeStatsTimeSeriesResponse derives
@@ -117,8 +117,8 @@ describe( 'useTrafficChart', () => {
 		// summary-read apart from a re-sum of the points.
 		expect( metrics[ 0 ].value ).toBe( 2000 );
 		expect( metrics[ 1 ].value ).toBe( 1500 );
-		expect( metrics[ 2 ].value ).toBe( 50 );
-		expect( metrics[ 3 ].value ).toBe( 20 );
+		expect( metrics[ 2 ].value ).toBe( 20 );
+		expect( metrics[ 3 ].value ).toBe( 50 );
 	} );
 
 	it( 'maps one chart point per period, oldest first', async () => {
@@ -157,12 +157,16 @@ describe( 'useTrafficChart', () => {
 
 		await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
 
-		const metrics = result.current.metrics;
-		expect( metrics[ 0 ].previousValue ).toBe( 500 );
-		expect( metrics[ 1 ].previousValue ).toBe( 400 );
-		expect( metrics[ 2 ].previousValue ).toBe( 10 );
-		expect( metrics[ 3 ].previousValue ).toBe( 4 );
-		expect( metrics[ 0 ].previous ).toHaveLength( 1 );
+		// Keyed rather than indexed: tab order is the sibling test's subject, not
+		// this one's, so a reorder shouldn't silently re-point these totals.
+		const byKey = Object.fromEntries(
+			result.current.metrics.map( metric => [ metric.key, metric ] )
+		);
+		expect( byKey.views.previousValue ).toBe( 500 );
+		expect( byKey.visitors.previousValue ).toBe( 400 );
+		expect( byKey.likes.previousValue ).toBe( 10 );
+		expect( byKey.comments.previousValue ).toBe( 4 );
+		expect( byKey.views.previous ).toHaveLength( 1 );
 	} );
 
 	// The misleading-zero guard: an empty comparison response must read as "no

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
@@ -43,8 +43,8 @@ export type TrafficChartType = ( typeof TRAFFIC_CHART_TYPES )[ number ][ 'id' ];
 export const TRAFFIC_CHART_METRICS = [
 	{ id: 'views', label: __( 'Views', 'jetpack-premium-analytics-pkg' ) },
 	{ id: 'visitors', label: __( 'Visitors', 'jetpack-premium-analytics-pkg' ) },
-	{ id: 'likes', label: __( 'Likes', 'jetpack-premium-analytics-pkg' ) },
 	{ id: 'comments', label: __( 'Comments', 'jetpack-premium-analytics-pkg' ) },
+	{ id: 'likes', label: __( 'Likes', 'jetpack-premium-analytics-pkg' ) },
 ] as const satisfies readonly { id: string; label: string }[];
 
 /**
@@ -65,9 +65,9 @@ export type TrafficChartAttributes = {
  * Widget type definition.
  *
  * Ported from the Jetpack Stats `stats-chart-tabs` card in wp-calypso (the chart
- * above the Traffic page). Renders the selected period's Views, Visitors, Likes,
- * and Comments as selectable metric tabs over a comparative chart. The date
- * range and comparison state come from the dashboard via `reportParams`; the
+ * above the Traffic page). Renders the selected period's Views, Visitors,
+ * Comments, and Likes as selectable metric tabs over a comparative chart. The
+ * date range and comparison state come from the dashboard via `reportParams`; the
  * `granularity` attribute (`relevance: 'high'`) chooses the bucket size within
  * that range, and `chartType` switches between lines and bars. Which metric is
  * plotted is the chart's own tab selection, not an attribute.


### PR DESCRIPTION
Fixes WOOA7S-1911

## Proposed changes

Align Premium Analytics widgets with the reference dashboard:

- Reorder the **Traffic** and **Site overview** metrics to **Views · Visitors · Comments · Likes**.
- Rename the **Latest emails sent** view options to **By open rate** and **By click rate** for consistency with the chart's other selectors.

Other copy suggestions from the audit are intentionally excluded because they conflict with the package's sentence-case titles or the established **Top ...** naming from #51090.

## Related product discussion/links

- WOOA7S-1911
- #51090

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Go to **Jetpack → Analytics → Traffic** and confirm the tiles appear as **Views · Visitors · Comments · Likes**. Click each tile and verify the chart shows the corresponding metric.
- Add the **Site overview** widget and confirm its tiles and settings use the same order. Untick a metric and verify the remaining tiles keep their relative order.
- Open the **Latest emails sent** widget settings and confirm the **View by** options are **By open rate** and **By click rate**, and that switching between them updates the rate column.

Existing dashboards are unaffected because saved metric IDs do not change.
