### PR TITLE
Charts: choose the bar chart's time-axis tick values

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-band-axis-tick-values
+++ b/projects/js-packages/charts/changelog/fix-charts-band-axis-tick-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: choose the tick values for a bar chart's time axis instead of sampling the band domain by index, so the axis stops skipping the tick that names the year or dates the day and no longer repeats a label.

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -1,7 +1,7 @@
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import { getBucketResolution, getFormatter } from '../../private/time-axis';
+import { getBandTickValues, getBucketResolution, getFormatter } from '../../private/time-axis';
 import { TruncatedXTickComponent, TruncatedYTickComponent } from './truncated-tick-component';
 import type { EnhancedDataPoint } from '../../../hooks/use-zero-value-display';
 import type { DataPointDate, BaseChartProps, SeriesData, TickResolution } from '../../../types';
@@ -11,6 +11,8 @@ import type { TickFormatter } from '@visx/axis';
 export const BASE_BAND_PADDING = 0.2;
 /** Inner padding of the category band scale (the base gap between ticks). */
 export const BASE_BAND_PADDING_INNER = 0.1;
+/** Ticks each axis carries unless the caller asks for a different count. */
+const DEFAULT_NUM_TICKS = 4;
 
 // The axis abbreviates to fit a tick; a tooltip has room to spell the same
 // bucket out in full.
@@ -55,6 +57,30 @@ const getTooltipFormatter = ( data: SeriesData[], tickResolution?: TickResolutio
 		TOOLTIP_FORMAT_BY_RESOLUTION.day;
 
 	return ( timestamp: number ) => new Date( timestamp ).toLocaleString( undefined, format );
+};
+
+/**
+ * The band scale's domain, as the dates the axis can put a tick on. Series are
+ * individually sorted already, so a merge on the timestamp restores axis order
+ * across all of them.
+ *
+ * @param data - Date-based series.
+ * @return Distinct dates, earliest first.
+ */
+const getBandDomain = ( data: SeriesData[] ): Date[] => {
+	const byTimestamp = new Map< number, Date >();
+	data.forEach( series =>
+		series.data.forEach( point => {
+			const { date } = point as DataPointDate;
+			if ( date && ! byTimestamp.has( date.getTime() ) ) {
+				byTimestamp.set( date.getTime(), date );
+			}
+		} )
+	);
+
+	return [ ...byTimestamp.keys() ]
+		.sort( ( a, b ) => a - b )
+		.map( timestamp => byTimestamp.get( timestamp ) );
 };
 
 /**
@@ -123,9 +149,8 @@ export function useBarChartOptions(
 		// formatter, which narrows with the overall span as well as the bucket
 		// size; the tooltip stays at the bucket's own granularity.
 		const hasLabels = Boolean( data?.[ 0 ]?.data?.[ 0 ]?.label );
-		const labelFormatter = hasLabels
-			? ( label: string ) => label
-			: getFormatter( data, tickResolution );
+		const timeTickFormatter = hasLabels ? null : getFormatter( data, tickResolution );
+		const labelFormatter = timeTickFormatter ?? ( ( label: string ) => label );
 		const tooltipDatumFormatter = hasLabels
 			? labelFormatter
 			: getTooltipFormatter( data, tickResolution );
@@ -139,6 +164,10 @@ export function useBarChartOptions(
 		};
 
 		return {
+			timeAxis: timeTickFormatter && {
+				domain: getBandDomain( data ),
+				tickFormatter: timeTickFormatter,
+			},
 			vertical: {
 				xTickFormat: labelFormatter,
 				yTickFormat: valueFormatter,
@@ -221,6 +250,22 @@ export function useBarChartOptions(
 			? yAxisOptions.tickFormat
 			: xAxisOptions.tickFormat;
 
+		// A band scale has no ticks of its own for visx to ask for, so it samples
+		// the domain by index and can miss the tick that dates the day or names the
+		// year. Pick the values here instead. Only for our own formatter — a
+		// caller's `tickFormat` may not be the one these values were chosen for.
+		const { timeAxis } = defaultOptions;
+		const dateAxisOptions = horizontal ? yAxisOptions : xAxisOptions;
+		const bandTickValues =
+			timeAxis && ! dateAxisOptions.tickFormat
+				? getBandTickValues(
+						timeAxis.domain,
+						timeAxis.tickFormatter,
+						dateAxisOptions.numTicks ?? DEFAULT_NUM_TICKS
+				  )
+				: null;
+		const dateAxisTickValues = bandTickValues ? { tickValues: bandTickValues } : {};
+
 		return {
 			gridVisibility,
 			xScale,
@@ -232,15 +277,17 @@ export function useBarChartOptions(
 			axis: {
 				x: {
 					orientation: 'bottom' as const,
-					numTicks: 4,
+					numTicks: DEFAULT_NUM_TICKS,
 					tickFormat: xTickFormat,
+					...( horizontal ? {} : dateAxisTickValues ),
 					...( xLabelOverflow === 'ellipsis' ? { tickComponent: TruncatedXTickComponent } : {} ),
 					...xAxisOptions,
 				},
 				y: {
 					orientation: 'left' as const,
-					numTicks: 4,
+					numTicks: DEFAULT_NUM_TICKS,
 					tickFormat: yTickFormat,
+					...( horizontal ? dateAxisTickValues : {} ),
 					...( yLabelOverflow === 'ellipsis' ? { tickComponent: TruncatedYTickComponent } : {} ),
 					...yAxisOptions,
 				},

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -252,6 +252,11 @@ span: hour ticks within a day, hour ticks dated at midnight for sub-daily data s
 to a week, calendar dates within a year, and years beyond that. An explicit
 `options.axis.x.tickFormat` still overrides (`axis.y` on a horizontal chart).
 
+Because bars sit on a band scale, which has no ticks of its own, the tick values are
+chosen rather than sampled evenly by index — otherwise the axis would routinely skip the
+bucket that prints the year or dates the day, and could repeat a label. `numTicks` caps
+how many it picks.
+
 <Canvas of={ BarChartStories.TimeAxisTickFormats } />
 
 Default tooltip labels name the hovered bar's bucket, spelled out in full:

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -254,8 +254,9 @@ to a week, calendar dates within a year, and years beyond that. An explicit
 
 Because bars sit on a band scale, which has no ticks of its own, the tick values are
 chosen rather than sampled evenly by index — otherwise the axis would routinely skip the
-bucket that prints the year or dates the day, and could repeat a label. `numTicks` caps
-how many it picks.
+bucket that prints the year or dates the day, and could repeat a label. Over spans long
+enough that nothing closer together reaches a boundary, the ticks fall on whole days or
+whole years instead. `numTicks` caps how many it picks.
 
 <Canvas of={ BarChartStories.TimeAxisTickFormats } />
 

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -183,18 +183,20 @@ const dailyPoints: Array< [ Date, number ] > = Array.from( { length: 30 }, ( _, 
 	Math.round( 60 + 40 * Math.sin( i / 4 ) ),
 ] );
 
-const threeDayHourlyPoints: Array< [ Date, number ] > = Array.from( { length: 72 }, ( _, i ) => [
+const twoDayHourlyPoints: Array< [ Date, number ] > = Array.from( { length: 48 }, ( _, i ) => [
 	new Date( 2026, 7, 2, i ),
 	Math.round( 60 + 40 * Math.sin( i / 3.5 ) ),
 ] );
 
-const oneYearMonthlyPoints: Array< [ Date, number ] > = Array.from( { length: 12 }, ( _, i ) => [
-	new Date( 2026, i, 1 ),
+// Both monthly series deliberately start mid-year: a January start would put a
+// year label on the first bucket for free, hiding whether the axis can find one.
+const oneYearMonthlyPoints: Array< [ Date, number ] > = Array.from( { length: 13 }, ( _, i ) => [
+	new Date( 2025, 7 + i, 1 ),
 	Math.round( 60 + 40 * Math.sin( i / 2 ) ),
 ] );
 
 const monthlyPoints: Array< [ Date, number ] > = Array.from( { length: 36 }, ( _, i ) => [
-	new Date( 2024, i, 1 ),
+	new Date( 2023, 6 + i, 1 ),
 	Math.round( 60 + 40 * Math.sin( i / 2 ) ),
 ] );
 
@@ -239,16 +241,16 @@ export const TimeAxisTickFormats: Story = {
 				data={ timeAxisSeries( hourlyPoints ) }
 			/>
 			<TimeAxisPanel
-				title="Hourly buckets over three days → hour ticks, dated at midnight"
-				data={ timeAxisSeries( threeDayHourlyPoints ) }
+				title="Hourly buckets, two days → hour ticks, date at midnight"
+				data={ timeAxisSeries( twoDayHourlyPoints ) }
 			/>
 			<TimeAxisPanel title="Daily buckets → date ticks" data={ timeAxisSeries( dailyPoints ) } />
 			<TimeAxisPanel
-				title="Monthly buckets within a year → month ticks, year at January"
+				title="Monthly buckets over a year → month ticks, year at January"
 				data={ timeAxisSeries( oneYearMonthlyPoints ) }
 			/>
 			<TimeAxisPanel
-				title="Monthly buckets over three years → month ticks, year at January"
+				title="Monthly buckets over three years → year ticks"
 				data={ timeAxisSeries( monthlyPoints ) }
 			/>
 			<TimeAxisPanel title="Yearly buckets → year ticks" data={ timeAxisSeries( yearlyPoints ) } />
@@ -262,7 +264,7 @@ export const TimeAxisTickFormats: Story = {
 		docs: {
 			description: {
 				story:
-					"Date-based series share the time-axis tick formatter with the line and area charts. Month-or-coarser buckets follow the resolution alone — month names with the year at January, or plain years for yearly buckets — since they carry no day to print at any span. Daily-or-finer buckets narrow with the span: hour ticks within a day, hour ticks dated at midnight for sub-daily data spanning up to a week, calendar dates within a year, and years beyond that. Hover any bar: the tooltip names that bar's bucket spelled out in full — `August 2026` for a monthly bar, `2026` for a yearly one, never a day the bucket doesn't carry. It always names the bucket's own granularity, so on the daily panel it stays finer than the ticks once a long span coarsens the axis. An explicit `options.axis.x.tickFormat` still overrides.",
+					"Date-based series share the time-axis tick formatter with the line and area charts, on the same data — compare these panels with the line chart's `TimeAxisTickFormats`. Month-or-coarser buckets follow the resolution alone — month names with the year at January, or plain years for yearly buckets — since they carry no day to print at any span. Daily-or-finer buckets narrow with the span: hour ticks within a day, hour ticks dated at midnight for sub-daily data spanning up to a week, calendar dates within a year, and years beyond that. The tick values are chosen rather than sampled: a band scale has no ticks of its own, so picking evenly by index would often skip the very bucket that carries the year or the date. Neither monthly panel starts in January, and both still name their years. Hover any bar: the tooltip names that bar's bucket spelled out in full — `August 2026` for a monthly bar, `2026` for a yearly one, never a day the bucket doesn't carry. It always names the bucket's own granularity, so on the daily panel it stays finer than the ticks once a long span coarsens the axis. An explicit `options.axis.x.tickFormat` still overrides.",
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -188,6 +188,13 @@ const twoDayHourlyPoints: Array< [ Date, number ] > = Array.from( { length: 48 }
 	Math.round( 60 + 40 * Math.sin( i / 3.5 ) ),
 ] );
 
+// The far end of the dated-hour format's range: too long for the axis to reach
+// a midnight without stepping whole days.
+const weekHourlyPoints: Array< [ Date, number ] > = Array.from( { length: 168 }, ( _, i ) => [
+	new Date( 2026, 7, 2, i ),
+	Math.round( 60 + 40 * Math.sin( i / 3.5 ) ),
+] );
+
 // Both monthly series deliberately start mid-year: a January start would put a
 // year label on the first bucket for free, hiding whether the axis can find one.
 const oneYearMonthlyPoints: Array< [ Date, number ] > = Array.from( { length: 13 }, ( _, i ) => [
@@ -244,13 +251,17 @@ export const TimeAxisTickFormats: Story = {
 				title="Hourly buckets, two days → hour ticks, date at midnight"
 				data={ timeAxisSeries( twoDayHourlyPoints ) }
 			/>
+			<TimeAxisPanel
+				title="Hourly buckets, a week → hour ticks, every tick at midnight"
+				data={ timeAxisSeries( weekHourlyPoints ) }
+			/>
 			<TimeAxisPanel title="Daily buckets → date ticks" data={ timeAxisSeries( dailyPoints ) } />
 			<TimeAxisPanel
 				title="Monthly buckets over a year → month ticks, year at January"
 				data={ timeAxisSeries( oneYearMonthlyPoints ) }
 			/>
 			<TimeAxisPanel
-				title="Monthly buckets over three years → year ticks"
+				title="Monthly buckets over three years → month ticks, every tick at January"
 				data={ timeAxisSeries( monthlyPoints ) }
 			/>
 			<TimeAxisPanel title="Yearly buckets → year ticks" data={ timeAxisSeries( yearlyPoints ) } />
@@ -258,13 +269,13 @@ export const TimeAxisTickFormats: Story = {
 	),
 	args: {
 		containerWidth: '1020px',
-		containerHeight: '1050px',
+		containerHeight: '1400px',
 	},
 	parameters: {
 		docs: {
 			description: {
 				story:
-					"Date-based series share the time-axis tick formatter with the line and area charts, on the same data — compare these panels with the line chart's `TimeAxisTickFormats`. Month-or-coarser buckets follow the resolution alone — month names with the year at January, or plain years for yearly buckets — since they carry no day to print at any span. Daily-or-finer buckets narrow with the span: hour ticks within a day, hour ticks dated at midnight for sub-daily data spanning up to a week, calendar dates within a year, and years beyond that. The tick values are chosen rather than sampled: a band scale has no ticks of its own, so picking evenly by index would often skip the very bucket that carries the year or the date. Neither monthly panel starts in January, and both still name their years. Hover any bar: the tooltip names that bar's bucket spelled out in full — `August 2026` for a monthly bar, `2026` for a yearly one, never a day the bucket doesn't carry. It always names the bucket's own granularity, so on the daily panel it stays finer than the ticks once a long span coarsens the axis. An explicit `options.axis.x.tickFormat` still overrides.",
+					"Date-based series share the time-axis tick formatter with the line and area charts, on the same data — compare these panels with the line chart's `TimeAxisTickFormats`. Month-or-coarser buckets follow the resolution alone — month names with the year at January, or plain years for yearly buckets — since they carry no day to print at any span. Daily-or-finer buckets narrow with the span: hour ticks within a day, hour ticks dated at midnight for sub-daily data spanning up to a week, calendar dates within a year, and years beyond that. The tick values are chosen rather than sampled: a band scale has no ticks of its own, so picking evenly by index would often skip the very bucket that carries the year or the date. Neither monthly panel starts in January, and both still name their years; the week-long and three-year panels step whole days and whole years, since at those spans nothing closer together reaches a boundary at all. Hover any bar: the tooltip names that bar's bucket spelled out in full — `August 2026` for a monthly bar, `2026` for a yearly one, never a day the bucket doesn't carry. It always names the bucket's own granularity, so on the daily panel it stays finer than the ticks once a long span coarsens the axis. An explicit `options.axis.x.tickFormat` still overrides.",
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -348,8 +348,30 @@ describe( 'BarChart', () => {
 
 			// Band ticks are sampled by index, so without steering they land on
 			// bare hours belonging to days the axis never names.
-			expect( screen.getByText( 'Aug 2' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Aug 3' ) ).toBeInTheDocument();
+			expect( inChart().getByText( 'Aug 2' ) ).toBeInTheDocument();
+			expect( inChart().getByText( 'Aug 3' ) ).toBeInTheDocument();
+		} );
+
+		test( 'dates every tick for sub-daily buckets spanning a week', () => {
+			renderWithTheme( {
+				width: 800,
+				data: [
+					{
+						label: 'Series A',
+						data: Array.from( { length: 168 }, ( _, i ) => ( {
+							date: new Date( 2026, 7, 2, i ),
+							value: 10 + i,
+						} ) ),
+						options: {},
+					},
+				],
+			} );
+
+			// Too long for a step within one day to fit the tick count, so the axis
+			// has to step whole days to keep naming them.
+			expect( inChart().queryByText( /\d{1,2}\s(AM|PM)/ ) ).not.toBeInTheDocument();
+			expect( inChart().getByText( 'Aug 2' ) ).toBeInTheDocument();
+			expect( inChart().getByText( 'Aug 8' ) ).toBeInTheDocument();
 		} );
 
 		test( 'names the year for monthly buckets that do not start in January', () => {
@@ -367,7 +389,7 @@ describe( 'BarChart', () => {
 				],
 			} );
 
-			const ticks = screen.getAllByText( /^\d{4}$/ );
+			const ticks = inChart().getAllByText( /^\d{4}$/ );
 			expect( distinctTexts( ticks ) ).toEqual( new Set( [ '2024', '2025', '2026' ] ) );
 		} );
 

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -1,4 +1,4 @@
-import { render, renderHook, screen } from '@testing-library/react';
+import { render, renderHook, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GlobalChartsProvider } from '../../../providers';
 import BarChart from '../bar-chart';
@@ -222,6 +222,12 @@ describe( 'BarChart', () => {
 		const distinctTexts = ( elements: HTMLElement[] ) =>
 			new Set( elements.map( el => el.textContent ) );
 
+		// @visx/text measures label widths through one reusable <text> node parked
+		// on document.body, which outlives RTL's cleanup still holding the last
+		// string measured. Query inside the chart so a previous test's measurement
+		// can't answer for this one's axis.
+		const inChart = () => within( screen.getByRole( 'grid', { name: /bar chart/i } ) );
+
 		test( 'renders distinct date ticks for daily buckets within a year', () => {
 			renderWithTheme( {
 				width: 800,
@@ -325,6 +331,46 @@ describe( 'BarChart', () => {
 			expect( screen.queryByText( /\d{1,2}\s(AM|PM)/ ) ).not.toBeInTheDocument();
 		} );
 
+		test( 'dates a midnight tick for sub-daily buckets spanning days', () => {
+			renderWithTheme( {
+				width: 800,
+				data: [
+					{
+						label: 'Series A',
+						data: Array.from( { length: 48 }, ( _, i ) => ( {
+							date: new Date( 2026, 7, 2, i ),
+							value: 10 + i,
+						} ) ),
+						options: {},
+					},
+				],
+			} );
+
+			// Band ticks are sampled by index, so without steering they land on
+			// bare hours belonging to days the axis never names.
+			expect( screen.getByText( 'Aug 2' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Aug 3' ) ).toBeInTheDocument();
+		} );
+
+		test( 'names the year for monthly buckets that do not start in January', () => {
+			renderWithTheme( {
+				width: 800,
+				data: [
+					{
+						label: 'Series A',
+						data: Array.from( { length: 36 }, ( _, i ) => ( {
+							date: new Date( 2023, 6 + i, 1 ),
+							value: 10 + i,
+						} ) ),
+						options: {},
+					},
+				],
+			} );
+
+			const ticks = screen.getAllByText( /^\d{4}$/ );
+			expect( distinctTexts( ticks ) ).toEqual( new Set( [ '2024', '2025', '2026' ] ) );
+		} );
+
 		test( 'reads tickResolution off the y axis on a horizontal chart', () => {
 			renderWithTheme( {
 				width: 800,
@@ -341,7 +387,7 @@ describe( 'BarChart', () => {
 
 			// The dates move to the y axis with the orientation, so the hint has to
 			// follow them; read off `axis.x` this would fall back to a date tick.
-			expect( screen.getByText( /^1\sPM$/ ) ).toBeInTheDocument();
+			expect( inChart().getByText( /^1\sPM$/ ) ).toBeInTheDocument();
 		} );
 
 		test( 'renders an hour tick when tickResolution declares the buckets sub-daily', () => {
@@ -359,7 +405,7 @@ describe( 'BarChart', () => {
 				options: { axis: { x: { tickResolution: 'hour' } } },
 			} );
 
-			expect( screen.getByText( /^1\sPM$/ ) ).toBeInTheDocument();
+			expect( inChart().getByText( /^1\sPM$/ ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
+++ b/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
@@ -323,6 +323,33 @@ describe( 'getBandTickValues', () => {
 		] );
 	} );
 
+	it( 'steps whole days once a sub-daily span is too long to date any other way', () => {
+		// No step inside a day fits four ticks across a week, so the offset sweep
+		// alone would leave every tick but the first a bare hour on an unnamed day.
+		expect( labelsFor( hourlyDomain( new Date( 2026, 7, 2 ), 168 ) ) ).toEqual( [
+			'Aug 2',
+			'Aug 4',
+			'Aug 6',
+			'Aug 8',
+		] );
+	} );
+
+	it( 'steps whole years once a monthly span is too long to reach January any other way', () => {
+		expect( labelsFor( monthlyDomain( 2023, 6, 120 ) ) ).toEqual( [
+			'2024',
+			'2027',
+			'2030',
+			'2033',
+		] );
+	} );
+
+	it( 'still names a year at the lowest tick counts a caller can ask for', () => {
+		// An anchor outranks a denser axis, so without a step that reaches two of
+		// them a two-tick axis would settle for a single January.
+		expect( labelsFor( monthlyDomain( 2023, 6, 36 ), 2 ) ).toEqual( [ '2024', '2026' ] );
+		expect( labelsFor( monthlyDomain( 2023, 6, 36 ), 3 ) ).toEqual( [ '2024', '2025', '2026' ] );
+	} );
+
 	it( 'never repeats a label on adjacent ticks', () => {
 		const labels = labelsFor( monthlyDomain( 2024, 0, 36 ) );
 

--- a/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
+++ b/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
@@ -1,4 +1,4 @@
-import { getBucketResolution, getFormatter } from '../time-axis';
+import { getBandTickValues, getBucketResolution, getFormatter } from '../time-axis';
 import type { useChartDataTransform } from '../../../hooks';
 
 type SortedData = ReturnType< typeof useChartDataTransform >;
@@ -286,5 +286,63 @@ describe( 'getBucketResolution', () => {
 		// Weeks and days are both calendar-date buckets as far as labelling goes,
 		// and 'week' is not a label format of its own.
 		expect( getBucketResolution( toSeries( [] ), 'week' ) ).toBe( 'day' );
+	} );
+} );
+
+describe( 'getBandTickValues', () => {
+	const monthlyDomain = ( year: number, month: number, months: number ) =>
+		Array.from( { length: months }, ( _, i ) => new Date( year, month + i, 1 ) );
+
+	const hourlyDomain = ( start: Date, hours: number ) =>
+		Array.from( { length: hours }, ( _, i ) => new Date( start.getTime() + i * 60 * 60 * 1000 ) );
+
+	const labelsFor = ( domain: Date[], maxTicks = 4 ) => {
+		const formatter = getFormatter( toSeries( domain ) );
+		return getBandTickValues( domain, formatter, maxTicks ).map( date =>
+			formatter( date.getTime() )
+		);
+	};
+
+	it( 'shifts the sampling offset onto January for a monthly series starting mid-year', () => {
+		// Sampling from index 0 gives Aug, Nov, Feb, May, Aug — no year at all on a
+		// series that crosses one, and "Aug" twice.
+		expect( labelsFor( monthlyDomain( 2025, 7, 13 ) ) ).toContain( '2026' );
+	} );
+
+	it( 'lands on every January of a multi-year monthly series that starts mid-year', () => {
+		expect( labelsFor( monthlyDomain( 2023, 6, 36 ) ) ).toEqual( [ '2024', '2025', '2026' ] );
+	} );
+
+	it( 'keeps the dated midnight ticks for sub-daily data spanning days', () => {
+		// Every bare hour tick needs a dated one before it to say which day it is.
+		expect( labelsFor( hourlyDomain( new Date( 2026, 7, 2 ), 48 ) ) ).toEqual( [
+			'Aug 2',
+			'12 PM',
+			'Aug 3',
+			'12 PM',
+		] );
+	} );
+
+	it( 'never repeats a label on adjacent ticks', () => {
+		const labels = labelsFor( monthlyDomain( 2024, 0, 36 ) );
+
+		expect( labels.some( ( label, i ) => i > 0 && label === labels[ i - 1 ] ) ).toBe( false );
+	} );
+
+	it( 'keeps the whole domain when it already fits', () => {
+		const domain = monthlyDomain( 2023, 0, 4 );
+
+		expect( getBandTickValues( domain, String, 4 ) ).toEqual( domain );
+	} );
+
+	it( 'never exceeds the requested tick count', () => {
+		const domain = monthlyDomain( 2023, 6, 36 );
+
+		expect( getBandTickValues( domain, String, 4 ).length ).toBeLessThanOrEqual( 4 );
+		expect( getBandTickValues( domain, String, 7 ).length ).toBeLessThanOrEqual( 7 );
+	} );
+
+	it( 'returns nothing for an empty domain', () => {
+		expect( getBandTickValues( [], String, 4 ) ).toEqual( [] );
 	} );
 } );

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -190,7 +190,8 @@ const TICK_ANCHORS = new Map< ( timestamp: number ) => string, ( date: Date ) =>
 ] );
 
 // Index distance between consecutive anchor buckets, or null below two of them.
-// Only a sampling step dividing this can land on more than one anchor.
+// The steps that can land on more than one anchor are the ones that divide it
+// and the ones that are whole multiples of it.
 const getAnchorPeriod = ( domain: Date[], isAnchor: ( date: Date ) => boolean ) => {
 	const first = domain.findIndex( isAnchor );
 	const second = domain.findIndex( ( date, index ) => index > first && isAnchor( date ) );
@@ -205,8 +206,9 @@ const getAnchorPeriod = ( domain: Date[], isAnchor: ( date: Date ) => boolean ) 
  * carry a boundary and without collapsing repeats — so the tick that prints the
  * year or the date often isn't sampled at all, and a long series can show the
  * same label twice. Choose the values instead: keep the even spacing, but slide
- * the offset onto the anchor buckets and reject any step that would put two
- * identical labels side by side.
+ * the offset onto the anchor buckets — stepping by whole anchor periods once the
+ * span is too long to reach them any other way — and reject any step that would
+ * put two identical labels side by side.
  *
  * @param domain        - Band domain, in axis order.
  * @param tickFormatter - Formatter the axis will render these values with.
@@ -234,19 +236,33 @@ export const getBandTickValues = (
 			steps.add( anchorPeriod / divisor );
 		}
 	}
+	if ( anchorPeriod ) {
+		// A divisor reaches every anchor but outruns `maxTicks` beyond a few
+		// periods, which would leave a week of hourly buckets naming one day out
+		// of seven. Whole multiples carry those longer spans, and the smallest one
+		// that still fits is the densest, so it reaches the most anchors.
+		const minStep = Math.floor( ( domain.length - 1 ) / Math.max( 1, maxTicks ) ) + 1;
+		steps.add( Math.ceil( minStep / anchorPeriod ) * anchorPeriod );
+	}
+
+	// Once per bucket rather than once per bucket per candidate: the sweep reads
+	// the same labels back for every step and offset, and these formatters go
+	// through `toLocaleDateString`.
+	const domainLabels = domain.map( date => tickFormatter( date.getTime() ) );
 
 	let best: { values: Date[]; anchors: number } | null = null;
 	for ( const step of steps ) {
 		for ( let offset = 0; offset < step; offset++ ) {
 			const values: Date[] = [];
+			const labels: string[] = [];
 			for ( let index = offset; index < domain.length; index += step ) {
 				values.push( domain[ index ] );
+				labels.push( domainLabels[ index ] );
 			}
 			if ( ! values.length || values.length > maxTicks ) {
 				continue;
 			}
 
-			const labels = values.map( date => tickFormatter( date.getTime() ) );
 			if ( labels.some( ( label, index ) => index > 0 && label === labels[ index - 1 ] ) ) {
 				continue;
 			}

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -180,6 +180,89 @@ export const getFormatter = (
 		: formatYearTick;
 };
 
+// Tick formats that print a coarser unit at a boundary — the date at midnight,
+// the year at January — say what their neighbours leave out. A time scale
+// always lands on those boundaries; a band scale samples by index and has to be
+// steered onto them.
+const TICK_ANCHORS = new Map< ( timestamp: number ) => string, ( date: Date ) => boolean >( [
+	[ formatDateOrHourTick, date => date.getHours() === 0 && date.getMinutes() === 0 ],
+	[ formatMonthOrYearTick, date => date.getMonth() === 0 ],
+] );
+
+// Index distance between consecutive anchor buckets, or null below two of them.
+// Only a sampling step dividing this can land on more than one anchor.
+const getAnchorPeriod = ( domain: Date[], isAnchor: ( date: Date ) => boolean ) => {
+	const first = domain.findIndex( isAnchor );
+	const second = domain.findIndex( ( date, index ) => index > first && isAnchor( date ) );
+
+	return first < 0 || second < 0 ? null : second - first;
+};
+
+/**
+ * Tick values for a band time axis.
+ *
+ * visx samples a band domain by index from offset zero, blind to which labels
+ * carry a boundary and without collapsing repeats — so the tick that prints the
+ * year or the date often isn't sampled at all, and a long series can show the
+ * same label twice. Choose the values instead: keep the even spacing, but slide
+ * the offset onto the anchor buckets and reject any step that would put two
+ * identical labels side by side.
+ *
+ * @param domain        - Band domain, in axis order.
+ * @param tickFormatter - Formatter the axis will render these values with.
+ * @param maxTicks      - Most ticks the axis should carry.
+ * @return Values to hand the axis as `tickValues`.
+ */
+export const getBandTickValues = (
+	domain: Date[],
+	tickFormatter: ( timestamp: number ) => string,
+	maxTicks: number
+): Date[] => {
+	if ( ! domain.length ) {
+		return [];
+	}
+
+	const isAnchor = TICK_ANCHORS.get( tickFormatter );
+
+	const steps = new Set< number >();
+	for ( let count = maxTicks; count > 1; count-- ) {
+		steps.add( Math.max( 1, Math.floor( ( domain.length - 1 ) / ( count - 1 ) ) ) );
+	}
+	const anchorPeriod = isAnchor ? getAnchorPeriod( domain, isAnchor ) : null;
+	for ( let divisor = 1; divisor <= ( anchorPeriod ?? 0 ); divisor++ ) {
+		if ( anchorPeriod % divisor === 0 ) {
+			steps.add( anchorPeriod / divisor );
+		}
+	}
+
+	let best: { values: Date[]; anchors: number } | null = null;
+	for ( const step of steps ) {
+		for ( let offset = 0; offset < step; offset++ ) {
+			const values: Date[] = [];
+			for ( let index = offset; index < domain.length; index += step ) {
+				values.push( domain[ index ] );
+			}
+			if ( ! values.length || values.length > maxTicks ) {
+				continue;
+			}
+
+			const labels = values.map( date => tickFormatter( date.getTime() ) );
+			if ( labels.some( ( label, index ) => index > 0 && label === labels[ index - 1 ] ) ) {
+				continue;
+			}
+
+			// The anchors first, then the denser axis.
+			const anchors = isAnchor ? values.filter( isAnchor ).length : 0;
+			const denser = anchors === best?.anchors && values.length > best.values.length;
+			if ( ! best || anchors > best.anchors || denser ) {
+				best = { values, anchors };
+			}
+		}
+	}
+
+	return best ? best.values : [ domain[ 0 ] ];
+};
+
 // Estimate the largest number of x-axis ticks that fit without producing
 // consecutive duplicate labels under the given formatter. Used so the axis
 // adapts to the data's resolution rather than picking a fixed count.

--- a/projects/plugins/jetpack/changelog/fix-charts-band-axis-tick-values
+++ b/projects/plugins/jetpack/changelog/fix-charts-band-axis-tick-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: keep the year and the day on the traffic chart's time axis, which could previously skip the tick that named them and repeat a label instead.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-band-axis-tick-values
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-band-axis-tick-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: keep the year and the day on the traffic chart's time axis, which could previously skip the tick that named them and repeat a label instead.

--- a/projects/plugins/premium-analytics/changelog/fix-charts-band-axis-tick-values
+++ b/projects/plugins/premium-analytics/changelog/fix-charts-band-axis-tick-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the year and the day on bar chart time axes, which could previously skip the tick that named them and repeat a label instead.

--- a/projects/plugins/wpcomsh/changelog/fix-charts-band-axis-tick-values
+++ b/projects/plugins/wpcomsh/changelog/fix-charts-band-axis-tick-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: keep the year and the day on the traffic chart's time axis, which could previously skip the tick that named them and repeat a label instead.


### PR DESCRIPTION
Fixes #

## Proposed changes

Bars sit on a band scale. visx has no ticks to ask a band scale for, so it falls back to sampling the domain by index from offset zero:

```js
scale.domain().filter( ( _, index, arr ) => index % Math.round( ( arr.length - 1 ) / numTicks ) === 0 )
```

No awareness of which labels carry a boundary, and no collapse of repeats. But `formatDateOrHourTick` prints the date **only at midnight** and `formatMonthOrYearTick` prints the year **only at January** — so the one tick that says which day or which year it is was routinely not sampled at all:

| data | rendered axis text |
| --- | --- |
| 72h hourly | `Aug 2 \| 6 PM \| 12 PM \| 6 AM` — three bare hours, three different days |
| 13 monthly points from Aug 2025 | `Aug \| Nov \| Feb \| May \| Aug` — no year, on a series that crosses one, and `Aug` twice |
| 36 monthly points from Jul 2023 | `Jul \| Apr \| Jan \| Oct` — no year at all |

`getBandTickValues` picks the values instead of letting them be sampled. It keeps the even spacing, but:

* sweeps the sampling offset and keeps the one landing on the most **anchor** buckets — an anchor being a tick whose format prints a coarser unit. The anchor predicate is keyed on the formatter that was chosen, so it can't drift out of step with `getFormatter`.
* adds the **divisors of the anchor period** as candidate steps — an even count sweep never proposes them, which is why shifting the offset alone can't fix the 72h case.
* adds the smallest **whole multiple of the anchor period** that still fits the tick count. A divisor reaches every anchor but outruns `numTicks` beyond a few periods, so past ~4 days of hourly buckets — or ~4 years of monthly ones — the multiples are the only steps left that reach more than one boundary. Without them a week of hourly data reads `Aug 2 · 7 AM · 2 PM · 9 PM`, which is the same failure as the 72h row above.
* **rejects any step** that would put two identical labels side by side.
* takes `numTicks` as the cap, so the existing axis API still governs density. Anchors outrank density, and the multiple keeps that from costing ticks: at `numTicks: 2` the three-year panel reads `2024 · 2026` rather than settling for a single January.

Each bucket's label is formatted once for the whole sweep rather than once per candidate step — 1095 daily points at `numTicks: 10` went from 143 ms to 15 ms, which pays for the extra step several times over.

**Stacked on #51274**, which is stacked on #51273. The diff here is against #51274.

## Related product discussion/links

* Split out of #51012, where this was raised in review.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Storybook → **Charts / Bar chart → Time axis tick formats**.

**Before** — the format is right, the values aren't. Hourly panel names one day out of three; three-year monthly panel repeats a year.

<img width="800" alt="Bar chart panels before: three-day hourly axis reading Aug 2 then three bare hour labels, three-year monthly axis repeating a year" src="https://github.com/user-attachments/assets/572c8d69-9e0d-46d6-acce-2724c12ff1af" />

**After** — every bare hour has a dated tick before it, and both monthly panels name their years despite neither starting in January.

<img width="800" alt="Bar chart time-axis panels: hourly single day, hourly two days dated at midnight, hourly over a week reading Aug 2, Aug 4, Aug 6, Aug 8, daily dates, monthly over a year naming 2026, monthly over three years reading 2024, 2025, 2026, and yearly buckets" src="https://github.com/user-attachments/assets/c635e349-b373-4671-9c6b-1a6432b918a6" />

* Compare each panel against **Charts / Line chart → Time axis tick formats**. The panels use the same series deliberately, so the two should agree in kind — that comparison is what surfaced this.
* Both monthly panels start mid-year on purpose (Aug 2025 and Jul 2023). A January start hands the first bucket a year label for free and hides whether the axis can find one; on trunk the three-year panel only looked right for that reason.
* The **week-long hourly panel** is the far end of the dated-hour format's range, where no step inside a day fits four ticks. It should read four dates, two days apart, and no bare hours at all.
* `jp test js js-packages/charts` — 1116 passing. Thirteen new: ten unit tests for `getBandTickValues` (offset steering, the anchor period, stepping whole days and whole years on long spans, the lowest tick counts, no adjacent repeats, the `numTicks` cap, whole-domain and empty-domain edges) and three `BarChart` renders for the cases in the table above plus the week-long span.

### One thing worth knowing if you write tests here

Adding a second hour-tick assertion surfaced a trap that predates this PR. `@visx/text` measures label widths through a single `<text id="__react_svg_text_measurement_id">` parked on `document.body`, and it outlives RTL's cleanup still holding the last string it measured. So `screen.getByText( /^1\sPM$/ )` can match a *previous test's measurement* rather than this test's axis. Every tick assertion added here queries inside the chart instead. Anything in this repo asserting on chart label text through `screen` has the same exposure.

