### PR TITLE
Stats: normalize time-series row order oldest first

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-wooa7s-1907-stats-time-series-order
+++ b/projects/packages/premium-analytics/changelog/fix-wooa7s-1907-stats-time-series-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers: fix the chart legend rendering its date range reversed.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/subscribers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/subscribers.ts
@@ -3,13 +3,14 @@ import type {
 	StatsSubscribersRawResponse,
 } from '../subscribers';
 
+// Rows are newest first, as the live `stats/subscribers` endpoint returns them.
 export const subscribersFixture = {
 	date: '2026-06-25',
 	unit: 'day',
 	fields: [ 'period', 'subscribers', 'subscribers_paid' ],
 	data: [
-		[ '2026-06-24', '10', '2' ],
 		[ '2026-06-25', 12, 3 ],
+		[ '2026-06-24', '10', '2' ],
 	],
 } satisfies StatsSubscribersRawResponse;
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/subscribers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/subscribers.ts
@@ -3,7 +3,7 @@ import type {
 	StatsSubscribersRawResponse,
 } from '../subscribers';
 
-// Rows are newest first, as the live `stats/subscribers` endpoint returns them.
+// Newest first, as the live endpoint returns them.
 export const subscribersFixture = {
 	date: '2026-06-25',
 	unit: 'day',

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -314,6 +314,37 @@ describe( 'Stats time-series normalizer', () => {
 		expect( withoutRows.summary.date_end ).toBe( withRows.summary.date_end );
 	} );
 
+	// `stats/subscribers` returns its buckets newest first, unlike `stats/visits`.
+	// Downstream code reads `data[0]` as the oldest bucket, so the order is
+	// normalized here rather than at each call site.
+	it( 'orders newest-first payloads oldest first', () => {
+		const result = sanitizeStatsTimeSeriesResponse(
+			{
+				date: '2026-06-17',
+				unit: 'day',
+				fields: [ 'period', 'subscribers' ],
+				data: [
+					[ '2026-06-17', 12 ],
+					[ '2026-06-16', 11 ],
+					[ '2026-06-15', 9 ],
+				],
+			},
+			{ period: 'day' }
+		);
+
+		expect( result.data.map( row => row.time_interval ) ).toEqual( [
+			'2026-06-15',
+			'2026-06-16',
+			'2026-06-17',
+		] );
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				date_start: '2026-06-15T00:00:00+00:00',
+				date_end: '2026-06-17T23:59:59+00:00',
+			} )
+		);
+	} );
+
 	it( 'detects supported time-series payload shapes', () => {
 		expect( isStatsTimeSeriesPayload( visitsFixture ) ).toBe( true );
 		expect( isStatsTimeSeriesPayload( scalarDaysTimeSeriesFixture ) ).toBe( true );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -314,9 +314,7 @@ describe( 'Stats time-series normalizer', () => {
 		expect( withoutRows.summary.date_end ).toBe( withRows.summary.date_end );
 	} );
 
-	// `stats/subscribers` returns its buckets newest first, unlike `stats/visits`.
-	// Downstream code reads `data[0]` as the oldest bucket, so the order is
-	// normalized here rather than at each call site.
+	// The shape `stats/subscribers` returns.
 	it( 'orders newest-first payloads oldest first', () => {
 		const result = sanitizeStatsTimeSeriesResponse(
 			{

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -95,6 +95,16 @@ function parseTimeSeriesRows( payload: unknown ) {
 	} );
 }
 
+// Ordinal, not lexical: `localeCompare` lets a collation reorder or ignore the
+// separators these bounds are built from.
+function compareBucketBounds( a: string, b: string ) {
+	if ( a === b ) {
+		return 0;
+	}
+
+	return a < b ? -1 : 1;
+}
+
 function getPrimaryMetricValue( row: StatsRecord ) {
 	// The first numeric metric is the headline value; matrix payloads preserve API field order.
 	const primaryMetric = Object.entries( row ).find(
@@ -279,19 +289,29 @@ export function sanitizeStatsTimeSeriesResponse(
 
 		return totals;
 	}, {} );
-	const data = rows.map< StatsTimeSeriesDataPoint >( row => {
-		const rawPeriod = row.period ?? row.time_interval ?? row.date_start ?? row.date;
-		const range = getRowIntervalFields( row, rawPeriod, unit );
-		const value = safeParseFloat( getPrimaryMetricValue( row ) );
+	const data = rows
+		.map< StatsTimeSeriesDataPoint >( row => {
+			const rawPeriod = row.period ?? row.time_interval ?? row.date_start ?? row.date;
+			const range = getRowIntervalFields( row, rawPeriod, unit );
+			const value = safeParseFloat( getPrimaryMetricValue( row ) );
 
-		return {
-			...row,
-			...range,
-			label: range.time_interval,
-			value,
-			items: [],
-		};
-	} );
+			return {
+				...row,
+				...range,
+				label: range.time_interval,
+				value,
+				items: [],
+			};
+		} )
+		// Row order differs by endpoint: `stats/visits` returns its buckets oldest
+		// first, `stats/subscribers` newest first. Everything downstream reads
+		// `data[0]` as the oldest bucket — the summary bounds below, chart legend
+		// ranges, and cumulative headline values — so the order is normalized once
+		// here instead of at each call site. `date_start` is a nominal wall-clock
+		// label rather than a real instant (see getStatsIntervalFields), so
+		// comparing the strings sorts chronologically without reintroducing an
+		// offset.
+		.sort( ( a, b ) => compareBucketBounds( a.date_start, b.date_start ) );
 	const firstRow = data[ 0 ];
 	const lastRow = data[ data.length - 1 ];
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -95,8 +95,7 @@ function parseTimeSeriesRows( payload: unknown ) {
 	} );
 }
 
-// Ordinal, not lexical: `localeCompare` lets a collation reorder or ignore the
-// separators these bounds are built from.
+// Not `localeCompare`: a collation may ignore the separators these bounds carry.
 function compareBucketBounds( a: string, b: string ) {
 	if ( a === b ) {
 		return 0;
@@ -303,14 +302,9 @@ export function sanitizeStatsTimeSeriesResponse(
 				items: [],
 			};
 		} )
-		// Row order differs by endpoint: `stats/visits` returns its buckets oldest
-		// first, `stats/subscribers` newest first. Everything downstream reads
-		// `data[0]` as the oldest bucket — the summary bounds below, chart legend
-		// ranges, and cumulative headline values — so the order is normalized once
-		// here instead of at each call site. `date_start` is a nominal wall-clock
-		// label rather than a real instant (see getStatsIntervalFields), so
-		// comparing the strings sorts chronologically without reintroducing an
-		// offset.
+		// `stats/visits` returns buckets oldest first, `stats/subscribers` newest
+		// first, but everything downstream reads `data[0]` as the oldest bucket —
+		// starting with the summary bounds below.
 		.sort( ( a, b ) => compareBucketBounds( a.date_start, b.date_start ) );
 	const firstRow = data[ 0 ];
 	const lastRow = data[ data.length - 1 ];

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -864,9 +864,8 @@ function buildSubscribersResponse( query: URLSearchParams ) {
 		date: endDate.toISOString().slice( 0, 10 ),
 		unit,
 		fields: [ 'period', 'subscribers', 'subscribers_paid' ],
-		// Newest first, as the live endpoint returns them — unlike `stats/visits`.
-		// An oldest-first mock here hid WOOA7S-1907, where the reversed order left
-		// the chart legend reading its date range backwards.
+		// Newest first, as the live endpoint returns them. An oldest-first mock here
+		// hid WOOA7S-1907.
 		data: rows.reverse(),
 	};
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -864,7 +864,10 @@ function buildSubscribersResponse( query: URLSearchParams ) {
 		date: endDate.toISOString().slice( 0, 10 ),
 		unit,
 		fields: [ 'period', 'subscribers', 'subscribers_paid' ],
-		data: rows,
+		// Newest first, as the live endpoint returns them — unlike `stats/visits`.
+		// An oldest-first mock here hid WOOA7S-1907, where the reversed order left
+		// the chart legend reading its date range backwards.
+		data: rows.reverse(),
 	};
 }
 


### PR DESCRIPTION
Fixes WOOA7S-1907

## Proposed changes

* Sort the rows in the shared Stats time-series normalizer so every consumer gets them oldest first.
* Fixes the Subscribers summary legend, which read its date range end-first (`August 13 – July 15, 2026`).
* Also fixes the widget's headline value, which took the cumulative count from the *start* of the range instead of the end.
* Make the subscribers fixture and Storybook mock newest-first, matching the live endpoint.

`stats/subscribers` returns its buckets newest first while `stats/visits` returns them oldest first. Everything downstream reads `data[0]` as the oldest bucket — the summary bounds, the chart legend ranges, and the cumulative headline — but nothing enforced that. The Traffic chart shares the same order-dependent code and was only correct because its endpoint happens to be ascending, so the invariant is now enforced once in the normalizer rather than at each call site.

The fixture and the Storybook mock were both written oldest-first in the same PR that introduced the legend, so neither Jest nor Storybook could ever catch this. They now mirror the real response order.

## Related product discussion/links

* WOOA7S-1907

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Verified against the live endpoint on a connected site:

```
stats/subscribers  unit=day    2026-08-14 | 08-13 | 08-12 | 08-11   <- newest first
stats/visits       unit=day    2026-08-10 | 08-11 | 08-12 | 08-13   <- oldest first
```

The same asymmetry holds for `unit=week` and `unit=month`.

To check in the dashboard:

* Go to **Jetpack → Stats → Subscribers** on a site with subscriber history.
* Set the date range to **Last 30 days** and comparison to **Previous period**.
* The chart legend under **Subscribers summary** should read like `July 15 – August 13, 2026` and `June 15 – July 14, 2026` — start date first, matching the range shown above the chart.
* Switch **Group by** between Day / Week / Month; the legend stays in chronological order.
* Check the **Traffic** tab's summary chart is unchanged — its endpoint was already ascending, so the sort is a no-op there.

Before:
<img width="2303" height="665" alt="Screenshot 2026-08-14 at 5 27 06 PM" src="https://github.com/user-attachments/assets/868708c6-c370-45be-a63e-c29674e7e0e4" />

After:
<img width="2305" height="662" alt="Screenshot 2026-08-14 at 5 37 49 PM" src="https://github.com/user-attachments/assets/772ae047-9af7-4a87-865b-df2ec10614ee" />
