### PR TITLE
Omnibar: track node clicks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/track-wpcom-admin-bar-all-nodes
+++ b/projects/packages/jetpack-mu-wpcom/changelog/track-wpcom-admin-bar-all-nodes
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Track clicks on all wpcom admin bar items.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
@@ -16,4 +16,29 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			wpcomTrackEvent( 'wpcom_adminbar_command_palette_clicked' );
 		} );
 	}
+
+	const adminBar = document.querySelector( '#wpadminbar' );
+	if ( ! adminBar ) {
+		return;
+	}
+
+	/**
+	 * Track clicks on any admin bar item, using the ID of the closest admin bar
+	 * node (minus the `wp-admin-bar-` prefix) as the event property.
+	 */
+	adminBar.addEventListener( 'click', event => {
+		const target = event.target.closest?.( 'a, button' );
+		if ( ! target ) {
+			return;
+		}
+
+		const node = target.closest( 'li[id^="wp-admin-bar-"]' );
+		if ( ! node ) {
+			return;
+		}
+
+		wpcomTrackEvent( 'wpcom_omnibar_node_click', {
+			node_id: node.id.replace( /^wp-admin-bar-/, '' ),
+		} );
+	} );
 } );


### PR DESCRIPTION
## Proposed changes

Track click of each admin bar node, with `wpcom_omnibar_node_click` event, and `node_id` prop.

## Related product discussion/links

See: pgle0O-1Om-p2#comment-3163 (and the actual P2 post)

We want to implement tracking in the omnibar nodes.

## Does this pull request change what data or activity we track or use?

Yes, we generalize the tracking already done in the following similar PRs:

- https://github.com/Automattic/jetpack/pull/44165
- https://github.com/Automattic/jetpack/pull/50659

## Testing instructions

- Patch this PR.
- Click any admin bar node, both top-level or menu items.
- Verify the Tracks event with the correct prop as described above is fired.

<img width="479" height="93" alt="image" src="https://github.com/user-attachments/assets/9afe76c7-42c9-44db-9240-f93ff956a365" />