### PR TITLE
Subscriptions: keep subscribe modal visible on wide screens

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nl-589-subscribe-modal-wide-viewports
+++ b/projects/plugins/jetpack/changelog/fix-nl-589-subscribe-modal-wide-viewports
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Keep the subscribe modal visible on wide screens.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css
@@ -26,7 +26,9 @@ body.jetpack-subscribe-modal-open {
 	overflow: hidden;
 	top: 100%;
 	background-color: #fefefe;
-	margin: 15% auto;
+
+	/* Percentage block margins scale with viewport width. */
+	margin: min(15%, 15vh) auto;
 	width: 100%;
 	max-width: 600px;
 	border-radius: 10px;
@@ -50,7 +52,7 @@ body.jetpack-subscribe-modal-open {
 	text-wrap: pretty;
 }
 
-@media screen and (max-width: 640px) {
+@media screen and ( max-width: 640px ) {
 
 	.jetpack-subscribe-modal__modal-content {
 		width: 94%;


### PR DESCRIPTION
Fixes NL-589

## Proposed changes

* Cap the subscribe modal's vertical percentage margin by viewport height so wide screens cannot push the form below the visible area.
* Preserve the existing percentage-based spacing on narrower viewports.

## Related product discussion/links

* NL-589

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Enable Jetpack's subscribe pop-up under Jetpack > Settings > Newsletter.
2. Open a published post in a logged-out browser and trigger the subscribe modal.
3. At a 3440 x 1080 viewport, confirm the full modal is visible without scrolling.
4. Repeat at 1920 x 1080 and 1440 x 900.
5. Repeat at a narrow portrait viewport and confirm the spacing is unchanged.
6. Repeat at a short landscape viewport and confirm the overlay can still scroll to the bottom of the modal.

Automated checks:

* `pnpm exec stylelint projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.css`
* `php tools/check-changelogger-use.php trunk HEAD`

The layout was also exercised in headless Chrome at 3440 x 1080, 1920 x 1080, 1440 x 900, 390 x 844, 844 x 390, and 720 x 450. Before the change, the modal started 514 px from the top at 3440 x 1080 and extended below the viewport. After the change, it starts 162 px from the top and fits without scrolling. Portrait-mobile spacing remains unchanged, and short landscape viewports retain access to the full modal through the existing overlay scroll.
