### PR TITLE
CI: Fix the PHP 7.x test fatal introduced by Mockery 1.6.13

### DIFF
--- a/projects/packages/connection/changelog/fix-connection-test-request-uri
+++ b/projects/packages/connection/changelog/fix-connection-test-request-uri
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: CI: Keep the shutdown cron run from fataling on PHP versions without a native str_contains().
+
+

--- a/projects/packages/connection/tests/php/bootstrap.php
+++ b/projects/packages/connection/tests/php/bootstrap.php
@@ -23,6 +23,19 @@ if ( empty( $_SERVER['PHP_SELF'] ) ) {
 	$_SERVER['PHP_SELF'] = '';
 }
 
+// WordPress runs `_wp_cron()` on `shutdown`, handing this superglobal to
+// `str_contains()`. CLI leaves it unset, and Mockery's strictly typed polyfill turns
+// that into a fatal on PHP without a native `str_contains()`. Filling it in earlier
+// would change what the tests see, so do it last: shutdown functions run in
+// registration order, and WordPress registers its own later than this.
+register_shutdown_function(
+	function () {
+		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+			$_SERVER['REQUEST_URI'] = '/';
+		}
+	}
+);
+
 define( 'WP_DEBUG', true );
 
 // Preloading the file to reconcile Brain\Monkey with Wordbless.


### PR DESCRIPTION

## Proposed changes

* Register a shutdown function in the Connection package's PHPUnit bootstrap that fills in `$_SERVER['REQUEST_URI']` if nothing else has.

This unblocks every PR in the repo: `PHP tests: PHP 7.3 WP previous` and `PHP tests: PHP 7.4 WP latest` are required checks and have been failing on trunk since 2026-08-16, with no Jetpack change involved.

### What happens

`packages/connection` runs its suite, reports its counts, and then dies at shutdown:

```
[packages/connection] PHP Fatal error: Uncaught TypeError: Argument 1 passed to str_contains()
must be of the type string, null given, called in wp-includes/cron.php on line 1020
and defined in projects/packages/connection/vendor/mockery/mockery/library/helpers.php:144
```

The chain:

1. On PHP < 8.0 `str_contains()` is not native, so somebody has to polyfill it.
2. WordPress polyfills it in `wp-includes/compat.php`, untyped: `str_contains( $haystack, $needle )`. A null haystack was harmless.
3. **Mockery 1.6.13, released 2026-08-15**, added its own polyfill in `library/helpers.php`, copied from symfony/polyfill and strictly typed: `str_contains( string $haystack, string $needle )`.
4. Composer's autoload `files` run before WordPress loads, so Mockery's definition wins and WordPress's `function_exists()` guard skips its own.
5. WordPress 6.9 moved `_wp_cron()` to the `shutdown` action. It calls `str_contains( $_SERVER['REQUEST_URI'], '/wp-cron.php' )`.
6. Under CLI `REQUEST_URI` is unset, so the strictly typed polyfill gets null and fatals.

`packages/connection` has no `composer.lock`, so each CI run resolves fresh and picked the new Mockery up on its own. It reaches Mockery through `brain/monkey`, whose constraint allows `^1.6.10`. Trunk was green on 2026-08-14 with Mockery 1.6.12 and red on 2026-08-16 with 1.6.13.

### Where it came from

No Jetpack change introduced this, so there is nothing here to revert. The polyfills came from upstream: [mockery/mockery#1436](https://github.com/mockery/mockery/pull/1436), commit [`da971719`](https://github.com/mockery/mockery/commit/da971719ee423f2e67abe6e993cee7f361bd7fbf), authored 2024-09-03 by Mockery's maintainer, [ghostwriter](https://github.com/ghostwriter). It added `str_contains()`, `str_starts_with()` and `str_ends_with()` together, then sat unreleased for almost two years and shipped in 1.6.13 on 2026-08-15.

Worth reporting upstream: the polyfills are stricter than the functions they stand in for. Native `str_contains()` is an internal function, so a null haystack coming from non-strict code is coerced and only raises a deprecation. The userland copy declares `string $haystack`, which is a hard TypeError on PHP 7.x. WordPress's own polyfill in `wp-includes/compat.php` is untyped, which is why nobody noticed until Mockery's definition started winning the `function_exists()` race.

### Why a shutdown function, and not a plain assignment

Setting the superglobal at the top of the bootstrap, next to the `SCRIPT_FILENAME`, `SCRIPT_NAME` and `PHP_SELF` entries already filled in there, is the obvious move and it is wrong: it takes 10 tests down. The REST endpoint tests sign requests with `$_SERVER['REQUEST_URI']`, so giving it a value changes the computed signature, and the Identity Crisis UI tests asserted on its absence. Measured: 897 tests and 2010 assertions before, 10 failures after.

Registering a shutdown function instead leaves the superglobal untouched for the entire run and fills it in only at the very end. Ordering is what makes it work: PHP calls shutdown functions in registration order, the bootstrap runs long before WordPress reaches `register_shutdown_function( 'shutdown_action_hook' )` in `wp-settings.php`, so the value is in place by the time the cron run reads it. `/` reproduces the old behavior exactly, since `_wp_cron()` looks for `/wp-cron.php`, does not find it, and carries on.

Two alternatives that do not work. Defining `DISABLE_WP_CRON` does not help, because it sits on the right-hand side of the `||` and PHP evaluates the `str_contains()` call first regardless. Pinning Mockery below 1.6.13 would work, but it leaves the landmine in place for any other strictly typed polyfill reaching a WordPress function that reads this superglobal.

## Related product discussion/links

* Mockery 1.6.13 release: https://github.com/mockery/mockery/releases/tag/1.6.13

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Only `packages/connection` is affected: it is the one project whose suite reaches `shutdown` with Mockery loaded on a PHP version without a native `str_contains()`.

* Confirm `PHP tests: PHP 7.2 WP previous`, `PHP tests: PHP 7.3 WP previous` and `PHP tests: PHP 7.4 WP latest` pass on this PR, and compare against the same jobs on trunk, where they fail with the fatal quoted above.
* On PHP 8.0 and later the fatal does not reproduce, since `str_contains()` is native and Mockery's polyfill never loads. The symptom is still visible as a warning though, which makes it easy to check locally: run `jetpack test php packages/connection` on trunk and the run ends with `Undefined array key "REQUEST_URI" in wp-includes/cron.php` plus a `str_contains(): Passing null` deprecation, after the PHPUnit summary. With this branch both are gone and the counts are unchanged at 897 tests and 2010 assertions.
