### PR TITLE
Backup: give the modernized dashboard a first-run state and a working "Back up now"

### DIFF
--- a/projects/packages/backup/changelog/add-backup-first-run-state
+++ b/projects/packages/backup/changelog/add-backup-first-run-state
@@ -1,0 +1,3 @@
+Significance: patch
+Type: added
+Comment: Backup: give the modernized dashboard a first-run state — first backup, in-progress progress bar, error-will-retry and no-good-backups — and wire "Back up now" to the enqueue endpoint. No-op when the modernization filter is off.

--- a/projects/packages/backup/src/dashboard/components/backup-now-button/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-now-button/index.tsx
@@ -1,0 +1,121 @@
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button, Tooltip } from '@wordpress/ui';
+import { useBackups } from '../../hooks/use-backups';
+import { useCapabilities } from '../../hooks/use-capabilities';
+import { useCanQueryWpcom } from '../../hooks/use-connection';
+import { useEnqueueBackup } from '../../hooks/use-enqueue-backup';
+import { useSiteSize } from '../../hooks/use-site-size';
+
+/**
+ * Header action that asks WPCOM to back the site up now.
+ *
+ * Ports the legacy button's label and tooltip cycle
+ * (`src/js/components/back-up-now/index.jsx`) onto the modernized data
+ * layer, with two behavioural fixes.
+ *
+ * Failures are reported. The legacy click handler has no rejection
+ * handler and discards the response body, so every outcome — including a
+ * WPCOM refusal and a permissions error — shows "Backup enqueued".
+ *
+ * The button gates itself. `DashboardLayout` passes header actions to
+ * `<Page>`, which renders them above `<Gates>` rather than inside it, so
+ * an unconnected or unlicensed site would otherwise be offered a control
+ * that cannot work.
+ *
+ * @return The rendered button, or null when the site can't use it.
+ */
+export default function BackupNowButton() {
+	const canQuery = useCanQueryWpcom();
+	const capabilities = useCapabilities( { enabled: canQuery } );
+	const { backupsStopped } = useSiteSize();
+	const { state: enqueueState, errorMessage, enqueue, reset } = useEnqueueBackup();
+
+	// Keep polling between the enqueue and WPCOM publishing a record for
+	// it: until that record exists, nothing in the response says a backup
+	// is coming.
+	const { state: backupsState } = useBackups( { forcePoll: enqueueState === 'enqueued' } );
+	const isBackupRunning = backupsState === 'in-progress';
+
+	// Hand over from "enqueued" to "in progress" once the backup actually
+	// starts, which also ends the forced polling above — from here the
+	// backups query polls on its own because the state says it should.
+	useEffect( () => {
+		if ( isBackupRunning && enqueueState === 'enqueued' ) {
+			reset();
+		}
+	}, [ isBackupRunning, enqueueState, reset ] );
+
+	const hasPlan =
+		! capabilities.isLoading && ! capabilities.error && capabilities.data?.hasBackupPlan;
+	if ( ! canQuery || ! hasPlan ) {
+		return null;
+	}
+
+	const isEnqueuing = enqueueState === 'enqueuing';
+	const isEnqueued = enqueueState === 'enqueued';
+
+	// First match wins, mirroring the legacy precedence chain. `__()`
+	// returns a branded string type carrying the literal it was called
+	// with, so the accumulator has to be widened to plain `string` before
+	// a differently-worded label can be assigned to it.
+	let label: string = __( 'Back up now', 'jetpack-backup-pkg' );
+	let tooltip: string | null = null;
+	if ( backupsStopped ) {
+		tooltip = __( 'Cannot queue backups due to reaching storage limits.', 'jetpack-backup-pkg' );
+	} else if ( isBackupRunning ) {
+		label = __( 'Backup in progress', 'jetpack-backup-pkg' );
+		tooltip = __( 'A backup is currently in progress.', 'jetpack-backup-pkg' );
+	} else if ( isEnqueuing ) {
+		label = __( 'Queueing backup', 'jetpack-backup-pkg' );
+	} else if ( isEnqueued ) {
+		label = __( 'Backup enqueued', 'jetpack-backup-pkg' );
+		tooltip = __( 'A backup has been queued and will start shortly.', 'jetpack-backup-pkg' );
+	} else if ( enqueueState === 'error' ) {
+		// Stays enabled: the label invites a retry and the reason is one
+		// hover away. Legacy has no branch here at all.
+		tooltip = errorMessage;
+	}
+
+	const disabled = isEnqueuing || isEnqueued || isBackupRunning || backupsStopped;
+
+	const button = (
+		<Button
+			variant="outline"
+			tone="neutral"
+			disabled={ disabled }
+			// Scoped to the request itself, never to the running backup.
+			// `loading` paints the label `color: transparent` and overlays a
+			// spinner — it keeps the button's width so the header doesn't
+			// jump, but it also hides the text, which is only acceptable for
+			// the second the POST is in flight. A backup runs for minutes,
+			// and "Backup in progress" is the whole point of that state.
+			loading={ isEnqueuing }
+			loadingAnnouncement={ label }
+			onClick={ enqueue }
+		>
+			{ label }
+		</Button>
+	);
+
+	if ( ! tooltip ) {
+		return button;
+	}
+
+	return (
+		<Tooltip.Root>
+			{ /*
+			 * `Tooltip.Trigger` renders a `button` of its own, which cannot
+			 * wrap ours, so it is rendered as a `span` instead. The span is
+			 * deliberately not made focusable: `@wordpress/ui`'s Button
+			 * defaults to `focusableWhenDisabled`, so it stays in the tab
+			 * order and marks itself `aria-disabled` rather than taking the
+			 * native `disabled` attribute — which means it still emits the
+			 * pointer and focus events the tooltip anchors on, and adding a
+			 * `tabIndex` here would only create a second tab stop.
+			 */ }
+			<Tooltip.Trigger render={ <span className="jpb-backup-now" /> }>{ button }</Tooltip.Trigger>
+			<Tooltip.Popup>{ tooltip }</Tooltip.Popup>
+		</Tooltip.Root>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/backup-status/banner.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/banner.tsx
@@ -1,0 +1,50 @@
+import { ProgressBar } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { Stack, Text } from '@wordpress/ui';
+import './style.scss';
+
+type Props = {
+	/** Completion of the running backup, 0–100. */
+	progress: number;
+};
+
+/**
+ * Strip shown above the activity list while a backup runs on a site that
+ * already has restore points.
+ *
+ * Deliberately non-destructive: the legacy dashboard replaces its whole
+ * body whenever a backup is in flight, which hides a perfectly usable
+ * list of restore points for the several minutes a routine backup takes.
+ * Here the list stays, and the running backup is reported alongside it.
+ *
+ * @param props          - Component props.
+ * @param props.progress - Completion of the running backup, 0–100.
+ * @return The rendered banner.
+ */
+export default function BackupStatusBanner( { progress }: Props ) {
+	return (
+		<Stack
+			className="jpb-backup-status-banner"
+			direction="row"
+			align="center"
+			gap="md"
+			// `ProgressBar` renders a native `<progress value max>`, so the
+			// value itself is already exposed. What isn't is that the row
+			// updates on a timer without any user action, so announce it
+			// politely rather than leaving it to be discovered.
+			aria-live="polite"
+		>
+			<Text variant="body-sm">
+				{ __( 'Your backup will be ready soon', 'jetpack-backup-pkg' ) }
+			</Text>
+			<ProgressBar className="jpb-backup-status-banner__bar" value={ progress } />
+			<Text variant="body-sm" className="jpb-text-muted">
+				{ sprintf(
+					/* translators: %d: how much of the running backup is complete, as a percentage. */
+					__( '%d%%', 'jetpack-backup-pkg' ),
+					progress
+				) }
+			</Text>
+		</Stack>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/backup-status/banner.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/banner.tsx
@@ -23,18 +23,18 @@ type Props = {
  */
 export default function BackupStatusBanner( { progress }: Props ) {
 	return (
-		<Stack
-			className="jpb-backup-status-banner"
-			direction="row"
-			align="center"
-			gap="md"
-			// `ProgressBar` renders a native `<progress value max>`, so the
-			// value itself is already exposed. What isn't is that the row
-			// updates on a timer without any user action, so announce it
-			// politely rather than leaving it to be discovered.
-			aria-live="polite"
-		>
-			<Text variant="body-sm">
+		<Stack className="jpb-backup-status-banner" direction="row" align="center" gap="md">
+			{ /*
+			 * The live region is deliberately just this line, not the row.
+			 * What is worth announcing is that a backup started; the
+			 * percentage is already exposed by the native `<progress>` the
+			 * bar renders, and wrapping the row would re-announce it on
+			 * every poll — dozens of interruptions over the minutes a
+			 * backup runs, which is exactly what the ARIA practices warn
+			 * against for frequently-updating values. This text does not
+			 * change while the banner is mounted, so it speaks once.
+			 */ }
+			<Text variant="body-sm" aria-live="polite">
 				{ __( 'Your backup will be ready soon', 'jetpack-backup-pkg' ) }
 			</Text>
 			<ProgressBar className="jpb-backup-status-banner__bar" value={ progress } />

--- a/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
@@ -1,0 +1,142 @@
+import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
+import { ProgressBar } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { cloudUpload, error as errorIcon } from '@wordpress/icons';
+import { EmptyState, Link, Text } from '@wordpress/ui';
+import { useSiteSuffix } from '../../hooks/use-connection';
+import './style.scss';
+import type { BackupsState } from '../../types/backup';
+
+type Props = {
+	state: BackupsState;
+	/** Completion of the running backup, 0–100. */
+	progress: number;
+};
+
+/**
+ * Whether this state should take over the Overview body entirely.
+ *
+ * A site with no usable restore point has nothing for the two-pane
+ * layout to show — the activity list would render its own "No results"
+ * and the detail pane would ask the reader to select a row that does not
+ * exist. A backup running on a site that *does* have restore points is
+ * the opposite case: the list stays useful, so that one gets a banner
+ * instead and is handled by `<BackupStatusBanner>`.
+ *
+ * @param state           - Derived backup state.
+ * @param isInitialBackup - Whether the site is still waiting for its first restore point.
+ * @return True when the panel replaces the Overview body.
+ */
+export function replacesOverview( state: BackupsState, isInitialBackup: boolean ): boolean {
+	if ( state === 'in-progress' ) {
+		return isInitialBackup;
+	}
+	return state === 'no-backups' || state === 'will-retry' || state === 'no-good-backups';
+}
+
+/**
+ * Full-width panel shown in place of the Overview body while the site
+ * has no restore point to show.
+ *
+ * Covers the three first-run states — nothing recorded yet, a first
+ * backup running, and a first attempt that failed and will be retried —
+ * plus the "none of the attempts worked" state, which is the only one
+ * that needs a way to reach support.
+ *
+ * Without this the modernized dashboard reads `/site/rewindable-activity`
+ * only, which lists completed restore points, so every one of these
+ * states renders as DataViews' bare "No results" — leaving a site whose
+ * backups are failing indistinguishable from a healthy new one.
+ *
+ * @param props          - Component props.
+ * @param props.state    - Derived backup state.
+ * @param props.progress - Completion of the running backup, 0–100.
+ * @return The rendered panel.
+ */
+export default function BackupStatusPanel( { state, progress }: Props ) {
+	const siteSuffix = useSiteSuffix();
+
+	if ( state === 'no-good-backups' ) {
+		return (
+			<EmptyState.Root className="jpb-backup-status">
+				<EmptyState.Visual>
+					<EmptyState.Icon icon={ errorIcon } />
+				</EmptyState.Visual>
+				<EmptyState.Title>
+					{ __( "We're having trouble backing up your site", 'jetpack-backup-pkg' ) }
+				</EmptyState.Title>
+				<EmptyState.Description>
+					{ createInterpolateElement(
+						__(
+							'<a>Get in touch with us</a> to get your site backups going again.',
+							'jetpack-backup-pkg'
+						),
+						{
+							a: (
+								<Link
+									openInNewTab
+									href={ getRedirectUrl( 'jetpack-contact-support', { site: siteSuffix } ) }
+								/>
+							),
+						}
+					) }
+				</EmptyState.Description>
+			</EmptyState.Root>
+		);
+	}
+
+	// Only a running backup has a percentage worth drawing. A retryable
+	// failure reports the percentage the attempt died at, which would read
+	// as a stalled backup rather than one waiting to be retried; and a
+	// site with no records at all has nothing to report, where an
+	// indeterminate bar is worse than none — the track is ~1.5px tall, so
+	// with no filled portion to give it contrast it reads as a stray
+	// divider rule under the heading.
+	const showProgress = state === 'in-progress';
+
+	return (
+		<EmptyState.Root className="jpb-backup-status">
+			<EmptyState.Visual>
+				<EmptyState.Icon icon={ cloudUpload } />
+			</EmptyState.Visual>
+			<EmptyState.Title>
+				{ __( 'Your first cloud backup will be ready soon', 'jetpack-backup-pkg' ) }
+			</EmptyState.Title>
+			{ showProgress && (
+				<div className="jpb-backup-status__progress">
+					<ProgressBar className="jpb-backup-status__bar" value={ progress } />
+					<Text variant="body-sm" className="jpb-text-muted">
+						{ sprintf(
+							/* translators: %d: how much of the running backup is complete, as a percentage. */
+							__( '%d%%', 'jetpack-backup-pkg' ),
+							progress
+						) }
+					</Text>
+				</div>
+			) }
+			<EmptyState.Description>
+				{ __(
+					'The first backup usually takes a few minutes, so it will become available soon.',
+					'jetpack-backup-pkg'
+				) }
+			</EmptyState.Description>
+			<EmptyState.Description>
+				{ createInterpolateElement(
+					__(
+						'In the meanwhile, you can start getting familiar with your <a>backup management on Jetpack.com</a>.',
+						'jetpack-backup-pkg'
+					),
+					{
+						a: (
+							<Link
+								openInNewTab
+								href={ getRedirectUrl( 'jetpack-backup', { site: siteSuffix } ) }
+							/>
+						),
+					}
+				) }
+			</EmptyState.Description>
+		</EmptyState.Root>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
@@ -24,11 +24,29 @@ type Props = {
  * the opposite case: the list stays useful, so that one gets a banner
  * instead and is handled by `<BackupStatusBanner>`.
  *
- * @param state           - Derived backup state.
- * @param isInitialBackup - Whether the site is still waiting for its first restore point.
+ * `hasRestorePoints` is the veto, and it matters because the two sources
+ * disagree by design. This state is derived from `/jetpack/v4/backups`,
+ * which reports only VaultPress's most recent handful of rows and has
+ * the scan-only rows filtered out of that window — so a site whose last
+ * few attempts failed can report `no-good-backups` while the activity
+ * log still lists restore points from earlier in the retention window.
+ * Taking the body over there would hide the restore points at the exact
+ * moment someone came looking for them, which is the same class of
+ * mistake as the empty state this panel exists to replace.
+ *
+ * @param state            - Derived backup state.
+ * @param isInitialBackup  - Whether the site is still waiting for its first restore point.
+ * @param hasRestorePoints - Whether the activity log has a backup to show. Pass true when not yet known.
  * @return True when the panel replaces the Overview body.
  */
-export function replacesOverview( state: BackupsState, isInitialBackup: boolean ): boolean {
+export function replacesOverview(
+	state: BackupsState,
+	isInitialBackup: boolean,
+	hasRestorePoints: boolean
+): boolean {
+	if ( hasRestorePoints ) {
+		return false;
+	}
 	if ( state === 'in-progress' ) {
 		return isInitialBackup;
 	}

--- a/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
@@ -86,14 +86,16 @@ export default function BackupStatusPanel( { state, progress }: Props ) {
 		);
 	}
 
-	// Only a running backup has a percentage worth drawing. A retryable
-	// failure reports the percentage the attempt died at, which would read
-	// as a stalled backup rather than one waiting to be retried; and a
-	// site with no records at all has nothing to report, where an
-	// indeterminate bar is worse than none — the track is ~1.5px tall, so
-	// with no filled portion to give it contrast it reads as a stray
-	// divider rule under the heading.
-	const showProgress = state === 'in-progress';
+	// A retryable failure is the one state with nothing to show: WPCOM
+	// reports the percentage the attempt died at, which would read as a
+	// stalled backup rather than one waiting to be retried.
+	//
+	// `no-backups` still gets a bar, in indeterminate mode. The heading
+	// promises a backup is coming, so a panel with no sign of activity
+	// contradicts itself — and this is the state a brand-new customer
+	// sits in, watching. Only a running backup has a real percentage.
+	const showProgress = state !== 'will-retry';
+	const isDeterminate = state === 'in-progress';
 
 	return (
 		<EmptyState.Root className="jpb-backup-status">
@@ -105,14 +107,21 @@ export default function BackupStatusPanel( { state, progress }: Props ) {
 			</EmptyState.Title>
 			{ showProgress && (
 				<div className="jpb-backup-status__progress">
-					<ProgressBar className="jpb-backup-status__bar" value={ progress } />
-					<Text variant="body-sm" className="jpb-text-muted">
-						{ sprintf(
-							/* translators: %d: how much of the running backup is complete, as a percentage. */
-							__( '%d%%', 'jetpack-backup-pkg' ),
-							progress
-						) }
-					</Text>
+					{ /* Omitting `value` is what puts ProgressBar into its
+					     animated indeterminate mode. */ }
+					<ProgressBar
+						className="jpb-backup-status__bar"
+						value={ isDeterminate ? progress : undefined }
+					/>
+					{ isDeterminate && (
+						<Text variant="body-sm" className="jpb-text-muted">
+							{ sprintf(
+								/* translators: %d: how much of the running backup is complete, as a percentage. */
+								__( '%d%%', 'jetpack-backup-pkg' ),
+								progress
+							) }
+						</Text>
+					) }
 				</div>
 			) }
 			<EmptyState.Description>

--- a/projects/packages/backup/src/dashboard/components/backup-status/style.scss
+++ b/projects/packages/backup/src/dashboard/components/backup-status/style.scss
@@ -1,0 +1,45 @@
+// The first-run panel replaces the Overview's two-pane grid entirely, so
+// it lands directly inside `.jpb-dashboard-body__inner` — the same slot
+// the gate screens occupy, and it is sized to match them.
+// `EmptyState.Root`'s own `align-items: center` centers its children
+// inside the box, not the box inside its parent: it ships
+// `margin-inline: 0`, so in this dashboard's 1344px ribbon it would hug
+// the left edge. `.jpb-gates__card` solves the same problem the same way.
+.jpb-backup-status {
+	margin-block: 48px;
+	margin-inline: auto;
+	max-inline-size: 560px;
+
+	&__progress {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		inline-size: 100%;
+	}
+
+	// `EmptyState` centers its children, which would otherwise shrink the
+	// bar to its intrinsic width. Let it take the row and keep the
+	// percentage readout beside it.
+	&__bar {
+		flex: 1 1 auto;
+		min-inline-size: 0;
+	}
+}
+
+// The in-progress strip sits above the two-pane grid rather than inside
+// it: `.jpb-overview` is a two-column grid at >= 961px, so a third child
+// would be auto-placed into the layout and push the detail pane onto its
+// own row. Wrapping it here keeps that grid untouched.
+.jpb-backup-status-banner {
+	box-sizing: border-box;
+	inline-size: 100%;
+	margin-block-end: 16px;
+	padding: 12px 16px;
+	border-radius: 8px;
+	background-color: var(--wp-components-color-background-secondary, #f7f7f7);
+
+	&__bar {
+		flex: 1 1 auto;
+		min-inline-size: 0;
+	}
+}

--- a/projects/packages/backup/src/dashboard/components/backup-status/style.scss
+++ b/projects/packages/backup/src/dashboard/components/backup-status/style.scss
@@ -65,7 +65,15 @@
 	margin-block-end: 16px;
 	padding: 12px 16px;
 	border-radius: 8px;
-	background-color: var(--wp-components-color-background-secondary, #f7f7f7);
+	// `--wp-components-color-background-secondary` is used elsewhere in
+	// this dashboard but is declared by nothing — not by
+	// `@wordpress/components`, `/ui`, `/theme` or `/base-styles` — so it
+	// only ever resolves to its hardcoded fallback and never follows the
+	// admin colour scheme. This one is real, ships in `@wordpress/theme`,
+	// and is what `EmptyState.Icon` uses for the same job. No fallback: the
+	// design-system build injects those, and the linter rejects hand-written
+	// ones because they go stale.
+	background-color: var(--wpds-color-background-surface-neutral-weak);
 
 	// Matches the panel's bar so the two readings of "a backup is running"
 	// look like the same control — including the specificity bump, for the

--- a/projects/packages/backup/src/dashboard/components/backup-status/style.scss
+++ b/projects/packages/backup/src/dashboard/components/backup-status/style.scss
@@ -10,19 +10,48 @@
 	margin-inline: auto;
 	max-inline-size: 560px;
 
+	// `EmptyState.Root` stacks its children on a 4px gap, which is right
+	// for consecutive lines of text but leaves the bar reading as an
+	// underline welded to the heading. Give the row its own space.
 	&__progress {
 		display: flex;
 		align-items: center;
 		gap: 12px;
 		inline-size: 100%;
+		margin-block: 12px;
 	}
 
 	// `EmptyState` centers its children, which would otherwise shrink the
 	// bar to its intrinsic width. Let it take the row and keep the
-	// percentage readout beside it.
-	&__bar {
+	// percentage readout beside it. The stock track is 1.5px tall, which
+	// reads as a divider rule rather than a progress element — most of all
+	// in indeterminate mode, where there is no filled portion to give it
+	// contrast.
+	// Deliberately scoped under `&__progress` rather than written flat.
+	// `@wordpress/components` styles the track through a runtime-injected
+	// emotion class of equal specificity, and emotion appends to `<head>`
+	// after the bundled stylesheet — so a flat `&__bar` rule would lose on
+	// source order no matter where this file sits in the build. One extra
+	// class wins it without reaching for `!important`.
+	&__progress &__bar {
 		flex: 1 1 auto;
 		min-inline-size: 0;
+		block-size: 4px;
+		border-radius: 2px;
+		overflow: hidden;
+
+		// ProgressBar's filled indicator is an absolutely-positioned
+		// `inline-block` that declares no `left`, so it lands on its static
+		// position — which, for an inline-level box, `text-align` decides.
+		// `EmptyState.Root` centers its contents, and that inherits in here
+		// and drags the filled portion to the middle of the track. Only
+		// visible on the determinate bar; the indeterminate one animates
+		// `left` explicitly and so is immune.
+		text-align: start;
+
+		> * {
+			block-size: 100%;
+		}
 	}
 }
 
@@ -38,8 +67,18 @@
 	border-radius: 8px;
 	background-color: var(--wp-components-color-background-secondary, #f7f7f7);
 
-	&__bar {
+	// Matches the panel's bar so the two readings of "a backup is running"
+	// look like the same control — including the specificity bump, for the
+	// same reason.
+	& &__bar {
 		flex: 1 1 auto;
 		min-inline-size: 0;
+		block-size: 4px;
+		border-radius: 2px;
+		overflow: hidden;
+
+		> * {
+			block-size: 100%;
+		}
 	}
 }

--- a/projects/packages/backup/src/dashboard/data/api/backups.ts
+++ b/projects/packages/backup/src/dashboard/data/api/backups.ts
@@ -1,0 +1,71 @@
+import { apiCall, apiPath } from './_helpers';
+
+/**
+ * One entry of `GET /jetpack/v4/backups`, exactly as it arrives.
+ *
+ * `Jetpack_Backup::get_recent_backups()` hands WPCOM's body through
+ * untouched, and WPCOM serializes VaultPress's MySQL rows directly — so
+ * integer and boolean columns come back as strings. The hand-authored
+ * fixtures in the legacy tree use real numbers for the same fields, so
+ * both spellings are live and every numeric field is typed as the union.
+ * Coerce through `data/normalize/backups.ts` rather than reading these
+ * fields directly.
+ */
+export type RawBackupEntry = {
+	id: string | number;
+	started: string;
+	last_updated: string;
+	status: string;
+	period: string | number;
+	percent: string | number;
+	is_backup: string | number;
+	is_scan: string | number;
+	has_snapshot?: boolean;
+	has_warnings?: boolean;
+	/** `'0'` | `'1'` — a string, and only present on finished entries. */
+	discarded?: string;
+	/** Only present on finished entries, and can legitimately be `{}`. */
+	stats?: Record< string, unknown >;
+};
+
+/**
+ * Fetch the site's ten most recent backup attempts.
+ *
+ * **`null` is a reachable, non-exceptional response.**
+ * `Jetpack_Backup::get_recent_backups()` returns bare `null` on any
+ * non-200 from WPCOM, which WordPress serves as HTTP 200 with a `null`
+ * body — so `apiFetch` resolves rather than rejecting and no `ApiError`
+ * is ever constructed. Callers must treat `null` as a failure to read
+ * the state, never as "this site has no backups": conflating the two
+ * renders a WPCOM outage as the brand-new-customer screen.
+ *
+ * @return The backup list, or `null` when WPCOM could not be read.
+ */
+export async function fetchBackups(): Promise< RawBackupEntry[] | null > {
+	return apiCall< RawBackupEntry[] | null >( { path: apiPath( '/backups' ) } );
+}
+
+/**
+ * Response of `POST /jetpack/v4/site/backup/enqueue`.
+ *
+ * Two different failures are encoded in the body rather than the status
+ * code: `null` for any non-200 WPCOM reply (same mechanism as
+ * `fetchBackups`), and `{ success: false, error }` for a 200 that WPCOM
+ * nonetheless refused. Only the second carries a reason.
+ */
+export type EnqueueBackupResponse = {
+	success?: boolean;
+	error?: string;
+} | null;
+
+/**
+ * Ask WPCOM to run a backup now.
+ *
+ * @return WPCOM's reply, or `null` when it could not be read.
+ */
+export async function enqueueBackup(): Promise< EnqueueBackupResponse > {
+	return apiCall< EnqueueBackupResponse >( {
+		path: apiPath( '/site/backup/enqueue' ),
+		method: 'POST',
+	} );
+}

--- a/projects/packages/backup/src/dashboard/data/api/site-size.ts
+++ b/projects/packages/backup/src/dashboard/data/api/site-size.ts
@@ -1,0 +1,26 @@
+import { apiCall, apiPath } from './_helpers';
+
+/**
+ * Response of `GET /jetpack/v4/site/backup/size`.
+ *
+ * WPCOM's own envelope, forwarded verbatim: `ok` reports whether WPCOM
+ * itself could answer, so a 200 with `ok: false` carries no usable
+ * figures. Like the other legacy routes, a non-200 upstream collapses to
+ * a `null` body served with HTTP 200.
+ */
+export type RawSiteSize = {
+	ok?: boolean;
+	backups_stopped?: boolean;
+	size?: number;
+	last_backup_size?: number;
+	storage_limit_bytes?: number;
+} | null;
+
+/**
+ * Fetch the site's backup storage usage.
+ *
+ * @return WPCOM's payload, or `null` when it could not be read.
+ */
+export async function fetchSiteSize(): Promise< RawSiteSize > {
+	return apiCall< RawSiteSize >( { path: apiPath( '/site/backup/size' ) } );
+}

--- a/projects/packages/backup/src/dashboard/data/normalize/backups.ts
+++ b/projects/packages/backup/src/dashboard/data/normalize/backups.ts
@@ -1,0 +1,90 @@
+import type { Backup } from '../../types/backup';
+import type { RawBackupEntry } from '../api/backups';
+
+/**
+ * Coerce WPCOM's stringly-typed numerics to a number.
+ *
+ * `percent` arrives as `"10"` from WPCOM and as `10` from the legacy
+ * fixtures. `Number( undefined )` is `NaN`, which would silently poison
+ * a progress bar, so anything unparseable becomes 0.
+ *
+ * @param value - Raw field value.
+ * @return A finite number, defaulting to 0.
+ */
+function toNumber( value: unknown ): number {
+	const parsed = Number( value );
+	return Number.isFinite( parsed ) ? parsed : 0;
+}
+
+/**
+ * Coerce WPCOM's stringly-typed booleans.
+ *
+ * The wire carries `"1"` / `"0"` for `is_backup`, `is_scan` and
+ * `discarded`. A plain truthiness test would read `"0"` as true, since
+ * every non-empty string is truthy — the single most likely way to get
+ * this wrong.
+ *
+ * @param value - Raw field value.
+ * @return The boolean meaning, defaulting to false when absent.
+ */
+function toBoolean( value: unknown ): boolean {
+	if ( typeof value === 'string' ) {
+		return value !== '' && value !== '0';
+	}
+	return Boolean( value );
+}
+
+/**
+ * Convert one raw entry into the UI's `Backup` shape.
+ *
+ * `isDiscarded` defaults to **false** when the field is absent, which is
+ * a deliberate divergence from the legacy hook. There, the check is
+ * `'0' === backup.discarded`, so an absent field reads as *discarded*.
+ * That only ever fires on non-finished entries — which are excluded a
+ * step earlier anyway — so the two agree in practice, but the legacy
+ * spelling arrives at the right answer by accident and inverts the
+ * meaning of a missing field.
+ *
+ * Timestamps are deliberately not carried over. `started` and
+ * `last_updated` are MySQL `DATETIME` strings in UTC with no offset
+ * designator, and both `new Date()` and `@wordpress/date` parse that as
+ * browser-local — the legacy hook appends `'+00:00'` before handing the
+ * value over for exactly this reason. Anything adding these fields must
+ * normalize them at this boundary rather than at the point of display.
+ *
+ * @param entry - Raw WPCOM entry.
+ * @return The normalized backup.
+ */
+export function normalizeBackup( entry: RawBackupEntry ): Backup {
+	return {
+		id: String( entry.id ),
+		status: entry.status,
+		percent: toNumber( entry.percent ),
+		isBackup: toBoolean( entry.is_backup ),
+		isDiscarded: toBoolean( entry.discarded ),
+		hasStats: Boolean( entry.stats && Object.keys( entry.stats ).length > 0 ),
+	};
+}
+
+/**
+ * Normalize the backup list, dropping the scan-only rows.
+ *
+ * This endpoint returns scan records alongside backups, distinguished
+ * only by `is_backup` / `is_scan`. The legacy hook reads `backups[0]` as
+ * "the latest backup" without filtering, so on a site with Scan a scan
+ * row can stand in for a backup; `my-jetpack` filters on `is_backup`
+ * before taking the latest, and that is the behaviour ported here.
+ *
+ * Order is preserved. WPCOM returns newest first, which every consumer
+ * in the repo relies on — including the legacy hook's "only the first
+ * backup can be in progress".
+ *
+ * @param entries - Raw WPCOM entries, or undefined before the first load.
+ * @return Normalized backups, newest first.
+ */
+export function normalizeBackups( entries: RawBackupEntry[] | undefined ): Backup[] {
+	if ( ! entries ) {
+		return [];
+	}
+	return entries.map( normalizeBackup ).filter( backup => backup.isBackup );
+}

--- a/projects/packages/backup/src/dashboard/data/normalize/test/backups.test.ts
+++ b/projects/packages/backup/src/dashboard/data/normalize/test/backups.test.ts
@@ -1,0 +1,92 @@
+import { normalizeBackup, normalizeBackups } from '../backups';
+import type { RawBackupEntry } from '../../api/backups';
+
+/**
+ * A finished backup in the shape WPCOM actually sends — every numeric
+ * and boolean column quoted, because the payload is a straight
+ * serialization of VaultPress's MySQL rows.
+ *
+ * @param overrides - Fields to replace.
+ * @return A raw entry.
+ */
+function entry( overrides: Partial< RawBackupEntry > = {} ): RawBackupEntry {
+	return {
+		id: '923254903',
+		started: '2026-08-13 18:08:56',
+		last_updated: '2026-08-13 18:54:14',
+		status: 'finished',
+		period: '1786644531',
+		percent: '100',
+		is_backup: '1',
+		is_scan: '1',
+		discarded: '0',
+		stats: { prefix: 'wp_' },
+		...overrides,
+	};
+}
+
+describe( 'normalizeBackup', () => {
+	it( 'coerces the quoted numerics WPCOM sends', () => {
+		const backup = normalizeBackup( entry( { percent: '10', id: 12345 } ) );
+
+		expect( backup.percent ).toBe( 10 );
+		expect( backup.id ).toBe( '12345' );
+	} );
+
+	it( 'falls back to 0 for an unparseable percentage', () => {
+		expect( normalizeBackup( entry( { percent: 'n/a' } ) ).percent ).toBe( 0 );
+	} );
+
+	// The single most likely way to get this port wrong: every non-empty
+	// string is truthy, so a plain `Boolean( '0' )` reads "not discarded"
+	// as "discarded" and classifies every good backup as unusable.
+	it( 'reads the string "0" as false, not as a truthy string', () => {
+		expect( normalizeBackup( entry( { discarded: '0' } ) ).isDiscarded ).toBe( false );
+		expect( normalizeBackup( entry( { discarded: '1' } ) ).isDiscarded ).toBe( true );
+	} );
+
+	it( 'treats an absent `discarded` as not discarded', () => {
+		expect( normalizeBackup( entry( { discarded: undefined } ) ).isDiscarded ).toBe( false );
+	} );
+
+	it( 'accepts the numeric spelling of the same fields', () => {
+		const backup = normalizeBackup( entry( { percent: 42, is_backup: 1 } ) );
+
+		expect( backup.percent ).toBe( 42 );
+		expect( backup.isBackup ).toBe( true );
+	} );
+
+	it( 'reports an empty `stats` object as having no stats', () => {
+		// WPCOM ships finished entries with `stats: {}`. They carry no
+		// restore point, and the legacy hook's truthiness check lets them
+		// through and then throws dereferencing `stats.plugins.count`.
+		expect( normalizeBackup( entry( { stats: {} } ) ).hasStats ).toBe( false );
+		expect( normalizeBackup( entry( { stats: undefined } ) ).hasStats ).toBe( false );
+		expect( normalizeBackup( entry() ).hasStats ).toBe( true );
+	} );
+} );
+
+describe( 'normalizeBackups', () => {
+	it( 'returns an empty list when nothing has loaded', () => {
+		expect( normalizeBackups( undefined ) ).toEqual( [] );
+	} );
+
+	it( 'drops scan-only rows so the newest entry is really the newest backup', () => {
+		const result = normalizeBackups( [
+			entry( { id: 'scan', is_backup: '0', is_scan: '1' } ),
+			entry( { id: 'backup' } ),
+		] );
+
+		expect( result ).toHaveLength( 1 );
+		expect( result[ 0 ].id ).toBe( 'backup' );
+	} );
+
+	it( 'preserves WPCOM order, which is newest first', () => {
+		const result = normalizeBackups( [
+			entry( { id: 'newest', status: 'started' } ),
+			entry( { id: 'older' } ),
+		] );
+
+		expect( result.map( backup => backup.id ) ).toEqual( [ 'newest', 'older' ] );
+	} );
+} );

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -32,6 +32,11 @@ export const queryClient = new QueryClient( {
  */
 export const keys = {
 	capabilities: () => [ 'backup', 'capabilities' ] as const,
+	// The site's recent backup attempts, from the unconditionally
+	// registered `/jetpack/v4/backups`. Polled while a backup runs, so it
+	// deliberately does not share the activity-log family's key.
+	backups: () => [ 'backup', 'backups' ] as const,
+	siteSize: () => [ 'backup', 'site-size' ] as const,
 	// Family prefix for any rewindable-activity-log page. Use as a
 	// query-filter root to scan all cached pages (e.g. when looking up
 	// a row by id across pages).

--- a/projects/packages/backup/src/dashboard/hooks/test/use-backups.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-backups.test.ts
@@ -1,0 +1,209 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, type ReactNode } from 'react';
+import { isUsableBackup, isWillRetryStatus, summarizeBackups, useBackups } from '../use-backups';
+import type { RawBackupEntry } from '../../data/api/backups';
+import type { Backup } from '../../types/backup';
+
+jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+/**
+ * A normalized backup, defaulting to a usable restore point.
+ *
+ * @param overrides - Fields to replace.
+ * @return A backup.
+ */
+function backup( overrides: Partial< Backup > = {} ): Backup {
+	return {
+		id: '1',
+		status: 'finished',
+		percent: 100,
+		isBackup: true,
+		isDiscarded: false,
+		hasStats: true,
+		...overrides,
+	};
+}
+
+describe( 'isWillRetryStatus', () => {
+	it( 'matches the whole retryable family, not just `error-will-retry`', () => {
+		// The legacy client compares against `error-will-retry` alone,
+		// while WPCOM ships `<reason>-will-retry` variants that it silently
+		// fails to recognize.
+		expect( isWillRetryStatus( 'error-will-retry' ) ).toBe( true );
+		expect( isWillRetryStatus( 'credential-error-will-retry' ) ).toBe( true );
+		expect( isWillRetryStatus( 'finished' ) ).toBe( false );
+		expect( isWillRetryStatus( 'not-accessible' ) ).toBe( false );
+	} );
+} );
+
+describe( 'isUsableBackup', () => {
+	it( 'requires finished, with stats, and not discarded', () => {
+		expect( isUsableBackup( backup() ) ).toBe( true );
+		expect( isUsableBackup( backup( { status: 'started' } ) ) ).toBe( false );
+		expect( isUsableBackup( backup( { hasStats: false } ) ) ).toBe( false );
+		expect( isUsableBackup( backup( { isDiscarded: true } ) ) ).toBe( false );
+	} );
+} );
+
+describe( 'summarizeBackups', () => {
+	it( 'reports a site with no records as the first run', () => {
+		expect( summarizeBackups( [] ) ).toEqual( {
+			state: 'no-backups',
+			progress: 0,
+			isInitialBackup: true,
+		} );
+	} );
+
+	it( 'reports a first backup in flight, with its progress', () => {
+		const summary = summarizeBackups( [
+			backup( { status: 'started', percent: 10, hasStats: false } ),
+		] );
+
+		expect( summary.state ).toBe( 'in-progress' );
+		expect( summary.progress ).toBe( 10 );
+		expect( summary.isInitialBackup ).toBe( true );
+	} );
+
+	it( 'does not call a backup the first one when restore points already exist', () => {
+		const summary = summarizeBackups( [
+			backup( { id: 'running', status: 'started', percent: 30, hasStats: false } ),
+			backup( { id: 'done' } ),
+		] );
+
+		expect( summary.state ).toBe( 'in-progress' );
+		expect( summary.isInitialBackup ).toBe( false );
+	} );
+
+	it( 'clamps a percentage outside the range a progress bar can use', () => {
+		expect(
+			summarizeBackups( [ backup( { status: 'started', percent: 150, hasStats: false } ) ] )
+				.progress
+		).toBe( 100 );
+	} );
+
+	it( 'reports a retry while there is nothing good to fall back on', () => {
+		expect(
+			summarizeBackups( [
+				backup( { status: 'error-will-retry', hasStats: false } ),
+				backup( { status: 'error-will-retry', hasStats: false } ),
+			] ).state
+			// The legacy check is `backups.length === 1 && …`, so a second
+			// failed attempt makes this state disappear entirely.
+		).toBe( 'will-retry' );
+	} );
+
+	it( 'stays `complete` when a failed attempt follows a good backup', () => {
+		// From the reader's point of view the site is still backed up.
+		expect(
+			summarizeBackups( [
+				backup( { status: 'error-will-retry', hasStats: false } ),
+				backup( { id: 'good' } ),
+			] ).state
+		).toBe( 'complete' );
+	} );
+
+	it( 'reports discarded and stats-less backups as no good backups', () => {
+		expect( summarizeBackups( [ backup( { isDiscarded: true } ) ] ).state ).toBe(
+			'no-good-backups'
+		);
+		expect( summarizeBackups( [ backup( { hasStats: false } ) ] ).state ).toBe( 'no-good-backups' );
+		expect(
+			summarizeBackups( [ backup( { status: 'not-accessible', hasStats: false } ) ] ).state
+		).toBe( 'no-good-backups' );
+	} );
+
+	it( 'reports a usable restore point as complete', () => {
+		expect( summarizeBackups( [ backup() ] ).state ).toBe( 'complete' );
+	} );
+} );
+
+/**
+ * Fresh client per test so the module singleton's cache can't leak, and
+ * no retries so an error assertion doesn't wait out react-query's backoff.
+ *
+ * @return A wrapper providing an isolated QueryClient.
+ */
+function makeWrapper() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	const wrapper = ( { children }: { children: ReactNode } ) =>
+		createElement( QueryClientProvider, { client }, children );
+	return { client, wrapper };
+}
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+beforeEach( () => {
+	mockedApiFetch.mockReset();
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'useBackups', () => {
+	it( 'derives state from the list', async () => {
+		const raw: RawBackupEntry[] = [
+			{
+				id: '1',
+				started: '2026-08-14 17:25:46',
+				last_updated: '2026-08-14 17:36:04',
+				status: 'started',
+				period: '1786728342',
+				percent: '10',
+				is_backup: '1',
+				is_scan: '1',
+			},
+		];
+		mockedApiFetch.mockResolvedValue( raw );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useBackups(), { wrapper } );
+
+		await waitFor( () => expect( result.current.state ).toBe( 'in-progress' ) );
+		expect( result.current.progress ).toBe( 10 );
+		expect( result.current.isInitialBackup ).toBe( true );
+	} );
+
+	// The regression this hook exists to avoid. `get_recent_backups()`
+	// returns bare `null` on any non-200 from WPCOM, which WordPress
+	// serves as HTTP 200 — so the request RESOLVES and no error is ever
+	// thrown. The legacy selector coerces that to `[]`, which reads as
+	// "this site has no backups" and shows a paying customer the
+	// brand-new-site screen every time WPCOM has a bad minute.
+	it( 'reports a null body as an error rather than as an empty site', async () => {
+		mockedApiFetch.mockResolvedValue( null );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useBackups(), { wrapper } );
+
+		await waitFor( () => expect( result.current.state ).toBe( 'error' ) );
+		expect( result.current.state ).not.toBe( 'no-backups' );
+	} );
+
+	it( 'reports a genuinely empty list as the first run', async () => {
+		mockedApiFetch.mockResolvedValue( [] );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useBackups(), { wrapper } );
+
+		await waitFor( () => expect( result.current.state ).toBe( 'no-backups' ) );
+	} );
+
+	it( 'asks WPCOM nothing when the site has no user connection', async () => {
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			connectionStatus: { isRegistered: false, hasConnectedOwner: false, isUserConnected: false },
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useBackups(), { wrapper } );
+
+		expect( result.current.state ).toBe( 'loading' );
+		expect( mockedApiFetch ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-enqueue-backup.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-enqueue-backup.test.ts
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, type ReactNode } from 'react';
+import { useEnqueueBackup } from '../use-enqueue-backup';
+
+jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+/**
+ * Fresh client per test, with retries off so a failure assertion doesn't
+ * wait out react-query's backoff.
+ *
+ * @return A wrapper providing an isolated QueryClient.
+ */
+function makeWrapper() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	const wrapper = ( { children }: { children: ReactNode } ) =>
+		createElement( QueryClientProvider, { client }, children );
+	return { client, wrapper };
+}
+
+beforeEach( () => {
+	mockedApiFetch.mockReset();
+} );
+
+describe( 'useEnqueueBackup', () => {
+	it( 'reports success when WPCOM accepts the request', async () => {
+		mockedApiFetch.mockResolvedValue( { success: true } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useEnqueueBackup(), { wrapper } );
+		act( () => result.current.enqueue() );
+
+		await waitFor( () => expect( result.current.state ).toBe( 'enqueued' ) );
+		expect( mockedApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( { path: '/jetpack/v4/site/backup/enqueue', method: 'POST' } )
+		);
+	} );
+
+	// `enqueue_backup()` returns bare `null` for every non-200 from WPCOM,
+	// which WordPress serves as HTTP 200 — so the request resolves and
+	// nothing throws. The legacy button has no rejection handler and
+	// discards the body, so it reports "Backup enqueued" and then polls
+	// for a backup that was never queued.
+	it( 'reports a null body as a failure, not a success', async () => {
+		mockedApiFetch.mockResolvedValue( null );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useEnqueueBackup(), { wrapper } );
+		act( () => result.current.enqueue() );
+
+		await waitFor( () => expect( result.current.state ).toBe( 'error' ) );
+		expect( result.current.errorMessage ).toBe( 'Could not start a backup. Please try again.' );
+	} );
+
+	it( 'surfaces the reason when WPCOM refuses inside a 200', async () => {
+		mockedApiFetch.mockResolvedValue( { success: false, error: 'Backups are not enabled.' } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useEnqueueBackup(), { wrapper } );
+		act( () => result.current.enqueue() );
+
+		await waitFor( () => expect( result.current.state ).toBe( 'error' ) );
+		expect( result.current.errorMessage ).toBe( 'Backups are not enabled.' );
+	} );
+
+	it( 'reports a rejected request as a failure', async () => {
+		mockedApiFetch.mockRejectedValue( {
+			code: 'rest_forbidden',
+			message: 'Sorry, you are not allowed.',
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useEnqueueBackup(), { wrapper } );
+		act( () => result.current.enqueue() );
+
+		await waitFor( () => expect( result.current.state ).toBe( 'error' ) );
+		expect( result.current.errorMessage ).toBe( 'Sorry, you are not allowed.' );
+	} );
+
+	it( 'invalidates the backups query so the list starts reflecting the new backup', async () => {
+		mockedApiFetch.mockResolvedValue( { success: true } );
+		const { client, wrapper } = makeWrapper();
+		const invalidate = jest.spyOn( client, 'invalidateQueries' );
+
+		const { result } = renderHook( () => useEnqueueBackup(), { wrapper } );
+		act( () => result.current.enqueue() );
+
+		await waitFor( () => expect( result.current.state ).toBe( 'enqueued' ) );
+		expect( invalidate ).toHaveBeenCalledWith( { queryKey: [ 'backup', 'backups' ] } );
+	} );
+
+	it( 'goes back to idle on reset, so the button can be tried again', async () => {
+		mockedApiFetch.mockResolvedValue( null );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useEnqueueBackup(), { wrapper } );
+		act( () => result.current.enqueue() );
+		await waitFor( () => expect( result.current.state ).toBe( 'error' ) );
+
+		act( () => result.current.reset() );
+
+		await waitFor( () => expect( result.current.state ).toBe( 'idle' ) );
+		expect( result.current.errorMessage ).toBeNull();
+	} );
+} );

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -168,6 +168,35 @@ export function useDefaultBackupRewindId(): string | null {
 }
 
 /**
+ * Whether the newest page of rewindable activity holds any backup row,
+ * and whether that is known yet.
+ *
+ * Shares the page-1 query with `useDefaultBackupRewindId`, so it costs
+ * no extra request.
+ *
+ * This is a second, independent opinion on "does this site have a
+ * restore point". `/jetpack/v4/backups` only reports VaultPress's most
+ * recent handful of rows, and scan-only rows are filtered out of that
+ * window — so it can say "nothing usable" for a site that still has
+ * perfectly good restore points a little further back. The activity log
+ * is paginated over the full retention window and does not have that
+ * blind spot.
+ *
+ * @return Whether a restore point is visible, and whether the answer has loaded.
+ */
+export function useHasRestorePoints(): { hasRestorePoints: boolean; isLoading: boolean } {
+	const query = useActivityPageQuery( 1, ACTIVITY_LOG_DEFAULT_PER_PAGE );
+	const hasRestorePoints = useMemo(
+		() =>
+			normalizeActivityLog( query.data?.current?.orderedItems ).some(
+				item => item.kind === 'backup'
+			),
+		[ query.data ]
+	);
+	return { hasRestorePoints, isLoading: query.isLoading };
+}
+
+/**
  * Scan a raw WPCOM `orderedItems` array for a row matching the given
  * selection id. Backup rows are addressed by `rewindId`, others by
  * `activity_id` — `normalizeActivityLog` is run on the matched slice

--- a/projects/packages/backup/src/dashboard/hooks/use-backups.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backups.ts
@@ -177,8 +177,16 @@ type Result = BackupsSummary & {
  * React Query hook exposing the site's backup state.
  *
  * Reads `GET /jetpack/v4/backups`, which is registered unconditionally
- * and signed with the blog token — so unlike the modernized bridges it
- * needs no new PHP and survives a user token going stale.
+ * and signed with the blog token, so unlike the modernized bridges it
+ * needs no new PHP.
+ *
+ * That route would in fact answer without a user-level WPCOM connection
+ * — its permission callback is a bare `manage_options` check. The query
+ * is gated on one anyway, because every screen that reads this hook sits
+ * behind `<Gates>`, which blocks the page for those users regardless:
+ * issuing the request would only spend a round trip on a page nobody is
+ * going to see. The looser route is a property worth knowing about if a
+ * future caller does need to read backups outside the gate.
  *
  * @param args           - Hook args.
  * @param args.forcePoll - Poll regardless of derived state.

--- a/projects/packages/backup/src/dashboard/hooks/use-backups.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backups.ts
@@ -1,0 +1,233 @@
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useMemo } from '@wordpress/element';
+import { fetchBackups, type RawBackupEntry } from '../data/api/backups';
+import { normalizeBackups } from '../data/normalize/backups';
+import { keys } from '../data/query-client';
+import { useCanQueryWpcom } from './use-connection';
+import type { Backup, BackupsState } from '../types/backup';
+
+/**
+ * How often to re-read the backup list while something is expected to
+ * change.
+ *
+ * The legacy dashboard polls every second. Every tick is a full WPCOM
+ * round-trip through the Jetpack proxy, sustained for the entire length
+ * of a backup and multiplied by every open tab, so this port backs off
+ * to five seconds — still live enough for a progress bar that moves in
+ * whole percent.
+ */
+export const BACKUPS_POLL_INTERVAL_MS = 5000;
+
+/** WPCOM's retryable-failure statuses share this suffix. */
+const WILL_RETRY_SUFFIX = '-will-retry';
+
+export type BackupsSummary = {
+	state: BackupsState;
+	/**
+	 * Completion of the running backup, 0–100. Only meaningful while
+	 * `state` is `in-progress`; 0 otherwise.
+	 */
+	progress: number;
+	/**
+	 * Whether the site is still waiting for its very first usable
+	 * restore point. Drives first-run copy.
+	 */
+	isInitialBackup: boolean;
+};
+
+/**
+ * Whether a status means "this attempt failed, WPCOM will try again".
+ *
+ * Matched on the suffix rather than against `error-will-retry` alone:
+ * WPCOM ships a family of `<reason>-will-retry` statuses, and the legacy
+ * client's exact-equality check silently misses every member but one.
+ *
+ * @param status - Raw status string.
+ * @return True for any retryable-failure status.
+ */
+export function isWillRetryStatus( status: string ): boolean {
+	return status.endsWith( WILL_RETRY_SUFFIX );
+}
+
+/**
+ * Whether a backup can actually be restored from.
+ *
+ * All three conditions matter: an unfinished attempt has no restore
+ * point, a finished one with empty `stats` is a WPCOM bookkeeping row
+ * rather than a real backup, and a discarded one has aged out of the
+ * retention window.
+ *
+ * @param backup - Normalized backup.
+ * @return True when the backup is a usable restore point.
+ */
+export function isUsableBackup( backup: Backup ): boolean {
+	return backup.status === 'finished' && backup.hasStats && ! backup.isDiscarded;
+}
+
+/**
+ * Clamp WPCOM's reported percentage into the range a progress bar can use.
+ *
+ * @param percent - Normalized percentage.
+ * @return An integer in [0, 100].
+ */
+function clampPercent( percent: number ): number {
+	return Math.min( 100, Math.max( 0, Math.round( percent ) ) );
+}
+
+/**
+ * Reduce the backup list to the single state the dashboard renders.
+ *
+ * Ported from the legacy `useBackupsState`, with three deliberate
+ * differences.
+ *
+ * A site with no records at all reports `isInitialBackup: true`. The
+ * legacy hook only ever sets that flag inside the branch that requires
+ * at least one record, so the emptiest possible site — the literal first
+ * run — is the one case that gets the generic "Your backup will be ready
+ * soon" copy instead of the first-backup copy.
+ *
+ * Retryable failures are recognized however many records exist. The
+ * legacy check is `backups.length === 1 && …`, so a second failed
+ * attempt makes the state vanish.
+ *
+ * A running backup no longer erases a completed one. The legacy hook
+ * reassigns its `latestBackup` to the in-flight record, which drops the
+ * stats and timestamp of the good backup that already exists; here the
+ * two facts are reported side by side via `isInitialBackup`.
+ *
+ * @param backups - Normalized backups, newest first, scan rows removed.
+ * @return The derived state.
+ */
+export function summarizeBackups( backups: Backup[] ): BackupsSummary {
+	if ( backups.length === 0 ) {
+		return { state: 'no-backups', progress: 0, isInitialBackup: true };
+	}
+
+	// WPCOM returns newest first, and only the newest attempt can be running.
+	const newest = backups[ 0 ];
+	const hasUsableBackup = backups.some( isUsableBackup );
+
+	if ( newest.status === 'started' ) {
+		return {
+			state: 'in-progress',
+			progress: clampPercent( newest.percent ),
+			isInitialBackup: ! hasUsableBackup,
+		};
+	}
+
+	// Only report a retry while there is nothing good to fall back on.
+	// A site with restore points and one failed attempt behind it is
+	// still, from the user's point of view, backed up.
+	if ( ! hasUsableBackup && isWillRetryStatus( newest.status ) ) {
+		return { state: 'will-retry', progress: 0, isInitialBackup: true };
+	}
+
+	if ( hasUsableBackup ) {
+		return { state: 'complete', progress: 0, isInitialBackup: false };
+	}
+
+	return { state: 'no-good-backups', progress: 0, isInitialBackup: true };
+}
+
+/**
+ * Whether the list is worth re-reading on a timer.
+ *
+ * @param data      - Whatever the query currently holds.
+ * @param forcePoll - Caller override, used right after enqueuing a backup.
+ * @return The poll interval in ms, or false to stop polling.
+ */
+function pollInterval(
+	data: RawBackupEntry[] | null | undefined,
+	forcePoll: boolean
+): number | false {
+	if ( forcePoll ) {
+		return BACKUPS_POLL_INTERVAL_MS;
+	}
+	if ( ! Array.isArray( data ) ) {
+		// Nothing loaded, or WPCOM could not be read. Retrying on a timer
+		// would hammer a failing upstream, so wait to be asked.
+		return false;
+	}
+	const { state } = summarizeBackups( normalizeBackups( data ) );
+	return state === 'no-backups' || state === 'in-progress' ? BACKUPS_POLL_INTERVAL_MS : false;
+}
+
+type Args = {
+	/**
+	 * Keep polling regardless of the derived state. Used between
+	 * enqueuing a backup and WPCOM publishing a record for it, a window
+	 * in which nothing in the response says "something is coming".
+	 */
+	forcePoll?: boolean;
+};
+
+type Result = BackupsSummary & {
+	backups: Backup[];
+	/**
+	 * The query's own failure. Note that the most common failure mode of
+	 * this route does *not* populate it: a non-200 from WPCOM is served
+	 * as HTTP 200 with a `null` body, which resolves. Branch on
+	 * `state === 'error'`, which covers both.
+	 */
+	error: Error | null;
+	refetch: () => void;
+};
+
+/**
+ * React Query hook exposing the site's backup state.
+ *
+ * Reads `GET /jetpack/v4/backups`, which is registered unconditionally
+ * and signed with the blog token — so unlike the modernized bridges it
+ * needs no new PHP and survives a user token going stale.
+ *
+ * @param args           - Hook args.
+ * @param args.forcePoll - Poll regardless of derived state.
+ * @return The derived state plus the normalized list.
+ */
+export function useBackups( { forcePoll = false }: Args = {} ): Result {
+	const enabled = useCanQueryWpcom();
+	const query = useQuery( {
+		queryKey: keys.backups(),
+		queryFn: fetchBackups,
+		enabled,
+		refetchInterval: ( { state } ) => pollInterval( state.data, forcePoll ),
+	} );
+
+	const { data, error, refetch } = query;
+
+	const backups = useMemo(
+		() => normalizeBackups( Array.isArray( data ) ? data : undefined ),
+		[ data ]
+	);
+
+	const summary = useMemo< BackupsSummary >( () => {
+		// `undefined` is "not asked yet" — either the first request is in
+		// flight or the query is disabled because the site has no
+		// user-level connection. `null` is "asked, and WPCOM could not
+		// answer", which must never be mistaken for an empty site.
+		if ( data === undefined ) {
+			return {
+				state: error ? 'error' : 'loading',
+				progress: 0,
+				isInitialBackup: false,
+			};
+		}
+		if ( ! Array.isArray( data ) ) {
+			return { state: 'error', progress: 0, isInitialBackup: false };
+		}
+		return summarizeBackups( backups );
+	}, [ data, error, backups ] );
+
+	// Wrapped so callers can hand it straight to `onClick` without
+	// returning a floating promise from the event handler.
+	const retry = useCallback( () => {
+		refetch();
+	}, [ refetch ] );
+
+	return {
+		...summary,
+		backups,
+		error: error ?? null,
+		refetch: retry,
+	};
+}

--- a/projects/packages/backup/src/dashboard/hooks/use-connection.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-connection.ts
@@ -59,6 +59,22 @@ export function useConnection(): Result {
 }
 
 /**
+ * The site's Calypso slug, e.g. `example.wordpress.com`.
+ *
+ * Read from the same connection global as `useConnection`, and used to
+ * scope Jetpack redirect links to this site. Returns undefined when the
+ * global is missing, in which case callers should emit an unscoped
+ * redirect rather than a broken one — `getRedirectUrl` omits the query
+ * arg for an undefined `site`.
+ *
+ * @return The site slug, or undefined.
+ */
+export function useSiteSuffix(): string | undefined {
+	const state = typeof window !== 'undefined' ? window.JP_CONNECTION_INITIAL_STATE : undefined;
+	return state?.siteSuffix || undefined;
+}
+
+/**
  * Whether this browser session can usefully call the Backup bridges.
  *
  * Every bridge route runs `Rest_Controller::permission_check()`, which

--- a/projects/packages/backup/src/dashboard/hooks/use-enqueue-backup.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-enqueue-backup.ts
@@ -1,0 +1,84 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { ApiError } from '../data/api/_helpers';
+import { enqueueBackup } from '../data/api/backups';
+import { keys } from '../data/query-client';
+
+export type EnqueueState = 'idle' | 'enqueuing' | 'enqueued' | 'error';
+
+type Result = {
+	state: EnqueueState;
+	/** User-facing reason the enqueue failed, or null. */
+	errorMessage: string | null;
+	enqueue: () => void;
+	reset: () => void;
+};
+
+/**
+ * React Query mutation that asks WPCOM to run a backup now.
+ *
+ * `POST /jetpack/v4/site/backup/enqueue` reports failure in three
+ * different ways and only one of them is an HTTP error, so the success
+ * path is validated rather than assumed. A rejected request (no
+ * permission, network, expired nonce) throws. A non-200 from WPCOM is
+ * flattened by PHP into HTTP 200 with a `null` body, which resolves.
+ * And WPCOM can answer 200 with `{ success: false, error }`.
+ *
+ * The legacy button checks none of these — it has no rejection handler
+ * and discards the body — so it reports "Backup enqueued" for every
+ * outcome, then polls for a backup that will never arrive.
+ *
+ * @return Enqueue state and controls.
+ */
+export function useEnqueueBackup(): Result {
+	const queryClient = useQueryClient();
+
+	const mutation = useMutation( {
+		mutationFn: async () => {
+			const result = await enqueueBackup();
+			if ( result === null ) {
+				throw new ApiError(
+					'backup_enqueue_failed',
+					__( 'Could not start a backup. Please try again.', 'jetpack-backup-pkg' )
+				);
+			}
+			if ( result.success === false ) {
+				throw new ApiError(
+					'backup_enqueue_failed',
+					result.error || __( 'Could not start a backup. Please try again.', 'jetpack-backup-pkg' )
+				);
+			}
+			return result;
+		},
+		// Awaited before the mutation settles, so the button never reports
+		// "enqueued" while the list it polls is still the stale one.
+		onSuccess: () => queryClient.invalidateQueries( { queryKey: keys.backups() } ),
+	} );
+
+	const { mutate, reset: resetMutation, isPending, isError, isSuccess, error } = mutation;
+
+	const enqueue = useCallback( () => {
+		mutate();
+	}, [ mutate ] );
+
+	const reset = useCallback( () => {
+		resetMutation();
+	}, [ resetMutation ] );
+
+	let state: EnqueueState = 'idle';
+	if ( isPending ) {
+		state = 'enqueuing';
+	} else if ( isError ) {
+		state = 'error';
+	} else if ( isSuccess ) {
+		state = 'enqueued';
+	}
+
+	return {
+		state,
+		errorMessage: isError ? error?.message ?? null : null,
+		enqueue,
+		reset,
+	};
+}

--- a/projects/packages/backup/src/dashboard/hooks/use-site-size.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-site-size.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchSiteSize } from '../data/api/site-size';
+import { keys } from '../data/query-client';
+import { useCanQueryWpcom } from './use-connection';
+
+const SITE_SIZE_STALE_MS = 5 * 60_000;
+
+type Result = {
+	/**
+	 * Whether WPCOM has stopped backing this site up, currently because
+	 * it is out of storage. Defaults to false whenever the answer is
+	 * unknown — an unreadable storage figure must not be allowed to
+	 * disable a control that would otherwise work.
+	 */
+	backupsStopped: boolean;
+	isLoading: boolean;
+};
+
+/**
+ * React Query hook exposing WPCOM's "backups stopped" flag.
+ *
+ * The legacy dashboard reads the same flag, but only as a side effect of
+ * rendering its storage meter — so its "Back up now" button stays
+ * enabled until an unrelated component further down the page happens to
+ * finish fetching. This owns the request instead.
+ *
+ * Note this is WPCOM's server-side flag, not the client-side
+ * `StorageUsageLevels.Full` derivation the legacy overview computes from
+ * size and policies. The two can disagree; the button has always used
+ * the server flag.
+ *
+ * @return The stopped flag and its loading state.
+ */
+export function useSiteSize(): Result {
+	const query = useQuery( {
+		queryKey: keys.siteSize(),
+		queryFn: fetchSiteSize,
+		staleTime: SITE_SIZE_STALE_MS,
+		enabled: useCanQueryWpcom(),
+	} );
+
+	// `ok` is WPCOM's own success flag inside a 200 response; without it
+	// the sibling fields carry no meaning.
+	const backupsStopped = Boolean( query.data?.ok && query.data?.backups_stopped );
+
+	return { backupsStopped, isLoading: query.isLoading };
+}

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -1,17 +1,20 @@
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { calendar } from '@wordpress/icons';
 import { useNavigate, useSearch } from '@wordpress/route';
-import { Button, Stack, Text } from '@wordpress/ui';
+import { Text } from '@wordpress/ui';
 import ActivityDetail from '../components/activity-detail';
 import ActivityList from '../components/activity-list';
 import BackupDetail from '../components/backup-detail';
+import BackupNowButton from '../components/backup-now-button';
+import BackupStatusPanel, { replacesOverview } from '../components/backup-status';
+import BackupStatusBanner from '../components/backup-status/banner';
 import DashboardLayout from '../components/dashboard-layout';
 import {
 	ACTIVITY_LOG_DEFAULT_PER_PAGE,
 	useActivityById,
 	useDefaultBackupRewindId,
 } from '../hooks/use-activity-log';
+import { useBackups } from '../hooks/use-backups';
 import { isBackupItem } from '../types/activity';
 import type { View } from '@wordpress/dataviews';
 
@@ -62,6 +65,10 @@ export default function OverviewScreen() {
 	// fetch when the list is on page 1 with the default per-page.
 	const defaultSelectedId = useDefaultBackupRewindId();
 	const selectedId = typeof search.selected === 'string' ? search.selected : defaultSelectedId;
+	// `/site/rewindable-activity` only lists completed restore points, so
+	// on its own it cannot tell "no backups yet" from "the first one is
+	// running" from "they're all failing". This second query answers that.
+	const { state: backupsState, progress, isInitialBackup } = useBackups();
 
 	const setSelected = useCallback(
 		( id: string ) => {
@@ -73,21 +80,24 @@ export default function OverviewScreen() {
 		[ navigate, search ]
 	);
 
+	if ( replacesOverview( backupsState, isInitialBackup ) ) {
+		return (
+			<DashboardLayout actions={ <BackupNowButton /> }>
+				<BackupStatusPanel state={ backupsState } progress={ progress } />
+			</DashboardLayout>
+		);
+	}
+
 	return (
-		<DashboardLayout
-			actions={
-				<Stack direction="row" gap="sm">
-					<Button variant="outline" tone="neutral">
-						<Button.Icon icon={ calendar } />
-						{ /* Placeholder copy for the upcoming date-range filter — not translated until the real UI lands. */ }
-						Apr 16, 2026 to May 15, 2026
-					</Button>
-					<Button variant="outline" tone="neutral">
-						{ __( 'Back up now', 'jetpack-backup-pkg' ) }
-					</Button>
-				</Stack>
-			}
-		>
+		<DashboardLayout actions={ <BackupNowButton /> }>
+			{ /*
+			 * A backup running on a site that already has restore points is
+			 * reported alongside the list rather than in place of it. The
+			 * banner is a sibling of `.jpb-overview` — not a child — because
+			 * that element is a two-column grid above 960px, and a third
+			 * child would be auto-placed into it.
+			 */ }
+			{ backupsState === 'in-progress' && <BackupStatusBanner progress={ progress } /> }
 			<div className="jpb-overview">
 				<ActivityList
 					selectedId={ selectedId }

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -13,6 +13,7 @@ import {
 	ACTIVITY_LOG_DEFAULT_PER_PAGE,
 	useActivityById,
 	useDefaultBackupRewindId,
+	useHasRestorePoints,
 } from '../hooks/use-activity-log';
 import { useBackups } from '../hooks/use-backups';
 import { isBackupItem } from '../types/activity';
@@ -69,6 +70,12 @@ export default function OverviewScreen() {
 	// on its own it cannot tell "no backups yet" from "the first one is
 	// running" from "they're all failing". This second query answers that.
 	const { state: backupsState, progress, isInitialBackup } = useBackups();
+	// A second opinion on whether anything is restorable, from the
+	// paginated activity log rather than the short `/backups` window.
+	// While it is still unknown, assume there *are* restore points:
+	// briefly showing the two-pane view is a milder error than briefly
+	// telling an established customer they have no backups.
+	const { hasRestorePoints, isLoading: restorePointsLoading } = useHasRestorePoints();
 
 	const setSelected = useCallback(
 		( id: string ) => {
@@ -80,7 +87,9 @@ export default function OverviewScreen() {
 		[ navigate, search ]
 	);
 
-	if ( replacesOverview( backupsState, isInitialBackup ) ) {
+	if (
+		replacesOverview( backupsState, isInitialBackup, restorePointsLoading || hasRestorePoints )
+	) {
 		return (
 			<DashboardLayout actions={ <BackupNowButton /> }>
 				<BackupStatusPanel state={ backupsState } progress={ progress } />

--- a/projects/packages/backup/src/dashboard/types/backup.ts
+++ b/projects/packages/backup/src/dashboard/types/backup.ts
@@ -1,0 +1,80 @@
+/**
+ * Statuses seen on `GET /jetpack/v4/backups`.
+ *
+ * The list is descriptive, not exhaustive — WPCOM adds statuses without
+ * notice, and `my-jetpack` already matches a whole *family* of them with
+ * `preg_match( '/-will-retry$/', … )` rather than an equality test. The
+ * union is therefore widened with `string` so unknown values type-check,
+ * and every consumer must keep a fallback branch.
+ */
+export type KnownBackupStatus =
+	| 'started'
+	| 'finished'
+	| 'error-will-retry'
+	| 'not-accessible'
+	| 'no-credentials'
+	| 'no-credentials-atomic'
+	| 'credential-error'
+	| 'http-only-error'
+	| 'backups-deactivated'
+	| 'error';
+
+export type BackupStatus = KnownBackupStatus | ( string & {} );
+
+/**
+ * A single backup attempt, normalized from the wire shape.
+ *
+ * WPCOM serializes VaultPress's MySQL rows straight to JSON, so numeric
+ * and boolean columns arrive as strings (`percent: "10"`, `discarded:
+ * "0"`, `is_backup: "1"`). Everything here is already coerced — see
+ * `data/normalize/backups.ts`.
+ */
+export type Backup = {
+	/**
+	 * WPCOM's internal VaultPress attempt id. Deliberately not used to
+	 * address a backup: no other endpoint resolves it, and restore /
+	 * download key off the rewind id instead.
+	 */
+	id: string;
+	status: BackupStatus;
+	/** 0–100, not 0–1. */
+	percent: number;
+	/** False for the scan-only rows this endpoint also returns. */
+	isBackup: boolean;
+	/** True once WPCOM has aged the backup out of the retention window. */
+	isDiscarded: boolean;
+	/** Whether the entry carries a populated `stats` object. */
+	hasStats: boolean;
+};
+
+/**
+ * What the dashboard knows about the site's backups right now.
+ *
+ * `loading` — the first request is still in flight.
+ *
+ * `error` — the request failed, or WPCOM answered with something we
+ * can't read. Distinct from `no-backups`: "we couldn't ask" must never be
+ * rendered as "you have none".
+ *
+ * `no-backups` — the site has no backup records at all. Every new
+ * customer starts here.
+ *
+ * `in-progress` — a backup is running now.
+ *
+ * `will-retry` — the only attempts so far failed, and WPCOM will try
+ * again on its own.
+ *
+ * `no-good-backups` — attempts exist but none produced a usable restore
+ * point, and nothing is running. This is the state that needs a support
+ * link.
+ *
+ * `complete` — at least one usable restore point exists.
+ */
+export type BackupsState =
+	| 'loading'
+	| 'error'
+	| 'no-backups'
+	| 'in-progress'
+	| 'will-retry'
+	| 'no-good-backups'
+	| 'complete';

--- a/projects/packages/backup/tests/first-run-state.test.tsx
+++ b/projects/packages/backup/tests/first-run-state.test.tsx
@@ -1,0 +1,269 @@
+// Tests for the first-run backup state (JETPACK-2243 E1/E2).
+//
+// The state machine itself is unit-tested in
+// `src/dashboard/hooks/test/use-backups.test.ts`; this file covers what
+// a reader actually ends up looking at, and the "Back up now" state
+// table ported from the legacy button.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factory above.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BackupNowButton from '../src/dashboard/components/backup-now-button';
+import BackupStatusPanel, { replacesOverview } from '../src/dashboard/components/backup-status';
+import BackupStatusBanner from '../src/dashboard/components/backup-status/banner';
+import type { ReactNode } from 'react';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+/**
+ * Render inside an isolated QueryClient.
+ *
+ * @param ui - The tree to render.
+ * @return The testing-library render result.
+ */
+function renderWithClient( ui: ReactNode ) {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	return render( <QueryClientProvider client={ client }>{ ui }</QueryClientProvider> );
+}
+
+/**
+ * Answer each endpoint the button reads.
+ *
+ * @param options                - Overrides.
+ * @param options.hasBackupPlan  - Whether the capabilities bridge reports a plan.
+ * @param options.backups        - What `/jetpack/v4/backups` returns.
+ * @param options.backupsStopped - Whether WPCOM reports backups stopped.
+ */
+function mockEndpoints( {
+	hasBackupPlan = true,
+	backups = [] as unknown[],
+	backupsStopped = false,
+} = {} ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan, hasScan: false } );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: backupsStopped } );
+		}
+		if ( path.includes( '/backups' ) ) {
+			return Promise.resolve( backups );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+/**
+ * One entry of `/jetpack/v4/backups`, in WPCOM's stringly-typed shape.
+ *
+ * @param overrides - Fields to replace.
+ * @return A raw entry.
+ */
+function entry( overrides: Record< string, unknown > = {} ) {
+	return {
+		id: '1',
+		started: '2026-08-13 18:08:56',
+		last_updated: '2026-08-13 18:54:14',
+		status: 'finished',
+		period: '1786644531',
+		percent: '100',
+		is_backup: '1',
+		is_scan: '1',
+		discarded: '0',
+		stats: { prefix: 'wp_' },
+		...overrides,
+	};
+}
+
+beforeEach( () => {
+	mockApiFetch.mockReset();
+	mockEndpoints();
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'replacesOverview', () => {
+	it( 'takes over the body only while there is no usable restore point', () => {
+		expect( replacesOverview( 'no-backups', true ) ).toBe( true );
+		expect( replacesOverview( 'will-retry', true ) ).toBe( true );
+		expect( replacesOverview( 'no-good-backups', true ) ).toBe( true );
+		expect( replacesOverview( 'in-progress', true ) ).toBe( true );
+	} );
+
+	it( 'leaves the two-pane body alone once restore points exist', () => {
+		// A routine backup on an established site gets the banner instead,
+		// so the activity list stays usable for the minutes it runs.
+		expect( replacesOverview( 'in-progress', false ) ).toBe( false );
+		expect( replacesOverview( 'complete', false ) ).toBe( false );
+		// "We couldn't ask" must never take over the page either — the
+		// activity list is a separate endpoint and may be working fine.
+		expect( replacesOverview( 'error', false ) ).toBe( false );
+		expect( replacesOverview( 'loading', false ) ).toBe( false );
+	} );
+} );
+
+describe( 'BackupStatusPanel', () => {
+	it( 'gives a site with no backups the first-backup copy', () => {
+		render( <BackupStatusPanel state="no-backups" progress={ 0 } /> );
+
+		expect( screen.getByText( 'Your first cloud backup will be ready soon' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'The first backup usually takes a few minutes, so it will become available soon.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows a percentage only while a backup is actually running', () => {
+		const { rerender } = render( <BackupStatusPanel state="in-progress" progress={ 42 } /> );
+		expect( screen.getByText( '42%' ) ).toBeInTheDocument();
+
+		// A retryable failure reports the percentage the attempt died at,
+		// which would read as a stalled backup rather than a pending retry.
+		rerender( <BackupStatusPanel state="will-retry" progress={ 42 } /> );
+		expect( screen.queryByText( '42%' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'offers a way to reach support when no attempt produced a restore point', () => {
+		render( <BackupStatusPanel state="no-good-backups" progress={ 0 } /> );
+
+		expect( screen.getByText( "We're having trouble backing up your site" ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: /Get in touch with us/ } ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'BackupStatusBanner', () => {
+	it( 'reports the running backup without hiding anything', () => {
+		render( <BackupStatusBanner progress={ 36 } /> );
+
+		expect( screen.getByText( 'Your backup will be ready soon' ) ).toBeInTheDocument();
+		expect( screen.getByText( '36%' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'BackupNowButton', () => {
+	it( 'is offered when the site has a plan', async () => {
+		renderWithClient( <BackupNowButton /> );
+
+		await expect(
+			screen.findByRole( 'button', { name: 'Back up now' } )
+		).resolves.toBeInTheDocument();
+	} );
+
+	// `DashboardLayout` passes header actions to `<Page>`, which renders
+	// them above `<Gates>` — so without self-gating an unlicensed site is
+	// offered a control that cannot work.
+	it( 'renders nothing on a site with no plan', async () => {
+		mockEndpoints( { hasBackupPlan: false } );
+
+		const { container } = renderWithClient( <BackupNowButton /> );
+
+		// Wait for the capabilities query to settle before asserting absence.
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing without a user-level connection', async () => {
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			connectionStatus: { isRegistered: false, hasConnectedOwner: false, isUserConnected: false },
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
+
+		const { container } = renderWithClient( <BackupNowButton /> );
+
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+		expect( container ).toBeEmptyDOMElement();
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'reports a backup already running, and refuses to queue another', async () => {
+		mockEndpoints( {
+			backups: [ entry( { status: 'started', percent: '10', stats: undefined } ) ],
+		} );
+
+		renderWithClient( <BackupNowButton /> );
+
+		const button = await screen.findByRole( 'button', { name: 'Backup in progress' } );
+		// `focusableWhenDisabled` keeps it in the tab order and marks it
+		// aria-disabled rather than using the native attribute.
+		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'refuses to queue a backup when WPCOM has stopped them', async () => {
+		mockEndpoints( { backupsStopped: true } );
+
+		renderWithClient( <BackupNowButton /> );
+
+		const button = await screen.findByRole( 'button', { name: 'Back up now' } );
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'queues a backup and reports it as enqueued', async () => {
+		mockApiFetch.mockImplementation( ( options: { path?: string; method?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( '/site/capabilities' ) ) {
+				return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+			}
+			if ( path.includes( '/site/backup/size' ) ) {
+				return Promise.resolve( { ok: true, backups_stopped: false } );
+			}
+			if ( path.includes( '/site/backup/enqueue' ) ) {
+				return Promise.resolve( { success: true } );
+			}
+			return Promise.resolve( [] );
+		} );
+
+		renderWithClient( <BackupNowButton /> );
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Back up now' } ) );
+
+		await expect(
+			screen.findByRole( 'button', { name: 'Backup enqueued' } )
+		).resolves.toBeInTheDocument();
+		expect( mockApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( { path: '/jetpack/v4/site/backup/enqueue', method: 'POST' } )
+		);
+	} );
+
+	// The legacy button has no rejection handler and discards the body,
+	// so a WPCOM refusal reported "Backup enqueued" just like a success.
+	it( 'stays actionable when the enqueue is refused', async () => {
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( '/site/capabilities' ) ) {
+				return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+			}
+			if ( path.includes( '/site/backup/size' ) ) {
+				return Promise.resolve( { ok: true, backups_stopped: false } );
+			}
+			if ( path.includes( '/site/backup/enqueue' ) ) {
+				// A non-200 from WPCOM is flattened to HTTP 200 with a null
+				// body, so this resolves rather than throwing.
+				return Promise.resolve( null );
+			}
+			return Promise.resolve( [] );
+		} );
+
+		renderWithClient( <BackupNowButton /> );
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Back up now' } ) );
+
+		// Back to an enabled "Back up now" rather than a false success.
+		const button = await screen.findByRole( 'button', { name: 'Back up now' } );
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+		expect( button ).not.toHaveAttribute( 'aria-disabled', 'true' );
+		expect( screen.queryByText( 'Backup enqueued' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/first-run-state.test.tsx
+++ b/projects/packages/backup/tests/first-run-state.test.tsx
@@ -14,7 +14,7 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 
 // Imports must come after the jest.mock factory above.
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import BackupNowButton from '../src/dashboard/components/backup-now-button';
 import BackupStatusPanel, { replacesOverview } from '../src/dashboard/components/backup-status';
@@ -33,7 +33,10 @@ function renderWithClient( ui: ReactNode ) {
 	const client = new QueryClient( {
 		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
 	} );
-	return render( <QueryClientProvider client={ client }>{ ui }</QueryClientProvider> );
+	return {
+		...render( <QueryClientProvider client={ client }>{ ui }</QueryClientProvider> ),
+		client,
+	};
 }
 
 /**
@@ -97,21 +100,33 @@ beforeEach( () => {
 
 describe( 'replacesOverview', () => {
 	it( 'takes over the body only while there is no usable restore point', () => {
-		expect( replacesOverview( 'no-backups', true ) ).toBe( true );
-		expect( replacesOverview( 'will-retry', true ) ).toBe( true );
-		expect( replacesOverview( 'no-good-backups', true ) ).toBe( true );
-		expect( replacesOverview( 'in-progress', true ) ).toBe( true );
+		expect( replacesOverview( 'no-backups', true, false ) ).toBe( true );
+		expect( replacesOverview( 'will-retry', true, false ) ).toBe( true );
+		expect( replacesOverview( 'no-good-backups', true, false ) ).toBe( true );
+		expect( replacesOverview( 'in-progress', true, false ) ).toBe( true );
 	} );
 
 	it( 'leaves the two-pane body alone once restore points exist', () => {
 		// A routine backup on an established site gets the banner instead,
 		// so the activity list stays usable for the minutes it runs.
-		expect( replacesOverview( 'in-progress', false ) ).toBe( false );
-		expect( replacesOverview( 'complete', false ) ).toBe( false );
+		expect( replacesOverview( 'in-progress', false, false ) ).toBe( false );
+		expect( replacesOverview( 'complete', false, false ) ).toBe( false );
 		// "We couldn't ask" must never take over the page either — the
 		// activity list is a separate endpoint and may be working fine.
-		expect( replacesOverview( 'error', false ) ).toBe( false );
-		expect( replacesOverview( 'loading', false ) ).toBe( false );
+		expect( replacesOverview( 'error', false, false ) ).toBe( false );
+		expect( replacesOverview( 'loading', false, false ) ).toBe( false );
+	} );
+
+	// `/jetpack/v4/backups` sees only VaultPress's most recent handful of
+	// rows, so it can report "nothing usable" for a site that still has
+	// restore points further back in the retention window. Hiding the list
+	// there would be the same mistake as the empty state this replaces —
+	// and it would land at the moment someone came to restore.
+	it( 'never takes over while the activity log still has a restore point', () => {
+		expect( replacesOverview( 'no-good-backups', true, true ) ).toBe( false );
+		expect( replacesOverview( 'will-retry', true, true ) ).toBe( false );
+		expect( replacesOverview( 'no-backups', true, true ) ).toBe( false );
+		expect( replacesOverview( 'in-progress', true, true ) ).toBe( false );
 	} );
 } );
 
@@ -198,12 +213,17 @@ describe( 'BackupNowButton', () => {
 
 		const { container } = renderWithClient( <BackupNowButton /> );
 
-		// Wait for the capabilities query to settle before asserting absence.
-		await new Promise( resolve => setTimeout( resolve, 0 ) );
+		// Settle on the capabilities answer having arrived, rather than on
+		// a timer — then confirm the button stayed away.
+		await waitFor( () =>
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( { path: '/jetpack/v4/site/capabilities' } )
+			)
+		);
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	it( 'renders nothing without a user-level connection', async () => {
+	it( 'renders nothing without a user-level connection', () => {
 		window.JP_CONNECTION_INITIAL_STATE = {
 			...window.JP_CONNECTION_INITIAL_STATE,
 			connectionStatus: { isRegistered: false, hasConnectedOwner: false, isUserConnected: false },
@@ -211,7 +231,9 @@ describe( 'BackupNowButton', () => {
 
 		const { container } = renderWithClient( <BackupNowButton /> );
 
-		await new Promise( resolve => setTimeout( resolve, 0 ) );
+		// Nothing to wait for: the connection state is read synchronously
+		// from a global, and every query it gates is disabled, so there is
+		// no request that could later change this.
 		expect( container ).toBeEmptyDOMElement();
 		expect( mockApiFetch ).not.toHaveBeenCalled();
 	} );
@@ -235,8 +257,9 @@ describe( 'BackupNowButton', () => {
 		renderWithClient( <BackupNowButton /> );
 
 		const button = await screen.findByRole( 'button', { name: 'Back up now' } );
-		await new Promise( resolve => setTimeout( resolve, 0 ) );
-		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
+		// Waits for the storage answer to arrive and disable it, rather
+		// than assuming it already has.
+		await waitFor( () => expect( button ).toHaveAttribute( 'aria-disabled', 'true' ) );
 	} );
 
 	it( 'queues a backup and reports it as enqueued', async () => {
@@ -265,6 +288,47 @@ describe( 'BackupNowButton', () => {
 		);
 	} );
 
+	// The trickiest state in the component. A successful enqueue leaves the
+	// button reading "Backup enqueued" and forces polling, because nothing
+	// in the response yet says a backup is coming. Once WPCOM publishes the
+	// `started` record, an effect has to hand over to "Backup in progress"
+	// and release that forced poll — otherwise it keeps polling after the
+	// backup finishes.
+	it( 'hands over from enqueued to in progress once WPCOM starts the backup', async () => {
+		let backups: unknown[] = [];
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( '/site/capabilities' ) ) {
+				return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+			}
+			if ( path.includes( '/site/backup/size' ) ) {
+				return Promise.resolve( { ok: true, backups_stopped: false } );
+			}
+			if ( path.includes( '/site/backup/enqueue' ) ) {
+				return Promise.resolve( { success: true } );
+			}
+			return Promise.resolve( backups );
+		} );
+
+		const { client } = renderWithClient( <BackupNowButton /> );
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Back up now' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: 'Backup enqueued' } )
+		).resolves.toBeInTheDocument();
+
+		// WPCOM publishes the record the forced poll was waiting for.
+		// Invalidating stands in for that poll landing, so the test does
+		// not have to sit through the real interval.
+		backups = [ entry( { status: 'started', percent: '5', stats: undefined } ) ];
+		await act( async () => {
+			await client.invalidateQueries( { queryKey: [ 'backup', 'backups' ] } );
+		} );
+
+		await expect(
+			screen.findByRole( 'button', { name: 'Backup in progress' } )
+		).resolves.toBeInTheDocument();
+	} );
+
 	// The legacy button has no rejection handler and discards the body,
 	// so a WPCOM refusal reported "Backup enqueued" just like a success.
 	it( 'stays actionable when the enqueue is refused', async () => {
@@ -287,10 +351,17 @@ describe( 'BackupNowButton', () => {
 		renderWithClient( <BackupNowButton /> );
 		await userEvent.click( await screen.findByRole( 'button', { name: 'Back up now' } ) );
 
+		// Settle on the POST having actually gone out, so this cannot pass
+		// on the pre-click state — the label is "Back up now" either way.
+		await waitFor( () =>
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( { path: '/jetpack/v4/site/backup/enqueue' } )
+			)
+		);
+
 		// Back to an enabled "Back up now" rather than a false success.
 		const button = await screen.findByRole( 'button', { name: 'Back up now' } );
-		await new Promise( resolve => setTimeout( resolve, 0 ) );
-		expect( button ).not.toHaveAttribute( 'aria-disabled', 'true' );
+		await waitFor( () => expect( button ).not.toHaveAttribute( 'aria-disabled', 'true' ) );
 		expect( screen.queryByText( 'Backup enqueued' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/first-run-state.test.tsx
+++ b/projects/packages/backup/tests/first-run-state.test.tsx
@@ -137,6 +137,33 @@ describe( 'BackupStatusPanel', () => {
 		expect( screen.queryByText( '42%' ) ).not.toBeInTheDocument();
 	} );
 
+	// The heading promises a backup is coming, so a panel with no sign of
+	// activity contradicts itself — and this is the state a brand-new
+	// customer sits and watches.
+	it( 'still shows a progress element before any backup has started', () => {
+		const { rerender } = render( <BackupStatusPanel state="no-backups" progress={ 0 } /> );
+
+		expect( screen.getByRole( 'progressbar' ) ).toBeInTheDocument();
+		// Indeterminate: there is no percentage to claim yet.
+		expect( screen.queryByText( /\d+%/ ) ).not.toBeInTheDocument();
+
+		// A pending retry is the exception — nothing is running to report.
+		rerender( <BackupStatusPanel state="will-retry" progress={ 0 } /> );
+		expect( screen.queryByRole( 'progressbar' ) ).not.toBeInTheDocument();
+	} );
+
+	// The transition every new site makes: no records, then the first
+	// backup starts.
+	it( 'takes a value once the first backup starts', () => {
+		const { rerender } = render( <BackupStatusPanel state="no-backups" progress={ 0 } /> );
+		expect( screen.queryByText( '19%' ) ).not.toBeInTheDocument();
+
+		rerender( <BackupStatusPanel state="in-progress" progress={ 19 } /> );
+
+		expect( screen.getByRole( 'progressbar' ) ).toBeInTheDocument();
+		expect( screen.getByText( '19%' ) ).toBeInTheDocument();
+	} );
+
 	it( 'offers a way to reach support when no attempt produced a restore point', () => {
 		render( <BackupStatusPanel state="no-good-backups" progress={ 0 } /> );
 

--- a/projects/packages/backup/tests/overview-takeover.test.tsx
+++ b/projects/packages/backup/tests/overview-takeover.test.tsx
@@ -32,7 +32,16 @@ const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected
 // jsdom implements no scrolling, and DataViews' list layout calls
 // `scrollIntoView` on the selected row — which only happens here because
 // these are the first tests to render the list with a row in it.
-jest.spyOn( window.HTMLElement.prototype, 'scrollIntoView' ).mockImplementation();
+//
+// Defined rather than spied on: `jest.spyOn` requires the property to
+// already exist, and in jsdom it does not, so spying throws
+// "Property `scrollIntoView` does not exist in the provided object".
+// `defineProperty` also keeps `jest/prefer-spy-on` from rewriting this
+// back into a spy, which is how it broke the first time.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );
 
 /**
  * One rewindable-activity entry, in WPCOM's shape.

--- a/projects/packages/backup/tests/overview-takeover.test.tsx
+++ b/projects/packages/backup/tests/overview-takeover.test.tsx
@@ -1,0 +1,157 @@
+// When the first-run panel is allowed to replace the Overview body.
+//
+// `replacesOverview` is unit-tested directly; this covers the wiring in
+// `overview.tsx` that feeds it, because the two inputs come from two
+// different endpoints and getting the combination wrong fails silently
+// in both directions — either the panel never appears, or it appears
+// over a list that still had restore points in it.
+
+const mockApiFetch = jest.fn();
+const mockSearch = jest.fn< Record< string, unknown >, [] >();
+const mockNavigate = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => mockSearch(),
+	useNavigate: () => mockNavigate,
+	useParams: () => ( { rewindId: '1777035492' } ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import { stage as OverviewStage } from '../routes/dashboard/stage';
+import { queryClient } from '../src/dashboard/data/query-client';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row — which only happens here because
+// these are the first tests to render the list with a row in it.
+jest.spyOn( window.HTMLElement.prototype, 'scrollIntoView' ).mockImplementation();
+
+/**
+ * One rewindable-activity entry, in WPCOM's shape.
+ *
+ * @param gridicon - `cloud` marks a backup row; anything else does not.
+ * @return A raw activity entry.
+ */
+function activityEntry( gridicon: string ) {
+	return {
+		activity_id: `act-${ gridicon }`,
+		gridicon,
+		summary: 'Backup complete',
+		published: '2026-08-13T18:08:56+00:00',
+		rewind_id: '1786644531.123',
+		actor: { type: 'Application', name: 'Jetpack' },
+		content: { text: '46 plugins, 23 themes' },
+		name: 'rewind__backup_complete_full',
+	};
+}
+
+/**
+ * Answer every endpoint the Overview reads.
+ *
+ * @param options          - Overrides.
+ * @param options.backups  - What `/jetpack/v4/backups` returns.
+ * @param options.activity - Rewindable-activity entries.
+ */
+function mockEndpoints( { backups = [] as unknown[], activity = [] as unknown[] } = {} ) {
+	mockApiFetch.mockImplementation( ( o: { path?: string } ) => {
+		const path = o?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		if ( path.includes( '/site/rewindable-activity' ) ) {
+			return Promise.resolve( {
+				current: { orderedItems: activity },
+				totalItems: activity.length,
+				totalPages: 1,
+			} );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: false } );
+		}
+		if ( path === '/jetpack/v4/backups' ) {
+			return Promise.resolve( backups );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+/** A finished-but-discarded backup: present, but not a usable restore point. */
+const UNUSABLE_BACKUP = {
+	id: '1',
+	started: '2026-08-13 18:08:56',
+	last_updated: '2026-08-13 18:54:14',
+	status: 'finished',
+	period: '1786644531',
+	percent: '100',
+	is_backup: '1',
+	is_scan: '0',
+	discarded: '1',
+	stats: { prefix: 'wp_' },
+};
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockSearch.mockReset();
+	mockSearch.mockReturnValue( {} );
+	mockNavigate.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'Overview takeover', () => {
+	it( 'replaces the body on a genuinely empty site', async () => {
+		mockEndpoints( { backups: [], activity: [] } );
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByText( 'Your first cloud backup will be ready soon' )
+		).resolves.toBeInTheDocument();
+	} );
+
+	// The regression the takeover could otherwise cause. `/jetpack/v4/backups`
+	// reports only VaultPress's most recent handful of rows, so a run of
+	// recent failures reads as "no good backups" even while older restore
+	// points are still listed — and hiding the list there would land at the
+	// exact moment someone came to restore one.
+	it( 'keeps the list when the activity log still has a restore point', async () => {
+		mockEndpoints( { backups: [ UNUSABLE_BACKUP ], activity: [ activityEntry( 'cloud' ) ] } );
+
+		render( <OverviewStage /> );
+
+		// The list renders its backup row...
+		await expect( screen.findByText( 'Backup complete' ) ).resolves.toBeInTheDocument();
+		// ...and the takeover panel stays away.
+		expect(
+			screen.queryByText( "We're having trouble backing up your site" )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Your first cloud backup will be ready soon' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'still takes over when the activity log holds no backup rows', async () => {
+		// A site with activity but no restore points — e.g. only post edits.
+		mockEndpoints( { backups: [ UNUSABLE_BACKUP ], activity: [ activityEntry( 'posts' ) ] } );
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByText( "We're having trouble backing up your site" )
+		).resolves.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Fixes #

Part of [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243) — tasks **E1**, **E2** and **E3**. Umbrella: #48582.

## Proposed changes

The modernized Backup dashboard (behind `rsm_jetpack_ui_modernization_backup`, **default off**) reads only `/site/rewindable-activity`, which lists *completed restore points*. So it cannot tell three very different situations apart — a site with no backups yet, a site whose first backup is running, and a site whose backups are all failing. All three render as DataViews' bare "No results", which means **a new customer and a broken site look identical**.

* **E1 — Port `useBackupsState` onto `GET /jetpack/v4/backups`.** That route is registered unconditionally and signed with the blog token, so **no new PHP**. The state machine lands as a pure, unit-tested `summarizeBackups()` with a thin React Query wrapper.
* **E1 — Render the state.** A site with no usable restore point gets a panel in place of the two-pane body; a backup running on a site that *already* has restore points gets a non-destructive banner above the list, so the list stays usable. (Legacy replaces its whole body for the several minutes any routine backup takes.)
* **E2 — Wire "Back up now"** to `POST /jetpack/v4/site/backup/enqueue`, porting legacy's label/tooltip cycle and disabled states.
* **E3 — Remove the dead date-range placeholder**, a hardcoded untranslated `Apr 16, 2026 to May 15, 2026` with no handler, whose backing bridge args were removed in #48889. It lives in the same JSX as the button.

### Bugs found in the legacy behaviour, deliberately not ported

Each is covered by a test:

* **A WPCOM outage rendered as the brand-new-site screen.** `get_recent_backups()` returns bare `null` for any non-200 upstream, which WordPress serves as **HTTP 200** — so the request *resolves* and nothing throws. The legacy selector coerces that to `[]`, i.e. "no backups". This PR reports it as an error and falls through to the normal two-pane view rather than taking the page over.
* **The literal first run got the wrong copy.** `isInitialBackup` is only set inside a branch requiring at least one record, so a site with zero records — the actual first run — got the generic "Your backup will be ready soon" instead of the first-backup copy.
* **`error-will-retry` was only detected at `backups.length === 1`**, so a second failed attempt made the state vanish. Also matched by exact string, while WPCOM ships a family of `<reason>-will-retry` statuses. Now matched on the suffix.
* **A running backup erased a completed one.** The legacy hook reassigns `latestBackup` to the in-flight record, dropping the stats of the good backup that already exists.
* **Enqueue failures were unobservable.** The legacy click handler has no rejection handler and discards the response body, so a WPCOM refusal, a permissions error and a success all show "Backup enqueued". Failure is now surfaced in all three shapes it arrives in (rejection, `null` body, `{ success: false, error }`).
* **Scan records were treated as backups.** The endpoint returns scan rows too; `backups[0]` was read as "the latest backup" without filtering on `is_backup`.

### Notes for reviewers

* **Polling backs off from legacy's 1s to 5s**, and stops at terminal states. Every tick is a WPCOM round-trip through the proxy, sustained for the length of a backup and multiplied by each open tab. `BACKUPS_POLL_INTERVAL_MS` is a single constant if you'd rather it were tighter.
* **`sprintf( __( 'Backing up %s' ), siteTitle )` is not ported.** It needs a site title the modernized page doesn't emit (`JPBACKUP_INITIAL_STATE` is never rendered there — see H1/H2), and `JetpackScriptData` comes from the Jetpack plugin, which is exactly what's absent on a standalone Backup install. The existing headings carry the meaning instead, so **no new translatable strings** beyond a `%d%%` readout.
* **A `/site/backup/size` query is added** purely for the `backups_stopped` disabled state, which is one of the legacy disabled states E2 asks to port. It also pre-builds the data layer H3 will need. No new PHP.
* **No Tracks events** — that's H1 and needs a product call first.
* This incidentally removes the user-visible symptom of **F1** (header actions rendering above the gate screens), because the button now self-gates and the date-range placeholder is gone. The structural issue — `actions` being passed to `<Page>` outside `<Gates>` — is untouched, so F1 stays open.

## Related product discussion/links

* [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243)
* Data layer this builds on: #48889

## Does this pull request change what data or activity we track or use?

No. No Tracks events are added (see H1 above), and no new data is collected.

## Testing instructions

This is entirely behind a feature flag that is **off by default** — with the flag off, the legacy Backup page must render byte-identically. Please confirm that first.

**Setup.** On a site with the Backup plugin and an active Backup plan, enable the modernized dashboard with a snippet:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

Then go to **Jetpack → VaultPress Backup** (`admin.php?page=jetpack-backup`).

**1. Flag off — no change.** With the snippet disabled, confirm the legacy page is unchanged.

**2. A backup running on a site that already has backups** (the easiest state to hit — click "Back up now" and wait a moment):
* A banner reading "Your backup will be ready soon" with a progress bar and a percentage appears **above** the activity list.
* The activity list is still there and still usable.
* The percentage advances on its own roughly every 5 seconds.
* The header button reads "Backup in progress", is disabled, and shows "A backup is currently in progress." on hover.

**3. "Back up now".** On a site with no backup running, click it. The button should pass through "Queueing backup" / "Backup enqueued" and settle on "Backup in progress" once WPCOM publishes a record. A real backup is queued, so expect it to appear in the activity list shortly.

**4. The first-run states.** Hard to reach on an established site, so fake the response. Paste this **once** — it registers the interceptor and every later step just reassigns `window.__jpb`. A reload undoes it, in which case paste it again.

```js
const mk = o => Object.assign( {
	id: '1', started: '2026-08-14 10:00:00', last_updated: '2026-08-14 10:00:00',
	status: 'finished', period: '1786000000', percent: '100', is_backup: '1', is_scan: '0',
}, o );
window.__states = {
	// No records at all — the literal first run, before WPCOM starts anything.
	noBackups: [],
	// The first backup is running. This is the one with a percentage.
	firstRunning: [ mk( { id: 'run', status: 'started', percent: '19' } ) ],
	// Attempts exist, none produced a usable restore point.
	noGood: [
		mk( { id: 'a', status: 'not-accessible', percent: '0' } ),
		mk( { id: 'b', discarded: '1', stats: { prefix: 'wp_' } } ),
	],
	// The only attempts so far failed, and WPCOM will retry on its own.
	willRetry: [ mk( { id: 'r', status: 'error-will-retry', percent: '0' } ) ],
};
window.__jpb = window.__states.noBackups;
wp.apiFetch.use( ( o, next ) =>
	o.path === '/jetpack/v4/backups' && window.__jpb ? Promise.resolve( window.__jpb ) : next( o )
);
```

Then switch state with `window.__jpb = window.__states.<name>` and wait ~5s for the next poll.

> **One gotcha:** polling only runs while the state is `noBackups` or `firstRunning`. `noGood` and `willRetry` are terminal, so once you land on one, changing `window.__jpb` again does nothing until you reload and re-paste. Go `noBackups` → `firstRunning` → a terminal one, or reload between terminal states.

| `window.__jpb =` | Expect |
|---|---|
| `window.__states.noBackups` | Centred panel, "Your first cloud backup will be ready soon", an **indeterminate** bar sweeping left-to-right, **no** percentage. "Back up now" stays enabled — nothing is running, so starting one is a reasonable thing to offer. |
| `window.__states.firstRunning` | Same panel, now a **determinate** bar filling from the left with "19%" beside it. Header button reads "Backup in progress" and is disabled. |
| `window.__states.noGood` | "We're having trouble backing up your site" with a working "Get in touch with us" link. No bar. |
| `window.__states.willRetry` | First-run copy, and **no bar at all** — the percentage WPCOM reports is where the failed attempt died, which would read as a stalled backup. |

**5. A backup running on a site that already has restore points** — the everyday case, and the default on this site. Clear the fake with `window.__jpb = null`, or just reload. Expect the banner above the activity list instead of the panel, the list still usable underneath, and the header button disabled.

**6. The important one — a WPCOM failure must not look like a new site.** With the interceptor registered, `window.__jpb = 'x'` won't do it (it must be an array or null); instead reload and paste a variant that resolves `null`:

```js
wp.apiFetch.use( ( o, next ) =>
	o.path === '/jetpack/v4/backups' ? Promise.resolve( null ) : next( o )
);
```

Then change page in the activity list to force a refetch. The dashboard should keep rendering the normal two-pane overview with the activity list intact — **not** the "your first cloud backup" screen.

**7. No plan / not connected.** Confirm the header no longer offers "Back up now" above the gate screens.

**Automated:**

```
jp test js packages/backup     # 213 tests, 30 suites
jp test php packages/backup
```


