### PR TITLE
VideoPress: add a playlist block

### DIFF
--- a/projects/packages/videopress/changelog/vidp-370-add-a-videopress-playlist-block
+++ b/projects/packages/videopress/changelog/vidp-370-add-a-videopress-playlist-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a VideoPress playlist block that stores a list of video GUIDs and plays them in sequence.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -625,6 +625,73 @@ class Initializer {
 	}
 
 	/**
+	 * Format a millisecond duration as m:ss or h:mm:ss.
+	 *
+	 * @param int $duration_ms Duration in milliseconds.
+	 *
+	 * @return string Formatted duration, or an empty string for unusable input.
+	 */
+	private static function format_playlist_duration( $duration_ms ) {
+		if ( ! is_numeric( $duration_ms ) || $duration_ms <= 0 ) {
+			return '';
+		}
+
+		$total_seconds = (int) round( $duration_ms / 1000 );
+		$hours         = (int) floor( $total_seconds / 3600 );
+		$minutes       = (int) floor( ( $total_seconds % 3600 ) / 60 );
+		$seconds       = $total_seconds % 60;
+
+		if ( $hours > 0 ) {
+			return sprintf( '%d:%02d:%02d', $hours, $minutes, $seconds );
+		}
+
+		return sprintf( '%d:%02d', $minutes, $seconds );
+	}
+
+	/**
+	 * Format a millisecond duration as a long runtime, e.g. "1 hr 13 min".
+	 *
+	 * @param int $duration_ms Duration in milliseconds.
+	 *
+	 * @return string Formatted runtime, or an empty string for unusable input.
+	 */
+	private static function format_playlist_runtime( $duration_ms ) {
+		if ( ! is_numeric( $duration_ms ) || $duration_ms <= 0 ) {
+			return '';
+		}
+
+		$total_minutes = max( 1, (int) round( $duration_ms / 60000 ) );
+		$hours         = (int) floor( $total_minutes / 60 );
+		$minutes       = $total_minutes % 60;
+
+		if ( $hours > 0 ) {
+			return $minutes > 0
+				/* translators: 1: hours, 2: minutes. */
+				? sprintf( __( '%1$d hr %2$d min', 'jetpack-videopress-pkg' ), $hours, $minutes )
+				/* translators: %d: hours. */
+				: sprintf( __( '%d hr', 'jetpack-videopress-pkg' ), $hours );
+		}
+
+		/* translators: %d: minutes. */
+		return sprintf( __( '%d min', 'jetpack-videopress-pkg' ), $minutes );
+	}
+
+	/**
+	 * Map a video height to a quality/resolution badge label.
+	 *
+	 * @param int $height Video height in pixels.
+	 *
+	 * @return string Badge label, or an empty string for unusable input.
+	 */
+	private static function playlist_quality_label( $height ) {
+		if ( ! is_numeric( $height ) || $height <= 0 ) {
+			return '';
+		}
+
+		return $height >= 2160 ? '4K' : ( (int) $height ) . 'p';
+	}
+
+	/**
 	 * VideoPress playlist block render method.
 	 *
 	 * @param array $block_attributes Block attributes.
@@ -646,8 +713,11 @@ class Initializer {
 				}
 
 				$videos[] = array(
-					'guid'  => $video['guid'],
-					'title' => isset( $video['title'] ) && is_string( $video['title'] ) ? $video['title'] : '',
+					'guid'       => $video['guid'],
+					'title'      => isset( $video['title'] ) && is_string( $video['title'] ) ? $video['title'] : '',
+					'durationMs' => isset( $video['durationMs'] ) && is_numeric( $video['durationMs'] ) ? (int) $video['durationMs'] : 0,
+					'height'     => isset( $video['height'] ) && is_numeric( $video['height'] ) ? (int) $video['height'] : 0,
+					'poster'     => isset( $video['poster'] ) && is_string( $video['poster'] ) ? $video['poster'] : '',
 				);
 			}
 		}
@@ -659,31 +729,91 @@ class Initializer {
 		$auto_advance = ! isset( $block_attributes['autoAdvance'] ) || $block_attributes['autoAdvance'];
 		$loop         = ! empty( $block_attributes['loop'] );
 
+		$layout = isset( $block_attributes['layout'] ) && in_array( $block_attributes['layout'], array( 'rail', 'grid', 'strip' ), true )
+			? $block_attributes['layout']
+			: 'rail';
+
+		$show = function ( $key ) use ( $block_attributes ) {
+			return ! isset( $block_attributes[ $key ] ) || $block_attributes[ $key ];
+		};
+
+		$wrapper_classes = array( 'videopress-playlist--' . $layout );
+		if ( ! empty( $block_attributes['darkSurface'] ) ) {
+			$wrapper_classes[] = 'is-dark';
+		}
+		if ( ! $show( 'showThumbnail' ) ) {
+			$wrapper_classes[] = 'hide-thumbnails';
+		}
+		if ( ! $show( 'showTitle' ) ) {
+			$wrapper_classes[] = 'hide-titles';
+		}
+		if ( ! $show( 'showResolution' ) ) {
+			$wrapper_classes[] = 'hide-resolution';
+		}
+		if ( ! $show( 'showDuration' ) ) {
+			$wrapper_classes[] = 'hide-duration';
+		}
+		if ( ! empty( $block_attributes['showPosition'] ) ) {
+			$wrapper_classes[] = 'show-position';
+		}
+		if ( ! $show( 'showTotalRuntime' ) ) {
+			$wrapper_classes[] = 'hide-runtime';
+		}
+
 		// The JWT token bridge lets the embed play private videos for authorized viewers.
 		Jwt_Token_Bridge::enqueue_jwt_token_bridge();
 
+		/*
+		 * Stored metadata is initial content only; the view script refreshes
+		 * title, thumbnail, duration, and quality from the VideoPress API on
+		 * the client so entries always reflect the videos' current data.
+		 */
 		$items_markup = '';
+		$total_ms     = 0;
 		foreach ( $videos as $index => $video ) {
 			$title = '' !== $video['title']
 				? $video['title']
 				/* translators: %d: position of the video in the playlist. */
 				: sprintf( __( 'Video %d', 'jetpack-videopress-pkg' ), $index + 1 );
 
-			/*
-			 * The stored title is initial content only; the view script refreshes
-			 * title, duration, and quality from the VideoPress API on the client,
-			 * filling the empty badge/duration placeholders.
-			 */
+			$duration  = self::format_playlist_duration( $video['durationMs'] );
+			$total_ms += $video['durationMs'];
+
+			$thumb_markup = '' !== $video['poster']
+				? sprintf( '<img src="%s" alt="" loading="lazy" />', esc_url( $video['poster'] ) )
+				: '';
+
 			$items_markup .= sprintf(
-				'<li><button type="button" class="videopress-playlist__item%1$s" data-guid="%2$s" data-src="%3$s" aria-current="%4$s"><span class="videopress-playlist__item-index">%5$d.</span><span class="videopress-playlist__item-title">%6$s</span><span class="videopress-playlist__item-badge"></span><span class="videopress-playlist__item-duration"></span></button></li>',
+				'<li><button type="button" class="videopress-playlist__item%1$s" data-guid="%2$s" data-src="%3$s" data-duration-ms="%4$d" aria-current="%5$s">' .
+					'<span class="videopress-playlist__item-thumb">%6$s<span class="videopress-playlist__item-index">%7$d</span><span class="videopress-playlist__item-thumb-duration">%8$s</span></span>' .
+					'<span class="videopress-playlist__item-text"><span class="videopress-playlist__item-title">%9$s</span><span class="videopress-playlist__item-meta"><span class="videopress-playlist__item-badge">%10$s</span><span class="videopress-playlist__item-duration">%11$s</span></span></span>' .
+					'</button></li>',
 				0 === $index ? ' is-current' : '',
 				esc_attr( $video['guid'] ),
 				esc_url( self::get_playlist_embed_url( $video['guid'], true ) ),
+				$video['durationMs'],
 				0 === $index ? 'true' : 'false',
+				$thumb_markup,
 				$index + 1,
-				esc_html( $title )
+				esc_html( $duration ),
+				esc_html( $title ),
+				esc_html( self::playlist_quality_label( $video['height'] ) ),
+				esc_html( $duration )
 			);
 		}
+
+		$runtime       = self::format_playlist_runtime( $total_ms );
+		$header_markup = sprintf(
+			'<div class="videopress-playlist__header"><span class="videopress-playlist__count">%s</span><span class="videopress-playlist__runtime">%s</span></div>',
+			esc_html(
+				sprintf(
+					/* translators: %d: number of videos in the playlist. */
+					_n( '%d video', '%d videos', count( $videos ), 'jetpack-videopress-pkg' ),
+					count( $videos )
+				)
+			),
+			esc_html( $runtime )
+		);
 
 		$player_markup = sprintf(
 			'<div class="videopress-playlist__player-wrapper"><iframe class="videopress-playlist__player" title="%1$s" aria-label="%1$s" src="%2$s" data-guid="%3$s" allowfullscreen allow="clipboard-write; presentation"></iframe></div>',
@@ -694,6 +824,7 @@ class Initializer {
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
+				'class'             => implode( ' ', $wrapper_classes ),
 				'data-auto-advance' => $auto_advance ? '1' : '0',
 				'data-loop'         => $loop ? '1' : '0',
 			)
@@ -702,8 +833,9 @@ class Initializer {
 		// An unordered list: item numbering comes from the index spans, so theme
 		// list styles can never double up the numbers.
 		return sprintf(
-			'<figure %1$s>%2$s<ul class="videopress-playlist__items">%3$s</ul></figure>',
+			'<figure %1$s>%2$s<div class="videopress-playlist__body">%3$s<ul class="videopress-playlist__items">%4$s</ul></div></figure>',
 			$wrapper_attributes,
+			$header_markup,
 			$player_markup,
 			$items_markup
 		);

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -558,9 +558,12 @@ class Initializer {
 	/**
 	 * Register the VideoPress playlist block.
 	 *
+	 * @param string|null $metadata_file Path to the block.json metadata file.
+	 *                                   Defaults to the package build output; tests can point at a fixture.
+	 *
 	 * @return void
 	 */
-	public static function register_videopress_playlist_block() {
+	public static function register_videopress_playlist_block( $metadata_file = null ) {
 		/*
 		 * Unlike the video block, the playlist block has no "activate the module"
 		 * placeholder, so don't register it at all when VideoPress isn't available.
@@ -572,7 +575,10 @@ class Initializer {
 			return;
 		}
 
-		$metadata_file = __DIR__ . '/../build/block-editor/blocks/playlist/block.json';
+		if ( null === $metadata_file ) {
+			$metadata_file = __DIR__ . '/../build/block-editor/blocks/playlist/block.json';
+		}
+
 		if ( ! file_exists( $metadata_file ) ) {
 			return;
 		}

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -269,6 +269,9 @@ class Initializer {
 	public static function register_videopress_blocks() {
 		// Register VideoPress Video block.
 		self::register_videopress_video_block();
+
+		// Register VideoPress Playlist block.
+		self::register_videopress_playlist_block();
 	}
 
 	/**
@@ -550,6 +553,147 @@ class Initializer {
 
 		// Register and enqueue scripts used by the VideoPress video block.
 		Block_Editor_Extensions::init( $script_handle );
+	}
+
+	/**
+	 * Register the VideoPress playlist block.
+	 *
+	 * @return void
+	 */
+	public static function register_videopress_playlist_block() {
+		/*
+		 * Unlike the video block, the playlist block has no "activate the module"
+		 * placeholder, so don't register it at all when VideoPress isn't available.
+		 */
+		if (
+			Status::is_jetpack_plugin_without_videopress_module_active()
+			&& ! Status::is_standalone_plugin_active()
+		) {
+			return;
+		}
+
+		$metadata_file = __DIR__ . '/../build/block-editor/blocks/playlist/block.json';
+		if ( ! file_exists( $metadata_file ) ) {
+			return;
+		}
+
+		$metadata = json_decode(
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			file_get_contents( $metadata_file )
+		);
+
+		if ( empty( $metadata->name ) ) {
+			return;
+		}
+
+		// Do not register if the block is already registered.
+		if ( \WP_Block_Type_Registry::get_instance()->is_registered( $metadata->name ) ) {
+			return;
+		}
+
+		register_block_type(
+			$metadata_file,
+			array(
+				'render_callback' => array( __CLASS__, 'render_videopress_playlist_block' ),
+			)
+		);
+	}
+
+	/**
+	 * Build the VideoPress embed URL for a playlist entry.
+	 *
+	 * @param string $guid     Video GUID.
+	 * @param bool   $autoplay Whether the video should start playing as soon as it loads.
+	 *
+	 * @return string Embed URL.
+	 */
+	private static function get_playlist_embed_url( $guid, $autoplay ) {
+		return add_query_arg(
+			array(
+				'cover'          => 1,
+				'autoPlay'       => (int) $autoplay,
+				'preloadContent' => 'metadata',
+			),
+			'https://videopress.com/embed/' . rawurlencode( $guid )
+		);
+	}
+
+	/**
+	 * VideoPress playlist block render method.
+	 *
+	 * @param array $block_attributes Block attributes.
+	 *
+	 * @return string Block markup.
+	 */
+	public static function render_videopress_playlist_block( $block_attributes ) {
+		$videos = array();
+
+		if ( isset( $block_attributes['videos'] ) && is_array( $block_attributes['videos'] ) ) {
+			foreach ( $block_attributes['videos'] as $video ) {
+				if ( ! is_array( $video ) || empty( $video['guid'] ) || ! is_string( $video['guid'] ) ) {
+					continue;
+				}
+
+				// VideoPress GUIDs are 8 alphanumeric characters; drop anything else.
+				if ( ! preg_match( '/^[a-z\d]{8}$/i', $video['guid'] ) ) {
+					continue;
+				}
+
+				$videos[] = array(
+					'guid'  => $video['guid'],
+					'title' => isset( $video['title'] ) && is_string( $video['title'] ) ? $video['title'] : '',
+				);
+			}
+		}
+
+		if ( ! $videos ) {
+			return '';
+		}
+
+		$auto_advance = ! isset( $block_attributes['autoAdvance'] ) || $block_attributes['autoAdvance'];
+		$loop         = ! empty( $block_attributes['loop'] );
+
+		// The JWT token bridge lets the embed play private videos for authorized viewers.
+		Jwt_Token_Bridge::enqueue_jwt_token_bridge();
+
+		$items_markup = '';
+		foreach ( $videos as $index => $video ) {
+			$title = '' !== $video['title']
+				? $video['title']
+				/* translators: %d: position of the video in the playlist. */
+				: sprintf( __( 'Video %d', 'jetpack-videopress-pkg' ), $index + 1 );
+
+			$items_markup .= sprintf(
+				'<li><button type="button" class="videopress-playlist__item%1$s" data-guid="%2$s" data-src="%3$s" aria-current="%4$s"><span class="videopress-playlist__item-index">%5$d.</span><span class="videopress-playlist__item-title">%6$s</span></button></li>',
+				0 === $index ? ' is-current' : '',
+				esc_attr( $video['guid'] ),
+				esc_url( self::get_playlist_embed_url( $video['guid'], true ) ),
+				0 === $index ? 'true' : 'false',
+				$index + 1,
+				esc_html( $title )
+			);
+		}
+
+		$player_markup = sprintf(
+			'<div class="videopress-playlist__player-wrapper"><iframe class="videopress-playlist__player" title="%1$s" aria-label="%1$s" src="%2$s" data-guid="%3$s" allowfullscreen allow="clipboard-write; presentation"></iframe></div>',
+			esc_attr__( 'VideoPress Playlist Player', 'jetpack-videopress-pkg' ),
+			esc_url( self::get_playlist_embed_url( $videos[0]['guid'], false ) ),
+			esc_attr( $videos[0]['guid'] )
+		);
+
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'data-auto-advance' => $auto_advance ? '1' : '0',
+				'data-loop'         => $loop ? '1' : '0',
+			)
+		);
+
+		return sprintf(
+			'<figure %1$s>%2$s<ol class="videopress-playlist__items">%3$s</ol></figure>',
+			$wrapper_attributes,
+			$player_markup,
+			$items_markup
+		);
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -699,8 +699,10 @@ class Initializer {
 			)
 		);
 
+		// An unordered list: item numbering comes from the index spans, so theme
+		// list styles can never double up the numbers.
 		return sprintf(
-			'<figure %1$s>%2$s<ol class="videopress-playlist__items">%3$s</ol></figure>',
+			'<figure %1$s>%2$s<ul class="videopress-playlist__items">%3$s</ul></figure>',
 			$wrapper_attributes,
 			$player_markup,
 			$items_markup

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -606,50 +606,6 @@ class Initializer {
 	}
 
 	/**
-	 * Get the freshest available title for a playlist video.
-	 *
-	 * Reads the public VideoPress API so renamed videos show their current
-	 * title, cached in a transient to keep renders cheap. Falls back to the
-	 * title stored in the block attributes when the API has no usable answer
-	 * (e.g. private videos or connectivity issues).
-	 *
-	 * @param string $guid         Video GUID.
-	 * @param string $stored_title Title stored in the block attributes.
-	 *
-	 * @return string Title to render.
-	 */
-	private static function get_playlist_video_title( $guid, $stored_title ) {
-		$cache_key = 'videopress_playlist_title_' . $guid;
-		$cached    = get_transient( $cache_key );
-
-		if ( false !== $cached ) {
-			// An empty string is a negative-cache entry from a recent failed lookup.
-			return is_string( $cached ) && '' !== $cached ? $cached : $stored_title;
-		}
-
-		$response = wp_remote_get(
-			'https://public-api.wordpress.com/rest/v1.1/videos/' . rawurlencode( $guid ),
-			array( 'timeout' => 2 )
-		);
-
-		if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
-			$body = json_decode( wp_remote_retrieve_body( $response ), true );
-
-			if ( ! empty( $body['title'] ) && is_string( $body['title'] ) ) {
-				$title = wp_specialchars_decode( $body['title'], ENT_QUOTES );
-				set_transient( $cache_key, $title, HOUR_IN_SECONDS );
-
-				return $title;
-			}
-		}
-
-		// Negative-cache failures briefly so an unreachable API doesn't slow every render.
-		set_transient( $cache_key, '', 5 * MINUTE_IN_SECONDS );
-
-		return $stored_title;
-	}
-
-	/**
 	 * Build the VideoPress embed URL for a playlist entry.
 	 *
 	 * @param string $guid     Video GUID.
@@ -708,15 +664,18 @@ class Initializer {
 
 		$items_markup = '';
 		foreach ( $videos as $index => $video ) {
-			$title = self::get_playlist_video_title( $video['guid'], $video['title'] );
-
-			if ( '' === $title ) {
+			$title = '' !== $video['title']
+				? $video['title']
 				/* translators: %d: position of the video in the playlist. */
-				$title = sprintf( __( 'Video %d', 'jetpack-videopress-pkg' ), $index + 1 );
-			}
+				: sprintf( __( 'Video %d', 'jetpack-videopress-pkg' ), $index + 1 );
 
+			/*
+			 * The stored title is initial content only; the view script refreshes
+			 * title, duration, and quality from the VideoPress API on the client,
+			 * filling the empty badge/duration placeholders.
+			 */
 			$items_markup .= sprintf(
-				'<li><button type="button" class="videopress-playlist__item%1$s" data-guid="%2$s" data-src="%3$s" aria-current="%4$s"><span class="videopress-playlist__item-index">%5$d.</span><span class="videopress-playlist__item-title">%6$s</span></button></li>',
+				'<li><button type="button" class="videopress-playlist__item%1$s" data-guid="%2$s" data-src="%3$s" aria-current="%4$s"><span class="videopress-playlist__item-index">%5$d.</span><span class="videopress-playlist__item-title">%6$s</span><span class="videopress-playlist__item-badge"></span><span class="videopress-playlist__item-duration"></span></button></li>',
 				0 === $index ? ' is-current' : '',
 				esc_attr( $video['guid'] ),
 				esc_url( self::get_playlist_embed_url( $video['guid'], true ) ),

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -606,6 +606,50 @@ class Initializer {
 	}
 
 	/**
+	 * Get the freshest available title for a playlist video.
+	 *
+	 * Reads the public VideoPress API so renamed videos show their current
+	 * title, cached in a transient to keep renders cheap. Falls back to the
+	 * title stored in the block attributes when the API has no usable answer
+	 * (e.g. private videos or connectivity issues).
+	 *
+	 * @param string $guid         Video GUID.
+	 * @param string $stored_title Title stored in the block attributes.
+	 *
+	 * @return string Title to render.
+	 */
+	private static function get_playlist_video_title( $guid, $stored_title ) {
+		$cache_key = 'videopress_playlist_title_' . $guid;
+		$cached    = get_transient( $cache_key );
+
+		if ( false !== $cached ) {
+			// An empty string is a negative-cache entry from a recent failed lookup.
+			return is_string( $cached ) && '' !== $cached ? $cached : $stored_title;
+		}
+
+		$response = wp_remote_get(
+			'https://public-api.wordpress.com/rest/v1.1/videos/' . rawurlencode( $guid ),
+			array( 'timeout' => 2 )
+		);
+
+		if ( ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response ) ) {
+			$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			if ( ! empty( $body['title'] ) && is_string( $body['title'] ) ) {
+				$title = wp_specialchars_decode( $body['title'], ENT_QUOTES );
+				set_transient( $cache_key, $title, HOUR_IN_SECONDS );
+
+				return $title;
+			}
+		}
+
+		// Negative-cache failures briefly so an unreachable API doesn't slow every render.
+		set_transient( $cache_key, '', 5 * MINUTE_IN_SECONDS );
+
+		return $stored_title;
+	}
+
+	/**
 	 * Build the VideoPress embed URL for a playlist entry.
 	 *
 	 * @param string $guid     Video GUID.
@@ -664,10 +708,12 @@ class Initializer {
 
 		$items_markup = '';
 		foreach ( $videos as $index => $video ) {
-			$title = '' !== $video['title']
-				? $video['title']
+			$title = self::get_playlist_video_title( $video['guid'], $video['title'] );
+
+			if ( '' === $title ) {
 				/* translators: %d: position of the video in the playlist. */
-				: sprintf( __( 'Video %d', 'jetpack-videopress-pkg' ), $index + 1 );
+				$title = sprintf( __( 'Video %d', 'jetpack-videopress-pkg' ), $index + 1 );
+			}
 
 			$items_markup .= sprintf(
 				'<li><button type="button" class="videopress-playlist__item%1$s" data-guid="%2$s" data-src="%3$s" aria-current="%4$s"><span class="videopress-playlist__item-index">%5$d.</span><span class="videopress-playlist__item-title">%6$s</span></button></li>',

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
@@ -32,11 +32,44 @@
 		"loop": {
 			"type": "boolean",
 			"default": false
+		},
+		"layout": {
+			"type": "string",
+			"enum": [ "rail", "grid", "strip" ],
+			"default": "rail"
+		},
+		"darkSurface": {
+			"type": "boolean",
+			"default": false
+		},
+		"showThumbnail": {
+			"type": "boolean",
+			"default": true
+		},
+		"showTitle": {
+			"type": "boolean",
+			"default": true
+		},
+		"showResolution": {
+			"type": "boolean",
+			"default": true
+		},
+		"showDuration": {
+			"type": "boolean",
+			"default": true
+		},
+		"showPosition": {
+			"type": "boolean",
+			"default": false
+		},
+		"showTotalRuntime": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"textdomain": "jetpack-videopress-pkg",
 	"editorScript": "file:./index.js",
-	"editorStyle": "file:./index.css",
+	"editorStyle": [ "file:./index.css", "file:./view.css" ],
 	"viewScript": "file:./view.js",
 	"viewStyle": "file:./view.css"
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
@@ -1,0 +1,42 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "videopress/playlist",
+	"version": "0.1.0",
+	"title": "VideoPress Playlist",
+	"category": "media",
+	"icon": "<svg viewBox='0 0 29 21' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M2.79037 0.59375C4.0363 0.59375 5.13102 1.41658 5.47215 2.60947L8.8452 14.4044C8.8486 14.4164 8.85411 14.4273 8.86124 14.4368L12.8572 0.59375H15.0927H21.2721C25.6033 0.59375 28.5066 3.39892 28.5066 7.64565C28.5066 11.9411 25.5272 14.6196 21.0818 14.6196H18.1499H14.3719L13.6379 16.8813C12.9796 18.9095 11.0827 20.2839 8.94152 20.2839C6.80035 20.2839 4.90341 18.9095 4.24517 16.8813L0.137069 4.22276C-0.444671 2.43022 0.898038 0.59375 2.79037 0.59375ZM15.7374 10.4119H20.0156C21.8718 10.4119 22.9856 9.35018 22.9856 7.64565C22.9856 5.93137 21.8718 4.91839 20.0156 4.91839H17.5202L15.7374 10.4119Z'></path></svg>",
+	"description": "Play a list of VideoPress videos in sequence.",
+	"keywords": [ "playlist", "video", "videopress" ],
+	"supports": {
+		"html": false,
+		"align": true,
+		"anchor": true,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"attributes": {
+		"videos": {
+			"type": "array",
+			"items": {
+				"type": "object"
+			},
+			"default": []
+		},
+		"autoAdvance": {
+			"type": "boolean",
+			"default": true
+		},
+		"loop": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+	"textdomain": "jetpack-videopress-pkg",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"viewScript": "file:./view.js",
+	"viewStyle": "file:./view.css"
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -347,9 +347,10 @@ export default function PlaylistBlockEdit( {
 				isBusy={ isAddingVideo }
 				disabled={ isAddingVideo }
 			>
-				{ isAddingVideo
-					? __( 'Adding…', 'jetpack-videopress-pkg' )
-					: __( 'Add', 'jetpack-videopress-pkg' ) }
+				{ /* Two separate expressions: a shared ternary would let the minifier
+				     merge the __() calls, breaking translation extraction. */ }
+				{ isAddingVideo && __( 'Adding…', 'jetpack-videopress-pkg' ) }
+				{ ! isAddingVideo && __( 'Add', 'jetpack-videopress-pkg' ) }
 			</Button>
 		</div>
 	);

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -17,7 +17,7 @@ import {
 } from '@wordpress/components';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { closeSmall, dragHandle, Icon } from '@wordpress/icons';
 /**
  * Internal dependencies
@@ -26,13 +26,20 @@ import { fetchVideoItem } from '../../../lib/fetch-video-item';
 import { isVideoPressGuid, pickGUIDFromUrl } from '../../../lib/url';
 import { VideoPressIcon } from '../video/components/icons';
 import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../video/constants';
+import { formatDuration, formatRuntimeLong, qualityLabel, totalDurationMs } from './utils';
 import './editor.scss';
 /**
  * Types
  */
-import type { PlaylistBlockAttributes, PlaylistVideo } from './types';
+import type { PlaylistBlockAttributes, PlaylistLayout, PlaylistVideo } from './types';
 import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../types';
 import type { BlockEditProps } from '@wordpress/blocks';
+
+const LAYOUT_OPTIONS: Array< { value: PlaylistLayout; label: string } > = [
+	{ value: 'rail', label: __( 'Side rail', 'jetpack-videopress-pkg' ) },
+	{ value: 'grid', label: __( 'Grid', 'jetpack-videopress-pkg' ) },
+	{ value: 'strip', label: __( 'Strip', 'jetpack-videopress-pkg' ) },
+];
 
 /**
  * Extract a VideoPress GUID from user input, which can be
@@ -56,6 +63,45 @@ function parseVideoInput( value: string ): string | null {
 }
 
 /**
+ * Build a playlist entry's metadata fields from a videos API response.
+ *
+ * @param videoItem - The API response for one video.
+ * @return Metadata fields present in the response.
+ */
+function metadataFromVideoItem(
+	videoItem: Record< string, unknown >
+): Omit< PlaylistVideo, 'guid' > {
+	const metadata: Omit< PlaylistVideo, 'guid' > = {};
+
+	if ( typeof videoItem?.title === 'string' && videoItem.title !== '' ) {
+		metadata.title = decodeEntities( videoItem.title );
+	}
+	if ( typeof videoItem?.duration === 'number' && videoItem.duration > 0 ) {
+		metadata.durationMs = videoItem.duration;
+	}
+	if ( typeof videoItem?.height === 'number' && videoItem.height > 0 ) {
+		metadata.height = videoItem.height;
+	}
+	if ( typeof videoItem?.poster === 'string' && videoItem.poster !== '' ) {
+		metadata.poster = videoItem.poster;
+	}
+
+	return metadata;
+}
+
+/**
+ * Format the "resolution · duration" meta line for a playlist entry.
+ *
+ * @param video - Playlist entry.
+ * @return Meta line, possibly empty.
+ */
+function metaLine( video: PlaylistVideo ): string {
+	return [ qualityLabel( video.height ), formatDuration( video.durationMs ) ]
+		.filter( Boolean )
+		.join( ' · ' );
+}
+
+/**
  * VideoPress Playlist block Edit component.
  *
  * @param props               - Block edit props.
@@ -67,60 +113,118 @@ export default function PlaylistBlockEdit( {
 	attributes,
 	setAttributes,
 }: BlockEditProps< PlaylistBlockAttributes > ) {
-	const { videos, autoAdvance, loop } = attributes;
+	const {
+		videos,
+		autoAdvance,
+		loop,
+		layout,
+		darkSurface,
+		showThumbnail,
+		showTitle,
+		showResolution,
+		showDuration,
+		showPosition,
+		showTotalRuntime,
+	} = attributes;
 	const [ currentIndex, setCurrentIndex ] = useState( 0 );
 	const [ newVideoInput, setNewVideoInput ] = useState( '' );
 	const [ errorNotice, setErrorNotice ] = useState< string | null >( null );
 	const [ isAddingVideo, setIsAddingVideo ] = useState( false );
 	const [ draggedIndex, setDraggedIndex ] = useState< number | null >( null );
 	const [ dropTargetIndex, setDropTargetIndex ] = useState< number | null >( null );
+	const [ filterText, setFilterText ] = useState( '' );
+	const [ pendingDuplicate, setPendingDuplicate ] = useState< PlaylistVideo | null >( null );
 
-	// Always points at the latest videos so async title fetches never clobber newer edits.
+	// Always points at the latest videos so async metadata fetches never clobber newer edits.
 	const videosRef = useRef( videos );
 	videosRef.current = videos;
 
-	// GUIDs with a title refresh already started this editor session; they are
-	// not re-fetched, so a failed lookup simply keeps the stored label.
-	const titleFetchesStarted = useRef( new Set< string >() );
+	// GUIDs with a metadata refresh already started this editor session; they are
+	// not re-fetched, so a failed lookup simply keeps the stored fields.
+	const metadataFetchesStarted = useRef( new Set< string >() );
 
-	// Titles always mirror the video data: every entry is refreshed once per
-	// editor session, and the stored title is replaced whenever it differs.
+	// Entry metadata always mirrors the video data: every entry is refreshed once
+	// per editor session, and stored fields are replaced whenever they differ.
 	useEffect( () => {
 		videos.forEach( video => {
-			if ( titleFetchesStarted.current.has( video.guid ) ) {
+			if ( metadataFetchesStarted.current.has( video.guid ) ) {
 				return;
 			}
 
-			titleFetchesStarted.current.add( video.guid );
+			metadataFetchesStarted.current.add( video.guid );
 
 			fetchVideoItem( { guid: video.guid, isPrivate: false, skipRatingControl: true } )
 				.then( videoItem => {
-					if ( ! videoItem?.title ) {
+					const metadata = metadataFromVideoItem( videoItem as Record< string, unknown > );
+					if ( ! Object.keys( metadata ).length ) {
 						return;
 					}
 
-					const title = decodeEntities( videoItem.title );
 					const current = videosRef.current;
+					const needsUpdate = current.some(
+						entry =>
+							entry.guid === video.guid &&
+							Object.entries( metadata ).some(
+								( [ key, value ] ) => entry[ key as keyof PlaylistVideo ] !== value
+							)
+					);
 
-					if ( ! current.some( entry => entry.guid === video.guid && entry.title !== title ) ) {
+					if ( ! needsUpdate ) {
 						return;
 					}
 
 					setAttributes( {
 						videos: current.map( entry =>
-							entry.guid === video.guid ? { ...entry, title } : entry
+							entry.guid === video.guid ? { ...entry, ...metadata } : entry
 						),
 					} );
 				} )
 				.catch( () => {
-					// Keep the stored title (or GUID) when the video data isn't reachable.
+					// Keep the stored fields when the video data isn't reachable.
 				} );
 		} );
 	}, [ videos, setAttributes ] );
 
-	const blockProps = useBlockProps( { className: 'videopress-playlist-editor' } );
+	const wrapperClasses = [
+		'videopress-playlist-editor',
+		`videopress-playlist--${ layout }`,
+		darkSurface ? 'is-dark' : '',
+		showThumbnail ? '' : 'hide-thumbnails',
+		showTitle ? '' : 'hide-titles',
+		showResolution ? '' : 'hide-resolution',
+		showDuration ? '' : 'hide-duration',
+		showPosition ? 'show-position' : '',
+		showTotalRuntime ? '' : 'hide-runtime',
+	]
+		.filter( Boolean )
+		.join( ' ' );
+
+	const blockProps = useBlockProps( { className: wrapperClasses } );
 
 	const currentVideo = videos[ currentIndex ] ?? videos[ 0 ];
+	const runtime = formatRuntimeLong( totalDurationMs( videos ) );
+
+	const performAdd = async ( guid: string ) => {
+		setIsAddingVideo( true );
+
+		// All entry data comes from the video itself; none of it is editable here.
+		let metadata: Omit< PlaylistVideo, 'guid' > = {};
+		try {
+			const videoItem = await fetchVideoItem( { guid, isPrivate: false, skipRatingControl: true } );
+			metadata = metadataFromVideoItem( videoItem as Record< string, unknown > );
+			// Fresh from the video data; no need for the refresh effect to re-fetch it.
+			metadataFetchesStarted.current.add( guid );
+		} catch {
+			// The entry still works without metadata; the list shows the GUID and
+			// the refresh effect retries once more.
+		}
+
+		setAttributes( { videos: [ ...videosRef.current, { guid, ...metadata } ] } );
+		setNewVideoInput( '' );
+		setErrorNotice( null );
+		setPendingDuplicate( null );
+		setIsAddingVideo( false );
+	};
 
 	const addVideo = async () => {
 		if ( isAddingVideo ) {
@@ -130,32 +234,21 @@ export default function PlaylistBlockEdit( {
 		const guid = parseVideoInput( newVideoInput );
 		if ( ! guid ) {
 			setErrorNotice(
-				__( 'Enter a VideoPress GUID or a VideoPress video URL.', 'jetpack-videopress-pkg' )
+				__(
+					'No video found at that link. Paste a VideoPress video URL or GUID.',
+					'jetpack-videopress-pkg'
+				)
 			);
 			return;
 		}
 
-		setIsAddingVideo( true );
-
-		// The title always comes from the video data, for library and URL/GUID
-		// additions alike; it's not editable in the playlist.
-		let title;
-		try {
-			const videoItem = await fetchVideoItem( { guid, isPrivate: false, skipRatingControl: true } );
-			if ( videoItem?.title ) {
-				title = decodeEntities( videoItem.title );
-				// Fresh from the video data; no need for the refresh effect to re-fetch it.
-				titleFetchesStarted.current.add( guid );
-			}
-		} catch {
-			// The entry still works without a title; the list shows the GUID and
-			// the refresh effect below retries once more.
+		const existing = videos.find( video => video.guid === guid );
+		if ( existing ) {
+			setPendingDuplicate( existing );
+			return;
 		}
 
-		setAttributes( { videos: [ ...videosRef.current, { guid, ...( title && { title } ) } ] } );
-		setNewVideoInput( '' );
-		setErrorNotice( null );
-		setIsAddingVideo( false );
+		await performAdd( guid );
 	};
 
 	const addVideosFromLibrary = (
@@ -176,9 +269,12 @@ export default function PlaylistBlockEdit( {
 				continue;
 			}
 
+			const poster = media.image?.src ?? media.thumb?.src;
+
 			libraryVideos.push( {
 				guid,
 				...( typeof media.title === 'string' && media.title !== '' && { title: media.title } ),
+				...( typeof poster === 'string' && poster !== '' && { poster } ),
 			} );
 		}
 
@@ -223,13 +319,154 @@ export default function PlaylistBlockEdit( {
 		}
 	};
 
+	const addUrlForm = (
+		<div className="videopress-playlist-editor__add-row">
+			<TextControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'Add a video', 'jetpack-videopress-pkg' ) }
+				hideLabelFromVision
+				placeholder={ __( 'Paste a video URL', 'jetpack-videopress-pkg' ) }
+				value={ newVideoInput }
+				onChange={ ( value: string ) => {
+					setNewVideoInput( value );
+					setErrorNotice( null );
+					setPendingDuplicate( null );
+				} }
+				onKeyDown={ event => {
+					if ( event.key === 'Enter' ) {
+						event.preventDefault();
+						addVideo();
+					}
+				} }
+			/>
+			<Button
+				__next40pxDefaultSize
+				variant="primary"
+				onClick={ addVideo }
+				isBusy={ isAddingVideo }
+				disabled={ isAddingVideo }
+			>
+				{ isAddingVideo
+					? __( 'Adding…', 'jetpack-videopress-pkg' )
+					: __( 'Add', 'jetpack-videopress-pkg' ) }
+			</Button>
+		</div>
+	);
+
+	const mediaLibraryButton = (
+		<MediaUploadCheck>
+			<MediaUpload
+				title={ __( 'Select videos from your VideoPress library', 'jetpack-videopress-pkg' ) }
+				onSelect={ addVideosFromLibrary }
+				allowedTypes={ VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES }
+				multiple
+				render={ ( { open }: { open: () => void } ) => (
+					<Button __next40pxDefaultSize variant="secondary" onClick={ open }>
+						{ __( 'Media Library', 'jetpack-videopress-pkg' ) }
+					</Button>
+				) }
+			/>
+		</MediaUploadCheck>
+	);
+
+	// Sidebar list entries keep their original index for reorder/remove even
+	// when a filter narrows the visible set.
+	const visibleEntries = videos
+		.map( ( video: PlaylistVideo, index: number ) => ( { video, index } ) )
+		.filter( ( { video } ) => {
+			if ( ! filterText ) {
+				return true;
+			}
+			const haystack = `${ video.title ?? '' } ${ video.guid }`.toLowerCase();
+			return haystack.includes( filterText.toLowerCase() );
+		} );
+	const isFiltering = filterText !== '';
+
 	// All playlist management (add, sort, delete) lives in the settings
 	// sidebar; the canvas below is a preview of what visitors see.
 	const inspectorControls = (
 		<InspectorControls>
 			<PanelBody title={ __( 'Videos', 'jetpack-videopress-pkg' ) }>
-				<ul className="videopress-playlist-editor__manage-list">
-					{ videos.map( ( video: PlaylistVideo, index: number ) => {
+				{ addUrlForm }
+				<p className="videopress-playlist-editor__add-help">
+					{ __(
+						'Any VideoPress video URL or GUID. Title, thumbnail, duration and resolution come from the video data.',
+						'jetpack-videopress-pkg'
+					) }
+				</p>
+				<div className="videopress-playlist-editor__add-library">{ mediaLibraryButton }</div>
+
+				{ errorNotice && (
+					<Notice
+						className="videopress-playlist-editor__notice"
+						status="error"
+						isDismissible={ false }
+					>
+						{ errorNotice }
+					</Notice>
+				) }
+
+				{ pendingDuplicate && (
+					<Notice
+						className="videopress-playlist-editor__notice"
+						status="warning"
+						isDismissible={ false }
+					>
+						{ sprintf(
+							/* translators: %s: video title or GUID. */
+							__( '“%s” is already in this playlist', 'jetpack-videopress-pkg' ),
+							pendingDuplicate.title || pendingDuplicate.guid
+						) }
+						<div className="videopress-playlist-editor__duplicate-actions">
+							<Button
+								size="small"
+								variant="secondary"
+								onClick={ () => performAdd( pendingDuplicate.guid ) }
+							>
+								{ __( 'Add anyway', 'jetpack-videopress-pkg' ) }
+							</Button>
+							<Button size="small" variant="tertiary" onClick={ () => setPendingDuplicate( null ) }>
+								{ __( 'Cancel', 'jetpack-videopress-pkg' ) }
+							</Button>
+						</div>
+					</Notice>
+				) }
+
+				<div className="videopress-playlist-editor__list-header">
+					<span className="videopress-playlist-editor__list-title">
+						{ __( 'Playlist', 'jetpack-videopress-pkg' ) }
+					</span>
+					<span className="videopress-playlist-editor__list-count">
+						{ videos.length }
+						{ runtime ? ` · ${ formatDuration( totalDurationMs( videos ) ) }` : '' }
+					</span>
+				</div>
+
+				{ videos.length > 8 && (
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						className="videopress-playlist-editor__filter"
+						label={ __( 'Filter videos', 'jetpack-videopress-pkg' ) }
+						hideLabelFromVision
+						placeholder={ sprintf(
+							/* translators: %d: number of videos in the playlist. */
+							__( 'Filter %d videos', 'jetpack-videopress-pkg' ),
+							videos.length
+						) }
+						value={ filterText }
+						onChange={ setFilterText }
+					/>
+				) }
+
+				{ /* A listbox: the options take focus and respond to arrow keys for reordering. */ }
+				<ul
+					className="videopress-playlist-editor__manage-list"
+					role="listbox"
+					aria-label={ __( 'Playlist videos', 'jetpack-videopress-pkg' ) }
+				>
+					{ visibleEntries.map( ( { video, index } ) => {
 						const classes = [ 'videopress-playlist-editor__manage-item' ];
 						if ( index === draggedIndex ) {
 							classes.push( 'is-dragging' );
@@ -242,12 +479,27 @@ export default function PlaylistBlockEdit( {
 							<li
 								key={ `${ video.guid }-${ index }` }
 								className={ classes.join( ' ' ) }
-								draggable
+								role="option"
+								aria-selected={ index === draggedIndex }
+								draggable={ ! isFiltering }
+								tabIndex={ 0 }
 								aria-label={ sprintf(
 									/* translators: %d: position of the video in the playlist. */
-									__( 'Video %d. Drag to reorder.', 'jetpack-videopress-pkg' ),
+									__( 'Video %d. Drag to reorder, or press up or down.', 'jetpack-videopress-pkg' ),
 									index + 1
 								) }
+								onKeyDown={ event => {
+									if ( isFiltering ) {
+										return;
+									}
+									if ( event.key === 'ArrowUp' ) {
+										event.preventDefault();
+										reorderVideo( index, index - 1 );
+									} else if ( event.key === 'ArrowDown' ) {
+										event.preventDefault();
+										reorderVideo( index, index + 1 );
+									}
+								} }
 								onDragStart={ event => {
 									setDraggedIndex( index );
 									event.dataTransfer?.setData( 'text/plain', String( index ) );
@@ -286,10 +538,20 @@ export default function PlaylistBlockEdit( {
 									<Icon icon={ dragHandle } size={ 16 } />
 								</span>
 								<span className="videopress-playlist-editor__manage-item-index">
-									{ index + 1 }.
+									{ String( index + 1 ).padStart( 2, '0' ) }
 								</span>
-								<span className="videopress-playlist-editor__manage-item-title">
-									{ video.title || video.guid }
+								<span className="videopress-playlist-editor__manage-item-thumb">
+									{ video.poster && <img src={ video.poster } alt="" loading="lazy" /> }
+								</span>
+								<span className="videopress-playlist-editor__manage-item-text">
+									<span className="videopress-playlist-editor__manage-item-title">
+										{ video.title || video.guid }
+									</span>
+									{ metaLine( video ) && (
+										<span className="videopress-playlist-editor__manage-item-meta">
+											{ metaLine( video ) }
+										</span>
+									) }
 								</span>
 								<Button
 									className="videopress-playlist-editor__manage-item-remove"
@@ -301,65 +563,51 @@ export default function PlaylistBlockEdit( {
 							</li>
 						);
 					} ) }
+					{ isAddingVideo && (
+						<li className="videopress-playlist-editor__manage-item is-loading" aria-hidden="true">
+							<span className="videopress-playlist-editor__manage-item-thumb" />
+							<span className="videopress-playlist-editor__manage-item-text">
+								<span className="videopress-playlist-editor__manage-item-meta">
+									{ __( 'Reading metadata…', 'jetpack-videopress-pkg' ) }
+								</span>
+							</span>
+						</li>
+					) }
 				</ul>
-
-				<div className="videopress-playlist-editor__add">
-					<TextControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Add video', 'jetpack-videopress-pkg' ) }
-						hideLabelFromVision
-						placeholder={ __( 'VideoPress GUID or URL', 'jetpack-videopress-pkg' ) }
-						value={ newVideoInput }
-						onChange={ ( value: string ) => {
-							setNewVideoInput( value );
-							setErrorNotice( null );
-						} }
-						onKeyDown={ event => {
-							if ( event.key === 'Enter' ) {
-								event.preventDefault();
-								addVideo();
-							}
-						} }
-					/>
-					<Button
-						__next40pxDefaultSize
-						variant="secondary"
-						onClick={ addVideo }
-						isBusy={ isAddingVideo }
-						disabled={ isAddingVideo }
-					>
-						{ __( 'Add to playlist', 'jetpack-videopress-pkg' ) }
-					</Button>
-					<MediaUploadCheck>
-						<MediaUpload
-							title={ __( 'Select videos from your VideoPress library', 'jetpack-videopress-pkg' ) }
-							onSelect={ addVideosFromLibrary }
-							allowedTypes={ VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES }
-							multiple
-							render={ ( { open }: { open: () => void } ) => (
-								<Button __next40pxDefaultSize variant="secondary" onClick={ open }>
-									{ __( 'Choose from library', 'jetpack-videopress-pkg' ) }
-								</Button>
-							) }
-						/>
-					</MediaUploadCheck>
-				</div>
-				{ errorNotice && (
-					<Notice
-						className="videopress-playlist-editor__notice"
-						status="error"
-						isDismissible={ false }
-					>
-						{ errorNotice }
-					</Notice>
-				) }
+				<p className="videopress-playlist-editor__reorder-help">
+					{ __(
+						'Drag to reorder, or focus an item and press ↑ / ↓. × removes the video.',
+						'jetpack-videopress-pkg'
+					) }
+				</p>
 			</PanelBody>
 
-			<PanelBody title={ __( 'Playlist settings', 'jetpack-videopress-pkg' ) }>
+			<PanelBody title={ __( 'Layout & playback', 'jetpack-videopress-pkg' ) }>
+				<div
+					className="videopress-playlist-editor__layout-picker"
+					role="group"
+					aria-label={ __( 'Layout', 'jetpack-videopress-pkg' ) }
+				>
+					{ LAYOUT_OPTIONS.map( option => (
+						<Button
+							key={ option.value }
+							variant={ layout === option.value ? 'primary' : 'secondary' }
+							isPressed={ layout === option.value }
+							onClick={ () => setAttributes( { layout: option.value } ) }
+						>
+							{ option.label }
+						</Button>
+					) ) }
+				</div>
 				<ToggleControl
 					__nextHasNoMarginBottom
-					label={ __( 'Autoplay next video', 'jetpack-videopress-pkg' ) }
+					label={ __( 'Dark player surface', 'jetpack-videopress-pkg' ) }
+					checked={ darkSurface }
+					onChange={ ( value: boolean ) => setAttributes( { darkSurface: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Autoplay next', 'jetpack-videopress-pkg' ) }
 					help={ __(
 						'Automatically play the next video when the current one ends.',
 						'jetpack-videopress-pkg'
@@ -378,6 +626,45 @@ export default function PlaylistBlockEdit( {
 					onChange={ ( value: boolean ) => setAttributes( { loop: value } ) }
 				/>
 			</PanelBody>
+
+			<PanelBody title={ __( 'Show on each entry', 'jetpack-videopress-pkg' ) }>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Thumbnail', 'jetpack-videopress-pkg' ) }
+					checked={ showThumbnail }
+					onChange={ ( value: boolean ) => setAttributes( { showThumbnail: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Title', 'jetpack-videopress-pkg' ) }
+					checked={ showTitle }
+					onChange={ ( value: boolean ) => setAttributes( { showTitle: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Resolution', 'jetpack-videopress-pkg' ) }
+					checked={ showResolution }
+					onChange={ ( value: boolean ) => setAttributes( { showResolution: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Duration', 'jetpack-videopress-pkg' ) }
+					checked={ showDuration }
+					onChange={ ( value: boolean ) => setAttributes( { showDuration: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Position number', 'jetpack-videopress-pkg' ) }
+					checked={ showPosition }
+					onChange={ ( value: boolean ) => setAttributes( { showPosition: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Total runtime in header', 'jetpack-videopress-pkg' ) }
+					checked={ showTotalRuntime }
+					onChange={ ( value: boolean ) => setAttributes( { showTotalRuntime: value } ) }
+				/>
+			</PanelBody>
 		</InspectorControls>
 	);
 
@@ -387,12 +674,29 @@ export default function PlaylistBlockEdit( {
 				{ inspectorControls }
 				<Placeholder
 					icon={ VideoPressIcon }
-					label={ __( 'VideoPress Playlist', 'jetpack-videopress-pkg' ) }
+					label={ __( 'Build a video playlist', 'jetpack-videopress-pkg' ) }
 					instructions={ __(
-						'Build a playlist that plays videos in sequence. Add videos in the block settings sidebar: choose them from your VideoPress library, or add them by GUID or URL.',
+						'Paste a link, or pick a video already in your media library. Title, thumbnail, duration and resolution are read for you.',
 						'jetpack-videopress-pkg'
 					) }
-				/>
+				>
+					<div className="videopress-playlist-editor__placeholder-form">
+						{ addUrlForm }
+						{ errorNotice && (
+							<Notice
+								className="videopress-playlist-editor__notice"
+								status="error"
+								isDismissible={ false }
+							>
+								{ errorNotice }
+							</Notice>
+						) }
+						<div className="videopress-playlist-editor__placeholder-divider">
+							<span>{ __( 'or', 'jetpack-videopress-pkg' ) }</span>
+						</div>
+						{ mediaLibraryButton }
+					</div>
+				</Placeholder>
 			</div>
 		);
 	}
@@ -401,45 +705,78 @@ export default function PlaylistBlockEdit( {
 		<div { ...blockProps }>
 			{ inspectorControls }
 
-			{ currentVideo && (
-				<div className="videopress-playlist-editor__player-wrapper">
-					<iframe
-						className="videopress-playlist-editor__player"
-						title={ __( 'VideoPress Playlist Player', 'jetpack-videopress-pkg' ) }
-						src={ `https://videopress.com/embed/${ currentVideo.guid }?cover=1&preloadContent=metadata` }
-						allowFullScreen
-						allow="clipboard-write"
-					/>
-				</div>
-			) }
+			<div className="videopress-playlist__header">
+				<span className="videopress-playlist__count">
+					{ sprintf(
+						/* translators: %d: number of videos in the playlist. */
+						_n( '%d video', '%d videos', videos.length, 'jetpack-videopress-pkg' ),
+						videos.length
+					) }
+				</span>
+				{ runtime && <span className="videopress-playlist__runtime">{ runtime }</span> }
+			</div>
 
-			<ul className="videopress-playlist-editor__items">
-				{ videos.map( ( video: PlaylistVideo, index: number ) => (
-					<li
-						key={ `${ video.guid }-${ index }` }
-						className={
-							index === currentIndex
-								? 'videopress-playlist-editor__item is-current'
-								: 'videopress-playlist-editor__item'
-						}
-					>
-						<Button
-							className="videopress-playlist-editor__item-select"
-							onClick={ () => setCurrentIndex( index ) }
-							label={ sprintf(
-								/* translators: %d: position of the video in the playlist. */
-								__( 'Preview video %d', 'jetpack-videopress-pkg' ),
-								index + 1
-							) }
-						>
-							<span className="videopress-playlist-editor__item-index">{ index + 1 }.</span>
-							<span className="videopress-playlist-editor__item-title">
-								{ video.title || video.guid }
-							</span>
-						</Button>
-					</li>
-				) ) }
-			</ul>
+			<div className="videopress-playlist__body">
+				{ currentVideo && (
+					<div className="videopress-playlist__player-wrapper">
+						<iframe
+							className="videopress-playlist__player"
+							title={ __( 'VideoPress Playlist Player', 'jetpack-videopress-pkg' ) }
+							src={ `https://videopress.com/embed/${ currentVideo.guid }?cover=1&preloadContent=metadata` }
+							allowFullScreen
+							allow="clipboard-write"
+						/>
+					</div>
+				) }
+
+				<ul className="videopress-playlist__items">
+					{ videos.map( ( video: PlaylistVideo, index: number ) => (
+						<li key={ `${ video.guid }-${ index }` }>
+							<button
+								type="button"
+								className={
+									index === currentIndex
+										? 'videopress-playlist__item is-current'
+										: 'videopress-playlist__item'
+								}
+								onClick={ () => setCurrentIndex( index ) }
+								aria-label={ sprintf(
+									/* translators: %d: position of the video in the playlist. */
+									__( 'Preview video %d', 'jetpack-videopress-pkg' ),
+									index + 1
+								) }
+							>
+								<span className="videopress-playlist__item-thumb">
+									{ video.poster && <img src={ video.poster } alt="" loading="lazy" /> }
+									<span className="videopress-playlist__item-index">{ index + 1 }</span>
+									{ formatDuration( video.durationMs ) && (
+										<span className="videopress-playlist__item-thumb-duration">
+											{ formatDuration( video.durationMs ) }
+										</span>
+									) }
+								</span>
+								<span className="videopress-playlist__item-text">
+									<span className="videopress-playlist__item-title">
+										{ video.title || video.guid }
+									</span>
+									<span className="videopress-playlist__item-meta">
+										{ qualityLabel( video.height ) && (
+											<span className="videopress-playlist__item-badge">
+												{ qualityLabel( video.height ) }
+											</span>
+										) }
+										{ formatDuration( video.durationMs ) && (
+											<span className="videopress-playlist__item-duration">
+												{ formatDuration( video.durationMs ) }
+											</span>
+										) }
+									</span>
+								</span>
+							</button>
+						</li>
+					) ) }
+				</ul>
+			</div>
 		</div>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -218,101 +218,139 @@ export default function PlaylistBlockEdit( {
 		}
 	};
 
-	const addVideoForm = (
-		<div className="videopress-playlist-editor__add-container">
-			<div className="videopress-playlist-editor__add">
-				<TextControl
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					label={ __( 'Add video', 'jetpack-videopress-pkg' ) }
-					hideLabelFromVision
-					placeholder={ __( 'VideoPress GUID or URL', 'jetpack-videopress-pkg' ) }
-					value={ newVideoInput }
-					onChange={ ( value: string ) => {
-						setNewVideoInput( value );
-						setErrorNotice( null );
-					} }
-					onKeyDown={ event => {
-						if ( event.key === 'Enter' ) {
-							event.preventDefault();
-							addVideo();
-						}
-					} }
-				/>
-				<Button
-					__next40pxDefaultSize
-					variant="secondary"
-					onClick={ addVideo }
-					isBusy={ isAddingVideo }
-					disabled={ isAddingVideo }
-				>
-					{ __( 'Add to playlist', 'jetpack-videopress-pkg' ) }
-				</Button>
-				<MediaUploadCheck>
-					<MediaUpload
-						title={ __( 'Select videos from your VideoPress library', 'jetpack-videopress-pkg' ) }
-						onSelect={ addVideosFromLibrary }
-						allowedTypes={ VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES }
-						multiple
-						render={ ( { open }: { open: () => void } ) => (
-							<Button __next40pxDefaultSize variant="secondary" onClick={ open }>
-								{ __( 'Choose from library', 'jetpack-videopress-pkg' ) }
-							</Button>
-						) }
+	// All playlist management (add, sort, delete) lives in the settings
+	// sidebar; the canvas below is a preview of what visitors see.
+	const inspectorControls = (
+		<InspectorControls>
+			<PanelBody title={ __( 'Videos', 'jetpack-videopress-pkg' ) }>
+				<ol className="videopress-playlist-editor__manage-list">
+					{ videos.map( ( video: PlaylistVideo, index: number ) => (
+						<li
+							key={ `${ video.guid }-${ index }` }
+							className="videopress-playlist-editor__manage-item"
+						>
+							<span className="videopress-playlist-editor__manage-item-title">
+								{ index + 1 }. { video.title || video.guid }
+							</span>
+							<span className="videopress-playlist-editor__manage-item-actions">
+								<Button
+									size="small"
+									icon={ chevronUp }
+									disabled={ index === 0 }
+									onClick={ () => moveVideo( index, -1 ) }
+									label={ __( 'Move up', 'jetpack-videopress-pkg' ) }
+								/>
+								<Button
+									size="small"
+									icon={ chevronDown }
+									disabled={ index === videos.length - 1 }
+									onClick={ () => moveVideo( index, 1 ) }
+									label={ __( 'Move down', 'jetpack-videopress-pkg' ) }
+								/>
+								<Button
+									size="small"
+									icon={ closeSmall }
+									onClick={ () => removeVideo( index ) }
+									label={ __( 'Remove from playlist', 'jetpack-videopress-pkg' ) }
+								/>
+							</span>
+						</li>
+					) ) }
+				</ol>
+
+				<div className="videopress-playlist-editor__add">
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Add video', 'jetpack-videopress-pkg' ) }
+						hideLabelFromVision
+						placeholder={ __( 'VideoPress GUID or URL', 'jetpack-videopress-pkg' ) }
+						value={ newVideoInput }
+						onChange={ ( value: string ) => {
+							setNewVideoInput( value );
+							setErrorNotice( null );
+						} }
+						onKeyDown={ event => {
+							if ( event.key === 'Enter' ) {
+								event.preventDefault();
+								addVideo();
+							}
+						} }
 					/>
-				</MediaUploadCheck>
-			</div>
-			{ errorNotice && (
-				<Notice status="error" isDismissible={ false }>
-					{ errorNotice }
-				</Notice>
-			) }
-		</div>
+					<Button
+						__next40pxDefaultSize
+						variant="secondary"
+						onClick={ addVideo }
+						isBusy={ isAddingVideo }
+						disabled={ isAddingVideo }
+					>
+						{ __( 'Add to playlist', 'jetpack-videopress-pkg' ) }
+					</Button>
+					<MediaUploadCheck>
+						<MediaUpload
+							title={ __( 'Select videos from your VideoPress library', 'jetpack-videopress-pkg' ) }
+							onSelect={ addVideosFromLibrary }
+							allowedTypes={ VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES }
+							multiple
+							render={ ( { open }: { open: () => void } ) => (
+								<Button __next40pxDefaultSize variant="secondary" onClick={ open }>
+									{ __( 'Choose from library', 'jetpack-videopress-pkg' ) }
+								</Button>
+							) }
+						/>
+					</MediaUploadCheck>
+				</div>
+				{ errorNotice && (
+					<Notice status="error" isDismissible={ false }>
+						{ errorNotice }
+					</Notice>
+				) }
+			</PanelBody>
+
+			<PanelBody title={ __( 'Playlist settings', 'jetpack-videopress-pkg' ) }>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Autoplay next video', 'jetpack-videopress-pkg' ) }
+					help={ __(
+						'Automatically play the next video when the current one ends.',
+						'jetpack-videopress-pkg'
+					) }
+					checked={ autoAdvance }
+					onChange={ ( value: boolean ) => setAttributes( { autoAdvance: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Loop playlist', 'jetpack-videopress-pkg' ) }
+					help={ __(
+						'Restart from the first video after the last one ends.',
+						'jetpack-videopress-pkg'
+					) }
+					checked={ loop }
+					onChange={ ( value: boolean ) => setAttributes( { loop: value } ) }
+				/>
+			</PanelBody>
+		</InspectorControls>
 	);
 
 	if ( ! videos.length ) {
 		return (
 			<div { ...blockProps }>
+				{ inspectorControls }
 				<Placeholder
 					icon={ VideoPressIcon }
 					label={ __( 'VideoPress Playlist', 'jetpack-videopress-pkg' ) }
 					instructions={ __(
-						'Build a playlist that plays videos in sequence. Choose videos from your VideoPress library, or add them by GUID or URL.',
+						'Build a playlist that plays videos in sequence. Add videos in the block settings sidebar: choose them from your VideoPress library, or add them by GUID or URL.',
 						'jetpack-videopress-pkg'
 					) }
-				>
-					{ addVideoForm }
-				</Placeholder>
+				/>
 			</div>
 		);
 	}
 
 	return (
 		<div { ...blockProps }>
-			<InspectorControls>
-				<PanelBody title={ __( 'Playlist settings', 'jetpack-videopress-pkg' ) }>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Autoplay next video', 'jetpack-videopress-pkg' ) }
-						help={ __(
-							'Automatically play the next video when the current one ends.',
-							'jetpack-videopress-pkg'
-						) }
-						checked={ autoAdvance }
-						onChange={ ( value: boolean ) => setAttributes( { autoAdvance: value } ) }
-					/>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Loop playlist', 'jetpack-videopress-pkg' ) }
-						help={ __(
-							'Restart from the first video after the last one ends.',
-							'jetpack-videopress-pkg'
-						) }
-						checked={ loop }
-						onChange={ ( value: boolean ) => setAttributes( { loop: value } ) }
-					/>
-				</PanelBody>
-			</InspectorControls>
+			{ inspectorControls }
 
 			{ currentVideo && (
 				<div className="videopress-playlist-editor__player-wrapper">
@@ -345,33 +383,14 @@ export default function PlaylistBlockEdit( {
 								index + 1
 							) }
 						>
-							{ index + 1 }.
+							<span className="videopress-playlist-editor__item-index">{ index + 1 }.</span>
+							<span className="videopress-playlist-editor__item-title">
+								{ video.title || video.guid }
+							</span>
 						</Button>
-						<span className="videopress-playlist-editor__item-title">
-							{ video.title || video.guid }
-						</span>
-						<Button
-							icon={ chevronUp }
-							disabled={ index === 0 }
-							onClick={ () => moveVideo( index, -1 ) }
-							label={ __( 'Move up', 'jetpack-videopress-pkg' ) }
-						/>
-						<Button
-							icon={ chevronDown }
-							disabled={ index === videos.length - 1 }
-							onClick={ () => moveVideo( index, 1 ) }
-							label={ __( 'Move down', 'jetpack-videopress-pkg' ) }
-						/>
-						<Button
-							icon={ closeSmall }
-							onClick={ () => removeVideo( index ) }
-							label={ __( 'Remove from playlist', 'jetpack-videopress-pkg' ) }
-						/>
 					</li>
 				) ) }
 			</ol>
-
-			{ addVideoForm }
 		</div>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -77,13 +77,15 @@ export default function PlaylistBlockEdit( {
 	const videosRef = useRef( videos );
 	videosRef.current = videos;
 
-	// GUIDs with a title fetch already started; they are not retried, so a
-	// failed fetch simply leaves the GUID as the visible label.
+	// GUIDs with a title refresh already started this editor session; they are
+	// not re-fetched, so a failed lookup simply keeps the stored label.
 	const titleFetchesStarted = useRef( new Set< string >() );
 
+	// Titles always mirror the video data: every entry is refreshed once per
+	// editor session, and the stored title is replaced whenever it differs.
 	useEffect( () => {
 		videos.forEach( video => {
-			if ( video.title || titleFetchesStarted.current.has( video.guid ) ) {
+			if ( titleFetchesStarted.current.has( video.guid ) ) {
 				return;
 			}
 
@@ -96,14 +98,20 @@ export default function PlaylistBlockEdit( {
 					}
 
 					const title = decodeEntities( videoItem.title );
+					const current = videosRef.current;
+
+					if ( ! current.some( entry => entry.guid === video.guid && entry.title !== title ) ) {
+						return;
+					}
+
 					setAttributes( {
-						videos: videosRef.current.map( entry =>
-							entry.guid === video.guid && ! entry.title ? { ...entry, title } : entry
+						videos: current.map( entry =>
+							entry.guid === video.guid ? { ...entry, title } : entry
 						),
 					} );
 				} )
 				.catch( () => {
-					// Leave the GUID as the visible label when the video data isn't reachable.
+					// Keep the stored title (or GUID) when the video data isn't reachable.
 				} );
 		} );
 	}, [ videos, setAttributes ] );
@@ -134,10 +142,12 @@ export default function PlaylistBlockEdit( {
 			const videoItem = await fetchVideoItem( { guid, isPrivate: false, skipRatingControl: true } );
 			if ( videoItem?.title ) {
 				title = decodeEntities( videoItem.title );
+				// Fresh from the video data; no need for the refresh effect to re-fetch it.
+				titleFetchesStarted.current.add( guid );
 			}
 		} catch {
 			// The entry still works without a title; the list shows the GUID and
-			// the backfill effect below retries once more.
+			// the refresh effect below retries once more.
 		}
 
 		setAttributes( { videos: [ ...videosRef.current, { guid, ...( title && { title } ) } ] } );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -71,6 +71,7 @@ export default function PlaylistBlockEdit( {
 	const [ currentIndex, setCurrentIndex ] = useState( 0 );
 	const [ newVideoInput, setNewVideoInput ] = useState( '' );
 	const [ errorNotice, setErrorNotice ] = useState< string | null >( null );
+	const [ isAddingVideo, setIsAddingVideo ] = useState( false );
 
 	// Always points at the latest videos so async title fetches never clobber newer edits.
 	const videosRef = useRef( videos );
@@ -111,7 +112,11 @@ export default function PlaylistBlockEdit( {
 
 	const currentVideo = videos[ currentIndex ] ?? videos[ 0 ];
 
-	const addVideo = () => {
+	const addVideo = async () => {
+		if ( isAddingVideo ) {
+			return;
+		}
+
 		const guid = parseVideoInput( newVideoInput );
 		if ( ! guid ) {
 			setErrorNotice(
@@ -120,9 +125,25 @@ export default function PlaylistBlockEdit( {
 			return;
 		}
 
-		setAttributes( { videos: [ ...videos, { guid } ] } );
+		setIsAddingVideo( true );
+
+		// The title always comes from the video data, for library and URL/GUID
+		// additions alike; it's not editable in the playlist.
+		let title;
+		try {
+			const videoItem = await fetchVideoItem( { guid, isPrivate: false, skipRatingControl: true } );
+			if ( videoItem?.title ) {
+				title = decodeEntities( videoItem.title );
+			}
+		} catch {
+			// The entry still works without a title; the list shows the GUID and
+			// the backfill effect below retries once more.
+		}
+
+		setAttributes( { videos: [ ...videosRef.current, { guid, ...( title && { title } ) } ] } );
 		setNewVideoInput( '' );
 		setErrorNotice( null );
+		setIsAddingVideo( false );
 	};
 
 	const addVideosFromLibrary = (
@@ -208,7 +229,13 @@ export default function PlaylistBlockEdit( {
 						}
 					} }
 				/>
-				<Button __next40pxDefaultSize variant="secondary" onClick={ addVideo }>
+				<Button
+					__next40pxDefaultSize
+					variant="secondary"
+					onClick={ addVideo }
+					isBusy={ isAddingVideo }
+					disabled={ isAddingVideo }
+				>
 					{ __( 'Add to playlist', 'jetpack-videopress-pkg' ) }
 				</Button>
 				<MediaUploadCheck>

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -1,8 +1,20 @@
 /**
  * WordPress dependencies
  */
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { Button, PanelBody, Placeholder, TextControl, ToggleControl } from '@wordpress/components';
+import {
+	InspectorControls,
+	MediaUpload,
+	MediaUploadCheck,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import {
+	Button,
+	Notice,
+	PanelBody,
+	Placeholder,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { chevronDown, chevronUp, closeSmall } from '@wordpress/icons';
@@ -11,11 +23,13 @@ import { chevronDown, chevronUp, closeSmall } from '@wordpress/icons';
  */
 import { isVideoPressGuid, pickGUIDFromUrl } from '../../../lib/url';
 import { VideoPressIcon } from '../video/components/icons';
+import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../video/constants';
 import './editor.scss';
 /**
  * Types
  */
 import type { PlaylistBlockAttributes, PlaylistVideo } from './types';
+import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../types';
 import type { BlockEditProps } from '@wordpress/blocks';
 
 /**
@@ -54,7 +68,7 @@ export default function PlaylistBlockEdit( {
 	const { videos, autoAdvance, loop } = attributes;
 	const [ currentIndex, setCurrentIndex ] = useState( 0 );
 	const [ newVideoInput, setNewVideoInput ] = useState( '' );
-	const [ inputError, setInputError ] = useState( false );
+	const [ errorNotice, setErrorNotice ] = useState< string | null >( null );
 
 	const blockProps = useBlockProps( { className: 'videopress-playlist-editor' } );
 
@@ -63,13 +77,53 @@ export default function PlaylistBlockEdit( {
 	const addVideo = () => {
 		const guid = parseVideoInput( newVideoInput );
 		if ( ! guid ) {
-			setInputError( true );
+			setErrorNotice(
+				__( 'Enter a VideoPress GUID or a VideoPress video URL.', 'jetpack-videopress-pkg' )
+			);
 			return;
 		}
 
 		setAttributes( { videos: [ ...videos, { guid } ] } );
 		setNewVideoInput( '' );
-		setInputError( false );
+		setErrorNotice( null );
+	};
+
+	const addVideosFromLibrary = (
+		selection:
+			| AdminAjaxQueryAttachmentsResponseItemProps
+			| AdminAjaxQueryAttachmentsResponseItemProps[]
+	) => {
+		const mediaItems = Array.isArray( selection ) ? selection : [ selection ];
+
+		const libraryVideos: PlaylistVideo[] = [];
+		for ( const media of mediaItems ) {
+			// Depending on the endpoint, `videopress_guid` can be an array or a string.
+			const guid = Array.isArray( media?.videopress_guid )
+				? media.videopress_guid[ 0 ]
+				: media?.videopress_guid;
+
+			if ( ! guid ) {
+				continue;
+			}
+
+			libraryVideos.push( {
+				guid,
+				...( typeof media.title === 'string' && media.title !== '' && { title: media.title } ),
+			} );
+		}
+
+		if ( ! libraryVideos.length ) {
+			setErrorNotice(
+				__(
+					'None of the selected items are VideoPress videos. Choose videos hosted on VideoPress.',
+					'jetpack-videopress-pkg'
+				)
+			);
+			return;
+		}
+
+		setAttributes( { videos: [ ...videos, ...libraryVideos ] } );
+		setErrorNotice( null );
 	};
 
 	const removeVideo = ( index: number ) => {
@@ -104,33 +158,48 @@ export default function PlaylistBlockEdit( {
 	};
 
 	const addVideoForm = (
-		<div className="videopress-playlist-editor__add">
-			<TextControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ __( 'Add video', 'jetpack-videopress-pkg' ) }
-				hideLabelFromVision
-				placeholder={ __( 'VideoPress GUID or URL', 'jetpack-videopress-pkg' ) }
-				value={ newVideoInput }
-				onChange={ ( value: string ) => {
-					setNewVideoInput( value );
-					setInputError( false );
-				} }
-				onKeyDown={ event => {
-					if ( event.key === 'Enter' ) {
-						event.preventDefault();
-						addVideo();
-					}
-				} }
-				help={
-					inputError
-						? __( 'Enter a VideoPress GUID or a VideoPress video URL.', 'jetpack-videopress-pkg' )
-						: undefined
-				}
-			/>
-			<Button __next40pxDefaultSize variant="secondary" onClick={ addVideo }>
-				{ __( 'Add to playlist', 'jetpack-videopress-pkg' ) }
-			</Button>
+		<div className="videopress-playlist-editor__add-container">
+			<div className="videopress-playlist-editor__add">
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					label={ __( 'Add video', 'jetpack-videopress-pkg' ) }
+					hideLabelFromVision
+					placeholder={ __( 'VideoPress GUID or URL', 'jetpack-videopress-pkg' ) }
+					value={ newVideoInput }
+					onChange={ ( value: string ) => {
+						setNewVideoInput( value );
+						setErrorNotice( null );
+					} }
+					onKeyDown={ event => {
+						if ( event.key === 'Enter' ) {
+							event.preventDefault();
+							addVideo();
+						}
+					} }
+				/>
+				<Button __next40pxDefaultSize variant="secondary" onClick={ addVideo }>
+					{ __( 'Add to playlist', 'jetpack-videopress-pkg' ) }
+				</Button>
+				<MediaUploadCheck>
+					<MediaUpload
+						title={ __( 'Select videos from your VideoPress library', 'jetpack-videopress-pkg' ) }
+						onSelect={ addVideosFromLibrary }
+						allowedTypes={ VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES }
+						multiple
+						render={ ( { open }: { open: () => void } ) => (
+							<Button __next40pxDefaultSize variant="secondary" onClick={ open }>
+								{ __( 'Choose from library', 'jetpack-videopress-pkg' ) }
+							</Button>
+						) }
+					/>
+				</MediaUploadCheck>
+			</div>
+			{ errorNotice && (
+				<Notice status="error" isDismissible={ false }>
+					{ errorNotice }
+				</Notice>
+			) }
 		</div>
 	);
 
@@ -141,7 +210,7 @@ export default function PlaylistBlockEdit( {
 					icon={ VideoPressIcon }
 					label={ __( 'VideoPress Playlist', 'jetpack-videopress-pkg' ) }
 					instructions={ __(
-						'Add VideoPress videos by GUID or URL to build a playlist that plays them in sequence.',
+						'Build a playlist that plays videos in sequence. Choose videos from your VideoPress library, or add them by GUID or URL.',
 						'jetpack-videopress-pkg'
 					) }
 				>

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -15,12 +15,14 @@ import {
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { chevronDown, chevronUp, closeSmall } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { fetchVideoItem } from '../../../lib/fetch-video-item';
 import { isVideoPressGuid, pickGUIDFromUrl } from '../../../lib/url';
 import { VideoPressIcon } from '../video/components/icons';
 import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../video/constants';
@@ -69,6 +71,41 @@ export default function PlaylistBlockEdit( {
 	const [ currentIndex, setCurrentIndex ] = useState( 0 );
 	const [ newVideoInput, setNewVideoInput ] = useState( '' );
 	const [ errorNotice, setErrorNotice ] = useState< string | null >( null );
+
+	// Always points at the latest videos so async title fetches never clobber newer edits.
+	const videosRef = useRef( videos );
+	videosRef.current = videos;
+
+	// GUIDs with a title fetch already started; they are not retried, so a
+	// failed fetch simply leaves the GUID as the visible label.
+	const titleFetchesStarted = useRef( new Set< string >() );
+
+	useEffect( () => {
+		videos.forEach( video => {
+			if ( video.title || titleFetchesStarted.current.has( video.guid ) ) {
+				return;
+			}
+
+			titleFetchesStarted.current.add( video.guid );
+
+			fetchVideoItem( { guid: video.guid, isPrivate: false, skipRatingControl: true } )
+				.then( videoItem => {
+					if ( ! videoItem?.title ) {
+						return;
+					}
+
+					const title = decodeEntities( videoItem.title );
+					setAttributes( {
+						videos: videosRef.current.map( entry =>
+							entry.guid === video.guid && ! entry.title ? { ...entry, title } : entry
+						),
+					} );
+				} )
+				.catch( () => {
+					// Leave the GUID as the visible label when the video data isn't reachable.
+				} );
+		} );
+	}, [ videos, setAttributes ] );
 
 	const blockProps = useBlockProps( { className: 'videopress-playlist-editor' } );
 
@@ -148,13 +185,6 @@ export default function PlaylistBlockEdit( {
 		} else if ( currentIndex === target ) {
 			setCurrentIndex( index );
 		}
-	};
-
-	const updateVideoTitle = ( index: number, title: string ) => {
-		const updated = videos.map( ( video: PlaylistVideo, i: number ) =>
-			i === index ? { ...video, title } : video
-		);
-		setAttributes( { videos: updated } );
 	};
 
 	const addVideoForm = (
@@ -280,16 +310,9 @@ export default function PlaylistBlockEdit( {
 						>
 							{ index + 1 }.
 						</Button>
-						<TextControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							className="videopress-playlist-editor__item-title"
-							label={ __( 'Video title', 'jetpack-videopress-pkg' ) }
-							hideLabelFromVision
-							placeholder={ video.guid }
-							value={ video.title ?? '' }
-							onChange={ ( value: string ) => updateVideoTitle( index, value ) }
-						/>
+						<span className="videopress-playlist-editor__item-title">
+							{ video.title || video.guid }
+						</span>
 						<Button
 							icon={ chevronUp }
 							disabled={ index === 0 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -1,0 +1,248 @@
+/**
+ * WordPress dependencies
+ */
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { Button, PanelBody, Placeholder, TextControl, ToggleControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { chevronDown, chevronUp, closeSmall } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import { isVideoPressGuid, pickGUIDFromUrl } from '../../../lib/url';
+import { VideoPressIcon } from '../video/components/icons';
+import './editor.scss';
+/**
+ * Types
+ */
+import type { PlaylistBlockAttributes, PlaylistVideo } from './types';
+import type { BlockEditProps } from '@wordpress/blocks';
+
+/**
+ * Extract a VideoPress GUID from user input, which can be
+ * either a bare GUID or any recognized VideoPress URL.
+ *
+ * @param value - Raw user input.
+ * @return The GUID, or null when the input is not recognized.
+ */
+function parseVideoInput( value: string ): string | null {
+	const trimmed = value.trim();
+	if ( ! trimmed ) {
+		return null;
+	}
+
+	const guid = isVideoPressGuid( trimmed );
+	if ( guid ) {
+		return guid as string;
+	}
+
+	return pickGUIDFromUrl( trimmed );
+}
+
+/**
+ * VideoPress Playlist block Edit component.
+ *
+ * @param props               - Block edit props.
+ * @param props.attributes    - Block attributes.
+ * @param props.setAttributes - Attributes setter.
+ * @return React component.
+ */
+export default function PlaylistBlockEdit( {
+	attributes,
+	setAttributes,
+}: BlockEditProps< PlaylistBlockAttributes > ) {
+	const { videos, autoAdvance, loop } = attributes;
+	const [ currentIndex, setCurrentIndex ] = useState( 0 );
+	const [ newVideoInput, setNewVideoInput ] = useState( '' );
+	const [ inputError, setInputError ] = useState( false );
+
+	const blockProps = useBlockProps( { className: 'videopress-playlist-editor' } );
+
+	const currentVideo = videos[ currentIndex ] ?? videos[ 0 ];
+
+	const addVideo = () => {
+		const guid = parseVideoInput( newVideoInput );
+		if ( ! guid ) {
+			setInputError( true );
+			return;
+		}
+
+		setAttributes( { videos: [ ...videos, { guid } ] } );
+		setNewVideoInput( '' );
+		setInputError( false );
+	};
+
+	const removeVideo = ( index: number ) => {
+		setAttributes( { videos: videos.filter( ( _, i ) => i !== index ) } );
+		if ( currentIndex >= index && currentIndex > 0 ) {
+			setCurrentIndex( currentIndex - 1 );
+		}
+	};
+
+	const moveVideo = ( index: number, direction: -1 | 1 ) => {
+		const target = index + direction;
+		if ( target < 0 || target >= videos.length ) {
+			return;
+		}
+
+		const reordered = [ ...videos ];
+		[ reordered[ index ], reordered[ target ] ] = [ reordered[ target ], reordered[ index ] ];
+		setAttributes( { videos: reordered } );
+
+		if ( currentIndex === index ) {
+			setCurrentIndex( target );
+		} else if ( currentIndex === target ) {
+			setCurrentIndex( index );
+		}
+	};
+
+	const updateVideoTitle = ( index: number, title: string ) => {
+		const updated = videos.map( ( video: PlaylistVideo, i: number ) =>
+			i === index ? { ...video, title } : video
+		);
+		setAttributes( { videos: updated } );
+	};
+
+	const addVideoForm = (
+		<div className="videopress-playlist-editor__add">
+			<TextControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'Add video', 'jetpack-videopress-pkg' ) }
+				hideLabelFromVision
+				placeholder={ __( 'VideoPress GUID or URL', 'jetpack-videopress-pkg' ) }
+				value={ newVideoInput }
+				onChange={ ( value: string ) => {
+					setNewVideoInput( value );
+					setInputError( false );
+				} }
+				onKeyDown={ event => {
+					if ( event.key === 'Enter' ) {
+						event.preventDefault();
+						addVideo();
+					}
+				} }
+				help={
+					inputError
+						? __( 'Enter a VideoPress GUID or a VideoPress video URL.', 'jetpack-videopress-pkg' )
+						: undefined
+				}
+			/>
+			<Button __next40pxDefaultSize variant="secondary" onClick={ addVideo }>
+				{ __( 'Add to playlist', 'jetpack-videopress-pkg' ) }
+			</Button>
+		</div>
+	);
+
+	if ( ! videos.length ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					icon={ VideoPressIcon }
+					label={ __( 'VideoPress Playlist', 'jetpack-videopress-pkg' ) }
+					instructions={ __(
+						'Add VideoPress videos by GUID or URL to build a playlist that plays them in sequence.',
+						'jetpack-videopress-pkg'
+					) }
+				>
+					{ addVideoForm }
+				</Placeholder>
+			</div>
+		);
+	}
+
+	return (
+		<div { ...blockProps }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Playlist settings', 'jetpack-videopress-pkg' ) }>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Autoplay next video', 'jetpack-videopress-pkg' ) }
+						help={ __(
+							'Automatically play the next video when the current one ends.',
+							'jetpack-videopress-pkg'
+						) }
+						checked={ autoAdvance }
+						onChange={ ( value: boolean ) => setAttributes( { autoAdvance: value } ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Loop playlist', 'jetpack-videopress-pkg' ) }
+						help={ __(
+							'Restart from the first video after the last one ends.',
+							'jetpack-videopress-pkg'
+						) }
+						checked={ loop }
+						onChange={ ( value: boolean ) => setAttributes( { loop: value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			{ currentVideo && (
+				<div className="videopress-playlist-editor__player-wrapper">
+					<iframe
+						className="videopress-playlist-editor__player"
+						title={ __( 'VideoPress Playlist Player', 'jetpack-videopress-pkg' ) }
+						src={ `https://videopress.com/embed/${ currentVideo.guid }?cover=1&preloadContent=metadata` }
+						allowFullScreen
+						allow="clipboard-write"
+					/>
+				</div>
+			) }
+
+			<ol className="videopress-playlist-editor__items">
+				{ videos.map( ( video: PlaylistVideo, index: number ) => (
+					<li
+						key={ `${ video.guid }-${ index }` }
+						className={
+							index === currentIndex
+								? 'videopress-playlist-editor__item is-current'
+								: 'videopress-playlist-editor__item'
+						}
+					>
+						<Button
+							className="videopress-playlist-editor__item-select"
+							onClick={ () => setCurrentIndex( index ) }
+							label={ sprintf(
+								/* translators: %d: position of the video in the playlist. */
+								__( 'Preview video %d', 'jetpack-videopress-pkg' ),
+								index + 1
+							) }
+						>
+							{ index + 1 }.
+						</Button>
+						<TextControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							className="videopress-playlist-editor__item-title"
+							label={ __( 'Video title', 'jetpack-videopress-pkg' ) }
+							hideLabelFromVision
+							placeholder={ video.guid }
+							value={ video.title ?? '' }
+							onChange={ ( value: string ) => updateVideoTitle( index, value ) }
+						/>
+						<Button
+							icon={ chevronUp }
+							disabled={ index === 0 }
+							onClick={ () => moveVideo( index, -1 ) }
+							label={ __( 'Move up', 'jetpack-videopress-pkg' ) }
+						/>
+						<Button
+							icon={ chevronDown }
+							disabled={ index === videos.length - 1 }
+							onClick={ () => moveVideo( index, 1 ) }
+							label={ __( 'Move down', 'jetpack-videopress-pkg' ) }
+						/>
+						<Button
+							icon={ closeSmall }
+							onClick={ () => removeVideo( index ) }
+							label={ __( 'Remove from playlist', 'jetpack-videopress-pkg' ) }
+						/>
+					</li>
+				) ) }
+			</ol>
+
+			{ addVideoForm }
+		</div>
+	);
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -18,7 +18,7 @@ import {
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
-import { chevronDown, chevronUp, closeSmall } from '@wordpress/icons';
+import { closeSmall, dragHandle, Icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
@@ -72,6 +72,8 @@ export default function PlaylistBlockEdit( {
 	const [ newVideoInput, setNewVideoInput ] = useState( '' );
 	const [ errorNotice, setErrorNotice ] = useState< string | null >( null );
 	const [ isAddingVideo, setIsAddingVideo ] = useState( false );
+	const [ draggedIndex, setDraggedIndex ] = useState< number | null >( null );
+	const [ dropTargetIndex, setDropTargetIndex ] = useState< number | null >( null );
 
 	// Always points at the latest videos so async title fetches never clobber newer edits.
 	const videosRef = useRef( videos );
@@ -201,20 +203,23 @@ export default function PlaylistBlockEdit( {
 		}
 	};
 
-	const moveVideo = ( index: number, direction: -1 | 1 ) => {
-		const target = index + direction;
-		if ( target < 0 || target >= videos.length ) {
+	const reorderVideo = ( from: number, to: number ) => {
+		if ( from === to || from < 0 || to < 0 || from >= videos.length || to >= videos.length ) {
 			return;
 		}
 
 		const reordered = [ ...videos ];
-		[ reordered[ index ], reordered[ target ] ] = [ reordered[ target ], reordered[ index ] ];
+		const [ moved ] = reordered.splice( from, 1 );
+		reordered.splice( to, 0, moved );
 		setAttributes( { videos: reordered } );
 
-		if ( currentIndex === index ) {
-			setCurrentIndex( target );
-		} else if ( currentIndex === target ) {
-			setCurrentIndex( index );
+		// Keep the canvas preview on the same video it showed before the move.
+		if ( currentIndex === from ) {
+			setCurrentIndex( to );
+		} else if ( from < currentIndex && to >= currentIndex ) {
+			setCurrentIndex( currentIndex - 1 );
+		} else if ( from > currentIndex && to <= currentIndex ) {
+			setCurrentIndex( currentIndex + 1 );
 		}
 	};
 
@@ -223,40 +228,80 @@ export default function PlaylistBlockEdit( {
 	const inspectorControls = (
 		<InspectorControls>
 			<PanelBody title={ __( 'Videos', 'jetpack-videopress-pkg' ) }>
-				<ol className="videopress-playlist-editor__manage-list">
-					{ videos.map( ( video: PlaylistVideo, index: number ) => (
-						<li
-							key={ `${ video.guid }-${ index }` }
-							className="videopress-playlist-editor__manage-item"
-						>
-							<span className="videopress-playlist-editor__manage-item-title">
-								{ index + 1 }. { video.title || video.guid }
-							</span>
-							<span className="videopress-playlist-editor__manage-item-actions">
+				<ul className="videopress-playlist-editor__manage-list">
+					{ videos.map( ( video: PlaylistVideo, index: number ) => {
+						const classes = [ 'videopress-playlist-editor__manage-item' ];
+						if ( index === draggedIndex ) {
+							classes.push( 'is-dragging' );
+						}
+						if ( index === dropTargetIndex && index !== draggedIndex ) {
+							classes.push( 'is-drop-target' );
+						}
+
+						return (
+							<li
+								key={ `${ video.guid }-${ index }` }
+								className={ classes.join( ' ' ) }
+								draggable
+								aria-label={ sprintf(
+									/* translators: %d: position of the video in the playlist. */
+									__( 'Video %d. Drag to reorder.', 'jetpack-videopress-pkg' ),
+									index + 1
+								) }
+								onDragStart={ event => {
+									setDraggedIndex( index );
+									event.dataTransfer?.setData( 'text/plain', String( index ) );
+									if ( event.dataTransfer ) {
+										event.dataTransfer.effectAllowed = 'move';
+									}
+								} }
+								onDragOver={ event => {
+									event.preventDefault();
+									if ( event.dataTransfer ) {
+										event.dataTransfer.dropEffect = 'move';
+									}
+									if ( draggedIndex !== null && index !== draggedIndex ) {
+										setDropTargetIndex( index );
+									}
+								} }
+								onDragLeave={ () => {
+									if ( dropTargetIndex === index ) {
+										setDropTargetIndex( null );
+									}
+								} }
+								onDrop={ event => {
+									event.preventDefault();
+									if ( draggedIndex !== null ) {
+										reorderVideo( draggedIndex, index );
+									}
+									setDraggedIndex( null );
+									setDropTargetIndex( null );
+								} }
+								onDragEnd={ () => {
+									setDraggedIndex( null );
+									setDropTargetIndex( null );
+								} }
+							>
+								<span className="videopress-playlist-editor__manage-item-handle">
+									<Icon icon={ dragHandle } size={ 16 } />
+								</span>
+								<span className="videopress-playlist-editor__manage-item-index">
+									{ index + 1 }.
+								</span>
+								<span className="videopress-playlist-editor__manage-item-title">
+									{ video.title || video.guid }
+								</span>
 								<Button
-									size="small"
-									icon={ chevronUp }
-									disabled={ index === 0 }
-									onClick={ () => moveVideo( index, -1 ) }
-									label={ __( 'Move up', 'jetpack-videopress-pkg' ) }
-								/>
-								<Button
-									size="small"
-									icon={ chevronDown }
-									disabled={ index === videos.length - 1 }
-									onClick={ () => moveVideo( index, 1 ) }
-									label={ __( 'Move down', 'jetpack-videopress-pkg' ) }
-								/>
-								<Button
+									className="videopress-playlist-editor__manage-item-remove"
 									size="small"
 									icon={ closeSmall }
 									onClick={ () => removeVideo( index ) }
 									label={ __( 'Remove from playlist', 'jetpack-videopress-pkg' ) }
 								/>
-							</span>
-						</li>
-					) ) }
-				</ol>
+							</li>
+						);
+					} ) }
+				</ul>
 
 				<div className="videopress-playlist-editor__add">
 					<TextControl
@@ -301,7 +346,11 @@ export default function PlaylistBlockEdit( {
 					</MediaUploadCheck>
 				</div>
 				{ errorNotice && (
-					<Notice status="error" isDismissible={ false }>
+					<Notice
+						className="videopress-playlist-editor__notice"
+						status="error"
+						isDismissible={ false }
+					>
 						{ errorNotice }
 					</Notice>
 				) }
@@ -364,7 +413,7 @@ export default function PlaylistBlockEdit( {
 				</div>
 			) }
 
-			<ol className="videopress-playlist-editor__items">
+			<ul className="videopress-playlist-editor__items">
 				{ videos.map( ( video: PlaylistVideo, index: number ) => (
 					<li
 						key={ `${ video.guid }-${ index }` }
@@ -390,7 +439,7 @@ export default function PlaylistBlockEdit( {
 						</Button>
 					</li>
 				) ) }
-			</ol>
+			</ul>
 		</div>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -1,73 +1,121 @@
+// Canvas: layout/preview styles come from view.scss (also loaded as an
+// editor style); only editor-specific chrome lives here.
 .videopress-playlist-editor {
 
-	&__player-wrapper {
-		position: relative;
-		aspect-ratio: 16 / 9;
-		background: #000;
-	}
-
-	&__player {
-		position: absolute;
-		inset: 0;
-		inline-size: 100%;
-		block-size: 100%;
-		border: 0;
-	}
-
-	// Canvas preview list: mirrors the frontend look, click to preview only.
-	&__items {
-		list-style: none;
-		margin: 8px 0 0;
-		padding: 0;
-	}
-
-	&__item {
-
-		&.is-current .videopress-playlist-editor__item-select {
-			background: rgba(0, 0, 0, 0.08);
-			font-weight: 600;
-		}
-	}
-
-	&__item-select {
-		display: flex;
-		inline-size: 100%;
+	.videopress-playlist__item {
 		block-size: auto;
+	}
+
+	&__placeholder-form {
+		inline-size: 100%;
+		max-inline-size: 400px;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	&__placeholder-divider {
+		display: flex;
 		align-items: center;
-		gap: 8px;
-		padding: 8px;
-		text-align: start;
-	}
+		gap: 10px;
+		color: rgba(0, 0, 0, 0.45);
+		font-size: 11.5px;
 
-	&__item-index {
-		flex-shrink: 0;
-		opacity: 0.7;
-	}
-
-	&__item-title {
-		flex: 1 1 auto;
-		min-inline-size: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+		&::before,
+		&::after {
+			content: "";
+			flex: 1;
+			block-size: 1px;
+			background: rgba(0, 0, 0, 0.12);
+		}
 	}
 }
 
 // Sidebar panel: playlist management (add, drag-to-sort, delete). These
 // elements render in the editor sidebar, outside the block wrapper.
+.videopress-playlist-editor__add-row {
+	display: flex;
+	gap: 6px;
+
+	.components-base-control {
+		flex: 1 1 auto;
+		min-inline-size: 0;
+	}
+
+	.components-button {
+		flex-shrink: 0;
+	}
+}
+
+.videopress-playlist-editor__placeholder-form .videopress-playlist-editor__add-row {
+	inline-size: 100%;
+}
+
+.videopress-playlist-editor__add-help {
+	margin: 7px 0 0;
+	font-size: 11.5px;
+	color: rgba(0, 0, 0, 0.55);
+}
+
+.videopress-playlist-editor__add-library {
+	margin-block-start: 8px;
+
+	.components-button {
+		inline-size: 100%;
+		justify-content: center;
+	}
+}
+
+.videopress-playlist-editor__notice {
+	margin: 10px 0 0;
+}
+
+.videopress-playlist-editor__duplicate-actions {
+	display: flex;
+	gap: 8px;
+	margin-block-start: 8px;
+}
+
+.videopress-playlist-editor__list-header {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	margin: 16px 0 10px;
+}
+
+.videopress-playlist-editor__list-title {
+	font-size: 11px;
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+}
+
+.videopress-playlist-editor__list-count {
+	font-size: 11.5px;
+	color: rgba(0, 0, 0, 0.55);
+	font-variant-numeric: tabular-nums;
+}
+
+.videopress-playlist-editor__filter {
+	margin-block-end: 10px;
+}
+
 .videopress-playlist-editor__manage-list {
 	list-style: none;
-	margin: 0 0 16px;
+	margin: 0;
 	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
 }
 
 .videopress-playlist-editor__manage-item {
 	display: flex;
 	align-items: center;
-	gap: 6px;
-	padding: 6px 4px;
-	border: 1px solid transparent;
-	border-radius: 2px;
+	gap: 8px;
+	padding: 6px;
+	border: 1px solid rgba(0, 0, 0, 0.12);
+	border-radius: 3px;
 	cursor: grab;
 
 	&:hover {
@@ -79,7 +127,12 @@
 	}
 
 	&.is-drop-target {
-		border-color: var(--wp-admin-theme-color, #3858e9);
+		box-shadow: 0 -2px 0 0 var(--wp-admin-theme-color, #3858e9);
+	}
+
+	&.is-loading {
+		cursor: default;
+		opacity: 0.7;
 	}
 
 	.videopress-playlist-editor__manage-item-handle {
@@ -90,15 +143,49 @@
 
 	.videopress-playlist-editor__manage-item-index {
 		flex-shrink: 0;
-		opacity: 0.7;
+		font-size: 10.5px;
+		color: rgba(0, 0, 0, 0.45);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.videopress-playlist-editor__manage-item-thumb {
+		position: relative;
+		flex-shrink: 0;
+		inline-size: 54px;
+		aspect-ratio: 16 / 9;
+		border-radius: 3px;
+		overflow: hidden;
+		background: rgba(0, 0, 0, 0.08);
+
+		img {
+			position: absolute;
+			inset: 0;
+			inline-size: 100%;
+			block-size: 100%;
+			object-fit: cover;
+		}
+	}
+
+	.videopress-playlist-editor__manage-item-text {
+		flex: 1 1 auto;
+		min-inline-size: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
 	}
 
 	.videopress-playlist-editor__manage-item-title {
-		flex: 1 1 auto;
-		min-inline-size: 0;
+		font-size: 12px;
+		font-weight: 500;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+
+	.videopress-playlist-editor__manage-item-meta {
+		font-size: 10.5px;
+		color: rgba(0, 0, 0, 0.55);
+		font-variant-numeric: tabular-nums;
 	}
 
 	.videopress-playlist-editor__manage-item-remove {
@@ -106,19 +193,19 @@
 	}
 }
 
-// The sidebar is a narrow column: stack the add controls vertically,
-// full width, rather than flowing them side by side.
-.videopress-playlist-editor__add {
-	display: flex;
-	flex-direction: column;
-	align-items: stretch;
-	gap: 8px;
-
-	.components-button {
-		justify-content: center;
-	}
+.videopress-playlist-editor__reorder-help {
+	margin: 9px 0 0;
+	font-size: 11.5px;
+	color: rgba(0, 0, 0, 0.55);
 }
 
-.videopress-playlist-editor__notice {
-	margin: 8px 0 0;
+.videopress-playlist-editor__layout-picker {
+	display: flex;
+	gap: 6px;
+	margin-block-end: 14px;
+
+	.components-button {
+		flex: 1;
+		justify-content: center;
+	}
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -33,6 +33,9 @@
 
 	&__item-title {
 		flex-grow: 1;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	&__add-container {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -40,50 +40,85 @@
 	}
 
 	&__item-index {
+		flex-shrink: 0;
 		opacity: 0.7;
 	}
 
 	&__item-title {
-		flex-grow: 1;
+		flex: 1 1 auto;
+		min-inline-size: 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
+}
 
-	// Sidebar panel: playlist management (add, sort, delete).
-	&__manage-list {
-		list-style: none;
-		margin: 0 0 12px;
-		padding: 0;
+// Sidebar panel: playlist management (add, drag-to-sort, delete). These
+// elements render in the editor sidebar, outside the block wrapper.
+.videopress-playlist-editor__manage-list {
+	list-style: none;
+	margin: 0 0 16px;
+	padding: 0;
+}
+
+.videopress-playlist-editor__manage-item {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 4px;
+	border: 1px solid transparent;
+	border-radius: 2px;
+	cursor: grab;
+
+	&:hover {
+		background: rgba(0, 0, 0, 0.04);
 	}
 
-	&__manage-item {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 4px;
-		padding: 2px 0;
+	&.is-dragging {
+		opacity: 0.4;
 	}
 
-	&__manage-item-title {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+	&.is-drop-target {
+		border-color: var(--wp-admin-theme-color, #3858e9);
 	}
 
-	&__manage-item-actions {
+	.videopress-playlist-editor__manage-item-handle {
 		display: flex;
 		flex-shrink: 0;
+		opacity: 0.6;
 	}
 
-	&__add {
-		display: flex;
-		flex-direction: column;
-		align-items: stretch;
-		gap: 8px;
+	.videopress-playlist-editor__manage-item-index {
+		flex-shrink: 0;
+		opacity: 0.7;
 	}
 
-	.components-notice {
-		margin: 8px 0 0;
+	.videopress-playlist-editor__manage-item-title {
+		flex: 1 1 auto;
+		min-inline-size: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
+
+	.videopress-playlist-editor__manage-item-remove {
+		flex-shrink: 0;
+	}
+}
+
+// The sidebar is a narrow column: stack the add controls vertically,
+// full width, rather than flowing them side by side.
+.videopress-playlist-editor__add {
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 8px;
+
+	.components-button {
+		justify-content: center;
+	}
+}
+
+.videopress-playlist-editor__notice {
+	margin: 8px 0 0;
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -35,14 +35,23 @@
 		flex-grow: 1;
 	}
 
+	&__add-container {
+		margin-block-start: 8px;
+
+		.components-notice {
+			margin: 8px 0 0;
+		}
+	}
+
 	&__add {
 		display: flex;
 		align-items: flex-start;
+		flex-wrap: wrap;
 		gap: 8px;
-		margin-block-start: 8px;
 
 		.components-base-control {
 			flex-grow: 1;
+			min-inline-size: 200px;
 		}
 	}
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -14,6 +14,7 @@
 		border: 0;
 	}
 
+	// Canvas preview list: mirrors the frontend look, click to preview only.
 	&__items {
 		list-style: none;
 		margin: 8px 0 0;
@@ -21,14 +22,25 @@
 	}
 
 	&__item {
-		display: flex;
-		align-items: center;
-		gap: 4px;
-		padding: 2px 0;
 
-		&.is-current {
-			background: rgba(0, 0, 0, 0.05);
+		&.is-current .videopress-playlist-editor__item-select {
+			background: rgba(0, 0, 0, 0.08);
+			font-weight: 600;
 		}
+	}
+
+	&__item-select {
+		display: flex;
+		inline-size: 100%;
+		block-size: auto;
+		align-items: center;
+		gap: 8px;
+		padding: 8px;
+		text-align: start;
+	}
+
+	&__item-index {
+		opacity: 0.7;
 	}
 
 	&__item-title {
@@ -38,23 +50,40 @@
 		white-space: nowrap;
 	}
 
-	&__add-container {
-		margin-block-start: 8px;
+	// Sidebar panel: playlist management (add, sort, delete).
+	&__manage-list {
+		list-style: none;
+		margin: 0 0 12px;
+		padding: 0;
+	}
 
-		.components-notice {
-			margin: 8px 0 0;
-		}
+	&__manage-item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 4px;
+		padding: 2px 0;
+	}
+
+	&__manage-item-title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&__manage-item-actions {
+		display: flex;
+		flex-shrink: 0;
 	}
 
 	&__add {
 		display: flex;
-		align-items: flex-start;
-		flex-wrap: wrap;
+		flex-direction: column;
+		align-items: stretch;
 		gap: 8px;
+	}
 
-		.components-base-control {
-			flex-grow: 1;
-			min-inline-size: 200px;
-		}
+	.components-notice {
+		margin: 8px 0 0;
 	}
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -1,0 +1,48 @@
+.videopress-playlist-editor {
+
+	&__player-wrapper {
+		position: relative;
+		aspect-ratio: 16 / 9;
+		background: #000;
+	}
+
+	&__player {
+		position: absolute;
+		inset: 0;
+		inline-size: 100%;
+		block-size: 100%;
+		border: 0;
+	}
+
+	&__items {
+		list-style: none;
+		margin: 8px 0 0;
+		padding: 0;
+	}
+
+	&__item {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 2px 0;
+
+		&.is-current {
+			background: rgba(0, 0, 0, 0.05);
+		}
+	}
+
+	&__item-title {
+		flex-grow: 1;
+	}
+
+	&__add {
+		display: flex;
+		align-items: flex-start;
+		gap: 8px;
+		margin-block-start: 8px;
+
+		.components-base-control {
+			flex-grow: 1;
+		}
+	}
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/index.ts
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+/**
+ * Internal dependencies
+ */
+// Overrides Webpack's publicPath before any lazy chunk loads on wpcom.
+import '../../set-webpack-public-path';
+import { VideoPressIcon as icon } from '../video/components/icons';
+import metadata from './block.json';
+import Edit from './edit';
+/**
+ * Types
+ */
+import type { PlaylistBlockAttributes } from './types';
+
+export const { name, title, description, attributes, category } = metadata;
+
+registerBlockType< PlaylistBlockAttributes >( name, {
+	edit: Edit,
+	save: () => null,
+	category,
+	title,
+	icon,
+	attributes,
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { fetchVideoItem } from '../../../../lib/fetch-video-item';
 import Edit from '../edit';
@@ -122,14 +122,15 @@ describe( 'PlaylistBlockEdit', () => {
 			expect.stringContaining( 'videopress.com/embed/abcd1234' )
 		);
 
-		expect( screen.getByText( 'First' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'efgh5678' ) ).toBeInTheDocument();
+		// Titles list in both the canvas preview and the sidebar manage list.
+		expect( screen.getAllByText( 'First' ) ).toHaveLength( 2 );
+		expect( screen.getAllByText( 'efgh5678' ) ).toHaveLength( 2 );
 	} );
 
 	it( 'shows item titles as plain text, with only the add-video field editable', () => {
 		renderEdit( { videos: [ { guid: 'abcd1234', title: 'First' } ] } );
 
-		expect( screen.getByText( 'First' ) ).toBeInTheDocument();
+		expect( screen.getAllByText( 'First' ).length ).toBeGreaterThan( 0 );
 		expect( screen.getAllByRole( 'textbox' ) ).toHaveLength( 1 );
 		expect( screen.getByRole( 'textbox' ) ).toHaveAttribute(
 			'placeholder',
@@ -170,20 +171,39 @@ describe( 'PlaylistBlockEdit', () => {
 		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ { guid: 'efgh5678' } ] } );
 	} );
 
-	it( 'moves an item down and disables the impossible directions', async () => {
-		const user = userEvent.setup();
+	it( 'reorders videos with drag and drop', () => {
 		const { setAttributes } = renderEdit( {
-			videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' } ],
+			videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' }, { guid: 'ijkl9012' } ],
 		} );
 
-		expect( screen.getAllByLabelText( 'Move up' )[ 0 ] ).toBeDisabled();
-		expect( screen.getAllByLabelText( 'Move down' )[ 1 ] ).toBeDisabled();
+		const sidebar = within( screen.getByTestId( 'inspector-controls' ) );
+		const items = sidebar.getAllByRole( 'listitem' );
 
-		await user.click( screen.getAllByLabelText( 'Move down' )[ 0 ] );
+		fireEvent.dragStart( items[ 0 ] );
+		fireEvent.dragOver( items[ 2 ] );
+		fireEvent.drop( items[ 2 ] );
 
 		expect( setAttributes ).toHaveBeenCalledWith( {
-			videos: [ { guid: 'efgh5678' }, { guid: 'abcd1234' } ],
+			videos: [ { guid: 'efgh5678' }, { guid: 'ijkl9012' }, { guid: 'abcd1234' } ],
 		} );
+	} );
+
+	it( 'marks the hovered item as the drop target while dragging', () => {
+		renderEdit( { videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' } ] } );
+
+		const sidebar = within( screen.getByTestId( 'inspector-controls' ) );
+		const items = sidebar.getAllByRole( 'listitem' );
+
+		fireEvent.dragStart( items[ 0 ] );
+		fireEvent.dragOver( items[ 1 ] );
+
+		expect( items[ 0 ] ).toHaveClass( 'is-dragging' );
+		expect( items[ 1 ] ).toHaveClass( 'is-drop-target' );
+
+		fireEvent.dragEnd( items[ 0 ] );
+
+		expect( items[ 0 ] ).not.toHaveClass( 'is-dragging' );
+		expect( items[ 1 ] ).not.toHaveClass( 'is-drop-target' );
 	} );
 
 	it( 'switches the preview when selecting another item', async () => {
@@ -241,17 +261,17 @@ describe( 'PlaylistBlockEdit', () => {
 
 		const sidebar = within( screen.getByTestId( 'inspector-controls' ) );
 
-		// Add, sort, and delete all live in the sidebar.
+		// Add, drag-to-sort, and delete all live in the sidebar.
 		expect( sidebar.getByPlaceholderText( 'VideoPress GUID or URL' ) ).toBeInTheDocument();
 		expect( sidebar.getByText( 'Add to playlist' ) ).toBeInTheDocument();
 		expect( sidebar.getByText( 'Choose from library' ) ).toBeInTheDocument();
-		expect( sidebar.getAllByLabelText( 'Move up' ) ).toHaveLength( 2 );
-		expect( sidebar.getAllByLabelText( 'Move down' ) ).toHaveLength( 2 );
 		expect( sidebar.getAllByLabelText( 'Remove from playlist' ) ).toHaveLength( 2 );
+		for ( const item of sidebar.getAllByRole( 'listitem' ) ) {
+			expect( item ).toHaveAttribute( 'draggable', 'true' );
+		}
 
 		// The canvas only previews: item selection, no management controls.
 		expect( screen.getAllByLabelText( 'Remove from playlist' ) ).toHaveLength( 2 );
-		expect( screen.getAllByLabelText( 'Move up' ) ).toHaveLength( 2 );
 		expect( screen.getByLabelText( 'Preview video 2' ) ).toBeInTheDocument();
 	} );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { fetchVideoItem } from '../../../../lib/fetch-video-item';
 import Edit from '../edit';
@@ -16,7 +16,9 @@ const mockFetchVideoItem = fetchVideoItem as jest.Mock;
 
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: ( props: Record< string, unknown > = {} ) => props,
-	InspectorControls: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	InspectorControls: ( { children }: { children: React.ReactNode } ) => (
+		<div data-testid="inspector-controls">{ children }</div>
+	),
 	MediaUploadCheck: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
 	MediaUpload: ( {
 		onSelect,
@@ -232,6 +234,35 @@ describe( 'PlaylistBlockEdit', () => {
 				'None of the selected items are VideoPress videos. Choose videos hosted on VideoPress.'
 			).length
 		).toBeGreaterThan( 0 );
+	} );
+
+	it( 'keeps all management controls in the settings sidebar; the canvas is preview-only', () => {
+		renderEdit( { videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' } ] } );
+
+		const sidebar = within( screen.getByTestId( 'inspector-controls' ) );
+
+		// Add, sort, and delete all live in the sidebar.
+		expect( sidebar.getByPlaceholderText( 'VideoPress GUID or URL' ) ).toBeInTheDocument();
+		expect( sidebar.getByText( 'Add to playlist' ) ).toBeInTheDocument();
+		expect( sidebar.getByText( 'Choose from library' ) ).toBeInTheDocument();
+		expect( sidebar.getAllByLabelText( 'Move up' ) ).toHaveLength( 2 );
+		expect( sidebar.getAllByLabelText( 'Move down' ) ).toHaveLength( 2 );
+		expect( sidebar.getAllByLabelText( 'Remove from playlist' ) ).toHaveLength( 2 );
+
+		// The canvas only previews: item selection, no management controls.
+		expect( screen.getAllByLabelText( 'Remove from playlist' ) ).toHaveLength( 2 );
+		expect( screen.getAllByLabelText( 'Move up' ) ).toHaveLength( 2 );
+		expect( screen.getByLabelText( 'Preview video 2' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the sidebar add controls alongside the empty-state placeholder', () => {
+		renderEdit();
+
+		expect( screen.getByText( 'VideoPress Playlist' ) ).toBeInTheDocument();
+
+		const sidebar = within( screen.getByTestId( 'inspector-controls' ) );
+		expect( sidebar.getByPlaceholderText( 'VideoPress GUID or URL' ) ).toBeInTheDocument();
+		expect( sidebar.getByText( 'Choose from library' ) ).toBeInTheDocument();
 	} );
 
 	it( 'toggles the auto-advance and loop settings', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Edit from '../edit';
 import type { PlaylistBlockAttributes } from '../types';
@@ -6,6 +6,10 @@ import type { BlockEditProps } from '@wordpress/blocks';
 
 // What the mocked media modal "returns" when the library button is clicked.
 let mockLibrarySelection: unknown = [];
+
+jest.mock( '../../../../lib/fetch-video-item', () => ( {
+	fetchVideoItem: jest.fn( () => Promise.resolve( { title: 'Fetched title' } ) ),
+} ) );
 
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: ( props: Record< string, unknown > = {} ) => props,
@@ -89,8 +93,29 @@ describe( 'PlaylistBlockEdit', () => {
 			expect.stringContaining( 'videopress.com/embed/abcd1234' )
 		);
 
-		expect( screen.getByDisplayValue( 'First' ) ).toBeInTheDocument();
-		expect( screen.getByPlaceholderText( 'efgh5678' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'First' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'efgh5678' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows item titles as plain text, with only the add-video field editable', () => {
+		renderEdit( { videos: [ { guid: 'abcd1234', title: 'First' } ] } );
+
+		expect( screen.getByText( 'First' ) ).toBeInTheDocument();
+		expect( screen.getAllByRole( 'textbox' ) ).toHaveLength( 1 );
+		expect( screen.getByRole( 'textbox' ) ).toHaveAttribute(
+			'placeholder',
+			'VideoPress GUID or URL'
+		);
+	} );
+
+	it( 'pulls missing titles from the video data', async () => {
+		const { setAttributes } = renderEdit( { videos: [ { guid: 'abcd1234' } ] } );
+
+		await waitFor( () =>
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				videos: [ { guid: 'abcd1234', title: 'Fetched title' } ],
+			} )
+		);
 	} );
 
 	it( 'removes an item from the playlist', async () => {
@@ -117,17 +142,6 @@ describe( 'PlaylistBlockEdit', () => {
 
 		expect( setAttributes ).toHaveBeenCalledWith( {
 			videos: [ { guid: 'efgh5678' }, { guid: 'abcd1234' } ],
-		} );
-	} );
-
-	it( 'updates an item title', async () => {
-		const user = userEvent.setup();
-		const { setAttributes } = renderEdit( { videos: [ { guid: 'abcd1234' } ] } );
-
-		await user.type( screen.getByPlaceholderText( 'abcd1234' ), 'A' );
-
-		expect( setAttributes ).toHaveBeenCalledWith( {
-			videos: [ { guid: 'abcd1234', title: 'A' } ],
 		} );
 	} );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -40,22 +40,44 @@ function renderEdit( attributes: Partial< PlaylistBlockAttributes > = {} ) {
 	// The component only consumes attributes/setAttributes; the remaining
 	// BlockEditProps fields are editor-runtime plumbing it never touches.
 	const props = {
-		attributes: { videos: [], autoAdvance: true, loop: false, ...attributes },
+		attributes: {
+			videos: [],
+			autoAdvance: true,
+			loop: false,
+			layout: 'rail',
+			darkSurface: false,
+			showThumbnail: true,
+			showTitle: true,
+			showResolution: true,
+			showDuration: true,
+			showPosition: false,
+			showTotalRuntime: true,
+			...attributes,
+		},
 		setAttributes,
 	} as unknown as BlockEditProps< PlaylistBlockAttributes >;
 	render( <Edit { ...props } /> );
 	return { setAttributes };
 }
 
+/**
+ * Scope queries to the settings sidebar.
+ *
+ * @return Queries bound to the InspectorControls container.
+ */
+function sidebar() {
+	return within( screen.getByTestId( 'inspector-controls' ) );
+}
+
 describe( 'PlaylistBlockEdit', () => {
-	it( 'shows the placeholder and adds a video by GUID with its fetched title', async () => {
+	it( 'shows the placeholder and adds a video by GUID with its fetched metadata', async () => {
 		const user = userEvent.setup();
 		const { setAttributes } = renderEdit();
 
-		expect( screen.getByText( 'VideoPress Playlist' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Build a video playlist' ) ).toBeInTheDocument();
 
-		await user.type( screen.getByPlaceholderText( 'VideoPress GUID or URL' ), 'abcd1234' );
-		await user.click( screen.getByText( 'Add to playlist' ) );
+		await user.type( sidebar().getByPlaceholderText( 'Paste a video URL' ), 'abcd1234' );
+		await user.click( sidebar().getByText( 'Add' ) );
 
 		await waitFor( () =>
 			expect( setAttributes ).toHaveBeenCalledWith( {
@@ -67,30 +89,44 @@ describe( 'PlaylistBlockEdit', () => {
 		);
 	} );
 
-	it( 'accepts a VideoPress URL and pulls the title from the video data', async () => {
+	it( 'accepts a VideoPress URL and stores duration, resolution, and poster', async () => {
 		const user = userEvent.setup();
+		mockFetchVideoItem.mockResolvedValueOnce( {
+			title: 'Kiln loading',
+			duration: 724000,
+			height: 1080,
+			poster: 'https://videos.files.wordpress.com/efgh5678/poster.jpg',
+		} );
 		const { setAttributes } = renderEdit();
 
 		await user.type(
-			screen.getByPlaceholderText( 'VideoPress GUID or URL' ),
+			sidebar().getByPlaceholderText( 'Paste a video URL' ),
 			'https://videopress.com/v/efgh5678'
 		);
 		await user.keyboard( '{Enter}' );
 
 		await waitFor( () =>
 			expect( setAttributes ).toHaveBeenCalledWith( {
-				videos: [ { guid: 'efgh5678', title: 'Fetched title' } ],
+				videos: [
+					{
+						guid: 'efgh5678',
+						title: 'Kiln loading',
+						durationMs: 724000,
+						height: 1080,
+						poster: 'https://videos.files.wordpress.com/efgh5678/poster.jpg',
+					},
+				],
 			} )
 		);
 	} );
 
-	it( 'still adds the video when the title fetch fails', async () => {
+	it( 'still adds the video when the metadata fetch fails', async () => {
 		const user = userEvent.setup();
 		mockFetchVideoItem.mockRejectedValueOnce( new Error( 'not reachable' ) );
 		const { setAttributes } = renderEdit();
 
-		await user.type( screen.getByPlaceholderText( 'VideoPress GUID or URL' ), 'abcd1234' );
-		await user.click( screen.getByText( 'Add to playlist' ) );
+		await user.type( sidebar().getByPlaceholderText( 'Paste a video URL' ), 'abcd1234' );
+		await user.click( sidebar().getByText( 'Add' ) );
 
 		await waitFor( () =>
 			expect( setAttributes ).toHaveBeenCalledWith( { videos: [ { guid: 'abcd1234' } ] } )
@@ -101,19 +137,65 @@ describe( 'PlaylistBlockEdit', () => {
 		const user = userEvent.setup();
 		const { setAttributes } = renderEdit();
 
-		await user.type( screen.getByPlaceholderText( 'VideoPress GUID or URL' ), 'not a video' );
-		await user.click( screen.getByText( 'Add to playlist' ) );
+		await user.type( sidebar().getByPlaceholderText( 'Paste a video URL' ), 'not a video' );
+		await user.click( sidebar().getByText( 'Add' ) );
 
 		expect( setAttributes ).not.toHaveBeenCalled();
 		// The Notice also announces via an a11y live region, so match all.
 		expect(
-			screen.getAllByText( 'Enter a VideoPress GUID or a VideoPress video URL.' ).length
+			screen.getAllByText( 'No video found at that link. Paste a VideoPress video URL or GUID.' )
+				.length
 		).toBeGreaterThan( 0 );
 	} );
 
-	it( 'previews the first video and lists every item', () => {
+	it( 'warns about duplicates and only adds again on Add anyway', async () => {
+		const user = userEvent.setup();
+		// Stored title matches the fetch mock so the background refresh no-ops.
+		const { setAttributes } = renderEdit( {
+			videos: [ { guid: 'abcd1234', title: 'Fetched title' } ],
+		} );
+
+		await user.type( sidebar().getByPlaceholderText( 'Paste a video URL' ), 'abcd1234' );
+		await user.click( sidebar().getByText( 'Add' ) );
+
+		expect( setAttributes ).not.toHaveBeenCalled();
+		expect(
+			screen.getAllByText( '“Fetched title” is already in this playlist' ).length
+		).toBeGreaterThan( 0 );
+
+		await user.click( sidebar().getByText( 'Add anyway' ) );
+
+		await waitFor( () =>
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				videos: [
+					{ guid: 'abcd1234', title: 'Fetched title' },
+					{ guid: 'abcd1234', title: 'Fetched title' },
+				],
+			} )
+		);
+	} );
+
+	it( 'dismisses the duplicate warning on Cancel', async () => {
+		const user = userEvent.setup();
+		// Stored title matches the fetch mock so the background refresh no-ops.
+		const { setAttributes } = renderEdit( {
+			videos: [ { guid: 'abcd1234', title: 'Fetched title' } ],
+		} );
+
+		await user.type( sidebar().getByPlaceholderText( 'Paste a video URL' ), 'abcd1234' );
+		await user.click( sidebar().getByText( 'Add' ) );
+		await user.click( sidebar().getByText( 'Cancel' ) );
+
+		expect( setAttributes ).not.toHaveBeenCalled();
+		expect( sidebar().queryByText( 'Add anyway' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'previews the first video and shows entry metadata', () => {
 		renderEdit( {
-			videos: [ { guid: 'abcd1234', title: 'First' }, { guid: 'efgh5678' } ],
+			videos: [
+				{ guid: 'abcd1234', title: 'First', durationMs: 724000, height: 1080 },
+				{ guid: 'efgh5678' },
+			],
 		} );
 
 		const preview = screen.getByTitle( 'VideoPress Playlist Player' );
@@ -125,39 +207,27 @@ describe( 'PlaylistBlockEdit', () => {
 		// Titles list in both the canvas preview and the sidebar manage list.
 		expect( screen.getAllByText( 'First' ) ).toHaveLength( 2 );
 		expect( screen.getAllByText( 'efgh5678' ) ).toHaveLength( 2 );
+		// Sidebar meta line and canvas meta/badges show resolution and duration.
+		expect( screen.getAllByText( '1080p · 12:04' ).length ).toBeGreaterThan( 0 );
+		expect( screen.getAllByText( '1080p' ).length ).toBeGreaterThan( 0 );
 	} );
 
-	it( 'shows item titles as plain text, with only the add-video field editable', () => {
-		renderEdit( { videos: [ { guid: 'abcd1234', title: 'First' } ] } );
-
-		expect( screen.getAllByText( 'First' ).length ).toBeGreaterThan( 0 );
-		expect( screen.getAllByRole( 'textbox' ) ).toHaveLength( 1 );
-		expect( screen.getByRole( 'textbox' ) ).toHaveAttribute(
-			'placeholder',
-			'VideoPress GUID or URL'
-		);
-	} );
-
-	it( 'pulls missing titles from the video data', async () => {
-		const { setAttributes } = renderEdit( { videos: [ { guid: 'abcd1234' } ] } );
-
-		await waitFor( () =>
-			expect( setAttributes ).toHaveBeenCalledWith( {
-				videos: [ { guid: 'abcd1234', title: 'Fetched title' } ],
-			} )
-		);
-	} );
-
-	it( 'replaces stored titles that differ from the video data', async () => {
+	it( 'refreshes stored metadata that differs from the video data', async () => {
+		mockFetchVideoItem.mockResolvedValue( {
+			title: 'Fetched title',
+			duration: 400000,
+			height: 720,
+		} );
 		const { setAttributes } = renderEdit( {
 			videos: [ { guid: 'abcd1234', title: 'Stale stored title' } ],
 		} );
 
 		await waitFor( () =>
 			expect( setAttributes ).toHaveBeenCalledWith( {
-				videos: [ { guid: 'abcd1234', title: 'Fetched title' } ],
+				videos: [ { guid: 'abcd1234', title: 'Fetched title', durationMs: 400000, height: 720 } ],
 			} )
 		);
+		mockFetchVideoItem.mockResolvedValue( { title: 'Fetched title' } );
 	} );
 
 	it( 'removes an item from the playlist', async () => {
@@ -176,8 +246,7 @@ describe( 'PlaylistBlockEdit', () => {
 			videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' }, { guid: 'ijkl9012' } ],
 		} );
 
-		const sidebar = within( screen.getByTestId( 'inspector-controls' ) );
-		const items = sidebar.getAllByRole( 'listitem' );
+		const items = sidebar().getAllByRole( 'option' );
 
 		fireEvent.dragStart( items[ 0 ] );
 		fireEvent.dragOver( items[ 2 ] );
@@ -188,11 +257,25 @@ describe( 'PlaylistBlockEdit', () => {
 		} );
 	} );
 
+	it( 'reorders videos with the keyboard', async () => {
+		const user = userEvent.setup();
+		const { setAttributes } = renderEdit( {
+			videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' } ],
+		} );
+
+		// Focus the first playlist option, then move it down with the arrow key.
+		await user.click( sidebar().getAllByRole( 'option' )[ 0 ] );
+		await user.keyboard( '{ArrowDown}' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			videos: [ { guid: 'efgh5678' }, { guid: 'abcd1234' } ],
+		} );
+	} );
+
 	it( 'marks the hovered item as the drop target while dragging', () => {
 		renderEdit( { videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' } ] } );
 
-		const sidebar = within( screen.getByTestId( 'inspector-controls' ) );
-		const items = sidebar.getAllByRole( 'listitem' );
+		const items = sidebar().getAllByRole( 'option' );
 
 		fireEvent.dragStart( items[ 0 ] );
 		fireEvent.dragOver( items[ 1 ] );
@@ -204,6 +287,25 @@ describe( 'PlaylistBlockEdit', () => {
 
 		expect( items[ 0 ] ).not.toHaveClass( 'is-dragging' );
 		expect( items[ 1 ] ).not.toHaveClass( 'is-drop-target' );
+	} );
+
+	it( 'filters long playlists without losing original positions', async () => {
+		const user = userEvent.setup();
+		const videos = Array.from( { length: 9 }, ( _, i ) => ( {
+			guid: `guid000${ i }`,
+			title: i === 8 ? 'Needle' : `Video ${ i }`,
+		} ) );
+		const { setAttributes } = renderEdit( { videos } );
+
+		await user.type( sidebar().getByPlaceholderText( 'Filter 9 videos' ), 'Needle' );
+
+		const items = sidebar().getAllByRole( 'option' );
+		expect( items ).toHaveLength( 1 );
+		// Removing the filtered item removes the right entry.
+		await user.click( within( items[ 0 ] ).getByLabelText( 'Remove from playlist' ) );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			videos: videos.slice( 0, 8 ),
+		} );
 	} );
 
 	it( 'switches the preview when selecting another item', async () => {
@@ -223,17 +325,21 @@ describe( 'PlaylistBlockEdit', () => {
 		const { setAttributes } = renderEdit( { videos: [ { guid: 'abcd1234' } ] } );
 
 		mockLibrarySelection = [
-			{ videopress_guid: [ 'efgh5678' ], title: 'Library video' },
+			{
+				videopress_guid: [ 'efgh5678' ],
+				title: 'Library video',
+				image: { src: 'https://example.test/thumb.jpg' },
+			},
 			{ videopress_guid: 'ijkl9012', title: '' },
 			{ title: 'Not a VideoPress video' },
 		];
 
-		await user.click( screen.getByText( 'Choose from library' ) );
+		await user.click( sidebar().getByText( 'Media Library' ) );
 
 		expect( setAttributes ).toHaveBeenCalledWith( {
 			videos: [
 				{ guid: 'abcd1234' },
-				{ guid: 'efgh5678', title: 'Library video' },
+				{ guid: 'efgh5678', title: 'Library video', poster: 'https://example.test/thumb.jpg' },
 				{ guid: 'ijkl9012' },
 			],
 		} );
@@ -245,7 +351,7 @@ describe( 'PlaylistBlockEdit', () => {
 
 		mockLibrarySelection = [ { title: 'Plain video attachment' } ];
 
-		await user.click( screen.getByText( 'Choose from library' ) );
+		await user.click( sidebar().getByText( 'Media Library' ) );
 
 		expect( setAttributes ).not.toHaveBeenCalled();
 		// The Notice also announces via an a11y live region, so match all.
@@ -259,14 +365,12 @@ describe( 'PlaylistBlockEdit', () => {
 	it( 'keeps all management controls in the settings sidebar; the canvas is preview-only', () => {
 		renderEdit( { videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' } ] } );
 
-		const sidebar = within( screen.getByTestId( 'inspector-controls' ) );
-
 		// Add, drag-to-sort, and delete all live in the sidebar.
-		expect( sidebar.getByPlaceholderText( 'VideoPress GUID or URL' ) ).toBeInTheDocument();
-		expect( sidebar.getByText( 'Add to playlist' ) ).toBeInTheDocument();
-		expect( sidebar.getByText( 'Choose from library' ) ).toBeInTheDocument();
-		expect( sidebar.getAllByLabelText( 'Remove from playlist' ) ).toHaveLength( 2 );
-		for ( const item of sidebar.getAllByRole( 'listitem' ) ) {
+		expect( sidebar().getByPlaceholderText( 'Paste a video URL' ) ).toBeInTheDocument();
+		expect( sidebar().getByText( 'Add' ) ).toBeInTheDocument();
+		expect( sidebar().getByText( 'Media Library' ) ).toBeInTheDocument();
+		expect( sidebar().getAllByLabelText( 'Remove from playlist' ) ).toHaveLength( 2 );
+		for ( const item of sidebar().getAllByRole( 'option' ) ) {
 			expect( item ).toHaveAttribute( 'draggable', 'true' );
 		}
 
@@ -275,24 +379,67 @@ describe( 'PlaylistBlockEdit', () => {
 		expect( screen.getByLabelText( 'Preview video 2' ) ).toBeInTheDocument();
 	} );
 
-	it( 'shows the sidebar add controls alongside the empty-state placeholder', () => {
+	it( 'offers URL input and Media Library in the empty-state placeholder', () => {
 		renderEdit();
 
-		expect( screen.getByText( 'VideoPress Playlist' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Build a video playlist' ) ).toBeInTheDocument();
 
-		const sidebar = within( screen.getByTestId( 'inspector-controls' ) );
-		expect( sidebar.getByPlaceholderText( 'VideoPress GUID or URL' ) ).toBeInTheDocument();
-		expect( sidebar.getByText( 'Choose from library' ) ).toBeInTheDocument();
+		// Both the placeholder and the sidebar offer the add controls.
+		expect( screen.getAllByPlaceholderText( 'Paste a video URL' ) ).toHaveLength( 2 );
+		expect( screen.getAllByText( 'Media Library' ) ).toHaveLength( 2 );
 	} );
 
-	it( 'toggles the auto-advance and loop settings', async () => {
+	it( 'switches layout from the layout picker', async () => {
 		const user = userEvent.setup();
 		const { setAttributes } = renderEdit( { videos: [ { guid: 'abcd1234' } ] } );
 
-		await user.click( screen.getByLabelText( 'Autoplay next video' ) );
+		await user.click( sidebar().getByText( 'Grid' ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { layout: 'grid' } );
+
+		await user.click( sidebar().getByText( 'Strip' ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { layout: 'strip' } );
+	} );
+
+	it( 'toggles playback and display settings', async () => {
+		const user = userEvent.setup();
+		const { setAttributes } = renderEdit( { videos: [ { guid: 'abcd1234' } ] } );
+
+		await user.click( sidebar().getByLabelText( 'Autoplay next' ) );
 		expect( setAttributes ).toHaveBeenCalledWith( { autoAdvance: false } );
 
-		await user.click( screen.getByLabelText( 'Loop playlist' ) );
+		await user.click( sidebar().getByLabelText( 'Loop playlist' ) );
 		expect( setAttributes ).toHaveBeenCalledWith( { loop: true } );
+
+		await user.click( sidebar().getByLabelText( 'Dark player surface' ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { darkSurface: true } );
+
+		await user.click( sidebar().getByLabelText( 'Thumbnail' ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { showThumbnail: false } );
+
+		await user.click( sidebar().getByLabelText( 'Position number' ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { showPosition: true } );
+
+		await user.click( sidebar().getByLabelText( 'Total runtime in header' ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { showTotalRuntime: false } );
+	} );
+
+	it( 'reflects layout and display attributes on the block wrapper', () => {
+		renderEdit( {
+			videos: [ { guid: 'abcd1234' } ],
+			layout: 'grid',
+			darkSurface: true,
+			showThumbnail: false,
+			showPosition: true,
+		} );
+
+		const preview = screen.getByTitle( 'VideoPress Playlist Player' );
+		// The wrapper is a plain div carrying only CSS classes, so there is no
+		// accessible query for it; walk up from the player instead.
+		// eslint-disable-next-line testing-library/no-node-access
+		const wrapper = preview.closest( '.videopress-playlist--grid' );
+		expect( wrapper ).not.toBeNull();
+		expect( wrapper ).toHaveClass( 'is-dark' );
+		expect( wrapper ).toHaveClass( 'hide-thumbnails' );
+		expect( wrapper ).toHaveClass( 'show-position' );
 	} );
 } );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Edit from '../edit';
+import type { PlaylistBlockAttributes } from '../types';
+import type { BlockEditProps } from '@wordpress/blocks';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: ( props: Record< string, unknown > = {} ) => props,
+	InspectorControls: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+} ) );
+
+/**
+ * Render the Edit component with the given attributes.
+ *
+ * @param attributes - Partial block attributes.
+ * @return The setAttributes mock.
+ */
+function renderEdit( attributes: Partial< PlaylistBlockAttributes > = {} ) {
+	const setAttributes = jest.fn();
+	// The component only consumes attributes/setAttributes; the remaining
+	// BlockEditProps fields are editor-runtime plumbing it never touches.
+	const props = {
+		attributes: { videos: [], autoAdvance: true, loop: false, ...attributes },
+		setAttributes,
+	} as unknown as BlockEditProps< PlaylistBlockAttributes >;
+	render( <Edit { ...props } /> );
+	return { setAttributes };
+}
+
+describe( 'PlaylistBlockEdit', () => {
+	it( 'shows the placeholder and adds a video by GUID', async () => {
+		const user = userEvent.setup();
+		const { setAttributes } = renderEdit();
+
+		expect( screen.getByText( 'VideoPress Playlist' ) ).toBeInTheDocument();
+
+		await user.type( screen.getByPlaceholderText( 'VideoPress GUID or URL' ), 'abcd1234' );
+		await user.click( screen.getByText( 'Add to playlist' ) );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ { guid: 'abcd1234' } ] } );
+	} );
+
+	it( 'accepts a VideoPress URL and extracts its GUID', async () => {
+		const user = userEvent.setup();
+		const { setAttributes } = renderEdit();
+
+		await user.type(
+			screen.getByPlaceholderText( 'VideoPress GUID or URL' ),
+			'https://videopress.com/v/efgh5678'
+		);
+		await user.keyboard( '{Enter}' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ { guid: 'efgh5678' } ] } );
+	} );
+
+	it( 'rejects unrecognized input with an error message', async () => {
+		const user = userEvent.setup();
+		const { setAttributes } = renderEdit();
+
+		await user.type( screen.getByPlaceholderText( 'VideoPress GUID or URL' ), 'not a video' );
+		await user.click( screen.getByText( 'Add to playlist' ) );
+
+		expect( setAttributes ).not.toHaveBeenCalled();
+		expect(
+			screen.getByText( 'Enter a VideoPress GUID or a VideoPress video URL.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'previews the first video and lists every item', () => {
+		renderEdit( {
+			videos: [ { guid: 'abcd1234', title: 'First' }, { guid: 'efgh5678' } ],
+		} );
+
+		const preview = screen.getByTitle( 'VideoPress Playlist Player' );
+		expect( preview ).toHaveAttribute(
+			'src',
+			expect.stringContaining( 'videopress.com/embed/abcd1234' )
+		);
+
+		expect( screen.getByDisplayValue( 'First' ) ).toBeInTheDocument();
+		expect( screen.getByPlaceholderText( 'efgh5678' ) ).toBeInTheDocument();
+	} );
+
+	it( 'removes an item from the playlist', async () => {
+		const user = userEvent.setup();
+		const { setAttributes } = renderEdit( {
+			videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' } ],
+		} );
+
+		await user.click( screen.getAllByLabelText( 'Remove from playlist' )[ 0 ] );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ { guid: 'efgh5678' } ] } );
+	} );
+
+	it( 'moves an item down and disables the impossible directions', async () => {
+		const user = userEvent.setup();
+		const { setAttributes } = renderEdit( {
+			videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' } ],
+		} );
+
+		expect( screen.getAllByLabelText( 'Move up' )[ 0 ] ).toBeDisabled();
+		expect( screen.getAllByLabelText( 'Move down' )[ 1 ] ).toBeDisabled();
+
+		await user.click( screen.getAllByLabelText( 'Move down' )[ 0 ] );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			videos: [ { guid: 'efgh5678' }, { guid: 'abcd1234' } ],
+		} );
+	} );
+
+	it( 'updates an item title', async () => {
+		const user = userEvent.setup();
+		const { setAttributes } = renderEdit( { videos: [ { guid: 'abcd1234' } ] } );
+
+		await user.type( screen.getByPlaceholderText( 'abcd1234' ), 'A' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			videos: [ { guid: 'abcd1234', title: 'A' } ],
+		} );
+	} );
+
+	it( 'switches the preview when selecting another item', async () => {
+		const user = userEvent.setup();
+		renderEdit( { videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' } ] } );
+
+		await user.click( screen.getByLabelText( 'Preview video 2' ) );
+
+		expect( screen.getByTitle( 'VideoPress Playlist Player' ) ).toHaveAttribute(
+			'src',
+			expect.stringContaining( 'videopress.com/embed/efgh5678' )
+		);
+	} );
+
+	it( 'toggles the auto-advance and loop settings', async () => {
+		const user = userEvent.setup();
+		const { setAttributes } = renderEdit( { videos: [ { guid: 'abcd1234' } ] } );
+
+		await user.click( screen.getByLabelText( 'Autoplay next video' ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { autoAdvance: false } );
+
+		await user.click( screen.getByLabelText( 'Loop playlist' ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { loop: true } );
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -145,6 +145,18 @@ describe( 'PlaylistBlockEdit', () => {
 		);
 	} );
 
+	it( 'replaces stored titles that differ from the video data', async () => {
+		const { setAttributes } = renderEdit( {
+			videos: [ { guid: 'abcd1234', title: 'Stale stored title' } ],
+		} );
+
+		await waitFor( () =>
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				videos: [ { guid: 'abcd1234', title: 'Fetched title' } ],
+			} )
+		);
+	} );
+
 	it( 'removes an item from the playlist', async () => {
 		const user = userEvent.setup();
 		const { setAttributes } = renderEdit( {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { fetchVideoItem } from '../../../../lib/fetch-video-item';
 import Edit from '../edit';
 import type { PlaylistBlockAttributes } from '../types';
 import type { BlockEditProps } from '@wordpress/blocks';
@@ -10,6 +11,8 @@ let mockLibrarySelection: unknown = [];
 jest.mock( '../../../../lib/fetch-video-item', () => ( {
 	fetchVideoItem: jest.fn( () => Promise.resolve( { title: 'Fetched title' } ) ),
 } ) );
+
+const mockFetchVideoItem = fetchVideoItem as jest.Mock;
 
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: ( props: Record< string, unknown > = {} ) => props,
@@ -43,7 +46,7 @@ function renderEdit( attributes: Partial< PlaylistBlockAttributes > = {} ) {
 }
 
 describe( 'PlaylistBlockEdit', () => {
-	it( 'shows the placeholder and adds a video by GUID', async () => {
+	it( 'shows the placeholder and adds a video by GUID with its fetched title', async () => {
 		const user = userEvent.setup();
 		const { setAttributes } = renderEdit();
 
@@ -52,10 +55,17 @@ describe( 'PlaylistBlockEdit', () => {
 		await user.type( screen.getByPlaceholderText( 'VideoPress GUID or URL' ), 'abcd1234' );
 		await user.click( screen.getByText( 'Add to playlist' ) );
 
-		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ { guid: 'abcd1234' } ] } );
+		await waitFor( () =>
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				videos: [ { guid: 'abcd1234', title: 'Fetched title' } ],
+			} )
+		);
+		expect( mockFetchVideoItem ).toHaveBeenCalledWith(
+			expect.objectContaining( { guid: 'abcd1234' } )
+		);
 	} );
 
-	it( 'accepts a VideoPress URL and extracts its GUID', async () => {
+	it( 'accepts a VideoPress URL and pulls the title from the video data', async () => {
 		const user = userEvent.setup();
 		const { setAttributes } = renderEdit();
 
@@ -65,7 +75,24 @@ describe( 'PlaylistBlockEdit', () => {
 		);
 		await user.keyboard( '{Enter}' );
 
-		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ { guid: 'efgh5678' } ] } );
+		await waitFor( () =>
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				videos: [ { guid: 'efgh5678', title: 'Fetched title' } ],
+			} )
+		);
+	} );
+
+	it( 'still adds the video when the title fetch fails', async () => {
+		const user = userEvent.setup();
+		mockFetchVideoItem.mockRejectedValueOnce( new Error( 'not reachable' ) );
+		const { setAttributes } = renderEdit();
+
+		await user.type( screen.getByPlaceholderText( 'VideoPress GUID or URL' ), 'abcd1234' );
+		await user.click( screen.getByText( 'Add to playlist' ) );
+
+		await waitFor( () =>
+			expect( setAttributes ).toHaveBeenCalledWith( { videos: [ { guid: 'abcd1234' } ] } )
+		);
 	} );
 
 	it( 'rejects unrecognized input with an error message', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -272,6 +272,70 @@ describe( 'PlaylistBlockEdit', () => {
 		} );
 	} );
 
+	it( 'does not reorder from the edges or while filtering', async () => {
+		const user = userEvent.setup();
+		// Titles match the fetch mock so the background refresh no-ops.
+		const videos = Array.from( { length: 9 }, ( _, i ) => ( {
+			guid: `guid000${ i }`,
+			title: 'Fetched title',
+		} ) );
+		const { setAttributes } = renderEdit( { videos } );
+
+		// ArrowUp on the first item is a no-op.
+		await user.click( sidebar().getAllByRole( 'option' )[ 0 ] );
+		await user.keyboard( '{ArrowUp}' );
+		expect( setAttributes ).not.toHaveBeenCalled();
+
+		// While filtering (the haystack includes the GUID), items are not
+		// draggable and arrows do nothing.
+		await user.type( sidebar().getByPlaceholderText( 'Filter 9 videos' ), 'guid0003' );
+		const filtered = sidebar().getAllByRole( 'option' );
+		expect( filtered ).toHaveLength( 1 );
+		expect( filtered[ 0 ] ).toHaveAttribute( 'draggable', 'false' );
+		await user.click( filtered[ 0 ] );
+		await user.keyboard( '{ArrowDown}' );
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'clears the drop target when the drag leaves an item', () => {
+		renderEdit( { videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' } ] } );
+
+		const items = sidebar().getAllByRole( 'option' );
+
+		fireEvent.dragStart( items[ 0 ] );
+		fireEvent.dragOver( items[ 1 ] );
+		expect( items[ 1 ] ).toHaveClass( 'is-drop-target' );
+
+		fireEvent.dragLeave( items[ 1 ] );
+		expect( items[ 1 ] ).not.toHaveClass( 'is-drop-target' );
+
+		// Dropping on the dragged item itself is a no-op reorder.
+		fireEvent.drop( items[ 0 ] );
+		expect( items[ 0 ] ).not.toHaveClass( 'is-dragging' );
+	} );
+
+	it( 'shows the skeleton row while metadata is being read', async () => {
+		const user = userEvent.setup();
+		let resolveFetch: ( value: unknown ) => void;
+		mockFetchVideoItem.mockImplementationOnce(
+			() =>
+				new Promise( resolve => {
+					resolveFetch = resolve;
+				} )
+		);
+		renderEdit();
+
+		await user.type( sidebar().getByPlaceholderText( 'Paste a video URL' ), 'abcd1234' );
+		await user.click( sidebar().getByText( 'Add' ) );
+
+		expect( sidebar().getByText( 'Reading metadata…' ) ).toBeInTheDocument();
+
+		resolveFetch( { title: 'Fetched title' } );
+		await waitFor( () =>
+			expect( sidebar().queryByText( 'Reading metadata…' ) ).not.toBeInTheDocument()
+		);
+	} );
+
 	it( 'marks the hovered item as the drop target while dragging', () => {
 		renderEdit( { videos: [ { guid: 'abcd1234' }, { guid: 'efgh5678' } ] } );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -4,9 +4,20 @@ import Edit from '../edit';
 import type { PlaylistBlockAttributes } from '../types';
 import type { BlockEditProps } from '@wordpress/blocks';
 
+// What the mocked media modal "returns" when the library button is clicked.
+let mockLibrarySelection: unknown = [];
+
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: ( props: Record< string, unknown > = {} ) => props,
 	InspectorControls: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	MediaUploadCheck: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
+	MediaUpload: ( {
+		onSelect,
+		render: renderProp,
+	}: {
+		onSelect: ( selection: unknown ) => void;
+		render: ( props: { open: () => void } ) => React.ReactNode;
+	} ) => <>{ renderProp( { open: () => onSelect( mockLibrarySelection ) } ) }</>,
 } ) );
 
 /**
@@ -61,9 +72,10 @@ describe( 'PlaylistBlockEdit', () => {
 		await user.click( screen.getByText( 'Add to playlist' ) );
 
 		expect( setAttributes ).not.toHaveBeenCalled();
+		// The Notice also announces via an a11y live region, so match all.
 		expect(
-			screen.getByText( 'Enter a VideoPress GUID or a VideoPress video URL.' )
-		).toBeInTheDocument();
+			screen.getAllByText( 'Enter a VideoPress GUID or a VideoPress video URL.' ).length
+		).toBeGreaterThan( 0 );
 	} );
 
 	it( 'previews the first video and lists every item', () => {
@@ -129,6 +141,44 @@ describe( 'PlaylistBlockEdit', () => {
 			'src',
 			expect.stringContaining( 'videopress.com/embed/efgh5678' )
 		);
+	} );
+
+	it( 'adds VideoPress videos selected from the media library', async () => {
+		const user = userEvent.setup();
+		const { setAttributes } = renderEdit( { videos: [ { guid: 'abcd1234' } ] } );
+
+		mockLibrarySelection = [
+			{ videopress_guid: [ 'efgh5678' ], title: 'Library video' },
+			{ videopress_guid: 'ijkl9012', title: '' },
+			{ title: 'Not a VideoPress video' },
+		];
+
+		await user.click( screen.getByText( 'Choose from library' ) );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			videos: [
+				{ guid: 'abcd1234' },
+				{ guid: 'efgh5678', title: 'Library video' },
+				{ guid: 'ijkl9012' },
+			],
+		} );
+	} );
+
+	it( 'shows an error when no library selection is a VideoPress video', async () => {
+		const user = userEvent.setup();
+		const { setAttributes } = renderEdit();
+
+		mockLibrarySelection = [ { title: 'Plain video attachment' } ];
+
+		await user.click( screen.getByText( 'Choose from library' ) );
+
+		expect( setAttributes ).not.toHaveBeenCalled();
+		// The Notice also announces via an a11y live region, so match all.
+		expect(
+			screen.getAllByText(
+				'None of the selected items are VideoPress videos. Choose videos hosted on VideoPress.'
+			).length
+		).toBeGreaterThan( 0 );
 	} );
 
 	it( 'toggles the auto-advance and loop settings', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/index.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/index.test.ts
@@ -1,0 +1,26 @@
+const mockRegisterBlockType = jest.fn();
+
+jest.mock( '@wordpress/blocks', () => ( {
+	registerBlockType: mockRegisterBlockType,
+} ) );
+
+// The edit component pulls in the real block-editor package, which expects a
+// full editor runtime; the registration test only needs stand-ins.
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: ( props: Record< string, unknown > = {} ) => props,
+	InspectorControls: () => null,
+} ) );
+
+describe( 'playlist block registration', () => {
+	it( 'registers videopress/playlist with an edit implementation', async () => {
+		await import( '../index' );
+
+		expect( mockRegisterBlockType ).toHaveBeenCalledTimes( 1 );
+
+		const [ name, settings ] = mockRegisterBlockType.mock.calls[ 0 ];
+		expect( name ).toBe( 'videopress/playlist' );
+		expect( settings.edit ).toEqual( expect.any( Function ) );
+		expect( settings.save() ).toBeNull();
+		expect( settings.attributes ).toHaveProperty( 'videos' );
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -1,0 +1,173 @@
+import { initAllPlaylists, initPlaylist } from '../view';
+
+const PLAYER_SELECTOR = '.videopress-playlist__player';
+const ITEM_SELECTOR = '.videopress-playlist__item';
+
+/**
+ * Build a playlist block DOM matching the server-rendered markup.
+ *
+ * @param guids       - Video GUIDs, first one loaded in the player.
+ * @param autoAdvance - Value for data-auto-advance.
+ * @param loop        - Value for data-loop.
+ * @return The block wrapper element, attached to the document.
+ */
+function buildPlaylist( guids: string[], autoAdvance = '1', loop = '0' ): HTMLElement {
+	const block = document.createElement( 'figure' );
+	block.className = 'wp-block-videopress-playlist';
+	block.dataset.autoAdvance = autoAdvance;
+	block.dataset.loop = loop;
+
+	const items = guids
+		.map(
+			( guid, index ) =>
+				`<li><button type="button" class="videopress-playlist__item${
+					index === 0 ? ' is-current' : ''
+				}" data-guid="${ guid }" data-src="https://videopress.com/embed/${ guid }?autoPlay=1" aria-current="${
+					index === 0 ? 'true' : 'false'
+				}"><span class="videopress-playlist__item-title">Video ${ index + 1 }</span></button></li>`
+		)
+		.join( '' );
+
+	block.innerHTML =
+		`<div class="videopress-playlist__player-wrapper"><iframe class="videopress-playlist__player" title="player" src="https://videopress.com/embed/${ guids[ 0 ] }?autoPlay=0" data-guid="${ guids[ 0 ] }"></iframe></div>` +
+		`<ol class="videopress-playlist__items">${ items }</ol>`;
+
+	document.body.appendChild( block );
+	return block;
+}
+
+/**
+ * Dispatch a player message event like the VideoPress embed does.
+ *
+ * @param guid   - GUID the message reports on.
+ * @param origin - Message origin.
+ * @param event  - Player event name.
+ */
+function postPlayerMessage(
+	guid: string,
+	origin = 'https://videopress.com',
+	event = 'videopress_ended'
+) {
+	window.dispatchEvent( new MessageEvent( 'message', { data: { event, id: guid }, origin } ) );
+}
+
+describe( 'playlist view script', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'swaps the player to the clicked item and marks it current', () => {
+		const block = buildPlaylist( [ 'aaaa1111', 'bbbb2222' ] );
+		initPlaylist( block );
+
+		const player = block.querySelector< HTMLIFrameElement >( PLAYER_SELECTOR );
+		const items = block.querySelectorAll< HTMLButtonElement >( ITEM_SELECTOR );
+
+		items[ 1 ].click();
+
+		expect( player.src ).toBe( 'https://videopress.com/embed/bbbb2222?autoPlay=1' );
+		expect( player.dataset.guid ).toBe( 'bbbb2222' );
+		expect( items[ 1 ] ).toHaveClass( 'is-current' );
+		expect( items[ 1 ] ).toHaveAttribute( 'aria-current', 'true' );
+		expect( items[ 0 ] ).not.toHaveClass( 'is-current' );
+		expect( items[ 0 ] ).toHaveAttribute( 'aria-current', 'false' );
+	} );
+
+	it( 'advances to the next video when the current one ends', () => {
+		const block = buildPlaylist( [ 'aaaa1111', 'bbbb2222' ] );
+		initPlaylist( block );
+
+		postPlayerMessage( 'aaaa1111' );
+
+		const player = block.querySelector< HTMLIFrameElement >( PLAYER_SELECTOR );
+		expect( player.src ).toBe( 'https://videopress.com/embed/bbbb2222?autoPlay=1' );
+	} );
+
+	it( 'ignores ended messages from untrusted origins', () => {
+		const block = buildPlaylist( [ 'aaaa1111', 'bbbb2222' ] );
+		initPlaylist( block );
+
+		postPlayerMessage( 'aaaa1111', 'https://evil.example' );
+
+		const player = block.querySelector< HTMLIFrameElement >( PLAYER_SELECTOR );
+		expect( player.dataset.guid ).toBe( 'aaaa1111' );
+	} );
+
+	it( 'ignores ended messages for videos other than the current one', () => {
+		const block = buildPlaylist( [ 'aaaa1111', 'bbbb2222', 'cccc3333' ] );
+		initPlaylist( block );
+
+		postPlayerMessage( 'bbbb2222' );
+
+		const player = block.querySelector< HTMLIFrameElement >( PLAYER_SELECTOR );
+		expect( player.dataset.guid ).toBe( 'aaaa1111' );
+	} );
+
+	it( 'ignores non-ended player events', () => {
+		const block = buildPlaylist( [ 'aaaa1111', 'bbbb2222' ] );
+		initPlaylist( block );
+
+		postPlayerMessage( 'aaaa1111', 'https://videopress.com', 'videopress_playing' );
+
+		const player = block.querySelector< HTMLIFrameElement >( PLAYER_SELECTOR );
+		expect( player.dataset.guid ).toBe( 'aaaa1111' );
+	} );
+
+	it( 'stops at the last video when looping is off', () => {
+		const block = buildPlaylist( [ 'aaaa1111', 'bbbb2222' ] );
+		initPlaylist( block );
+
+		postPlayerMessage( 'aaaa1111' );
+		postPlayerMessage( 'bbbb2222' );
+
+		const player = block.querySelector< HTMLIFrameElement >( PLAYER_SELECTOR );
+		expect( player.dataset.guid ).toBe( 'bbbb2222' );
+	} );
+
+	it( 'returns to the first video when looping is on', () => {
+		const block = buildPlaylist( [ 'aaaa1111', 'bbbb2222' ], '1', '1' );
+		initPlaylist( block );
+
+		postPlayerMessage( 'aaaa1111' );
+		postPlayerMessage( 'bbbb2222' );
+
+		const player = block.querySelector< HTMLIFrameElement >( PLAYER_SELECTOR );
+		expect( player.src ).toBe( 'https://videopress.com/embed/aaaa1111?autoPlay=1' );
+	} );
+
+	it( 'does not auto-advance when auto-advance is off, but clicks still work', () => {
+		const block = buildPlaylist( [ 'aaaa1111', 'bbbb2222' ], '0' );
+		initPlaylist( block );
+
+		postPlayerMessage( 'aaaa1111' );
+
+		const player = block.querySelector< HTMLIFrameElement >( PLAYER_SELECTOR );
+		expect( player.dataset.guid ).toBe( 'aaaa1111' );
+
+		block.querySelectorAll< HTMLButtonElement >( ITEM_SELECTOR )[ 1 ].click();
+		expect( player.dataset.guid ).toBe( 'bbbb2222' );
+	} );
+
+	it( 'keeps two playlists on the same page independent', () => {
+		const first = buildPlaylist( [ 'aaaa1111', 'bbbb2222' ] );
+		const second = buildPlaylist( [ 'dddd4444', 'eeee5555' ] );
+		initAllPlaylists();
+
+		postPlayerMessage( 'aaaa1111' );
+
+		expect( first.querySelector< HTMLIFrameElement >( PLAYER_SELECTOR ).dataset.guid ).toBe(
+			'bbbb2222'
+		);
+		expect( second.querySelector< HTMLIFrameElement >( PLAYER_SELECTOR ).dataset.guid ).toBe(
+			'dddd4444'
+		);
+	} );
+
+	it( 'bails on blocks without a player or items', () => {
+		const empty = document.createElement( 'figure' );
+		empty.className = 'wp-block-videopress-playlist';
+		document.body.appendChild( empty );
+
+		expect( () => initAllPlaylists() ).not.toThrow();
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -28,17 +28,20 @@ function buildPlaylist( guids: string[], autoAdvance = '1', loop = '0' ): HTMLEl
 			( guid, index ) =>
 				`<li><button type="button" class="videopress-playlist__item${
 					index === 0 ? ' is-current' : ''
-				}" data-guid="${ guid }" data-src="https://videopress.com/embed/${ guid }?autoPlay=1" aria-current="${
+				}" data-guid="${ guid }" data-src="https://videopress.com/embed/${ guid }?autoPlay=1" data-duration-ms="0" aria-current="${
 					index === 0 ? 'true' : 'false'
-				}"><span class="videopress-playlist__item-title">Video ${
+				}"><span class="videopress-playlist__item-thumb"><span class="videopress-playlist__item-index">${
 					index + 1
-				}</span><span class="videopress-playlist__item-badge"></span><span class="videopress-playlist__item-duration"></span></button></li>`
+				}</span><span class="videopress-playlist__item-thumb-duration"></span></span><span class="videopress-playlist__item-text"><span class="videopress-playlist__item-title">Video ${
+					index + 1
+				}</span><span class="videopress-playlist__item-meta"><span class="videopress-playlist__item-badge"></span><span class="videopress-playlist__item-duration"></span></span></span></button></li>`
 		)
 		.join( '' );
 
 	block.innerHTML =
-		`<div class="videopress-playlist__player-wrapper"><iframe class="videopress-playlist__player" title="player" src="https://videopress.com/embed/${ guids[ 0 ] }?autoPlay=0" data-guid="${ guids[ 0 ] }"></iframe></div>` +
-		`<ol class="videopress-playlist__items">${ items }</ol>`;
+		`<div class="videopress-playlist__header"><span class="videopress-playlist__count">${ guids.length } videos</span><span class="videopress-playlist__runtime"></span></div>` +
+		`<div class="videopress-playlist__body"><div class="videopress-playlist__player-wrapper"><iframe class="videopress-playlist__player" title="player" src="https://videopress.com/embed/${ guids[ 0 ] }?autoPlay=0" data-guid="${ guids[ 0 ] }"></iframe></div>` +
+		`<ul class="videopress-playlist__items">${ items }</ul></div>`;
 
 	document.body.appendChild( block );
 	return block;
@@ -181,7 +184,7 @@ describe( 'playlist view script', () => {
 		);
 	} );
 
-	it( 'refreshes titles, durations, and quality badges from the video data', async () => {
+	it( 'refreshes titles, durations, badges, posters, and the total runtime', async () => {
 		const block = buildPlaylist( [ 'aaaa1111', 'bbbb2222' ] );
 		( global.fetch as jest.Mock ).mockImplementation( ( url: string ) =>
 			Promise.resolve( {
@@ -189,7 +192,12 @@ describe( 'playlist view script', () => {
 				json: () =>
 					Promise.resolve(
 						url.includes( 'aaaa1111' )
-							? { title: 'Renamed on VideoPress', duration: 83000, height: 1080 }
+							? {
+									title: 'Renamed on VideoPress',
+									duration: 83000,
+									height: 1080,
+									poster: 'https://example.test/poster-a.jpg',
+							  }
 							: { title: 'Second video', duration: 3723000, height: 2160 }
 					),
 			} )
@@ -204,14 +212,25 @@ describe( 'playlist view script', () => {
 		expect( items[ 0 ].querySelector( '.videopress-playlist__item-duration' ) ).toHaveTextContent(
 			'1:23'
 		);
+		expect(
+			items[ 0 ].querySelector( '.videopress-playlist__item-thumb-duration' )
+		).toHaveTextContent( '1:23' );
 		expect( items[ 0 ].querySelector( '.videopress-playlist__item-badge' ) ).toHaveTextContent(
 			'1080p'
+		);
+		expect( items[ 0 ].querySelector( '.videopress-playlist__item-thumb img' ) ).toHaveAttribute(
+			'src',
+			'https://example.test/poster-a.jpg'
 		);
 		expect( items[ 1 ].querySelector( '.videopress-playlist__item-duration' ) ).toHaveTextContent(
 			'1:02:03'
 		);
 		expect( items[ 1 ].querySelector( '.videopress-playlist__item-badge' ) ).toHaveTextContent(
 			'4K'
+		);
+		// 83000 + 3723000 ms ≈ 1 hr 3 min total runtime.
+		expect( block.querySelector( '.videopress-playlist__runtime' ) ).toHaveTextContent(
+			'1 hr 3 min'
 		);
 	} );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -1,4 +1,10 @@
-import { initAllPlaylists, initPlaylist } from '../view';
+import {
+	formatDuration,
+	initAllPlaylists,
+	initPlaylist,
+	qualityLabel,
+	refreshPlaylistMetadata,
+} from '../view';
 
 const PLAYER_SELECTOR = '.videopress-playlist__player';
 const ITEM_SELECTOR = '.videopress-playlist__item';
@@ -24,7 +30,9 @@ function buildPlaylist( guids: string[], autoAdvance = '1', loop = '0' ): HTMLEl
 					index === 0 ? ' is-current' : ''
 				}" data-guid="${ guid }" data-src="https://videopress.com/embed/${ guid }?autoPlay=1" aria-current="${
 					index === 0 ? 'true' : 'false'
-				}"><span class="videopress-playlist__item-title">Video ${ index + 1 }</span></button></li>`
+				}"><span class="videopress-playlist__item-title">Video ${
+					index + 1
+				}</span><span class="videopress-playlist__item-badge"></span><span class="videopress-playlist__item-duration"></span></button></li>`
 		)
 		.join( '' );
 
@@ -52,6 +60,16 @@ function postPlayerMessage(
 }
 
 describe( 'playlist view script', () => {
+	beforeAll( () => {
+		// The jsdom test environment ships no fetch implementation to spy on.
+		Object.defineProperty( global, 'fetch', { writable: true, value: jest.fn() } );
+	} );
+
+	beforeEach( () => {
+		// Default: metadata lookups fail, so server-rendered labels stay put.
+		( global.fetch as jest.Mock ).mockReset().mockResolvedValue( { ok: false } as Response );
+	} );
+
 	afterEach( () => {
 		document.body.innerHTML = '';
 	} );
@@ -163,11 +181,102 @@ describe( 'playlist view script', () => {
 		);
 	} );
 
+	it( 'refreshes titles, durations, and quality badges from the video data', async () => {
+		const block = buildPlaylist( [ 'aaaa1111', 'bbbb2222' ] );
+		( global.fetch as jest.Mock ).mockImplementation( ( url: string ) =>
+			Promise.resolve( {
+				ok: true,
+				json: () =>
+					Promise.resolve(
+						url.includes( 'aaaa1111' )
+							? { title: 'Renamed on VideoPress', duration: 83000, height: 1080 }
+							: { title: 'Second video', duration: 3723000, height: 2160 }
+					),
+			} )
+		);
+
+		await refreshPlaylistMetadata( block );
+
+		const items = block.querySelectorAll< HTMLButtonElement >( ITEM_SELECTOR );
+		expect( items[ 0 ].querySelector( '.videopress-playlist__item-title' ) ).toHaveTextContent(
+			'Renamed on VideoPress'
+		);
+		expect( items[ 0 ].querySelector( '.videopress-playlist__item-duration' ) ).toHaveTextContent(
+			'1:23'
+		);
+		expect( items[ 0 ].querySelector( '.videopress-playlist__item-badge' ) ).toHaveTextContent(
+			'1080p'
+		);
+		expect( items[ 1 ].querySelector( '.videopress-playlist__item-duration' ) ).toHaveTextContent(
+			'1:02:03'
+		);
+		expect( items[ 1 ].querySelector( '.videopress-playlist__item-badge' ) ).toHaveTextContent(
+			'4K'
+		);
+	} );
+
+	it( 'keeps server-rendered labels when the metadata lookup fails', async () => {
+		const block = buildPlaylist( [ 'aaaa1111' ] );
+
+		await refreshPlaylistMetadata( block );
+
+		const item = block.querySelector< HTMLButtonElement >( ITEM_SELECTOR );
+		expect( item.querySelector( '.videopress-playlist__item-title' ) ).toHaveTextContent(
+			'Video 1'
+		);
+		expect( item.querySelector( '.videopress-playlist__item-badge' ) ).toHaveTextContent( '' );
+		expect( item.querySelector( '.videopress-playlist__item-duration' ) ).toHaveTextContent( '' );
+	} );
+
+	it( 'requests metadata when a playlist initializes', () => {
+		const block = buildPlaylist( [ 'aaaa1111', 'bbbb2222' ] );
+		initPlaylist( block );
+
+		expect( global.fetch ).toHaveBeenCalledWith(
+			'https://public-api.wordpress.com/rest/v1.1/videos/aaaa1111'
+		);
+		expect( global.fetch ).toHaveBeenCalledWith(
+			'https://public-api.wordpress.com/rest/v1.1/videos/bbbb2222'
+		);
+	} );
+
 	it( 'bails on blocks without a player or items', () => {
 		const empty = document.createElement( 'figure' );
 		empty.className = 'wp-block-videopress-playlist';
 		document.body.appendChild( empty );
 
 		expect( () => initAllPlaylists() ).not.toThrow();
+	} );
+} );
+
+describe( 'formatDuration', () => {
+	it.each( [
+		[ 83000, '1:23' ],
+		[ 3723000, '1:02:03' ],
+		[ 500, '0:01' ],
+		[ 59499, '0:59' ],
+		[ 3600000, '1:00:00' ],
+	] )( 'formats %d ms as %s', ( ms, expected ) => {
+		expect( formatDuration( ms ) ).toBe( expected );
+	} );
+
+	it.each( [ [ 0 ], [ -5 ], [ NaN ], [ Infinity ] ] )( 'returns an empty string for %p', ms => {
+		expect( formatDuration( ms ) ).toBe( '' );
+	} );
+} );
+
+describe( 'qualityLabel', () => {
+	it.each( [
+		[ 2160, '4K' ],
+		[ 4320, '4K' ],
+		[ 1080, '1080p' ],
+		[ 720, '720p' ],
+		[ 480, '480p' ],
+	] )( 'labels height %d as %s', ( height, expected ) => {
+		expect( qualityLabel( height ) ).toBe( expected );
+	} );
+
+	it.each( [ [ 0 ], [ -1 ], [ NaN ] ] )( 'returns an empty string for %p', height => {
+		expect( qualityLabel( height ) ).toBe( '' );
 	} );
 } );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -234,6 +234,31 @@ describe( 'playlist view script', () => {
 		);
 	} );
 
+	it( 'reuses the poster image and tolerates missing header/guid on refresh', async () => {
+		const block = buildPlaylist( [ 'aaaa1111' ] );
+		// No runtime element and an item without a GUID must not break the refresh.
+		block.querySelector( '.videopress-playlist__runtime' ).remove();
+		block
+			.querySelector< HTMLButtonElement >( ITEM_SELECTOR )
+			.insertAdjacentHTML(
+				'beforebegin',
+				'<li><button type="button" class="videopress-playlist__item"></button></li>'
+			);
+
+		( global.fetch as jest.Mock ).mockResolvedValue( {
+			ok: true,
+			json: () => Promise.resolve( { duration: 5000, poster: 'https://example.test/p.jpg' } ),
+		} );
+
+		await refreshPlaylistMetadata( block );
+		await refreshPlaylistMetadata( block );
+
+		// The second refresh reuses the created img instead of adding another.
+		expect( block.querySelectorAll( '.videopress-playlist__item-thumb img' ) ).toHaveLength( 1 );
+		// Only the GUID-carrying item was fetched, once per refresh.
+		expect( global.fetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
 	it( 'keeps server-rendered labels when the metadata lookup fails', async () => {
 		const block = buildPlaylist( [ 'aaaa1111' ] );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
@@ -3,10 +3,23 @@ import type { VideoGUID } from '../video/types';
 export type PlaylistVideo = {
 	guid: VideoGUID;
 	title?: string;
+	durationMs?: number;
+	height?: number;
+	poster?: string;
 };
+
+export type PlaylistLayout = 'rail' | 'grid' | 'strip';
 
 export type PlaylistBlockAttributes = {
 	videos: PlaylistVideo[];
 	autoAdvance: boolean;
 	loop: boolean;
+	layout: PlaylistLayout;
+	darkSurface: boolean;
+	showThumbnail: boolean;
+	showTitle: boolean;
+	showResolution: boolean;
+	showDuration: boolean;
+	showPosition: boolean;
+	showTotalRuntime: boolean;
 };

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
@@ -1,0 +1,12 @@
+import type { VideoGUID } from '../video/types';
+
+export type PlaylistVideo = {
+	guid: VideoGUID;
+	title?: string;
+};
+
+export type PlaylistBlockAttributes = {
+	videos: PlaylistVideo[];
+	autoAdvance: boolean;
+	loop: boolean;
+};

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/utils.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/utils.ts
@@ -1,0 +1,82 @@
+/**
+ * Formatting helpers shared by the playlist editor and view script.
+ */
+
+/**
+ * Format a millisecond duration as m:ss or h:mm:ss.
+ *
+ * @param durationMs - Duration in milliseconds.
+ * @return Formatted duration, or an empty string for unusable input.
+ */
+export function formatDuration( durationMs: number ): string {
+	if ( ! Number.isFinite( durationMs ) || durationMs <= 0 ) {
+		return '';
+	}
+
+	const totalSeconds = Math.round( durationMs / 1000 );
+	const hours = Math.floor( totalSeconds / 3600 );
+	const minutes = Math.floor( ( totalSeconds % 3600 ) / 60 );
+	const seconds = totalSeconds % 60;
+
+	const paddedSeconds = String( seconds ).padStart( 2, '0' );
+
+	if ( hours > 0 ) {
+		return `${ hours }:${ String( minutes ).padStart( 2, '0' ) }:${ paddedSeconds }`;
+	}
+
+	return `${ minutes }:${ paddedSeconds }`;
+}
+
+/**
+ * Format a millisecond duration as a long runtime, e.g. "1 hr 13 min".
+ *
+ * @param durationMs - Duration in milliseconds.
+ * @return Formatted runtime, or an empty string for unusable input.
+ */
+export function formatRuntimeLong( durationMs: number ): string {
+	if ( ! Number.isFinite( durationMs ) || durationMs <= 0 ) {
+		return '';
+	}
+
+	const totalMinutes = Math.max( 1, Math.round( durationMs / 60000 ) );
+	const hours = Math.floor( totalMinutes / 60 );
+	const minutes = totalMinutes % 60;
+
+	if ( hours > 0 ) {
+		return minutes > 0 ? `${ hours } hr ${ minutes } min` : `${ hours } hr`;
+	}
+
+	return `${ minutes } min`;
+}
+
+/**
+ * Map a video height to a quality/resolution badge label.
+ *
+ * @param height - Video height in pixels.
+ * @return Badge label, or an empty string for unusable input.
+ */
+export function qualityLabel( height: number ): string {
+	if ( ! Number.isFinite( height ) || height <= 0 ) {
+		return '';
+	}
+
+	if ( height >= 2160 ) {
+		return '4K';
+	}
+
+	return `${ height }p`;
+}
+
+/**
+ * Sum the known durations of a list of playlist videos.
+ *
+ * @param videos - Playlist entries.
+ * @return Total known duration in milliseconds (0 when nothing is known).
+ */
+export function totalDurationMs( videos: Array< { durationMs?: number } > ): number {
+	return videos.reduce(
+		( sum, video ) =>
+			Number.isFinite( video.durationMs ) && video.durationMs > 0 ? sum + video.durationMs : sum,
+		0
+	);
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -1,9 +1,47 @@
 .wp-block-videopress-playlist {
+	--vpp-border: rgba(0, 0, 0, 0.12);
+	--vpp-border-soft: rgba(0, 0, 0, 0.06);
+	--vpp-muted: rgba(0, 0, 0, 0.55);
+	--vpp-current-bg: rgba(0, 0, 0, 0.05);
+	--vpp-accent: var(--wp--preset--color--primary, #2a78d6);
+
+	&.is-dark {
+		--vpp-border: rgba(255, 255, 255, 0.16);
+		--vpp-border-soft: rgba(255, 255, 255, 0.08);
+		--vpp-muted: rgba(255, 255, 255, 0.6);
+		--vpp-current-bg: rgba(255, 255, 255, 0.08);
+
+		background: #131315;
+		color: #f2f1ee;
+		padding: 24px;
+		border-radius: 8px;
+	}
+
+	.videopress-playlist__header {
+		display: flex;
+		align-items: baseline;
+		justify-content: flex-end;
+		gap: 6px;
+		margin-block-end: 12px;
+		font-size: 0.8em;
+		color: var(--vpp-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.videopress-playlist__runtime::before {
+		content: "· ";
+	}
+
+	&.hide-runtime .videopress-playlist__runtime {
+		display: none;
+	}
 
 	.videopress-playlist__player-wrapper {
 		position: relative;
 		aspect-ratio: 16 / 9;
 		background: #000;
+		border-radius: 6px;
+		overflow: hidden;
 	}
 
 	.videopress-playlist__player {
@@ -16,16 +54,15 @@
 
 	.videopress-playlist__items {
 		list-style: none;
-		margin: 8px 0 0;
+		margin: 0;
 		padding: 0;
 	}
 
 	.videopress-playlist__item {
 		display: flex;
-		align-items: center;
-		gap: 8px;
+		gap: 10px;
 		inline-size: 100%;
-		padding: 8px;
+		padding: 10px 12px;
 		border: 0;
 		background: transparent;
 		color: inherit;
@@ -35,48 +72,241 @@
 
 		&:hover,
 		&:focus-visible {
-			background: rgba(0, 0, 0, 0.05);
+			background: var(--vpp-current-bg);
 		}
+	}
 
-		&.is-current {
-			background: rgba(0, 0, 0, 0.08);
-			font-weight: 600;
+	.videopress-playlist__item-thumb {
+		position: relative;
+		flex-shrink: 0;
+		inline-size: 76px;
+		aspect-ratio: 16 / 9;
+		border-radius: 4px;
+		overflow: hidden;
+		background: var(--vpp-border-soft);
+
+		img {
+			position: absolute;
+			inset: 0;
+			inline-size: 100%;
+			block-size: 100%;
+			object-fit: cover;
+			max-inline-size: 100%;
 		}
 	}
 
 	.videopress-playlist__item-index {
-		opacity: 0.7;
-	}
-
-	.videopress-playlist__item-title {
-		flex-grow: 1;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.videopress-playlist__item-badge {
-		flex-shrink: 0;
-		padding: 1px 6px;
-		border: 1px solid currentColor;
+		display: none;
+		position: absolute;
+		inset-inline-start: 4px;
+		inset-block-start: 4px;
+		padding: 1px 4px;
 		border-radius: 2px;
-		font-size: 0.75em;
-		font-weight: 600;
-		letter-spacing: 0.02em;
-		opacity: 0.8;
+		background: rgba(255, 255, 255, 0.85);
+		color: #1e1e1e;
+		font-size: 0.7em;
+		font-variant-numeric: tabular-nums;
+	}
+
+	&.show-position .videopress-playlist__item-index {
+		display: inline-block;
+	}
+
+	.videopress-playlist__item-thumb-duration {
+		position: absolute;
+		inset-inline-end: 4px;
+		inset-block-end: 4px;
+		padding: 1px 4px;
+		border-radius: 2px;
+		background: rgba(0, 0, 0, 0.7);
+		color: #fff;
+		font-size: 0.7em;
+		font-variant-numeric: tabular-nums;
 
 		&:empty {
 			display: none;
 		}
 	}
 
-	.videopress-playlist__item-duration {
-		flex-shrink: 0;
-		opacity: 0.7;
+	.videopress-playlist__item-text {
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+		min-inline-size: 0;
+	}
+
+	.videopress-playlist__item-title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-size: 0.9em;
+	}
+
+	.videopress-playlist__item-meta {
+		display: flex;
+		gap: 4px;
+		font-size: 0.75em;
+		color: var(--vpp-muted);
 		font-variant-numeric: tabular-nums;
+
+		.videopress-playlist__item-badge + .videopress-playlist__item-duration:not(:empty)::before {
+			content: "· ";
+		}
 
 		&:empty {
 			display: none;
+		}
+	}
+
+	.videopress-playlist__item.is-current {
+		background: var(--vpp-current-bg);
+
+		.videopress-playlist__item-title {
+			font-weight: 600;
+		}
+
+		.videopress-playlist__item-thumb {
+			outline: 2px solid var(--vpp-accent);
+			outline-offset: -2px;
+		}
+	}
+
+	// Display toggles.
+	&.hide-thumbnails .videopress-playlist__item-thumb {
+		display: none;
+	}
+
+	&.hide-titles .videopress-playlist__item-title {
+		display: none;
+	}
+
+	&.hide-resolution .videopress-playlist__item-badge {
+		display: none;
+	}
+
+	&.hide-duration .videopress-playlist__item-duration,
+	&.hide-duration .videopress-playlist__item-thumb-duration {
+		display: none;
+	}
+
+	// Layout: side rail (default) — player left, vertical list right.
+	&.videopress-playlist--rail {
+
+		.videopress-playlist__body {
+			display: flex;
+			gap: 18px;
+			align-items: flex-start;
+		}
+
+		.videopress-playlist__player-wrapper {
+			flex: 1 1 auto;
+			min-inline-size: 0;
+		}
+
+		.videopress-playlist__items {
+			flex-shrink: 0;
+			inline-size: min(296px, 38%);
+			max-block-size: 420px;
+			overflow-y: auto;
+			border: 1px solid var(--vpp-border);
+			border-radius: 6px;
+		}
+
+		.videopress-playlist__item {
+			border-block-start: 1px solid var(--vpp-border-soft);
+		}
+
+		li:first-child .videopress-playlist__item {
+			border-block-start: 0;
+		}
+
+		.videopress-playlist__item.is-current {
+			border-inline-start: 3px solid var(--vpp-accent);
+			padding-inline-start: 9px;
+
+			.videopress-playlist__item-thumb {
+				outline: none;
+			}
+		}
+	}
+
+	// Layout: grid — player on top, cards below.
+	&.videopress-playlist--grid {
+
+		.videopress-playlist__player-wrapper {
+			margin-block-end: 16px;
+		}
+
+		.videopress-playlist__items {
+			display: grid;
+			grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+			gap: 14px;
+		}
+
+		.videopress-playlist__item {
+			flex-direction: column;
+			gap: 7px;
+			padding: 0;
+
+			&:hover,
+			&:focus-visible,
+			&.is-current {
+				background: transparent;
+			}
+		}
+
+		.videopress-playlist__item-thumb {
+			inline-size: 100%;
+			border-radius: 5px;
+		}
+	}
+
+	// Layout: strip — player on top, horizontal scroll strip below.
+	&.videopress-playlist--strip {
+
+		.videopress-playlist__player-wrapper {
+			margin-block-end: 16px;
+		}
+
+		.videopress-playlist__items {
+			display: flex;
+			gap: 10px;
+			overflow-x: auto;
+			padding-block-end: 4px;
+		}
+
+		li {
+			flex-shrink: 0;
+			inline-size: 176px;
+		}
+
+		.videopress-playlist__item {
+			flex-direction: column;
+			gap: 6px;
+			padding: 0;
+
+			&:hover,
+			&:focus-visible,
+			&.is-current {
+				background: transparent;
+			}
+		}
+
+		.videopress-playlist__item-thumb {
+			inline-size: 100%;
+			border-radius: 3px;
+		}
+	}
+
+	// Narrow viewports: the rail folds under the player.
+	@media (max-width: 600px) {
+
+		&.videopress-playlist--rail .videopress-playlist__body {
+			flex-direction: column;
+		}
+
+		&.videopress-playlist--rail .videopress-playlist__items {
+			inline-size: 100%;
 		}
 	}
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -1,0 +1,50 @@
+.wp-block-videopress-playlist {
+
+	.videopress-playlist__player-wrapper {
+		position: relative;
+		aspect-ratio: 16 / 9;
+		background: #000;
+	}
+
+	.videopress-playlist__player {
+		position: absolute;
+		inset: 0;
+		inline-size: 100%;
+		block-size: 100%;
+		border: 0;
+	}
+
+	.videopress-playlist__items {
+		list-style: none;
+		margin: 8px 0 0;
+		padding: 0;
+	}
+
+	.videopress-playlist__item {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		inline-size: 100%;
+		padding: 8px;
+		border: 0;
+		background: transparent;
+		color: inherit;
+		font: inherit;
+		text-align: start;
+		cursor: pointer;
+
+		&:hover,
+		&:focus-visible {
+			background: rgba(0, 0, 0, 0.05);
+		}
+
+		&.is-current {
+			background: rgba(0, 0, 0, 0.08);
+			font-weight: 600;
+		}
+	}
+
+	.videopress-playlist__item-index {
+		opacity: 0.7;
+	}
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -47,4 +47,36 @@
 	.videopress-playlist__item-index {
 		opacity: 0.7;
 	}
+
+	.videopress-playlist__item-title {
+		flex-grow: 1;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.videopress-playlist__item-badge {
+		flex-shrink: 0;
+		padding: 1px 6px;
+		border: 1px solid currentColor;
+		border-radius: 2px;
+		font-size: 0.75em;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		opacity: 0.8;
+
+		&:empty {
+			display: none;
+		}
+	}
+
+	.videopress-playlist__item-duration {
+		flex-shrink: 0;
+		opacity: 0.7;
+		font-variant-numeric: tabular-nums;
+
+		&:empty {
+			display: none;
+		}
+	}
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -13,6 +13,110 @@ type PlayerMessage = {
 	id?: string;
 };
 
+type VideoMetadata = {
+	title?: string;
+	duration?: number;
+	height?: number;
+};
+
+/**
+ * Format a millisecond duration as m:ss or h:mm:ss.
+ *
+ * @param durationMs - Duration in milliseconds.
+ * @return Formatted duration, or an empty string for unusable input.
+ */
+export function formatDuration( durationMs: number ): string {
+	if ( ! Number.isFinite( durationMs ) || durationMs <= 0 ) {
+		return '';
+	}
+
+	const totalSeconds = Math.round( durationMs / 1000 );
+	const hours = Math.floor( totalSeconds / 3600 );
+	const minutes = Math.floor( ( totalSeconds % 3600 ) / 60 );
+	const seconds = totalSeconds % 60;
+
+	const paddedSeconds = String( seconds ).padStart( 2, '0' );
+
+	if ( hours > 0 ) {
+		return `${ hours }:${ String( minutes ).padStart( 2, '0' ) }:${ paddedSeconds }`;
+	}
+
+	return `${ minutes }:${ paddedSeconds }`;
+}
+
+/**
+ * Map a video height to a quality/resolution badge label.
+ *
+ * @param height - Video height in pixels.
+ * @return Badge label, or an empty string for unusable input.
+ */
+export function qualityLabel( height: number ): string {
+	if ( ! Number.isFinite( height ) || height <= 0 ) {
+		return '';
+	}
+
+	if ( height >= 2160 ) {
+		return '4K';
+	}
+
+	return `${ height }p`;
+}
+
+/**
+ * Refresh a playlist's item metadata (title, duration, quality) from the
+ * VideoPress API, so the list always reflects the videos' current data.
+ *
+ * Lookups are anonymous: private videos (or API failures) keep their
+ * server-rendered title and simply get no duration/quality badge.
+ *
+ * @param block - The playlist block wrapper element.
+ * @return Promise resolving once every item has been processed.
+ */
+export function refreshPlaylistMetadata( block: HTMLElement ): Promise< void[] > {
+	const items = Array.from(
+		block.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__item' )
+	);
+
+	return Promise.all(
+		items.map( async item => {
+			const guid = item.dataset.guid;
+			if ( ! guid ) {
+				return;
+			}
+
+			let metadata: VideoMetadata;
+			try {
+				const response = await fetch(
+					`https://public-api.wordpress.com/rest/v1.1/videos/${ encodeURIComponent( guid ) }`
+				);
+				if ( ! response.ok ) {
+					return;
+				}
+				metadata = await response.json();
+			} catch {
+				return;
+			}
+
+			if ( metadata?.title ) {
+				const titleElement = item.querySelector( '.videopress-playlist__item-title' );
+				if ( titleElement ) {
+					titleElement.textContent = metadata.title;
+				}
+			}
+
+			const durationElement = item.querySelector( '.videopress-playlist__item-duration' );
+			if ( durationElement ) {
+				durationElement.textContent = formatDuration( metadata?.duration );
+			}
+
+			const badgeElement = item.querySelector( '.videopress-playlist__item-badge' );
+			if ( badgeElement ) {
+				badgeElement.textContent = qualityLabel( metadata?.height );
+			}
+		} )
+	);
+}
+
 /**
  * Wire up a single playlist block: item clicks swap the player iframe,
  * and `videopress_ended` messages from the player advance the playlist.
@@ -28,6 +132,10 @@ export function initPlaylist( block: HTMLElement ) {
 	if ( ! player || ! items.length ) {
 		return;
 	}
+
+	// Fire-and-forget: the list stays usable with the server-rendered labels
+	// while (or if) the metadata lookups are still pending.
+	refreshPlaylistMetadata( block );
 
 	const autoAdvance = block.dataset.autoAdvance === '1';
 	const loop = block.dataset.loop === '1';

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -1,0 +1,92 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+/**
+ * Internal dependencies
+ */
+import { isAllowedOrigin } from '../../../lib/videopress-allowed-origins';
+import './view.scss';
+
+type PlayerMessage = {
+	event?: string;
+	id?: string;
+};
+
+/**
+ * Wire up a single playlist block: item clicks swap the player iframe,
+ * and `videopress_ended` messages from the player advance the playlist.
+ *
+ * @param block - The playlist block wrapper element.
+ */
+function initPlaylist( block: HTMLElement ) {
+	const player = block.querySelector< HTMLIFrameElement >( '.videopress-playlist__player' );
+	const items = Array.from(
+		block.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__item' )
+	);
+
+	if ( ! player || ! items.length ) {
+		return;
+	}
+
+	const autoAdvance = block.dataset.autoAdvance === '1';
+	const loop = block.dataset.loop === '1';
+	let currentIndex = items.findIndex( item => item.dataset.guid === player.dataset.guid );
+
+	if ( currentIndex === -1 ) {
+		currentIndex = 0;
+	}
+
+	const setCurrent = ( index: number ) => {
+		const item = items[ index ];
+		if ( ! item || ! item.dataset.src ) {
+			return;
+		}
+
+		currentIndex = index;
+		player.src = item.dataset.src;
+		player.dataset.guid = item.dataset.guid;
+
+		items.forEach( ( entry, i ) => {
+			entry.classList.toggle( 'is-current', i === index );
+			entry.setAttribute( 'aria-current', i === index ? 'true' : 'false' );
+		} );
+	};
+
+	items.forEach( ( item, index ) => {
+		item.addEventListener( 'click', () => setCurrent( index ) );
+	} );
+
+	if ( ! autoAdvance ) {
+		return;
+	}
+
+	window.addEventListener( 'message', ( event: MessageEvent< PlayerMessage > ) => {
+		if ( ! isAllowedOrigin( event.origin ) ) {
+			return;
+		}
+
+		const { event: eventName, id } = event.data || {};
+		if ( eventName !== 'videopress_ended' || ! id ) {
+			return;
+		}
+
+		// Only react to the video currently loaded in this playlist's player.
+		if ( id !== items[ currentIndex ]?.dataset.guid ) {
+			return;
+		}
+
+		const nextIndex = currentIndex + 1;
+		if ( nextIndex < items.length ) {
+			setCurrent( nextIndex );
+		} else if ( loop ) {
+			setCurrent( 0 );
+		}
+	} );
+}
+
+domReady( () => {
+	document
+		.querySelectorAll< HTMLElement >( '.wp-block-videopress-playlist' )
+		.forEach( initPlaylist );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -19,7 +19,7 @@ type PlayerMessage = {
  *
  * @param block - The playlist block wrapper element.
  */
-function initPlaylist( block: HTMLElement ) {
+export function initPlaylist( block: HTMLElement ) {
 	const player = block.querySelector< HTMLIFrameElement >( '.videopress-playlist__player' );
 	const items = Array.from(
 		block.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__item' )
@@ -85,8 +85,13 @@ function initPlaylist( block: HTMLElement ) {
 	} );
 }
 
-domReady( () => {
+/**
+ * Initialize every playlist block on the page.
+ */
+export function initAllPlaylists() {
 	document
 		.querySelectorAll< HTMLElement >( '.wp-block-videopress-playlist' )
 		.forEach( initPlaylist );
-} );
+}
+
+domReady( initAllPlaylists );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -6,7 +6,10 @@ import domReady from '@wordpress/dom-ready';
  * Internal dependencies
  */
 import { isAllowedOrigin } from '../../../lib/videopress-allowed-origins';
+import { formatDuration, formatRuntimeLong, qualityLabel } from './utils';
 import './view.scss';
+
+export { formatDuration, formatRuntimeLong, qualityLabel };
 
 type PlayerMessage = {
 	event?: string;
@@ -17,62 +20,21 @@ type VideoMetadata = {
 	title?: string;
 	duration?: number;
 	height?: number;
+	poster?: string;
 };
 
 /**
- * Format a millisecond duration as m:ss or h:mm:ss.
- *
- * @param durationMs - Duration in milliseconds.
- * @return Formatted duration, or an empty string for unusable input.
- */
-export function formatDuration( durationMs: number ): string {
-	if ( ! Number.isFinite( durationMs ) || durationMs <= 0 ) {
-		return '';
-	}
-
-	const totalSeconds = Math.round( durationMs / 1000 );
-	const hours = Math.floor( totalSeconds / 3600 );
-	const minutes = Math.floor( ( totalSeconds % 3600 ) / 60 );
-	const seconds = totalSeconds % 60;
-
-	const paddedSeconds = String( seconds ).padStart( 2, '0' );
-
-	if ( hours > 0 ) {
-		return `${ hours }:${ String( minutes ).padStart( 2, '0' ) }:${ paddedSeconds }`;
-	}
-
-	return `${ minutes }:${ paddedSeconds }`;
-}
-
-/**
- * Map a video height to a quality/resolution badge label.
- *
- * @param height - Video height in pixels.
- * @return Badge label, or an empty string for unusable input.
- */
-export function qualityLabel( height: number ): string {
-	if ( ! Number.isFinite( height ) || height <= 0 ) {
-		return '';
-	}
-
-	if ( height >= 2160 ) {
-		return '4K';
-	}
-
-	return `${ height }p`;
-}
-
-/**
- * Refresh a playlist's item metadata (title, duration, quality) from the
- * VideoPress API, so the list always reflects the videos' current data.
+ * Refresh a playlist's item metadata (title, thumbnail, duration, quality)
+ * from the VideoPress API, so the list always reflects the videos' current
+ * data, and update the header's total runtime.
  *
  * Lookups are anonymous: private videos (or API failures) keep their
- * server-rendered title and simply get no duration/quality badge.
+ * server-rendered fields and simply get no duration/quality badge.
  *
  * @param block - The playlist block wrapper element.
  * @return Promise resolving once every item has been processed.
  */
-export function refreshPlaylistMetadata( block: HTMLElement ): Promise< void[] > {
+export function refreshPlaylistMetadata( block: HTMLElement ): Promise< void > {
 	const items = Array.from(
 		block.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__item' )
 	);
@@ -104,17 +66,58 @@ export function refreshPlaylistMetadata( block: HTMLElement ): Promise< void[] >
 				}
 			}
 
+			if ( Number.isFinite( metadata?.duration ) && metadata.duration > 0 ) {
+				item.dataset.durationMs = String( metadata.duration );
+			}
+
 			const durationElement = item.querySelector( '.videopress-playlist__item-duration' );
 			if ( durationElement ) {
 				durationElement.textContent = formatDuration( metadata?.duration );
+			}
+
+			const thumbDurationElement = item.querySelector(
+				'.videopress-playlist__item-thumb-duration'
+			);
+			if ( thumbDurationElement ) {
+				thumbDurationElement.textContent = formatDuration( metadata?.duration );
 			}
 
 			const badgeElement = item.querySelector( '.videopress-playlist__item-badge' );
 			if ( badgeElement ) {
 				badgeElement.textContent = qualityLabel( metadata?.height );
 			}
+
+			const thumbElement = item.querySelector( '.videopress-playlist__item-thumb' );
+			if ( thumbElement && metadata?.poster ) {
+				let image = thumbElement.querySelector( 'img' );
+				if ( ! image ) {
+					image = document.createElement( 'img' );
+					image.alt = '';
+					image.loading = 'lazy';
+					thumbElement.prepend( image );
+				}
+				if ( image.src !== metadata.poster ) {
+					image.src = metadata.poster;
+				}
+			}
 		} )
-	);
+	).then( () => {
+		// Recompute the header's total runtime from the freshest durations.
+		const runtimeElement = block.querySelector( '.videopress-playlist__runtime' );
+		if ( ! runtimeElement ) {
+			return;
+		}
+
+		const total = items.reduce( ( sum, item ) => {
+			const durationMs = Number( item.dataset.durationMs );
+			return Number.isFinite( durationMs ) && durationMs > 0 ? sum + durationMs : sum;
+		}, 0 );
+
+		const runtime = formatRuntimeLong( total );
+		if ( runtime ) {
+			runtimeElement.textContent = runtime;
+		}
+	} );
 }
 
 /**

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -27,20 +27,6 @@ use WorDBless\BaseTestCase;
 class Playlist_Block_Test extends BaseTestCase {
 
 	/**
-	 * Number of title lookups attempted during the current test.
-	 *
-	 * @var int
-	 */
-	private $title_requests = 0;
-
-	/**
-	 * Canned response for title lookups, or null to simulate an unreachable API.
-	 *
-	 * @var array|null
-	 */
-	private $title_response = null;
-
-	/**
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
@@ -49,29 +35,6 @@ class Playlist_Block_Test extends BaseTestCase {
 		if ( \WP_Block_Type_Registry::get_instance()->is_registered( 'videopress/playlist' ) ) {
 			\WP_Block_Type_Registry::get_instance()->unregister( 'videopress/playlist' );
 		}
-
-		// Drop title transients so caching state never leaks between tests.
-		foreach ( array( 'abcd1234', 'efgh5678' ) as $guid ) {
-			delete_transient( 'videopress_playlist_title_' . $guid );
-		}
-	}
-
-	/**
-	 * Intercept the title lookup so tests never hit the network.
-	 *
-	 * @param false|array|\WP_Error $preempt Whether to preempt the request.
-	 * @param array                 $args    Request arguments.
-	 * @param string                $url     Request URL.
-	 * @return false|array|\WP_Error
-	 */
-	public function intercept_title_request( $preempt, $args, $url ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		if ( ! str_contains( $url, 'public-api.wordpress.com/rest/v1.1/videos/' ) ) {
-			return $preempt;
-		}
-
-		++$this->title_requests;
-
-		return $this->title_response ?? new \WP_Error( 'http_request_failed', 'unreachable' );
 	}
 
 	/**
@@ -122,12 +85,7 @@ class Playlist_Block_Test extends BaseTestCase {
 
 		// Empty attributes encode to `[]`, which the block parser rejects; omit them instead.
 		$json = empty( $attributes ) ? '' : wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES ) . ' ';
-
-		add_filter( 'pre_http_request', array( $this, 'intercept_title_request' ), 10, 3 );
-		$html = do_blocks( '<!-- wp:videopress/playlist ' . $json . '/-->' );
-		remove_filter( 'pre_http_request', array( $this, 'intercept_title_request' ) );
-
-		return $html;
+		return do_blocks( '<!-- wp:videopress/playlist ' . $json . '/-->' );
 	}
 
 	/** Tests that the block registers from metadata with the render callback wired. */
@@ -204,59 +162,14 @@ class Playlist_Block_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'data-loop="0"', $html );
 	}
 
-	/** Tests that rendering pulls the current title from the video data over the stored one. */
-	public function test_render_uses_fresh_title_from_video_data() {
-		$this->title_response = array(
-			'response' => array( 'code' => 200 ),
-			'body'     => wp_json_encode( array( 'title' => 'Renamed on VideoPress' ), JSON_UNESCAPED_SLASHES ),
-		);
-
+	/** Tests that items carry the placeholders the view script fills with live metadata. */
+	public function test_render_includes_metadata_placeholders() {
 		$html = $this->render(
-			array(
-				'videos' => array(
-					array(
-						'guid'  => 'abcd1234',
-						'title' => 'Stale stored title',
-					),
-				),
-			)
+			array( 'videos' => array( array( 'guid' => 'abcd1234' ) ) )
 		);
 
-		$this->assertStringContainsString( 'Renamed on VideoPress', $html );
-		$this->assertStringNotContainsString( 'Stale stored title', $html );
-	}
-
-	/** Tests that title lookups are cached and fall back to the stored title on failure. */
-	public function test_render_title_lookups_are_cached() {
-		$this->title_response = array(
-			'response' => array( 'code' => 200 ),
-			'body'     => wp_json_encode( array( 'title' => 'Fresh title' ), JSON_UNESCAPED_SLASHES ),
-		);
-
-		$attributes = array(
-			'videos' => array(
-				array(
-					'guid'  => 'abcd1234',
-					'title' => 'Stored title',
-				),
-			),
-		);
-
-		$this->render( $attributes );
-		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Deliberate identical re-render to prove the lookup is served from cache.
-		$this->render( $attributes );
-		$this->assertSame( 1, $this->title_requests, 'The second render must be served from cache.' );
-
-		// Unreachable API: the stored title is kept, and the failure is negative-cached.
-		$this->title_requests = 0;
-		$this->title_response = null;
-		delete_transient( 'videopress_playlist_title_abcd1234' );
-
-		$html = $this->render( $attributes );
-		$this->assertStringContainsString( 'Stored title', $html );
-
-		$this->render( $attributes );
-		$this->assertSame( 1, $this->title_requests, 'Failed lookups must be negative-cached.' );
+		$this->assertStringContainsString( 'videopress-playlist__item-badge', $html );
+		$this->assertStringContainsString( 'videopress-playlist__item-duration', $html );
 	}
 
 	/** Tests that autoAdvance and loop attributes reach the frontend dataset. */

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -27,28 +27,43 @@ use WorDBless\BaseTestCase;
 class Playlist_Block_Test extends BaseTestCase {
 
 	/**
-	 * Set up before each test.
-	 */
-	public function set_up() {
-		parent::set_up();
-
-		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'videopress/playlist' ) ) {
-			register_block_type(
-				'videopress/playlist',
-				array(
-					'render_callback' => array( VideoPress_Initializer::class, 'render_videopress_playlist_block' ),
-				)
-			);
-		}
-	}
-
-	/**
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
 		parent::tear_down();
 
-		\WP_Block_Type_Registry::get_instance()->unregister( 'videopress/playlist' );
+		if ( \WP_Block_Type_Registry::get_instance()->is_registered( 'videopress/playlist' ) ) {
+			\WP_Block_Type_Registry::get_instance()->unregister( 'videopress/playlist' );
+		}
+	}
+
+	/**
+	 * Write a block.json fixture for registration tests and return its path.
+	 *
+	 * The build output isn't present when the PHP suite runs in CI, so
+	 * registration is exercised against a fixture instead.
+	 *
+	 * @param array $metadata Metadata to encode.
+	 * @return string Path to the fixture file.
+	 */
+	private function create_metadata_fixture( $metadata ) {
+		// register_block_type_from_metadata() requires the file to be named block.json.
+		$dir = get_temp_dir() . uniqid( 'playlist-block-', true );
+		mkdir( $dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		$file = $dir . '/block.json';
+		file_put_contents( $file, wp_json_encode( $metadata, JSON_UNESCAPED_SLASHES ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+		return $file;
+	}
+
+	/**
+	 * Remove a fixture created by create_metadata_fixture().
+	 *
+	 * @param string $file Path returned by create_metadata_fixture().
+	 */
+	private function remove_metadata_fixture( $file ) {
+		unlink( $file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+		rmdir( dirname( $file ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
 	}
 
 	/**
@@ -59,9 +74,57 @@ class Playlist_Block_Test extends BaseTestCase {
 	 * @return string Rendered markup.
 	 */
 	private function render( $attributes ) {
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'videopress/playlist' ) ) {
+			register_block_type(
+				'videopress/playlist',
+				array(
+					'render_callback' => array( VideoPress_Initializer::class, 'render_videopress_playlist_block' ),
+				)
+			);
+		}
+
 		// Empty attributes encode to `[]`, which the block parser rejects; omit them instead.
 		$json = empty( $attributes ) ? '' : wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES ) . ' ';
 		return do_blocks( '<!-- wp:videopress/playlist ' . $json . '/-->' );
+	}
+
+	/** Tests that the block registers from metadata with the render callback wired. */
+	public function test_registration_from_metadata() {
+		$fixture = $this->create_metadata_fixture(
+			array(
+				'name'  => 'videopress/playlist',
+				'title' => 'VideoPress Playlist',
+			)
+		);
+
+		VideoPress_Initializer::register_videopress_playlist_block( $fixture );
+
+		$registry = \WP_Block_Type_Registry::get_instance();
+		$this->assertTrue( $registry->is_registered( 'videopress/playlist' ) );
+		$this->assertSame(
+			array( VideoPress_Initializer::class, 'render_videopress_playlist_block' ),
+			$registry->get_registered( 'videopress/playlist' )->render_callback
+		);
+
+		// A second call must not fatal on (or duplicate) the existing registration.
+		VideoPress_Initializer::register_videopress_playlist_block( $fixture );
+		$this->assertTrue( $registry->is_registered( 'videopress/playlist' ) );
+
+		$this->remove_metadata_fixture( $fixture );
+	}
+
+	/** Tests that registration is skipped when the metadata file is missing or unusable. */
+	public function test_registration_skipped_without_usable_metadata() {
+		$registry = \WP_Block_Type_Registry::get_instance();
+
+		VideoPress_Initializer::register_videopress_playlist_block( '/nonexistent/block.json' );
+		$this->assertFalse( $registry->is_registered( 'videopress/playlist' ) );
+
+		$nameless = $this->create_metadata_fixture( array( 'title' => 'No name' ) );
+		VideoPress_Initializer::register_videopress_playlist_block( $nameless );
+		$this->assertFalse( $registry->is_registered( 'videopress/playlist' ) );
+
+		$this->remove_metadata_fixture( $nameless );
 	}
 
 	/** Tests that the player and playlist items are rendered. */
@@ -120,6 +183,8 @@ class Playlist_Block_Test extends BaseTestCase {
 				'videos' => array(
 					array( 'guid' => '"><script>alert(1)</script>' ),
 					array( 'guid' => 'short' ),
+					'not-an-array-entry',
+					array( 'title' => 'No guid at all' ),
 					array( 'guid' => 'abcd1234' ),
 				),
 			)

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -27,6 +27,20 @@ use WorDBless\BaseTestCase;
 class Playlist_Block_Test extends BaseTestCase {
 
 	/**
+	 * Number of title lookups attempted during the current test.
+	 *
+	 * @var int
+	 */
+	private $title_requests = 0;
+
+	/**
+	 * Canned response for title lookups, or null to simulate an unreachable API.
+	 *
+	 * @var array|null
+	 */
+	private $title_response = null;
+
+	/**
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
@@ -35,6 +49,29 @@ class Playlist_Block_Test extends BaseTestCase {
 		if ( \WP_Block_Type_Registry::get_instance()->is_registered( 'videopress/playlist' ) ) {
 			\WP_Block_Type_Registry::get_instance()->unregister( 'videopress/playlist' );
 		}
+
+		// Drop title transients so caching state never leaks between tests.
+		foreach ( array( 'abcd1234', 'efgh5678' ) as $guid ) {
+			delete_transient( 'videopress_playlist_title_' . $guid );
+		}
+	}
+
+	/**
+	 * Intercept the title lookup so tests never hit the network.
+	 *
+	 * @param false|array|\WP_Error $preempt Whether to preempt the request.
+	 * @param array                 $args    Request arguments.
+	 * @param string                $url     Request URL.
+	 * @return false|array|\WP_Error
+	 */
+	public function intercept_title_request( $preempt, $args, $url ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! str_contains( $url, 'public-api.wordpress.com/rest/v1.1/videos/' ) ) {
+			return $preempt;
+		}
+
+		++$this->title_requests;
+
+		return $this->title_response ?? new \WP_Error( 'http_request_failed', 'unreachable' );
 	}
 
 	/**
@@ -85,7 +122,12 @@ class Playlist_Block_Test extends BaseTestCase {
 
 		// Empty attributes encode to `[]`, which the block parser rejects; omit them instead.
 		$json = empty( $attributes ) ? '' : wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES ) . ' ';
-		return do_blocks( '<!-- wp:videopress/playlist ' . $json . '/-->' );
+
+		add_filter( 'pre_http_request', array( $this, 'intercept_title_request' ), 10, 3 );
+		$html = do_blocks( '<!-- wp:videopress/playlist ' . $json . '/-->' );
+		remove_filter( 'pre_http_request', array( $this, 'intercept_title_request' ) );
+
+		return $html;
 	}
 
 	/** Tests that the block registers from metadata with the render callback wired. */
@@ -160,6 +202,60 @@ class Playlist_Block_Test extends BaseTestCase {
 		// Sequence defaults: auto-advance on, loop off.
 		$this->assertStringContainsString( 'data-auto-advance="1"', $html );
 		$this->assertStringContainsString( 'data-loop="0"', $html );
+	}
+
+	/** Tests that rendering pulls the current title from the video data over the stored one. */
+	public function test_render_uses_fresh_title_from_video_data() {
+		$this->title_response = array(
+			'response' => array( 'code' => 200 ),
+			'body'     => wp_json_encode( array( 'title' => 'Renamed on VideoPress' ), JSON_UNESCAPED_SLASHES ),
+		);
+
+		$html = $this->render(
+			array(
+				'videos' => array(
+					array(
+						'guid'  => 'abcd1234',
+						'title' => 'Stale stored title',
+					),
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'Renamed on VideoPress', $html );
+		$this->assertStringNotContainsString( 'Stale stored title', $html );
+	}
+
+	/** Tests that title lookups are cached and fall back to the stored title on failure. */
+	public function test_render_title_lookups_are_cached() {
+		$this->title_response = array(
+			'response' => array( 'code' => 200 ),
+			'body'     => wp_json_encode( array( 'title' => 'Fresh title' ), JSON_UNESCAPED_SLASHES ),
+		);
+
+		$attributes = array(
+			'videos' => array(
+				array(
+					'guid'  => 'abcd1234',
+					'title' => 'Stored title',
+				),
+			),
+		);
+
+		$this->render( $attributes );
+		$this->render( $attributes );
+		$this->assertSame( 1, $this->title_requests, 'The second render must be served from cache.' );
+
+		// Unreachable API: the stored title is kept, and the failure is negative-cached.
+		$this->title_requests = 0;
+		$this->title_response = null;
+		delete_transient( 'videopress_playlist_title_abcd1234' );
+
+		$html = $this->render( $attributes );
+		$this->assertStringContainsString( 'Stored title', $html );
+
+		$this->render( $attributes );
+		$this->assertSame( 1, $this->title_requests, 'Failed lookups must be negative-cached.' );
 	}
 
 	/** Tests that autoAdvance and loop attributes reach the frontend dataset. */

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Tests for Initializer::render_videopress_playlist_block.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack;
+
+use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Initializer;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test suite for the VideoPress playlist block server-side rendering.
+ *
+ * Runs each test in a separate process: rendering enqueues the real
+ * Jwt_Token_Bridge, which other tests in this suite replace with alias
+ * mocks that require the class to be unloaded.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
+class Playlist_Block_Test extends BaseTestCase {
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'videopress/playlist' ) ) {
+			register_block_type(
+				'videopress/playlist',
+				array(
+					'render_callback' => array( VideoPress_Initializer::class, 'render_videopress_playlist_block' ),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		\WP_Block_Type_Registry::get_instance()->unregister( 'videopress/playlist' );
+	}
+
+	/**
+	 * Render the playlist block through do_blocks() so block supports
+	 * (wrapper class names) apply like on a real page.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered markup.
+	 */
+	private function render( $attributes ) {
+		// Empty attributes encode to `[]`, which the block parser rejects; omit them instead.
+		$json = empty( $attributes ) ? '' : wp_json_encode( $attributes, JSON_UNESCAPED_SLASHES ) . ' ';
+		return do_blocks( '<!-- wp:videopress/playlist ' . $json . '/-->' );
+	}
+
+	/** Tests that the player and playlist items are rendered. */
+	public function test_renders_player_and_items() {
+		$html = $this->render(
+			array(
+				'videos' => array(
+					array(
+						'guid'  => 'abcd1234',
+						'title' => 'First video',
+					),
+					array( 'guid' => 'efgh5678' ),
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'wp-block-videopress-playlist', $html );
+
+		// The player starts on the first video, without autoplay.
+		$this->assertSame( 1, preg_match( '/<iframe[^>]+src="([^"]+)"/', $html, $matches ) );
+		$this->assertStringContainsString( 'videopress.com/embed/abcd1234', $matches[1] );
+		$this->assertStringContainsString( 'autoPlay=0', $matches[1] );
+
+		// Each item carries an autoplaying embed URL for the click/advance handlers.
+		$this->assertStringContainsString( 'data-guid="abcd1234"', $html );
+		$this->assertStringContainsString( 'data-guid="efgh5678"', $html );
+		$this->assertSame( 2, substr_count( $html, 'autoPlay=1' ) );
+
+		// Titles fall back to a numbered label.
+		$this->assertStringContainsString( 'First video', $html );
+		$this->assertStringContainsString( 'Video 2', $html );
+
+		// Sequence defaults: auto-advance on, loop off.
+		$this->assertStringContainsString( 'data-auto-advance="1"', $html );
+		$this->assertStringContainsString( 'data-loop="0"', $html );
+	}
+
+	/** Tests that autoAdvance and loop attributes reach the frontend dataset. */
+	public function test_auto_advance_and_loop_attributes() {
+		$html = $this->render(
+			array(
+				'videos'      => array( array( 'guid' => 'abcd1234' ) ),
+				'autoAdvance' => false,
+				'loop'        => true,
+			)
+		);
+
+		$this->assertStringContainsString( 'data-auto-advance="0"', $html );
+		$this->assertStringContainsString( 'data-loop="1"', $html );
+	}
+
+	/** Tests that entries without a valid 8-character GUID are dropped. */
+	public function test_invalid_guids_are_dropped() {
+		$html = $this->render(
+			array(
+				'videos' => array(
+					array( 'guid' => '"><script>alert(1)</script>' ),
+					array( 'guid' => 'short' ),
+					array( 'guid' => 'abcd1234' ),
+				),
+			)
+		);
+
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $html );
+		$this->assertStringNotContainsString( 'short', $html );
+		$this->assertSame( 1, substr_count( $html, 'data-src=' ) );
+		$this->assertStringContainsString( 'data-guid="abcd1234"', $html );
+	}
+
+	/** Tests that video titles are escaped. */
+	public function test_titles_are_escaped() {
+		$html = $this->render(
+			array(
+				'videos' => array(
+					array(
+						'guid'  => 'abcd1234',
+						'title' => '<script>alert(1)</script>',
+					),
+				),
+			)
+		);
+
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+
+	/** Tests that a playlist without valid videos renders nothing. */
+	public function test_empty_playlist_renders_nothing() {
+		$this->assertSame( '', trim( $this->render( array( 'videos' => array() ) ) ) );
+		$this->assertSame( '', trim( $this->render( array() ) ) );
+		$this->assertSame( '', trim( $this->render( array( 'videos' => array( array( 'guid' => 'bad' ) ) ) ) ) );
+	}
+}

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -170,6 +170,78 @@ class Playlist_Block_Test extends BaseTestCase {
 
 		$this->assertStringContainsString( 'videopress-playlist__item-badge', $html );
 		$this->assertStringContainsString( 'videopress-playlist__item-duration', $html );
+		$this->assertStringContainsString( 'videopress-playlist__item-thumb', $html );
+		$this->assertStringContainsString( 'videopress-playlist__header', $html );
+	}
+
+	/** Tests that stored metadata renders as initial content. */
+	public function test_render_uses_stored_metadata() {
+		$html = $this->render(
+			array(
+				'videos' => array(
+					array(
+						'guid'       => 'abcd1234',
+						'title'      => 'Kiln loading',
+						'durationMs' => 724000,
+						'height'     => 1080,
+						'poster'     => 'https://videos.files.wordpress.com/abcd1234/poster.jpg',
+					),
+					array(
+						'guid'       => 'efgh5678',
+						'durationMs' => 3660000,
+						'height'     => 2160,
+					),
+				),
+			)
+		);
+
+		$this->assertStringContainsString( '12:04', $html );
+		$this->assertStringContainsString( '1080p', $html );
+		$this->assertStringContainsString( '4K', $html );
+		$this->assertStringContainsString( 'poster.jpg', $html );
+		$this->assertStringContainsString( 'data-duration-ms="724000"', $html );
+		// Header: count and long-form total runtime (724000 + 3660000 ms ≈ 1 hr 13 min).
+		$this->assertStringContainsString( '2 videos', $html );
+		$this->assertStringContainsString( '1 hr 13 min', $html );
+	}
+
+	/** Tests that layout, dark surface, and display toggles map to wrapper classes. */
+	public function test_render_layout_and_display_classes() {
+		$base = array( 'videos' => array( array( 'guid' => 'abcd1234' ) ) );
+
+		$default_html = $this->render( $base );
+		$this->assertStringContainsString( 'videopress-playlist--rail', $default_html );
+		$this->assertStringNotContainsString( 'is-dark', $default_html );
+		$this->assertStringNotContainsString( 'hide-thumbnails', $default_html );
+		$this->assertStringNotContainsString( 'show-position', $default_html );
+
+		$custom_html = $this->render(
+			array_merge(
+				$base,
+				array(
+					'layout'           => 'grid',
+					'darkSurface'      => true,
+					'showThumbnail'    => false,
+					'showResolution'   => false,
+					'showDuration'     => false,
+					'showTitle'        => false,
+					'showPosition'     => true,
+					'showTotalRuntime' => false,
+				)
+			)
+		);
+		$this->assertStringContainsString( 'videopress-playlist--grid', $custom_html );
+		$this->assertStringContainsString( 'is-dark', $custom_html );
+		$this->assertStringContainsString( 'hide-thumbnails', $custom_html );
+		$this->assertStringContainsString( 'hide-resolution', $custom_html );
+		$this->assertStringContainsString( 'hide-duration', $custom_html );
+		$this->assertStringContainsString( 'hide-titles', $custom_html );
+		$this->assertStringContainsString( 'show-position', $custom_html );
+		$this->assertStringContainsString( 'hide-runtime', $custom_html );
+
+		// Unknown layout values fall back to the rail layout.
+		$fallback_html = $this->render( array_merge( $base, array( 'layout' => 'bogus' ) ) );
+		$this->assertStringContainsString( 'videopress-playlist--rail', $fallback_html );
 	}
 
 	/** Tests that autoAdvance and loop attributes reach the frontend dataset. */

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -243,6 +243,7 @@ class Playlist_Block_Test extends BaseTestCase {
 		);
 
 		$this->render( $attributes );
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Deliberate identical re-render to prove the lookup is served from cache.
 		$this->render( $attributes );
 		$this->assertSame( 1, $this->title_requests, 'The second render must be served from cache.' );
 

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -120,6 +120,16 @@ class Playlist_Block_Test extends BaseTestCase {
 		VideoPress_Initializer::register_videopress_playlist_block( '/nonexistent/block.json' );
 		$this->assertFalse( $registry->is_registered( 'videopress/playlist' ) );
 
+		/*
+		 * The no-argument default reads the package build output. Whether or not
+		 * a build is present where the suite runs, the call must not error, and
+		 * any resulting registration must use the real block name.
+		 */
+		VideoPress_Initializer::register_videopress_playlist_block();
+		if ( $registry->is_registered( 'videopress/playlist' ) ) {
+			$registry->unregister( 'videopress/playlist' );
+		}
+
 		$nameless = $this->create_metadata_fixture( array( 'title' => 'No name' ) );
 		VideoPress_Initializer::register_videopress_playlist_block( $nameless );
 		$this->assertFalse( $registry->is_registered( 'videopress/playlist' ) );

--- a/projects/packages/videopress/webpack.config.js
+++ b/projects/packages/videopress/webpack.config.js
@@ -67,6 +67,10 @@ module.exports = [
 			'block-editor/blocks/video/index': './src/client/block-editor/blocks/video/index.ts',
 			'block-editor/blocks/video/view': './src/client/block-editor/blocks/video/view.ts',
 
+			// Playlist block
+			'block-editor/blocks/playlist/index': './src/client/block-editor/blocks/playlist/index.ts',
+			'block-editor/blocks/playlist/view': './src/client/block-editor/blocks/playlist/view.ts',
+
 			'lib/token-bridge': './src/client/lib/token-bridge/index.ts',
 			'lib/player-bridge': './src/client/lib/player-bridge/index.ts',
 


### PR DESCRIPTION
## Proposed changes

Adds a lightweight `videopress/playlist` block to the VideoPress package (VIDP-370). The block stores a list of VideoPress video GUIDs and plays them in sequence.

* **Editor**: playlist management (add, sort, delete) lives in a **Videos** panel in the block settings sidebar. Videos can be added by pasting a VideoPress GUID or URL, or picked from the site's VideoPress library via the media modal (multi-select). Item titles are read-only and always come from the video data — fetched from the VideoPress API on add, and refreshed once per editor session so renames are picked up. The block canvas is a preview of what visitors see: the player plus a click-to-preview item list. Inspector toggles for "Autoplay next video" (default on) and "Loop playlist" (default off).
* **Frontend (server-rendered)**: the first video renders in an embed player above a clickable list of the playlist items. Clicking an item swaps the player to that video. When a video ends (the player posts `videopress_ended` from a trusted VideoPress origin), the view script advances to the next item, optionally looping back to the first.
* **Live metadata on the client**: the view script refreshes each item from the public VideoPress API in the visitor's browser — titles always reflect the videos' current data, and each item shows its **duration** (`m:ss` / `h:mm:ss`) and a **quality badge** (480p/720p/1080p/4K). Failed lookups (e.g. private videos, anonymously unreadable) keep the server-rendered title and show no badge. No remote requests happen in the PHP render path.
* **Access rules**: the block embeds by GUID, so playback follows the videos' existing VideoPress privacy settings — the JWT token bridge is enqueued so private videos play for authorized, logged-in viewers, and restricting a playlist is done by restricting the page it lives on (e.g. logged-in users only), as requested in the issue.
* Registered via `Initializer::register_videopress_blocks()`, so it ships wherever the VideoPress package blocks are registered (standalone VideoPress plugin). Exposing it through the Jetpack plugin's extension list (index.json + extended-blocks shim) can follow up separately.
* Test coverage: PHP render/registration tests (`Playlist_Block_Test`) and jest suites for the editor component, view script (playback sequencing, metadata refresh), and block registration.

## Related product discussion/links

* Linear: VIDP-370
* https://wordpress.org/support/topic/videopress-playlist-queue-integration-with-wordpress-and-elementor/

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the package: `jp build packages/videopress`
* On a site with the standalone VideoPress plugin active (`jp docker up -d` + activate), edit a post and insert the **VideoPress Playlist** block.
* Open the block settings sidebar → **Videos** panel:
  * Add videos via **Choose from library** (multi-select from the site's VideoPress videos) and by pasting a GUID or VideoPress URL (e.g. `https://videopress.com/v/xxxxxxxx`).
  * Confirm item titles appear automatically from the video data and are not editable.
  * Reorder with the up/down buttons and remove items; confirm the canvas preview follows.
* In the canvas, click an item to preview that video.
* Publish and view the post:
  * The first video renders with the item list below it; after load, titles refresh from the VideoPress API and each item shows duration and a quality badge (public videos).
  * Clicking an item loads and autoplays that video.
  * Letting a video play to the end advances to the next one (with **Autoplay next video** on); with **Loop playlist** enabled, the last video hands back to the first.
* Run `jp test php packages/videopress` and `jp test js packages/videopress` — all tests should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
