### PR TITLE
Podcast Player: stop preloading episode audio before playback

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-podcast-player-preload-none
+++ b/projects/plugins/jetpack/changelog/fix-podcast-player-preload-none
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Podcast Player: stop preloading episode audio before playback to avoid inflating podcast download metrics.

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/components/podcast-player.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/components/podcast-player.jsx
@@ -330,6 +330,10 @@ export class PodcastPlayer extends Component {
 						currentTime={ currentTime }
 						onTimeChange={ this.handleTimeChange }
 						onMetadataLoaded={ this.updateMediaData }
+						// Avoid fetching the episode before the listener presses play. Preloading
+						// generates phantom downloads that inflate podcast metrics and skew hosts'
+						// IAB-compliant analytics. See https://github.com/Automattic/jetpack/issues/51138.
+						preload="none"
 					/>
 				</Header>
 

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/components/podcast-player.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/components/podcast-player.jsx
@@ -330,9 +330,6 @@ export class PodcastPlayer extends Component {
 						currentTime={ currentTime }
 						onTimeChange={ this.handleTimeChange }
 						onMetadataLoaded={ this.updateMediaData }
-						// Avoid fetching the episode before the listener presses play. Preloading
-						// generates phantom downloads that inflate podcast metrics and skew hosts'
-						// IAB-compliant analytics. See https://github.com/Automattic/jetpack/issues/51138.
 						preload="none"
 					/>
 				</Header>

--- a/projects/plugins/jetpack/extensions/blocks/podcast-player/test/podcast-player.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/podcast-player/test/podcast-player.jsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react';
+import AudioPlayer from '../../../shared/components/audio-player';
+import { PodcastPlayer } from '../components/podcast-player';
+
+// Stub the audio player so we can assert the props the block hands it without
+// mounting the real MediaElement machinery.
+jest.mock( '../../../shared/components/audio-player', () => jest.fn( () => null ) );
+
+const track = {
+	id: '1',
+	guid: 'guid-1',
+	title: 'Episode 1',
+	link: 'https://example.com/episode',
+	src: 'https://example.com/episode.mp3',
+	description: '',
+};
+
+const defaultProps = {
+	playerId: 'podcast-player-1',
+	title: 'My Podcast',
+	tracks: [ track ],
+	playerState: 'is-paused',
+	attributes: {
+		itemsToShow: 5,
+		showCoverArt: false,
+		showEpisodeTitle: false,
+		showEpisodeDescription: false,
+	},
+	// Media-source store dispatchers, unused by this render but called on mount.
+	registerMediaSource: jest.fn(),
+	setDefaultMediaSource: jest.fn(),
+	unregisterMediaSource: jest.fn(),
+	updateMediaSourceData: jest.fn(),
+	toggleMediaSource: jest.fn(),
+	pauseMediaSource: jest.fn(),
+	playMediaSource: jest.fn(),
+	errorMediaSource: jest.fn(),
+	setMediaSourceCurrentTime: jest.fn(),
+};
+
+describe( 'PodcastPlayer', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders the audio player with preload disabled to avoid inflating download metrics', () => {
+		render( <PodcastPlayer { ...defaultProps } /> );
+
+		expect( AudioPlayer ).toHaveBeenCalledWith(
+			expect.objectContaining( { preload: 'none', trackSource: track.src } ),
+			expect.anything()
+		);
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/shared/components/audio-player/test/index.test.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/audio-player/test/index.test.jsx
@@ -1,12 +1,14 @@
 import { render } from '@testing-library/react';
 import AudioPlayer from '../index';
 
-/**
- * Minimal MediaElementPlayer stand-in. The real one is a global provided by
- * WordPress' wp-mediaelement script and isn't available in the test environment.
- */
+// The component hands its <audio> node to MediaElementPlayer right after setting
+// preload on it. Capture that node from the mock so we can assert on preload
+// without reaching into the DOM directly.
+let audioNode;
+
 class MockMediaElementPlayer {
 	constructor( node ) {
+		audioNode = node;
 		this.domNode = node;
 		this.media = node;
 		this.options = { classPrefix: 'mejs-' };
@@ -18,6 +20,7 @@ class MockMediaElementPlayer {
 
 describe( 'shared AudioPlayer', () => {
 	beforeEach( () => {
+		audioNode = undefined;
 		global.MediaElementPlayer = MockMediaElementPlayer;
 	} );
 
@@ -26,18 +29,14 @@ describe( 'shared AudioPlayer', () => {
 	} );
 
 	test( 'propagates the preload prop to the audio element', () => {
-		const { container } = render(
-			<AudioPlayer trackSource="https://example.com/episode.mp3" preload="none" />
-		);
+		render( <AudioPlayer trackSource="https://example.com/episode.mp3" preload="none" /> );
 
-		expect( container.querySelector( 'audio' ).preload ).toBe( 'none' );
+		expect( audioNode.preload ).toBe( 'none' );
 	} );
 
 	test( 'defaults preload to metadata when the prop is omitted', () => {
-		const { container } = render(
-			<AudioPlayer trackSource="https://example.com/episode.mp3" />
-		);
+		render( <AudioPlayer trackSource="https://example.com/episode.mp3" /> );
 
-		expect( container.querySelector( 'audio' ).preload ).toBe( 'metadata' );
+		expect( audioNode.preload ).toBe( 'metadata' );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/shared/components/audio-player/test/index.test.jsx
+++ b/projects/plugins/jetpack/extensions/shared/components/audio-player/test/index.test.jsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import AudioPlayer from '../index';
+
+/**
+ * Minimal MediaElementPlayer stand-in. The real one is a global provided by
+ * WordPress' wp-mediaelement script and isn't available in the test environment.
+ */
+class MockMediaElementPlayer {
+	constructor( node ) {
+		this.domNode = node;
+		this.media = node;
+		this.options = { classPrefix: 'mejs-' };
+	}
+	setResponsiveMode() {}
+	addControlElement() {}
+	remove() {}
+}
+
+describe( 'shared AudioPlayer', () => {
+	beforeEach( () => {
+		global.MediaElementPlayer = MockMediaElementPlayer;
+	} );
+
+	afterEach( () => {
+		delete global.MediaElementPlayer;
+	} );
+
+	test( 'propagates the preload prop to the audio element', () => {
+		const { container } = render(
+			<AudioPlayer trackSource="https://example.com/episode.mp3" preload="none" />
+		);
+
+		expect( container.querySelector( 'audio' ).preload ).toBe( 'none' );
+	} );
+
+	test( 'defaults preload to metadata when the prop is omitted', () => {
+		const { container } = render(
+			<AudioPlayer trackSource="https://example.com/episode.mp3" />
+		);
+
+		expect( container.querySelector( 'audio' ).preload ).toBe( 'metadata' );
+	} );
+} );


### PR DESCRIPTION
Fixes #51138

## Proposed changes

The Podcast Player block builds its `<audio>` element through the shared `AudioPlayer` component, which defaults to `preload="metadata"`. The block never overrode that, so every visitor who opened a page with the block sent a request to the first episode's URL before pressing play. Podcast hosts count those requests as downloads; they inflate listening numbers and can cost owners revenue once the traffic gets filtered out as non-human. IAB guidelines ask for no request against the content until the listener acts.

* Pass `preload="none"` at the podcast player's `AudioPlayer` call site so nothing reaches the episode URL until playback starts.
* Add a regression test for the shared `AudioPlayer` confirming the `preload` prop reaches the `<audio>` element, and that the default stays `metadata` for any other consumer.

## What about the episode duration?

The audio player's control bar won't show the episode's total length until someone presses play. That number comes from the file's metadata, and we're not fetching that up front anymore, so it only fills in once playback starts and `loadedmetadata` fires. Related PR: #18761

The durations next to each episode in the track list aren't affected; those come from the RSS feed rather than the audio file, so they still show on load. I don't think a length readout in the player controls is worth a phantom download on every page view :) And if we ever want it back without a request, we can read it from the feed's `duration` too.

## Related product discussion/links

* https://github.com/Automattic/jetpack/issues/51138

## Does this pull request change what data or activity we track or use?

No. If anything it removes network requests that were going out before anyone pressed play.

## Testing instructions

* Add a Podcast Player block to a post or page, point it at any valid podcast RSS feed, and publish.
* Open the published page, then open the browser DevTools Network tab (filter to Media, or to the episode's host).
* Confirm no request goes out to the episode audio file on load.
* Press play. Confirm the episode loads and plays, and the total length shows up in the player controls once playback starts.
