### PR TITLE
Status: treat WordPress Playground sites as local

### DIFF
--- a/projects/packages/status/changelog/jetpack-1422-playground-offline-mode
+++ b/projects/packages/status/changelog/jetpack-1422-playground-offline-mode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Identify WordPress Playground sites as local, so Jetpack starts in offline mode there.

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -161,6 +161,7 @@ class Status {
 			'#\.lndo\.site$#i',    // Lando.
 			'#\.ddev\.site$#i',    // DDEV.
 			'#^https?://127\.0\.0\.1$#',
+			'#^https?://playground\.wordpress\.net(/|$)#i', // WordPress Playground, which runs entirely in the browser.
 		);
 
 		if ( ! $is_local ) {

--- a/projects/packages/status/tests/php/Status_Test.php
+++ b/projects/packages/status/tests/php/Status_Test.php
@@ -429,27 +429,43 @@ class Status_Test extends TestCase {
 	 */
 	public static function get_is_local_site_known_tld() {
 		return array(
-			'vvv'            => array(
+			'vvv'                       => array(
 				'http://jetpack.test',
 				true,
 			),
-			'docksal'        => array(
+			'docksal'                   => array(
 				'http://jetpack.docksal',
 				true,
 			),
-			'serverpress'    => array(
+			'serverpress'               => array(
 				'http://jetpack.dev.cc',
 				true,
 			),
-			'lando'          => array(
+			'lando'                     => array(
 				'http://jetpack.lndo.site',
 				true,
 			),
-			'test_subdomain' => array(
+			'playground'                => array(
+				'https://playground.wordpress.net/scope:0.8362470763364798',
+				true,
+			),
+			'playground_root'           => array(
+				'https://playground.wordpress.net',
+				true,
+			),
+			'playground_lookalike_host' => array(
+				'https://notplayground.wordpress.net',
+				false,
+			),
+			'playground_in_domain'      => array(
+				'https://playground.wordpress.net.example.com',
+				false,
+			),
+			'test_subdomain'            => array(
 				'https://test.jetpack.com',
 				false,
 			),
-			'test_in_domain' => array(
+			'test_in_domain'            => array(
 				'https://jetpack.test.jetpack.com',
 				false,
 			),


### PR DESCRIPTION
Fixes JETPACK-1422

## Proposed changes

* Add `playground.wordpress.net` to the known-local URL list in `Status::is_local_site()`, so Jetpack starts in offline mode on WordPress Playground instances instead of pushing the connection flow.

Loading Jetpack in Playground currently drops the user into the WordPress.com connection flow. That flow can't be completed usefully on a browser-only, ephemeral site, and it takes over the interface, so Playground becomes unusable for trying the plugin out.

I confirmed the URL shape against a live Playground instance rather than assuming it. On `https://playground.wordpress.net/?url=/wp-admin/options-general.php`, both **WordPress Address (URL)** and **Site Address (URL)** read `https://playground.wordpress.net/scope:calm-quiet-lake`. The scope segment varies per boot (word slugs, or `scope:0.123…` numeric ones), so the pattern anchors on scheme + host and accepts either a following `/` or end-of-string:

```
'#^https?://playground\.wordpress\.net(/|$)#i'
```

Anchoring at the start means lookalike hosts (`notplayground.wordpress.net`) and the host appearing inside a longer domain (`playground.wordpress.net.example.com`) do not match. All four cases are covered by new data-provider rows in `Status_Test`.

Note this makes offline mode the default on Playground, not a hard rule. Anyone who wants Jetpack to connect from a Playground instance can still filter `jetpack_is_local_site` or `jetpack_offline_mode`, or define `JETPACK_DEV_DEBUG`, from a blueprint.

Only the hosted `playground.wordpress.net` host is covered here. Locally-run Playground (`@wp-playground/cli`) serves on `127.0.0.1:<port>`, which the existing `#^https?://127\.0\.0\.1$#` pattern does not match because of the port. That's a pre-existing gap and I left it alone rather than widen the scope of this PR.

## Related product discussion/links

* https://linear.app/a8c/issue/JETPACK-1422/jetpack-should-auto-detect-development-environment

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated:

* `jp test php packages/status` — the `test_is_local_site_for_known_tld` data provider gains `playground`, `playground_root`, `playground_lookalike_host`, and `playground_in_domain` rows.

Manual, on a real Playground instance:

1. Open https://playground.wordpress.net/?plugin=jetpack&url=wp-admin and confirm the current behavior: Jetpack takes over the screen with the connection flow.
2. Build the Jetpack plugin from this branch and load it in Playground instead of the released version (for example, mount the built plugin via a blueprint, or point Playground at a zip built from this branch).
3. Go to **Jetpack → Dashboard**. Jetpack should now report that it is in offline mode rather than prompting to connect, and the rest of wp-admin should be usable.
4. Sanity check that nothing regressed off Playground: on any normal site (a Jurassic Ninja site, say), Jetpack should still offer the connection flow as before.
