### PR TITLE
Boost: harden the cache post type storage

### DIFF
--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -36,6 +36,7 @@ use Automattic\Jetpack_Boost\Lib\Super_Cache_Tracking;
 use Automattic\Jetpack_Boost\Modules\Module;
 use Automattic\Jetpack_Boost\Modules\Modules_Setup;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP_State;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP_Storage;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Cache_Preload;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache_Setup;
@@ -466,8 +467,9 @@ class Jetpack_Boost {
 		delete_site_option( 'jetpack_boost_404_tester_last_run' );
 		delete_site_option( 'jetpack_boost_minify_cron_cache_cleanup_last_run' );
 
-		// Delete stored Critical CSS.
+		// Delete stored Critical CSS and LCP data.
 		( new Critical_CSS_Storage() )->clear();
+		( new LCP_Storage() )->clear();
 
 		// Delete all transients created by boost.
 		Transient::delete_bulk();

--- a/projects/plugins/boost/app/lib/class-debug.php
+++ b/projects/plugins/boost/app/lib/class-debug.php
@@ -31,4 +31,44 @@ class Debug {
 		 */
 		return apply_filters( 'jetpack_boost_debug', $debug );
 	}
+
+	/**
+	 * Write one line to the PHP error log, under WP_DEBUG only.
+	 *
+	 * The messages carry third-party text (exception messages, file paths, cache
+	 * keys), so the line is scrubbed of CR/LF first: a message spanning two lines can
+	 * otherwise forge a log entry of its own (CWE-117).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $message What happened. Prefixed with "Jetpack Boost: ".
+	 *
+	 * @return void
+	 */
+	public static function log( $message ) {
+		if ( ! defined( 'WP_DEBUG' ) || ! \WP_DEBUG ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( self::scrub( 'Jetpack Boost: ' . $message ) );
+	}
+
+	/**
+	 * Flatten a log line to one physical line.
+	 *
+	 * Separate from log(), and public, so a unit test can assert the rule without
+	 * defining WP_DEBUG for the whole process. log() is the only caller.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param mixed $message Text that may contain CR/LF. Cast rather than typed: a
+	 *                       logging helper must not raise a TypeError on a path
+	 *                       that is already handling a failure.
+	 *
+	 * @return string
+	 */
+	public static function scrub( $message ) {
+		return str_replace( array( "\r", "\n" ), ' ', (string) $message );
+	}
 }

--- a/projects/plugins/boost/app/lib/class-storage-post-type.php
+++ b/projects/plugins/boost/app/lib/class-storage-post-type.php
@@ -11,8 +11,29 @@ namespace Automattic\Jetpack_Boost\Lib;
 
 /**
  * Class Storage_Post_type
+ *
+ * Internal to Boost. Stores arrays and scalars only, never objects.
  */
 class Storage_Post_Type {
+
+	/**
+	 * Cache format version, part of the transient key.
+	 *
+	 * Keeps get() away from transients an earlier release wrote, which were cached
+	 * without the object checks below.
+	 *
+	 * @since $$next-version$$
+	 */
+	const CACHE_VERSION = 'v2';
+
+	/**
+	 * Matches a serialized object (O:), custom-serialized class (C:) or enum case
+	 * (E:) anywhere in a serialized string. Boost never stores objects, so a match
+	 * means the row is not one Boost wrote.
+	 *
+	 * @since $$next-version$$
+	 */
+	const OBJECT_TOKEN_PATTERN = '/(^|[;{])[OCE]:\+?[0-9]+:/';
 
 	/**
 	 * The name.
@@ -20,6 +41,17 @@ class Storage_Post_Type {
 	 * @var string
 	 */
 	private $name;
+
+	/**
+	 * Slugs this class has registered on this request, keyed by slug.
+	 *
+	 * Tells "somebody else owns this slug" apart from "we already registered it".
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var array<string, bool>
+	 */
+	private static $registered = array();
 
 	/**
 	 * Storage_Post_type constructor.
@@ -39,22 +71,60 @@ class Storage_Post_Type {
 	}
 
 	/**
+	 * Get the transient key backing a cache entry.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $key Cache key name.
+	 *
+	 * @return string
+	 */
+	private function transient_key( $key ) {
+		return $this->post_type_slug() . '_' . self::CACHE_VERSION . '_' . $key;
+	}
+
+	/**
 	 * Static initialization.
 	 */
 	private function init() {
 		// Check if post type already registered.
 		if ( post_type_exists( $this->post_type_slug() ) ) {
+			if ( ! isset( self::$registered[ $this->post_type_slug() ] ) ) {
+				Debug::log( 'cache post type "' . $this->post_type_slug() . '" was already registered elsewhere; Boost\'s REST and capability restrictions are not in effect for it' );
+			}
+
 			return;
 		}
+
+		self::$registered[ $this->post_type_slug() ] = true;
+
 		register_post_type(
 			$this->post_type_slug(),
 			array(
 				'description'      => 'Cache entries for the Jetpack Boost plugin.',
 				'public'           => false,
-				'show_in_rest'     => true,
+				'show_in_rest'     => false,
 				'rewrite'          => false,
 				'can_export'       => false,
 				'delete_with_user' => false,
+				// Boost writes through wp_insert_post and friends, which bypass capability
+				// checks, so denying every generated capability closes the write vector into
+				// get()'s unserialize sink (CWE-502).
+				'map_meta_cap'     => true,
+				'capabilities'     => array(
+					'read'                   => 'do_not_allow',
+					'create_posts'           => 'do_not_allow',
+					'edit_posts'             => 'do_not_allow',
+					'edit_others_posts'      => 'do_not_allow',
+					'edit_published_posts'   => 'do_not_allow',
+					'edit_private_posts'     => 'do_not_allow',
+					'publish_posts'          => 'do_not_allow',
+					'read_private_posts'     => 'do_not_allow',
+					'delete_posts'           => 'do_not_allow',
+					'delete_others_posts'    => 'do_not_allow',
+					'delete_published_posts' => 'do_not_allow',
+					'delete_private_posts'   => 'do_not_allow',
+				),
 			)
 		);
 	}
@@ -87,7 +157,7 @@ class Storage_Post_Type {
 			'data'   => $value,
 			'expiry' => $expiry_timestamp,
 		);
-		$data_post_data['post_content'] = base64_encode( maybe_serialize( $value ) ); // phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$data_post_data['post_content'] = base64_encode( maybe_serialize( $value ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 
 		// Update an existing data post if we have one or create a new one.
 		if ( $data_post ) {
@@ -97,7 +167,7 @@ class Storage_Post_Type {
 			wp_insert_post( $data_post_data );
 		}
 
-		delete_transient( $this->post_type_slug() . '_' . $key );
+		delete_transient( $this->transient_key( $key ) );
 	}
 
 	/**
@@ -109,7 +179,7 @@ class Storage_Post_Type {
 	 * @return mixed
 	 */
 	public function get( $key, $default ) {
-		$cached = get_transient( $this->post_type_slug() . '_' . $key );
+		$cached = get_transient( $this->transient_key( $key ) );
 		if ( $cached ) {
 			return $cached;
 		}
@@ -127,9 +197,34 @@ class Storage_Post_Type {
 		 * )
 		 */
 
-		// phpcs:disable
-		$value = maybe_unserialize( base64_decode( $data_post->post_content ) );
-		// phpcs:enable
+		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize, WordPress.PHP.NoSilencedErrors.Discouraged
+		$decoded = base64_decode( $data_post->post_content );
+		$value   = $decoded;
+
+		if ( is_serialized( $decoded ) ) {
+			$trimmed = trim( $decoded );
+
+			// Refuse the row before unserialize() sees it: checking the wire format means
+			// no object is ever instantiated, not even __PHP_Incomplete_Class. A payload
+			// whose own string data happens to match only costs a regeneration.
+			if ( preg_match( self::OBJECT_TOKEN_PATTERN, $trimmed ) ) {
+				$this->delete_rejected_row( $key, $data_post, 'contains an object' );
+
+				return $default;
+			}
+
+			// allowed_classes as a second layer behind the pattern above.
+			$value = @unserialize( $trimmed, array( 'allowed_classes' => false ) );
+
+			// Claimed serialized and would not deserialize: not a row Boost wrote.
+			// b:0; legitimately gives false.
+			if ( false === $value && 'b:0;' !== $trimmed ) {
+				$this->delete_rejected_row( $key, $data_post, 'is malformed' );
+
+				return $default;
+			}
+		}
+		// phpcs:enable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize, WordPress.PHP.NoSilencedErrors.Discouraged
 
 		if ( isset( $value['expiry'] ) && intval( $value['expiry'] ) > 0 ) {
 			if ( time() > intval( $value['expiry'] ) ) {
@@ -144,9 +239,35 @@ class Storage_Post_Type {
 			return $default;
 		}
 
-		set_transient( $this->post_type_slug() . '_' . $key, $value['data'], HOUR_IN_SECONDS );
+		set_transient( $this->transient_key( $key ), $value['data'], HOUR_IN_SECONDS );
 
 		return $value['data'];
+	}
+
+	/**
+	 * Delete a cache row get() refused to load.
+	 *
+	 * Contained, because get() has already decided to serve the default and a
+	 * throwing wp_delete_post() subscriber must not fatal the render.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string   $key       Cache key name.
+	 * @param \WP_Post $data_post The refused row.
+	 * @param string   $reason    For the debug log.
+	 *
+	 * @return void
+	 */
+	private function delete_rejected_row( $key, $data_post, $reason ) {
+		Debug::log( 'refused cache entry "' . $key . '": stored content ' . $reason . '; deleting the row' );
+
+		try {
+			wp_delete_post( $data_post->ID, true );
+		} catch ( \Throwable $e ) {
+			Debug::log( 'deleting cache entry "' . $key . '" threw: ' . $e->getMessage() );
+		}
+
+		delete_transient( $this->transient_key( $key ) );
 	}
 
 	/**
@@ -163,6 +284,9 @@ class Storage_Post_Type {
 		if ( $data_post ) {
 			wp_delete_post( $data_post->ID, true );
 		}
+
+		// Match set(), which clears the transient whenever the row changes.
+		delete_transient( $this->transient_key( $key ) );
 	}
 
 	/**
@@ -266,21 +390,12 @@ class Storage_Post_Type {
 			)
 		);
 
-		$keys = array();
 		foreach ( $posts as $post ) {
 			wp_delete_post( $post->ID, true );
 			wp_cache_delete( $post->post_name, $this->post_type_slug() );
-			$keys[] = '_transient_' . $this->post_type_slug() . '_' . $post->post_name;
-			$keys[] = '_transient_timeout_' . $this->post_type_slug() . '_' . $post->post_name;
-		}
-
-		if ( empty( $keys ) ) {
-			return;
-		}
-
-		foreach ( $posts as $post ) {
-			$key = $this->post_type_slug() . '_' . $post->post_name;
-			delete_transient( $key );
+			// The versioned key, and the key a pre-CACHE_VERSION release wrote.
+			delete_transient( $this->transient_key( $post->post_name ) );
+			delete_transient( $this->post_type_slug() . '_' . $post->post_name );
 		}
 	}
 }

--- a/projects/plugins/boost/app/lib/class-storage-post-type.php
+++ b/projects/plugins/boost/app/lib/class-storage-post-type.php
@@ -17,10 +17,11 @@ namespace Automattic\Jetpack_Boost\Lib;
 class Storage_Post_Type {
 
 	/**
-	 * Cache format version, part of the transient key.
+	 * Cache format version. Part of the transient key, and the prefix on post_content.
 	 *
 	 * Keeps get() away from transients an earlier release wrote, which were cached
-	 * without the object checks below.
+	 * without the object checks below, and away from rows written while the REST
+	 * route and the default capabilities were open.
 	 *
 	 * @since $$next-version$$
 	 */
@@ -81,6 +82,20 @@ class Storage_Post_Type {
 	 */
 	private function transient_key( $key ) {
 		return $this->post_type_slug() . '_' . self::CACHE_VERSION . '_' . $key;
+	}
+
+	/**
+	 * The prefix set() puts in front of the encoded payload.
+	 *
+	 * Sits outside the payload so get() can tell a row this release wrote from one
+	 * written while anyone could write it, without decoding or parsing either.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string
+	 */
+	private function row_prefix() {
+		return self::CACHE_VERSION . ':';
 	}
 
 	/**
@@ -157,7 +172,7 @@ class Storage_Post_Type {
 			'data'   => $value,
 			'expiry' => $expiry_timestamp,
 		);
-		$data_post_data['post_content'] = base64_encode( maybe_serialize( $value ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$data_post_data['post_content'] = $this->row_prefix() . base64_encode( maybe_serialize( $value ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 
 		// Update an existing data post if we have one or create a new one.
 		if ( $data_post ) {
@@ -197,29 +212,42 @@ class Storage_Post_Type {
 		 * )
 		 */
 
+		$prefix = $this->row_prefix();
+
+		// A row without the prefix was written before this release, when the REST route
+		// and the default capabilities let anyone create one. Refuse it whole: neither
+		// base64_decode() nor unserialize() sees a byte of it, so an object payload
+		// cannot be built and a deeply nested one cannot exhaust the parser.
+		if ( 0 !== strpos( $data_post->post_content, $prefix ) ) {
+			$this->delete_rejected_row( $key, $data_post, 'predates the current row format' );
+
+			return $default;
+		}
+
 		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize, WordPress.PHP.NoSilencedErrors.Discouraged
-		$decoded = base64_decode( $data_post->post_content );
+		$decoded = base64_decode( substr( $data_post->post_content, strlen( $prefix ) ) );
 		$value   = $decoded;
+
+		// Ahead of is_serialized(), which has no case for C:, and ahead of unserialize(),
+		// so no object is instantiated: not O:/C: as __PHP_Incomplete_Class, and not E:,
+		// which allowed_classes does not filter at all.
+		if ( preg_match( self::OBJECT_TOKEN_PATTERN, trim( $decoded ) ) ) {
+			$this->refuse_row( $key, 'contains an object' );
+
+			return $default;
+		}
 
 		if ( is_serialized( $decoded ) ) {
 			$trimmed = trim( $decoded );
 
-			// Refuse the row before unserialize() sees it: checking the wire format means
-			// no object is ever instantiated, not even __PHP_Incomplete_Class. A payload
-			// whose own string data happens to match only costs a regeneration.
-			if ( preg_match( self::OBJECT_TOKEN_PATTERN, $trimmed ) ) {
-				$this->delete_rejected_row( $key, $data_post, 'contains an object' );
-
-				return $default;
-			}
-
-			// allowed_classes as a second layer behind the pattern above.
+			// Degrades O:/C: to an inert __PHP_Incomplete_Class if the pattern above ever
+			// misses one. It is not a second layer for E:, where the pattern is the only guard.
 			$value = @unserialize( $trimmed, array( 'allowed_classes' => false ) );
 
 			// Claimed serialized and would not deserialize: not a row Boost wrote.
 			// b:0; legitimately gives false.
 			if ( false === $value && 'b:0;' !== $trimmed ) {
-				$this->delete_rejected_row( $key, $data_post, 'is malformed' );
+				$this->refuse_row( $key, 'is malformed' );
 
 				return $default;
 			}
@@ -245,7 +273,30 @@ class Storage_Post_Type {
 	}
 
 	/**
-	 * Delete a cache row get() refused to load.
+	 * Serve the default for a row get() will not read, and leave the row alone.
+	 *
+	 * The checks that land here are inexact. serialize() embeds CSS and markup
+	 * verbatim, so ordinary content can carry something the object pattern matches,
+	 * and a truncated row looks the same as a crafted one. Deleting would cost a
+	 * regeneration on a false positive; the next set() overwrites the row anyway.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $key    Cache key name.
+	 * @param string $reason For the debug log.
+	 *
+	 * @return void
+	 */
+	private function refuse_row( $key, $reason ) {
+		Debug::log( 'refused cache entry "' . $key . '": stored content ' . $reason );
+	}
+
+	/**
+	 * Delete a row get() can prove it did not write, and serve the default.
+	 *
+	 * The prefix check is exact, so this cannot fire on a row the current release
+	 * wrote. Deleting clears out anything planted while the post types were open,
+	 * one key at a time as each is read, instead of in a sweep on upgrade.
 	 *
 	 * Contained, because get() has already decided to serve the default and a
 	 * throwing wp_delete_post() subscriber must not fatal the render.

--- a/projects/plugins/boost/app/lib/class-storage-post-type.php
+++ b/projects/plugins/boost/app/lib/class-storage-post-type.php
@@ -19,9 +19,10 @@ class Storage_Post_Type {
 	/**
 	 * Cache format version. Part of the transient key, and the prefix on post_content.
 	 *
-	 * Keeps get() away from transients an earlier release wrote, which were cached
-	 * without the object checks below, and away from rows written while the REST
-	 * route and the default capabilities were open.
+	 * On the transient key it keeps get() away from transients an earlier release
+	 * wrote, which were cached without the object checks below. On the row it marks
+	 * where the encoded payload starts; get() validates every row, prefixed or not,
+	 * before serving it.
 	 *
 	 * @since $$next-version$$
 	 */
@@ -87,8 +88,9 @@ class Storage_Post_Type {
 	/**
 	 * The prefix set() puts in front of the encoded payload.
 	 *
-	 * Sits outside the payload so get() can tell a row this release wrote from one
-	 * written while anyone could write it, without decoding or parsing either.
+	 * Sits outside the payload so get() knows where the encoded bytes start on a row
+	 * this release wrote, without decoding to find out. A row without it is still
+	 * read; get() just decodes from the first byte.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -212,20 +214,23 @@ class Storage_Post_Type {
 		 * )
 		 */
 
-		$prefix = $this->row_prefix();
+		$prefix  = $this->row_prefix();
+		$encoded = $data_post->post_content;
 
 		// A row without the prefix was written before this release, when the REST route
-		// and the default capabilities let anyone create one. Refuse it whole: neither
-		// base64_decode() nor unserialize() sees a byte of it, so an object payload
-		// cannot be built and a deeply nested one cannot exhaust the parser.
-		if ( 0 !== strpos( $data_post->post_content, $prefix ) ) {
-			$this->delete_rejected_row( $key, $data_post, 'predates the current row format' );
-
-			return $default;
+		// and the default capabilities let anyone create one. Most such rows are cache
+		// Boost itself wrote, so the prefix only marks where the payload starts, not
+		// whether the row can be served: that is settled below, by the same object-token
+		// scan and allowed_classes => false every row runs through. The strip is
+		// conditional because ':' is not in the base64 alphabet, so a legitimate
+		// unprefixed payload can never begin with the prefix, and stripping one that is
+		// not there would misalign the decode.
+		if ( 0 === strpos( $encoded, $prefix ) ) {
+			$encoded = substr( $encoded, strlen( $prefix ) );
 		}
 
 		// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize, WordPress.PHP.NoSilencedErrors.Discouraged
-		$decoded = base64_decode( substr( $data_post->post_content, strlen( $prefix ) ) );
+		$decoded = base64_decode( $encoded );
 		$value   = $decoded;
 
 		// Ahead of is_serialized(), which has no case for C:, and ahead of unserialize(),
@@ -289,36 +294,6 @@ class Storage_Post_Type {
 	 */
 	private function refuse_row( $key, $reason ) {
 		Debug::log( 'refused cache entry "' . $key . '": stored content ' . $reason );
-	}
-
-	/**
-	 * Delete a row get() can prove it did not write, and serve the default.
-	 *
-	 * The prefix check is exact, so this cannot fire on a row the current release
-	 * wrote. Deleting clears out anything planted while the post types were open,
-	 * one key at a time as each is read, instead of in a sweep on upgrade.
-	 *
-	 * Contained, because get() has already decided to serve the default and a
-	 * throwing wp_delete_post() subscriber must not fatal the render.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @param string   $key       Cache key name.
-	 * @param \WP_Post $data_post The refused row.
-	 * @param string   $reason    For the debug log.
-	 *
-	 * @return void
-	 */
-	private function delete_rejected_row( $key, $data_post, $reason ) {
-		Debug::log( 'refused cache entry "' . $key . '": stored content ' . $reason . '; deleting the row' );
-
-		try {
-			wp_delete_post( $data_post->ID, true );
-		} catch ( \Throwable $e ) {
-			Debug::log( 'deleting cache entry "' . $key . '" threw: ' . $e->getMessage() );
-		}
-
-		delete_transient( $this->transient_key( $key ) );
 	}
 
 	/**

--- a/projects/plugins/boost/app/lib/critical-css/class-critical-css-storage.php
+++ b/projects/plugins/boost/app/lib/critical-css/class-critical-css-storage.php
@@ -62,7 +62,9 @@ class Critical_CSS_Storage {
 	public function get_css( $provider_keys ) {
 		foreach ( $provider_keys as $key ) {
 			$data = $this->storage->get( $key, false );
-			if ( $data && $data['css'] ) {
+			// Shape-check: the store vets its payloads for objects but not for shape, so
+			// a row Boost did not write can come back as a scalar or a wrong-typed array.
+			if ( is_array( $data ) && isset( $data['css'] ) && is_string( $data['css'] ) && '' !== $data['css'] ) {
 				return array(
 					'key' => $key,
 					'css' => $data['css'],

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-bg-image.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-bg-image.php
@@ -43,6 +43,11 @@ class LCP_Optimize_Bg_Image {
 				continue;
 			}
 
+			// The field is optional, and an undefined key here is a warning on wp_head.
+			if ( ! isset( $lcp_data['selector'] ) ) {
+				continue;
+			}
+
 			if ( in_array( $lcp_data['selector'], $selectors, true ) ) {
 				// If we already printed the styling for this element, skip it.
 				continue;
@@ -78,6 +83,11 @@ class LCP_Optimize_Bg_Image {
 		foreach ( $this->lcp_data as $lcp_data ) {
 			$lcp_optimizer = new LCP_Optimization_Util( $lcp_data );
 			if ( ! $lcp_optimizer->can_optimize() ) {
+				continue;
+			}
+
+			// The field is optional, and an undefined key here is a warning on wp_head.
+			if ( ! isset( $lcp_data['selector'] ) ) {
 				continue;
 			}
 
@@ -129,7 +139,9 @@ class LCP_Optimize_Bg_Image {
 	}
 
 	private function get_responsive_image_rules( $lcp_data ) {
-		if ( $lcp_data['type'] !== LCP::TYPE_BACKGROUND_IMAGE || empty( $lcp_data['breakpoints'] ) ) {
+		// is_array() as well as empty(): empty( 'not-an-array' ) is false, so a string
+		// breakpoints field would reach array_reverse() as a TypeError on wp_head.
+		if ( $lcp_data['type'] !== LCP::TYPE_BACKGROUND_IMAGE || empty( $lcp_data['breakpoints'] ) || ! is_array( $lcp_data['breakpoints'] ) ) {
 			return array();
 		}
 
@@ -160,6 +172,12 @@ class LCP_Optimize_Bg_Image {
 
 			// The Cloud should always return a fixed pixel width for background images, so catering for that is easy peasy.
 			if ( empty( $breakpoint['imageDimensions'] ) || ! is_array( $breakpoint['imageDimensions'] ) ) {
+				continue;
+			}
+
+			// Non-empty and an array does not mean it has an index 0.
+			// @phan-suppress-next-line PhanTypeMismatchDimFetch -- The isset() is the check phan asks for.
+			if ( ! isset( $breakpoint['imageDimensions'][0] ) || ! is_array( $breakpoint['imageDimensions'][0] ) ) {
 				continue;
 			}
 

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
@@ -130,7 +130,9 @@ class LCP_Optimize_Img_Tag {
 	 * @since 4.0.0
 	 */
 	private function add_responsive_image_attributes( $element, $image_url ) {
-		if ( empty( $this->lcp_data['breakpoints'] ) ) {
+		// is_array() as well as empty(): empty( 'not-an-array' ) is false, so a string
+		// breakpoints field would reach the foreach in get_srcset() and get_sizes().
+		if ( empty( $this->lcp_data['breakpoints'] ) || ! is_array( $this->lcp_data['breakpoints'] ) ) {
 			return $element;
 		}
 
@@ -158,13 +160,31 @@ class LCP_Optimize_Img_Tag {
 	private function get_srcset( $original_url ) {
 		$dimensions = array();
 		foreach ( $this->lcp_data['breakpoints'] as $breakpoint ) {
+			// The field is optional; the background-image sibling has always carried
+			// this guard, and without it an absent one is a foreach() TypeError on
+			// wp_head.
+			if ( empty( $breakpoint['imageDimensions'] ) || ! is_array( $breakpoint['imageDimensions'] ) ) {
+				continue;
+			}
+
 			foreach ( $breakpoint['imageDimensions'] as $breakpoint_dimensions ) {
+				if ( ! is_array( $breakpoint_dimensions ) ) {
+					continue;
+				}
+
+				// isset() as well as is_numeric(): is_numeric( $absent ) is an undefined
+				// key warning before it is false.
+				if ( ! isset( $breakpoint_dimensions['width'] ) || ! isset( $breakpoint_dimensions['height'] ) ) {
+					continue;
+				}
+
 				if ( ! is_numeric( $breakpoint_dimensions['width'] ) || ! is_numeric( $breakpoint_dimensions['height'] ) ) {
 					continue;
 				}
 
-				$width                = (int) $breakpoint_dimensions['width'];
-				$height               = (int) $breakpoint_dimensions['height'];
+				$width  = (int) $breakpoint_dimensions['width'];
+				$height = (int) $breakpoint_dimensions['height'];
+
 				$dimensions[ $width ] = $height;
 
 				// If it's a Moto G Power, include a 1.75 DPR for accurate lighthouse representation of the optimized image.

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-optimize-img-tag.php
@@ -249,8 +249,9 @@ class LCP_Optimize_Img_Tag {
 	private function get_sizes() {
 		$sizes = array();
 		foreach ( $this->lcp_data['breakpoints'] as $breakpoint ) {
-			// Make sure widthValue is a known format.
-			if ( ! isset( $breakpoint['widthValue'] ) || ! preg_match( '/^[0-9]+(?:\.[0-9]+)?(?:px|vw)$/', $breakpoint['widthValue'] ) ) {
+			// is_string() as well as isset(): an array widthValue is a TypeError from
+			// preg_match(), inside the output buffer callback.
+			if ( ! isset( $breakpoint['widthValue'] ) || ! is_string( $breakpoint['widthValue'] ) || ! preg_match( '/^[0-9]+(?:\.[0-9]+)?(?:px|vw)$/', $breakpoint['widthValue'] ) ) {
 				continue;
 			}
 

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-storage.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-storage.php
@@ -58,13 +58,22 @@ class LCP_Storage {
 			return false;
 		}
 
-		foreach ( $data as $record ) {
-			if ( ! is_array( $record ) ) {
-				return false;
+		// type as well: all three consumers compare it without checking it is there,
+		// which is an undefined key warning on wp_head for a record that omits it.
+		// Drop the record rather than the report: a report holds one record per viewport,
+		// and Critical_CSS_Storage::get_css() and every optimizer already skip per record.
+		$records = array_filter(
+			$data,
+			function ( $record ) {
+				return is_array( $record ) && isset( $record['type'] );
 			}
+		);
+
+		if ( empty( $records ) ) {
+			return false;
 		}
 
-		return $data;
+		return $records;
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-storage.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-storage.php
@@ -50,7 +50,21 @@ class LCP_Storage {
 	 * @return array|false
 	 */
 	public function get_lcp( $page_key ) {
-		return $this->storage->get( $page_key, false );
+		$data = $this->storage->get( $page_key, false );
+
+		// Shape-check: the store vets its payloads for objects but not for shape, and
+		// consumers foreach() the report and index into each record on wp_head.
+		if ( ! is_array( $data ) ) {
+			return false;
+		}
+
+		foreach ( $data as $record ) {
+			if ( ! is_array( $record ) ) {
+				return false;
+			}
+		}
+
+		return $data;
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/fix-storage-post-type-object-injection
+++ b/projects/plugins/boost/changelog/fix-storage-post-type-object-injection
@@ -1,4 +1,4 @@
 Significance: patch
 Type: security
 
-Critical CSS/LCP: Close REST API access to the cache storage, and refuse to load a stored cache entry that contains a PHP object.
+Critical CSS/LCP: Close REST API access to the cache storage, refuse to load a stored cache entry that contains a PHP object, and discard entries written before this release.

--- a/projects/plugins/boost/changelog/fix-storage-post-type-object-injection
+++ b/projects/plugins/boost/changelog/fix-storage-post-type-object-injection
@@ -1,4 +1,4 @@
 Significance: patch
 Type: security
 
-Critical CSS/LCP: Close REST API access to the cache storage, refuse to load a stored cache entry that contains a PHP object, and discard entries written before this release.
+Critical CSS/LCP: Close REST API access to the cache storage, and refuse to load a stored cache entry that contains a PHP object.

--- a/projects/plugins/boost/changelog/fix-storage-post-type-object-injection
+++ b/projects/plugins/boost/changelog/fix-storage-post-type-object-injection
@@ -1,4 +1,5 @@
 Significance: patch
-Type: security
+Type: changed
+Comment: Entry text lands with the stable release.
 
-Critical CSS/LCP: Close REST API access to the cache storage, and refuse to load a stored cache entry that contains a PHP object.
+

--- a/projects/plugins/boost/changelog/fix-storage-post-type-object-injection
+++ b/projects/plugins/boost/changelog/fix-storage-post-type-object-injection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Critical CSS/LCP: Close REST API access to the cache storage, and refuse to load a stored cache entry that contains a PHP object.

--- a/projects/plugins/boost/phpunit.11.xml.dist
+++ b/projects/plugins/boost/phpunit.11.xml.dist
@@ -26,6 +26,7 @@
 			<exclude>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</exclude>
 			<exclude>tests/php/Jetpack_Boost_Test.php</exclude>
 			<exclude>tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php</exclude>
+			<exclude>tests/php/modules/optimizations/lcp/LCP_Storage_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</exclude>
 			<exclude>tests/php/lib/Body_Close_Locator_Test.php</exclude>
@@ -38,6 +39,7 @@
 			<file>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</file>
 			<file>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</file>
 			<file>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</file>
+			<file>tests/php/modules/optimizations/lcp/LCP_Storage_Test.php</file>
 			<file>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</file>
 			<file>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</file>
 			<file>tests/php/lib/Body_Close_Locator_Test.php</file>

--- a/projects/plugins/boost/phpunit.9.xml.dist
+++ b/projects/plugins/boost/phpunit.9.xml.dist
@@ -17,6 +17,7 @@
 			<exclude>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</exclude>
 			<exclude>tests/php/Jetpack_Boost_Test.php</exclude>
 			<exclude>tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php</exclude>
+			<exclude>tests/php/modules/optimizations/lcp/LCP_Storage_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</exclude>
 			<exclude>tests/php/lib/Body_Close_Locator_Test.php</exclude>
@@ -29,6 +30,7 @@
 			<file>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</file>
 			<file>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</file>
 			<file>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</file>
+			<file>tests/php/modules/optimizations/lcp/LCP_Storage_Test.php</file>
 			<file>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</file>
 			<file>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</file>
 			<file>tests/php/lib/Body_Close_Locator_Test.php</file>

--- a/projects/plugins/boost/tests/php/lib/Debug_Test.php
+++ b/projects/plugins/boost/tests/php/lib/Debug_Test.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Tests for the shared logging helper.
+ *
+ * @package automattic/jetpack-boost
+ */
+
+namespace Automattic\Jetpack_Boost\Tests\Lib;
+
+use Automattic\Jetpack_Boost\Lib\Debug;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class Debug_Test
+ */
+class Debug_Test extends TestCase {
+
+	/**
+	 * Every message Boost logs interpolates text it did not write, and one carrying a
+	 * newline writes a second line that looks exactly like a real entry (CWE-117).
+	 * A single str_replace shared by every log site, so cheap to break silently.
+	 */
+	public function test_a_message_cannot_forge_a_second_log_entry() {
+		$forged = Debug::scrub( "cache miss\n[04-Aug-2026 00:00:00 UTC] PHP Fatal error: nothing to see here" );
+
+		$this->assertStringNotContainsString( "\n", $forged, 'A logged message must be one physical line.' );
+		$this->assertStringNotContainsString( "\r", $forged, 'Including under a lone CR, which some log readers also treat as a line break.' );
+	}
+
+	/**
+	 * All three line endings, since the text comes from wherever the exception did.
+	 */
+	public function test_every_line_ending_is_flattened() {
+		$this->assertSame(
+			'a b c  d',
+			Debug::scrub( "a\rb\nc\r\nd" ),
+			'CR, LF and CRLF must each become a space -- CRLF two, since each half is replaced.'
+		);
+	}
+
+	/**
+	 * Non-strings reach this from getMessage() calls on odd throwables and from
+	 * interpolated integers; casting rather than fataling is deliberate.
+	 */
+	public function test_a_non_string_message_is_cast_rather_than_fataling() {
+		$this->assertSame( '42', Debug::scrub( 42 ), 'A logging helper must not be the thing that raises a TypeError.' );
+	}
+}

--- a/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
+++ b/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
@@ -111,12 +111,14 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 	 * Write a cache row directly, bypassing set()'s own encoding, to stand in for
 	 * a write to the CPT that did not come from Boost.
 	 *
-	 * @param string $key     Cache key.
-	 * @param mixed  $payload Payload to encode into post_content.
+	 * @param string $key      Cache key.
+	 * @param mixed  $payload  Payload to encode into post_content.
+	 * @param bool   $prefixed Write the current row-format prefix. False stands in for
+	 *                         a row written before this release.
 	 */
-	private function write_raw_cache_entry( $key, $payload ) {
+	private function write_raw_cache_entry( $key, $payload, $prefixed = true ) {
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
-		$this->write_raw_serialized_entry( $key, serialize( $payload ) );
+		$this->write_raw_serialized_entry( $key, serialize( $payload ), $prefixed );
 	}
 
 	/**
@@ -125,8 +127,11 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 	 *
 	 * @param string $key        Cache key.
 	 * @param string $serialized Serialized payload to encode into post_content.
+	 * @param bool   $prefixed   Write the current row-format prefix.
 	 */
-	private function write_raw_serialized_entry( $key, $serialized ) {
+	private function write_raw_serialized_entry( $key, $serialized, $prefixed = true ) {
+		$prefix = $prefixed ? Storage_Post_Type::CACHE_VERSION . ':' : '';
+
 		wp_insert_post(
 			array(
 				'post_type'    => 'jb_store_css',
@@ -134,7 +139,7 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 				'post_name'    => $key,
 				'post_status'  => 'publish',
 				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-				'post_content' => base64_encode( $serialized ),
+				'post_content' => $prefix . base64_encode( $serialized ),
 			)
 		);
 	}
@@ -265,7 +270,7 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 	 * on its wire format, before unserialize() runs, so no object -- not even a
 	 * __PHP_Incomplete_Class -- is ever instantiated from a cache row (CWE-502).
 	 */
-	public function test_get_rejects_and_deletes_cache_content_containing_an_object() {
+	public function test_get_rejects_cache_content_containing_an_object() {
 		$key     = 'poi_probe';
 		$storage = new Storage_Post_Type( 'css' );
 
@@ -290,9 +295,9 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 			'A rejected payload must never reach the transient cache.'
 		);
 
-		$this->assertFalse(
+		$this->assertNotFalse(
 			$storage->get_post_by_name( $key ),
-			'The poisoned cache entry must be deleted.'
+			'The object check is inexact, so it refuses without deleting; the next set() overwrites the row.'
 		);
 
 		$this->assertFalse(
@@ -333,8 +338,8 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The object rejection must not reject the ordinary array payloads that set()
-	 * writes, which are what every Boost read depends on.
+	 * The checks must not reject the ordinary array payloads that set() writes, which
+	 * are what every Boost read depends on.
 	 */
 	public function test_get_still_returns_ordinary_array_payloads() {
 		$key     = 'benign_probe';
@@ -343,10 +348,15 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 		$storage->set( $key, array( 'css' => '.a {}' ) );
 		delete_transient( self::transient_key( $key ) );
 
+		$this->assertStringStartsWith(
+			Storage_Post_Type::CACHE_VERSION . ':',
+			$storage->get_post_by_name( $key )->post_content,
+			'set() must write the row-format prefix.'
+		);
 		$this->assertSame(
 			array( 'css' => '.a {}' ),
 			$storage->get( $key, 'default_value' ),
-			'A normal payload must survive the object check.'
+			'A normal payload must survive the prefix and object checks.'
 		);
 	}
 
@@ -390,37 +400,39 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A serialized enum case (an 'E:' token) is not covered by
-	 * allowed_classes => false, and resolving it hands an attacker-chosen class
-	 * name to the autoloader. The wire-format check refuses it first.
+	 * An 'E:' token builds an enum case whatever allowed_classes says, so for enums
+	 * the wire-format check is the only guard there is.
 	 */
-	public function test_get_rejects_and_deletes_a_serialized_enum_token() {
+	public function test_get_rejects_a_serialized_enum_token() {
 		$key     = 'enum_probe';
 		$storage = new Storage_Post_Type( 'css' );
 
-		$token = 'Boost_Absent_Attacker_Chosen:CASE_A';
+		$token   = 'Boost_Absent_Attacker_Chosen:CASE_A';
+		$payload = 'a:2:{s:4:"data";E:' . strlen( $token ) . ':"' . $token . '";s:6:"expiry";i:0;}';
 
-		$this->write_raw_serialized_entry(
-			$key,
-			'a:2:{s:4:"data";E:' . strlen( $token ) . ':"' . $token . '";s:6:"expiry";i:0;}'
+		// Assert the pattern directly as well. Naming an absent class makes unserialize()
+		// fail on its own, so the outcome below is the same with E: dropped from the
+		// pattern, and narrowing it to [OC] would otherwise pass the whole suite.
+		$this->assertSame(
+			1,
+			preg_match( Storage_Post_Type::OBJECT_TOKEN_PATTERN, $payload ),
+			'The wire-format check must still recognise an E: enum token.'
 		);
+
+		$this->write_raw_serialized_entry( $key, $payload );
 
 		$this->assertSame(
 			'default_value',
 			$storage->get( $key, 'default_value' ),
 			'An enum token in the payload must never reach unserialize().'
 		);
-		$this->assertFalse(
-			$storage->get_post_by_name( $key ),
-			'A row carrying an enum token must be deleted, like any other object.'
-		);
 	}
 
 	/**
-	 * A row that claims to be serialized and will not deserialize cannot have been
-	 * written by Boost, and left alone it would be re-parsed on every read.
+	 * A row that claims to be serialized and will not deserialize is not one Boost
+	 * can serve, whether it was truncated by a bad import or built by hand.
 	 */
-	public function test_get_deletes_a_payload_that_claims_to_be_serialized_and_is_not() {
+	public function test_get_refuses_a_payload_that_claims_to_be_serialized_and_is_not() {
 		$key     = 'malformed_probe';
 		$storage = new Storage_Post_Type( 'css' );
 
@@ -432,9 +444,39 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 			$storage->get( $key, 'default_value' ),
 			'A payload that will not deserialize must not be served.'
 		);
+		$this->assertNotFalse(
+			$storage->get_post_by_name( $key ),
+			'A truncated row and a crafted one look the same here, so neither is deleted.'
+		);
+	}
+
+	/**
+	 * The post types carried show_in_rest => true and the default capabilities until
+	 * this release, so a row can predate the fix. Refusing on the prefix settles it
+	 * without decoding: an object payload is never built, and a deeply nested one
+	 * never reaches the parser that PHP 7.2 and 7.3 recurse on.
+	 */
+	public function test_get_rejects_and_deletes_a_row_without_the_current_format_prefix() {
+		$key     = 'legacy_row_probe';
+		$storage = new Storage_Post_Type( 'css' );
+
+		$this->write_raw_cache_entry(
+			$key,
+			array(
+				'data'   => array( 'css' => 'body{display:none}' ),
+				'expiry' => 0,
+			),
+			false
+		);
+
+		$this->assertSame(
+			'default_value',
+			$storage->get( $key, 'default_value' ),
+			'A row written before the current format must not be served, object token or not.'
+		);
 		$this->assertFalse(
 			$storage->get_post_by_name( $key ),
-			'A payload that will not deserialize must be deleted.'
+			'The prefix check is exact, so the row can be deleted rather than left in place.'
 		);
 	}
 

--- a/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
+++ b/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
@@ -451,12 +451,11 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The post types carried show_in_rest => true and the default capabilities until
-	 * this release, so a row can predate the fix. Refusing on the prefix settles it
-	 * without decoding: an object payload is never built, and a deeply nested one
-	 * never reaches the parser that PHP 7.2 and 7.3 recurse on.
+	 * A row written before this release carries no prefix. It is cache Boost itself
+	 * wrote, so get() serves it: the prefix marks where the payload starts, it does
+	 * not decide whether the row is safe. The row is left in place either way.
 	 */
-	public function test_get_rejects_and_deletes_a_row_without_the_current_format_prefix() {
+	public function test_get_serves_a_legitimate_row_without_the_current_format_prefix() {
 		$key     = 'legacy_row_probe';
 		$storage = new Storage_Post_Type( 'css' );
 
@@ -470,13 +469,45 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 		);
 
 		$this->assertSame(
+			array( 'css' => 'body{display:none}' ),
+			$storage->get( $key, 'default_value' ),
+			'A legitimate row from before the current format must still be served.'
+		);
+		$this->assertNotFalse(
+			$storage->get_post_by_name( $key ),
+			'Serving a legacy row must not delete it.'
+		);
+	}
+
+	/**
+	 * A row from before this release still runs through the object-token scan, so a
+	 * payload planted while the post types were open is refused rather than served. It
+	 * is left in place, like every other refused row; the next regeneration clears the
+	 * whole store.
+	 */
+	public function test_get_refuses_but_keeps_an_unprefixed_row_containing_an_object() {
+		$key     = 'legacy_object_probe';
+		$storage = new Storage_Post_Type( 'css' );
+
+		// An O: object token in a row with no format prefix.
+		$this->write_raw_serialized_entry(
+			$key,
+			'a:2:{s:4:"data";O:8:"stdClass":0:{}s:6:"expiry";i:0;}',
+			false
+		);
+
+		$this->assertSame(
 			'default_value',
 			$storage->get( $key, 'default_value' ),
-			'A row written before the current format must not be served, object token or not.'
+			'An object payload must never be served, prefix or not.'
+		);
+		$this->assertNotFalse(
+			$storage->get_post_by_name( $key ),
+			'A refused row is left in place, not deleted.'
 		);
 		$this->assertFalse(
-			$storage->get_post_by_name( $key ),
-			'The prefix check is exact, so the row can be deleted rather than left in place.'
+			get_transient( self::transient_key( $key ) ),
+			'A refused row must not populate the transient cache.'
 		);
 	}
 

--- a/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
+++ b/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
@@ -8,13 +8,18 @@
 namespace Automattic\Jetpack_Boost\Tests\Lib\Critical_CSS;
 
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_Storage;
+use Automattic\Jetpack_Boost\Lib\Storage_Post_Type;
+use Automattic\Jetpack_Boost\Tests\Lib\Mocks\Boost_POI_Test_Gadget;
 use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '/../mocks/class-boost-poi-test-gadget.php';
 
 /**
  * Class Critical_CSS_Storage_Test
  *
- * Verifies that generated Critical CSS survives a save/load round-trip intact,
- * including double quotes and inline SVG markup in CSS values.
+ * Covers the save/load round-trip and the PHP Object Injection fix (CWE-502):
+ * the cache post types deny all access, and get() refuses stored content that
+ * declares a PHP object.
  *
  * @see https://github.com/Automattic/jetpack/issues/42321
  */
@@ -22,12 +27,11 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 
 	/**
 	 * Set up test environment.
-	 *
-	 * WorDBless does not implement the SQL used by WP_Query post_name lookups,
-	 * so emulate them from the WorDBless in-memory post store.
 	 */
 	public function set_up() {
 		parent::set_up();
+
+		Boost_POI_Test_Gadget::$woken = false;
 
 		add_filter( 'posts_pre_query', array( $this, 'emulate_name_query' ), 10, 2 );
 	}
@@ -36,44 +40,103 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 	 * Tear down test environment.
 	 */
 	public function tear_down() {
+		// Unconditional, so a test that fails part-way cannot leave a user logged in
+		// for every test after it.
+		wp_set_current_user( 0 );
+
 		remove_filter( 'posts_pre_query', array( $this, 'emulate_name_query' ), 10 );
 		\WorDBless\Posts::init()->clear_all_posts();
 		parent::tear_down();
 	}
 
 	/**
-	 * Emulate WP_Query post_name lookups against the WorDBless post store.
+	 * Emulate get_post_by_name()'s post_name lookup against the WorDBless
+	 * in-memory post store, which does not implement the SQL WP_Query uses.
 	 *
 	 * @param \WP_Post[]|null $posts Posts with which to short-circuit the query, or null.
 	 * @param \WP_Query       $query The running query.
 	 * @return \WP_Post[]|null
 	 */
 	public function emulate_name_query( $posts, $query ) {
-		// Respect any earlier filter that already short-circuited the query.
 		if ( null !== $posts ) {
 			return $posts;
 		}
 
-		$name      = $query->get( 'name' );
 		$post_type = $query->get( 'post_type' );
 
-		if ( ! $name || ! $post_type ) {
+		if ( ! is_string( $post_type ) || 0 !== strpos( $post_type, 'jb_store_' ) ) {
 			return $posts;
 		}
 
-		// Mirror get_post_by_name(), which restricts to published posts. Other
-		// WP_Query semantics are intentionally not emulated here.
+		$name = $query->get( 'name' );
+
 		$post_status = $query->get( 'post_status' );
+		$post_status = empty( $post_status ) ? array( 'publish' ) : (array) $post_status;
+
+		$matches = array();
 
 		foreach ( \WorDBless\Posts::init()->posts as $id => $post ) {
-			if ( $post->post_name === $name
-				&& $post->post_type === $post_type
-				&& ( ! $post_status || $post->post_status === $post_status ) ) {
-				return array( get_post( $id ) );
+			if ( $post->post_type !== $post_type ) {
+				continue;
+			}
+			if ( $name && $post->post_name !== $name ) {
+				continue;
+			}
+			if ( ! in_array( $post->post_status, $post_status, true ) ) {
+				continue;
+			}
+
+			$matches[] = get_post( $id );
+
+			if ( $name ) {
+				break;
 			}
 		}
 
-		return array();
+		return $matches;
+	}
+
+	/**
+	 * The transient key get() reads and writes.
+	 *
+	 * @param string $key Cache key.
+	 *
+	 * @return string
+	 */
+	private static function transient_key( $key ) {
+		return 'jb_store_css_' . Storage_Post_Type::CACHE_VERSION . '_' . $key;
+	}
+
+	/**
+	 * Write a cache row directly, bypassing set()'s own encoding, to stand in for
+	 * a write to the CPT that did not come from Boost.
+	 *
+	 * @param string $key     Cache key.
+	 * @param mixed  $payload Payload to encode into post_content.
+	 */
+	private function write_raw_cache_entry( $key, $payload ) {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$this->write_raw_serialized_entry( $key, serialize( $payload ) );
+	}
+
+	/**
+	 * Write a cache row from an already-serialized string, for payload shapes PHP
+	 * will not produce from a live value.
+	 *
+	 * @param string $key        Cache key.
+	 * @param string $serialized Serialized payload to encode into post_content.
+	 */
+	private function write_raw_serialized_entry( $key, $serialized ) {
+		wp_insert_post(
+			array(
+				'post_type'    => 'jb_store_css',
+				'post_title'   => $key,
+				'post_name'    => $key,
+				'post_status'  => 'publish',
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				'post_content' => base64_encode( $serialized ),
+			)
+		);
 	}
 
 	/**
@@ -107,5 +170,337 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertSame( $css, $result['css'] );
+	}
+
+	/**
+	 * The access-control half of the PHP Object Injection fix. Both stores are
+	 * covered: they share one class and one args array, but jb_store_lcp is half
+	 * the production surface.
+	 */
+	public function test_cache_post_types_deny_all_mapped_capabilities() {
+		foreach ( array( 'css', 'lcp' ) as $name ) {
+			$storage = new Storage_Post_Type( $name );
+
+			$slug = $storage->post_type_slug();
+			$this->assertSame( 'jb_store_' . $name, $slug );
+
+			$post_type = get_post_type_object( $slug );
+
+			$this->assertNotNull( $post_type, "{$slug} post type should be registered." );
+			$this->assertFalse( $post_type->show_in_rest, "{$slug} must not be exposed to the REST API." );
+
+			foreach (
+				array(
+					'read',
+					'create_posts',
+					'edit_posts',
+					'edit_others_posts',
+					'edit_published_posts',
+					'edit_private_posts',
+					'publish_posts',
+					'read_private_posts',
+					'delete_posts',
+					'delete_others_posts',
+					'delete_published_posts',
+					'delete_private_posts',
+				) as $cap
+			) {
+				$this->assertSame(
+					'do_not_allow',
+					$post_type->cap->$cap,
+					"{$slug} capability {$cap} must map to do_not_allow."
+				);
+			}
+		}
+	}
+
+	/**
+	 * The assertions above prove the strings reached the post type object; this
+	 * proves WordPress's capability mapping refuses a real administrator.
+	 */
+	public function test_administrator_cannot_touch_cache_post_type_rows() {
+		$stores = array();
+		foreach ( array( 'css', 'lcp' ) as $store ) {
+			$stores[ $store ] = new Storage_Post_Type( $store );
+			$stores[ $store ]->set( 'cap_probe', array( 'css' => '.a {}' ) );
+		}
+
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'boost_cap_probe_admin',
+				'user_pass'  => wp_generate_password(),
+				'user_email' => 'boost_cap_probe_admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		$this->assertIsInt( $admin_id, 'Test administrator should have been created.' );
+		wp_set_current_user( $admin_id );
+
+		// Control: the same meta caps resolve to true for an ordinary post, so a
+		// false below is the post type's policy and not an inert test harness.
+		$ordinary = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_title'  => 'ordinary',
+				'post_status' => 'publish',
+			)
+		);
+		$this->assertTrue( current_user_can( 'edit_post', $ordinary ), 'Control: an administrator can edit an ordinary post.' );
+
+		foreach ( $stores as $store => $storage ) {
+			$row = $storage->get_post_by_name( 'cap_probe' );
+			$this->assertNotFalse( $row, $store . ': Boost should still be able to write and read its own row.' );
+
+			$caps = get_post_type_object( 'jb_store_' . $store )->cap;
+
+			$this->assertFalse( current_user_can( $caps->create_posts ), $store . ': creating a cache row must be denied.' );
+			$this->assertFalse( current_user_can( 'edit_post', $row->ID ), $store . ': editing a cache row must be denied.' );
+			$this->assertFalse( current_user_can( 'delete_post', $row->ID ), $store . ': deleting a cache row must be denied.' );
+			$this->assertFalse( current_user_can( 'read_post', $row->ID ), $store . ': reading a cache row must be denied.' );
+		}
+	}
+
+	/**
+	 * The stored-content half of the fix: a payload declaring an object is refused
+	 * on its wire format, before unserialize() runs, so no object -- not even a
+	 * __PHP_Incomplete_Class -- is ever instantiated from a cache row (CWE-502).
+	 */
+	public function test_get_rejects_and_deletes_cache_content_containing_an_object() {
+		$key     = 'poi_probe';
+		$storage = new Storage_Post_Type( 'css' );
+
+		$this->write_raw_cache_entry(
+			$key,
+			array(
+				'data'   => new Boost_POI_Test_Gadget(),
+				'expiry' => 0,
+			)
+		);
+
+		$result = $storage->get( $key, 'default_value' );
+
+		$this->assertSame(
+			'default_value',
+			$result,
+			'A payload containing an object must be rejected in favour of the default.'
+		);
+
+		$this->assertFalse(
+			get_transient( self::transient_key( $key ) ),
+			'A rejected payload must never reach the transient cache.'
+		);
+
+		$this->assertFalse(
+			$storage->get_post_by_name( $key ),
+			'The poisoned cache entry must be deleted.'
+		);
+
+		$this->assertFalse(
+			Boost_POI_Test_Gadget::$woken,
+			'__wakeup() must never fire; the gadget class must not be instantiated.'
+		);
+	}
+
+	/**
+	 * The object rejection must catch an object anywhere in the payload, not just
+	 * at its top level.
+	 */
+	public function test_get_rejects_objects_nested_inside_the_payload() {
+		$key     = 'poi_nested_probe';
+		$storage = new Storage_Post_Type( 'css' );
+
+		$this->write_raw_cache_entry(
+			$key,
+			array(
+				'data'   => array(
+					'css' => array( 'deep' => new Boost_POI_Test_Gadget() ),
+				),
+				'expiry' => 0,
+			)
+		);
+
+		$result = $storage->get( $key, 'default_value' );
+
+		$this->assertSame(
+			'default_value',
+			$result,
+			'An object nested inside the payload must be rejected too.'
+		);
+		$this->assertFalse(
+			get_transient( self::transient_key( $key ) ),
+			'A rejected payload must never reach the transient cache.'
+		);
+	}
+
+	/**
+	 * The object rejection must not reject the ordinary array payloads that set()
+	 * writes, which are what every Boost read depends on.
+	 */
+	public function test_get_still_returns_ordinary_array_payloads() {
+		$key     = 'benign_probe';
+		$storage = new Storage_Post_Type( 'css' );
+
+		$storage->set( $key, array( 'css' => '.a {}' ) );
+		delete_transient( self::transient_key( $key ) );
+
+		$this->assertSame(
+			array( 'css' => '.a {}' ),
+			$storage->get( $key, 'default_value' ),
+			'A normal payload must survive the object check.'
+		);
+	}
+
+	/**
+	 * The object-token pattern must not misfire on real Critical CSS, which is
+	 * mostly braces and colons.
+	 */
+	public function test_get_still_returns_css_full_of_braces() {
+		$key     = 'brace_heavy_probe';
+		$storage = new Storage_Post_Type( 'css' );
+
+		$css = str_repeat( '.a{color:red}', 500 ) . '.b:after{content:"' . str_repeat( '{', 500 ) . '"}';
+
+		$storage->set( $key, array( 'css' => $css ) );
+		delete_transient( self::transient_key( $key ) );
+
+		$this->assertSame(
+			array( 'css' => $css ),
+			$storage->get( $key, 'default_value' ),
+			'Braces inside the stored CSS are string content, not an object token.'
+		);
+	}
+
+	/**
+	 * A cached value is served before any of get()'s validation runs, so a transient
+	 * written by a release predating that validation can only be avoided. The cache
+	 * version in the transient key is what avoids it.
+	 */
+	public function test_get_ignores_a_transient_written_by_an_earlier_cache_version() {
+		$key     = 'legacy_probe';
+		$storage = new Storage_Post_Type( 'css' );
+
+		// The key shape a pre-CACHE_VERSION release used.
+		set_transient( 'jb_store_css_' . $key, 'value_from_the_vulnerable_version', HOUR_IN_SECONDS );
+
+		$this->assertSame(
+			'default_value',
+			$storage->get( $key, 'default_value' ),
+			'A transient from an earlier cache version must never be read back.'
+		);
+	}
+
+	/**
+	 * A serialized enum case (an 'E:' token) is not covered by
+	 * allowed_classes => false, and resolving it hands an attacker-chosen class
+	 * name to the autoloader. The wire-format check refuses it first.
+	 */
+	public function test_get_rejects_and_deletes_a_serialized_enum_token() {
+		$key     = 'enum_probe';
+		$storage = new Storage_Post_Type( 'css' );
+
+		$token = 'Boost_Absent_Attacker_Chosen:CASE_A';
+
+		$this->write_raw_serialized_entry(
+			$key,
+			'a:2:{s:4:"data";E:' . strlen( $token ) . ':"' . $token . '";s:6:"expiry";i:0;}'
+		);
+
+		$this->assertSame(
+			'default_value',
+			$storage->get( $key, 'default_value' ),
+			'An enum token in the payload must never reach unserialize().'
+		);
+		$this->assertFalse(
+			$storage->get_post_by_name( $key ),
+			'A row carrying an enum token must be deleted, like any other object.'
+		);
+	}
+
+	/**
+	 * A row that claims to be serialized and will not deserialize cannot have been
+	 * written by Boost, and left alone it would be re-parsed on every read.
+	 */
+	public function test_get_deletes_a_payload_that_claims_to_be_serialized_and_is_not() {
+		$key     = 'malformed_probe';
+		$storage = new Storage_Post_Type( 'css' );
+
+		// Passes is_serialized(); the declared string length is wrong.
+		$this->write_raw_serialized_entry( $key, 'a:1:{s:4:"data";s:99:"short";}' );
+
+		$this->assertSame(
+			'default_value',
+			$storage->get( $key, 'default_value' ),
+			'A payload that will not deserialize must not be served.'
+		);
+		$this->assertFalse(
+			$storage->get_post_by_name( $key ),
+			'A payload that will not deserialize must be deleted.'
+		);
+	}
+
+	/**
+	 * 'b:0;' is serialize( false ), the one input for which a false return from
+	 * unserialize() means success.
+	 */
+	public function test_get_does_not_treat_a_serialized_false_as_malformed() {
+		$key     = 'serialized_false_probe';
+		$storage = new Storage_Post_Type( 'css' );
+
+		$this->write_raw_serialized_entry( $key, 'b:0;' );
+
+		$this->assertSame(
+			'default_value',
+			$storage->get( $key, 'default_value' ),
+			'A payload with no data key is a miss either way.'
+		);
+		$this->assertNotFalse(
+			$storage->get_post_by_name( $key ),
+			'serialize( false ) deserializes correctly, so the row must not be deleted as malformed.'
+		);
+	}
+
+	/**
+	 * The store vets payloads for objects but not for shape, so get_css() has to
+	 * treat anything that is not Critical-CSS-shaped as a miss rather than a fatal.
+	 */
+	public function test_get_css_treats_a_wrong_shaped_payload_as_a_miss() {
+		$key     = 'wrong_shape_probe';
+		$storage = new Critical_CSS_Storage();
+
+		$this->write_raw_cache_entry(
+			$key,
+			array(
+				'data'   => 'not-an-array',
+				'expiry' => 0,
+			)
+		);
+
+		$this->assertFalse(
+			$storage->get_css( array( $key ) ),
+			'A payload that is not shaped like Critical CSS must be a miss, not a fatal.'
+		);
+	}
+
+	/**
+	 * The wrapper check alone is not enough: get_css()'s return value is concatenated
+	 * into a <style> tag, where an array-valued leaf renders the literal string
+	 * "Array" alongside a PHP notice.
+	 */
+	public function test_get_css_treats_a_non_string_css_leaf_as_a_miss() {
+		$key     = 'array_leaf_probe';
+		$storage = new Critical_CSS_Storage();
+
+		$this->write_raw_cache_entry(
+			$key,
+			array(
+				'data'   => array( 'css' => array( '.a {}' ) ),
+				'expiry' => 0,
+			)
+		);
+
+		$this->assertFalse(
+			$storage->get_css( array( $key ) ),
+			'Critical CSS that is not a string must be a miss, not a rendered "Array".'
+		);
 	}
 }

--- a/projects/plugins/boost/tests/php/lib/mocks/class-boost-poi-test-gadget.php
+++ b/projects/plugins/boost/tests/php/lib/mocks/class-boost-poi-test-gadget.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Mock gadget class for the PHP Object Injection tests.
+ *
+ * Stands in for a class an attacker would name in a serialized payload; in a real
+ * attack it lives in WordPress core, another plugin, or a theme. The tests use it
+ * to prove that reading a poisoned cache entry never instantiates it and never
+ * fires its magic methods.
+ *
+ * @package automattic/jetpack-boost
+ */
+
+namespace Automattic\Jetpack_Boost\Tests\Lib\Mocks;
+
+/**
+ * Class Boost_POI_Test_Gadget
+ */
+class Boost_POI_Test_Gadget {
+
+	/**
+	 * Set to true if __wakeup() ever runs, which would mean unserialize()
+	 * really instantiated this class. Reset between tests.
+	 *
+	 * @var bool
+	 */
+	public static $woken = false;
+
+	/**
+	 * Marker property, stands in for attacker-controlled gadget state.
+	 *
+	 * @var string
+	 */
+	public $payload = 'rce';
+
+	/**
+	 * Records that deserialization instantiated this class for real.
+	 */
+	public function __wakeup() {
+		self::$woken = true;
+	}
+}

--- a/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php
+++ b/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack_Boost\Tests\Modules\Optimizations\Lcp;
 
-use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\Lcp;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP_Optimize_Bg_Image;
 use WorDBless\BaseTestCase;
 
@@ -54,7 +54,7 @@ class LCP_Optimize_Bg_Image_Test extends BaseTestCase {
 	private function create_lcp_data( $optimizations = null ) {
 		$data = array(
 			'success'     => true,
-			'type'        => LCP::TYPE_BACKGROUND_IMAGE,
+			'type'        => Lcp::TYPE_BACKGROUND_IMAGE,
 			'selector'    => 'div.hero-bg',
 			'html'        => '<div class="hero-bg" id="test-bg"></div>',
 			'url'         => 'https://example.com/background.jpg',
@@ -171,7 +171,7 @@ class LCP_Optimize_Bg_Image_Test extends BaseTestCase {
 	 */
 	public function test_get_responsive_image_rules_returns_empty_for_non_bg_type() {
 		$lcp_data         = $this->create_lcp_data( array( 'cssOverride' => true ) );
-		$lcp_data['type'] = LCP::TYPE_IMAGE; // Not a background image
+		$lcp_data['type'] = Lcp::TYPE_IMAGE; // Not a background image
 
 		$instance = new LCP_Optimize_Bg_Image( array( $lcp_data ) );
 		$method   = $this->get_private_method( $instance, 'get_responsive_image_rules' );
@@ -238,6 +238,82 @@ class LCP_Optimize_Bg_Image_Test extends BaseTestCase {
 		// With empty optimizations object, empty() check will return true for missing cssOverride
 		// so optimizations won't be applied (empty array returned)
 		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Both public entry points index 'selector' before anything else touches the
+	 * record, and the field is optional.
+	 */
+	public function test_a_record_with_no_selector_is_skipped_rather_than_indexed() {
+		$lcp_data = $this->create_lcp_data( array( 'cssOverride' => true ) );
+		unset( $lcp_data['selector'] );
+
+		$instance = new LCP_Optimize_Bg_Image( array( $lcp_data ) );
+
+		ob_start();
+		$instance->preload_background_images();
+		$instance->add_bg_style_override();
+		$output = ob_get_clean();
+
+		$this->assertSame(
+			'',
+			$output,
+			'A record missing the field both of these paths are keyed on must produce nothing, not a warning and a half-built rule.'
+		);
+	}
+
+	/**
+	 * A non-empty 'imageDimensions' array does not have to carry an index 0: a JSON
+	 * object decodes to a string-keyed array. This path indexes [0] directly.
+	 */
+	public function test_image_dimensions_without_a_first_entry_is_skipped_rather_than_indexed() {
+		$lcp_data = $this->create_lcp_data( array( 'cssOverride' => true ) );
+
+		$lcp_data['breakpoints'] = array_map(
+			function ( $breakpoint ) {
+				$breakpoint['imageDimensions'] = array(
+					'desktop' => array(
+						'width'  => 1200,
+						'height' => 800,
+					),
+				);
+
+				return $breakpoint;
+			},
+			$lcp_data['breakpoints']
+		);
+
+		$instance = new LCP_Optimize_Bg_Image( array( $lcp_data ) );
+
+		// Captured explicitly. Indexing a missing key yields null, so the breakpoint is
+		// skipped either way and the rendered output cannot tell the guard from its
+		// absence. The warning is the whole difference.
+		$raised = array();
+		set_error_handler(
+			function ( $errno, $errstr ) use ( &$raised ) {
+				$raised[] = $errstr;
+				return true;
+			},
+			E_WARNING | E_NOTICE
+		);
+
+		ob_start();
+		$instance->preload_background_images();
+		$instance->add_bg_style_override();
+		$output = ob_get_clean();
+
+		restore_error_handler();
+
+		$this->assertSame(
+			array(),
+			$raised,
+			'A breakpoint whose dimensions are not keyed from zero must be skipped, not indexed.'
+		);
+		$this->assertSame(
+			'',
+			$output,
+			'...and it must contribute nothing to the rendered rule.'
+		);
 	}
 
 	/**

--- a/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php
+++ b/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php
@@ -363,4 +363,26 @@ class LCP_Optimize_Img_Tag_Test extends BaseTestCase {
 			);
 		}
 	}
+
+	/**
+	 * An array passes isset(), and preg_match() throws a TypeError on one.
+	 * This runs inside the output buffer callback, so the throw is a blank page.
+	 */
+	public function test_an_array_width_value_is_a_skipped_breakpoint_not_a_type_error() {
+		$data = $this->create_lcp_data( $this->get_default_optimizations() );
+
+		$data['breakpoints'] = array_map(
+			function ( $breakpoint ) {
+				$breakpoint['widthValue'] = array( '100vw' );
+				return $breakpoint;
+			},
+			$data['breakpoints']
+		);
+
+		$this->assertStringNotContainsString(
+			'sizes=',
+			( new LCP_Optimize_Img_Tag( $data ) )->optimize_buffer( $this->get_test_buffer() ),
+			'A non-string widthValue must be skipped before it reaches preg_match().'
+		);
+	}
 }

--- a/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php
+++ b/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack_Boost\Tests\Modules\Optimizations\Lcp;
 
-use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\Lcp;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP_Optimize_Img_Tag;
 use WorDBless\BaseTestCase;
 
@@ -58,7 +58,7 @@ class LCP_Optimize_Img_Tag_Test extends BaseTestCase {
 	private function create_lcp_data( $optimizations = null ) {
 		$data = array(
 			'success'     => true,
-			'type'        => LCP::TYPE_IMAGE,
+			'type'        => Lcp::TYPE_IMAGE,
 			'selector'    => 'img.wp-post-image',
 			'html'        => '<img class="wp-post-image" id="test-img" src="https://example.com/image.jpg">',
 			'url'         => 'https://example.com/image.jpg',
@@ -259,7 +259,7 @@ class LCP_Optimize_Img_Tag_Test extends BaseTestCase {
 	public function test_optimize_buffer_returns_original_when_lcp_data_invalid() {
 		$lcp_data = array(
 			'success' => false,
-			'type'    => LCP::TYPE_IMAGE,
+			'type'    => Lcp::TYPE_IMAGE,
 		);
 
 		$optimizer = new LCP_Optimize_Img_Tag( $lcp_data );
@@ -275,7 +275,7 @@ class LCP_Optimize_Img_Tag_Test extends BaseTestCase {
 	 */
 	public function test_optimize_buffer_returns_original_when_type_is_not_image() {
 		$lcp_data         = $this->create_lcp_data( $this->get_default_optimizations() );
-		$lcp_data['type'] = LCP::TYPE_BACKGROUND_IMAGE;
+		$lcp_data['type'] = Lcp::TYPE_BACKGROUND_IMAGE;
 
 		$optimizer = new LCP_Optimize_Img_Tag( $lcp_data );
 		$buffer    = $this->get_test_buffer();
@@ -320,5 +320,47 @@ class LCP_Optimize_Img_Tag_Test extends BaseTestCase {
 
 		// data attribute should still be added
 		$this->assertStringContainsString( 'data-jp-lcp-optimized="true"', $result );
+	}
+
+	/**
+	 * 'imageDimensions' is an optional field, so the consumer has to guard what it
+	 * indexes directly. An absent one is "foreach() argument must be of type
+	 * array|object, null given" plus an undefined-key warning, on wp_head.
+	 *
+	 * Asserted through the srcset rather than through an unchanged buffer: these
+	 * records still optimize and just contribute no widths, so "the page rendered" is
+	 * not on its own evidence that the guard ran.
+	 */
+	public function test_an_absent_field_is_a_skipped_breakpoint_not_a_warning() {
+		$buffer = $this->get_test_buffer();
+
+		// Applied to every breakpoint in the fixture, not just the first: the srcset
+		// is the union of all of them, so one intact breakpoint would supply widths
+		// and hide the skip.
+		$omissions = array(
+			'no imageDimensions on a breakpoint'      => function ( $breakpoint ) {
+				unset( $breakpoint['imageDimensions'] );
+				return $breakpoint;
+			},
+			'an imageDimensions entry with no width'  => function ( $breakpoint ) {
+				unset( $breakpoint['imageDimensions'][0]['width'] );
+				return $breakpoint;
+			},
+			'an imageDimensions entry with no height' => function ( $breakpoint ) {
+				unset( $breakpoint['imageDimensions'][0]['height'] );
+				return $breakpoint;
+			},
+		);
+
+		foreach ( $omissions as $label => $omit ) {
+			$data                = $this->create_lcp_data( $this->get_default_optimizations() );
+			$data['breakpoints'] = array_map( $omit, $data['breakpoints'] );
+
+			$this->assertStringNotContainsString(
+				'srcset=',
+				( new LCP_Optimize_Img_Tag( $data ) )->optimize_buffer( $buffer ),
+				$label . ': a breakpoint with nothing to size from must be skipped rather than indexed.'
+			);
+		}
 	}
 }

--- a/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_Storage_Test.php
+++ b/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_Storage_Test.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Tests for LCP_Storage class.
+ *
+ * @package automattic/jetpack-boost
+ */
+
+namespace Automattic\Jetpack_Boost\Tests\Modules\Optimizations\Lcp;
+
+use Automattic\Jetpack_Boost\Lib\Storage_Post_Type;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\Lcp;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP_Optimize_Bg_Image;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP_Storage;
+use WorDBless\BaseTestCase;
+
+/**
+ * Class LCP_Storage_Test
+ */
+class LCP_Storage_Test extends BaseTestCase {
+
+	/**
+	 * Set up test environment.
+	 *
+	 * WorDBless does not implement the SQL used by WP_Query post_name lookups,
+	 * so emulate the one LCP_Storage makes.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		add_filter( 'posts_pre_query', array( $this, 'emulate_name_query' ), 10, 2 );
+	}
+
+	/**
+	 * Tear down test environment.
+	 */
+	public function tear_down() {
+		remove_filter( 'posts_pre_query', array( $this, 'emulate_name_query' ), 10 );
+		\WorDBless\Posts::init()->clear_all_posts();
+		parent::tear_down();
+	}
+
+	/**
+	 * Emulate Storage_Post_Type::get_post_by_name()'s single post_name lookup
+	 * against the WorDBless in-memory post store.
+	 *
+	 * @param \WP_Post[]|null $posts Posts with which to short-circuit the query, or null.
+	 * @param \WP_Query       $query The running query.
+	 * @return \WP_Post[]|null
+	 */
+	public function emulate_name_query( $posts, $query ) {
+		if ( null !== $posts ) {
+			return $posts;
+		}
+
+		$post_type = $query->get( 'post_type' );
+		$name      = $query->get( 'name' );
+
+		if ( 'jb_store_lcp' !== $post_type || ! $name ) {
+			return $posts;
+		}
+
+		foreach ( \WorDBless\Posts::init()->posts as $id => $post ) {
+			if ( $post->post_type === $post_type && $post->post_name === $name ) {
+				return array( get_post( $id ) );
+			}
+		}
+
+		return array();
+	}
+
+	/**
+	 * The store vets payloads for PHP objects rather than shape, and the pre-fix REST
+	 * hole could write jb_store_lcp exactly as it could jb_store_css, so a row can
+	 * come back as a scalar into a foreach() in Lcp::filter_output().
+	 */
+	public function test_get_lcp_treats_a_wrong_shaped_payload_as_a_miss() {
+		$key     = 'wrong_shape_probe';
+		$storage = new LCP_Storage();
+
+		wp_insert_post(
+			array(
+				'post_type'    => 'jb_store_lcp',
+				'post_title'   => $key,
+				'post_name'    => $key,
+				'post_status'  => 'publish',
+				'post_content' => base64_encode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+					maybe_serialize(
+						array(
+							'data'   => 'not-an-array',
+							'expiry' => 0,
+						)
+					)
+				),
+			)
+		);
+
+		$this->assertFalse(
+			$storage->get_lcp( $key ),
+			'A payload that is not shaped like LCP data must be a miss.'
+		);
+	}
+
+	/**
+	 * The guard must not swallow the data it exists to protect.
+	 */
+	public function test_get_lcp_still_returns_well_shaped_payloads() {
+		$key     = 'well_shaped_probe';
+		$storage = new LCP_Storage();
+		$data    = array(
+			array(
+				'success' => true,
+				'type'    => 'img',
+			),
+		);
+
+		$storage->store_lcp( $key, $data );
+		delete_transient( 'jb_store_lcp_' . Storage_Post_Type::CACHE_VERSION . '_' . $key );
+
+		$this->assertSame(
+			$data,
+			$storage->get_lcp( $key ),
+			'Well-shaped LCP data must survive the shape check.'
+		);
+	}
+
+	/**
+	 * The top-level is_array() check is not the shape consumers need: every optimizer
+	 * indexes straight into each record, and indexing into a string is an uncaught
+	 * TypeError on PHP 8, raised from wp_head on an anonymous render.
+	 */
+	public function test_get_lcp_treats_a_scalar_record_as_a_miss() {
+		$key     = 'scalar_record_probe';
+		$storage = new LCP_Storage();
+
+		$this->write_raw_lcp_entry( $key, array( 'not-a-record' ) );
+
+		$this->assertFalse(
+			$storage->get_lcp( $key ),
+			'A list whose records are not arrays must be a miss, not a payload every consumer will index into.'
+		);
+	}
+
+	/**
+	 * The reproduced crash. An object-free, correctly listed, correctly recorded
+	 * payload whose breakpoints field is a string passes every guard between the
+	 * store and array_reverse(), because empty( 'not-an-array' ) is false.
+	 *
+	 * @see \Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP_Optimize_Bg_Image::get_responsive_image_rules()
+	 */
+	public function test_a_string_breakpoints_field_cannot_reach_array_reverse() {
+		// Complete enough to clear every guard between the entry point and
+		// array_reverse(). Without all of them the assertion below passes whether or
+		// not the fix is present.
+		$record = array(
+			'success'     => true,
+			'type'        => Lcp::TYPE_BACKGROUND_IMAGE,
+			'selector'    => '.hero',
+			'url'         => home_url( '/hero.jpg' ),
+			'breakpoints' => 'not-an-array',
+		);
+
+		$rules = $this->private_method( LCP_Optimize_Bg_Image::class, 'get_responsive_image_rules' );
+
+		$this->assertSame(
+			array(),
+			$rules->invoke( new LCP_Optimize_Bg_Image( array( $record ) ), $record ),
+			'A non-array breakpoints field must produce no rules, not a TypeError on the render path.'
+		);
+	}
+
+	/**
+	 * Resolve a private method so a test can invoke it.
+	 *
+	 * ReflectionMethod::setAccessible() is a no-op from PHP 8.1 and deprecated as of
+	 * 8.5, where phpunit.11/12.xml.dist's failOnDeprecation turns calling it into a
+	 * test failure.
+	 *
+	 * @param string $class  Class holding the method.
+	 * @param string $method Method name.
+	 *
+	 * @return \ReflectionMethod
+	 */
+	private function private_method( $class, $method ) {
+		$reflection = new \ReflectionMethod( $class, $method );
+
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflection->setAccessible( true );
+		}
+
+		return $reflection;
+	}
+
+	/**
+	 * Write a cache row directly, bypassing store_lcp()'s own serialization.
+	 *
+	 * @param string $key   Cache key name.
+	 * @param mixed  $value Payload to store under 'data'.
+	 *
+	 * @return void
+	 */
+	private function write_raw_lcp_entry( $key, $value ) {
+		wp_insert_post(
+			array(
+				'post_type'    => 'jb_store_lcp',
+				'post_title'   => $key,
+				'post_name'    => $key,
+				'post_status'  => 'publish',
+				'post_content' => base64_encode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+					maybe_serialize(
+						array(
+							'data'   => $value,
+							'expiry' => 0,
+						)
+					)
+				),
+			)
+		);
+	}
+}

--- a/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_Storage_Test.php
+++ b/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_Storage_Test.php
@@ -77,22 +77,7 @@ class LCP_Storage_Test extends BaseTestCase {
 		$key     = 'wrong_shape_probe';
 		$storage = new LCP_Storage();
 
-		wp_insert_post(
-			array(
-				'post_type'    => 'jb_store_lcp',
-				'post_title'   => $key,
-				'post_name'    => $key,
-				'post_status'  => 'publish',
-				'post_content' => base64_encode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-					maybe_serialize(
-						array(
-							'data'   => 'not-an-array',
-							'expiry' => 0,
-						)
-					)
-				),
-			)
-		);
+		$this->write_raw_lcp_entry( $key, 'not-an-array' );
 
 		$this->assertFalse(
 			$storage->get_lcp( $key ),
@@ -137,6 +122,50 @@ class LCP_Storage_Test extends BaseTestCase {
 		$this->assertFalse(
 			$storage->get_lcp( $key ),
 			'A list whose records are not arrays must be a miss, not a payload every consumer will index into.'
+		);
+	}
+
+	/**
+	 * LCP_Optimize_Img_Tag, LCP_Optimize_Bg_Image and LCP_Optimization_Util all compare
+	 * $record['type'] without checking it is there, which warns from wp_head.
+	 */
+	public function test_get_lcp_treats_a_record_without_a_type_as_a_miss() {
+		$key     = 'typeless_record_probe';
+		$storage = new LCP_Storage();
+
+		$this->write_raw_lcp_entry( $key, array( array( 'success' => true ) ) );
+
+		$this->assertFalse(
+			$storage->get_lcp( $key ),
+			'A record without a type must be a miss, not a payload three consumers index for it.'
+		);
+	}
+
+	/**
+	 * A report holds one record per viewport, and Update_LCP::response() stores a page's
+	 * reports whether or not every viewport succeeded. Dropping the whole report over one
+	 * bad viewport would lose the optimization the good one still describes.
+	 */
+	public function test_get_lcp_keeps_the_good_records_alongside_a_bad_one() {
+		$key     = 'mixed_report_probe';
+		$storage = new LCP_Storage();
+		$good    = array(
+			'success' => true,
+			'type'    => 'img',
+		);
+
+		$this->write_raw_lcp_entry(
+			$key,
+			array(
+				'mobile'  => $good,
+				'desktop' => array( 'success' => false ),
+			)
+		);
+
+		$this->assertSame(
+			array( 'mobile' => $good ),
+			$storage->get_lcp( $key ),
+			'A malformed viewport must cost its own record, not the whole report.'
 		);
 	}
 
@@ -205,7 +234,7 @@ class LCP_Storage_Test extends BaseTestCase {
 				'post_title'   => $key,
 				'post_name'    => $key,
 				'post_status'  => 'publish',
-				'post_content' => base64_encode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				'post_content' => Storage_Post_Type::CACHE_VERSION . ':' . base64_encode( // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 					maybe_serialize(
 						array(
 							'data'   => $value,


### PR DESCRIPTION
## Proposed changes

See BOOST-590

## Related product discussion/links

* BOOST-590

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

See BOOST-590. Automated coverage: `jp test php plugins/boost` (both the `unit` and `with-wordpress` suites pass).