### PR TITLE
Charts: pin the test locale alongside the timezone

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-test-locale-pin
+++ b/projects/js-packages/charts/changelog/fix-charts-test-locale-pin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Tests: pin the locale alongside the timezone so date assertions are deterministic.
+

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -65,7 +65,7 @@
 		"build": "pnpm run build:prod",
 		"build:prod": "tsdown",
 		"storybook": "cd ../storybook && pnpm run storybook:dev",
-		"test": "TZ=UTC jest --config=tests/jest.config.cjs",
+		"test": "TZ=UTC LC_ALL=en_US.UTF-8 jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
 		"typecheck": "tsgo --noEmit"
 	},


### PR DESCRIPTION
Fixes #

## Proposed changes

* Pin `LC_ALL=en_US.UTF-8` alongside the existing `TZ=UTC` in the charts package's test script.

The charts test script pins the timezone but not the locale. Date formatting through `toLocaleDateString`/`toLocaleTimeString` with an `undefined` locale follows `LC_ALL`/`LANG`, and eleven tests in the suite assert English month names and AM/PM markers. They fail on any machine whose shell is set to a non-English locale — a real papercut for contributors outside en_US, and a latent CI hazard if a runner image ever ships with `LANG` set.

CI passes today only because GitHub's runners leave `LANG` unset.

Split out of #51012, which added more date-asserting tests and made this worse. No behaviour change — test tooling only.

## Related product discussion/links

* #51012

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* From `projects/js-packages/charts`, reproduce the failures on trunk:
  ```
  TZ=UTC LC_ALL=de_DE.UTF-8 pnpm exec jest --config=tests/jest.config.cjs
  ```
  → `Tests: 11 failed, 1063 passed, 1074 total` (e.g. `1. Januar 2024` instead of `January 1, 2024`).
* On this branch, the pin makes the script self-contained, so the ambient locale no longer matters:
  ```
  LC_ALL=de_DE.UTF-8 pnpm run test
  ```
  → `Tests: 1074 passed, 1074 total`.
* `pnpm run test` on its own is unchanged: 1074 passing.
