### PR TITLE
VideoPress: add the Activity Log page to the standalone plugin

### DIFF
--- a/projects/plugins/videopress/changelog/add-activity-log-page
+++ b/projects/plugins/videopress/changelog/add-activity-log-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Activity Log page to wp-admin, so it is available without the Jetpack plugin installed.

--- a/projects/plugins/videopress/composer.json
+++ b/projects/plugins/videopress/composer.json
@@ -4,6 +4,7 @@
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"require": {
+		"automattic/jetpack-activity-log": "@dev",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0cd83f92dd568ec2c929d75bd16b63fd",
+    "content-hash": "c2210b0b9a8daf0b75a11ab977b92afd",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -55,6 +55,82 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-activity-log",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/activity-log",
+                "reference": "46b819ca318f43e022d73a2ce76ef337e48bd169"
+            },
+            "require": {
+                "automattic/jetpack-admin-ui": "@dev",
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-autoloader": "@dev",
+                "automattic/jetpack-composer-plugin": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-activity-log",
+                "textdomain": "jetpack-activity-log",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-activity-log/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Activity Log UI for the Jetpack plugin in wp-admin.",
             "transport-options": {
                 "relative": true
             }
@@ -1981,6 +2057,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "automattic/jetpack-activity-log": 20,
         "automattic/jetpack-assets": 20,
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-composer-plugin": 20,

--- a/projects/plugins/videopress/src/class-jetpack-videopress-plugin.php
+++ b/projects/plugins/videopress/src/class-jetpack-videopress-plugin.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
+use Automattic\Jetpack\Activity_Log\Jetpack_Activity_Log;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
@@ -62,6 +63,10 @@ class Jetpack_VideoPress_Plugin {
 		add_action( 'init', array( $this, 'register_videopress_blocks' ) );
 
 		My_Jetpack_Initializer::init();
+
+		// Activity Log. Idempotent, so it no-ops when the Jetpack plugin already
+		// initialized the package on this request.
+		Jetpack_Activity_Log::initialize();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Add `automattic/jetpack-activity-log` and initialize it on the VideoPress plugin.

#48244 replaced My Jetpack's Cloud-redirect "Activity Log ↗" item with a native wp-admin page from the new `automattic/jetpack-activity-log` package, which is only wired into the Jetpack plugin.

That item used to be registered by `My_Jetpack\Activitylog::init()`, called unconditionally from the my-jetpack package's `Initializer::init()` — so every standalone plugin that bootstraps My Jetpack inherited it for free, with no product gating (just connected user + non-multisite + `manage_options`). When #48244 deleted that class, **all** My Jetpack consumers lost the entry point, not just Backup and Protect. Standalone Jetpack VideoPress is one of them.

This is the same fix already landed for Backup (#51154) and Protect (#51157), applied here. `Jetpack_Activity_Log::initialize()` is idempotent, so it no-ops when the Jetpack plugin already initialized the package on the same request. It runs from the `Jetpack_VideoPress_Plugin` constructor, which fires while the plugin file loads — well before the `admin_menu` and `rest_api_init` hooks the package registers.

The new dependency brings in exactly one package: every transitive dependency of `jetpack-activity-log` (`admin-ui`, `assets`, `connection`, `status`, `wp-build-polyfills`) was already in VideoPress's lock file, so the `composer.lock` diff is a single added entry with no removals.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1786381350378919-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->

* On a test site, make sure the **Jetpack plugin is not active** — this regression is only visible on the standalone plugin.
* Using Jetpack Beta, activate Jetpack VideoPress on this branch (`add/videopress-plugin-activity-log-page`) and connect the site to WordPress.com with a user account.
* Go to the **Jetpack** menu in wp-admin. An **Activity Log** item should appear (no `↗` arrow — it is a native page now, not a Cloud redirect).
* Open it and confirm the Activity Log renders, loads events, and that filtering and the date range picker work.
* Compare against the `bleeding edge` channel to see the current broken state, where no Activity Log item is present at all.
* Regression checks:
  * Confirm the VideoPress Library and Settings pages still render correctly, and that the VideoPress block still works in the editor.
  * Activate the Jetpack plugin alongside VideoPress and confirm there is still exactly **one** Activity Log menu item (the idempotency guard).
  * Confirm the item is hidden for a site that is not user-connected, and on multisite.
  * Load a few other wp-admin pages and the block editor to confirm the wp-build polyfills stay scoped to the Activity Log request only.
