### PR TITLE
Premium Analytics: settle the pinned section header into a chrome bar

### DIFF
--- a/projects/packages/premium-analytics/changelog/section-header-subtitle-condense
+++ b/projects/packages/premium-analytics/changelog/section-header-subtitle-condense
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: fade the section header subtitle out as the widgets scroll.

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.module.scss
@@ -32,9 +32,12 @@ $section-header-title-min-inline-size: 200px;
 	grid-template-columns: minmax($section-header-title-min-inline-size, 1fr) minmax(0, max-content);
 	align-items: start;
 
-	// One value on both axes: it separates the title from the controls beside it
-	// and from the subtitle below, stacked or not.
-	gap: var(--wpds-dimension-gap-sm);
+	// Separates the title from the controls beside it. The rows carry their own
+	// spacing as padding instead: a row gap belongs to the track, so nothing
+	// inside a row can give it back, and a condensed subtitle would leave its
+	// gap behind as a band under the title.
+	column-gap: var(--wpds-dimension-gap-sm);
+	row-gap: 0;
 
 	.title {
 		overflow: hidden;
@@ -42,8 +45,90 @@ $section-header-title-min-inline-size: 200px;
 		white-space: nowrap;
 	}
 
-	.subtitle {
+	// The row rather than the text: condensing animates the row, so it has to be
+	// the thing the grid places. It also carries the spacing the row gap used to
+	// provide, as padding it can give back on its way out.
+	.subtitleRow {
 		grid-column: 1 / -1;
+		padding-block-start: var(--wpds-dimension-gap-sm);
+	}
+}
+
+/*
+ * Settles the header into a chrome bar as it pins: the subtitle fades and hands
+ * its row back to the content below, and the title drops a step on the type
+ * scale so the pinned band stops reading as the page's own heading.
+ *
+ * The timeline is the surface's, not this component's: the header knows nothing
+ * about what sits above it, so it cannot know the scroll offset at which it
+ * pins, and starting from the top of the scroll would condense it while it is
+ * still on its way up. The surface publishes a `--section-header-pin` view
+ * timeline instead, whose `exit` phase begins the moment the header sticks and
+ * runs for however far the surface wants the fade to take.
+ *
+ * Progress-driven rather than threshold-driven, so it follows the scroll in
+ * both directions instead of playing on its own once a boundary is crossed.
+ * Reclaiming the row means animating layout, not just paint, so this does cost
+ * a layout pass per frame while it runs; the range is deliberately short so
+ * that stays bounded. Where the timeline is unsupported or absent the subtitle
+ * simply stays, which is the resting layout.
+ *
+ * What animates is the grid row: `fr` values interpolate, so it shrinks to
+ * nothing without anything having to measure a string whose length changes with
+ * the date configuration. The padding above it goes at the same time, which is
+ * why that spacing is not the grid's row gap: a gap belongs to the track, so
+ * the row could not take it along and would leave a band under the title.
+ */
+.condensing {
+
+	.subtitleRow {
+		display: grid;
+		grid-template-rows: 1fr;
+		animation: condense-subtitle linear both;
+		animation-timeline: --section-header-pin;
+		animation-range: exit;
+
+		> .subtitle {
+			min-block-size: 0;
+			overflow: hidden;
+		}
+	}
+
+	// A step down the type scale, paired line height included. This buys no
+	// height: the row is floored by the date controls beside it, which keep
+	// theirs. What it changes is what the pinned band says it is.
+	.title {
+		animation: condense-title linear both;
+		animation-timeline: --section-header-pin;
+		animation-range: exit;
+	}
+}
+
+@keyframes condense-subtitle {
+
+	to {
+		grid-template-rows: 0fr;
+		opacity: 0;
+		padding-block-start: 0;
+	}
+}
+
+@keyframes condense-title {
+
+	to {
+		font-size: var(--wpds-typography-font-size-xl);
+		line-height: var(--wpds-typography-line-height-xl);
+	}
+}
+
+// The effect tracks the reader's own scrolling rather than playing by itself,
+// but it is still chrome moving under them, so it comes off with the
+// preference. The header then holds still, as it does without timeline support.
+@media (prefers-reduced-motion: reduce) {
+
+	.condensing .subtitleRow,
+	.condensing .title {
+		animation: none;
 	}
 }
 
@@ -88,14 +173,17 @@ $section-header-title-min-inline-size: 200px;
 
 	// One column, so source order would leave the controls between the title and
 	// the subtitle describing it.
-	.subtitle {
+	.subtitleRow {
 		order: 1;
 	}
 
 	// Last row, reading from the same edge as the title instead of the far one.
+	// A row of its own here, so it carries the spacing above it the way the
+	// subtitle does; beside the title there is nothing above it to clear.
 	.controls {
 		order: 2;
 		justify-content: flex-start;
+		padding-block-start: var(--wpds-dimension-gap-sm);
 
 		:global(.date-filters-panel__row) {
 			justify-content: flex-start;

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.tsx
@@ -1,4 +1,5 @@
 import { Stack, Text } from '@jetpack-premium-analytics/externals';
+import clsx from 'clsx';
 import { ReactNode } from 'react';
 import styles from './section-header.module.scss';
 
@@ -10,6 +11,21 @@ type SectionHeaderProps = {
 	 * consumer has nothing to describe.
 	 */
 	subtitle?: string;
+
+	/**
+	 * Settles the header into a chrome bar once it pins: the subtitle fades and
+	 * gives its row back to the content below, and the title drops a step on
+	 * the type scale. For surfaces that pin this header, where it would
+	 * otherwise hold a page heading's worth of the viewport for the whole
+	 * scroll. Off by default: where the header scrolls away with the content
+	 * there is nothing to settle into.
+	 *
+	 * The surface has to say where it pins, since this component cannot know
+	 * what sits above it. Turning this on without publishing a
+	 * `--section-header-pin` view timeline leaves the header as it is. See the
+	 * dashboard's pin marker in `routes/dashboard/stage.module.scss`.
+	 */
+	condenseOnScroll?: boolean;
 
 	/**
 	 * Date controls anchored to the end of the header row.
@@ -32,9 +48,14 @@ type SectionHeaderProps = {
  * @param {SectionHeaderProps} props - The props for the SectionHeader component.
  * @return The section header element.
  */
-export function SectionHeader( { title, subtitle, children }: SectionHeaderProps ) {
+export function SectionHeader( {
+	title,
+	subtitle,
+	condenseOnScroll = false,
+	children,
+}: SectionHeaderProps ) {
 	return (
-		<div className={ styles.container }>
+		<div className={ clsx( styles.container, condenseOnScroll && styles.condensing ) }>
 			<div className={ styles.layout }>
 				{ /* The `title` attribute is the only way back to a name the
 				     ellipsis cut off. */ }
@@ -47,9 +68,11 @@ export function SectionHeader( { title, subtitle, children }: SectionHeaderProps
 				</Stack>
 
 				{ subtitle ? (
-					<Text className={ styles.subtitle } variant="body-md">
-						{ subtitle }
-					</Text>
+					<div className={ styles.subtitleRow }>
+						<Text className={ styles.subtitle } variant="body-md">
+							{ subtitle }
+						</Text>
+					</div>
 				) : null }
 			</div>
 		</div>

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/stories/section-header.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/stories/section-header.stories.tsx
@@ -278,9 +278,10 @@ function YearDateControls( {
 type SectionHeaderStoryProps = {
 	title: string;
 	subtitle?: string;
+	condenseOnScroll?: boolean;
 };
 
-function RollingSectionHeaderStory( { title }: SectionHeaderStoryProps ) {
+function RollingSectionHeaderStory( { title, condenseOnScroll }: SectionHeaderStoryProps ) {
 	const [ applied, setApplied ] = useState< AppliedDateState >( () => {
 		const initial = buildInitialPrimaryState();
 
@@ -292,7 +293,11 @@ function RollingSectionHeaderStory( { title }: SectionHeaderStoryProps ) {
 	} );
 
 	return (
-		<SectionHeader title={ title } subtitle={ getSectionSubtitle( applied ) }>
+		<SectionHeader
+			title={ title }
+			subtitle={ getSectionSubtitle( applied ) }
+			condenseOnScroll={ condenseOnScroll }
+		>
 			<RollingDateControls onAppliedChange={ setApplied } />
 		</SectionHeader>
 	);
@@ -372,6 +377,60 @@ export const Stacked: Story = {
 	render: ( { title } ) => (
 		<div style={ { inlineSize: 520 } }>
 			<RollingSectionHeaderStory title={ title } />
+		</div>
+	),
+};
+
+/*
+ * Story-only stand-in for what a real surface provides around a pinned header:
+ * a strip above it to scroll past, and the pin marker whose view timeline says
+ * when the header has come to rest. The dashboard does this in
+ * `routes/dashboard/stage.module.scss`; here it is inline so the story stays
+ * self-contained.
+ */
+const PIN_TIMELINE = '--section-header-pin';
+const PIN_MARKER_STYLE = {
+	position: 'absolute',
+	insetBlockStart: 0,
+	inlineSize: 1,
+	blockSize: 40,
+	visibility: 'hidden',
+	pointerEvents: 'none',
+	viewTimelineName: PIN_TIMELINE,
+	viewTimelineAxis: 'block',
+} as const;
+
+/**
+ * `condenseOnScroll` on a pinned header: scroll the box below, and once
+ * the header clears the strip above it and comes to rest, the subtitle fades
+ * and hands its row back over the next 40px. Before that it holds still, so
+ * nothing condenses while the header is on its way up.
+ *
+ * The effect follows the scroll rather than playing once a threshold is
+ * crossed, so it also runs backwards on the way down. Browsers without
+ * scroll-progress timelines, surfaces that publish no pin marker, and readers
+ * who asked for reduced motion all keep the subtitle where it is.
+ */
+export const CondensingOnScroll: Story = {
+	args: {
+		title: 'Site traffic',
+	},
+	render: ( { title } ) => (
+		<div style={ { blockSize: 320, overflowY: 'auto' } }>
+			<div style={ { blockSize: 48 } }>Something to scroll past, as the section tabs are.</div>
+			<div style={ { position: 'relative', timelineScope: PIN_TIMELINE } }>
+				<div style={ PIN_MARKER_STYLE } aria-hidden="true" />
+				<div
+					style={ {
+						position: 'sticky',
+						insetBlockStart: 0,
+						background: 'var(--wpds-color-background-surface-neutral-strong)',
+					} }
+				>
+					<RollingSectionHeaderStory title={ title } condenseOnScroll />
+				</div>
+				<div style={ { blockSize: 900 } } />
+			</div>
 		</div>
 	),
 };

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
@@ -32,9 +32,15 @@
 	padding-inline: var(--wpds-dimension-padding-2xl);
 	z-index: 0;
 
-	// The gap under the tabs moves into the section header below, whose fill
-	// bleeds to the page edges and so has to begin at the tabs' hairline instead
-	// of after a strip of canvas. Only here: the same tab bar carries post
-	// detail and the report pages, which have nothing opaque beneath it.
+	/*
+	 * The page header's fill, which the section header below also takes: the
+	 * tabs and that header are the page's own chrome, not part of the surface
+	 * the widgets sit on, so the whole block above the grid reads as one plane
+	 * and the canvas begins where the widgets do.
+	 */
+	background: var(--wpds-color-background-surface-neutral-strong);
+
+	// The gap under the tabs moves into the section header below, so its fill
+	// begins at the tabs' hairline instead of after a strip of canvas.
 	margin-block-end: 0;
 }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -62,8 +62,6 @@
 	position: relative;
 	timeline-scope: --section-header-pin;
 
-	// Reserve paint space for the widget host's outer focus outline.
-	padding-block-start: calc(var(--wpds-border-width-focus) + 2px);
 	padding-block-end: var(--wpds-dimension-padding-3xl);
 	// Match the horizontal padding of the page header and the section tabs so the
 	// widget grid lines up with them instead of sitting flush to the edge.
@@ -140,6 +138,8 @@
 	// this surface so it falls inside the fill rather than before it.
 	padding-block-start: var(--wpds-dimension-gap-lg);
 	padding-block-end: var(--wpds-dimension-gap-lg);
+
+	margin-block-end: var(--wpds-dimension-gap-lg);
 
 	// Tightens to the same beat as the subtitle it sits around: at rest the
 	// padding holds the header apart from the tabs above and the grid below,

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -56,6 +56,12 @@
 	// never rendered.
 	flex: 1 1 auto;
 
+	// Containing block for the pin marker below, and the scope that lets the
+	// marker's timeline reach the header beside it: a named timeline is
+	// otherwise invisible to anything but its own descendants.
+	position: relative;
+	timeline-scope: --section-header-pin;
+
 	// Reserve paint space for the widget host's outer focus outline.
 	padding-block-start: calc(var(--wpds-border-width-focus) + 2px);
 	padding-block-end: var(--wpds-dimension-padding-3xl);
@@ -83,6 +89,27 @@
 	}
 }
 
+/*
+ * Tells the section header where it pins, so its subtitle starts condensing
+ * there rather than from the top of the scroll. The header cannot work this out
+ * itself: what it has to clear is the section tabs, which belong to this route.
+ *
+ * The marker is measured, never seen. Sitting at the top of the panel puts its
+ * own leading edge exactly where the header comes to rest, so the `exit` phase
+ * of its view timeline opens the moment the header sticks, and its height is
+ * how far the fade then runs.
+ */
+.pinMarker {
+	position: absolute;
+	inset-block-start: 0;
+	inline-size: 1px;
+	block-size: 40px;
+	visibility: hidden;
+	pointer-events: none;
+	view-timeline-name: --section-header-pin;
+	view-timeline-axis: block;
+}
+
 .sectionHeader {
 	// Pins directly under the page header. The offset is 0 rather than that
 	// header's height because the scroll container is the sections root, which
@@ -91,11 +118,16 @@
 	inset-block-start: 0;
 	z-index: 1;
 
-	// A stuck header has to be opaque, and it takes the fill and hairline of the
-	// page header it pins under so the two read as one piece of chrome. That
-	// means reaching the page edges the way that header does: the panel's gutter
-	// is given back as padding, so the header row itself does not move, and the
-	// container query measuring it sees the same width as before.
+	/*
+	 * A stuck header has to be opaque, and it takes the page header's fill, as
+	 * the section tabs above it do: this header is the page's own chrome, not
+	 * part of the surface the widgets sit on, and the canvas begins where the
+	 * grid does. The hairline is the edge between the two.
+	 *
+	 * It spans the page edges to cover everything that passes under it, which
+	 * means giving the panel's gutter back as padding, so the header row itself
+	 * does not move and the container query measuring it sees the same width.
+	 */
 	margin-inline: calc(-1 * var(--wpds-dimension-padding-2xl));
 	padding-inline: var(--wpds-dimension-padding-2xl);
 	background: var(--wpds-color-background-surface-neutral-strong);
@@ -108,4 +140,27 @@
 	// this surface so it falls inside the fill rather than before it.
 	padding-block-start: var(--wpds-dimension-gap-lg);
 	padding-block-end: var(--wpds-dimension-gap-lg);
+
+	// Tightens to the same beat as the subtitle it sits around: at rest the
+	// padding holds the header apart from the tabs above and the grid below,
+	// and once pinned there are no tabs left to clear and the band should cost
+	// the widgets as little as it can. Same marker, so the two move as one.
+	animation: condense-section-header linear both;
+	animation-timeline: --section-header-pin;
+	animation-range: exit;
+}
+
+@keyframes condense-section-header {
+
+	to {
+		padding-block-start: var(--wpds-dimension-gap-sm);
+		padding-block-end: var(--wpds-dimension-gap-sm);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+	.sectionHeader {
+		animation: none;
+	}
 }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -219,10 +219,15 @@ function Dashboard(): JSX.Element {
 								value={ section.slug }
 								className={ styles.content }
 							>
+								{ /* Marks where the header below comes to rest, so its subtitle
+								     starts condensing there. Measured, never seen. */ }
+								<div className={ styles.pinMarker } aria-hidden="true" />
+
 								<div ref={ setContainerElement } className={ styles.sectionHeader }>
 									<SectionHeader
 										title={ resolveSectionHeading( section ) }
 										subtitle={ sectionSubtitle }
+										condenseOnScroll
 									>
 										{ dateControls }
 									</SectionHeader>


### PR DESCRIPTION
Closes WOOA7S-1825

## Proposed changes

Once the section header pins, it stops looking like the page's own heading and becomes a chrome bar. Three things happen across the same 40px of scroll:

- The subtitle fades out and gives its row back to the widgets.
- The band's vertical padding tightens from `gap-lg` to `gap-sm`.
- The title drops from `font-size-2xl` to `font-size-xl`, with the paired line height.

Pinned chrome goes from 190px to 146px. The title change buys none of that: the header row is floored by the date controls beside it, not by the title. It is there so the pinned band reads as chrome, not as a heading.

The section tabs also take the page header's fill now, so the whole block above the grid is one plane and the canvas starts where the widgets do.

<!-- SCREENSHOT: resting state, full header with subtitle -->

<!-- SCREENSHOT: pinned state, condensed -->

<!-- VIDEO: scrolling down and back up, showing the fade tracking the scroll in both directions -->

## How it works

`SectionHeader` gains one opt-in prop, `condenseOnScroll`, off by default. Where the header scrolls away with the content there is nothing to settle into.

The animation is a **scroll-progress timeline**, not a threshold: it follows the scroll and runs backwards on the way up, with no boundary to cross and no hysteresis to tune.

**The surface says where the header pins.** The component cannot know: what the header has to clear is the section tabs, which belong to the route. So the route publishes a `--section-header-pin` view timeline from a 1×40px marker, out of flow and unpainted, sitting at the top of the tab panel. Its leading edge is exactly where the header comes to rest, so the timeline's `exit` phase opens the moment it sticks, and the marker's height is how far the fade runs.

Two details worth knowing while reviewing:

**`timeline-scope` is required.** A named timeline is invisible to siblings, only to descendants. Without it on the panel the name silently fails to resolve and nothing animates.

**The subtitle collapses via `grid-template-rows: 1fr → 0fr`.** `fr` values interpolate, so the row shrinks to nothing without anyone measuring a string whose length changes with the date configuration. Its spacing is `padding` on the row rather than the grid's `row-gap`, because a gap belongs to the track: the row cannot take it along and would leave a band under the title.

## Trade-offs

**It animates layout, not just paint.** Reclaiming space means a layout pass per frame while the range is active, with the widget grid below. The range is deliberately short to bound it. Worth a look on a slow machine with many widgets.

**It degrades to nothing.** No scroll-progress timeline support, no marker published, or `prefers-reduced-motion` set, and the header simply stays as it is today. Verified in Chrome 151; other engines not checked here, so treat it as progressive enhancement rather than guaranteed behaviour.

## Related product discussion/links

* [WOOA7S-1793](https://linear.app/a8c/issue/WOOA7S-1793) is the umbrella for this surface
* #51232 is the base branch: it pins the header and fixes the page header sliding away
* [WOOA7S-1931](https://linear.app/a8c/issue/WOOA7S-1931) is the follow-up that moves the tabs into `Page`'s navigation slot, which will change the chrome's shape again

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Open **Jetpack → Stats**, Traffic section, with enough widgets to scroll.

### The condense

* Scroll slowly. Nothing changes until the tabs clear the top and the header pins. **The fade must not start at scroll zero.**
* From there the subtitle fades and the band tightens over the next ~40px. Scroll up and it runs backwards.
* At any offset the effect should match the scroll position, not play on its own.
* Once condensed the title and the date controls should sit centred in the band, with no leftover gap where the subtitle was.


https://github.com/user-attachments/assets/a47b4974-57ad-4e89-b007-95d67729a05d


### Nothing breaks

* Open the **Custom** range popover while pinned and condensed; apply a range and confirm the subtitle returns with the new text on scroll up.
* Step with the arrows, open the interval and comparison menus.
* Narrow the window until the header stacks. It should still condense, and the stacking breakpoint should not move: the change is height-only, so the date panel's measured label boundary is unaffected.
* **Customize** mode: widget toolbars, resize, remove, drag.

### Degradation

* Enable *Reduce motion* in the OS. The header should hold still, subtitle and all.
* Go to **Insights** and **Subscribers** and confirm the same behaviour on the year surface.
* Open a post detail page and a report page with tabs. They share `SectionHeader` and `SectionTabs` but do not opt in, so nothing there should move or change colour.
