### PR TITLE
Backup: surface the query errors the modernized dashboard already computes

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-surface-query-errors
+++ b/projects/packages/backup/changelog/fix-backup-surface-query-errors
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Backup: report failed requests in the modernized dashboard instead of rendering them as empty states, and add a route-level error boundary. No-op when the modernization filter is off.

--- a/projects/packages/backup/routes/dashboard/stage.tsx
+++ b/projects/packages/backup/routes/dashboard/stage.tsx
@@ -1,3 +1,4 @@
+import ErrorBoundary from '../../src/dashboard/components/error-boundary';
 import QueryClientProvider from '../../src/dashboard/providers/query-client-provider';
 import OverviewScreen from '../../src/dashboard/screens/overview';
 import './style.scss';
@@ -10,12 +11,19 @@ import './style.scss';
  * component's hooks before it renders that component's children — so a
  * provider mounted by the layout would never be in scope.
  *
+ * `<ErrorBoundary>` is outermost so it also covers the provider, and
+ * because the screen's own hooks run before it renders `<DashboardLayout>`
+ * — a boundary inside the layout would never mount in time to catch them.
+ * The trade-off is that the fallback renders without the page chrome.
+ *
  * @return The Overview screen wrapped in the dashboard's query client.
  */
 const Stage = () => (
-	<QueryClientProvider>
-		<OverviewScreen />
-	</QueryClientProvider>
+	<ErrorBoundary>
+		<QueryClientProvider>
+			<OverviewScreen />
+		</QueryClientProvider>
+	</ErrorBoundary>
 );
 
 export { Stage as stage };

--- a/projects/packages/backup/routes/download/stage.tsx
+++ b/projects/packages/backup/routes/download/stage.tsx
@@ -1,3 +1,4 @@
+import ErrorBoundary from '../../src/dashboard/components/error-boundary';
 import QueryClientProvider from '../../src/dashboard/providers/query-client-provider';
 import DownloadScreen from '../../src/dashboard/screens/download';
 import './style.scss';
@@ -6,14 +7,17 @@ import './style.scss';
  * wp-build stage: boot mounts this into the page's app container.
  *
  * See `routes/dashboard/stage.tsx` for why the provider lives in the
- * stage rather than in `<DashboardLayout>`.
+ * stage rather than in `<DashboardLayout>`, and why the error boundary
+ * sits outside both.
  *
  * @return The Download screen wrapped in the dashboard's query client.
  */
 const Stage = () => (
-	<QueryClientProvider>
-		<DownloadScreen />
-	</QueryClientProvider>
+	<ErrorBoundary>
+		<QueryClientProvider>
+			<DownloadScreen />
+		</QueryClientProvider>
+	</ErrorBoundary>
 );
 
 export { Stage as stage };

--- a/projects/packages/backup/routes/restore/stage.tsx
+++ b/projects/packages/backup/routes/restore/stage.tsx
@@ -1,3 +1,4 @@
+import ErrorBoundary from '../../src/dashboard/components/error-boundary';
 import QueryClientProvider from '../../src/dashboard/providers/query-client-provider';
 import RestoreScreen from '../../src/dashboard/screens/restore';
 import './style.scss';
@@ -6,14 +7,17 @@ import './style.scss';
  * wp-build stage: boot mounts this into the page's app container.
  *
  * See `routes/dashboard/stage.tsx` for why the provider lives in the
- * stage rather than in `<DashboardLayout>`.
+ * stage rather than in `<DashboardLayout>`, and why the error boundary
+ * sits outside both.
  *
  * @return The Restore screen wrapped in the dashboard's query client.
  */
 const Stage = () => (
-	<QueryClientProvider>
-		<RestoreScreen />
-	</QueryClientProvider>
+	<ErrorBoundary>
+		<QueryClientProvider>
+			<RestoreScreen />
+		</QueryClientProvider>
+	</ErrorBoundary>
 );
 
 export { Stage as stage };

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -6,6 +6,7 @@ import { Icon, cloud, image, post, plugins as pluginsIcon, color, info } from '@
 import { Card, Stack, Text } from '@wordpress/ui';
 import { ACTIVITY_LOG_DEFAULT_PER_PAGE, useActivityLog } from '../../hooks/use-activity-log';
 import { isBackupItem } from '../../types/activity';
+import QueryError from '../query-error';
 import './style.scss';
 import type { ActivityItem, ActivityKind } from '../../types/activity';
 import type { Field, View } from '@wordpress/dataviews';
@@ -102,10 +103,23 @@ function DescriptionCell( { item }: { item: ActivityItem } ) {
 export default function ActivityList( { selectedId, onSelect, view, onChangeView }: Props ) {
 	const page = view.page ?? 1;
 	const perPage = view.perPage ?? ACTIVITY_LOG_DEFAULT_PER_PAGE;
-	const { items, totalItems, totalPages, isLoading } = useActivityLog( {
+	const { items, totalItems, totalPages, isLoading, error, refetch } = useActivityLog( {
 		page,
 		pageSize: perPage,
 	} );
+
+	// DataViews shows its own "No results" whenever `data` is empty, and a
+	// failed request leaves it empty — so without this a 5xx tells the
+	// reader their site has no activity. The `empty` slot is the same node
+	// that copy renders in, so replacing it puts the reason exactly where
+	// the wrong answer used to be.
+	const emptyState = error ? (
+		<QueryError
+			title={ __( "We couldn't load your site's activity.", 'jetpack-backup-pkg' ) }
+			error={ error }
+			onRetry={ refetch }
+		/>
+	) : undefined;
 
 	const fields: Field< ActivityItem >[] = useMemo(
 		() => [
@@ -169,6 +183,7 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 				onChangeSelection={ onChangeSelection }
 				isLoading={ isLoading }
 				search={ false }
+				empty={ emptyState }
 			/>
 		</Card.Root>
 	);

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -103,7 +103,7 @@ function DescriptionCell( { item }: { item: ActivityItem } ) {
 export default function ActivityList( { selectedId, onSelect, view, onChangeView }: Props ) {
 	const page = view.page ?? 1;
 	const perPage = view.perPage ?? ACTIVITY_LOG_DEFAULT_PER_PAGE;
-	const { items, totalItems, totalPages, isLoading, error, refetch } = useActivityLog( {
+	const { items, totalItems, totalPages, isLoading, isFetching, error, refetch } = useActivityLog( {
 		page,
 		pageSize: perPage,
 	} );
@@ -118,6 +118,7 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 			title={ __( "We couldn't load your site's activity.", 'jetpack-backup-pkg' ) }
 			error={ error }
 			onRetry={ refetch }
+			isRetrying={ isFetching }
 		/>
 	) : undefined;
 

--- a/projects/packages/backup/src/dashboard/components/error-boundary/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/error-boundary/index.tsx
@@ -1,0 +1,104 @@
+import { Button, Card } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Stack, Text } from '@wordpress/ui';
+import './style.scss';
+import type { ErrorInfo, ReactNode } from 'react';
+
+type Props = {
+	children: ReactNode;
+};
+
+type State = {
+	error: Error | null;
+};
+
+/**
+ * Reload the current page.
+ *
+ * Hoisted out of the render so the button's handler is a stable
+ * reference rather than a new closure on every render.
+ */
+function reloadPage() {
+	window.location.reload();
+}
+
+/**
+ * Route-level error boundary for the modernized Backup dashboard.
+ *
+ * Without one, a throw anywhere on the render path unmounts the whole
+ * React tree and leaves an empty `<div>` inside the page chrome — a
+ * blank panel with no explanation and nothing to click. The tree has at
+ * least one known way to get there: `toFileNode` parses a `period`
+ * straight out of a WPCOM manifest, and a non-numeric value makes
+ * `new Date( NaN ).toISOString()` raise `RangeError: Invalid time
+ * value` inside a `useMemo`. That hazard is called out in
+ * `use-file-tree.ts` precisely because nothing was catching it.
+ *
+ * A class component because that is still the only way to implement
+ * `getDerivedStateFromError` — React exposes no hook equivalent.
+ *
+ * Recovery is a reload rather than a state reset: by the time this
+ * renders, the failed subtree's state is gone, so offering "try again"
+ * without remounting would re-throw immediately.
+ */
+export default class ErrorBoundary extends Component< Props, State > {
+	state: State = { error: null };
+
+	/**
+	 * Record the error so the next render shows the fallback.
+	 *
+	 * @param error - The thrown error.
+	 * @return The next state.
+	 */
+	static getDerivedStateFromError( error: Error ): State {
+		return { error };
+	}
+
+	/**
+	 * Log the component stack, which the fallback deliberately does not
+	 * show — it is the only part of the report that identifies where the
+	 * throw came from, and support needs it more than the reader does.
+	 *
+	 * @param error     - The thrown error.
+	 * @param errorInfo - React's component stack.
+	 */
+	componentDidCatch( error: Error, errorInfo: ErrorInfo ) {
+		// eslint-disable-next-line no-console
+		console.error( '[Jetpack Backup] Unhandled error:', error, errorInfo.componentStack );
+	}
+
+	/**
+	 * Render the children, or the fallback once an error has been caught.
+	 *
+	 * @return The rendered tree.
+	 */
+	render() {
+		const { error } = this.state;
+		if ( ! error ) {
+			return this.props.children;
+		}
+
+		return (
+			<Card className="jpb-error-boundary">
+				<Stack direction="column" gap="md" align="center">
+					<Text variant="heading-md" render={ <h2 /> }>
+						{ __( 'Something went wrong', 'jetpack-backup-pkg' ) }
+					</Text>
+					<Text>
+						{ __(
+							'The page ran into an unexpected problem. Your backups are unaffected.',
+							'jetpack-backup-pkg'
+						) }
+					</Text>
+					<Text variant="body-sm" className="jpb-text-muted">
+						{ error.message }
+					</Text>
+					<Button variant="primary" onClick={ reloadPage }>
+						{ __( 'Reload the page', 'jetpack-backup-pkg' ) }
+					</Button>
+				</Stack>
+			</Card>
+		);
+	}
+}

--- a/projects/packages/backup/src/dashboard/components/error-boundary/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/error-boundary/index.tsx
@@ -28,12 +28,15 @@ function reloadPage() {
  *
  * Without one, a throw anywhere on the render path unmounts the whole
  * React tree and leaves an empty `<div>` inside the page chrome — a
- * blank panel with no explanation and nothing to click. The tree has at
- * least one known way to get there: `toFileNode` parses a `period`
- * straight out of a WPCOM manifest, and a non-numeric value makes
- * `new Date( NaN ).toISOString()` raise `RangeError: Invalid time
- * value` inside a `useMemo`. That hazard is called out in
- * `use-file-tree.ts` precisely because nothing was catching it.
+ * blank panel with no explanation and nothing to click.
+ *
+ * This is defence in depth rather than a fix for one known hole. The
+ * hazard it was written for — `toFileNode` calling `toISOString()` on a
+ * `period` parsed straight out of an unvalidated WPCOM manifest — is
+ * guarded at the source, and that guard is the right place for it,
+ * because dropping one timestamp beats blanking the file browser. What
+ * the boundary buys is that the next such field, in the next component,
+ * costs a legible error screen instead of a white rectangle.
  *
  * A class component because that is still the only way to implement
  * `getDerivedStateFromError` — React exposes no hook equivalent.
@@ -82,7 +85,16 @@ export default class ErrorBoundary extends Component< Props, State > {
 		return (
 			<Card className="jpb-error-boundary">
 				<Stack direction="column" gap="md" align="center">
-					<Text variant="heading-md" render={ <h2 /> }>
+					{ /*
+					 * An `h1`, not an `h2`: the page's own `h1` comes from
+					 * `<Page title>` inside `<DashboardLayout>`, and this
+					 * fallback renders *instead of* that whole subtree. When
+					 * it is on screen there is no other heading on the page,
+					 * so this is the document's first one. (The gate screens
+					 * use lower levels because they render inside the layout,
+					 * with that `h1` still above them.)
+					 */ }
+					<Text variant="heading-md" render={ <h1 /> }>
 						{ __( 'Something went wrong', 'jetpack-backup-pkg' ) }
 					</Text>
 					<Text>

--- a/projects/packages/backup/src/dashboard/components/error-boundary/style.scss
+++ b/projects/packages/backup/src/dashboard/components/error-boundary/style.scss
@@ -1,0 +1,8 @@
+// Sized and spaced to match `.jpb-gates__card`, which occupies the same
+// slot inside `.jpb-dashboard-body__inner` when a gate blocks the body.
+.jpb-error-boundary {
+	max-inline-size: 560px;
+	margin-inline: auto;
+	margin-block: 48px;
+	padding: 32px;
+}

--- a/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
@@ -12,6 +12,7 @@ import { Stack } from '@wordpress/ui';
 import { useFileTree } from '../../hooks/use-file-tree';
 import { isFolder } from '../../types/file-tree';
 import FileInfoCard from '../file-info-card';
+import QueryError from '../query-error';
 import './style.scss';
 import type { FileNode, FileNodeFile } from '../../types/file-tree';
 
@@ -322,7 +323,12 @@ export default function FileBrowser( {
 	onSelectionCountChange,
 }: Props ) {
 	const [ openFile, setOpenFile ] = useState< FileNodeFile | null >( null );
-	const { children: rootsData, isLoading: rootsLoading } = useFileTree( rewindId, null );
+	const {
+		children: rootsData,
+		isLoading: rootsLoading,
+		error: rootsError,
+		refetch: refetchRoots,
+	} = useFileTree( rewindId, null );
 	const roots = useMemo< FileNode[] >( () => rootsData ?? [], [ rootsData ] );
 	const { selected, deselected } = selection;
 
@@ -418,6 +424,23 @@ export default function FileBrowser( {
 
 	const closeInfoCard = useCallback( () => setOpenFile( null ), [] );
 
+	// A failed root tree is indistinguishable from a backup that contains
+	// nothing: `children` is null either way, so the tree renders empty
+	// under a "0 items selected" header that invites the reader to select
+	// from it. Replace the whole browser rather than just the tree — the
+	// selection header is meaningless without a tree to select from.
+	if ( rootsError ) {
+		return (
+			<div className="jpb-file-browser" data-rewind-id={ rewindId }>
+				<QueryError
+					title={ __( "We couldn't load this backup's files.", 'jetpack-backup-pkg' ) }
+					error={ rootsError }
+					onRetry={ refetchRoots }
+				/>
+			</div>
+		);
+	}
+
 	return (
 		<div className="jpb-file-browser" data-rewind-id={ rewindId }>
 			<Stack direction="row" align="center" gap="sm" className="jpb-file-browser__selection">
@@ -505,7 +528,10 @@ function NodeRow( {
 }: NodeRowProps ) {
 	const [ open, setOpen ] = useState( false );
 	const nodeIsFolder = isFolder( node );
-	const { children, isLoading } = useFileTree( rewindId, open && nodeIsFolder ? node.path : null );
+	const { children, isLoading, error } = useFileTree(
+		rewindId,
+		open && nodeIsFolder ? node.path : null
+	);
 	const { selected, deselected } = selection;
 
 	// Effective check: own positive > own negative > inherited positive.
@@ -588,7 +614,21 @@ function NodeRow( {
 							<Spinner />
 						</div>
 					) }
-					{ ! isLoading && ( children ?? [] ).length === 0 && (
+					{ /*
+					 * A folder whose fetch failed also has no children, so
+					 * without this branch it reports itself as empty — the
+					 * reader is told the folder contains nothing rather than
+					 * that we couldn't look inside it.
+					 */ }
+					{ ! isLoading && error && (
+						<div className="jpb-file-browser__error" style={ { paddingLeft: 44 + depth * 16 } }>
+							{
+								/* translators: shown inside an expanded folder in the backup file browser when its contents could not be fetched. */
+								__( "Couldn't load this folder.", 'jetpack-backup-pkg' )
+							}
+						</div>
+					) }
+					{ ! isLoading && ! error && ( children ?? [] ).length === 0 && (
 						<div className="jpb-file-browser__empty" style={ { paddingLeft: 44 + depth * 16 } }>
 							{
 								/* translators: shown inside an expanded folder in the backup file browser when the folder contains no files. */

--- a/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
@@ -327,6 +327,7 @@ export default function FileBrowser( {
 		children: rootsData,
 		isLoading: rootsLoading,
 		error: rootsError,
+		isFetching: rootsFetching,
 		refetch: refetchRoots,
 	} = useFileTree( rewindId, null );
 	const roots = useMemo< FileNode[] >( () => rootsData ?? [], [ rootsData ] );
@@ -436,6 +437,7 @@ export default function FileBrowser( {
 					title={ __( "We couldn't load this backup's files.", 'jetpack-backup-pkg' ) }
 					error={ rootsError }
 					onRetry={ refetchRoots }
+					isRetrying={ rootsFetching }
 				/>
 			</div>
 		);
@@ -586,7 +588,7 @@ function NodeRow( {
 
 	return (
 		<div>
-			<div className={ rowClassName } style={ { paddingLeft: 12 + depth * 16 } }>
+			<div className={ rowClassName } style={ { paddingInlineStart: 12 + depth * 16 } }>
 				<CheckboxControl
 					checked={ isEffectivelySelected }
 					indeterminate={ isIndeterminate }
@@ -610,7 +612,10 @@ function NodeRow( {
 			{ open && nodeIsFolder && (
 				<div className="jpb-file-browser__children">
 					{ isLoading && (
-						<div className="jpb-file-browser__loading" style={ { paddingLeft: 28 + depth * 16 } }>
+						<div
+							className="jpb-file-browser__loading"
+							style={ { paddingInlineStart: 28 + depth * 16 } }
+						>
 							<Spinner />
 						</div>
 					) }
@@ -621,7 +626,10 @@ function NodeRow( {
 					 * that we couldn't look inside it.
 					 */ }
 					{ ! isLoading && error && (
-						<div className="jpb-file-browser__error" style={ { paddingLeft: 44 + depth * 16 } }>
+						<div
+							className="jpb-file-browser__error"
+							style={ { paddingInlineStart: 44 + depth * 16 } }
+						>
 							{
 								/* translators: shown inside an expanded folder in the backup file browser when its contents could not be fetched. */
 								__( "Couldn't load this folder.", 'jetpack-backup-pkg' )
@@ -629,7 +637,10 @@ function NodeRow( {
 						</div>
 					) }
 					{ ! isLoading && ! error && ( children ?? [] ).length === 0 && (
-						<div className="jpb-file-browser__empty" style={ { paddingLeft: 44 + depth * 16 } }>
+						<div
+							className="jpb-file-browser__empty"
+							style={ { paddingInlineStart: 44 + depth * 16 } }
+						>
 							{
 								/* translators: shown inside an expanded folder in the backup file browser when the folder contains no files. */
 								__( 'Empty', 'jetpack-backup-pkg' )

--- a/projects/packages/backup/src/dashboard/components/file-browser/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-browser/style.scss
@@ -62,6 +62,14 @@
 		padding: 4px 0;
 	}
 
+	// Sits where `&__empty` would, and is deliberately styled apart from
+	// it: "we couldn't look inside this folder" and "this folder is empty"
+	// occupy the same slot and used to render identically.
+	&__error {
+		color: var(--wp-components-color-alert-red, #cc1818);
+		padding: 4px 0;
+	}
+
 	&__loading {
 		padding: 4px 0;
 	}

--- a/projects/packages/backup/src/dashboard/components/file-browser/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-browser/style.scss
@@ -65,8 +65,12 @@
 	// Sits where `&__empty` would, and is deliberately styled apart from
 	// it: "we couldn't look inside this folder" and "this folder is empty"
 	// occupy the same slot and used to render identically.
+	// `--wp-components-color-alert-red` looks like it belongs here but is
+	// declared nowhere — that set is only accent / background / foreground
+	// / gray — so it would always have fallen through to a hardcoded red
+	// that ignores the theme. This one is real.
 	&__error {
-		color: var(--wp-components-color-alert-red, #cc1818);
+		color: var(--wpds-color-foreground-content-error);
 		padding: 4px 0;
 	}
 

--- a/projects/packages/backup/src/dashboard/components/query-error/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/query-error/index.tsx
@@ -1,0 +1,51 @@
+import { Button, Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Stack, Text } from '@wordpress/ui';
+import './style.scss';
+
+type Props = {
+	/** What failed, in the reader's terms. */
+	title: string;
+	error: Error;
+	/** Refetches the failed query. Omitted when the caller has no way to retry. */
+	onRetry?: () => void;
+};
+
+/**
+ * Inline report for a query that failed.
+ *
+ * Exists because "the request failed" and "there is nothing here" are
+ * indistinguishable in this dashboard by default: React Query hands back
+ * an error, the consumer reads only `isLoading` and `data`, and an empty
+ * `data` renders the same empty state either way. A reader whose
+ * activity log 5xx'd is told their site has no activity.
+ *
+ * The upstream message is shown verbatim alongside the friendly line.
+ * It is the only part a support agent can act on, and the bridges
+ * already translate WPCOM's failures into human-readable text.
+ *
+ * @param props         - Component props.
+ * @param props.title   - What failed, in the reader's terms.
+ * @param props.error   - The query's error.
+ * @param props.onRetry - Refetches the failed query, when the caller can.
+ * @return The rendered error.
+ */
+export default function QueryError( { title, error, onRetry }: Props ) {
+	return (
+		<Notice status="error" isDismissible={ false } className="jpb-query-error">
+			<Stack direction="column" gap="sm" align="flex-start">
+				<Text>{ title }</Text>
+				{ error.message && (
+					<Text variant="body-sm" className="jpb-text-muted">
+						{ error.message }
+					</Text>
+				) }
+				{ onRetry && (
+					<Button variant="secondary" size="compact" onClick={ onRetry }>
+						{ __( 'Try again', 'jetpack-backup-pkg' ) }
+					</Button>
+				) }
+			</Stack>
+		</Notice>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/query-error/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/query-error/index.tsx
@@ -9,6 +9,8 @@ type Props = {
 	error: Error;
 	/** Refetches the failed query. Omitted when the caller has no way to retry. */
 	onRetry?: () => void;
+	/** Whether a retry is in flight. */
+	isRetrying?: boolean;
 };
 
 /**
@@ -24,13 +26,21 @@ type Props = {
  * It is the only part a support agent can act on, and the bridges
  * already translate WPCOM's failures into human-readable text.
  *
- * @param props         - Component props.
- * @param props.title   - What failed, in the reader's terms.
- * @param props.error   - The query's error.
- * @param props.onRetry - Refetches the failed query, when the caller can.
+ * `isRetrying` matters more than it looks. React Query defines
+ * `isLoading` as `isPending && isFetching`, and a query sitting in the
+ * error state is never pending — so a refetch leaves `isLoading` false
+ * for its whole duration. Without a separate signal the button would not
+ * change, and a retry that failed again would leave the DOM
+ * byte-identical to before the click, which reads as a dead control.
+ *
+ * @param props            - Component props.
+ * @param props.title      - What failed, in the reader's terms.
+ * @param props.error      - The query's error.
+ * @param props.onRetry    - Refetches the failed query, when the caller can.
+ * @param props.isRetrying - Whether a retry is currently in flight.
  * @return The rendered error.
  */
-export default function QueryError( { title, error, onRetry }: Props ) {
+export default function QueryError( { title, error, onRetry, isRetrying = false }: Props ) {
 	return (
 		<Notice status="error" isDismissible={ false } className="jpb-query-error">
 			<Stack direction="column" gap="sm" align="flex-start">
@@ -41,7 +51,14 @@ export default function QueryError( { title, error, onRetry }: Props ) {
 					</Text>
 				) }
 				{ onRetry && (
-					<Button variant="secondary" size="compact" onClick={ onRetry }>
+					<Button
+						variant="secondary"
+						size="compact"
+						onClick={ onRetry }
+						isBusy={ isRetrying }
+						disabled={ isRetrying }
+						accessibleWhenDisabled
+					>
 						{ __( 'Try again', 'jetpack-backup-pkg' ) }
 					</Button>
 				) }

--- a/projects/packages/backup/src/dashboard/components/query-error/style.scss
+++ b/projects/packages/backup/src/dashboard/components/query-error/style.scss
@@ -1,0 +1,9 @@
+// Rendered in two very different slots — DataViews' centered
+// `.dataviews-no-results` box and the left-aligned file tree — so it
+// takes the width it is given and left-aligns its own contents rather
+// than inheriting the container's text alignment.
+.jpb-query-error {
+	inline-size: 100%;
+	margin: 0;
+	text-align: start;
+}

--- a/projects/packages/backup/src/dashboard/hooks/test/use-file-tree.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-file-tree.test.ts
@@ -21,15 +21,20 @@ describe( 'toFileNode', () => {
 	} );
 
 	// `period` comes straight from a WPCOM manifest with nothing validating
-	// it. Before the guard, a non-numeric value reached
-	// `new Date( NaN ).toISOString()`, which throws `RangeError: Invalid time
-	// value` — inside a `useMemo` on the render path with no error boundary
-	// above it, so a single bad entry blanked the entire file browser.
+	// it. `toISOString()` throws `RangeError: Invalid time value` on an
+	// unrepresentable date, from inside a `useMemo` on the render path —
+	// so a single bad entry takes the whole file browser down with it.
 	// Dropping one timestamp is the correct failure mode.
+	//
+	// `out-of-range` is the case a `Number.isFinite` check on the parsed
+	// number misses: it is a perfectly finite number, but `Date` is only
+	// defined within ±8.64e15 ms, so a `period` that arrives in
+	// milliseconds or microseconds is still unrepresentable.
 	test.each( [
 		[ 'non-numeric', 'not-a-timestamp' ],
 		[ 'empty string', '' ],
 		[ 'whitespace', '   ' ],
+		[ 'out-of-range', '1777035492000000' ],
 	] )( 'omits lastModified rather than throwing on a %s period', ( _label, period ) => {
 		let node;
 		expect( () => {

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -20,6 +20,13 @@ type Result = {
 	totalItems: number;
 	totalPages: number;
 	isLoading: boolean;
+	/**
+	 * True while a refetch is in flight. Distinct from `isLoading`, which
+	 * React Query defines as `isPending && isFetching` — a query in the
+	 * error state is never pending, so `isLoading` stays false for the
+	 * whole duration of a retry.
+	 */
+	isFetching: boolean;
 	error: Error | null;
 	refetch: () => void;
 };
@@ -92,6 +99,7 @@ export function useActivityLog( { page, pageSize }: Args ): Result {
 		totalItems: query.data?.totalItems ?? items.length,
 		totalPages: query.data?.totalPages ?? Math.max( 1, Math.ceil( items.length / pageSize ) ),
 		isLoading: query.isLoading,
+		isFetching: query.isFetching,
 		error: query.error ?? null,
 		refetch: retry,
 	};

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -1,5 +1,5 @@
 import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useMemo } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import {
 	fetchActivityLog,
 	type WpcomActivityEntry,
@@ -21,6 +21,7 @@ type Result = {
 	totalPages: number;
 	isLoading: boolean;
 	error: Error | null;
+	refetch: () => void;
 };
 
 /**
@@ -69,15 +70,22 @@ function useActivityPageQuery( page: number, pageSize: number ) {
  * @param args          - Query args.
  * @param args.page     - 1-indexed page number.
  * @param args.pageSize - Items per page.
- * @return Items, total items, total pages, loading, error.
+ * @return Items, total items, total pages, loading, error, refetch.
  */
 export function useActivityLog( { page, pageSize }: Args ): Result {
 	const query = useActivityPageQuery( page, pageSize );
+	const { refetch } = query;
 
 	const items = useMemo(
 		() => normalizeActivityLog( query.data?.current?.orderedItems ),
 		[ query.data ]
 	);
+
+	// Wrapped so callers can hand it straight to `onClick` without
+	// returning a floating promise from the event handler.
+	const retry = useCallback( () => {
+		refetch();
+	}, [ refetch ] );
 
 	return {
 		items,
@@ -85,6 +93,7 @@ export function useActivityLog( { page, pageSize }: Args ): Result {
 		totalPages: query.data?.totalPages ?? Math.max( 1, Math.ceil( items.length / pageSize ) ),
 		isLoading: query.isLoading,
 		error: query.error ?? null,
+		refetch: retry,
 	};
 }
 

--- a/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
@@ -9,6 +9,12 @@ const BASE_FOLDER_PATH = '/';
 type Result = {
 	children: FileNode[] | null;
 	isLoading: boolean;
+	/**
+	 * True while a refetch is in flight. Distinct from `isLoading`: a
+	 * query in the error state is never pending, so `isLoading` stays
+	 * false for the whole duration of a retry.
+	 */
+	isFetching: boolean;
 	error: Error | null;
 	refetch: () => void;
 };
@@ -50,15 +56,24 @@ export function toFileNode( name: string, raw: WpcomFileNode, parentPath: string
 	}
 
 	// `period` is unix seconds as a string, but it comes straight from a
-	// WPCOM manifest and nothing validates it. A non-numeric value makes
-	// `new Date( NaN ).toISOString()` throw `RangeError: Invalid time
-	// value` — and this runs inside a `useMemo` on the render path with no
-	// error boundary above it, so one malformed entry would blank the whole
-	// file browser rather than dropping a single timestamp.
+	// WPCOM manifest and nothing validates it. `toISOString()` throws
+	// `RangeError: Invalid time value` on an unrepresentable date, and one
+	// malformed entry would take the whole file browser down with it —
+	// this runs inside a `useMemo` on the render path, so the route-level
+	// error boundary would catch it, but as a blanked screen rather than a
+	// single dropped timestamp.
+	//
+	// Testing the resulting `Date` rather than the parsed number is what
+	// makes this complete: `Number.isFinite` alone rejects non-numeric
+	// values but happily passes anything inside float range, and `Date` is
+	// only defined within ±8.64e15 ms. A `period` in milliseconds or
+	// microseconds — ordinary upstream drift for an unvalidated field —
+	// is finite and still unrepresentable.
 	const periodSeconds = raw.period ? Number.parseInt( raw.period, 10 ) : NaN;
-	const lastModified = Number.isFinite( periodSeconds )
-		? new Date( periodSeconds * 1000 ).toISOString()
-		: undefined;
+	const lastModifiedDate = new Date( periodSeconds * 1000 );
+	const lastModified = Number.isNaN( lastModifiedDate.getTime() )
+		? undefined
+		: lastModifiedDate.toISOString();
 	return {
 		type: 'file',
 		name,
@@ -113,6 +128,7 @@ export function useFileTree( rewindId: string, folderPath: string | null ): Resu
 	return {
 		children,
 		isLoading: query.isLoading,
+		isFetching: query.isFetching,
 		error: query.error ?? null,
 		refetch: retry,
 	};

--- a/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useMemo } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { fetchFileTree, type WpcomFileNode } from '../data/api/file-tree';
 import { keys } from '../data/query-client';
 import type { FileNode } from '../types/file-tree';
@@ -10,6 +10,7 @@ type Result = {
 	children: FileNode[] | null;
 	isLoading: boolean;
 	error: Error | null;
+	refetch: () => void;
 };
 
 /**
@@ -76,7 +77,7 @@ export function toFileNode( name: string, raw: WpcomFileNode, parentPath: string
  *
  * @param rewindId   - The backup's rewind id (decimal-suffix-safe).
  * @param folderPath - Folder to load, or null for the root.
- * @return Children list, loading flag, error.
+ * @return Children list, loading flag, error, refetch.
  */
 export function useFileTree( rewindId: string, folderPath: string | null ): Result {
 	const path = folderPath ?? BASE_FOLDER_PATH;
@@ -85,6 +86,7 @@ export function useFileTree( rewindId: string, folderPath: string | null ): Resu
 		queryFn: () => fetchFileTree( rewindId, path ),
 		enabled: Boolean( rewindId ),
 	} );
+	const { refetch } = query;
 
 	const children = useMemo< FileNode[] | null >( () => {
 		if ( ! query.data ) {
@@ -102,9 +104,16 @@ export function useFileTree( rewindId: string, folderPath: string | null ): Resu
 			.map( ( [ name, raw ] ) => toFileNode( name, raw, path ) );
 	}, [ query.data, path ] );
 
+	// Wrapped so callers can hand it straight to `onClick` without
+	// returning a floating promise from the event handler.
+	const retry = useCallback( () => {
+		refetch();
+	}, [ refetch ] );
+
 	return {
 		children,
 		isLoading: query.isLoading,
 		error: query.error ?? null,
+		refetch: retry,
 	};
 }

--- a/projects/packages/backup/tests/error-surfacing.test.tsx
+++ b/projects/packages/backup/tests/error-surfacing.test.tsx
@@ -35,6 +35,17 @@ const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected
 const CAPABILITIES = { hasBackupPlan: true, hasScan: false };
 
 /**
+ * These render a whole route stage behind three sequential round-trips —
+ * capabilities, then activity, then the file listing — each with its own
+ * React Query state transitions. Testing Library's default `findBy`
+ * window is 1s, which is comfortable locally and not on a loaded CI
+ * runner under coverage instrumentation: this suite has taken 32s there
+ * against 8s here. The wait is for a deterministic chain, so a longer
+ * ceiling costs nothing when it passes.
+ */
+const SETTLE = { timeout: 10000 };
+
+/**
  * Route requests by path so one endpoint can fail while the rest answer.
  * The gates have to pass before the body — and therefore the failure
  * under test — is ever rendered.
@@ -137,7 +148,7 @@ describe( 'activity list', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByText( "We couldn't load your site's activity." )
+			screen.findByText( "We couldn't load your site's activity.", undefined, SETTLE )
 		).resolves.toBeInTheDocument();
 		// The upstream reason is the only part a support agent can act on.
 		expect( screen.getByText( 'Service unavailable' ) ).toBeInTheDocument();
@@ -158,7 +169,9 @@ describe( 'activity list', () => {
 
 		render( <OverviewStage /> );
 
-		await expect( screen.findByText( 'No results' ) ).resolves.toBeInTheDocument();
+		await expect(
+			screen.findByText( 'No results', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
 		expect(
 			screen.queryByText( "We couldn't load your site's activity." )
 		).not.toBeInTheDocument();
@@ -177,7 +190,7 @@ describe( 'file browser', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByText( "We couldn't load this backup's files." )
+			screen.findByText( "We couldn't load this backup's files.", undefined, SETTLE )
 		).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Backup storage unreachable' ) ).toBeInTheDocument();
 		// The regression: a selection summary over a tree that isn't there.
@@ -210,11 +223,13 @@ describe( 'file browser', () => {
 
 		render( <OverviewStage /> );
 
-		await userEvent.click( await screen.findByRole( 'button', { name: /wp-content/ } ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: /wp-content/ }, SETTLE ) );
 
 		// "we couldn't look inside" and "there is nothing inside" used to
 		// be the same output.
-		await expect( screen.findByText( "Couldn't load this folder." ) ).resolves.toBeInTheDocument();
+		await expect(
+			screen.findByText( "Couldn't load this folder.", undefined, SETTLE )
+		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'Empty' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/error-surfacing.test.tsx
+++ b/projects/packages/backup/tests/error-surfacing.test.tsx
@@ -1,0 +1,148 @@
+// Regression tests for JETPACK-2243 D3.
+//
+// Every one of these failures used to render as an ordinary empty state.
+// `useActivityLog` and `useFileTree` both computed an `error` and handed
+// it back; three consumers destructured everything except that field, so
+// a 5xx and "there is nothing here" produced identical output. The whole
+// point of these tests is the *distinction*, so each one asserts both
+// that the reason appears and that the misleading empty-state copy does
+// not.
+
+const mockApiFetch = jest.fn();
+const mockSearch = jest.fn< Record< string, unknown >, [] >();
+const mockNavigate = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => mockSearch(),
+	useNavigate: () => mockNavigate,
+	useParams: () => ( { rewindId: '1777035492' } ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import { stage as OverviewStage } from '../routes/dashboard/stage';
+import ErrorBoundary from '../src/dashboard/components/error-boundary';
+import { queryClient } from '../src/dashboard/data/query-client';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const CAPABILITIES = { hasBackupPlan: true, hasScan: false };
+
+/**
+ * Route requests by path so one endpoint can fail while the rest answer.
+ * The gates have to pass before the body — and therefore the failure
+ * under test — is ever rendered.
+ *
+ * @param failing       - Path fragment that should reject.
+ * @param error         - The rejection payload.
+ * @param error.code    - Error code, as the bridges emit it.
+ * @param error.message - Human-readable reason.
+ */
+function failOnly( failing: string, error: { code: string; message: string } ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( failing ) ) {
+			return Promise.reject( error );
+		}
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( CAPABILITIES );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockApiFetch.mockResolvedValue( CAPABILITIES );
+	mockSearch.mockReset();
+	mockSearch.mockReturnValue( {} );
+	mockNavigate.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'activity list', () => {
+	it( 'reports a failed request instead of "No results"', async () => {
+		failOnly( '/site/rewindable-activity', {
+			code: 'activity_log_fetch_failed',
+			message: 'Service unavailable',
+		} );
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByText( "We couldn't load your site's activity." )
+		).resolves.toBeInTheDocument();
+		// The upstream reason is the only part a support agent can act on.
+		expect( screen.getByText( 'Service unavailable' ) ).toBeInTheDocument();
+		// The regression: a 5xx telling the reader their site has no activity.
+		expect( screen.queryByText( 'No results' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'still shows the plain empty state when the request simply returns nothing', async () => {
+		// Same rendered path, opposite cause — proves the new branch is
+		// keyed on the error and not on emptiness.
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( '/site/capabilities' ) ) {
+				return Promise.resolve( CAPABILITIES );
+			}
+			return Promise.resolve( { current: { orderedItems: [] }, totalItems: 0, totalPages: 0 } );
+		} );
+
+		render( <OverviewStage /> );
+
+		await expect( screen.findByText( 'No results' ) ).resolves.toBeInTheDocument();
+		expect(
+			screen.queryByText( "We couldn't load your site's activity." )
+		).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'ErrorBoundary', () => {
+	/**
+	 * Stands in for the known real hazard: `toFileNode` raising
+	 * `RangeError: Invalid time value` on a malformed manifest timestamp,
+	 * inside a `useMemo` on the render path.
+	 */
+	function Exploding(): never {
+		throw new Error( 'Invalid time value' );
+	}
+
+	it( 'replaces a crashed subtree with a recoverable message', () => {
+		render(
+			<ErrorBoundary>
+				<Exploding />
+			</ErrorBoundary>
+		);
+
+		expect( screen.getByText( 'Something went wrong' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Invalid time value' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Reload the page' } ) ).toBeInTheDocument();
+		// React logs the caught error, and so does componentDidCatch —
+		// @wordpress/jest-console fails the test unless that is claimed.
+		expect( console ).toHaveErrored();
+	} );
+
+	it( 'renders children untouched when nothing throws', () => {
+		render(
+			<ErrorBoundary>
+				<p>All good</p>
+			</ErrorBoundary>
+		);
+
+		expect( screen.getByText( 'All good' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Something went wrong' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/error-surfacing.test.tsx
+++ b/projects/packages/backup/tests/error-surfacing.test.tsx
@@ -26,6 +26,7 @@ jest.mock( '@wordpress/route', () => ( {
 
 // Imports must come after the jest.mock factories above.
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
 import ErrorBoundary from '../src/dashboard/components/error-boundary';
 import { queryClient } from '../src/dashboard/data/query-client';
@@ -55,6 +56,60 @@ function failOnly( failing: string, error: { code: string; message: string } ) {
 		return Promise.resolve( {} );
 	} );
 }
+
+/**
+ * One rewindable-activity backup row, enough for the Overview to
+ * preselect it and mount the file browser against it.
+ *
+ * @return A raw activity entry.
+ */
+function backupActivityEntry() {
+	return {
+		activity_id: 'act-1',
+		gridicon: 'cloud',
+		summary: 'Backup complete',
+		published: '2026-08-13T18:08:56+00:00',
+		rewind_id: '1786644531.123',
+		actor: { type: 'Application', name: 'Jetpack' },
+		content: { text: '46 plugins, 23 themes' },
+		name: 'rewind__backup_complete_full',
+	};
+}
+
+/**
+ * Serve a selectable backup, and fail the file-tree listing.
+ *
+ * @param error         - The rejection payload for `/rewind/backup/ls`.
+ * @param error.code    - Error code, as the bridges emit it.
+ * @param error.message - Human-readable reason.
+ */
+function failFileTree( error: { code: string; message: string } ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/rewind/backup/ls' ) ) {
+			return Promise.reject( error );
+		}
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( CAPABILITIES );
+		}
+		if ( path.includes( '/site/rewindable-activity' ) ) {
+			return Promise.resolve( {
+				current: { orderedItems: [ backupActivityEntry() ] },
+				totalItems: 1,
+				totalPages: 1,
+			} );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row. Defined rather than spied on:
+// `jest.spyOn` requires the property to already exist.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );
 
 beforeEach( () => {
 	queryClient.clear();
@@ -107,6 +162,60 @@ describe( 'activity list', () => {
 		expect(
 			screen.queryByText( "We couldn't load your site's activity." )
 		).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'file browser', () => {
+	// The only change in this PR that *removes* rendered UI, which is why
+	// it is worth pinning: a failed root tree used to render an empty tree
+	// under a "0 items selected" header, i.e. a successfully-loaded backup
+	// that happens to contain nothing. A silently restored header would put
+	// that misleading affordance back with every other test still green.
+	it( 'reports a failed root tree and drops the selection header', async () => {
+		failFileTree( { code: 'file_tree_fetch_failed', message: 'Backup storage unreachable' } );
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByText( "We couldn't load this backup's files." )
+		).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Backup storage unreachable' ) ).toBeInTheDocument();
+		// The regression: a selection summary over a tree that isn't there.
+		expect( screen.queryByText( /items? selected/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'says a folder could not be read rather than that it is empty', async () => {
+		// The root listing succeeds; only the folder's own fetch fails.
+		mockApiFetch.mockImplementation( ( options: { path?: string; data?: unknown } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( '/site/capabilities' ) ) {
+				return Promise.resolve( CAPABILITIES );
+			}
+			if ( path.includes( '/site/rewindable-activity' ) ) {
+				return Promise.resolve( {
+					current: { orderedItems: [ backupActivityEntry() ] },
+					totalItems: 1,
+					totalPages: 1,
+				} );
+			}
+			if ( path.includes( '/rewind/backup/ls' ) ) {
+				const folder = ( options as { data?: { path?: string } } )?.data?.path;
+				if ( folder && folder !== '/' ) {
+					return Promise.reject( { code: 'x', message: 'Unreadable' } );
+				}
+				return Promise.resolve( { contents: { 'wp-content': { type: 'dir' } } } );
+			}
+			return Promise.resolve( {} );
+		} );
+
+		render( <OverviewStage /> );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: /wp-content/ } ) );
+
+		// "we couldn't look inside" and "there is nothing inside" used to
+		// be the same output.
+		await expect( screen.findByText( "Couldn't load this folder." ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Empty' ) ).not.toBeInTheDocument();
 	} );
 } );
 

--- a/projects/packages/backup/tests/stages.test.tsx
+++ b/projects/packages/backup/tests/stages.test.tsx
@@ -65,23 +65,36 @@ beforeEach( () => {
 	setConnection( CONNECTED );
 } );
 
+/**
+ * The stages are wrapped in `<ErrorBoundary>`, so a reintroduced render
+ * throw no longer propagates to the runner — the test would still fail,
+ * but on a `findByText` timeout that points nowhere near the cause.
+ * Asserting the fallback is absent keeps the failure legible.
+ */
+function expectNoBoundaryFallback() {
+	expect( screen.queryByText( 'Something went wrong' ) ).not.toBeInTheDocument();
+}
+
 describe( 'route stages mount their screens with a QueryClient in scope', () => {
 	it( 'renders the Overview stage', async () => {
 		render( <OverviewStage /> );
 
 		await expect( screen.findByText( 'VaultPress Backup' ) ).resolves.toBeInTheDocument();
+		expectNoBoundaryFallback();
 	} );
 
 	it( 'renders the Download stage', async () => {
 		render( <DownloadStage /> );
 
 		await expect( screen.findByText( 'Download backup' ) ).resolves.toBeInTheDocument();
+		expectNoBoundaryFallback();
 	} );
 
 	it( 'renders the Restore stage', async () => {
 		render( <RestoreStage /> );
 
 		await expect( screen.findByText( 'Restore backup' ) ).resolves.toBeInTheDocument();
+		expectNoBoundaryFallback();
 	} );
 } );
 


### PR DESCRIPTION
Fixes #

Part of [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243) — task **D3**. Umbrella: #48582. Independent of #51292 (E1/E2); either can land first.

## Proposed changes

`useActivityLog` and `useFileTree` both compute an `error` and hand it back. Three consumers destructured everything **except** that field — and because a failed query also leaves `data` empty, every one of those failures rendered as an ordinary empty state. The reader is not told something went wrong; they're told a confident, wrong answer.

* **A 5xx on the activity log showed DataViews' "No results"** — your site has no activity, when in fact we couldn't ask. Now reports the failure in DataViews' `empty` slot, which is the exact node that copy rendered in.
* **A failed root file tree showed an empty tree under a "0 items selected" header** — indistinguishable from a backup that legitimately contains nothing. The selection header is now removed along with the tree: a selection summary is meaningless without a tree to select from.
* **A folder whose fetch failed printed "Empty"** — so "we couldn't look inside" and "there is nothing inside" produced identical output.

Each now names what failed, shows WPCOM's message verbatim (the only part a support agent can act on — the bridges already translate upstream failures into readable text), and offers a retry. That meant threading `refetch` out of both hooks.

**Plus a route-level error boundary** on all three stages. Until now a throw anywhere on the render path unmounted the whole tree and left an empty `<div>` inside the page chrome — a blank panel with nothing to click. This is defence in depth rather than a fix for one known hole. The hazard it was written for — `toFileNode` calling `toISOString()` on a `period` parsed straight out of an unvalidated WPCOM manifest — is guarded at the source, and that guard is the right place for it, since dropping one timestamp beats blanking the file browser. (This PR also closes a gap in that guard: `Number.isFinite` passes any in-range float, but `Date` is only defined within ±8.64e15 ms, so a `period` in milliseconds still threw.) What the boundary buys is that the *next* such field, in the next component, costs a legible error screen instead of a white rectangle.

### Notes for reviewers

* The boundary is a class component because `getDerivedStateFromError` still has no hook equivalent. It sits **outside** `QueryClientProvider` so it also covers the provider, and because a screen's own hooks run before it renders `<DashboardLayout>` — a boundary inside the layout would never mount in time. The trade-off is that the fallback renders without the page chrome, which is a deliberate choice over not catching at all.
* Recovery is a reload rather than a state reset: by the time the fallback renders, the failed subtree's state is gone, so a "try again" that didn't remount would re-throw immediately.
* `empty` on `DataViews` is a first-class prop and **is** honoured by the `list` layout — there's a test asserting the default "No results" still appears when the query merely returns nothing, so the new branch is provably keyed on the error and not on emptiness.

## Related product discussion/links

* [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243)

## Does this pull request change what data or activity we track or use?

No. Error messages already returned by the bridges are shown to the admin who triggered the request; nothing new is collected or sent.

## Testing instructions

All of this is behind `rsm_jetpack_ui_modernization_backup`, **default off**. Confirm the legacy page is unchanged first.

**Setup.** On a site with the Backup plugin and an active Backup plan:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

Then go to **Jetpack → VaultPress Backup**.

These failures are hard to provoke for real, so inject them from the browser console. Each snippet registers an `apiFetch` middleware against the running app; a reload undoes it.

**1. Activity log fails.** Paste, then click the **next page** arrow at the bottom of the list (a new page is a new query, so it refetches):

```js
wp.apiFetch.use( ( o, next ) =>
	typeof o.path === 'string' && o.path.includes( '/site/rewindable-activity' )
		? Promise.reject( { code: 'x', message: 'Service unavailable (injected)' } )
		: next( o )
);
```

Expect a red notice reading "We couldn't load your site's activity.", the injected message beneath it, and a working **Try again**. Expect **no** "No results".

**2. File tree fails.** Reload, then paste:

```js
wp.apiFetch.use( ( o, next ) =>
	typeof o.path === 'string' && o.path.includes( '/rewind/backup/ls' )
		? Promise.reject( { code: 'x', message: 'Backup storage unreachable (injected)' } )
		: next( o )
);
```

* **Folder level:** expand any folder in the right-hand file list (e.g. `sql`). It should read "Couldn't load this folder." — **not** "Empty".
* **Root level:** now click a *different* backup row in the activity list. The right pane should show "We couldn't load this backup's files." with the reason and a retry, and the **"0 items selected" header should be gone**.

**3. Error boundary.** Hard to trigger by hand; covered by tests. If you want to see it, temporarily add `throw new Error( 'boom' )` to the top of `OverviewScreen` and rebuild — you should get a "Something went wrong" card with the message and a "Reload the page" button, rather than a blank panel.

**4. Nothing regressed.** With no injection, confirm the activity list, pagination, file browser and folder expansion all behave as before, and that an genuinely empty folder still says "Empty".

**Automated:**

```
jp test js packages/backup     # 171 tests, 26 suites
jp test php packages/backup
```

