### PR TITLE
Classic Search: honor post__in when the search term has been cleared

### DIFF
--- a/projects/packages/search/changelog/search-fix-post-in-should-handle-query
+++ b/projects/packages/search/changelog/search-fix-post-in-should-handle-query
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Classic Search: Don't override a query already restricted by post__in once its search term has been cleared.

--- a/projects/packages/search/src/classic-search/class-classic-search.php
+++ b/projects/packages/search/src/classic-search/class-classic-search.php
@@ -2017,6 +2017,14 @@ class Classic_Search {
 	 * @return bool
 	 */
 	public function should_handle_query( $query ) {
+		$should_handle = $query->is_main_query() && $query->is_search();
+
+		// is_search() can stay true after a pre_get_posts callback clears 's' having already
+		// used it to set post__in; defer to WP's normal query so post__in is honored.
+		if ( $should_handle && $query->get( 'post__in' ) && ! $query->get( 's' ) ) {
+			$should_handle = false;
+		}
+
 		/**
 		 * Determine whether a given WP_Query should be handled by ElasticSearch.
 		 *
@@ -2027,7 +2035,7 @@ class Classic_Search {
 		 * @param bool     $should_handle Should be handled by Jetpack Search.
 		 * @param WP_Query $query         The WP_Query object.
 		 */
-		return apply_filters( 'jetpack_search_should_handle_query', $query->is_main_query() && $query->is_search(), $query );
+		return apply_filters( 'jetpack_search_should_handle_query', $should_handle, $query );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Jetpack_Search_Test.php
+++ b/projects/packages/search/tests/php/Jetpack_Search_Test.php
@@ -15,6 +15,15 @@ use PHPUnit\Framework\TestCase;
 class Jetpack_Search_Test extends TestCase {
 
 	/**
+	 * Reset the main query global after each test.
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		$GLOBALS['wp_the_query'] = null;
+	}
+
+	/**
 	 * Verify deprecated classes still exist.
 	 *
 	 * @since 10.6.1
@@ -22,5 +31,40 @@ class Jetpack_Search_Test extends TestCase {
 	public function test_deprecated_jetpack_search_class() {
 		$search = Classic_Search::instance();
 		self::assertTrue( is_a( $search, 'Automattic\Jetpack\Search\Classic_Search' ) );
+	}
+
+	/**
+	 * A plain main search query should be handled as usual.
+	 */
+	public function test_should_handle_query_true_for_a_normal_search() {
+		$query                   = new \WP_Query( array( 's' => 'hello world' ) );
+		$GLOBALS['wp_the_query'] = $query;
+
+		self::assertTrue( Classic_Search::instance()->should_handle_query( $query ) );
+	}
+
+	/**
+	 * A search combined with post__in should still be handled by Jetpack Search.
+	 */
+	public function test_should_handle_query_true_for_search_with_post_in() {
+		$query = new \WP_Query( array( 's' => 'hello world' ) );
+		$query->set( 'post__in', array( 1, 2, 3 ) );
+		$GLOBALS['wp_the_query'] = $query;
+
+		self::assertTrue( Classic_Search::instance()->should_handle_query( $query ) );
+	}
+
+	/**
+	 * If a pre_get_posts callback set post__in and then cleared 's' (e.g. to restrict a
+	 * search to SKU matches without also double-filtering on the term), Jetpack Search
+	 * must not replace that restriction with an unrestricted ES result set.
+	 */
+	public function test_should_handle_query_false_when_post_in_restricts_a_cleared_search() {
+		$query = new \WP_Query( array( 's' => 'sku-12345' ) );
+		$query->set( 'post__in', array( 1, 2, 3 ) );
+		$query->set( 's', '' );
+		$GLOBALS['wp_the_query'] = $query;
+
+		self::assertFalse( Classic_Search::instance()->should_handle_query( $query ) );
 	}
 }


### PR DESCRIPTION
Fixes SEARCH-330

## Proposed changes
* `Classic_Search::should_handle_query()` now checks for the case where a `pre_get_posts` callback has set `post__in` to restrict a query (e.g. to match a SKU) and then cleared the `s` query var afterward (a common pattern to avoid double-filtering by core search). Previously, Jetpack Search's `is_search()` check still passed (it reflects `s` at parse time, not at query-execution time), so Jetpack Search would replace the restricted results with an unrestricted Elasticsearch result set for the post type — effectively ignoring `post__in` and returning the full catalog.
* When `post__in` is set and `s` has since been cleared, `should_handle_query()` now returns `false` so WordPress's normal query execution runs instead, correctly honoring `post__in`.
* A query that combines `post__in` with a live (non-empty) search term is unaffected — Jetpack Search still handles it as before.
* `Inline_Search` inherits this fix automatically, since it doesn't override `should_handle_query()`.

## Related product discussion/links
* SEARCH-330

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Added `Jetpack_Search_Test::test_should_handle_query_true_for_a_normal_search`, `test_should_handle_query_true_for_search_with_post_in`, and `test_should_handle_query_false_when_post_in_restricts_a_cleared_search` covering the three relevant scenarios.
* Run `jp test php packages/search -v` — full suite passes.
* Run `jp phan packages/search` — no issues.
* Manual repro: register a `pre_get_posts` callback on a search query that sets `post__in` to a specific post ID and then sets `s` to `''`. Before this change, Jetpack Search (with Elasticsearch active) returns all posts of the matching post type. After this change, only the post(s) in `post__in` are returned.
