### PR TITLE
Connection: compare WordPress.com and site emails case-insensitively

### DIFF
--- a/projects/packages/connection/changelog/fix-account-mismatch-email-case
+++ b/projects/packages/connection/changelog/fix-account-mismatch-email-case
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Account status: Do not report an account mismatch when the WordPress.com email and the site email differ only in letter case.

--- a/projects/packages/connection/src/class-user-account-status.php
+++ b/projects/packages/connection/src/class-user-account-status.php
@@ -61,14 +61,22 @@ class User_Account_Status {
 	 * @return bool Whether there is a possible account mismatch.
 	 */
 	public function possible_account_mismatch( $current_user_email, $wpcom_user_email ) {
-		// If emails are the same or there's no WPCOM email, there's no mismatch.
-		if ( $current_user_email === $wpcom_user_email || ! $wpcom_user_email ) {
+		if ( ! $wpcom_user_email ) {
+			return false;
+		}
+
+		$normalized_wpcom_email = self::normalize_email( $wpcom_user_email );
+
+		// WordPress.com preserves the casing an address was registered with, while WordPress
+		// stores addresses lowercased, so the two can represent the same address. Compare them
+		// case-insensitively, the same way the get_user_by() lookup below matches.
+		if ( self::normalize_email( $current_user_email ) === $normalized_wpcom_email ) {
 			return false;
 		}
 
 		// Generate transient key with both wpcom email and user ID if available.
 		$transient_key  = 'jetpack_account_mismatch_';
-		$transient_key .= md5( $wpcom_user_email );
+		$transient_key .= md5( $normalized_wpcom_email );
 
 		$cached_result = get_transient( $transient_key );
 
@@ -110,7 +118,20 @@ class User_Account_Status {
 			return;
 		}
 
-		$transient_key = 'jetpack_account_mismatch_' . md5( $email );
+		$transient_key = 'jetpack_account_mismatch_' . md5( self::normalize_email( $email ) );
 		delete_transient( $transient_key );
+	}
+
+	/**
+	 * Normalize an email address so that addresses differing only in case are treated as equal.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $email The email address to normalize.
+	 *
+	 * @return string The normalized email address.
+	 */
+	private static function normalize_email( $email ) {
+		return strtolower( trim( (string) $email ) );
 	}
 }

--- a/projects/packages/connection/src/class-user-account-status.php
+++ b/projects/packages/connection/src/class-user-account-status.php
@@ -74,9 +74,9 @@ class User_Account_Status {
 			return false;
 		}
 
-		// Generate transient key with both wpcom email and user ID if available.
-		$transient_key  = 'jetpack_account_mismatch_';
-		$transient_key .= md5( $normalized_wpcom_email );
+		// The result depends only on the WordPress.com address, so it is cached per address
+		// rather than per user.
+		$transient_key = 'jetpack_account_mismatch_' . md5( $normalized_wpcom_email );
 
 		$cached_result = get_transient( $transient_key );
 

--- a/projects/packages/connection/tests/php/User_Account_Status_Test.php
+++ b/projects/packages/connection/tests/php/User_Account_Status_Test.php
@@ -119,6 +119,8 @@ class User_Account_Status_Test extends TestCase {
 		delete_transient( 'jetpack_account_mismatch_' . md5( 'wpcom@example.com' ) );
 		delete_transient( 'jetpack_account_mismatch_' . md5( 'another_wpcom@example.com' ) );
 		delete_transient( 'jetpack_account_mismatch_' . md5( 'test_clean@example.com' ) );
+		delete_transient( 'jetpack_account_mismatch_' . md5( 'joe@example.com' ) );
+		delete_transient( 'jetpack_account_mismatch_' . md5( 'joe@Example.com' ) );
 
 		// Reset WorDBless state
 		WorDBless_Options::init()->clear_options();
@@ -132,6 +134,42 @@ class User_Account_Status_Test extends TestCase {
 		// When emails match, should return false
 		$result = $this->user_account_status->possible_account_mismatch( 'same@example.com', 'same@example.com' );
 		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test possible_account_mismatch when the emails only differ in case.
+	 *
+	 * WordPress.com keeps the casing the account was registered with, while WordPress lowercases
+	 * the local user's address, so the same address can reach us in two different casings.
+	 */
+	public function test_possible_account_mismatch_with_emails_differing_only_in_case() {
+		// WorDBless looks users up case-sensitively where MySQL's default collation does not, so
+		// seed the cache under both casings to stand in for the lookup finding the local user.
+		$this->seed_mismatch_transients( 'joe@example.com', 'joe@Example.com' );
+
+		$result = $this->user_account_status->possible_account_mismatch( 'joe@example.com', 'joe@Example.com' );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Cache a mismatch for every given casing of an address.
+	 *
+	 * @param string ...$emails The addresses to cache a mismatch for.
+	 */
+	private function seed_mismatch_transients( ...$emails ) {
+		foreach ( $emails as $email ) {
+			set_transient( 'jetpack_account_mismatch_' . md5( $email ), true, DAY_IN_SECONDS );
+		}
+	}
+
+	/**
+	 * Test that possible_account_mismatch caches under a case-insensitive key.
+	 */
+	public function test_possible_account_mismatch_transient_key_is_case_insensitive() {
+		set_transient( 'jetpack_account_mismatch_' . md5( 'joe@example.com' ), true, DAY_IN_SECONDS );
+
+		$result = $this->user_account_status->possible_account_mismatch( 'local@example.com', 'joe@Example.com' );
+		$this->assertTrue( $result );
 	}
 
 	/**
@@ -185,6 +223,16 @@ class User_Account_Status_Test extends TestCase {
 	public function test_check_account_errors_with_no_errors() {
 		// Use same email to avoid mismatch (no errors)
 		$result = $this->user_account_status->check_account_errors( 'same@example.com', 'same@example.com' );
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Test check_account_errors when the emails only differ in case.
+	 */
+	public function test_check_account_errors_with_emails_differing_only_in_case() {
+		$this->seed_mismatch_transients( 'joe@example.com', 'joe@Example.com' );
+
+		$result = $this->user_account_status->check_account_errors( 'joe@example.com', 'joe@Example.com' );
 		$this->assertEmpty( $result );
 	}
 
@@ -281,6 +329,18 @@ class User_Account_Status_Test extends TestCase {
 		$this->user_account_status->clean_account_mismatch_transients( self::$user_id );
 
 		// Verify it's gone
+		$this->assertFalse( get_transient( $transient_key ) );
+	}
+
+	/**
+	 * Test clean_account_mismatch_transients with an email whose casing differs from the cached one.
+	 */
+	public function test_clean_account_mismatch_transients_is_case_insensitive() {
+		$transient_key = 'jetpack_account_mismatch_' . md5( 'joe@example.com' );
+		set_transient( $transient_key, true, DAY_IN_SECONDS );
+
+		$this->user_account_status->clean_account_mismatch_transients( 'joe@Example.com' );
+
 		$this->assertFalse( get_transient( $transient_key ) );
 	}
 

--- a/projects/plugins/backup/changelog/fix-account-mismatch-email-case
+++ b/projects/plugins/backup/changelog/fix-account-mismatch-email-case
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Stop showing a duplicate account notice when your WordPress.com email differs from your site email only in letter case.

--- a/projects/plugins/boost/changelog/fix-account-mismatch-email-case
+++ b/projects/plugins/boost/changelog/fix-account-mismatch-email-case
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Stop showing a duplicate account notice when your WordPress.com email differs from your site email only in letter case.

--- a/projects/plugins/jetpack/changelog/fix-account-mismatch-email-case
+++ b/projects/plugins/jetpack/changelog/fix-account-mismatch-email-case
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Connection: Stop showing a duplicate account notice when your WordPress.com email differs from your site email only in letter case.

--- a/projects/plugins/protect/changelog/fix-account-mismatch-email-case
+++ b/projects/plugins/protect/changelog/fix-account-mismatch-email-case
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Stop showing a duplicate account notice when your WordPress.com email differs from your site email only in letter case.

--- a/projects/plugins/search/changelog/fix-account-mismatch-email-case
+++ b/projects/plugins/search/changelog/fix-account-mismatch-email-case
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Stop showing a duplicate account notice when your WordPress.com email differs from your site email only in letter case.

--- a/projects/plugins/social/changelog/fix-account-mismatch-email-case
+++ b/projects/plugins/social/changelog/fix-account-mismatch-email-case
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Stop showing a duplicate account notice when your WordPress.com email differs from your site email only in letter case.

--- a/projects/plugins/videopress/changelog/fix-account-mismatch-email-case
+++ b/projects/plugins/videopress/changelog/fix-account-mismatch-email-case
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Stop showing a duplicate account notice when your WordPress.com email differs from your site email only in letter case.


### PR DESCRIPTION
Closes CONNECT-429

## Proposed changes

`User_Account_Status::possible_account_mismatch()` compared the local WordPress user's email against the connected WordPress.com email with a strict `===`. WordPress.com preserves the casing an account was registered with, while WordPress stores the local address lowercased, so the same address routinely arrives in two different casings (`joe@example.com` vs `joe@Example.com`). The strict comparison missed that and skipped the early return. The `get_user_by( 'email', ... )` lookup that follows matches case-insensitively under MySQL's default collation, so it found the local user and reported a mismatch against the very account it was comparing to.

The result was the notice *"Your WordPress.com email is also used by another user account. This won't affect functionality but may cause confusion about which user account is connected."* appearing on every connected site, including single-user sites where no second account exists.

* Normalize both addresses before comparing them, so addresses differing only in case bail out before the lookup runs.
* Normalize the address hashed into the mismatch transient key. This was a second instance of the same bug: `possible_account_mismatch()` cached under the mixed-case WordPress.com address, while `clean_account_mismatch_transients()` deleted the key built from the lowercase local user record. The two never lined up, so when a genuine mismatch was resolved — the conflicting user deleted, or their email changed — the stale `true` survived for the full 24-hour TTL.

Both go through one small `normalize_email()` helper that lowercases and trims. The `get_user_by()` call still receives the original address, since the default collation matches it case-insensitively either way and there's no reason to change lookup behavior on unusual collations.

Sites currently showing the notice get relief immediately on upgrade: the early return happens before any cache read, so an already-cached `true` is never consulted.

The notice is rendered by My Jetpack, so changelog entries went to the seven plugins that bundle it alongside the package's own entry.

## Related product discussion/links

* Reported by a Jetpack Agency partner managing 136 sites; the notice fired on every one of them. The workaround required internal intervention to lowercase the WordPress.com address, because the customer-facing account settings on WordPress.com and the mobile app both preserve the original casing and silently revert a lowercased value.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated coverage is in `projects/packages/connection/tests/php/User_Account_Status_Test.php` — four new cases covering the case-only difference in both `possible_account_mismatch()` and `check_account_errors()`, plus the two transient-key paths. Run them with:

```
jp test php packages/connection
```

Worth knowing when reading those tests: WorDBless matches `user_email` with `===`, so it is case-sensitive where real MySQL is not. A test that simply creates a local user and asserts no mismatch passes against the unfixed code and proves nothing. The tests here instead seed a cached mismatch under both casings to stand in for the lookup finding the local user. All four fail on `trunk` and pass with this change.

To verify by hand on a site whose connected WordPress.com account has a mixed-case email:

* Confirm the local user's email and the WordPress.com email are the same address differing only in case.
* Visit **Jetpack → My Jetpack** and hover the connection status card.
* Before: the "also used by another user account" notice appears. After: no notice.
* Then confirm real mismatches still surface — point the site's user at a genuinely different address than the connected WordPress.com account, create a second local user holding the WordPress.com address, and check that the notice comes back.
