### PR TITLE
Update phpcs packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,13 +112,6 @@
 		"sort-packages": true,
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
-		},
-		"policy": {
-			"advisories": {
-				"ignore-id": [
-					"GHSA-3pwp-g2mj-5p3v"
-				]
-			}
 		}
 	},
 	"require": {

--- a/composer.lock
+++ b/composer.lock
@@ -63,17 +63,17 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/codesniffer",
-                "reference": "0fafab50710c2510e7fc6daba3ea52c6b41dd884"
+                "reference": "de88fc94f6bd01bd589b58798f3bd5a3f6e90782"
             },
             "require": {
                 "automattic/vipwpcs": "^3.0",
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "mediawiki/mediawiki-codesniffer": "^52.0",
+                "mediawiki/mediawiki-codesniffer": "^52.0.1",
                 "php": ">=8.3",
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
                 "phpcsstandards/phpcsutils": "^1.0",
                 "sirbrillig/phpcs-variable-analysis": "^2.10",
-                "wp-coding-standards/wpcs": "^3.0"
+                "wp-coding-standards/wpcs": "^3.4.1"
             },
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",
@@ -247,32 +247,32 @@
         },
         {
             "name": "automattic/vipwpcs",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8"
+                "reference": "9c47cd036754e0e5f354a9914568f052043c3f30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/2b1d206d81b74ed999023cffd924f862ff2753c8",
-                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/9c47cd036754e0e5f354a9914568f052043c3f30",
+                "reference": "9c47cd036754e0e5f354a9914568f052043c3f30",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.2.1",
-                "phpcsstandards/phpcsutils": "^1.0.11",
-                "sirbrillig/phpcs-variable-analysis": "^2.11.18",
-                "squizlabs/php_codesniffer": "^3.9.2",
-                "wp-coding-standards/wpcs": "^3.1.0"
+                "php": ">=7.4",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
+                "sirbrillig/phpcs-variable-analysis": "^2.13.0",
+                "squizlabs/php_codesniffer": "^3.13.5",
+                "wp-coding-standards/wpcs": "^3.4.1"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+                "phpcsstandards/phpcsdevtools": "^1.2.3",
+                "phpunit/phpunit": "^9"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -297,7 +297,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2024-05-10T20:31:09+00:00"
+            "time": "2026-07-27T14:33:48+00:00"
         },
         {
             "name": "composer/pcre",
@@ -785,16 +785,16 @@
         },
         {
             "name": "mediawiki/mediawiki-codesniffer",
-            "version": "v52.0.0",
+            "version": "v52.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wikimedia/mediawiki-tools-codesniffer.git",
-                "reference": "bf16d45cb62ecd614e3d565e3b883a268aeba988"
+                "reference": "940b65ca196ec6ce0d2728a6fc1d69465a4b8ba6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/mediawiki-tools-codesniffer/zipball/bf16d45cb62ecd614e3d565e3b883a268aeba988",
-                "reference": "bf16d45cb62ecd614e3d565e3b883a268aeba988",
+                "url": "https://api.github.com/repos/wikimedia/mediawiki-tools-codesniffer/zipball/940b65ca196ec6ce0d2728a6fc1d69465a4b8ba6",
+                "reference": "940b65ca196ec6ce0d2728a6fc1d69465a4b8ba6",
                 "shasum": ""
             },
             "require": {
@@ -802,7 +802,7 @@
                 "composer/spdx-licenses": "~1.6.0",
                 "ext-mbstring": "*",
                 "php": ">=8.3.0",
-                "phpcsstandards/phpcsextra": "1.5.0",
+                "phpcsstandards/phpcsextra": "1.5.1",
                 "squizlabs/php_codesniffer": "3.13.6"
             },
             "require-dev": {
@@ -830,9 +830,9 @@
                 "mediawiki"
             ],
             "support": {
-                "source": "https://github.com/wikimedia/mediawiki-tools-codesniffer/tree/v52.0.0"
+                "source": "https://github.com/wikimedia/mediawiki-tools-codesniffer/tree/v52.0.1"
             },
-            "time": "2026-08-06T12:11:22+00:00"
+            "time": "2026-08-14T15:19:36+00:00"
         },
         {
             "name": "microsoft/tolerant-php-parser",
@@ -1466,21 +1466,21 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "b598aa890815b8df16363271b659d73280129101"
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
-                "reference": "b598aa890815b8df16363271b659d73280129101",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/39467533fdb742446d68c1d10ac33d625ee0311c",
+                "reference": "39467533fdb742446d68c1d10ac33d625ee0311c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.2.0",
+                "phpcsstandards/phpcsutils": "^1.2.3",
                 "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
             },
             "require-dev": {
@@ -1544,7 +1544,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-12T23:06:57+00:00"
+            "time": "2026-07-27T11:13:17+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
@@ -3123,16 +3123,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab"
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
-                "reference": "469c18ceab4d642b15bad4c65ebf3b307bfd55ab",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/ec2ff942335f33683a5957a85d138753876a05cf",
+                "reference": "ec2ff942335f33683a5957a85d138753876a05cf",
                 "shasum": ""
             },
             "require": {
@@ -3141,8 +3141,8 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=7.2",
-                "phpcsstandards/phpcsextra": "^1.5.0",
-                "phpcsstandards/phpcsutils": "^1.2.2",
+                "phpcsstandards/phpcsextra": "^1.5.1",
+                "phpcsstandards/phpcsutils": "^1.2.3",
                 "squizlabs/php_codesniffer": "^3.13.5"
             },
             "require-dev": {
@@ -3185,7 +3185,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-07-16T13:05:29+00:00"
+            "time": "2026-07-27T11:53:23+00:00"
         }
     ],
     "aliases": [],

--- a/projects/packages/codesniffer/CHANGELOG.md
+++ b/projects/packages/codesniffer/CHANGELOG.md
@@ -6,19 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [8.1.1] - 2026-07-28
-### Fixed
-- Keep the package installable while WPCS 3.4.1 is blocked by mediawiki/mediawiki-codesniffer: cap wp-coding-standards/wpcs below 3.4.1 and ignore the GHSA-3pwp-g2mj-5p3v advisory (the vulnerable sniff is already excluded).
+### Changed
+- Cap wp-coding-standards/wpcs below 3.4.1. [#50867]
 
 ## [8.1.0] - 2026-07-28
 ### Security
-- Exclude the WordPress.WP.EnqueuedResourceParameters sniff from the Jetpack standard: versions of WordPressCS before 3.4.1 pass untrusted code through eval() when the sniff runs (GHSA-3pwp-g2mj-5p3v).
+- Exclude the WordPress.WP.EnqueuedResourceParameters sniff from the Jetpack standard: versions of WordPressCS before 3.4.1 pass untrusted code through eval() when the sniff runs (GHSA-3pwp-g2mj-5p3v). [#50839]
 
 ### Added
 - Add the Jetpack.FeatureFlags.FeatureFlagName sniff to validate feature flag names registered via the jetpack-feature-flags package. [#49698]
 
 ### Changed
 - Bump `minimum_supported_wp_version` in README to 6.9. [#49021]
-- Internal: No longer require automattic/jetpack-changelogger as a per-project dev dependency. [#48225]
 - Update package dependencies. [#50237]
 - Update `Jetpack-Compat-*` rulesets. [#50240]
 

--- a/projects/packages/codesniffer/Jetpack/ruleset.xml
+++ b/projects/packages/codesniffer/Jetpack/ruleset.xml
@@ -3,14 +3,7 @@
 	<description>Jetpack coding standards. Based on the WordPress coding standards, with some additions.</description>
 
 	<rule ref="PHPCompatibilityWP" />
-	<rule ref="WordPress">
-		<!-- Versions of WordPressCS before 3.4.1 pass the `$ver` argument of enqueue/register calls
-		     through `eval()`, allowing arbitrary code execution when scanning untrusted code
-		     (GHSA-3pwp-g2mj-5p3v). WordPressCS 3.4.1 is currently blocked by
-		     mediawiki/mediawiki-codesniffer pinning phpcsstandards/phpcsextra to 1.5.0.
-		     Remove this exclusion once WordPressCS >= 3.4.1 is installable. -->
-		<exclude name="WordPress.WP.EnqueuedResourceParameters" />
-	</rule>
+	<rule ref="WordPress" />
 	<rule ref="VariableAnalysis" />
 
 	<!-- We only include some rules from mediawiki/mediawiki-codesniffer. -->

--- a/projects/packages/codesniffer/changelog/fix-phpcs-filter-duplicated-phpcs-constraint
+++ b/projects/packages/codesniffer/changelog/fix-phpcs-filter-duplicated-phpcs-constraint
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Stop ignoring the php_codesniffer advisory PKSA-rdkp-vv9z-mjkg, as the fixed 3.13.6 release is now installable here.
 
-Stop ignoring the php_codesniffer advisory PKSA-rdkp-vv9z-mjkg, as the fixed 3.13.6 release is now installable here.

--- a/projects/packages/codesniffer/changelog/update-codesniffer-packages
+++ b/projects/packages/codesniffer/changelog/update-codesniffer-packages
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update mediawiki/mediawiki-codesniffer ruleset to v52.0.1.

--- a/projects/packages/codesniffer/changelog/update-codesniffer-packages#2
+++ b/projects/packages/codesniffer/changelog/update-codesniffer-packages#2
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update wp-coding-standards/wpcs ruleset to v3.4.1 and re-enable `WordPress.WP.EnqueuedResourceParameters`.

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -14,10 +14,10 @@
 	"require": {
 		"php": ">=8.3",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-		"mediawiki/mediawiki-codesniffer": "^52.0",
+		"mediawiki/mediawiki-codesniffer": "^52.0.1",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"sirbrillig/phpcs-variable-analysis": "^2.10",
-		"wp-coding-standards/wpcs": "^3.0",
+		"wp-coding-standards/wpcs": "^3.4.1",
 		"automattic/vipwpcs": "^3.0",
 		"phpcsstandards/phpcsutils": "^1.0"
 	},
@@ -73,13 +73,6 @@
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
-		},
-		"policy": {
-			"advisories": {
-				"ignore-id": [
-					"GHSA-3pwp-g2mj-5p3v"
-				]
-			}
 		}
 	}
 }

--- a/projects/packages/scheduled-updates/.phpcs.dir.xml
+++ b/projects/packages/scheduled-updates/.phpcs.dir.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0"?>
 <ruleset>
-	<rule ref="WordPress">
-		<!-- Excluded for security (GHSA-3pwp-g2mj-5p3v), see the exclusion in the Jetpack standard's
-		     ruleset.xml. Remove once WordPressCS >= 3.4.1 is installable. -->
-		<exclude name="WordPress.WP.EnqueuedResourceParameters" />
-	</rule>
-
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">

--- a/projects/packages/scheduled-updates/changelog/update-codesniffer-packages
+++ b/projects/packages/scheduled-updates/changelog/update-codesniffer-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Reenable `WordPress.WP.EnqueuedResourceParameters` now that `wp-coding-standards/wpcs` is updated.
+
+

--- a/projects/packages/stats-admin/changelog/update-codesniffer-packages
+++ b/projects/packages/stats-admin/changelog/update-codesniffer-packages
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix WordPress.WP.EnqueuedResourceParameters in one test file.
+
+

--- a/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
+++ b/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
@@ -32,7 +32,7 @@ class Odyssey_Assets_Test extends Stats_TestCase {
 	 */
 	public function test_odyssey_style_declares_wp_components_dependency() {
 		$this->reset_wp_styles();
-		wp_register_style( 'wp-components', false );
+		wp_register_style( 'wp-components', false, array(), 'irrelevant' );
 		$this->assertFalse( wp_style_is( 'wp-components', 'enqueued' ) );
 
 		// An asset name with no dist/ file forces the CDN branch regardless of what's on disk.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
`mediawiki/mediawiki-codesniffer` released v52.0.1 that updates the `phpcsstandards/phpcsextra` dep to v1.5.1, allowing us to update `wp-coding-standards/wpcs` to get the fix for GHSA-3pwp-g2mj-5p3v.

This allows us to re-enable the `WordPress.WP.EnqueuedResourceParameters` sniff and remove the composer `config.policy.advisories.ignore-id` entries that had been added to keep things working in the mean time.

Also, let's clean up some of the past changelog entries that went into excess detail over internal matters.

P.S. I don't know why `projects/packages/scheduled-updates/.phpcs.dir.xml` had had `<rule ref="WordPress" />` in the first place. At best it's redundant, and at worst it might get things confused over which rules are enabled.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
Following up various recent PRs.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* Did I miss any cleanup?