### PR TITLE
wpcomsh: run the WordPress database upgrade automatically after a restore

### DIFF
--- a/projects/plugins/wpcomsh/changelog/restore-db-upgrade
+++ b/projects/plugins/wpcomsh/changelog/restore-db-upgrade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Run the WordPress database upgrade automatically after a restore instead of prompting the user to confirm it.

--- a/projects/plugins/wpcomsh/feature-plugins/wordpress-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/wordpress-mods.php
@@ -125,6 +125,63 @@ function wpcomsh_upgrade_transferred_db() {
 add_action( 'muplugins_loaded', 'wpcomsh_upgrade_transferred_db' );
 
 /**
+ * Whether core's DB upgrade should be run on this request.
+ *
+ * @return bool
+ */
+function wpcomsh_should_upgrade_db_after_restore() {
+	global $wp_db_version;
+
+	// Core upgrades multisite on its own rather than prompting, and the prompt
+	// only ever appears on a regular admin request.
+	if ( is_multisite() || ! is_admin() || wp_doing_ajax() || wp_installing() ) {
+		return false;
+	}
+
+	// A DB from newer core sitting on older files means the restore itself was
+	// mismatched. Upgrading would only walk `db_version` backwards, so leave it.
+	$current_db_version = (int) get_option( 'db_version' );
+	if ( $current_db_version >= (int) $wp_db_version ) {
+		return false;
+	}
+
+	// One attempt per core DB version. Clears itself when core next bumps
+	// $wp_db_version.
+	return (int) get_option( 'wpcomsh_db_upgrade_attempted' ) !== (int) $wp_db_version;
+}
+
+/**
+ * Runs core's DB upgrade when a restore leaves `db_version` behind.
+ *
+ * A restore can write a stale `db_version` into `wp_options` while the core
+ * files on disk are current. Core then redirects every admin request to
+ * wp-admin/upgrade.php and waits for someone to click "Update WordPress
+ * Database". Do it for them, before that check runs.
+ *
+ * @return void
+ */
+function wpcomsh_maybe_upgrade_db_after_restore() {
+	global $wp_db_version;
+
+	if ( ! wpcomsh_should_upgrade_db_after_restore() ) {
+		return;
+	}
+
+	// Recorded before the upgrade runs: if it fatals, retrying on every admin
+	// request would wedge the site, and a stuck prompt is the better failure.
+	update_option( 'wpcomsh_db_upgrade_attempted', (int) $wp_db_version, false /* Do not autoload. */ );
+
+	// Preserve the previous version for troubleshooting.
+	update_option( 'wpcomsh_db_version_before_restore_upgrade', (int) get_option( 'db_version' ), false /* Do not autoload. */ );
+
+	require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+	// Re-reads `db_version` itself and no-ops if it is already current.
+	wp_upgrade();
+}
+add_action( 'wp_loaded', 'wpcomsh_maybe_upgrade_db_after_restore' );
+
+/**
  * Logs wp_die() calls.
  *
  * @param string|WP_Error $message Error message or WP_Error object.

--- a/projects/plugins/wpcomsh/tests/RestoreDbUpgradeTest.php
+++ b/projects/plugins/wpcomsh/tests/RestoreDbUpgradeTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Tests for the post-restore DB upgrade check.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Class RestoreDbUpgradeTest.
+ */
+class RestoreDbUpgradeTest extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * The real $wp_db_version, restored after each test.
+	 *
+	 * @var int
+	 */
+	private $original_db_version;
+
+	/**
+	 * Set up.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		global $wp_db_version;
+		$this->original_db_version = $wp_db_version;
+
+		set_current_screen( 'dashboard' );
+		delete_option( 'wpcomsh_db_upgrade_attempted' );
+	}
+
+	/**
+	 * Tear down.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		global $wp_db_version;
+		$wp_db_version = $this->original_db_version; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		update_option( 'db_version', $this->original_db_version );
+		delete_option( 'wpcomsh_db_upgrade_attempted' );
+		delete_option( 'wpcomsh_db_version_before_restore_upgrade' );
+		set_current_screen( 'front' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * A stale db_version on an admin request should be upgraded.
+	 *
+	 * @return void
+	 */
+	public function test_stale_db_version_should_upgrade() {
+		update_option( 'db_version', $this->original_db_version - 1 );
+
+		$this->assertTrue( wpcomsh_should_upgrade_db_after_restore() );
+	}
+
+	/**
+	 * A current db_version is left alone.
+	 *
+	 * @return void
+	 */
+	public function test_current_db_version_should_not_upgrade() {
+		update_option( 'db_version', $this->original_db_version );
+
+		$this->assertFalse( wpcomsh_should_upgrade_db_after_restore() );
+	}
+
+	/**
+	 * A db_version ahead of core is left alone rather than walked backwards.
+	 *
+	 * @return void
+	 */
+	public function test_db_version_ahead_of_core_should_not_upgrade() {
+		update_option( 'db_version', $this->original_db_version + 1 );
+
+		$this->assertFalse( wpcomsh_should_upgrade_db_after_restore() );
+	}
+
+	/**
+	 * Only one attempt is made per core DB version.
+	 *
+	 * @return void
+	 */
+	public function test_previous_attempt_should_not_retry() {
+		update_option( 'db_version', $this->original_db_version - 1 );
+		update_option( 'wpcomsh_db_upgrade_attempted', $this->original_db_version, false );
+
+		$this->assertFalse( wpcomsh_should_upgrade_db_after_restore() );
+	}
+
+	/**
+	 * An attempt recorded against an older core release does not block a retry.
+	 *
+	 * @return void
+	 */
+	public function test_stale_attempt_marker_should_upgrade() {
+		update_option( 'db_version', $this->original_db_version - 2 );
+		update_option( 'wpcomsh_db_upgrade_attempted', $this->original_db_version - 1, false );
+
+		$this->assertTrue( wpcomsh_should_upgrade_db_after_restore() );
+	}
+
+	/**
+	 * Front end requests never trigger the upgrade.
+	 *
+	 * @return void
+	 */
+	public function test_front_end_request_should_not_upgrade() {
+		update_option( 'db_version', $this->original_db_version - 1 );
+		set_current_screen( 'front' );
+
+		$this->assertFalse( wpcomsh_should_upgrade_db_after_restore() );
+	}
+}


### PR DESCRIPTION
Fixes DOTMSD-1518

## Proposed changes
* After a restore, a site can end up with a stale `db_version` recorded in the database while the WordPress files on disk are current. WordPress reacts by redirecting every admin request to the "Database Update Required" screen and waiting for someone to click the button. Users hit this on a site they never intentionally changed.
* This runs that database upgrade automatically on Atomic sites, so the prompt never appears. It is a no-op on every request where the versions already agree.

Jetpack Backup can't fix this on its own: its restore path is a proxy that forwards to the rewind service on the WordPress.com side, and nothing fires on the site afterwards that we could hook. The real fix belongs in the restore service itself — this is a defensive net that also catches restores performed by other means, and it only covers Atomic.

There is precedent right next to this code: the existing transferred-site handler solves the same class of problem (a database arriving with a version marker that disagrees with the files on disk) and this follows its conventions.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Considerations

**When the database is *ahead* of core** (a newer database restored onto older files), this deliberately does nothing and leaves the prompt in place. Running the upgrade there performs no actual migration work — it would only move the recorded version backwards and hide a mismatched restore that deserves attention.

**Only one attempt is made per WordPress release.** A marker is recorded before the upgrade runs, so if it ever fails fatally we don't retry on every single admin request and take the site down. A stuck upgrade prompt is the better failure mode. The marker is tied to the WordPress version rather than being a simple on/off flag, so it clears itself the next time core updates and a later restore isn't permanently locked out.

**Timing.** This runs early enough in the request that WordPress hasn't yet decided whether to show the prompt, so there's no visible redirect or flash.

## Testing instructions

On an Atomic site (or any site with wpcomsh active):

1. Confirm you can load `/wp-admin/` normally.
2. Simulate what a restore leaves behind by lowering the recorded database version: `wp option update db_version 57155`
3. Load `/wp-admin/` again. **Before this change** you'd land on "WordPress has been updated! Before we send you on your way, we have to update your database to the newest version." **After** it should load the dashboard as usual, with no prompt.
4. Check that the version was repaired: `wp option get db_version` should match the value in `wp-includes/version.php`, and `wp option get wpcomsh_db_version_before_restore_upgrade` should show the stale value it started from.

To confirm the safety valve, set the version *higher* than core's (`wp option update db_version 99999`) — the prompt should still appear, untouched.

Automated coverage is included; the full wpcomsh suite passes.
