### PR TITLE
Premium Analytics: Hide the Shares widget outside WPCOM Simple

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1720-shares-simple-only
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1720-shares-simple-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Shares: Hide the widget outside WPCOM Simple, where share counts are never recorded.

--- a/projects/packages/premium-analytics/src/widget-type-support.php
+++ b/projects/packages/premium-analytics/src/widget-type-support.php
@@ -36,6 +36,13 @@ function get_unsupported_widget_types( $context ) {
 	// the same boundary, which excludes self-hosted Jetpack and Atomic sites.
 	if ( ! $context['is_wpcom_simple'] ) {
 		$unsupported[] = 'jpa/file-downloads';
+
+		// Share counts are recorded when the share request is processed, which
+		// only happens on WPCOM Simple. Elsewhere the button click is handled by
+		// the site itself and never reaches the counter, so the site summary's
+		// `shares_<service>` fields stay at zero however much the content is
+		// shared. Calypso excludes the module on the same grounds.
+		$unsupported[] = 'jpa/shares';
 	}
 
 	return $unsupported;

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -210,6 +210,28 @@ class Dashboard_Layout_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Shares is Simple-only too, so the Insights default drops it on self-hosted
+	 * Jetpack sites (this test env).
+	 */
+	public function test_insights_default_excludes_shares_on_self_hosted() {
+		$layout_types = array_column( get_dashboard_default_layout_for( DASHBOARD_INSIGHTS_SECTION_ID ), 'type' );
+
+		$this->assertNotContains( 'jpa/shares', $layout_types, 'Simple-only widget instances must not be part of the default layout on self-hosted sites.' );
+		$this->assertContains( 'jpa/tags', $layout_types, 'Regular widget instances remain in the default layout.' );
+	}
+
+	/**
+	 * WPCOM Simple keeps Shares in the Insights default.
+	 */
+	public function test_insights_default_keeps_shares_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		$layout_types = array_column( get_dashboard_default_layout_for( DASHBOARD_INSIGHTS_SECTION_ID ), 'type' );
+
+		$this->assertContains( 'jpa/shares', $layout_types );
+	}
+
+	/**
 	 * Traffic section aliases resolve to the same default layout.
 	 */
 	public function test_traffic_aliases_resolve_same_default_layout() {

--- a/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
@@ -67,6 +67,10 @@ class Widget_Availability_Test extends BaseTestCase {
 				'category' => 'traffic',
 			),
 			array(
+				'name'     => 'jpa/shares',
+				'category' => 'traffic',
+			),
+			array(
 				'name'     => 'jpa/hello-world',
 				'category' => 'demo',
 			),
@@ -153,6 +157,23 @@ class Widget_Availability_Test extends BaseTestCase {
 	 */
 	public function test_type_policy_keeps_file_downloads_on_simple() {
 		$this->assertContains( 'jpa/file-downloads', $this->available_names( true ) );
+	}
+
+	/**
+	 * Shares is unavailable outside WPCOM Simple, where nothing records a share.
+	 */
+	public function test_type_policy_removes_shares_on_non_simple() {
+		$names = $this->available_names( false );
+
+		$this->assertNotContains( 'jpa/shares', $names );
+		$this->assertContains( 'jpa/hello-world', $names );
+	}
+
+	/**
+	 * WPCOM Simple keeps Shares.
+	 */
+	public function test_type_policy_keeps_shares_on_simple() {
+		$this->assertContains( 'jpa/shares', $this->available_names( true ) );
 	}
 
 	/**
@@ -362,9 +383,9 @@ class Widget_Availability_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The host callback removes File downloads on Atomic.
+	 * The host callback removes the Simple-only types on Atomic.
 	 */
-	public function test_registry_callback_removes_file_downloads_on_atomic() {
+	public function test_registry_callback_removes_simple_only_types_on_atomic() {
 		Constants::set_constant( 'ATOMIC_SITE_ID', 123 );
 		Constants::set_constant( 'ATOMIC_CLIENT_ID', 456 );
 
@@ -374,12 +395,13 @@ class Widget_Availability_Test extends BaseTestCase {
 		);
 
 		$this->assertNotContains( 'jpa/file-downloads', $names );
+		$this->assertNotContains( 'jpa/shares', $names );
 	}
 
 	/**
-	 * The host callback keeps File downloads on WPCOM Simple.
+	 * The host callback keeps the Simple-only types on WPCOM Simple.
 	 */
-	public function test_registry_callback_keeps_file_downloads_on_wpcom_simple() {
+	public function test_registry_callback_keeps_simple_only_types_on_wpcom_simple() {
 		Constants::set_constant( 'IS_WPCOM', true );
 
 		$names = array_column(
@@ -388,6 +410,7 @@ class Widget_Availability_Test extends BaseTestCase {
 		);
 
 		$this->assertContains( 'jpa/file-downloads', $names );
+		$this->assertContains( 'jpa/shares', $names );
 	}
 
 	/**


### PR DESCRIPTION
Fixes WOOA7S-1720

## Proposed changes

- Add `jpa/shares` to the Simple-only widget types, next to `jpa/file-downloads`.
- Drop the widget from the widget picker, the REST widget-modules list, and the Insights default layout on self-hosted Jetpack and Atomic sites.
- Leave persisted layouts untouched, so an already-saved Shares instance stays as a removable ghost widget.
- Cover the new boundary in the availability and default-layout tests.

Share counts are recorded where the share request is processed, and that only happens on WordPress.com Simple. Everywhere else the button click is handled by the site itself and never reaches the counter, so the site summary's `shares_<service>` fields stay at zero however much the content is shared — the widget renders its empty state rather than erroring, which is why this went unnoticed. Calypso excludes the module on the same grounds (`! isJetpackSite()` in `client/my-sites/stats/pages/insights/index.jsx`); the port already dropped the other half of that reason by no longer calling `/sites/{id}/sharing-buttons`.

## Related product discussion/links

- WOOA7S-1720
- #50732 — the same boundary, for File downloads

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Self-hosted Jetpack or another non-Simple site

1. Build the package: `jetpack build packages/premium-analytics --deps`.
2. Open the Analytics dashboard's **Insights** tab. **Top social media shares** is gone from the default layout — the comment leaderboards row now ends at **Top tags & categories**.
3. Open **Customize → Add widget** and search for `shares`. It returns **No results**.
4. Confirm `GET /wpcom/v2/widget-modules` no longer lists `jpa/shares`.
5. If you have an Insights layout saved before this branch that contains Shares, confirm it is left in place and renders as **Widget is no longer available.** Enter **Customize** and remove it.

Before this branch, the widget sat in that row but only ever showed its empty state ("Learn where your content has been shared the most"): `GET /rest/v1.1/sites/{id}/stats` on a Jetpack-connected site returns `shares`, `shares_x` and `shares_facebook`, all `0`.

<img width="2542" height="1249" alt="Screenshot 2026-08-13 at 4 28 43 PM" src="https://github.com/user-attachments/assets/3dcc4ac3-b950-4537-9f70-ee06fba00326" />



### WordPress.com Simple

1. On a sandbox: `bin/jetpack-downloader test jetpack-mu-wpcom-plugin change/shares-simple-only`.
2. Sandbox the test site and `public-api.wordpress.com` in `/etc/hosts`.
3. Open Premium Analytics on a Simple site carrying the `jetpack-premium-analytics` sticker:

   ```
   wp blog-stickers add --sticker=jetpack-premium-analytics --who=<your_wpcom_login> --blog_id=<blog_id>
   ```

4. Confirm Shares stays in the Insights default layout and in the widget picker.

<img width="2560" height="1253" alt="Screenshot 2026-08-13 at 4 28 55 PM" src="https://github.com/user-attachments/assets/57a3affe-6b4c-4bca-95b8-5f9509407692" />
