### PR TITLE
Stats: document the Tracks service and link the source code in the readme

### DIFF
--- a/projects/plugins/stats/changelog/stats-343-plugin-review-feedback
+++ b/projects/plugins/stats/changelog/stats-343-plugin-review-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Document the WordPress.com Tracks service and link to the plugin source code in the readme.

--- a/projects/plugins/stats/readme.txt
+++ b/projects/plugins/stats/readme.txt
@@ -122,9 +122,9 @@ It connects to the following external services:
 
 **WordPress.com Tracks (`https://stats.wp.com/w.js` and `https://pixel.wp.com/t.gif`)**
 
-* What it does: records how site administrators use the plugin, so that Automattic can improve it. This is separate from your site statistics.
-* Data sent: the name of the action taken, your site ID, your WordPress.com user ID, the browser user agent, the browser language, and the IP address of the request.
-* When: only while a logged-in administrator uses the plugin screens in the WordPress admin. Nothing is recorded for your site visitors.
+* What it does: records how people who can open the plugin screens use them, so that Automattic can improve the plugin. This is separate from your site statistics.
+* Data sent: the name of the action taken, your site ID, your WordPress.com user ID and username, the browser user agent, the browser language, and the IP address of the request. If the person is not connected to a WordPress.com account, a random identifier is used in place of the user ID and username, and it is stored in a `tk_ai` cookie in their browser.
+* When: only while a logged-in user with access to the plugin screens uses them in the WordPress admin. You control who has that access through the Stats settings. Nothing is recorded for your site visitors.
 
 This plugin requires a connection to a WordPress.com account. Until that connection is complete, no data is collected and no reports are available.
 

--- a/projects/plugins/stats/readme.txt
+++ b/projects/plugins/stats/readme.txt
@@ -120,10 +120,25 @@ It connects to the following external services:
 * Data sent: no personal data; these are static front-end assets served from Automattic's CDN.
 * When: whenever you open the Stats dashboard.
 
+**WordPress.com Tracks (`https://stats.wp.com/w.js` and `https://pixel.wp.com/t.gif`)**
+
+* What it does: records how site administrators use the plugin, so that Automattic can improve it. This is separate from your site statistics.
+* Data sent: the name of the action taken, your site ID, your WordPress.com user ID, the browser user agent, the browser language, and the IP address of the request.
+* When: only while a logged-in administrator uses the plugin screens in the WordPress admin. Nothing is recorded for your site visitors.
+
 This plugin requires a connection to a WordPress.com account. Until that connection is complete, no data is collected and no reports are available.
 
 Service terms: [Terms of Service](https://wordpress.com/tos/)
 Service privacy policy: [Privacy Policy](https://automattic.com/privacy/)
+
+== Source code ==
+
+Jetpack Stats is developed in the open. The plugin, every bundled `automattic/jetpack-*` package, and the build tools that produce the released package are all in the Jetpack monorepo:
+
+* Plugin source: [Automattic/jetpack/projects/plugins/stats](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/stats)
+* Monorepo and build tools: [Automattic/jetpack](https://github.com/Automattic/jetpack)
+
+To build the plugin from source, follow the instructions in the monorepo [development guide](https://github.com/Automattic/jetpack/blob/trunk/docs/development-environment.md).
 
 == Changelog ==
 


### PR DESCRIPTION
Fixes UNI-640

## Proposed changes
* Add WordPress.com Tracks (`stats.wp.com/w.js` and `pixel.wp.com/t.gif`) to the readme's External services section. It was the one external service the standalone plugin reaches that the readme did not disclose. It is admin-only telemetry, separate from the front-end view-tracking pixel that was already listed.
* Add a `== Source code ==` section linking to the plugin source and to the monorepo, so the readme points at the development location and the build tooling.

Both items come from the WordPress.org plugin review of the standalone Jetpack Stats submission. The first was raised as a line-level finding against `jetpack-connection/src/class-tracking.php:114`; the second against Guidelines 1 and 4.

## Related product discussion/links
* https://linear.app/a8c/issue/UNI-640/draft-txt-file-for-wordpressorg-submission
* STATS-343: https://linear.app/a8c/issue/STATS-343/create-standalone-jetpack-stats-plugin

## Does this pull request change what data or activity we track or use?
No. This documents behaviour that already exists — Tracks is loaded today by the connection, admin-ui and My Jetpack packages that the plugin bundles. Nothing about what is collected changes.

## Testing instructions

* Read `projects/plugins/stats/readme.txt` and confirm the External services section now lists five services, with Tracks described as admin-only.
* Confirm the two links in the new `== Source code ==` section resolve.
* Optional, to verify the claim that Tracks is admin-only: `grep -rn "register_tracks_functions_scripts" projects/packages/`. Every caller reachable from this plugin (`admin-ui/src/class-admin-menu.php`, `my-jetpack/src/class-initializer.php`, `connection/src/identity-crisis/class-ui.php`) is admin-side, and the AJAX handler is registered on `wp_ajax_jetpack_tracks` with no `nopriv` variant.


