### PR TITLE
Premium Analytics: add metric sparkline, bar chart and heatmap skeletons

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1781-widget-skeleton-charts
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1781-widget-skeleton-charts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Show content-shaped skeleton placeholders while widget content loads.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/__tests__/bar-chart-skeleton.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/__tests__/bar-chart-skeleton.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { BarChartSkeleton } from '../bar-chart-skeleton';
+
+describe( 'BarChartSkeleton', () => {
+	it( 'draws the columns the widget asked for, inside a status region', () => {
+		render( <BarChartSkeleton columns={ 2 } /> );
+
+		expect( screen.getByRole( 'status' ) ).toBeInTheDocument();
+		expect( screen.getAllByTestId( 'skeleton-bar-column' ) ).toHaveLength( 2 );
+	} );
+
+	it( 'falls back to a handful of columns when the widget cannot count its bars', () => {
+		// Only `sales-by-device` builds its bars from the response; the rest
+		// pass a count they know, so the default just has to read as a small
+		// categorical chart rather than the prototype's dense time series.
+		render( <BarChartSkeleton /> );
+
+		expect( screen.getAllByTestId( 'skeleton-bar-column' ) ).toHaveLength( 4 );
+	} );
+
+	it( "keeps the columns out of the status region's direct children", () => {
+		// The heights are written with `:nth-child()`, which would count
+		// `SkeletonRoot`'s visually hidden label and shift every column.
+		render( <BarChartSkeleton /> );
+
+		const [ firstColumn ] = screen.getAllByTestId( 'skeleton-bar-column' );
+
+		// eslint-disable-next-line testing-library/no-node-access -- the assertion is about which element the columns are indexed within.
+		expect( firstColumn.parentElement ).not.toHaveAttribute( 'role', 'status' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart-skeleton.module.scss
@@ -1,8 +1,9 @@
 @use "sass:list";
 
-/* Geometry from the design prototype's `columns` skeleton variant. */
-$column-gap: 6px;
-$column-padding-block: 12px 4px;
+/* Geometry from the design prototype's `columns` skeleton variant, on WPDS
+ * dimension tokens: the prototype's 6px column gap sits between `xs` and `sm`,
+ * and `xs` is the one that leaves the bars their width. Only the proportional
+ * heights stay literal — no token expresses them. */
 $column-block-sizes: 40%, 62%, 34%, 78%, 52%, 88%, 46%, 70%, 30%, 60%, 82%, 44%;
 
 /* Bottom-aligned so the varying heights read as a bar chart, not a grid. */
@@ -11,9 +12,9 @@ $column-block-sizes: 40%, 62%, 34%, 78%, 52%, 88%, 46%, 70%, 30%, 60%, 82%, 44%;
 	flex: 1 1 auto;
 	flex-direction: row;
 	align-items: flex-end;
-	gap: $column-gap;
+	gap: var(--wpds-dimension-gap-xs);
 	min-block-size: 0;
-	padding-block: $column-padding-block;
+	padding-block: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-xs);
 }
 
 /* The prototype's 3px radius has no token here; `sm` (2px) is the nearest. */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart-skeleton.module.scss
@@ -1,0 +1,31 @@
+@use "sass:list";
+
+/* Geometry from the design prototype's `columns` skeleton variant. */
+$column-gap: 6px;
+$column-padding-block: 12px 4px;
+$column-block-sizes: 40%, 62%, 34%, 78%, 52%, 88%, 46%, 70%, 30%, 60%, 82%, 44%;
+
+/* Bottom-aligned so the varying heights read as a bar chart, not a grid. */
+.columns {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: row;
+	align-items: flex-end;
+	gap: $column-gap;
+	min-block-size: 0;
+	padding-block: $column-padding-block;
+}
+
+/* The prototype's 3px radius has no token here; `sm` (2px) is the nearest. */
+.column {
+	flex: 1 1 0;
+	inline-size: 100%;
+	min-inline-size: 0;
+	border-radius: var(--wpds-border-radius-sm);
+}
+
+@for $index from 1 through list.length($column-block-sizes) {
+	.columns .column:nth-child(#{$index}) {
+		block-size: list.nth($column-block-sizes, $index);
+	}
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart-skeleton.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart-skeleton.tsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { Skeleton } from '@jetpack-premium-analytics/externals';
+/**
+ * Internal dependencies
+ */
+import { SkeletonRoot } from '../widget-skeleton';
+import styles from './bar-chart-skeleton.module.scss';
+
+/**
+ * Columns for a widget that cannot know its own bar count. These charts are
+ * categorical rather than time series, so a handful of bars is the shape to
+ * expect — the prototype's denser twelve stands in for a chart this package
+ * has no consumer for.
+ */
+const DEFAULT_COLUMN_COUNT = 4;
+
+export interface BarChartSkeletonProps {
+	/** Columns to draw; pass the widget's own bar count where it is known before the response. */
+	columns?: number;
+}
+
+/**
+ * Loading shape for `BarChart`: bottom-aligned columns of stepping heights.
+ *
+ * @param props         - Component props.
+ * @param props.columns - Columns to draw.
+ * @return The rendered skeleton.
+ */
+export function BarChartSkeleton( { columns = DEFAULT_COLUMN_COUNT }: BarChartSkeletonProps ) {
+	const columnCount = columns > 0 ? columns : DEFAULT_COLUMN_COUNT;
+
+	return (
+		<SkeletonRoot>
+			{ /* Own wrapper: the `:nth-child()` height steps must not count
+			     SkeletonRoot's hidden label. */ }
+			<div className={ styles.columns }>
+				{ Array.from( { length: columnCount }, ( _, index ) => (
+					<Skeleton key={ index } className={ styles.column } data-testid="skeleton-bar-column" />
+				) ) }
+			</div>
+		</SkeletonRoot>
+	);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/index.ts
@@ -1,1 +1,2 @@
 export { BarChart, type BarChartProps, type BarChartData, type BarChartStyle } from './bar-chart';
+export { BarChartSkeleton } from './bar-chart-skeleton';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/stories/bar-chart.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/stories/bar-chart.stories.tsx
@@ -354,9 +354,10 @@ type SkeletonStory = StoryObj< typeof BarChartSkeleton >;
 
 /**
  * The loading shape widgets pass through `WidgetState`'s `renderLoading`: a
- * bottom-aligned row of columns. The count is fixed at the prototype's twelve —
- * the loaded chart's bar count comes from the response, so a data-derived count
- * would land as the jump the placeholder is there to prevent.
+ * bottom-aligned row of columns, here at the default four. Widgets that know
+ * their bar count up front pass it through `columns`; the rest keep the default
+ * rather than deriving one from a response that has not arrived, which would
+ * land as the jump the placeholder is there to prevent.
  */
 export const Skeleton: SkeletonStory = {
 	render: () => (

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/stories/bar-chart.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/stories/bar-chart.stories.tsx
@@ -1,5 +1,7 @@
+import { WidgetCard } from '../../../stories/widget-card';
 import { withChartTheme } from '../../../stories/with-chart-theme';
 import { BarChart, type BarChartStyle } from '../bar-chart';
+import { BarChartSkeleton } from '../bar-chart-skeleton';
 import type { SeriesData } from '@jetpack-premium-analytics/externals';
 import type { Meta, StoryObj } from '@storybook/react';
 
@@ -346,4 +348,32 @@ export const EmptyState: Story = {
 			},
 		},
 	},
+};
+
+type SkeletonStory = StoryObj< typeof BarChartSkeleton >;
+
+/**
+ * The loading shape widgets pass through `WidgetState`'s `renderLoading`: a
+ * bottom-aligned row of columns. The count is fixed at the prototype's twelve —
+ * the loaded chart's bar count comes from the response, so a data-derived count
+ * would land as the jump the placeholder is there to prevent.
+ */
+export const Skeleton: SkeletonStory = {
+	render: () => (
+		<WidgetCard width="360px" height="260px">
+			<BarChartSkeleton />
+		</WidgetCard>
+	),
+};
+
+/**
+ * A height-1 dashboard tile. The columns are sized as a share of the body, so
+ * they shrink with it instead of pushing past the widget.
+ */
+export const SkeletonShortTile: SkeletonStory = {
+	render: () => (
+		<WidgetCard width="360px" height="140px">
+			<BarChartSkeleton />
+		</WidgetCard>
+	),
 };

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
@@ -55,7 +55,13 @@ export {
 	type LeaderboardRowProps,
 	type LeaderboardRowVariant,
 } from './chart-leaderboard';
-export { BarChart, type BarChartProps, type BarChartData, type BarChartStyle } from './chart-bar';
+export {
+	BarChart,
+	BarChartSkeleton,
+	type BarChartProps,
+	type BarChartData,
+	type BarChartStyle,
+} from './chart-bar';
 export { ChartEmptyState, type ChartEmptyStateProps } from './chart-empty-state';
 export {
 	AdaptiveCalendarHeatmap,
@@ -134,4 +140,11 @@ export {
 	getWordAdsHistoryFields,
 	type EarningsHistoryRow,
 } from './wordads-earnings-history';
-export { GenericSkeleton, SkeletonRoot, type SkeletonRootProps } from './widget-skeleton';
+export {
+	GenericSkeleton,
+	HeatmapSkeleton,
+	MetricSparklineSkeleton,
+	type MetricSparklineSkeletonProps,
+	SkeletonRoot,
+	type SkeletonRootProps,
+} from './widget-skeleton';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/__tests__/heatmap-skeleton.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/__tests__/heatmap-skeleton.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { HeatmapSkeleton } from '../heatmap-skeleton';
+
+describe( 'HeatmapSkeleton', () => {
+	it( "draws the design's 28 by 3 grid inside a status region", () => {
+		render( <HeatmapSkeleton /> );
+
+		expect( screen.getByRole( 'status' ) ).toBeInTheDocument();
+		expect( screen.getAllByTestId( 'skeleton-cell' ) ).toHaveLength( 84 );
+	} );
+
+	it( 'keeps the cells in their own wrapper', () => {
+		// SkeletonRoot's hidden label is a real element; cells sharing its parent
+		// would take a grid slot.
+		render( <HeatmapSkeleton /> );
+
+		const status = screen.getByRole( 'status' );
+		// eslint-disable-next-line testing-library/no-node-access -- the wrapper is the assertion: the grid must be one element beside the hidden label.
+		expect( status.children ).toHaveLength( 2 );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/__tests__/metric-sparkline-skeleton.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/__tests__/metric-sparkline-skeleton.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { MetricSparklineSkeleton } from '../metric-sparkline-skeleton';
+
+describe( 'MetricSparklineSkeleton', () => {
+	it( 'draws the headline and the sparkline band in a status region', () => {
+		render( <MetricSparklineSkeleton /> );
+
+		expect( screen.getByRole( 'status' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'skeleton-metric-value' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'skeleton-chart-block' ) ).toBeInTheDocument();
+	} );
+
+	it( 'leaves out the headline count unless the widget renders one', () => {
+		// Two of the three widgets show only a value, so a count placeholder
+		// would settle into nothing when the data lands.
+		render( <MetricSparklineSkeleton /> );
+
+		expect( screen.queryByTestId( 'skeleton-metric-count' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'draws the headline count between the value and the chart when asked', () => {
+		render( <MetricSparklineSkeleton withHeadlineCount /> );
+
+		const value = screen.getByTestId( 'skeleton-metric-value' );
+		const count = screen.getByTestId( 'skeleton-metric-count' );
+		const chart = screen.getByTestId( 'skeleton-chart-block' );
+
+		expect( value.compareDocumentPosition( count ) ).toBe( Node.DOCUMENT_POSITION_FOLLOWING );
+		expect( count.compareDocumentPosition( chart ) ).toBe( Node.DOCUMENT_POSITION_FOLLOWING );
+	} );
+
+	it( 'puts the sparkline band after the headline', () => {
+		// Order is the whole point of a content-shaped skeleton: the widgets it
+		// stands in for render the value above the chart.
+		render( <MetricSparklineSkeleton /> );
+
+		const value = screen.getByTestId( 'skeleton-metric-value' );
+		const chart = screen.getByTestId( 'skeleton-chart-block' );
+
+		expect( value.compareDocumentPosition( chart ) ).toBe( Node.DOCUMENT_POSITION_FOLLOWING );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/heatmap-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/heatmap-skeleton.module.scss
@@ -1,8 +1,6 @@
 /* Geometry from the design prototype's `heatmap` skeleton variant: 28 columns
  * of square cells, 4px apart, with the strip inset from the body. */
 $columns: 28;
-$cell-gap: 4px;
-$grid-block-padding: 8px;
 
 /* Auto margins centre the strip the way the loaded heatmap centres in the tile,
  * and — unlike `justify-content` — give up their space instead of pushing the
@@ -17,10 +15,10 @@ $grid-block-padding: 8px;
 	display: grid;
 	grid-template-columns: repeat($columns, 1fr);
 	grid-auto-rows: 1fr;
-	gap: $cell-gap;
+	gap: var(--wpds-dimension-gap-xs);
 	min-block-size: 0;
 	margin-block: auto;
-	padding-block: $grid-block-padding;
+	padding-block: var(--wpds-dimension-padding-sm);
 	overflow: hidden;
 }
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/heatmap-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/heatmap-skeleton.module.scss
@@ -1,0 +1,33 @@
+/* Geometry from the design prototype's `heatmap` skeleton variant: 28 columns
+ * of square cells, 4px apart, with the strip inset from the body. */
+$columns: 28;
+$cell-gap: 4px;
+$grid-block-padding: 8px;
+
+/* Auto margins centre the strip the way the loaded heatmap centres in the tile,
+ * and — unlike `justify-content` — give up their space instead of pushing the
+ * first row past the top of the body.
+ *
+ * The cells' `aspect-ratio` decides the row height while the grid is at its
+ * content height. On a tile too short for that, `min-block-size: 0` lets the
+ * grid shrink to the body instead: `1fr` rows then split the shorter definite
+ * height, so the cells flatten rather than overflowing into the widget footer,
+ * and `overflow: hidden` clips whatever still does not fit. */
+.grid {
+	display: grid;
+	grid-template-columns: repeat($columns, 1fr);
+	grid-auto-rows: 1fr;
+	gap: $cell-gap;
+	min-block-size: 0;
+	margin-block: auto;
+	padding-block: $grid-block-padding;
+	overflow: hidden;
+}
+
+/* `sm` (2px) is the nearest token to the prototype's 3px radius — this package
+ * has no 3px token. */
+.cell {
+	inline-size: 100%;
+	aspect-ratio: 1 / 1;
+	border-radius: var(--wpds-border-radius-sm);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/heatmap-skeleton.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/heatmap-skeleton.tsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { Skeleton } from '@jetpack-premium-analytics/externals';
+/**
+ * Internal dependencies
+ */
+import styles from './heatmap-skeleton.module.scss';
+import { SkeletonRoot } from './skeleton-root';
+
+/** The design prototype's grid: 28 week columns of 3 cells. */
+const COLUMNS = 28;
+const ROWS = 3;
+
+/**
+ * Loading shape for the calendar-heatmap widgets: a fixed grid of square cells.
+ *
+ * The grid is deliberately not derived from the widget: the loaded heatmap's
+ * column count comes from `computeCalendarHeatmapLayout` over the measured tile,
+ * which is only known after the first paint, so a stand-in tracking it would land
+ * on the wrong count and read as the jump it was meant to prevent.
+ *
+ * @return The rendered skeleton.
+ */
+export function HeatmapSkeleton() {
+	return (
+		<SkeletonRoot>
+			{ /* Own wrapper: SkeletonRoot's hidden label is a real element, and the
+			     grid must not lay it out as a cell. */ }
+			<div className={ styles.grid }>
+				{ Array.from( { length: COLUMNS * ROWS }, ( _, index ) => (
+					<Skeleton key={ index } className={ styles.cell } data-testid="skeleton-cell" />
+				) ) }
+			</div>
+		</SkeletonRoot>
+	);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/index.ts
@@ -1,2 +1,7 @@
 export { GenericSkeleton } from './generic-skeleton';
+export { HeatmapSkeleton } from './heatmap-skeleton';
+export {
+	MetricSparklineSkeleton,
+	type MetricSparklineSkeletonProps,
+} from './metric-sparkline-skeleton';
 export { SkeletonRoot, type SkeletonRootProps } from './skeleton-root';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/metric-sparkline-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/metric-sparkline-skeleton.module.scss
@@ -1,0 +1,50 @@
+/* Geometry from the design prototype's `metric` skeleton, which reads lighter
+ * than the loaded headline rather than tracing its 32px/40px type. */
+$headline-padding-block-start: 4px;
+$value-inline-size: 46%;
+$value-block-size: 30px;
+$count-inline-size: 30%;
+$count-block-size: 12px;
+$chart-min-block-size: 26px;
+$chart-padding-block-start: 12px;
+
+/* The loaded headline aligns its count on the value's baseline
+ * (`popular-days`'s `.headline`). These placeholders hold no text, so their
+ * baseline is their bottom edge and `flex-end` reproduces that alignment. */
+.headline {
+	display: flex;
+	align-items: flex-end;
+	gap: var(--wpds-dimension-gap-sm);
+	padding-block-start: $headline-padding-block-start;
+}
+
+/* The prototype's 6px radius has no token here; 8px is the nearest, and at 30px
+ * the block is too tall for the browser to clamp it back to a smaller value. */
+.value {
+	inline-size: $value-inline-size;
+	block-size: $value-block-size;
+	border-radius: var(--wpds-border-radius-lg);
+}
+
+.count {
+	inline-size: $count-inline-size;
+	block-size: $count-block-size;
+	border-radius: var(--wpds-border-radius-md);
+}
+
+/* The band takes whatever the headline leaves, as the loaded widgets' own
+ * `.chart` does; the minimum keeps it legible on a short tile. */
+.chart {
+	display: flex;
+	flex: 1 1 0;
+	min-block-size: $chart-min-block-size;
+	padding-block-start: $chart-padding-block-start;
+}
+
+/* Same nearest-token substitution for 6px as `.value`. */
+.chartBlock {
+	align-self: stretch;
+	inline-size: 100%;
+	block-size: 100%;
+	border-radius: var(--wpds-border-radius-lg);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/metric-sparkline-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/metric-sparkline-skeleton.module.scss
@@ -1,12 +1,9 @@
 /* Geometry from the design prototype's `metric` skeleton, which reads lighter
- * than the loaded headline rather than tracing its 32px/40px type. */
-$headline-padding-block-start: 4px;
+ * than the loaded headline rather than tracing its 32px/40px type. Lengths are
+ * on WPDS dimension tokens; only the proportional widths stay literal, since no
+ * token expresses them. */
 $value-inline-size: 46%;
-$value-block-size: 30px;
 $count-inline-size: 30%;
-$count-block-size: 12px;
-$chart-min-block-size: 26px;
-$chart-padding-block-start: 12px;
 
 /* The loaded headline aligns its count on the value's baseline
  * (`popular-days`'s `.headline`). These placeholders hold no text, so their
@@ -15,20 +12,20 @@ $chart-padding-block-start: 12px;
 	display: flex;
 	align-items: flex-end;
 	gap: var(--wpds-dimension-gap-sm);
-	padding-block-start: $headline-padding-block-start;
+	padding-block-start: var(--wpds-dimension-padding-xs);
 }
 
-/* The prototype's 6px radius has no token here; 8px is the nearest, and at 30px
+/* The prototype's 6px radius has no token here; 8px is the nearest, and at 32px
  * the block is too tall for the browser to clamp it back to a smaller value. */
 .value {
 	inline-size: $value-inline-size;
-	block-size: $value-block-size;
+	block-size: var(--wpds-dimension-size-md);
 	border-radius: var(--wpds-border-radius-lg);
 }
 
 .count {
 	inline-size: $count-inline-size;
-	block-size: $count-block-size;
+	block-size: var(--wpds-dimension-size-3xs);
 	border-radius: var(--wpds-border-radius-md);
 }
 
@@ -37,8 +34,8 @@ $chart-padding-block-start: 12px;
 .chart {
 	display: flex;
 	flex: 1 1 0;
-	min-block-size: $chart-min-block-size;
-	padding-block-start: $chart-padding-block-start;
+	min-block-size: var(--wpds-dimension-size-sm);
+	padding-block-start: var(--wpds-dimension-padding-md);
 }
 
 /* Same nearest-token substitution for 6px as `.value`. */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/metric-sparkline-skeleton.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/metric-sparkline-skeleton.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { Skeleton } from '@jetpack-premium-analytics/externals';
+/**
+ * Internal dependencies
+ */
+import styles from './metric-sparkline-skeleton.module.scss';
+import { SkeletonRoot } from './skeleton-root';
+
+export interface MetricSparklineSkeletonProps {
+	/** Draw a second placeholder beside the value, for headlines that carry a trailing count. */
+	withHeadlineCount?: boolean;
+}
+
+/**
+ * Loading shape for the widgets that put a headline metric over a sparkline:
+ * the headline, and the sparkline band filling what it leaves.
+ *
+ * The prototype stacks a label under the value, but none of these widgets
+ * render one — `popular-days` sits its count beside the weekday on the same
+ * line, and the two totals widgets have no second line at all. So the count is
+ * opt-in and inline, and drawing it is the caller's call.
+ *
+ * @param props                   - Component props.
+ * @param props.withHeadlineCount - Whether the headline carries a trailing count.
+ * @return The rendered skeleton.
+ */
+export function MetricSparklineSkeleton( {
+	withHeadlineCount = false,
+}: MetricSparklineSkeletonProps ) {
+	return (
+		<SkeletonRoot>
+			<div className={ styles.headline }>
+				<Skeleton className={ styles.value } data-testid="skeleton-metric-value" />
+				{ withHeadlineCount && (
+					<Skeleton className={ styles.count } data-testid="skeleton-metric-count" />
+				) }
+			</div>
+			{ /* Own wrapper: the band keeps its minimum height independently of the
+			     headline above it. */ }
+			<div className={ styles.chart }>
+				<Skeleton className={ styles.chartBlock } data-testid="skeleton-chart-block" />
+			</div>
+		</SkeletonRoot>
+	);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/stories/widget-skeleton.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/stories/widget-skeleton.stories.tsx
@@ -1,22 +1,8 @@
+import { WidgetCard } from '../../../stories/widget-card';
 import { GenericSkeleton } from '../generic-skeleton';
+import { HeatmapSkeleton } from '../heatmap-skeleton';
+import { MetricSparklineSkeleton } from '../metric-sparkline-skeleton';
 import type { Meta, StoryObj } from '@storybook/react';
-
-const WidgetCard = ( { height, children }: { height: string; children: React.ReactNode } ) => (
-	<div
-		style={ {
-			width: '360px',
-			height,
-			border: '1px solid var(--wpds-color-stroke-surface-neutral-weak)',
-			borderRadius: 'var(--wpds-border-radius-md)',
-			background: 'var(--wpds-color-background-surface-neutral)',
-			display: 'flex',
-			flexDirection: 'column',
-			overflow: 'hidden',
-		} }
-	>
-		<div style={ { position: 'relative', flex: 1, minHeight: 0 } }>{ children }</div>
-	</div>
-);
 
 const meta: Meta< typeof GenericSkeleton > = {
 	title: 'Packages/Premium Analytics/Widgets Toolkit/Components/WidgetSkeleton',
@@ -48,6 +34,60 @@ export const ShortTile: Story = {
 	render: () => (
 		<WidgetCard height="140px">
 			<GenericSkeleton />
+		</WidgetCard>
+	),
+};
+
+type MetricSparklineStory = StoryObj< typeof MetricSparklineSkeleton >;
+
+/**
+ * The shape the headline-over-sparkline widgets (Total views, Total visitors,
+ * Popular days) pass through `WidgetState`'s `renderLoading`: the metric value
+ * and its label at the top, the sparkline band at the bottom of the body.
+ */
+export const MetricSparkline: MetricSparklineStory = {
+	render: () => (
+		<WidgetCard height="320px">
+			<MetricSparklineSkeleton />
+		</WidgetCard>
+	),
+};
+
+/**
+ * A height-1 dashboard tile. The band gives up its room down to 26px rather
+ * than pushing the shape past the widget body.
+ */
+export const MetricSparklineShortTile: MetricSparklineStory = {
+	render: () => (
+		<WidgetCard height="140px">
+			<MetricSparklineSkeleton />
+		</WidgetCard>
+	),
+};
+
+type HeatmapStory = StoryObj< typeof HeatmapSkeleton >;
+
+/**
+ * The shape the calendar-heatmap widgets (Traffic activity, Posting activity,
+ * Post traffic activity) pass through `WidgetState`'s `renderLoading`: a fixed
+ * 28-column, 3-row grid of square cells, centred in the body.
+ */
+export const Heatmap: HeatmapStory = {
+	render: () => (
+		<WidgetCard width="720px" height="320px">
+			<HeatmapSkeleton />
+		</WidgetCard>
+	),
+};
+
+/**
+ * A height-1 dashboard tile. The rows flatten to the room the body has rather
+ * than pushing the grid past it into the widget footer.
+ */
+export const HeatmapShortTile: HeatmapStory = {
+	render: () => (
+		<WidgetCard width="720px" height="140px">
+			<HeatmapSkeleton />
 		</WidgetCard>
 	),
 };

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -49,6 +49,7 @@ export {
 	type LeaderboardRowProps,
 	type LeaderboardRowVariant,
 	BarChart,
+	BarChartSkeleton,
 	type BarChartProps,
 	type BarChartData,
 	type BarChartStyle,
@@ -126,6 +127,9 @@ export {
 	getWordAdsHistoryFields,
 	type EarningsHistoryRow,
 	GenericSkeleton,
+	HeatmapSkeleton,
+	MetricSparklineSkeleton,
+	type MetricSparklineSkeletonProps,
 	SkeletonRoot,
 	type SkeletonRootProps,
 } from './components';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/revenue-by-customer-type/revenue-by-customer-type-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/revenue-by-customer-type/revenue-by-customer-type-widget.tsx
@@ -5,7 +5,7 @@ import { useReportCustomers, type FilterCondition } from '@jetpack-premium-analy
 import { customer } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import { BarChart, WidgetState } from '../../components';
+import { BarChart, BarChartSkeleton, WidgetState } from '../../components';
 /**
  * Internal dependencies
  */
@@ -66,6 +66,7 @@ function CustomerTypeRevenueWidget( { filter }: CustomerTypeRevenueWidgetProps )
 				icon: customer,
 				description: __( 'No customer revenue in this period.', 'jetpack-premium-analytics-pkg' ),
 			} }
+			renderLoading={ <BarChartSkeleton columns={ 2 } /> }
 		>
 			<BarChart
 				chartData={ chartData }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-coupon/sales-by-coupon-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-coupon/sales-by-coupon-widget.tsx
@@ -5,13 +5,16 @@ import { useReportCoupons } from '@jetpack-premium-analytics/data';
 import { coupon } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import { BarChart, WidgetState } from '../../components';
+import { BarChart, BarChartSkeleton, WidgetState } from '../../components';
 /**
  * Internal dependencies
  */
 import { useWidgetRootContext } from '../../components/widget-root';
 import { buildSalesByCouponData, isEmptyChartData } from '../../helpers';
 import { useBarStyles } from '../common';
+
+/** Top coupons charted individually; the rest are summed into an "Other" bar. */
+const TOP_COUPON_SEGMENTS = 3;
 
 /**
  * Displays a bar chart showing coupon discount distribution.
@@ -27,7 +30,8 @@ export function SalesByCouponWidget() {
 		useReportCoupons( reportParams );
 
 	const { chartData } = useMemo(
-		() => buildSalesByCouponData( primary.data, comparison.data, reportParams, 3 ),
+		() =>
+			buildSalesByCouponData( primary.data, comparison.data, reportParams, TOP_COUPON_SEGMENTS ),
 		[ primary.data, comparison.data, reportParams ]
 	);
 
@@ -53,6 +57,7 @@ export function SalesByCouponWidget() {
 				icon: coupon,
 				description: __( 'No coupon sales in this period.', 'jetpack-premium-analytics-pkg' ),
 			} }
+			renderLoading={ <BarChartSkeleton columns={ TOP_COUPON_SEGMENTS + 1 } /> }
 		>
 			<BarChart
 				chartData={ chartData }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-device/sales-by-device-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-device/sales-by-device-widget.tsx
@@ -5,7 +5,7 @@ import { useReportOrderAttribution, type FilterCondition } from '@jetpack-premiu
 import { device } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import { BarChart, WidgetState } from '../../components';
+import { BarChart, BarChartSkeleton, WidgetState } from '../../components';
 /**
  * Internal dependencies
  */
@@ -81,6 +81,7 @@ export function SalesByDeviceWidget( {
 				description:
 					emptyStateText ?? __( 'No sales data in this period.', 'jetpack-premium-analytics-pkg' ),
 			} }
+			renderLoading={ <BarChartSkeleton /> }
 		>
 			<BarChart
 				chartData={ chartData }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/total-returns/total-returns-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/total-returns/total-returns-widget.tsx
@@ -5,7 +5,7 @@ import { useReportOrders } from '@jetpack-premium-analytics/data';
 import { paymentReturn } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import { BarChart, WidgetState } from '../../components';
+import { BarChart, BarChartSkeleton, WidgetState } from '../../components';
 /**
  * Internal dependencies
  */
@@ -52,6 +52,7 @@ export function TotalReturnsWidget() {
 				icon: paymentReturn,
 				description: __( 'No returns in this period.', 'jetpack-premium-analytics-pkg' ),
 			} }
+			renderLoading={ <BarChartSkeleton columns={ 2 } /> }
 		>
 			<BarChart
 				chartData={ chartData }

--- a/projects/packages/premium-analytics/widgets/popular-days/render.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-days/render.tsx
@@ -4,6 +4,7 @@
 import { calendar } from '@jetpack-premium-analytics/icons';
 import {
 	describeError,
+	MetricSparklineSkeleton,
 	PeakDistribution,
 	WidgetRoot,
 	WidgetState,
@@ -62,6 +63,7 @@ function PopularDaysReport() {
 					icon: calendar,
 					description: __( 'No views in this period.', 'jetpack-premium-analytics-pkg' ),
 				} }
+				renderLoading={ <MetricSparklineSkeleton withHeadlineCount /> }
 			>
 				<PeakDistribution
 					label={ peak?.label ?? '' }

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -6,6 +6,7 @@ import { reports } from '@jetpack-premium-analytics/icons';
 import {
 	CalendarHeatmapTooltip,
 	HeatmapChartUnresponsive,
+	HeatmapSkeleton,
 	WidgetRoot,
 	WidgetState,
 	buildCalendarHeatmapData,
@@ -156,6 +157,7 @@ function PostTrafficActivityInner() {
 							'jetpack-premium-analytics-pkg'
 						),
 					} }
+					renderLoading={ <HeatmapSkeleton /> }
 				>
 					<div className={ styles.content }>
 						{ /* The pager centers with the grid as one block; it only exists

--- a/projects/packages/premium-analytics/widgets/posting-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/render.tsx
@@ -7,6 +7,7 @@ import {
 	AdaptiveCalendarHeatmap,
 	CalendarHeatmapTooltip,
 	HeatmapChartUnresponsive,
+	HeatmapSkeleton,
 	WidgetRoot,
 	WidgetState,
 	describeError,
@@ -119,6 +120,7 @@ function PostingActivityInner() {
 							'jetpack-premium-analytics-pkg'
 						),
 					} }
+					renderLoading={ <HeatmapSkeleton /> }
 				>
 					{ /* No legend: the cell tooltips carry the counts, and the legend's
 					     44px comes out of the cells. */ }

--- a/projects/packages/premium-analytics/widgets/total-views/render.tsx
+++ b/projects/packages/premium-analytics/widgets/total-views/render.tsx
@@ -6,6 +6,7 @@ import { Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import {
 	describeError,
+	MetricSparklineSkeleton,
 	Sparkline,
 	useWidgetRootContext,
 	WidgetRoot,
@@ -98,6 +99,7 @@ function TotalViewsMetric() {
 					icon: seen,
 					description: __( 'No views in this period.', 'jetpack-premium-analytics-pkg' ),
 				} }
+				renderLoading={ <MetricSparklineSkeleton /> }
 			>
 				<div className={ styles.body }>
 					{ /* Not `MetricValue`: it pins a 20px line-height at any font size, which

--- a/projects/packages/premium-analytics/widgets/total-visitors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/total-visitors/render.tsx
@@ -6,6 +6,7 @@ import { Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import {
 	describeError,
+	MetricSparklineSkeleton,
 	Sparkline,
 	useWidgetRootContext,
 	WidgetRoot,
@@ -99,6 +100,7 @@ function TotalVisitorsMetric() {
 					icon: people,
 					description: __( 'No visitors in this period.', 'jetpack-premium-analytics-pkg' ),
 				} }
+				renderLoading={ <MetricSparklineSkeleton /> }
 			>
 				<div className={ styles.body }>
 					{ /* Not `MetricValue`: it pins a 20px line-height at any font size, which

--- a/projects/packages/premium-analytics/widgets/traffic-views-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-views-activity/render.tsx
@@ -12,6 +12,7 @@ import {
 	AdaptiveCalendarHeatmap,
 	CalendarHeatmapTooltip,
 	HeatmapChartUnresponsive,
+	HeatmapSkeleton,
 	WidgetRoot,
 	WidgetState,
 	describeError,
@@ -145,6 +146,7 @@ function TrafficViewsActivityInner() {
 						icon: seen,
 						description: emptyDescription,
 					} }
+					renderLoading={ <HeatmapSkeleton /> }
 				>
 					<HeatmapChartUnresponsive
 						{ ...chartProps }


### PR DESCRIPTION
Part of WOOA7S-1781. Third of four; #51236 has merged, so this now targets trunk.

## Proposed changes

- Add `MetricSparklineSkeleton` for the three widgets that put a headline over a sparkline. Its count placeholder is opt-in: only `popular-days` renders one, and it sits beside the headline rather than under it, so the other two would settle into a line that never appears.
- Add `BarChartSkeleton` for the four `BarChart` widgets. It takes a `columns` prop because three of them know their bar count up front — two fixed bars each, and top-3-plus-Other for coupons.
- Add `HeatmapSkeleton` for the three calendar heatmaps. Its grid is fixed: the real one sizes itself from the tile after measuring it, so a derived count would jump on the frame the measurement lands.

## Screenshots

Storybook → _Widgets Toolkit / Components_, each at its widget's standard tile height.

**`MetricSparklineSkeleton`** — Total views, Total visitors, Popular days

<img src="https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1781-widget-skeleton-charts/metric-sparkline-skeleton.png" width="360">

**`HeatmapSkeleton`** — Traffic activity, Posting activity, Post traffic activity

<img src="https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1781-widget-skeleton-charts/heatmap-skeleton.png" width="720">

**`BarChartSkeleton`** — the Woo store's bar-chart widgets

<img src="https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1781-widget-skeleton-charts/bar-chart-skeleton.png" width="360">

## Related product discussion/links

- WOOA7S-1781

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open the Premium Analytics dashboard with a throttled connection (DevTools → Network → Slow 4G) and reload.
- Total views, Total visitors and Popular days should show a headline block over a full-width sparkline block.
- Traffic views activity, Posting activity and Post traffic activity should show a grid of square cells, clipped to the body on a short tile.
- The Woo store's bar-chart widgets should show bottom-aligned columns matching the bar count that loads.
- Storybook → _Widgets Toolkit / Components_ → `BarChart` and `WidgetSkeleton` have the new `Skeleton` stories.

