### PR TITLE
test: cover the block editor extension-loading chain end to end

### DIFF
--- a/projects/plugins/jetpack/changelog/add-editor-extension-loading-integration-test
+++ b/projects/plugins/jetpack/changelog/add-editor-extension-loading-integration-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add integration test coverage for the block editor extension-loading chain.
+
+

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
@@ -636,7 +636,7 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $name Extension name; the PID suffix is appended.
 	 *
-	 * @return array Fixture data: the final `name`/`slug` and the `dir`/`file` paths.
+	 * @return array Fixture data: the final `slug` and the `dir`/`file` paths.
 	 */
 	private function create_fixture_editor_extension( $name ) {
 		$name .= '-' . getmypid();
@@ -650,7 +650,6 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		return array(
-			'name' => $name,
 			'slug' => $name,
 			'dir'  => $dir,
 			'file' => $file,
@@ -1207,6 +1206,12 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	 * load_block_editor_extensions() -> include of the extension file ->
 	 * its jetpack_register_gutenberg_extensions callback -> get_availability(),
 	 * which is the structure Jetpack_Editor_Initial_State hands to the editor.
+	 *
+	 * Note: load_block_editor_extensions() globs and include_once's every real
+	 * extension file too (the jetpack_set_available_extensions filter narrows only
+	 * get_availability()'s output, not the include loop). Isolation therefore relies
+	 * on set_up()'s remove_all_actions( 'jetpack_register_gutenberg_extensions' ) plus
+	 * this filter, which ignores whatever those real extensions register.
 	 *
 	 * @param string $slug Fixture extension slug to expose and look up.
 	 *

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
@@ -621,6 +621,57 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Create a throwaway editor-only extension fixture under extensions/extended-blocks.
+	 *
+	 * Mirrors the shape of a real editor-only extension such as
+	 * extensions/extended-blocks/core-video/core-video.php: the file registers an
+	 * availability callback on `jetpack_register_gutenberg_extensions`, which is the
+	 * hook get_availability() fires. The extension name is not in
+	 * Jetpack_Gutenberg::$frontend_editor_extensions, so load_block_editor_extensions()
+	 * includes it only in a block-editor context.
+	 *
+	 * The name is suffixed with the current PID for the same reason as
+	 * create_lazy_fixture_block(): php-normal and php-multisite run concurrently in
+	 * the same checkout.
+	 *
+	 * @param string $name Extension name; the PID suffix is appended.
+	 *
+	 * @return array Fixture data: the final `name`/`slug` and the `dir`/`file` paths.
+	 */
+	private function create_fixture_editor_extension( $name ) {
+		$name .= '-' . getmypid();
+		$dir   = JETPACK__PLUGIN_DIR . 'extensions/extended-blocks/' . $name;
+		$file  = $dir . '/' . $name . '.php';
+		wp_mkdir_p( $dir );
+
+		file_put_contents(
+			$file,
+			"<?php\nadd_action( 'jetpack_register_gutenberg_extensions', function () { \\Jetpack_Gutenberg::set_extension_available( '{$name}' ); } );\n"
+		);
+
+		return array(
+			'name' => $name,
+			'slug' => $name,
+			'dir'  => $dir,
+			'file' => $file,
+		);
+	}
+
+	/**
+	 * Remove a throwaway editor-only extension fixture.
+	 *
+	 * @param array $fixture Fixture data from create_fixture_editor_extension().
+	 */
+	private function remove_fixture_editor_extension( $fixture ) {
+		if ( file_exists( $fixture['file'] ) ) {
+			unlink( $fixture['file'] );
+		}
+		if ( is_dir( $fixture['dir'] ) ) {
+			rmdir( $fixture['dir'] );
+		}
+	}
+
+	/**
 	 * Non-web contexts (empty REQUEST_URI: WP-CLI, test runs) load blocks eagerly.
 	 */
 	public function test_is_block_editor_context_is_true_without_request_uri() {
@@ -1145,6 +1196,117 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 			} else {
 				unset( $_SERVER['REQUEST_URI'] );
 			}
+		}
+	}
+
+	/**
+	 * Run load_block_editor_extensions() against a fixture extension and return its
+	 * entry from get_availability().
+	 *
+	 * Drives the whole observable chain rather than the gate predicate alone:
+	 * load_block_editor_extensions() -> include of the extension file ->
+	 * its jetpack_register_gutenberg_extensions callback -> get_availability(),
+	 * which is the structure Jetpack_Editor_Initial_State hands to the editor.
+	 *
+	 * @param string $slug Fixture extension slug to expose and look up.
+	 *
+	 * @return array|null The availability entry for $slug, or null if absent.
+	 */
+	private function get_availability_after_loading_extensions( $slug ) {
+		$extensions_filter = static function () use ( $slug ) {
+			return array( $slug );
+		};
+
+		add_filter( 'jetpack_offline_mode', '__return_true' );
+		add_filter( 'jetpack_gutenberg', '__return_true' );
+		add_filter( 'jetpack_set_available_extensions', $extensions_filter, 99 );
+		Jetpack_Gutenberg::reset();
+
+		try {
+			Jetpack_Gutenberg::load_block_editor_extensions();
+
+			$availability = Jetpack_Gutenberg::get_availability();
+
+			return $availability[ $slug ] ?? null;
+		} finally {
+			remove_filter( 'jetpack_set_available_extensions', $extensions_filter, 99 );
+			remove_filter( 'jetpack_offline_mode', '__return_true' );
+			remove_filter( 'jetpack_gutenberg', '__return_true' );
+			Jetpack_Gutenberg::reset();
+		}
+	}
+
+	/**
+	 * On a WordPress.com Simple REST request, an editor-only extension is loaded and
+	 * reaches get_availability() as available.
+	 *
+	 * This is the integration counterpart to
+	 * test_is_block_editor_context_is_true_for_wpcom_rest_api_request: that test proves
+	 * the predicate flips, this one proves the extension actually reaches the editor.
+	 * Without REST_API_REQUEST detection, extensions/extended-blocks/core-video is never
+	 * included, so available_blocks['core/video'] never reaches the editor and the
+	 * upgrade nudge silently disappears.
+	 */
+	public function test_wpcom_rest_api_request_loads_editor_only_extension() {
+		$fixture   = $this->create_fixture_editor_extension( 'zz-editor-extension-rest-fixture' );
+		$saved_uri = $_SERVER['REQUEST_URI'] ?? null;
+
+		// A front-end URL: only the REST_API_REQUEST constant should open the eager path.
+		$_SERVER['REQUEST_URI'] = '/sample-page/';
+		Constants::set_constant( 'REST_API_REQUEST', true );
+
+		try {
+			$entry = $this->get_availability_after_loading_extensions( $fixture['slug'] );
+
+			$this->assertIsArray( $entry, 'The fixture extension should appear in get_availability().' );
+			$this->assertTrue(
+				$entry['available'],
+				'An editor-only extension should be available on a WordPress.com Simple REST request.'
+			);
+		} finally {
+			Constants::clear_single_constant( 'REST_API_REQUEST' );
+			if ( null !== $saved_uri ) {
+				$_SERVER['REQUEST_URI'] = $saved_uri;
+			} else {
+				unset( $_SERVER['REQUEST_URI'] );
+			}
+			$this->remove_fixture_editor_extension( $fixture );
+		}
+	}
+
+	/**
+	 * The counterpart negative case: on a plain front-end request an editor-only
+	 * extension is not loaded, so it never becomes available.
+	 *
+	 * Without this the positive test above would pass even if the front-end skip in
+	 * load_block_editor_extensions() stopped working entirely.
+	 *
+	 * Uses its own fixture name because load_block_editor_extensions() includes the
+	 * file with include_once; reusing the positive test's name could leave its
+	 * already-registered callback in place within the same process.
+	 */
+	public function test_frontend_request_does_not_load_editor_only_extension() {
+		$fixture   = $this->create_fixture_editor_extension( 'zz-editor-extension-frontend-fixture' );
+		$saved_uri = $_SERVER['REQUEST_URI'] ?? null;
+
+		$_SERVER['REQUEST_URI'] = '/sample-page/';
+
+		try {
+			$entry = $this->get_availability_after_loading_extensions( $fixture['slug'] );
+
+			$this->assertIsArray( $entry, 'The fixture extension should still be listed in get_availability().' );
+			$this->assertFalse(
+				$entry['available'],
+				'An editor-only extension should not be loaded on a plain front-end request.'
+			);
+			$this->assertSame( 'missing_module', $entry['unavailable_reason'] );
+		} finally {
+			if ( null !== $saved_uri ) {
+				$_SERVER['REQUEST_URI'] = $saved_uri;
+			} else {
+				unset( $_SERVER['REQUEST_URI'] );
+			}
+			$this->remove_fixture_editor_extension( $fixture );
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #50819, addressing https://github.com/Automattic/jetpack/pull/50819#discussion_r3722016812.

## Proposed changes

* Add two integration tests covering the block editor extension-loading chain end to end, rather than the `is_block_editor_context()` predicate alone.

The three tests added in #50819 call the private predicate through the `invoke_is_block_editor_context()` reflection helper. They prove the boolean flips, but they would still pass if the gate were correct and the extension wiring regressed underneath it. The regression users actually hit runs one layer lower:

```
is_block_editor_context() returns false
→ load_block_editor_extensions() skips extensions/extended-blocks/core-video/core-video.php
→ its jetpack_register_gutenberg_extensions callback never registers
→ available_blocks['core/video'] never reaches Jetpack_Editor_Initial_State
→ isUpgradable() reads exactly that entry, so no upgrade nudge renders
```

The new tests assert on `Jetpack_Gutenberg::get_availability()` — the same structure the front end reads — after running the real loading path:

* `test_wpcom_rest_api_request_loads_editor_only_extension` — with `REST_API_REQUEST` set and a front-end `REQUEST_URI`, an editor-only extension is loaded and reported available.
* `test_frontend_request_does_not_load_editor_only_extension` — on a plain front-end request the same extension is absent. Without this the positive test would still pass if the front-end skip in `load_block_editor_extensions()` stopped working entirely.

### Implementation notes

`Jetpack_Gutenberg_Test::set_up()` ends with `remove_all_actions( 'jetpack_register_gutenberg_extensions' )`, which is exactly the hook a real extension registers on. Rather than re-adding that action and destabilizing a 77-test class, the tests use a throwaway fixture extension following the existing `create_lazy_fixture_block()` / `remove_lazy_fixture_block()` pattern already in this file. That keeps the class-level `remove_all_actions()` intact and avoids coupling the tests to `core-video` shipping forever.

Two details worth flagging for review:

* The fixture name carries a `getmypid()` suffix, matching the existing lazy-block fixtures — php-normal and php-multisite run concurrently in the same checkout, so a fixed path lets one process delete the fixture out from under the other.
* Each test uses its own fixture name because `load_block_editor_extensions()` includes files with `include_once`; a shared name would leave the first test's already-registered callback in place for the second.

No production code changes — the only non-test file is the changelog entry.

## Related product discussion/links

* #50819

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

These tests need the full WordPress environment:

```
jp docker up -d
jp docker install
```

Run the new tests:

```
jp docker phpunit jetpack -- --filter 'test_wpcom_rest_api_request_loads_editor_only_extension|test_frontend_request_does_not_load_editor_only_extension'
```

Expected: `OK (2 tests, 5 assertions)`.

Run the full class:

```
jp docker phpunit jetpack -- --filter Jetpack_Gutenberg_Test
```

Expected: `OK (79 tests, 282 assertions)`. Baseline on trunk is 77 tests / 277 assertions.
