### PR TITLE
Forms: always request the collection field format for response records

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-fields-format-on-writes
+++ b/projects/packages/forms/changelog/fix-forms-fields-format-on-writes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: keep response field icons and formatting after marking a response as spam.

--- a/projects/packages/forms/routes/responses/actions.tsx
+++ b/projects/packages/forms/routes/responses/actions.tsx
@@ -16,6 +16,7 @@ import * as React from 'react';
 import { notSpam, spam } from '../../src/dashboard/icons';
 import { defaultView } from '../../src/dashboard/inbox/stage/views.js';
 import { getFormsMenuBadgeSlug, getMenuBadgeCount } from '../../src/dashboard/inbox/utils';
+import { deleteResponse, saveResponse } from '../../src/dashboard/response-records';
 import { store as dashboardStore } from '../../src/dashboard/store';
 /**
  * Types
@@ -415,8 +416,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 				const { itemsUpdated, numberOfErrors } = await processStatusChange( {
 					items,
 					newStatus: 'spam',
-					apiCall: ( id: number ) =>
-						saveEntityRecord( 'postType', 'feedback', { id, status: 'spam' } ),
+					apiCall: ( id: number ) => saveResponse( saveEntityRecord, { id, status: 'spam' } ),
 					editEntityRecord,
 					updateCountsOptimistically,
 					queryParams,
@@ -557,8 +557,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 				const { itemsUpdated, numberOfErrors } = await processStatusChange( {
 					items,
 					newStatus: 'publish',
-					apiCall: ( id: number ) =>
-						saveEntityRecord( 'postType', 'feedback', { id, status: 'publish' } ),
+					apiCall: ( id: number ) => saveResponse( saveEntityRecord, { id, status: 'publish' } ),
 					editEntityRecord,
 					updateCountsOptimistically,
 					queryParams,
@@ -692,8 +691,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 				const { itemsUpdated, numberOfErrors } = await processStatusChange( {
 					items,
 					newStatus,
-					apiCall: ( id: number ) =>
-						saveEntityRecord( 'postType', 'feedback', { id, status: newStatus } ),
+					apiCall: ( id: number ) => saveResponse( saveEntityRecord, { id, status: newStatus } ),
 					editEntityRecord,
 					updateCountsOptimistically,
 					queryParams,
@@ -823,7 +821,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 					items,
 					newStatus: 'trash',
 					apiCall: ( id: number ) =>
-						deleteEntityRecord( 'postType', 'feedback', id, {}, { throwOnError: true } ),
+						deleteResponse( deleteEntityRecord, id, {}, { throwOnError: true } ),
 					editEntityRecord,
 					updateCountsOptimistically,
 					queryParams,
@@ -939,7 +937,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 
 			const promises = await Promise.allSettled(
 				items.map( ( { id } ) =>
-					deleteEntityRecord( 'postType', 'feedback', id, { force: true }, { throwOnError: true } )
+					deleteResponse( deleteEntityRecord, id, { force: true }, { throwOnError: true } )
 				)
 			);
 

--- a/projects/packages/forms/src/dashboard/hooks/test/use-mark-as-spam.test.js
+++ b/projects/packages/forms/src/dashboard/hooks/test/use-mark-as-spam.test.js
@@ -67,11 +67,13 @@ describe( 'useMarkAsSpam', () => {
 			await result.current.onConfirmMarkAsSpam();
 		} );
 
+		// objectContaining, not an exact match: saveResponse() also supplies the
+		// __unstableFetch override that keeps the saved record in collection format.
 		expect( saveEntityRecord ).toHaveBeenCalledWith(
 			'postType',
 			'feedback',
 			{ id: 7, status: 'spam' },
-			{ throwOnError: true }
+			expect.objectContaining( { throwOnError: true } )
 		);
 	} );
 

--- a/projects/packages/forms/src/dashboard/hooks/use-mark-as-spam.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-mark-as-spam.ts
@@ -5,6 +5,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { saveResponse } from '../response-records.ts';
 import { store as dashboardStore } from '../store/index.js';
 /**
  * Types
@@ -54,13 +55,9 @@ export const useMarkAsSpam = ( response: FormResponse | null, options: UseMarkAs
 			// `throwOnError` matters: without it core-data resolves `undefined` on a
 			// failed save instead of rejecting, so the `catch` below never runs and
 			// callers act on a change the server refused.
-			await saveEntityRecord(
-				'postType',
-				'feedback',
-				{
-					id: response.id,
-					status: 'spam',
-				},
+			await saveResponse(
+				saveEntityRecord,
+				{ id: response.id, status: 'spam' },
 				{ throwOnError: true }
 			);
 

--- a/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/actions.tsx
@@ -12,6 +12,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import { notSpam, spam } from '../../icons/index.ts';
+import { deleteResponse, saveResponse } from '../../response-records.ts';
 import { store as dashboardStore } from '../../store/index.js';
 import { getFormsMenuBadgeSlug, getMenuBadgeCount, withTimeout } from '../utils.js';
 import { optimisticallyUpdateUnreadCount, processStatusChange } from './process-status-change';
@@ -251,8 +252,7 @@ export const markAsSpamAction: Action = {
 			const { itemsUpdated, numberOfErrors } = await processStatusChange( {
 				items,
 				newStatus: 'spam',
-				apiCall: ( id: number ) =>
-					saveEntityRecord( 'postType', 'feedback', { id, status: 'spam' } ),
+				apiCall: ( id: number ) => saveResponse( saveEntityRecord, { id, status: 'spam' } ),
 				editEntityRecord,
 				updateCountsOptimistically,
 				queryParams,
@@ -393,8 +393,7 @@ export const markAsNotSpamAction: Action = {
 			const { itemsUpdated, numberOfErrors } = await processStatusChange( {
 				items,
 				newStatus: 'publish',
-				apiCall: ( id: number ) =>
-					saveEntityRecord( 'postType', 'feedback', { id, status: 'publish' } ),
+				apiCall: ( id: number ) => saveResponse( saveEntityRecord, { id, status: 'publish' } ),
 				editEntityRecord,
 				updateCountsOptimistically,
 				queryParams,
@@ -524,8 +523,7 @@ export const restoreAction: Action = {
 			const { itemsUpdated, numberOfErrors } = await processStatusChange( {
 				items,
 				newStatus,
-				apiCall: ( id: number ) =>
-					saveEntityRecord( 'postType', 'feedback', { id, status: newStatus } ),
+				apiCall: ( id: number ) => saveResponse( saveEntityRecord, { id, status: newStatus } ),
 				editEntityRecord,
 				updateCountsOptimistically,
 				queryParams,
@@ -657,7 +655,7 @@ export const moveToTrashAction: Action = {
 				items,
 				newStatus: 'trash',
 				apiCall: ( id: number ) =>
-					deleteEntityRecord( 'postType', 'feedback', id, {}, { throwOnError: true } ),
+					deleteResponse( deleteEntityRecord, id, {}, { throwOnError: true } ),
 				editEntityRecord,
 				updateCountsOptimistically,
 				queryParams,
@@ -775,7 +773,7 @@ export const deleteAction: Action = {
 
 		const promises = await Promise.allSettled(
 			items.map( ( { id } ) =>
-				deleteEntityRecord( 'postType', 'feedback', id, { force: true }, { throwOnError: true } )
+				deleteResponse( deleteEntityRecord, id, { force: true }, { throwOnError: true } )
 			)
 		);
 

--- a/projects/packages/forms/src/dashboard/response-records.ts
+++ b/projects/packages/forms/src/dashboard/response-records.ts
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+/**
+ * Types
+ */
+import type { APIFetchOptions } from '@wordpress/api-fetch';
+
+/**
+ * Query argument that asks the REST API for the collection field shape.
+ *
+ * The controller falls back to the legacy `label-value` shape whenever
+ * `fields_format` is absent. A write that omits it answers with legacy-shaped
+ * fields, and `@wordpress/core-data` caches that over the good record: the open
+ * response inspector then re-renders without field icons, value badges or
+ * type-specific formatting until the page is reloaded.
+ */
+const FIELDS_FORMAT_QUERY = { fields_format: 'collection' };
+
+const ENTITY = [ 'postType', 'feedback' ] as const;
+
+/**
+ * `apiFetch` that asks for the collection field format.
+ *
+ * `saveEntityRecord()` builds its own request path and takes no query
+ * arguments, so this rides in through its `__unstableFetch` option. (core-data's
+ * `baseURLParams` is not an alternative: resolvers apply it, its write actions
+ * do not.)
+ *
+ * @param options - The apiFetch options supplied by core-data.
+ * @return          The apiFetch promise.
+ */
+const fetchWithFieldsFormat = ( options: APIFetchOptions ) =>
+	apiFetch( { ...options, path: addQueryArgs( options.path, FIELDS_FORMAT_QUERY ) } );
+
+type SaveEntityRecord = (
+	kind: string,
+	name: string,
+	record: Record< string, unknown >,
+	options?: Record< string, unknown >
+) => Promise< unknown >;
+
+type DeleteEntityRecord = (
+	kind: string,
+	name: string,
+	recordId: number,
+	query?: Record< string, unknown >,
+	options?: Record< string, unknown >
+) => Promise< unknown >;
+
+/**
+ * Save a form response, keeping its fields in the shape the dashboard renders.
+ *
+ * Always use this rather than dispatching `saveEntityRecord` for a feedback
+ * record directly — a save without the field format silently degrades the open
+ * inspector.
+ *
+ * Caveat: core-data's `__experimentalBatch` substitutes its own fetch, so a
+ * batched save would drop the format again.
+ *
+ * @param saveEntityRecord - core-data's `saveEntityRecord` dispatcher.
+ * @param record           - The response record to save.
+ * @param options          - Additional `saveEntityRecord` options.
+ * @return                   The dispatch promise.
+ */
+export const saveResponse = (
+	saveEntityRecord: SaveEntityRecord,
+	record: Record< string, unknown >,
+	options: Record< string, unknown > = {}
+) =>
+	saveEntityRecord( ...ENTITY, record, {
+		...options,
+		__unstableFetch: fetchWithFieldsFormat,
+	} );
+
+/**
+ * Delete (or trash) a form response.
+ *
+ * The deleted record never reaches the core-data cache, but the response body
+ * is still serialized, so the format is requested here too for consistency with
+ * `saveResponse()`.
+ *
+ * @param deleteEntityRecord - core-data's `deleteEntityRecord` dispatcher.
+ * @param recordId           - The response ID.
+ * @param query              - Additional query arguments (e.g. `force`).
+ * @param options            - Additional `deleteEntityRecord` options.
+ * @return                     The dispatch promise.
+ */
+export const deleteResponse = (
+	deleteEntityRecord: DeleteEntityRecord,
+	recordId: number,
+	query: Record< string, unknown > = {},
+	options: Record< string, unknown > = {}
+) => deleteEntityRecord( ...ENTITY, recordId, { ...query, ...FIELDS_FORMAT_QUERY }, options );

--- a/projects/packages/forms/tests/js/dashboard/response-records.test.js
+++ b/projects/packages/forms/tests/js/dashboard/response-records.test.js
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { jest } from '@jest/globals';
+
+const apiFetch = jest.fn( () => Promise.resolve( {} ) );
+
+// Native-ESM Jest: `jest.mock()` cannot hoist here, so mock the module registry
+// and import the subject afterwards.
+jest.unstable_mockModule( '@wordpress/api-fetch', () => ( { default: apiFetch } ) );
+
+const { deleteResponse, saveResponse } = await import(
+	'../../../src/dashboard/response-records.ts'
+);
+
+describe( 'response records', () => {
+	beforeEach( () => {
+		apiFetch.mockClear();
+	} );
+
+	describe( 'saveResponse', () => {
+		it( 'targets the feedback entity', async () => {
+			const saveEntityRecord = jest.fn();
+
+			await saveResponse( saveEntityRecord, { id: 17, status: 'spam' } );
+
+			const [ kind, name, record ] = saveEntityRecord.mock.calls[ 0 ];
+			expect( [ kind, name ] ).toEqual( [ 'postType', 'feedback' ] );
+			expect( record ).toEqual( { id: 17, status: 'spam' } );
+		} );
+
+		it( 'requests the collection field format on the path core-data builds', async () => {
+			const saveEntityRecord = jest.fn();
+
+			await saveResponse( saveEntityRecord, { id: 17, status: 'spam' } );
+
+			const { __unstableFetch } = saveEntityRecord.mock.calls[ 0 ][ 3 ];
+			await __unstableFetch( { path: '/wp/v2/feedback/17', method: 'PUT', data: { id: 17 } } );
+
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/wp/v2/feedback/17?fields_format=collection',
+				method: 'PUT',
+				data: { id: 17 },
+			} );
+		} );
+
+		it( 'appends to a path that already carries a query string', async () => {
+			const saveEntityRecord = jest.fn();
+
+			await saveResponse( saveEntityRecord, { id: 17 } );
+
+			const { __unstableFetch } = saveEntityRecord.mock.calls[ 0 ][ 3 ];
+			await __unstableFetch( { path: '/wp/v2/feedback/17?context=edit' } );
+
+			const { path } = apiFetch.mock.calls[ 0 ][ 0 ];
+			expect( path ).toContain( 'context=edit' );
+			expect( path ).toContain( 'fields_format=collection' );
+			// A second "?" would make the query string unparseable.
+			expect( path.indexOf( '?' ) ).toBe( path.lastIndexOf( '?' ) );
+		} );
+
+		it( 'preserves caller options', async () => {
+			const saveEntityRecord = jest.fn();
+
+			await saveResponse( saveEntityRecord, { id: 17 }, { throwOnError: true } );
+
+			expect( saveEntityRecord.mock.calls[ 0 ][ 3 ] ).toEqual(
+				expect.objectContaining( { throwOnError: true } )
+			);
+		} );
+	} );
+
+	describe( 'deleteResponse', () => {
+		it( 'targets the feedback entity and asks for the collection format', async () => {
+			const deleteEntityRecord = jest.fn();
+
+			await deleteResponse( deleteEntityRecord, 17 );
+
+			expect( deleteEntityRecord ).toHaveBeenCalledWith(
+				'postType',
+				'feedback',
+				17,
+				{ fields_format: 'collection' },
+				{}
+			);
+		} );
+
+		it( 'keeps caller query arguments and options', async () => {
+			const deleteEntityRecord = jest.fn();
+
+			await deleteResponse( deleteEntityRecord, 17, { force: true }, { throwOnError: true } );
+
+			expect( deleteEntityRecord ).toHaveBeenCalledWith(
+				'postType',
+				'feedback',
+				17,
+				{ force: true, fields_format: 'collection' },
+				{ throwOnError: true }
+			);
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/fix-forms-fields-format-on-writes
+++ b/projects/plugins/jetpack/changelog/fix-forms-fields-format-on-writes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: keep response field icons and formatting after marking a response as spam.


### PR DESCRIPTION
Fixes FORMS-761

## Proposed changes
* Send `fields_format=collection` on every write to a response record, so a write can no longer replace a cached response with legacy-shaped fields.

The REST controller falls back to the legacy `label-value` field shape whenever `fields_format` is absent:

```php
// class-contact-form-endpoint.php
$fields_format  = $request->get_param( 'fields_format' ) ?? 'label-value';
$data['fields'] = $feedback_response->get_compiled_fields( 'api', $fields_format );
```

Only the list query was sending it. Writes were not: marking a response as spam issues `POST wp/v2/feedback/<id>` with no `fields_format`, so the response body came back legacy-shaped and `@wordpress/core-data` cached it over the good record. The still-open inspector re-rendered, `isFieldsCollection()` now returned false, and `response-fields/index.tsx` fell into its legacy branch — which renders `` `${key}:` `` with no icon element at all. The follow-up list request only refetches `status=draft,publish`, so the now-spam record was never corrected and the panel stayed broken until a page reload.

User-visible effect: after marking a response as spam from the open response, the field **icons disappear**, values lose their badges, and the email/phone/file/rating-specific rendering degrades to plain text. The tell-tale is labels suddenly gaining a trailing colon.

### Implementation

A new `src/dashboard/response-records.ts` exposes two verbs — `saveResponse()` and `deleteResponse()` — used at all 11 feedback write sites across both dashboards (6 in `src/dashboard`, 5 in `routes/responses/actions.tsx`). They encapsulate both the entity (`postType`/`feedback`) and the field format, so the call sites read as one-liners and a future write picks the format up for free:

```ts
saveResponse( saveEntityRecord, { id, status: 'spam' } )
deleteResponse( deleteEntityRecord, id, { force: true }, { throwOnError: true } )
```

The two dispatchers need the parameter delivered differently, which is exactly what the wrappers hide:

* `deleteEntityRecord()` accepts a `query` argument, so the format is merged into it.
* `saveEntityRecord()` builds its own path and takes no query arguments, so the format is applied through core-data's `__unstableFetch` option. (`baseURLParams` is not an option: core-data applies it in resolvers, not in write actions.)

`store/actions.js` already carried a defensive `fields_format: currentQuery ?? previousQuery ?? 'collection'` with the comment "Ensure fields_format is always included". That patched the same bug class for the list query only; this covers the writes.

### Follow-ups, deliberately not in this PR

* The read side still spells `fields_format: 'collection'` inline in ~6 places (`routes/*/route.tsx`, `routes/*/stage.tsx`, `store/reducer.js`, `store/actions.js`) plus the PHP preload. Worth consolidating onto one constant.
* `fields_format` is declared only in `get_collection_params()`, so the item routes accept it purely via query-var fallback — undeclared and unvalidated. Declaring it in the item-route args would make the contract this fix relies on explicit.
* The same server default has already produced two other client-side workarounds (see the comments in `routes/response/stage.tsx` and `routes/response/use-navigation.ts` about avoiding `getEditedEntityRecord`). An apiFetch middleware could retire all three at once; removing those two workarounds would be the acceptance criterion.
* Not changed: the controller's `label-value` default. Flipping it would fix this at the root but changes the public REST contract for any other consumer.

Note that `bulk_actions` is intentionally left alone — it returns an empty array and never serializes response fields. The deleted-record body is likewise never cached by core-data; `deleteResponse()` requests the format for consistency with `saveResponse()` rather than out of necessity.

## Related product discussion/links
* https://linear.app/a8c/issue/FORMS-761/forms-always-request-the-collection-field-format-for-response-records

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Setup: a site with Jetpack Forms and at least one form response in the **inbox** (not spam).

1. Go to **Jetpack → Forms → Responses**.
2. Click **View** on a response to open the detail panel on the right.
3. Confirm each field has an icon to the left of its label, labels have **no** trailing colon, and short values (e.g. a checkbox's "Yes") render in a badge.
4. Click **Spam** in the panel's toolbar (the one inside the opened response).
5. **Before this change:** the panel re-renders without any field icons, every label gains a trailing colon, and the badges disappear until you reload the page.
   **After this change:** the panel keeps its icons, badge and formatting.

Repeat for **Trash**, and for the same actions triggered from a row's action menu rather than the open panel.

To confirm at the network level, open DevTools → Network and filter for `feedback` while performing step 4. The `POST /wp-json/wp/v2/feedback/<id>` request should carry `fields_format=collection`.

Verified live on a Jurassic Ninja site: before the change the panel dropped from 5 collection-rendered fields to 5 legacy-rendered ones on the spam click; after it, it stays at 5 collection-rendered fields and the write request carries the parameter.

