### PR TITLE
Newsletter: normalize settings card spacing

### DIFF
--- a/projects/packages/newsletter/changelog/nl-831-fix-inconsistent-spacing-in-newsletter-sections
+++ b/projects/packages/newsletter/changelog/nl-831-fix-inconsistent-spacing-in-newsletter-sections
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Normalize spacing in Newsletter settings cards.

--- a/projects/packages/newsletter/src/settings/sections/email-byline-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-byline-section.tsx
@@ -4,7 +4,7 @@
 import { getAdminUrl, getScriptData } from '@automattic/jetpack-script-data';
 import { DataForm, type Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
-import { Card, Text } from '@wordpress/ui';
+import { Card, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -83,43 +83,43 @@ export function EmailBylineSection( {
 				<Card.Title>{ __( 'Email byline', 'jetpack-newsletter' ) }</Card.Title>
 			</Card.Header>
 			<Card.Content>
-				<p>
-					<Text>
+				<Stack direction="column" gap="xl">
+					<Text variant="body-md" render={ <p /> }>
 						{ __(
 							'Customize the information you want to display below your post title in emails.',
 							'jetpack-newsletter'
 						) }
 					</Text>
-				</p>
-				<fieldset disabled={ ! isNewsletterEnabled }>
-					<DataForm
-						data={ data }
-						fields={ fields }
-						form={ {
-							layout: {
-								type: 'regular',
-								labelPosition: 'top',
-							},
-							fields: [
-								'jetpack_gravatar_in_email',
-								'jetpack_author_in_email',
-								'jetpack_post_date_in_email',
-							],
-						} }
-						onChange={ onChange }
-					/>
-
-					{ newsletterScriptData && (
-						<BylinePreview
-							isGravatarEnabled={ data.jetpack_gravatar_in_email }
-							isAuthorEnabled={ data.jetpack_author_in_email }
-							isPostDateEnabled={ data.jetpack_post_date_in_email }
-							gravatar={ newsletterScriptData.gravatar }
-							displayName={ getScriptData()?.user.current_user?.display_name ?? '' }
-							dateExample={ newsletterScriptData.dateExample }
+					<fieldset disabled={ ! isNewsletterEnabled }>
+						<DataForm
+							data={ data }
+							fields={ fields }
+							form={ {
+								layout: {
+									type: 'regular',
+									labelPosition: 'top',
+								},
+								fields: [
+									'jetpack_gravatar_in_email',
+									'jetpack_author_in_email',
+									'jetpack_post_date_in_email',
+								],
+							} }
+							onChange={ onChange }
 						/>
-					) }
-				</fieldset>
+
+						{ newsletterScriptData && (
+							<BylinePreview
+								isGravatarEnabled={ data.jetpack_gravatar_in_email }
+								isAuthorEnabled={ data.jetpack_author_in_email }
+								isPostDateEnabled={ data.jetpack_post_date_in_email }
+								gravatar={ newsletterScriptData.gravatar }
+								displayName={ getScriptData()?.user.current_user?.display_name ?? '' }
+								dateExample={ newsletterScriptData.dateExample }
+							/>
+						) }
+					</fieldset>
+				</Stack>
 			</Card.Content>
 		</Card.Root>
 	);

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -13,7 +13,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button, Card, Fieldset, Link, Notice, Text } from '@wordpress/ui';
+import { Button, Card, Fieldset, Link, Notice, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -207,8 +207,8 @@ export function NewsletterCategoriesSection( {
 				<Card.Title>{ __( 'Newsletter categories', 'jetpack-newsletter' ) }</Card.Title>
 			</Card.Header>
 			<Card.Content>
-				<p>
-					<Text>
+				<Stack direction="column" gap="xl">
+					<Text variant="body-md" render={ <p /> }>
 						{ createInterpolateElement(
 							__(
 								"Newsletter categories let you select the content that's emailed to subscribers. When enabled, only posts in the selected categories will be sent as newsletters. By default, subscribers can choose from your selected categories, or you can pre-select categories using the <link>subscribe block</link>. When you add a new category, your existing subscribers will be automatically subscribed to it.",
@@ -219,29 +219,29 @@ export function NewsletterCategoriesSection( {
 							}
 						) }
 					</Text>
-				</p>
-				{ categoriesError && (
-					<Notice.Root intent="error">
-						<Notice.Description>{ categoriesError }</Notice.Description>
-					</Notice.Root>
-				) }
-				<Fieldset.Root disabled={ ! isNewsletterEnabled || !! categoriesError }>
-					<CreatableCategoryContext.Provider value={ creatableContext }>
-						<DataForm
-							data={ data }
-							fields={ newsletterCategoriesFields }
-							form={ newsletterCategoriesForm }
-							onChange={ onChange }
-							validity={ validity }
-						/>
-					</CreatableCategoryContext.Provider>
-
-					{ data.wpcom_newsletter_categories_enabled && createCategoryError && (
+					{ categoriesError && (
 						<Notice.Root intent="error">
-							<Notice.Description>{ createCategoryError }</Notice.Description>
+							<Notice.Description>{ categoriesError }</Notice.Description>
 						</Notice.Root>
 					) }
-				</Fieldset.Root>
+					<Fieldset.Root disabled={ ! isNewsletterEnabled || !! categoriesError }>
+						<CreatableCategoryContext.Provider value={ creatableContext }>
+							<DataForm
+								data={ data }
+								fields={ newsletterCategoriesFields }
+								form={ newsletterCategoriesForm }
+								onChange={ onChange }
+								validity={ validity }
+							/>
+						</CreatableCategoryContext.Provider>
+
+						{ data.wpcom_newsletter_categories_enabled && createCategoryError && (
+							<Notice.Root intent="error">
+								<Notice.Description>{ createCategoryError }</Notice.Description>
+							</Notice.Root>
+						) }
+					</Fieldset.Root>
+				</Stack>
 				<div className="newsletter-card-footer">
 					<Button
 						onClick={ handleSave }

--- a/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
@@ -6,7 +6,7 @@ import { getSiteType } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Card, Text } from '@wordpress/ui';
+import { Card, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -60,27 +60,27 @@ export function PaidNewsletterSection( {
 				<Card.Title>{ __( 'Paid newsletter', 'jetpack-newsletter' ) }</Card.Title>
 			</Card.Header>
 			<Card.Content>
-				<p>
-					<Text>
+				<Stack direction="column" gap="xl">
+					<Text variant="body-md" render={ <p /> }>
 						{ __(
 							'Earn money through your Newsletter. Reward your most loyal subscribers with exclusive content or add a paywall to monetize content.',
 							'jetpack-newsletter'
 						) }
 					</Text>
-				</p>
-				<fieldset disabled={ ! isNewsletterEnabled }>
-					<Button
-						__next40pxDefaultSize
-						variant="primary"
-						href={ newsletterScriptData.setupPaymentPlansUrl }
-						target="_blank"
-						rel="noopener noreferrer"
-						disabled={ ! isNewsletterEnabled }
-						onClick={ handlePaidPlansClick }
-					>
-						{ buttonText }
-					</Button>
-				</fieldset>
+					<fieldset disabled={ ! isNewsletterEnabled }>
+						<Button
+							__next40pxDefaultSize
+							variant="primary"
+							href={ newsletterScriptData.setupPaymentPlansUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+							disabled={ ! isNewsletterEnabled }
+							onClick={ handlePaidPlansClick }
+						>
+							{ buttonText }
+						</Button>
+					</fieldset>
+				</Stack>
 			</Card.Content>
 		</Card.Root>
 	);

--- a/projects/packages/newsletter/src/settings/sections/subscribe-modal-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscribe-modal-section.tsx
@@ -7,7 +7,7 @@ import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/com
 import { DataForm, type Field } from '@wordpress/dataviews';
 import { createInterpolateElement, useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button, Card, Fieldset, Link, Text } from '@wordpress/ui';
+import { Button, Card, Fieldset, Link, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -122,28 +122,28 @@ export function SubscribeModalSection( {
 				<Card.Title>{ __( 'Subscribe modal heading', 'jetpack-newsletter' ) }</Card.Title>
 			</Card.Header>
 			<Card.Content>
-				<p>
-					<Text>
+				<Stack direction="column" gap="xl">
+					<Text variant="body-md" render={ <p /> }>
 						{ __(
 							'Shown at the top of the subscribe popup that appears when a visitor clicks a Subscribe block.',
 							'jetpack-newsletter'
 						) }
 					</Text>
-				</p>
-				<Fieldset.Root disabled={ ! isNewsletterEnabled }>
-					<DataForm
-						data={ formData }
-						fields={ fields }
-						form={ {
-							layout: {
-								type: 'regular',
-								labelPosition: 'top',
-							},
-							fields: [ 'subscribe_modal_heading' ],
-						} }
-						onChange={ handleDataFormChange }
-					/>
-				</Fieldset.Root>
+					<Fieldset.Root disabled={ ! isNewsletterEnabled }>
+						<DataForm
+							data={ formData }
+							fields={ fields }
+							form={ {
+								layout: {
+									type: 'regular',
+									labelPosition: 'top',
+								},
+								fields: [ 'subscribe_modal_heading' ],
+							} }
+							onChange={ handleDataFormChange }
+						/>
+					</Fieldset.Root>
+				</Stack>
 				<div className="newsletter-card-footer">
 					<Button
 						onClick={ handleSave }

--- a/projects/packages/newsletter/src/settings/sections/welcome-email-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/welcome-email-section.tsx
@@ -6,7 +6,7 @@ import { getSiteType } from '@automattic/jetpack-script-data';
 import { DataForm, type Field } from '@wordpress/dataviews';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button, Card, Fieldset, Text } from '@wordpress/ui';
+import { Button, Card, Fieldset, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -106,28 +106,28 @@ export function WelcomeEmailSection( {
 				<Card.Title>{ __( 'Welcome email message', 'jetpack-newsletter' ) }</Card.Title>
 			</Card.Header>
 			<Card.Content>
-				<p>
-					<Text>
+				<Stack direction="column" gap="xl">
+					<Text variant="body-md" render={ <p /> }>
 						{ __(
 							'Sent to your email subscribers when they subscribe to your newsletter.',
 							'jetpack-newsletter'
 						) }
 					</Text>
-				</p>
-				<Fieldset.Root disabled={ ! isNewsletterEnabled }>
-					<DataForm
-						data={ formData }
-						fields={ fields }
-						form={ {
-							layout: {
-								type: 'regular',
-								labelPosition: 'top',
-							},
-							fields: [ 'welcome_message' ],
-						} }
-						onChange={ handleDataFormChange }
-					/>
-				</Fieldset.Root>
+					<Fieldset.Root disabled={ ! isNewsletterEnabled }>
+						<DataForm
+							data={ formData }
+							fields={ fields }
+							form={ {
+								layout: {
+									type: 'regular',
+									labelPosition: 'top',
+								},
+								fields: [ 'welcome_message' ],
+							} }
+							onChange={ handleDataFormChange }
+						/>
+					</Fieldset.Root>
+				</Stack>
 				<div className="newsletter-card-footer">
 					<Button
 						onClick={ handleSave }

--- a/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
@@ -151,6 +151,7 @@ jest.mock( '@wordpress/ui', () => ( {
 		Root: ( { children }: { children: React.ReactNode } ) => <div role="alert">{ children }</div>,
 		Description: ( { children }: { children: React.ReactNode } ) => <p>{ children }</p>,
 	},
+	Stack: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
 	Text: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
 } ) );
 

--- a/projects/packages/newsletter/tests/subscribe-modal-section.test.tsx
+++ b/projects/packages/newsletter/tests/subscribe-modal-section.test.tsx
@@ -39,6 +39,7 @@ jest.mock( '@wordpress/ui', () => ( {
 			</fieldset>
 		),
 	},
+	Stack: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
 	Text: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
 	Link: ( {
 		children,


### PR DESCRIPTION
Closes NL-831

| after | before |
|--------|--------|
| <img width="2570" height="7666" alt="CleanShot 2026-08-13 at 21 27 51@2x" src="https://github.com/user-attachments/assets/e38decd8-f446-466c-995a-b51aabbffb76" /> | <img width="3498" height="7688" alt="image" src="https://github.com/user-attachments/assets/4a113ea4-7abd-4561-9a73-443945453721" /> | 




## Proposed changes
* Use WordPress UI `Stack` spacing tokens to add 24px between descriptions and controls in Paid newsletter, Email byline, Welcome email message, Subscribe modal heading, and Newsletter categories.
* Render the affected descriptions consistently as `body-md` paragraphs.
* Keep the existing section tests compatible with the added `Stack` primitive.

## Related product discussion/links
* NL-831

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

### Scenario 1 - Desktop spacing:
- Go to `/wp-admin/admin.php?page=jetpack-newsletter&p=%2F%3Ftab%3Dsettings` on a connected Jetpack site at desktop width.
- Check if Paid newsletter, Email byline, Welcome email message, Subscribe modal heading, and Newsletter categories each show 24px between their description and first control.
- Check that Sender settings is unchanged.

### Scenario 2 - Mobile spacing:
- Go to `/wp-admin/admin.php?page=jetpack-newsletter&p=%2F%3Ftab%3Dsettings` at a 375px viewport width.
- Check if the same five cards retain the 24px spacing without clipped content or horizontal overflow.