### PR TITLE
Subscriptions: persist subscriber email prompt suppression

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nl-823-subscriber-prompt
+++ b/projects/plugins/jetpack/changelog/fix-nl-823-subscriber-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Keep subscribe prompts hidden after visits from subscriber emails.

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -98,10 +98,23 @@ class Jetpack_Subscribe_Modal {
 				'subscribe-modal-js',
 				'Jetpack_Subscriptions',
 				array(
+					'siteId'               => Jetpack_Options::get_option( 'id' ),
 					'modalLoadTime'        => $load_time,
 					'modalScrollThreshold' => $scroll_threshold,
 					'modalInterval'        => ( $modal_interval * HOUR_IN_SECONDS * 1000 ),
 				)
+			);
+			return;
+		}
+
+		// Subscriber email links carry this read-only marker, so no nonce is required.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['jetpack_skip_subscription_popup'] ) ) {
+			wp_enqueue_script( 'subscribe-modal-js', plugins_url( 'subscribe-modal.js', __FILE__ ), array( 'wp-dom-ready' ), JETPACK__VERSION, true );
+			wp_localize_script(
+				'subscribe-modal-js',
+				'Jetpack_Subscriptions',
+				array( 'siteId' => Jetpack_Options::get_option( 'id' ) )
 			);
 		}
 	}

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.php
@@ -98,7 +98,6 @@ class Jetpack_Subscribe_Modal {
 				'subscribe-modal-js',
 				'Jetpack_Subscriptions',
 				array(
-					'siteId'               => Jetpack_Options::get_option( 'id' ),
 					'modalLoadTime'        => $load_time,
 					'modalScrollThreshold' => $scroll_threshold,
 					'modalInterval'        => ( $modal_interval * HOUR_IN_SECONDS * 1000 ),
@@ -111,11 +110,6 @@ class Jetpack_Subscribe_Modal {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['jetpack_skip_subscription_popup'] ) ) {
 			wp_enqueue_script( 'subscribe-modal-js', plugins_url( 'subscribe-modal.js', __FILE__ ), array( 'wp-dom-ready' ), JETPACK__VERSION, true );
-			wp_localize_script(
-				'subscribe-modal-js',
-				'Jetpack_Subscriptions',
-				array( 'siteId' => Jetpack_Options::get_option( 'id' ) )
-			);
 		}
 	}
 

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -3,10 +3,46 @@ const { domReady } = wp;
 domReady( () => {
 	const modal = document.querySelector( '.jetpack-subscribe-modal' );
 	const modalDismissedCookie = 'jetpack_post_subscribe_modal_dismissed';
+	const knownSubscriberKey = `jetpack_post_subscribe_known_subscriber_${ Jetpack_Subscriptions.siteId }`;
 	const skipUrlParam = 'jetpack_skip_subscription_popup';
 
+	function getLocalStorageItem( key ) {
+		try {
+			return localStorage.getItem( key );
+		} catch {
+			return null;
+		}
+	}
+
+	function storeCloseTimestamp() {
+		try {
+			localStorage.setItem( modalDismissedCookie, Date.now() );
+		} catch {
+			// Dismissal timing is best-effort when browser storage is unavailable.
+		}
+	}
+
+	function hasKnownSubscriber() {
+		try {
+			return (
+				localStorage.getItem( knownSubscriberKey ) === 'true' ||
+				document.cookie.split( '; ' ).includes( `${ knownSubscriberKey }=true` )
+			);
+		} catch {
+			return document.cookie.split( '; ' ).includes( `${ knownSubscriberKey }=true` );
+		}
+	}
+
+	function storeKnownSubscriber() {
+		try {
+			localStorage.setItem( knownSubscriberKey, 'true' );
+		} catch {
+			document.cookie = `${ knownSubscriberKey }=true; max-age=31536000; path=/; SameSite=Lax`;
+		}
+	}
+
 	function hasEnoughTimePassed() {
-		const lastDismissed = localStorage.getItem( modalDismissedCookie );
+		const lastDismissed = getLocalStorageItem( modalDismissedCookie );
 		return lastDismissed ? Date.now() - lastDismissed > Jetpack_Subscriptions.modalInterval : true;
 	}
 
@@ -17,14 +53,14 @@ domReady( () => {
 		if ( url.searchParams.has( skipUrlParam ) ) {
 			url.searchParams.delete( skipUrlParam );
 			window.history.replaceState( {}, '', url );
-			storeCloseTimestamp();
+			storeKnownSubscriber();
 			return true;
 		}
 
 		return false;
 	}
 
-	if ( ! modal || ! hasEnoughTimePassed() || skipModal() ) {
+	if ( skipModal() || ! modal || hasKnownSubscriber() || ! hasEnoughTimePassed() ) {
 		return;
 	}
 
@@ -54,12 +90,20 @@ domReady( () => {
 
 	// This take care of the case where the user has multiple tabs open.
 	function onLocalStorage( event ) {
-		if ( event.key === modalDismissedCookie ) {
+		if ( event.key === modalDismissedCookie || event.key === knownSubscriberKey ) {
 			closeModal();
 			removeEventListeners();
 		}
 	}
 	window.addEventListener( 'storage', onLocalStorage );
+
+	function onFocus() {
+		if ( hasKnownSubscriber() ) {
+			closeModal();
+			removeEventListeners();
+		}
+	}
+	window.addEventListener( 'focus', onFocus );
 
 	// When the form is submitted, and next modal loads, it'll fire "subscription-modal-loaded" signalling that this form can be hidden.
 	const form = modal.querySelector( 'form' );
@@ -90,6 +134,11 @@ domReady( () => {
 	}
 
 	function openModal() {
+		if ( hasKnownSubscriber() ) {
+			removeEventListeners();
+			return;
+		}
+
 		// If the user is typing in a form, don't open the modal or has anything else focused.
 		if ( document.activeElement && document.activeElement.tagName !== 'BODY' ) {
 			return;
@@ -107,6 +156,7 @@ domReady( () => {
 		document.body.classList.remove( 'jetpack-subscribe-modal-open' );
 		window.removeEventListener( 'keydown', closeModalOnEscapeKeydown );
 		window.removeEventListener( 'storage', onLocalStorage );
+		window.removeEventListener( 'focus', onFocus );
 		window.removeEventListener( 'click', closeOnWindowClick );
 		storeCloseTimestamp();
 	}
@@ -115,9 +165,5 @@ domReady( () => {
 	function removeEventListeners() {
 		window.removeEventListener( 'scroll', onScroll );
 		clearTimeout( modalLoadTimeout );
-	}
-
-	function storeCloseTimestamp() {
-		localStorage.setItem( modalDismissedCookie, Date.now() );
 	}
 } );

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-modal/subscribe-modal.js
@@ -3,7 +3,7 @@ const { domReady } = wp;
 domReady( () => {
 	const modal = document.querySelector( '.jetpack-subscribe-modal' );
 	const modalDismissedCookie = 'jetpack_post_subscribe_modal_dismissed';
-	const knownSubscriberKey = `jetpack_post_subscribe_known_subscriber_${ Jetpack_Subscriptions.siteId }`;
+	const knownSubscriberKey = 'jetpack_post_subscribe_known_subscriber';
 	const skipUrlParam = 'jetpack_skip_subscription_popup';
 
 	function getLocalStorageItem( key ) {
@@ -23,14 +23,10 @@ domReady( () => {
 	}
 
 	function hasKnownSubscriber() {
-		try {
-			return (
-				localStorage.getItem( knownSubscriberKey ) === 'true' ||
-				document.cookie.split( '; ' ).includes( `${ knownSubscriberKey }=true` )
-			);
-		} catch {
-			return document.cookie.split( '; ' ).includes( `${ knownSubscriberKey }=true` );
-		}
+		return (
+			getLocalStorageItem( knownSubscriberKey ) === 'true' ||
+			document.cookie.split( '; ' ).includes( `${ knownSubscriberKey }=true` )
+		);
 	}
 
 	function storeKnownSubscriber() {

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
@@ -148,11 +148,10 @@ HTML;
 	 */
 	public function enqueue_assets() {
 		$should_user_see_overlay = $this->should_user_see_overlay();
+
 		// Subscriber email links carry this read-only marker, so no nonce is required.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$is_subscriber_email_link = isset( $_GET['jetpack_skip_subscription_popup'] );
-
-		if ( ! $should_user_see_overlay && ! $is_subscriber_email_link ) {
+		if ( ! $should_user_see_overlay && ! isset( $_GET['jetpack_skip_subscription_popup'] ) ) {
 			return;
 		}
 
@@ -160,12 +159,8 @@ HTML;
 			wp_enqueue_style( 'subscribe-overlay-css', plugins_url( 'subscribe-overlay.css', __FILE__ ), array(), JETPACK__VERSION );
 		}
 
+		// The script also records the subscriber signal from email links, so it loads either way.
 		wp_enqueue_script( 'subscribe-overlay-js', plugins_url( 'subscribe-overlay.js', __FILE__ ), array( 'wp-dom-ready' ), JETPACK__VERSION, true );
-		wp_localize_script(
-			'subscribe-overlay-js',
-			'Jetpack_Subscribe_Overlay',
-			array( 'siteId' => Jetpack_Options::get_option( 'id' ) )
-		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php
@@ -147,10 +147,25 @@ HTML;
 	 * @return void
 	 */
 	public function enqueue_assets() {
-		if ( $this->should_user_see_overlay() ) {
-			wp_enqueue_style( 'subscribe-overlay-css', plugins_url( 'subscribe-overlay.css', __FILE__ ), array(), JETPACK__VERSION );
-			wp_enqueue_script( 'subscribe-overlay-js', plugins_url( 'subscribe-overlay.js', __FILE__ ), array( 'wp-dom-ready' ), JETPACK__VERSION, true );
+		$should_user_see_overlay = $this->should_user_see_overlay();
+		// Subscriber email links carry this read-only marker, so no nonce is required.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$is_subscriber_email_link = isset( $_GET['jetpack_skip_subscription_popup'] );
+
+		if ( ! $should_user_see_overlay && ! $is_subscriber_email_link ) {
+			return;
 		}
+
+		if ( $should_user_see_overlay ) {
+			wp_enqueue_style( 'subscribe-overlay-css', plugins_url( 'subscribe-overlay.css', __FILE__ ), array(), JETPACK__VERSION );
+		}
+
+		wp_enqueue_script( 'subscribe-overlay-js', plugins_url( 'subscribe-overlay.js', __FILE__ ), array( 'wp-dom-ready' ), JETPACK__VERSION, true );
+		wp_localize_script(
+			'subscribe-overlay-js',
+			'Jetpack_Subscribe_Overlay',
+			array( 'siteId' => Jetpack_Options::get_option( 'id' ) )
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.js
@@ -1,11 +1,36 @@
+/* global Jetpack_Subscribe_Overlay */
 const { domReady } = wp;
 
 domReady( function () {
 	const overlay = document.querySelector( '.jetpack-subscribe-overlay' );
 	const overlayDismissedCookie = 'jetpack_post_subscribe_overlay_dismissed';
+	const knownSubscriberKey = `jetpack_post_subscribe_known_subscriber_${ Jetpack_Subscribe_Overlay.siteId }`;
 	const skipUrlParam = 'jetpack_skip_subscription_popup';
 	const hasOverlayDismissedCookie =
 		document.cookie && document.cookie.indexOf( overlayDismissedCookie ) > -1;
+
+	function getLocalStorageItem( key ) {
+		try {
+			return localStorage.getItem( key );
+		} catch {
+			return null;
+		}
+	}
+
+	function hasKnownSubscriber() {
+		return (
+			getLocalStorageItem( knownSubscriberKey ) === 'true' ||
+			document.cookie.split( '; ' ).includes( `${ knownSubscriberKey }=true` )
+		);
+	}
+
+	function storeKnownSubscriber() {
+		try {
+			localStorage.setItem( knownSubscriberKey, 'true' );
+		} catch {
+			document.cookie = `${ knownSubscriberKey }=true; max-age=31536000; path=/; SameSite=Lax`;
+		}
+	}
 
 	// Subscriber ended up here e.g. from emails:
 	// we won't show the overlay to them in future since they most likely are already a subscriber.
@@ -14,14 +39,14 @@ domReady( function () {
 		if ( url.searchParams.has( skipUrlParam ) ) {
 			url.searchParams.delete( skipUrlParam );
 			window.history.replaceState( {}, '', url );
-			setOverlayDismissedCookie();
+			storeKnownSubscriber();
 			return true;
 		}
 
 		return false;
 	}
 
-	if ( ! overlay || hasOverlayDismissedCookie || skipOverlay() ) {
+	if ( skipOverlay() || ! overlay || hasKnownSubscriber() || hasOverlayDismissedCookie ) {
 		return;
 	}
 
@@ -46,6 +71,20 @@ domReady( function () {
 		form.addEventListener( 'subscription-modal-loaded', closeOverlay );
 	}
 
+	function onLocalStorage( event ) {
+		if ( event.key === knownSubscriberKey ) {
+			closeOverlay();
+		}
+	}
+	window.addEventListener( 'storage', onLocalStorage );
+
+	function onFocus() {
+		if ( hasKnownSubscriber() ) {
+			closeOverlay();
+		}
+	}
+	window.addEventListener( 'focus', onFocus );
+
 	function closeOverlayOnEscapeKeydown( event ) {
 		if ( event.key === 'Escape' ) {
 			closeOverlay();
@@ -63,6 +102,8 @@ domReady( function () {
 		overlay.classList.remove( 'open' );
 		document.body.classList.remove( 'jetpack-subscribe-overlay-open' );
 		window.removeEventListener( 'keydown', closeOverlayOnEscapeKeydown );
+		window.removeEventListener( 'storage', onLocalStorage );
+		window.removeEventListener( 'focus', onFocus );
 	}
 
 	function setOverlayDismissedCookie() {

--- a/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.js
+++ b/projects/plugins/jetpack/modules/subscriptions/subscribe-overlay/subscribe-overlay.js
@@ -1,10 +1,9 @@
-/* global Jetpack_Subscribe_Overlay */
 const { domReady } = wp;
 
 domReady( function () {
 	const overlay = document.querySelector( '.jetpack-subscribe-overlay' );
 	const overlayDismissedCookie = 'jetpack_post_subscribe_overlay_dismissed';
-	const knownSubscriberKey = `jetpack_post_subscribe_known_subscriber_${ Jetpack_Subscribe_Overlay.siteId }`;
+	const knownSubscriberKey = 'jetpack_post_subscribe_known_subscriber';
 	const skipUrlParam = 'jetpack_skip_subscription_popup';
 	const hasOverlayDismissedCookie =
 		document.cookie && document.cookie.indexOf( overlayDismissedCookie ) > -1;

--- a/projects/plugins/jetpack/modules/subscriptions/test/subscriber-email-prompt-suppression.test.js
+++ b/projects/plugins/jetpack/modules/subscriptions/test/subscriber-email-prompt-suppression.test.js
@@ -1,0 +1,231 @@
+const siteId = 123;
+const knownSubscriberKey = `jetpack_post_subscribe_known_subscriber_${ siteId }`;
+const modalDismissedKey = 'jetpack_post_subscribe_modal_dismissed';
+const overlayDismissedKey = 'jetpack_post_subscribe_overlay_dismissed';
+const skipUrlParam = 'jetpack_skip_subscription_popup';
+const oneDay = 24 * 60 * 60 * 1000;
+
+function visitSubscriberEmailLink() {
+	window.history.replaceState( {}, '', `/?${ skipUrlParam }` );
+}
+
+describe( 'subscriber email prompt suppression', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.setSystemTime( new Date( '2026-08-13T12:00:00Z' ) );
+		jest.resetModules();
+		localStorage.clear();
+		document.body.innerHTML = '';
+		document.cookie = `${ overlayDismissedKey }=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;`;
+		document.cookie = `${ knownSubscriberKey }=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;`;
+		window.history.replaceState( {}, '', '/' );
+		global.wp = { domReady: callback => callback() };
+		global.Jetpack_Subscriptions = {
+			siteId,
+			modalInterval: oneDay,
+			modalLoadTime: 0,
+			modalScrollThreshold: 50,
+		};
+		global.Jetpack_Subscribe_Overlay = { siteId };
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+		jest.restoreAllMocks();
+		delete global.wp;
+		delete global.Jetpack_Subscriptions;
+		delete global.Jetpack_Subscribe_Overlay;
+	} );
+
+	it( 'keeps the subscribe modal suppressed after a subscriber email visit', () => {
+		localStorage.setItem( modalDismissedKey, Date.now() );
+		visitSubscriberEmailLink();
+
+		require( '../subscribe-modal/subscribe-modal' );
+
+		expect( localStorage.getItem( knownSubscriberKey ) ).toBe( 'true' );
+		expect( window.location.search ).toBe( '' );
+
+		jest.resetModules();
+		jest.setSystemTime( Date.now() + oneDay + 1 );
+		document.body.innerHTML = `
+			<div class="entry-content"></div>
+			<div class="jetpack-subscribe-modal">
+				<a class="jetpack-subscribe-modal__close" href="#">Close</a>
+			</div>
+		`;
+		window.history.replaceState( {}, '', '/' );
+		require( '../subscribe-modal/subscribe-modal' );
+		jest.runOnlyPendingTimers();
+
+		expect( document.querySelector( '.jetpack-subscribe-modal' ) ).not.toHaveClass( 'open' );
+	} );
+
+	it( 'keeps the subscribe overlay suppressed after a subscriber email visit', () => {
+		document.cookie = `${ overlayDismissedKey }=true; path=/;`;
+		visitSubscriberEmailLink();
+
+		require( '../subscribe-overlay/subscribe-overlay' );
+
+		expect( localStorage.getItem( knownSubscriberKey ) ).toBe( 'true' );
+		expect( window.location.search ).toBe( '' );
+
+		jest.resetModules();
+		document.body.innerHTML = `
+			<div class="jetpack-subscribe-overlay">
+				<a class="jetpack-subscribe-overlay__close" href="#">Close</a>
+			</div>
+		`;
+		document.cookie = `${ overlayDismissedKey }=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;`;
+		window.history.replaceState( {}, '', '/' );
+		require( '../subscribe-overlay/subscribe-overlay' );
+
+		expect( document.querySelector( '.jetpack-subscribe-overlay' ) ).not.toHaveClass( 'open' );
+	} );
+
+	it( 'closes a pending modal when another tab identifies the visitor as a subscriber', () => {
+		document.body.innerHTML = `
+			<div class="entry-content"></div>
+			<div class="jetpack-subscribe-modal">
+				<a class="jetpack-subscribe-modal__close" href="#">Close</a>
+			</div>
+		`;
+		global.Jetpack_Subscriptions.modalLoadTime = oneDay;
+		require( '../subscribe-modal/subscribe-modal' );
+
+		window.dispatchEvent(
+			new StorageEvent( 'storage', { key: knownSubscriberKey, newValue: 'true' } )
+		);
+		jest.runOnlyPendingTimers();
+
+		expect( document.querySelector( '.jetpack-subscribe-modal' ) ).not.toHaveClass( 'open' );
+	} );
+
+	it( 'does not reopen the modal from a queued animation frame after another tab identifies the visitor', () => {
+		let queuedAnimationFrame;
+		jest.spyOn( window, 'requestAnimationFrame' ).mockImplementation( callback => {
+			queuedAnimationFrame = callback;
+		} );
+		document.body.innerHTML = `
+			<div class="entry-content"></div>
+			<div class="jetpack-subscribe-modal">
+				<a class="jetpack-subscribe-modal__close" href="#">Close</a>
+			</div>
+		`;
+		global.Jetpack_Subscriptions.modalLoadTime = oneDay;
+		require( '../subscribe-modal/subscribe-modal' );
+		window.dispatchEvent( new Event( 'scroll' ) );
+		localStorage.setItem( knownSubscriberKey, 'true' );
+		window.dispatchEvent(
+			new StorageEvent( 'storage', { key: knownSubscriberKey, newValue: 'true' } )
+		);
+
+		queuedAnimationFrame();
+
+		expect( document.querySelector( '.jetpack-subscribe-modal' ) ).not.toHaveClass( 'open' );
+	} );
+
+	it( 'uses a persistent site-specific cookie when local storage is unavailable', () => {
+		const cookieSetter = jest.spyOn( document, 'cookie', 'set' );
+		jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+			throw new DOMException( 'Blocked', 'SecurityError' );
+		} );
+		jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new DOMException( 'Blocked', 'SecurityError' );
+		} );
+		visitSubscriberEmailLink();
+
+		require( '../subscribe-modal/subscribe-modal' );
+
+		expect( document.cookie ).toContain( `${ knownSubscriberKey }=true` );
+		expect( cookieSetter ).toHaveBeenCalledWith( expect.stringContaining( 'max-age=31536000' ) );
+		expect( cookieSetter ).toHaveBeenCalledWith( expect.stringContaining( 'SameSite=Lax' ) );
+		expect( window.location.search ).toBe( '' );
+
+		jest.resetModules();
+		document.body.innerHTML = `
+			<div class="entry-content"></div>
+			<div class="jetpack-subscribe-modal">
+				<a class="jetpack-subscribe-modal__close" href="#">Close</a>
+			</div>
+		`;
+		require( '../subscribe-modal/subscribe-modal' );
+		jest.runOnlyPendingTimers();
+
+		expect( document.querySelector( '.jetpack-subscribe-modal' ) ).not.toHaveClass( 'open' );
+	} );
+
+	it( 'uses a persistent site-specific cookie for the overlay when local storage is unavailable', () => {
+		const cookieSetter = jest.spyOn( document, 'cookie', 'set' );
+		jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+			throw new DOMException( 'Blocked', 'SecurityError' );
+		} );
+		jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new DOMException( 'Blocked', 'SecurityError' );
+		} );
+		visitSubscriberEmailLink();
+
+		require( '../subscribe-overlay/subscribe-overlay' );
+
+		expect( document.cookie ).toContain( `${ knownSubscriberKey }=true` );
+		expect( cookieSetter ).toHaveBeenCalledWith( expect.stringContaining( 'max-age=31536000' ) );
+		expect( cookieSetter ).toHaveBeenCalledWith( expect.stringContaining( 'SameSite=Lax' ) );
+		expect( window.location.search ).toBe( '' );
+
+		jest.resetModules();
+		document.body.innerHTML = `
+			<div class="jetpack-subscribe-overlay">
+				<a class="jetpack-subscribe-overlay__close" href="#">Close</a>
+			</div>
+		`;
+		require( '../subscribe-overlay/subscribe-overlay' );
+
+		expect( document.querySelector( '.jetpack-subscribe-overlay' ) ).not.toHaveClass( 'open' );
+	} );
+
+	it( 'shows the overlay when local storage is unavailable without a subscriber cookie', () => {
+		jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+			throw new DOMException( 'Blocked', 'SecurityError' );
+		} );
+		document.body.innerHTML = `
+			<div class="jetpack-subscribe-overlay">
+				<a class="jetpack-subscribe-overlay__close" href="#">Close</a>
+			</div>
+		`;
+
+		require( '../subscribe-overlay/subscribe-overlay' );
+
+		expect( document.querySelector( '.jetpack-subscribe-overlay' ) ).toHaveClass( 'open' );
+		window.dispatchEvent(
+			new StorageEvent( 'storage', { key: knownSubscriberKey, newValue: 'true' } )
+		);
+	} );
+
+	it( 'closes prompts on focus when another tab sets the fallback cookie', () => {
+		jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+			throw new DOMException( 'Blocked', 'SecurityError' );
+		} );
+		document.body.innerHTML = `
+			<div class="entry-content"></div>
+			<div class="jetpack-subscribe-modal">
+				<a class="jetpack-subscribe-modal__close" href="#">Close</a>
+			</div>
+			<div class="jetpack-subscribe-overlay">
+				<a class="jetpack-subscribe-overlay__close" href="#">Close</a>
+			</div>
+		`;
+
+		require( '../subscribe-modal/subscribe-modal' );
+		require( '../subscribe-overlay/subscribe-overlay' );
+		jest.runOnlyPendingTimers();
+		expect( document.querySelector( '.jetpack-subscribe-modal' ) ).toHaveClass( 'open' );
+		expect( document.querySelector( '.jetpack-subscribe-overlay' ) ).toHaveClass( 'open' );
+
+		document.cookie = `${ knownSubscriberKey }=true; max-age=31536000; path=/; SameSite=Lax`;
+		window.dispatchEvent( new Event( 'focus' ) );
+
+		expect( document.querySelector( '.jetpack-subscribe-modal' ) ).not.toHaveClass( 'open' );
+		expect( document.querySelector( '.jetpack-subscribe-overlay' ) ).not.toHaveClass( 'open' );
+	} );
+} );

--- a/projects/plugins/jetpack/modules/subscriptions/test/subscriber-email-prompt-suppression.test.js
+++ b/projects/plugins/jetpack/modules/subscriptions/test/subscriber-email-prompt-suppression.test.js
@@ -1,5 +1,4 @@
-const siteId = 123;
-const knownSubscriberKey = `jetpack_post_subscribe_known_subscriber_${ siteId }`;
+const knownSubscriberKey = 'jetpack_post_subscribe_known_subscriber';
 const modalDismissedKey = 'jetpack_post_subscribe_modal_dismissed';
 const overlayDismissedKey = 'jetpack_post_subscribe_overlay_dismissed';
 const skipUrlParam = 'jetpack_skip_subscription_popup';
@@ -21,12 +20,10 @@ describe( 'subscriber email prompt suppression', () => {
 		window.history.replaceState( {}, '', '/' );
 		global.wp = { domReady: callback => callback() };
 		global.Jetpack_Subscriptions = {
-			siteId,
 			modalInterval: oneDay,
 			modalLoadTime: 0,
 			modalScrollThreshold: 50,
 		};
-		global.Jetpack_Subscribe_Overlay = { siteId };
 	} );
 
 	afterEach( () => {
@@ -35,7 +32,6 @@ describe( 'subscriber email prompt suppression', () => {
 		jest.restoreAllMocks();
 		delete global.wp;
 		delete global.Jetpack_Subscriptions;
-		delete global.Jetpack_Subscribe_Overlay;
 	} );
 
 	it( 'keeps the subscribe modal suppressed after a subscriber email visit', () => {
@@ -60,6 +56,17 @@ describe( 'subscriber email prompt suppression', () => {
 		jest.runOnlyPendingTimers();
 
 		expect( document.querySelector( '.jetpack-subscribe-modal' ) ).not.toHaveClass( 'open' );
+	} );
+
+	// Off the modal surface the script is enqueued without localized settings.
+	it( 'records the subscriber signal without localized modal settings', () => {
+		delete global.Jetpack_Subscriptions;
+		visitSubscriberEmailLink();
+
+		require( '../subscribe-modal/subscribe-modal' );
+
+		expect( localStorage.getItem( knownSubscriberKey ) ).toBe( 'true' );
+		expect( window.location.search ).toBe( '' );
 	} );
 
 	it( 'keeps the subscribe overlay suppressed after a subscriber email visit', () => {
@@ -126,7 +133,7 @@ describe( 'subscriber email prompt suppression', () => {
 		expect( document.querySelector( '.jetpack-subscribe-modal' ) ).not.toHaveClass( 'open' );
 	} );
 
-	it( 'uses a persistent site-specific cookie when local storage is unavailable', () => {
+	it( 'uses a persistent cookie when local storage is unavailable', () => {
 		const cookieSetter = jest.spyOn( document, 'cookie', 'set' );
 		jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
 			throw new DOMException( 'Blocked', 'SecurityError' );
@@ -156,7 +163,7 @@ describe( 'subscriber email prompt suppression', () => {
 		expect( document.querySelector( '.jetpack-subscribe-modal' ) ).not.toHaveClass( 'open' );
 	} );
 
-	it( 'uses a persistent site-specific cookie for the overlay when local storage is unavailable', () => {
+	it( 'uses a persistent cookie for the overlay when local storage is unavailable', () => {
 		const cookieSetter = jest.spyOn( document, 'cookie', 'set' );
 		jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
 			throw new DOMException( 'Blocked', 'SecurityError' );

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Subscribe_Prompt_Assets_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Subscribe_Prompt_Assets_Test.php
@@ -1,0 +1,63 @@
+<?php
+
+require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions.php';
+
+class Subscribe_Prompt_Assets_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$_GET['jetpack_skip_subscription_popup'] = '';
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		unset( $_GET['jetpack_skip_subscription_popup'] );
+		wp_dequeue_script( 'subscribe-modal-js' );
+		wp_deregister_script( 'subscribe-modal-js' );
+		wp_dequeue_style( 'subscribe-modal-css' );
+		wp_deregister_style( 'subscribe-modal-css' );
+		wp_dequeue_script( 'subscribe-overlay-js' );
+		wp_deregister_script( 'subscribe-overlay-js' );
+		wp_dequeue_style( 'subscribe-overlay-css' );
+		wp_deregister_style( 'subscribe-overlay-css' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Subscriber email markers must be processed even off the modal surface.
+	 */
+	public function test_subscriber_email_link_enqueues_modal_script_without_modal_styles() {
+		$modal = $this->getMockBuilder( Jetpack_Subscribe_Modal::class )
+			->onlyMethods( array( 'should_user_see_modal' ) )
+			->disableOriginalConstructor()
+			->getMock();
+		$modal->expects( $this->once() )->method( 'should_user_see_modal' )->willReturn( false );
+
+		$modal->enqueue_assets();
+
+		$this->assertTrue( wp_script_is( 'subscribe-modal-js', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'subscribe-modal-css', 'enqueued' ) );
+	}
+
+	/**
+	 * Subscriber email markers must be processed even off the overlay surface.
+	 */
+	public function test_subscriber_email_link_enqueues_overlay_script_without_overlay_styles() {
+		$overlay = $this->getMockBuilder( Jetpack_Subscribe_Overlay::class )
+			->onlyMethods( array( 'should_user_see_overlay' ) )
+			->disableOriginalConstructor()
+			->getMock();
+		$overlay->expects( $this->once() )->method( 'should_user_see_overlay' )->willReturn( false );
+
+		$overlay->enqueue_assets();
+
+		$this->assertTrue( wp_script_is( 'subscribe-overlay-js', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'subscribe-overlay-css', 'enqueued' ) );
+	}
+}


### PR DESCRIPTION
Fixes NL-823

## Proposed changes

* Store a known-subscriber signal when a visitor arrives through a newsletter email link.
* Process that signal even when the landing page cannot render the configured subscribe modal or overlay.
* Keep other tabs from showing an already-scheduled prompt, with a persistent cookie fallback when local storage is unavailable.
* Add focused browser-script and PHP asset-enqueue regression tests.

## Related product discussion/links

* NL-823

## Does this pull request change what data or activity we track or use?

No. This changes only local browser suppression state and does not add analytics or server-side tracking.

## Testing instructions

### Automated

* `pnpm --dir projects/plugins/jetpack exec jest --config=tests/jest.config.client.js modules/subscriptions/test/subscriber-email-prompt-suppression.test.js --runInBand --coverage=false`
* `pnpm jetpack docker phpunit jetpack -- --filter=Subscribe_Prompt_Assets_Test`
* `pnpm run lint-changed`
* `pnpm --dir projects/plugins/jetpack run typecheck`

### Manual

1. Enable the Subscribe Modal or Subscribe Overlay.
2. Visit a site URL with `?jetpack_skip_subscription_popup`, as newsletter email links do.
3. Confirm the query parameter is removed without showing a subscribe prompt.
4. Return after the normal modal dismissal interval, or clear the ordinary overlay dismissal cookie.
5. Confirm the configured prompt remains hidden.
6. Clear the `jetpack_post_subscribe_known_subscriber` key from local storage and cookies.
7. Reload an eligible page and confirm the configured prompt opens normally.
