### PR TITLE
Podcast: speed up feed generation

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-inefficient-feed-generator
+++ b/projects/packages/podcast/changelog/fix-podcast-inefficient-feed-generator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Feed: speed up podcast feed generation on large catalogues.

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -31,7 +31,7 @@ class Customize_Feed {
 	/**
 	 * Enclosure URLs already emitted in the current feed render, keyed by post
 	 * ID then URL. Reset on `rss2_head` so each feed starts clean — see
-	 * {@see self::is_duplicate_enclosure()}.
+	 * {@see self::reset_render_state()}.
 	 *
 	 * @var array<int, array<string, true>>
 	 */
@@ -41,6 +41,8 @@ class Customize_Feed {
 	 * The `<description>` most recently rendered, as `[ post ID, value ]`, for
 	 * {@see self::output_item_tags()} to reuse. One slot: the template emits
 	 * `<description>` immediately before `rss2_item` fires for the same item.
+	 * Reset per render — see {@see self::reset_render_state()} — so a template
+	 * that skips `<description>` can't match a previous render's post ID.
 	 *
 	 * @var array{0: int, 1: string}
 	 */
@@ -93,7 +95,7 @@ class Customize_Feed {
 		add_action( 'rss2_ns', array( __CLASS__, 'output_namespaces' ) );
 		add_filter( 'wp_title_rss', array( __CLASS__, 'feed_title' ) );
 		add_filter( 'bloginfo_rss', array( __CLASS__, 'feed_description' ), 10, 2 );
-		add_action( 'rss2_head', array( __CLASS__, 'reset_enclosure_dedup' ), 0 );
+		add_action( 'rss2_head', array( __CLASS__, 'reset_render_state' ), 0 );
 		add_action( 'rss2_head', array( __CLASS__, 'output_channel_tags' ) );
 		add_action( 'rss2_item', array( __CLASS__, 'output_item_tags' ) );
 		add_filter( 'rss_enclosure', array( __CLASS__, 'rewrite_enclosure' ) );
@@ -360,7 +362,7 @@ class Customize_Feed {
 
 		// Drop repeats: rows keyed per post, by final URL, so distinct enclosures
 		// survive while the duplicate stats URLs collapse to one. Registry is
-		// cleared per render — see `reset_enclosure_dedup()`.
+		// cleared per render — see `reset_render_state()`.
 		$post_id = null !== $post_obj ? (int) $post_obj->ID : 0;
 		if ( isset( self::$seen_enclosures[ $post_id ][ $final_url ] ) ) {
 			return '';
@@ -380,13 +382,14 @@ class Customize_Feed {
 	}
 
 	/**
-	 * Clear the per-render enclosure dedup registry. Hooked on `rss2_head` (at
-	 * priority 0, before any item renders) so re-generating a feed within a
-	 * single long-lived process — WP-CLI, a warm worker — starts fresh instead
-	 * of dropping every enclosure as already-seen.
+	 * Clear the per-render statics. Hooked on `rss2_head` (at priority 0, before
+	 * any item renders) so re-generating a feed within a single long-lived
+	 * process — WP-CLI, a warm worker — starts fresh instead of dropping every
+	 * enclosure as already-seen or reusing the last render's summary.
 	 */
-	public static function reset_enclosure_dedup() {
+	public static function reset_render_state() {
 		self::$seen_enclosures = array();
+		self::$item_summary    = array( 0, '' );
 	}
 
 	/**

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -385,10 +385,10 @@ class Customize_Feed {
 	}
 
 	/**
-	 * Clear every per-render registry. Called at the top of each feed render so
-	 * re-generating a feed within a single long-lived process — WP-CLI, a warm
-	 * worker — starts fresh instead of dropping every enclosure as already-seen
-	 * or reusing the previous render's summaries.
+	 * Clear the per-render registries. Hooked on `rss2_head` (at priority 0,
+	 * before any item renders) so re-generating a feed within a single
+	 * long-lived process — WP-CLI, a warm worker — starts fresh instead of
+	 * dropping every enclosure as already-seen or reusing stale summaries.
 	 */
 	public static function reset_render_state() {
 		self::$seen_enclosures = array();

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -29,13 +29,42 @@ class Customize_Feed {
 	private static $registered = false;
 
 	/**
+	 * Blocks that are chrome rather than show notes: they're dropped from
+	 * `<content:encoded>` so only the surrounding prose survives.
+	 *
+	 * @var string[]
+	 */
+	private const CHROME_BLOCKS = array(
+		'jetpack/podcast-episode',
+		'jetpack/podcast-player',
+		'jetpack/subscriptions',
+	);
+
+	/**
 	 * Enclosure URLs already emitted in the current feed render, keyed by post
 	 * ID then URL. Reset on `rss2_head` so each feed starts clean — see
-	 * {@see self::is_duplicate_enclosure()}.
+	 * {@see self::rewrite_enclosure()}.
 	 *
 	 * @var array<int, array<string, true>>
 	 */
 	private static $seen_enclosures = array();
+
+	/**
+	 * `<description>` values already rendered this feed, keyed by post ID, so
+	 * `<itunes:summary>` can reuse them instead of rebuilding the excerpt — see
+	 * {@see self::capture_item_summary()}.
+	 *
+	 * @var array<int, string>
+	 */
+	private static $item_summaries = array();
+
+	/**
+	 * Enclosure URL → attachment ID for every episode in this feed, resolved in
+	 * one batch by {@see self::prime_feed_caches()}.
+	 *
+	 * @var array<string, int>
+	 */
+	private static $attachment_ids = array();
 
 	/**
 	 * Wire the late-binding `wp` action that decides whether to register the
@@ -84,15 +113,16 @@ class Customize_Feed {
 		add_action( 'rss2_ns', array( __CLASS__, 'output_namespaces' ) );
 		add_filter( 'wp_title_rss', array( __CLASS__, 'feed_title' ) );
 		add_filter( 'bloginfo_rss', array( __CLASS__, 'feed_description' ), 10, 2 );
-		add_action( 'rss2_head', array( __CLASS__, 'reset_enclosure_dedup' ), 0 );
+		add_action( 'rss2_head', array( __CLASS__, 'prime_feed_caches' ), 0 );
 		add_action( 'rss2_head', array( __CLASS__, 'output_channel_tags' ) );
 		add_action( 'rss2_item', array( __CLASS__, 'output_item_tags' ) );
 		add_filter( 'rss_enclosure', array( __CLASS__, 'rewrite_enclosure' ) );
+		add_filter( 'the_excerpt_rss', array( __CLASS__, 'capture_item_summary' ) );
 
 		add_filter( 'option_rss_use_excerpt', '__return_false' );
 		// Request-scoped to the feed: only the queried episodes render here, so
 		// this never touches block output outside the podcast feed response.
-		add_filter( 'render_block', array( __CLASS__, 'strip_block_from_feed' ), 10, 2 );
+		add_filter( 'pre_render_block', array( __CLASS__, 'skip_block_in_feed' ), 10, 2 );
 		add_filter( 'comments_open', '__return_false' );
 		add_filter( 'get_comments_number', '__return_zero' );
 		add_filter( 'the_category_rss', '__return_empty_string' );
@@ -205,10 +235,14 @@ class Customize_Feed {
 			echo '<itunes:author>' . esc_xml( wp_strip_all_tags( $author ) ) . "</itunes:author>\n";
 		}
 
-		// Re-applying `the_excerpt_rss` so `<itunes:summary>` matches whatever
-		// the item's `<description>` ends up emitting — `get_the_excerpt()`
-		// doesn't run the filter chain itself.
-		$excerpt = (string) apply_filters( 'the_excerpt_rss', get_the_excerpt() );
+		// `<itunes:summary>` mirrors the item's `<description>`, which the feed
+		// template rendered a few lines earlier — reuse that string rather than
+		// rebuild it. Regenerating means a second `wp_trim_excerpt()` pass over
+		// the whole post body, per item. Recompute only if `<description>` never
+		// ran (a replaced feed template), where `get_the_excerpt()` needs the
+		// filter chain applied on top since it doesn't run it itself.
+		$excerpt = self::$item_summaries[ (int) $post->ID ]
+			?? (string) apply_filters( 'the_excerpt_rss', get_the_excerpt() );
 		if ( '' !== $excerpt ) {
 			echo '<itunes:summary>' . esc_xml( wp_strip_all_tags( $excerpt ) ) . "</itunes:summary>\n";
 		}
@@ -233,23 +267,41 @@ class Customize_Feed {
 	}
 
 	/**
-	 * Strip the episode, feed-player, and subscribe blocks from
+	 * Keep the episode, feed-player, and subscribe blocks out of
 	 * `<content:encoded>`, leaving the surrounding show-note prose.
 	 *
-	 * @param string $block_content Rendered block HTML.
-	 * @param array  $block         Parsed block, including its `blockName`.
-	 * @return string
+	 * Short-circuits on `pre_render_block` rather than blanking the result on
+	 * `render_block`: the output is discarded either way, so running the render
+	 * callback first is pure waste — and an expensive kind. The episode block
+	 * validates its media URLs through `wp_http_validate_url()`, which resolves
+	 * DNS, and the player block server-renders by fetching a feed over HTTP.
+	 * Per item, across a full catalogue, that dominated the feed's build time.
+	 *
+	 * @param string|null $pre_render   Short-circuit value; `null` renders normally.
+	 * @param array       $parsed_block Parsed block, including its `blockName`.
+	 * @return string|null
 	 */
-	public static function strip_block_from_feed( $block_content, $block ) {
-		static $chrome = array(
-			'jetpack/podcast-episode',
-			'jetpack/podcast-player',
-			'jetpack/subscriptions',
-		);
-		if ( isset( $block['blockName'] ) && in_array( $block['blockName'], $chrome, true ) ) {
+	public static function skip_block_in_feed( $pre_render, $parsed_block ) {
+		if ( isset( $parsed_block['blockName'] ) && in_array( $parsed_block['blockName'], self::CHROME_BLOCKS, true ) ) {
 			return '';
 		}
-		return $block_content;
+		return $pre_render;
+	}
+
+	/**
+	 * Record the `<description>` the feed template just rendered for the current
+	 * item so {@see self::output_item_tags()} can reuse it for
+	 * `<itunes:summary>`. Pass-through filter — the value is never modified.
+	 *
+	 * @param string $excerpt Filtered item excerpt.
+	 * @return string
+	 */
+	public static function capture_item_summary( $excerpt ) {
+		$post_id = (int) get_the_ID();
+		if ( $post_id > 0 ) {
+			self::$item_summaries[ $post_id ] = (string) $excerpt;
+		}
+		return $excerpt;
 	}
 
 	/**
@@ -329,7 +381,7 @@ class Customize_Feed {
 
 		// Drop repeats: rows keyed per post, by final URL, so distinct enclosures
 		// survive while the duplicate stats URLs collapse to one. Registry is
-		// cleared per render — see `reset_enclosure_dedup()`.
+		// cleared per render — see `reset_render_state()`.
 		$post_id = null !== $post_obj ? (int) $post_obj->ID : 0;
 		if ( isset( self::$seen_enclosures[ $post_id ][ $final_url ] ) ) {
 			return '';
@@ -349,13 +401,187 @@ class Customize_Feed {
 	}
 
 	/**
-	 * Clear the per-render enclosure dedup registry. Hooked on `rss2_head` (at
-	 * priority 0, before any item renders) so re-generating a feed within a
-	 * single long-lived process — WP-CLI, a warm worker — starts fresh instead
-	 * of dropping every enclosure as already-seen.
+	 * Clear every per-render registry. Called at the top of each feed render so
+	 * re-generating a feed within a single long-lived process — WP-CLI, a warm
+	 * worker — starts fresh instead of dropping every enclosure as already-seen
+	 * or reusing the previous render's summaries.
 	 */
-	public static function reset_enclosure_dedup() {
+	public static function reset_render_state() {
 		self::$seen_enclosures = array();
+		self::$item_summaries  = array();
+		self::$attachment_ids  = array();
+	}
+
+	/**
+	 * Resolve, in bulk, the per-episode data the item loop would otherwise fetch
+	 * one row at a time. Hooked on `rss2_head` at priority 0 — after the query
+	 * has run and primed its post caches, before the first item renders.
+	 *
+	 * Item rendering needs, for every episode: the attachment behind each
+	 * enclosure URL, that attachment's metadata (for `<itunes:duration>`), and
+	 * the featured image (for `<itunes:image>`). Left alone that's several
+	 * uncached queries per item, and the enclosure lookup is the expensive one —
+	 * an unindexed `meta_value` comparison that some hosts extend with a
+	 * `guid LIKE` fallback scan. Here it's a handful of queries for the whole
+	 * feed instead.
+	 */
+	public static function prime_feed_caches() {
+		self::reset_render_state();
+
+		$query = $GLOBALS['wp_query'] ?? null;
+		if ( ! $query instanceof \WP_Query || empty( $query->posts ) ) {
+			return;
+		}
+
+		$post_ids = array();
+		foreach ( $query->posts as $post ) {
+			if ( $post instanceof WP_Post ) {
+				$post_ids[] = (int) $post->ID;
+			}
+		}
+		if ( empty( $post_ids ) ) {
+			return;
+		}
+
+		// No-op when the query already primed these; covers the paths where it didn't.
+		update_meta_cache( 'post', $post_ids );
+
+		// Mirror how `rss_enclosure()` builds the URL it hands to `rss_enclosure`
+		// filters, so the primed keys match what `rewrite_enclosure()` looks up.
+		$urls = array();
+		foreach ( $post_ids as $post_id ) {
+			foreach ( (array) get_post_meta( $post_id, 'enclosure', false ) as $enclosure ) {
+				$url = esc_url( trim( (string) explode( "\n", (string) $enclosure )[0] ) );
+				if ( '' !== $url ) {
+					$urls[ $url ] = true;
+				}
+			}
+		}
+
+		$attachment_ids = self::prime_attachment_ids( array_keys( $urls ) );
+
+		foreach ( $post_ids as $post_id ) {
+			$thumbnail_id = (int) get_post_thumbnail_id( $post_id );
+			if ( $thumbnail_id > 0 ) {
+				$attachment_ids[] = $thumbnail_id;
+			}
+		}
+
+		$attachment_ids = array_values( array_unique( $attachment_ids ) );
+		if ( ! empty( $attachment_ids ) ) {
+			// Terms aren't read off attachments here; metadata is (duration, image src).
+			_prime_post_caches( $attachment_ids, false, true );
+		}
+
+		// Registered only now that the map is built, so the `apply_filters()`
+		// calls inside `prime_attachment_ids()` can't recurse into it.
+		add_filter( 'pre_attachment_url_to_postid', array( __CLASS__, 'primed_attachment_id' ), 10, 2 );
+	}
+
+	/**
+	 * Resolve a batch of enclosure URLs to attachment IDs in one query, caching
+	 * the answers in {@see self::$attachment_ids}.
+	 *
+	 * Reproduces `attachment_url_to_postid()` exactly — same URL-to-path
+	 * normalization, same preference for a case-sensitive match among rows a
+	 * case-insensitive collation returns together, same two filters in the same
+	 * order — so a primed answer is the one core would have given. The only
+	 * difference is that the `meta_value` comparison happens once for the whole
+	 * feed rather than once per episode.
+	 *
+	 * @param string[] $urls Enclosure URLs to resolve.
+	 * @return int[] Attachment IDs that resolved, for cache priming.
+	 */
+	private static function prime_attachment_ids( array $urls ): array {
+		if ( empty( $urls ) ) {
+			return array();
+		}
+
+		global $wpdb;
+
+		$dir          = wp_get_upload_dir();
+		$base         = $dir['baseurl'] . '/';
+		$site_scheme  = (string) wp_parse_url( $dir['url'], PHP_URL_SCHEME );
+		$paths_by_url = array();
+
+		foreach ( $urls as $url ) {
+			$path       = $url;
+			$url_scheme = (string) wp_parse_url( $path, PHP_URL_SCHEME );
+			if ( '' !== $url_scheme && $url_scheme !== $site_scheme ) {
+				$path = str_replace( $url_scheme, $site_scheme, $path );
+			}
+			if ( 0 === strpos( $path, $base ) ) {
+				$path = substr( $path, strlen( $base ) );
+			}
+			$paths_by_url[ $url ] = $path;
+		}
+
+		$paths        = array_values( array_unique( $paths_by_url ) );
+		$placeholders = implode( ', ', array_fill( 0, count( $paths ), '%s' ) );
+		$rows         = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Batched replacement for N uncached `attachment_url_to_postid()` lookups; results are cached in `self::$attachment_ids` for the render.
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- `$placeholders` is a generated list of `%s`, one per path; the sniff can't see through the interpolation.
+				"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_wp_attached_file' AND meta_value IN ( {$placeholders} )",
+				$paths
+			)
+		);
+
+		// A case-insensitive collation can return several rows for one path.
+		// Keep the first, but let an exact match displace it — as core does.
+		$wanted = array();
+		foreach ( $paths as $path ) {
+			$wanted[ strtolower( $path ) ] = $path;
+		}
+		$first = array();
+		$exact = array();
+		foreach ( (array) $rows as $row ) {
+			$value = (string) $row->meta_value;
+			$path  = $wanted[ strtolower( $value ) ] ?? null;
+			if ( null === $path ) {
+				continue;
+			}
+			if ( ! isset( $first[ $path ] ) ) {
+				$first[ $path ] = (int) $row->post_id;
+			}
+			if ( $path === $value && ! isset( $exact[ $path ] ) ) {
+				$exact[ $path ] = (int) $row->post_id;
+			}
+		}
+		$ids_by_path = $exact + $first;
+
+		$resolved = array();
+		foreach ( $paths_by_url as $url => $path ) {
+			/** This filter is documented in wp-includes/media.php */
+			$post_id = apply_filters( 'pre_attachment_url_to_postid', null, $url );
+			if ( null === $post_id ) {
+				/** This filter is documented in wp-includes/media.php */
+				$post_id = apply_filters( 'attachment_url_to_postid', $ids_by_path[ $path ] ?? null, $url );
+			}
+
+			$post_id                      = (int) $post_id;
+			self::$attachment_ids[ $url ] = $post_id;
+			if ( $post_id > 0 ) {
+				$resolved[] = $post_id;
+			}
+		}
+
+		return $resolved;
+	}
+
+	/**
+	 * Serve `attachment_url_to_postid()` from the batch resolved in
+	 * {@see self::prime_attachment_ids()}.
+	 *
+	 * A primed `0` short-circuits too: the full filter chain already ran against
+	 * that URL during priming, so re-running the lookup would only repeat a miss
+	 * we've already paid for. URLs we never primed fall through to core.
+	 *
+	 * @param int|null $post_id Result so far; `null` when no lookup has run.
+	 * @param string   $url     URL being looked up.
+	 * @return int|null
+	 */
+	public static function primed_attachment_id( $post_id, $url ) {
+		return self::$attachment_ids[ $url ] ?? $post_id;
 	}
 
 	/**

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -357,7 +357,7 @@ class Customize_Feed {
 
 		// Drop repeats: rows keyed per post, by final URL, so distinct enclosures
 		// survive while the duplicate stats URLs collapse to one. Registry is
-		// cleared per render — see `reset_render_state()`.
+		// cleared per render — see `reset_enclosure_dedup()`.
 		$post_id = null !== $post_obj ? (int) $post_obj->ID : 0;
 		if ( isset( self::$seen_enclosures[ $post_id ][ $final_url ] ) ) {
 			return '';

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -97,7 +97,10 @@ class Customize_Feed {
 		add_action( 'rss2_head', array( __CLASS__, 'output_channel_tags' ) );
 		add_action( 'rss2_item', array( __CLASS__, 'output_item_tags' ) );
 		add_filter( 'rss_enclosure', array( __CLASS__, 'rewrite_enclosure' ) );
-		add_filter( 'the_excerpt_rss', array( __CLASS__, 'capture_item_summary' ) );
+		// Last, so the captured value is what `<description>` actually printed —
+		// a filter above priority 10 would otherwise leave us caching an
+		// intermediate string and `<itunes:summary>` disagreeing with it.
+		add_filter( 'the_excerpt_rss', array( __CLASS__, 'capture_item_summary' ), PHP_INT_MAX );
 
 		add_filter( 'option_rss_use_excerpt', '__return_false' );
 		// Request-scoped to the feed: only the queried episodes render here, so

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -31,20 +31,20 @@ class Customize_Feed {
 	/**
 	 * Enclosure URLs already emitted in the current feed render, keyed by post
 	 * ID then URL. Reset on `rss2_head` so each feed starts clean — see
-	 * {@see self::rewrite_enclosure()}.
+	 * {@see self::is_duplicate_enclosure()}.
 	 *
 	 * @var array<int, array<string, true>>
 	 */
 	private static $seen_enclosures = array();
 
 	/**
-	 * `<description>` values already rendered this feed, keyed by post ID, so
-	 * `<itunes:summary>` can reuse them instead of rebuilding the excerpt — see
-	 * {@see self::capture_item_summary()}.
+	 * The `<description>` most recently rendered, as `[ post ID, value ]`, for
+	 * {@see self::output_item_tags()} to reuse. One slot: the template emits
+	 * `<description>` immediately before `rss2_item` fires for the same item.
 	 *
-	 * @var array<int, string>
+	 * @var array{0: int, 1: string}
 	 */
-	private static $item_summaries = array();
+	private static $item_summary = array( 0, '' );
 
 	/**
 	 * Wire the late-binding `wp` action that decides whether to register the
@@ -93,7 +93,7 @@ class Customize_Feed {
 		add_action( 'rss2_ns', array( __CLASS__, 'output_namespaces' ) );
 		add_filter( 'wp_title_rss', array( __CLASS__, 'feed_title' ) );
 		add_filter( 'bloginfo_rss', array( __CLASS__, 'feed_description' ), 10, 2 );
-		add_action( 'rss2_head', array( __CLASS__, 'reset_render_state' ), 0 );
+		add_action( 'rss2_head', array( __CLASS__, 'reset_enclosure_dedup' ), 0 );
 		add_action( 'rss2_head', array( __CLASS__, 'output_channel_tags' ) );
 		add_action( 'rss2_item', array( __CLASS__, 'output_item_tags' ) );
 		add_filter( 'rss_enclosure', array( __CLASS__, 'rewrite_enclosure' ) );
@@ -215,14 +215,12 @@ class Customize_Feed {
 			echo '<itunes:author>' . esc_xml( wp_strip_all_tags( $author ) ) . "</itunes:author>\n";
 		}
 
-		// `<itunes:summary>` mirrors the item's `<description>`, which the feed
-		// template rendered a few lines earlier — reuse that string rather than
-		// rebuild it. Regenerating means a second `wp_trim_excerpt()` pass over
-		// the whole post body, per item. Recompute only if `<description>` never
-		// ran (a replaced feed template), where `get_the_excerpt()` needs the
-		// filter chain applied on top since it doesn't run it itself.
-		$excerpt = self::$item_summaries[ (int) $post->ID ]
-			?? (string) apply_filters( 'the_excerpt_rss', get_the_excerpt() );
+		// Reuse the string `<description>` just emitted for this item; rebuilding
+		// it costs a second `wp_trim_excerpt()` pass over the whole post body.
+		// The fallback covers a feed template that skips `<description>`.
+		$excerpt = self::$item_summary[0] === (int) $post->ID
+			? self::$item_summary[1]
+			: (string) apply_filters( 'the_excerpt_rss', get_the_excerpt() );
 		if ( '' !== $excerpt ) {
 			echo '<itunes:summary>' . esc_xml( wp_strip_all_tags( $excerpt ) ) . "</itunes:summary>\n";
 		}
@@ -250,12 +248,10 @@ class Customize_Feed {
 	 * Keep the episode, feed-player, and subscribe blocks out of
 	 * `<content:encoded>`, leaving the surrounding show-note prose.
 	 *
-	 * Short-circuits on `pre_render_block` rather than blanking the result on
-	 * `render_block`: the output is discarded either way, so running the render
-	 * callback first is pure waste — and an expensive kind. The episode block
-	 * validates its media URLs through `wp_http_validate_url()`, which resolves
-	 * DNS, and the player block server-renders by fetching a feed over HTTP.
-	 * Per item, across a full catalogue, that dominated the feed's build time.
+	 * Short-circuits on `pre_render_block` rather than blanking the output on
+	 * `render_block`, which runs the callback first and throws the result away.
+	 * That callback is expensive per item: the episode block resolves DNS via
+	 * `wp_http_validate_url()`, the player block fetches a feed over HTTP.
 	 *
 	 * @param string|null $pre_render   Short-circuit value; `null` renders normally.
 	 * @param array       $parsed_block Parsed block, including its `blockName`.
@@ -273,18 +269,14 @@ class Customize_Feed {
 	}
 
 	/**
-	 * Record the `<description>` the feed template just rendered for the current
-	 * item so {@see self::output_item_tags()} can reuse it for
-	 * `<itunes:summary>`. Pass-through filter — the value is never modified.
+	 * Stash the item's rendered `<description>` for `<itunes:summary>` to reuse.
+	 * Pass-through — the value is never modified.
 	 *
 	 * @param string $excerpt Filtered item excerpt.
 	 * @return string
 	 */
 	public static function capture_item_summary( $excerpt ) {
-		$post_id = (int) get_the_ID();
-		if ( $post_id > 0 ) {
-			self::$item_summaries[ $post_id ] = (string) $excerpt;
-		}
+		self::$item_summary = array( (int) get_the_ID(), (string) $excerpt );
 		return $excerpt;
 	}
 
@@ -385,14 +377,13 @@ class Customize_Feed {
 	}
 
 	/**
-	 * Clear the per-render registries. Hooked on `rss2_head` (at priority 0,
-	 * before any item renders) so re-generating a feed within a single
-	 * long-lived process — WP-CLI, a warm worker — starts fresh instead of
-	 * dropping every enclosure as already-seen or reusing stale summaries.
+	 * Clear the per-render enclosure dedup registry. Hooked on `rss2_head` (at
+	 * priority 0, before any item renders) so re-generating a feed within a
+	 * single long-lived process — WP-CLI, a warm worker — starts fresh instead
+	 * of dropping every enclosure as already-seen.
 	 */
-	public static function reset_render_state() {
+	public static function reset_enclosure_dedup() {
 		self::$seen_enclosures = array();
-		self::$item_summaries  = array();
 	}
 
 	/**

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -29,18 +29,6 @@ class Customize_Feed {
 	private static $registered = false;
 
 	/**
-	 * Blocks that are chrome rather than show notes: they're dropped from
-	 * `<content:encoded>` so only the surrounding prose survives.
-	 *
-	 * @var string[]
-	 */
-	private const CHROME_BLOCKS = array(
-		'jetpack/podcast-episode',
-		'jetpack/podcast-player',
-		'jetpack/subscriptions',
-	);
-
-	/**
 	 * Enclosure URLs already emitted in the current feed render, keyed by post
 	 * ID then URL. Reset on `rss2_head` so each feed starts clean — see
 	 * {@see self::rewrite_enclosure()}.
@@ -282,7 +270,11 @@ class Customize_Feed {
 	 * @return string|null
 	 */
 	public static function skip_block_in_feed( $pre_render, $parsed_block ) {
-		if ( isset( $parsed_block['blockName'] ) && in_array( $parsed_block['blockName'], self::CHROME_BLOCKS, true ) ) {
+		if ( isset( $parsed_block['blockName'] ) && in_array(
+			$parsed_block['blockName'],
+			array( 'jetpack/podcast-episode', 'jetpack/podcast-player', 'jetpack/subscriptions' ),
+			true
+		) ) {
 			return '';
 		}
 		return $pre_render;
@@ -467,7 +459,7 @@ class Customize_Feed {
 			}
 		}
 
-		$attachment_ids = array_values( array_unique( $attachment_ids ) );
+		$attachment_ids = array_unique( $attachment_ids );
 		if ( ! empty( $attachment_ids ) ) {
 			// Terms aren't read off attachments here; metadata is (duration, image src).
 			_prime_post_caches( $attachment_ids, false, true );

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -47,14 +47,6 @@ class Customize_Feed {
 	private static $item_summaries = array();
 
 	/**
-	 * Enclosure URL → attachment ID for every episode in this feed, resolved in
-	 * one batch by {@see self::prime_feed_caches()}.
-	 *
-	 * @var array<string, int>
-	 */
-	private static $attachment_ids = array();
-
-	/**
 	 * Wire the late-binding `wp` action that decides whether to register the
 	 * feed-modification hooks for this request. Idempotent.
 	 */
@@ -101,7 +93,7 @@ class Customize_Feed {
 		add_action( 'rss2_ns', array( __CLASS__, 'output_namespaces' ) );
 		add_filter( 'wp_title_rss', array( __CLASS__, 'feed_title' ) );
 		add_filter( 'bloginfo_rss', array( __CLASS__, 'feed_description' ), 10, 2 );
-		add_action( 'rss2_head', array( __CLASS__, 'prime_feed_caches' ), 0 );
+		add_action( 'rss2_head', array( __CLASS__, 'reset_render_state' ), 0 );
 		add_action( 'rss2_head', array( __CLASS__, 'output_channel_tags' ) );
 		add_action( 'rss2_item', array( __CLASS__, 'output_item_tags' ) );
 		add_filter( 'rss_enclosure', array( __CLASS__, 'rewrite_enclosure' ) );
@@ -401,179 +393,6 @@ class Customize_Feed {
 	public static function reset_render_state() {
 		self::$seen_enclosures = array();
 		self::$item_summaries  = array();
-		self::$attachment_ids  = array();
-	}
-
-	/**
-	 * Resolve, in bulk, the per-episode data the item loop would otherwise fetch
-	 * one row at a time. Hooked on `rss2_head` at priority 0 — after the query
-	 * has run and primed its post caches, before the first item renders.
-	 *
-	 * Item rendering needs, for every episode: the attachment behind each
-	 * enclosure URL, that attachment's metadata (for `<itunes:duration>`), and
-	 * the featured image (for `<itunes:image>`). Left alone that's several
-	 * uncached queries per item, and the enclosure lookup is the expensive one —
-	 * an unindexed `meta_value` comparison that some hosts extend with a
-	 * `guid LIKE` fallback scan. Here it's a handful of queries for the whole
-	 * feed instead.
-	 */
-	public static function prime_feed_caches() {
-		self::reset_render_state();
-
-		$query = $GLOBALS['wp_query'] ?? null;
-		if ( ! $query instanceof \WP_Query || empty( $query->posts ) ) {
-			return;
-		}
-
-		$post_ids = array();
-		foreach ( $query->posts as $post ) {
-			if ( $post instanceof WP_Post ) {
-				$post_ids[] = (int) $post->ID;
-			}
-		}
-		if ( empty( $post_ids ) ) {
-			return;
-		}
-
-		// No-op when the query already primed these; covers the paths where it didn't.
-		update_meta_cache( 'post', $post_ids );
-
-		// Mirror how `rss_enclosure()` builds the URL it hands to `rss_enclosure`
-		// filters, so the primed keys match what `rewrite_enclosure()` looks up.
-		$urls = array();
-		foreach ( $post_ids as $post_id ) {
-			foreach ( (array) get_post_meta( $post_id, 'enclosure', false ) as $enclosure ) {
-				$url = esc_url( trim( (string) explode( "\n", (string) $enclosure )[0] ) );
-				if ( '' !== $url ) {
-					$urls[ $url ] = true;
-				}
-			}
-		}
-
-		$attachment_ids = self::prime_attachment_ids( array_keys( $urls ) );
-
-		foreach ( $post_ids as $post_id ) {
-			$thumbnail_id = (int) get_post_thumbnail_id( $post_id );
-			if ( $thumbnail_id > 0 ) {
-				$attachment_ids[] = $thumbnail_id;
-			}
-		}
-
-		$attachment_ids = array_unique( $attachment_ids );
-		if ( ! empty( $attachment_ids ) ) {
-			// Terms aren't read off attachments here; metadata is (duration, image src).
-			_prime_post_caches( $attachment_ids, false, true );
-		}
-
-		// Registered only now that the map is built, so the `apply_filters()`
-		// calls inside `prime_attachment_ids()` can't recurse into it.
-		add_filter( 'pre_attachment_url_to_postid', array( __CLASS__, 'primed_attachment_id' ), 10, 2 );
-	}
-
-	/**
-	 * Resolve a batch of enclosure URLs to attachment IDs in one query, caching
-	 * the answers in {@see self::$attachment_ids}.
-	 *
-	 * Reproduces `attachment_url_to_postid()` exactly — same URL-to-path
-	 * normalization, same preference for a case-sensitive match among rows a
-	 * case-insensitive collation returns together, same two filters in the same
-	 * order — so a primed answer is the one core would have given. The only
-	 * difference is that the `meta_value` comparison happens once for the whole
-	 * feed rather than once per episode.
-	 *
-	 * @param string[] $urls Enclosure URLs to resolve.
-	 * @return int[] Attachment IDs that resolved, for cache priming.
-	 */
-	private static function prime_attachment_ids( array $urls ): array {
-		if ( empty( $urls ) ) {
-			return array();
-		}
-
-		global $wpdb;
-
-		$dir          = wp_get_upload_dir();
-		$base         = $dir['baseurl'] . '/';
-		$site_scheme  = (string) wp_parse_url( $dir['url'], PHP_URL_SCHEME );
-		$paths_by_url = array();
-
-		foreach ( $urls as $url ) {
-			$path       = $url;
-			$url_scheme = (string) wp_parse_url( $path, PHP_URL_SCHEME );
-			if ( '' !== $url_scheme && $url_scheme !== $site_scheme ) {
-				$path = str_replace( $url_scheme, $site_scheme, $path );
-			}
-			if ( 0 === strpos( $path, $base ) ) {
-				$path = substr( $path, strlen( $base ) );
-			}
-			$paths_by_url[ $url ] = $path;
-		}
-
-		$paths        = array_values( array_unique( $paths_by_url ) );
-		$placeholders = implode( ', ', array_fill( 0, count( $paths ), '%s' ) );
-		$rows         = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Batched replacement for N uncached `attachment_url_to_postid()` lookups; results are cached in `self::$attachment_ids` for the render.
-			$wpdb->prepare(
-				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- `$placeholders` is a generated list of `%s`, one per path; the sniff can't see through the interpolation.
-				"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_wp_attached_file' AND meta_value IN ( {$placeholders} )",
-				$paths
-			)
-		);
-
-		// A case-insensitive collation can return several rows for one path.
-		// Keep the first, but let an exact match displace it — as core does.
-		$wanted = array();
-		foreach ( $paths as $path ) {
-			$wanted[ strtolower( $path ) ] = $path;
-		}
-		$first = array();
-		$exact = array();
-		foreach ( (array) $rows as $row ) {
-			$value = (string) $row->meta_value;
-			$path  = $wanted[ strtolower( $value ) ] ?? null;
-			if ( null === $path ) {
-				continue;
-			}
-			if ( ! isset( $first[ $path ] ) ) {
-				$first[ $path ] = (int) $row->post_id;
-			}
-			if ( $path === $value && ! isset( $exact[ $path ] ) ) {
-				$exact[ $path ] = (int) $row->post_id;
-			}
-		}
-		$ids_by_path = $exact + $first;
-
-		$resolved = array();
-		foreach ( $paths_by_url as $url => $path ) {
-			/** This filter is documented in wp-includes/media.php */
-			$post_id = apply_filters( 'pre_attachment_url_to_postid', null, $url );
-			if ( null === $post_id ) {
-				/** This filter is documented in wp-includes/media.php */
-				$post_id = apply_filters( 'attachment_url_to_postid', $ids_by_path[ $path ] ?? null, $url );
-			}
-
-			$post_id                      = (int) $post_id;
-			self::$attachment_ids[ $url ] = $post_id;
-			if ( $post_id > 0 ) {
-				$resolved[] = $post_id;
-			}
-		}
-
-		return $resolved;
-	}
-
-	/**
-	 * Serve `attachment_url_to_postid()` from the batch resolved in
-	 * {@see self::prime_attachment_ids()}.
-	 *
-	 * A primed `0` short-circuits too: the full filter chain already ran against
-	 * that URL during priming, so re-running the lookup would only repeat a miss
-	 * we've already paid for. URLs we never primed fall through to core.
-	 *
-	 * @param int|null $post_id Result so far; `null` when no lookup has run.
-	 * @param string   $url     URL being looked up.
-	 * @return int|null
-	 */
-	public static function primed_attachment_id( $post_id, $url ) {
-		return self::$attachment_ids[ $url ] ?? $post_id;
 	}
 
 	/**

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -38,7 +38,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
 		Jetpack_Options::delete_option( 'id' );
-		Customize_Feed::reset_render_state();
+		Customize_Feed::reset_enclosure_dedup();
 		wp_cache_flush();
 		unset( $GLOBALS['post'] );
 		parent::tearDown();
@@ -397,7 +397,7 @@ class Customize_Feed_Test extends BaseTestCase {
 	 * on `rss2_head`) clears it so re-generating the same feed within one
 	 * long-lived process emits enclosures again instead of dropping them all.
 	 */
-	public function test_reset_render_state_lets_the_same_url_emit_on_a_fresh_render() {
+	public function test_reset_enclosure_dedup_lets_the_same_url_emit_on_a_fresh_render() {
 		global $post;
 		$post = new WP_Post(
 			(object) array(
@@ -413,7 +413,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'url="https://example.com/episode.mp3"', Customize_Feed::rewrite_enclosure( $markup ) );
 		$this->assertSame( '', Customize_Feed::rewrite_enclosure( $markup ) );
 
-		Customize_Feed::reset_render_state();
+		Customize_Feed::reset_enclosure_dedup();
 
 		$this->assertStringContainsString( 'url="https://example.com/episode.mp3"', Customize_Feed::rewrite_enclosure( $markup ) );
 	}
@@ -727,7 +727,10 @@ class Customize_Feed_Test extends BaseTestCase {
 	public function test_skip_block_in_feed_strips_episode_block() {
 		$this->assertSame(
 			'',
-			Customize_Feed::skip_block_in_feed( null, array( 'blockName' => 'jetpack/podcast-episode' ) )
+			Customize_Feed::skip_block_in_feed(
+				'<figure class="wp-block-jetpack-podcast-episode">player widget</figure>',
+				array( 'blockName' => 'jetpack/podcast-episode' )
+			)
 		);
 	}
 
@@ -735,21 +738,25 @@ class Customize_Feed_Test extends BaseTestCase {
 		foreach ( array( 'jetpack/podcast-player', 'jetpack/subscriptions' ) as $block_name ) {
 			$this->assertSame(
 				'',
-				Customize_Feed::skip_block_in_feed( null, array( 'blockName' => $block_name ) ),
+				Customize_Feed::skip_block_in_feed( 'rendered widget', array( 'blockName' => $block_name ) ),
 				"Expected {$block_name} to be stripped from the feed body."
 			);
 		}
 	}
 
-	/**
-	 * Returning `null` leaves `render_block()` to render as usual — anything else
-	 * would short-circuit the block away.
-	 */
 	public function test_skip_block_in_feed_keeps_prose_blocks() {
-		$this->assertNull( Customize_Feed::skip_block_in_feed( null, array( 'blockName' => 'core/paragraph' ) ) );
+		$html = '<p>Real show notes prose listeners should see.</p>';
+		$this->assertSame(
+			$html,
+			Customize_Feed::skip_block_in_feed( $html, array( 'blockName' => 'core/paragraph' ) )
+		);
 	}
 
 	public function test_skip_block_in_feed_keeps_classic_freeform_content() {
-		$this->assertNull( Customize_Feed::skip_block_in_feed( null, array( 'blockName' => null ) ) );
+		$html = '<p>Classic editor content.</p>';
+		$this->assertSame(
+			$html,
+			Customize_Feed::skip_block_in_feed( $html, array( 'blockName' => null ) )
+		);
 	}
 }

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -38,7 +38,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
 		Jetpack_Options::delete_option( 'id' );
-		Customize_Feed::reset_enclosure_dedup();
+		Customize_Feed::reset_render_state();
 		wp_cache_flush();
 		unset( $GLOBALS['post'] );
 		parent::tearDown();
@@ -393,11 +393,11 @@ class Customize_Feed_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The dedup registry is per feed render: `reset_enclosure_dedup()` (hooked
+	 * The dedup registry is per feed render: `reset_render_state()` (hooked
 	 * on `rss2_head`) clears it so re-generating the same feed within one
 	 * long-lived process emits enclosures again instead of dropping them all.
 	 */
-	public function test_reset_enclosure_dedup_lets_the_same_url_emit_on_a_fresh_render() {
+	public function test_reset_render_state_lets_the_same_url_emit_on_a_fresh_render() {
 		global $post;
 		$post = new WP_Post(
 			(object) array(
@@ -413,7 +413,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'url="https://example.com/episode.mp3"', Customize_Feed::rewrite_enclosure( $markup ) );
 		$this->assertSame( '', Customize_Feed::rewrite_enclosure( $markup ) );
 
-		Customize_Feed::reset_enclosure_dedup();
+		Customize_Feed::reset_render_state();
 
 		$this->assertStringContainsString( 'url="https://example.com/episode.mp3"', Customize_Feed::rewrite_enclosure( $markup ) );
 	}
@@ -722,6 +722,50 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'Body prose that listeners should see.', $output );
 		$this->assertStringNotContainsString( 'mediaUrl', $output );
 		$this->assertStringNotContainsString( 'example.com/ep.mp3', $output );
+	}
+
+	/**
+	 * `<itunes:summary>` reuses the `<description>` captured for the same item,
+	 * and `reset_render_state()` drops it — otherwise a second render in one
+	 * long-lived process could match a stale post ID and emit the previous
+	 * feed's text instead of falling back to a fresh excerpt.
+	 */
+	public function test_reset_render_state_drops_the_captured_item_summary() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Episode with Excerpt',
+				'post_status'  => 'publish',
+				'post_excerpt' => 'Authored summary for this episode.',
+				'post_content' => '<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://example.com/ep.mp3"} /-->',
+			)
+		);
+
+		global $post;
+		$post = get_post( $post_id );
+		setup_postdata( $post );
+
+		Customize_Feed::capture_item_summary( 'Summary the description actually printed.' );
+
+		ob_start();
+		Customize_Feed::output_item_tags();
+		$reused = (string) ob_get_clean();
+
+		Customize_Feed::reset_render_state();
+
+		ob_start();
+		Customize_Feed::output_item_tags();
+		$after_reset = (string) ob_get_clean();
+
+		wp_reset_postdata();
+
+		$this->assertStringContainsString(
+			'<itunes:summary>Summary the description actually printed.</itunes:summary>',
+			$reused
+		);
+		$this->assertStringContainsString(
+			'<itunes:summary>Authored summary for this episode.</itunes:summary>',
+			$after_reset
+		);
 	}
 
 	public function test_skip_block_in_feed_strips_episode_block() {

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -38,7 +38,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
 		Jetpack_Options::delete_option( 'id' );
-		Customize_Feed::reset_enclosure_dedup();
+		Customize_Feed::reset_render_state();
 		wp_cache_flush();
 		unset( $GLOBALS['post'] );
 		parent::tearDown();
@@ -397,7 +397,7 @@ class Customize_Feed_Test extends BaseTestCase {
 	 * on `rss2_head`) clears it so re-generating the same feed within one
 	 * long-lived process emits enclosures again instead of dropping them all.
 	 */
-	public function test_reset_enclosure_dedup_lets_the_same_url_emit_on_a_fresh_render() {
+	public function test_reset_render_state_lets_the_same_url_emit_on_a_fresh_render() {
 		global $post;
 		$post = new WP_Post(
 			(object) array(
@@ -413,7 +413,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'url="https://example.com/episode.mp3"', Customize_Feed::rewrite_enclosure( $markup ) );
 		$this->assertSame( '', Customize_Feed::rewrite_enclosure( $markup ) );
 
-		Customize_Feed::reset_enclosure_dedup();
+		Customize_Feed::reset_render_state();
 
 		$this->assertStringContainsString( 'url="https://example.com/episode.mp3"', Customize_Feed::rewrite_enclosure( $markup ) );
 	}
@@ -724,39 +724,32 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertStringNotContainsString( 'example.com/ep.mp3', $output );
 	}
 
-	public function test_strip_block_from_feed_strips_episode_block() {
+	public function test_skip_block_in_feed_strips_episode_block() {
 		$this->assertSame(
 			'',
-			Customize_Feed::strip_block_from_feed(
-				'<figure class="wp-block-jetpack-podcast-episode">player widget</figure>',
-				array( 'blockName' => 'jetpack/podcast-episode' )
-			)
+			Customize_Feed::skip_block_in_feed( null, array( 'blockName' => 'jetpack/podcast-episode' ) )
 		);
 	}
 
-	public function test_strip_block_from_feed_strips_player_and_subscribe_blocks() {
+	public function test_skip_block_in_feed_strips_player_and_subscribe_blocks() {
 		foreach ( array( 'jetpack/podcast-player', 'jetpack/subscriptions' ) as $block_name ) {
 			$this->assertSame(
 				'',
-				Customize_Feed::strip_block_from_feed( 'rendered widget', array( 'blockName' => $block_name ) ),
+				Customize_Feed::skip_block_in_feed( null, array( 'blockName' => $block_name ) ),
 				"Expected {$block_name} to be stripped from the feed body."
 			);
 		}
 	}
 
-	public function test_strip_block_from_feed_keeps_prose_blocks() {
-		$html = '<p>Real show notes prose listeners should see.</p>';
-		$this->assertSame(
-			$html,
-			Customize_Feed::strip_block_from_feed( $html, array( 'blockName' => 'core/paragraph' ) )
-		);
+	/**
+	 * Returning `null` leaves `render_block()` to render as usual — anything else
+	 * would short-circuit the block away.
+	 */
+	public function test_skip_block_in_feed_keeps_prose_blocks() {
+		$this->assertNull( Customize_Feed::skip_block_in_feed( null, array( 'blockName' => 'core/paragraph' ) ) );
 	}
 
-	public function test_strip_block_from_feed_keeps_classic_freeform_content() {
-		$html = '<p>Classic editor content.</p>';
-		$this->assertSame(
-			$html,
-			Customize_Feed::strip_block_from_feed( $html, array( 'blockName' => null ) )
-		);
+	public function test_skip_block_in_feed_keeps_classic_freeform_content() {
+		$this->assertNull( Customize_Feed::skip_block_in_feed( null, array( 'blockName' => null ) ) );
 	}
 }


### PR DESCRIPTION
Related to PODS-210

## Proposed changes

The podcast feed did work and then threw it away, once per episode. On a big back catalogue that adds up, and apps like Apple and Spotify time out waiting.

Two fixes. Neither changes a single character of what the feed says.

* **Stop building things we're about to delete.** The feed leaves the player and subscribe blocks out of the show notes — but it built them first and deleted the result afterwards. Building is the slow part: one does a DNS lookup, the other downloads a whole other feed. Now we answer "what should this block look like?" with "nothing" *before* WordPress starts building instead of after. WordPress asks that same question for blocks nested inside a Group or Columns, so those stay out of the feed too.
* **Stop writing the summary twice.** Every episode's `<description>` and `<itunes:summary>` are the same text, and we built it from scratch twice — each time re-reading the whole post. Now the second one reuses the first. We remember one episode's summary at a time and wipe that memory at the start of every feed, so one feed can never borrow the previous one's text.

Measured on a 212-episode feed: **34% less time to build, and the output is byte-for-byte identical.** Nothing was cut — same episodes, same full show notes. A third fix (batching the database lookups) is held back for its own PR.

Heads up: two internal methods were renamed — `strip_block_from_feed` → `skip_block_in_feed` and `reset_enclosure_dedup` → `reset_render_state`. Nothing outside this package calls either one, but shout if you're unhooking them somewhere.

## Related product discussion/links

* PODS-210

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a site with podcasting on and a few episodes in the podcast category, save the feed first. Use a unique query string and skip the cache — otherwise you'll compare two copies of the same cached response and get a false pass:
   `curl -s -H 'Cache-Control: no-cache' "https://<site>/category/<podcast-category>/feed/?cb=1" > before.xml`
2. Apply this branch, fetch again with a **different** `?cb=` value into `after.xml`, then `diff` the two ignoring the `<atom:link rel="self">` line (it echoes the query string back). The diff should be **completely empty** — `<lastBuildDate>` and `<pubDate>` come from post dates, not the clock, so nothing should move on a site you haven't edited in between.
3. Spot-check that an episode still has its `<enclosure>`, `<itunes:duration>`, `<itunes:image>`, and full `<content:encoded>` show notes.
4. Confirm the player/subscribe markup is still absent from `<content:encoded>` — including on a post where the player block sits inside a Group block.
5. Paste the feed into a validator (e.g. Cast Feed Validator) and confirm it still passes.

Done on a live 4-episode site: production vs sandbox, both uncached, byte-identical output.

WordPress.com's private-podcasts feed runs through the same code path (it calls `maybe_register_feed_hooks()` directly and includes core's `feed-rss2.php`), so it's covered by the same behaviour.
