### PR TITLE
Sharing: randomize share popup window names

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-randomize-popup-window-name
+++ b/projects/plugins/jetpack/changelog/fix-sharing-randomize-popup-window-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: use an unpredictable name for share and Press This popups so another page cannot pre-register the same window name.

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -708,12 +708,6 @@ abstract class Sharing_Source {
 			'sharing-js',
 			"var windowOpen;
 			( function () {
-				/*
-				 * Randomize the popup's window name. A fixed, predictable name lets a malicious
-				 * page pre-register a same-named browsing context and hijack the share popup.
-				 * Generate it in JS (not PHP) so full-page HTML caching can't freeze it to a
-				 * single predictable value shared across all visitors.
-				 */
 				var shareWindowName = 'wpcom$name-' + Math.random().toString( 36 ).slice( 2 );
 
 				function matches( el, sel ) {

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing-sources.php
@@ -708,6 +708,14 @@ abstract class Sharing_Source {
 			'sharing-js',
 			"var windowOpen;
 			( function () {
+				/*
+				 * Randomize the popup's window name. A fixed, predictable name lets a malicious
+				 * page pre-register a same-named browsing context and hijack the share popup.
+				 * Generate it in JS (not PHP) so full-page HTML caching can't freeze it to a
+				 * single predictable value shared across all visitors.
+				 */
+				var shareWindowName = 'wpcom$name-' + Math.random().toString( 36 ).slice( 2 );
+
 				function matches( el, sel ) {
 					return !! (
 						el.matches && el.matches( sel ) ||
@@ -734,7 +742,7 @@ abstract class Sharing_Source {
 						if ( typeof windowOpen !== 'undefined' ) {
 							windowOpen.close();
 						}
-						windowOpen = window.open( el.getAttribute( 'href' ), 'wpcom$name', '$opts' );
+						windowOpen = window.open( el.getAttribute( 'href' ), shareWindowName, '$opts' );
 						return false;
 					}
 				} );

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.js
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.js
@@ -548,6 +548,8 @@
 
 			// Press This button
 			forEachNode( group.querySelectorAll( 'a.share-press-this' ), function ( pressThisButton ) {
+				// Unpredictable, but stable per page load so repeat clicks reuse the same popup.
+				var pressThisWindowName = 'wp-press-this-' + Math.random().toString( 36 ).slice( 2 );
 				pressThisButton.addEventListener( 'click', function ( event ) {
 					event.preventDefault();
 					event.stopPropagation();
@@ -570,8 +572,7 @@
 					if (
 						! window.open(
 							pressThisButton.getAttribute( 'href' ),
-							// Unpredictable window name so another page can't hijack the popup.
-							'wp-press-this-' + Math.random().toString( 36 ).slice( 2 ),
+							pressThisWindowName,
 							'toolbar=0,resizable=1,scrollbars=1,status=1,width=720,height=570'
 						)
 					) {

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.js
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.js
@@ -570,7 +570,8 @@
 					if (
 						! window.open(
 							pressThisButton.getAttribute( 'href' ),
-							't',
+							// Unpredictable window name so another page can't hijack the popup.
+							'wp-press-this-' + Math.random().toString( 36 ).slice( 2 ),
 							'toolbar=0,resizable=1,scrollbars=1,status=1,width=720,height=570'
 						)
 					) {


### PR DESCRIPTION
## Proposed changes

Give Jetpack Sharing pop-ups an unpredictable window name instead of a fixed, guessable one. This aligns with common best practice for `window.open()` — several major sites use unique per-pop-up names rather than static ones.

* Share buttons: `wpcom<service>` (e.g. `wpcomtwitter`) becomes `wpcom<service>-<random>`.
* Press This button: `t` becomes `wp-press-this-<random>`.
* The random suffix is generated in JS at click time (not in PHP), so full-page HTML caching can't freeze it to a single value.

No user-facing change: the click handler already closes the previous pop-up explicitly, so it never depended on the fixed name. Only two changed files plus a changelog entry.

## Related product discussion/links

* _Internal reference to be added._

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a site with the Jetpack Sharing module active and at least one pop-up-style button enabled (X/Twitter, LinkedIn, Tumblr, or Telegram):

* View a post with the sharing buttons and view source. Confirm the inline handler builds the name as `var shareWindowName = 'wpcom<service>-' + Math.random().toString( 36 ).slice( 2 );` and calls `window.open( ..., shareWindowName, ... )`.
* Click a share button and confirm the pop-up opens and shares correctly. In the pop-up's console, `window.name` reads `wpcom<service>-<random>` and changes on each page load.
* Click a second share button and confirm the previous pop-up still closes (single pop-up at a time).
* Press This: with a text selection on a post, click Press This and confirm the editor pop-up still opens.
