### PR TITLE
Forms: label the preview admin bar edit link "Edit Form"

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-edit-form-admin-bar
+++ b/projects/packages/forms/changelog/fix-forms-edit-form-admin-bar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: label the admin bar edit link "Edit Form" on the form preview.

--- a/projects/packages/forms/changelog/fix-forms-edit-form-admin-bar
+++ b/projects/packages/forms/changelog/fix-forms-edit-form-admin-bar
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Form preview: label the admin bar edit link "Edit Form" instead of "Edit Page".
+Form preview: Label the admin bar edit link "Edit Form" instead of "Edit Page".

--- a/projects/packages/forms/changelog/fix-forms-edit-form-admin-bar
+++ b/projects/packages/forms/changelog/fix-forms-edit-form-admin-bar
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: label the admin bar edit link "Edit Form" on the form preview.
+Form preview: label the admin bar edit link "Edit Form" instead of "Edit Page".

--- a/projects/packages/forms/src/contact-form/class-form-preview.php
+++ b/projects/packages/forms/src/contact-form/class-form-preview.php
@@ -246,6 +246,11 @@ class Form_Preview {
 		// Add preview mode script variable.
 		add_action( 'wp_head', array( __CLASS__, 'add_preview_mode_script' ) );
 
+		// Relabel the admin bar's edit link. The preview renders through a fake
+		// `page` post object, so core would otherwise label the link "Edit Page".
+		// Priority 81 runs just after core's wp_admin_bar_edit_menu (80).
+		add_action( 'admin_bar_menu', array( __CLASS__, 'relabel_admin_bar_edit_link' ), 81 );
+
 		// Hook the_content filter to render the form.
 		add_filter(
 			'the_content',
@@ -323,6 +328,33 @@ class Form_Preview {
 		}
 
 		return $output;
+	}
+
+	/**
+	 * Relabel the admin bar's "Edit Page" link as "Edit Form" during a form preview.
+	 *
+	 * The preview sets up a fake `page` post object so themes render it like any
+	 * other singular view, which means core labels the edit link with the page post
+	 * type's `edit_item` label. The link itself already points at the form editor,
+	 * since it is built from the form's real post ID.
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar The admin bar instance.
+	 */
+	public static function relabel_admin_bar_edit_link( $wp_admin_bar ) {
+		if ( ! self::$is_preview_mode ) {
+			return;
+		}
+
+		if ( ! $wp_admin_bar->get_node( 'edit' ) ) {
+			return;
+		}
+
+		$wp_admin_bar->add_node(
+			array(
+				'id'    => 'edit',
+				'title' => __( 'Edit Form', 'jetpack-forms' ),
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-form-preview.php
+++ b/projects/packages/forms/src/contact-form/class-form-preview.php
@@ -246,10 +246,8 @@ class Form_Preview {
 		// Add preview mode script variable.
 		add_action( 'wp_head', array( __CLASS__, 'add_preview_mode_script' ) );
 
-		// Relabel the admin bar's edit link. The preview renders through a fake
-		// `page` post object, so core would otherwise label the link "Edit Page".
-		// Priority 81 runs just after core's wp_admin_bar_edit_menu (80).
-		add_action( 'admin_bar_menu', array( __CLASS__, 'relabel_admin_bar_edit_link' ), 81 );
+		// Relabel the admin bar's edit link.
+		add_action( 'wp_before_admin_bar_render', array( __CLASS__, 'relabel_admin_bar_edit_link' ) );
 
 		// Hook the_content filter to render the form.
 		add_filter(
@@ -338,14 +336,15 @@ class Form_Preview {
 	 * type's `edit_item` label. The link itself already points at the form editor,
 	 * since it is built from the form's real post ID.
 	 *
-	 * @param \WP_Admin_Bar $wp_admin_bar The admin bar instance.
+	 * Runs on `wp_before_admin_bar_render`, which core documents as the way to
+	 * manipulate existing nodes without depending on an `admin_bar_menu` priority.
 	 */
-	public static function relabel_admin_bar_edit_link( $wp_admin_bar ) {
-		if ( ! self::$is_preview_mode ) {
-			return;
-		}
+	public static function relabel_admin_bar_edit_link() {
+		global $wp_admin_bar;
 
-		if ( ! $wp_admin_bar->get_node( 'edit' ) ) {
+		// Only relabel a node core actually added: `add_node()` on an unknown id
+		// would create a new orphan node, promoted to a top-level unlinked item.
+		if ( ! is_object( $wp_admin_bar ) || ! $wp_admin_bar->get_node( 'edit' ) ) {
 			return;
 		}
 

--- a/projects/packages/forms/tests/php/contact-form/Form_Preview_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Form_Preview_Test.php
@@ -230,6 +230,75 @@ class Form_Preview_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Build a WP_Admin_Bar carrying an `edit` node shaped like the one core adds.
+	 *
+	 * @return \WP_Admin_Bar
+	 */
+	private function make_admin_bar_with_edit_node() {
+		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+
+		$admin_bar = new \WP_Admin_Bar();
+		$admin_bar->add_node(
+			array(
+				'id'     => 'edit',
+				'title'  => 'Edit Page',
+				'parent' => 'top-secondary',
+				'href'   => 'https://example.org/wp-admin/post.php?post=1&action=edit',
+				'meta'   => array( 'class' => 'edit-node' ),
+			)
+		);
+
+		return $admin_bar;
+	}
+
+	/**
+	 * Test relabel_admin_bar_edit_link() retitles the node without disturbing the link.
+	 */
+	public function test_relabel_admin_bar_edit_link_retitles_node() {
+		global $wp_admin_bar;
+
+		$wp_admin_bar = $this->make_admin_bar_with_edit_node(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test fixture.
+
+		Form_Preview::relabel_admin_bar_edit_link();
+
+		$node = $wp_admin_bar->get_node( 'edit' );
+
+		$this->assertSame( 'Edit Form', $node->title );
+
+		// add_node() merges into the existing node, so everything else survives.
+		$this->assertSame( 'https://example.org/wp-admin/post.php?post=1&action=edit', $node->href );
+		$this->assertSame( 'top-secondary', $node->parent );
+		$this->assertSame( array( 'class' => 'edit-node' ), $node->meta );
+	}
+
+	/**
+	 * Test relabel_admin_bar_edit_link() never creates an edit node core did not add.
+	 */
+	public function test_relabel_admin_bar_edit_link_ignores_missing_node() {
+		global $wp_admin_bar;
+
+		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+		$wp_admin_bar = new \WP_Admin_Bar(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test fixture.
+
+		Form_Preview::relabel_admin_bar_edit_link();
+
+		$this->assertNull( $wp_admin_bar->get_node( 'edit' ) );
+	}
+
+	/**
+	 * Test relabel_admin_bar_edit_link() tolerates an uninitialized admin bar.
+	 */
+	public function test_relabel_admin_bar_edit_link_without_admin_bar() {
+		global $wp_admin_bar;
+
+		$wp_admin_bar = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test fixture.
+
+		Form_Preview::relabel_admin_bar_edit_link();
+
+		$this->assertNull( $wp_admin_bar );
+	}
+
+	/**
 	 * Test preview works with draft forms.
 	 */
 	public function test_preview_works_with_draft_form() {


### PR DESCRIPTION
Fixes #

## Proposed changes
* When previewing a form, the WP admin bar's edit link is now labelled "Edit Form" instead of "Edit Page".
* The form preview sets up a fake `page` post object so themes render it like any other singular view. As a side effect, core's `wp_admin_bar_edit_menu()` picked up the *page* post type's `edit_item` label. `Form_Preview` now re-adds the admin bar's `edit` node with the correct label, on `wp_before_admin_bar_render` — which core documents as the way to manipulate existing nodes without depending on an `admin_bar_menu` priority.
* The link target is unchanged — it is built from the form's real post ID, so it already pointed at the form editor.
* The node is only relabelled if core actually added it; it is never created. That keeps the preview from surfacing an edit link where core decided there shouldn't be one.

Setting the fake post's `post_type` to `jetpack_form` instead was considered and rejected: the CPT registers `show_in_menu => false`, so `show_in_admin_bar` defaults to false and core would drop the edit node entirely. Forcing it true would leak the form CPT into the site-wide "+ New" menu.

## Screenshots

Captured on a live Jurassic Ninja site at `/?jetpack_form_preview=<id>&jetpack_form_preview_nonce=<nonce>`, 1440px wide. The "before" shot is the same site with only this PR's `add_action` disabled, so nothing else differs between the two.

| | |
|---|---|
| **Before** | ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-edit-form-admin-bar/before-admin-bar.png) |
| **After** | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-edit-form-admin-bar/after-admin-bar.png) |

<details>
<summary>Wider shot, with the preview page below the admin bar</summary>

![after preview](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-edit-form-admin-bar/after-preview.png)

</details>

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Go to **Jetpack → Forms** and create (or open) a form.
* In the form editor, click **Preview**. You land on a URL like `/?jetpack_form_preview=<id>&jetpack_form_preview_nonce=<nonce>`.
* Look at the WP admin bar at the top of the preview.
  * **Before:** the pencil link reads **"Edit Page"**.
  * **After:** it reads **"Edit Form"**.
* Click the link and confirm it still opens the form in the block editor.
* Confirm nothing else changed: visit a regular page and a regular post on the front end and check their admin bar links still read "Edit Page" / "Edit Post".
