### PR TITLE
Forms: add illustrations to the form editor welcome guide

### DIFF
--- a/projects/packages/forms/changelog/add-forms-editor-welcome-guide-artwork
+++ b/projects/packages/forms/changelog/add-forms-editor-welcome-guide-artwork
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Form editor: Add illustrations to the welcome guide slides.

--- a/projects/packages/forms/src/form-editor/welcome-guide/illustrations.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/illustrations.tsx
@@ -1,0 +1,274 @@
+/**
+ * Welcome guide illustrations
+ *
+ * One flat illustration per guide slide, drawn on a 312×240 canvas to match the
+ * artwork region of the core welcome guide. Shapes are deliberately abstract —
+ * they stand for fields, panels, and buttons rather than reproducing the real
+ * editor chrome, so they don't go stale as the UI changes.
+ *
+ * @package
+ */
+
+import { SVG, Rect, Circle, Path, G } from '@wordpress/primitives';
+import type { ReactNode } from 'react';
+
+const WIDTH = 312;
+const HEIGHT = 240;
+
+/** Panel background — jp-green-40. */
+const GREEN = '#069e08';
+/** Accent used for buttons, selection, and toggles — jp-green-50. */
+const GREEN_DEEP = '#008710';
+/** Card surfaces. */
+const CARD = '#ffffff';
+/** Label bars. */
+const LINE = '#dcdcde';
+/** Input and chip fills. */
+const FILL = '#f0f0f1';
+/** Outlines and de-emphasised marks. */
+const MUTED = '#c3c4c7';
+
+/**
+ * Shared canvas: a green panel that every illustration is drawn on.
+ *
+ * @param props          - Component props
+ * @param props.children - Shapes to draw over the panel
+ * @return The illustration canvas.
+ */
+const Canvas = ( { children }: { children: ReactNode } ) => (
+	<SVG
+		className="jetpack-forms-welcome-guide__illustration"
+		viewBox={ `0 0 ${ WIDTH } ${ HEIGHT }` }
+		width={ WIDTH }
+		height={ HEIGHT }
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		aria-hidden="true"
+		focusable="false"
+	>
+		<Rect width={ WIDTH } height={ HEIGHT } fill={ GREEN } />
+		{ children }
+	</SVG>
+);
+
+/**
+ * A rounded bar standing in for a text label.
+ *
+ * @param props        - Component props
+ * @param props.x      - Left edge
+ * @param props.y      - Top edge
+ * @param props.width  - Bar width
+ * @param props.height - Bar height, defaults to 6
+ * @param props.fill   - Bar colour, defaults to the label grey
+ * @return The bar.
+ */
+const Bar = ( {
+	x,
+	y,
+	width,
+	height = 6,
+	fill = LINE,
+}: {
+	x: number;
+	y: number;
+	width: number;
+	height?: number;
+	fill?: string;
+} ) => <Rect x={ x } y={ y } width={ width } height={ height } rx={ height / 2 } fill={ fill } />;
+
+/**
+ * Slide 1 — a form card layered over two more sheets, for "create it once,
+ * then add it anywhere".
+ *
+ * @return The illustration.
+ */
+export const ReusableFormIllustration = () => (
+	<Canvas>
+		<Rect x={ 92 } y={ 34 } width={ 140 } height={ 150 } rx={ 8 } fill={ CARD } opacity={ 0.2 } />
+		<Rect x={ 84 } y={ 42 } width={ 140 } height={ 150 } rx={ 8 } fill={ CARD } opacity={ 0.4 } />
+		<Rect x={ 76 } y={ 50 } width={ 140 } height={ 150 } rx={ 8 } fill={ CARD } />
+		<Bar x={ 90 } y={ 66 } width={ 44 } />
+		<Rect x={ 90 } y={ 79 } width={ 112 } height={ 20 } rx={ 4 } fill={ FILL } />
+		<Bar x={ 90 } y={ 109 } width={ 56 } />
+		<Rect x={ 90 } y={ 122 } width={ 112 } height={ 20 } rx={ 4 } fill={ FILL } />
+		<Rect x={ 152 } y={ 158 } width={ 50 } height={ 20 } rx={ 4 } fill={ GREEN_DEEP } />
+	</Canvas>
+);
+
+/**
+ * Slide 2 — an inserter beside a form with an open slot, for adding fields.
+ *
+ * @return The illustration.
+ */
+export const AddFieldsIllustration = () => (
+	<Canvas>
+		{ /* Inserter panel */ }
+		<Rect x={ 28 } y={ 44 } width={ 92 } height={ 152 } rx={ 8 } fill={ CARD } />
+		<Rect x={ 38 } y={ 56 } width={ 72 } height={ 12 } rx={ 6 } fill={ FILL } />
+		<Rect
+			x={ 38 }
+			y={ 78 }
+			width={ 72 }
+			height={ 18 }
+			rx={ 4 }
+			fill={ GREEN_DEEP }
+			opacity={ 0.15 }
+		/>
+		<Rect x={ 38 } y={ 102 } width={ 72 } height={ 18 } rx={ 4 } fill={ FILL } />
+		<Rect x={ 38 } y={ 126 } width={ 72 } height={ 18 } rx={ 4 } fill={ FILL } />
+		<Rect x={ 38 } y={ 150 } width={ 72 } height={ 18 } rx={ 4 } fill={ FILL } />
+
+		{ /* Form card with an empty slot */ }
+		<Rect x={ 136 } y={ 44 } width={ 148 } height={ 152 } rx={ 8 } fill={ CARD } />
+		<Bar x={ 148 } y={ 60 } width={ 40 } />
+		<Rect x={ 148 } y={ 71 } width={ 124 } height={ 18 } rx={ 4 } fill={ FILL } />
+		<Bar x={ 148 } y={ 97 } width={ 52 } />
+		<Rect x={ 148 } y={ 108 } width={ 124 } height={ 18 } rx={ 4 } fill={ FILL } />
+		<Rect
+			x={ 148 }
+			y={ 136 }
+			width={ 124 }
+			height={ 34 }
+			rx={ 4 }
+			stroke={ GREEN_DEEP }
+			strokeWidth={ 2 }
+			strokeDasharray="5 4"
+		/>
+		<G fill={ GREEN_DEEP }>
+			<Rect x={ 203 } y={ 151 } width={ 14 } height={ 3 } rx={ 1.5 } />
+			<Rect x={ 208.5 } y={ 145.5 } width={ 3 } height={ 14 } rx={ 1.5 } />
+		</G>
+	</Canvas>
+);
+
+/**
+ * Slide 3 — a selected field with its settings sidebar.
+ *
+ * @return The illustration.
+ */
+export const FieldSettingsIllustration = () => (
+	<Canvas>
+		{ /* Form card with one field selected */ }
+		<Rect x={ 24 } y={ 48 } width={ 150 } height={ 144 } rx={ 8 } fill={ CARD } />
+		<Bar x={ 36 } y={ 62 } width={ 40 } />
+		<Rect x={ 36 } y={ 73 } width={ 126 } height={ 18 } rx={ 4 } fill={ FILL } />
+		<Bar x={ 36 } y={ 101 } width={ 52 } fill={ GREEN_DEEP } />
+		<Rect
+			x={ 36 }
+			y={ 112 }
+			width={ 126 }
+			height={ 20 }
+			rx={ 4 }
+			fill={ CARD }
+			stroke={ GREEN_DEEP }
+			strokeWidth={ 2 }
+		/>
+		<Bar x={ 36 } y={ 146 } width={ 44 } />
+		<Rect x={ 36 } y={ 157 } width={ 126 } height={ 18 } rx={ 4 } fill={ FILL } />
+
+		{ /* Settings sidebar */ }
+		<Rect x={ 188 } y={ 48 } width={ 100 } height={ 144 } rx={ 8 } fill={ CARD } />
+		<Bar x={ 198 } y={ 60 } width={ 54 } />
+		<Bar x={ 198 } y={ 78 } width={ 40 } height={ 5 } fill={ MUTED } />
+		<Rect x={ 198 } y={ 88 } width={ 80 } height={ 14 } rx={ 3 } fill={ FILL } />
+		<Bar x={ 198 } y={ 110 } width={ 44 } height={ 5 } fill={ MUTED } />
+		<Rect x={ 198 } y={ 120 } width={ 80 } height={ 14 } rx={ 3 } fill={ FILL } />
+		<Bar x={ 198 } y={ 148 } width={ 36 } height={ 5 } fill={ MUTED } />
+		<Rect x={ 246 } y={ 142 } width={ 32 } height={ 16 } rx={ 8 } fill={ GREEN_DEEP } />
+		<Circle cx={ 270 } cy={ 150 } r={ 6 } fill={ CARD } />
+	</Canvas>
+);
+
+/**
+ * Slide 4 — a submitted form branching into a confirmation and a notification.
+ *
+ * @return The illustration.
+ */
+export const AfterSubmitIllustration = () => (
+	<Canvas>
+		{ /* Form being submitted */ }
+		<Rect x={ 86 } y={ 26 } width={ 140 } height={ 96 } rx={ 8 } fill={ CARD } />
+		<Bar x={ 98 } y={ 42 } width={ 40 } />
+		<Rect x={ 98 } y={ 53 } width={ 116 } height={ 16 } rx={ 4 } fill={ FILL } />
+		<Rect x={ 164 } y={ 82 } width={ 50 } height={ 20 } rx={ 4 } fill={ GREEN_DEEP } />
+
+		{ /* Flow arrow */ }
+		<Rect x={ 154 } y={ 130 } width={ 4 } height={ 16 } rx={ 2 } fill={ CARD } opacity={ 0.9 } />
+		<Path d="M148 146 L164 146 L156 158 Z" fill={ CARD } opacity={ 0.9 } />
+
+		{ /* Confirmation message */ }
+		<Rect x={ 40 } y={ 170 } width={ 108 } height={ 44 } rx={ 8 } fill={ CARD } />
+		<Circle cx={ 64 } cy={ 192 } r={ 11 } fill={ GREEN_DEEP } />
+		<Path
+			d="M59 192 L63 196 L70 188"
+			stroke={ CARD }
+			strokeWidth={ 2.5 }
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+		<Bar x={ 82 } y={ 185 } width={ 50 } />
+		<Bar x={ 82 } y={ 197 } width={ 32 } fill={ FILL } />
+
+		{ /* Email notification */ }
+		<Rect x={ 164 } y={ 170 } width={ 108 } height={ 44 } rx={ 8 } fill={ CARD } />
+		<Rect
+			x={ 176 }
+			y={ 181 }
+			width={ 30 }
+			height={ 22 }
+			rx={ 3 }
+			fill={ FILL }
+			stroke={ MUTED }
+			strokeWidth={ 1.5 }
+		/>
+		<Path
+			d="M176 184 L191 195 L206 184"
+			stroke={ MUTED }
+			strokeWidth={ 1.5 }
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+		<Bar x={ 216 } y={ 185 } width={ 44 } />
+		<Bar x={ 216 } y={ 197 } width={ 28 } fill={ FILL } />
+	</Canvas>
+);
+
+/**
+ * Slide 5 — the published form on a page, with responses arriving in the inbox.
+ *
+ * @return The illustration.
+ */
+export const PublishIllustration = () => (
+	<Canvas>
+		{ /* Page containing the form */ }
+		<Rect x={ 26 } y={ 40 } width={ 150 } height={ 160 } rx={ 8 } fill={ CARD } />
+		<Circle cx={ 40 } cy={ 52 } r={ 3 } fill={ MUTED } />
+		<Circle cx={ 50 } cy={ 52 } r={ 3 } fill={ MUTED } />
+		<Circle cx={ 60 } cy={ 52 } r={ 3 } fill={ MUTED } />
+		<Rect x={ 26 } y={ 63 } width={ 150 } height={ 1 } fill={ LINE } />
+		<Bar x={ 40 } y={ 78 } width={ 36 } />
+		<Rect x={ 40 } y={ 89 } width={ 122 } height={ 16 } rx={ 4 } fill={ FILL } />
+		<Bar x={ 40 } y={ 115 } width={ 48 } />
+		<Rect x={ 40 } y={ 126 } width={ 122 } height={ 16 } rx={ 4 } fill={ FILL } />
+		<Rect x={ 112 } y={ 154 } width={ 50 } height={ 18 } rx={ 4 } fill={ GREEN_DEEP } />
+
+		{ /* Responses inbox */ }
+		<Rect x={ 196 } y={ 64 } width={ 92 } height={ 112 } rx={ 8 } fill={ CARD } />
+		<Bar x={ 206 } y={ 76 } width={ 48 } />
+		<G>
+			<Circle cx={ 214 } cy={ 104 } r={ 7 } fill={ FILL } />
+			<Bar x={ 227 } y={ 99 } width={ 48 } height={ 5 } />
+			<Bar x={ 227 } y={ 108 } width={ 32 } height={ 5 } fill={ FILL } />
+		</G>
+		<G>
+			<Circle cx={ 214 } cy={ 132 } r={ 7 } fill={ FILL } />
+			<Bar x={ 227 } y={ 127 } width={ 42 } height={ 5 } />
+			<Bar x={ 227 } y={ 136 } width={ 36 } height={ 5 } fill={ FILL } />
+		</G>
+		<G>
+			<Circle cx={ 214 } cy={ 160 } r={ 7 } fill={ FILL } />
+			<Bar x={ 227 } y={ 155 } width={ 50 } height={ 5 } />
+			<Bar x={ 227 } y={ 164 } width={ 28 } height={ 5 } fill={ FILL } />
+		</G>
+	</Canvas>
+);

--- a/projects/packages/forms/src/form-editor/welcome-guide/pages.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/pages.tsx
@@ -6,6 +6,13 @@
  */
 
 import { __ } from '@wordpress/i18n';
+import {
+	AddFieldsIllustration,
+	AfterSubmitIllustration,
+	FieldSettingsIllustration,
+	PublishIllustration,
+	ReusableFormIllustration,
+} from './illustrations';
 import type { ReactNode } from 'react';
 
 interface GuidePage {
@@ -14,17 +21,14 @@ interface GuidePage {
 }
 
 /**
- * Placeholder for slide artwork.
+ * Wrapper for a slide's artwork.
  *
- * Reserves the image region so the guide keeps a stable size across slides
- * while the artwork is still being designed.
- *
- * @return The placeholder element.
+ * @param props          - Component props
+ * @param props.children - The illustration to frame
+ * @return The framed artwork.
  */
-const ImageSlot = () => (
-	<div className="jetpack-forms-welcome-guide__image">
-		<div className="jetpack-forms-welcome-guide__image-slot" aria-hidden="true" />
-	</div>
+const Artwork = ( { children }: { children: ReactNode } ) => (
+	<div className="jetpack-forms-welcome-guide__image">{ children }</div>
 );
 
 /**
@@ -38,7 +42,11 @@ const ImageSlot = () => (
 export function getWelcomeGuidePages(): GuidePage[] {
 	return [
 		{
-			image: <ImageSlot />,
+			image: (
+				<Artwork>
+					<ReusableFormIllustration />
+				</Artwork>
+			),
 			content: (
 				<>
 					<h1 className="jetpack-forms-welcome-guide__heading">
@@ -54,7 +62,11 @@ export function getWelcomeGuidePages(): GuidePage[] {
 			),
 		},
 		{
-			image: <ImageSlot />,
+			image: (
+				<Artwork>
+					<AddFieldsIllustration />
+				</Artwork>
+			),
 			content: (
 				<>
 					<h1 className="jetpack-forms-welcome-guide__heading">
@@ -70,7 +82,11 @@ export function getWelcomeGuidePages(): GuidePage[] {
 			),
 		},
 		{
-			image: <ImageSlot />,
+			image: (
+				<Artwork>
+					<FieldSettingsIllustration />
+				</Artwork>
+			),
 			content: (
 				<>
 					<h1 className="jetpack-forms-welcome-guide__heading">
@@ -86,7 +102,11 @@ export function getWelcomeGuidePages(): GuidePage[] {
 			),
 		},
 		{
-			image: <ImageSlot />,
+			image: (
+				<Artwork>
+					<AfterSubmitIllustration />
+				</Artwork>
+			),
 			content: (
 				<>
 					<h1 className="jetpack-forms-welcome-guide__heading">
@@ -102,7 +122,11 @@ export function getWelcomeGuidePages(): GuidePage[] {
 			),
 		},
 		{
-			image: <ImageSlot />,
+			image: (
+				<Artwork>
+					<PublishIllustration />
+				</Artwork>
+			),
 			content: (
 				<>
 					<h1 className="jetpack-forms-welcome-guide__heading">

--- a/projects/packages/forms/src/form-editor/welcome-guide/style.scss
+++ b/projects/packages/forms/src/form-editor/welcome-guide/style.scss
@@ -5,16 +5,16 @@
 	inline-size: 312px;
 
 	.jetpack-forms-welcome-guide__image {
+		line-height: 0;
 		margin-block: 0 16px;
 	}
 
-	// Placeholder standing in for the slide artwork. Sized to the artwork
-	// region of the core guide so the modal keeps its final proportions
-	// while the illustrations are still being designed.
-	.jetpack-forms-welcome-guide__image-slot {
-		background: #f0f0f0;
-		block-size: 240px;
-		border: 1px dashed #c3c4c7;
+	// The illustration is authored on a 312×240 canvas — the artwork region of
+	// the core guide — and scales with the modal rather than being pinned to
+	// those pixels.
+	.jetpack-forms-welcome-guide__illustration {
+		block-size: auto;
+		display: block;
 		inline-size: 100%;
 	}
 


### PR DESCRIPTION
## Proposed changes

Adds illustrations to the five welcome guide slides, replacing the placeholder regions left in #51039.

**Stacked on #51039** — the placeholder slots only exist on that branch. Review and merge that one first; this branch targets it and will rebase cleanly onto trunk afterwards.

Each illustration is an inline SVG component drawn on the same 312×240 canvas the placeholders reserved, so the modal's proportions don't change.

| Slide | Illustration |
|---|---|
| Welcome to the form editor | A form card layered over two more sheets — create it once, reuse it anywhere |
| Add fields | An inserter panel beside a form with an open, dashed slot and a `+` |
| Make each field yours | One field selected, with its settings sidebar alongside |
| Decide what happens after submit | A submitted form branching into a confirmation and an email notification |
| Publish and share it | The form on a page, with responses stacking up in the inbox |

### Implementation notes

* **Inline SVG components, not image assets.** Drawn with `SVG`/`Rect`/`Path` from `@wordpress/primitives`, matching the existing convention in `src/icons/*.tsx`. No new build step, no binaries in the repo, crisp at any DPI, and translatable-free.
* **Abstract, not literal.** The shapes stand for fields, panels, and buttons rather than reproducing the real editor chrome, so they won't go stale the next time the Forms UI shifts.
* **Palette is Jetpack green** — `#069e08` (`--jp-green-40`) for the panel and `#008710` (`--jp-green-50`) for buttons, selection, and toggles, with neutral greys for the shape work. Both are the values already defined in `js-packages/base-styles/root-variables.scss`.
* The SVG scales to the modal rather than being pinned to 312px, and each canvas is `aria-hidden` — the slides' meaning lives entirely in the heading and body text, so nothing is lost to screen readers.
* Shared `Canvas` and `Bar` helpers keep the five illustrations consistent and the coordinate soup readable.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to **Jetpack → Forms → Add new form**, or `/wp-admin/post-new.php?post_type=jetpack_form&jetpack_forms_welcome_guide=1` to force the guide open on every load.
* Step through all five slides and confirm each has its illustration, that the artwork fills the panel edge to edge with no gaps or scrollbars, and that the modal is still 312px wide.
* Resize the browser and confirm the illustrations scale with the modal rather than clipping.
* Switch to an RTL locale and confirm the guide's text padding still mirrors correctly. The illustrations are intentionally *not* mirrored — they depict a left-to-right editor layout that stays left-to-right in RTL admin.

## Screenshots

Captured on a live Jurassic Ninja site at 1440×900.

| | |
|---|---|
| ![Slide 1 — Welcome to the form editor](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-editor-welcome-guide-artwork/slide-1.png) | ![Slide 2 — Add fields](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-editor-welcome-guide-artwork/slide-2.png) |
| **1.** Welcome to the form editor | **2.** Add fields |
| ![Slide 3 — Make each field yours](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-editor-welcome-guide-artwork/slide-3.png) | ![Slide 4 — Decide what happens after submit](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-editor-welcome-guide-artwork/slide-4.png) |
| **3.** Make each field yours | **4.** Decide what happens after submit |
| ![Slide 5 — Publish and share it](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-editor-welcome-guide-artwork/slide-5.png) | |
| **5.** Publish and share it | |

### In context

![The illustrated welcome guide open over the form editor](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-editor-welcome-guide-artwork/guide-in-context.png)
