### PR TITLE
Status: Add a shared Automattician tracking signal and use it in Content Guidelines AI

### DIFF
--- a/projects/packages/status/changelog/add-visitor-is-tracking-automattician
+++ b/projects/packages/status/changelog/add-visitor-is-tracking-automattician
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Visitor: Add is_tracking_automattician() to identify Automattician traffic for analytics reporting.

--- a/projects/packages/status/src/class-visitor.php
+++ b/projects/packages/status/src/class-visitor.php
@@ -53,4 +53,35 @@ class Visitor {
 	public function is_automattician_feature_flags_only() {
 		return ( defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST );
 	}
+
+	/**
+	 * Whether the current request should be attributed to an Automattician in analytics.
+	 *
+	 * True for an identified Automattician on WordPress.com Simple, and for A8C-proxied
+	 * requests on both Simple and WoA. Use it to tag Tracks events as internal traffic so
+	 * it can be filtered out of product reporting — this matters most for newly launched
+	 * features, where a small amount of internal testing is a large share of the totals
+	 * and there is no way to separate it after the fact.
+	 *
+	 * IMPORTANT: Reporting signal only, never authorization. A proxied request says
+	 * something about where the request came from, not who the user is.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool True if the request looks like Automattician traffic, false otherwise.
+	 */
+	public function is_tracking_automattician() {
+		// Identified Automattician on WordPress.com Simple.
+		if ( function_exists( 'is_automattician' ) && \is_automattician() ) {
+			return true;
+		}
+
+		// Proxied A8C request on WordPress.com Simple.
+		if ( function_exists( 'wpcom_is_proxied_request' ) && \wpcom_is_proxied_request() ) {
+			return true;
+		}
+
+		// Proxied A8C request on WoA.
+		return $this->is_automattician_feature_flags_only();
+	}
 }

--- a/projects/packages/status/tests/php/Visitor_Test.php
+++ b/projects/packages/status/tests/php/Visitor_Test.php
@@ -9,6 +9,8 @@ namespace Automattic\Jetpack\Status;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -222,5 +224,39 @@ class Visitor_Test extends TestCase {
 
 		$is_a11n = $this->visitor_obj->is_automattician_feature_flags_only();
 		$this->assertTrue( $is_a11n );
+	}
+
+	/**
+	 * Tests is_tracking_automattician returns false for an ordinary request.
+	 *
+	 * Isolated because AT_PROXIED_REQUEST cannot be undefined once set. Without a
+	 * fresh process this assertion would silently depend on running before every
+	 * test that defines the constant.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_is_tracking_automattician_is_false_for_an_ordinary_request() {
+		// Neither wpcom function exists off WordPress.com, so every branch falls through.
+		$this->assertFalse( $this->visitor_obj->is_tracking_automattician() );
+	}
+
+	/**
+	 * Tests is_tracking_automattician treats a proxied request as Automattician traffic.
+	 *
+	 * Isolated for the same reason: this test defines the constant, and doing so in a
+	 * shared process would leak into the assertion above.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_is_tracking_automattician_is_true_for_a_proxied_request() {
+		define( 'AT_PROXIED_REQUEST', true );
+
+		$this->assertTrue( $this->visitor_obj->is_tracking_automattician() );
 	}
 }

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai.php
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai.php
@@ -10,6 +10,7 @@
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Status\Visitor;
 use Automattic\Jetpack\Tracking;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -86,6 +87,10 @@ function jetpack_content_guidelines_ai_enqueue_scripts( $hook_suffix ) {
 	// and upgrade notice.
 	$initial_state = array(
 		'bannerDismissed' => class_exists( 'Jetpack_AI_Helper' ) && Jetpack_AI_Helper::is_guidelines_banner_dismissed(),
+		// Tags every Tracks event fired from this page as internal traffic. The
+		// feature is new and low-volume, so Automattician testing is otherwise a
+		// visible share of the numbers with no way to filter it out after the fact.
+		'isA11n'          => ( new Visitor() )->is_tracking_automattician(),
 	);
 
 	// Resolve the AI feature state server-side so the bundle can hydrate the

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/lib/tracks.js
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/lib/tracks.js
@@ -1,13 +1,33 @@
 import analytics from '@automattic/jetpack-analytics';
 
 /**
+ * Default properties attached to every Tracks event this feature records.
+ *
+ * `is_a11n` marks internal traffic so Automattician testing can be filtered out
+ * of product reporting. Read at call time rather than at module load: the inline
+ * script defining the global runs before the bundle, but reading lazily keeps
+ * this module importable in tests that never define it.
+ *
+ * @return {Object} Properties merged into every recorded event, before any
+ *                   explicitly passed by the caller.
+ */
+function getDefaultProperties() {
+	return {
+		is_a11n: !! window.jetpackContentGuidelinesAi?.isA11n,
+	};
+}
+
+/**
  * Record a content guidelines Tracks event.
  *
  * @param {string} eventName  - Event name suffix (appended to `jetpack_ai_guidelines_`).
  * @param {Object} properties - Event properties.
  */
 export function recordGuidelinesEvent( eventName, properties = {} ) {
-	analytics.tracks.recordEvent( `jetpack_ai_guidelines_${ eventName }`, properties );
+	analytics.tracks.recordEvent( `jetpack_ai_guidelines_${ eventName }`, {
+		...getDefaultProperties(),
+		...properties,
+	} );
 }
 
 /**
@@ -18,5 +38,8 @@ export function recordGuidelinesEvent( eventName, properties = {} ) {
  * @param {Object} properties - Event properties.
  */
 export function recordAiEvent( eventName, properties = {} ) {
-	analytics.tracks.recordEvent( eventName, properties );
+	analytics.tracks.recordEvent( eventName, {
+		...getDefaultProperties(),
+		...properties,
+	} );
 }

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/test/tracks.test.js
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/test/tracks.test.js
@@ -7,7 +7,14 @@ jest.mock( '@automattic/jetpack-analytics', () => ( {
 } ) );
 
 describe( 'tracks', () => {
-	beforeEach( () => jest.clearAllMocks() );
+	beforeEach( () => {
+		jest.clearAllMocks();
+		delete window.jetpackContentGuidelinesAi;
+	} );
+
+	afterEach( () => {
+		delete window.jetpackContentGuidelinesAi;
+	} );
 
 	it( 'prefixes guidelines events with jetpack_ai_guidelines_', () => {
 		recordGuidelinesEvent( 'accept', { type: 'section', slug: 'copy' } );
@@ -15,15 +22,16 @@ describe( 'tracks', () => {
 		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_ai_guidelines_accept', {
 			type: 'section',
 			slug: 'copy',
+			is_a11n: false,
 		} );
 	} );
 
-	it( 'defaults properties to an empty object', () => {
+	it( 'sends only the defaults when no properties are passed', () => {
 		recordGuidelinesEvent( 'read_more_click' );
 
 		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith(
 			'jetpack_ai_guidelines_read_more_click',
-			{}
+			{ is_a11n: false }
 		);
 	} );
 
@@ -32,6 +40,50 @@ describe( 'tracks', () => {
 
 		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_ai_upgrade_button', {
 			placement: 'content-guidelines',
+			is_a11n: false,
+		} );
+	} );
+
+	it( 'reports is_a11n false when the initial state is missing', () => {
+		recordGuidelinesEvent( 'generate_all', { action: 'generate' } );
+
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_guidelines_generate_all',
+			{ action: 'generate', is_a11n: false }
+		);
+	} );
+
+	it( 'marks Automattician traffic on guidelines events', () => {
+		window.jetpackContentGuidelinesAi = { isA11n: true };
+
+		recordGuidelinesEvent( 'generate_all', { action: 'generate' } );
+
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'jetpack_ai_guidelines_generate_all',
+			{ action: 'generate', is_a11n: true }
+		);
+	} );
+
+	it( 'marks Automattician traffic on generic AI events', () => {
+		window.jetpackContentGuidelinesAi = { isA11n: true };
+
+		recordAiEvent( 'jetpack_ai_upgrade_button', { placement: 'content-guidelines' } );
+
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_ai_upgrade_button', {
+			placement: 'content-guidelines',
+			is_a11n: true,
+		} );
+	} );
+
+	it( 'coerces a non-boolean flag to a boolean', () => {
+		window.jetpackContentGuidelinesAi = { isA11n: 1 };
+
+		recordGuidelinesEvent( 'dismiss', { type: 'section', slug: 'site' } );
+
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_ai_guidelines_dismiss', {
+			type: 'section',
+			slug: 'site',
+			is_a11n: true,
 		} );
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/add-content-guidelines-ai-a11n-tracking
+++ b/projects/plugins/jetpack/changelog/add-content-guidelines-ai-a11n-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Content Guidelines AI: Mark Automattician traffic in Tracks events so internal testing can be filtered out of product reporting.

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -420,10 +420,7 @@ function get_tracking_site_type() {
  * @return bool True when the current visitor is an Automattician.
  */
 function is_tracking_automattician() {
-	$is_automattician = function_exists( 'is_automattician' ) && (bool) \is_automattician();
-	$is_wpcom_proxied = function_exists( 'wpcom_is_proxied_request' ) && \wpcom_is_proxied_request();
-
-	return $is_automattician || $is_wpcom_proxied || ( new Visitor() )->is_automattician_feature_flags_only();
+	return ( new Visitor() )->is_tracking_automattician();
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

* Adds `Status\Visitor::is_tracking_automattician()`, using the three signals settled on in #51217: an identified Automattician on WordPress.com Simple, and A8C-proxied requests on Simple and WoA. It sits beside the existing `is_automattician_feature_flags_only()` and delegates to it for the WoA case.
* Content Guidelines AI now tags every Tracks event it records with an `is_a11n` boolean, so internal testing can be filtered out of product reporting.
* Image Studio drops its own copy of this logic and calls the shared method instead.

Why in `jetpack-status` rather than the plugin: the package is autoloaded everywhere Jetpack runs, including on WordPress.com Simple, where extensions load through wpcom's own loader and `load-jetpack.php` never runs. That makes it usable from both an editor extension and a settings page without either one requiring the other's bootstrap. Image Studio already imported `Visitor`, so it costs it nothing.

Why now: Content Guidelines is new and low-volume. Internal testing is a visible share of the totals, and none of its events carry anything that lets us separate it — including retrospectively, since the signal simply isn't in the data.

The flag is attached once in the feature's Tracks wrapper (`_inc/content-guidelines-ai/lib/tracks.js`) rather than at each call site, so events added later pick it up without anyone remembering to.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

Yes — it adds one new property, `is_a11n` (boolean), to the events fired by Content Guidelines AI:

* `jetpack_ai_guidelines_generate`
* `jetpack_ai_guidelines_generate_all`
* `jetpack_ai_guidelines_accept`
* `jetpack_ai_guidelines_dismiss`
* `jetpack_ai_guidelines_upgrade_notice`
* `jetpack_ai_guidelines_read_more_click`
* `jetpack_ai_upgrade_button`, when fired from this page (`placement=content-guidelines`)

No new personal data is collected. The value is derived from signals already available server-side and records only whether the request is internal Automattician traffic. It is a reporting signal and is never used for authorization — a proxied request says something about where a request came from, not who the user is.

Image Studio's tracking is unchanged: it already sent `is_a11n`, and the shared method is behaviourally identical to the code it replaces.

The Content Guidelines event registrations will need a follow-up to declare the new property.

## Testing instructions

Content Guidelines is gated to WordPress.com platform sites (Simple and WoA), so test there.

* Build the plugin and open the Content Guidelines settings page.
* In the browser console, confirm the preloaded state carries the flag: `window.jetpackContentGuidelinesAi.isA11n`.
* Click **Generate guidelines** on any section and inspect the recorded Tracks event — it should now include `is_a11n`.
* Expected values: `true` when proxied, or when signed in as an identified Automattician on Simple; `false` otherwise. A regular user session should always report `false`.
* Worth checking the paywall path too: with no Jetpack AI plan, click a locked Generate button and confirm both `jetpack_ai_guidelines_upgrade_notice` and the `jetpack_ai_upgrade_button` click carry the flag.
* Image Studio regression check: open the Image Studio in the block editor and confirm its events still report `is_a11n` as before.

Automated coverage:

* `pnpm run test-client` in `projects/plugins/jetpack` — covers the Tracks wrapper, including the true, false, missing-global and non-boolean cases. Run locally: 17 suites / 99 tests passing.
* `Visitor_Test` in `projects/packages/status` — covers the new method. The false case is declared before the test that defines `AT_PROXIED_REQUEST`, since a constant cannot be unset once defined.
