### PR TITLE
Premium Analytics: add Regions to the Top locations "View by" control

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-wooa7s-1940-locations-regions-view
+++ b/projects/packages/premium-analytics/changelog/add-wooa7s-1940-locations-regions-view
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Locations: offer Regions in the widget's "View by" control.

--- a/projects/packages/premium-analytics/changelog/add-wooa7s-1940-locations-regions-view
+++ b/projects/packages/premium-analytics/changelog/add-wooa7s-1940-locations-regions-view
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Locations: offer Regions in the widget's "View by" control.
+Top locations: offer Regions in the widget's "View by" control.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
@@ -1100,8 +1100,15 @@ function getLocationRows(
 	}
 
 	if ( geoMode === 'region' ) {
-		const countryCode = query.get( 'filter_by_country' ) || 'US';
+		const countryCode = query.get( 'filter_by_country' );
 		const regionRows = isComparison ? REGION_COMPARISON_ROWS_BY_COUNTRY : REGION_ROWS_BY_COUNTRY;
+
+		// Unfiltered, the endpoint returns the top regions worldwide.
+		if ( ! countryCode ) {
+			return Object.values( regionRows )
+				.flat()
+				.sort( ( a, b ) => b.views - a.views );
+		}
 
 		return regionRows[ countryCode ] ?? regionRows.US;
 	}

--- a/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
@@ -45,7 +45,11 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 	GeoChart: () => <div data-testid="geo-chart" />,
 } ) );
 
-const LOADING_STATE = {
+// Typed off the hook itself so a new field on `LocationView` breaks this
+// fixture instead of being silently cast away.
+type LocationViewsState = ReturnType< typeof import('../use-location-views').default >;
+
+const LOADING_STATE: LocationViewsState = {
 	data: [],
 	hasComparison: false,
 	isLoading: true,
@@ -119,7 +123,7 @@ describe( 'LocationsWidget', () => {
 			isLoading: false,
 			isFetching: false,
 			hasData: true,
-		} as unknown as typeof LOADING_STATE );
+		} );
 
 		const { rerender } = render( <LocationsWidget attributes={ { geoGranularity: 'country' } } /> );
 		await userEvent.click(
@@ -135,6 +139,8 @@ describe( 'LocationsWidget', () => {
 		expect( mockUseLocationViews ).toHaveBeenLastCalledWith(
 			expect.objectContaining( { geoMode: 'region', countryFilter: undefined } )
 		);
+		// Regions mode keeps the map alongside the leaderboard.
+		expect( screen.getByTestId( 'geo-chart' ) ).toBeInTheDocument();
 
 		rerender( <LocationsWidget attributes={ { geoGranularity: 'country' } } /> );
 

--- a/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
@@ -83,12 +83,14 @@ describe( 'LocationsWidget', () => {
 	} );
 
 	it.each( [
-		[ undefined, 'countries' ],
+		[ 'default', 'countries' ],
 		[ 'country', 'countries' ],
 		[ 'region', 'regions' ],
 		[ 'city', 'cities' ],
 	] as const )( 'opens the %s granularity on the %s report tab', ( geoGranularity, section ) => {
-		render( <LocationsWidget attributes={ geoGranularity ? { geoGranularity } : {} } /> );
+		render(
+			<LocationsWidget attributes={ geoGranularity === 'default' ? {} : { geoGranularity } } />
+		);
 
 		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
 			'href',

--- a/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
@@ -38,27 +38,56 @@ jest.mock( '@wordpress/route', () => ( {
 	useSearch: () => ( {} ),
 } ) );
 
+const mockUseLocationViews = jest.fn( () => ( {
+	data: [],
+	comparisonData: [],
+	hasComparison: false,
+	isLoading: true,
+	isFetching: true,
+	hasData: false,
+	isError: false,
+	isPlaceholderData: false,
+} ) );
+
 jest.mock( '../use-location-views', () => ( {
 	__esModule: true,
-	default: () => ( {
-		data: [],
-		comparisonData: [],
-		hasComparison: false,
-		isLoading: true,
-		isFetching: true,
-		hasData: false,
-		isError: false,
-		isPlaceholderData: false,
-	} ),
+	default: ( ...args: unknown[] ) => mockUseLocationViews( ...( args as [] ) ),
 } ) );
 
 describe( 'LocationsWidget', () => {
+	beforeEach( () => {
+		mockUseLocationViews.mockClear();
+	} );
+
 	it( 'links to the Locations report', () => {
 		render( <LocationsWidget attributes={ {} } /> );
 
 		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
 			'href',
 			expect.stringContaining( '/reports/locations' )
+		);
+	} );
+
+	it.each( [
+		[ undefined, 'countries' ],
+		[ 'country', 'countries' ],
+		[ 'region', 'regions' ],
+		[ 'city', 'cities' ],
+	] as const )( 'opens the %s report tab for the %s granularity', ( geoGranularity, section ) => {
+		render( <LocationsWidget attributes={ geoGranularity ? { geoGranularity } : {} } /> );
+
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining( `section=${ section }` )
+		);
+	} );
+
+	// Regions mode is worldwide; only the country drill-down scopes it.
+	it( 'requests unfiltered region rows in Regions mode', () => {
+		render( <LocationsWidget attributes={ { geoGranularity: 'region' } } /> );
+
+		expect( mockUseLocationViews ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { geoMode: 'region', countryFilter: undefined } )
 		);
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
@@ -45,8 +45,8 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 	GeoChart: () => <div data-testid="geo-chart" />,
 } ) );
 
-// Typed off the hook itself so a new field on `LocationView` breaks this
-// fixture instead of being silently cast away.
+// Typed off the hook so the mocked state and the rows passed to
+// `mockReturnValue` are type-checked rather than cast away.
 type LocationViewsState = ReturnType< typeof import('../use-location-views').default >;
 
 const LOADING_STATE: LocationViewsState = {

--- a/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
 /**
  * Internal dependencies
@@ -38,16 +39,24 @@ jest.mock( '@wordpress/route', () => ( {
 	useSearch: () => ( {} ),
 } ) );
 
-const mockUseLocationViews = jest.fn( () => ( {
+// Google Charts loads asynchronously and is outside this widget's concern.
+jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/widgets-toolkit' ),
+	GeoChart: () => <div data-testid="geo-chart" />,
+} ) );
+
+const LOADING_STATE = {
 	data: [],
-	comparisonData: [],
 	hasComparison: false,
 	isLoading: true,
 	isFetching: true,
 	hasData: false,
 	isError: false,
 	isPlaceholderData: false,
-} ) );
+	refetch: () => {},
+};
+
+const mockUseLocationViews = jest.fn( () => LOADING_STATE );
 
 jest.mock( '../use-location-views', () => ( {
 	__esModule: true,
@@ -56,7 +65,8 @@ jest.mock( '../use-location-views', () => ( {
 
 describe( 'LocationsWidget', () => {
 	beforeEach( () => {
-		mockUseLocationViews.mockClear();
+		mockUseLocationViews.mockReset();
+		mockUseLocationViews.mockReturnValue( LOADING_STATE );
 	} );
 
 	it( 'links to the Locations report', () => {
@@ -73,7 +83,7 @@ describe( 'LocationsWidget', () => {
 		[ 'country', 'countries' ],
 		[ 'region', 'regions' ],
 		[ 'city', 'cities' ],
-	] as const )( 'opens the %s report tab for the %s granularity', ( geoGranularity, section ) => {
+	] as const )( 'opens the %s granularity on the %s report tab', ( geoGranularity, section ) => {
 		render( <LocationsWidget attributes={ geoGranularity ? { geoGranularity } : {} } /> );
 
 		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
@@ -88,6 +98,48 @@ describe( 'LocationsWidget', () => {
 
 		expect( mockUseLocationViews ).toHaveBeenLastCalledWith(
 			expect.objectContaining( { geoMode: 'region', countryFilter: undefined } )
+		);
+	} );
+
+	// Without the reset, the drill-down survives the trip through Regions and
+	// Countries mode comes back scoped to one country instead of listing them all.
+	it( 'drops a drilled-down country when switching to Regions', async () => {
+		mockUseLocationViews.mockReturnValue( {
+			...LOADING_STATE,
+			data: [
+				{
+					key: 'US:United States',
+					label: 'United States',
+					countryCode: 'US',
+					countryFull: 'United States',
+					value: 10,
+					region: '',
+				},
+			],
+			isLoading: false,
+			isFetching: false,
+			hasData: true,
+		} as unknown as typeof LOADING_STATE );
+
+		const { rerender } = render( <LocationsWidget attributes={ { geoGranularity: 'country' } } /> );
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'View regions in United States' } )
+		);
+
+		expect( mockUseLocationViews ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { geoMode: 'region', countryFilter: 'US' } )
+		);
+
+		rerender( <LocationsWidget attributes={ { geoGranularity: 'region' } } /> );
+
+		expect( mockUseLocationViews ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { geoMode: 'region', countryFilter: undefined } )
+		);
+
+		rerender( <LocationsWidget attributes={ { geoGranularity: 'country' } } /> );
+
+		expect( mockUseLocationViews ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { geoMode: 'country', countryFilter: undefined } )
 		);
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -63,6 +63,14 @@ const MISSING_MAP_ERROR_MESSAGE = 'Requested map does not exist';
 // load each country pays the failed draw (a brief error flash) at most once.
 const runtimeUnsupportedProvinceMapCountries = new Set< string >();
 
+type GeoGranularity = NonNullable< LocationsAttributes[ 'geoGranularity' ] >;
+
+const REPORT_SECTIONS: Record< GeoGranularity, string > = {
+	country: 'countries',
+	region: 'regions',
+	city: 'cities',
+};
+
 function getGeoChartCountryId( countryCode: string ): string {
 	if ( countryCode.toUpperCase() === 'TW' ) {
 		return 'Taiwan';
@@ -91,9 +99,10 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
 	} = useWidgetDrillDown< DrillDownCountry >();
 
 	// The "View by" control lives in the widget host header (the
-	// `relevance: 'high'` attribute). City mode disables country drill-down.
+	// `relevance: 'high'` attribute). Only Countries mode drills down, so leaving
+	// the other modes would strand a selected country the user can't clear.
 	useEffect( () => {
-		if ( geoGranularity === 'city' ) {
+		if ( geoGranularity !== 'country' ) {
 			clearSelectedCountry();
 		}
 	}, [ clearSelectedCountry, geoGranularity ] );
@@ -134,11 +143,15 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
 	const useCountryFallbackMap =
 		renderGeoMode === 'region' && !! renderSelectedCountry && ! useProvinceMap;
 	const fallbackCountry = useCountryFallbackMap ? renderSelectedCountry : undefined;
-	const useCityCountryMap = renderGeoMode === 'city';
-	const cityCountryRows = useMemo( () => {
+	// Cities, and Regions outside a country drill-down, span the whole world.
+	// Google GeoChart can't place either row type on the world map, so both are
+	// summed back up to their country.
+	const useCountrySummaryMap =
+		renderGeoMode === 'city' || ( renderGeoMode === 'region' && ! renderSelectedCountry );
+	const countrySummaryRows = useMemo( () => {
 		const countryRows = new Map< string, { countryFull: string; value: number } >();
 
-		if ( ! useCityCountryMap ) {
+		if ( ! useCountrySummaryMap ) {
 			return [];
 		}
 
@@ -152,7 +165,7 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
 		} );
 
 		return Array.from( countryRows.entries() );
-	}, [ data, useCityCountryMap ] );
+	}, [ data, useCountrySummaryMap ] );
 	const handleGeoChartError = useCallback(
 		( error: GeoChartError ) => {
 			const message = `${ error.message ?? '' } ${ error.detailedMessage ?? '' }`;
@@ -201,9 +214,10 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
 	);
 
 	const geoData = useMemo( (): GeoData => {
-		const useLocationHeader = renderGeoMode === 'region' && ! useCountryFallbackMap;
+		// Only the provinces map plots sub-country rows; every other map is
+		// country-scoped, whatever the leaderboard beside it lists.
 		const header: GoogleDataTableColumn[] = [
-			useLocationHeader
+			useProvinceMap
 				? __( 'Location', 'jetpack-premium-analytics-pkg' )
 				: __( 'Country', 'jetpack-premium-analytics-pkg' ),
 			__( 'Views', 'jetpack-premium-analytics-pkg' ),
@@ -227,10 +241,10 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
 			];
 		}
 
-		if ( useCityCountryMap ) {
+		if ( useCountrySummaryMap ) {
 			return [
 				header,
-				...cityCountryRows.map(
+				...countrySummaryRows.map(
 					( [ countryCode, location ] ): GoogleDataTableRow => [
 						{
 							v: getGeoChartCountryId( countryCode ),
@@ -244,14 +258,7 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
 
 		const rows: GoogleDataTableRow[] = data.map( location => [ location.label, location.value ] );
 		return [ header, ...rows ];
-	}, [
-		cityCountryRows,
-		data,
-		fallbackCountry,
-		renderGeoMode,
-		useCityCountryMap,
-		useCountryFallbackMap,
-	] );
+	}, [ countrySummaryRows, data, fallbackCountry, useCountrySummaryMap, useProvinceMap ] );
 
 	const leaderboardData = useMemo( () => {
 		const maxValue = getCombinedPeriodMax(
@@ -389,10 +396,7 @@ export default function Locations( { attributes = {} }: LocationsWidgetProps ) {
 			<div className={ styles.root }>
 				<LocationsInner max={ max } geoGranularity={ geoGranularity } />
 				<WidgetFooter>
-					<ReportLink
-						report="locations"
-						section={ geoGranularity === 'city' ? 'cities' : 'countries' }
-					/>
+					<ReportLink report="locations" section={ REPORT_SECTIONS[ geoGranularity ] } />
 				</WidgetFooter>
 			</div>
 		</WidgetRoot>

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -73,6 +73,7 @@ const REPORT_SECTIONS: Record< GeoGranularity, LocationsReportSection > = {
 	region: 'regions',
 	city: 'cities',
 };
+const DEFAULT_GEO_GRANULARITY: GeoGranularity = 'country';
 
 function getGeoChartCountryId( countryCode: string ): string {
 	if ( countryCode.toUpperCase() === 'TW' ) {
@@ -119,7 +120,7 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
 			reportParams,
 			max,
 			geoMode,
-			countryFilter: geoMode === 'region' ? activeSelectedCountry?.code : undefined,
+			countryFilter: activeSelectedCountry?.code,
 		} );
 	const [ renderLocationState, setRenderLocationState ] = useState< RenderLocationState >( {
 		geoMode,
@@ -395,12 +396,12 @@ export default function Locations( { attributes = {} }: LocationsWidgetProps ) {
 	// Attributes are persisted, so a stale layout can carry a granularity this
 	// widget no longer knows. Normalize once, before it becomes both the endpoint
 	// path segment and the report tab.
-	const storedGranularity = attributes?.geoGranularity ?? 'country';
+	const storedGranularity = attributes?.geoGranularity ?? DEFAULT_GEO_GRANULARITY;
 	// `in` would also accept inherited keys such as `toString`, which would then
 	// reach the endpoint as a path segment.
 	const geoGranularity = Object.prototype.hasOwnProperty.call( REPORT_SECTIONS, storedGranularity )
 		? storedGranularity
-		: 'country';
+		: DEFAULT_GEO_GRANULARITY;
 
 	return (
 		<WidgetRoot attributes={ attributes }>

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -64,8 +64,12 @@ const MISSING_MAP_ERROR_MESSAGE = 'Requested map does not exist';
 const runtimeUnsupportedProvinceMapCountries = new Set< string >();
 
 type GeoGranularity = NonNullable< LocationsAttributes[ 'geoGranularity' ] >;
+// Tab ids owned by the Locations report; `ReportLink` takes a bare string, so
+// naming them here is what catches a typo at build time.
+type LocationsReportSection = 'countries' | 'regions' | 'cities';
 
-const REPORT_SECTIONS: Record< GeoGranularity, string > = {
+const DEFAULT_REPORT_SECTION: LocationsReportSection = 'countries';
+const REPORT_SECTIONS: Record< GeoGranularity, LocationsReportSection > = {
 	country: 'countries',
 	region: 'regions',
 	city: 'cities',
@@ -396,7 +400,12 @@ export default function Locations( { attributes = {} }: LocationsWidgetProps ) {
 			<div className={ styles.root }>
 				<LocationsInner max={ max } geoGranularity={ geoGranularity } />
 				<WidgetFooter>
-					<ReportLink report="locations" section={ REPORT_SECTIONS[ geoGranularity ] } />
+					<ReportLink
+						report="locations"
+						// Attributes are persisted, so a stale layout can carry a granularity
+						// outside the union the map covers.
+						section={ REPORT_SECTIONS[ geoGranularity ] ?? DEFAULT_REPORT_SECTION }
+					/>
 				</WidgetFooter>
 			</div>
 		</WidgetRoot>

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -68,7 +68,6 @@ type GeoGranularity = NonNullable< LocationsAttributes[ 'geoGranularity' ] >;
 // naming them here is what catches a typo at build time.
 type LocationsReportSection = 'countries' | 'regions' | 'cities';
 
-const DEFAULT_REPORT_SECTION: LocationsReportSection = 'countries';
 const REPORT_SECTIONS: Record< GeoGranularity, LocationsReportSection > = {
 	country: 'countries',
 	region: 'regions',
@@ -393,19 +392,18 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
  */
 export default function Locations( { attributes = {} }: LocationsWidgetProps ) {
 	const max = attributes?.max ?? 10;
-	const geoGranularity = attributes?.geoGranularity ?? 'country';
+	// Attributes are persisted, so a stale layout can carry a granularity this
+	// widget no longer knows. Normalize once, before it becomes both the endpoint
+	// path segment and the report tab.
+	const storedGranularity = attributes?.geoGranularity ?? 'country';
+	const geoGranularity = storedGranularity in REPORT_SECTIONS ? storedGranularity : 'country';
 
 	return (
 		<WidgetRoot attributes={ attributes }>
 			<div className={ styles.root }>
 				<LocationsInner max={ max } geoGranularity={ geoGranularity } />
 				<WidgetFooter>
-					<ReportLink
-						report="locations"
-						// Attributes are persisted, so a stale layout can carry a granularity
-						// outside the union the map covers.
-						section={ REPORT_SECTIONS[ geoGranularity ] ?? DEFAULT_REPORT_SECTION }
-					/>
+					<ReportLink report="locations" section={ REPORT_SECTIONS[ geoGranularity ] } />
 				</WidgetFooter>
 			</div>
 		</WidgetRoot>

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -396,7 +396,11 @@ export default function Locations( { attributes = {} }: LocationsWidgetProps ) {
 	// widget no longer knows. Normalize once, before it becomes both the endpoint
 	// path segment and the report tab.
 	const storedGranularity = attributes?.geoGranularity ?? 'country';
-	const geoGranularity = storedGranularity in REPORT_SECTIONS ? storedGranularity : 'country';
+	// `in` would also accept inherited keys such as `toString`, which would then
+	// reach the endpoint as a path segment.
+	const geoGranularity = Object.prototype.hasOwnProperty.call( REPORT_SECTIONS, storedGranularity )
+		? storedGranularity
+		: 'country';
 
 	return (
 		<WidgetRoot attributes={ attributes }>

--- a/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
@@ -93,7 +93,7 @@ const meta = {
 		},
 		geoGranularity: {
 			control: 'radio',
-			options: [ 'country', 'city' ],
+			options: [ 'country', 'region', 'city' ],
 			description: 'The "View by" toolbar attribute rendered by the widget host.',
 		},
 	},
@@ -101,7 +101,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Locations" widget. Shows visitor views by country or city, with country drill-down into regions, using the global dashboard date range. The Countries/Cities view is the `geoGranularity` attribute (`relevance: \'high\'`), exposed as a control by the widget host.',
+					'The "Locations" widget. Shows visitor views by country, region, or city, with country drill-down into regions, using the global dashboard date range. The Countries/Regions/Cities view is the `geoGranularity` attribute (`relevance: \'high\'`), exposed as a control by the widget host.',
 			},
 		},
 	},
@@ -120,6 +120,14 @@ export const Default: StoryObj< LocationsStoryControls > = {
 export const WithComparison: StoryObj< LocationsStoryControls > = {
 	render: renderLocationsWidget,
 	args: { withComparison: true, geoGranularity: 'country' },
+	decorators: [ withWidgetCanvas, withStoryRouter ],
+};
+
+// Regions mode — region rows worldwide in the leaderboard, aggregated by country
+// on the map.
+export const RegionsMode: StoryObj< LocationsStoryControls > = {
+	render: renderLocationsWidget,
+	args: { withComparison: false, geoGranularity: 'region' },
 	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
@@ -190,7 +198,7 @@ export const WidgetDashboardWithWidget: DashboardStory = {
 		},
 		geoGranularity: {
 			control: 'radio',
-			options: [ 'country', 'city' ],
+			options: [ 'country', 'region', 'city' ],
 			description: 'The "View by" toolbar attribute rendered by the widget host.',
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/locations/widget.ts
+++ b/projects/packages/premium-analytics/widgets/locations/widget.ts
@@ -12,16 +12,16 @@ import { SelectField } from '@jetpack-premium-analytics/fields';
 
 export type LocationsAttributes = {
 	max?: number;
-	geoGranularity?: 'country' | 'city';
+	geoGranularity?: 'country' | 'region' | 'city';
 };
 
 /**
  * Widget type definition.
  *
- * Ported from the Jetpack Stats "Locations" module. v1 ships Countries mode
- * (with region drill-down) and Cities mode via the `location-views/{geoMode}`
- * endpoint. City rows are listed in the leaderboard and summarized on the map
- * by country.
+ * Ported from the Jetpack Stats "Locations" module. Countries, Regions, and
+ * Cities modes all read the `location-views/{geoMode}` endpoint; Countries mode
+ * additionally drills down into one country's regions. Region and city rows are
+ * listed in the leaderboard and summarized on the map by country.
  *
  * Data: fetched via the PA proxy at `stats/location-views/{country|region|city}`.
  * Date range comes from WidgetRoot's reportParams (the shared dashboard date
@@ -48,6 +48,10 @@ export default {
 				{
 					label: __( 'Countries', 'jetpack-premium-analytics-pkg' ),
 					value: 'country',
+				},
+				{
+					label: __( 'Regions', 'jetpack-premium-analytics-pkg' ),
+					value: 'region',
 				},
 				{
 					label: __( 'Cities', 'jetpack-premium-analytics-pkg' ),

--- a/projects/plugins/premium-analytics/changelog/add-wooa7s-1940-locations-regions-view
+++ b/projects/plugins/premium-analytics/changelog/add-wooa7s-1940-locations-regions-view
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Top locations: add Regions to the "View by" control, listing the top regions worldwide.


### PR DESCRIPTION
Fixes WOOA7S-1940

## Why

Site owners could see which countries their visitors came from, and which cities — but not which regions, unless they clicked into one country at a time and read its regions in isolation. There was no way to ask "which regions send me the most traffic overall". The full Locations report has had a **Regions** tab all along; the dashboard widget just never offered it. Now it does.

## Proposed changes

* Add **Regions** to the Top locations widget's "View by" control, between Countries and Cities.
* Regions mode is worldwide, like Cities: the leaderboard lists the top regions across every country, each with its country's flag.
* The map summarises those regions back up to their country — Google GeoChart can't place sub-country rows on the world map. Cities mode already did this; the same path now serves both.
* Switching to Regions (or Cities) clears an active country drill-down, so a country selected in Countries mode can't linger in a mode that has no way to clear it.
* "View all" from Regions mode opens the Locations report on its **Regions** tab, matching what Countries and Cities already did.

Countries mode, its click-through drill-down into one country's regions, and the province map for the selected country are all unchanged.

## Screenshots

The "View by" control, before and after — same widget, same data, same scroll position:

![Top locations "View by" dropdown, before and after](https://github.com/user-attachments/assets/ef1809bf-3e83-4b14-afa8-c19ac163b5ef)

Regions selected — worldwide regions in the leaderboard with their country flags, summarised by country on the map:

![Top locations widget in Regions mode](https://github.com/user-attachments/assets/9d13f3f0-1ca2-4e32-845a-4b09d0982afa)

## Related product discussion/links

* WOOA7S-1940

## Does this pull request change what data or activity we track or use?

No. Regions mode reads the same `stats/location-views/{geoMode}` endpoint the widget already used for the country drill-down, and the Locations report already queries it unfiltered for its Regions tab.

## Testing instructions

Acceptance criteria from the issue, as a checklist:

* [ ] Go to **Jetpack → Stats → Traffic** on a Jetpack-connected site with location data.
* [ ] Open the **Top locations** widget's "View by" dropdown — it lists **Countries, Regions, Cities**. Before this change only Countries and Cities were there.
* [ ] Select **Regions**. The leaderboard lists regions from across the world (not one country's), each with its country flag, and the map highlights the countries those regions belong to.
* [ ] Click **View all** — the Locations report opens on its **Regions** tab.
* [ ] Switch back to **Countries** and click a country row. It still drills into that country's regions, still draws the province map, and the "All locations" back link still returns to the country list.
* [ ] While drilled into a country, switch to **Regions**: the drill-down clears and the worldwide region list appears.
* [ ] **Cities** is unchanged — city rows in the leaderboard, summarised by country on the map, "View all" opening the **Cities** tab.

The screenshots above come from a local docker site whose `stats/location-views` responses were mocked, since an offline-mode site has no live Stats data. Storybook covers the same states without a WordPress install: **Packages/Premium Analytics/Widgets/Locations** now has a **RegionsMode** story alongside Default and CitiesMode.

The second observation in the issue — "the Top platforms widget is missing platform distribution" — was checked separately and is **not** the same issue. Its dropdown offers Browser and OS and both render correctly (Windows / macOS / Android / iOS / Linux under OS). The Desktop / Mobile / Tablet split lives in the separate **Devices** widget. Nothing to fix there; if that split should also appear inside Top platforms, that is a product decision worth its own issue.
