### PR TITLE
Backup: repoint the modernized download flow at the v2 downloads routes

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-repoint-download
+++ b/projects/packages/backup/changelog/fix-backup-repoint-download
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Backup: repoint the modernized dashboard's download flow at the v2 downloads routes, project the status response, and fix the progress scale. No-op when the modernization filter is off.

--- a/projects/packages/backup/src/dashboard/data/api/_helpers.ts
+++ b/projects/packages/backup/src/dashboard/data/api/_helpers.ts
@@ -31,8 +31,13 @@ export function apiPath(
 
 /**
  * Strip the decimal suffix WPCOM ships on rewind ids (e.g.
- * `'1777035492.615'` → `'1777035492'`). The `/rewind/backup/$rewindId`
- * URLs reject the suffixed form with a 404.
+ * `'1777035492.615'` → `'1777035492'`).
+ *
+ * **Only the file-browser URL family needs this.** Those routes match
+ * `(?P<backup_id>\d+)`, so a fractional id 404s before WPCOM is reached.
+ * The restore and download mutations are the opposite case: they take
+ * the rewind id in the request *body*, in full, and truncating it there
+ * addresses a different backup than the one the reader picked.
  *
  * @param rewindId - Raw rewind id, possibly with a decimal suffix.
  * @return The integer-seconds portion only.
@@ -40,6 +45,40 @@ export function apiPath(
 export function toIntRewindId( rewindId: string ): string {
 	const idx = rewindId.indexOf( '.' );
 	return idx === -1 ? rewindId : rewindId.slice( 0, idx );
+}
+
+/**
+ * Serialize a restore/download category checklist for WPCOM.
+ *
+ * WPCOM parses `types` with `array_keys( $param, true )`, which compares
+ * **loosely** — so a JSON array of names does not mean what it looks
+ * like. `[ "themes" ]` matches `'themes' == true` and yields `[ 0 ]`,
+ * and `[ "themes", "plugins" ]` yields `[ 0, 1 ]`: integer indices,
+ * forwarded to VaultPress as if they were type names. An emptiness
+ * check would never catch it, because the list is not empty.
+ *
+ * The object form is therefore the only safe spelling, and this is the
+ * single place that builds it. Only `true` entries are included, so the
+ * result never depends on that loose comparison.
+ *
+ * Returns `undefined` when nothing is selected. Callers must omit the
+ * key entirely in that case rather than sending `{}` — the restore route
+ * rejects any `types` value that names no type, and on the download side
+ * an empty list would silently ask for nothing.
+ *
+ * @param items - The category checklist.
+ * @return The object form, or undefined when no category is selected.
+ */
+export function serializeTypes(
+	items: Record< string, boolean >
+): Record< string, true > | undefined {
+	const selected: Record< string, true > = {};
+	for ( const key of Object.keys( items ) ) {
+		if ( items[ key ] ) {
+			selected[ key ] = true;
+		}
+	}
+	return Object.keys( selected ).length ? selected : undefined;
 }
 
 /**

--- a/projects/packages/backup/src/dashboard/data/api/_helpers.ts
+++ b/projects/packages/backup/src/dashboard/data/api/_helpers.ts
@@ -50,12 +50,12 @@ export function toIntRewindId( rewindId: string ): string {
 /**
  * Serialize a restore/download category checklist for WPCOM.
  *
- * WPCOM parses `types` with `array_keys( $param, true )`, which compares
- * **loosely** — so a JSON array of names does not mean what it looks
- * like. `[ "themes" ]` matches `'themes' == true` and yields `[ 0 ]`,
- * and `[ "themes", "plugins" ]` yields `[ 0, 1 ]`: integer indices,
- * forwarded to VaultPress as if they were type names. An emptiness
- * check would never catch it, because the list is not empty.
+ * WPCOM selects the enabled categories with a **loose** comparison, so a
+ * JSON array of names does not mean what it looks like: every name
+ * compares equal, and what comes back out is the array's own integer
+ * indices. `[ "themes" ]` becomes `[ 0 ]` and `[ "themes", "plugins" ]`
+ * becomes `[ 0, 1 ]`, which are then treated as category names. An
+ * emptiness check would never catch it, because the list is not empty.
  *
  * The object form is therefore the only safe spelling, and this is the
  * single place that builds it. Only `true` entries are included, so the

--- a/projects/packages/backup/src/dashboard/data/api/_helpers.ts
+++ b/projects/packages/backup/src/dashboard/data/api/_helpers.ts
@@ -33,11 +33,24 @@ export function apiPath(
  * Strip the decimal suffix WPCOM ships on rewind ids (e.g.
  * `'1777035492.615'` → `'1777035492'`).
  *
- * **Only the file-browser URL family needs this.** Those routes match
- * `(?P<backup_id>\d+)`, so a fractional id 404s before WPCOM is reached.
- * The restore and download mutations are the opposite case: they take
- * the rewind id in the request *body*, in full, and truncating it there
- * addresses a different backup than the one the reader picked.
+ * Truncating is a WPCOM-side requirement, not a local one — no route in
+ * this package matches the id against `\d+`. Where the two remaining
+ * callers stand:
+ *
+ * `fetchFileTree` needs it. It sends the id in the body as `rewind_id`,
+ * and the bridge forwards that to WPCOM as `backup_id`, which is an
+ * integer identifier there.
+ *
+ * `initiateRestore` still calls it, but only because it targets the v1
+ * activity-log route with the id in the *path*. That is a temporary
+ * arrangement: the v2 restore route takes the id in the body, in full,
+ * and the call moves with it when it is repointed. Note the Jetpack
+ * route it goes through already accepts a decimal, so the truncation is
+ * not protecting anything.
+ *
+ * Download no longer calls it at all: `/rewind/downloads` takes the id
+ * in the body and truncating it there addresses a different backup than
+ * the reader picked.
  *
  * @param rewindId - Raw rewind id, possibly with a decimal suffix.
  * @return The integer-seconds portion only.

--- a/projects/packages/backup/src/dashboard/data/api/download.ts
+++ b/projects/packages/backup/src/dashboard/data/api/download.ts
@@ -1,24 +1,39 @@
-import { apiCall, apiPath, toIntRewindId } from './_helpers';
+import { apiCall, apiPath, serializeTypes } from './_helpers';
 import type { RestoreItems } from '../../types/restore';
 
 export type InitiateDownloadResponse = {
 	id: number;
 };
 
+/**
+ * Lifecycle of a download, derived by the bridge.
+ *
+ * WPCOM's own payload carries no status field: `format_download()`
+ * builds a base object and then attaches keys by branch — `url` and
+ * `validUntil` once the archive is ready, `error` when it failed, and
+ * `progress` only while it is still being built. The bridge reads which
+ * branch fired and reports it as one of these instead, so the client
+ * never has to infer lifecycle from field presence.
+ */
+export type DownloadStatus = 'running' | 'finished' | 'failed';
+
 export type DownloadStatusResponse = {
-	url?: string;
-	valid_until?: string;
-	progress?: number;
-	status: 'in-progress' | 'completed' | 'failed' | string;
+	id: number;
+	status: DownloadStatus;
+	/** 0–100. Absent upstream once the download finishes or fails; the bridge sends 0. */
+	progress: number;
+	/** Signed archive URL. Only present once `status` is `finished`. */
+	url: string;
+	/** ISO-8601 expiry of `url`, or empty. */
+	valid_until: string;
+	/** WPCOM's reason, only when `status` is `failed`. */
+	error: string;
 };
 
 /**
  * Initiate a backup download.
  *
- * `types` maps directly to WPCOM's `types` payload (the keys match the
- * `RestoreItems` checklist). Sending `{}` means "include everything".
- *
- * @param rewindId - The backup's rewind id.
+ * @param rewindId - The backup's rewind id, in full — the decimal suffix is significant.
  * @param types    - Which categories to include in the download.
  * @return The download id.
  */
@@ -27,16 +42,18 @@ export async function initiateDownload(
 	types: RestoreItems
 ): Promise< InitiateDownloadResponse > {
 	return apiCall< InitiateDownloadResponse >( {
-		path: apiPath( `/backups/download/${ toIntRewindId( rewindId ) }` ),
+		path: apiPath( `/backups/download/${ rewindId }` ),
 		method: 'POST',
-		data: { types },
+		// Omitted entirely when nothing is selected: an empty `types`
+		// asks WPCOM for a download containing nothing.
+		data: { types: serializeTypes( types ) },
 	} );
 }
 
 /**
  * Poll status for an in-flight download.
  *
- * @param rewindId   - The backup's rewind id.
+ * @param rewindId   - The backup's rewind id, in full.
  * @param downloadId - The download id returned by `initiateDownload`.
  * @return The current download state.
  */
@@ -45,7 +62,7 @@ export async function fetchDownloadStatus(
 	downloadId: number
 ): Promise< DownloadStatusResponse > {
 	return apiCall< DownloadStatusResponse >( {
-		path: apiPath( `/backups/download/${ toIntRewindId( rewindId ) }/status`, {
+		path: apiPath( `/backups/download/${ rewindId }/status`, {
 			download_id: downloadId,
 		} ),
 	} );

--- a/projects/packages/backup/src/dashboard/data/api/download.ts
+++ b/projects/packages/backup/src/dashboard/data/api/download.ts
@@ -8,12 +8,12 @@ export type InitiateDownloadResponse = {
 /**
  * Lifecycle of a download, derived by the bridge.
  *
- * WPCOM's own payload carries no status field: `format_download()`
- * builds a base object and then attaches keys by branch — `url` and
- * `validUntil` once the archive is ready, `error` when it failed, and
- * `progress` only while it is still being built. The bridge reads which
- * branch fired and reports it as one of these instead, so the client
- * never has to infer lifecycle from field presence.
+ * WPCOM's own payload carries no status field. It returns a base object
+ * and attaches further keys according to where the download has got to —
+ * `url` and `validUntil` once the archive is ready, `error` when it
+ * failed, and `progress` only while it is still being built. The bridge
+ * reads which of those arrived and reports it as one of these instead,
+ * so the client never has to infer lifecycle from field presence.
  */
 export type DownloadStatus = 'running' | 'finished' | 'failed';
 

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -1,4 +1,4 @@
-import { apiCall, apiPath, toIntRewindId } from './_helpers';
+import { apiCall, apiPath, serializeTypes, toIntRewindId } from './_helpers';
 import type { RestoreItems } from '../../types/restore';
 
 export type InitiateRestoreResponse = {
@@ -17,8 +17,14 @@ export type RestoreStatusResponse = {
 /**
  * Start a restore for the given backup point.
  *
- * `types` maps directly to WPCOM's `types` payload (the keys match the
- * `RestoreItems` checklist). Sending `{}` means "restore everything".
+ * Shares `serializeTypes` with the download call so both emit the object
+ * form; see that helper for why a JSON array is never safe here. An
+ * unselected checklist sends no `types` at all rather than an empty one.
+ *
+ * Note this still targets the v1 activity-log route, which discards
+ * Jetpack user tokens and therefore always answers 401. Repointing it at
+ * the v2 restore routes is separate work — only the `types` serialization
+ * is changed here, so restore and download share one spelling.
  *
  * @param rewindId - The backup's rewind id.
  * @param types    - Which categories to restore (themes/plugins/roots/contents/sqls/uploads).
@@ -31,7 +37,7 @@ export async function initiateRestore(
 	return apiCall< InitiateRestoreResponse >( {
 		path: apiPath( `/rewind/to/${ toIntRewindId( rewindId ) }` ),
 		method: 'POST',
-		data: { types },
+		data: { types: serializeTypes( types ) },
 	} );
 }
 

--- a/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
@@ -22,11 +22,11 @@ describe( 'serializeTypes', () => {
 		} );
 	} );
 
-	// The whole reason this helper exists. WPCOM parses `types` with
-	// `array_keys( $param, true )`, which compares loosely — so a JSON
-	// array of names yields its integer indices (`[ "themes" ]` becomes
-	// `[ 0 ]`) and forwards those to VaultPress as if they were type
-	// names. An emptiness check would never catch it.
+	// The whole reason this helper exists. WPCOM selects the enabled
+	// categories with a loose comparison, so a JSON array of names yields
+	// its own integer indices — `[ "themes" ]` becomes `[ 0 ]` — and
+	// those get treated as category names. An emptiness check would never
+	// catch it, because the list is not empty.
 	test( 'never produces an array', () => {
 		const result = serializeTypes( { themes: true, plugins: true } );
 

--- a/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
@@ -1,4 +1,4 @@
-import { toIntRewindId } from '../_helpers';
+import { serializeTypes, toIntRewindId } from '../_helpers';
 
 describe( 'toIntRewindId', () => {
 	test( 'returns the input unchanged when there is no decimal suffix', () => {
@@ -11,5 +11,34 @@ describe( 'toIntRewindId', () => {
 
 	test( 'strips everything from the first dot onwards', () => {
 		expect( toIntRewindId( '1777035492.615.123' ) ).toBe( '1777035492' );
+	} );
+} );
+
+describe( 'serializeTypes', () => {
+	test( 'emits the object form, keeping only the selected categories', () => {
+		expect( serializeTypes( { themes: true, plugins: false, sqls: true } ) ).toEqual( {
+			themes: true,
+			sqls: true,
+		} );
+	} );
+
+	// The whole reason this helper exists. WPCOM parses `types` with
+	// `array_keys( $param, true )`, which compares loosely — so a JSON
+	// array of names yields its integer indices (`[ "themes" ]` becomes
+	// `[ 0 ]`) and forwards those to VaultPress as if they were type
+	// names. An emptiness check would never catch it.
+	test( 'never produces an array', () => {
+		const result = serializeTypes( { themes: true, plugins: true } );
+
+		expect( Array.isArray( result ) ).toBe( false );
+		expect( result ).toEqual( { themes: true, plugins: true } );
+	} );
+
+	test( 'returns undefined when nothing is selected, so the key can be omitted', () => {
+		// `{}` is not a safe stand-in: the restore route rejects a `types`
+		// value that names nothing, and the download side would build an
+		// archive containing nothing.
+		expect( serializeTypes( { themes: false, plugins: false } ) ).toBeUndefined();
+		expect( serializeTypes( {} ) ).toBeUndefined();
 	} );
 } );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-download.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-download.test.ts
@@ -55,7 +55,15 @@ describe( 'useDownload', () => {
 		const { wrapper } = makeWrapper();
 
 		const { result } = renderHook( () => useDownload( REWIND_ID ), { wrapper } );
-		act( () => result.current.submit( DEFAULT_RESTORE_ITEMS ) );
+		act( () =>
+			result.current.submit( {
+				...DEFAULT_RESTORE_ITEMS,
+				plugins: false,
+				roots: false,
+				contents: false,
+				uploads: false,
+			} )
+		);
 
 		await waitFor( () => expect( mockedApiFetch ).toHaveBeenCalled() );
 		const [ initiate ] = mockedApiFetch.mock.calls[ 0 ];
@@ -63,7 +71,9 @@ describe( 'useDownload', () => {
 		// different backup than the one the reader picked.
 		expect( initiate.path ).toContain( REWIND_ID );
 		expect( Array.isArray( initiate.data.types ) ).toBe( false );
-		expect( initiate.data.types ).toEqual( DEFAULT_RESTORE_ITEMS );
+		// A partial selection, so this proves the filtering rather than
+		// echoing an all-true default back at itself.
+		expect( initiate.data.types ).toEqual( { themes: true, sqls: true } );
 	} );
 
 	// `progress` is already 0–100: WPCOM coerces it to an integer, which
@@ -106,6 +116,7 @@ describe( 'useDownload', () => {
 			expect( result.current.state ).toEqual( {
 				phase: 'success',
 				downloadUrl: 'https://example.com/archive.zip',
+				validUntil: '2026-08-20T00:00:00+00:00',
 			} )
 		);
 	} );
@@ -125,7 +136,11 @@ describe( 'useDownload', () => {
 		act( () => result.current.submit( DEFAULT_RESTORE_ITEMS ) );
 
 		await waitFor( () =>
-			expect( result.current.state ).toEqual( { phase: 'error', message: 'Archive expired' } )
+			expect( result.current.state ).toEqual( {
+				phase: 'error',
+				// Carried inside a translated frame rather than shown raw.
+				message: 'Download failed: Archive expired',
+			} )
 		);
 	} );
 } );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-download.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-download.test.ts
@@ -1,0 +1,131 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, type ReactNode } from 'react';
+import { DEFAULT_RESTORE_ITEMS } from '../../types/restore';
+import { useDownload } from '../use-download';
+
+jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+const REWIND_ID = '1786663613.9425';
+
+/**
+ * Fresh client per test, retries off so failures assert immediately.
+ *
+ * @return A wrapper providing an isolated QueryClient.
+ */
+function makeWrapper() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	const wrapper = ( { children }: { children: ReactNode } ) =>
+		createElement( QueryClientProvider, { client }, children );
+	return { wrapper };
+}
+
+/**
+ * Answer the initiate call, then every status poll with `status`.
+ *
+ * @param status - The projected status payload the bridge would return.
+ */
+function respondWith( status: Record< string, unknown > ) {
+	mockedApiFetch.mockImplementation( ( options: { path?: string; method?: string } ) => {
+		if ( options?.method === 'POST' ) {
+			return Promise.resolve( { id: 4321 } );
+		}
+		return Promise.resolve( status );
+	} );
+}
+
+beforeEach( () => {
+	mockedApiFetch.mockReset();
+} );
+
+describe( 'useDownload', () => {
+	it( 'sends the rewind id in full, and the types as an object', async () => {
+		respondWith( {
+			id: 4321,
+			status: 'running',
+			progress: 0,
+			url: '',
+			valid_until: '',
+			error: '',
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useDownload( REWIND_ID ), { wrapper } );
+		act( () => result.current.submit( DEFAULT_RESTORE_ITEMS ) );
+
+		await waitFor( () => expect( mockedApiFetch ).toHaveBeenCalled() );
+		const [ initiate ] = mockedApiFetch.mock.calls[ 0 ];
+		// The decimal suffix is significant — truncating it addresses a
+		// different backup than the one the reader picked.
+		expect( initiate.path ).toContain( REWIND_ID );
+		expect( Array.isArray( initiate.data.types ) ).toBe( false );
+		expect( initiate.data.types ).toEqual( DEFAULT_RESTORE_ITEMS );
+	} );
+
+	// `progress` is already 0–100: WPCOM runs it through `intval()`, which
+	// a 0–1 float could not survive. The old `* 100` fed the ProgressBar
+	// values up to 10000.
+	it( 'reports progress on the 0-100 scale it arrives on', async () => {
+		respondWith( {
+			id: 4321,
+			status: 'running',
+			progress: 42,
+			url: '',
+			valid_until: '',
+			error: '',
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useDownload( REWIND_ID ), { wrapper } );
+		act( () => result.current.submit( DEFAULT_RESTORE_ITEMS ) );
+
+		await waitFor( () =>
+			expect( result.current.state ).toEqual( { phase: 'progress', percent: 42 } )
+		);
+	} );
+
+	it( 'resolves to the archive url when the download finishes', async () => {
+		respondWith( {
+			id: 4321,
+			status: 'finished',
+			progress: 0,
+			url: 'https://example.com/archive.zip',
+			valid_until: '2026-08-20T00:00:00+00:00',
+			error: '',
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useDownload( REWIND_ID ), { wrapper } );
+		act( () => result.current.submit( DEFAULT_RESTORE_ITEMS ) );
+
+		await waitFor( () =>
+			expect( result.current.state ).toEqual( {
+				phase: 'success',
+				downloadUrl: 'https://example.com/archive.zip',
+			} )
+		);
+	} );
+
+	it( "surfaces WPCOM's reason when the download fails", async () => {
+		respondWith( {
+			id: 4321,
+			status: 'failed',
+			progress: 0,
+			url: '',
+			valid_until: '',
+			error: 'Archive expired',
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useDownload( REWIND_ID ), { wrapper } );
+		act( () => result.current.submit( DEFAULT_RESTORE_ITEMS ) );
+
+		await waitFor( () =>
+			expect( result.current.state ).toEqual( { phase: 'error', message: 'Archive expired' } )
+		);
+	} );
+} );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-download.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-download.test.ts
@@ -66,7 +66,7 @@ describe( 'useDownload', () => {
 		expect( initiate.data.types ).toEqual( DEFAULT_RESTORE_ITEMS );
 	} );
 
-	// `progress` is already 0–100: WPCOM runs it through `intval()`, which
+	// `progress` is already 0–100: WPCOM coerces it to an integer, which
 	// a 0–1 float could not survive. The old `* 100` fed the ProgressBar
 	// values up to 10000.
 	it( 'reports progress on the 0-100 scale it arrives on', async () => {

--- a/projects/packages/backup/src/dashboard/hooks/use-download.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-download.ts
@@ -24,9 +24,12 @@ const POLL_INTERVAL_MS = 1500;
  * Real `useDownload` driving the modernized Download screen via the
  * `/jetpack/v4/backups/download/$rewindId` bridge.
  *
- * Submit kicks off the WPCOM `prepare-download` and stores the download
- * id; a polled status query then advances the state machine
+ * Submit asks WPCOM to build the archive and stores the download id; a
+ * polled status query then advances the state machine
  * idle → submitting → progress → success | error.
+ *
+ * The bridge derives `status` for us, because WPCOM's own payload has no
+ * status field — it signals lifecycle by which keys are present.
  *
  * @param rewindId - The backup's rewind id.
  * @return state + submit + reset.
@@ -55,8 +58,7 @@ export function useDownload( rewindId: string ): Result {
 		queryKey: keys.downloadStatus( rewindId, effectiveDownloadId ),
 		queryFn: () => fetchDownloadStatus( rewindId, effectiveDownloadId ),
 		enabled: downloadId !== null,
-		refetchInterval: query =>
-			query.state.data?.status === 'in-progress' ? POLL_INTERVAL_MS : false,
+		refetchInterval: query => ( query.state.data?.status === 'running' ? POLL_INTERVAL_MS : false ),
 	} );
 
 	const submit = useCallback(
@@ -74,10 +76,15 @@ export function useDownload( rewindId: string ): Result {
 		state = { phase: 'error', message: errorMessage };
 	} else if ( isInitiating ) {
 		state = { phase: 'submitting' };
-	} else if ( statusQuery.data?.status === 'completed' && statusQuery.data.url ) {
+	} else if ( statusQuery.data?.status === 'finished' && statusQuery.data.url ) {
 		state = { phase: 'success', downloadUrl: statusQuery.data.url };
 	} else if ( statusQuery.data?.status === 'failed' ) {
-		state = { phase: 'error', message: __( 'Download failed.', 'jetpack-backup-pkg' ) };
+		state = {
+			phase: 'error',
+			// WPCOM's reason when it gave one; the generic line only as a
+			// fallback, since "Download failed." tells nobody anything.
+			message: statusQuery.data.error || __( 'Download failed.', 'jetpack-backup-pkg' ),
+		};
 	} else if ( downloadId !== null && statusQuery.error ) {
 		// Network/HTTP failure mid-poll: surface so the UI doesn't sit
 		// in `progress` at the last known percent with no way out.
@@ -89,8 +96,11 @@ export function useDownload( rewindId: string ): Result {
 		};
 	} else if ( downloadId !== null && statusQuery.data ) {
 		state = {
+			// `progress` is already 0–100 — WPCOM runs it through
+			// `intval()`, which a 0–1 float could not survive. Multiplying
+			// by 100 fed the ProgressBar values up to 10000.
 			phase: 'progress',
-			percent: Math.round( ( statusQuery.data.progress ?? 0 ) * 100 ),
+			percent: statusQuery.data.progress ?? 0,
 		};
 	} else if ( downloadId !== null ) {
 		state = { phase: 'progress', percent: 0 };

--- a/projects/packages/backup/src/dashboard/hooks/use-download.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-download.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useCallback, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { fetchDownloadStatus, initiateDownload } from '../data/api/download';
 import { keys } from '../data/query-client';
 import type { RestoreItems } from '../types/restore';
@@ -9,7 +9,7 @@ type DownloadState =
 	| { phase: 'idle' }
 	| { phase: 'submitting' }
 	| { phase: 'progress'; percent: number }
-	| { phase: 'success'; downloadUrl: string }
+	| { phase: 'success'; downloadUrl: string; validUntil: string }
 	| { phase: 'error'; message: string };
 
 type Result = {
@@ -77,13 +77,26 @@ export function useDownload( rewindId: string ): Result {
 	} else if ( isInitiating ) {
 		state = { phase: 'submitting' };
 	} else if ( statusQuery.data?.status === 'finished' && statusQuery.data.url ) {
-		state = { phase: 'success', downloadUrl: statusQuery.data.url };
+		state = {
+			phase: 'success',
+			downloadUrl: statusQuery.data.url,
+			validUntil: statusQuery.data.valid_until,
+		};
 	} else if ( statusQuery.data?.status === 'failed' ) {
 		state = {
 			phase: 'error',
-			// WPCOM's reason when it gave one; the generic line only as a
-			// fallback, since "Download failed." tells nobody anything.
-			message: statusQuery.data.error || __( 'Download failed.', 'jetpack-backup-pkg' ),
+			// WPCOM's reason when it gave one, since "Download failed."
+			// tells nobody anything — but carried inside a translated frame
+			// rather than shown as the whole message, so an upstream string
+			// in one language can't be the only text on an otherwise
+			// translated screen.
+			message: statusQuery.data.error
+				? sprintf(
+						/* translators: %s: the reason WordPress.com gave for the failure. */
+						__( 'Download failed: %s', 'jetpack-backup-pkg' ),
+						statusQuery.data.error
+				  )
+				: __( 'Download failed.', 'jetpack-backup-pkg' ),
 		};
 	} else if ( downloadId !== null && statusQuery.error ) {
 		// Network/HTTP failure mid-poll: surface so the UI doesn't sit

--- a/projects/packages/backup/src/dashboard/hooks/use-download.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-download.ts
@@ -96,9 +96,9 @@ export function useDownload( rewindId: string ): Result {
 		};
 	} else if ( downloadId !== null && statusQuery.data ) {
 		state = {
-			// `progress` is already 0–100 — WPCOM runs it through
-			// `intval()`, which a 0–1 float could not survive. Multiplying
-			// by 100 fed the ProgressBar values up to 10000.
+			// `progress` is already 0–100 — WPCOM coerces it to an
+			// integer, which a 0–1 float could not survive. Multiplying by
+			// 100 fed the ProgressBar values up to 10000.
 			phase: 'progress',
 			percent: statusQuery.data.progress ?? 0,
 		};

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -1,7 +1,7 @@
 import { Notice, ProgressBar, Spinner } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { useCallback, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon, cloud, download as downloadIcon, arrowLeft } from '@wordpress/icons';
 import { Link, useParams } from '@wordpress/route';
 import { Button, Card, Stack, Text } from '@wordpress/ui';
@@ -105,6 +105,20 @@ export default function DownloadScreen() {
 							>
 								{ __( 'Download the file', 'jetpack-backup-pkg' ) }
 							</a>
+							{ /*
+							 * WPCOM signs the archive URL with an expiry. Saying
+							 * when it lapses is the difference between coming back
+							 * to a dead link and knowing to fetch it again.
+							 */ }
+							{ state.validUntil && (
+								<Text variant="body-sm" className="jpb-text-muted">
+									{ sprintf(
+										/* translators: %s: date and time the download link stops working. */
+										__( 'This link expires %s.', 'jetpack-backup-pkg' ),
+										dateI18n( 'M j, Y, g:i A', state.validUntil, undefined )
+									) }
+								</Text>
+							) }
 						</Stack>
 					) }
 					{ state.phase === 'error' && (

--- a/projects/packages/backup/src/rest/class-download-bridge.php
+++ b/projects/packages/backup/src/rest/class-download-bridge.php
@@ -43,7 +43,16 @@ class Download_Bridge {
 						'required' => true,
 					),
 					'types'     => array(
-						'type' => 'object',
+						'type'                 => 'object',
+						// Values must be booleans. WordPress validates
+						// `object` with `rest_is_object()`, which is just
+						// `is_array()`, so without this a JSON list of
+						// category names passes and reaches WPCOM as a list
+						// whose numeric keys it reads as category names.
+						// This rejects that with a 400 before the callback
+						// runs; `Rest_Controller::named_types()` makes the
+						// shape guarantee that a value check cannot.
+						'additionalProperties' => array( 'type' => 'boolean' ),
 					),
 				),
 			)
@@ -99,11 +108,9 @@ class Download_Bridge {
 		// Omit `types` rather than defaulting it to an empty object.
 		// WPCOM selects the enabled categories loosely, so an empty
 		// value names no category and asks for a download of nothing.
-		if ( is_array( $types ) || is_object( $types ) ) {
-			$types = (array) $types;
-			if ( ! empty( $types ) ) {
-				$body['types'] = $types;
-			}
+		$named_types = Rest_Controller::named_types( $types );
+		if ( ! empty( $named_types ) ) {
+			$body['types'] = $named_types;
 		}
 
 		$response = Client::wpcom_json_api_request_as_user(
@@ -193,8 +200,21 @@ class Download_Bridge {
 			$body = array();
 		}
 
-		$error = isset( $body['error'] ) ? (string) $body['error'] : '';
-		$url   = isset( $body['url'] ) ? (string) $body['url'] : '';
+		$error   = isset( $body['error'] ) ? (string) $body['error'] : '';
+		$raw_url = isset( $body['url'] ) ? (string) $body['url'] : '';
+
+		// The client puts this straight into an `<a href>`, and React does
+		// not strip dangerous schemes — so check before handing it over.
+		//
+		// Deliberately a scheme check rather than `wp_http_validate_url()`,
+		// which the file-browser bridge uses: that one is built for URLs
+		// *this server* is about to fetch, so it also does a DNS lookup and
+		// rejects private IPs and non-standard ports. Right there, wrong
+		// here — this URL is only ever loaded by the browser, so those
+		// rules could reject a perfectly good host while costing a DNS
+		// lookup on every poll.
+		$scheme = '' === $raw_url ? null : wp_parse_url( $raw_url, PHP_URL_SCHEME );
+		$url    = ( 'https' === $scheme || 'http' === $scheme ) ? $raw_url : '';
 
 		// Order matters: a failed download can still carry a stale `url`
 		// from an earlier attempt, so the error branch is checked first.
@@ -202,6 +222,13 @@ class Download_Bridge {
 			$status = 'failed';
 		} elseif ( '' !== $url ) {
 			$status = 'finished';
+		} elseif ( '' !== $raw_url ) {
+			// A URL arrived but is not one we will hand to the browser.
+			// Reported as a failure rather than left to fall through to
+			// `running`, which would poll forever against a download that
+			// is in fact finished.
+			$status = 'failed';
+			$error  = __( 'The download link could not be used.', 'jetpack-backup-pkg' );
 		} else {
 			$status = 'running';
 		}
@@ -211,8 +238,12 @@ class Download_Bridge {
 				'id'          => isset( $body['downloadId'] ) ? (int) $body['downloadId'] : $download_id,
 				'status'      => $status,
 				// 0-100, and absent entirely once the download leaves the
-				// in-flight branch.
-				'progress'    => isset( $body['progress'] ) ? (int) $body['progress'] : 0,
+				// in-flight branch. Clamped rather than trusted: the client
+				// feeds this straight to a progress bar, and the headline bug
+				// this projection replaces was a bar being handed 10000. Making
+				// the range true here means no future upstream change can
+				// reproduce that symptom.
+				'progress'    => isset( $body['progress'] ) ? max( 0, min( 100, (int) $body['progress'] ) ) : 0,
 				'url'         => $url,
 				'valid_until' => isset( $body['validUntil'] ) ? (string) $body['validUntil'] : '',
 				'error'       => $error,

--- a/projects/packages/backup/src/rest/class-download-bridge.php
+++ b/projects/packages/backup/src/rest/class-download-bridge.php
@@ -97,7 +97,7 @@ class Download_Bridge {
 
 		$body = array( 'rewindId' => $rewind_id );
 		// Omit `types` rather than defaulting it to an empty object.
-		// WPCOM reads it with `array_keys( $param, true )`, so an empty
+		// WPCOM selects the enabled categories loosely, so an empty
 		// value names no category and asks for a download of nothing.
 		if ( is_array( $types ) || is_object( $types ) ) {
 			$types = (array) $types;

--- a/projects/packages/backup/src/rest/class-download-bridge.php
+++ b/projects/packages/backup/src/rest/class-download-bridge.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Download REST bridge — proxies /sites/{id}/rewind/backups/* prepare-download
- * + status endpoints.
+ * Download REST bridge — proxies the /sites/{id}/rewind/downloads
+ * collection and its per-download status.
  *
  * @package automattic/jetpack-backup-plugin
  */
@@ -19,8 +19,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Download endpoints powering the Download screen:
- *   - POST /jetpack/v4/backups/download/{rewindId}            → initiate prepare-download
- *   - GET  /jetpack/v4/backups/download/{rewindId}/status     → poll status
+ *   - POST /jetpack/v4/backups/download/{rewindId}            → ask WPCOM to build the archive
+ *   - GET  /jetpack/v4/backups/download/{rewindId}/status     → poll progress
  */
 class Download_Bridge {
 
@@ -73,7 +73,15 @@ class Download_Bridge {
 	/**
 	 * Initiate a backup download.
 	 *
-	 * Proxies POST wpcom/v2 /sites/{id}/rewind/backups/{rewindId}/prepare-download.
+	 * Proxies POST wpcom/v2 /sites/{id}/rewind/downloads. The previous
+	 * target — a `prepare-download` path under the backup — is not a
+	 * registered route and answered `rest_no_route` on every site tested,
+	 * so the Download screen could never have worked.
+	 *
+	 * The rewind id travels in the request **body**, in full. It is not a
+	 * path segment here, and truncating its decimal suffix would address
+	 * a different backup than the one the reader picked.
+	 *
 	 * Returns `{ id }` for the React layer (the WPCOM key is `downloadId`).
 	 *
 	 * @param WP_REST_Request $request The REST request.
@@ -85,18 +93,24 @@ class Download_Bridge {
 			return $blog_id;
 		}
 		$rewind_id = (string) $request->get_param( 'rewind_id' );
+		$types     = $request->get_param( 'types' );
+
+		$body = array( 'rewindId' => $rewind_id );
+		// Omit `types` rather than defaulting it to an empty object.
+		// WPCOM reads it with `array_keys( $param, true )`, so an empty
+		// value names no category and asks for a download of nothing.
+		if ( is_array( $types ) || is_object( $types ) ) {
+			$types = (array) $types;
+			if ( ! empty( $types ) ) {
+				$body['types'] = $types;
+			}
+		}
 
 		$response = Client::wpcom_json_api_request_as_user(
-			sprintf(
-				'/sites/%d/rewind/backups/%s/prepare-download',
-				$blog_id,
-				rawurlencode( $rewind_id )
-			),
+			sprintf( '/sites/%d/rewind/downloads', $blog_id ),
 			'v2',
 			array( 'method' => 'POST' ),
-			array(
-				'types' => $request->get_param( 'types' ) ? $request->get_param( 'types' ) : (object) array(),
-			),
+			$body,
 			'wpcom'
 		);
 
@@ -129,7 +143,19 @@ class Download_Bridge {
 	/**
 	 * Poll download status.
 	 *
-	 * Proxies GET wpcom/v2 /sites/{id}/rewind/backups/{rewindId}/downloads/{downloadId}.
+	 * Proxies GET wpcom/v2 /sites/{id}/rewind/downloads/{downloadId}. The
+	 * rewind id is not part of the upstream path — it is kept on our own
+	 * route because the client keys its poll cache on (rewindId,
+	 * downloadId), and because it keeps the two download routes
+	 * symmetrical.
+	 *
+	 * The response is projected rather than forwarded, the way restore
+	 * status already is. WPCOM's payload carries **no status field**: it
+	 * attaches keys by branch — `url` and `validUntil` once the archive
+	 * is ready, `error` when it failed, and `progress` only while the
+	 * archive is still being built. Leaving that shape for the client to
+	 * interpret is what left the React layer testing three status strings
+	 * that never appear in the payload.
 	 *
 	 * @param WP_REST_Request $request The REST request.
 	 * @return \WP_REST_Response|WP_Error
@@ -139,16 +165,10 @@ class Download_Bridge {
 		if ( is_wp_error( $blog_id ) ) {
 			return $blog_id;
 		}
-		$rewind_id   = (string) $request->get_param( 'rewind_id' );
 		$download_id = (int) $request->get_param( 'download_id' );
 
 		$response = Client::wpcom_json_api_request_as_user(
-			sprintf(
-				'/sites/%d/rewind/backups/%s/downloads/%d',
-				$blog_id,
-				rawurlencode( $rewind_id ),
-				$download_id
-			),
+			sprintf( '/sites/%d/rewind/downloads/%d', $blog_id, $download_id ),
 			'v2',
 			array(),
 			null,
@@ -168,6 +188,35 @@ class Download_Bridge {
 			);
 		}
 
-		return rest_ensure_response( json_decode( wp_remote_retrieve_body( $response ), true ) );
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $body ) ) {
+			$body = array();
+		}
+
+		$error = isset( $body['error'] ) ? (string) $body['error'] : '';
+		$url   = isset( $body['url'] ) ? (string) $body['url'] : '';
+
+		// Order matters: a failed download can still carry a stale `url`
+		// from an earlier attempt, so the error branch is checked first.
+		if ( '' !== $error ) {
+			$status = 'failed';
+		} elseif ( '' !== $url ) {
+			$status = 'finished';
+		} else {
+			$status = 'running';
+		}
+
+		return rest_ensure_response(
+			array(
+				'id'          => isset( $body['downloadId'] ) ? (int) $body['downloadId'] : $download_id,
+				'status'      => $status,
+				// 0-100, and absent entirely once the download leaves the
+				// in-flight branch.
+				'progress'    => isset( $body['progress'] ) ? (int) $body['progress'] : 0,
+				'url'         => $url,
+				'valid_until' => isset( $body['validUntil'] ) ? (string) $body['validUntil'] : '',
+				'error'       => $error,
+			)
+		);
 	}
 }

--- a/projects/packages/backup/src/rest/class-rest-controller.php
+++ b/projects/packages/backup/src/rest/class-rest-controller.php
@@ -90,4 +90,38 @@ class Rest_Controller {
 		}
 		return $blog_id;
 	}
+
+	/**
+	 * Rebuild a restore/download `types` parameter as a named map.
+	 *
+	 * The PHP counterpart of the client's `serializeTypes`, and the reason
+	 * it exists here rather than being trusted from the request: WordPress
+	 * validates `'type' => 'object'` with `rest_is_object()`, which is
+	 * `is_array()`. A JSON list therefore passes validation and arrives as
+	 * a PHP list, whose numeric keys WPCOM reads as category names. The
+	 * route schema rejects the realistic version of that, but only because
+	 * the members fail a boolean check — shape itself is never asserted —
+	 * so the guarantee is made here, where the payload is actually built.
+	 *
+	 * Only string keys with a truthy value survive, and every surviving
+	 * value is normalized to `true`. Values are read with
+	 * `rest_sanitize_boolean()` so a form-encoded `"false"` or `"0"` means
+	 * skip rather than select.
+	 *
+	 * @param mixed $types Raw `types` parameter from the request.
+	 * @return array<string, true> Named types, empty when none are selected.
+	 */
+	public static function named_types( $types ) {
+		if ( ! is_array( $types ) && ! is_object( $types ) ) {
+			return array();
+		}
+
+		$named = array();
+		foreach ( (array) $types as $key => $value ) {
+			if ( is_string( $key ) && '' !== $key && rest_sanitize_boolean( $value ) ) {
+				$named[ $key ] = true;
+			}
+		}
+		return $named;
+	}
 }

--- a/projects/packages/backup/src/rest/class-restore-bridge.php
+++ b/projects/packages/backup/src/rest/class-restore-bridge.php
@@ -42,7 +42,11 @@ class Restore_Bridge {
 						'required' => true,
 					),
 					'types'     => array(
-						'type' => 'object',
+						'type'                 => 'object',
+						// See the download bridge: `object` alone accepts a
+						// JSON list, because WordPress validates it with
+						// `is_array()`.
+						'additionalProperties' => array( 'type' => 'boolean' ),
 					),
 				),
 			)
@@ -88,10 +92,17 @@ class Restore_Bridge {
 		$rewind_id = (string) $request->get_param( 'rewind_id' );
 		$types     = $request->get_param( 'types' );
 
-		$body = array(
-			'force_rewind' => true,
-			'types'        => is_array( $types ) || is_object( $types ) ? $types : (object) array(),
-		);
+		$body = array( 'force_rewind' => true );
+		// Omit `types` entirely when nothing is named, and rebuild it as a
+		// named map otherwise — the same contract the download bridge and
+		// the client's `serializeTypes` follow. Defaulting to `{}` sent the
+		// one value that names no category, which the v2 restore route
+		// rejects outright and which the client had already been careful to
+		// leave out.
+		$named_types = Rest_Controller::named_types( $types );
+		if ( ! empty( $named_types ) ) {
+			$body['types'] = $named_types;
+		}
 
 		// `base_api_path` defaults to 'wpcom' on `as_user`, but the
 		// activity-log endpoints live under `rest/v1/...`

--- a/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
@@ -14,6 +14,7 @@ namespace Automattic\Jetpack\Backup\V0005\REST;
 
 use Automattic\Jetpack\Backup\V0005\Jetpack_Backup;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WP_REST_Server;
 use function add_action;
@@ -108,5 +109,76 @@ class Rest_Bridge_Gating_Test extends TestCase {
 		sort( $expected );
 
 		$this->assertSame( $expected, $added );
+	}
+
+	/**
+	 * `named_types()` is the PHP half of the shared `types` contract, used
+	 * by both the download and restore bridges.
+	 *
+	 * It exists because WordPress validates `'type' => 'object'` with
+	 * `rest_is_object()`, which is `is_array()` — so a JSON list reaches
+	 * the callback intact and WPCOM reads its numeric keys as category
+	 * names. Rebuilding from named keys is what makes the object form a
+	 * guarantee rather than a convention.
+	 *
+	 * @param string $label    Case description.
+	 * @param mixed  $input    Raw `types` parameter.
+	 * @param array  $expected Expected named map.
+	 * @dataProvider provide_types
+	 */
+	#[DataProvider( 'provide_types' )]
+	public function test_named_types( $label, $input, $expected ) {
+		$this->assertSame( $expected, Rest_Controller::named_types( $input ), $label );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: mixed, 2: array}>
+	 */
+	public static function provide_types() {
+		return array(
+			'keeps selected, drops unselected' => array(
+				'keeps selected, drops unselected',
+				array(
+					'themes'  => true,
+					'plugins' => false,
+					'sqls'    => true,
+				),
+				array(
+					'themes' => true,
+					'sqls'   => true,
+				),
+			),
+			'normalises truthy values to true' => array(
+				'normalises truthy values to true',
+				array( 'themes' => '1' ),
+				array( 'themes' => true ),
+			),
+			'reads "false" and "0" as skip'    => array(
+				'reads "false" and "0" as skip',
+				array(
+					'themes'  => 'false',
+					'plugins' => '0',
+				),
+				array(),
+			),
+			'drops a list of names'            => array(
+				'drops a list of names',
+				array( 'themes', 'plugins' ),
+				array(),
+			),
+			'drops a list of booleans'         => array(
+				'drops a list of booleans',
+				array( true, false ),
+				array(),
+			),
+			'empty array'                      => array( 'empty array', array(), array() ),
+			'null'                             => array( 'null', null, array() ),
+			'scalar'                           => array( 'scalar', 'themes', array() ),
+			'object'                           => array(
+				'object',
+				(object) array( 'themes' => true ),
+				array( 'themes' => true ),
+			),
+		);
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
@@ -17,8 +17,11 @@ use WP_REST_Server;
 use function add_action;
 use function add_filter;
 use function do_action;
+use function get_current_user_id;
+use function remove_all_filters;
 use function remove_filter;
 use function wp_insert_user;
+use function wp_json_encode;
 use function wp_set_current_user;
 
 /**
@@ -35,6 +38,20 @@ class Rest_Download_Bridge_Test extends TestCase {
 	 * @var WP_REST_Server
 	 */
 	private $server;
+
+	/**
+	 * URL of the last request the bridge made to WPCOM.
+	 *
+	 * @var string
+	 */
+	private $captured_url = '';
+
+	/**
+	 * Decoded body of the last request the bridge made to WPCOM.
+	 *
+	 * @var array|null
+	 */
+	private $captured_body = null;
 
 	/**
 	 * Enable modernization, register routes, and prepare a fresh REST server.
@@ -56,7 +73,12 @@ class Rest_Download_Bridge_Test extends TestCase {
 	 */
 	public function tearDown(): void {
 		remove_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
+		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10 );
 		wp_set_current_user( 0 );
+
+		$this->captured_url  = '';
+		$this->captured_body = null;
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
@@ -101,5 +123,190 @@ class Rest_Download_Bridge_Test extends TestCase {
 		$status_request->set_param( 'download_id', 1 );
 		$status_response = $this->server->dispatch( $status_request );
 		$this->assertSame( 403, $status_response->get_status() );
+	}
+
+	/**
+	 * Stand in for a connected site so `Client` can sign a request.
+	 *
+	 * @param mixed  $value Original option value.
+	 * @param string $name  Option name.
+	 * @return mixed
+	 */
+	public function mock_jetpack_connection_options( $value, $name ) {
+		switch ( $name ) {
+			case 'blog_token':
+				return 'test.blogtoken';
+			case 'id':
+				return '999';
+			case 'user_tokens':
+				$user_id = get_current_user_id();
+				if ( $user_id ) {
+					return array( $user_id => sprintf( 'token%d.secret%d.%d', $user_id, $user_id, $user_id ) );
+				}
+		}
+		return $value;
+	}
+
+	/**
+	 * Sign in as an administrator and intercept the bridge's WPCOM call.
+	 *
+	 * The callbacks below are invoked directly rather than dispatched
+	 * through the REST server, because `Rest_Controller::permission_check()`
+	 * additionally requires a user-level WPCOM connection that WorDBless
+	 * cannot stand up. The permission boundary itself is covered by
+	 * `test_routes_require_manage_options`.
+	 *
+	 * @param array $body   Payload WPCOM should answer with.
+	 * @param int   $status HTTP status WPCOM should answer with.
+	 */
+	private function arrange_wpcom( array $body, $status = 200 ) {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'admin_user_' . wp_rand( 1, PHP_INT_MAX ),
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10, 2 );
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( $body, $status ) {
+				$this->captured_url  = $url;
+				$this->captured_body = isset( $args['body'] ) ? json_decode( $args['body'], true ) : null;
+				return array(
+					'response' => array( 'code' => $status ),
+					'body'     => wp_json_encode( $body, JSON_UNESCAPED_SLASHES ),
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * The rewind id goes in the body, in full, and the target is the
+	 * downloads collection.
+	 *
+	 * The previous target was a `prepare-download` path under the backup,
+	 * which is not a registered route — the Download screen answered
+	 * `rest_no_route` on every site it was tried against.
+	 */
+	public function test_initiate_sends_full_rewind_id_in_the_body() {
+		$this->arrange_wpcom( array( 'downloadId' => 4321 ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/1786663613.9425' );
+		$request->set_param( 'rewind_id', '1786663613.9425' );
+		$request->set_param( 'types', array( 'themes' => true ) );
+		$response = Download_Bridge::initiate_download( $request );
+
+		$sent = (array) $this->captured_body;
+
+		$this->assertStringContainsString( '/sites/999/rewind/downloads', $this->captured_url );
+		// In full: truncating the decimal addresses a different backup.
+		$this->assertSame( '1786663613.9425', $sent['rewindId'] );
+		$this->assertSame( array( 'themes' => true ), $sent['types'] );
+		$this->assertSame( array( 'id' => 4321 ), $response->get_data() );
+	}
+
+	/**
+	 * An empty `types` is omitted rather than sent as `{}`.
+	 *
+	 * WPCOM reads it with `array_keys( $param, true )`, so an empty value
+	 * names no category — it asks for a download containing nothing.
+	 */
+	public function test_initiate_omits_empty_types() {
+		$this->arrange_wpcom( array( 'downloadId' => 1 ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'types', array() );
+		Download_Bridge::initiate_download( $request );
+
+		$this->assertArrayNotHasKey( 'types', (array) $this->captured_body );
+	}
+
+	/**
+	 * Run a status request against a canned WPCOM body.
+	 *
+	 * @param array $body WPCOM's payload.
+	 * @return array The projected response data.
+	 */
+	private function project_status( array $body ) {
+		$this->arrange_wpcom( $body );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/backups/download/123/status' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'download_id', 55 );
+
+		return Download_Bridge::get_download_status( $request )->get_data();
+	}
+
+	/**
+	 * The status call addresses the download directly — the rewind id is
+	 * not part of the upstream path.
+	 */
+	public function test_status_targets_the_download_directly() {
+		$this->project_status(
+			array(
+				'downloadId' => 55,
+				'progress'   => 10,
+			)
+		);
+
+		$this->assertStringContainsString( '/sites/999/rewind/downloads/55', $this->captured_url );
+	}
+
+	/**
+	 * WPCOM sends no status field, so the bridge derives one from which
+	 * branch of its formatter fired.
+	 */
+	public function test_status_is_derived_from_the_fields_present() {
+		// In flight: `progress` only.
+		$running = $this->project_status(
+			array(
+				'downloadId' => 55,
+				'progress'   => 42,
+			)
+		);
+		$this->assertSame( 'running', $running['status'] );
+		$this->assertSame( 42, $running['progress'] );
+	}
+
+	/**
+	 * A ready archive reports `finished`, and carries no progress at all.
+	 */
+	public function test_a_ready_archive_reports_finished() {
+		$finished = $this->project_status(
+			array(
+				'downloadId' => 55,
+				'url'        => 'https://example.com/archive.zip',
+				'validUntil' => '2026-08-20T00:00:00+00:00',
+			)
+		);
+
+		$this->assertSame( 'finished', $finished['status'] );
+		$this->assertSame( 'https://example.com/archive.zip', $finished['url'] );
+		$this->assertSame( '2026-08-20T00:00:00+00:00', $finished['valid_until'] );
+		// Absent upstream once the download leaves the in-flight branch.
+		$this->assertSame( 0, $finished['progress'] );
+	}
+
+	/**
+	 * A failed download can still carry a stale `url`, so the error
+	 * branch has to win.
+	 */
+	public function test_error_beats_a_stale_url() {
+		$failed = $this->project_status(
+			array(
+				'downloadId' => 55,
+				'error'      => 'Archive expired',
+				'url'        => 'https://example.com/stale.zip',
+			)
+		);
+
+		$this->assertSame( 'failed', $failed['status'] );
+		$this->assertSame( 'Archive expired', $failed['error'] );
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
@@ -9,9 +9,11 @@ namespace Automattic\Jetpack\Backup\V0005\REST;
 
 use Automattic\Jetpack\Backup\V0005\Jetpack_Backup;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
 use function add_action;
@@ -215,16 +217,189 @@ class Rest_Download_Bridge_Test extends TestCase {
 	 *
 	 * WPCOM selects the enabled categories loosely, so an empty value
 	 * names no category — it asks for a download containing nothing.
+	 *
+	 * @param string $label Case description.
+	 * @param mixed  $types The `types` parameter to send, or null to omit it.
+	 * @dataProvider provide_types_that_name_nothing
 	 */
-	public function test_initiate_omits_empty_types() {
+	#[DataProvider( 'provide_types_that_name_nothing' )]
+	public function test_initiate_omits_types_that_name_nothing( $label, $types ) {
 		$this->arrange_wpcom( array( 'downloadId' => 1 ) );
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
 		$request->set_param( 'rewind_id', '123' );
-		$request->set_param( 'types', array() );
+		if ( null !== $types ) {
+			$request->set_param( 'types', $types );
+		}
 		Download_Bridge::initiate_download( $request );
 
-		$this->assertArrayNotHasKey( 'types', (array) $this->captured_body );
+		$this->assertArrayNotHasKey( 'types', (array) $this->captured_body, $label );
+	}
+
+	/**
+	 * Every shape that names no category.
+	 *
+	 * `absent` is what the client actually sends when the checklist is
+	 * empty; `list of booleans` is the shape the route schema cannot
+	 * reject, since it constrains values rather than shape.
+	 *
+	 * @return array<string, array{0: string, 1: mixed}>
+	 */
+	public static function provide_types_that_name_nothing() {
+		return array(
+			'empty array'      => array( 'empty array', array() ),
+			'absent'           => array( 'absent', null ),
+			'all false'        => array( 'all false', array( 'themes' => false ) ),
+			'list of booleans' => array( 'list of booleans', array( true, false ) ),
+		);
+	}
+
+	/**
+	 * Only the selected categories are forwarded, each normalised to true.
+	 */
+	public function test_initiate_forwards_only_selected_types() {
+		$this->arrange_wpcom( array( 'downloadId' => 1 ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param(
+			'types',
+			array(
+				'themes'  => true,
+				'plugins' => false,
+				'sqls'    => true,
+			)
+		);
+		Download_Bridge::initiate_download( $request );
+
+		$sent = (array) $this->captured_body;
+		$this->assertSame(
+			array(
+				'themes' => true,
+				'sqls'   => true,
+			),
+			$sent['types']
+		);
+	}
+
+	/**
+	 * A JSON list of category names never reaches the callback.
+	 *
+	 * WordPress validates `'type' => 'object'` with `rest_is_object()`,
+	 * which is `is_array()` — so without the schema's value constraint a
+	 * list passes validation, arrives as a PHP list, and WPCOM reads its
+	 * numeric keys as category names.
+	 */
+	public function test_a_list_of_type_names_is_rejected_by_the_schema() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'schema_admin',
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode( array( 'types' => array( 'themes' ) ), JSON_UNESCAPED_SLASHES )
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$data = $response->get_data();
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $data['code'] );
+		// Name the parameter, so this cannot pass on some unrelated 400.
+		$this->assertArrayHasKey( 'types', $data['data']['params'] );
+	}
+
+	/**
+	 * A non-200 from WordPress.com becomes a WP_Error carrying its status.
+	 */
+	public function test_initiate_reports_a_non_200_from_wpcom() {
+		$this->arrange_wpcom( array( 'error' => 'nope' ), 503 );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$result = Download_Bridge::initiate_download( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'download_initiate_failed', $result->get_error_code() );
+		$this->assertSame( 503, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A 200 with no `downloadId` is a failure, not a queued download.
+	 */
+	public function test_initiate_reports_a_missing_download_id() {
+		$this->arrange_wpcom( array( 'ok' => true ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$result = Download_Bridge::initiate_download( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'download_initiate_failed', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A non-200 on the status route is reported too.
+	 */
+	public function test_status_reports_a_non_200_from_wpcom() {
+		$this->arrange_wpcom( array(), 502 );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/backups/download/123/status' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'download_id', 55 );
+		$result = Download_Bridge::get_download_status( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'download_status_fetch_failed', $result->get_error_code() );
+		$this->assertSame( 502, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A URL we would not hand to the browser is a failure, not an
+	 * in-progress download.
+	 *
+	 * Left as an empty `url` it would fall through to `running`, and the
+	 * client would poll forever against a download that is in fact done.
+	 */
+	public function test_a_non_http_url_is_reported_as_failed() {
+		$failed = $this->project_status(
+			array(
+				'downloadId' => 55,
+				'url'        => 'javascript:alert(1)',
+			)
+		);
+
+		$this->assertSame( 'failed', $failed['status'] );
+		$this->assertSame( '', $failed['url'] );
+		$this->assertNotSame( '', $failed['error'] );
+	}
+
+	/**
+	 * `progress` is clamped to the range the field documents.
+	 */
+	public function test_progress_is_clamped() {
+		$over = $this->project_status(
+			array(
+				'downloadId' => 55,
+				'progress'   => 10000,
+			)
+		);
+		$this->assertSame( 100, $over['progress'] );
+
+		$under = $this->project_status(
+			array(
+				'downloadId' => 55,
+				'progress'   => -5,
+			)
+		);
+		$this->assertSame( 0, $under['progress'] );
 	}
 
 	/**
@@ -260,9 +435,10 @@ class Rest_Download_Bridge_Test extends TestCase {
 
 	/**
 	 * WPCOM sends no status field, so the bridge derives one from which
-	 * branch of its formatter fired.
+	 * of its lifecycle keys arrived. The other branches have their own
+	 * tests below.
 	 */
-	public function test_status_is_derived_from_the_fields_present() {
+	public function test_an_in_flight_download_reports_running() {
 		// In flight: `progress` only.
 		$running = $this->project_status(
 			array(

--- a/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
@@ -213,7 +213,7 @@ class Rest_Download_Bridge_Test extends TestCase {
 	/**
 	 * An empty `types` is omitted rather than sent as `{}`.
 	 *
-	 * WPCOM reads it with `array_keys( $param, true )`, so an empty value
+	 * WPCOM selects the enabled categories loosely, so an empty value
 	 * names no category — it asks for a download containing nothing.
 	 */
 	public function test_initiate_omits_empty_types() {


### PR DESCRIPTION
Fixes #

Part of [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243) — tasks **C1**, **C2**, **C5** and **C6**. Umbrella: #48582. Independent of #51292 (E1/E2) and #51294 (D3).

## Proposed changes

**The Download screen could never have worked.** Initiate targeted a `prepare-download` path under the backup, which is not a registered route — it answers `rest_no_route`, verified on two separate sites.

* **C1 — Repoint initiate** at `POST /sites/{id}/rewind/downloads`, with the rewind id in the request **body**.
* **C2 — Repoint status** at `GET /sites/{id}/rewind/downloads/{downloadId}`, which does not take a rewind id at all, and *project* the response in PHP the way restore status already is.
* **C5 — Stop truncating the rewind id.** Both mutations take it in full; `toIntRewindId` belongs only to the file-browser URLs, whose route regex really is `\d+`. Its docblock now says so.
* **C6 — One shared `types` serializer** for restore and download.

### Three real bugs behind this

**The download had no reachable terminal state.** WPCOM's payload carries **no status field**. It returns a base object and attaches further keys according to where the download has got to: `url` + `validUntil` once the archive is ready, `error` when it failed, `progress` only while it is still being packaged. The client was comparing against `'in-progress' | 'completed' | 'failed'` — three strings that never appear in the payload. This is the same class of bug as the restore status enum. The bridge now reads which branch fired and reports `running | finished | failed`, so the client never infers lifecycle from field presence. The error branch is checked first, because a failed download can still carry a stale `url`.

**The progress bar could be fed 10000.** `progress` is already 0–100 — WPCOM runs it through `intval()`, which a 0–1 float could not survive — so `use-download.ts`'s `* 100` was wrong. This is not theoretical: on the live download I used to verify this PR, the **first** poll returned `progress: 100` while the archive was still being packaged. That single tick would have rendered as 10000%. It also confirms `progress: 100` does not mean finished, which is exactly why completion has to be derived from the URL.

**A `types` array would have sent integer indices upstream.** WPCOM selects the enabled categories with a **loose** comparison, so a JSON array of names yields the array's own integer indices instead — `[ "themes" ]` becomes `[ 0 ]` — and those are then treated as category names. An emptiness check would never catch it, because the list isn't empty. The new serializer only ever emits the object form and returns `undefined` when nothing is selected, so the key is omitted rather than sent empty — an empty `types` asks for a download containing nothing.

### Notes for reviewers

* **`restore.ts` is touched, but only its `types` serialization** — that's the "shared" half of C6. Restore's own route repoint (it still targets the v1 activity-log route, which discards Jetpack user tokens and always 401s) is separate work and deliberately not in this PR.
* The rewind id is **kept on our own status route** even though it no longer reaches WPCOM: the client keys its poll cache on `(rewindId, downloadId)`, and it keeps the two download routes symmetrical. Called out in the docblock so it doesn't read as a leftover.
* **These are the first tests in the package to execute a bridge callback body** (J1 notes all five were unexecuted). They call the callback directly rather than dispatching, because `Rest_Controller::permission_check()` also wants a user-level WPCOM connection that WorDBless can't stand up; the permission boundary itself keeps its existing dispatch-based test.

## Related product discussion/links

* [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, **default off** — confirm the legacy page is unchanged first.

**Setup.** On a site with the Backup plugin and an active Backup plan:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

**1. Through the UI.** Go to **Jetpack → VaultPress Backup**, pick a backup, choose **Download backup**, select some categories and submit. Expect a progress bar that shows a sane percentage (0–100, never above 100), then a working download link. Before this PR the request failed outright with `rest_no_route`.

**2. Directly, which is how I verified it.** From the browser console on the Backup page — note this asks WPCOM to actually build an archive:

```js
const nonce = window.JP_CONNECTION_INITIAL_STATE.apiNonce;
// Use a real rewind id from the activity list — keep the decimal suffix.
const rewindId = '1786732569.266';
const start = await ( await fetch( `/wp-json/jetpack/v4/backups/download/${ rewindId }`, {
	method: 'POST',
	headers: { 'X-WP-Nonce': nonce, 'Content-Type': 'application/json' },
	credentials: 'same-origin',
	body: JSON.stringify( { types: { themes: true } } ),
} ) ).json();
console.log( start ); // { id: <downloadId> }

const status = await ( await fetch(
	`/wp-json/jetpack/v4/backups/download/${ rewindId }/status?download_id=${ start.id }`,
	{ headers: { 'X-WP-Nonce': nonce }, credentials: 'same-origin' }
) ).json();
console.log( status );
```

Expect initiate to return `{ id: <number> }`, and status to move `running` → `finished` with a `url` and an ISO-8601 `valid_until`. Watch for `progress: 100` arriving while still `running` — that is the case the old scale bug rendered as 10000%.

**3. Empty selection.** Submitting with no categories selected should omit `types` entirely rather than sending `{}`. Covered by a PHP test; visible in the outgoing body if you're inspecting.

**Automated:**

```
jp test js packages/backup     # 171 tests, 26 suites
jp test php packages/backup    # 134 tests
jp phan packages/backup
```


