### PR TITLE
Premium Analytics: shape the metric tile skeleton like its grid

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1781-widget-skeleton-metric-tiles
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1781-widget-skeleton-metric-tiles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Show content-shaped skeleton placeholders while widget content loads.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
@@ -1,5 +1,9 @@
 export { MetricDelta } from './metric-delta';
-export { MetricTileGrid } from './metric-tile';
+export {
+	MetricTileGrid,
+	MetricTileGridSkeleton,
+	type MetricTileGridSkeletonProps,
+} from './metric-tile';
 export { MetricValue } from './metric-value';
 export { MetricWithComparison } from './metric-with-comparison';
 export { PeakDistribution, type PeakDistributionProps } from './peak-distribution';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/__tests__/metric-tile-grid-skeleton.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/__tests__/metric-tile-grid-skeleton.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { MetricTileGridSkeleton } from '../metric-tile-grid-skeleton';
+
+describe( 'MetricTileGridSkeleton', () => {
+	it( 'draws the tiles the widget asked for', () => {
+		render( <MetricTileGridSkeleton tiles={ 3 } /> );
+
+		expect( screen.getAllByTestId( 'skeleton-tile' ) ).toHaveLength( 3 );
+	} );
+
+	it( 'fills the grid when every metric is switched off', () => {
+		// Callers pass a count they know before the response, but it is 0 when
+		// the user has deselected every metric — drawing that literally would
+		// leave an empty loading state.
+		render( <MetricTileGridSkeleton tiles={ 0 } /> );
+
+		expect( screen.getAllByTestId( 'skeleton-tile' ).length ).toBeGreaterThan( 1 );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/index.ts
@@ -1,1 +1,5 @@
 export { MetricTileGrid } from './metric-tile-grid';
+export {
+	MetricTileGridSkeleton,
+	type MetricTileGridSkeletonProps,
+} from './metric-tile-grid-skeleton';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.module.scss
@@ -1,0 +1,93 @@
+@use "../../styles/widget-container" as *;
+
+/* Placeholder treatment from the design prototype's highlights skeleton: flat
+ * label and value stand-ins, without the loaded tile's border or type scale.
+ *
+ * The prototype only draws the wide arrangement. The narrow one below mirrors
+ * `metric-tile-grid.module.scss` instead, which stacks full-width rows until
+ * `$widget-wide-min-inline-size` — at a 360px dashboard tile, the common
+ * case, a centred wrap would read as a block of cards against four full-width
+ * rows. */
+$label-block-size: 10px;
+$value-block-size: 24px;
+$row-label-inline-size: 45%;
+
+/* Stands in for the formatted count at the end of a narrow row ("12.8k"), which
+ * barely varies in width, so it is fixed rather than proportional. */
+$row-value-inline-size: 72px;
+
+$tile-gap: 24px;
+$tile-min-inline-size: 90px;
+$tile-label-inline-size: 55%;
+$tile-value-inline-size: 70%;
+$tile-value-gap: 10px;
+
+/* The skeleton renders outside the grid's own container, so it establishes one
+ * to query. */
+.container {
+	container-type: inline-size;
+	display: flex;
+	flex: 1 1 auto;
+	min-block-size: 0;
+}
+
+/* Narrow: one full-width row per metric, as the loaded grid's single column. */
+.tiles {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	justify-content: safe center;
+	gap: var(--wpds-dimension-gap-sm);
+	min-block-size: 0;
+	overflow: hidden;
+}
+
+.tile {
+	display: flex;
+	flex: none;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-gap-md);
+}
+
+.label {
+	inline-size: $row-label-inline-size;
+	block-size: $label-block-size;
+	border-radius: var(--wpds-border-radius-md);
+}
+
+.value {
+	inline-size: $row-value-inline-size;
+	block-size: $value-block-size;
+	border-radius: var(--wpds-border-radius-md);
+}
+
+/* Wide: the tiles sit side by side with the value under its label, as the
+ * loaded grid switches to at the same threshold. `safe` keeps a wrapped set
+ * taller than the body from being pushed past the top edge, where `overflow:
+ * hidden` would put it out of reach. */
+@container (min-inline-size: #{$widget-wide-min-inline-size}) {
+
+	.tiles {
+		flex-flow: row wrap;
+		align-content: safe center;
+		gap: $tile-gap;
+	}
+
+	.tile {
+		flex: 1 1 0;
+		flex-direction: column;
+		justify-content: unset;
+		gap: 0;
+		min-inline-size: $tile-min-inline-size;
+	}
+
+	.label {
+		inline-size: $tile-label-inline-size;
+	}
+
+	.value {
+		inline-size: $tile-value-inline-size;
+		margin-block-start: $tile-value-gap;
+	}
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.module.scss
@@ -7,20 +7,24 @@
  * `metric-tile-grid.module.scss` instead, which stacks full-width rows until
  * `$widget-wide-min-inline-size` — at a 360px dashboard tile, the common
  * case, a centred wrap would read as a block of cards against four full-width
- * rows. */
-$label-block-size: 10px;
-$value-block-size: 24px;
+ * rows.
+ *
+ * Lengths use WPDS dimension tokens wherever the scale expresses them, so the
+ * label stand-in carries the same weight as the leaderboard skeleton's and the
+ * value gap matches the gap the loaded tile puts there. What stays literal is
+ * what no token reaches: the proportional widths, and the two stand-ins sized
+ * from the text they replace. */
 $row-label-inline-size: 45%;
 
 /* Stands in for the formatted count at the end of a narrow row ("12.8k"), which
  * barely varies in width, so it is fixed rather than proportional. */
 $row-value-inline-size: 72px;
 
-$tile-gap: 24px;
+/* Stands in for a tile's minimum width, which the loaded grid expresses as a
+ * fraction of the row rather than a token. */
 $tile-min-inline-size: 90px;
 $tile-label-inline-size: 55%;
 $tile-value-inline-size: 70%;
-$tile-value-gap: 10px;
 
 /* The skeleton renders outside the grid's own container, so it establishes one
  * to query. */
@@ -52,13 +56,13 @@ $tile-value-gap: 10px;
 
 .label {
 	inline-size: $row-label-inline-size;
-	block-size: $label-block-size;
+	block-size: var(--wpds-dimension-size-4xs);
 	border-radius: var(--wpds-border-radius-md);
 }
 
 .value {
 	inline-size: $row-value-inline-size;
-	block-size: $value-block-size;
+	block-size: var(--wpds-dimension-size-sm);
 	border-radius: var(--wpds-border-radius-md);
 }
 
@@ -71,7 +75,7 @@ $tile-value-gap: 10px;
 	.tiles {
 		flex-flow: row wrap;
 		align-content: safe center;
-		gap: $tile-gap;
+		gap: var(--wpds-dimension-gap-xl);
 	}
 
 	.tile {
@@ -88,6 +92,6 @@ $tile-value-gap: 10px;
 
 	.value {
 		inline-size: $tile-value-inline-size;
-		margin-block-start: $tile-value-gap;
+		margin-block-start: var(--wpds-dimension-gap-sm);
 	}
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { Skeleton } from '@jetpack-premium-analytics/externals';
+/**
+ * Internal dependencies
+ */
+import { SkeletonRoot } from '../widget-skeleton';
+import styles from './metric-tile-grid-skeleton.module.scss';
+
+const DEFAULT_TILE_COUNT = 4;
+
+export interface MetricTileGridSkeletonProps {
+	/** Tiles to draw; pass the widget's own tile count so the grid lands where the tiles will. */
+	tiles?: number;
+}
+
+/**
+ * Loading shape for `MetricTileGrid`: a label and value placeholder per metric,
+ * stacked as full-width rows and switching to a centred row of columns at the
+ * same width the loaded grid does.
+ *
+ * @param props       - Component props.
+ * @param props.tiles - Tiles to draw.
+ * @return The rendered skeleton.
+ */
+export function MetricTileGridSkeleton( {
+	tiles = DEFAULT_TILE_COUNT,
+}: MetricTileGridSkeletonProps ) {
+	// Every caller passes a count it knows before the response, but that count
+	// is 0 when the user has switched every metric off; drawing it literally
+	// would leave an empty loading state.
+	const tileCount = tiles > 0 ? tiles : DEFAULT_TILE_COUNT;
+
+	return (
+		<SkeletonRoot>
+			<div className={ styles.container }>
+				<div className={ styles.tiles }>
+					{ Array.from( { length: tileCount }, ( _, index ) => (
+						<div key={ index } className={ styles.tile } data-testid="skeleton-tile">
+							<Skeleton className={ styles.label } />
+							<Skeleton className={ styles.value } />
+						</div>
+					) ) }
+				</div>
+			</div>
+		</SkeletonRoot>
+	);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/stories/metric-tile-grid.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/stories/metric-tile-grid.stories.tsx
@@ -1,5 +1,6 @@
 import { comment, paragraph, postList, starEmpty } from '@wordpress/icons';
 import { MetricTileGrid } from '../metric-tile-grid';
+import { MetricTileGridSkeleton } from '../metric-tile-grid-skeleton';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { ComponentProps } from 'react';
 
@@ -143,4 +144,38 @@ export const WithPlaceholderValue: Story = {
 		],
 	},
 	decorators: [ makeCanvas( '100%', '320px' ) ],
+};
+
+type SkeletonStory = StoryObj< ComponentProps< typeof MetricTileGridSkeleton > >;
+
+/**
+ * The loading shape widgets pass through `WidgetState`'s `renderLoading`, wide
+ * enough for the side-by-side arrangement: one label and value placeholder per
+ * metric, centred in the widget body.
+ */
+export const Skeleton: SkeletonStory = {
+	render: args => <MetricTileGridSkeleton { ...args } />,
+	args: { tiles: 4 },
+	decorators: [ makeCanvas( '100%', '480px' ) ],
+};
+
+/**
+ * A 360px dashboard tile — the common width, and below the threshold where the
+ * loaded grid lays its tiles out in a row. The shape stacks full-width rows to
+ * match, rather than wrapping into a block of cards.
+ */
+export const SkeletonNarrowTile: SkeletonStory = {
+	render: args => <MetricTileGridSkeleton { ...args } />,
+	args: { tiles: 4 },
+	decorators: [ makeCanvas( '360px', '320px' ) ],
+};
+
+/**
+ * A wide, height-1 dashboard tile: the tiles stay on one row and the shape
+ * centres in what little height the cell has.
+ */
+export const SkeletonShortTile: SkeletonStory = {
+	render: args => <MetricTileGridSkeleton { ...args } />,
+	args: { tiles: 4 },
+	decorators: [ makeCanvas( '720px', '140px' ) ],
 };

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/stories/metric-tile-grid.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/stories/metric-tile-grid.stories.tsx
@@ -16,10 +16,26 @@ const TILES = [
 	{ key: 'comments', icon: comment, label: 'Comments', value: 42 },
 ];
 
+/* Frames a story as a dashboard widget body: the tile's own box, inset by the
+ * dashboard's `--wp-ui-card-padding` override, so a shape clears the card
+ * border by the same distance it does in product. */
 const makeCanvas = ( width: string, height: string ): Decorator =>
 	function CanvasDecorator( Story ) {
 		return (
-			<div style={ { width, height, display: 'flex', flexDirection: 'column' } }>
+			<div
+				style={ {
+					width,
+					height,
+					border: '1px solid var(--wpds-color-stroke-surface-neutral-weak)',
+					borderRadius: 'var(--wpds-border-radius-md)',
+					background: 'var(--wpds-color-background-surface-neutral)',
+					padding: 'var(--wpds-dimension-padding-lg)',
+					boxSizing: 'border-box',
+					display: 'flex',
+					flexDirection: 'column',
+					overflow: 'hidden',
+				} }
+			>
 				<Story />
 			</div>
 		);

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -4,6 +4,8 @@
 export {
 	MetricDelta,
 	MetricTileGrid,
+	MetricTileGridSkeleton,
+	type MetricTileGridSkeletonProps,
 	MetricValue,
 	MetricWithComparison,
 	PeakDistribution,

--- a/projects/packages/premium-analytics/widgets/all-time-stats/render.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/render.tsx
@@ -4,6 +4,7 @@
 import { useStatsSite } from '@jetpack-premium-analytics/data';
 import {
 	MetricTileGrid,
+	MetricTileGridSkeleton,
 	summaryCount,
 	WidgetRoot,
 	WidgetState,
@@ -126,6 +127,10 @@ function AllTimeStatsReport( {
 							? __( 'Select at least one metric to display.', 'jetpack-premium-analytics-pkg' )
 							: __( 'No stats recorded yet.', 'jetpack-premium-analytics-pkg' ),
 				} }
+				// `tiles` is built from the summary, so it is empty until the
+				// response lands; the enabled metrics are the count the loaded
+				// grid will show.
+				renderLoading={ <MetricTileGridSkeleton tiles={ enabledMetrics.length } /> }
 			>
 				<MetricTileGrid tiles={ tiles } dataFormat={ COUNT_FORMAT } />
 			</WidgetState>

--- a/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
@@ -9,6 +9,7 @@ import {
 } from '@jetpack-premium-analytics/data';
 import {
 	MetricTileGrid,
+	MetricTileGridSkeleton,
 	WidgetRoot,
 	WidgetState,
 	useWidgetRootContext,
@@ -238,12 +239,27 @@ export function toEmailTopRowMetrics(
 	return tiles;
 }
 
+/**
+ * How many tiles a view shows, read from the same table. The view is known
+ * before the rate summaries are, so this is the count the loading shape can
+ * draw; `hideWhenZero` may still drop one once the data lands.
+ */
+function countEmailTopRowTiles( metric: EmailMetric ): number {
+	return EMAIL_METRICS.filter( spec => spec.views.includes( metric ) ).length;
+}
+
 type EmailTopRowTilesProps = {
 	/**
 	 * The ordered metric tiles to render. When omitted, the empty state is shown
 	 * (unless the widget is loading or in error).
 	 */
 	metrics?: EmailTopRowMetric[];
+	/**
+	 * Tiles the active view will show, so the loading shape draws the row that is
+	 * coming. The view lives in the report above, not here, and `metrics` is
+	 * `undefined` until the request resolves.
+	 */
+	tileCount?: number;
 	/**
 	 * Whether an email is selected. Drives the empty-state message: a prompt to
 	 * select an email when `false`, or a "no stats yet" message when `true`.
@@ -269,6 +285,7 @@ type EmailTopRowTilesProps = {
  */
 const EmailTopRowTiles = ( {
 	metrics,
+	tileCount,
 	hasSelection = false,
 	isLoading = false,
 	isFetching = false,
@@ -298,6 +315,7 @@ const EmailTopRowTiles = ( {
 							? __( 'No stats are available for this email yet.', 'jetpack-premium-analytics-pkg' )
 							: __( 'Select an email to see its stats.', 'jetpack-premium-analytics-pkg' ),
 					} }
+					renderLoading={ <MetricTileGridSkeleton tiles={ tileCount } /> }
 				>
 					<MetricTileGrid tiles={ metrics ?? [] } />
 				</WidgetState>
@@ -363,6 +381,7 @@ function EmailTopRowReport( { metric }: EmailTopRowReportProps ) {
 	return (
 		<EmailTopRowTiles
 			metrics={ metrics }
+			tileCount={ countEmailTopRowTiles( metric ) }
 			hasSelection={ hasSelection }
 			isLoading={ activeQueries.some( query => query.isLoading ) }
 			isFetching={ activeQueries.some( query => query.isFetching ) }

--- a/projects/packages/premium-analytics/widgets/post-detail-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-detail-highlights/render.tsx
@@ -5,6 +5,7 @@ import { toPostId } from '@jetpack-premium-analytics/data';
 import { reports } from '@jetpack-premium-analytics/icons';
 import {
 	MetricTileGrid,
+	MetricTileGridSkeleton,
 	WidgetRoot,
 	WidgetState,
 	useWidgetRootContext,
@@ -114,6 +115,7 @@ function PostDetailHighlightsInner() {
 						'jetpack-premium-analytics-pkg'
 					),
 				} }
+				renderLoading={ <MetricTileGridSkeleton tiles={ tiles.length } /> }
 			>
 				<MetricTileGrid tiles={ tiles } dataFormat={ COUNT_FORMAT } />
 			</WidgetState>

--- a/projects/packages/premium-analytics/widgets/site-overview/render.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/render.tsx
@@ -5,6 +5,7 @@ import { useStatsSummary, type StatsSummaryResponse } from '@jetpack-premium-ana
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import {
 	MetricTileGrid,
+	MetricTileGridSkeleton,
 	WidgetRoot,
 	WidgetState,
 	useWidgetRootContext,
@@ -158,6 +159,7 @@ function SiteOverviewReport( {
 					icon: globe,
 					description: __( 'No stats recorded for this period.', 'jetpack-premium-analytics-pkg' ),
 				} }
+				renderLoading={ <MetricTileGridSkeleton tiles={ visibleMetrics.length } /> }
 			>
 				<MetricTileGrid tiles={ tiles } dataFormat={ COUNT_FORMAT } />
 			</WidgetState>

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/render.tsx
@@ -8,6 +8,7 @@ import {
 import { customer } from '@jetpack-premium-analytics/icons';
 import {
 	MetricTileGrid,
+	MetricTileGridSkeleton,
 	WidgetRoot,
 	WidgetState,
 	type DataFormat,
@@ -105,6 +106,7 @@ function SubscriberHighlightsReport( {
 					icon: customer,
 					description: __( 'No subscriber counts available yet.', 'jetpack-premium-analytics-pkg' ),
 				} }
+				renderLoading={ <MetricTileGridSkeleton tiles={ tiles.length } /> }
 			>
 				{ tiles.length === 0 ? (
 					<Text className={ styles.placeholder }>

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/render.tsx
@@ -4,6 +4,7 @@
 import { toPostId, useStatsSingleVideo } from '@jetpack-premium-analytics/data';
 import {
 	MetricTileGrid,
+	MetricTileGridSkeleton,
 	WidgetRoot,
 	WidgetState,
 	describeError,
@@ -121,6 +122,7 @@ function VideoDetailHighlightsInner() {
 								'jetpack-premium-analytics-pkg'
 						  ),
 				} }
+				renderLoading={ <MetricTileGridSkeleton tiles={ tiles.length } /> }
 			>
 				<MetricTileGrid tiles={ tiles } dataFormat={ COUNT_FORMAT } />
 			</WidgetState>

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/render.tsx
@@ -8,6 +8,7 @@ import {
 import { megaphone } from '@jetpack-premium-analytics/icons';
 import {
 	MetricTileGrid,
+	MetricTileGridSkeleton,
 	WidgetRoot,
 	WidgetState,
 	type DataFormat,
@@ -112,6 +113,7 @@ function WordAdsHighlightsReport( {
 						'jetpack-premium-analytics-pkg'
 					),
 				} }
+				renderLoading={ <MetricTileGridSkeleton tiles={ tiles.length } /> }
 			>
 				<MetricTileGrid tiles={ tiles } dataFormat={ CURRENCY_FORMAT } currencyCode="USD" />
 			</WidgetState>


### PR DESCRIPTION
Part of WOOA7S-1781. Second of four; stacked on #51207 — review that one first.

## Proposed changes

- Add `MetricTileGridSkeleton` and draw it at the 7 `<WidgetState>` call sites whose content is a `MetricTileGrid`.
- Placeholder treatment follows the design prototype: a flat label and value stand-in per metric, without the loaded tile's border or type scale.
- Arrangement follows the grid it stands in for — full-width rows below the same 640px threshold the loaded grid uses, side-by-side columns above it — so a 360px dashboard tile does not show a wrapped block of cards against full-width rows.
- Every caller passes a tile count it knows before the response; the fallback covers the case where the user has switched every metric off.

## Related product discussion/links

- WOOA7S-1781

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open the Premium Analytics dashboard with a throttled connection (DevTools → Network → Slow 4G) and reload.
- Site overview, All-time stats, and the highlights widgets should show one label and value placeholder per metric.
- Compare a narrow (single column) and a wide (side-by-side) tile: the skeleton should switch arrangement at the same width the loaded grid does.
- Storybook → _Widgets Toolkit / Components / MetricTileGrid_ has `Skeleton`, `SkeletonNarrowTile` and `SkeletonShortTile`.


https://github.com/user-attachments/assets/5cd6e59e-bb8b-4392-aa68-f9884b4d3042

<img width="2560" height="1319" alt="Screenshot 2026-08-19 at 2 53 50 PM" src="https://github.com/user-attachments/assets/2daad0e2-d670-41fc-9a1e-3f197e49c362" />
