### PR TITLE
Jetpack AI: respect the SEO Enhancer toggle in the editor

### DIFF
--- a/projects/packages/seo/changelog/fix-ai-seo-enhancer-editor-gate
+++ b/projects/packages/seo/changelog/fix-ai-seo-enhancer-editor-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+SEO: add an is_switched_off predicate so callers can honor a deliberate admin off without hiding the enhancer from sites that never stored the toggle.

--- a/projects/packages/seo/src/class-ai-seo-enhancer.php
+++ b/projects/packages/seo/src/class-ai-seo-enhancer.php
@@ -17,6 +17,14 @@ use Automattic\Jetpack\Modules;
 class AI_SEO_Enhancer {
 
 	/**
+	 * The user-facing toggle, round-tripped through `/jetpack/v4/settings`.
+	 * Opt-in: absent means the admin never chose.
+	 *
+	 * @var string
+	 */
+	const OPTION = 'ai_seo_enhancer_enabled';
+
+	/**
 	 * Whether the site can offer the enhancer, independent of the admin's
 	 * toggle. Callers own the outer AI master and host gates. The AI sidebar's
 	 * SEO suggestions intentionally use a different plan slug — do not unify.
@@ -32,5 +40,20 @@ class AI_SEO_Enhancer {
 			&& ! apply_filters( 'jetpack_disable_seo_tools', false )
 			&& ( new Modules() )->is_active( 'seo-tools' )
 			&& Current_Plan::supports( 'ai-seo-enhancer' );
+	}
+
+	/**
+	 * Whether the admin has deliberately switched the enhancer off. Absent is
+	 * not off — the enhancer pre-dates its toggle, and only PHP can tell the
+	 * two apart (the module-settings payload collapses absent and off to 0).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	public static function is_switched_off() {
+		$stored = get_option( self::OPTION, null );
+
+		return null !== $stored && ! $stored;
 	}
 }

--- a/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
+++ b/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
@@ -82,4 +82,44 @@ class AiSeoEnhancerTest extends SeoTestCase {
 
 		$this->assertFalse( AI_SEO_Enhancer::is_available() );
 	}
+
+	/**
+	 * An absent option is not "switched off": the enhancer pre-dates its toggle,
+	 * so most sites have never stored a value, and hiding the editor feature on
+	 * absence would take it away from all of them. Only a deliberate off hides.
+	 */
+	public function test_is_switched_off_false_when_option_absent() {
+		delete_option( AI_SEO_Enhancer::OPTION );
+
+		$this->assertFalse( AI_SEO_Enhancer::is_switched_off() );
+	}
+
+	/**
+	 * A stored falsy value is a deliberate off. The module-settings endpoint
+	 * stores `(int) 0`.
+	 */
+	public function test_is_switched_off_true_when_option_stored_off() {
+		update_option( AI_SEO_Enhancer::OPTION, 0 );
+
+		$this->assertTrue( AI_SEO_Enhancer::is_switched_off() );
+	}
+
+	/**
+	 * The AI feature settings endpoint stores a sanitized bool, which
+	 * `update_option()` persists as an empty string — still a deliberate off.
+	 */
+	public function test_is_switched_off_true_when_option_stored_as_empty_string() {
+		update_option( AI_SEO_Enhancer::OPTION, '' );
+
+		$this->assertTrue( AI_SEO_Enhancer::is_switched_off() );
+	}
+
+	/**
+	 * A stored on is not off.
+	 */
+	public function test_is_switched_off_false_when_option_stored_on() {
+		update_option( AI_SEO_Enhancer::OPTION, 1 );
+
+		$this->assertFalse( AI_SEO_Enhancer::is_switched_off() );
+	}
 }

--- a/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
+++ b/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
@@ -84,9 +84,8 @@ class AiSeoEnhancerTest extends SeoTestCase {
 	}
 
 	/**
-	 * An absent option is not "switched off": the enhancer pre-dates its toggle,
-	 * so most sites have never stored a value, and hiding the editor feature on
-	 * absence would take it away from all of them. Only a deliberate off hides.
+	 * An absent option is not "switched off": most sites never stored a value,
+	 * and hiding on absence would take the feature away from all of them.
 	 */
 	public function test_is_switched_off_false_when_option_absent() {
 		delete_option( AI_SEO_Enhancer::OPTION );

--- a/projects/plugins/jetpack/changelog/fix-ai-seo-enhancer-editor-gate
+++ b/projects/plugins/jetpack/changelog/fix-ai-seo-enhancer-editor-gate
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Jetpack AI: make the SEO Enhancer toggle govern the editor's SEO surfaces in internal testing environments.
+Jetpack AI: respect the SEO Enhancer toggle in the editor, in internal testing environments.

--- a/projects/plugins/jetpack/changelog/fix-ai-seo-enhancer-editor-gate
+++ b/projects/plugins/jetpack/changelog/fix-ai-seo-enhancer-editor-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI: hide the editor's SEO enhancer features when the AI SEO toggle is switched off.

--- a/projects/plugins/jetpack/changelog/fix-ai-seo-enhancer-editor-gate
+++ b/projects/plugins/jetpack/changelog/fix-ai-seo-enhancer-editor-gate
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: other
 
-Jetpack AI: hide the editor's SEO enhancer features when the AI SEO toggle is switched off.
+Jetpack AI: make the SEO Enhancer toggle govern the editor's SEO surfaces in internal testing environments.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -104,7 +104,17 @@ add_action(
 				Jetpack_Gutenberg::set_extension_available( 'ai-assistant-image-extension' );
 			}
 
-			if ( apply_filters( 'ai_seo_enhancer_enabled', true ) && ! AI_SEO_Enhancer::is_switched_off() ) {
+			// The stored toggle only governs the editor inside internal testing
+			// environments while the AI feature settings ship dark — real sites
+			// keep the pre-toggle behavior until the flag lifts. Guarded with
+			// function_exists because this file also loads through wpcom's own
+			// loader on Simple, where the plugin bootstrap (and so
+			// functions.global.php) never runs.
+			$enhancer_switched_off = function_exists( 'jetpack_is_internal_testing_environment' )
+				&& jetpack_is_internal_testing_environment()
+				&& AI_SEO_Enhancer::is_switched_off();
+
+			if ( apply_filters( 'ai_seo_enhancer_enabled', true ) && ! $enhancer_switched_off ) {
 				Jetpack_Gutenberg::set_availability_for_plan( 'ai-seo-enhancer' );
 			} else {
 				// A deliberate admin off (or a host veto) withholds the extension,

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -10,6 +10,7 @@
 namespace Automattic\Jetpack\Extensions\AIAssistant;
 
 use Automattic\Jetpack\Blocks;
+use Automattic\Jetpack\SEO\AI_SEO_Enhancer;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Gutenberg;
@@ -103,8 +104,14 @@ add_action(
 				Jetpack_Gutenberg::set_extension_available( 'ai-assistant-image-extension' );
 			}
 
-			if ( apply_filters( 'ai_seo_enhancer_enabled', true ) ) {
+			if ( apply_filters( 'ai_seo_enhancer_enabled', true ) && ! AI_SEO_Enhancer::is_switched_off() ) {
 				Jetpack_Gutenberg::set_availability_for_plan( 'ai-seo-enhancer' );
+			} else {
+				// A deliberate admin off (or a host veto) withholds the extension,
+				// which removes every enhancer surface in the editor. The reason is
+				// deliberately not missing_plan: that value has upgrade-nudge
+				// semantics client-side, and off must not render upgrade messaging.
+				Jetpack_Gutenberg::set_extension_unavailable( 'ai-seo-enhancer', 'ai_seo_enhancer_disabled' );
 			}
 		}
 	}

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -104,12 +104,9 @@ add_action(
 				Jetpack_Gutenberg::set_extension_available( 'ai-assistant-image-extension' );
 			}
 
-			// The stored toggle only governs the editor inside internal testing
-			// environments while the AI feature settings ship dark — real sites
-			// keep the pre-toggle behavior until the flag lifts. Guarded with
-			// function_exists because this file also loads through wpcom's own
-			// loader on Simple, where the plugin bootstrap (and so
-			// functions.global.php) never runs.
+			// The stored toggle only applies inside internal testing environments
+			// while the AI feature settings ship dark. function_exists: on Simple
+			// this file loads through wpcom's loader, without functions.global.php.
 			$enhancer_switched_off = function_exists( 'jetpack_is_internal_testing_environment' )
 				&& jetpack_is_internal_testing_environment()
 				&& AI_SEO_Enhancer::is_switched_off();
@@ -117,10 +114,9 @@ add_action(
 			if ( apply_filters( 'ai_seo_enhancer_enabled', true ) && ! $enhancer_switched_off ) {
 				Jetpack_Gutenberg::set_availability_for_plan( 'ai-seo-enhancer' );
 			} else {
-				// A deliberate admin off (or a host veto) withholds the extension,
-				// which removes every enhancer surface in the editor. The reason is
-				// deliberately not missing_plan: that value has upgrade-nudge
-				// semantics client-side, and off must not render upgrade messaging.
+				// A deliberate off (or host veto) withholds the extension, removing
+				// every enhancer surface in the editor. Not missing_plan: that
+				// reason renders upgrade nudges client-side.
 				Jetpack_Gutenberg::set_extension_unavailable( 'ai-seo-enhancer', 'ai_seo_enhancer_disabled' );
 			}
 		}

--- a/projects/plugins/jetpack/extensions/plugins/seo/test/index-available.test.jsx
+++ b/projects/plugins/jetpack/extensions/plugins/seo/test/index-available.test.jsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+// `isSeoEnhancerEnabled` is a module-level constant in index.jsx, computed
+// once at import time from `getJetpackExtensionAvailability( 'ai-seo-enhancer' )`.
+// To pin behaviour for a fixed availability value without `jest.resetModules()`
+// (which reloads React itself and trips React's hooks dispatcher — see the
+// sibling `index-withheld.test.jsx` file for the same note), this file mocks
+// availability as permanently `true` and does a single top-level import of
+// `../index`, matching normal Jest/ESM module semantics.
+jest.mock( '@automattic/jetpack-publicize/link-preview', () => ( {
+	LinkPreviewModalWithTrigger: () => <div data-testid="link-preview" />,
+} ) );
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	isWpcomPlatformSite: () => false,
+	isSimpleSite: () => false,
+} ) );
+jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
+	useModuleStatus: () => ( {
+		isLoadingModules: false,
+		isChangingStatus: false,
+		isModuleActive: true,
+		changeStatus: jest.fn(),
+	} ),
+	getJetpackExtensionAvailability: () => ( { available: true } ),
+	getRequiredPlan: () => false,
+} ) );
+jest.mock( '@automattic/jetpack-shared-extension-utils/components', () => ( {
+	JetpackEditorPanelLogo: () => null,
+} ) );
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( { children } ) => <div>{ children }</div>,
+	PanelRow: ( { children } ) => <div>{ children }</div>,
+} ) );
+jest.mock( '@wordpress/core-data', () => ( { store: 'core' } ) );
+const mockStore = {
+	isPublishSidebarOpened: () => false,
+	getCurrentPostType: () => 'post',
+	getPostType: () => ( { viewable: true } ),
+};
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: selector => selector( () => mockStore ),
+	useDispatch: () => ( { closePublishSidebar: jest.fn() } ),
+	select: () => mockStore,
+} ) );
+jest.mock( '@wordpress/editor', () => ( {
+	PluginDocumentSettingPanel: ( { children } ) => <div>{ children }</div>,
+	PluginPrePublishPanel: ( { children } ) => <div>{ children }</div>,
+	PluginPostPublishPanel: ( { children } ) => <div>{ children }</div>,
+	store: 'core/editor',
+} ) );
+// NOTE: paths are relative to THIS test file (one level deeper than index.jsx).
+jest.mock( '../../../shared/jetpack-plugin-sidebar', () => ( { children } ) => (
+	<div>{ children }</div>
+) );
+jest.mock( '../../ai-assistant-plugin/components/seo-enhancer', () => ( {
+	SeoEnhancer: () => <div data-testid="seo-enhancer" />,
+} ) );
+jest.mock( '../../ai-assistant-plugin/components/seo-enhancer/seo-summary', () => ( {
+	SeoSummary: () => <div data-testid="seo-summary" />,
+} ) );
+jest.mock( '../../ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings', () => ( {
+	useSeoModuleSettings: () => ( { isEnabled: false, isToggling: false } ),
+} ) );
+jest.mock( '../../ai-assistant-plugin/components/seo-enhancer/use-seo-requests', () => ( {
+	useSeoRequests: () => ( { updateSeoData: jest.fn(), isBusy: false } ),
+} ) );
+jest.mock( '../components/placeholder', () => ( {
+	SeoPlaceholder: () => null,
+} ) );
+jest.mock( '../components/skeleton-loader', () => ( {
+	SeoSkeletonLoader: () => null,
+} ) );
+jest.mock( '../components/upsell', () => () => null );
+jest.mock( '../description-panel', () => () => <div data-testid="seo-description-panel" /> );
+jest.mock( '../noindex-panel', () => () => null );
+jest.mock( '../schema-panel', () => () => null );
+jest.mock( '../title-panel', () => () => <div data-testid="seo-title-panel" /> );
+jest.mock( '../show-seo-section', () => ( { showSeoSection: jest.fn() } ) );
+// A plain `require()` here (rather than a top-level `import`) so it runs
+// AFTER `mockStore` above is initialized: ES imports are hoisted above
+// regular statements, and index.jsx reads `mockStore` synchronously at
+// module-evaluation time (via `globalSelect( editorStore )`), so a hoisted
+// import would hit it in its temporal dead zone.
+const { settings } = require( '../index' );
+
+describe( 'Seo panel when ai-seo-enhancer is available', () => {
+	test( 'the enhancer renders in all three placements plus the post-publish summary', () => {
+		render( settings.render() );
+
+		expect( screen.getAllByTestId( 'seo-enhancer' ) ).toHaveLength( 3 );
+		expect( screen.getByTestId( 'seo-summary' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/plugins/seo/test/index-available.test.jsx
+++ b/projects/plugins/jetpack/extensions/plugins/seo/test/index-available.test.jsx
@@ -1,11 +1,7 @@
 import { render, screen } from '@testing-library/react';
-// `isSeoEnhancerEnabled` is a module-level constant in index.jsx, computed
-// once at import time from `getJetpackExtensionAvailability( 'ai-seo-enhancer' )`.
-// To pin behaviour for a fixed availability value without `jest.resetModules()`
-// (which reloads React itself and trips React's hooks dispatcher — see the
-// sibling `index-withheld.test.jsx` file for the same note), this file mocks
-// availability as permanently `true` and does a single top-level import of
-// `../index`, matching normal Jest/ESM module semantics.
+// index.jsx computes `isSeoEnhancerEnabled` once at import, so this file
+// hardcodes availability `true` and requires `../index` exactly once. Why not
+// one file with jest.resetModules(): see index-withheld.test.jsx.
 jest.mock( '@automattic/jetpack-publicize/link-preview', () => ( {
 	LinkPreviewModalWithTrigger: () => <div data-testid="link-preview" />,
 } ) );
@@ -75,11 +71,9 @@ jest.mock( '../noindex-panel', () => () => null );
 jest.mock( '../schema-panel', () => () => null );
 jest.mock( '../title-panel', () => () => <div data-testid="seo-title-panel" /> );
 jest.mock( '../show-seo-section', () => ( { showSeoSection: jest.fn() } ) );
-// A plain `require()` here (rather than a top-level `import`) so it runs
-// AFTER `mockStore` above is initialized: ES imports are hoisted above
-// regular statements, and index.jsx reads `mockStore` synchronously at
-// module-evaluation time (via `globalSelect( editorStore )`), so a hoisted
-// import would hit it in its temporal dead zone.
+// Plain require(), not import: ES imports hoist above `mockStore`'s
+// initialization, and index.jsx reads it synchronously at module evaluation —
+// a hoisted import would hit its temporal dead zone.
 const { settings } = require( '../index' );
 
 describe( 'Seo panel when ai-seo-enhancer is available', () => {

--- a/projects/plugins/jetpack/extensions/plugins/seo/test/index-withheld.test.jsx
+++ b/projects/plugins/jetpack/extensions/plugins/seo/test/index-withheld.test.jsx
@@ -1,18 +1,7 @@
 import { render, screen } from '@testing-library/react';
-// `isSeoEnhancerEnabled` is a module-level constant in index.jsx, computed
-// once at import time from `getJetpackExtensionAvailability( 'ai-seo-enhancer' )`.
-// This is a separate file (rather than one file toggling availability with
-// `jest.resetModules()`) because reloading the module registry mid-test also
-// reloads React itself: a fresh `require( '../index' )` picks up a fresh
-// copy of React, while the render helper stays bound to the React instance
-// from before the reset, producing a "Cannot read properties of null
-// (reading 'useRef')" hooks-dispatcher crash. Re-requiring
-// `@testing-library/react` fresh alongside it avoids that crash but then
-// trips a second issue: RTL registers its `afterEach` cleanup hook at
-// import time, and jest-circus refuses hook registration once test
-// execution has started ("Hooks cannot be defined inside tests"). A plain
-// top-level import with a fixed, hardcoded availability value sidesteps
-// both problems by relying on normal one-time module evaluation.
+// Separate file instead of jest.resetModules(): resetting reloads React, so a
+// fresh require of index.jsx crashes the hooks dispatcher against the old RTL
+// binding — and re-requiring RTL trips jest-circus's late-hook registration.
 jest.mock( '@automattic/jetpack-publicize/link-preview', () => ( {
 	LinkPreviewModalWithTrigger: () => <div data-testid="link-preview" />,
 } ) );
@@ -82,11 +71,9 @@ jest.mock( '../noindex-panel', () => () => null );
 jest.mock( '../schema-panel', () => () => null );
 jest.mock( '../title-panel', () => () => <div data-testid="seo-title-panel" /> );
 jest.mock( '../show-seo-section', () => ( { showSeoSection: jest.fn() } ) );
-// A plain `require()` here (rather than a top-level `import`) so it runs
-// AFTER `mockStore` above is initialized: ES imports are hoisted above
-// regular statements, and index.jsx reads `mockStore` synchronously at
-// module-evaluation time (via `globalSelect( editorStore )`), so a hoisted
-// import would hit it in its temporal dead zone.
+// Plain require(), not import: ES imports hoist above `mockStore`'s
+// initialization, and index.jsx reads it synchronously at module evaluation —
+// a hoisted import would hit its temporal dead zone.
 const { settings } = require( '../index' );
 
 describe( 'Seo panel when ai-seo-enhancer is withheld', () => {

--- a/projects/plugins/jetpack/extensions/plugins/seo/test/index-withheld.test.jsx
+++ b/projects/plugins/jetpack/extensions/plugins/seo/test/index-withheld.test.jsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react';
+// `isSeoEnhancerEnabled` is a module-level constant in index.jsx, computed
+// once at import time from `getJetpackExtensionAvailability( 'ai-seo-enhancer' )`.
+// This is a separate file (rather than one file toggling availability with
+// `jest.resetModules()`) because reloading the module registry mid-test also
+// reloads React itself: a fresh `require( '../index' )` picks up a fresh
+// copy of React, while the render helper stays bound to the React instance
+// from before the reset, producing a "Cannot read properties of null
+// (reading 'useRef')" hooks-dispatcher crash. Re-requiring
+// `@testing-library/react` fresh alongside it avoids that crash but then
+// trips a second issue: RTL registers its `afterEach` cleanup hook at
+// import time, and jest-circus refuses hook registration once test
+// execution has started ("Hooks cannot be defined inside tests"). A plain
+// top-level import with a fixed, hardcoded availability value sidesteps
+// both problems by relying on normal one-time module evaluation.
+jest.mock( '@automattic/jetpack-publicize/link-preview', () => ( {
+	LinkPreviewModalWithTrigger: () => <div data-testid="link-preview" />,
+} ) );
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	isWpcomPlatformSite: () => false,
+	isSimpleSite: () => false,
+} ) );
+jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
+	useModuleStatus: () => ( {
+		isLoadingModules: false,
+		isChangingStatus: false,
+		isModuleActive: true,
+		changeStatus: jest.fn(),
+	} ),
+	getJetpackExtensionAvailability: () => ( { available: false } ),
+	getRequiredPlan: () => false,
+} ) );
+jest.mock( '@automattic/jetpack-shared-extension-utils/components', () => ( {
+	JetpackEditorPanelLogo: () => null,
+} ) );
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( { children } ) => <div>{ children }</div>,
+	PanelRow: ( { children } ) => <div>{ children }</div>,
+} ) );
+jest.mock( '@wordpress/core-data', () => ( { store: 'core' } ) );
+const mockStore = {
+	isPublishSidebarOpened: () => false,
+	getCurrentPostType: () => 'post',
+	getPostType: () => ( { viewable: true } ),
+};
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: selector => selector( () => mockStore ),
+	useDispatch: () => ( { closePublishSidebar: jest.fn() } ),
+	select: () => mockStore,
+} ) );
+jest.mock( '@wordpress/editor', () => ( {
+	PluginDocumentSettingPanel: ( { children } ) => <div>{ children }</div>,
+	PluginPrePublishPanel: ( { children } ) => <div>{ children }</div>,
+	PluginPostPublishPanel: ( { children } ) => <div>{ children }</div>,
+	store: 'core/editor',
+} ) );
+// NOTE: paths are relative to THIS test file (one level deeper than index.jsx).
+jest.mock( '../../../shared/jetpack-plugin-sidebar', () => ( { children } ) => (
+	<div>{ children }</div>
+) );
+jest.mock( '../../ai-assistant-plugin/components/seo-enhancer', () => ( {
+	SeoEnhancer: () => <div data-testid="seo-enhancer" />,
+} ) );
+jest.mock( '../../ai-assistant-plugin/components/seo-enhancer/seo-summary', () => ( {
+	SeoSummary: () => <div data-testid="seo-summary" />,
+} ) );
+jest.mock( '../../ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings', () => ( {
+	useSeoModuleSettings: () => ( { isEnabled: false, isToggling: false } ),
+} ) );
+jest.mock( '../../ai-assistant-plugin/components/seo-enhancer/use-seo-requests', () => ( {
+	useSeoRequests: () => ( { updateSeoData: jest.fn(), isBusy: false } ),
+} ) );
+jest.mock( '../components/placeholder', () => ( {
+	SeoPlaceholder: () => null,
+} ) );
+jest.mock( '../components/skeleton-loader', () => ( {
+	SeoSkeletonLoader: () => null,
+} ) );
+jest.mock( '../components/upsell', () => () => null );
+jest.mock( '../description-panel', () => () => <div data-testid="seo-description-panel" /> );
+jest.mock( '../noindex-panel', () => () => null );
+jest.mock( '../schema-panel', () => () => null );
+jest.mock( '../title-panel', () => () => <div data-testid="seo-title-panel" /> );
+jest.mock( '../show-seo-section', () => ( { showSeoSection: jest.fn() } ) );
+// A plain `require()` here (rather than a top-level `import`) so it runs
+// AFTER `mockStore` above is initialized: ES imports are hoisted above
+// regular statements, and index.jsx reads `mockStore` synchronously at
+// module-evaluation time (via `globalSelect( editorStore )`), so a hoisted
+// import would hit it in its temporal dead zone.
+const { settings } = require( '../index' );
+
+describe( 'Seo panel when ai-seo-enhancer is withheld', () => {
+	test( 'no enhancer surface renders — including the component owning the manual Generate button — while plain SEO panels stay', () => {
+		render( settings.render() );
+
+		expect( screen.queryByTestId( 'seo-enhancer' ) ).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'seo-summary' ) ).not.toBeInTheDocument();
+		// The non-AI SEO panels are untouched by the gate (3 placements each).
+		expect( screen.getAllByTestId( 'seo-title-panel' ).length ).toBeGreaterThan( 0 );
+		expect( screen.getAllByTestId( 'seo-description-panel' ).length ).toBeGreaterThan( 0 );
+	} );
+} );

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_SEO_Enhancer_Extension_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_SEO_Enhancer_Extension_Test.php
@@ -35,6 +35,10 @@ class AI_SEO_Enhancer_Extension_Test extends WP_UnitTestCase {
 		parent::set_up();
 
 		Jetpack_Gutenberg::reset();
+		// The toggle ships dark behind the internal-testing flag this release, so
+		// the option-state tests below need to run inside one; individual tests
+		// unset this to exercise the outside-internal-testing (real site) path.
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_offline_mode', '__return_false' );
 		// `get_availability()` walks `get_extensions()`, which is empty under
 		// `TESTING_IN_JETPACK` unless the allowed list is filtered back in, and
@@ -52,6 +56,7 @@ class AI_SEO_Enhancer_Extension_Test extends WP_UnitTestCase {
 	 * Tear down: drop the option, filters, plan pin and availability state.
 	 */
 	public function tear_down() {
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		delete_option( AI_SEO_Enhancer::OPTION );
 		remove_filter( 'jetpack_offline_mode', '__return_false' );
 		remove_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
@@ -181,5 +186,20 @@ class AI_SEO_Enhancer_Extension_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( $row['available'] );
 		$this->assertSame( 'ai_seo_enhancer_disabled', $row['unavailable_reason'] );
+	}
+
+	/**
+	 * The toggle ships dark behind the internal-testing flag this release:
+	 * outside an internal testing environment a stored off must not change
+	 * the editor, so real sites keep the pre-toggle behavior until the flag
+	 * lifts.
+	 */
+	public function test_switched_off_option_is_available_outside_internal_testing_environment() {
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
+		update_option( AI_SEO_Enhancer::OPTION, 0 );
+
+		$row = $this->register_and_get_availability();
+
+		$this->assertTrue( $row['available'] );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_SEO_Enhancer_Extension_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_SEO_Enhancer_Extension_Test.php
@@ -40,10 +40,9 @@ class AI_SEO_Enhancer_Extension_Test extends WP_UnitTestCase {
 		// unset this to exercise the outside-internal-testing (real site) path.
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_offline_mode', '__return_false' );
-		// `get_availability()` walks `get_extensions()`, which is empty under
-		// `TESTING_IN_JETPACK` unless the allowed list is filtered back in, and
-		// `should_load()` bails out early without a ready connection. Mirrors the
-		// minimal pattern `Jetpack_AI_Sidebar_Test` uses for the same reason.
+		// Under TESTING_IN_JETPACK, get_availability() is empty and should_load()
+		// bails without a ready connection unless these are filtered back in.
+		// Mirrors Jetpack_AI_Sidebar_Test's minimal pattern.
 		add_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
 		add_filter( 'jetpack_gutenberg', '__return_true' );
 		add_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_extension_allowlist' ) );
@@ -189,10 +188,8 @@ class AI_SEO_Enhancer_Extension_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The toggle ships dark behind the internal-testing flag this release:
-	 * outside an internal testing environment a stored off must not change
-	 * the editor, so real sites keep the pre-toggle behavior until the flag
-	 * lifts.
+	 * Outside an internal testing environment a stored off must not change the
+	 * editor: real sites keep the pre-toggle behavior until the flag lifts.
 	 */
 	public function test_switched_off_option_is_available_outside_internal_testing_environment() {
 		unset( $_SERVER['A8C_PROXIED_REQUEST'] );

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_SEO_Enhancer_Extension_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_SEO_Enhancer_Extension_Test.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Tests that the `ai-seo-enhancer` extension registration honors the stored
+ * admin toggle: absent = offered, stored off = withheld with a named,
+ * non-upsell reason.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\SEO\AI_SEO_Enhancer;
+use Automattic\Jetpack\Status\Cache as Status_Cache;
+
+require_once JETPACK__PLUGIN_DIR . '/extensions/blocks/ai-assistant/ai-assistant.php';
+
+/**
+ * Tests the `ai-seo-enhancer` extension registration gate.
+ */
+class AI_SEO_Enhancer_Extension_Test extends WP_UnitTestCase {
+	use Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+	use \Activates_Ai_Module;
+
+	const EXTENSION_SLUG = 'ai-seo-enhancer';
+
+	/**
+	 * Priority for the plan pin — later than a dev environment's own
+	 * `pre_option_jetpack_active_plan` short-circuit, so ours wins.
+	 */
+	const PLAN_FILTER_PRIORITY = 20;
+
+	/**
+	 * Set up: AI master on, business plan pinned, clean availability slate.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		Jetpack_Gutenberg::reset();
+		add_filter( 'jetpack_offline_mode', '__return_false' );
+		// `get_availability()` walks `get_extensions()`, which is empty under
+		// `TESTING_IN_JETPACK` unless the allowed list is filtered back in, and
+		// `should_load()` bails out early without a ready connection. Mirrors the
+		// minimal pattern `Jetpack_AI_Sidebar_Test` uses for the same reason.
+		add_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
+		add_filter( 'jetpack_gutenberg', '__return_true' );
+		add_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_extension_allowlist' ) );
+		Status_Cache::clear();
+		$this->activate_ai_module_for_test();
+		self::pin_plan( 'jetpack_business' );
+	}
+
+	/**
+	 * Tear down: drop the option, filters, plan pin and availability state.
+	 */
+	public function tear_down() {
+		delete_option( AI_SEO_Enhancer::OPTION );
+		remove_filter( 'jetpack_offline_mode', '__return_false' );
+		remove_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
+		remove_filter( 'jetpack_gutenberg', '__return_true' );
+		remove_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_extension_allowlist' ) );
+		remove_all_filters( 'ai_seo_enhancer_enabled' );
+		remove_all_filters( 'pre_option_' . Current_Plan::PLAN_OPTION, self::PLAN_FILTER_PRIORITY );
+		self::reset_active_plan_cache();
+		$this->deactivate_ai_module_for_test();
+		Jetpack_Gutenberg::reset();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Limit Jetpack Gutenberg availability checks to the extension under test.
+	 *
+	 * @return array
+	 */
+	public static function get_extension_allowlist() {
+		return array( self::EXTENSION_SLUG );
+	}
+
+	/**
+	 * Pin the site's plan without writing the option, surviving dev-env pins.
+	 *
+	 * @param string $product_slug Plan product slug.
+	 */
+	private static function pin_plan( $product_slug ) {
+		add_filter(
+			'pre_option_' . Current_Plan::PLAN_OPTION,
+			static function () use ( $product_slug ) {
+				return array( 'product_slug' => $product_slug );
+			},
+			self::PLAN_FILTER_PRIORITY
+		);
+		self::reset_active_plan_cache();
+	}
+
+	/**
+	 * `Current_Plan::get()` memoizes per request; reset between tests.
+	 */
+	private static function reset_active_plan_cache() {
+		$property = ( new ReflectionClass( Current_Plan::class ) )->getProperty( 'active_plan_cache' );
+		// @todo Remove once we drop PHP < 8.1 support. `setAccessible()` is
+		// deprecated in 8.5 (a no-op since 8.1), so only call it where needed.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Run the extension registration and return this slug's availability row.
+	 *
+	 * @return array
+	 */
+	private function register_and_get_availability() {
+		do_action( 'jetpack_register_gutenberg_extensions' );
+		$availability = Jetpack_Gutenberg::get_availability();
+
+		$this->assertArrayHasKey( self::EXTENSION_SLUG, $availability );
+
+		return $availability[ self::EXTENSION_SLUG ];
+	}
+
+	/**
+	 * An absent option must not hide the feature: the enhancer pre-dates its
+	 * toggle, so most sites never stored a value. Absent = offered.
+	 */
+	public function test_extension_is_available_when_option_absent() {
+		delete_option( AI_SEO_Enhancer::OPTION );
+
+		$row = $this->register_and_get_availability();
+
+		$this->assertTrue( $row['available'] );
+	}
+
+	/**
+	 * A stored on is offered.
+	 */
+	public function test_extension_is_available_when_option_on() {
+		update_option( AI_SEO_Enhancer::OPTION, 1 );
+
+		$row = $this->register_and_get_availability();
+
+		$this->assertTrue( $row['available'] );
+	}
+
+	/**
+	 * Todd's case: the admin switched the enhancer off, so the extension is
+	 * withheld — which removes every enhancer surface in the editor, including
+	 * the manual "Generate metadata" path.
+	 */
+	public function test_extension_is_unavailable_when_option_off() {
+		update_option( AI_SEO_Enhancer::OPTION, 0 );
+
+		$row = $this->register_and_get_availability();
+
+		$this->assertFalse( $row['available'] );
+		$this->assertSame( 'ai_seo_enhancer_disabled', $row['unavailable_reason'] );
+	}
+
+	/**
+	 * The withheld reason must never be `missing_plan`: that is the only
+	 * reason value with upgrade-nudge semantics in the editor's shared
+	 * helpers, and a deliberate off must not render upgrade messaging.
+	 */
+	public function test_switched_off_reason_is_not_missing_plan() {
+		update_option( AI_SEO_Enhancer::OPTION, 0 );
+
+		$row = $this->register_and_get_availability();
+
+		$this->assertStringNotContainsString( 'missing_plan', $row['unavailable_reason'] );
+	}
+
+	/**
+	 * The host veto filter still wins regardless of the stored toggle, and now
+	 * leaves a named reason instead of silence.
+	 */
+	public function test_filter_veto_wins_over_stored_on() {
+		update_option( AI_SEO_Enhancer::OPTION, 1 );
+		add_filter( 'ai_seo_enhancer_enabled', '__return_false' );
+
+		$row = $this->register_and_get_availability();
+
+		$this->assertFalse( $row['available'] );
+		$this->assertSame( 'ai_seo_enhancer_disabled', $row['unavailable_reason'] );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_SEO_Enhancer_Extension_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_SEO_Enhancer_Extension_Test.php
@@ -60,6 +60,7 @@ class AI_SEO_Enhancer_Extension_Test extends WP_UnitTestCase {
 		remove_all_filters( 'ai_seo_enhancer_enabled' );
 		remove_all_filters( 'pre_option_' . Current_Plan::PLAN_OPTION, self::PLAN_FILTER_PRIORITY );
 		self::reset_active_plan_cache();
+		Status_Cache::clear();
 		$this->deactivate_ai_module_for_test();
 		Jetpack_Gutenberg::reset();
 

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_SEO_Enhancer_Extension_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_SEO_Enhancer_Extension_Test.php
@@ -124,6 +124,21 @@ class AI_SEO_Enhancer_Extension_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Assert our gate offered the extension. Under the wpcomsh suite the WPCOM
+	 * feature gate bypasses the plan pin and reports missing_plan, so the plan
+	 * verdict is only asserted where the plan path is in effect.
+	 *
+	 * @param array $row The slug's availability row.
+	 */
+	private function assert_not_withheld_by_gate( $row ) {
+		$this->assertNotSame( 'ai_seo_enhancer_disabled', $row['unavailable_reason'] ?? '' );
+
+		if ( Current_Plan::supports( 'ai-seo-enhancer' ) ) {
+			$this->assertTrue( $row['available'] );
+		}
+	}
+
+	/**
 	 * An absent option must not hide the feature: the enhancer pre-dates its
 	 * toggle, so most sites never stored a value. Absent = offered.
 	 */
@@ -132,7 +147,7 @@ class AI_SEO_Enhancer_Extension_Test extends WP_UnitTestCase {
 
 		$row = $this->register_and_get_availability();
 
-		$this->assertTrue( $row['available'] );
+		$this->assert_not_withheld_by_gate( $row );
 	}
 
 	/**
@@ -143,7 +158,7 @@ class AI_SEO_Enhancer_Extension_Test extends WP_UnitTestCase {
 
 		$row = $this->register_and_get_availability();
 
-		$this->assertTrue( $row['available'] );
+		$this->assert_not_withheld_by_gate( $row );
 	}
 
 	/**
@@ -197,6 +212,6 @@ class AI_SEO_Enhancer_Extension_Test extends WP_UnitTestCase {
 
 		$row = $this->register_and_get_availability();
 
-		$this->assertTrue( $row['available'] );
+		$this->assert_not_withheld_by_gate( $row );
 	}
 }


### PR DESCRIPTION
## Proposed changes

Hide the editor's SEO Enhancer surfaces when the AI SEO toggle is off, in internal testing environments only. A never-set option keeps today's behavior.

### Screenshots(Jurassic Ninja, internal-testing env)

Captured on a JN site running this branch (also exercised on my Atomic) 

<details>

| State | Editor |
|---|---|
| Toggle never touched | ![absent](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-enhancer-editor-gate/01-absent-panel.jpg) |
| Toggled on | ![on](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-enhancer-editor-gate/02-on-panel-task-list.jpg) |
| Toggled off (AI settings page) | ![off](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-enhancer-editor-gate/05-off-panel-everything-gone.jpg) |
| Off — post-publish (no SEO summary) | ![postpublish](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-enhancer-editor-gate/07-off-postpublish-no-summary.jpg) |
| Back on — enhancer returns | ![roundtrip](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-enhancer-editor-gate/09-roundtrip-panel-restored.jpg) |

</details>

## Related product discussion/links

* FORNO-468
* Base: #51169 (the shared enhancer gate this consumes)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On an internal testing environment (e.g. Jurassic Ninja) with a Business+ plan and SEO tools active:

* Untouched or on: the editor's Optimize SEO enhancer works as before.
* Toggle AI SEO off, reload the editor: the enhancer is gone — no panel section, no "Generate metadata" button — while the non-AI SEO panels keep working.

Reload the editor after each flip; production sites are unaffected (flag off).

🤖 AI Assisted

