### PR TITLE
Premium Analytics: let a dashboard section declare whether its date bar offers comparison

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-pa-section-date-comparison-option
+++ b/projects/packages/premium-analytics/changelog/update-pa-section-date-comparison-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Date controls: Let each dashboard section declare whether its header offers the period-over-period comparison control.

--- a/projects/packages/premium-analytics/routes/dashboard/config/date-filter.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/date-filter.test.ts
@@ -1,5 +1,10 @@
 import { PRESET_ALL_TIME, toYearPresetId } from '@jetpack-premium-analytics/datetime';
-import { DATE_FILTER_RANGE, DATE_FILTER_YEAR, resolvePresetForSurface } from './date-filter';
+import {
+	DATE_FILTER_RANGE,
+	DATE_FILTER_YEAR,
+	offersDateComparison,
+	resolvePresetForSurface,
+} from './date-filter';
 
 describe( 'resolvePresetForSurface', () => {
 	describe( 'on the year surface', () => {
@@ -30,5 +35,27 @@ describe( 'resolvePresetForSurface', () => {
 				'last-30-days'
 			);
 		} );
+	} );
+} );
+
+describe( 'offersDateComparison', () => {
+	it( 'follows the section on the date-range surface', () => {
+		expect( offersDateComparison( DATE_FILTER_RANGE, { with_date_comparison: true } ) ).toBe(
+			true
+		);
+		expect( offersDateComparison( DATE_FILTER_RANGE, { with_date_comparison: false } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'keeps the control when the section carries no options', () => {
+		expect( offersDateComparison( DATE_FILTER_RANGE, undefined ) ).toBe( true );
+	} );
+
+	it( 'never offers it on the year surface, whatever the section says', () => {
+		expect( offersDateComparison( DATE_FILTER_YEAR, undefined ) ).toBe( false );
+		expect( offersDateComparison( DATE_FILTER_YEAR, { with_date_comparison: true } ) ).toBe(
+			false
+		);
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/dashboard/config/date-filter.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/date-filter.ts
@@ -28,6 +28,35 @@ export const DATE_FILTER_YEAR = 'year';
 export type DateFilterSurface = typeof DATE_FILTER_RANGE | typeof DATE_FILTER_YEAR;
 
 /**
+ * Which optional controls a section's date filter offers. Mirrors
+ * `Dashboard_Section::$date_filter_options` on the server.
+ */
+export type DateFilterOptions = {
+	with_date_comparison: boolean;
+};
+
+/**
+ * Whether the section's header offers the comparison control.
+ *
+ * The year surface never does; on the range surface the section decides.
+ * Absent options keep the control, as every section did before the field.
+ *
+ * @param surface - The active section's date-filter surface.
+ * @param options - The active section's date-filter options, if any.
+ * @return Whether to render the comparison control.
+ */
+export function offersDateComparison(
+	surface: DateFilterSurface,
+	options: DateFilterOptions | undefined
+): boolean {
+	if ( surface === DATE_FILTER_YEAR ) {
+		return false;
+	}
+
+	return options?.with_date_comparison ?? true;
+}
+
+/**
  * The preset a surface should take over with when the URL carries one it cannot
  * represent, or `null` when the current preset is already coherent.
  *

--- a/projects/packages/premium-analytics/routes/dashboard/config/index.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/index.ts
@@ -8,7 +8,9 @@ export {
 export {
 	DATE_FILTER_RANGE,
 	DATE_FILTER_YEAR,
+	offersDateComparison,
 	resolvePresetForSurface,
+	type DateFilterOptions,
 	type DateFilterSurface,
 } from './date-filter';
 

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import type { DateFilterSurface } from './date-filter';
+import type { DateFilterOptions, DateFilterSurface } from './date-filter';
 /**
  * External dependencies
  */
@@ -61,6 +61,12 @@ export type DashboardSection = {
 	 * the date-range surface.
 	 */
 	date_filter?: DateFilterSurface;
+
+	/**
+	 * Which optional controls this section's date filter offers. Optional for
+	 * the same reason as `date_filter` above; absent means every control.
+	 */
+	date_filter_options?: DateFilterOptions;
 
 	/**
 	 * Bundled default widget layout, consumed by the reset action.

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -20,7 +20,7 @@ import { WidgetDashboard } from '@wordpress/widget-dashboard';
 import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
 import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
 import { DashboardSections } from './components';
-import { DATE_FILTER_YEAR, resolveSectionHeading } from './config';
+import { DATE_FILTER_YEAR, offersDateComparison, resolveSectionHeading } from './config';
 import {
 	useActiveSection,
 	useDashboardGridSettings,
@@ -88,16 +88,20 @@ function Dashboard(): JSX.Element {
 	 */
 	const dateFilterSurface = useSectionDateFilter( activeSectionRecord, dateFilters );
 
+	// Server-driven, like the surface above.
+	const showComparison = offersDateComparison(
+		dateFilterSurface,
+		activeSectionRecord?.date_filter_options
+	);
+
 	/*
 	 * The subtitle states what the widgets are currently showing, so it follows
 	 * the applied range and comparison rather than the picker's staged draft:
 	 * it must not move while an edit is open, only once Apply commits it.
 	 *
-	 * The year surface offers no comparison control, so its subtitle must not
-	 * announce one it cannot be switched off from.
+	 * A header without the comparison control must not announce one.
 	 */
-	const comparisonPresetId =
-		dateFilterSurface === DATE_FILTER_YEAR ? undefined : dateFilters.appliedComparisonPresetId;
+	const comparisonPresetId = showComparison ? dateFilters.appliedComparisonPresetId : undefined;
 	const sectionSubtitle = useMemo(
 		() =>
 			getSectionSubtitle( {
@@ -185,7 +189,7 @@ function Dashboard(): JSX.Element {
 			 * report pages mount this same panel over records tables, which are
 			 * not, so the control is asked for rather than implied by the props.
 			 */
-			<DateFiltersPanel { ...dateFilters } withIntervalControl />
+			<DateFiltersPanel { ...dateFilters } withIntervalControl showComparison={ showComparison } />
 		);
 
 	return (

--- a/projects/packages/premium-analytics/src/class-dashboard-section.php
+++ b/projects/packages/premium-analytics/src/class-dashboard-section.php
@@ -104,6 +104,16 @@ final class Dashboard_Section {
 	public $date_filter = self::DATE_FILTER_RANGE;
 
 	/**
+	 * Which optional controls the section's date filter offers.
+	 *
+	 * @since $$next-version$$
+	 * @var array
+	 */
+	public $date_filter_options = array(
+		'with_date_comparison' => true,
+	);
+
+	/**
 	 * Availability flag or callback.
 	 *
 	 * @var bool|callable
@@ -178,14 +188,15 @@ final class Dashboard_Section {
 	 */
 	public function to_array() {
 		return array(
-			'id'             => $this->id,
-			'slug'           => $this->slug,
-			'label'          => $this->label,
-			'title'          => $this->title,
-			'description'    => $this->description,
-			'order'          => (int) $this->order,
-			'date_filter'    => $this->date_filter,
-			'default_layout' => $this->get_default_layout(),
+			'id'                  => $this->id,
+			'slug'                => $this->slug,
+			'label'               => $this->label,
+			'title'               => $this->title,
+			'description'         => $this->description,
+			'order'               => (int) $this->order,
+			'date_filter'         => $this->date_filter,
+			'date_filter_options' => $this->date_filter_options,
+			'default_layout'      => $this->get_default_layout(),
 		);
 	}
 
@@ -224,6 +235,16 @@ final class Dashboard_Section {
 		// dashboard, where the frontend has no filter to render for it.
 		if ( isset( $args['date_filter'] ) && in_array( $args['date_filter'], self::DATE_FILTERS, true ) ) {
 			$this->date_filter = (string) $args['date_filter'];
+		}
+
+		// Merged over the defaults so a partial array keeps the rest, and narrowed
+		// to the known options, which is all the dashboard renders.
+		if ( isset( $args['date_filter_options'] ) && is_array( $args['date_filter_options'] ) ) {
+			$options = array_merge( $this->date_filter_options, $args['date_filter_options'] );
+
+			$this->date_filter_options = array(
+				'with_date_comparison' => (bool) $options['with_date_comparison'],
+			);
 		}
 
 		if ( array_key_exists( 'is_available', $args ) ) {

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -108,14 +108,17 @@ function register_default_dashboard_sections() {
 			},
 		),
 		'analytics/insights'    => array(
-			'label'          => __( 'Insights', 'jetpack-premium-analytics-pkg' ),
-			'title'          => __( 'Activity insights', 'jetpack-premium-analytics-pkg' ),
-			'description'    => __( 'Longer-term patterns in your content and audience.', 'jetpack-premium-analytics-pkg' ),
-			'order'          => 20,
-			// Insights reads whole history, so it offers all time and single
-			// years instead of the rolling date-range picker.
-			'date_filter'    => Dashboard_Section::DATE_FILTER_YEAR,
-			'default_layout' => static function () {
+			'label'               => __( 'Insights', 'jetpack-premium-analytics-pkg' ),
+			'title'               => __( 'Activity insights', 'jetpack-premium-analytics-pkg' ),
+			'description'         => __( 'Longer-term patterns in your content and audience.', 'jetpack-premium-analytics-pkg' ),
+			'order'               => 20,
+			// Insights reads whole history: all time and single years instead of
+			// the rolling picker, with nothing to compare them against.
+			'date_filter'         => Dashboard_Section::DATE_FILTER_YEAR,
+			'date_filter_options' => array(
+				'with_date_comparison' => false,
+			),
+			'default_layout'      => static function () {
 				return get_dashboard_default_layout_for( 'analytics/insights' );
 			},
 		),
@@ -213,44 +216,56 @@ function get_dashboard_section_schema() {
 		'title'      => 'jetpack-premium-analytics-dashboard-section',
 		'type'       => 'object',
 		'properties' => array(
-			'id'             => array(
+			'id'                  => array(
 				'description' => __( 'Namespaced section identifier.', 'jetpack-premium-analytics-pkg' ),
 				'type'        => 'string',
 				'readonly'    => true,
 			),
-			'slug'           => array(
+			'slug'                => array(
 				'description' => __( 'URL-facing section slug, derived from the identifier.', 'jetpack-premium-analytics-pkg' ),
 				'type'        => 'string',
 				'readonly'    => true,
 			),
-			'label'          => array(
+			'label'               => array(
 				'description' => __( 'Translated display label, naming the section tab.', 'jetpack-premium-analytics-pkg' ),
 				'type'        => 'string',
 				'readonly'    => true,
 			),
-			'title'          => array(
+			'title'               => array(
 				'description' => __( 'Translated section heading, distinct from the tab label. Null falls back to the label.', 'jetpack-premium-analytics-pkg' ),
 				'type'        => array( 'string', 'null' ),
 				'readonly'    => true,
 			),
-			'description'    => array(
+			'description'         => array(
 				'description' => __( 'Translated section description, shown as the page subtitle while the section is active.', 'jetpack-premium-analytics-pkg' ),
 				'type'        => array( 'string', 'null' ),
 				'readonly'    => true,
 			),
-			'order'          => array(
+			'order'               => array(
 				'description' => __( 'Sort order, ascending.', 'jetpack-premium-analytics-pkg' ),
 				'type'        => 'integer',
 				'readonly'    => true,
 			),
-			'date_filter'    => array(
+			'date_filter'         => array(
 				'description' => __( 'Which date filter the section header offers: the rolling date range, or all time plus single years.', 'jetpack-premium-analytics-pkg' ),
 				'type'        => 'string',
 				'enum'        => Dashboard_Section::DATE_FILTERS,
 				'default'     => Dashboard_Section::DATE_FILTER_RANGE,
 				'readonly'    => true,
 			),
-			'default_layout' => array(
+			'date_filter_options' => array(
+				'description' => __( 'Which optional controls the section date filter offers.', 'jetpack-premium-analytics-pkg' ),
+				'type'        => 'object',
+				'properties'  => array(
+					'with_date_comparison' => array(
+						'description' => __( 'Whether the section header offers the period-over-period comparison control.', 'jetpack-premium-analytics-pkg' ),
+						'type'        => 'boolean',
+						'default'     => true,
+					),
+				),
+				'readonly'    => true,
+			),
+			'default_layout'      => array(
 				'description' => __( 'Bundled default widget layout.', 'jetpack-premium-analytics-pkg' ),
 				'type'        => 'array',
 				'items'       => array( 'type' => 'object' ),

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -252,6 +252,87 @@ class Dashboard_Section_Test extends BaseTestCase {
 	}
 
 	/**
+	 * A section can turn off an optional date-filter control.
+	 */
+	public function test_section_accepts_date_filter_options() {
+		$section = new Dashboard_Section(
+			'example_dashboard',
+			'example/insights',
+			array( 'date_filter_options' => array( 'with_date_comparison' => false ) )
+		);
+
+		$this->assertSame(
+			array( 'with_date_comparison' => false ),
+			$section->date_filter_options
+		);
+		$this->assertSame(
+			array( 'with_date_comparison' => false ),
+			$section->to_array()['date_filter_options']
+		);
+	}
+
+	/**
+	 * Unknown options are dropped and known ones normalised to booleans.
+	 */
+	public function test_section_normalises_date_filter_options() {
+		$section = new Dashboard_Section(
+			'example_dashboard',
+			'example/traffic',
+			array(
+				'date_filter_options' => array(
+					'with_date_comparison' => 1,
+					'with_moon_phase'      => true,
+				),
+			)
+		);
+
+		$this->assertSame( array( 'with_date_comparison' => true ), $section->date_filter_options );
+	}
+
+	/**
+	 * Every optional control is offered when the arg is omitted.
+	 */
+	public function test_section_defaults_to_offering_every_date_filter_option() {
+		$section = new Dashboard_Section( 'example_dashboard', 'example/traffic' );
+
+		$this->assertSame(
+			array( 'with_date_comparison' => true ),
+			$section->to_array()['date_filter_options']
+		);
+	}
+
+	/**
+	 * Insights drops the comparison control; the rest keep it.
+	 */
+	public function test_built_in_sections_declare_their_date_filter_options() {
+		// Store needs both gates: the filter stands in for WooCommerce being active,
+		// and the admin user satisfies the capability check added in #50889.
+		$this->set_admin_user();
+		add_filter( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_true' );
+
+		register_default_dashboard_sections();
+
+		$this->assertSame(
+			array(
+				'traffic'     => array( 'with_date_comparison' => true ),
+				'insights'    => array( 'with_date_comparison' => false ),
+				'subscribers' => array( 'with_date_comparison' => true ),
+				'store'       => array( 'with_date_comparison' => true ),
+			),
+			array_column(
+				array_map(
+					static function ( Dashboard_Section $section ) {
+						return $section->to_array();
+					},
+					get_available_dashboard_sections( DASHBOARD_NAME )
+				),
+				'date_filter_options',
+				'slug'
+			)
+		);
+	}
+
+	/**
 	 * The analytics sections carry their own heading; Store still falls back to its label.
 	 */
 	public function test_built_in_sections_declare_their_headings() {
@@ -291,7 +372,17 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$schema = get_dashboard_section_schema();
 
 		$this->assertSame(
-			array( 'id', 'slug', 'label', 'title', 'description', 'order', 'date_filter', 'default_layout' ),
+			array(
+				'id',
+				'slug',
+				'label',
+				'title',
+				'description',
+				'order',
+				'date_filter',
+				'date_filter_options',
+				'default_layout',
+			),
 			array_keys( $schema['properties'] )
 		);
 		$this->assertSame(
@@ -299,6 +390,9 @@ class Dashboard_Section_Test extends BaseTestCase {
 			$schema['properties']['date_filter']['enum']
 		);
 		$this->assertSame( 'range', $schema['properties']['date_filter']['default'] );
+		$this->assertTrue(
+			$schema['properties']['date_filter_options']['properties']['with_date_comparison']['default']
+		);
 	}
 
 	/**
@@ -456,14 +550,15 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'             => 'analytics/traffic',
-					'slug'           => 'traffic',
-					'label'          => 'Traffic',
-					'title'          => null,
-					'description'    => null,
-					'order'          => 10,
-					'date_filter'    => 'range',
-					'default_layout' => array(),
+					'id'                  => 'analytics/traffic',
+					'slug'                => 'traffic',
+					'label'               => 'Traffic',
+					'title'               => null,
+					'description'         => null,
+					'order'               => 10,
+					'date_filter'         => 'range',
+					'date_filter_options' => array( 'with_date_comparison' => true ),
+					'default_layout'      => array(),
 				),
 			),
 			$response->get_data()
@@ -574,31 +669,34 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'          => 'analytics/traffic',
-					'slug'        => 'traffic',
-					'label'       => 'Traffic',
-					'title'       => 'Site traffic',
-					'description' => 'Views, visitors, and where they came from.',
-					'order'       => 10,
-					'date_filter' => 'range',
+					'id'                  => 'analytics/traffic',
+					'slug'                => 'traffic',
+					'label'               => 'Traffic',
+					'title'               => 'Site traffic',
+					'description'         => 'Views, visitors, and where they came from.',
+					'order'               => 10,
+					'date_filter'         => 'range',
+					'date_filter_options' => array( 'with_date_comparison' => true ),
 				),
 				array(
-					'id'          => 'analytics/insights',
-					'slug'        => 'insights',
-					'label'       => 'Insights',
-					'title'       => 'Activity insights',
-					'description' => 'Longer-term patterns in your content and audience.',
-					'order'       => 20,
-					'date_filter' => 'year',
+					'id'                  => 'analytics/insights',
+					'slug'                => 'insights',
+					'label'               => 'Insights',
+					'title'               => 'Activity insights',
+					'description'         => 'Longer-term patterns in your content and audience.',
+					'order'               => 20,
+					'date_filter'         => 'year',
+					'date_filter_options' => array( 'with_date_comparison' => false ),
 				),
 				array(
-					'id'          => 'analytics/subscribers',
-					'slug'        => 'subscribers',
-					'label'       => 'Subscribers',
-					'title'       => 'Subscribers stats',
-					'description' => 'How your subscriber list is growing, and how your emails land.',
-					'order'       => 30,
-					'date_filter' => 'range',
+					'id'                  => 'analytics/subscribers',
+					'slug'                => 'subscribers',
+					'label'               => 'Subscribers',
+					'title'               => 'Subscribers stats',
+					'description'         => 'How your subscriber list is growing, and how your emails land.',
+					'order'               => 30,
+					'date_filter'         => 'range',
+					'date_filter_options' => array( 'with_date_comparison' => true ),
 				),
 			),
 			array_map(
@@ -787,24 +885,26 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'             => 'example/first',
-					'slug'           => 'first',
-					'label'          => 'First',
-					'title'          => null,
-					'description'    => null,
-					'order'          => 10,
-					'date_filter'    => 'range',
-					'default_layout' => array(),
+					'id'                  => 'example/first',
+					'slug'                => 'first',
+					'label'               => 'First',
+					'title'               => null,
+					'description'         => null,
+					'order'               => 10,
+					'date_filter'         => 'range',
+					'date_filter_options' => array( 'with_date_comparison' => true ),
+					'default_layout'      => array(),
 				),
 				array(
-					'id'             => 'example/later',
-					'slug'           => 'later',
-					'label'          => 'Later',
-					'title'          => null,
-					'description'    => null,
-					'order'          => 20,
-					'date_filter'    => 'range',
-					'default_layout' => array(),
+					'id'                  => 'example/later',
+					'slug'                => 'later',
+					'label'               => 'Later',
+					'title'               => null,
+					'description'         => null,
+					'order'               => 20,
+					'date_filter'         => 'range',
+					'date_filter_options' => array( 'with_date_comparison' => true ),
+					'default_layout'      => array(),
 				),
 			),
 			$response->get_data()
@@ -874,14 +974,15 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'             => 'analytics/traffic',
-					'slug'           => 'traffic',
-					'label'          => 'Traffic',
-					'title'          => null,
-					'description'    => null,
-					'order'          => 10,
-					'date_filter'    => 'range',
-					'default_layout' => array(
+					'id'                  => 'analytics/traffic',
+					'slug'                => 'traffic',
+					'label'               => 'Traffic',
+					'title'               => null,
+					'description'         => null,
+					'order'               => 10,
+					'date_filter'         => 'range',
+					'date_filter_options' => array( 'with_date_comparison' => true ),
+					'default_layout'      => array(
 						array(
 							'uuid' => 'default-route-widget',
 							'type' => 'example/widget',


### PR DESCRIPTION
Fixes #

## Proposed changes

A dashboard section can now declare whether its header offers the comparison control, the same way it already declares its date-filter surface. Part of [WOOA7S-1815](https://linear.app/a8c/issue/WOOA7S-1815/date-controls-year-surface-drops-comparison-and-period-navigation): comparison on the year surface stops being inferred by the frontend and becomes a server-registered fact.

No visual change for the four sections shipping today. Insights already rendered no comparison control, since its branch of the date bar composes the year pills and the interval control alone. What changes is that the exclusion is declared and testable, and a range-surface section can opt out too.

### Server

`Dashboard_Section` gains `$date_filter_options`, defaulting to `array( 'with_date_comparison' => true )`. Registrant values are merged over the defaults and narrowed to the known keys, so a partial array cannot drop the rest. The field rides along in `to_array()` and is documented in the sections REST schema, which WPCOM also serves for Simple sites.

Insights registers `with_date_comparison => false`: it reads whole history, so there is nothing outside a selection to compare it against.

### Dashboard

`offersDateComparison( surface, options )` resolves availability in one place. The year surface never offers the control; on the range surface the section decides. Absent options keep it, which is how every section behaved before the field existed, and matters because WPCOM registers this route from its own checkout.

The resolved value drives both `DateFiltersPanel`'s `showComparison` prop and the section subtitle, so a header without the control never announces a comparison.

The year-aware period navigation, the other half of WOOA7S-1815, is not in this PR.

## Related product discussion/links

* [WOOA7S-1815](https://linear.app/a8c/issue/WOOA7S-1815/date-controls-year-surface-drops-comparison-and-period-navigation)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Build the package:

```bash
jetpack build --deps packages/premium-analytics
```

Go to **Jetpack → Stats**:

* On **Traffic**, the date bar shows the range picker, the interval control, and **Compare**. Set a comparison; the subtitle names it.
* Switch to **Insights**: year pills and interval control, no **Compare**, and no comparison in the subtitle. The interval control must still be there, since a regression here would be the flag gating the wrong control.
* Switch back to **Traffic**: the comparison and its subtitle return.
* `GET /wpcom/v2/dashboards/<name>/sections` returns `date_filter_options.with_date_comparison` as `false` for `insights`, `true` for the rest.

To exercise the range-surface opt-out, filter a section's registration args to add `'date_filter_options' => array( 'with_date_comparison' => false )` and confirm **Compare** and the subtitle's comparison both disappear.

```bash
jetpack test php packages/premium-analytics
jetpack test js packages/premium-analytics
```

`Widget_Metadata_Test` fails on trunk without a built `build/` directory; unrelated to this change.

## Follow-ups

- [ ] Hiding the control does not strip `comp=1` / `compare_from` / `compare_to` from the URL, so a comparison set on one section still reaches the widgets of a section offering none. Pre-existing on the year surface. The detail pages inject stripped `reportParams` into the layout (`routes/video-detail/stage.tsx:106`); the dashboard injects no `reportParams`, so its widgets read the raw URL.
