### PR TITLE
Premium Analytics: restore the country map beside the email clicks Locations leaderboard

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-pa-email-clicks-locations-map
+++ b/projects/packages/premium-analytics/changelog/update-pa-email-clicks-locations-map
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Email clicks: draw the country map beside the Locations leaderboard again, per the updated design mocks.

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -102,7 +102,7 @@ describe( 'post detail tab layouts', () => {
 			{
 				uuid: 'email-clicks-countries',
 				type: 'jpa/email-breakdown--location-clicks',
-				attributes: { view: 'countries', metric: 'clicks', max: 8 },
+				attributes: { view: 'countries', metric: 'clicks', max: 8, showMap: true },
 				placement: { width: 2, height: 2, order: 5 },
 			},
 			{

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -109,9 +109,11 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 		},
 		{
 			uuid: 'email-clicks-countries',
-			// Plain leaderboard per the design mocks — no map beside it.
+			// The updated design mocks draw the country map beside the
+			// leaderboard again (the earlier mocks dropped it in #50928); the
+			// widget still unmounts the map below its 720px container floor.
 			type: 'jpa/email-breakdown--location-clicks',
-			attributes: { view: 'countries', metric: 'clicks', max: 8 },
+			attributes: { view: 'countries', metric: 'clicks', max: 8, showMap: true },
 			placement: { width: 2, height: 2, order: 5 },
 		},
 		{


### PR DESCRIPTION
## Proposed changes

* **Post detail → Email clicks**: render the country map beside the Locations leaderboard again, per the updated design mocks.

The `email-breakdown` widget has supported this composition since #50545 (`showMap` attribute: GeoChart beside the capped leaderboard, fed by the full row set, unmounted below the 720px container floor so narrow tiles never load Google Charts). #50928 turned it off because the mocks at the time showed a plain leaderboard; the updated mocks bring the map back, so this restores `showMap: true` on the tab-layout entry.

## Related product discussion/links

* Part of the updated-mock alignment pass following WOOA7S-1785 (see WOOA7S-1905 / STATS-428 for the related design-alignment items).
* The map was originally added in #50545 and removed in #50928 against the earlier mocks.

## Does this pull request change what data or activity we track or use?

No. The widget already fetches the full country breakdown; the map only renders more of what is fetched.

## Testing instructions

* Build `packages/premium-analytics` and open the Premium Analytics dashboard.
* Open a post report for a post that was sent as a newsletter → Email clicks tab.
* The Locations card renders the leaderboard on the left and the world map on the right at desktop widths; below ~720px of card width the map is hidden and the leaderboard spans the card.
* The Email opens tab's Locations card is unchanged (plain leaderboard, per the mocks).
* `pnpm run test routes/post-detail widgets/email-breakdown` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

Post detail → Email clicks → Locations.

| Before | After |
| --- | --- |
|<img width="925" height="539" alt="截圖 2026-08-14 凌晨1 18 43" src="https://github.com/user-attachments/assets/4a70f475-daa3-4c16-a74c-ec1c2e04a404" />|<img width="965" height="544" alt="截圖 2026-08-14 凌晨1 14 49" src="https://github.com/user-attachments/assets/0194e2b5-f22f-44e2-8199-a601cbececfc" />|