### PR TITLE
WordPress Agent: enable for proxied self-hosted sites

### DIFF
--- a/projects/plugins/jetpack/changelog/enable-self-hosted-wordpress-agent-shell
+++ b/projects/plugins/jetpack/changelog/enable-self-hosted-wordpress-agent-shell
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI Assistant: Allow internal testing of the WordPress Agent in the editor on self-hosted sites.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -314,23 +314,39 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
+	 * Whether this request is proxied by Automattic.
+	 *
+	 * @return bool
+	 */
+	private static function is_proxied_request(): bool {
+		return isset( $_SERVER['A8C_PROXIED_REQUEST'] )
+			? (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) )
+			: defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
+	}
+
+	/**
 	 * UI feature flag for the public Jetpack AI Sidebar Preview surface.
 	 *
-	 * Defaults to enabled only on WordPress.com platform sites (Simple or WoA)
-	 * that have the Big Sky plugin present and enabled. Big Sky defaults on for
-	 * Simple sites and off on WoA/Atomic. The jetpack_ai_sidebar_enabled filter
-	 * is a host-level override of that default, respected by init() and every
-	 * sidebar surface that gates on this method. Independently of the filter,
-	 * the sidebar requires at least one of its features (writing assistant or
-	 * SEO enhancer) to be enabled.
+	 * Defaults to enabled for A8C-proxied requests off the WordPress.com platform,
+	 * so Automatticians can test on connected self-hosted sites. WordPress.com
+	 * platform sites (Simple or WoA) continue to require the Big Sky plugin to be
+	 * present and enabled. Big Sky defaults on for Simple sites and off on
+	 * WoA/Atomic. The jetpack_ai_sidebar_enabled filter is a host-level override
+	 * of that default, respected by init() and every sidebar surface that gates
+	 * on this method.
+	 * Independently of the filter, the sidebar requires at least one of its
+	 * features (writing assistant or SEO enhancer) to be enabled. Actual provider
+	 * exposure remains subject to is_supported_provider_surface() and
+	 * has_ai_features(), including their connection and offline checks.
 	 *
 	 * @return bool
 	 */
 	private static function is_jetpack_ai_sidebar_preview_enabled(): bool {
-		$host = new Host();
+		$host              = new Host();
+		$is_wpcom_platform = $host->is_wpcom_platform();
 
-		$enabled = false;
-		if ( $host->is_wpcom_platform() && class_exists( 'Big_Sky' ) ) {
+		$enabled = ! $is_wpcom_platform && self::is_proxied_request();
+		if ( $is_wpcom_platform && class_exists( 'Big_Sky' ) ) {
 			$default = $host->is_wpcom_simple() ? '1' : '0';
 			$enabled = (bool) get_option( 'big_sky_enable', $default );
 		}
@@ -338,12 +354,13 @@ class Jetpack_AI_Sidebar {
 		/**
 		 * Filter to enable or disable the Jetpack AI sidebar feature.
 		 *
-		 * Defaults to true only on WordPress.com platform sites with Big Sky
-		 * present and enabled. Acts as a host-level override that can force the
-		 * sidebar on (e.g. for local development) or off, and is respected by
-		 * init() and every sidebar surface. The override cannot force the
-		 * sidebar on while the writing-assistant and SEO enhancer features are
-		 * both off — a featureless sidebar never loads.
+		 * Defaults to true for A8C-proxied requests off the WordPress.com platform,
+		 * and on WordPress.com platform sites with Big Sky present and enabled.
+		 * Acts as a host-level override that can force the sidebar on (e.g. for
+		 * local development) or off, and is respected by init() and every sidebar
+		 * surface. The override cannot force the sidebar on while the
+		 * writing-assistant and SEO enhancer features are both off — a featureless
+		 * sidebar never loads.
 		 *
 		 * @param bool $enabled Whether the Jetpack AI sidebar is enabled.
 		 */

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -371,6 +371,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test that init() does nothing when the sidebar gate is explicitly disabled.
 	 */
 	public function test_init_does_nothing_when_filter_is_false() {
+		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
+		$this->simulate_self_hosted();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 		Jetpack_AI_Sidebar::init();
 
@@ -385,28 +388,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertFalse(
 			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
 			'register_toolbar_button_extension should not be hooked when filter is false.'
-		);
-	}
-
-	/**
-	 * Test that init() does nothing on a self-hosted site (off the wpcom platform).
-	 */
-	public function test_init_does_nothing_on_self_hosted() {
-		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
-		$this->simulate_self_hosted();
-		Jetpack_AI_Sidebar::init();
-
-		$this->assertFalse(
-			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
-			'register_provider should not be hooked on a self-hosted site.'
-		);
-		$this->assertFalse(
-			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_on_provider_surfaces' ) ),
-			'enable_agents_manager_on_provider_surfaces should not be hooked on a self-hosted site.'
-		);
-		$this->assertFalse(
-			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
-			'register_toolbar_button_extension should not be hooked when the preview gate is false.'
 		);
 	}
 
@@ -464,15 +445,45 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The preview gate is closed off the WordPress.com platform, even with Big Sky present.
+	 * The preview gate stays closed on unproxied self-hosted sites.
 	 */
-	public function test_preview_disabled_on_self_hosted() {
+	public function test_preview_disabled_on_unproxied_self_hosted() {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_self_hosted();
-		$this->simulate_big_sky_class();
-		update_option( 'big_sky_enable', '1' );
+		$_SERVER['A8C_PROXIED_REQUEST'] = '0';
 
 		$this->assertFalse( $this->gate_open() );
+	}
+
+	/**
+	 * The preview gate opens on proxied self-hosted sites.
+	 */
+	public function test_preview_enabled_on_proxied_self_hosted() {
+		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
+		$this->simulate_self_hosted();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$this->assertTrue( $this->gate_open() );
+	}
+
+	/**
+	 * Provider exposure stays closed without a connected owner through has_ai_features().
+	 */
+	public function test_provider_exposure_disabled_on_self_hosted_without_connected_owner() {
+		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
+		$this->simulate_self_hosted();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		\Jetpack_Options::delete_option( 'master_user' );
+		\Jetpack_Options::delete_option( 'user_tokens' );
+		$connection_manager = new \Automattic\Jetpack\Connection\Manager( 'jetpack' );
+		$connection_manager->reset_connection_status();
+
+		try {
+			$this->set_block_editor_screen();
+			$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
+		} finally {
+			$connection_manager->reset_connection_status();
+		}
 	}
 
 	/**
@@ -517,16 +528,18 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * The jetpack_ai_sidebar_enabled filter overrides the gate in both directions.
 	 */
 	public function test_preview_filter_overrides_gate() {
-		// Gate is closed off-platform; the filter forces it on.
-		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
-		$this->simulate_self_hosted();
-		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );
-		$this->assertTrue( $this->gate_open() );
-
-		// Gate is open on Simple + Big Sky; the filter forces it off.
+		// Gate is closed on Simple when Big Sky is off; the filter forces it on.
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_wpcom_simple();
 		$this->simulate_big_sky_class();
+		update_option( 'big_sky_enable', '0' );
+		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );
+		$this->assertTrue( $this->gate_open() );
+
+		// Gate is open on proxied self-hosted; the filter forces it off.
+		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
+		$this->simulate_self_hosted();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 		$this->assertFalse( $this->gate_open() );
 	}
@@ -1977,6 +1990,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test full flow: init, simulate AM filter, verify provider registered.
 	 */
 	public function test_full_flow_with_default_enabled() {
+		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
+		$this->simulate_self_hosted();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->set_block_editor_screen();
 		Jetpack_AI_Sidebar::init();
 		$this->cache_sidebar_asset_data();


### PR DESCRIPTION
Fixes #

## Proposed changes

* Enable the standard WordPress Agent shell by default only for A8C-proxied requests on self-hosted Jetpack sites.
* Leave unproxied self-hosted sites disabled; use the explicit proxy signal rather than the broader internal-testing predicate.
* Keep the existing WordPress.com Simple, WoA, and Atomic Big Sky behavior unchanged.
* Preserve the existing `jetpack_ai_sidebar_enabled` override and the Jetpack AI master, feature, connection, offline, and supported-editor gates.
* Keep capability and ability permission callbacks authoritative for server-side access. The proxy marker is a rollout signal, not authorization.

## Related product discussion/links

None.

## Does this pull request change what data or activity we track or use?

No. It adds no tracking and does not change the existing AI request payload.

## Testing instructions

Automated:

```bash
jp docker phpunit jetpack -- --filter=Jetpack_AI_Sidebar_Test
```

Manual:

1. On a connected self-hosted site without the A8C proxy marker or an explicit filter override, open the post, page, and site editors and confirm the WordPress Agent shell does not load.
2. Repeat through the A8C proxy and confirm the shell loads with `wp-orchestrator`.
3. Disconnect Jetpack, enable offline mode, or disable Jetpack AI and confirm the Agent provider is not exposed even for a proxied request.
4. Add `jetpack_ai_sidebar_enabled` returning `false` and confirm the shell stays off.
5. Confirm WordPress.com Simple, WoA, and Atomic sites continue to follow their existing Big Sky behavior.
