### PR TITLE
Charts: format horizontal y ticks once when measuring the margin

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-horizontal-tick-margin
+++ b/projects/js-packages/charts/changelog/fix-charts-horizontal-tick-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: measure a horizontal chart's left margin from the labels it will actually draw, so a caller's tick formatter is applied exactly once and time-of-day labels stop reserving room for the string "Invalid Date".

--- a/projects/js-packages/charts/src/hooks/test/use-chart-margin.test.tsx
+++ b/projects/js-packages/charts/src/hooks/test/use-chart-margin.test.tsx
@@ -184,4 +184,64 @@ describe( 'useChartMargin', () => {
 		// This is larger than the 20px default bottom margin, so it should be used.
 		expect( result.current.bottom ).toBe( 25 );
 	} );
+
+	describe( 'horizontal y ticks', () => {
+		const horizontalOptions = ( tickFormat: ( value: string | number ) => string ) => ( {
+			...optionsBase,
+			axis: {
+				...optionsBase.axis,
+				y: { ...optionsBase.axis.y, orientation: Orientation.left, tickFormat },
+			},
+		} );
+
+		it( 'measures dated ticks by formatting the raw timestamps once', () => {
+			const formatHour = ( timestamp: string | number ) =>
+				new Date( timestamp ).toLocaleTimeString( undefined, { hour: 'numeric', hour12: true } );
+			const hourlyData = [
+				{
+					label: 'Series 1',
+					data: [
+						{ date: new Date( 2024, 0, 1, 6 ), value: 10 },
+						{ date: new Date( 2024, 0, 1, 7 ), value: 20 },
+					],
+				},
+			];
+
+			renderHook( () =>
+				useChartMargin( 300, horizontalOptions( formatHour ), hourlyData, baseTheme, true )
+			);
+
+			const [ ticks, measureFormatter ] = mockGetLongestTickWidth.mock.calls[ 0 ];
+			// Raw timestamps, so the formatter runs exactly once — formatting here
+			// and again while measuring would date-parse "6 AM" to "Invalid Date".
+			expect( ticks ).toEqual( [
+				new Date( 2024, 0, 1, 6 ).getTime(),
+				new Date( 2024, 0, 1, 7 ).getTime(),
+			] );
+			expect( measureFormatter ).toBe( formatHour );
+		} );
+
+		it( "measures labelled ticks through the caller's formatter", () => {
+			const withSuffix = ( label: string | number ) => `${ label } (total)`;
+			const labelledData = [
+				{
+					label: 'Series 1',
+					data: [
+						{ label: 'Mon', value: 10 },
+						{ label: 'Tuesday', value: 20 },
+					],
+				},
+			];
+
+			renderHook( () =>
+				useChartMargin( 300, horizontalOptions( withSuffix ), labelledData, baseTheme, true )
+			);
+
+			const [ ticks, measureFormatter ] = mockGetLongestTickWidth.mock.calls[ 0 ];
+			// A formatter that lengthens labels has to reach the measurement, or the
+			// margin under-measures and the widest label clips at the SVG edge.
+			expect( ticks ).toEqual( [ 'Mon', 'Tuesday' ] );
+			expect( measureFormatter ).toBe( withSuffix );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/hooks/use-chart-margin.tsx
+++ b/projects/js-packages/charts/src/hooks/use-chart-margin.tsx
@@ -75,10 +75,9 @@ export const useChartMargin = (
 		const allDataPoints = data.flatMap( series => series.data as DataPointDate[] );
 
 		if ( horizontal ) {
-			// When horizontal, y ticks renders fixed tick labels.
-			return allDataPoints.map(
-				d => d.label || options.axis?.y?.tickFormat( d.date.getTime(), 0, [] )
-			);
+			// When horizontal, y ticks render the category values; leave them raw so
+			// the axis tick formatter is applied exactly once, when measuring below.
+			return allDataPoints.map( d => d.label || d.date?.getTime() );
 		}
 
 		if ( options.axis?.y?.tickValues?.length ) {


### PR DESCRIPTION
Fixes #

## Proposed changes

* Leave a horizontal chart's y tick values raw in `useChartMargin`, so the axis tick formatter is applied exactly once — when measuring — instead of once while building the list and again while measuring.

`useChartMargin` builds horizontal `yTicks` as `d.label || options.axis?.y?.tickFormat( d.date.getTime(), 0, [] )`. The `||` short-circuits, so labelled points arrive raw while dated points arrive already formatted. The whole mixed list then goes to `getLongestTickWidth` with that same formatter, which formats the dates a second time.

Round-tripping a formatted date back through `new Date()` only survives if the label happens to parse. `new Date( 'Jan 5' )` does; `new Date( '6 AM' )` does not. So any horizontal chart whose y axis carries time-of-day labels measures its widest label as **"Invalid Date"** — 12 characters where `6 AM` is 4 — and reserves roughly 33px of left margin it never draws into.

## Related product discussion/links

* Split out of #51012, where the bar chart starts emitting hour labels by default and would hit this on every horizontal sub-daily chart. Worth landing on its own — it is reachable on trunk today by any caller passing an `options.axis.y.tickFormat` that produces a non-date-parseable label.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

A horizontal bar chart with an hour tick formatter, `width={ 520 } height={ 260 }`. Note the gap between the labels and the axis:

**Before** — margin sized from "Invalid Date"

<img width="620" alt="Horizontal bar chart with hour labels 6 AM to 12 PM, showing a wide empty gap between the labels and the value axis" src="https://github.com/user-attachments/assets/4959436e-d01d-4f13-af76-031989d529d4" />

**After** — margin sized from the labels actually drawn

<img width="620" alt="The same horizontal bar chart with the labels sitting snug against the value axis and the plot area correspondingly wider" src="https://github.com/user-attachments/assets/3c9ad0df-3f3c-4a99-b429-00ae165c4401" />

To reproduce, drop this story into `projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx` and run Storybook:

```tsx
export const HorizontalHourly: Story = {
	args: {
		width: 520,
		height: 260,
		orientation: 'horizontal',
		gridVisibility: 'none',
		options: {
			axis: {
				y: {
					tickFormat: ( timestamp: number ) =>
						new Date( timestamp ).toLocaleTimeString( undefined, { hour: 'numeric', hour12: true } ),
				},
			},
		},
		data: [
			{
				label: 'Views',
				data: Array.from( { length: 8 }, ( _, i ) => ( {
					date: new Date( 2026, 7, 2, 6 + i ),
					value: 20 + i * 7,
				} ) ),
				options: {},
			},
		],
	},
};
```

* `jp test js js-packages/charts` — 1076 passing, including two new `useChartMargin` cases: dated ticks measured from raw timestamps, and a label-lengthening formatter reaching the measurement (the direction that would clip rather than over-reserve).
* Check the existing `HorizontalBarChart` story is unchanged — categorical labels were already formatted exactly once, and still are.
