### PR TITLE
Newsletter: rename the Access panel to Audience and explain post access

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-audience-panel-copy
+++ b/projects/plugins/jetpack/changelog/update-newsletter-audience-panel-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Newsletter: Rename the Access panel to Audience, describe who can read each post, and link out to set up paid subscribers.

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.jsx
@@ -150,7 +150,6 @@ function PaywallEdit() {
 					initialOpen={ true }
 				>
 					<NewsletterAccessRadioButtons
-						isEditorPanel={ true }
 						accessLevel={ _accessLevel }
 						stripeConnectUrl={ stripeConnectUrl }
 						hasTierPlans={ hasTierPlans }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.jsx
@@ -99,7 +99,7 @@ function NewsletterEditorSettingsPanel( { accessLevel } ) {
 	return (
 		<PluginDocumentSettingPanel
 			className="jetpack-subscribe-newsletter-panel"
-			title={ __( 'Access', 'jetpack' ) }
+			title={ __( 'Audience', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 			name="jetpack-subscribe-newsletters-editor-panel"
 		>
@@ -137,7 +137,7 @@ const NewsletterDisabledPanels = () => (
 	<>
 		<PluginDocumentSettingPanel
 			className="jetpack-subscribe-newsletters-panel"
-			title={ __( 'Access', 'jetpack' ) }
+			title={ __( 'Audience', 'jetpack' ) }
 			icon={ <JetpackEditorPanelLogo /> }
 		>
 			<NewsletterDisabledNotice />
@@ -171,7 +171,7 @@ function NewsletterPrePublishSettingsPanel( { accessLevel, showPreviewModal } ) 
 				className="jetpack-subscribe-newsletters-panel"
 				title={
 					<>
-						{ __( 'Access:', 'jetpack' ) }
+						{ __( 'Audience:', 'jetpack' ) }
 						{ accessLevel && (
 							<span className={ 'jetpack-subscribe-post-publish-panel__heading' }>
 								{ accessOptions[ accessLevel ].panelHeading }

--- a/projects/plugins/jetpack/extensions/shared/memberships/constants.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/constants.js
@@ -12,7 +12,7 @@ export const accessOptions = {
 	subscribers: {
 		key: 'subscribers',
 		label: __( 'Subscribers', 'jetpack' ),
-		panelHeading: __( 'All subscribers', 'jetpack' ),
+		panelHeading: __( 'Subscribers', 'jetpack' ),
 	},
 	paid_subscribers: {
 		key: 'paid_subscribers',

--- a/projects/plugins/jetpack/extensions/shared/memberships/constants.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/constants.js
@@ -11,12 +11,12 @@ export const accessOptions = {
 	},
 	subscribers: {
 		key: 'subscribers',
-		label: __( 'Anyone subscribed', 'jetpack' ),
+		label: __( 'Subscribers', 'jetpack' ),
 		panelHeading: __( 'All subscribers', 'jetpack' ),
 	},
 	paid_subscribers: {
 		key: 'paid_subscribers',
-		label: __( 'Paid subscribers only', 'jetpack' ),
+		label: __( 'Paid subscribers', 'jetpack' ),
 		panelHeading: __( 'Paid subscribers', 'jetpack' ),
 	},
 };

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
@@ -88,7 +88,7 @@ export function getAccessDescription( accessLevel, postHasPaywallBlock = false )
 		case accessOptions.paid_subscribers.key:
 			return postHasPaywallBlock
 				? __(
-						'Only paid subscribers can read the content below the paywall. Subscribers receive it by email.',
+						'Only paid subscribers can read the content below the paywall. All subscribers receive it by email.',
 						'jetpack',
 						0
 				  )

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
@@ -187,6 +187,11 @@ export function NewsletterAccessRadioButtons( {
 	const showPaidAsDisabled = ! isPaidAvailable && ! isPaidSelected;
 
 	const setAccess = useSetAccess();
+	// The count beside each option is the size of the audience that can read it, which
+	// is what distinguishes the options from one another. postHasPaywallBlock is
+	// deliberately not forwarded here: it would switch the paid count to the email
+	// reach, making both options report the same total on a post with a paywall block.
+	// Who receives the email is stated in getAccessDescription instead.
 	const subscribersReach = getReachForAccessLevelKey( {
 		accessLevel: accessOptions.subscribers.key,
 		subscribers: totalSubscribers,
@@ -205,6 +210,7 @@ export function NewsletterAccessRadioButtons( {
 		NewsletterAccessRadioButtons,
 		'jetpack-newsletter-access-paid-subscribers-disabled'
 	);
+	const setupLinkId = `${ disabledPaidOptionId }-setup-link`;
 
 	return (
 		<div className="jetpack-newsletter-access-radio-buttons">
@@ -240,19 +246,32 @@ export function NewsletterAccessRadioButtons( {
 			{ showPaidAsDisabled && (
 				<>
 					<div className="components-radio-control__option jetpack-newsletter-access-radio-buttons__disabled-option">
+						{ /*
+						 * aria-disabled rather than disabled: a disabled input leaves the tab
+						 * order and is skipped by screen readers, which would hide the paid
+						 * option from exactly the people the setup link is there to inform.
+						 * It stays focusable and announced, but cannot be selected.
+						 */ }
 						<input
 							type="radio"
 							className="components-radio-control__input"
-							disabled
+							aria-disabled="true"
+							aria-describedby={ setupLinkId }
 							checked={ false }
 							readOnly
+							onClick={ event => event.preventDefault() }
+							onKeyDown={ event => {
+								if ( event.key === ' ' ) {
+									event.preventDefault();
+								}
+							} }
 							id={ disabledPaidOptionId }
 						/>
 						<label className="components-radio-control__label" htmlFor={ disabledPaidOptionId }>
 							{ paidOptionLabel }
 						</label>
 					</div>
-					<ExternalLink openInNewTab href={ getPaidPlanLink( hasTierPlans ) }>
+					<ExternalLink id={ setupLinkId } openInNewTab href={ getPaidPlanLink( hasTierPlans ) }>
 						{ __( 'Turn on paid subscribers', 'jetpack' ) }
 					</ExternalLink>
 				</>

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
@@ -6,28 +6,25 @@ import {
 	FlexBlock,
 	RadioControl,
 	Spinner,
-	VisuallyHidden,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
+import { useInstanceId, useViewportMatch } from '@wordpress/compose';
 import { useEntityId, useEntityProp, store as coreDataStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PostVisibilityCheck, store as editorStore } from '@wordpress/editor';
-import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon } from '@wordpress/icons';
+import { Icon, external } from '@wordpress/icons';
 import paywallBlockMetadata from '../../blocks/paywall/block.json';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import './settings.scss';
-import PlansSetupDialog from '../components/plans-setup-dialog';
 import {
 	accessOptions,
 	META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS,
 	META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS,
 	META_NAME_FOR_POST_TIER_ID_SETTINGS,
 } from './constants';
-import { getShowMisconfigurationWarning, MisconfigurationWarning } from './utils';
+import { getPaidPlanLink, getShowMisconfigurationWarning, MisconfigurationWarning } from './utils';
 
 const paywallIcon = getBlockIconComponent( paywallBlockMetadata );
 
@@ -57,6 +54,44 @@ export function getReachForAccessLevelKey( {
 			return postHasPaywallBlock ? subscribers : paidSubscribers;
 		default:
 			return 0;
+	}
+}
+
+/**
+ * Describe, in plain language, who can read the post and who receives it by email.
+ *
+ * Email reach is not always the same as read access: when the post contains a paywall
+ * block, every subscriber is emailed the portion above the paywall, so a paid post
+ * still goes out to the full list. See getAccessLabelForCopy in subscribers-affirmation.
+ *
+ * @param {string}  accessLevel         - Access level key, e.g. 'paid_subscribers'.
+ * @param {boolean} postHasPaywallBlock - Whether the post contains a paywall block.
+ * @return {string} Description of the current access level.
+ */
+export function getAccessDescription( accessLevel, postHasPaywallBlock = false ) {
+	switch ( accessLevel ) {
+		case accessOptions.subscribers.key:
+			return postHasPaywallBlock
+				? __(
+						'Only subscribers can read the content below the paywall. Subscribers receive it by email.',
+						'jetpack'
+				  )
+				: __(
+						'Only subscribers can read this post. Others see a preview and can subscribe. Subscribers receive it by email.',
+						'jetpack'
+				  );
+		case accessOptions.paid_subscribers.key:
+			return postHasPaywallBlock
+				? __(
+						'Only paid subscribers can read the content below the paywall. Subscribers receive it by email.',
+						'jetpack'
+				  )
+				: __(
+						'Only paid subscribers can read this post. Others see a preview and can subscribe. Only paid subscribers receive it by email.',
+						'jetpack'
+				  );
+		default:
+			return __( 'Anyone can read this post. Subscribers receive it by email.', 'jetpack' );
 	}
 }
 
@@ -129,15 +164,21 @@ export function NewsletterAccessRadioButtons( {
 	accessLevel,
 	hasTierPlans,
 	stripeConnectUrl,
-	isEditorPanel = false,
 	postHasPaywallBlock: postHasPaywallBlock = false,
 } ) {
 	const isStripeConnected = stripeConnectUrl === null;
 	const { totalSubscribers, paidSubscribers } = useSelect( select =>
 		select( membershipProductsStore ).getSubscriberCounts()
 	);
-	const [ showDialog, setShowDialog ] = useState( false );
-	const closeDialog = () => setShowDialog( false );
+
+	// Paid subscribers can only be chosen once Stripe is connected and a tier exists.
+	// Rather than hiding the option, we show it disabled alongside a link to set it up,
+	// so creators discover that paid newsletters are available to them.
+	const isPaidAvailable = isStripeConnected && hasTierPlans;
+	const isPaidSelected = accessLevel === accessOptions.paid_subscribers.key;
+	// Keep the option selectable when it is already the saved value, so a post set to
+	// paid before Stripe was disconnected does not end up with nothing selected.
+	const showPaidAsDisabled = ! isPaidAvailable && ! isPaidSelected;
 
 	const setAccess = useSetAccess();
 	const subscribersReach = getReachForAccessLevelKey( {
@@ -151,20 +192,19 @@ export function NewsletterAccessRadioButtons( {
 		paidSubscribers,
 	} );
 
+	const paidOptionLabel = `${ accessOptions.paid_subscribers.label } (${ formatNumberCompact(
+		paidSubscribersReach
+	) })`;
+	const disabledPaidOptionId = useInstanceId(
+		NewsletterAccessRadioButtons,
+		'jetpack-newsletter-access-paid-subscribers-disabled'
+	);
+
 	return (
-		<fieldset className="jetpack-newsletter-access-radio-buttons">
-			<VisuallyHidden as="legend">{ __( 'Access', 'jetpack' ) } </VisuallyHidden>
+		<div className="jetpack-newsletter-access-radio-buttons">
 			<RadioControl
-				onChange={ value => {
-					if (
-						accessOptions.paid_subscribers.key === value &&
-						( stripeConnectUrl || ! hasTierPlans )
-					) {
-						setShowDialog( true );
-						return;
-					}
-					setAccess( value );
-				} }
+				label={ __( 'Who can read this post?', 'jetpack' ) }
+				onChange={ setAccess }
 				options={ [
 					...( ! postHasPaywallBlock
 						? [
@@ -180,23 +220,43 @@ export function NewsletterAccessRadioButtons( {
 						) })`,
 						value: accessOptions.subscribers.key,
 					},
-					{
-						label: `${ accessOptions.paid_subscribers.label } (${ formatNumberCompact(
-							paidSubscribersReach
-						) })`,
-						value: accessOptions.paid_subscribers.key,
-					},
+					...( ! showPaidAsDisabled
+						? [
+								{
+									label: paidOptionLabel,
+									value: accessOptions.paid_subscribers.key,
+								},
+						  ]
+						: [] ),
 				] }
 				selected={ accessLevel }
 			/>
-			{ accessLevel === accessOptions.paid_subscribers.key && isStripeConnected && hasTierPlans && (
-				<TierSelector></TierSelector>
+			{ showPaidAsDisabled && (
+				<>
+					<div className="components-radio-control__option jetpack-newsletter-access-radio-buttons__disabled-option">
+						<input
+							type="radio"
+							className="components-radio-control__input"
+							disabled
+							checked={ false }
+							readOnly
+							id={ disabledPaidOptionId }
+						/>
+						<label className="components-radio-control__label" htmlFor={ disabledPaidOptionId }>
+							{ paidOptionLabel }
+						</label>
+					</div>
+					<Link href={ getPaidPlanLink( hasTierPlans ) }>
+						{ __( 'Turn on paid subscribers', 'jetpack' ) }
+						<Icon icon={ external } size={ 16 } />
+					</Link>
+				</>
 			) }
-
-			{ isEditorPanel && (
-				<PlansSetupDialog closeDialog={ closeDialog } showDialog={ showDialog } />
-			) }
-		</fieldset>
+			{ isPaidSelected && isPaidAvailable && <TierSelector></TierSelector> }
+			<p className="jetpack-newsletter-access-radio-buttons__description">
+				{ getAccessDescription( accessLevel, !! postHasPaywallBlock ) }
+			</p>
+		</div>
 	);
 }
 
@@ -273,7 +333,6 @@ export function NewsletterAccessDocumentSettings( { accessLevel } ) {
 						<FlexBlock direction="row" justify="flex-start">
 							{ canEdit && (
 								<NewsletterAccessRadioButtons
-									isEditorPanel={ true }
 									accessLevel={ _accessLevel }
 									stripeConnectUrl={ stripeConnectUrl }
 									hasTierPlans={ hasTierPlans }

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
@@ -14,7 +14,8 @@ import { useEntityId, useEntityProp, store as coreDataStore } from '@wordpress/c
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PostVisibilityCheck, store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-import { Icon, external } from '@wordpress/icons';
+import { Icon } from '@wordpress/icons';
+import { Link as ExternalLink } from '@wordpress/ui';
 import paywallBlockMetadata from '../../blocks/paywall/block.json';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import './settings.scss';
@@ -246,10 +247,9 @@ export function NewsletterAccessRadioButtons( {
 							{ paidOptionLabel }
 						</label>
 					</div>
-					<Link href={ getPaidPlanLink( hasTierPlans ) }>
+					<ExternalLink openInNewTab href={ getPaidPlanLink( hasTierPlans ) }>
 						{ __( 'Turn on paid subscribers', 'jetpack' ) }
-						<Icon icon={ external } size={ 16 } />
-					</Link>
+					</ExternalLink>
 				</>
 			) }
 			{ isPaidSelected && isPaidAvailable && <TierSelector></TierSelector> }

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
@@ -70,12 +70,16 @@ export function getReachForAccessLevelKey( {
  * @return {string} Description of the current access level.
  */
 export function getAccessDescription( accessLevel, postHasPaywallBlock = false ) {
+	// The unused third argument to __() keeps the two calls in each branch from being
+	// merged into a single __( cond ? a : b ) by the production minifier, which would
+	// leave a non-literal msgid and fail the i18n check.
 	switch ( accessLevel ) {
 		case accessOptions.subscribers.key:
 			return postHasPaywallBlock
 				? __(
 						'Only subscribers can read the content below the paywall. Subscribers receive it by email.',
-						'jetpack'
+						'jetpack',
+						0
 				  )
 				: __(
 						'Only subscribers can read this post. Others see a preview and can subscribe. Subscribers receive it by email.',
@@ -85,7 +89,8 @@ export function getAccessDescription( accessLevel, postHasPaywallBlock = false )
 			return postHasPaywallBlock
 				? __(
 						'Only paid subscribers can read the content below the paywall. Subscribers receive it by email.',
-						'jetpack'
+						'jetpack',
+						0
 				  )
 				: __(
 						'Only paid subscribers can read this post. Others see a preview and can subscribe. Only paid subscribers receive it by email.',

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
@@ -46,19 +46,15 @@
 		margin-block-end: 16px;
 	}
 
-	.jetpack-newsletter-link,
+	> a,
 	&__description {
 		padding-block-start: 4px;
 	}
 
-	.jetpack-newsletter-link {
-		display: inline-flex;
-		align-items: center;
+	// The setup link is a @wordpress/ui Link, which brings its own underline and
+	// "opens in a new tab" affordance; it only needs to stop filling the column.
+	> a {
 		align-self: flex-start;
-		gap: 2px;
-		// Overrides the unstyled .jetpack-newsletter-link default. The link sits
-		// under dimmed text, so colour alone should not be what marks it as a link.
-		text-decoration: underline;
 	}
 
 	&__description {

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
@@ -14,6 +14,13 @@
 }
 
 .jetpack-newsletter-access-radio-buttons {
+	// The container owns the vertical rhythm. Spacing the children with their own
+	// margins does not survive here: wp-admin zeroes paragraph margins inside the
+	// sidebar with a higher-specificity rule. 12px matches the VStack spacing
+	// RadioControl uses between its own options.
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
 
 	input[type="radio"] {
 		flex-shrink: 0;
@@ -21,6 +28,43 @@
 
 	label {
 		text-wrap: balance;
+	}
+
+	&__disabled-option {
+
+		input[type="radio"],
+		label {
+			cursor: default;
+			opacity: 0.5;
+		}
+	}
+
+	// Two tiers of spacing: the options sit close together, while the legend, the
+	// setup link and the description are each set apart from the group by a wider
+	// gap. Gutenberg gives the legend 8px of its own, so it needs half as much.
+	legend {
+		margin-block-end: 16px;
+	}
+
+	.jetpack-newsletter-link,
+	&__description {
+		padding-block-start: 4px;
+	}
+
+	.jetpack-newsletter-link {
+		display: inline-flex;
+		align-items: center;
+		align-self: flex-start;
+		gap: 2px;
+		// Overrides the unstyled .jetpack-newsletter-link default. The link sits
+		// under dimmed text, so colour alone should not be what marks it as a link.
+		text-decoration: underline;
+	}
+
+	&__description {
+		margin: 0;
+		color: gb.$gray-700;
+		font-size: 12px;
 	}
 }
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/test/settings-test.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/test/settings-test.jsx
@@ -1,8 +1,21 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as wpData from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as membershipProductsStore } from '../../../store/membership-products';
-import { Link, getReachForAccessLevelKey, NewsletterEmailDocumentSettings } from '../settings';
+import { META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS } from '../constants';
+import {
+	Link,
+	getAccessDescription,
+	getReachForAccessLevelKey,
+	NewsletterAccessRadioButtons,
+	NewsletterEmailDocumentSettings,
+} from '../settings';
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	...jest.requireActual( '@automattic/jetpack-script-data' ),
+	isWpcomPlatformSite: jest.fn( () => true ),
+} ) );
 
 const mockUseSelect = jest.fn();
 const mockUseEntityProp = jest.fn();
@@ -117,6 +130,185 @@ describe( 'Link', () => {
 	test( 'has jetpack-newsletter-link class', () => {
 		render( <Link href="/">Test</Link> );
 		expect( screen.getByRole( 'link' ) ).toHaveClass( 'jetpack-newsletter-link' );
+	} );
+} );
+
+describe( 'getAccessDescription', () => {
+	test( 'describes open access for everybody', () => {
+		expect( getAccessDescription( 'everybody' ) ).toBe(
+			'Anyone can read this post. Subscribers receive it by email.'
+		);
+	} );
+
+	test( 'describes the subscriber preview for subscribers', () => {
+		expect( getAccessDescription( 'subscribers' ) ).toBe(
+			'Only subscribers can read this post. Others see a preview and can subscribe. Subscribers receive it by email.'
+		);
+	} );
+
+	test( 'says only paid subscribers are emailed when there is no paywall block', () => {
+		expect( getAccessDescription( 'paid_subscribers' ) ).toBe(
+			'Only paid subscribers can read this post. Others see a preview and can subscribe. Only paid subscribers receive it by email.'
+		);
+	} );
+
+	// With a paywall block the email goes to every subscriber, because free subscribers
+	// still receive the portion above the paywall.
+	test( 'says all subscribers are emailed when a paywall block is present', () => {
+		expect( getAccessDescription( 'paid_subscribers', true ) ).toBe(
+			'Only paid subscribers can read the content below the paywall. Subscribers receive it by email.'
+		);
+	} );
+
+	test( 'scopes the subscribers description to the paywall when one is present', () => {
+		expect( getAccessDescription( 'subscribers', true ) ).toBe(
+			'Only subscribers can read the content below the paywall. Subscribers receive it by email.'
+		);
+	} );
+
+	test( 'falls back to the open description for an unknown access level', () => {
+		expect( getAccessDescription( undefined ) ).toBe(
+			'Anyone can read this post. Subscribers receive it by email.'
+		);
+	} );
+} );
+
+describe( 'NewsletterAccessRadioButtons', () => {
+	const mockSetPostMeta = jest.fn();
+
+	const createMockSelect =
+		( { totalSubscribers = 120, paidSubscribers = 8, tierProducts = [] } = {} ) =>
+		store => {
+			if ( store === editorStore ) {
+				return { getCurrentPostType: () => 'post' };
+			}
+			if ( store === membershipProductsStore ) {
+				return {
+					getSubscriberCounts: () => ( { totalSubscribers, paidSubscribers } ),
+					getNewsletterTierProducts: () => tierProducts,
+				};
+			}
+			return {};
+		};
+
+	// stripeConnectUrl === null means Stripe is already connected.
+	const CONNECTED = null;
+	const NOT_CONNECTED = 'https://connect.stripe.example/oauth';
+
+	const renderPanel = ( props = {}, selectOptions = {} ) => {
+		mockUseSelect.mockImplementation( selector => selector( createMockSelect( selectOptions ) ) );
+		return render(
+			<NewsletterAccessRadioButtons
+				accessLevel="everybody"
+				stripeConnectUrl={ CONNECTED }
+				hasTierPlans
+				{ ...props }
+			/>
+		);
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseEntityProp.mockReturnValue( [ {}, mockSetPostMeta ] );
+		jest.spyOn( wpData, 'useSelect' ).mockImplementation( selector => mockUseSelect( selector ) );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	test( 'labels the radio group with the question it answers', () => {
+		renderPanel();
+		expect(
+			screen.getByRole( 'radiogroup', { name: /who can read this post\?/i } )
+		).toBeInTheDocument();
+	} );
+
+	test( 'shows subscriber reach counts next to each audience', () => {
+		renderPanel( {}, { totalSubscribers: 2450, paidSubscribers: 122 } );
+		expect( screen.getByRole( 'radio', { name: 'Subscribers (2.5K)' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'radio', { name: 'Paid subscribers (122)' } ) ).toBeInTheDocument();
+	} );
+
+	test( 'saves the chosen access level', async () => {
+		renderPanel();
+		await userEvent.click( screen.getByRole( 'radio', { name: /^Subscribers/ } ) );
+		expect( mockSetPostMeta ).toHaveBeenCalledWith(
+			expect.objectContaining( { [ META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ]: 'subscribers' } )
+		);
+	} );
+
+	test( 'describes the currently selected access level', () => {
+		renderPanel( { accessLevel: 'subscribers' } );
+		expect(
+			screen.getByText(
+				'Only subscribers can read this post. Others see a preview and can subscribe. Subscribers receive it by email.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	describe( 'when paid subscribers are not set up', () => {
+		test( 'disables the paid option and links out when Stripe is not connected', () => {
+			renderPanel( { stripeConnectUrl: NOT_CONNECTED, hasTierPlans: true } );
+
+			expect( screen.getByRole( 'radio', { name: /^Paid subscribers/ } ) ).toBeDisabled();
+			expect(
+				screen.getByRole( 'link', { name: /turn on paid subscribers/i } )
+			).toBeInTheDocument();
+		} );
+
+		test( 'disables the paid option when Stripe is connected but no tier exists', () => {
+			renderPanel( { stripeConnectUrl: CONNECTED, hasTierPlans: false } );
+
+			expect( screen.getByRole( 'radio', { name: /^Paid subscribers/ } ) ).toBeDisabled();
+			expect(
+				screen.getByRole( 'link', { name: /turn on paid subscribers/i } )
+			).toBeInTheDocument();
+		} );
+
+		test( 'still offers the other audiences', () => {
+			renderPanel( { stripeConnectUrl: NOT_CONNECTED, hasTierPlans: false } );
+
+			expect( screen.getByRole( 'radio', { name: 'Everyone' } ) ).toBeEnabled();
+			expect( screen.getByRole( 'radio', { name: /^Subscribers/ } ) ).toBeEnabled();
+		} );
+
+		test( 'sends the setup link to the tier creation screen', () => {
+			renderPanel( { stripeConnectUrl: NOT_CONNECTED, hasTierPlans: false } );
+
+			expect( screen.getByRole( 'link', { name: /turn on paid subscribers/i } ) ).toHaveAttribute(
+				'href',
+				expect.stringContaining( '#add-tier-plan' )
+			);
+		} );
+
+		// A post saved as paid before Stripe was disconnected must not lose its selection.
+		test( 'leaves the paid option enabled when it is already the saved value', () => {
+			renderPanel( { accessLevel: 'paid_subscribers', stripeConnectUrl: NOT_CONNECTED } );
+
+			expect( screen.getByRole( 'radio', { name: /^Paid subscribers/ } ) ).toBeEnabled();
+			expect(
+				screen.queryByRole( 'link', { name: /turn on paid subscribers/i } )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'when paid subscribers are set up', () => {
+		test( 'offers the paid option without a setup link', () => {
+			renderPanel( { stripeConnectUrl: CONNECTED, hasTierPlans: true } );
+
+			expect( screen.getByRole( 'radio', { name: /^Paid subscribers/ } ) ).toBeEnabled();
+			expect(
+				screen.queryByRole( 'link', { name: /turn on paid subscribers/i } )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
+	test( 'omits Everyone when the post has a paywall block', () => {
+		renderPanel( { postHasPaywallBlock: true, accessLevel: 'subscribers' } );
+
+		expect( screen.queryByRole( 'radio', { name: 'Everyone' } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'radio', { name: /^Subscribers/ } ) ).toBeInTheDocument();
 	} );
 } );
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/test/settings-test.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/test/settings-test.jsx
@@ -153,10 +153,11 @@ describe( 'getAccessDescription', () => {
 	} );
 
 	// With a paywall block the email goes to every subscriber, because free subscribers
-	// still receive the portion above the paywall.
+	// still receive the portion above the paywall. The copy has to say so explicitly,
+	// otherwise it reads as though only paid subscribers are emailed.
 	test( 'says all subscribers are emailed when a paywall block is present', () => {
 		expect( getAccessDescription( 'paid_subscribers', true ) ).toBe(
-			'Only paid subscribers can read the content below the paywall. Subscribers receive it by email.'
+			'Only paid subscribers can read the content below the paywall. All subscribers receive it by email.'
 		);
 	} );
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/test/settings-test.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/test/settings-test.jsx
@@ -252,7 +252,10 @@ describe( 'NewsletterAccessRadioButtons', () => {
 		test( 'disables the paid option and links out when Stripe is not connected', () => {
 			renderPanel( { stripeConnectUrl: NOT_CONNECTED, hasTierPlans: true } );
 
-			expect( screen.getByRole( 'radio', { name: /^Paid subscribers/ } ) ).toBeDisabled();
+			expect( screen.getByRole( 'radio', { name: /^Paid subscribers/ } ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			);
 			expect(
 				screen.getByRole( 'link', { name: /turn on paid subscribers/i } )
 			).toBeInTheDocument();
@@ -261,10 +264,36 @@ describe( 'NewsletterAccessRadioButtons', () => {
 		test( 'disables the paid option when Stripe is connected but no tier exists', () => {
 			renderPanel( { stripeConnectUrl: CONNECTED, hasTierPlans: false } );
 
-			expect( screen.getByRole( 'radio', { name: /^Paid subscribers/ } ) ).toBeDisabled();
+			expect( screen.getByRole( 'radio', { name: /^Paid subscribers/ } ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			);
 			expect(
 				screen.getByRole( 'link', { name: /turn on paid subscribers/i } )
 			).toBeInTheDocument();
+		} );
+
+		// A native `disabled` attribute would drop the option out of the tab order and
+		// hide it from screen readers, defeating the point of surfacing it at all.
+		test( 'keeps the paid option reachable and described by the setup link', () => {
+			renderPanel( { stripeConnectUrl: NOT_CONNECTED, hasTierPlans: false } );
+
+			const paid = screen.getByRole( 'radio', { name: /^Paid subscribers/ } );
+			expect( paid ).toBeEnabled();
+
+			const link = screen.getByRole( 'link', { name: /turn on paid subscribers/i } );
+			expect( paid ).toHaveAttribute( 'aria-describedby', link.getAttribute( 'id' ) );
+
+			// A natively disabled input cannot take focus; this one must be able to.
+			paid.focus();
+			expect( paid ).toHaveFocus();
+		} );
+
+		test( 'does not save the paid level when the disabled option is clicked', async () => {
+			renderPanel( { stripeConnectUrl: NOT_CONNECTED, hasTierPlans: false } );
+
+			await userEvent.click( screen.getByRole( 'radio', { name: /^Paid subscribers/ } ) );
+			expect( mockSetPostMeta ).not.toHaveBeenCalled();
 		} );
 
 		test( 'still offers the other audiences', () => {
@@ -310,6 +339,19 @@ describe( 'NewsletterAccessRadioButtons', () => {
 
 		expect( screen.queryByRole( 'radio', { name: 'Everyone' } ) ).not.toBeInTheDocument();
 		expect( screen.getByRole( 'radio', { name: /^Subscribers/ } ) ).toBeInTheDocument();
+	} );
+
+	// The counts report how many people can read each level. Switching the paid count to
+	// the email reach on a paywalled post would make both options read the same total,
+	// so the two must stay distinct here.
+	test( 'keeps the paid count distinct from the subscriber count on a paywalled post', () => {
+		renderPanel(
+			{ postHasPaywallBlock: true, accessLevel: 'paid_subscribers' },
+			{ totalSubscribers: 21, paidSubscribers: 2 }
+		);
+
+		expect( screen.getByRole( 'radio', { name: 'Subscribers (21)' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'radio', { name: 'Paid subscribers (2)' } ) ).toBeInTheDocument();
 	} );
 } );
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/test/utils-test.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/test/utils-test.jsx
@@ -1,0 +1,62 @@
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
+import { getPaidPlanLink, getShowMisconfigurationWarning } from '../utils';
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	...jest.requireActual( '@automattic/jetpack-script-data' ),
+	isWpcomPlatformSite: jest.fn(),
+} ) );
+
+describe( 'getPaidPlanLink', () => {
+	describe( 'on WordPress.com and Atomic sites', () => {
+		beforeEach( () => isWpcomPlatformSite.mockReturnValue( true ) );
+
+		test( 'points at the site-scoped earn screen', () => {
+			expect( getPaidPlanLink( true ) ).toBe(
+				`https://wordpress.com/earn/payments/${ window.location.hostname }`
+			);
+		} );
+
+		test( 'jumps straight to tier creation when no tier exists yet', () => {
+			expect( getPaidPlanLink( false ) ).toBe(
+				`https://wordpress.com/earn/payments/${ window.location.hostname }#add-tier-plan`
+			);
+		} );
+	} );
+
+	// Self-hosted Jetpack sites manage payments in Jetpack Cloud, which serves these
+	// screens under /monetize rather than /earn.
+	describe( 'on self-hosted Jetpack sites', () => {
+		beforeEach( () => isWpcomPlatformSite.mockReturnValue( false ) );
+
+		test( 'points at Jetpack Cloud rather than WordPress.com', () => {
+			expect( getPaidPlanLink( true ) ).toBe(
+				`https://cloud.jetpack.com/monetize/payments/${ window.location.hostname }`
+			);
+		} );
+
+		test( 'jumps straight to tier creation when no tier exists yet', () => {
+			expect( getPaidPlanLink( false ) ).toBe(
+				`https://cloud.jetpack.com/monetize/payments/${ window.location.hostname }#add-tier-plan`
+			);
+		} );
+	} );
+
+	test( 'always scopes the link to the current site', () => {
+		isWpcomPlatformSite.mockReturnValue( true );
+		expect( getPaidPlanLink( true ) ).toContain( window.location.hostname );
+	} );
+} );
+
+describe( 'getShowMisconfigurationWarning', () => {
+	test( 'warns when a restricted post is not publicly visible', () => {
+		expect( getShowMisconfigurationWarning( 'private', 'subscribers' ) ).toBe( true );
+	} );
+
+	test( 'stays quiet for a public post', () => {
+		expect( getShowMisconfigurationWarning( 'public', 'subscribers' ) ).toBe( false );
+	} );
+
+	test( 'stays quiet when the post is open to everybody', () => {
+		expect( getShowMisconfigurationWarning( 'private', 'everybody' ) ).toBe( false );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/shared/memberships/utils.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/utils.jsx
@@ -1,3 +1,4 @@
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -23,7 +24,12 @@ export const encodeValueForShortcodeAttribute = value => {
 };
 
 export const getPaidPlanLink = alreadyHasTierPlans => {
-	const link = 'https://wordpress.com/earn/payments/' + location.hostname;
+	// Self-hosted Jetpack sites manage payments from Jetpack Cloud, which serves the
+	// same screens under /monetize rather than /earn.
+	const base = isWpcomPlatformSite()
+		? 'https://wordpress.com/earn/payments/'
+		: 'https://cloud.jetpack.com/monetize/payments/';
+	const link = base + location.hostname;
 	// We force the "Newsletters plan" link only if there is no plans already created
 	return alreadyHasTierPlans ? link : link + '#add-tier-plan';
 };


### PR DESCRIPTION
Fixes NL-766
Fixes NL-794

## Proposed changes

The newsletter **Access** panel had two problems raised in creator feedback sessions: the label did not convey that it controls who can *read* the post, and "Paid subscribers only" was offered with no indication of how to turn paid subscriptions on.

* Rename the panel to **Audience** in both the editor sidebar and the pre-publish view, so the two match.
* Give the radio group the visible legend "Who can read this post?" — this replaces a `VisuallyHidden` legend, so it also improves the accessible name.
* Shorten the options: "Anyone subscribed" → "Subscribers", "Paid subscribers only" → "Paid subscribers".
* Add a description of the selected level beneath the group.
* When paid subscriptions are not set up, render "Paid subscribers" **disabled** with a "Turn on paid subscribers" link, instead of letting the option be picked and opening the setup dialog. The option stays selectable when it is already the saved value, so a post set to paid before Stripe was disconnected keeps its selection.
* Point `getPaidPlanLink` at Jetpack Cloud on self-hosted sites, which serve these screens under `/monetize` rather than `/earn`.

Before | After
---- | ----
<img width="274" height="171" alt="Screenshot 2026-08-13 at 2 23 10 PM" src="https://github.com/user-attachments/assets/1427b5e7-236f-42d7-9927-e83bc1534faa" /> | <img width="275" height="269" alt="Screenshot 2026-08-13 at 2 31 22 PM" src="https://github.com/user-attachments/assets/df9527b1-a054-41b0-a4e7-3972ddddd21f" />
<img width="255" height="163" alt="Screenshot 2026-08-13 at 2 23 16 PM" src="https://github.com/user-attachments/assets/ac2bd871-38f2-4a77-95c3-c0db9bfcaa94" /> | <img width="270" height="288" alt="Screenshot 2026-08-13 at 2 39 44 PM" src="https://github.com/user-attachments/assets/cf4151a6-cbaa-49d5-91f4-40c294dba806" />
<img width="266" height="165" alt="Screenshot 2026-08-13 at 3 51 45 PM" src="https://github.com/user-attachments/assets/04b67f43-5b0f-44d3-8cd0-83097c27ace9" /> | <img width="269" height="251" alt="Screenshot 2026-08-13 at 3 41 51 PM" src="https://github.com/user-attachments/assets/153c27a7-56c6-41c2-8360-c595e2519944" />



Two details worth reviewer attention:

**The email line is conditional.** With a paywall block, a paid post is still emailed to every subscriber, because free subscribers receive the portion above the paywall — this is the behaviour `getAccessLabelForCopy` already encodes. The description reflects that rather than claiming only paid subscribers are emailed.

**The setup link uses the shared component.** It is `@wordpress/ui`'s `Link` with `openInNewTab`, the same one the SEO panel and a dozen other extensions use, so it picks up the underline, the diagonal arrow and an "(opens in a new tab)" label without any local styling.

Because the option labels come from the shared `accessOptions` constant, the renames also surface in the paywall block toolbar, the command palette, and the email preview audience selector. The disabled/link treatment also applies to the paywall block's "Content access" inspector panel, since it renders the same component.

## Related product discussion/links

* NL-766
* NL-794

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Panel copy (NL-766)**

* Create or edit a post, and open the settings sidebar.
* Confirm the panel is titled **Audience**, with the legend "Who can read this post?" above the options.
* Confirm the options read "Everyone", "Subscribers (n)", "Paid subscribers (n)".
* Select each option and confirm the description beneath updates:
  * Everyone — "Anyone can read this post. Subscribers receive it by email."
  * Subscribers — "Only subscribers can read this post. Others see a preview and can subscribe. Subscribers receive it by email."
  * Paid subscribers — "Only paid subscribers can read this post. Others see a preview and can subscribe. Only paid subscribers receive it by email."
* Click **Publish** and confirm the pre-publish panel reads "Audience: …" with the same legend, options, and description.

**Paid subscribers not set up (NL-794)**

On a site with no Stripe connection, or with Stripe connected but no newsletter tier:

* Confirm "Paid subscribers" is visible but disabled, and that "Everyone" and "Subscribers" are still selectable.
* Confirm a "Turn on paid subscribers" link appears beneath the options and opens the payments screen in a new tab, scoped to the current site. On a self-hosted site it should go to `cloud.jetpack.com/monetize/payments/<site>`; on WordPress.com or Atomic, `wordpress.com/earn/payments/<site>`. With no tier yet, it should include `#add-tier-plan`.

**Regression checks**

* With paid subscriptions fully set up, confirm "Paid subscribers" is selectable, no setup link shows, and the tier selector still appears when a tier is chosen.
* Set a post to paid, then test with Stripe disconnected: the option should stay selected and selectable rather than resetting.
* Add a paywall block and confirm "Everyone" is removed from the options, and that the paid description refers to content below the paywall.
* Confirm the paywall block toolbar and the newsletter command palette still show the renamed labels.
