### PR TITLE
Forms: make Group and Columns blocks fill the form width

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-column-group-field-width
+++ b/projects/packages/forms/changelog/fix-forms-column-group-field-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Make Group and Columns blocks fill the form width so nested fields render full-width.

--- a/projects/packages/forms/changelog/fix-forms-column-group-field-width
+++ b/projects/packages/forms/changelog/fix-forms-column-group-field-width
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Make Group and Columns blocks fill the form width so nested fields render full-width.
+Contact Form: Make Group and Columns blocks fill the form width so nested fields render full-width.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -12,10 +12,17 @@
 	gap: var(--wp--style--block-gap, 1.5rem);
 
 	.wp-block {
-		flex: 0 0 100%;
 		margin-top: 0;
 		margin-bottom: 0;
 		max-width: 100%;
+	}
+
+	// Only the form's own children are full-width rows. Without the child
+	// combinator this also matches blocks nested inside a Columns or Group
+	// added to the form, forcing every column to 100% so they stack in the
+	// editor while the front end keeps them side by side.
+	> .wp-block {
+		flex: 0 0 100%;
 	}
 
 	> div {

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -12,17 +12,20 @@
 	gap: var(--wp--style--block-gap, 1.5rem);
 
 	.wp-block {
-		margin-top: 0;
-		margin-bottom: 0;
 		max-width: 100%;
 	}
 
-	// Only the form's own children are full-width rows. Without the child
-	// combinator this also matches blocks nested inside a Columns or Group
-	// added to the form, forcing every column to 100% so they stack in the
-	// editor while the front end keeps them side by side.
+	// Only the form's own children are full-width rows with the flex gap
+	// standing in for block margins. Without the child combinator these also
+	// match blocks nested inside a Columns or Group added to the form: the
+	// flex rule forced every column to 100% so they stacked in the editor
+	// while the front end kept them side by side, and zeroing the margins
+	// collapsed the spacing between a container's own children, which the
+	// front end still renders with the theme's block gap.
 	> .wp-block {
 		flex: 0 0 100%;
+		margin-top: 0;
+		margin-bottom: 0;
 	}
 
 	> div {
@@ -86,9 +89,17 @@
 		// not horizontal or vertical means a form created
 		// before layout support was added
 
-		.wp-block {
+		// The form's flex gap stands in for block margins, so its own children
+		// have theirs zeroed. Scoped to direct children: a Group or Columns
+		// added to the form lays its children out itself, and the front end
+		// spaces them with the theme's block gap, so zeroing them here would
+		// collapse that spacing in the editor only.
+		> .wp-block {
 			margin-top: 0;
 			margin-bottom: 0;
+		}
+
+		.wp-block {
 			max-width: 100%;
 
 			&.wp-block-button,

--- a/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
+++ b/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
@@ -4,6 +4,31 @@
 .wp-block-jetpack-contact-form.is-layout-flex,
 .wp-block-jetpack-contact-form-is-layout-flex {
 
+	// Container blocks added to a form should behave the way they do on a page:
+	// fill the form's width and lay out their own children. The form is a flex
+	// container, so otherwise they are flex items defaulting to `flex: 0 1 auto`
+	// and shrink to fit their content, which keeps any field nested inside them
+	// from ever reaching 100%.
+	// `width` rather than `flex-basis`, because a form can be laid out either
+	// horizontally or vertically: in a vertical form `flex-basis` sizes the main
+	// axis (the height) and the width is left to `align-items`, while in a
+	// horizontal form a 100%-wide item still wraps onto its own row.
+	// `core/row` and `core/stack` are `core/group` variations, so they come
+	// along with `.wp-block-group`; multistep forms nest one level deeper,
+	// inside the step, hence the second set of selectors.
+	> .wp-block-group,
+	> .wp-block-columns,
+	> .wp-block-details,
+	> .wp-block-accordion,
+	> .wp-block-jetpack-form-step > .wp-block-group,
+	> .wp-block-jetpack-form-step > .wp-block-columns,
+	> .wp-block-jetpack-form-step > .wp-block-details,
+	> .wp-block-jetpack-form-step > .wp-block-accordion {
+		box-sizing: border-box;
+		width: 100%;
+		max-width: 100%;
+	}
+
 	&.is-horizontal {
 		// Ignore the wrap setting and use flex-flow to control the layout.
 		// In the end this is what we want as our form layout doesn't really

--- a/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
+++ b/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
@@ -19,9 +19,13 @@
 	// levels down — `.jetpack-form-steps-wrapper` >
 	// `.wp-block-jetpack-form-step-container` > `.wp-block-jetpack-form-step` —
 	// so the second set of selectors matches the step as a descendant, not a
-	// child. The front end already covers this via `.wp-block-jetpack-form-step
-	// > *` in grunion.scss, but that stylesheet is registered separately and
-	// isn't one of the block's `style_handles`, so it never loads in the editor.
+	// child.
+	// grunion.scss does set `.wp-block-jetpack-form-step > * { flex: 0 0 100% }`,
+	// but that does not make the containers full width here: a multistep form is
+	// vertical, which gives the step `flex-direction: column` (below), so that
+	// `100%` is a height basis and the width falls to `align-items` — which
+	// `is-content-justification-left` sets to `flex-start`, i.e. shrink to fit.
+	// The same axis caveat as above, one level down.
 	> .wp-block-group,
 	> .wp-block-columns,
 	> .wp-block-details,

--- a/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
+++ b/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
@@ -14,19 +14,24 @@
 	// axis (the height) and the width is left to `align-items`, while in a
 	// horizontal form a 100%-wide item still wraps onto its own row.
 	// `core/row` and `core/stack` are `core/group` variations, so they come
-	// along with `.wp-block-group`; multistep forms nest one level deeper,
-	// inside the step, hence the second set of selectors.
+	// along with `.wp-block-group`.
+	// In a multistep form the containers sit inside the step instead, three
+	// levels down — `.jetpack-form-steps-wrapper` >
+	// `.wp-block-jetpack-form-step-container` > `.wp-block-jetpack-form-step` —
+	// so the second set of selectors matches the step as a descendant, not a
+	// child. The front end already covers this via `.wp-block-jetpack-form-step
+	// > *` in grunion.scss, but that stylesheet is registered separately and
+	// isn't one of the block's `style_handles`, so it never loads in the editor.
 	> .wp-block-group,
 	> .wp-block-columns,
 	> .wp-block-details,
 	> .wp-block-accordion,
-	> .wp-block-jetpack-form-step > .wp-block-group,
-	> .wp-block-jetpack-form-step > .wp-block-columns,
-	> .wp-block-jetpack-form-step > .wp-block-details,
-	> .wp-block-jetpack-form-step > .wp-block-accordion {
+	.wp-block-jetpack-form-step > .wp-block-group,
+	.wp-block-jetpack-form-step > .wp-block-columns,
+	.wp-block-jetpack-form-step > .wp-block-details,
+	.wp-block-jetpack-form-step > .wp-block-accordion {
 		box-sizing: border-box;
 		width: 100%;
-		max-width: 100%;
 	}
 
 	&.is-horizontal {

--- a/projects/plugins/jetpack/changelog/fix-forms-column-group-field-width
+++ b/projects/plugins/jetpack/changelog/fix-forms-column-group-field-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Make Group and Columns blocks fill the form width so nested fields render full-width.


### PR DESCRIPTION
Fixes FORMS-760

## Proposed changes

Group, Columns and Grid blocks added to a Form now fill the form's width, so field blocks nested inside them render full-width — the way they would if you'd added them straight to the page. This applies to regular forms and to blocks placed inside a multistep form's step.

Two separate defects were at play:

* **Container blocks shrank to their content.** The form is a flex container, so a Group or Columns block added to it is a flex item defaulting to `flex: 0 1 auto`, sizing itself to its content rather than filling the row. Any field nested inside inherited that narrow width. This affected every form carrying a layout attribute (i.e. all modern forms), in both the editor and the front end.
* **Legacy forms leaked a full-width rule into nested columns.** `.jetpack-contact-form.has-no-jetpack-form-layout .wp-block` is a descendant selector, so it also matched `.wp-block-column` and forced every column to 100%. Columns stacked in the editor (with the second column overflowing off-canvas) while the front end kept them side by side.

The fix is CSS-only, across two files in `packages/forms`:

* `src/contact-form/css/jetpack-forms-layout.scss` — container blocks (`.wp-block-group`, `.wp-block-columns`, `.wp-block-details`, `.wp-block-accordion`) get `width: 100%`, both as direct children of the form and as children of a multistep step. This stylesheet is the block's `style`, so it loads in the editor too; the editor's form container carries the same `is-layout-flex` classes, so one rule covers both surfaces.
* `src/blocks/contact-form/editor.scss` — the legacy full-width rule is scoped to direct children (`> .wp-block`).

`width` rather than `flex-basis` is deliberate: a form can be laid out horizontally or vertically, and in a vertical (column) form `flex-basis` sizes the main axis — the height — leaving the width to `align-items`. An earlier `flex: 1 1 100%` version fixed legacy and horizontal forms but left vertical ones broken.

The Row, Stack and Grid variations of `core/group` all render as `.wp-block-group`, so they're covered by the same rule — Grid is included in the multistep measurements below.

One behaviour change worth a design opinion: in vertical forms, `is-content-justification-center`/`right` no longer visibly affects container blocks, since they're now full-width. That follows from "behave as if added to the page", but flagging it explicitly.

## Related product discussion/links

* [FORMS-760](https://linear.app/a8c/issue/FORMS-760/forms-make-group-and-columns-blocks-fill-the-form-width)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Create a page and add a **Form** block (any variation).
* Inside the form, add a **Group** block and put a text field in it.
* Inside the form, add a **Columns** block (2 columns) and put a text field in each column.
* Confirm in the editor that the Group fills the form width, and that the two columns sit side by side at even widths (before this change the second column overflowed off-canvas on legacy forms, and Group/Columns were roughly a third of the form width on modern ones).
* Publish and view the page. The front end should match the editor exactly.
* Repeat with the form's layout set to **vertical** in the block sidebar — this was the case that needed `width` rather than `flex-basis`.
* For multistep: the variation is behind a paid-plan flag, so filter `jetpack_block_editor_feature_flags` to force `multistep-form` on. Add a **Multistep Form**, then drop a Group, a Columns and a **Grid** into the first step and check the same things.

Verified with Playwright on a Jurassic Ninja site by measuring rendered widths in a 620px content column. Both passes were captured against the same baseline — `origin/trunk` built and synced to the site, then the branch built and synced — so before/after differ only by this change.

### Regular forms

Three form-layout variants: legacy (no layout attribute), horizontal, vertical.

| Form layout | Group | Columns | Column | Field in column |
|---|---|---|---|---|
| Before — legacy | 620 | 620 | 620 editor / 300 front ❌ | mismatch |
| Before — horizontal | 223 ❌ | 465 ❌ | 223 | 223 |
| Before — vertical | 223 ❌ | 465 ❌ | 223 | 223 |
| After — all three | 620 ✅ | 620 ✅ | 300 ✅ | 300 ✅ |

Editor and front end now agree in all nine cells.

| Editor before | Editor after |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-column-group-field-width/before-editor.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-column-group-field-width/after-editor.png) |

| Front end before | Front end after |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-column-group-field-width/before-frontend.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-column-group-field-width/after-frontend.png) |

### Multistep forms

A Group, a 2-column Columns and a 2-column Grid dropped into the first step of a real multistep form. Identical numbers in the editor and on the front end, before and after.

| Element | Before | After |
|---|---|---|
| Step | 620 | 620 |
| Group | 223 ❌ | 620 ✅ |
| Columns | 465 ❌ | 620 ✅ |
| Column | 223 | 300 ✅ |
| Grid | 465 ❌ | 620 ✅ |
| Grid tracks | `223px 223px` ❌ | `300.4px 300.4px` ✅ |

| Editor before | Editor after |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-column-group-field-width/before-multistep-editor.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-column-group-field-width/after-multistep-editor.png) |

| Front end before | Front end after |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-column-group-field-width/before-multistep-frontend.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-column-group-field-width/after-multistep-frontend.png) |

### Tests

* `pnpm test` in `packages/forms` — 718/718 pass.
* `jetpack test php packages/forms` — 979/980 pass. The failure, `Form_Webhooks_Test::test_send_webhooks_blocks_localhost_hostname`, is pre-existing: with both changed SCSS files reverted to their `origin/trunk` state it fails identically (980 tests, 1 failure, same assertion), and this branch changes zero PHP files.

