### PR TITLE
Podcast: add feed episode limit setting

### DIFF
--- a/projects/packages/podcast/changelog/podcasting-feed-limit
+++ b/projects/packages/podcast/changelog/podcasting-feed-limit
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Settings: add an episode limit for the podcast feed, defaulting to 300 episodes.
+Settings: add an episode limit for the podcast feed.

--- a/projects/packages/podcast/changelog/podcasting-feed-limit
+++ b/projects/packages/podcast/changelog/podcasting-feed-limit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Settings: add an episode limit for the podcast feed, defaulting to 300 episodes.

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -152,6 +152,7 @@ class Admin_Page {
 			'is_connected'        => $is_wpcom || ( new Connection_Manager( 'jetpack' ) )->is_connected(),
 			'show_url_hosts'      => Settings::SHOW_URL_HOSTS,
 			'show_url_max_length' => Settings::SHOW_URL_MAX_LENGTH,
+			'feed_limit_max'      => Settings::feed_limit_max(),
 			'preload'             => rest_preload_api_request( array(), '/wpcom/v2/podcast/settings' ),
 			'selected_category'   => self::get_selected_category(),
 			'upgrade'             => array(

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -233,9 +233,8 @@ class Settings {
 	}
 
 	/**
-	 * Episodes the podcast feed should carry. Until the site sets one, this seeds
-	 * from core's `posts_per_rss` so existing feeds keep their current length; once
-	 * the option exists that value is never consulted again.
+	 * Episodes the podcast feed should carry. Until the site sets one this seeds
+	 * from core's `posts_per_rss`, so existing feeds keep their current length.
 	 *
 	 * Sanitized on read because Sync writes on shadow blogs never hit the
 	 * registered `sanitize_callback`.
@@ -243,12 +242,7 @@ class Settings {
 	 * @return int
 	 */
 	public static function feed_limit(): int {
-		$stored = get_option( 'podcasting_feed_limit', false );
-		if ( false === $stored ) {
-			$stored = get_option( 'posts_per_rss', self::FEED_LIMIT_DEFAULT );
-		}
-
-		return self::sanitize_feed_limit( $stored );
+		return self::sanitize_feed_limit( get_option( 'podcasting_feed_limit', 0 ) );
 	}
 
 	/**
@@ -342,13 +336,18 @@ class Settings {
 
 	/**
 	 * Clamp the feed episode limit to 1–{@see self::feed_limit_max()}. Cleared and
-	 * junk input falls back to the default rather than emptying the feed.
+	 * junk input resolves the way an unset option does — the site's own
+	 * `posts_per_rss` — rather than emptying the feed or jumping it to a default
+	 * far above whatever the site was already serving.
 	 *
 	 * @param mixed $value Raw input.
 	 * @return int
 	 */
 	public static function sanitize_feed_limit( $value ) {
 		$value = (int) $value;
+		if ( $value < 1 ) {
+			$value = (int) get_option( 'posts_per_rss', self::FEED_LIMIT_DEFAULT );
+		}
 
 		return min( $value < 1 ? self::FEED_LIMIT_DEFAULT : $value, self::feed_limit_max() );
 	}

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -45,6 +45,19 @@ class Settings {
 	const SHOW_URL_MAX_LENGTH = 2048;
 
 	/**
+	 * Episodes a podcast feed carries when the site hasn't chosen. Deep enough
+	 * that podcatchers see a real back catalog rather than core's blog-sized
+	 * `posts_per_rss`.
+	 */
+	const FEED_LIMIT_DEFAULT = 300;
+
+	/**
+	 * Ceiling for `podcasting_feed_limit`. Sized against measured feed generation
+	 * — roughly 4s for 215 episodes.
+	 */
+	const FEED_LIMIT_MAX = 500;
+
+	/**
 	 * Drives `register_settings()` and the sync whitelist.
 	 *
 	 * @var string[]
@@ -64,6 +77,7 @@ class Settings {
 		'podcasting_email',
 		'podcasting_show_urls',
 		'podcasting_show_states',
+		'podcasting_feed_limit',
 	);
 
 	/**
@@ -176,6 +190,16 @@ class Settings {
 				'sanitize_callback' => array( __CLASS__, 'sanitize_show_states' ),
 			)
 		);
+
+		register_setting(
+			'options',
+			'podcasting_feed_limit',
+			array(
+				'type'              => 'integer',
+				'default'           => self::FEED_LIMIT_DEFAULT,
+				'sanitize_callback' => array( __CLASS__, 'sanitize_feed_limit' ),
+			)
+		);
 	}
 
 	/**
@@ -205,8 +229,19 @@ class Settings {
 			'podcasting_email'       => (string) get_option( 'podcasting_email', '' ),
 			'podcasting_show_urls'   => array_merge( $empty_map, array_intersect_key( $show_urls, $empty_map ) ),
 			'podcasting_show_states' => array_merge( $empty_map, array_intersect_key( $show_states, $empty_map ) ),
+			'podcasting_feed_limit'  => self::feed_limit(),
 			'podcasting_feed_url'    => self::feed_url(),
 		);
+	}
+
+	/**
+	 * Episodes the podcast feed should carry. Sanitized on read because Sync
+	 * writes on shadow blogs never hit the registered `sanitize_callback`.
+	 *
+	 * @return int
+	 */
+	public static function feed_limit(): int {
+		return self::sanitize_feed_limit( get_option( 'podcasting_feed_limit', self::FEED_LIMIT_DEFAULT ) );
 	}
 
 	/**
@@ -261,6 +296,7 @@ class Settings {
 			'podcasting_email'       => array( 'type' => 'string' ),
 			'podcasting_show_urls'   => array( 'type' => 'object' ),
 			'podcasting_show_states' => array( 'type' => 'object' ),
+			'podcasting_feed_limit'  => array( 'type' => 'integer' ),
 		);
 	}
 
@@ -295,6 +331,39 @@ class Settings {
 			return in_array( strtolower( $value ), array( 'yes', 'true', '1' ), true );
 		}
 		return true === $value || 1 === $value;
+	}
+
+	/**
+	 * Clamp the feed episode limit to 1–{@see self::feed_limit_max()}. Cleared and
+	 * junk input falls back to the default rather than emptying the feed.
+	 *
+	 * @param mixed $value Raw input.
+	 * @return int
+	 */
+	public static function sanitize_feed_limit( $value ) {
+		$value = (int) $value;
+
+		return $value < 1 ? self::FEED_LIMIT_DEFAULT : min( $value, self::feed_limit_max() );
+	}
+
+	/**
+	 * Most episodes the podcast feed will carry.
+	 *
+	 * @return int
+	 */
+	public static function feed_limit_max(): int {
+		/**
+		 * Filters the ceiling for the podcast feed's episode limit. Raising it
+		 * renders that many items in one request, so only where the host can
+		 * absorb it.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int $max Maximum episodes a podcast feed may carry.
+		 */
+		$max = (int) apply_filters( 'jetpack_podcast_feed_limit_max', self::FEED_LIMIT_MAX );
+
+		return max( 1, $max );
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -343,7 +343,7 @@ class Settings {
 	public static function sanitize_feed_limit( $value ) {
 		$value = (int) $value;
 
-		return $value < 1 ? self::FEED_LIMIT_DEFAULT : min( $value, self::feed_limit_max() );
+		return min( $value < 1 ? self::FEED_LIMIT_DEFAULT : $value, self::feed_limit_max() );
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -188,12 +188,15 @@ class Settings {
 			)
 		);
 
+		// Default is the unset sentinel, not `FEED_LIMIT_DEFAULT`: `update_option()`
+		// compares against the default-backed read and bails before creating the
+		// row, so any other default would make that exact value unsavable.
 		register_setting(
 			'options',
 			'podcasting_feed_limit',
 			array(
 				'type'              => 'integer',
-				'default'           => self::FEED_LIMIT_DEFAULT,
+				'default'           => 0,
 				'sanitize_callback' => array( __CLASS__, 'sanitize_feed_limit' ),
 			)
 		);

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -45,9 +45,7 @@ class Settings {
 	const SHOW_URL_MAX_LENGTH = 2048;
 
 	/**
-	 * Episodes a podcast feed carries when the site hasn't chosen. Deep enough
-	 * that podcatchers see a real back catalog rather than core's blog-sized
-	 * `posts_per_rss`.
+	 * Fallback when neither `podcasting_feed_limit` nor `posts_per_rss` is set.
 	 */
 	const FEED_LIMIT_DEFAULT = 300;
 
@@ -235,13 +233,22 @@ class Settings {
 	}
 
 	/**
-	 * Episodes the podcast feed should carry. Sanitized on read because Sync
-	 * writes on shadow blogs never hit the registered `sanitize_callback`.
+	 * Episodes the podcast feed should carry. Until the site sets one, this seeds
+	 * from core's `posts_per_rss` so existing feeds keep their current length; once
+	 * the option exists that value is never consulted again.
+	 *
+	 * Sanitized on read because Sync writes on shadow blogs never hit the
+	 * registered `sanitize_callback`.
 	 *
 	 * @return int
 	 */
 	public static function feed_limit(): int {
-		return self::sanitize_feed_limit( get_option( 'podcasting_feed_limit', self::FEED_LIMIT_DEFAULT ) );
+		$stored = get_option( 'podcasting_feed_limit', false );
+		if ( false === $stored ) {
+			$stored = get_option( 'posts_per_rss', self::FEED_LIMIT_DEFAULT );
+		}
+
+		return self::sanitize_feed_limit( $stored );
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -50,8 +50,7 @@ class Settings {
 	const FEED_LIMIT_DEFAULT = 300;
 
 	/**
-	 * Ceiling for `podcasting_feed_limit`. Sized against measured feed generation
-	 * — roughly 4s for 215 episodes.
+	 * Ceiling for `podcasting_feed_limit`. Sized against measured feed generation.
 	 */
 	const FEED_LIMIT_MAX = 500;
 

--- a/projects/packages/podcast/src/dashboard/declarations.d.ts
+++ b/projects/packages/podcast/src/dashboard/declarations.d.ts
@@ -5,6 +5,7 @@ declare module '@automattic/jetpack-script-data' {
 			is_connected?: boolean;
 			show_url_hosts?: Record< string, readonly string[] >;
 			show_url_max_length?: number;
+			feed_limit_max?: number;
 			preload?: Record< string, { body: unknown; headers?: Record< string, string > } >;
 			selected_category?: { id: number; name: string } | null;
 			upgrade?: {

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -57,6 +57,7 @@ const PODCAST_KEYS: Array< keyof PodcastSettings > = [
 	'podcasting_email',
 	'podcasting_show_urls',
 	'podcasting_show_states',
+	'podcasting_feed_limit',
 	'podcasting_feed_url',
 ];
 
@@ -92,7 +93,9 @@ const normalizeShowStates = ( raw: unknown ): PodcastShowStates => {
 
 const pickPodcastFields = ( raw: Record< string, unknown > ): PodcastSettings => {
 	const numericKey = ( key: keyof PodcastSettings ) =>
-		key === 'podcasting_category_id' || key === 'podcasting_image_id';
+		key === 'podcasting_category_id' ||
+		key === 'podcasting_image_id' ||
+		key === 'podcasting_feed_limit';
 
 	const toString = ( value: unknown ): string => {
 		if ( typeof value === 'string' ) {

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -33,6 +33,11 @@ const EXPLICIT_OPTIONS: Array< { label: string; value: string } > = [
 	{ label: __( 'Yes', 'jetpack-podcast' ), value: 'yes' },
 ];
 
+// Read rather than mirrored: the ceiling is filterable server-side, so a
+// hardcoded twin here would clamp against the wrong number on a site that
+// moved it. Absent, clamping is left to the server.
+const feedLimitMax = getScriptData()?.podcast?.feed_limit_max;
+
 // Flatten the Apple Podcasts topic tree into one searchable token list for
 // `FormTokenField`. Display strings use `Primary » Subtopic` (matching
 // Calypso's renderer); storage strings use the legacy `Primary,Subtopic`
@@ -81,9 +86,15 @@ type StringFieldKey =
 // state per keystroke, then commits on blur if the value differs from what's
 // saved. Re-syncs from `stored` when the saved value changes externally.
 // Spread directly onto `<TextControl>` etc. for `value` / `onChange` / `onBlur`.
+//
+// `normalize` snaps the input to what will actually be stored. Fields whose
+// server-side sanitizer can rewrite input need it: a value rewritten back to
+// the current `stored` leaves `stored` unchanged, so the re-sync effect never
+// fires and the input would sit showing the number that was rejected.
 const useFieldEditor = (
 	stored: string,
-	onCommit: ( value: string ) => void
+	onCommit: ( value: string ) => void,
+	normalize?: ( value: string ) => string
 ): { value: string; onChange: ( v: string ) => void; onBlur: () => void } => {
 	const [ local, setLocal ] = useState( stored );
 	useEffect( () => {
@@ -93,8 +104,10 @@ const useFieldEditor = (
 		value: local,
 		onChange: setLocal,
 		onBlur: () => {
-			if ( local !== stored ) {
-				onCommit( local );
+			const next = normalize ? normalize( local ) : local;
+			setLocal( next );
+			if ( next !== stored ) {
+				onCommit( next );
 			}
 		},
 	};
@@ -212,15 +225,27 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 		commitField( 'podcasting_email' )
 	);
 
-	// Numeric, so it can't ride `commitField`. The server owns the range — a
-	// cleared field comes back as the default once the save resyncs the draft.
+	// Numeric, so it can't ride `commitField`. Cleared or junk input keeps the
+	// saved limit instead of committing 0, which the server would swap for a
+	// default well above what the site was serving.
+	const normalizeFeedLimit = useCallback(
+		( value: string ) => {
+			const parsed = Number.parseInt( value, 10 );
+			if ( Number.isNaN( parsed ) || parsed < 1 ) {
+				return String( draft?.podcasting_feed_limit ?? '' );
+			}
+			return String( feedLimitMax ? Math.min( parsed, feedLimitMax ) : parsed );
+		},
+		[ draft?.podcasting_feed_limit ]
+	);
 	const commitFeedLimit = useCallback(
-		( value: string ) => commit( { podcasting_feed_limit: Number.parseInt( value, 10 ) || 0 } ),
+		( value: string ) => commit( { podcasting_feed_limit: Number.parseInt( value, 10 ) } ),
 		[ commit ]
 	);
 	const feedLimitField = useFieldEditor(
 		String( draft?.podcasting_feed_limit ?? '' ),
-		commitFeedLimit
+		commitFeedLimit,
+		normalizeFeedLimit
 	);
 
 	// Discrete-action handlers — these controls "commit" on each user choice
@@ -482,7 +507,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							__nextHasNoMarginBottom
 							type="number"
 							min={ 1 }
-							max={ getScriptData()?.podcast?.feed_limit_max }
+							max={ feedLimitMax }
 							step={ 1 }
 							label={ __( 'Episodes in feed', 'jetpack-podcast' ) }
 							help={ __(

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -33,9 +33,6 @@ const EXPLICIT_OPTIONS: Array< { label: string; value: string } > = [
 	{ label: __( 'Yes', 'jetpack-podcast' ), value: 'yes' },
 ];
 
-// Read rather than mirrored: the ceiling is filterable server-side, so a
-// hardcoded twin here would clamp against the wrong number on a site that
-// moved it. Absent, clamping is left to the server.
 const feedLimitMax = getScriptData()?.podcast?.feed_limit_max;
 
 // Flatten the Apple Podcasts topic tree into one searchable token list for
@@ -86,11 +83,6 @@ type StringFieldKey =
 // state per keystroke, then commits on blur if the value differs from what's
 // saved. Re-syncs from `stored` when the saved value changes externally.
 // Spread directly onto `<TextControl>` etc. for `value` / `onChange` / `onBlur`.
-//
-// `normalize` snaps the input to what will actually be stored. Fields whose
-// server-side sanitizer can rewrite input need it: a value rewritten back to
-// the current `stored` leaves `stored` unchanged, so the re-sync effect never
-// fires and the input would sit showing the number that was rejected.
 const useFieldEditor = (
 	stored: string,
 	onCommit: ( value: string ) => void,
@@ -225,9 +217,6 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 		commitField( 'podcasting_email' )
 	);
 
-	// Numeric, so it can't ride `commitField`. Cleared or junk input keeps the
-	// saved limit instead of committing 0, which the server would swap for a
-	// default well above what the site was serving.
 	const normalizeFeedLimit = useCallback(
 		( value: string ) => {
 			const parsed = Number.parseInt( value, 10 );

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -1,3 +1,4 @@
+import { getScriptData } from '@automattic/jetpack-script-data';
 import {
 	Button,
 	Card,
@@ -209,6 +210,17 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 	const emailField = useFieldEditor(
 		draft?.podcasting_email ?? '',
 		commitField( 'podcasting_email' )
+	);
+
+	// Numeric, so it can't ride `commitField`. The server owns the range — a
+	// cleared field comes back as the default once the save resyncs the draft.
+	const commitFeedLimit = useCallback(
+		( value: string ) => commit( { podcasting_feed_limit: Number.parseInt( value, 10 ) || 0 } ),
+		[ commit ]
+	);
+	const feedLimitField = useFieldEditor(
+		String( draft?.podcasting_feed_limit ?? '' ),
+		commitFeedLimit
 	);
 
 	// Discrete-action handlers — these controls "commit" on each user choice
@@ -464,6 +476,20 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							) }
 							disabled={ isLocked }
 							{ ...emailField }
+						/>
+						<TextControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							type="number"
+							min={ 1 }
+							max={ getScriptData()?.podcast?.feed_limit_max }
+							step={ 1 }
+							label={ __( 'Episodes in feed', 'jetpack-podcast' ) }
+							help={ __(
+								'How many of your most recent episodes the feed includes.',
+								'jetpack-podcast'
+							) }
+							{ ...feedLimitField }
 						/>
 					</VStack>
 				</CardBody>

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -489,6 +489,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 								'How many of your most recent episodes the feed includes.',
 								'jetpack-podcast'
 							) }
+							disabled={ isLocked }
 							{ ...feedLimitField }
 						/>
 					</VStack>

--- a/projects/packages/podcast/src/dashboard/types.ts
+++ b/projects/packages/podcast/src/dashboard/types.ts
@@ -28,6 +28,7 @@ export interface PodcastSettings {
 	podcasting_email: string;
 	podcasting_show_urls: PodcastShowUrls;
 	podcasting_show_states: PodcastShowStates;
+	podcasting_feed_limit: number;
 	// Read-only: canonical category feed URL derived server-side via
 	// get_term_feed_link(). Never sent back in an update.
 	podcasting_feed_url: string;

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -67,7 +67,11 @@ class Customize_Feed {
 		// `posts_where` constrains the SQL itself so LIMIT/OFFSET paginate over
 		// episodes that actually have an enclosure; `the_posts` is a cheap final
 		// guard for the rare row the SQL constraint can't reach.
-		add_action( 'pre_get_posts', array( __CLASS__, 'apply_feed_limit' ) );
+		//
+		// `pre_get_posts` runs last so the gate reads the category every other
+		// callback has finished rewriting — and so `get_queried_object()` doesn't
+		// memoize a term ahead of them, which `posts_where` would then inherit.
+		add_action( 'pre_get_posts', array( __CLASS__, 'apply_feed_limit' ), PHP_INT_MAX );
 		add_filter( 'posts_where', array( __CLASS__, 'constrain_feed_query' ), 10, 2 );
 		add_filter( 'the_posts', array( __CLASS__, 'filter_posts_with_enclosure' ), 10, 2 );
 	}

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -60,13 +60,14 @@ class Customize_Feed {
 
 		add_action( 'wp', array( __CLASS__, 'maybe_register_feed_hooks' ) );
 
-		// Both hooks fire during query execution — before the `wp` action — so
+		// These hooks fire during query execution — before the `wp` action — so
 		// they're registered up-front and self-gated to the podcast feed query,
 		// rather than wired conditionally in `maybe_register_feed_hooks`.
 		//
 		// `posts_where` constrains the SQL itself so LIMIT/OFFSET paginate over
 		// episodes that actually have an enclosure; `the_posts` is a cheap final
 		// guard for the rare row the SQL constraint can't reach.
+		add_action( 'pre_get_posts', array( __CLASS__, 'apply_feed_limit' ) );
 		add_filter( 'posts_where', array( __CLASS__, 'constrain_feed_query' ), 10, 2 );
 		add_filter( 'the_posts', array( __CLASS__, 'filter_posts_with_enclosure' ), 10, 2 );
 	}
@@ -390,6 +391,21 @@ class Customize_Feed {
 	public static function reset_render_state() {
 		self::$seen_enclosures = array();
 		self::$item_summary    = array( 0, '' );
+	}
+
+	/**
+	 * Cap the podcast feed at the configured number of episodes. Core reads the
+	 * `posts_per_rss` *query var* before the site option of the same name, so the
+	 * podcast feed gets its own length and every other feed keeps the site's.
+	 *
+	 * @param \WP_Query $query Query about to run.
+	 */
+	public static function apply_feed_limit( $query ) {
+		if ( ! self::is_podcast_feed_query( $query ) ) {
+			return;
+		}
+
+		$query->set( 'posts_per_rss', Settings::feed_limit() );
 	}
 
 	/**

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -592,7 +592,6 @@ class Customize_Feed_Test extends BaseTestCase {
 		);
 		$stubs    = array_merge( $defaults, $overrides );
 
-		// A mock rather than a stub so callers can assert on `set()`.
 		$query = $this->createMock( \WP_Query::class );
 		foreach ( $stubs as $method => $value ) {
 			$query->method( $method )->willReturn( $value );

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -556,7 +556,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		update_option( 'podcasting_category_id', 17 );
 		update_option( 'podcasting_feed_limit', 25 );
 
-		$query = $this->build_podcast_feed_query_mock( 17 );
+		$query = $this->build_podcast_feed_query_mock( 17, array(), true );
 		$query->expects( $this->once() )->method( 'set' )->with( 'posts_per_rss', 25 );
 
 		Customize_Feed::apply_feed_limit( $query );
@@ -571,20 +571,25 @@ class Customize_Feed_Test extends BaseTestCase {
 		update_option( 'podcasting_category_id', 17 );
 		update_option( 'podcasting_feed_limit', 25 );
 
-		$query = $this->build_podcast_feed_query_mock( 999 );
+		$query = $this->build_podcast_feed_query_mock( 999, array(), true );
 		$query->expects( $this->never() )->method( 'set' );
 
 		Customize_Feed::apply_feed_limit( $query );
 	}
 
 	/**
-	 * Build a `WP_Query` mock pre-stubbed for the podcast-feed happy path,
+	 * Build a `WP_Query` double pre-stubbed for the podcast-feed happy path,
 	 * with optional per-method overrides.
+	 *
+	 * A stub unless `$expects_calls` — only the `apply_feed_limit` tests assert on
+	 * a call, and handing every caller a mock makes PHPUnit flag the ones that
+	 * configure no expectations.
 	 *
 	 * @param int   $queried_term_id Term ID returned from `get_queried_object()`.
 	 * @param array $overrides       Map of method-name => return value to override defaults.
+	 * @param bool  $expects_calls   Whether the caller will set expectations on the double.
 	 */
-	private function build_podcast_feed_query_mock( int $queried_term_id, array $overrides = array() ) {
+	private function build_podcast_feed_query_mock( int $queried_term_id, array $overrides = array(), bool $expects_calls = false ) {
 		$defaults = array(
 			'is_main_query' => true,
 			'is_feed'       => true,
@@ -592,7 +597,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		);
 		$stubs    = array_merge( $defaults, $overrides );
 
-		$query = $this->createMock( \WP_Query::class );
+		$query = $expects_calls ? $this->createMock( \WP_Query::class ) : $this->createStub( \WP_Query::class );
 		foreach ( $stubs as $method => $value ) {
 			$query->method( $method )->willReturn( $value );
 		}

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -6,6 +6,7 @@
 namespace Automattic\Jetpack\Podcast\Tests\Feed;
 
 use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
+use Automattic\Jetpack\Podcast\Settings;
 use Jetpack_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
@@ -34,6 +35,7 @@ class Customize_Feed_Test extends BaseTestCase {
 		delete_option( 'podcasting_title' );
 		delete_option( 'podcasting_category_id' );
 		delete_option( 'podcasting_archive' );
+		delete_option( 'podcasting_feed_limit' );
 		remove_all_filters( 'pre_attachment_url_to_postid' );
 		remove_all_filters( 'wpcom_podcasting_enable_play_tracking' );
 		remove_all_filters( 'wpcom_podcasting_tracked_blog_id' );
@@ -550,6 +552,42 @@ class Customize_Feed_Test extends BaseTestCase {
 		$this->assertStringStartsWith( ' AND 1=1', $result );
 	}
 
+	public function test_apply_feed_limit_sets_posts_per_rss_for_podcast_feed() {
+		$this->seed_category_term( 17 );
+		update_option( 'podcasting_category_id', 17 );
+		update_option( 'podcasting_feed_limit', 25 );
+
+		$query = $this->build_podcast_feed_query_mock( 17 );
+		$query->expects( $this->once() )->method( 'set' )->with( 'posts_per_rss', 25 );
+
+		Customize_Feed::apply_feed_limit( $query );
+	}
+
+	public function test_apply_feed_limit_uses_the_default_when_the_site_has_not_chosen() {
+		$this->seed_category_term( 17 );
+		update_option( 'podcasting_category_id', 17 );
+
+		$query = $this->build_podcast_feed_query_mock( 17 );
+		$query->expects( $this->once() )->method( 'set' )->with( 'posts_per_rss', Settings::FEED_LIMIT_DEFAULT );
+
+		Customize_Feed::apply_feed_limit( $query );
+	}
+
+	/**
+	 * `pre_get_posts` runs for every query on the site, so the gate is what keeps
+	 * the podcast limit off everyone else's feeds.
+	 */
+	public function test_apply_feed_limit_ignores_queries_that_are_not_the_podcast_feed() {
+		$this->seed_category_term( 17 );
+		update_option( 'podcasting_category_id', 17 );
+		update_option( 'podcasting_feed_limit', 25 );
+
+		$query = $this->build_podcast_feed_query_mock( 999 );
+		$query->expects( $this->never() )->method( 'set' );
+
+		Customize_Feed::apply_feed_limit( $query );
+	}
+
 	/**
 	 * Build a `WP_Query` mock pre-stubbed for the podcast-feed happy path,
 	 * with optional per-method overrides.
@@ -565,7 +603,8 @@ class Customize_Feed_Test extends BaseTestCase {
 		);
 		$stubs    = array_merge( $defaults, $overrides );
 
-		$query = $this->createStub( \WP_Query::class );
+		// A mock rather than a stub so callers can assert on `set()`.
+		$query = $this->createMock( \WP_Query::class );
 		foreach ( $stubs as $method => $value ) {
 			$query->method( $method )->willReturn( $value );
 		}

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -6,7 +6,6 @@
 namespace Automattic\Jetpack\Podcast\Tests\Feed;
 
 use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
-use Automattic\Jetpack\Podcast\Settings;
 use Jetpack_Options;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
@@ -559,16 +558,6 @@ class Customize_Feed_Test extends BaseTestCase {
 
 		$query = $this->build_podcast_feed_query_mock( 17 );
 		$query->expects( $this->once() )->method( 'set' )->with( 'posts_per_rss', 25 );
-
-		Customize_Feed::apply_feed_limit( $query );
-	}
-
-	public function test_apply_feed_limit_uses_the_default_when_the_site_has_not_chosen() {
-		$this->seed_category_term( 17 );
-		update_option( 'podcasting_category_id', 17 );
-
-		$query = $this->build_podcast_feed_query_mock( 17 );
-		$query->expects( $this->once() )->method( 'set' )->with( 'posts_per_rss', Settings::FEED_LIMIT_DEFAULT );
 
 		Customize_Feed::apply_feed_limit( $query );
 	}

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -141,6 +141,23 @@ class Settings_Test extends BaseTestCase {
 		delete_option( 'posts_per_rss' );
 	}
 
+	/**
+	 * A registered default other than the unset sentinel makes that one value
+	 * unsavable: `update_option()` reads it back as the current value and returns
+	 * before creating the row, so the save no-ops and the read reseeds from
+	 * `posts_per_rss`.
+	 */
+	public function test_feed_limit_persists_a_value_matching_the_package_default() {
+		Settings::register_settings();
+		update_option( 'posts_per_rss', 12 );
+
+		$this->assertTrue( update_option( 'podcasting_feed_limit', Settings::FEED_LIMIT_DEFAULT ) );
+		$this->assertSame( Settings::FEED_LIMIT_DEFAULT, Settings::feed_limit() );
+
+		delete_option( 'podcasting_feed_limit' );
+		delete_option( 'posts_per_rss' );
+	}
+
 	public function test_feed_limit_max_filter_moves_the_ceiling_both_ways() {
 		update_option( 'podcasting_feed_limit', 900 );
 		add_filter(

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -118,8 +118,14 @@ class Settings_Test extends BaseTestCase {
 		update_option( 'podcasting_feed_limit', 999999 );
 		$this->assertSame( Settings::FEED_LIMIT_MAX, Settings::feed_limit() );
 
-		// Not `absint()`, which would serve a five-episode feed here.
+		// Not `absint()`, which would serve a five-episode feed here. Junk resolves
+		// the way an unset option does rather than jumping the feed to the default,
+		// which on a real site is far longer than `posts_per_rss`.
+		update_option( 'posts_per_rss', 12 );
 		update_option( 'podcasting_feed_limit', -5 );
+		$this->assertSame( 12, Settings::feed_limit() );
+
+		delete_option( 'posts_per_rss' );
 		$this->assertSame( Settings::FEED_LIMIT_DEFAULT, Settings::feed_limit() );
 
 		delete_option( 'podcasting_feed_limit' );
@@ -162,6 +168,8 @@ class Settings_Test extends BaseTestCase {
 		// The fallback is bound by the ceiling too, not just stored values.
 		delete_option( 'podcasting_feed_limit' );
 		$this->assertSame( 100, Settings::feed_limit() );
+
+		remove_all_filters( 'jetpack_podcast_feed_limit_max' );
 	}
 
 	public function test_sanitize_show_urls_merges_partial_patch_into_stored_value() {

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -132,6 +132,21 @@ class Settings_Test extends BaseTestCase {
 		delete_option( 'podcasting_feed_limit' );
 	}
 
+	public function test_feed_limit_seeds_from_the_site_feed_length_until_it_is_set() {
+		// Registered so the seeding survives the `default_option_*` filter that
+		// `register_setting()` adds.
+		Settings::register_settings();
+
+		update_option( 'posts_per_rss', 12 );
+		$this->assertSame( 12, Settings::feed_limit() );
+
+		update_option( 'podcasting_feed_limit', 40 );
+		$this->assertSame( 40, Settings::feed_limit() );
+
+		delete_option( 'podcasting_feed_limit' );
+		delete_option( 'posts_per_rss' );
+	}
+
 	public function test_feed_limit_max_filter_raises_the_ceiling() {
 		add_filter(
 			'jetpack_podcast_feed_limit_max',

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -118,9 +118,6 @@ class Settings_Test extends BaseTestCase {
 		update_option( 'podcasting_feed_limit', 999999 );
 		$this->assertSame( Settings::FEED_LIMIT_MAX, Settings::feed_limit() );
 
-		// Not `absint()`, which would serve a five-episode feed here. Junk resolves
-		// the way an unset option does rather than jumping the feed to the default,
-		// which on a real site is far longer than `posts_per_rss`.
 		update_option( 'posts_per_rss', 12 );
 		update_option( 'podcasting_feed_limit', -5 );
 		$this->assertSame( 12, Settings::feed_limit() );
@@ -132,8 +129,6 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	public function test_feed_limit_seeds_from_the_site_feed_length_until_it_is_set() {
-		// Registered so the seeding survives the `default_option_*` filter that
-		// `register_setting()` adds.
 		Settings::register_settings();
 
 		update_option( 'posts_per_rss', 12 );
@@ -165,7 +160,6 @@ class Settings_Test extends BaseTestCase {
 		);
 		$this->assertSame( 100, Settings::feed_limit() );
 
-		// The fallback is bound by the ceiling too, not just stored values.
 		delete_option( 'podcasting_feed_limit' );
 		$this->assertSame( 100, Settings::feed_limit() );
 

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -114,6 +114,39 @@ class Settings_Test extends BaseTestCase {
 		$this->assertFalse( Settings::sanitize_explicit( null ) );
 	}
 
+	public function test_feed_limit_clamps_stored_values_on_read() {
+		$this->assertSame( Settings::FEED_LIMIT_DEFAULT, Settings::feed_limit() );
+
+		update_option( 'podcasting_feed_limit', '50' );
+		$this->assertSame( 50, Settings::feed_limit() );
+
+		update_option( 'podcasting_feed_limit', -5 );
+		$this->assertSame( Settings::FEED_LIMIT_DEFAULT, Settings::feed_limit() );
+
+		update_option( 'podcasting_feed_limit', 'all of them' );
+		$this->assertSame( Settings::FEED_LIMIT_DEFAULT, Settings::feed_limit() );
+
+		update_option( 'podcasting_feed_limit', 999999 );
+		$this->assertSame( Settings::FEED_LIMIT_MAX, Settings::feed_limit() );
+
+		delete_option( 'podcasting_feed_limit' );
+	}
+
+	public function test_feed_limit_max_filter_raises_the_ceiling() {
+		add_filter(
+			'jetpack_podcast_feed_limit_max',
+			function () {
+				return 1000;
+			}
+		);
+		update_option( 'podcasting_feed_limit', 900 );
+
+		$this->assertSame( 900, Settings::feed_limit() );
+
+		remove_all_filters( 'jetpack_podcast_feed_limit_max' );
+		delete_option( 'podcasting_feed_limit' );
+	}
+
 	public function test_sanitize_show_urls_merges_partial_patch_into_stored_value() {
 		update_option(
 			'podcasting_show_urls',

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -143,7 +143,22 @@ class Settings_Test extends BaseTestCase {
 
 		$this->assertSame( 900, Settings::feed_limit() );
 
-		remove_all_filters( 'jetpack_podcast_feed_limit_max' );
+		delete_option( 'podcasting_feed_limit' );
+	}
+
+	public function test_feed_limit_max_filter_also_binds_the_default() {
+		add_filter(
+			'jetpack_podcast_feed_limit_max',
+			function () {
+				return 100;
+			}
+		);
+
+		$this->assertSame( 100, Settings::feed_limit() );
+
+		update_option( 'podcasting_feed_limit', 0 );
+		$this->assertSame( 100, Settings::feed_limit() );
+
 		delete_option( 'podcasting_feed_limit' );
 	}
 

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -115,19 +115,12 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	public function test_feed_limit_clamps_stored_values_on_read() {
-		$this->assertSame( Settings::FEED_LIMIT_DEFAULT, Settings::feed_limit() );
-
-		update_option( 'podcasting_feed_limit', '50' );
-		$this->assertSame( 50, Settings::feed_limit() );
-
-		update_option( 'podcasting_feed_limit', -5 );
-		$this->assertSame( Settings::FEED_LIMIT_DEFAULT, Settings::feed_limit() );
-
-		update_option( 'podcasting_feed_limit', 'all of them' );
-		$this->assertSame( Settings::FEED_LIMIT_DEFAULT, Settings::feed_limit() );
-
 		update_option( 'podcasting_feed_limit', 999999 );
 		$this->assertSame( Settings::FEED_LIMIT_MAX, Settings::feed_limit() );
+
+		// Not `absint()`, which would serve a five-episode feed here.
+		update_option( 'podcasting_feed_limit', -5 );
+		$this->assertSame( Settings::FEED_LIMIT_DEFAULT, Settings::feed_limit() );
 
 		delete_option( 'podcasting_feed_limit' );
 	}
@@ -147,34 +140,28 @@ class Settings_Test extends BaseTestCase {
 		delete_option( 'posts_per_rss' );
 	}
 
-	public function test_feed_limit_max_filter_raises_the_ceiling() {
+	public function test_feed_limit_max_filter_moves_the_ceiling_both_ways() {
+		update_option( 'podcasting_feed_limit', 900 );
 		add_filter(
 			'jetpack_podcast_feed_limit_max',
 			function () {
 				return 1000;
 			}
 		);
-		update_option( 'podcasting_feed_limit', 900 );
-
 		$this->assertSame( 900, Settings::feed_limit() );
 
-		delete_option( 'podcasting_feed_limit' );
-	}
-
-	public function test_feed_limit_max_filter_also_binds_the_default() {
+		remove_all_filters( 'jetpack_podcast_feed_limit_max' );
 		add_filter(
 			'jetpack_podcast_feed_limit_max',
 			function () {
 				return 100;
 			}
 		);
-
 		$this->assertSame( 100, Settings::feed_limit() );
 
-		update_option( 'podcasting_feed_limit', 0 );
-		$this->assertSame( 100, Settings::feed_limit() );
-
+		// The fallback is bound by the ceiling too, not just stored values.
 		delete_option( 'podcasting_feed_limit' );
+		$this->assertSame( 100, Settings::feed_limit() );
 	}
 
 	public function test_sanitize_show_urls_merges_partial_patch_into_stored_value() {

--- a/projects/plugins/jetpack/changelog/podcasting-feed-limit
+++ b/projects/plugins/jetpack/changelog/podcasting-feed-limit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Podcast: Add a setting for how many episodes the podcast feed includes.


### PR DESCRIPTION
## Proposed changes

<img width="798" height="641" alt="Screenshot on 2026-08-16 at 04-52-29" src="https://github.com/user-attachments/assets/e859d1f8-1c05-407f-8ea5-23c586972a55" />

* Adds an "Episodes in feed" setting so a podcast can choose how many episodes its feed carries, instead of always using the site's Reading setting.
* Existing sites keep the length they have today — the setting starts out matching `posts_per_rss` until it's set.
* The number is capped (500 by default, movable with the `jetpack_podcast_feed_limit_max` filter) so a huge feed can't take the site down. Sites already serving more than that — or `posts_per_rss` set to unlimited — come down to the cap.

The option is on the package's sync whitelist; the matching WordPress.com side has already landed, so the value reaches shadow blogs.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Set up a podcast and publish a few episodes.
* Go to **Jetpack → Podcast → Settings → Feed settings** and set **Episodes in feed** to 2.
* Load the podcast feed URL and confirm only 2 `<item>` entries show up.
* Bump it back up and reload — more episodes appear.
* Boundaries, from a site that has never saved the setting: `0` and junk both snap back to the current value; above the cap clamps to 500; `300` saves and sticks (it used to silently revert).
* Check **Settings → Reading** still controls every other feed on the site.
