### PR TITLE
Social: Explain why an Instagram Business connection found no accounts

### DIFF
--- a/projects/packages/publicize/_inc/components/manage-connections-modal/confirmation-form/index.tsx
+++ b/projects/packages/publicize/_inc/components/manage-connections-modal/confirmation-form/index.tsx
@@ -44,6 +44,48 @@ function AccountInfo( { label, profile_picture }: AccountInfoProps ) {
 const noop = () => {};
 
 /**
+ * Maps the reason wpcom reported for an empty account list to copy the user can
+ * act on. Unknown or absent reasons fall back to the generic message.
+ *
+ * @param reason - Value of `additional_external_users_empty_reason` on the keyring result.
+ *
+ * @return The message to show when there are no accounts to connect.
+ */
+function getNoAccountsFoundMessage(
+	reason: KeyringResult[ 'additional_external_users_empty_reason' ]
+) {
+	switch ( reason ) {
+		case 'no_instagram_account':
+			return __(
+				'None of your Facebook Pages has an Instagram professional account linked. Link one in Meta Business Suite, then try connecting again.',
+				'jetpack-publicize-pkg'
+			);
+		case 'no_pages':
+			return __(
+				"You don't manage any Facebook Pages. Instagram Business posting requires a Facebook Page linked to an Instagram professional account.",
+				'jetpack-publicize-pkg'
+			);
+		case 'page_access_denied':
+			return __(
+				"We couldn't access your Facebook Pages. Reconnect and make sure every Page is selected.",
+				'jetpack-publicize-pkg'
+			);
+		case 'account_check_failed':
+			return __(
+				"We couldn't check your Instagram account just now. Please try again.",
+				'jetpack-publicize-pkg'
+			);
+		case 'service_error':
+			return __(
+				"Facebook didn't respond. Please try again in a few minutes.",
+				'jetpack-publicize-pkg'
+			);
+		default:
+			return __( 'No accounts/pages found.', 'jetpack-publicize-pkg' );
+	}
+}
+
+/**
  * Connection confirmation component
  *
  * @param {ConfirmationFormProps} props - Component props
@@ -181,16 +223,13 @@ export function ConfirmationForm( {
 		<section className={ styles.confirmation }>
 			{ ! accounts.not_connected.length ? (
 				<p className={ styles[ 'header-text' ] }>
-					{
-						// TODO Make this more useful. For example, in case of Instagram, we could show a message that only Instagra business accounts are supported.
-						accounts.connected.length
-							? _x(
-									'No more accounts/pages found.',
-									'Message shown when there are no connections found to connect',
-									'jetpack-publicize-pkg'
-							  )
-							: __( 'No accounts/pages found.', 'jetpack-publicize-pkg' )
-					}
+					{ accounts.connected.length
+						? _x(
+								'No more accounts/pages found.',
+								'Message shown when there are no connections found to connect',
+								'jetpack-publicize-pkg'
+						  )
+						: getNoAccountsFoundMessage( keyringResult.additional_external_users_empty_reason ) }
 				</p>
 			) : (
 				<div>

--- a/projects/packages/publicize/_inc/components/manage-connections-modal/tests/confirmation-form.test.jsx
+++ b/projects/packages/publicize/_inc/components/manage-connections-modal/tests/confirmation-form.test.jsx
@@ -169,4 +169,80 @@ describe( 'ConfirmationForm', () => {
 		expect( screen.getByText( 'Additional User 1' ) ).toBeInTheDocument();
 		expect( screen.queryByLabelText( 'Additional User 1' ) ).not.toBeInTheDocument(); // Should not be selectable
 	} );
+
+	describe( 'empty account list', () => {
+		const emptyKeyringResult = {
+			ID: 987654,
+			service: 'instagram-business',
+			external_ID: 'ig-user-1',
+			external_name: 'IG User',
+			external_display: 'IG User',
+			additional_external_users: [],
+		};
+
+		const renderEmpty = reason =>
+			render(
+				<ConfirmationForm
+					keyringResult={ {
+						...emptyKeyringResult,
+						additional_external_users_empty_reason: reason,
+					} }
+					onComplete={ jest.fn() }
+				/>
+			);
+
+		beforeEach( () => {
+			setup( { connections: [] } );
+		} );
+
+		test.each( [
+			[
+				'no_instagram_account',
+				/None of your Facebook Pages has an Instagram professional account linked/,
+			],
+			[ 'no_pages', /You don't manage any Facebook Pages/ ],
+			[ 'page_access_denied', /We couldn't access your Facebook Pages/ ],
+			[ 'account_check_failed', /We couldn't check your Instagram account just now/ ],
+			[ 'service_error', /Facebook didn't respond/ ],
+		] )( 'explains the %s reason', ( reason, message ) => {
+			renderEmpty( reason );
+
+			expect( screen.getByText( message ) ).toBeInTheDocument();
+		} );
+
+		test.each( [
+			[ 'null', null ],
+			[ 'absent', undefined ],
+			[ 'unknown', 'some_future_reason' ],
+		] )( 'falls back to the generic message for a %s reason', ( _label, reason ) => {
+			renderEmpty( reason );
+
+			expect( screen.getByText( 'No accounts/pages found.' ) ).toBeInTheDocument();
+		} );
+
+		test( 'keeps the "no more accounts" message when all accounts are already connected', () => {
+			setup( {
+				connections: [ { service_name: 'instagram-business', external_id: 'ig-account-1' } ],
+			} );
+
+			render(
+				<ConfirmationForm
+					keyringResult={ {
+						...emptyKeyringResult,
+						additional_external_users: [
+							{
+								external_ID: 'ig-account-1',
+								external_name: 'IG Account 1',
+								external_profile_picture: '',
+							},
+						],
+						additional_external_users_empty_reason: 'no_instagram_account',
+					} }
+					onComplete={ jest.fn() }
+				/>
+			);
+
+			expect( screen.getByText( 'No more accounts/pages found.' ) ).toBeInTheDocument();
+		} );
+	} );
 } );

--- a/projects/packages/publicize/_inc/social-store/types.ts
+++ b/projects/packages/publicize/_inc/social-store/types.ts
@@ -222,9 +222,24 @@ export interface KeyringAdditionalUser {
 	external_profile_picture: string;
 }
 
+/**
+ * Reason codes wpcom reports for an empty Instagram Business account list.
+ */
+export type AccountsEmptyReason =
+	| 'no_instagram_account'
+	| 'no_pages'
+	| 'page_access_denied'
+	| 'account_check_failed'
+	| 'service_error';
+
 export interface KeyringResult extends KeyringAdditionalUser {
 	ID: number;
 	additional_external_users: Array< KeyringAdditionalUser >;
+	/**
+	 * Why `additional_external_users` came back empty; null or absent means no
+	 * reason. Kept open because wpcom may add codes; unknown gets generic copy.
+	 */
+	additional_external_users_empty_reason?: AccountsEmptyReason | ( string & {} ) | null;
 	external_display: string;
 	label: string;
 	service: string;

--- a/projects/packages/publicize/changelog/add-publicize-empty-accounts-reason
+++ b/projects/packages/publicize/changelog/add-publicize-empty-accounts-reason
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connections: Explain why an Instagram Business connection found no accounts to choose from.


### PR DESCRIPTION
Related to SOCIAL-559

## Proposed changes

- When an Instagram Business connect finds no accounts to pick, read the new `additional_external_users_empty_reason` field from the keyring result and show copy the user can act on, instead of the one-size-fits-all `No accounts/pages found.`
- The five reason codes map to messages in [confirmation-form/index.tsx](https://github.com/Automattic/jetpack/blob/add/publicize-empty-accounts-reason/projects/packages/publicize/_inc/components/manage-connections-modal/confirmation-form/index.tsx); null, absent, or unknown values keep the generic copy.
- The field is served by 234497-ghe-Automattic/wpcom; until that deploys, nothing changes visually.

## Related product discussion/links

- SOCIAL-559
- 234497-ghe-Automattic/wpcom

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Run `pnpm jest manage-connections-modal` in `projects/packages/publicize`: covers each reason code, the null/absent/unknown fallbacks, and the already-connected branch.
- For a live check (needs the wpcom PR sandboxed or deployed), connect Instagram Business as a user whose Facebook Pages have no Instagram professional account linked and confirm the message explains the missing link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)