### PR TITLE
Charts: classify the time-axis bucket once, and guard the measured span

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-time-axis-coarse-buckets
+++ b/projects/js-packages/charts/changelog/fix-charts-time-axis-coarse-buckets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Derive time-axis tick formats from one bucket classification, and stop an undated series collapsing the measured span. No user-visible change on a time scale.
+

--- a/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
+++ b/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
@@ -1,4 +1,4 @@
-import { getFormatter } from '../time-axis';
+import { getBucketResolution, getFormatter } from '../time-axis';
 import type { useChartDataTransform } from '../../../hooks';
 
 type SortedData = ReturnType< typeof useChartDataTransform >;
@@ -17,7 +17,7 @@ const hourlyDates = ( start: Date, hours: number ): Date[] =>
 const dailyDates = ( start: Date, days: number ): Date[] =>
 	Array.from( { length: days }, ( _, i ) => new Date( start.getTime() + i * 24 * 60 * 60 * 1000 ) );
 
-// TZ is pinned to UTC by the test script, so local formatting is deterministic.
+// The test script pins TZ and locale, so local formatting is deterministic.
 describe( 'getFormatter', () => {
 	it( 'uses hour ticks within a single day', () => {
 		const formatter = getFormatter(
@@ -124,6 +124,46 @@ describe( 'getFormatter', () => {
 		expect( yearly( new Date( '2023-01-01T00:00:00' ).getTime() ) ).toBe( '2023' );
 	} );
 
+	it( 'keeps month ticks for monthly buckets spanning several years', () => {
+		const monthlyDates = Array.from(
+			{ length: 36 },
+			( _, i ) => new Date( Date.UTC( 2024, i, 1 ) )
+		);
+		const formatter = getFormatter( toSeries( monthlyDates ) );
+
+		// Year ticks here would render the same year for every tick the band scale
+		// samples out of a calendar year.
+		expect( formatter( new Date( '2024-10-01T00:00:00' ).getTime() ) ).toBe( 'Oct' );
+		expect( formatter( new Date( '2025-01-01T00:00:00' ).getTime() ) ).toBe( '2025' );
+	} );
+
+	it( 'uses year ticks for inferred yearly buckets that do not start in January', () => {
+		const formatter = getFormatter(
+			toSeries( [ new Date( '2023-07-01T00:00:00' ), new Date( '2024-07-01T00:00:00' ) ] )
+		);
+
+		// The month regime would print a bare "Jul" for both.
+		expect( formatter( new Date( '2023-07-01T00:00:00' ).getTime() ) ).toBe( '2023' );
+		expect( formatter( new Date( '2024-07-01T00:00:00' ).getTime() ) ).toBe( '2024' );
+	} );
+
+	it( 'ignores series with no dated points when measuring the span', () => {
+		const formatter = getFormatter( [
+			...toSeries( dailyDates( new Date( '2024-01-01T00:00:00' ), 14 ) ),
+			...toSeries( [] ),
+		] );
+
+		// An empty comparison series must not turn the span into NaN, which would
+		// fall through every span check to year ticks.
+		expect( formatter( new Date( '2024-01-03T00:00:00' ).getTime() ) ).toMatch( /Jan 3/ );
+	} );
+
+	it( 'falls back to date ticks when nothing is dated', () => {
+		const formatter = getFormatter( toSeries( [] ) );
+
+		expect( formatter( new Date( '2024-01-03T00:00:00' ).getTime() ) ).toMatch( /Jan 3/ );
+	} );
+
 	describe( 'with an explicit tickResolution', () => {
 		it( 'uses hour ticks for two hourly points a day apart, where spacing would read as daily', () => {
 			const formatter = getFormatter(
@@ -178,5 +218,73 @@ describe( 'getFormatter', () => {
 			expect( formatter( new Date( '2025-06-01T00:00:00' ).getTime() ) ).toBe( '2025' );
 			expect( formatter( new Date( '2026-06-01T00:00:00' ).getTime() ) ).toBe( '2026' );
 		} );
+	} );
+} );
+
+describe( 'getBucketResolution', () => {
+	it( 'infers hourly buckets from sub-daily spacing', () => {
+		expect(
+			getBucketResolution( toSeries( hourlyDates( new Date( '2026-08-02T00:00:00' ), 6 ) ) )
+		).toBe( 'hour' );
+	} );
+
+	it( 'infers daily buckets from daily spacing', () => {
+		expect(
+			getBucketResolution( toSeries( dailyDates( new Date( '2026-08-01T00:00:00' ), 5 ) ) )
+		).toBe( 'day' );
+	} );
+
+	it( 'infers daily buckets from weekly spacing, which labels the same way', () => {
+		const weeklyDates = Array.from(
+			{ length: 5 },
+			( _, i ) => new Date( Date.UTC( 2026, 0, 5 + i * 7 ) )
+		);
+
+		expect( getBucketResolution( toSeries( weeklyDates ) ) ).toBe( 'day' );
+	} );
+
+	it( 'infers monthly buckets from a shortest-month gap', () => {
+		expect(
+			getBucketResolution(
+				toSeries( [ new Date( '2026-02-01T00:00:00' ), new Date( '2026-03-01T00:00:00' ) ] )
+			)
+		).toBe( 'month' );
+	} );
+
+	it( 'infers yearly buckets from a yearly gap', () => {
+		expect(
+			getBucketResolution(
+				toSeries( [ new Date( '2025-06-01T00:00:00' ), new Date( '2026-06-01T00:00:00' ) ] )
+			)
+		).toBe( 'year' );
+	} );
+
+	it( 'keeps a daily gap across spring-forward out of the hourly bucket', () => {
+		const start = new Date( '2026-03-08T00:00:00' );
+		const dstDates = [ 0, 23, 47 ].map(
+			offsetHours => new Date( start.getTime() + offsetHours * 60 * 60 * 1000 )
+		);
+
+		expect( getBucketResolution( toSeries( dstDates ) ) ).toBe( 'day' );
+	} );
+
+	it( 'reports daily buckets when no series has two points', () => {
+		// Unmeasurable spacing reads as Infinity, which must not be mistaken for a
+		// very coarse bucket.
+		expect( getBucketResolution( toSeries( [ new Date( '2026-08-02T00:00:00' ) ] ) ) ).toBe(
+			'day'
+		);
+	} );
+
+	it( 'reports a declared resolution over the measured spacing', () => {
+		const hourly = toSeries( hourlyDates( new Date( '2026-08-02T00:00:00' ), 6 ) );
+
+		expect( getBucketResolution( hourly, 'month' ) ).toBe( 'month' );
+	} );
+
+	it( 'reports a declared weekly resolution as daily', () => {
+		// Weeks and days are both calendar-date buckets as far as labelling goes,
+		// and 'week' is not a label format of its own.
+		expect( getBucketResolution( toSeries( [] ), 'week' ) ).toBe( 'day' );
 	} );
 } );

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -66,6 +66,24 @@ const formatMonthOrYearTick = ( timestamp: number ) => {
 		: date.toLocaleDateString( undefined, { month: 'short' } );
 };
 
+// Overall time span of the data. Series with no dated points are dropped rather
+// than folded in: an empty comparison series is legitimate, and one undefined
+// bound would turn the whole span into NaN. Null when nothing is dated.
+const getSpan = ( sortedData: ReturnType< typeof useChartDataTransform > ) => {
+	const bounds = sortedData
+		.map( datom => [ datom.data.at( 0 )?.date, datom.data.at( -1 )?.date ] )
+		.filter( ( [ first, last ] ) => first !== undefined && last !== undefined );
+
+	if ( ! bounds.length ) {
+		return null;
+	}
+
+	return {
+		minX: Math.min( ...bounds.map( ( [ first ] ) => Number( first ) ) ),
+		maxX: Math.max( ...bounds.map( ( [ , last ] ) => Number( last ) ) ),
+	};
+};
+
 // Smallest interval between consecutive points across all series, in hours.
 // Infinity when no series has two points.
 const getPointSpacingInHours = ( sortedData: ReturnType< typeof useChartDataTransform > ) => {
@@ -85,64 +103,81 @@ const getPointSpacingInHours = ( sortedData: ReturnType< typeof useChartDataTran
 	);
 };
 
-// Nominal point spacing for a caller-declared bucket resolution. A month maps
-// to the shortest month so the month-or-coarser regime engages (see
-// getFormatter). Year is absent: it short-circuits to year ticks before the
-// spacing regimes run.
-const SPACING_BY_RESOLUTION: Record< Exclude< TickResolution, 'year' >, number > = {
-	hour: 1,
-	day: 24,
-	week: 24 * 7,
-	month: 28 * 24,
+// 23, not 24: a daily gap shrinks to 23 wall-clock hours across a
+// spring-forward DST transition.
+const SUB_DAILY_SPACING_HOURS = 23;
+
+// The shortest month, so monthly buckets clear it but weekly ones don't.
+const MONTHLY_SPACING_HOURS = 28 * 24;
+
+// The bucket size behind the data, as the resolution label the tick formats are
+// keyed on. Exported so consumers that label a single point — bar chart
+// tooltips — read the same classification the axis does instead of inferring
+// the resolution a second way. Weeks report as 'day': both are calendar-date
+// buckets as far as labelling goes.
+export const getBucketResolution = (
+	sortedData: ReturnType< typeof useChartDataTransform >,
+	tickResolution?: TickResolution
+): Exclude< TickResolution, 'week' > => {
+	if ( tickResolution ) {
+		return tickResolution === 'week' ? 'day' : tickResolution;
+	}
+
+	const spacingInHours = getPointSpacingInHours( sortedData );
+	if ( spacingInHours < SUB_DAILY_SPACING_HOURS ) {
+		return 'hour';
+	}
+	// Fewer than two points leaves the spacing unknowable, so fall back to
+	// calendar dates rather than reading Infinity as a very coarse bucket.
+	if ( ! Number.isFinite( spacingInHours ) || spacingInHours < MONTHLY_SPACING_HOURS ) {
+		return 'day';
+	}
+	// Twelve shortest months: above any monthly gap (31 days at most) and below
+	// any yearly one (365 days at least).
+	return spacingInHours < 12 * MONTHLY_SPACING_HOURS ? 'month' : 'year';
 };
 
-// Pick the most informative tick formatter for the data's resolution and time
+// Pick the most informative tick formatter for the data's bucket resolution and
+// time span. Month-or-coarser buckets are formatted from the resolution alone —
+// they carry no day to print at any span — while finer buckets narrow with the
 // span: hours within a day, hours with day boundaries for sub-daily data
-// spanning up to a week, calendar dates for daily-or-finer buckets within a
-// year, months (with the year at January) for month-or-coarser buckets,
-// otherwise just years. The resolution comes from `tickResolution` when the
-// caller knows it, and is inferred from point spacing otherwise.
+// spanning up to a week, calendar dates within a year, otherwise years.
 export const getFormatter = (
 	sortedData: ReturnType< typeof useChartDataTransform >,
 	tickResolution?: TickResolution
 ) => {
+	const resolution = getBucketResolution( sortedData, tickResolution );
+
 	// The month regime only prints the year at January boundaries, so yearly
-	// buckets starting mid-year would render as month names; year ticks are
-	// correct for yearly buckets at any span.
-	if ( tickResolution === 'year' ) {
+	// buckets starting mid-year would render as bare month names.
+	if ( resolution === 'year' ) {
 		return formatYearTick;
 	}
 
-	const minX = Math.min( ...sortedData.map( datom => datom.data.at( 0 )?.date ) );
-	const maxX = Math.max( ...sortedData.map( datom => datom.data.at( -1 )?.date ) );
-
-	const spacingInHours = tickResolution
-		? SPACING_BY_RESOLUTION[ tickResolution ]
-		: getPointSpacingInHours( sortedData );
-	// 23, not 24: a daily gap shrinks to 23 wall-clock hours across a
-	// spring-forward DST transition.
-	const isSubDaily = spacingInHours < 23;
-
-	const diffInHours = Math.abs( differenceInHours( maxX, minX ) );
-	if ( diffInHours <= 24 && isSubDaily ) {
-		return formatHourTick;
+	if ( resolution === 'month' ) {
+		return formatMonthOrYearTick;
 	}
 
-	if ( diffInHours <= 24 * 7 && isSubDaily ) {
-		return formatDateOrHourTick;
+	const span = getSpan( sortedData );
+	if ( ! span ) {
+		return formatDateTick;
 	}
 
-	const diffInYears = Math.abs( differenceInYears( maxX, minX ) );
-	if ( diffInYears <= 1 ) {
-		// 28 days: the shortest month, so monthly buckets qualify but weekly
-		// don't. The finiteness check keeps all-single-point series — whose
-		// resolution is unknowable — on date ticks.
-		return Number.isFinite( spacingInHours ) && spacingInHours >= 28 * 24
-			? formatMonthOrYearTick
-			: formatDateTick;
+	const diffInHours = Math.abs( differenceInHours( span.maxX, span.minX ) );
+	if ( resolution === 'hour' ) {
+		if ( diffInHours <= 24 ) {
+			return formatHourTick;
+		}
+		if ( diffInHours <= 24 * 7 ) {
+			return formatDateOrHourTick;
+		}
 	}
 
-	return formatYearTick;
+	// Beyond a year, dates repeat often enough under tick sampling that the year
+	// is the only part worth printing.
+	return Math.abs( differenceInYears( span.maxX, span.minX ) ) <= 1
+		? formatDateTick
+		: formatYearTick;
 };
 
 // Estimate the largest number of x-axis ticks that fit without producing
@@ -153,9 +188,12 @@ export const guessOptimalNumTicks = (
 	chartWidth: number,
 	tickFormatter: ( timestamp: number, index?: number, values?: unknown ) => string
 ) => {
-	const minX = Math.min( ...data.map( datom => datom.data.at( 0 )?.date ) );
-	const maxX = Math.max( ...data.map( datom => datom.data.at( -1 )?.date ) );
-	const xScale = scaleTime( { domain: [ minX, maxX ] } );
+	const span = getSpan( data );
+	if ( ! span ) {
+		return 1;
+	}
+
+	const xScale = scaleTime( { domain: [ span.minX, span.maxX ] } );
 
 	const upperBound = Math.min(
 		data[ 0 ]?.data.length || 3,


### PR DESCRIPTION
Fixes #

## Proposed changes

* Extract `getBucketResolution` from `getFormatter`, so the bucket size behind a time series is classified in one place instead of re-derived by every caller that wants it. Month-or-coarser buckets now follow that classification alone — they carry no day to print at any span, and folding the span in was what made a yearly bucket starting mid-year render as a bare month name.
* Add `getSpan`, which drops series with no dated points before measuring the overall span, and returns `null` when nothing is dated.

The span was `Math.min( ...sortedData.map( d => d.data.at( 0 )?.date ) )` across every series. One series with no dated points makes that `NaN` — and an empty comparison series is legitimate, and passes `validateData`, because `[].some( … )` is `false`. Every subsequent comparison then fails and control falls off the end of `getFormatter` into `return formatYearTick`. The year branch was being reached by comparison failure rather than by decision. `guessOptimalNumTicks` had the same hazard and now shares the helper.

**No user-visible change on its own.** On a time scale, d3 already places ticks on the boundaries these formats key off, so line and area charts render identically before and after — I checked each panel of both `TimeAxisTickFormats` stories, plus a 3-year monthly series, a mid-year yearly pair, and a series with an empty sibling. It is the band scale, where ticks are sampled by index, that can tell the difference; that is a separate PR.

## Related product discussion/links

* Split out of #51012. Prerequisite for the bar chart time-axis work, which needs `getBucketResolution` exported.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

No screenshots: there is nothing to see on a time scale, which is the point of the paragraph above. If you want to confirm that rather than take my word for it, the fastest check is the story pair.

* `jp test js js-packages/charts` — 1087 passing, 13 of them new in `src/charts/private/test/time-axis.test.ts`:
  * `getFormatter` — the empty-sibling-series guard, the nothing-is-dated fallback, month ticks for monthly buckets over several years, year ticks for inferred yearly buckets that don't start in January.
  * `getBucketResolution` — each inferred resolution, the `week` → `day` mapping, the DST-safe 23-hour threshold, and the unmeasurable-spacing guard.
* Storybook → **Charts / Line chart → Time axis tick formats** and **Area chart → Time axis tick formats**: every panel should be pixel-identical to trunk.
* To see the guard working, render a line chart whose series list includes `{ label: 'Previous', data: [] }` alongside a normal daily series. On trunk `getFormatter` returns `formatYearTick` for it; on this branch it returns `formatDateTick`.
