### PR TITLE
Newsletter: make settings save feedback consistent

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-settings-save-consistency
+++ b/projects/packages/newsletter/changelog/fix-newsletter-settings-save-consistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Make newsletter settings save feedback consistent and allow sender settings to save with Enter.

--- a/projects/packages/newsletter/src/settings/newsletter-settings.tsx
+++ b/projects/packages/newsletter/src/settings/newsletter-settings.tsx
@@ -267,7 +267,7 @@ export function NewsletterSettingsBody( {
 
 	// Handle auto-save for newsletter toggle and email settings.
 	const handleAutoSave = useCallback(
-		( updates: Partial< NewsletterSettings > ) => {
+		( updates: Partial< NewsletterSettings >, successMessage: string ) => {
 			if ( ! data ) {
 				return;
 			}
@@ -306,7 +306,7 @@ export function NewsletterSettingsBody( {
 				.then( () => {
 					// Advance the saved baseline now that these values are persisted.
 					setSavedData( prev => ( { ...prev, ...updates } ) );
-					createSuccessNotice( __( 'Settings saved', 'jetpack-newsletter' ) );
+					createSuccessNotice( successMessage );
 				} )
 				.catch( ( err: Error ) => {
 					// eslint-disable-next-line no-console
@@ -317,6 +317,32 @@ export function NewsletterSettingsBody( {
 				} );
 		},
 		[ createErrorNotice, createSuccessNotice, data, siteType ]
+	);
+
+	const autoSaveNewsletterSettings = useCallback(
+		( updates: Partial< NewsletterSettings > ) =>
+			handleAutoSave( updates, __( 'Newsletter settings saved', 'jetpack-newsletter' ) ),
+		[ handleAutoSave ]
+	);
+	const autoSaveEmailDefaults = useCallback(
+		( updates: Partial< NewsletterSettings > ) =>
+			handleAutoSave( updates, __( 'Email defaults saved', 'jetpack-newsletter' ) ),
+		[ handleAutoSave ]
+	);
+	const autoSaveEmailContent = useCallback(
+		( updates: Partial< NewsletterSettings > ) =>
+			handleAutoSave( updates, __( 'Email content saved', 'jetpack-newsletter' ) ),
+		[ handleAutoSave ]
+	);
+	const autoSaveEmailByline = useCallback(
+		( updates: Partial< NewsletterSettings > ) =>
+			handleAutoSave( updates, __( 'Email byline saved', 'jetpack-newsletter' ) ),
+		[ handleAutoSave ]
+	);
+	const autoSaveReplyToSettings = useCallback(
+		( updates: Partial< NewsletterSettings > ) =>
+			handleAutoSave( updates, __( 'Reply-to settings saved', 'jetpack-newsletter' ) ),
+		[ handleAutoSave ]
 	);
 
 	// Handle sender name changes (staged, not auto-saved).
@@ -339,7 +365,7 @@ export function NewsletterSettingsBody( {
 			.then( () => {
 				setSavedData( prev => ( { ...prev, ...senderNameChanges } ) );
 				setSenderNameChanges( {} );
-				createSuccessNotice( __( 'Sender name saved', 'jetpack-newsletter' ) );
+				createSuccessNotice( __( 'Sender settings saved', 'jetpack-newsletter' ) );
 			} )
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
@@ -375,7 +401,7 @@ export function NewsletterSettingsBody( {
 				// link reflects the just-saved enabled state.
 				setSavedData( prev => ( { ...prev, ...subscriptionChanges } ) );
 				setSubscriptionChanges( {} );
-				createSuccessNotice( __( 'Settings saved', 'jetpack-newsletter' ) );
+				createSuccessNotice( __( 'Subscription settings saved', 'jetpack-newsletter' ) );
 			} )
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
@@ -465,7 +491,7 @@ export function NewsletterSettingsBody( {
 			.then( () => {
 				setSavedData( prev => ( { ...prev, ...welcomeEmailChanges } ) );
 				setWelcomeEmailChanges( {} );
-				createSuccessNotice( __( 'Welcome email message saved', 'jetpack-newsletter' ) );
+				createSuccessNotice( __( 'Welcome email saved', 'jetpack-newsletter' ) );
 			} )
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
@@ -497,7 +523,7 @@ export function NewsletterSettingsBody( {
 			.then( () => {
 				setSavedData( prev => ( { ...prev, ...subscribeModalChanges } ) );
 				setSubscribeModalChanges( {} );
-				createSuccessNotice( __( 'Subscribe modal heading saved', 'jetpack-newsletter' ) );
+				createSuccessNotice( __( 'Subscribe modal saved', 'jetpack-newsletter' ) );
 			} )
 			.catch( ( err: Error ) => {
 				// eslint-disable-next-line no-console
@@ -573,7 +599,7 @@ export function NewsletterSettingsBody( {
 
 								<EmailDefaultsSection
 									data={ data }
-									onChange={ handleAutoSave }
+									onChange={ autoSaveEmailDefaults }
 									isNewsletterEnabled={ data.subscriptions }
 								/>
 
@@ -590,13 +616,13 @@ export function NewsletterSettingsBody( {
 
 								<EmailContentSection
 									data={ data }
-									onChange={ handleAutoSave }
+									onChange={ autoSaveEmailContent }
 									isNewsletterEnabled={ data.subscriptions }
 								/>
 
 								<EmailBylineSection
 									data={ data }
-									onChange={ handleAutoSave }
+									onChange={ autoSaveEmailByline }
 									isNewsletterEnabled={ data.subscriptions }
 								/>
 
@@ -612,7 +638,7 @@ export function NewsletterSettingsBody( {
 
 								<EmailReplyToSettingsSection
 									data={ data }
-									onChange={ handleAutoSave }
+									onChange={ autoSaveReplyToSettings }
 									isNewsletterEnabled={ data.subscriptions }
 								/>
 
@@ -649,7 +675,7 @@ export function NewsletterSettingsBody( {
 						</Disabled>
 					) : (
 						<>
-							<NewsletterSection data={ data } onChange={ handleAutoSave } />
+							<NewsletterSection data={ data } onChange={ autoSaveNewsletterSettings } />
 
 							<Disabled isDisabled={ ! data.subscriptions }>
 								<Stack gap="xl" direction="column">
@@ -679,13 +705,13 @@ export function NewsletterSettingsBody( {
 
 									<EmailContentSection
 										data={ data }
-										onChange={ handleAutoSave }
+										onChange={ autoSaveEmailContent }
 										isNewsletterEnabled={ data.subscriptions }
 									/>
 
 									<EmailBylineSection
 										data={ data }
-										onChange={ handleAutoSave }
+										onChange={ autoSaveEmailByline }
 										isNewsletterEnabled={ data.subscriptions }
 									/>
 
@@ -701,7 +727,7 @@ export function NewsletterSettingsBody( {
 
 									<EmailReplyToSettingsSection
 										data={ data }
-										onChange={ handleAutoSave }
+										onChange={ autoSaveReplyToSettings }
 										isNewsletterEnabled={ data.subscriptions }
 									/>
 

--- a/projects/packages/newsletter/src/settings/newsletter-settings.tsx
+++ b/projects/packages/newsletter/src/settings/newsletter-settings.tsx
@@ -359,12 +359,23 @@ export function NewsletterSettingsBody( {
 			return;
 		}
 
+		const submittedSenderNameChanges = senderNameChanges;
 		setIsSavingSenderName( true );
 
-		updateSettings( senderNameChanges )
+		updateSettings( submittedSenderNameChanges )
 			.then( () => {
-				setSavedData( prev => ( { ...prev, ...senderNameChanges } ) );
-				setSenderNameChanges( {} );
+				setSavedData( prev => ( { ...prev, ...submittedSenderNameChanges } ) );
+				setSenderNameChanges( currentChanges => {
+					const pendingChanges = { ...currentChanges };
+					for ( const key of Object.keys( submittedSenderNameChanges ) as Array<
+						keyof NewsletterSettings
+					> ) {
+						if ( currentChanges[ key ] === submittedSenderNameChanges[ key ] ) {
+							delete pendingChanges[ key ];
+						}
+					}
+					return pendingChanges;
+				} );
 				createSuccessNotice( __( 'Sender settings saved', 'jetpack-newsletter' ) );
 			} )
 			.catch( ( err: Error ) => {

--- a/projects/packages/newsletter/src/settings/sections/email-sender-settings-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-sender-settings-section.tsx
@@ -11,6 +11,7 @@ import { Button, Card, Fieldset, Text } from '@wordpress/ui';
  * Internal dependencies
  */
 import type { NewsletterSettings } from '../types';
+import type { FormEvent } from 'react';
 
 interface EmailSenderSettingsSectionProps {
 	data: NewsletterSettings;
@@ -57,6 +58,16 @@ export function EmailSenderSettingsSection( {
 		onSave();
 	}, [ changedKeys, onSave, siteType ] );
 
+	const handleSubmit = useCallback(
+		( event: FormEvent< HTMLFormElement > ) => {
+			event.preventDefault();
+			if ( isNewsletterEnabled && hasChanges && ! isSaving ) {
+				handleSave();
+			}
+		},
+		[ handleSave, hasChanges, isNewsletterEnabled, isSaving ]
+	);
+
 	const siteName = getSiteData()?.title;
 
 	const fields: Field< NewsletterSettings >[] = [
@@ -81,47 +92,52 @@ export function EmailSenderSettingsSection( {
 				<Card.Title>{ __( 'Sender settings', 'jetpack-newsletter' ) }</Card.Title>
 			</Card.Header>
 			<Card.Content>
-				<Fieldset.Root disabled={ ! isNewsletterEnabled }>
-					<DataForm
-						data={ data }
-						fields={ fields }
-						form={ {
-							layout: {
-								type: 'regular',
-								labelPosition: 'top',
-							},
-							fields: [ 'jetpack_subscriptions_from_name' ],
-						} }
-						onChange={ onChange }
-					/>
-					<p>
-						<Text>
-							{ createInterpolateElement(
-								sprintf(
-									/* translators: %1$s is the sender name that will appear in subscriber inboxes */
-									__(
-										'Preview: <strong>%1$s</strong> <author-name@example.com>',
-										'jetpack-newsletter'
+				<form
+					onSubmit={ handleSubmit }
+					aria-label={ __( 'Sender settings', 'jetpack-newsletter' ) }
+				>
+					<Fieldset.Root disabled={ ! isNewsletterEnabled }>
+						<DataForm
+							data={ data }
+							fields={ fields }
+							form={ {
+								layout: {
+									type: 'regular',
+									labelPosition: 'top',
+								},
+								fields: [ 'jetpack_subscriptions_from_name' ],
+							} }
+							onChange={ onChange }
+						/>
+						<p>
+							<Text>
+								{ createInterpolateElement(
+									sprintf(
+										/* translators: %1$s is the sender name that will appear in subscriber inboxes */
+										__(
+											'Preview: <strong>%1$s</strong> <author-name@example.com>',
+											'jetpack-newsletter'
+										),
+										senderName || siteName || __( 'Your Name', 'jetpack-newsletter' )
 									),
-									senderName || siteName || __( 'Your Name', 'jetpack-newsletter' )
-								),
-								{
-									strong: <strong />,
-								}
-							) }
-						</Text>
-					</p>
-				</Fieldset.Root>
-				<div className="newsletter-card-footer">
-					<Button
-						onClick={ handleSave }
-						disabled={ ! isNewsletterEnabled || isSaving || ! hasChanges }
-						loading={ isSaving }
-						loadingAnnouncement={ savingText }
-					>
-						{ saveText }
-					</Button>
-				</div>
+									{
+										strong: <strong />,
+									}
+								) }
+							</Text>
+						</p>
+					</Fieldset.Root>
+					<div className="newsletter-card-footer">
+						<Button
+							type="submit"
+							disabled={ ! isNewsletterEnabled || isSaving || ! hasChanges }
+							loading={ isSaving }
+							loadingAnnouncement={ savingText }
+						>
+							{ saveText }
+						</Button>
+					</div>
+				</form>
 			</Card.Content>
 		</Card.Root>
 	);

--- a/projects/packages/newsletter/tests/email-sender-settings-section.test.tsx
+++ b/projects/packages/newsletter/tests/email-sender-settings-section.test.tsx
@@ -1,0 +1,81 @@
+jest.mock( '@wordpress/dataviews', () => ( {
+	__esModule: true,
+	DataForm: ( {
+		data,
+		fields,
+		onChange,
+	}: {
+		data: Record< string, string >;
+		fields: Array< { id: string; label: string } >;
+		onChange: ( updates: Record< string, string > ) => void;
+	} ) => {
+		const field = fields[ 0 ];
+		const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) =>
+			onChange( { [ field.id ]: event.target.value } );
+		return (
+			<input
+				aria-label={ field.label }
+				value={ data[ field.id ] ?? '' }
+				// Test-only mock; rebinding is irrelevant to this isolated render.
+				// eslint-disable-next-line react/jsx-no-bind
+				onChange={ handleChange }
+			/>
+		);
+	},
+} ) );
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: { tracks: { recordEvent: jest.fn() } },
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getSiteData: jest.fn( () => ( { title: 'Test site' } ) ),
+	getSiteType: jest.fn( () => 'jetpack' ),
+} ) );
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { EmailSenderSettingsSection } from '../src/settings/sections/email-sender-settings-section';
+import type { NewsletterSettings } from '../src/settings/types';
+
+describe( 'EmailSenderSettingsSection', () => {
+	it( 'saves pending sender settings when its form is submitted', () => {
+		const onSave = jest.fn();
+
+		render(
+			<EmailSenderSettingsSection
+				data={ { jetpack_subscriptions_from_name: 'Test site' } as NewsletterSettings }
+				onChange={ jest.fn() }
+				onSave={ onSave }
+				isSaving={ false }
+				hasChanges
+				changedKeys={ [ 'jetpack_subscriptions_from_name' ] }
+				isNewsletterEnabled
+			/>
+		);
+
+		fireEvent.submit( screen.getByRole( 'form', { name: 'Sender settings' } ) );
+
+		expect( onSave ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not save on submit when there are no pending changes', () => {
+		const onSave = jest.fn();
+
+		render(
+			<EmailSenderSettingsSection
+				data={ { jetpack_subscriptions_from_name: 'Test site' } as NewsletterSettings }
+				onChange={ jest.fn() }
+				onSave={ onSave }
+				isSaving={ false }
+				hasChanges={ false }
+				changedKeys={ [] }
+				isNewsletterEnabled
+			/>
+		);
+
+		fireEvent.submit( screen.getByRole( 'form', { name: 'Sender settings' } ) );
+
+		expect( onSave ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/newsletter/tests/email-sender-settings-section.test.tsx
+++ b/projects/packages/newsletter/tests/email-sender-settings-section.test.tsx
@@ -12,6 +12,11 @@ jest.mock( '@wordpress/dataviews', () => ( {
 		const field = fields[ 0 ];
 		const handleChange = ( event: React.ChangeEvent< HTMLInputElement > ) =>
 			onChange( { [ field.id ]: event.target.value } );
+		const handleKeyDown = ( event: React.KeyboardEvent< HTMLInputElement > ) => {
+			if ( event.key === 'Enter' ) {
+				event.currentTarget.form?.requestSubmit();
+			}
+		};
 		return (
 			<input
 				aria-label={ field.label }
@@ -19,6 +24,8 @@ jest.mock( '@wordpress/dataviews', () => ( {
 				// Test-only mock; rebinding is irrelevant to this isolated render.
 				// eslint-disable-next-line react/jsx-no-bind
 				onChange={ handleChange }
+				// eslint-disable-next-line react/jsx-no-bind
+				onKeyDown={ handleKeyDown }
 			/>
 		);
 	},
@@ -34,48 +41,103 @@ jest.mock( '@automattic/jetpack-script-data', () => ( {
 	getSiteType: jest.fn( () => 'jetpack' ),
 } ) );
 
+import analytics from '@automattic/jetpack-analytics';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { EmailSenderSettingsSection } from '../src/settings/sections/email-sender-settings-section';
 import type { NewsletterSettings } from '../src/settings/types';
 
+/**
+ * Render Sender settings with saveable defaults and optional state overrides.
+ *
+ * @param props - Component prop overrides.
+ * @return Render spies for change and save behavior.
+ */
+function renderSection(
+	props: Partial< React.ComponentProps< typeof EmailSenderSettingsSection > > = {}
+) {
+	const onChange = jest.fn();
+	const onSave = jest.fn();
+	render(
+		<EmailSenderSettingsSection
+			data={ { jetpack_subscriptions_from_name: 'Test site' } as NewsletterSettings }
+			onChange={ onChange }
+			onSave={ onSave }
+			isSaving={ false }
+			hasChanges
+			changedKeys={ [ 'jetpack_subscriptions_from_name' ] }
+			isNewsletterEnabled
+			{ ...props }
+		/>
+	);
+	return { onChange, onSave };
+}
+
 describe( 'EmailSenderSettingsSection', () => {
-	it( 'saves pending sender settings when its form is submitted', () => {
-		const onSave = jest.fn();
-
-		render(
-			<EmailSenderSettingsSection
-				data={ { jetpack_subscriptions_from_name: 'Test site' } as NewsletterSettings }
-				onChange={ jest.fn() }
-				onSave={ onSave }
-				isSaving={ false }
-				hasChanges
-				changedKeys={ [ 'jetpack_subscriptions_from_name' ] }
-				isNewsletterEnabled
-			/>
-		);
-
-		fireEvent.submit( screen.getByRole( 'form', { name: 'Sender settings' } ) );
-
-		expect( onSave ).toHaveBeenCalledTimes( 1 );
+	beforeEach( () => {
+		jest.clearAllMocks();
 	} );
 
-	it( 'does not save on submit when there are no pending changes', () => {
-		const onSave = jest.fn();
+	it( 'saves a changed sender name when Enter is pressed in the input', () => {
+		const { onChange, onSave } = renderSection();
+		const input = screen.getByRole( 'textbox', { name: 'Sender name' } );
 
-		render(
-			<EmailSenderSettingsSection
-				data={ { jetpack_subscriptions_from_name: 'Test site' } as NewsletterSettings }
-				onChange={ jest.fn() }
-				onSave={ onSave }
-				isSaving={ false }
-				hasChanges={ false }
-				changedKeys={ [] }
-				isNewsletterEnabled
-			/>
+		// user-event is not a dependency of this package.
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.change( input, { target: { value: 'Updated sender' } } );
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.keyDown( input, { key: 'Enter', code: 'Enter' } );
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			jetpack_subscriptions_from_name: 'Updated sender',
+		} );
+		expect( onSave ).toHaveBeenCalledTimes( 1 );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'jetpack_newsletter_section_save',
+			{
+				site_type: 'jetpack',
+				section: 'sender_settings',
+				changed_keys: 'jetpack_subscriptions_from_name',
+				change_count: 1,
+			}
 		);
+	} );
 
-		fireEvent.submit( screen.getByRole( 'form', { name: 'Sender settings' } ) );
+	it( 'uses the same save behavior when the Save button is clicked', () => {
+		const { onSave } = renderSection();
+
+		// user-event is not a dependency of this package.
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		expect( onSave ).toHaveBeenCalledTimes( 1 );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'jetpack_newsletter_section_save',
+			{
+				site_type: 'jetpack',
+				section: 'sender_settings',
+				changed_keys: 'jetpack_subscriptions_from_name',
+				change_count: 1,
+			}
+		);
+	} );
+
+	it.each( [
+		[ 'there are no pending changes', { hasChanges: false } ],
+		[ 'a save is already in progress', { isSaving: true } ],
+		[ 'the newsletter is disabled', { isNewsletterEnabled: false } ],
+	] )( 'does not save when %s', ( _condition, props ) => {
+		const { onSave } = renderSection( props );
+		const input = screen.getByRole( 'textbox', { name: 'Sender name' } );
+		const saveButton = screen.getByRole( 'button' );
+
+		expect( saveButton ).toHaveAttribute( 'aria-disabled', 'true' );
+		// user-event is not a dependency of this package.
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.keyDown( input, { key: 'Enter', code: 'Enter' } );
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.click( saveButton );
 
 		expect( onSave ).not.toHaveBeenCalled();
+		expect( analytics.tracks.recordEvent ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/newsletter/tests/settings.test.jsx
+++ b/projects/packages/newsletter/tests/settings.test.jsx
@@ -59,33 +59,72 @@ jest.mock( '@automattic/jetpack-components', () => ( {
 // `saveSubscribeModal`, and `hasSubscribeModalChanges` without going through
 // the real card UI.
 const subscribeModalProps = { current: null };
+const emailBylineProps = { current: null };
 const emailContentProps = { current: null };
+const emailDefaultsProps = { current: null };
+const emailReplyToProps = { current: null };
+const senderSettingsProps = { current: null };
+const newsletterCategoriesProps = { current: null };
+const newsletterProps = { current: null };
+const subscriptionsProps = { current: null };
+const welcomeEmailProps = { current: null };
 
 jest.mock( '../src/settings/sections', () => ( {
-	EmailBylineSection: () => <div data-testid="email-byline-section" />,
+	EmailBylineSection: props => {
+		emailBylineProps.current = props;
+		return <div data-testid="email-byline-section" />;
+	},
 	EmailContentSection: props => {
 		emailContentProps.current = props;
 		return <div data-testid="email-content-section" />;
 	},
-	EmailDefaultsSection: () => <div data-testid="email-defaults-section" />,
-	EmailReplyToSettingsSection: () => <div data-testid="email-reply-to-settings-section" />,
-	EmailSenderSettingsSection: () => <div data-testid="email-sender-settings-section" />,
-	LegacySubscriptionsSection: () => <div data-testid="legacy-subscriptions-section" />,
-	NewsletterCategoriesSection: () => <div data-testid="newsletter-categories-section" />,
-	NewsletterSection: () => <div data-testid="newsletter-section" />,
+	EmailDefaultsSection: props => {
+		emailDefaultsProps.current = props;
+		return <div data-testid="email-defaults-section" />;
+	},
+	EmailReplyToSettingsSection: props => {
+		emailReplyToProps.current = props;
+		return <div data-testid="email-reply-to-settings-section" />;
+	},
+	EmailSenderSettingsSection: props => {
+		senderSettingsProps.current = props;
+		return <div data-testid="email-sender-settings-section" />;
+	},
+	LegacySubscriptionsSection: props => {
+		subscriptionsProps.current = props;
+		return <div data-testid="legacy-subscriptions-section" />;
+	},
+	NewsletterCategoriesSection: props => {
+		newsletterCategoriesProps.current = props;
+		return <div data-testid="newsletter-categories-section" />;
+	},
+	NewsletterSection: props => {
+		newsletterProps.current = props;
+		return <div data-testid="newsletter-section" />;
+	},
 	PaidNewsletterSection: () => <div data-testid="paid-newsletter-section" />,
 	SubscribeModalSection: props => {
 		subscribeModalProps.current = props;
 		return <div data-testid="subscribe-modal-section" />;
 	},
-	SubscriptionsSection: () => <div data-testid="subscriptions-section" />,
-	WelcomeEmailSection: () => <div data-testid="welcome-email-section" />,
+	SubscriptionsSection: props => {
+		subscriptionsProps.current = props;
+		return <div data-testid="subscriptions-section" />;
+	},
+	WelcomeEmailSection: props => {
+		welcomeEmailProps.current = props;
+		return <div data-testid="welcome-email-section" />;
+	},
 } ) );
 
 import { useConnection } from '@automattic/jetpack-connection';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { NewsletterSettingsApp } from '../src/settings';
 import { fetchSettings, updateSettings } from '../src/settings/api';
+import {
+	NewsletterSettingsBody,
+	__resetNewsletterSettingsCacheForTests,
+} from '../src/settings/newsletter-settings';
 
 const defaultSettings = {
 	subscriptions: true,
@@ -113,6 +152,17 @@ const defaultSettings = {
 describe( 'NewsletterSettingsApp', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		__resetNewsletterSettingsCacheForTests();
+		subscribeModalProps.current = null;
+		emailBylineProps.current = null;
+		emailContentProps.current = null;
+		emailDefaultsProps.current = null;
+		emailReplyToProps.current = null;
+		senderSettingsProps.current = null;
+		newsletterCategoriesProps.current = null;
+		newsletterProps.current = null;
+		subscriptionsProps.current = null;
+		welcomeEmailProps.current = null;
 		fetchSettings.mockResolvedValue( defaultSettings );
 	} );
 
@@ -286,47 +336,180 @@ describe( 'NewsletterSettingsApp', () => {
 				isRegistered: true,
 				isUserConnected: true,
 			} );
-			subscribeModalProps.current = null;
 		} );
 
-		it( 'uses a section-specific message after saving subscribe modal settings', async () => {
-			updateSettings.mockResolvedValue( {} );
-			render( <NewsletterSettingsApp /> );
+		it.each( [
+			[
+				'newsletter settings',
+				newsletterProps,
+				{ subscriptions: false },
+				'Newsletter settings saved',
+				false,
+			],
+			[
+				'email defaults',
+				emailDefaultsProps,
+				{ wpcom_newsletter_send_default: true },
+				'Email defaults saved',
+				true,
+			],
+			[
+				'email content',
+				emailContentProps,
+				{ wpcom_featured_image_in_email: true },
+				'Email content saved',
+				false,
+			],
+			[
+				'email byline',
+				emailBylineProps,
+				{ jetpack_author_in_email: true },
+				'Email byline saved',
+				false,
+			],
+			[
+				'reply-to settings',
+				emailReplyToProps,
+				{ jetpack_subscriptions_reply_to: 'author' },
+				'Reply-to settings saved',
+				false,
+			],
+		] )(
+			'names %s after auto-save',
+			async ( _section, propsRef, updates, successMessage, isModernized ) => {
+				updateSettings.mockResolvedValue( {} );
+				if ( isModernized ) {
+					render( <NewsletterSettingsBody isModernized /> );
+				} else {
+					render( <NewsletterSettingsApp /> );
+				}
 
-			await waitFor( () => expect( subscribeModalProps.current ).not.toBeNull() );
+				await waitFor( () => expect( propsRef.current ).not.toBeNull() );
+				act( () => propsRef.current.onChange( updates ) );
 
-			act( () => {
-				subscribeModalProps.current.onChange( {
+				await waitFor( () => {
+					expect( mockCreateNotice ).toHaveBeenCalledWith( 'success', successMessage, {
+						type: 'snackbar',
+					} );
+				} );
+			}
+		);
+
+		it.each( [
+			[
+				'sender settings',
+				senderSettingsProps,
+				{ jetpack_subscriptions_from_name: 'New sender' },
+				'Sender settings saved',
+			],
+			[
+				'subscription settings',
+				subscriptionsProps,
+				{ stb_enabled: true },
+				'Subscription settings saved',
+			],
+			[
+				'newsletter categories',
+				newsletterCategoriesProps,
+				{ wpcom_newsletter_categories_enabled: true },
+				'Newsletter categories saved',
+			],
+			[
+				'welcome email',
+				welcomeEmailProps,
+				{
+					subscription_options: {
+						invitation: '',
+						welcome: 'Welcome aboard',
+						comment_follow: '',
+						subscribe_modal_heading: '',
+					},
+				},
+				'Welcome email saved',
+			],
+			[
+				'subscribe modal',
+				subscribeModalProps,
+				{
 					subscription_options: {
 						invitation: '',
 						welcome: '',
 						comment_follow: '',
 						subscribe_modal_heading: 'New heading',
 					},
-				} );
-			} );
-
-			await act( async () => subscribeModalProps.current.onSave() );
-
-			expect( mockCreateNotice ).toHaveBeenCalledWith( 'success', 'Subscribe modal saved', {
-				type: 'snackbar',
-			} );
-		} );
-
-		it( 'names the section after auto-saving email content settings', async () => {
+				},
+				'Subscribe modal saved',
+			],
+		] )( 'names %s after manual save', async ( _section, propsRef, updates, successMessage ) => {
 			updateSettings.mockResolvedValue( {} );
 			render( <NewsletterSettingsApp /> );
 
-			await waitFor( () => expect( emailContentProps.current ).not.toBeNull() );
-
-			await act( async () => {
-				emailContentProps.current.onChange( { wpcom_featured_image_in_email: true } );
-			} );
+			await waitFor( () => expect( propsRef.current ).not.toBeNull() );
+			act( () => propsRef.current.onChange( updates ) );
+			await waitFor( () => expect( propsRef.current.hasChanges ).toBe( true ) );
+			act( () => propsRef.current.onSave() );
 
 			await waitFor( () => {
-				expect( mockCreateNotice ).toHaveBeenCalledWith( 'success', 'Email content saved', {
+				expect( mockCreateNotice ).toHaveBeenCalledWith( 'success', successMessage, {
 					type: 'snackbar',
 				} );
+			} );
+		} );
+	} );
+
+	describe( 'EmailSenderSettingsSection wiring', () => {
+		beforeEach( () => {
+			useConnection.mockReturnValue( {
+				hasConnectedOwner: true,
+				isRegistered: true,
+				isUserConnected: true,
+			} );
+		} );
+
+		it( 'preserves edits made while an earlier sender settings save is pending', async () => {
+			let resolveFirstSave;
+			const firstSave = new Promise( resolve => {
+				resolveFirstSave = resolve;
+			} );
+			updateSettings.mockReturnValueOnce( firstSave ).mockResolvedValueOnce( {} );
+			render( <NewsletterSettingsApp /> );
+
+			await waitFor( () => expect( senderSettingsProps.current ).not.toBeNull() );
+
+			act( () => {
+				senderSettingsProps.current.onChange( {
+					jetpack_subscriptions_from_name: 'First sender',
+				} );
+			} );
+			await waitFor( () => expect( senderSettingsProps.current.hasChanges ).toBe( true ) );
+
+			act( () => senderSettingsProps.current.onSave() );
+			await waitFor( () => expect( senderSettingsProps.current.isSaving ).toBe( true ) );
+
+			act( () => {
+				senderSettingsProps.current.onChange( {
+					jetpack_subscriptions_from_name: 'Second sender',
+				} );
+			} );
+
+			await act( async () => {
+				resolveFirstSave( {} );
+				await firstSave;
+			} );
+
+			expect( senderSettingsProps.current.hasChanges ).toBe( true );
+			expect( senderSettingsProps.current.data.jetpack_subscriptions_from_name ).toBe(
+				'Second sender'
+			);
+
+			act( () => senderSettingsProps.current.onSave() );
+			await waitFor( () => expect( updateSettings ).toHaveBeenCalledTimes( 2 ) );
+
+			expect( updateSettings ).toHaveBeenNthCalledWith( 1, {
+				jetpack_subscriptions_from_name: 'First sender',
+			} );
+			expect( updateSettings ).toHaveBeenNthCalledWith( 2, {
+				jetpack_subscriptions_from_name: 'Second sender',
 			} );
 		} );
 	} );

--- a/projects/packages/newsletter/tests/settings.test.jsx
+++ b/projects/packages/newsletter/tests/settings.test.jsx
@@ -28,6 +28,21 @@ jest.mock( '@automattic/jetpack-analytics', () => ( {
 	},
 } ) );
 
+const mockCreateNotice = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { createNotice: mockCreateNotice } ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Disabled: ( { children } ) => <div>{ children }</div>,
+	Spinner: () => <div role="status" />,
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: {},
+} ) );
+
 jest.mock( '@automattic/jetpack-components', () => ( {
 	AdminPage: ( { children } ) => <div data-testid="admin-page">{ children }</div>,
 	Col: ( { children } ) => <div>{ children }</div>,
@@ -44,10 +59,14 @@ jest.mock( '@automattic/jetpack-components', () => ( {
 // `saveSubscribeModal`, and `hasSubscribeModalChanges` without going through
 // the real card UI.
 const subscribeModalProps = { current: null };
+const emailContentProps = { current: null };
 
 jest.mock( '../src/settings/sections', () => ( {
 	EmailBylineSection: () => <div data-testid="email-byline-section" />,
-	EmailContentSection: () => <div data-testid="email-content-section" />,
+	EmailContentSection: props => {
+		emailContentProps.current = props;
+		return <div data-testid="email-content-section" />;
+	},
 	EmailDefaultsSection: () => <div data-testid="email-defaults-section" />,
 	EmailReplyToSettingsSection: () => <div data-testid="email-reply-to-settings-section" />,
 	EmailSenderSettingsSection: () => <div data-testid="email-sender-settings-section" />,
@@ -257,6 +276,58 @@ describe( 'NewsletterSettingsApp', () => {
 				expect( subscribeModalProps.current.hasChanges ).toBe( false );
 			} );
 			expect( subscribeModalProps.current.isSaving ).toBe( false );
+		} );
+	} );
+
+	describe( 'save notices', () => {
+		beforeEach( () => {
+			useConnection.mockReturnValue( {
+				hasConnectedOwner: true,
+				isRegistered: true,
+				isUserConnected: true,
+			} );
+			subscribeModalProps.current = null;
+		} );
+
+		it( 'uses a section-specific message after saving subscribe modal settings', async () => {
+			updateSettings.mockResolvedValue( {} );
+			render( <NewsletterSettingsApp /> );
+
+			await waitFor( () => expect( subscribeModalProps.current ).not.toBeNull() );
+
+			act( () => {
+				subscribeModalProps.current.onChange( {
+					subscription_options: {
+						invitation: '',
+						welcome: '',
+						comment_follow: '',
+						subscribe_modal_heading: 'New heading',
+					},
+				} );
+			} );
+
+			await act( async () => subscribeModalProps.current.onSave() );
+
+			expect( mockCreateNotice ).toHaveBeenCalledWith( 'success', 'Subscribe modal saved', {
+				type: 'snackbar',
+			} );
+		} );
+
+		it( 'names the section after auto-saving email content settings', async () => {
+			updateSettings.mockResolvedValue( {} );
+			render( <NewsletterSettingsApp /> );
+
+			await waitFor( () => expect( emailContentProps.current ).not.toBeNull() );
+
+			await act( async () => {
+				emailContentProps.current.onChange( { wpcom_featured_image_in_email: true } );
+			} );
+
+			await waitFor( () => {
+				expect( mockCreateNotice ).toHaveBeenCalledWith( 'success', 'Email content saved', {
+					type: 'snackbar',
+				} );
+			} );
 		} );
 	} );
 } );

--- a/projects/packages/newsletter/tests/subscribe-modal-section.test.tsx
+++ b/projects/packages/newsletter/tests/subscribe-modal-section.test.tsx
@@ -275,6 +275,24 @@ describe( 'SubscribeModalSection', () => {
 		} );
 	} );
 
+	it( 'keeps Enter as a newline in the textarea instead of saving the section', () => {
+		const { onChange, onSave } = renderSection( { hasChanges: true } );
+		const textarea = screen.getByLabelText( 'Subscribe modal heading' ) as HTMLTextAreaElement;
+
+		textarea.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true } ) );
+		setTextareaValue( textarea, 'Existing\nSecond line' );
+
+		expect( onChange ).toHaveBeenLastCalledWith( {
+			subscription_options: {
+				invitation: 'I',
+				welcome: 'W',
+				comment_follow: 'CF',
+				subscribe_modal_heading: 'Existing\nSecond line',
+			},
+		} );
+		expect( onSave ).not.toHaveBeenCalled();
+	} );
+
 	it( 'fires analytics event with subscribe_modal section + changedKeys, then calls onSave', () => {
 		const { onSave } = renderSection( {
 			hasChanges: true,


### PR DESCRIPTION
Related to NL-781
Closes NL-835

## Proposed changes
* Name the relevant settings section in every successful autosave and manual-save notification.
* Make Sender settings a semantic form so pressing Enter saves a pending sender name, while preserving disabled and in-flight guards.
* Preserve newer Sender edits made while an earlier save is still in flight.
* Add regression coverage for Sender keyboard/click submission, guards, analytics, concurrent edits, and section-specific save notifications.

## Related product discussion/links
* Linear: https://linear.app/a8c/issue/NL-781/newsletter-settings-save-inconsistently-auto-save-vs-save-button-enter

## Does this pull request change what data or activity we track or use?
No. Existing Tracks events and payloads are unchanged.

## Testing instructions
* On a test site with this branch active, go to **Jetpack > Newsletter > Settings**.
* Toggle an autosaved setting in Email content and confirm the snackbar says **Email content saved**.
* Toggle settings in other autosaved sections and confirm each snackbar names its section, such as **Email byline saved** or **Reply-to settings saved**.
* Change **Sender name**, press Enter, and confirm the value saves and the snackbar says **Sender settings saved**.
* Change **Sender name** again and click **Save**; confirm the same save behavior and message.
* While a Sender save is pending, type another value; confirm the newer value remains pending and can be saved after the first request finishes.
* Change and save settings in Subscriptions, Newsletter categories, Welcome email, and Subscribe modal; confirm each success message names its section.
* Confirm Enter still inserts a new line in Welcome email and Subscribe modal textareas rather than submitting them.
* Automated checks run locally: `pnpm test --runInBand` (23 suites, 181 tests), `pnpm typecheck`, and focused ESLint.
* Not tested: error-notification copy.



