### PR TITLE
Charts: give the bar chart the shared time-axis tick formatter

### DIFF
--- a/projects/js-packages/charts/changelog/add-charts-bar-chart-time-axis-ticks
+++ b/projects/js-packages/charts/changelog/add-charts-bar-chart-time-axis-ticks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Charts: adapt bar chart time-axis tick labels to the data's bucket resolution and time span, support the `tickResolution` hint, and name each bar's bucket in its tooltip.

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -1,4 +1,5 @@
 import { formatNumberCompact } from '@automattic/number-formatters';
+import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import { getBucketResolution, getFormatter } from '../../private/time-axis';
 import { TruncatedXTickComponent, TruncatedYTickComponent } from './truncated-tick-component';
@@ -24,36 +25,36 @@ const TOOLTIP_FORMAT_BY_RESOLUTION: Record<
 };
 
 /**
- * Tick and tooltip formatters for date-based series. Ticks share the line/area
- * charts' time-axis formatter, which also narrows with the overall span; a
- * tooltip labels one bar, so it names that bar's bucket at the bucket's own
- * granularity — finer than the ticks whenever the span coarsens the axis.
+ * Labels one bar's bucket, at the bucket's own granularity — finer than the
+ * ticks whenever the overall time span coarsens the axis.
  *
  * @param data           - Date-based series, already parsed and sorted by `useChartDataTransform`.
  * @param tickResolution - Caller-declared bucket resolution, when known.
- * @return Tick and tooltip label formatters.
+ * @return Tooltip label formatter.
  */
-const getTimeSeriesFormatters = ( data: SeriesData[], tickResolution?: TickResolution ) => {
+const getTooltipFormatter = ( data: SeriesData[], tickResolution?: TickResolution ) => {
+	// Only a declared 'week' reaches this branch: seven-day spacing is
+	// indistinguishable from sparse daily data, so inference reports 'day'.
 	if ( tickResolution === 'week' ) {
-		const tooltipFormatter = ( timestamp: number ) =>
-			`Week of ${ new Date( timestamp ).toLocaleDateString( undefined, {
-				year: 'numeric',
-				month: 'long',
-				day: 'numeric',
-			} ) }`;
-
-		return { tickFormatter: getFormatter( data, tickResolution ), tooltipFormatter };
+		return ( timestamp: number ) =>
+			sprintf(
+				/* translators: %s is the first day of the week the bar covers. */
+				__( 'Week of %s', 'jetpack-charts' ),
+				new Date( timestamp ).toLocaleDateString( undefined, {
+					year: 'numeric',
+					month: 'long',
+					day: 'numeric',
+				} )
+			);
 	}
 
 	// Fall back to the day format rather than `undefined` options, which would
 	// print a full locale date-time for an unrecognised `tickResolution`.
-	const tooltipFormat =
+	const format =
 		TOOLTIP_FORMAT_BY_RESOLUTION[ getBucketResolution( data, tickResolution ) ] ??
 		TOOLTIP_FORMAT_BY_RESOLUTION.day;
-	const tooltipFormatter = ( timestamp: number ) =>
-		new Date( timestamp ).toLocaleString( undefined, tooltipFormat );
 
-	return { tickFormatter: getFormatter( data, tickResolution ), tooltipFormatter };
+	return ( timestamp: number ) => new Date( timestamp ).toLocaleString( undefined, format );
 };
 
 /**
@@ -79,11 +80,32 @@ export function useBarChartOptions(
 	horizontal: boolean,
 	options: BaseChartProps[ 'options' ] = {}
 ) {
-	// `tickResolution` is a hint for the tick formatter rather than a visx axis
-	// prop, so it is read here and stripped from the axis options spread below.
-	const tickResolution = horizontal
-		? options.axis?.y?.tickResolution
-		: options.axis?.x?.tickResolution;
+	// `labelOverflow` and `tickResolution` are consumed by this hook rather than
+	// forwarded — visx has an axis prop for neither — so they are split off the
+	// caller's axis options once, here, and only the rest reaches visx below.
+	const axisConfig = useMemo( () => {
+		const {
+			labelOverflow: xLabelOverflow,
+			tickResolution: xTickResolution,
+			...xAxisOptions
+		} = options.axis?.x || {};
+		const {
+			labelOverflow: yLabelOverflow,
+			tickResolution: yTickResolution,
+			...yAxisOptions
+		} = options.axis?.y || {};
+
+		return {
+			xLabelOverflow,
+			yLabelOverflow,
+			xAxisOptions,
+			yAxisOptions,
+			// The dates sit on the x axis normally, and on the y axis when the
+			// chart is horizontal, so the hint follows them.
+			tickResolution: horizontal ? yTickResolution : xTickResolution,
+		};
+	}, [ options, horizontal ] );
+	const { tickResolution } = axisConfig;
 
 	const defaultOptions = useMemo( () => {
 		const bandScale = {
@@ -97,14 +119,16 @@ export function useBarChartOptions(
 			zero: false,
 		};
 
+		// Ticks on a date-based series share the line/area charts' time-axis
+		// formatter, which narrows with the overall span as well as the bucket
+		// size; the tooltip stays at the bucket's own granularity.
 		const hasLabels = Boolean( data?.[ 0 ]?.data?.[ 0 ]?.label );
-		const timeSeriesFormatters = hasLabels ? null : getTimeSeriesFormatters( data, tickResolution );
-		const labelFormatter = timeSeriesFormatters
-			? timeSeriesFormatters.tickFormatter
-			: ( label: string ) => label;
-		const tooltipDatumFormatter = timeSeriesFormatters
-			? timeSeriesFormatters.tooltipFormatter
-			: labelFormatter;
+		const labelFormatter = hasLabels
+			? ( label: string ) => label
+			: getFormatter( data, tickResolution );
+		const tooltipDatumFormatter = hasLabels
+			? labelFormatter
+			: getTooltipFormatter( data, tickResolution );
 		const valueFormatter = formatNumberCompact as TickFormatter< unknown >;
 
 		const labelAccessor = ( d: DataPointDate ) => d?.label || d?.date;
@@ -192,15 +216,10 @@ export function useBarChartOptions(
 			...( options.yScale || {} ),
 			...( ! horizontal ? valueScaleDomainOverride : {} ),
 		};
+		const { xLabelOverflow, yLabelOverflow, xAxisOptions, yAxisOptions } = axisConfig;
 		const providedToolTipLabelFormatter = horizontal
-			? options.axis?.y?.tickFormat
-			: options.axis?.x?.tickFormat;
-
-		const { labelOverflow: xLabelOverflow, ...xAxisOptions } = options.axis?.x || {};
-		const { labelOverflow: yLabelOverflow, ...yAxisOptions } = options.axis?.y || {};
-		// Consumed above as a formatter hint; visx has no such axis prop.
-		delete xAxisOptions.tickResolution;
-		delete yAxisOptions.tickResolution;
+			? yAxisOptions.tickFormat
+			: xAxisOptions.tickFormat;
 
 		return {
 			gridVisibility,
@@ -233,5 +252,5 @@ export function useBarChartOptions(
 				labelFormatter: providedToolTipLabelFormatter || defaultTooltipLabelFormatter,
 			},
 		};
-	}, [ defaultOptions, options, horizontal, data ] );
+	}, [ defaultOptions, axisConfig, options, horizontal, data ] );
 }

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -34,6 +34,17 @@ const TOOLTIP_FORMAT_BY_RESOLUTION: Record<
  * @return Tick and tooltip label formatters.
  */
 const getTimeSeriesFormatters = ( data: SeriesData[], tickResolution?: TickResolution ) => {
+	if ( tickResolution === 'week' ) {
+		const tooltipFormatter = ( timestamp: number ) =>
+			`Week of ${ new Date( timestamp ).toLocaleDateString( undefined, {
+				year: 'numeric',
+				month: 'long',
+				day: 'numeric',
+			} ) }`;
+
+		return { tickFormatter: getFormatter( data, tickResolution ), tooltipFormatter };
+	}
+
 	// Fall back to the day format rather than `undefined` options, which would
 	// print a full locale date-time for an unrecognised `tickResolution`.
 	const tooltipFormat =

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -1,8 +1,9 @@
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { useMemo } from 'react';
+import { getBucketResolution, getFormatter } from '../../private/time-axis';
 import { TruncatedXTickComponent, TruncatedYTickComponent } from './truncated-tick-component';
 import type { EnhancedDataPoint } from '../../../hooks/use-zero-value-display';
-import type { DataPointDate, BaseChartProps, SeriesData } from '../../../types';
+import type { DataPointDate, BaseChartProps, SeriesData, TickResolution } from '../../../types';
 import type { TickFormatter } from '@visx/axis';
 
 /** Outer padding of the category band scale (space at the chart edges). */
@@ -10,12 +11,38 @@ export const BASE_BAND_PADDING = 0.2;
 /** Inner padding of the category band scale (the base gap between ticks). */
 export const BASE_BAND_PADDING_INNER = 0.1;
 
-const formatDateTick = ( timestamp: number ) => {
-	const date = new Date( timestamp );
-	return date.toLocaleDateString( undefined, {
-		month: 'short',
-		day: 'numeric',
-	} );
+// The axis abbreviates to fit a tick; a tooltip has room to spell the same
+// bucket out in full.
+const TOOLTIP_FORMAT_BY_RESOLUTION: Record<
+	Exclude< TickResolution, 'week' >,
+	Intl.DateTimeFormatOptions
+> = {
+	hour: { year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', hour12: true },
+	day: { year: 'numeric', month: 'long', day: 'numeric' },
+	month: { year: 'numeric', month: 'long' },
+	year: { year: 'numeric' },
+};
+
+/**
+ * Tick and tooltip formatters for date-based series. Ticks share the line/area
+ * charts' time-axis formatter, which also narrows with the overall span; a
+ * tooltip labels one bar, so it names that bar's bucket at the bucket's own
+ * granularity — finer than the ticks whenever the span coarsens the axis.
+ *
+ * @param data           - Date-based series, already parsed and sorted by `useChartDataTransform`.
+ * @param tickResolution - Caller-declared bucket resolution, when known.
+ * @return Tick and tooltip label formatters.
+ */
+const getTimeSeriesFormatters = ( data: SeriesData[], tickResolution?: TickResolution ) => {
+	// Fall back to the day format rather than `undefined` options, which would
+	// print a full locale date-time for an unrecognised `tickResolution`.
+	const tooltipFormat =
+		TOOLTIP_FORMAT_BY_RESOLUTION[ getBucketResolution( data, tickResolution ) ] ??
+		TOOLTIP_FORMAT_BY_RESOLUTION.day;
+	const tooltipFormatter = ( timestamp: number ) =>
+		new Date( timestamp ).toLocaleString( undefined, tooltipFormat );
+
+	return { tickFormatter: getFormatter( data, tickResolution ), tooltipFormatter };
 };
 
 /**
@@ -41,6 +68,12 @@ export function useBarChartOptions(
 	horizontal: boolean,
 	options: BaseChartProps[ 'options' ] = {}
 ) {
+	// `tickResolution` is a hint for the tick formatter rather than a visx axis
+	// prop, so it is read here and stripped from the axis options spread below.
+	const tickResolution = horizontal
+		? options.axis?.y?.tickResolution
+		: options.axis?.x?.tickResolution;
+
 	const defaultOptions = useMemo( () => {
 		const bandScale = {
 			type: 'band' as const,
@@ -53,9 +86,14 @@ export function useBarChartOptions(
 			zero: false,
 		};
 
-		const labelFormatter = data?.[ 0 ]?.data?.[ 0 ]?.label
-			? ( label: string ) => label
-			: formatDateTick;
+		const hasLabels = Boolean( data?.[ 0 ]?.data?.[ 0 ]?.label );
+		const timeSeriesFormatters = hasLabels ? null : getTimeSeriesFormatters( data, tickResolution );
+		const labelFormatter = timeSeriesFormatters
+			? timeSeriesFormatters.tickFormatter
+			: ( label: string ) => label;
+		const tooltipDatumFormatter = timeSeriesFormatters
+			? timeSeriesFormatters.tooltipFormatter
+			: labelFormatter;
 		const valueFormatter = formatNumberCompact as TickFormatter< unknown >;
 
 		const labelAccessor = ( d: DataPointDate ) => d?.label || d?.date;
@@ -69,7 +107,7 @@ export function useBarChartOptions(
 			vertical: {
 				xTickFormat: labelFormatter,
 				yTickFormat: valueFormatter,
-				tooltipLabelFormatter: labelFormatter,
+				tooltipLabelFormatter: tooltipDatumFormatter,
 				xAccessor: labelAccessor,
 				yAccessor: valueAccessor,
 				gridVisibility: 'x',
@@ -79,7 +117,7 @@ export function useBarChartOptions(
 			horizontal: {
 				xTickFormat: valueFormatter,
 				yTickFormat: labelFormatter,
-				tooltipLabelFormatter: labelFormatter,
+				tooltipLabelFormatter: tooltipDatumFormatter,
 				xAccessor: valueAccessor,
 				yAccessor: labelAccessor,
 				gridVisibility: 'y',
@@ -87,7 +125,7 @@ export function useBarChartOptions(
 				yScale: bandScale,
 			},
 		};
-	}, [ data ] );
+	}, [ data, tickResolution ] );
 
 	return useMemo( () => {
 		const orientationKey = horizontal ? 'horizontal' : 'vertical';
@@ -149,6 +187,9 @@ export function useBarChartOptions(
 
 		const { labelOverflow: xLabelOverflow, ...xAxisOptions } = options.axis?.x || {};
 		const { labelOverflow: yLabelOverflow, ...yAxisOptions } = options.axis?.y || {};
+		// Consumed above as a formatter hint; visx has no such axis prop.
+		delete xAxisOptions.tickResolution;
+		delete yAxisOptions.tickResolution;
 
 		return {
 			gridVisibility,

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
@@ -114,11 +114,13 @@ type ChartOptions = {
 			orientation?: 'top' | 'bottom';
 			numTicks?: number;
 			tickFormat?: (value: any) => string;
+			tickResolution?: 'hour' | 'day' | 'week' | 'month' | 'year';
 		};
 		y?: {
 			orientation?: 'left' | 'right';
 			numTicks?: number;
 			tickFormat?: (value: number) => string;
+			tickResolution?: 'hour' | 'day' | 'week' | 'month' | 'year';
 		};
 	};
 };

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -244,6 +244,30 @@ Bar charts support both categorical labels and time-series data:
 
 <Canvas of={ BarChartStories.TimeSeries } />
 
+Date-based series pick their default tick format from the data's bucket resolution and
+overall span, the same way line and area charts do. Month-or-coarser buckets follow the
+resolution alone — month names with the year at January, or plain years for yearly buckets
+— since they carry no day to print at any span. Daily-or-finer buckets narrow with the
+span: hour ticks within a day, hour ticks dated at midnight for sub-daily data spanning up
+to a week, calendar dates within a year, and years beyond that. An explicit
+`options.axis.x.tickFormat` still overrides (`axis.y` on a horizontal chart).
+
+<Canvas of={ BarChartStories.TimeAxisTickFormats } />
+
+Default tooltip labels name the hovered bar's bucket, spelled out in full:
+`August 2, 2026 at 6 AM` for hourly buckets, `August 2, 2026` for daily ones,
+`August 2026` for monthly, and `2026` for yearly. A monthly bar reads `August 2026` rather
+than `August 1, 2026` — the day is precision the bucket doesn't carry. The tooltip always
+names the bucket's own granularity, so it stays finer than the ticks whenever the span
+coarsens the axis.
+
+When the bucket resolution is already known — from a granularity selector, say — declare it
+with `options.axis.x.tickResolution` (`axis.y` on a horizontal chart) instead of leaving the
+chart to infer it from point spacing. This is what a single-bucket series needs, since one
+point has no spacing to measure.
+
+<Canvas of={ BarChartStories.TimeAxisTickResolution } />
+
 <Source
 	language="jsx"
 	code={ `// Date objects

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -256,15 +256,17 @@ to a week, calendar dates within a year, and years beyond that. An explicit
 
 Default tooltip labels name the hovered bar's bucket, spelled out in full:
 `August 2, 2026 at 6 AM` for hourly buckets, `August 2, 2026` for daily ones,
-`August 2026` for monthly, and `2026` for yearly. A monthly bar reads `August 2026` rather
-than `August 1, 2026` — the day is precision the bucket doesn't carry. The tooltip always
-names the bucket's own granularity, so it stays finer than the ticks whenever the span
-coarsens the axis.
+`August 2026` for monthly, `2026` for yearly, and `Week of January 12, 2026` for weekly.
+A monthly bar reads `August 2026` rather than `August 1, 2026` — the day is precision the
+bucket doesn't carry. The tooltip always names the bucket's own granularity, so it stays
+finer than the ticks whenever the span coarsens the axis.
 
 When the bucket resolution is already known — from a granularity selector, say — declare it
 with `options.axis.x.tickResolution` (`axis.y` on a horizontal chart) instead of leaving the
-chart to infer it from point spacing. This is what a single-bucket series needs, since one
-point has no spacing to measure.
+chart to infer it from point spacing. Two cases need it: a single-bucket series, which has
+no spacing to measure, and weekly buckets, whose seven-day spacing is indistinguishable from
+sparse daily data — undeclared, they are read as daily and the tooltip names one day instead
+of the week.
 
 <Canvas of={ BarChartStories.TimeAxisTickResolution } />
 

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -207,6 +207,11 @@ const yearlyPoints: Array< [ Date, number ] > = [ 72, 95, 58, 86 ].map( ( value,
 // declared `tickResolution` can reach the hour format.
 const loneHourlyBucket = timeAxisSeries( [ [ new Date( 2026, 7, 2, 13 ), 42 ] ] );
 
+const weeklyPoints: Array< [ Date, number ] > = Array.from( { length: 8 }, ( _, i ) => [
+	new Date( 2026, 0, 5 + i * 7 ),
+	Math.round( 60 + 40 * Math.sin( i / 2 ) ),
+] );
+
 type TimeAxisPanelProps = {
 	title: string;
 	data: SeriesData[];
@@ -276,17 +281,22 @@ export const TimeAxisTickResolution: Story = {
 				data={ loneHourlyBucket }
 				options={ { yScale: { zero: true }, axis: { x: { tickResolution: 'hour' } } } }
 			/>
+			<TimeAxisPanel
+				title="Weekly buckets, tickResolution: 'week' → date ticks, 'Week of' tooltips"
+				data={ timeAxisSeries( weeklyPoints ) }
+				options={ { axis: { x: { tickResolution: 'week' } } } }
+			/>
 		</div>
 	),
 	args: {
 		containerWidth: '1020px',
-		containerHeight: '400px',
+		containerHeight: '700px',
 	},
 	parameters: {
 		docs: {
 			description: {
 				story:
-					"When the caller already knows the data's bucket resolution — e.g. from a granularity selector — `options.axis.x.tickResolution` declares it and the tick formatter derives the format from it instead of inferring the resolution from point spacing. Inference needs at least two points, so a single-bucket series always falls back to date ticks; the declared resolution picks the right format, and the tooltip follows it. On a horizontal bar chart the hint lives on `axis.y`, which is where the dates are. An explicit `tickFormat` takes precedence over the hint.",
+					"When the caller already knows the data's bucket resolution — e.g. from a granularity selector — `options.axis.x.tickResolution` declares it and the tick formatter derives the format from it instead of inferring the resolution from point spacing. Inference needs at least two points, so a single-bucket series always falls back to date ticks; the declared resolution picks the right format, and the tooltip follows it. `'week'` is the other case that has to be declared: seven-day spacing is indistinguishable from sparse daily data, so undeclared weekly buckets are read as daily and their tooltips name a single day rather than `Week of …`. On a horizontal bar chart the hint lives on `axis.y`, which is where the dates are. An explicit `tickFormat` takes precedence over the hint.",
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -163,6 +163,135 @@ export const TimeSeries: Story = {
 	},
 };
 
+// Wall-clock dates in the browser frame — the library's parsing convention —
+// so the ticks read the same in any viewer timezone.
+const timeAxisSeries = ( points: Array< [ Date, number ] > ): SeriesData[] => [
+	{
+		label: 'Views',
+		data: points.map( ( [ date, value ] ) => ( { date, value } ) ),
+		options: {},
+	},
+];
+
+const hourlyPoints: Array< [ Date, number ] > = Array.from( { length: 24 }, ( _, i ) => [
+	new Date( 2026, 7, 2, i ),
+	Math.round( 60 + 40 * Math.sin( i / 3.5 ) ),
+] );
+
+const dailyPoints: Array< [ Date, number ] > = Array.from( { length: 30 }, ( _, i ) => [
+	new Date( 2026, 6, 1 + i ),
+	Math.round( 60 + 40 * Math.sin( i / 4 ) ),
+] );
+
+const threeDayHourlyPoints: Array< [ Date, number ] > = Array.from( { length: 72 }, ( _, i ) => [
+	new Date( 2026, 7, 2, i ),
+	Math.round( 60 + 40 * Math.sin( i / 3.5 ) ),
+] );
+
+const oneYearMonthlyPoints: Array< [ Date, number ] > = Array.from( { length: 12 }, ( _, i ) => [
+	new Date( 2026, i, 1 ),
+	Math.round( 60 + 40 * Math.sin( i / 2 ) ),
+] );
+
+const monthlyPoints: Array< [ Date, number ] > = Array.from( { length: 36 }, ( _, i ) => [
+	new Date( 2024, i, 1 ),
+	Math.round( 60 + 40 * Math.sin( i / 2 ) ),
+] );
+
+const yearlyPoints: Array< [ Date, number ] > = [ 72, 95, 58, 86 ].map( ( value, i ) => [
+	new Date( 2023 + i, 0, 1 ),
+	value,
+] );
+
+// A single bucket has no point spacing to infer the resolution from, so only a
+// declared `tickResolution` can reach the hour format.
+const loneHourlyBucket = timeAxisSeries( [ [ new Date( 2026, 7, 2, 13 ), 42 ] ] );
+
+type TimeAxisPanelProps = {
+	title: string;
+	data: SeriesData[];
+	options?: React.ComponentProps< typeof BarChart >[ 'options' ];
+};
+
+const TimeAxisPanel = ( { title, data, options }: TimeAxisPanelProps ) => (
+	<div>
+		<h3>{ title }</h3>
+		<BarChart width={ 460 } height={ 220 } withTooltips data={ data } options={ options } />
+	</div>
+);
+
+const timeAxisPanelGrid = {
+	display: 'grid',
+	gap: '2rem',
+	gridTemplateColumns: 'repeat(auto-fit, minmax(440px, 1fr))',
+} as const;
+
+export const TimeAxisTickFormats: Story = {
+	render: () => (
+		<div style={ timeAxisPanelGrid }>
+			<TimeAxisPanel
+				title="Hourly buckets, single day → hour ticks"
+				data={ timeAxisSeries( hourlyPoints ) }
+			/>
+			<TimeAxisPanel
+				title="Hourly buckets over three days → hour ticks, dated at midnight"
+				data={ timeAxisSeries( threeDayHourlyPoints ) }
+			/>
+			<TimeAxisPanel title="Daily buckets → date ticks" data={ timeAxisSeries( dailyPoints ) } />
+			<TimeAxisPanel
+				title="Monthly buckets within a year → month ticks, year at January"
+				data={ timeAxisSeries( oneYearMonthlyPoints ) }
+			/>
+			<TimeAxisPanel
+				title="Monthly buckets over three years → month ticks, year at January"
+				data={ timeAxisSeries( monthlyPoints ) }
+			/>
+			<TimeAxisPanel title="Yearly buckets → year ticks" data={ timeAxisSeries( yearlyPoints ) } />
+		</div>
+	),
+	args: {
+		containerWidth: '1020px',
+		containerHeight: '1050px',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"Date-based series share the time-axis tick formatter with the line and area charts. Month-or-coarser buckets follow the resolution alone — month names with the year at January, or plain years for yearly buckets — since they carry no day to print at any span. Daily-or-finer buckets narrow with the span: hour ticks within a day, hour ticks dated at midnight for sub-daily data spanning up to a week, calendar dates within a year, and years beyond that. Hover any bar: the tooltip names that bar's bucket spelled out in full — `August 2026` for a monthly bar, `2026` for a yearly one, never a day the bucket doesn't carry. It always names the bucket's own granularity, so on the daily panel it stays finer than the ticks once a long span coarsens the axis. An explicit `options.axis.x.tickFormat` still overrides.",
+			},
+		},
+	},
+};
+
+export const TimeAxisTickResolution: Story = {
+	render: () => (
+		<div style={ timeAxisPanelGrid }>
+			<TimeAxisPanel
+				title="Lone hourly bucket, resolution inferred → date tick"
+				data={ loneHourlyBucket }
+				options={ { yScale: { zero: true } } }
+			/>
+			<TimeAxisPanel
+				title="Same bar, tickResolution: 'hour' → hour tick"
+				data={ loneHourlyBucket }
+				options={ { yScale: { zero: true }, axis: { x: { tickResolution: 'hour' } } } }
+			/>
+		</div>
+	),
+	args: {
+		containerWidth: '1020px',
+		containerHeight: '400px',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"When the caller already knows the data's bucket resolution — e.g. from a granularity selector — `options.axis.x.tickResolution` declares it and the tick formatter derives the format from it instead of inferring the resolution from point spacing. Inference needs at least two points, so a single-bucket series always falls back to date ticks; the declared resolution picks the right format, and the tooltip follows it. On a horizontal bar chart the hint lives on `axis.y`, which is where the dates are. An explicit `tickFormat` takes precedence over the hint.",
+			},
+		},
+	},
+};
+
 export const WithPatterns: Story = {
 	args: {
 		...Default.args,

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -218,6 +218,300 @@ describe( 'BarChart', () => {
 		} );
 	} );
 
+	describe( 'Time axis ticks', () => {
+		const distinctTexts = ( elements: HTMLElement[] ) =>
+			new Set( elements.map( el => el.textContent ) );
+
+		test( 'renders distinct date ticks for daily buckets within a year', () => {
+			renderWithTheme( {
+				width: 800,
+				data: [
+					{
+						label: 'Series A',
+						data: Array.from( { length: 14 }, ( _, i ) => ( {
+							date: new Date( 2024, 0, 1 + i ),
+							value: 10 + i,
+						} ) ),
+						options: {},
+					},
+				],
+			} );
+
+			const ticks = screen.getAllByText(
+				/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d+$/
+			);
+			expect( distinctTexts( ticks ).size ).toBeGreaterThan( 1 );
+		} );
+
+		test( 'renders distinct hour ticks for sub-daily buckets in a single day', () => {
+			renderWithTheme( {
+				width: 800,
+				data: [
+					{
+						label: 'Series A',
+						data: Array.from( { length: 12 }, ( _, i ) => ( {
+							date: new Date( 2024, 0, 1, i ),
+							value: 10 + i,
+						} ) ),
+						options: {},
+					},
+				],
+			} );
+
+			const ticks = screen.getAllByText( /^\d{1,2}\s(AM|PM)$/ );
+			expect( distinctTexts( ticks ).size ).toBeGreaterThan( 1 );
+		} );
+
+		test( 'renders date ticks, not hour ticks, for a two-point daily series', () => {
+			renderWithTheme( {
+				width: 800,
+				data: [
+					{
+						label: 'Series A',
+						data: [
+							{ date: new Date( 2024, 0, 1 ), value: 10 },
+							{ date: new Date( 2024, 0, 2 ), value: 20 },
+						],
+						options: {},
+					},
+				],
+			} );
+
+			expect( screen.getByText( 'Jan 1' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Jan 2' ) ).toBeInTheDocument();
+			expect( screen.queryByText( /12\sAM/ ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'renders distinct year ticks for series spanning multiple years', () => {
+			renderWithTheme( {
+				width: 800,
+				data: [
+					{
+						label: 'Series A',
+						data: Array.from( { length: 4 }, ( _, i ) => ( {
+							date: new Date( 2021 + i, 0, 1 ),
+							value: 10 + i,
+						} ) ),
+						options: {},
+					},
+				],
+			} );
+
+			const ticks = screen.getAllByText( /^\d{4}$/ );
+			expect( distinctTexts( ticks ).size ).toBeGreaterThan( 1 );
+		} );
+
+		test( 'renders date ticks for daily buckets whose gaps shrink to 23 hours', () => {
+			// The gaps are built at 23 hours rather than dated across a real
+			// spring-forward, because the suite pins TZ=UTC and so has no DST to
+			// straddle. A strict 24h rule would read these as sub-daily buckets and
+			// label them by the hour.
+			const start = new Date( 2026, 2, 8 );
+			renderWithTheme( {
+				width: 800,
+				data: [
+					{
+						label: 'Series A',
+						data: [ 0, 23, 46 ].map( ( offsetHours, i ) => ( {
+							date: new Date( start.getTime() + offsetHours * 60 * 60 * 1000 ),
+							value: 10 * ( i + 1 ),
+						} ) ),
+						options: {},
+					},
+				],
+			} );
+
+			expect( screen.getAllByText( /^Mar \d+$/ ).length ).toBeGreaterThan( 0 );
+			expect( screen.queryByText( /\d{1,2}\s(AM|PM)/ ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'reads tickResolution off the y axis on a horizontal chart', () => {
+			renderWithTheme( {
+				width: 800,
+				orientation: 'horizontal',
+				data: [
+					{
+						label: 'Series A',
+						data: [ { date: new Date( 2024, 0, 1, 13 ), value: 10 } ],
+						options: {},
+					},
+				],
+				options: { axis: { y: { tickResolution: 'hour' } } },
+			} );
+
+			// The dates move to the y axis with the orientation, so the hint has to
+			// follow them; read off `axis.x` this would fall back to a date tick.
+			expect( screen.getByText( /^1\sPM$/ ) ).toBeInTheDocument();
+		} );
+
+		test( 'renders an hour tick when tickResolution declares the buckets sub-daily', () => {
+			// A single bucket has no point spacing to infer the resolution from,
+			// so only the declared resolution can reach the hour format.
+			renderWithTheme( {
+				width: 800,
+				data: [
+					{
+						label: 'Series A',
+						data: [ { date: new Date( 2024, 0, 1, 13 ), value: 10 } ],
+						options: {},
+					},
+				],
+				options: { axis: { x: { tickResolution: 'hour' } } },
+			} );
+
+			expect( screen.getByText( /^1\sPM$/ ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Time series tooltip labels', () => {
+		const optionsFor = (
+			data: Parameters< typeof useBarChartOptions >[ 0 ],
+			options?: Parameters< typeof useBarChartOptions >[ 2 ]
+		) => renderHook( () => useBarChartOptions( data, false, options ) ).result.current;
+
+		test( 'names the full date for daily buckets', () => {
+			const { tooltip } = optionsFor( [
+				{
+					label: 'Series A',
+					data: Array.from( { length: 14 }, ( _, i ) => ( {
+						date: new Date( 2024, 0, 1 + i ),
+						value: 10 + i,
+					} ) ),
+					options: {},
+				},
+			] );
+
+			expect( tooltip.labelFormatter( new Date( 2024, 0, 3 ).getTime(), 0, [] ) ).toBe(
+				'January 3, 2024'
+			);
+		} );
+
+		test( 'names the month, without a day, for monthly buckets', () => {
+			const { tooltip } = optionsFor( [
+				{
+					label: 'Series A',
+					data: Array.from( { length: 24 }, ( _, i ) => ( {
+						date: new Date( 2024, i, 1 ),
+						value: 10 + i,
+					} ) ),
+					options: {},
+				},
+			] );
+
+			expect( tooltip.labelFormatter( new Date( 2025, 2, 1 ).getTime(), 0, [] ) ).toBe(
+				'March 2025'
+			);
+		} );
+
+		test( 'names only the year for yearly buckets', () => {
+			const { tooltip } = optionsFor( [
+				{
+					label: 'Series A',
+					data: Array.from( { length: 4 }, ( _, i ) => ( {
+						date: new Date( 2023 + i, 0, 1 ),
+						value: 10 + i,
+					} ) ),
+					options: {},
+				},
+			] );
+
+			expect( tooltip.labelFormatter( new Date( 2024, 0, 1 ).getTime(), 0, [] ) ).toBe( '2024' );
+		} );
+
+		test( 'follows a declared tickResolution coarser than the point spacing', () => {
+			const { tooltip } = optionsFor(
+				[
+					{
+						label: 'Series A',
+						data: Array.from( { length: 24 }, ( _, i ) => ( {
+							date: new Date( 2024, i, 1 ),
+							value: 10 + i,
+						} ) ),
+						options: {},
+					},
+				],
+				{ axis: { x: { tickResolution: 'year' } } }
+			);
+
+			expect( tooltip.labelFormatter( new Date( 2025, 2, 1 ).getTime(), 0, [] ) ).toBe( '2025' );
+		} );
+
+		test( 'detects sub-daily resolution past a leading gap', () => {
+			const { tooltip } = optionsFor( [
+				{
+					label: 'Series A',
+					data: [
+						{ date: new Date( 2024, 0, 1 ), value: 10 },
+						{ date: new Date( 2024, 0, 3 ), value: 20 },
+						{ date: new Date( 2024, 0, 3, 6 ), value: 30 },
+					],
+					options: {},
+				},
+			] );
+
+			expect( tooltip.labelFormatter( new Date( 2024, 0, 3, 6 ).getTime(), 0, [] ) ).toMatch(
+				/^January 3, 2024 at 6\sAM$/
+			);
+		} );
+
+		test( 'adds the hour for sub-daily buckets', () => {
+			const { tooltip } = optionsFor( [
+				{
+					label: 'Series A',
+					data: Array.from( { length: 12 }, ( _, i ) => ( {
+						date: new Date( 2024, 0, 1, i ),
+						value: 10 + i,
+					} ) ),
+					options: {},
+				},
+			] );
+
+			expect( tooltip.labelFormatter( new Date( 2024, 0, 1, 6 ).getTime(), 0, [] ) ).toMatch(
+				/^January 1, 2024 at 6\sAM$/
+			);
+		} );
+
+		test( 'adds the hour when tickResolution declares the buckets sub-daily', () => {
+			const { tooltip } = optionsFor(
+				[
+					{
+						label: 'Series A',
+						data: [ { date: new Date( 2024, 0, 1, 13 ), value: 10 } ],
+						options: {},
+					},
+				],
+				{ axis: { x: { tickResolution: 'hour' } } }
+			);
+
+			expect( tooltip.labelFormatter( new Date( 2024, 0, 1, 13 ).getTime(), 0, [] ) ).toMatch(
+				/^January 1, 2024 at 1\sPM$/
+			);
+		} );
+
+		test( 'names the hovered bar bucket in the rendered tooltip', async () => {
+			const user = userEvent.setup();
+			renderWithTheme( {
+				withTooltips: true,
+				data: [
+					{
+						label: 'Series A',
+						data: Array.from( { length: 24 }, ( _, i ) => ( {
+							date: new Date( 2024, i, 1 ),
+							value: 10 + i,
+						} ) ),
+						options: {},
+					},
+				],
+			} );
+
+			screen.getByRole( 'grid', { name: /bar chart/i } ).focus();
+			await user.keyboard( '{ArrowRight}' );
+
+			// The month tick reads "2024" here; the tooltip names the bucket itself.
+			expect( screen.getByTestId( 'chart-tooltip-0' ) ).toHaveTextContent( 'January 2024: 10' );
+		} );
+	} );
+
 	describe( 'Pattern', () => {
 		test( 'renders with patterns', () => {
 			renderWithTheme( { withPatterns: true } );

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -508,6 +508,54 @@ describe( 'BarChart', () => {
 			);
 		} );
 
+		test( 'follows tickResolution declared on the y axis of a horizontal chart', () => {
+			// The dates move to the y axis with the orientation, so the tooltip has
+			// to follow them the way the ticks do.
+			const { tooltip } = renderHook( () =>
+				useBarChartOptions(
+					[
+						{
+							label: 'Series A',
+							data: [ { date: new Date( 2024, 0, 1, 13 ), value: 10 } ],
+							options: {},
+						},
+					],
+					true,
+					{ axis: { y: { tickResolution: 'hour' } } }
+				)
+			).result.current;
+
+			expect( tooltip.labelFormatter( new Date( 2024, 0, 1, 13 ).getTime(), 0, [] ) ).toMatch(
+				/^January 1, 2024 at 1\sPM$/
+			);
+		} );
+
+		test( 'lets an explicit tickFormat override the resolution-derived label', () => {
+			const { tooltip } = optionsFor(
+				[
+					{
+						label: 'Series A',
+						data: Array.from( { length: 24 }, ( _, i ) => ( {
+							date: new Date( 2024, i, 1 ),
+							value: 10 + i,
+						} ) ),
+						options: {},
+					},
+				],
+				{
+					axis: {
+						x: {
+							tickResolution: 'month',
+							tickFormat: ( timestamp: number ) =>
+								new Date( timestamp ).toLocaleDateString( 'en-US', { dateStyle: 'short' } ),
+						},
+					},
+				}
+			);
+
+			expect( tooltip.labelFormatter( new Date( 2025, 2, 1 ).getTime(), 0, [] ) ).toBe( '3/1/25' );
+		} );
+
 		test( 'names the hovered bar bucket in the rendered tooltip', async () => {
 			const user = userEvent.setup();
 			renderWithTheme( {

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -488,6 +488,26 @@ describe( 'BarChart', () => {
 			);
 		} );
 
+		test( 'names a declared weekly bucket as a week, not a single day', () => {
+			const { tooltip } = optionsFor(
+				[
+					{
+						label: 'Series A',
+						data: Array.from( { length: 8 }, ( _, i ) => ( {
+							date: new Date( 2026, 0, 5 + i * 7 ),
+							value: 10 + i,
+						} ) ),
+						options: {},
+					},
+				],
+				{ axis: { x: { tickResolution: 'week' } } }
+			);
+
+			expect( tooltip.labelFormatter( new Date( 2026, 0, 12 ).getTime(), 0, [] ) ).toBe(
+				'Week of January 12, 2026'
+			);
+		} );
+
 		test( 'names the hovered bar bucket in the rendered tooltip', async () => {
 			const user = userEvent.setup();
 			renderWithTheme( {

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -482,12 +482,12 @@ export type AxisOptions = {
 	tickClassName?: string;
 	tickFormat?: TickFormatter< ScaleInput< AxisScale > >;
 	/**
-	 * Bucket resolution of the data on a time x-axis. When set, the automatic
-	 * tick formatter derives tick formats from it directly instead of
-	 * inferring the resolution from point spacing. The overall time span still
-	 * constrains the choice — e.g. hourly buckets spanning more than a week
-	 * get date ticks, since hour ticks would be unreadable at that span.
-	 * Ignored when `tickFormat` is set.
+	 * Bucket resolution of the data, set on whichever axis carries the dates.
+	 * When set, the automatic tick formatter derives tick formats from it
+	 * directly instead of inferring the resolution from point spacing. For
+	 * daily-or-finer buckets the overall time span still constrains the choice —
+	 * e.g. hourly buckets spanning more than a week get date ticks, since hour
+	 * ticks would be unreadable at that span. Ignored when `tickFormat` is set.
 	 */
 	tickResolution?: TickResolution;
 	/**

--- a/projects/plugins/jetpack/changelog/add-charts-bar-chart-time-axis-ticks
+++ b/projects/plugins/jetpack/changelog/add-charts-bar-chart-time-axis-ticks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Podcast: label the stats chart's time axis by the size of the bucket behind the data, and name each bar's period in full in its tooltip.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-charts-bar-chart-time-axis-ticks
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-charts-bar-chart-time-axis-ticks
@@ -1,4 +1,4 @@
 Significance: minor
-Type: enhancement
+Type: changed
 
 Premium Analytics: label the traffic chart's time axis by the size of the bucket behind the data, and name each bar's period in full in its tooltip.

--- a/projects/plugins/premium-analytics/changelog/add-charts-bar-chart-time-axis-ticks
+++ b/projects/plugins/premium-analytics/changelog/add-charts-bar-chart-time-axis-ticks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Label bar chart time axes by the size of the bucket behind the data, and name each bar's period in full in its tooltip.

--- a/projects/plugins/wpcomsh/changelog/add-charts-bar-chart-time-axis-ticks
+++ b/projects/plugins/wpcomsh/changelog/add-charts-bar-chart-time-axis-ticks
@@ -1,4 +1,4 @@
 Significance: minor
-Type: enhancement
+Type: changed
 
 Premium Analytics: label the traffic chart's time axis by the size of the bucket behind the data, and name each bar's period in full in its tooltip.


### PR DESCRIPTION
Fixes #

## Proposed changes

Someone reading a bar chart of hourly traffic currently sees the same date under all four ticks, and someone reading monthly traffic sees `Jan 1 | Apr 1 | Jul 1 | Oct 1` — a day that the bucket behind the bar doesn't carry. The axis says nothing about the period the bars cover, so the chart has to be read from its title.

* Give the bar chart the time-axis tick formatter that line and area charts already share, so the format follows the data's bucket resolution and overall span instead of always printing a calendar date.
* Accept the `tickResolution` hint on whichever axis carries the dates — `x` normally, `y` when the chart is horizontal.
* Give tooltips their own format, keyed on the same bucket classification: `August 2, 2026 at 6 AM` for hourly buckets, `August 2026` for monthly, `2026` for yearly. A tooltip labels one bar rather than a shared axis, so it can spell the period out in full — and it never invents a day the bucket doesn't carry.

**Stacked on #51273**, which extracts the classification this reads. Best reviewed after that one; the diff here is against it. It also wants #51272 landed, or a horizontal sub-daily chart reserves an over-wide left margin — cosmetic, and independent of anything here.

## Related product discussion/links

* Split out of #51012.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Storybook → **Charts / Bar chart → Time axis tick formats**.

**Before** — every panel prints a calendar date. Four identical `Aug 2` ticks on the single-day hourly panel; `Jan 1 … Oct 1` on the monthly one.

<img width="800" alt="Bar chart time axis panels on trunk: hourly panels labelled Aug 2 four times, monthly panel labelled Jan 1, Apr 1, Jul 1, Oct 1" src="https://github.com/user-attachments/assets/e5434784-19f1-4e21-b0fc-24224c2e0d51" />

**After** — hours within a day, hours dated at midnight across days, dates for daily buckets, months for monthly, years for yearly.

<img width="800" alt="The same panels with adaptive ticks: 12 AM to 6 PM on the single-day panel, Aug 2 with hour ticks across days, Jul 1 to Jul 29 daily, and 2026 with month names monthly" src="https://github.com/user-attachments/assets/572c8d69-9e0d-46d6-acce-2724c12ff1af" />

* Hover any bar in either panel: the tooltip should name that bar's bucket in full and never show a day for a monthly or yearly bucket.
* Storybook → **Bar chart → Time axis tick resolution**: the same single bar rendered twice, once with the resolution inferred (date tick — one point has no spacing to measure) and once with `tickResolution: 'hour'` (hour tick).
* `jp test js js-packages/charts` — 1102 passing. Fifteen new: six render `BarChart` and assert on rendered tick text, seven cover the tooltip formats including a declared `tickResolution` coarser than the point spacing, and one pins the horizontal `axis.y.tickResolution` routing end to end.
* Regression check — Storybook → **Bar chart → Time series** and **Custom tickFormat**: both pass an explicit `tickFormat` and must be unchanged, since the hint is ignored when one is set.

### Known limitation, fixed in the follow-up

Bars sit on a band scale, which visx samples by index. So the three-day hourly panel reads `Aug 2 | 6 PM | 12 PM | 6 AM` — three bare hours belonging to three different days — and the three-year monthly panel repeats a year. The tick *format* is right in both; the tick *values* aren't. That is the next PR in the stack.
