### PR TITLE
Premium Analytics: reorder the date controls, label the comparison, shorten the custom range

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-date-controls-design-tweaks
+++ b/projects/packages/premium-analytics/changelog/update-date-controls-design-tweaks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Date controls: place the comparison before the chart interval, mark the interval with a chart glyph, and shorten a custom range to its shortest unambiguous form.

--- a/projects/packages/premium-analytics/changelog/update-date-controls-design-tweaks
+++ b/projects/packages/premium-analytics/changelog/update-date-controls-design-tweaks
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Date controls: place the comparison before the chart interval, mark the interval with a chart glyph, and shorten a custom range to its shortest unambiguous form.
+Date controls: label the comparison control "Compare" instead of a bare plus, place it before the chart interval, mark the interval with a chart glyph, and shorten a custom range to its shortest unambiguous form.

--- a/projects/packages/premium-analytics/packages/formatters/README.md
+++ b/projects/packages/premium-analytics/packages/formatters/README.md
@@ -13,6 +13,8 @@ import {
 	formatMetricValue,
 	formatDate,
 	formatDateRange,
+	formatDateRangeCompact,
+	formatDateRangeMinimal,
 	formatDateRangeLong,
 	type DateFormatName,
 } from '@jetpack-premium-analytics/formatters';
@@ -57,27 +59,38 @@ browser's locale. Defaults to `'medium'`.
 ```typescript
 // On a site left on the US English default:
 formatDate( date ); // 'June 21, 2025'
+formatDate( date, 'compact' ); // 'Jun 21, 2025'
+formatDate( date, 'compactNoYear' ); // 'Jun 21'
 formatDate( date, 'short' ); // 'June 21'
 formatDate( date, 'year' ); // '2025'
 formatDate( date, 'iso' ); // '2025-06-21'
 
 // The same calls on an es_ES site:
 formatDate( date ); // '21 de junio de 2025'
+formatDate( date, 'compact' ); // '21 de jun de 2025'
 formatDate( date, 'short' ); // '21 de junio'
 ```
 
-| Name         | Purpose                                             |
-| ------------ | --------------------------------------------------- |
-| `medium`     | Default. The site's `date_format` verbatim.         |
-| `short`      | The site format minus its year.                     |
-| `full`       | The site format led by the weekday.                 |
-| `fullNoYear` | `short` led by the weekday.                         |
-| `year`       | Year alone.                                         |
-| `iso`        | Machine-readable `YYYY-MM-DD`. Never localized.     |
+| Name            | Purpose                                         |
+| --------------- | ----------------------------------------------- |
+| `medium`        | Default. The site's `date_format` verbatim.     |
+| `compact`       | The site format with its month abbreviated.     |
+| `compactNoYear` | `compact` minus its year.                       |
+| `short`         | The site format minus its year.                 |
+| `full`          | The site format led by the weekday.             |
+| `fullNoYear`    | `short` led by the weekday.                     |
+| `year`          | Year alone.                                     |
+| `iso`           | Machine-readable `YYYY-MM-DD`. Never localized. |
 
-The two weekday forms are derived, since core publishes no weekday-bearing
-format. The weekday name itself still comes from WordPress's translation
-tables; only the comma joining it to the date is ours.
+Every form but `year` and `iso` is derived from the site's own `date_format`,
+so the day/month order and the punctuation are always the site's. Dropping the
+year takes the punctuation that introduced it along with it, and the
+abbreviated month still comes from WordPress's translation tables, so a locale
+that does not shorten its month names simply keeps them whole.
+
+The two weekday forms are derived for the same reason, since core publishes no
+weekday-bearing format. The weekday name itself is WordPress's; only the comma
+joining it to the date is ours.
 
 There is no custom-pattern escape hatch: a hand-written pattern fixes the
 day/month order to whatever the author happened to type, which is the problem
@@ -134,6 +147,38 @@ translated WordPress range pattern instead:
 | --------- | ---------------------------- | ----------------- |
 | `range`   | `{ from?: Date; to?: Date }` | Date range object |
 
+## `formatDateRangeCompact( range? )` and `formatDateRangeMinimal( range? )`
+
+Two shorter forms of the same range, for controls sized by the row they sit in
+rather than by their content. Everything else follows `formatDateRange`,
+including the elision, so all three stay one typographic system.
+
+`formatDateRangeCompact` abbreviates the month. `formatDateRangeMinimal` also
+drops the year, but only while the whole range sits in the site's current year:
+a range anywhere else needs its year to say which one it is, and reads as the
+compact form instead.
+
+```typescript
+// On a site left on the US English default, read during 2026:
+formatDateRangeCompact( { from, to } ); // 'Jun 21 – 25, 2026'
+formatDateRangeMinimal( { from, to } ); // 'Jun 21 – 25'
+
+// The same minimal call on a range in 2025:
+// 'Jun 21 – 25, 2025'
+```
+
+Both checks in `formatDateRange` run per form, so a locale can be trusted with
+one width and not another. Two things to know if you add a form:
+
+- The year-bearing forms are probed across a year boundary, so nothing in the
+  probe can elide. The year-less form has to be probed inside one year instead:
+  asked to span two with no year to tell them apart, ICU puts one back, and a
+  probe that provokes that rejects the form outright. Hungarian and Czech are
+  the locales this was found on.
+- A form whose derivation has nothing to change returns the site format
+  unaltered, and then fails the first check against `Intl`'s own abbreviation.
+  That is the intended outcome: the site keeps the format it asked for.
+
 ## `formatDateRangeLong( range?, options? )`
 
 Format a date range in explicit, readable form, for prominent surfaces such as
@@ -165,11 +210,11 @@ formatDateRangeLong( { from, to }, { calendarScale: true } );
 // without the flag, the first of those reads 'Thursday, January 1 – Thursday, July 30'
 ```
 
-| Parameter               | Type                         | Default      | Description                                    |
-| ----------------------- | ---------------------------- | ------------ | ---------------------------------------------- |
-| `range`                 | `{ from?: Date; to?: Date }` |              | Date range object                              |
-| `options.referenceYear` | `number`                     | current year | Year against which the year is redundant       |
-| `options.calendarScale` | `boolean`                    | `false`      | Force the calendar shape whatever it measures  |
+| Parameter               | Type                         | Default      | Description                                   |
+| ----------------------- | ---------------------------- | ------------ | --------------------------------------------- |
+| `range`                 | `{ from?: Date; to?: Date }` |              | Date range object                             |
+| `options.referenceYear` | `number`                     | current year | Year against which the year is redundant      |
+| `options.calendarScale` | `boolean`                    | `false`      | Force the calendar shape whatever it measures |
 
 ## Implementation
 

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__fixtures__/wp-date-settings.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__fixtures__/wp-date-settings.ts
@@ -49,27 +49,32 @@ const ES_WEEKDAYS = [ 'domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'vie
  * running the suite. Tests that vary the zone spread the result and replace
  * the `timezone` block.
  *
- * @param locale     - Moment locale name. Must be unique per fixture, since
- *                   `setSettings` skips redefining a locale it already knows.
- * @param dateFormat - The site's `date_format` option, in PHP tokens.
- * @param months     - Translated month names, January first. Defaults to the
- *                   package's English names.
- * @param weekdays   - Translated weekday names, Sunday first. Defaults to the
- *                   package's English names.
+ * @param locale      - Moment locale name. Must be unique per fixture, since
+ *                    `setSettings` skips redefining a locale it already knows.
+ * @param dateFormat  - The site's `date_format` option, in PHP tokens.
+ * @param months      - Translated month names, January first. Defaults to the
+ *                    package's English names.
+ * @param weekdays    - Translated weekday names, Sunday first. Defaults to the
+ *                    package's English names.
+ * @param monthsShort - Abbreviated month names. Defaults to the first three
+ *                    letters of each, which is only right where the locale
+ *                    abbreviates that way. Hungarian, for one, punctuates its
+ *                    abbreviations, so it has to pass its own.
  * @return Settings ready for `setSettings`.
  */
 export const settingsFor = (
 	locale: string,
 	dateFormat: string,
 	months: string[] = DEFAULT_MONTHS,
-	weekdays: string[] = DEFAULTS.l10n.weekdays as string[]
+	weekdays: string[] = DEFAULTS.l10n.weekdays as string[],
+	monthsShort: string[] = months.map( month => month.slice( 0, 3 ) )
 ): DateSettings => ( {
 	...DEFAULTS,
 	l10n: {
 		...DEFAULTS.l10n,
 		locale,
 		months,
-		monthsShort: months.map( month => month.slice( 0, 3 ) ),
+		monthsShort,
 		weekdays,
 		weekdaysShort: weekdays.map( weekday => weekday.slice( 0, 3 ) ),
 	},

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range.test.ts
@@ -12,7 +12,11 @@ import {
 	settingsFor,
 	utcDate,
 } from '../__fixtures__/wp-date-settings';
-import { formatDateRange, formatDateRangeCompact } from '../format-date-range';
+import {
+	formatDateRange,
+	formatDateRangeCompact,
+	formatDateRangeMinimal,
+} from '../format-date-range';
 
 // The en dash between thin spaces that CLDR puts between the ends of a range.
 const SEP = '\u2009\u2013\u2009';
@@ -204,5 +208,81 @@ describe( 'formatDateRangeCompact', () => {
 		const range = { from: utcDate( 2025, 6, 21 ), to: utcDate( 2025, 6, 25 ) };
 
 		expect( formatDateRangeCompact( range ) ).toBe( formatDateRange( range ) );
+	} );
+} );
+
+describe( 'formatDateRangeMinimal', () => {
+	// The fixtures put the site in UTC, so the site's year is this instant's.
+	beforeAll( () => jest.useFakeTimers().setSystemTime( utcDate( 2026, 8, 13 ) ) );
+	afterAll( () => jest.useRealTimers() );
+
+	describe( 'en_US site', () => {
+		beforeEach( () => setSettings( EN_US_SETTINGS ) );
+
+		it( 'drops the year from a single day in the current year', () => {
+			const date = utcDate( 2026, 7, 24 );
+			expect( formatDateRangeMinimal( { from: date, to: date } ) ).toBe( 'Jul 24' );
+		} );
+
+		it( 'drops the year from a range inside the current year', () => {
+			expect(
+				formatDateRangeMinimal( { from: utcDate( 2026, 7, 13 ), to: utcDate( 2026, 7, 26 ) } )
+			).toBe( `Jul 13${ SEP }26` );
+		} );
+
+		it( 'elides across months of the current year without naming it', () => {
+			expect(
+				formatDateRangeMinimal( { from: utcDate( 2026, 6, 21 ), to: utcDate( 2026, 7, 25 ) } )
+			).toBe( `Jun 21${ SEP }Jul 25` );
+		} );
+
+		// A range elsewhere in time needs its year to say which one it is, so it
+		// reads as the compact form rather than a shorter but ambiguous one.
+		it( 'keeps the year on a range in an earlier year', () => {
+			const range = { from: utcDate( 2025, 7, 13 ), to: utcDate( 2025, 7, 26 ) };
+
+			expect( formatDateRangeMinimal( range ) ).toBe( formatDateRangeCompact( range ) );
+		} );
+
+		it( 'keeps the year on a range straddling the turn of the year', () => {
+			const range = { from: utcDate( 2025, 12, 28 ), to: utcDate( 2026, 1, 3 ) };
+
+			expect( formatDateRangeMinimal( range ) ).toBe( formatDateRangeCompact( range ) );
+		} );
+	} );
+
+	describe( 'es_ES site', () => {
+		beforeEach( () => setSettings( ES_ES_SETTINGS ) );
+
+		// Dropping the year takes the "de" that introduced it along with it, so
+		// the shorter form is still written the way the locale writes dates.
+		// Spanish keeps both ends spelled out here for the same reason the
+		// compact form does: its abbreviated dates and CLDR's do not agree.
+		it( 'drops the year the way the locale writes the rest of the date', () => {
+			expect(
+				formatDateRangeMinimal( { from: utcDate( 2026, 7, 13 ), to: utcDate( 2026, 7, 26 ) } )
+			).toBe( `13 de jul${ FALLBACK_SEP }26 de jul` );
+		} );
+	} );
+
+	describe( 'edge cases', () => {
+		beforeEach( () => setSettings( EN_US_SETTINGS ) );
+
+		it( 'returns an empty string when an end is missing', () => {
+			expect( formatDateRangeMinimal( { from: utcDate( 2026, 7, 13 ), to: undefined } ) ).toBe(
+				''
+			);
+			expect( formatDateRangeMinimal() ).toBe( '' );
+		} );
+
+		// Nothing to abbreviate, but the year still comes off: the site's own
+		// ordering is kept, exactly as the year-less single-date form does.
+		it( 'still drops the year where the site numbers its month', () => {
+			setSettings( settingsFor( 'en-numeric-minimal-test', 'd/m/Y' ) );
+
+			expect(
+				formatDateRangeMinimal( { from: utcDate( 2026, 7, 13 ), to: utcDate( 2026, 7, 26 ) } )
+			).toBe( `13/07${ FALLBACK_SEP }26/07` );
+		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range.test.ts
@@ -24,6 +24,37 @@ const SEP = '\u2009\u2013\u2009';
 // The package's translatable spelled-out range pattern.
 const FALLBACK_SEP = ' \u2013 ';
 
+const HU_MONTHS = [
+	'január',
+	'február',
+	'március',
+	'április',
+	'május',
+	'június',
+	'július',
+	'augusztus',
+	'szeptember',
+	'október',
+	'november',
+	'december',
+];
+
+// Punctuated, so they cannot be sliced out of the full names.
+const HU_MONTHS_SHORT = [
+	'jan.',
+	'febr.',
+	'márc.',
+	'ápr.',
+	'máj.',
+	'jún.',
+	'júl.',
+	'aug.',
+	'szept.',
+	'okt.',
+	'nov.',
+	'dec.',
+];
+
 const JA_MONTHS = [
 	'1\u6708',
 	'2\u6708',
@@ -262,6 +293,28 @@ describe( 'formatDateRangeMinimal', () => {
 			expect(
 				formatDateRangeMinimal( { from: utcDate( 2026, 7, 13 ), to: utcDate( 2026, 7, 26 ) } )
 			).toBe( `13 de jul${ FALLBACK_SEP }26 de jul` );
+		} );
+	} );
+
+	// A year-less range spanning two years leaves ICU nothing to tell them
+	// apart by, so it puts a year back. Probing the year-less form across the
+	// turn of a year measures that instead of the rendering the form produces,
+	// and locales whose ranges ICU re-years that way lose their elision.
+	describe( 'hu_HU site', () => {
+		beforeEach( () =>
+			setSettings( settingsFor( 'hu-HU-test', 'Y. F j.', HU_MONTHS, undefined, HU_MONTHS_SHORT ) )
+		);
+
+		it( 'elides a range inside the current year', () => {
+			expect(
+				formatDateRangeMinimal( { from: utcDate( 2026, 7, 13 ), to: utcDate( 2026, 7, 26 ) } )
+			).toBe( 'júl. 13–26.' );
+		} );
+
+		it( 'still spells out a range that needs its year', () => {
+			expect(
+				formatDateRangeMinimal( { from: utcDate( 2025, 7, 13 ), to: utcDate( 2025, 7, 26 ) } )
+			).toBe( '2025. júl. 13–26.' );
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
@@ -35,11 +35,29 @@ const SINGLE_PROBES = [
 ];
 
 /**
- * Two dates with no requested date part in common. The site timezone is
- * applied by both formatters, so a probe crossing a UTC day boundary is safe.
+ * The near end of the probe range. The site timezone is applied by both
+ * formatters, so a probe crossing a UTC day boundary is safe.
  */
 const PROBE_FROM = SINGLE_PROBES[ 0 ];
-const PROBE_TO = new Date( Date.UTC( 2021, 1, 3, 12 ) );
+
+/**
+ * The far end, per form: a date sharing no requested part with `PROBE_FROM`,
+ * so nothing in the probe can be elided and both ends have to render whole.
+ *
+ * Which year it falls in is what has to vary. A form carrying the year needs
+ * the two ends in different ones, or the year elides and the probe measures an
+ * elision rather than the full rendering it is checking for.
+ *
+ * The year-less form needs them in the same one. Asked to span two years with
+ * no year to tell them apart, ICU puts one back to keep the range unambiguous.
+ * That is right of ICU, but it is not a rendering this form ever produces, and
+ * a probe that provokes it costs Hungarian and Czech their elision.
+ */
+const PROBE_TO: Record< RangeFormatName, Date > = {
+	medium: new Date( Date.UTC( 2021, 1, 3, 12 ) ),
+	compact: new Date( Date.UTC( 2021, 1, 3, 12 ) ),
+	compactNoYear: new Date( Date.UTC( 2020, 1, 3, 12 ) ),
+};
 
 /** Treat typographically different Unicode spaces as equivalent. */
 const normalizeSpaces = ( value: string ): string =>
@@ -134,7 +152,7 @@ function buildRangeFormatter( name: RangeFormatName ): Intl.DateTimeFormat | und
 	);
 	const single = formatter.format( PROBE_FROM );
 	const rangeKeepsRendering = normalizeSpaces(
-		formatter.formatRange( PROBE_FROM, PROBE_TO )
+		formatter.formatRange( PROBE_FROM, PROBE_TO[ name ] )
 	).startsWith( normalizeSpaces( single ) );
 
 	return rendersLikeSite && rangeKeepsRendering ? formatter : undefined;

--- a/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
@@ -9,15 +9,17 @@ import { formatDate } from './format-date';
 import { siteTimeZone } from './site-time-zone';
 
 /**
- * Forms a range can be elided in. Both name the month, so the elision rules
- * CLDR publishes for one apply to the other; they differ only in its width.
+ * Forms a range can be elided in. All three name the month, so the elision
+ * rules CLDR publishes for one apply to the others; they differ in its width
+ * and in whether the year is carried at all.
  */
-export type RangeFormatName = 'medium' | 'compact';
+export type RangeFormatName = 'medium' | 'compact' | 'compactNoYear';
 
 /** The date parts requested from `Intl` when comparing it with WordPress. */
 const RANGE_PARTS: Record< RangeFormatName, Intl.DateTimeFormatOptions > = {
 	medium: { year: 'numeric', month: 'long', day: 'numeric' },
 	compact: { year: 'numeric', month: 'short', day: 'numeric' },
+	compactNoYear: { month: 'short', day: 'numeric' },
 };
 
 /**

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date-range.ts
@@ -84,3 +84,36 @@ export const formatDateRange = ( range?: DateRange ): string => formatRange( 'me
  */
 export const formatDateRangeCompact = ( range?: DateRange ): string =>
 	formatRange( 'compact', range );
+
+/**
+ * Format a date range in the shortest form that still identifies it.
+ *
+ * For controls that carry a range as their own label, where every character is
+ * width taken from something else on the row. It drops the year on top of what
+ * `formatDateRangeCompact` already shortens, but only while the whole range
+ * sits in the current year — a range anywhere else needs its year to say which
+ * one it is, and reads as the compact form instead.
+ *
+ * "Current" is the site's own year, since the year each end falls in is read in
+ * the site's timezone like every other date the dashboard renders.
+ *
+ * @param range - The range to format.
+ * @return The formatted range.
+ *
+ * @example
+ * formatDateRangeMinimal( { from, to } ) // this year:  'Jul 24' / 'Jul 13 – 26'
+ *                                        // any other: 'Jun 21, 2025'
+ */
+export const formatDateRangeMinimal = ( range?: DateRange ): string => {
+	const { from, to } = range ?? {};
+
+	if ( ! from || ! to ) {
+		return '';
+	}
+
+	const currentYear = formatDate( Date.now(), 'year' );
+	const isCurrentYear =
+		formatDate( from, 'year' ) === currentYear && formatDate( to, 'year' ) === currentYear;
+
+	return formatRange( isCurrentYear ? 'compactNoYear' : 'compact', range );
+};

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
@@ -16,6 +16,7 @@ const YEAR_FORMAT = 'Y';
 export type DateFormatName =
 	| 'medium'
 	| 'compact'
+	| 'compactNoYear'
 	| 'short'
 	| 'year'
 	| 'iso'
@@ -54,6 +55,10 @@ function formatFor( name: DateFormatName ): string {
 		return withShortMonth( siteFormat );
 	}
 
+	if ( name === 'compactNoYear' ) {
+		return withShortMonth( withoutYearFormat );
+	}
+
 	if ( name === 'short' ) {
 		return withoutYearFormat;
 	}
@@ -81,10 +86,11 @@ function formatFor( name: DateFormatName ): string {
  * @return The formatted date.
  *
  * @example
- * formatDate( date )            // 'June 21, 2025'           — or '21 de junio de 2025'
- * formatDate( date, 'compact' ) // 'Jun 21, 2025'            — or '21 de jun de 2025'
- * formatDate( date, 'short' )   // 'June 21'                 — or '21 de junio'
- * formatDate( date, 'full' )    // 'Saturday, June 21, 2025' — or 'sábado, 21 de junio de 2025'
+ * formatDate( date )                  // 'June 21, 2025'           — or '21 de junio de 2025'
+ * formatDate( date, 'compact' )       // 'Jun 21, 2025'            — or '21 de jun de 2025'
+ * formatDate( date, 'compactNoYear' ) // 'Jun 21'                  — or '21 de jun'
+ * formatDate( date, 'short' )         // 'June 21'                 — or '21 de junio'
+ * formatDate( date, 'full' )          // 'Saturday, June 21, 2025' — or 'sábado, 21 de junio de 2025'
  */
 export const formatDate = ( date: DateInput, name: DateFormatName = 'medium' ): string =>
 	dateI18n( formatFor( name ), date );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/index.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/index.ts
@@ -1,3 +1,7 @@
 export { formatDate, formatWeekday, type DateFormatName } from './format-date';
-export { formatDateRange, formatDateRangeCompact } from './format-date-range';
+export {
+	formatDateRange,
+	formatDateRangeCompact,
+	formatDateRangeMinimal,
+} from './format-date-range';
 export { formatDateRangeLong } from './format-date-range-long';

--- a/projects/packages/premium-analytics/packages/formatters/src/index.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/index.ts
@@ -3,6 +3,7 @@ export {
 	formatWeekday,
 	formatDateRange,
 	formatDateRangeCompact,
+	formatDateRangeMinimal,
 	formatDateRangeLong,
 	type DateFormatName,
 } from './date';

--- a/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/__tests__/date-comparison-dropdown.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/__tests__/date-comparison-dropdown.test.tsx
@@ -32,9 +32,10 @@ describe( 'DateComparisonDropdown', () => {
 			/>
 		);
 
-		// Named by its tooltip: the `+` trigger carries no text of its own.
-		const trigger = screen.getByRole( 'button', { name: 'Add comparison' } );
-		expect( trigger ).toHaveTextContent( '' );
+		// The additive state names itself, so what is on screen is also what a
+		// screen reader or a speech-input user gets.
+		const trigger = screen.getByRole( 'button', { name: 'Compare' } );
+		expect( trigger ).toHaveTextContent( 'Compare' );
 
 		await user.click( trigger );
 		expect( screen.getByRole( 'menuitemradio', { name: 'No comparison' } ) ).toBeChecked();

--- a/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/date-comparison-dropdown.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/date-comparison-dropdown.scss
@@ -25,11 +25,5 @@
 		@media (min-width: 600px) {
 			font-size: var(--wpds-typography-font-size-md);
 		}
-
-		// The `+` is a square icon button. The labelled state is sized by its
-		// label, the way the select's trigger is.
-		&:not(.date-comparison-dropdown__toggle--active) {
-			min-width: var(--wpds-dimension-size-lg);
-		}
 	}
 }

--- a/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/date-comparison-dropdown.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/date-comparison-dropdown.tsx
@@ -28,9 +28,8 @@ type DateComparisonDropdownProps = {
 	enabled: boolean;
 	presetId?: ComparisonPresetId;
 	/**
-	 * Names the trigger, as its tooltip and, with no comparison active, as its
-	 * accessible name. Defaults to "Add comparison" / "Compare to" depending on
-	 * the state.
+	 * Names the trigger, and with no comparison active is also its visible
+	 * text. Defaults to "Compare" / "Compare to" depending on the state.
 	 */
 	label?: string;
 	onPresetChange: ( id: ComparisonPresetId ) => void;
@@ -46,6 +45,8 @@ export function DateComparisonDropdown( {
 	onClear,
 }: DateComparisonDropdownProps ) {
 	const noComparisonLabel = __( 'No comparison', 'jetpack-premium-analytics-pkg' );
+	const additiveLabel = __( 'Compare', 'jetpack-premium-analytics-pkg' );
+	const compareToLabel = __( 'Compare to', 'jetpack-premium-analytics-pkg' );
 
 	const items = useMemo( (): ComparisonMenuItem[] => {
 		return [
@@ -83,8 +84,12 @@ export function DateComparisonDropdown( {
 	);
 
 	/*
-	 * Additive: a `+` until a preset is picked, then a trigger naming it. Both
-	 * open the same menu, so the way back to "No comparison" is the way in.
+	 * Additive: `Compare +` until a preset is picked, then a trigger naming it.
+	 * Both open the same menu, so the way back to "No comparison" is the way in.
+	 *
+	 * The additive state spells itself out rather than offering a bare `+`: a
+	 * glyph alone left the one control on the row that adds something reading
+	 * as decoration, and its purpose behind a hover.
 	 *
 	 * It names the preset rather than the period it resolves to, which the
 	 * section header's subtitle already spells out.
@@ -93,20 +98,18 @@ export function DateComparisonDropdown( {
 		<DropdownMenu
 			className="date-comparison-dropdown"
 			icon={ isComparisonActive ? chevronDown : plus }
-			text={ selectedPreset?.shortLabel }
-			label={
-				label ??
-				( isComparisonActive
-					? __( 'Compare to', 'jetpack-premium-analytics-pkg' )
-					: __( 'Add comparison', 'jetpack-premium-analytics-pkg' ) )
-			}
+			text={ selectedPreset?.shortLabel ?? additiveLabel }
+			label={ label ?? ( isComparisonActive ? compareToLabel : additiveLabel ) }
 			popoverProps={ { placement: 'bottom-start' } }
 			toggleProps={ {
 				className: clsx( 'date-comparison-dropdown__toggle', {
 					'date-comparison-dropdown__toggle--active': isComparisonActive,
 				} ),
 				iconPosition: 'right',
-				iconSize: isComparisonActive ? 18 : 24,
+				iconSize: 18,
+				// A tooltip only where the trigger's text is an abbreviation.
+				// Over the additive state it would repeat the label beneath it.
+				showTooltip: isComparisonActive,
 				// The trigger shows an abbreviation, so carry the full preset
 				// name for anyone not reading the glyphs. Same treatment the
 				// preset pills give their short labels.

--- a/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/stories/date-comparison-dropdown.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/stories/date-comparison-dropdown.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta< typeof DateComparisonDropdown > = {
 		docs: {
 			description: {
 				component:
-					'Additive comparison control: a `+` button with no comparison active, a labelled trigger once a period is chosen. Both open the same menu.',
+					'Additive comparison control: `Compare +` with no comparison active, a trigger naming the period once one is chosen. Both open the same menu.',
 			},
 		},
 	},
@@ -72,7 +72,7 @@ export const Default: Story = {
 };
 
 /**
- * No comparison active: the control is a `+` button that opens the same menu.
+ * No comparison active: the control reads `Compare +` and opens the same menu.
  */
 export const NoComparison: Story = {
 	render: () => <DateComparisonDropdownWithState initialEnabled={ false } />,

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
@@ -147,4 +147,23 @@ describe( 'DateFiltersPanel', () => {
 
 		expect( screen.queryByRole( 'button', { name: 'Previous period' } ) ).not.toBeInTheDocument();
 	} );
+
+	// The comparison qualifies the range the presets just set; the interval only
+	// buckets the charts. Reading order follows that, so it is worth pinning.
+	it( 'places the comparison before the chart interval', () => {
+		mockContainerResize();
+		renderPanel( {
+			withIntervalControl: true,
+			intervalOptions: [ 'day', 'week' ],
+			interval: 'day',
+			onIntervalChange: jest.fn(),
+		} );
+
+		const comparison = screen.getByRole( 'button', { name: 'Add comparison' } );
+		const chartInterval = screen.getByRole( 'button', { name: 'Chart interval' } );
+
+		expect( comparison.compareDocumentPosition( chartInterval ) ).toBe(
+			Node.DOCUMENT_POSITION_FOLLOWING
+		);
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
@@ -159,7 +159,7 @@ describe( 'DateFiltersPanel', () => {
 			onIntervalChange: jest.fn(),
 		} );
 
-		const comparison = screen.getByRole( 'button', { name: 'Add comparison' } );
+		const comparison = screen.getByRole( 'button', { name: 'Compare' } );
 		const chartInterval = screen.getByRole( 'button', { name: 'Chart interval' } );
 
 		expect( comparison.compareDocumentPosition( chartInterval ) ).toBe(

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
@@ -430,8 +430,8 @@ export function DateFiltersPanel( {
 				presets={ surfacePresets }
 				customTriggerLabel={ customTriggerLabel }
 				navigation={ navigationControl }
-				interval={ intervalControl }
 				comparison={ comparisonControl }
+				interval={ intervalControl }
 				onMeasure={ handleProbeMeasure }
 			/>
 
@@ -461,8 +461,8 @@ export function DateFiltersPanel( {
 					/>
 				</BaseControl>
 
-				{ intervalControl }
-
+				{ /* Comparison before the interval: it qualifies the range the
+				     presets just set, while the interval only buckets the charts. */ }
 				{ showComparison && (
 					<BaseControl
 						className="date-filters-panel__comparison"
@@ -471,6 +471,8 @@ export function DateFiltersPanel( {
 						{ comparisonControl }
 					</BaseControl>
 				) }
+
+				{ intervalControl }
 			</Stack>
 		</div>
 	);

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
@@ -12,7 +12,7 @@ import {
 	type StepDirection,
 } from '@jetpack-premium-analytics/datetime';
 import { Stack } from '@jetpack-premium-analytics/externals';
-import { formatDateRangeCompact } from '@jetpack-premium-analytics/formatters';
+import { formatDateRangeMinimal } from '@jetpack-premium-analytics/formatters';
 import { BaseControl } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { flushSync } from '@wordpress/element';
@@ -309,7 +309,7 @@ export function DateFiltersPanel( {
 			committedRange,
 			rememberedCustomRange,
 			customLabel: __( 'Custom', 'jetpack-premium-analytics-pkg' ),
-			formatRange: formatDateRangeCompact,
+			formatRange: formatDateRangeMinimal,
 		} );
 	}, [
 		appliedRange,

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/preset-row-probe.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/preset-row-probe.tsx
@@ -26,16 +26,16 @@ export type PresetRowProbeProps = {
 	navigation?: ReactNode;
 
 	/**
-	 * The chart interval control, as the panel renders it. A glyph, so its width
-	 * is the same fixed cost in every locale.
-	 */
-	interval?: ReactNode;
-
-	/**
 	 * The comparison control, as the panel renders it. It has no abbreviated
 	 * form, so its width is a fixed cost the presets have to absorb.
 	 */
 	comparison?: ReactNode;
+
+	/**
+	 * The chart interval control, as the panel renders it. A glyph, so its width
+	 * is the same fixed cost in every locale.
+	 */
+	interval?: ReactNode;
 
 	/** Reports the row's natural width whenever it changes. */
 	onMeasure: ( width: number ) => void;
@@ -59,8 +59,8 @@ function PresetRowProbeComponent( {
 	presets,
 	customTriggerLabel,
 	navigation,
-	interval,
 	comparison,
+	interval,
 	onMeasure,
 }: PresetRowProbeProps ) {
 	const rowRef = useRef< HTMLDivElement >( null );
@@ -91,7 +91,7 @@ function PresetRowProbeComponent( {
 	// `max-content`, so the width only moves on a render that changes the row.
 	useLayoutEffect( () => {
 		measure();
-	}, [ measure, presets, customTriggerLabel, navigation, interval, comparison ] );
+	}, [ measure, presets, customTriggerLabel, navigation, comparison, interval ] );
 
 	// Web fonts land after first paint and shift the metrics. Insurance: the
 	// dashboard ships none today.
@@ -145,8 +145,8 @@ function PresetRowProbeComponent( {
 
 				{ /* The real controls, not mirrors: the panel hands the same elements
 				     here and to the row, so the two cannot drift. */ }
-				{ interval }
 				{ comparison }
+				{ interval }
 			</div>
 		</div>
 	);

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/stories/date-filters-panel.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/stories/date-filters-panel.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta< typeof DateFiltersPanel > = {
 			description: {
 				component:
 					'Dashboard date filters: primary date range (surface presets + custom calendar), ' +
-					'the chart interval, and an optional comparison range.',
+					'an optional comparison range, and the chart interval.',
 			},
 		},
 	},
@@ -377,7 +377,7 @@ const LADDER_WIDTHS = [ 960, 782, 600, 360, 280 ];
  * is visible rather than asserted.
  *
  * Rungs are annotated against the four preset pills alone. That is a floor: the
- * custom trigger, the interval control, and the comparison control share the
+ * custom trigger, the comparison control, and the interval control share the
  * same line, as will the period navigation.
  */
 function WidthLadder( { fixture }: { fixture: LocaleFixture } ) {

--- a/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/date-interval-dropdown.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/date-interval-dropdown.scss
@@ -1,7 +1,8 @@
 @use "../styles/menu-trigger";
 
 // A glyph and nothing else, so it takes the shared trigger box squared off
-// against the row's height, the way the comparison control's `+` state does.
+// against the row's height. The only control on the row sized that way: the
+// comparison beside it carries text in both of its states.
 .date-interval-dropdown {
 
 	@include menu-trigger.container;

--- a/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/date-interval-dropdown.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/date-interval-dropdown.tsx
@@ -4,7 +4,7 @@
 import { type IntervalType } from '@jetpack-premium-analytics/datetime';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { check, time } from '@wordpress/icons';
+import { chartBar, check } from '@wordpress/icons';
 
 import './date-interval-dropdown.scss';
 
@@ -54,6 +54,9 @@ function getIntervalLabel( interval: IntervalType ): string {
  * The bucket size every chart on the page draws, as a glyph opening a menu of
  * the buckets the active range allows.
  *
+ * The glyph is a chart rather than a clock: the control buckets what the charts
+ * draw, it does not narrow the period the rest of the surface reports on.
+ *
  * A range with one allowed bucket still opens a menu listing it, checked: the
  * trigger carries no text, so the menu is the only place the choice can be
  * inspected. The section header's subtitle names the active bucket.
@@ -67,7 +70,7 @@ export function DateIntervalDropdown( {
 	return (
 		<DropdownMenu
 			className="date-interval-dropdown"
-			icon={ time }
+			icon={ chartBar }
 			label={ label ?? __( 'Chart interval', 'jetpack-premium-analytics-pkg' ) }
 			popoverProps={ { placement: 'bottom-end' } }
 			toggleProps={ { className: 'date-interval-dropdown__toggle' } }

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.tsx
@@ -3,7 +3,7 @@
  */
 import { PRESET_CUSTOM, type PrimaryPresetId } from '@jetpack-premium-analytics/datetime';
 import { Button, DateRangeCalendar, Icon, Stack } from '@jetpack-premium-analytics/externals';
-import { formatDateRangeCompact } from '@jetpack-premium-analytics/formatters';
+import { formatDateRangeMinimal } from '@jetpack-premium-analytics/formatters';
 import { Composite, Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronDown } from '@wordpress/icons';
@@ -268,7 +268,7 @@ export function DateRangePopover( {
 		committedRange,
 		rememberedCustomRange,
 		customLabel: __( 'Custom', 'jetpack-premium-analytics-pkg' ),
-		formatRange: formatDateRangeCompact,
+		formatRange: formatDateRangeMinimal,
 	} );
 
 	return (


### PR DESCRIPTION

Fixes WOOA7S-1929
Part of WOOA7S-1793

## What?

Four corrections to the date controls, from Eder's August 11 date selection review (p1786489373546949-slack-C06FSDTSN82) and the review of this PR.

1. The comparison control reads `Compare +` instead of a bare `+`.
2. It moves ahead of the chart interval.
3. The interval trigger swaps its clock for a chart glyph.
4. A custom range drops its year while the whole range sits in the current year: `Jul 13 – 26` rather than `Jul 13 – 26, 2026`.

📸 _Before / after: the date controls row._

Two other items in that thread need no code. The panel's actions have been small from the start, and the dashboard already uses `DropdownMenu` + `MenuGroup` + `MenuItem`. Both were prototype-side corrections.

## Why?

**Label.** A bare `+` left the one control on the row that adds something reading as decoration, with its purpose behind a hover. It is also the only control there with no text, so it did not read as a sibling of the ones beside it.

**Order.** The comparison qualifies the range the presets just set. The interval only buckets what the charts draw. Reading order should follow that.

**Glyph.** A clock reads as "narrow the period", which is not what the control does. `chartBar` is what WOOA7S-1793 specified in the first place, and the clock was one of the discrepancies Gary reported against the demo (p1786372383059599-slack-C06FSDTSN82).

**Range label.** WOOA7S-1812 asked for the shortest unambiguous format and shipped `formatDateRangeCompact`, which abbreviates the month but keeps the year. After the presets, that trigger is the widest thing on the row, and the year is the part of it carrying the least.

## How?

### Compare

`text` falls back to `Compare` when no preset is selected, and the plus drops from 24 to 18 to sit beside it. The chevron in the active state was already 18, so both states now share one size.

The tooltip goes with it. It existed to name a glyph, and repeated over a labelled trigger it would only restate what is already on screen. The active state keeps its tooltip, since its text is an abbreviation.

The accessible name follows the visible one, which the `+` version could not do: it was named "Add comparison" while showing nothing, so anyone driving the page by voice had nothing to say.

Its `min-width` came off with it. The additive state is no longer a square glyph box, so both states are sized by their text.

### Order

`date-filters-panel.tsx` and `preset-row-probe.tsx`, together.

The probe renders the real controls rather than mirrors of them, to measure what the row needs before the labels abbreviate. Move them in one place only and the measurement stops describing what renders.

No CSS moved. The row is a flex `Stack`, and the interval is `flex: 0 0 auto` on either side of the comparison.

### Glyph

One line: `time` → `chartBar` from `@wordpress/icons`.

### Label

New `formatDateRangeMinimal()`, used by the trigger and by the probe that measures it.

It drops the year while both ends fall in the site's current year, and reads as the compact form anywhere else. A range in an earlier year, or one straddling New Year, needs its year to say which one it is.

📸 _Before / after: the custom range trigger._

**The part worth reviewing.** The year-less form is a fourth named form (`compactNoYear`) alongside `medium` and `compact`, not a string edit on the compact output.

That is what keeps the elision coming from CLDR. `elideRange` borrows a locale's range pattern only after checking, per form, that `Intl` renders dates the way the site does. A fourth form means that check runs for the year-less one too.

So a site whose abbreviated dates agree with CLDR gets `Jul 13 – 26`, and one whose do not gets both ends spelled out instead of an invented elision. Spanish is the second case, and reads `13 de jul – 26 de jul`.

Dropping the year takes the punctuation that introduced it along with it. `withoutYear` already handled that for the year-less `short` form, including the Spanish `\d\e` literals and the trailing dot some locales terminate an ordinal with.

**Probe direction, from @chihsuan's review.** The probe range now varies by form.

The year-bearing forms are probed across a year boundary so nothing in the probe can elide. Given the same range, the year-less form asks ICU to span two years with no year to tell them apart, and ICU puts one back to keep it unambiguous. That is right of ICU, but it is not a rendering the form ever produces, and the probe rejected the form over it.

Hungarian and Czech are the two locales I could reproduce it on. Hungarian lost `júl. 13–26.` to `júl. 13. – júl. 26.`. The year-less form is now probed inside one year, and the test asserts the Hungarian elision directly.

Italian is rejected either way, and correctly: it pads to `01 gen` inside a range while rendering `1 gen` on its own, which is the "restyles its ranges" case the check exists for.

The formatters `README` also gains `formatDateRangeCompact`, `formatDateRangeMinimal`, `compact`, and `compactNoYear`. The first two of those predate this PR and were never documented.

## Does this pull request change what data or activity we track or use?

No. Presentation only: the order of two existing controls, one icon, and the format of a label. Nothing is added to the report params, and no new request is made.

## Testing instructions

### Storybook

```bash
cd projects/packages/premium-analytics && pnpm run storybook
```

`Packages/Premium Analytics/UI/DateFiltersPanel`.

1. **DashboardFilters.** The comparison sits between the preset group and the interval, and the interval trigger is a bar chart rather than a clock.
2. **WithoutComparison.** The comparison control reads `Compare +`, and hovering it shows no tooltip. Pick a period: it collapses to the period's name, and now hovering does show one.
3. Open the interval menu. It still opens bottom-end and lists only the buckets the range allows.
4. **CustomRangeWithComparison.** The trigger names a range with no year on it.
5. **AbbreviatedLabels.** The presets are in their short form. The row measures itself through the probe, so this is where a mismatch between the probe's order and the row's would show up.
6. **TranslatedRussian / TranslatedDutch / TranslatedGerman.** The row still fits at each width. Two widths moved in opposite directions here: `Compare` costs more than a `+`, and the custom label costs less than it did.

Also `Packages/Premium Analytics/UI/DateComparisonDropdown`, for the control on its own in both states.

📸 _Storybook: DashboardFilters._

### Dashboard

Jetpack → Analytics.

1. Same checks as steps 1 and 2 above, on a real header row rather than the story rig.
2. Clear the comparison from its menu. The control goes back to `Compare +` rather than to a bare glyph.
3. Pick `Custom` and apply a range inside this year. The trigger reads without a year.
4. Do the same with a range that starts in December and ends in January. The year comes back, on both ends.
5. Step off a preset with the arrows. The stepped window is a custom range, so it takes the short form too.
6. Reload on a custom range. The label survives, since the range is URL state.
7. Narrow the window until the presets abbreviate, with a comparison active and without one. The boundary should move but not oscillate.
8. Any report page, which gives the panel a full-width row instead of a header cell.
9. If you can, a site set to Spanish. The range label should read `13 de jul – 26 de jul`, not an English elision with Spanish month names.

📸 _Dashboard: video of the row, the custom range, and the narrow-width pass._

### Automated

`pnpm run test` and `pnpm run typecheck` in `projects/packages/premium-analytics`. 1991 tests.

New coverage: the control order, pinned by document position, and ten cases on the year-dropping rule, including Spanish, Hungarian, and a site whose date format numbers its month. The comparison control's own test now asserts that its visible text and its accessible name are the same string.

The Hungarian case fails against the old probe with `júl. 13. – júl. 26.`, so it pins the review fix rather than just describing it.

## Follow-ups

- [ ] `Compare` is a bare verb, and this surface already has two translation collisions open in WOOA7S-1818. Worth folding into the i18n pass in WOOA7S-1817 rather than adding a lone `_x()` here.
- [ ] Nothing pins the interval glyph. Icons render as inline SVG with no accessible name of their own, so asserting one means matching path data.
- [ ] The range label's form depends on the current year, read at render. A dashboard left open across midnight on December 31 keeps the year-less label until something else re-renders it. Cosmetic, and it heals itself.
