### PR TITLE
Image Studio: Preserve Jetpack AI fallback when assets fail

### DIFF
--- a/projects/plugins/jetpack/changelog/image-studio-manifest-fallback
+++ b/projects/plugins/jetpack/changelog/image-studio-manifest-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Image Studio: Fall back to Jetpack AI image tools when the asset manifest cannot load.

--- a/projects/plugins/jetpack/changelog/image-studio-manifest-observability
+++ b/projects/plugins/jetpack/changelog/image-studio-manifest-observability
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Image Studio: Record MC stats and a Tracks event when the asset manifest cannot load and the legacy AI image tools are offered instead.

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -440,6 +440,17 @@ function do_enqueue_assets() {
 		return;
 	}
 
+	// Availability is computed before this callback in the block editor. If that
+	// check found that Image Studio cannot be delivered, keep the decision stable
+	// for the rest of the request instead of retrying after preserving the legacy
+	// AI image extensions.
+	if (
+		did_action( 'jetpack_register_gutenberg_extensions' )
+		&& ! \Jetpack_Gutenberg::is_available( FEATURE_NAME )
+	) {
+		return;
+	}
+
 	$asset_data = get_asset_data();
 	if ( ! $asset_data ) {
 		return;
@@ -604,15 +615,28 @@ function get_ai_image_extensions() {
 }
 
 /**
- * Disable Jetpack AI image extensions when Image Studio is available.
+ * Disable Jetpack AI image extensions when Image Studio replaces them.
  *
- * When Image Studio is available (via Jetpack_Gutenberg::is_available), AI image
- * extensions are disabled globally to avoid duplicate functionality.
+ * Connected users retain the legacy extensions when Image Studio's asset
+ * manifest is unavailable. For disconnected users, the legacy extensions stay
+ * disabled because they cannot make authenticated AI requests either.
  *
  * @return void
  */
 function disable_jetpack_ai_image_extensions() {
 	if ( ! \Jetpack_Gutenberg::is_available( FEATURE_NAME ) ) {
+		return;
+	}
+
+	// For connected users, only replace the legacy AI image extensions when the
+	// Image Studio manifest is usable. A disconnected user's behavior remains
+	// unchanged: neither implementation can make authenticated AI requests, so
+	// the legacy entries must stay suppressed.
+	if ( is_current_user_connected() && ! get_asset_data() ) {
+		\Jetpack_Gutenberg::set_extension_unavailable(
+			FEATURE_NAME,
+			'image_studio_asset_manifest_unavailable'
+		);
 		return;
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -7,10 +7,12 @@
 
 namespace Automattic\Jetpack\Extensions\ImageStudio;
 
+use Automattic\Jetpack\A8c_Mc_Stats;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Status\Visitor;
+use Automattic\Jetpack\Tracking;
 use function Automattic\Jetpack\Extensions\Shared\determine_iso_639_locale;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -23,16 +25,18 @@ require_once __DIR__ . '/../../shared/cdn-locale.php';
 // and load-jetpack.php never runs.
 require_once __DIR__ . '/../../../_inc/lib/class-jetpack-ai-settings.php';
 
-const FEATURE_NAME           = 'image-studio';
-const FEATURE_CLIP_META_KEY  = '_jetpack_feature_clip_id';
-const ASSET_BASE_PATH        = 'widgets.wp.com/agents-manager/';
-const ASSET_JS_URL           = 'https://' . ASSET_BASE_PATH . 'image-studio.min.js';
-const ASSET_CSS_URL          = 'https://' . ASSET_BASE_PATH . 'image-studio.css';
-const ASSET_RTL_URL          = 'https://' . ASSET_BASE_PATH . 'image-studio.rtl.css';
-const ASSET_JSON_URL         = 'https://' . ASSET_BASE_PATH . 'image-studio.asset.json';
-const ASSET_JSON_PATH        = ASSET_BASE_PATH . 'image-studio.asset.json';
-const ASSET_TRANSLATIONS_URL = 'https://' . ASSET_BASE_PATH . 'languages/';
-const ASSET_TRANSIENT        = 'jetpack_image_studio_asset';
+const FEATURE_NAME             = 'image-studio';
+const FEATURE_CLIP_META_KEY    = '_jetpack_feature_clip_id';
+const ASSET_BASE_PATH          = 'widgets.wp.com/agents-manager/';
+const ASSET_JS_URL             = 'https://' . ASSET_BASE_PATH . 'image-studio.min.js';
+const ASSET_CSS_URL            = 'https://' . ASSET_BASE_PATH . 'image-studio.css';
+const ASSET_RTL_URL            = 'https://' . ASSET_BASE_PATH . 'image-studio.rtl.css';
+const ASSET_JSON_URL           = 'https://' . ASSET_BASE_PATH . 'image-studio.asset.json';
+const ASSET_JSON_PATH          = ASSET_BASE_PATH . 'image-studio.asset.json';
+const ASSET_TRANSLATIONS_URL   = 'https://' . ASSET_BASE_PATH . 'languages/';
+const ASSET_TRANSIENT          = 'jetpack_image_studio_asset';
+const FAILURE_REPORT_TRANSIENT = 'jetpack_image_studio_manifest_fail_reported';
+const FAILURE_EVENT_NAME       = 'image_studio_manifest_unavailable';
 
 /**
  * Whether the environment offers Image Studio at all: the host and master
@@ -315,14 +319,19 @@ function get_asset_data() {
 		return $cached;
 	}
 
+	// A local-file miss or failure falls through to the remote fetch, so only
+	// the remote attempt — the last one made — is classified for telemetry.
 	$data = get_asset_data_from_file();
-	if ( false === $data ) {
+	if ( ! is_array( $data ) ) {
 		$data = get_asset_data_from_remote();
 	}
 
-	if ( false === $data ) {
+	if ( is_wp_error( $data ) ) {
+		last_manifest_failure( $data );
 		return false;
 	}
+
+	last_manifest_failure( null );
 
 	if ( ! ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
 		set_transient( ASSET_TRANSIENT, $data, HOUR_IN_SECONDS );
@@ -333,7 +342,9 @@ function get_asset_data() {
 /**
  * Try to read the asset manifest from the local filesystem.
  *
- * On WordPress.com, widgets.wp.com assets are available at ABSPATH.
+ * On WordPress.com, widgets.wp.com assets are available at ABSPATH. Every
+ * failure returns false because the caller falls back to the remote fetch,
+ * whose failure is the one classified for telemetry.
  *
  * @return array|false The decoded asset data, or false if not available locally.
  */
@@ -362,26 +373,149 @@ function get_asset_data_from_file() {
  *
  * Used as a fallback when the file is not available locally (e.g. self-hosted sites).
  *
- * @return array|false The decoded asset data, or false on failure.
+ * @return array|\WP_Error The decoded asset data, or WP_Error classifying the failure.
  */
 function get_asset_data_from_remote() {
 	$response = wp_safe_remote_get( ASSET_JSON_URL );
-	if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-		return false;
+	if ( is_wp_error( $response ) ) {
+		return new \WP_Error( 'manifest_request_failed', 'The Image Studio asset manifest request failed.' );
+	}
+
+	$response_code = wp_remote_retrieve_response_code( $response );
+	if ( 200 !== $response_code ) {
+		return new \WP_Error(
+			'manifest_http_error',
+			'The Image Studio asset manifest request returned an unexpected status.',
+			// An empty code means the response had no status line; attach nothing.
+			$response_code ? array( 'http_code' => (int) $response_code ) : null
+		);
 	}
 
 	$content_type = wp_remote_retrieve_header( $response, 'content-type' );
 	if ( is_string( $content_type ) && false === stripos( $content_type, 'json' ) ) {
-		return false;
+		return new \WP_Error( 'manifest_invalid', 'The Image Studio asset manifest response is not JSON.' );
 	}
 
 	$body = wp_remote_retrieve_body( $response );
 	$data = json_decode( $body, true );
 	if ( json_last_error() !== JSON_ERROR_NONE || ! is_array( $data ) ) {
-		return false;
+		return new \WP_Error( 'manifest_invalid', 'The Image Studio asset manifest response is not JSON.' );
 	}
 
 	return $data;
+}
+
+/**
+ * Remember or read the manifest failure behind get_asset_data()'s last result.
+ *
+ * Telemetry-only per-request state: get_asset_data() stores the failure that
+ * made it return false (and clears it on success), and
+ * report_manifest_unavailable() reads it back.
+ *
+ * @param \WP_Error|null $failure When passed, replaces the stored failure (null clears it).
+ * @return \WP_Error|null The stored failure.
+ */
+function last_manifest_failure( $failure = null ) {
+	static $stored = null;
+
+	if ( func_num_args() > 0 ) {
+		$stored = $failure;
+	}
+
+	return $stored;
+}
+
+/**
+ * Map a manifest failure to its telemetry class.
+ *
+ * 'none' means no failure was recorded (e.g. an empty manifest was cached);
+ * 'unknown' means a failure carried an unrecognised error code.
+ *
+ * @param \WP_Error|null $failure The failure recorded by get_asset_data().
+ * @return string One of 'request', 'http', 'invalid', 'none', or 'unknown'.
+ */
+function get_manifest_failure_class( $failure ) {
+	if ( ! is_wp_error( $failure ) ) {
+		return 'none';
+	}
+
+	switch ( $failure->get_error_code() ) {
+		case 'manifest_request_failed':
+			return 'request';
+		case 'manifest_http_error':
+			return 'http';
+		case 'manifest_invalid':
+			return 'invalid';
+		default:
+			return 'unknown';
+	}
+}
+
+/**
+ * Build the Tracks properties describing a manifest failure.
+ *
+ * Tracking::record_user_event() appends the standard Jetpack Tracks props and
+ * request metadata (blog_id, blog_url, jetpack_version, user agent, and so
+ * on), so only the failure specifics and the host type are included here.
+ *
+ * @param \WP_Error|null $failure The failure recorded by get_asset_data().
+ * @return array
+ */
+function get_manifest_failure_props( $failure ) {
+	$props = array(
+		'failure_class' => get_manifest_failure_class( $failure ),
+		'host'          => get_tracking_site_type(),
+	);
+
+	if ( is_wp_error( $failure ) ) {
+		$data = $failure->get_error_data();
+		if ( is_array( $data ) && isset( $data['http_code'] ) ) {
+			$props['http_code'] = (int) $data['http_code'];
+		}
+	}
+
+	return $props;
+}
+
+/**
+ * Record that the manifest failed and the legacy AI image tools were offered.
+ *
+ * Telemetry only: never changes Image Studio's availability or fallback
+ * decision. Rate-limited to one report per site per hour via a transient, set
+ * before sending so a failing stats endpoint is not hammered on every request.
+ *
+ * @return void
+ */
+function report_manifest_unavailable() {
+	if ( get_transient( FAILURE_REPORT_TRANSIENT ) ) {
+		return;
+	}
+
+	set_transient( FAILURE_REPORT_TRANSIENT, time(), HOUR_IN_SECONDS );
+
+	$failure = last_manifest_failure();
+
+	$stats = new A8c_Mc_Stats();
+	$stats->add( 'image-studio', 'manifest-fail-' . get_manifest_failure_class( $failure ) );
+	$stats->add( 'image-studio', 'legacy-fallback' );
+
+	// Dispatched without waiting, like the Tracks pixel: this can run during
+	// extension registration on a front-end request, and a firewalled host
+	// must not stall there for the stats endpoint's timeout.
+	foreach ( $stats->get_stats_urls() as $stats_url ) {
+		wp_remote_get(
+			esc_url_raw( $stats_url ),
+			array(
+				'blocking' => false,
+				'timeout'  => 2,
+			)
+		);
+	}
+
+	( new Tracking( 'jetpack', new Connection_Manager( 'jetpack' ) ) )->record_user_event(
+		FAILURE_EVENT_NAME,
+		get_manifest_failure_props( $failure )
+	);
 }
 
 /**
@@ -637,6 +771,7 @@ function disable_jetpack_ai_image_extensions() {
 			FEATURE_NAME,
 			'image_studio_asset_manifest_unavailable'
 		);
+		report_manifest_unavailable();
 		return;
 	}
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -73,6 +73,25 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		// self-hosted connection path. The wpcom/Big Sky gating itself is covered
 		// by the preview-gate tests, which remove this override.
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );
+		// Image Studio reports manifest failures under this suite's
+		// get_availability() calls; short-circuit only its stats pixel so a
+		// widgets.wp.com flake in CI cannot send live telemetry.
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) {
+				unset( $args );
+				if ( false !== strpos( $url, 'pixel.wp.com' ) ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'headers'  => array(),
+						'body'     => '',
+					);
+				}
+				return $preempt;
+			},
+			5,
+			3
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -92,6 +92,9 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'locale' );
 		remove_all_filters( 'jetpack_ai_enabled' );
+		remove_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
+		remove_filter( 'jetpack_gutenberg', '__return_true' );
+		remove_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_image_studio_extension_allowlist' ) );
 		delete_option( 'jetpack_ai_enabled' );
 		( new \Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
 		\Jetpack_Options::delete_option( array( 'id', 'blog_token' ) );
@@ -100,6 +103,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$GLOBALS['current_screen'] = $this->saved_screen;
 		$GLOBALS['wp_scripts']     = $this->saved_wp_scripts;
 		$GLOBALS['wp_styles']      = $this->saved_wp_styles;
+		\Jetpack_Gutenberg::reset();
 		parent::tear_down();
 	}
 
@@ -165,6 +169,39 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		foreach ( self::get_ai_image_extensions() as $ext ) {
 			\Jetpack_Gutenberg::set_extension_available( $ext );
 		}
+	}
+
+	/**
+	 * Cache a usable Image Studio asset manifest.
+	 */
+	private function make_image_studio_assets_available() {
+		set_transient(
+			ImageStudio\ASSET_TRANSIENT,
+			array(
+				'version'      => '1.0.0',
+				'dependencies' => array(),
+			),
+			HOUR_IN_SECONDS
+		);
+	}
+
+	/**
+	 * Limit Gutenberg availability output to Image Studio for payload assertions.
+	 *
+	 * @return array
+	 */
+	public static function get_image_studio_extension_allowlist() {
+		return array( ImageStudio\FEATURE_NAME );
+	}
+
+	/**
+	 * Enable the standard Gutenberg availability payload for Image Studio.
+	 */
+	private function enable_image_studio_extension_availability_checks() {
+		add_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
+		add_filter( 'jetpack_gutenberg', '__return_true' );
+		add_filter( 'jetpack_set_available_extensions', array( __CLASS__, 'get_image_studio_extension_allowlist' ) );
+		\Jetpack_Gutenberg::reset();
 	}
 
 	/**
@@ -1384,6 +1421,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 */
 	public function test_ai_extensions_disabled_when_available() {
 		$this->enable_big_sky();
+		$this->make_image_studio_assets_available();
 		ImageStudio\register_plugin();
 		$this->make_ai_extensions_available();
 		$this->set_block_editor_screen();
@@ -1416,6 +1454,56 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * A connected user keeps the legacy AI image extensions when Image Studio's
+	 * asset manifest cannot be loaded.
+	 */
+	public function test_ai_extensions_remain_available_when_asset_manifest_is_unavailable() {
+		$this->enable_image_studio_extension_availability_checks();
+		$this->enable_big_sky();
+		ImageStudio\register_plugin();
+		$this->make_ai_extensions_available();
+		$this->mock_remote_asset( false );
+
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		foreach ( self::get_ai_image_extensions() as $ext ) {
+			$this->assertTrue(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should remain available when Image Studio assets cannot load."
+			);
+		}
+
+		$availability = \Jetpack_Gutenberg::get_availability();
+		$this->assertFalse( $availability[ ImageStudio\FEATURE_NAME ]['available'] );
+		$this->assertSame(
+			'image_studio_asset_manifest_unavailable',
+			$availability[ ImageStudio\FEATURE_NAME ]['unavailable_reason']
+		);
+	}
+
+	/**
+	 * A disconnected user does not get legacy AI image extensions that cannot
+	 * make authenticated requests.
+	 */
+	public function test_ai_extensions_remain_disabled_when_current_user_is_not_connected() {
+		$this->enable_big_sky();
+		ImageStudio\register_plugin();
+		$this->make_ai_extensions_available();
+
+		$non_connected_admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $non_connected_admin );
+
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		foreach ( self::get_ai_image_extensions() as $ext ) {
+			$this->assertFalse(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should remain unavailable when the current user is disconnected."
+			);
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// disable_jetpack_ai_image_extensions() screen-aware tests
 	// -------------------------------------------------------------------------
@@ -1425,6 +1513,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 */
 	public function test_ai_extensions_disabled_on_block_editor() {
 		$this->enable_big_sky();
+		$this->make_image_studio_assets_available();
 		ImageStudio\register_plugin();
 		$this->make_ai_extensions_available();
 
@@ -1444,6 +1533,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 */
 	public function test_ai_extensions_disabled_on_media_library() {
 		$this->enable_big_sky();
+		$this->make_image_studio_assets_available();
 		ImageStudio\register_plugin();
 		$this->make_ai_extensions_available();
 
@@ -1466,6 +1556,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 */
 	public function test_ai_extensions_disabled_on_dashboard() {
 		$this->enable_big_sky();
+		$this->make_image_studio_assets_available();
 		ImageStudio\register_plugin();
 		$this->make_ai_extensions_available();
 
@@ -1488,6 +1579,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 */
 	public function test_ai_extensions_disabled_when_no_screen() {
 		$this->enable_big_sky();
+		$this->make_image_studio_assets_available();
 		ImageStudio\register_plugin();
 		$this->make_ai_extensions_available();
 
@@ -2071,6 +2163,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 */
 	public function test_ai_extensions_disabled_when_enabled_via_big_sky() {
 		$this->enable_big_sky();
+		$this->make_image_studio_assets_available();
 		ImageStudio\register_plugin();
 		$this->make_ai_extensions_available();
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -65,6 +65,8 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		delete_transient( ImageStudio\ASSET_TRANSIENT );
+		delete_transient( ImageStudio\FAILURE_REPORT_TRANSIENT );
+		ImageStudio\last_manifest_failure( null );
 		$this->saved_wp_scripts = $GLOBALS['wp_scripts'] ?? null;
 		$this->saved_wp_styles  = $GLOBALS['wp_styles'] ?? null;
 		$GLOBALS['wp_scripts']  = new WP_Scripts();
@@ -87,6 +89,8 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	public function tear_down() {
 		$this->deactivate_ai_module_for_test();
 		delete_transient( ImageStudio\ASSET_TRANSIENT );
+		delete_transient( ImageStudio\FAILURE_REPORT_TRANSIENT );
+		ImageStudio\last_manifest_failure( null );
 		remove_all_filters( 'jetpack_image_studio_enabled' );
 		remove_all_filters( 'jetpack_image_studio_can_generate_video_clips' );
 		remove_all_filters( 'pre_http_request' );
@@ -330,6 +334,60 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 				);
 			}
 		);
+	}
+
+	/**
+	 * Intercept every HTTP request, recording each URL and letting none escape.
+	 *
+	 * The manifest URL gets $manifest_response (a WP_Error or a response array);
+	 * every other URL — including the MC stats pixel — gets an empty 200.
+	 *
+	 * @param \WP_Error|array|null $manifest_response Response for the manifest URL, or null to 200 it too.
+	 * @return \ArrayObject The recorded request URLs, in order.
+	 */
+	private function capture_http_requests( $manifest_response = null ) {
+		$requests = new \ArrayObject();
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( $requests, $manifest_response ) {
+				unset( $preempt, $args );
+				$requests[] = $url;
+
+				if ( null !== $manifest_response && false !== strpos( $url, 'image-studio.asset.json' ) ) {
+					return $manifest_response;
+				}
+
+				return array(
+					'response' => array( 'code' => 200 ),
+					'headers'  => array(),
+					'body'     => '',
+				);
+			},
+			5,
+			3
+		);
+
+		return $requests;
+	}
+
+	/**
+	 * Filter captured request URLs down to MC stats pixel requests.
+	 *
+	 * Matches the MC pixel (b.gif) specifically, so a Tracks pixel (t.gif)
+	 * ever firing in a test is never miscounted as an MC stat.
+	 *
+	 * @param \ArrayObject $requests The URLs recorded by capture_http_requests().
+	 * @return array Decoded pixel URLs.
+	 */
+	private function get_pixel_requests( $requests ) {
+		$pixels = array();
+		foreach ( $requests as $url ) {
+			if ( false !== strpos( $url, 'pixel.wp.com/b.gif' ) ) {
+				$pixels[] = urldecode( $url );
+			}
+		}
+		return $pixels;
 	}
 
 	// -------------------------------------------------------------------------
@@ -1727,69 +1785,398 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_asset_data_from_remote returns false on WP_Error.
+	 * Test get_asset_data_from_remote classifies a transport failure as manifest_request_failed.
 	 */
-	public function test_get_asset_data_from_remote_returns_false_on_wp_error() {
+	public function test_get_asset_data_from_remote_returns_error_on_wp_error() {
 		$this->mock_remote_asset( false );
 
 		$result = ImageStudio\get_asset_data_from_remote();
 
-		$this->assertFalse( $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'manifest_request_failed', $result->get_error_code() );
 	}
 
 	/**
-	 * Test get_asset_data_from_remote returns false on non-200 status code.
+	 * Test get_asset_data_from_remote classifies a non-200 status as manifest_http_error
+	 * and records the status code.
 	 */
-	public function test_get_asset_data_from_remote_returns_false_on_non_200() {
+	public function test_get_asset_data_from_remote_returns_error_on_non_200() {
 		$this->mock_remote_asset_with_status( 500, 'Internal Server Error' );
 
 		$result = ImageStudio\get_asset_data_from_remote();
 
-		$this->assertFalse( $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'manifest_http_error', $result->get_error_code() );
+		$this->assertSame( array( 'http_code' => 500 ), $result->get_error_data() );
 	}
 
 	/**
-	 * Test get_asset_data_from_remote returns false on 404 status code.
+	 * Test get_asset_data_from_remote records a 404 status code in the failure data.
 	 */
-	public function test_get_asset_data_from_remote_returns_false_on_404() {
+	public function test_get_asset_data_from_remote_returns_error_on_404() {
 		$this->mock_remote_asset_with_status( 404, 'Not Found' );
 
 		$result = ImageStudio\get_asset_data_from_remote();
 
-		$this->assertFalse( $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'manifest_http_error', $result->get_error_code() );
+		$this->assertSame( array( 'http_code' => 404 ), $result->get_error_data() );
 	}
 
 	/**
-	 * Test get_asset_data_from_remote returns false on invalid JSON body.
+	 * Test get_asset_data_from_remote classifies an invalid JSON body as manifest_invalid.
 	 */
-	public function test_get_asset_data_from_remote_returns_false_on_invalid_json() {
+	public function test_get_asset_data_from_remote_returns_error_on_invalid_json() {
 		$this->mock_remote_asset_with_status( 200, 'not valid json{{{' );
 
 		$result = ImageStudio\get_asset_data_from_remote();
 
-		$this->assertFalse( $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'manifest_invalid', $result->get_error_code() );
 	}
 
 	/**
-	 * Test get_asset_data_from_remote returns false on JSON string body.
+	 * Test get_asset_data_from_remote classifies a JSON string body as manifest_invalid.
 	 */
-	public function test_get_asset_data_from_remote_returns_false_on_json_string() {
+	public function test_get_asset_data_from_remote_returns_error_on_json_string() {
 		$this->mock_remote_asset_with_status( 200, '"just a string"' );
 
 		$result = ImageStudio\get_asset_data_from_remote();
 
-		$this->assertFalse( $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'manifest_invalid', $result->get_error_code() );
 	}
 
 	/**
-	 * Test get_asset_data_from_remote returns false on non-JSON content type.
+	 * Test get_asset_data_from_remote classifies a non-JSON content type as manifest_invalid.
 	 */
-	public function test_get_asset_data_from_remote_returns_false_on_non_json_content_type() {
+	public function test_get_asset_data_from_remote_returns_error_on_non_json_content_type() {
 		$this->mock_remote_asset_with_status( 200, '<html>Not JSON</html>', 'text/html' );
 
 		$result = ImageStudio\get_asset_data_from_remote();
 
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'manifest_invalid', $result->get_error_code() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Manifest failure telemetry tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Test that get_asset_data() records the failure that made it return false.
+	 */
+	public function test_get_asset_data_records_request_failure() {
+		$this->mock_remote_asset( false );
+
+		$this->assertFalse( ImageStudio\get_asset_data() );
+
+		$failure = ImageStudio\last_manifest_failure();
+		$this->assertInstanceOf( WP_Error::class, $failure );
+		$this->assertSame( 'manifest_request_failed', $failure->get_error_code() );
+	}
+
+	/**
+	 * Test that get_asset_data() records an HTTP failure with its status code.
+	 */
+	public function test_get_asset_data_records_http_failure_with_code() {
+		$this->mock_remote_asset_with_status( 503, 'Service Unavailable' );
+
+		$this->assertFalse( ImageStudio\get_asset_data() );
+
+		$failure = ImageStudio\last_manifest_failure();
+		$this->assertInstanceOf( WP_Error::class, $failure );
+		$this->assertSame( 'manifest_http_error', $failure->get_error_code() );
+		$this->assertSame( array( 'http_code' => 503 ), $failure->get_error_data() );
+	}
+
+	/**
+	 * Test that get_asset_data() clears a previously recorded failure on success.
+	 */
+	public function test_get_asset_data_clears_failure_on_success() {
+		$this->mock_remote_asset( false );
+		ImageStudio\get_asset_data();
+		$this->assertInstanceOf( WP_Error::class, ImageStudio\last_manifest_failure() );
+
+		remove_all_filters( 'pre_http_request' );
+		$this->mock_remote_asset(
+			array(
+				'version'      => '1.0.0',
+				'dependencies' => array(),
+			)
+		);
+
+		$this->assertIsArray( ImageStudio\get_asset_data() );
+		$this->assertNull( ImageStudio\last_manifest_failure() );
+	}
+
+	/**
+	 * When the local manifest is invalid but the remote succeeds, data is
+	 * returned and no failure is recorded.
+	 */
+	public function test_local_invalid_falls_back_to_remote_and_clears_failure() {
+		$local_path = ABSPATH . ImageStudio\ASSET_JSON_PATH;
+		wp_mkdir_p( dirname( $local_path ) );
+		file_put_contents( $local_path, 'not valid json{{{' );
+
+		$remote_data = array(
+			'version'      => '9.0.0',
+			'dependencies' => array(),
+		);
+		$this->mock_remote_asset( $remote_data );
+
+		$result = ImageStudio\get_asset_data();
+
+		unlink( $local_path );
+
+		$this->assertEquals( $remote_data, $result );
+		$this->assertNull( ImageStudio\last_manifest_failure() );
+	}
+
+	/**
+	 * When both local and remote manifests fail, the remote failure is recorded.
+	 */
+	public function test_remote_failure_recorded_when_local_also_fails() {
+		$local_path = ABSPATH . ImageStudio\ASSET_JSON_PATH;
+		wp_mkdir_p( dirname( $local_path ) );
+		file_put_contents( $local_path, 'not valid json{{{' );
+
+		$this->mock_remote_asset( false );
+
+		$result = ImageStudio\get_asset_data();
+
+		unlink( $local_path );
+
 		$this->assertFalse( $result );
+		$failure = ImageStudio\last_manifest_failure();
+		$this->assertInstanceOf( WP_Error::class, $failure );
+		$this->assertSame( 'manifest_request_failed', $failure->get_error_code() );
+	}
+
+	/**
+	 * Failure classes map from the recorded WP_Error codes.
+	 *
+	 * @dataProvider provide_failure_classes
+	 *
+	 * @param \WP_Error|null $failure  The recorded failure.
+	 * @param string         $expected The expected telemetry class.
+	 */
+	#[DataProvider( 'provide_failure_classes' )]
+	public function test_get_manifest_failure_class( $failure, $expected ) {
+		$this->assertSame( $expected, ImageStudio\get_manifest_failure_class( $failure ) );
+	}
+
+	/**
+	 * Data provider for failure class mapping.
+	 *
+	 * @return array[]
+	 */
+	public static function provide_failure_classes() {
+		return array(
+			'request'    => array( new WP_Error( 'manifest_request_failed' ), 'request' ),
+			'http'       => array( new WP_Error( 'manifest_http_error' ), 'http' ),
+			'invalid'    => array( new WP_Error( 'manifest_invalid' ), 'invalid' ),
+			'other code' => array( new WP_Error( 'something_else' ), 'unknown' ),
+			'no failure' => array( null, 'none' ),
+		);
+	}
+
+	/**
+	 * Tracks props carry the failure class and host, without an http_code for
+	 * non-HTTP failures.
+	 */
+	public function test_manifest_failure_props_for_request_failure() {
+		$props = ImageStudio\get_manifest_failure_props( new WP_Error( 'manifest_request_failed' ) );
+
+		$this->assertSame( 'request', $props['failure_class'] );
+		$this->assertSame( 'jetpack', $props['host'] );
+		$this->assertArrayNotHasKey( 'http_code', $props );
+	}
+
+	/**
+	 * Tracks props include the status code for HTTP failures.
+	 */
+	public function test_manifest_failure_props_include_http_code() {
+		$failure = new WP_Error( 'manifest_http_error', '', array( 'http_code' => 502 ) );
+
+		$props = ImageStudio\get_manifest_failure_props( $failure );
+
+		$this->assertSame( 'http', $props['failure_class'] );
+		$this->assertSame( 502, $props['http_code'] );
+	}
+
+	/**
+	 * Test that report_manifest_unavailable() sends one MC stats pixel carrying
+	 * the failure cause and the legacy-fallback effect, and sets the rate-limit
+	 * transient for an hour.
+	 */
+	public function test_report_sends_pixel_and_sets_transient() {
+		$requests = $this->capture_http_requests();
+		ImageStudio\last_manifest_failure( new WP_Error( 'manifest_http_error', '', array( 'http_code' => 500 ) ) );
+
+		ImageStudio\report_manifest_unavailable();
+
+		$pixels = $this->get_pixel_requests( $requests );
+		$this->assertCount( 1, $pixels );
+		$this->assertStringContainsString( 'x_jetpack-image-studio=manifest-fail-http,legacy-fallback', $pixels[0] );
+		$this->assertNotFalse( get_transient( ImageStudio\FAILURE_REPORT_TRANSIENT ) );
+
+		if ( ! wp_using_ext_object_cache() ) {
+			$timeout = (int) get_option( '_transient_timeout_' . ImageStudio\FAILURE_REPORT_TRANSIENT );
+			$this->assertEqualsWithDelta( time() + HOUR_IN_SECONDS, $timeout, 30, 'Rate-limit window should be one hour.' );
+		}
+	}
+
+	/**
+	 * Test that an invalid-manifest failure reports the invalid class end to end.
+	 */
+	public function test_report_sends_invalid_class() {
+		$requests = $this->capture_http_requests();
+		ImageStudio\last_manifest_failure( new WP_Error( 'manifest_invalid' ) );
+
+		ImageStudio\report_manifest_unavailable();
+
+		$pixels = $this->get_pixel_requests( $requests );
+		$this->assertCount( 1, $pixels );
+		$this->assertStringContainsString( 'x_jetpack-image-studio=manifest-fail-invalid,legacy-fallback', $pixels[0] );
+	}
+
+	/**
+	 * A second report within the rate-limit window sends nothing.
+	 */
+	public function test_report_rate_limited_by_transient() {
+		$requests = $this->capture_http_requests();
+		ImageStudio\last_manifest_failure( new WP_Error( 'manifest_request_failed' ) );
+
+		ImageStudio\report_manifest_unavailable();
+		ImageStudio\report_manifest_unavailable();
+
+		$this->assertCount( 1, $this->get_pixel_requests( $requests ) );
+	}
+
+	/**
+	 * A pre-existing rate-limit transient suppresses the report entirely.
+	 */
+	public function test_report_suppressed_by_existing_transient() {
+		set_transient( ImageStudio\FAILURE_REPORT_TRANSIENT, time(), HOUR_IN_SECONDS );
+		$requests = $this->capture_http_requests();
+
+		ImageStudio\report_manifest_unavailable();
+
+		$this->assertCount( 0, $this->get_pixel_requests( $requests ) );
+	}
+
+	/**
+	 * Reporting without a recorded failure still sends, classed as none.
+	 */
+	public function test_report_defaults_to_none_class() {
+		$requests = $this->capture_http_requests();
+
+		ImageStudio\report_manifest_unavailable();
+
+		$pixels = $this->get_pixel_requests( $requests );
+		$this->assertCount( 1, $pixels );
+		$this->assertStringContainsString( 'x_jetpack-image-studio=manifest-fail-none,legacy-fallback', $pixels[0] );
+	}
+
+	/**
+	 * The fallback branch reports the manifest failure without changing the
+	 * fallback behaviour: legacy extensions stay available and Image Studio
+	 * carries the unavailable reason.
+	 */
+	public function test_fallback_branch_reports_manifest_failure() {
+		$this->enable_image_studio_extension_availability_checks();
+		$this->enable_big_sky();
+		ImageStudio\register_plugin();
+		$this->make_ai_extensions_available();
+		$requests = $this->capture_http_requests( new WP_Error( 'http_request_failed', 'Request failed' ) );
+
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		$pixels = $this->get_pixel_requests( $requests );
+		$this->assertCount( 1, $pixels );
+		$this->assertStringContainsString( 'x_jetpack-image-studio=manifest-fail-request,legacy-fallback', $pixels[0] );
+		$this->assertNotFalse( get_transient( ImageStudio\FAILURE_REPORT_TRANSIENT ) );
+
+		foreach ( self::get_ai_image_extensions() as $ext ) {
+			$this->assertTrue(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should remain available when the manifest failure is reported."
+			);
+		}
+
+		$availability = \Jetpack_Gutenberg::get_availability();
+		$this->assertFalse( $availability[ ImageStudio\FEATURE_NAME ]['available'] );
+		$this->assertSame(
+			'image_studio_asset_manifest_unavailable',
+			$availability[ ImageStudio\FEATURE_NAME ]['unavailable_reason']
+		);
+	}
+
+	/**
+	 * No report is sent for a disconnected user: the fallback branch is not
+	 * taken and the legacy extensions stay suppressed.
+	 */
+	public function test_no_report_when_current_user_not_connected() {
+		$this->enable_big_sky();
+		ImageStudio\register_plugin();
+		$this->make_ai_extensions_available();
+		$requests = $this->capture_http_requests( new WP_Error( 'http_request_failed', 'Request failed' ) );
+
+		$non_connected_admin = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $non_connected_admin );
+
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		$this->assertCount( 0, $this->get_pixel_requests( $requests ) );
+		$this->assertFalse( get_transient( ImageStudio\FAILURE_REPORT_TRANSIENT ) );
+
+		foreach ( self::get_ai_image_extensions() as $ext ) {
+			$this->assertFalse(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should stay suppressed for a disconnected user."
+			);
+		}
+	}
+
+	/**
+	 * No report is sent when the manifest loads.
+	 */
+	public function test_no_report_when_manifest_available() {
+		$this->enable_big_sky();
+		$this->make_image_studio_assets_available();
+		ImageStudio\register_plugin();
+		$this->make_ai_extensions_available();
+		$requests = $this->capture_http_requests();
+
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		$this->assertCount( 0, $this->get_pixel_requests( $requests ) );
+		$this->assertFalse( get_transient( ImageStudio\FAILURE_REPORT_TRANSIENT ) );
+	}
+
+	/**
+	 * The telemetry rate limit never changes the fallback outcome: with the
+	 * report suppressed by the transient, a manifest failure still preserves
+	 * the legacy extensions and marks Image Studio unavailable.
+	 */
+	public function test_rate_limited_report_does_not_change_fallback() {
+		set_transient( ImageStudio\FAILURE_REPORT_TRANSIENT, time(), HOUR_IN_SECONDS );
+		$this->enable_big_sky();
+		ImageStudio\register_plugin();
+		$this->make_ai_extensions_available();
+		$requests = $this->capture_http_requests( new WP_Error( 'http_request_failed', 'Request failed' ) );
+
+		ImageStudio\disable_jetpack_ai_image_extensions();
+
+		$this->assertCount( 0, $this->get_pixel_requests( $requests ) );
+		$this->assertFalse( \Jetpack_Gutenberg::is_available( ImageStudio\FEATURE_NAME ) );
+		foreach ( self::get_ai_image_extensions() as $ext ) {
+			$this->assertTrue(
+				\Jetpack_Gutenberg::is_available( $ext ),
+				"Extension $ext should remain available when the report is rate-limited."
+			);
+		}
 	}
 
 	// -------------------------------------------------------------------------
@@ -2226,6 +2613,22 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 */
 	public function test_asset_transient_constant() {
 		$this->assertEquals( 'jetpack_image_studio_asset', ImageStudio\ASSET_TRANSIENT );
+	}
+
+	/**
+	 * Test that the failure report transient constant is defined correctly.
+	 */
+	public function test_failure_report_transient_constant() {
+		$this->assertEquals( 'jetpack_image_studio_manifest_fail_reported', ImageStudio\FAILURE_REPORT_TRANSIENT );
+	}
+
+	/**
+	 * Test that the Tracks event name constant is defined correctly. Tracking
+	 * prefixes it with the jetpack product, giving
+	 * jetpack_image_studio_manifest_unavailable on the wire.
+	 */
+	public function test_failure_event_name_constant() {
+		$this->assertEquals( 'image_studio_manifest_unavailable', ImageStudio\FAILURE_EVENT_NAME );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
Relates to JPAI-109

## Proposed changes

- Check that Image Studio's asset manifest is usable before suppressing Jetpack's legacy AI image extensions for a connected user.
- If the manifest is unavailable, mark Image Studio unavailable with `image_studio_asset_manifest_unavailable` and keep the legacy **Generate with AI** entry points available.
- Preserve the existing successful Image Studio path and disconnected-user behavior.
- Keep the fallback decision stable for the rest of the request while allowing a later request to retry normally.
- Add regression coverage and a Jetpack changelog entry.

## Related product discussion/links

- A report showed that an AI image entry point was missing before a site was launched and appeared afterward.
- The investigation found no Coming Soon gate for editor-side Jetpack AI features. This PR narrowly hardens the handoff between Image Studio and the legacy Jetpack AI image tools when the replacement assets cannot be delivered; it does not introduce a launch-state condition.

## Does this pull request change what data or activity we track or use?

No. The change adds no analytics or logging. It exposes the manifest failure through Jetpack's existing extension-availability payload.

## Testing instructions

- Start with a WordPress.com Business Atomic test site that is still in Coming Soon mode.
- Ensure Jetpack AI is enabled and the current user has a connected WordPress.com account.
- Install this branch using Jetpack Beta.
- Open a post in the block editor and add an Image block.
- Add an existing image to the block, then open the **Replace** menu.
- Confirm that **Generate Image** is available and opens Image Studio.
- Generate an image, insert it, and confirm that it replaces the existing image in the block.
- Confirm that the site remains in Coming Soon mode throughout the test.

Expected result: Image Studio remains available for image generation and replacement on an unlaunched Business Atomic site.

The PHP regression tests separately simulate an unavailable manifest and verify that connected users retain Jetpack's legacy AI image entry points while disconnected-user behavior remains unchanged.
