### PR TITLE
Status: match is_local_site() on the host, so any port is detected as local

### DIFF
--- a/projects/packages/jitm/changelog/jetpack-2225-localhost-any-port
+++ b/projects/packages/jitm/changelog/jetpack-2225-localhost-any-port
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Tests only: stub wp_parse_url, now used by Status::is_local_site().
+
+

--- a/projects/packages/jitm/tests/php/Jetpack_JITM_Test.php
+++ b/projects/packages/jitm/tests/php/Jetpack_JITM_Test.php
@@ -25,6 +25,7 @@ class Jetpack_JITM_Test extends TestCase {
 		Functions\when( 'get_current_blog_id' )->justReturn( 1 );
 		Functions\when( 'get_current_screen' )->justReturn( new \stdClass() );
 		Functions\when( 'site_url' )->justReturn( 'unit-test' );
+		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
 		Functions\when( 'wp_get_environment_type' )->justReturn( '' );
 		Functions\when( 'current_user_can' )->justReturn( true );
 	}

--- a/projects/packages/jitm/tests/php/Pre_Connection_JITM_Test.php
+++ b/projects/packages/jitm/tests/php/Pre_Connection_JITM_Test.php
@@ -36,6 +36,7 @@ class Pre_Connection_JITM_Test extends TestCase {
 
 		Functions\when( 'get_current_screen' )->justReturn( new \stdClass() );
 		Functions\when( 'site_url' )->justReturn( 'unit-test' );
+		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
 		Functions\when( 'wp_get_environment_type' )->justReturn( '' );
 		Functions\when( 'get_option' )->justReturn( '' );
 		Functions\when( '__' )->returnArg();

--- a/projects/packages/status/changelog/jetpack-2225-localhost-any-port
+++ b/projects/packages/status/changelog/jetpack-2225-localhost-any-port
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Status: detect localhost and 127.0.0.1 as local sites on any port.

--- a/projects/packages/status/changelog/jetpack-2225-localhost-any-port
+++ b/projects/packages/status/changelog/jetpack-2225-localhost-any-port
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Status: detect localhost and 127.0.0.1 as local sites on any port.
+Status: detect local development sites served on a port, such as http://127.0.0.1:8080.

--- a/projects/packages/status/changelog/jetpack-2225-localhost-any-port
+++ b/projects/packages/status/changelog/jetpack-2225-localhost-any-port
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Status: detect local development sites served on a port, such as http://127.0.0.1:8080.
+Status: detect local development sites served on a port, such as http://127.0.0.1:8080, and stop treating a production site as local when a domain like .test or .localhost appears in its URL path.

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -153,14 +153,14 @@ class Status {
 		// Then check for usual usual domains used by local dev tools.
 		$known_local = array(
 			'#\.local$#i',
-			'#\.localhost$#i',
+			'#^https?://([^/]+\.)?localhost(:\d+)?(/|$)#i', // localhost and its subdomains, on any port.
 			'#\.test$#i',
 			'#\.docksal$#i',      // Docksal.
 			'#\.docksal\.site$#i', // Docksal.
 			'#\.dev\.cc$#i',       // ServerPress.
 			'#\.lndo\.site$#i',    // Lando.
 			'#\.ddev\.site$#i',    // DDEV.
-			'#^https?://127\.0\.0\.1$#',
+			'#^https?://127\.0\.0\.1(:\d+)?(/|$)#', // Loopback, on any port.
 		);
 
 		if ( ! $is_local ) {

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -141,9 +141,20 @@ class Status {
 
 		$site_url = site_url();
 
+		/*
+		 * Every check below cares about the host, not the rest of the URL. Matching the host
+		 * alone means a port, a subdirectory install, or a trailing slash can't defeat them,
+		 * and a known local domain sitting in the path can't trigger them by accident.
+		 */
+		$host = wp_parse_url( $site_url, PHP_URL_HOST );
+		if ( ! is_string( $host ) || '' === $host ) {
+			// site_url() should always be absolute, but fall back to the raw value if it isn't.
+			$host = (string) $site_url;
+		}
+
 		// Check for localhost and sites using an IP only first.
 		// Note: str_contains() is not used here, as wp-includes/compat.php is not loaded in this file.
-		$is_local = $site_url && false === strpos( $site_url, '.' );
+		$is_local = '' !== $host && false === strpos( $host, '.' );
 
 		// Use Core's environment check, if available.
 		if ( 'local' === wp_get_environment_type() ) {
@@ -153,20 +164,20 @@ class Status {
 		// Then check for usual usual domains used by local dev tools.
 		$known_local = array(
 			'#\.local$#i',
-			'#^https?://([^/]+\.)?localhost(:\d+)?(/|$)#i', // localhost and its subdomains, on any port.
+			'#(^|\.)localhost$#i', // localhost and any subdomain of it.
 			'#\.test$#i',
-			'#\.docksal$#i',      // Docksal.
+			'#\.docksal$#i',       // Docksal.
 			'#\.docksal\.site$#i', // Docksal.
 			'#\.dev\.cc$#i',       // ServerPress.
 			'#\.lndo\.site$#i',    // Lando.
 			'#\.ddev\.site$#i',    // DDEV.
-			'#^https?://127\.0\.0\.1(:\d+)?(/|$)#', // Loopback, on any port.
-			'#^https?://playground\.wordpress\.net(/|$)#i', // WordPress Playground, which runs entirely in the browser.
+			'#^127\.0\.0\.1$#',
+			'#^playground\.wordpress\.net$#i', // WordPress Playground, which runs entirely in the browser.
 		);
 
-		if ( ! $is_local ) {
+		if ( ! $is_local && '' !== $host ) {
 			foreach ( $known_local as $url ) {
-				if ( preg_match( $url, $site_url ) ) {
+				if ( preg_match( $url, $host ) ) {
 					$is_local = true;
 					break;
 				}

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -164,7 +164,6 @@ class Status {
 		}
 
 		// Check for localhost and sites using an IP only first.
-		// Note: str_contains() is not used here, as wp-includes/compat.php is not loaded in this file.
 		$is_local = '' !== $host && false === strpos( $host, '.' );
 
 		// Use Core's environment check, if available.
@@ -172,7 +171,7 @@ class Status {
 			$is_local = true;
 		}
 
-		// Then check for usual usual domains used by local dev tools.
+		// Then check for usual domains used by local dev tools.
 		$known_local = array(
 			'#\.local$#i',
 			'#(^|\.)localhost$#i', // localhost and any subdomain of it.
@@ -187,8 +186,8 @@ class Status {
 		);
 
 		if ( ! $is_local && '' !== $host ) {
-			foreach ( $known_local as $url ) {
-				if ( preg_match( $url, $host ) ) {
+			foreach ( $known_local as $pattern ) {
+				if ( preg_match( $pattern, $host ) ) {
 					$is_local = true;
 					break;
 				}

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -147,8 +147,12 @@ class Status {
 		 * and a known local domain sitting in the path can't trigger them by accident.
 		 */
 		$host = wp_parse_url( $site_url, PHP_URL_HOST );
-		if ( ! is_string( $host ) || '' === $host ) {
-			// site_url() should always be absolute. If it isn't, read the value as a bare host.
+		if ( ( ! is_string( $host ) || '' === $host ) && ! preg_match( '#^[a-z][a-z0-9+.\-]*:#i', $site_url ) ) {
+			/*
+			 * No scheme, so site_url() isn't absolute. Read the value as a bare host.
+			 * A value that does carry a scheme but still won't parse is malformed, and
+			 * guessing at it would read "https:/example.com" as the host "https".
+			 */
 			$host = wp_parse_url( '//' . ltrim( $site_url, '/' ), PHP_URL_HOST );
 		}
 		if ( ! is_string( $host ) ) {

--- a/projects/packages/status/src/class-status.php
+++ b/projects/packages/status/src/class-status.php
@@ -139,7 +139,7 @@ class Status {
 			return $cached;
 		}
 
-		$site_url = site_url();
+		$site_url = trim( (string) site_url() );
 
 		/*
 		 * Every check below cares about the host, not the rest of the URL. Matching the host
@@ -148,8 +148,15 @@ class Status {
 		 */
 		$host = wp_parse_url( $site_url, PHP_URL_HOST );
 		if ( ! is_string( $host ) || '' === $host ) {
-			// site_url() should always be absolute, but fall back to the raw value if it isn't.
-			$host = (string) $site_url;
+			// site_url() should always be absolute. If it isn't, read the value as a bare host.
+			$host = wp_parse_url( '//' . ltrim( $site_url, '/' ), PHP_URL_HOST );
+		}
+		if ( ! is_string( $host ) ) {
+			/*
+			 * Nothing host-shaped to test. Treat the site as remote rather than matching the
+			 * raw URL: a false "local" silently drops a live site into offline mode.
+			 */
+			$host = '';
 		}
 
 		// Check for localhost and sites using an IP only first.

--- a/projects/packages/status/tests/php/Status_Test.php
+++ b/projects/packages/status/tests/php/Status_Test.php
@@ -68,7 +68,59 @@ class Status_Test extends TestCase {
 			}
 		);
 		Functions\when( 'wp_get_environment_type' )->justReturn( 'production' );
-		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
+
+		/*
+		 * Core's wp_parse_url() is not a plain parse_url() alias: it rewrites protocol-relative
+		 * and root-relative URLs behind a placeholder scheme. Mirror that, so these tests
+		 * exercise the function the production code actually calls.
+		 */
+		Functions\when( 'wp_parse_url' )->alias(
+			function ( $url, $component = -1 ) {
+				$to_unset = array();
+				$url      = (string) $url;
+
+				if ( 0 === strpos( $url, '//' ) ) {
+					$to_unset[] = 'scheme';
+					$url        = 'placeholder:' . $url;
+				} elseif ( 0 === strpos( $url, '/' ) ) {
+					$to_unset[] = 'scheme';
+					$to_unset[] = 'host';
+					$url        = 'placeholder://placeholder' . $url;
+				}
+
+				$parts = parse_url( $url );
+				if ( false === $parts ) {
+					return $parts;
+				}
+
+				foreach ( $to_unset as $key ) {
+					unset( $parts[ $key ] );
+				}
+
+				if ( -1 === $component ) {
+					return $parts;
+				}
+
+				$key = array(
+					PHP_URL_SCHEME   => 'scheme',
+					PHP_URL_HOST     => 'host',
+					PHP_URL_PORT     => 'port',
+					PHP_URL_USER     => 'user',
+					PHP_URL_PASS     => 'pass',
+					PHP_URL_PATH     => 'path',
+					PHP_URL_QUERY    => 'query',
+					PHP_URL_FRAGMENT => 'fragment',
+				);
+
+				if ( ! isset( $key[ $component ] ) ) {
+					return null;
+				}
+
+				$name = $key[ $component ];
+
+				return isset( $parts[ $name ] ) ? $parts[ $name ] : null;
+			}
+		);
 
 		// Default to a front-end request with no persistent object cache (no seeding).
 		Functions\when( 'wp_using_ext_object_cache' )->justReturn( false );
@@ -617,10 +669,6 @@ class Status_Test extends TestCase {
 				'localhost',
 				true,
 			),
-			'schemeless_host_with_port'      => array(
-				'localhost:8080',
-				true,
-			),
 			'schemeless_local_domain'        => array(
 				'jetpack.test',
 				true,
@@ -631,6 +679,24 @@ class Status_Test extends TestCase {
 			),
 			'empty_site_url'                 => array(
 				'',
+				false,
+			),
+
+			/*
+			 * A value that carries a scheme but still won't parse is malformed, not a bare
+			 * host. Reading "https:/example.com" as the host "https" would make a dotless
+			 * "host" out of the scheme and drop a live site into offline mode.
+			 */
+			'single_slash_after_scheme'      => array(
+				'https:/example.com',
+				false,
+			),
+			'single_slash_with_path'         => array(
+				'https:/www.example.com/wordpress',
+				false,
+			),
+			'triple_slash_after_scheme'      => array(
+				'https:///example.com',
 				false,
 			),
 		);

--- a/projects/packages/status/tests/php/Status_Test.php
+++ b/projects/packages/status/tests/php/Status_Test.php
@@ -567,6 +567,10 @@ class Status_Test extends TestCase {
 				'https://jetpack.notlocalhost.com',
 				false,
 			),
+			'lookalike_localhost_with_port'  => array(
+				'https://jetpack.notlocalhost.com:8080',
+				false,
+			),
 			'host_ending_in_localhost'       => array(
 				'https://jetpack.notlocalhost',
 				false,

--- a/projects/packages/status/tests/php/Status_Test.php
+++ b/projects/packages/status/tests/php/Status_Test.php
@@ -412,7 +412,7 @@ class Status_Test extends TestCase {
 	public function test_is_local_site_for_known_tld( $site_url, $expected_response ) {
 		$this->site_url = $site_url;
 		$result         = $this->status_obj->is_local_site();
-		$this->assertEquals(
+		$this->assertSame(
 			$expected_response,
 			$result,
 			sprintf(

--- a/projects/packages/status/tests/php/Status_Test.php
+++ b/projects/packages/status/tests/php/Status_Test.php
@@ -433,16 +433,56 @@ class Status_Test extends TestCase {
 				'http://jetpack.test',
 				true,
 			),
+			'vvv_with_port'                  => array(
+				'http://jetpack.test:8080',
+				true,
+			),
+			'wp_local'                       => array(
+				'http://jetpack.local',
+				true,
+			),
+			'wp_local_with_port'             => array(
+				'http://jetpack.local:8080',
+				true,
+			),
 			'docksal'                        => array(
 				'http://jetpack.docksal',
+				true,
+			),
+			'docksal_with_port'              => array(
+				'http://jetpack.docksal:8080',
+				true,
+			),
+			'docksal_site'                   => array(
+				'http://jetpack.docksal.site',
+				true,
+			),
+			'docksal_site_with_port'         => array(
+				'http://jetpack.docksal.site:8080',
 				true,
 			),
 			'serverpress'                    => array(
 				'http://jetpack.dev.cc',
 				true,
 			),
+			'serverpress_with_port'          => array(
+				'http://jetpack.dev.cc:8080',
+				true,
+			),
 			'lando'                          => array(
 				'http://jetpack.lndo.site',
+				true,
+			),
+			'lando_with_port'                => array(
+				'http://jetpack.lndo.site:8080',
+				true,
+			),
+			'ddev'                           => array(
+				'https://jetpack.ddev.site',
+				true,
+			),
+			'ddev_with_port'                 => array(
+				'https://jetpack.ddev.site:8443',
 				true,
 			),
 			'localhost'                      => array(
@@ -485,19 +525,28 @@ class Status_Test extends TestCase {
 				'https://127.0.0.1:8443/wordpress',
 				true,
 			),
-			'playground'                => array(
+			// A host with no dot at all can't be a public domain, so it is treated as local.
+			'dotless_host'                   => array(
+				'http://intranet',
+				true,
+			),
+			'dotless_host_with_port'         => array(
+				'http://intranet:8080',
+				true,
+			),
+			'playground'                     => array(
 				'https://playground.wordpress.net/scope:0.8362470763364798',
 				true,
 			),
-			'playground_root'           => array(
+			'playground_root'                => array(
 				'https://playground.wordpress.net',
 				true,
 			),
-			'playground_lookalike_host' => array(
+			'playground_lookalike_host'      => array(
 				'https://notplayground.wordpress.net',
 				false,
 			),
-			'playground_in_domain'      => array(
+			'playground_in_domain'           => array(
 				'https://playground.wordpress.net.example.com',
 				false,
 			),
@@ -513,6 +562,18 @@ class Status_Test extends TestCase {
 				'https://localhost.jetpack.com',
 				false,
 			),
+			'lookalike_localhost_host'       => array(
+				'https://jetpack.notlocalhost.com',
+				false,
+			),
+			'host_ending_in_localhost'       => array(
+				'https://jetpack.notlocalhost',
+				false,
+			),
+			'loopback_ip_in_domain'          => array(
+				'https://127.0.0.1.jetpack.com',
+				false,
+			),
 			'localhost_in_path'              => array(
 				'https://jetpack.com/localhost',
 				false,
@@ -521,8 +582,12 @@ class Status_Test extends TestCase {
 				'https://jetpack.com/foo.localhost',
 				false,
 			),
-			'loopback_ip_in_domain'          => array(
-				'https://127.0.0.1.jetpack.com',
+			'known_tld_in_path'              => array(
+				'https://jetpack.com/jetpack.test',
+				false,
+			),
+			'loopback_ip_in_path'            => array(
+				'https://jetpack.com/127.0.0.1',
 				false,
 			),
 		);

--- a/projects/packages/status/tests/php/Status_Test.php
+++ b/projects/packages/status/tests/php/Status_Test.php
@@ -69,58 +69,7 @@ class Status_Test extends TestCase {
 		);
 		Functions\when( 'wp_get_environment_type' )->justReturn( 'production' );
 
-		/*
-		 * Core's wp_parse_url() is not a plain parse_url() alias: it rewrites protocol-relative
-		 * and root-relative URLs behind a placeholder scheme. Mirror that, so these tests
-		 * exercise the function the production code actually calls.
-		 */
-		Functions\when( 'wp_parse_url' )->alias(
-			function ( $url, $component = -1 ) {
-				$to_unset = array();
-				$url      = (string) $url;
-
-				if ( 0 === strpos( $url, '//' ) ) {
-					$to_unset[] = 'scheme';
-					$url        = 'placeholder:' . $url;
-				} elseif ( 0 === strpos( $url, '/' ) ) {
-					$to_unset[] = 'scheme';
-					$to_unset[] = 'host';
-					$url        = 'placeholder://placeholder' . $url;
-				}
-
-				$parts = parse_url( $url );
-				if ( false === $parts ) {
-					return $parts;
-				}
-
-				foreach ( $to_unset as $key ) {
-					unset( $parts[ $key ] );
-				}
-
-				if ( -1 === $component ) {
-					return $parts;
-				}
-
-				$key = array(
-					PHP_URL_SCHEME   => 'scheme',
-					PHP_URL_HOST     => 'host',
-					PHP_URL_PORT     => 'port',
-					PHP_URL_USER     => 'user',
-					PHP_URL_PASS     => 'pass',
-					PHP_URL_PATH     => 'path',
-					PHP_URL_QUERY    => 'query',
-					PHP_URL_FRAGMENT => 'fragment',
-				);
-
-				if ( ! isset( $key[ $component ] ) ) {
-					return null;
-				}
-
-				$name = $key[ $component ];
-
-				return isset( $parts[ $name ] ) ? $parts[ $name ] : null;
-			}
-		);
+		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
 
 		// Default to a front-end request with no persistent object cache (no seeding).
 		Functions\when( 'wp_using_ext_object_cache' )->justReturn( false );

--- a/projects/packages/status/tests/php/Status_Test.php
+++ b/projects/packages/status/tests/php/Status_Test.php
@@ -590,6 +590,49 @@ class Status_Test extends TestCase {
 				'https://jetpack.com/127.0.0.1',
 				false,
 			),
+			// Hosts are compared case-insensitively; parse_url does not lowercase them for us.
+			'uppercase_host'                 => array(
+				'HTTPS://JETPACK.TEST',
+				true,
+			),
+			'uppercase_production_host'      => array(
+				'HTTPS://JETPACK.COM',
+				false,
+			),
+			// Userinfo must not be mistaken for the host.
+			'localhost_as_userinfo'          => array(
+				'https://localhost@jetpack.com/',
+				false,
+			),
+			'userinfo_on_local_host'         => array(
+				'http://user:pass@jetpack.localhost:8080',
+				true,
+			),
+
+			/*
+			 * site_url() is always absolute in practice. When it isn't, the value is read as a
+			 * bare host, so a known local domain in the path still must not match.
+			 */
+			'schemeless_host'                => array(
+				'localhost',
+				true,
+			),
+			'schemeless_host_with_port'      => array(
+				'localhost:8080',
+				true,
+			),
+			'schemeless_local_domain'        => array(
+				'jetpack.test',
+				true,
+			),
+			'schemeless_local_in_path'       => array(
+				'jetpack.com/foo.test',
+				false,
+			),
+			'empty_site_url'                 => array(
+				'',
+				false,
+			),
 		);
 	}
 

--- a/projects/packages/status/tests/php/Status_Test.php
+++ b/projects/packages/status/tests/php/Status_Test.php
@@ -429,28 +429,84 @@ class Status_Test extends TestCase {
 	 */
 	public static function get_is_local_site_known_tld() {
 		return array(
-			'vvv'            => array(
+			'vvv'                            => array(
 				'http://jetpack.test',
 				true,
 			),
-			'docksal'        => array(
+			'docksal'                        => array(
 				'http://jetpack.docksal',
 				true,
 			),
-			'serverpress'    => array(
+			'serverpress'                    => array(
 				'http://jetpack.dev.cc',
 				true,
 			),
-			'lando'          => array(
+			'lando'                          => array(
 				'http://jetpack.lndo.site',
 				true,
 			),
-			'test_subdomain' => array(
+			'localhost'                      => array(
+				'http://localhost',
+				true,
+			),
+			'localhost_trailing_slash'       => array(
+				'http://localhost/',
+				true,
+			),
+			'localhost_with_port'            => array(
+				'http://localhost:8080',
+				true,
+			),
+			'localhost_with_port_and_path'   => array(
+				'https://localhost:8443/wordpress',
+				true,
+			),
+			'localhost_subdomain'            => array(
+				'http://jetpack.localhost',
+				true,
+			),
+			'localhost_subdomain_with_port'  => array(
+				'http://jetpack.localhost:8080',
+				true,
+			),
+			'loopback_ip'                    => array(
+				'http://127.0.0.1',
+				true,
+			),
+			'loopback_ip_trailing_slash'     => array(
+				'http://127.0.0.1/',
+				true,
+			),
+			'loopback_ip_with_port'          => array(
+				'http://127.0.0.1:8080',
+				true,
+			),
+			'loopback_ip_with_port_and_path' => array(
+				'https://127.0.0.1:8443/wordpress',
+				true,
+			),
+			'test_subdomain'                 => array(
 				'https://test.jetpack.com',
 				false,
 			),
-			'test_in_domain' => array(
+			'test_in_domain'                 => array(
 				'https://jetpack.test.jetpack.com',
+				false,
+			),
+			'localhost_in_domain'            => array(
+				'https://localhost.jetpack.com',
+				false,
+			),
+			'localhost_in_path'              => array(
+				'https://jetpack.com/localhost',
+				false,
+			),
+			'localhost_in_dotted_path'       => array(
+				'https://jetpack.com/foo.localhost',
+				false,
+			),
+			'loopback_ip_in_domain'          => array(
+				'https://127.0.0.1.jetpack.com',
 				false,
 			),
 		);


### PR DESCRIPTION
Fixes JETPACK-2225

## Proposed changes

`Status::is_local_site()` decides whether Jetpack starts in offline mode. Every entry in its local-domain list was matched against the **full site URL**, which made two things go wrong.

**Ports and paths defeated the checks.** The patterns are end-anchored, so anything after the host broke them:

| Site URL | Before | After |
| --- | --- | --- |
| `http://127.0.0.1` | local | local |
| `http://127.0.0.1/` | not local | local |
| `http://127.0.0.1:8080` | not local | local |
| `http://jetpack.localhost:8080` | not local | local |
| `http://jetpack.test:8080` | not local | local |
| `http://jetpack.lndo.site:8080` | not local | local |
| `http://jetpack.docksal:8080` | not local | local |
| `http://jetpack.dev.cc:8080` | not local | local |
| `https://jetpack.ddev.site:8443` | not local | local |

Serving a dev site on a non-default port is the norm under Docker, `wp server`, Studio, Valet, and Lando, so this was the common case rather than an edge case.

**A local domain in the path was enough to match.** The suffix patterns aren't start-anchored, so `https://example.com/foo.localhost` and `https://example.com/dir.test` were reported as local sites — a production site could be pushed into offline mode by its URL path.

Rather than patching ten regexes individually, this parses the host out of the site URL once and matches against that, the way `is_staging_site()` already does:

```php
$host = wp_parse_url( $site_url, PHP_URL_HOST );
```

Ports, paths, and trailing slashes stop mattering, and a local domain in the path no longer matches.

The "no dot means local" shortcut now runs on the host rather than the whole URL, which slightly widens it: `http://intranet/2026/report.pdf` used to have a dot in the path and reported remote, and is local now. It takes a dotless host plus a dotted path, so it's close to unreachable in practice, and matching the reachable name rather than an incidental dot in the path is the more correct behavior — but it's a change beyond the ports-and-paths table above.

`site_url()` is always absolute in practice. When it isn't, the value is re-read as a bare host so a schemeless `localhost` still resolves. A value that *carries* a scheme and still won't parse is treated as malformed rather than guessed at — otherwise `https:/example.com` (one slash, the shape a botched search-replace leaves behind) reads as the host `https`, which is dotless, and a live site lands in offline mode. When nothing host-shaped can be recovered the site is treated as remote: a false "local" silently disconnects a live site, while a false "remote" only prompts to connect.

## Related product discussion/links

* Builds on PR 51216 / JETPACK-1422 (WordPress Playground detection), merged into this branch. The Playground entry is included in the host-matching conversion and keeps its existing test coverage.
* JETPACK-2226 tracks a known follow-up. The "no dot means local" shortcut asks whether a host is publicly reachable, which it answers correctly for names but not for IPv6, since IPv6 addresses are dot-free whether public or not — so a globally routable `http://[2606:4700:4700::1111]` is treated as local. That predates this PR; what changed here is that matching on the host removed the accidental escape hatch a dot in the *path* used to provide. Deliberately out of scope: it is a separate judgment about the dotless rule, not about ports.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated coverage is the main thing here. `get_is_local_site_known_tld` in `projects/packages/status/tests/php/Status_Test.php` grows from 10 cases to 51, covering each local dev tool bare and with a port, `localhost` and its subdomains, the loopback address, Playground, uppercase hosts, userinfo, malformed URLs, and a set of production hosts that merely look local.

* Run `jp test php packages/status`. Expect `OK (154 tests, 173 assertions)`.
* To see the original bug, restore `class-status.php` from the merge commit (`git checkout b57983788d -- projects/packages/status/src/class-status.php`) and re-run. 8 cases fail: every `*_with_port` variant, plus `known_tld_in_path` (`https://jetpack.com/jetpack.test` wrongly reported as local).
* `jp test php packages/jitm` and `jp test php packages/connection` pass. JITM's Brain Monkey suites needed a `wp_parse_url` stub, since they exercise the real `Status::is_local_site()` without WordPress loaded.

To check on a real site:

* Run WordPress locally with `home`/`siteurl` set to `http://127.0.0.1:8080` (for example, `wp option update siteurl http://127.0.0.1:8080`).
* Install and activate Jetpack. Before this change Jetpack prompts you to connect to WordPress.com; after it, Jetpack starts in offline mode and says so on the Jetpack dashboard.
* Repeat with `http://jetpack.localhost:8080` and `http://jetpack.test:8080`.
* Confirm no regression on a normal production URL: a site on `https://example.com` must still not be in offline mode.

