### PR TITLE
Update plugin list in GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -26,16 +26,14 @@ body:
         - Jetpack
         - Backup
         - Boost
-        - Beta
-        - Debug Helper
-        - Migration
-        - mu wpcom
         - Protect
         - Search
         - Social
-        - Super Cache
         - VaultPress
         - VideoPress
+        - Beta
+        - Debug Helper
+        - Wpcomsh
         - None / Other
       multiple: true
     validations:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -13,16 +13,14 @@ body:
         - Jetpack
         - Backup
         - Boost
-        - Beta
-        - Debug Helper
-        - Migration
-        - mu wpcom
         - Protect
         - Search
         - Social
-        - Super Cache
         - VaultPress
         - VideoPress
+        - Beta
+        - Debug Helper
+        - Wpcomsh
         - None / Other
       multiple: true
     validations:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -13,16 +13,14 @@ body:
         - Jetpack
         - Backup
         - Boost
-        - Beta
-        - Debug Helper
-        - Migration
-        - mu wpcom
         - Protect
         - Search
         - Social
-        - Super Cache
         - VaultPress
         - VideoPress
+        - Beta
+        - Debug Helper
+        - Wpcomsh
         - None / Other
       multiple: true
     validations:


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Super Cache and Migration are no longer in the monorepo.

Also I moved the "dev" plugins Beta and Debug Helper to the end of the list.

Then I added Wpcomsh to the list too, and removed mu wpcom since it seems unlikely anyone would really track down a bug to "mu wpcom" and report it in GitHub.

Besides mu wpcom, we're also currently omitting Agents Manager, Automattic For Agencies Client, Classic Theme Helper Plugin, Inspect, Paypal Payment Buttons, Premium Analytics, Starter Plugin, and Wpcloud Sso. Some of those are not released anywhere, while others may intend to be tracked elsewhere. I'll leave determining that for someone more familiar with them.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷