### PR TITLE
Premium Analytics: give the post detail email tabs an email header identity

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1762-email-tab-header-identity
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1762-email-tab-header-identity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Post detail: give the email tabs an email header identity — envelope tile and the email sent date.

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
@@ -59,3 +59,11 @@
 	background: var(--wpds-color-background-surface-neutral-weak);
 	color: var(--wpds-color-foreground-content-neutral-weak);
 }
+
+// The email tabs' envelope tile is brand-tinted per the design mocks. The
+// weak interactive tokens are the only weak brand pair in the set; the tile
+// is not interactive, but the mapping keeps it on theme tokens.
+.emailTile {
+	background: var(--wpds-color-background-interactive-brand-weak-active);
+	color: var(--wpds-color-foreground-interactive-brand);
+}

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
@@ -60,10 +60,9 @@
 	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
-// The email tabs' envelope tile is brand-tinted per the design mocks. The
-// weak interactive tokens are the only weak brand pair in the set; the tile
-// is not interactive, but the mapping keeps it on theme tokens.
+// The email tabs' envelope tile is brand-tinted per the design mocks:
+// the non-interactive brand surface behind the brand foreground.
 .emailTile {
-	background: var(--wpds-color-background-interactive-brand-weak-active);
+	background: var(--wpds-color-background-surface-brand);
 	color: var(--wpds-color-foreground-interactive-brand);
 }

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { PostSummaryCard } from './post-summary-card';
+import type { PostSummary } from '../../hooks';
+
+const SUMMARY: PostSummary = {
+	title: 'Hello world',
+	type: 'post',
+	publishedDate: '2026-01-10T08:00:00',
+	imageUrl: 'https://example.com/thumb.jpg',
+	url: 'https://example.com/hello-world',
+	isLoading: false,
+};
+
+describe( 'PostSummaryCard', () => {
+	it( 'shows the post identity by default: thumbnail and publish wording', () => {
+		render( <PostSummaryCard summary={ SUMMARY } /> );
+
+		expect( screen.getByText( /Post published on Jan 10, 2026\./ ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'post-summary-image' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'post-summary-email-tile' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the email identity on the email variant: envelope tile and sent wording', () => {
+		render( <PostSummaryCard summary={ SUMMARY } variant="email" /> );
+
+		expect( screen.getByText( /Email sent on Jan 10, 2026\./ ) ).toBeInTheDocument();
+		// The envelope tile replaces the featured image even when one exists.
+		expect( screen.getByTestId( 'post-summary-email-tile' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'post-summary-image' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.tsx
@@ -3,7 +3,7 @@
  */
 import { Icon, Text } from '@jetpack-premium-analytics/externals';
 import { __, sprintf } from '@wordpress/i18n';
-import { page as pageIcon, post as postIcon } from '@wordpress/icons';
+import { envelope as envelopeIcon, page as pageIcon, post as postIcon } from '@wordpress/icons';
 import { format, isValid } from 'date-fns';
 /**
  * Internal dependencies
@@ -13,6 +13,13 @@ import type { PostSummary } from '../../hooks';
 
 type PostSummaryCardProps = {
 	summary: PostSummary;
+	/**
+	 * Which identity the header carries, per the design mocks. The email tabs
+	 * describe the post's newsletter send — an envelope tile instead of the
+	 * featured image, and "Email sent on …" instead of the publish wording —
+	 * while the default post identity shows the thumbnail and publish date.
+	 */
+	variant?: 'post' | 'email';
 	/**
 	 * The committed report date range, rendered as the performance window
 	 * ("Performance from … to …") so the header states what period every
@@ -42,22 +49,41 @@ function getTypeLabel( type?: string ): string {
  *
  * @param props                  - Component props.
  * @param props.summary          - The resolved post summary.
+ * @param props.variant          - The header identity: post (default) or email.
  * @param props.performanceRange - The committed report date range.
  * @return The summary header element.
  */
-export function PostSummaryCard( { summary, performanceRange }: PostSummaryCardProps ) {
+export function PostSummaryCard( {
+	summary,
+	variant = 'post',
+	performanceRange,
+}: PostSummaryCardProps ) {
 	const { title, type, publishedDate, imageUrl } = summary;
 
 	const publishedDateObject = publishedDate ? new Date( publishedDate ) : undefined;
-	const publishedSentence =
+	const formattedDate =
 		publishedDateObject && isValid( publishedDateObject )
-			? sprintf(
-					/* translators: %1$s: "Post" or "Page". %2$s: the publish date, e.g. "Aug 19, 2025". */
-					__( '%1$s published on %2$s.', 'jetpack-premium-analytics-pkg' ),
-					getTypeLabel( type ),
-					format( publishedDateObject, DATE_FORMAT )
-			  )
+			? format( publishedDateObject, DATE_FORMAT )
 			: undefined;
+	// The email wording reuses the publish date: WordPress.com sends the
+	// newsletter when the post publishes, and the email stats API exposes no
+	// separate send timestamp (`stats/emails/summary` returns the post date).
+	let publishedSentence;
+	if ( formattedDate ) {
+		publishedSentence =
+			variant === 'email'
+				? sprintf(
+						/* translators: %s: the date the newsletter was sent, e.g. "Aug 19, 2025". */
+						__( 'Email sent on %s.', 'jetpack-premium-analytics-pkg' ),
+						formattedDate
+				  )
+				: sprintf(
+						/* translators: %1$s: "Post" or "Page". %2$s: the publish date, e.g. "Aug 19, 2025". */
+						__( '%1$s published on %2$s.', 'jetpack-premium-analytics-pkg' ),
+						getTypeLabel( type ),
+						formattedDate
+				  );
+	}
 
 	const { from, to } = performanceRange ?? {};
 	const performanceSentence =
@@ -71,17 +97,37 @@ export function PostSummaryCard( { summary, performanceRange }: PostSummaryCardP
 			: undefined;
 	const subtitle = [ publishedSentence, performanceSentence ].filter( Boolean ).join( ' ' );
 
+	// The email identity always shows the envelope tile — even when the post
+	// has a featured image — so the email tabs read as the newsletter send
+	// rather than the post, per the design mocks. The post identity shows the
+	// thumbnail, or a type-glyph placeholder so the type still reads at a
+	// glance without its own badge row.
+	let media;
+	if ( variant === 'email' ) {
+		media = (
+			<div
+				className={ `${ styles.imagePlaceholder } ${ styles.emailTile }` }
+				aria-hidden="true"
+				data-testid="post-summary-email-tile"
+			>
+				<Icon icon={ envelopeIcon } size={ 28 } />
+			</div>
+		);
+	} else if ( imageUrl ) {
+		media = (
+			<img className={ styles.image } src={ imageUrl } alt="" data-testid="post-summary-image" />
+		);
+	} else {
+		media = (
+			<div className={ styles.imagePlaceholder } aria-hidden="true">
+				<Icon icon={ type === 'page' ? pageIcon : postIcon } size={ 28 } />
+			</div>
+		);
+	}
+
 	return (
 		<div className={ styles.card }>
-			{ imageUrl ? (
-				<img className={ styles.image } src={ imageUrl } alt="" />
-			) : (
-				// The placeholder carries the type glyph, so the type still
-				// reads at a glance without its own badge row.
-				<div className={ styles.imagePlaceholder } aria-hidden="true">
-					<Icon icon={ type === 'page' ? pageIcon : postIcon } size={ 28 } />
-				</div>
-			) }
+			{ media }
 			<div className={ styles.details }>
 				{ /* The heading ellipsizes to one line; `title` keeps the full text
 				     reachable on hover. */ }

--- a/projects/packages/premium-analytics/routes/post-detail/config/index.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/index.ts
@@ -1,5 +1,6 @@
 export {
 	POST_DETAIL_TAB_IDS,
+	EMAIL_TAB_IDS,
 	DEFAULT_TAB_ID,
 	getTabLabel,
 	getPostDetailTabs,

--- a/projects/packages/premium-analytics/routes/post-detail/config/tabs.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tabs.ts
@@ -19,6 +19,13 @@ export const POST_DETAIL_TAB_IDS = [ 'post-traffic', 'email-opens', 'email-click
 export type PostDetailTabId = ( typeof POST_DETAIL_TAB_IDS )[ number ];
 
 /**
+ * The tabs that describe the post's newsletter send rather than the post
+ * itself. The header keys its email identity off this list, so a future tab
+ * defaults to the post identity unless it is added here.
+ */
+export const EMAIL_TAB_IDS: readonly PostDetailTabId[] = [ 'email-opens', 'email-clicks' ];
+
+/**
  * Default tab shown when the URL has no (or an unknown) tab param.
  */
 export const DEFAULT_TAB_ID: PostDetailTabId = 'post-traffic';

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -19,7 +19,7 @@ import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
 import { useDetailBreadcrumbs } from '../use-detail-breadcrumbs';
 import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
 import { PostDetailTabs, PostSummaryCard } from './components';
-import { POST_DETAIL_WIDGET_TYPE_ALIASES } from './config';
+import { EMAIL_TAB_IDS, POST_DETAIL_WIDGET_TYPE_ALIASES } from './config';
 import { usePostDetailTabs, usePostSummary } from './hooks';
 import { route } from './package.json';
 import styles from './stage.module.scss';
@@ -166,7 +166,7 @@ function PostDetail(): JSX.Element {
 									     performance window stay the post's. */ }
 									<PostSummaryCard
 										summary={ summary }
-										variant={ activeTab === 'post-traffic' ? 'post' : 'email' }
+										variant={ EMAIL_TAB_IDS.includes( activeTab ) ? 'email' : 'post' }
 										performanceRange={ dateFilters.appliedRange }
 									/>
 								</div>

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -161,8 +161,12 @@ function PostDetail(): JSX.Element {
 							 */ }
 							<div ref={ setHeaderElement } className={ styles.header }>
 								<div className={ styles.summary }>
+									{ /* The email tabs give the shared header an email identity
+									     (envelope tile, "Email sent on …") while the title and
+									     performance window stay the post's. */ }
 									<PostSummaryCard
 										summary={ summary }
+										variant={ activeTab === 'post-traffic' ? 'post' : 'email' }
 										performanceRange={ dateFilters.appliedRange }
 									/>
 								</div>


### PR DESCRIPTION
## Proposed changes

Per-tab header identity for the post detail page, from WOOA7S-1762 and the updated design mocks:

* On the **Email opens / Email clicks** tabs, the shared header now carries an email identity: a brand-tinted envelope tile instead of the featured-image thumbnail, and **"Email sent on …"** instead of "Post published on …". The title and the performance window stay the post's.
* The **Post traffic** tab is unchanged (featured image or type-glyph placeholder, publish wording).

The sent date reuses the publish date: WordPress.com sends the newsletter when the post publishes, and the email stats API exposes no separate send timestamp (verified against `stats/opens/emails/{id}/rate`, `stats/emails/summary` — whose `date` equals the post date — and the timeline endpoint). If a real send timestamp ever lands server-side, only the value feeding the sentence changes.

Out of scope (still on WOOA7S-1762): the "Performance: All time" subtitle wording, which depends on the All time preset work under WOOA7S-1793.

## Related product discussion/links

* WOOA7S-1762 (per-tab header identity), part of the updated-mock alignment pass following WOOA7S-1785.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build `packages/premium-analytics` and open the Premium Analytics dashboard.
* Open a post report for a post that was sent as a newsletter.
* Post traffic tab: header shows the featured image (or type glyph) and "Post published on <date>."
* Email opens / Email clicks tabs: header shows the tinted envelope tile — even when the post has a featured image — and "Email sent on <date>."
* `pnpm run test routes/post-detail` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

Email opens tab header.

| Before | After |
| --- | --- |
|<img width="1292" height="480" alt="截圖 2026-08-14 凌晨1 19 18" src="https://github.com/user-attachments/assets/7a8cd931-75a7-4ccc-b176-044853344e3c" />|<img width="1287" height="431" alt="截圖 2026-08-14 凌晨1 13 41" src="https://github.com/user-attachments/assets/0c735768-53a1-41f4-8f65-14b927963e50" />|

Email clicks tab header.

| Before | After |
| --- | --- |
|<img width="1291" height="483" alt="截圖 2026-08-14 凌晨1 19 26" src="https://github.com/user-attachments/assets/6954cc71-68b4-4cad-8805-cad68716ed66" />|<img width="1294" height="433" alt="截圖 2026-08-14 凌晨1 13 52" src="https://github.com/user-attachments/assets/40d5a9bf-c0ab-48af-bd61-a96f97700b5d" />|