### PR TITLE
Premium Analytics: add Size to the Top platforms "View by" control

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-wooa7s-1940-top-platforms-size
+++ b/projects/packages/premium-analytics/changelog/add-wooa7s-1940-top-platforms-size
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Top platforms: offer Size alongside Browser and OS in the widget's "View by" control.

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-devices-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-devices-query.ts
@@ -3,7 +3,9 @@
  */
 import { statsReportQuery, type StatsReportParams } from './stats-query';
 
-export type StatsDeviceProperty = 'screensize' | 'browser' | 'platform' | 'client_type';
+// The only three properties `stats/devices/{property}` accepts; anything else
+// is rejected with a 400 before the query runs.
+export type StatsDeviceProperty = 'screensize' | 'browser' | 'platform';
 
 export const statsDevicesQuery = (
 	params: StatsReportParams & { deviceProperty?: StatsDeviceProperty }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/format-display-label.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/format-display-label.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { formatDisplayLabel } from '../format-display-label';
+
+describe( 'formatDisplayLabel', () => {
+	it( 'prefers a mapped label, matching case-insensitively', () => {
+		expect( formatDisplayLabel( 'Desktop', { desktop: 'Desktop screen' } ) ).toBe(
+			'Desktop screen'
+		);
+	} );
+
+	it( 'title-cases an unmapped key', () => {
+		expect( formatDisplayLabel( 'vivaldi', { chrome: 'Chrome' } ) ).toBe( 'Vivaldi' );
+		expect( formatDisplayLabel( 'chrome' ) ).toBe( 'Chrome' );
+	} );
+
+	// The map is a plain object, so an inherited member would otherwise be
+	// returned where a string is expected.
+	it.each( [ 'toString', 'constructor', 'hasOwnProperty' ] )(
+		'does not return the inherited %s member',
+		key => {
+			expect( formatDisplayLabel( key, { chrome: 'Chrome' } ) ).toBe(
+				key.charAt( 0 ).toUpperCase() + key.slice( 1 )
+			);
+		}
+	);
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/device-labels.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/device-labels.ts
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Display labels for the keys `stats/devices/screensize` returns.
+ *
+ * Shared so the two widgets that render this property — Devices and Top
+ * platforms — cannot drift apart, and so translators see each string once.
+ * Keys outside this map are title-cased by `formatDisplayLabel`.
+ */
+export const SCREEN_SIZE_LABELS: Record< string, string > = {
+	desktop: __( 'Desktop', 'jetpack-premium-analytics-pkg' ),
+	mobile: __( 'Mobile', 'jetpack-premium-analytics-pkg' ),
+	tablet: __( 'Tablet', 'jetpack-premium-analytics-pkg' ),
+	phone: __( 'Phone', 'jetpack-premium-analytics-pkg' ),
+	other: __( 'Other', 'jetpack-premium-analytics-pkg' ),
+	unknown: __( 'Unknown', 'jetpack-premium-analytics-pkg' ),
+};

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/format-display-label.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/format-display-label.ts
@@ -7,6 +7,11 @@
  */
 export function formatDisplayLabel( key: string, labels: Record< string, string > = {} ): string {
 	const normalized = key.toLowerCase();
+	// Own-property only: a key such as `toString` would otherwise resolve to an
+	// inherited `Object.prototype` member and return a function.
+	if ( Object.prototype.hasOwnProperty.call( labels, normalized ) ) {
+		return labels[ normalized ];
+	}
 
-	return labels[ normalized ] ?? key.charAt( 0 ).toUpperCase() + key.slice( 1 );
+	return key.charAt( 0 ).toUpperCase() + key.slice( 1 );
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -46,6 +46,7 @@ export {
 export { flagUrl } from './flag-url';
 export { isEmptyChartData, isEmptyPieChartData, getEmptyChartDomain } from './chart-empty-state';
 export { getFixedYAxis, type FixedYAxis } from './fixed-y-axis';
+export { SCREEN_SIZE_LABELS } from './device-labels';
 export { formatDisplayLabel } from './format-display-label';
 export {
 	buildCsv,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -150,6 +150,7 @@ export {
 	buildSalesByUtmData,
 	formatLegendLabels,
 	formatDisplayLabel,
+	SCREEN_SIZE_LABELS,
 	buildCsv,
 	buildCsvDateRangeFilename,
 	saveCsv,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
@@ -1191,7 +1191,7 @@ export function getStatsMock( path: string ): unknown | null {
 	if ( subPath.startsWith( '/devices/browser' ) ) {
 		return isComparison ? MOCK_DEVICES_BROWSER_COMPARISON : MOCK_DEVICES_BROWSER;
 	}
-	if ( subPath.startsWith( '/devices/client_type' ) || subPath.startsWith( '/devices/platform' ) ) {
+	if ( subPath.startsWith( '/devices/platform' ) ) {
 		return isComparison ? MOCK_DEVICES_PLATFORM_COMPARISON : MOCK_DEVICES_PLATFORM;
 	}
 

--- a/projects/packages/premium-analytics/widgets/devices/use-device-views.ts
+++ b/projects/packages/premium-analytics/widgets/devices/use-device-views.ts
@@ -1,12 +1,8 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-/**
  * Internal dependencies
  */
 import { useStatsDevices } from '@jetpack-premium-analytics/data';
-import { formatDisplayLabel } from '@jetpack-premium-analytics/widgets-toolkit';
+import { formatDisplayLabel, SCREEN_SIZE_LABELS } from '@jetpack-premium-analytics/widgets-toolkit';
 import type {
 	ReportParams,
 	StatsDevicesComparisonItem,
@@ -46,25 +42,13 @@ interface DeviceViewsState {
 }
 
 /**
- * Maps raw API device keys to human-readable display labels.
- * Keys not in this map are title-cased as a fallback.
- */
-const DEVICE_LABELS: Record< string, string > = {
-	desktop: __( 'Desktop', 'jetpack-premium-analytics-pkg' ),
-	mobile: __( 'Mobile', 'jetpack-premium-analytics-pkg' ),
-	tablet: __( 'Tablet', 'jetpack-premium-analytics-pkg' ),
-	phone: __( 'Phone', 'jetpack-premium-analytics-pkg' ),
-	unknown: __( 'Unknown', 'jetpack-premium-analytics-pkg' ),
-};
-
-/**
  * Converts a StatsDevicesItem from the data layer to the widget's DeviceView shape.
  */
 function toDeviceView( item: StatsDevicesComparisonItem ): DeviceView {
 	const key = typeof item.label === 'string' ? item.label : String( item.label );
 	return {
 		label: key,
-		displayLabel: formatDisplayLabel( key, DEVICE_LABELS ),
+		displayLabel: formatDisplayLabel( key, SCREEN_SIZE_LABELS ),
 		percentage: item.value,
 		previousPercentage: item.previousValue,
 	};

--- a/projects/packages/premium-analytics/widgets/top-platforms/__tests__/top-platforms.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/__tests__/top-platforms.test.tsx
@@ -6,6 +6,7 @@ import { render, screen } from '@testing-library/react';
  * Internal dependencies
  */
 import TopPlatformsWidget from '../render';
+import widgetDefinition from '../widget';
 
 // WidgetRoot reads URL search params as a fallback for report params; outside
 // a matched route the real hook warns and throws.
@@ -48,6 +49,20 @@ describe( 'TopPlatformsWidget', () => {
 			);
 		}
 	);
+
+	// `SelectField` renders the first element when the attribute is unset, so the
+	// control would otherwise name a dimension the widget is not fetching.
+	it( 'defaults to the first offered dimension', () => {
+		const firstElement = widgetDefinition.attributes.find(
+			field => field.id === 'platformDimension'
+		)?.elements?.[ 0 ];
+
+		render( <TopPlatformsWidget attributes={ {} } /> );
+
+		expect( mockUsePlatformViews ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { deviceProperty: firstElement?.value } )
+		);
+	} );
 
 	// A stale layout can name a dimension the widget no longer knows; unchecked it
 	// becomes the endpoint path segment, which WPCOM rejects with a 400.

--- a/projects/packages/premium-analytics/widgets/top-platforms/__tests__/top-platforms.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/__tests__/top-platforms.test.tsx
@@ -14,7 +14,10 @@ jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mo
 
 const mockUsePlatformViews = jest.fn();
 
+// Only the hook itself is stubbed; `isPlatformDimension` stays real so the
+// guard below exercises the shipped implementation.
 jest.mock( '../use-platform-views', () => ( {
+	...jest.requireActual( '../use-platform-views' ),
 	__esModule: true,
 	default: ( ...args: unknown[] ) => mockUsePlatformViews( ...( args as [] ) ),
 } ) );
@@ -37,15 +40,13 @@ describe( 'TopPlatformsWidget', () => {
 		mockUsePlatformViews.mockReturnValue( stateWith( [] ) );
 	} );
 
-	it.each( [ [ undefined, 'browser' ], [ 'screensize' ], [ 'browser' ], [ 'platform' ] ] as const )(
+	it.each( [ 'screensize', 'browser', 'platform' ] as const )(
 		'requests the %s device property',
-		( platformDimension, expected = platformDimension ) => {
-			render(
-				<TopPlatformsWidget attributes={ platformDimension ? { platformDimension } : {} } />
-			);
+		platformDimension => {
+			render( <TopPlatformsWidget attributes={ { platformDimension } } /> );
 
 			expect( mockUsePlatformViews ).toHaveBeenLastCalledWith(
-				expect.objectContaining( { deviceProperty: expected } )
+				expect.objectContaining( { deviceProperty: platformDimension } )
 			);
 		}
 	);

--- a/projects/packages/premium-analytics/widgets/top-platforms/__tests__/top-platforms.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/__tests__/top-platforms.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import TopPlatformsWidget from '../render';
+
+// WidgetRoot reads URL search params as a fallback for report params; outside
+// a matched route the real hook warns and throws.
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
+
+const mockUsePlatformViews = jest.fn();
+
+jest.mock( '../use-platform-views', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockUsePlatformViews( ...( args as [] ) ),
+} ) );
+
+function stateWith( rows: { key: string; label: string; views: number }[] ) {
+	return {
+		data: rows,
+		hasComparison: false,
+		isLoading: false,
+		isFetching: false,
+		isError: false,
+		error: null,
+		refetch: () => {},
+	};
+}
+
+describe( 'TopPlatformsWidget', () => {
+	beforeEach( () => {
+		mockUsePlatformViews.mockReset();
+		mockUsePlatformViews.mockReturnValue( stateWith( [] ) );
+	} );
+
+	it.each( [ [ undefined, 'browser' ], [ 'screensize' ], [ 'browser' ], [ 'platform' ] ] as const )(
+		'requests the %s device property',
+		( platformDimension, expected = platformDimension ) => {
+			render(
+				<TopPlatformsWidget attributes={ platformDimension ? { platformDimension } : {} } />
+			);
+
+			expect( mockUsePlatformViews ).toHaveBeenLastCalledWith(
+				expect.objectContaining( { deviceProperty: expected } )
+			);
+		}
+	);
+
+	// A stale layout can name a dimension the widget no longer knows; unchecked it
+	// becomes the endpoint path segment, which WPCOM rejects with a 400.
+	it( 'falls back to Browser for a dimension outside the supported set', () => {
+		render(
+			<TopPlatformsWidget
+				attributes={
+					{ platformDimension: 'client_type' } as unknown as { platformDimension: 'browser' }
+				}
+			/>
+		);
+
+		expect( mockUsePlatformViews ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { deviceProperty: 'browser' } )
+		);
+	} );
+
+	// WPCOM returns `screensize` as percentage shares and the other two as view
+	// counts, so the same leaderboard has to print two different units.
+	it( 'prints Size rows as percentages', () => {
+		mockUsePlatformViews.mockReturnValue(
+			stateWith( [ { key: 'desktop', label: 'Desktop', views: 57.8 } ] )
+		);
+
+		render( <TopPlatformsWidget attributes={ { platformDimension: 'screensize' } } /> );
+
+		expect( screen.getByText( '57.8%' ) ).toBeInTheDocument();
+	} );
+
+	it( 'prints Browser rows as counts', () => {
+		mockUsePlatformViews.mockReturnValue(
+			stateWith( [ { key: 'chrome', label: 'Chrome', views: 812 } ] )
+		);
+
+		render( <TopPlatformsWidget attributes={ { platformDimension: 'browser' } } /> );
+
+		expect( screen.getByText( '812' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/top-platforms/__tests__/use-platform-views-labels.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/__tests__/use-platform-views-labels.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { queryClient, type ReportParams } from '@jetpack-premium-analytics/data';
+import { renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import { queryClientWrapper as wrapper } from '../../test-utils';
+import usePlatformViews from '../use-platform-views';
+
+jest.mock( '@wordpress/api-fetch' );
+
+const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+const reportParams = { from: '2026-06-01', to: '2026-06-30' } as ReportParams;
+
+// `stats/devices/{property}` answers with a flat key/value map; the keys are the
+// raw API vocabulary each dimension uses.
+const RESPONSES: Record< string, Record< string, number > > = {
+	screensize: { desktop: 57.8, mobile: 37, tablet: 5.2 },
+	browser: { chrome: 812, miui: 190 },
+	platform: { mac: 402, android_tablet: 65 },
+};
+
+type MockedFetchArgs = { path?: string; url?: string };
+
+beforeEach( () => {
+	queryClient.clear();
+	mockApiFetch.mockImplementation( ( { path = '', url = '' }: MockedFetchArgs ) => {
+		const target = path || url;
+		const property = Object.keys( RESPONSES ).find( key => target.includes( `devices/${ key }` ) );
+
+		return Promise.resolve( { top_values: property ? RESPONSES[ property ] : {} } );
+	} );
+} );
+
+describe( 'usePlatformViews labels', () => {
+	// Each dimension has its own vocabulary, so the row label depends on which
+	// map the hook picks — the thing that silently breaks if the mapping drifts.
+	it.each( [
+		[ 'screensize', 'desktop', 'Desktop' ],
+		[ 'browser', 'miui', 'Mi Browser' ],
+		[ 'platform', 'android_tablet', 'Android Tablet' ],
+	] as const )( 'maps the %s key %s to %s', async ( deviceProperty, key, expected ) => {
+		const { result } = renderHook(
+			() => usePlatformViews( { reportParams, max: 10, deviceProperty } ),
+			{ wrapper }
+		);
+
+		await waitFor( () => expect( result.current.data.length ).toBeGreaterThan( 0 ) );
+
+		expect( result.current.data.find( row => row.key === key )?.label ).toBe( expected );
+	} );
+
+	// Keys outside the map are title-cased rather than dropped.
+	it( 'falls back to title case for an unmapped key', async () => {
+		RESPONSES.browser = { vivaldi: 12 };
+
+		const { result } = renderHook(
+			() => usePlatformViews( { reportParams, max: 10, deviceProperty: 'browser' } ),
+			{ wrapper }
+		);
+
+		await waitFor( () => expect( result.current.data.length ).toBeGreaterThan( 0 ) );
+
+		expect( result.current.data[ 0 ].label ).toBe( 'Vivaldi' );
+
+		RESPONSES.browser = { chrome: 812, miui: 190 };
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/top-platforms/__tests__/use-platform-views-labels.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/__tests__/use-platform-views-labels.test.tsx
@@ -18,7 +18,7 @@ const reportParams = { from: '2026-06-01', to: '2026-06-30' } as ReportParams;
 
 // `stats/devices/{property}` answers with a flat key/value map; the keys are the
 // raw API vocabulary each dimension uses.
-const RESPONSES: Record< string, Record< string, number > > = {
+const RESPONSES: Readonly< Record< string, Record< string, number > > > = {
 	screensize: { desktop: 57.8, mobile: 37, tablet: 5.2 },
 	browser: { chrome: 812, miui: 190 },
 	platform: { mac: 402, android_tablet: 65 },
@@ -56,7 +56,9 @@ describe( 'usePlatformViews labels', () => {
 
 	// Keys outside the map are title-cased rather than dropped.
 	it( 'falls back to title case for an unmapped key', async () => {
-		RESPONSES.browser = { vivaldi: 12 };
+		// A local implementation rather than a reassignment of RESPONSES: a
+		// failing assertion below must not leak a fixture into the next test.
+		mockApiFetch.mockImplementation( () => Promise.resolve( { top_values: { vivaldi: 12 } } ) );
 
 		const { result } = renderHook(
 			() => usePlatformViews( { reportParams, max: 10, deviceProperty: 'browser' } ),
@@ -66,7 +68,5 @@ describe( 'usePlatformViews labels', () => {
 		await waitFor( () => expect( result.current.data.length ).toBeGreaterThan( 0 ) );
 
 		expect( result.current.data[ 0 ].label ).toBe( 'Vivaldi' );
-
-		RESPONSES.browser = { chrome: 812, miui: 190 };
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/top-platforms/__tests__/use-platform-views.test.ts
+++ b/projects/packages/premium-analytics/widgets/top-platforms/__tests__/use-platform-views.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { isPlatformDimension } from '../use-platform-views';
+
+describe( 'isPlatformDimension', () => {
+	// The three properties `stats/devices/{property}` accepts. Anything else is
+	// rejected upstream with a 400, so it must never reach the request.
+	it.each( [ 'screensize', 'browser', 'platform' ] )( 'accepts %s', dimension => {
+		expect( isPlatformDimension( dimension ) ).toBe( true );
+	} );
+
+	it.each( [ 'client_type', 'toString', 'constructor', '' ] )( 'rejects %s', dimension => {
+		expect( isPlatformDimension( dimension ) ).toBe( false );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/top-platforms/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/render.tsx
@@ -143,7 +143,7 @@ function TopPlatformsInner( { max, platformDimension }: TopPlatformsInnerProps )
  * dimension is the `platformDimension` attribute (`relevance: 'high'`), exposed
  * as a control by the widget host.
  */
-export default function TopPlatformsWidget( { attributes }: TopPlatformsWidgetProps ) {
+export default function TopPlatformsWidget( { attributes = {} }: TopPlatformsWidgetProps ) {
 	const max = attributes?.max ?? 10;
 	// Attributes are persisted, so a stale layout can name a dimension this
 	// widget no longer knows. Unchecked it becomes the `stats/devices/{property}`

--- a/projects/packages/premium-analytics/widgets/top-platforms/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/render.tsx
@@ -23,7 +23,7 @@ import {
  * Internal dependencies
  */
 import styles from './style.module.css';
-import usePlatformViews from './use-platform-views';
+import usePlatformViews, { type PlatformDimension } from './use-platform-views';
 import { type TopPlatformsAttributes } from './widget';
 /**
  * Types
@@ -33,9 +33,24 @@ import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 type TopPlatformsRenderAttributes = TopPlatformsAttributes & Partial< ReportParamsFieldAttributes >;
 type TopPlatformsWidgetProps = WidgetRenderProps< TopPlatformsRenderAttributes >;
 
-const DATA_FORMAT = { type: 'number' as const, options: { useMultipliers: true, decimals: 0 } };
+const COUNT_DATA_FORMAT = {
+	type: 'number' as const,
+	options: { useMultipliers: true, decimals: 0 },
+};
+// WPCOM returns `screensize` as percentage shares rather than view counts, and
+// the shared percentage formatter takes a 0-1 ratio.
+const PERCENTAGE_DATA_FORMAT = {
+	type: 'percentage' as const,
+	options: { decimals: 1, signDisplay: 'auto' as const },
+};
 
-type PlatformMode = 'browser' | 'platform';
+type PlatformMode = PlatformDimension;
+
+const SUPPORTED_DIMENSIONS: Record< PlatformMode, true > = {
+	screensize: true,
+	browser: true,
+	platform: true,
+};
 
 type TopPlatformsInnerProps = {
 	/**
@@ -43,7 +58,7 @@ type TopPlatformsInnerProps = {
 	 */
 	max: number;
 	/**
-	 * Device dimension to rank: browsers or operating systems.
+	 * Device dimension to rank: screen sizes, browsers, or operating systems.
 	 */
 	platformDimension: PlatformMode;
 };
@@ -59,6 +74,11 @@ function TopPlatformsInner( { max, platformDimension }: TopPlatformsInnerProps )
 		}
 	);
 
+	const isShare = platformDimension === 'screensize';
+	// Bar widths stay relative to the largest visible value either way; only the
+	// number printed on the row changes unit.
+	const toDisplayValue = ( value: number ) => ( isShare ? value / 100 : value );
+
 	const maxViews = getCombinedPeriodMax(
 		data.map( item => item.views ),
 		hasComparison ? data.map( item => item.previousViews ) : []
@@ -73,9 +93,9 @@ function TopPlatformsInner( { max, platformDimension }: TopPlatformsInnerProps )
 					<Text>{ item.label }</Text>
 				</Stack>
 			),
-			currentValue: item.views,
+			currentValue: toDisplayValue( item.views ),
 			currentShare: sharePercentage( item.views, maxViews ),
-			previousValue,
+			previousValue: previousValue === undefined ? undefined : toDisplayValue( previousValue ),
 			previousShare:
 				hasComparison && previousValue !== undefined
 					? sharePercentage( previousValue, maxViews )
@@ -111,7 +131,7 @@ function TopPlatformsInner( { max, platformDimension }: TopPlatformsInnerProps )
 					withComparison={ hasComparison }
 					withOverlayLabel
 					showLegend={ false }
-					dataFormat={ DATA_FORMAT }
+					dataFormat={ isShare ? PERCENTAGE_DATA_FORMAT : COUNT_DATA_FORMAT }
 				/>
 			</WidgetState>
 		</div>
@@ -119,13 +139,22 @@ function TopPlatformsInner( { max, platformDimension }: TopPlatformsInnerProps )
 }
 
 /**
- * Browser or OS breakdown as a ranked leaderboard. The active dimension is the
- * `platformDimension` attribute (`relevance: 'high'`), exposed as a control by
- * the widget host.
+ * Screen size, browser, or OS breakdown as a ranked leaderboard. The active
+ * dimension is the `platformDimension` attribute (`relevance: 'high'`), exposed
+ * as a control by the widget host.
  */
 export default function TopPlatformsWidget( { attributes }: TopPlatformsWidgetProps ) {
 	const max = attributes?.max ?? 10;
-	const platformDimension = attributes?.platformDimension ?? 'browser';
+	// Attributes are persisted, so a stale layout can name a dimension this
+	// widget no longer knows. Unchecked it becomes the `stats/devices/{property}`
+	// path segment, which WPCOM rejects with a 400.
+	const storedDimension = attributes?.platformDimension ?? 'browser';
+	const platformDimension = Object.prototype.hasOwnProperty.call(
+		SUPPORTED_DIMENSIONS,
+		storedDimension
+	)
+		? storedDimension
+		: 'browser';
 
 	return (
 		<WidgetRoot attributes={ attributes }>

--- a/projects/packages/premium-analytics/widgets/top-platforms/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/render.tsx
@@ -23,7 +23,10 @@ import {
  * Internal dependencies
  */
 import styles from './style.module.css';
-import usePlatformViews, { type PlatformDimension } from './use-platform-views';
+import usePlatformViews, {
+	isPlatformDimension,
+	type PlatformDimension,
+} from './use-platform-views';
 import { type TopPlatformsAttributes } from './widget';
 /**
  * Types
@@ -44,14 +47,6 @@ const PERCENTAGE_DATA_FORMAT = {
 	options: { decimals: 1, signDisplay: 'auto' as const },
 };
 
-type PlatformMode = PlatformDimension;
-
-const SUPPORTED_DIMENSIONS: Record< PlatformMode, true > = {
-	screensize: true,
-	browser: true,
-	platform: true,
-};
-
 type TopPlatformsInnerProps = {
 	/**
 	 * Max rows to display.
@@ -60,7 +55,7 @@ type TopPlatformsInnerProps = {
 	/**
 	 * Device dimension to rank: screen sizes, browsers, or operating systems.
 	 */
-	platformDimension: PlatformMode;
+	platformDimension: PlatformDimension;
 };
 
 function TopPlatformsInner( { max, platformDimension }: TopPlatformsInnerProps ) {
@@ -75,8 +70,8 @@ function TopPlatformsInner( { max, platformDimension }: TopPlatformsInnerProps )
 	);
 
 	const isShare = platformDimension === 'screensize';
-	// Bar widths stay relative to the largest visible value either way; only the
-	// number printed on the row changes unit.
+	// Only the number printed on the row changes unit; the percentage formatter
+	// takes a 0-1 ratio while WPCOM sends screensize as 0-100.
 	const toDisplayValue = ( value: number ) => ( isShare ? value / 100 : value );
 
 	const maxViews = getCombinedPeriodMax(
@@ -94,6 +89,8 @@ function TopPlatformsInner( { max, platformDimension }: TopPlatformsInnerProps )
 				</Stack>
 			),
 			currentValue: toDisplayValue( item.views ),
+			// Bar widths come from the raw values on purpose: the ratio to `maxViews`
+			// is the same before and after the unit conversion.
 			currentShare: sharePercentage( item.views, maxViews ),
 			previousValue: previousValue === undefined ? undefined : toDisplayValue( previousValue ),
 			previousShare:
@@ -144,17 +141,12 @@ function TopPlatformsInner( { max, platformDimension }: TopPlatformsInnerProps )
  * as a control by the widget host.
  */
 export default function TopPlatformsWidget( { attributes = {} }: TopPlatformsWidgetProps ) {
-	const max = attributes?.max ?? 10;
+	const max = attributes.max ?? 10;
 	// Attributes are persisted, so a stale layout can name a dimension this
 	// widget no longer knows. Unchecked it becomes the `stats/devices/{property}`
 	// path segment, which WPCOM rejects with a 400.
-	const storedDimension = attributes?.platformDimension ?? 'browser';
-	const platformDimension = Object.prototype.hasOwnProperty.call(
-		SUPPORTED_DIMENSIONS,
-		storedDimension
-	)
-		? storedDimension
-		: 'browser';
+	const storedDimension = attributes.platformDimension ?? 'browser';
+	const platformDimension = isPlatformDimension( storedDimension ) ? storedDimension : 'browser';
 
 	return (
 		<WidgetRoot attributes={ attributes }>

--- a/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
@@ -134,6 +134,15 @@ export const BySize: StoryObj< TopPlatformsStoryControls > = {
 	decorators: [ withWidgetCanvas ],
 };
 
+// Size with comparison — the one Size state where two percentages sit side by
+// side: the share itself and `calculateDelta`'s relative change against the
+// previous period. Worth a look when reviewing the copy.
+export const BySizeWithComparison: StoryObj< TopPlatformsStoryControls > = {
+	render: renderTopPlatformsWidget,
+	args: { withComparison: true, platformDimension: 'screensize' },
+	decorators: [ withWidgetCanvas ],
+};
+
 // OS view — the `platformDimension` attribute set to operating systems.
 export const ByOS: StoryObj< TopPlatformsStoryControls > = {
 	render: renderTopPlatformsWidget,

--- a/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
@@ -97,7 +97,7 @@ const meta = {
 		},
 		platformDimension: {
 			control: 'radio',
-			options: [ 'browser', 'platform' ],
+			options: [ 'screensize', 'browser', 'platform' ],
 			description: 'The "View by" toolbar attribute rendered by the widget host.',
 		},
 	},
@@ -105,7 +105,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Top Platforms" widget. Shows browser and OS breakdown as a ranked leaderboard. The active dimension is the `platformDimension` attribute (`relevance: \'high\'`), exposed as a control by the widget host.',
+					'The "Top Platforms" widget. Shows the screen size, browser, and OS breakdowns as a ranked leaderboard. The active dimension is the `platformDimension` attribute (`relevance: \'high\'`), exposed as a control by the widget host. Screen size is returned by WordPress.com as percentage shares, so it is formatted as a percentage rather than a view count.',
 			},
 		},
 	},
@@ -124,6 +124,13 @@ export const Default: StoryObj< TopPlatformsStoryControls > = {
 export const WithComparison: StoryObj< TopPlatformsStoryControls > = {
 	render: renderTopPlatformsWidget,
 	args: { withComparison: true, platformDimension: 'browser' },
+	decorators: [ withWidgetCanvas ],
+};
+
+// Size view — screen sizes, the one dimension returned as percentage shares.
+export const BySize: StoryObj< TopPlatformsStoryControls > = {
+	render: renderTopPlatformsWidget,
+	args: { withComparison: false, platformDimension: 'screensize' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -208,7 +215,7 @@ export const WidgetDashboardWithWidget: DashboardStory = {
 		},
 		platformDimension: {
 			control: 'radio',
-			options: [ 'browser', 'platform' ],
+			options: [ 'screensize', 'browser', 'platform' ],
 			description: 'The "View by" toolbar attribute rendered by the widget host.',
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
@@ -97,7 +97,7 @@ const meta = {
 		},
 		platformDimension: {
 			control: 'radio',
-			options: [ 'screensize', 'browser', 'platform' ],
+			options: [ 'browser', 'platform', 'screensize' ],
 			description: 'The "View by" toolbar attribute rendered by the widget host.',
 		},
 	},
@@ -215,7 +215,7 @@ export const WidgetDashboardWithWidget: DashboardStory = {
 		},
 		platformDimension: {
 			control: 'radio',
-			options: [ 'screensize', 'browser', 'platform' ],
+			options: [ 'browser', 'platform', 'screensize' ],
 			description: 'The "View by" toolbar attribute rendered by the widget host.',
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/top-platforms/use-platform-views.ts
+++ b/projects/packages/premium-analytics/widgets/top-platforms/use-platform-views.ts
@@ -6,10 +6,17 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useStatsDevices } from '@jetpack-premium-analytics/data';
-import { formatDisplayLabel } from '@jetpack-premium-analytics/widgets-toolkit';
-import type { ReportParams, StatsDevicesComparisonItem } from '@jetpack-premium-analytics/data';
+import { formatDisplayLabel, SCREEN_SIZE_LABELS } from '@jetpack-premium-analytics/widgets-toolkit';
+import type {
+	ReportParams,
+	StatsDeviceProperty,
+	StatsDevicesComparisonItem,
+} from '@jetpack-premium-analytics/data';
 
-export type PlatformDimension = 'screensize' | 'browser' | 'platform';
+// The endpoint's own property set. Aliasing rather than restating it keeps
+// LABELS_BY_DIMENSION exhaustive: adding a property upstream breaks the build
+// here instead of silently falling through to an undefined label map.
+export type PlatformDimension = StatsDeviceProperty;
 
 export interface PlatformView {
 	key: string;
@@ -56,15 +63,6 @@ const BROWSER_LABELS: Record< string, string > = {
 	other: __( 'Other', 'jetpack-premium-analytics-pkg' ),
 };
 
-const SCREENSIZE_LABELS: Record< string, string > = {
-	desktop: __( 'Desktop', 'jetpack-premium-analytics-pkg' ),
-	mobile: __( 'Mobile', 'jetpack-premium-analytics-pkg' ),
-	tablet: __( 'Tablet', 'jetpack-premium-analytics-pkg' ),
-	phone: __( 'Phone', 'jetpack-premium-analytics-pkg' ),
-	other: __( 'Other', 'jetpack-premium-analytics-pkg' ),
-	unknown: __( 'Unknown', 'jetpack-premium-analytics-pkg' ),
-};
-
 const PLATFORM_LABELS: Record< string, string > = {
 	windows: __( 'Windows', 'jetpack-premium-analytics-pkg' ),
 	mac: __( 'macOS', 'jetpack-premium-analytics-pkg' ),
@@ -81,10 +79,19 @@ const PLATFORM_LABELS: Record< string, string > = {
 };
 
 const LABELS_BY_DIMENSION: Record< PlatformDimension, Record< string, string > > = {
-	screensize: SCREENSIZE_LABELS,
+	screensize: SCREEN_SIZE_LABELS,
 	browser: BROWSER_LABELS,
 	platform: PLATFORM_LABELS,
 };
+
+/**
+ * Whether a persisted attribute names a dimension this widget can fetch.
+ *
+ * Keyed off the label map so the supported set is spelled out once.
+ */
+export function isPlatformDimension( value: string ): value is PlatformDimension {
+	return Object.prototype.hasOwnProperty.call( LABELS_BY_DIMENSION, value );
+}
 
 function toPlatformView(
 	item: StatsDevicesComparisonItem,
@@ -102,7 +109,8 @@ function toPlatformView(
 }
 
 /**
- * Fetch platform views (browser or OS) via the shared Stats data layer.
+ * Fetch platform views (screen size, browser, or OS) via the shared Stats data
+ * layer.
  */
 export default function usePlatformViews( {
 	reportParams,

--- a/projects/packages/premium-analytics/widgets/top-platforms/use-platform-views.ts
+++ b/projects/packages/premium-analytics/widgets/top-platforms/use-platform-views.ts
@@ -9,6 +9,8 @@ import { useStatsDevices } from '@jetpack-premium-analytics/data';
 import { formatDisplayLabel } from '@jetpack-premium-analytics/widgets-toolkit';
 import type { ReportParams, StatsDevicesComparisonItem } from '@jetpack-premium-analytics/data';
 
+export type PlatformDimension = 'screensize' | 'browser' | 'platform';
+
 export interface PlatformView {
 	key: string;
 	label: string;
@@ -26,9 +28,9 @@ interface UsePlatformViewsArgs {
 	 */
 	max: number;
 	/**
-	 * 'browser' or 'platform' (OS).
+	 * 'screensize' (Size), 'browser', or 'platform' (OS).
 	 */
-	deviceProperty: 'browser' | 'platform';
+	deviceProperty: PlatformDimension;
 }
 
 interface PlatformViewsState {
@@ -54,6 +56,15 @@ const BROWSER_LABELS: Record< string, string > = {
 	other: __( 'Other', 'jetpack-premium-analytics-pkg' ),
 };
 
+const SCREENSIZE_LABELS: Record< string, string > = {
+	desktop: __( 'Desktop', 'jetpack-premium-analytics-pkg' ),
+	mobile: __( 'Mobile', 'jetpack-premium-analytics-pkg' ),
+	tablet: __( 'Tablet', 'jetpack-premium-analytics-pkg' ),
+	phone: __( 'Phone', 'jetpack-premium-analytics-pkg' ),
+	other: __( 'Other', 'jetpack-premium-analytics-pkg' ),
+	unknown: __( 'Unknown', 'jetpack-premium-analytics-pkg' ),
+};
+
 const PLATFORM_LABELS: Record< string, string > = {
 	windows: __( 'Windows', 'jetpack-premium-analytics-pkg' ),
 	mac: __( 'macOS', 'jetpack-premium-analytics-pkg' ),
@@ -69,12 +80,18 @@ const PLATFORM_LABELS: Record< string, string > = {
 	other: __( 'Other', 'jetpack-premium-analytics-pkg' ),
 };
 
+const LABELS_BY_DIMENSION: Record< PlatformDimension, Record< string, string > > = {
+	screensize: SCREENSIZE_LABELS,
+	browser: BROWSER_LABELS,
+	platform: PLATFORM_LABELS,
+};
+
 function toPlatformView(
 	item: StatsDevicesComparisonItem,
-	deviceProperty: 'browser' | 'platform'
+	deviceProperty: PlatformDimension
 ): PlatformView {
 	const key = String( item.label ?? '' );
-	const labels = deviceProperty === 'browser' ? BROWSER_LABELS : PLATFORM_LABELS;
+	const labels = LABELS_BY_DIMENSION[ deviceProperty ];
 
 	return {
 		key,

--- a/projects/packages/premium-analytics/widgets/top-platforms/widget.json
+++ b/projects/packages/premium-analytics/widgets/top-platforms/widget.json
@@ -1,9 +1,9 @@
 {
 	"name": "jpa/top-platforms",
 	"title": "Top platforms",
-	"description": "Top browsers and operating systems your visitors use.",
+	"description": "Top screen sizes, browsers, and operating systems your visitors use.",
 	"help": {
-		"content": "A breakdown of the operating systems and browsers your visitors used, sorted by views.",
+		"content": "A breakdown of the screen sizes, browsers, and operating systems your visitors used. Screen sizes are shown as a share of all views; browsers and operating systems are sorted by views.",
 		"links": [
 			{
 				"label": "Learn more",

--- a/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { desktop } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+import type { StatsDeviceProperty } from '@jetpack-premium-analytics/data';
 
 /**
  * Internal dependencies
@@ -18,7 +19,7 @@ export type TopPlatformsAttributes = {
 	/**
 	 * Device dimension to rank: screen sizes, browsers, or operating systems.
 	 */
-	platformDimension?: 'screensize' | 'browser' | 'platform';
+	platformDimension?: StatsDeviceProperty;
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
@@ -16,17 +16,21 @@ export type TopPlatformsAttributes = {
 	 */
 	max?: number;
 	/**
-	 * Device dimension to rank: browsers or operating systems.
+	 * Device dimension to rank: screen sizes, browsers, or operating systems.
 	 */
-	platformDimension?: 'browser' | 'platform';
+	platformDimension?: 'screensize' | 'browser' | 'platform';
 };
 
 /**
  * Top Platforms widget type definition.
  *
- * Shows Browser and OS breakdown as a ranked leaderboard. The active
- * dimension is the `platformDimension` attribute (`relevance: 'high'`),
- * so the widget host renders its control.
+ * Shows the Size, Browser, and OS breakdowns as a ranked leaderboard — the
+ * three properties `stats/devices/{property}` exposes. The active dimension is
+ * the `platformDimension` attribute (`relevance: 'high'`), so the widget host
+ * renders its control.
+ *
+ * Size is the odd one out: WPCOM returns it as percentage shares while the
+ * other two are view counts, so it is formatted as a percentage.
  */
 export default {
 	icon: desktop,
@@ -42,6 +46,10 @@ export default {
 			type: 'text',
 			Edit: SelectField,
 			elements: [
+				{
+					label: __( 'Size', 'jetpack-premium-analytics-pkg' ),
+					value: 'screensize',
+				},
 				{
 					label: __( 'Browser', 'jetpack-premium-analytics-pkg' ),
 					value: 'browser',

--- a/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
@@ -45,11 +45,9 @@ export default {
 			label: __( 'View by', 'jetpack-premium-analytics-pkg' ),
 			type: 'text',
 			Edit: SelectField,
+			// Browser stays first: `SelectField` shows the first element when the
+			// attribute is unset, so it has to match the render default.
 			elements: [
-				{
-					label: __( 'Size', 'jetpack-premium-analytics-pkg' ),
-					value: 'screensize',
-				},
 				{
 					label: __( 'Browser', 'jetpack-premium-analytics-pkg' ),
 					value: 'browser',
@@ -57,6 +55,10 @@ export default {
 				{
 					label: __( 'OS', 'jetpack-premium-analytics-pkg' ),
 					value: 'platform',
+				},
+				{
+					label: __( 'Size', 'jetpack-premium-analytics-pkg' ),
+					value: 'screensize',
 				},
 			],
 			relevance: 'high',

--- a/projects/plugins/premium-analytics/changelog/add-wooa7s-1940-top-platforms-size
+++ b/projects/plugins/premium-analytics/changelog/add-wooa7s-1940-top-platforms-size
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Top platforms: add Size to the "View by" control, showing the Desktop, Mobile and Tablet split.


### PR DESCRIPTION
Follows WOOA7S-1940 (the second half of that report)

## Why

WOOA7S-1940 said the Top platforms widget was "missing platform distribution". It was: the widget offered Browser and OS, which is two of the three breakdowns `stats/devices/{property}` actually serves. The screen-size split — Desktop / Mobile / Tablet — was unreachable from it. This adds it as **Size**.

## Proposed changes

* Add **Size** to the Top platforms "View by" control. The options are now Browser, OS, Size.
* Format Size as a percentage. WordPress.com special-cases `screensize` and returns percentage shares, while `browser` and `platform` return view counts, so the leaderboard prints the two units accordingly. Bar widths stay relative to the largest visible value either way.
* Guard the persisted `platformDimension` against a value outside the supported set, so a stale layout can't turn into a `stats/devices/<unknown>` request.
* Drop `client_type` from `StatsDeviceProperty`. It is not one of the properties the endpoint accepts, so a request naming it is rejected before any query runs. Nothing called it; the Storybook mock that pretended it worked is gone too.

Browser stays the first option deliberately: the shared `SelectField` displays the first element when the attribute is unset, so the first option has to match the render default. If the design wants Size first, the render default and the `example` attributes should move with it — say the word and I'll flip both together.

## Screenshots

Size selected — Desktop / Mobile / Tablet as shares of all views:

![Top platforms widget in Size mode](https://github.com/user-attachments/assets/453ff1ef-82dc-49f5-8f57-636f2967dcc4)

## Related product discussion/links

* WOOA7S-1940

## Does this pull request change what data or activity we track or use?

No. Size reads `stats/devices/screensize`, the same endpoint and property the existing Devices widget already requests.

## Testing instructions

* [ ] Go to **Jetpack → Stats → Traffic** on a Jetpack-connected site with traffic.
* [ ] Open the **Top platforms** widget's "View by" dropdown — it lists **Browser, OS, Size**. Before this change only Browser and OS were there.
* [ ] Select **Size**. Rows read Desktop / Mobile / Tablet with **percentages** (e.g. `57.8%`), not view counts.
* [ ] Switch back to **Browser** and **OS** — both still list view counts, unchanged.
* [ ] Add a fresh Top platforms widget to the dashboard. The control reads **Browser** and the rows are browsers — the label and the data agree.

Storybook covers the same states without a WordPress install: **Packages/Premium Analytics/Widgets/TopPlatforms** now has a **BySize** story alongside Default and ByOS.

### Note on the screenshot

The dashboard site used for the screenshot is in offline mode, so its `stats/devices/*` responses were mocked locally with the shapes WordPress.com actually returns (percentage shares for `screensize`, counts for the other two). The endpoint's property set and response shapes were confirmed against the WordPress.com server code rather than assumed.
