### PR TITLE
Premium Analytics: add a content-shaped skeleton for the leaderboard widgets

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1781-widget-skeleton-shapes
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1781-widget-skeleton-shapes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Show content-shaped skeleton placeholders while widget content loads.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/__tests__/leaderboard-skeleton.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/__tests__/leaderboard-skeleton.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { LeaderboardSkeleton } from '../leaderboard-skeleton';
+
+describe( 'LeaderboardSkeleton', () => {
+	it( 'draws the rows the widget asked for', () => {
+		render( <LeaderboardSkeleton rows={ 3 } /> );
+
+		expect( screen.getAllByTestId( 'skeleton-row' ) ).toHaveLength( 3 );
+	} );
+
+	it( 'fills the tile when the widget asks for every row', () => {
+		// Widgets pass their `max` straight through, and `max = 0` means "all
+		// rows" — drawing it literally would leave an empty loading state.
+		render( <LeaderboardSkeleton rows={ 0 } /> );
+
+		expect( screen.getAllByTestId( 'skeleton-row' ) ).toHaveLength( 12 );
+	} );
+
+	it( 'draws a label and its value on one line by default', () => {
+		// The default matches a chart drawn `withOverlayLabel`, which every
+		// widget but `sales-by-utm` uses.
+		render( <LeaderboardSkeleton rows={ 2 } /> );
+
+		expect( screen.getAllByTestId( 'skeleton-list-label' ) ).toHaveLength( 2 );
+		expect( screen.getAllByTestId( 'skeleton-value' ) ).toHaveLength( 2 );
+		expect( screen.queryByTestId( 'skeleton-bar' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'stacks the label over its bar for the plain chart', () => {
+		render( <LeaderboardSkeleton rows={ 2 } variant="bars" /> );
+
+		expect( screen.getAllByTestId( 'skeleton-bar-label' ) ).toHaveLength( 2 );
+		expect( screen.getAllByTestId( 'skeleton-bar' ) ).toHaveLength( 2 );
+		expect( screen.queryByTestId( 'skeleton-value' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/index.ts
@@ -5,6 +5,8 @@ export type {
 	LegendLabels,
 } from './leaderboard-chart';
 
+export { LeaderboardSkeleton, type LeaderboardSkeletonProps } from './leaderboard-skeleton';
+
 export { LeaderboardLabel } from './leaderboard-label';
 export type { LeaderboardLabelProps, LeaderboardRowMedia } from './leaderboard-label';
 export {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-skeleton.module.scss
@@ -1,22 +1,19 @@
 @use "sass:list";
 
 /* Geometry from the design prototype's two leaderboard skeletons, which read
- * lighter than the loaded rows rather than tracing their 36px height. */
-$row-gap: 15px;
+ * lighter than the loaded rows rather than tracing their 36px height. Every
+ * length is snapped to the nearest WPDS dimension token: the prototype's values
+ * sat 1–2px off the scale, close enough that the tokens preserve the intended
+ * density (the list row's pitch moves 25px → 24px, the bar row's 43px → 44px).
+ * Only the proportional widths stay literal — no token expresses them. */
 
 /* `bars`: a fixed-width label line above the row's proportional bar. */
 $bar-label-inline-size: 40%;
-$bar-label-block-size: 9px;
-$bar-block-size: 12px;
-$bar-row-gap: 7px;
 $bar-widths: 92%, 78%, 64%, 50%, 38%;
 
 /* `list`: the label on one line with the value trailing it. These widths stand
  * in for label text, so they vary without trending down — a label's length says
  * nothing about its rank. */
-$list-column-gap: 10px;
-$list-line-block-size: 10px;
-$list-value-inline-size: 34px;
 $list-label-widths: 85%, 70%, 78%, 58%, 66%, 48%;
 
 /* `safe` keeps the centring from pushing the first rows out of the top of the
@@ -28,7 +25,7 @@ $list-label-widths: 85%, 70%, 78%, 58%, 66%, 48%;
 	flex: 1 1 auto;
 	flex-direction: column;
 	justify-content: safe center;
-	gap: $row-gap;
+	gap: var(--wpds-dimension-gap-lg);
 	min-block-size: 0;
 	overflow: hidden;
 }
@@ -40,17 +37,17 @@ $list-label-widths: 85%, 70%, 78%, 58%, 66%, 48%;
 
 .bars .row {
 	flex-direction: column;
-	row-gap: $bar-row-gap;
+	row-gap: var(--wpds-dimension-gap-sm);
 }
 
 .list .row {
 	align-items: center;
-	column-gap: $list-column-gap;
+	column-gap: var(--wpds-dimension-gap-sm);
 }
 
 .barLabel {
 	inline-size: $bar-label-inline-size;
-	block-size: $bar-label-block-size;
+	block-size: var(--wpds-dimension-size-4xs);
 	border-radius: var(--wpds-border-radius-md);
 }
 
@@ -58,7 +55,7 @@ $list-label-widths: 85%, 70%, 78%, 58%, 66%, 48%;
  * browser clamps the radius to half the bar's height, giving the prototype's
  * fully rounded ends. */
 .bar {
-	block-size: $bar-block-size;
+	block-size: var(--wpds-dimension-size-3xs);
 	border-radius: var(--wpds-border-radius-lg);
 }
 
@@ -70,7 +67,7 @@ $list-label-widths: 85%, 70%, 78%, 58%, 66%, 48%;
 
 /* Width comes from the `@for` loop below, which covers every row. */
 .listLabel {
-	block-size: $list-line-block-size;
+	block-size: var(--wpds-dimension-size-4xs);
 	border-radius: var(--wpds-border-radius-md);
 }
 
@@ -81,8 +78,8 @@ $list-label-widths: 85%, 70%, 78%, 58%, 66%, 48%;
 }
 
 .value {
-	inline-size: $list-value-inline-size;
-	block-size: $list-line-block-size;
+	inline-size: var(--wpds-dimension-size-md);
+	block-size: var(--wpds-dimension-size-4xs);
 	margin-inline-start: auto;
 	border-radius: var(--wpds-border-radius-md);
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-skeleton.module.scss
@@ -1,0 +1,88 @@
+@use "sass:list";
+
+/* Geometry from the design prototype's two leaderboard skeletons, which read
+ * lighter than the loaded rows rather than tracing their 36px height. */
+$row-gap: 15px;
+
+/* `bars`: a fixed-width label line above the row's proportional bar. */
+$bar-label-inline-size: 40%;
+$bar-label-block-size: 9px;
+$bar-block-size: 12px;
+$bar-row-gap: 7px;
+$bar-widths: 92%, 78%, 64%, 50%, 38%;
+
+/* `list`: the label on one line with the value trailing it. These widths stand
+ * in for label text, so they vary without trending down — a label's length says
+ * nothing about its rank. */
+$list-column-gap: 10px;
+$list-line-block-size: 10px;
+$list-value-inline-size: 34px;
+$list-label-widths: 85%, 70%, 78%, 58%, 66%, 48%;
+
+/* `safe` keeps the centring from pushing the first rows out of the top of the
+ * tile: once they no longer fit it falls back to packing them at the start, so
+ * what gets clipped is the tail — the same rows the loaded chart's `fitRows`
+ * drops. */
+.rows {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	justify-content: safe center;
+	gap: $row-gap;
+	min-block-size: 0;
+	overflow: hidden;
+}
+
+.row {
+	display: flex;
+	flex: none;
+}
+
+.bars .row {
+	flex-direction: column;
+	row-gap: $bar-row-gap;
+}
+
+.list .row {
+	align-items: center;
+	column-gap: $list-column-gap;
+}
+
+.barLabel {
+	inline-size: $bar-label-inline-size;
+	block-size: $bar-label-block-size;
+	border-radius: var(--wpds-border-radius-md);
+}
+
+/* The `@for` loop below sets every row's width, so there is none here. The
+ * browser clamps the radius to half the bar's height, giving the prototype's
+ * fully rounded ends. */
+.bar {
+	block-size: $bar-block-size;
+	border-radius: var(--wpds-border-radius-lg);
+}
+
+@for $index from 1 through list.length( $bar-widths ) {
+	.rows .row:nth-child( #{list.length($bar-widths)}n + #{$index} ) .bar {
+		inline-size: list.nth($bar-widths, $index);
+	}
+}
+
+/* Width comes from the `@for` loop below, which covers every row. */
+.listLabel {
+	block-size: $list-line-block-size;
+	border-radius: var(--wpds-border-radius-md);
+}
+
+@for $index from 1 through list.length( $list-label-widths ) {
+	.rows .row:nth-child( #{list.length($list-label-widths)}n + #{$index} ) .listLabel {
+		inline-size: list.nth($list-label-widths, $index);
+	}
+}
+
+.value {
+	inline-size: $list-value-inline-size;
+	block-size: $list-line-block-size;
+	margin-inline-start: auto;
+	border-radius: var(--wpds-border-radius-md);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-skeleton.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-skeleton.tsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import { Skeleton } from '@jetpack-premium-analytics/externals';
+import clsx from 'clsx';
+/**
+ * Internal dependencies
+ */
+import { SkeletonRoot } from '../widget-skeleton';
+import styles from './leaderboard-skeleton.module.scss';
+
+const DEFAULT_ROW_COUNT = 5;
+
+/**
+ * What a widget asking for every row draws — enough to fill a tall tile, and
+ * the wrapper clips whatever does not fit.
+ */
+const ALL_ROWS_COUNT = 12;
+
+/**
+ * Which of the design's two leaderboard shapes to draw.
+ *
+ * `list` matches a chart drawn `withOverlayLabel`, where the label sits on the
+ * bar and the row loads as one line. `bars` matches the plain chart, whose
+ * label sits above its bar.
+ */
+export type LeaderboardSkeletonVariant = 'list' | 'bars';
+
+export interface LeaderboardSkeletonProps {
+	/** Rows to draw; pass the widget's own row count so the shape matches the list that will load. */
+	rows?: number;
+	/** Which shape to draw. */
+	variant?: LeaderboardSkeletonVariant;
+}
+
+/**
+ * Loading shape for `LeaderboardChart`: a centred stack of rows.
+ *
+ * Rows past the tile's height are clipped rather than overflowing, mirroring
+ * the chart's `fitRows` — a ten-row widget in a tile with room for three shows
+ * three either way.
+ *
+ * @param props         - Component props.
+ * @param props.rows    - Rows to draw.
+ * @param props.variant - Which shape to draw.
+ * @return The rendered skeleton.
+ */
+export function LeaderboardSkeleton( {
+	rows = DEFAULT_ROW_COUNT,
+	variant = 'list',
+}: LeaderboardSkeletonProps ) {
+	// A widget's `max` of 0 means "all rows", so it cannot be drawn literally.
+	const rowCount = rows > 0 ? rows : ALL_ROWS_COUNT;
+
+	return (
+		<SkeletonRoot>
+			{ /* Own wrapper: the `:nth-child()` width steps must not count
+			     SkeletonRoot's hidden label. */ }
+			<div className={ clsx( styles.rows, styles[ variant ] ) }>
+				{ Array.from( { length: rowCount }, ( _, index ) => (
+					<div key={ index } className={ styles.row } data-testid="skeleton-row">
+						{ variant === 'bars' ? (
+							<>
+								<Skeleton className={ styles.barLabel } data-testid="skeleton-bar-label" />
+								<Skeleton className={ styles.bar } data-testid="skeleton-bar" />
+							</>
+						) : (
+							<>
+								<Skeleton className={ styles.listLabel } data-testid="skeleton-list-label" />
+								<Skeleton className={ styles.value } data-testid="skeleton-value" />
+							</>
+						) }
+					</div>
+				) ) }
+			</div>
+		</SkeletonRoot>
+	);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/stories/leaderboard-chart.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/stories/leaderboard-chart.stories.tsx
@@ -1,5 +1,7 @@
+import { WidgetCard } from '../../../stories/widget-card';
 import { withChartTheme } from '../../../stories/with-chart-theme';
 import { LeaderboardChart } from '../leaderboard-chart';
+import { LeaderboardSkeleton } from '../leaderboard-skeleton';
 import type { LeaderboardChartData } from '../leaderboard-chart';
 import type { Meta, StoryObj, Decorator } from '@storybook/react';
 
@@ -317,4 +319,47 @@ export const Resizable: Story = {
 	parameters: {
 		layout: 'padded',
 	},
+};
+
+type SkeletonStory = StoryObj< typeof LeaderboardSkeleton >;
+
+/**
+ * The loading shape widgets pass through `WidgetState`'s `renderLoading`, in the
+ * default `list` variant: the label and its value on one line, centred in the
+ * body. A full-height tile fits every row the widget asked for.
+ */
+export const Skeleton: SkeletonStory = {
+	render: args => (
+		<WidgetCard width="360px" height="320px">
+			<LeaderboardSkeleton { ...args } />
+		</WidgetCard>
+	),
+	args: { rows: 5 },
+};
+
+/**
+ * The `bars` variant, for a chart drawn without `withOverlayLabel`: the label
+ * sits above its bar, so the row loads as two lines rather than one.
+ */
+export const SkeletonBars: SkeletonStory = {
+	render: args => (
+		<WidgetCard width="360px" height="320px">
+			<LeaderboardSkeleton { ...args } />
+		</WidgetCard>
+	),
+	args: { rows: 5, variant: 'bars' },
+};
+
+/**
+ * A height-1 dashboard tile. Too short to centre eight rows, so they pack from
+ * the top and the tail is clipped rather than pushed past the widget body —
+ * the rows the loaded chart's `fitRows` drops.
+ */
+export const SkeletonShortTile: SkeletonStory = {
+	render: args => (
+		<WidgetCard width="360px" height="140px">
+			<LeaderboardSkeleton { ...args } />
+		</WidgetCard>
+	),
+	args: { rows: 8 },
 };

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
@@ -34,6 +34,8 @@ export {
 } from './metric-tabs-chart';
 export {
 	LeaderboardChart,
+	LeaderboardSkeleton,
+	type LeaderboardSkeletonProps,
 	type LeaderboardChartProps,
 	type LeaderboardChartData,
 	type LegendLabels,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -30,6 +30,8 @@ export {
 	type LegendItem,
 	type SeriesStyle,
 	LeaderboardChart,
+	LeaderboardSkeleton,
+	type LeaderboardSkeletonProps,
 	type LeaderboardChartProps,
 	type LeaderboardChartData,
 	type LegendLabels,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/widget-card.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/widget-card.tsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import type { ReactNode } from 'react';
+
+export interface WidgetCardProps {
+	/** Card height, which is what each skeleton story varies. */
+	height: string;
+	/** Card width; the dashboard's common tile width unless a story needs another. */
+	width?: string;
+	children: ReactNode;
+}
+
+/**
+ * Widget card wrapper for skeleton stories, simulating a dashboard widget
+ * container so a shape is shown within typical widget dimensions.
+ *
+ * @param props          - Component props.
+ * @param props.height   - Card height.
+ * @param props.width    - Card width.
+ * @param props.children - The shape to frame.
+ * @return The rendered card.
+ */
+export function WidgetCard( { height, width = '360px', children }: WidgetCardProps ) {
+	return (
+		<div
+			style={ {
+				width,
+				height,
+				border: '1px solid var(--wpds-color-stroke-surface-neutral-weak)',
+				borderRadius: 'var(--wpds-border-radius-md)',
+				background: 'var(--wpds-color-background-surface-neutral)',
+				display: 'flex',
+				flexDirection: 'column',
+				overflow: 'hidden',
+			} }
+		>
+			<div style={ { position: 'relative', flex: 1, minHeight: 0 } }>{ children }</div>
+		</div>
+	);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/widget-card.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/widget-card.tsx
@@ -13,7 +13,9 @@ export interface WidgetCardProps {
 
 /**
  * Widget card wrapper for skeleton stories, simulating a dashboard widget
- * container so a shape is shown within typical widget dimensions.
+ * container so a shape is shown within typical widget dimensions. The inset
+ * matches the dashboard's `--wp-ui-card-padding` override, so a story's shape
+ * clears the card border by the same distance it does in product.
  *
  * @param props          - Component props.
  * @param props.height   - Card height.
@@ -30,6 +32,8 @@ export function WidgetCard( { height, width = '360px', children }: WidgetCardPro
 				border: '1px solid var(--wpds-color-stroke-surface-neutral-weak)',
 				borderRadius: 'var(--wpds-border-radius-md)',
 				background: 'var(--wpds-color-background-surface-neutral)',
+				padding: 'var(--wpds-dimension-padding-lg)',
+				boxSizing: 'border-box',
 				display: 'flex',
 				flexDirection: 'column',
 				overflow: 'hidden',

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/product-leaderboard/top-performing-product-leaderboard-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/product-leaderboard/top-performing-product-leaderboard-widget.tsx
@@ -10,7 +10,11 @@ import { Icon } from '@jetpack-premium-analytics/externals';
 import { productBlouse } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import { buildLeaderboardRow, LeaderboardChart } from '../../components/chart-leaderboard';
+import {
+	buildLeaderboardRow,
+	LeaderboardChart,
+	LeaderboardSkeleton,
+} from '../../components/chart-leaderboard';
 import { useWidgetRootContext } from '../../components/widget-root';
 import { WidgetState } from '../../components/widget-state';
 /**
@@ -184,6 +188,7 @@ export function TopPerformingProductLeaderboardWidget( {
 					emptyStateText ??
 					__( 'No product sales in this period.', 'jetpack-premium-analytics-pkg' ),
 			} }
+			renderLoading={ <LeaderboardSkeleton rows={ limit } /> }
 		>
 			<LeaderboardChart
 				data={ chartData }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-utm/sales-by-utm-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-utm/sales-by-utm-widget.tsx
@@ -8,7 +8,7 @@ import {
 import { megaphone, search, channel } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
 import { useMemo, type CSSProperties } from 'react';
-import { LeaderboardChart, WidgetState } from '../../components';
+import { LeaderboardChart, LeaderboardSkeleton, WidgetState } from '../../components';
 /**
  * Internal dependencies
  */
@@ -90,6 +90,7 @@ export function SalesByUtmWidget( { view }: SalesByUtmWidgetProps ) {
 				icon: emptyStateIcon,
 				description: __( 'No attribution data in this period.', 'jetpack-premium-analytics-pkg' ),
 			} }
+			renderLoading={ <LeaderboardSkeleton variant="bars" /> }
 		>
 			<LeaderboardChart
 				data={ chartData }

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -4,6 +4,7 @@
 import { useStatsTopAuthors } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	LeaderboardPostLabel,
 	ReportLink,
 	WidgetBackLink,
@@ -47,6 +48,11 @@ export type AuthorsLeaderboardProps = {
 	 */
 	rows?: AuthorLeaderboardRow[];
 	/**
+	 * Rows the report was asked for, so the loading skeleton draws the list that
+	 * is coming rather than a default-length one.
+	 */
+	max?: number;
+	/**
 	 * When `true`, the first fetch is in flight and there is no data to show yet.
 	 */
 	isLoading?: boolean;
@@ -89,6 +95,7 @@ export type AuthorsLeaderboardProps = {
  */
 export function AuthorsLeaderboard( {
 	rows = [],
+	max,
 	isLoading = false,
 	isFetching = false,
 	isError = false,
@@ -196,6 +203,7 @@ export function AuthorsLeaderboard( {
 						  )
 						: __( 'No author views in this period.', 'jetpack-premium-analytics-pkg' ),
 				} }
+				renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 			>
 				<LeaderboardChart
 					data={ chartData }
@@ -255,6 +263,7 @@ function AuthorsReport( { max }: AuthorsReportProps ) {
 		<>
 			<AuthorsLeaderboard
 				rows={ rows }
+				max={ max }
 				isLoading={ isInitialLoading }
 				isFetching={ isFetching }
 				// The Stats queries carry `placeholderData: previousData => previousData`, so a

--- a/projects/packages/premium-analytics/widgets/clicks/render.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/render.tsx
@@ -11,6 +11,7 @@ import {
 } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	ReportLink,
 	WidgetBackLink,
 	WidgetFooter,
@@ -303,6 +304,7 @@ function ClicksInner( { max }: ClicksInnerProps ) {
 					icon: link,
 					description: __( 'No clicks in this period.', 'jetpack-premium-analytics-pkg' ),
 				} }
+				renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 			>
 				<ClicksLeaderboard
 					rows={ activeRows }

--- a/projects/packages/premium-analytics/widgets/emails/render.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/render.tsx
@@ -4,6 +4,7 @@
 import { useStatsEmailSummary, type StatsEmailSummary } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	LeaderboardPostLabel,
 	ReportLink,
 	WidgetFooter,
@@ -203,6 +204,7 @@ function EmailsReport( { attributes }: EmailsReportProps ) {
 							'jetpack-premium-analytics-pkg'
 						),
 					} }
+					renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 				>
 					<EmailsLeaderboard rows={ rows } metric={ metric } />
 				</WidgetState>

--- a/projects/packages/premium-analytics/widgets/file-downloads/render.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/render.tsx
@@ -18,6 +18,7 @@ import {
 	getCombinedPeriodMax,
 	safeHttpUrl,
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	ReportLink,
 	sharePercentage,
 	WidgetFooter,
@@ -191,6 +192,7 @@ function FileDownloadsInner( { max }: FileDownloadsInnerProps ) {
 						icon: download,
 						description: __( 'No file downloads in this period.', 'jetpack-premium-analytics-pkg' ),
 					} }
+					renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 				>
 					<FileDownloadsLeaderboard rows={ rows } withComparison={ withComparison } />
 				</WidgetState>

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/render.tsx
@@ -4,6 +4,7 @@
 import { useStatsCommentsRows } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	ReportLink,
 	WidgetFooter,
 	WidgetRoot,
@@ -92,6 +93,7 @@ function MostCommentedAuthorsInner( { max }: MostCommentedAuthorsInnerProps ) {
 							'jetpack-premium-analytics-pkg'
 						),
 					} }
+					renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 				>
 					<LeaderboardChart
 						data={ leaderboardData }

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/render.tsx
@@ -4,6 +4,7 @@
 import { useStatsCommentsRows } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	LeaderboardPostLabel,
 	ReportLink,
 	WidgetFooter,
@@ -85,6 +86,7 @@ function MostCommentedPostsInner( { max }: MostCommentedPostsInnerProps ) {
 							'jetpack-premium-analytics-pkg'
 						),
 					} }
+					renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 				>
 					<LeaderboardChart
 						data={ leaderboardData }

--- a/projects/packages/premium-analytics/widgets/referrers/render.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/render.tsx
@@ -8,6 +8,7 @@ import {
 } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	ReportLink,
 	WidgetBackLink,
 	WidgetFooter,
@@ -295,6 +296,7 @@ function ReferrersInner( { max }: { max: number } ) {
 					icon: globe,
 					description: __( 'No referrers in this period.', 'jetpack-premium-analytics-pkg' ),
 				} }
+				renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 			>
 				<ReferrersLeaderboard
 					rows={ activeRows }

--- a/projects/packages/premium-analytics/widgets/search-terms/render.tsx
+++ b/projects/packages/premium-analytics/widgets/search-terms/render.tsx
@@ -6,6 +6,7 @@ import {
 	describeError,
 	getCombinedPeriodMax,
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	ReportLink,
 	WidgetFooter,
 	WidgetRoot,
@@ -92,6 +93,7 @@ function SearchTermsInner( { max = 10 }: SearchTermsAttributes ) {
 						icon: search,
 						description: __( 'No search terms in this period.', 'jetpack-premium-analytics-pkg' ),
 					} }
+					renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 				>
 					<LeaderboardChart
 						data={ leaderboardData }

--- a/projects/packages/premium-analytics/widgets/shares/render.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/render.tsx
@@ -3,6 +3,7 @@
  */
 import {
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	WidgetRoot,
 	WidgetState,
 	sharePercentage,
@@ -70,6 +71,7 @@ function SharesInner( { max = 10 }: SharesAttributes ) {
 							'jetpack-premium-analytics-pkg'
 						),
 					} }
+					renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 				>
 					<LeaderboardChart
 						data={ leaderboardData }

--- a/projects/packages/premium-analytics/widgets/tags/render.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/render.tsx
@@ -3,6 +3,7 @@
  */
 import {
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	ReportLink,
 	WidgetBackLink,
 	WidgetFooter,
@@ -176,6 +177,9 @@ function TagsInner( { max = 10 }: TagsAttributes ) {
 							'jetpack-premium-analytics-pkg'
 						),
 					} }
+					// The drilled-in view is a plain link list, not a leaderboard, so it
+					// keeps the default shape.
+					renderLoading={ selectedGroup ? undefined : <LeaderboardSkeleton rows={ max } /> }
 				>
 					{ selectedGroup ? (
 						<TagGroupMembers members={ selectedGroup.children } />

--- a/projects/packages/premium-analytics/widgets/top-platforms/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/render.tsx
@@ -12,6 +12,7 @@ import {
 	describeError,
 	getCombinedPeriodMax,
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	sharePercentage,
 	WidgetRoot,
 	WidgetState,
@@ -105,6 +106,7 @@ function TopPlatformsInner( { max, platformDimension }: TopPlatformsInnerProps )
 					icon: device,
 					description: __( 'No platform data in this period.', 'jetpack-premium-analytics-pkg' ),
 				} }
+				renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 			>
 				<LeaderboardChart
 					data={ leaderboardData }

--- a/projects/packages/premium-analytics/widgets/top-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/render.tsx
@@ -11,6 +11,7 @@ import { reports } from '@jetpack-premium-analytics/icons';
 import { pickReportDateParams } from '@jetpack-premium-analytics/routing';
 import {
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	PostTitleLink,
 	ReportLink,
 	RowsCsvDownloadButton,
@@ -321,6 +322,7 @@ function TopPostsReport( { max }: TopPostsReportProps ) {
 						icon: reports,
 						description: __( 'No views in this period.', 'jetpack-premium-analytics-pkg' ),
 					} }
+					renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 				>
 					<TopPostsLeaderboard
 						rows={ rows }
@@ -532,6 +534,7 @@ function ArchivesReport( { max }: { max: number } ) {
 					icon: reports,
 					description: __( 'No views in this period.', 'jetpack-premium-analytics-pkg' ),
 				} }
+				renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 			>
 				<TopPostsLeaderboard
 					rows={ activeRows }

--- a/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
@@ -9,6 +9,7 @@ import {
 	describeError,
 	getCombinedPeriodMax,
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	LeaderboardPostLabel,
 	ReportLink,
 	WidgetBackLink,
@@ -200,6 +201,7 @@ function UtmInsightsInner( { utmDimension, max, showReportLink }: UtmInsightsInn
 						icon: megaphone,
 						description: __( 'No UTM data in this period.', 'jetpack-premium-analytics-pkg' ),
 					} }
+					renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 				>
 					<LeaderboardChart
 						data={ leaderboardData }

--- a/projects/packages/premium-analytics/widgets/videopress/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/render.tsx
@@ -5,6 +5,7 @@ import { useStatsVideoPlays } from '@jetpack-premium-analytics/data';
 import { pickReportDateParams } from '@jetpack-premium-analytics/routing';
 import {
 	LeaderboardChart,
+	LeaderboardSkeleton,
 	ReportLink,
 	VideoTitleLink,
 	WidgetFooter,
@@ -151,6 +152,7 @@ function VideoPressReport( { max }: VideoPressReportProps ) {
 				icon: video,
 				description: __( 'No VideoPress plays in this period.', 'jetpack-premium-analytics-pkg' ),
 			} }
+			renderLoading={ <LeaderboardSkeleton rows={ max } /> }
 		>
 			<LeaderboardChart
 				data={ chartData }


### PR DESCRIPTION
Part of WOOA7S-1781. Stacked on #51202 — review that one first.

#51202 gave every widget a generic four-line skeleton. This PR is the first of four that replace it with a skeleton shaped like the content each widget is about to render, one archetype per PR.

The geometry comes from the design prototype rather than from the loaded component: the shapes read lighter than the real content and centre in the widget body.

## Proposed changes

- Add `LeaderboardSkeleton` and draw it at the 16 `<WidgetState>` call sites whose content is a `LeaderboardChart`.
- Two variants: `list` (the default) puts the label and its value on one line, matching the 15 charts drawn `withOverlayLabel`; `bars` stacks a label over its bar for `sales-by-utm`, the one chart without it.
- Rows past the tile's height are clipped rather than overflowing, mirroring `LeaderboardChart`'s `fitRows`.
- Add a shared `WidgetCard` story helper, which the later PRs in the stack reuse.

## Follow-ups in this stack

- #51236 — metric tile grid
- #51237 — metric sparkline, bar chart, heatmap
- #51238 — donut, subscriber list, post highlight card, annual highlights

Shapes with no prototype reference (comparative line, data table, leaderboard-plus-map, gauge, and the one-off funnel / progress meter / highlight / embed list shapes) stay on the generic skeleton pending design input.

## Related product discussion/links

- WOOA7S-1781

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open the Premium Analytics dashboard with a throttled connection (DevTools → Network → Slow 4G) and reload.
- Leaderboard widgets (Most viewed, Referrers, Search terms, Clicks, Top videos, …) should show a placeholder line per row with a value trailing it, centred in the body, instead of four generic lines.
- Resize one to a height-1 tile: the rows should clip inside the body, never spill over the footer.
- Storybook → _Widgets Toolkit / Components / LeaderboardChart_ has `Skeleton`, `SkeletonBars` and `SkeletonShortTile`.


https://github.com/user-attachments/assets/094d77ca-b998-4ad9-8524-b67b9245f15d

<img width="2560" height="1327" alt="Screenshot 2026-08-19 at 2 34 06 PM" src="https://github.com/user-attachments/assets/6f051f01-4e7e-48af-b09a-2fa1478ae855" />
