### PR TITLE
Premium Analytics: give the Insights views heatmap two rows by default

### DIFF
--- a/projects/packages/premium-analytics/changelog/change-insights-views-activity-two-rows
+++ b/projects/packages/premium-analytics/changelog/change-insights-views-activity-two-rows
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Insights: give the Traffic views activity heatmap two rows by default, so each day shows its view count.

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -362,15 +362,15 @@ function get_dashboard_default_section_layouts() {
 				1,
 				1
 			),
-			// Row 5: daily views heatmap. One row tall, as in the prototype: at this
-			// height it renders compact squares, so the tile's width buys years of
-			// history instead of the ~14 weeks labelled cells would fit.
+			// Row 5: daily views heatmap. Two rows tall, as in the prototype: the
+			// cells are sized from the tile's height, and only at this height do they
+			// grow wide enough to label each day with its view count.
 			get_dashboard_default_widget_instance(
 				'default-traffic-views-activity-widget-instance',
 				'jpa/traffic-views-activity',
 				8,
 				4,
-				1
+				2
 			),
 			// Row 6: the comment leaderboards, shares, and tags.
 			get_dashboard_default_widget_instance(

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -291,7 +291,7 @@ class Dashboard_Layout_Test extends BaseTestCase {
 			'default-total-visitors-widget-instance'       => array( 'jpa/total-visitors', 1, 1, 5 ),
 			'default-popular-days-widget-instance'         => array( 'jpa/popular-days', 1, 1, 6 ),
 			'default-most-popular-day-widget-instance'     => array( 'jpa/most-popular-day', 1, 1, 7 ),
-			'default-traffic-views-activity-widget-instance' => array( 'jpa/traffic-views-activity', 4, 1, 8 ),
+			'default-traffic-views-activity-widget-instance' => array( 'jpa/traffic-views-activity', 4, 2, 8 ),
 			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 9 ),
 			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 10 ),
 			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 11 ),


### PR DESCRIPTION
## Proposed changes

- Insights default layout: Traffic views activity is now two rows tall instead of one.
- The heatmap sizes its cells from the tile's height, so at two rows they grow wide enough to label each day with its view count — the way the prototype shows it. At one row they collapse to compact unlabelled squares.
- Updates the layout test and the comment that justified the one-row placement.

Only the bundled default changes; anyone who has already customized their Insights layout keeps their own placement until they reset it.

## Related product discussion/links

-

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open the Premium Analytics dashboard and go to the **Insights** tab.
- If you have customized this tab before, reset the layout to the default first.
- The **Traffic views activity** heatmap should occupy two grid rows and show a view count inside each day cell, instead of a one-row strip of small unlabelled squares.
- Resize the browser and confirm the grid still fills the tile without overflowing, and that the tooltips still name the right day.
