### PR TITLE
Premium Analytics: full-width post highlights row and video upload-date wording

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-pa-detail-mock-alignment
+++ b/projects/packages/premium-analytics/changelog/update-pa-detail-mock-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Post and video detail: stretch the post highlights row full width and label the video date as its upload date, per the updated design mocks.

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -2,12 +2,12 @@ import { WIDGET_DASHBOARD_COLUMN_COUNT } from '@wordpress/widget-dashboard';
 import { POST_DETAIL_TAB_LAYOUTS } from './tab-layouts';
 
 describe( 'post detail tab layouts', () => {
-	it( 'composes Post traffic as a three-column highlights row, a Post views chart beside the interaction cards, then Traffic activity beside UTM', () => {
+	it( 'composes Post traffic as a full-width highlights row, a Post views chart beside the interaction cards, then Traffic activity beside UTM', () => {
 		expect( POST_DETAIL_TAB_LAYOUTS[ 'post-traffic' ] ).toEqual( [
 			{
 				uuid: 'post-detail-highlights',
 				type: 'jpa/post-detail-highlights',
-				placement: { width: 3, height: 1, order: 1 },
+				placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
 			},
 			{
 				uuid: 'post-views',

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -13,10 +13,10 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 	'post-traffic': [
 		{
 			uuid: 'post-detail-highlights',
-			// Three quarter-width tiles with the last column left empty, per the
-			// design mocks — unlike the email highlights rows, which span all four.
+			// Full-width row like the email highlights, per the updated design
+			// mocks; the widget spreads its three tiles across the span.
 			type: 'jpa/post-detail-highlights',
-			placement: { width: 3, height: 1, order: 1 },
+			placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
 		},
 		{
 			uuid: 'post-views',

--- a/projects/packages/premium-analytics/routes/video-detail/components/video-summary-card/video-summary-card.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/components/video-summary-card/video-summary-card.tsx
@@ -47,8 +47,8 @@ export function VideoSummaryCard( { summary, performanceRange }: VideoSummaryCar
 	const publishedSentence =
 		publishedDateObject && isValid( publishedDateObject )
 			? sprintf(
-					/* translators: %s: the video publish date, e.g. "Aug 19, 2025". */
-					__( 'Video published on %s.', 'jetpack-premium-analytics-pkg' ),
+					/* translators: %s: the video upload date, e.g. "Aug 19, 2025". */
+					__( 'Video uploaded on %s.', 'jetpack-premium-analytics-pkg' ),
 					format( publishedDateObject, DATE_FORMAT )
 			  )
 			: undefined;


### PR DESCRIPTION
## Proposed changes

Two small alignments with the updated design mocks for the detail pages:

* **Post detail → Post traffic**: the Post highlights row now spans the full dashboard width. It was previously three quarter-width tiles with the fourth column left empty, per the earlier mocks; the updated mocks stretch the three tiles across the whole row, matching the email highlights rows. The widget's `MetricTileGrid` spreads its tiles across whatever span it is given, so this is a layout-placement change only.
* **Video detail**: the summary subtitle now reads "Video uploaded on …" instead of "Video published on …". The date shown is the VideoPress attachment's post date, which is the upload date, so only the wording changes.

## Related product discussion/links

* Part of the updated-mock alignment pass following WOOA7S-1785 (see WOOA7S-1905 / STATS-428 for the related design-alignment items).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build `packages/premium-analytics` and open the Premium Analytics dashboard.
* Open a post report → Post traffic tab: the Views / Likes / Comments highlights row stretches across the full content width with no empty fourth column.
* Open a video report: the header subtitle reads "Video uploaded on <date>." followed by the performance range.
* `pnpm run test routes/post-detail routes/video-detail` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

Post detail → Post traffic, "Last 30 days": the highlights row spans the full width.

| Before | After |
| --- | --- |
|<img width="1278" height="482" alt="截圖 2026-08-14 凌晨1 18 56" src="https://github.com/user-attachments/assets/5a2f8641-5e1c-4aee-ba7f-a412eb1c5580" />|<img width="1288" height="443" alt="截圖 2026-08-14 凌晨1 12 26" src="https://github.com/user-attachments/assets/d40b2b5d-e05a-45b9-9272-0e635d59f493" />|

Video detail: the subtitle reads "Video uploaded on …".

| Before | After |
| --- | --- |
|<img width="1291" height="428" alt="截圖 2026-08-14 凌晨1 19 57" src="https://github.com/user-attachments/assets/315ed743-6c8b-45fe-8bed-d04fff9ba4c2" />|<img width="1292" height="427" alt="截圖 2026-08-14 凌晨1 15 31" src="https://github.com/user-attachments/assets/2ffaed44-8e50-4c4c-bbf2-b056b8e5965a" />|