### PR TITLE
AGENTS.md: require plugin changelog entries for user-facing package changes

### DIFF
--- a/.github/instructions/changelog.instructions.md
+++ b/.github/instructions/changelog.instructions.md
@@ -18,3 +18,4 @@ When reviewing these files:
 - Do NOT suggest changes to the Significance or Type header format.
 - DO review the entry text for grammar, clarity, and adherence to project conventions (imperative mood, capital letter, ends with period, user-facing description).
 - Note: Jetpack plugin (`projects/plugins/jetpack/`) uses custom types: major, enhancement, compat, bugfix, other.
+- If the entry is in a package (`projects/packages/`) and describes a user-facing change, check that the PR also adds entries to the plugins that ship that package — an entry only appears in the CHANGELOG of the project it lives in, so otherwise the change is invisible in the plugin changelog. See "User-Facing Package Changes Also Need Plugin Entries" in `AGENTS.md`.

--- a/.github/instructions/changelog.instructions.md
+++ b/.github/instructions/changelog.instructions.md
@@ -18,4 +18,4 @@ When reviewing these files:
 - Do NOT suggest changes to the Significance or Type header format.
 - DO review the entry text for grammar, clarity, and adherence to project conventions (imperative mood, capital letter, ends with period, user-facing description).
 - Note: Jetpack plugin (`projects/plugins/jetpack/`) uses custom types: major, enhancement, compat, bugfix, other.
-- If the entry is in a package (`projects/packages/`) and describes a user-facing change, check that the PR also adds entries to the plugins that ship that package — an entry only appears in the CHANGELOG of the project it lives in, so otherwise the change is invisible in the plugin changelog. See "User-Facing Package Changes Also Need Plugin Entries" in `AGENTS.md`.
+- If the entry is in a non-plugin project (`projects/packages/`, `projects/js-packages/`) and describes a user-facing change, check that the PR also adds entries to the plugins that ship it — an entry only appears in the CHANGELOG of the project it lives in, so otherwise the change is invisible in the plugin changelog. See "User-Facing Changes Outside a Plugin Also Need Plugin Entries" in `AGENTS.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ Two gates enforce this, both running `tools/check-changelogger-use.php`: the pre
 
 ### User-Facing Changes Outside a Plugin Also Need Plugin Entries
 
-An entry only lands in the CHANGELOG of the project it was added to. A PR confined to a shared project — a PHP package under `projects/packages/`, a JS package under `projects/js-packages/`, or any other non-plugin project — therefore appears in that project's CHANGELOG and, in the plugins that bundle it, as nothing more than "Update package dependencies." — invisible to the users, release posts, and support documentation that read the plugin changelog.
+An entry only lands in the CHANGELOG of the project it was added to. A PR confined to a shared project — a PHP package under `projects/packages/`, a JS package under `projects/js-packages/`, or any other non-plugin project — therefore reaches that project's CHANGELOG and nowhere else: the plugins that bundle it get, at most, the generic "Update package dependencies." line the release tooling files under "Other changes", which is never copied to `readme.txt`. Users, release posts, and support documentation read the plugin changelog, so the change is invisible to them.
 
 **When a change to a package or js-package is user-facing — a new block, new or changed UI, a behavior change, a bug fix someone would notice — add a changelog entry to every plugin that ships it, on top of the project's own entry.** Write each one from that plugin's user's perspective; the wording rarely needs to be identical.
 
@@ -196,7 +196,7 @@ jp changelog add plugins/search  -s minor -t added       -e "Add a Search Result
 jp changelog add plugins/jetpack -s minor -t enhancement -e "Search: Add a Search Results block."
 ```
 
-**The non-interactive form never prompts for this.** Interactive `jp changelog add` (no project argument) asks "The following plugins are indirectly affected by this commit: … Is this change something an end user or site administrator of a site using any of those plugins would like to know about?", and answering yes writes the plugin entries for you. Naming a project disables that check, so `jp changelog add <project> -s … -t … -e …` silently skips the dependent plugins. Anyone — human or agent — using the non-interactive form MUST add the plugin entries themselves. To be asked again after the fact, run `jp changelog add --check-indirect-plugins`.
+**The non-interactive form never prompts for this.** Naming a project (`jp changelog add <project> -s … -t … -e …`) disables the indirect-plugin check, so dependent plugins are silently skipped; only bare `jp changelog add` offers to write those entries for you. Using the non-interactive form means adding the plugin entries yourself — or running `jp changelog add --check-indirect-plugins` afterwards to be asked.
 
 The project's own entry alone is correct only when nothing is observable to a site owner: internal refactors, tests, tooling, type fixes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,17 +173,20 @@ Every PR touching `/projects` MUST include a changelog file in the project's `ch
 
 Two gates enforce this, both running `tools/check-changelogger-use.php`: the pre-push hook (see "Linting & Formatting" above) and the `linting.yml` CI job. The repo-gardening bot also comments on the PR listing any projects still missing entries. There is no AI-generated-changelog checkbox in the PR template — that feature was removed. Write the entries yourself, with `jp changelog add`.
 
-### User-Facing Package Changes Also Need Plugin Entries
+### User-Facing Changes Outside a Plugin Also Need Plugin Entries
 
-An entry only lands in the CHANGELOG of the project it was added to. A package-only PR therefore appears in that package's CHANGELOG and, in the plugins that bundle the package, as nothing more than "Update package dependencies." — invisible to the users, release posts, and support documentation that read the plugin changelog.
+An entry only lands in the CHANGELOG of the project it was added to. A PR confined to a shared project — a PHP package under `projects/packages/`, a JS package under `projects/js-packages/`, or any other non-plugin project — therefore appears in that project's CHANGELOG and, in the plugins that bundle it, as nothing more than "Update package dependencies." — invisible to the users, release posts, and support documentation that read the plugin changelog.
 
-**When a change to a package is user-facing — a new block, new or changed UI, a behavior change, a bug fix someone would notice — add a changelog entry to every plugin that ships that package, on top of the package's own entry.** Write each one from that plugin's user's perspective; the wording rarely needs to be identical.
+**When a change to a package or js-package is user-facing — a new block, new or changed UI, a behavior change, a bug fix someone would notice — add a changelog entry to every plugin that ships it, on top of the project's own entry.** Write each one from that plugin's user's perspective; the wording rarely needs to be identical.
 
-List the plugins that ship a package:
+List the plugins that ship a project (works the same for `packages/…` and `js-packages/…`):
 
 ```bash
 jp dependencies list packages/search --add-dependents --extra build --no-dev | grep '^plugins/'
+jp dependencies list js-packages/components --add-dependents --extra build --no-dev | grep '^plugins/'
 ```
+
+A widely-shared js-package can list a dozen plugins. Add entries to the ones where the change is actually reachable by that plugin's users, not to every dependent by reflex.
 
 Then add one entry per plugin. Each project defines its own types — `plugins/jetpack` uses `major` | `enhancement` | `compat` | `bugfix` | `other`:
 
@@ -195,7 +198,7 @@ jp changelog add plugins/jetpack -s minor -t enhancement -e "Search: Add a Searc
 
 **The non-interactive form never prompts for this.** Interactive `jp changelog add` (no project argument) asks "The following plugins are indirectly affected by this commit: … Is this change something an end user or site administrator of a site using any of those plugins would like to know about?", and answering yes writes the plugin entries for you. Naming a project disables that check, so `jp changelog add <project> -s … -t … -e …` silently skips the dependent plugins. Anyone — human or agent — using the non-interactive form MUST add the plugin entries themselves. To be asked again after the fact, run `jp changelog add --check-indirect-plugins`.
 
-The package entry alone is correct only when nothing is observable to a site owner: internal refactors, tests, tooling, type fixes.
+The project's own entry alone is correct only when nothing is observable to a site owner: internal refactors, tests, tooling, type fixes.
 
 ### Interactive Mode
 
@@ -269,7 +272,7 @@ The exception is the **WordPress.com Tests** check (the TeamCity `JetpackPreFlig
 
 When reviewing code, check for:
 - Adherence to `docs/coding-guidelines.md`
-- User-facing package changes missing changelog entries in the plugins that ship the package (see "User-Facing Package Changes Also Need Plugin Entries" above) — CI only checks the directly-touched project, so this gap is reviewer-only
+- User-facing changes in a package or js-package missing changelog entries in the plugins that ship it (see "User-Facing Changes Outside a Plugin Also Need Plugin Entries" above) — CI only checks the directly-touched project, so this gap is reviewer-only
 - Missing documentation for public APIs, or missing explanations for non-obvious logic
 - Typos in user-facing strings, comments, and docs — PHPCS and ESLint check naming and formatting, not spelling, so this needs human eyes
 - Performance hazards that no sniff catches: uncached `wp_remote_*` calls, queries inside loops, `meta_query`/`tax_query`/`orderby => rand` on large tables, and newly autoloaded options. `WordPress.DB.SlowDBQuery` is excluded from the Jetpack ruleset as too noisy, so this is reviewer-only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,30 @@ Every PR touching `/projects` MUST include a changelog file in the project's `ch
 
 Two gates enforce this, both running `tools/check-changelogger-use.php`: the pre-push hook (see "Linting & Formatting" above) and the `linting.yml` CI job. The repo-gardening bot also comments on the PR listing any projects still missing entries. There is no AI-generated-changelog checkbox in the PR template — that feature was removed. Write the entries yourself, with `jp changelog add`.
 
+### User-Facing Package Changes Also Need Plugin Entries
+
+An entry only lands in the CHANGELOG of the project it was added to. A package-only PR therefore appears in that package's CHANGELOG and, in the plugins that bundle the package, as nothing more than "Update package dependencies." — invisible to the users, release posts, and support documentation that read the plugin changelog.
+
+**When a change to a package is user-facing — a new block, new or changed UI, a behavior change, a bug fix someone would notice — add a changelog entry to every plugin that ships that package, on top of the package's own entry.** Write each one from that plugin's user's perspective; the wording rarely needs to be identical.
+
+List the plugins that ship a package:
+
+```bash
+jp dependencies list packages/search --add-dependents --extra build --no-dev | grep '^plugins/'
+```
+
+Then add one entry per plugin. Each project defines its own types — `plugins/jetpack` uses `major` | `enhancement` | `compat` | `bugfix` | `other`:
+
+```bash
+jp changelog add packages/search -s minor -t added       -e "Add a Search Results block."
+jp changelog add plugins/search  -s minor -t added       -e "Add a Search Results block."
+jp changelog add plugins/jetpack -s minor -t enhancement -e "Search: Add a Search Results block."
+```
+
+**The non-interactive form never prompts for this.** Interactive `jp changelog add` (no project argument) asks "The following plugins are indirectly affected by this commit: … Is this change something an end user or site administrator of a site using any of those plugins would like to know about?", and answering yes writes the plugin entries for you. Naming a project disables that check, so `jp changelog add <project> -s … -t … -e …` silently skips the dependent plugins. Anyone — human or agent — using the non-interactive form MUST add the plugin entries themselves. To be asked again after the fact, run `jp changelog add --check-indirect-plugins`.
+
+The package entry alone is correct only when nothing is observable to a site owner: internal refactors, tests, tooling, type fixes.
+
 ### Interactive Mode
 
 Run `jp changelog add` and follow the prompts.
@@ -245,6 +269,7 @@ The exception is the **WordPress.com Tests** check (the TeamCity `JetpackPreFlig
 
 When reviewing code, check for:
 - Adherence to `docs/coding-guidelines.md`
+- User-facing package changes missing changelog entries in the plugins that ship the package (see "User-Facing Package Changes Also Need Plugin Entries" above) — CI only checks the directly-touched project, so this gap is reviewer-only
 - Missing documentation for public APIs, or missing explanations for non-obvious logic
 - Typos in user-facing strings, comments, and docs — PHPCS and ESLint check naming and formatting, not spelling, so this needs human eyes
 - Performance hazards that no sniff catches: uncached `wp_remote_*` calls, queries inside loops, `meta_query`/`tax_query`/`orderby => rand` on large tables, and newly autoloaded options. `WordPress.DB.SlowDBQuery` is excluded from the Jetpack ruleset as too noisy, so this is reviewer-only


### PR DESCRIPTION
## Proposed changes

A changelog entry only lands in the CHANGELOG of the project it was added to. When a user-facing change ships entirely inside a package, the plugins that bundle that package get nothing but "Update package dependencies." — so the change is invisible to the users, release posts, and support documentation that read the *plugin* changelog. This has bitten the docs team more than once when tracing which release a feature shipped in.

The changelogger already handles this: interactive `jp changelog add` asks "The following plugins are indirectly affected by this commit: … Is this change something an end user or site administrator of a site using any of those plugins would like to know about?" But the non-interactive form (`jp changelog add <project> -s … -t … -e …`), which is what AI coding agents follow from `AGENTS.md`, disables that check and skips the prompt silently.

This PR documents the expectation so it is followed regardless of which form is used:

* `AGENTS.md` — new "User-Facing Package Changes Also Need Plugin Entries" section under "Changelog Entries": why the plugin entry is needed, how to list the plugins that ship a package (`jp dependencies list <project> --add-dependents --extra build --no-dev`), an example set of commands, the explicit warning that the non-interactive form skips the prompt, and when a package-only entry is in fact correct.
* `AGENTS.md` — one more bullet under "Code Review Guidelines", since CI only checks the directly-touched project and this gap is reviewer-only.
* `.github/instructions/changelog.instructions.md` — the same check for reviews scoped to changelog files.

No behavior or tooling changes; documentation only.

## Related product discussion/links

* p1786455008634679-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Documentation-only, so mostly a read-through. To verify the commands quoted in the new section:

* Run `jp dependencies list packages/search --add-dependents --extra build --no-dev | grep '^plugins/'` — it should list `plugins/search` and `plugins/jetpack`.
* Run `jp changelog add` with no arguments on a branch that touches a package, and confirm the "indirectly affected" prompt appears.
* Run `jp changelog add packages/search -s patch -t fixed -e "Test."` and confirm the prompt does *not* appear — the behavior the new section warns about. (`git checkout` the resulting file afterwards.)