### PR TITLE
VideoPress: make the chapters editor generally available

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-videopress-chapters-editor-ga
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-videopress-chapters-editor-ga
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+VideoPress: enable the chapters editor for all users.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-videopress/wpcom-videopress.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-videopress/wpcom-videopress.php
@@ -19,25 +19,6 @@
 use Automattic\Jetpack\Status\Host;
 
 /**
- * Whether the VideoPress chapters editor is available to this Simple user.
- *
- * Gates the chapters editor UI in both places it lives: the dashboard's Editor
- * tab (and the `/video/$id/editor` route behind it, stripped from the wp-build
- * registry when this is false) and the block editor's "Manage chapters"
- * toolbar button. Automatticians only while the feature is in development —
- * there is deliberately no blog-sticker branch yet.
- *
- * UI-only by design: the chapters REST surface (the VideoPress endpoints that
- * read and write the chapters track) stays registered regardless, so the API
- * contract doesn't flap with the flag.
- *
- * @return bool Whether the chapters editor UI should be enabled.
- */
-function wpcom_videopress_chapters_editor_enabled() {
-	return function_exists( 'is_automattician' ) && is_automattician( get_current_user_id() );
-}
-
-/**
  * Initialize the VideoPress Admin UI on WordPress.com Simple sites.
  *
  * Guarded on Simple because on Atomic and standalone Jetpack the VideoPress package
@@ -52,17 +33,6 @@ function wpcom_videopress_init_admin_ui() {
 	if ( ! ( new Host() )->is_wpcom_simple() ) {
 		return;
 	}
-
-	/*
-	 * Registered on Simple only, so self-hosted and Atomic keep the filter's
-	 * default (disabled). Registered before the class_exists() guard below and
-	 * from a plugins_loaded-time call site, so it also covers block editor
-	 * requests — where the flag is read at enqueue_block_editor_assets — not
-	 * just the VideoPress admin page. The callbacks that consult the filter all
-	 * run at admin_menu/enqueue time, well after this registration, so
-	 * is_automattician() sees the resolved current user.
-	 */
-	add_filter( 'jetpack_videopress_chapters_editor', 'wpcom_videopress_chapters_editor_enabled' );
 
 	if ( ! class_exists( '\Automattic\Jetpack\VideoPress\Admin_UI' ) ) {
 		return;

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-videopress/Wpcom_Videopress_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-videopress/Wpcom_Videopress_Test.php
@@ -15,7 +15,8 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-videopress/wpcom-videopress.php';
 
 /**
- * Tests for the VIDP-285 rollout and the chapters editor gate.
+ * Tests that neither the VIDP-285 dashboard rollout nor the chapters editor
+ * still registers a restricting gate here — both are at 100%.
  */
 class Wpcom_Videopress_Test extends \WorDBless\BaseTestCase {
 	/**
@@ -51,37 +52,22 @@ class Wpcom_Videopress_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * On Simple the chapters editor gate must be registered, so the VideoPress
-	 * package's default-false filter is answered by the Automattician check
-	 * rather than left at its default.
+	 * The chapters editor is generally available: init must not register any
+	 * callback on its filter, so Simple keeps
+	 * Admin_UI::is_chapters_editor_enabled()'s default (enabled) like every
+	 * other host. This pins the absence of the old Automattician-only gate —
+	 * a stray re-registration of a restricting callback would hide the feature
+	 * from every non-Automattician on Simple, and shows up here.
+	 *
+	 * Simple is simulated because that is the only host the removed callback
+	 * was ever registered on.
 	 */
-	public function test_chapters_editor_gate_registered_on_simple() {
+	public function test_no_chapters_editor_gate_registered() {
 		$this->simulate_wpcom_simple();
 
 		\wpcom_videopress_init_admin_ui();
 
-		$this->assertNotFalse(
-			has_filter( 'jetpack_videopress_chapters_editor', 'wpcom_videopress_chapters_editor_enabled' )
-		);
-	}
-
-	/**
-	 * Off-Simple, init must not register the chapters editor gate: self-hosted
-	 * and Atomic keep Admin_UI::is_chapters_editor_enabled()'s default (off),
-	 * and the Host::is_wpcom_simple() guard is what keeps this Simple-only.
-	 */
-	public function test_chapters_editor_gate_not_registered_off_simple() {
-		\wpcom_videopress_init_admin_ui();
-
 		$this->assertFalse( has_filter( 'jetpack_videopress_chapters_editor' ) );
-	}
-
-	/**
-	 * The gate fails closed: without the wpcom platform's is_automattician()
-	 * primitive (absent in this environment, function_exists-guarded in the
-	 * callback), the chapters editor stays hidden.
-	 */
-	public function test_chapters_editor_gate_defaults_to_disabled() {
-		$this->assertFalse( \wpcom_videopress_chapters_editor_enabled() );
+		$this->assertFalse( function_exists( 'wpcom_videopress_chapters_editor_enabled' ) );
 	}
 }

--- a/projects/packages/videopress/changelog/update-videopress-chapters-editor-ga
+++ b/projects/packages/videopress/changelog/update-videopress-chapters-editor-ga
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Enable the chapters editor on all sites.

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -48,10 +48,10 @@ class Admin_UI {
 	/**
 	 * Filter name that gates the chapters editor.
 	 *
-	 * When this filter returns true, the chapters editor is exposed in both
-	 * places it lives: the dashboard's Editor tab (and the `/video/$id/editor`
-	 * route behind it) and the block editor's chapter manager modal. Unlike the
-	 * modernization filter, this defaults to false.
+	 * The chapters editor is generally available, so this defaults to true and
+	 * the filter serves as a kill switch: returning false withdraws it from both
+	 * places it lives — the dashboard's Editor tab (and the `/video/$id/editor`
+	 * route behind it) and the block editor's chapter manager modal.
 	 */
 	const CHAPTERS_EDITOR_FILTER = 'jetpack_videopress_chapters_editor';
 
@@ -815,10 +815,10 @@ class Admin_UI {
 	/**
 	 * Returns true when the chapters editor feature filter is enabled.
 	 *
-	 * Note the default is false: the dashboard Editor tab, the
+	 * Note the default is true: the dashboard Editor tab, the
 	 * `/video/$id/editor` route, the Details-tab deep link, and the block
-	 * editor's "Manage chapters" toolbar button all stay hidden unless a site
-	 * explicitly opts in via the filter.
+	 * editor's "Manage chapters" toolbar button are all available unless a site
+	 * explicitly opts out via the filter.
 	 *
 	 * @since 0.45.0
 	 *
@@ -832,9 +832,9 @@ class Admin_UI {
 		 *
 		 * @since 0.45.0
 		 *
-		 * @param bool $enabled Whether the chapters editor UI is enabled. Default false.
+		 * @param bool $enabled Whether the chapters editor UI is enabled. Default true.
 		 */
-		return (bool) apply_filters( self::CHAPTERS_EDITOR_FILTER, false );
+		return (bool) apply_filters( self::CHAPTERS_EDITOR_FILTER, true );
 	}
 
 	/**

--- a/projects/packages/videopress/src/client/lib/chapters-editor/index.ts
+++ b/projects/packages/videopress/src/client/lib/chapters-editor/index.ts
@@ -2,11 +2,12 @@
  * Whether the chapters editor is enabled in the block editor.
  *
  * Mirrors the PHP-side `Admin_UI::is_chapters_editor_enabled()` gate (the
- * `jetpack_videopress_chapters_editor` filter, default false) via the
+ * `jetpack_videopress_chapters_editor` filter, default true) via the
  * `videoPressEditorState` object localized by
  * `Block_Editor_Extensions::enqueue_extensions()`, guarding for environments
- * (tests, front end, a stale build) where the global is absent. Defaults to
- * false.
+ * (tests, front end, a stale build) where the global is absent. Falls back to
+ * false there: an absent global is no evidence the feature is on, so the
+ * conservative answer stays right even though the PHP default flipped.
  *
  * `wp_localize_script()` casts every scalar to a string, so a PHP `true`
  * arrives as `'1'` and a PHP `false` as `''` — the same shape the neighboring

--- a/projects/packages/videopress/src/dashboard/utils/chapters-editor.ts
+++ b/projects/packages/videopress/src/dashboard/utils/chapters-editor.ts
@@ -2,9 +2,11 @@
  * Whether the chapters editor is enabled on the dashboard.
  *
  * Mirrors the PHP-side `Admin_UI::is_chapters_editor_enabled()` gate (the
- * `jetpack_videopress_chapters_editor` filter, default false) via the inlined
+ * `jetpack_videopress_chapters_editor` filter, default true) via the inlined
  * initial state, guarding for environments (tests, the legacy page) where the
- * `var JPVIDEOPRESS_INITIAL_STATE` is absent. Defaults to false.
+ * `var JPVIDEOPRESS_INITIAL_STATE` is absent. Falls back to false there: an
+ * absent payload is no evidence the feature is on, so the conservative answer
+ * stays right even though the PHP default flipped.
  *
  * Dashboard-only: the block editor reads its own channel — see
  * `src/client/lib/chapters-editor` — because the two surfaces are localized by

--- a/projects/packages/videopress/tests/php/Admin_UI_Chapters_Editor_Test.php
+++ b/projects/packages/videopress/tests/php/Admin_UI_Chapters_Editor_Test.php
@@ -77,12 +77,19 @@ class Admin_UI_Chapters_Editor_Test extends BaseTestCase {
 		return array_column( $routes, 'path' );
 	}
 
-	/** Tests that the chapters editor filter defaults to off. */
-	public function test_is_chapters_editor_enabled_defaults_to_false() {
+	/** Tests that the chapters editor is generally available, so the filter defaults to on. */
+	public function test_is_chapters_editor_enabled_defaults_to_true() {
+		$this->assertTrue( Admin_UI::is_chapters_editor_enabled() );
+	}
+
+	/** Tests that the filter still works as a kill switch when it returns false. */
+	public function test_is_chapters_editor_enabled_false_when_filter_disabled() {
+		add_filter( Admin_UI::CHAPTERS_EDITOR_FILTER, '__return_false' );
+
 		$this->assertFalse( Admin_UI::is_chapters_editor_enabled() );
 	}
 
-	/** Tests that the chapters editor filter enables the feature when it returns true. */
+	/** Tests that an explicit opt-in filter is honored too. */
 	public function test_is_chapters_editor_enabled_true_when_filter_enabled() {
 		add_filter( Admin_UI::CHAPTERS_EDITOR_FILTER, '__return_true' );
 
@@ -110,8 +117,22 @@ class Admin_UI_Chapters_Editor_Test extends BaseTestCase {
 		$this->assertSame( array( array( 'name' => 'pathless' ) ), $stripped );
 	}
 
+	/**
+	 * Opt out of the now-default-on chapters editor.
+	 *
+	 * Every guard below the early return in `maybe_strip_chapters_editor_routes()`
+	 * is only reachable with the feature disabled, so these tests have to turn it
+	 * off explicitly — without this they would pass vacuously, returning before
+	 * touching the code they exist to cover.
+	 */
+	private function disable_chapters_editor() {
+		add_filter( Admin_UI::CHAPTERS_EDITOR_FILTER, '__return_false' );
+	}
+
 	/** Tests that the registry global loses the editor route when the filter is off. */
 	public function test_maybe_strip_chapters_editor_routes_strips_global_when_off() {
+		$this->disable_chapters_editor();
+
 		$GLOBALS[ self::ROUTES_GLOBAL ] = $this->get_fixture_routes();
 
 		Admin_UI::maybe_strip_chapters_editor_routes();
@@ -119,10 +140,8 @@ class Admin_UI_Chapters_Editor_Test extends BaseTestCase {
 		$this->assertSame( self::OTHER_ROUTE_PATHS, $this->get_paths( $GLOBALS[ self::ROUTES_GLOBAL ] ) );
 	}
 
-	/** Tests that the registry global is left untouched when the filter is on. */
+	/** Tests that the registry global is left untouched when the filter is on, which is now the default. */
 	public function test_maybe_strip_chapters_editor_routes_leaves_global_untouched_when_on() {
-		add_filter( Admin_UI::CHAPTERS_EDITOR_FILTER, '__return_true' );
-
 		$fixture                        = $this->get_fixture_routes();
 		$GLOBALS[ self::ROUTES_GLOBAL ] = $fixture;
 
@@ -133,6 +152,8 @@ class Admin_UI_Chapters_Editor_Test extends BaseTestCase {
 
 	/** Tests that a missing registry global does not error. */
 	public function test_maybe_strip_chapters_editor_routes_missing_global_does_not_error() {
+		$this->disable_chapters_editor();
+
 		unset( $GLOBALS[ self::ROUTES_GLOBAL ] );
 
 		Admin_UI::maybe_strip_chapters_editor_routes();
@@ -142,6 +163,8 @@ class Admin_UI_Chapters_Editor_Test extends BaseTestCase {
 
 	/** Tests that an empty registry global does not error and stays empty. */
 	public function test_maybe_strip_chapters_editor_routes_empty_global_does_not_error() {
+		$this->disable_chapters_editor();
+
 		$GLOBALS[ self::ROUTES_GLOBAL ] = array();
 
 		Admin_UI::maybe_strip_chapters_editor_routes();
@@ -151,6 +174,8 @@ class Admin_UI_Chapters_Editor_Test extends BaseTestCase {
 
 	/** Tests that a non-array registry global is left untouched (graceful degradation). */
 	public function test_maybe_strip_chapters_editor_routes_non_array_global_does_not_error() {
+		$this->disable_chapters_editor();
+
 		$GLOBALS[ self::ROUTES_GLOBAL ] = 'not-an-array';
 
 		Admin_UI::maybe_strip_chapters_editor_routes();

--- a/projects/packages/videopress/tests/php/Block_Editor_Extensions_Chapters_Editor_Test.php
+++ b/projects/packages/videopress/tests/php/Block_Editor_Extensions_Chapters_Editor_Test.php
@@ -77,24 +77,25 @@ class Block_Editor_Extensions_Chapters_Editor_Test extends BaseTestCase {
 		return json_decode( $matches[1], true );
 	}
 
-	/** Tests that the gate is mirrored at the exact key the client reads, empty-string-false by default. */
-	public function test_chapters_editor_enabled_is_empty_string_by_default() {
+	/** Tests that the gate is mirrored at the exact key the client reads, as the '1' it matches on by default. */
+	public function test_chapters_editor_enabled_is_one_by_default() {
 		$state = $this->get_localized_state();
 
 		$this->assertIsArray( $state, 'videoPressEditorState was not localized as decodable JSON.' );
 		$this->assertArrayHasKey( 'chaptersEditorEnabled', $state );
 
-		// Not `false`: wp_localize_script() casts scalars to strings. The client
-		// matches `'1'` exactly, so anything falsy-but-not-'1' reads as disabled.
-		$this->assertSame( '', $state['chaptersEditorEnabled'] );
+		// Not `true`: wp_localize_script() casts scalars to strings, and the
+		// client matches `'1'` exactly.
+		$this->assertSame( '1', $state['chaptersEditorEnabled'] );
 	}
 
-	/** Tests that the filter flips the mirrored value to the '1' the client matches on. */
-	public function test_chapters_editor_enabled_is_one_when_filter_enabled() {
-		add_filter( Admin_UI::CHAPTERS_EDITOR_FILTER, '__return_true' );
+	/** Tests that the kill switch flips the mirrored value to the empty string the client reads as disabled. */
+	public function test_chapters_editor_enabled_is_empty_string_when_filter_disabled() {
+		add_filter( Admin_UI::CHAPTERS_EDITOR_FILTER, '__return_false' );
 
 		$state = $this->get_localized_state();
 
-		$this->assertSame( '1', $state['chaptersEditorEnabled'] );
+		// Not `false`: same string cast. Anything falsy-but-not-'1' reads as disabled.
+		$this->assertSame( '', $state['chaptersEditorEnabled'] );
 	}
 }

--- a/projects/packages/videopress/tests/php/Initial_State_Chapters_Editor_Test.php
+++ b/projects/packages/videopress/tests/php/Initial_State_Chapters_Editor_Test.php
@@ -67,22 +67,22 @@ class Initial_State_Chapters_Editor_Test extends BaseTestCase {
 		return json_decode( $json, true );
 	}
 
-	/** Tests that the gate is mirrored at the exact key path the client reads, and is off by default. */
-	public function test_features_chapters_editor_is_false_by_default() {
+	/** Tests that the gate is mirrored at the exact key path the client reads, and is on by default. */
+	public function test_features_chapters_editor_is_true_by_default() {
 		$state = $this->get_rendered_state();
 
 		$this->assertIsArray( $state, 'Initial_State::render() did not produce decodable JSON.' );
 		$this->assertArrayHasKey( 'features', $state );
 		$this->assertArrayHasKey( 'chaptersEditor', $state['features'] );
-		$this->assertFalse( $state['features']['chaptersEditor'] );
+		$this->assertTrue( $state['features']['chaptersEditor'] );
 	}
 
-	/** Tests that the mirrored value follows the filter, as a real JSON boolean. */
-	public function test_features_chapters_editor_is_true_when_filter_enabled() {
-		add_filter( Admin_UI::CHAPTERS_EDITOR_FILTER, '__return_true' );
+	/** Tests that the mirrored value follows the kill switch, as a real JSON boolean. */
+	public function test_features_chapters_editor_is_false_when_filter_disabled() {
+		add_filter( Admin_UI::CHAPTERS_EDITOR_FILTER, '__return_false' );
 
 		$state = $this->get_rendered_state();
 
-		$this->assertTrue( $state['features']['chaptersEditor'] );
+		$this->assertFalse( $state['features']['chaptersEditor'] );
 	}
 }


### PR DESCRIPTION
Fixes N/A

## Proposed changes

Makes the VideoPress chapters editor generally available. It shipped in #50986 behind `jetpack_videopress_chapters_editor` (default off), enabled only for Automatticians on WordPress.com Simple.

* **`jetpack_videopress_chapters_editor` now defaults to `true`** (`Admin_UI::is_chapters_editor_enabled()`), so the dashboard's Editor tab, the `/video/$id/editor` route, the Details-tab "Edit chapters" deep link, and the block editor's "Manage chapters" toolbar button are available on every host — self-hosted, Atomic, and Simple.
* **Removes the Automattician-only callback** `wpcom_videopress_chapters_editor_enabled()` and its `add_filter()` from the Simple mu-plugin. This is not optional cleanup: with that callback still registered, flipping the default would leave the editor off for every non-Automattician on Simple, which is the opposite of the intent.

The filter itself stays, as a kill switch. That mirrors what the modernized dashboard did when it reached 100% (#50866, VIDP-285) — a site or wpcom can withdraw the feature by returning `false`, with no deploy. Removing the filter, the route-stripping machinery, and the two client mirrors is a follow-up once GA has stuck, not part of this PR.

Two details worth a reviewer's eye:

* **The route-stripping guard tests now disable the feature explicitly.** With the default flipped, `maybe_strip_chapters_editor_routes()` returns at its early guard, so the missing-global / empty-global / non-array-global tests would have kept passing without ever reaching the code they exist to cover. They opt out via a `disable_chapters_editor()` helper so they still exercise it.
* **The two client helpers still fall back to `false`** when their payload is absent (`JPVIDEOPRESS_INITIAL_STATE.features.chaptersEditor` and `window.videoPressEditorState.chaptersEditorEnabled`). A missing global is no evidence the feature is on, so the conservative fallback stays correct even though the PHP default changed. Only the docblocks describing the PHP default were updated.

Unchanged: the chapters REST surface, which was always registered regardless of the flag, so no API contract moves here.

## Related product discussion/links

* Introduced the gate this PR opens: #50986.
* Same un-gating pattern as the modernized dashboard rollout: #50866, VIDP-285.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The feature itself was tested in #50986; what needs verifying here is that it now appears without any opt-in, and that the kill switch still works.

**Default (no filter anywhere):**

* On a Jetpack-connected site with at least one VideoPress video, go to Jetpack → VideoPress and open a video. The page shows the Details | Editor sub-nav, and the Details description card shows a "Chapters (N)" summary with an "Edit chapters" link. Confirm you did *not* add any `jetpack_videopress_chapters_editor` filter to get there — if you have one in a local snippets mu-plugin, remove it first, since it will mask the change.
* Open the Editor tab and confirm the chapters timeline loads and saves.
* In the post editor, select a VideoPress video block and confirm the "Manage chapters" toolbar button is present next to "Manage subtitles", and that the modal opens.

**Kill switch:**

* Add `add_filter( 'jetpack_videopress_chapters_editor', '__return_false' );` in an mu-plugin.
* The sub-nav disappears from the video page, the Details summary drops its "Edit chapters" link, the "Manage chapters" toolbar button disappears, and `/video/$id/editor` is not registered — navigating to it directly lands on the editor-not-found state rather than a half-mounted editor.

**On WordPress.com Simple:** sandbox a Simple site as a non-Automattician user (or check with an Automattician account that nothing changed for you) and confirm the chapters editor is present. Before this PR it was Automattician-only there.

**Automated:**

* `jetpack test php packages/videopress` — 16 chapters-gate tests across `Admin_UI_Chapters_Editor_Test`, `Initial_State_Chapters_Editor_Test`, and `Block_Editor_Extensions_Chapters_Editor_Test` now assert the default-on behavior and the kill switch in both directions.
* `jetpack test php packages/jetpack-mu-wpcom` — `Wpcom_Videopress_Test::test_no_chapters_editor_gate_registered` pins the absence of the removed callback, alongside the existing VIDP-285 equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJkVWzJ9jFeJXpoE1Rxdhc
