### PR TITLE
My Jetpack: prefix the historically active modules refresh transient

### DIFF
--- a/projects/packages/my-jetpack/changelog/stats-343-plugin-review-feedback
+++ b/projects/packages/my-jetpack/changelog/stats-343-plugin-review-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Prefix the transient that flags a historically active modules refresh.

--- a/projects/packages/my-jetpack/src/class-historically-active-modules.php
+++ b/projects/packages/my-jetpack/src/class-historically-active-modules.php
@@ -14,7 +14,7 @@ use WP_Error;
  * and includes all helper functions for triggering an update elsewhere
  */
 class Historically_Active_Modules {
-	public const UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY = 'update-historically-active-jetpack-modules';
+	public const UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY = 'jetpack_update_historically_active_modules';
 
 	/**
 	 * Register the REST API routes.


### PR DESCRIPTION
Fixes #

## Proposed changes
* Prefix the transient that queues a historically-active-modules refresh: `update-historically-active-jetpack-modules` becomes `jetpack_update_historically_active_modules`. The constant name is unchanged, only the stored key.

This comes from the WordPress.org plugin review of the standalone Jetpack Stats submission. Under "Use Prefixes for declarations, globals and stored data" it was the only example the reviewer gave, named with file and line:

> \# Using the common word "update" as a prefix.
> `jetpack_vendor/automattic/jetpack-my-jetpack/src/class-historically-active-modules.php:109`
> `set_transient(self::UPDATE_HISTORICALLY_ACTIVE_JETPACK_MODULES_KEY, true);`

### Why there is no cleanup of the old key

The rename can leave the unprefixed row behind on a site that had the flag set but not yet consumed at upgrade time. We are deliberately not adding code to delete it:

* **It should be rare.** The flag is a one-shot queue marker. It is set on `activated_plugin` / `jetpack_site_registered` / `jetpack_user_authorized`, and `Initializer::setup_historically_active_jetpack_modules_sync()` reads it, acts on it and deletes it on the very next non-AJAX admin page load. A site only keeps the row if it never loads wp-admin between setting the flag and updating the package.
* **Losing it is harmless.** A missed refresh self-heals — the flag is re-queued by those same three actions, and the module list is also recomputed directly on module changes. The worst case is a briefly stale My Jetpack badge.
* **A cleanup costs more than it saves.** `delete_transient()` bottoms out in `delete_option()`, which runs `SELECT autoload FROM wp_options WHERE option_name = %s` unconditionally, with no cache check first. Left in place that is one query on every admin page load, on every site running any of the nine plugins that bundle this package, to remove a row almost none of them have.

## Related product discussion/links
* MYJP-331: https://linear.app/a8c/issue/MYJP-331/prefix-the-historically-active-modules-refresh-transient
* STATS-343: https://linear.app/a8c/issue/STATS-343/create-standalone-jetpack-stats-plugin

## Does this pull request change what data or activity we track or use?
No. This is an internal cache key. Nothing is sent anywhere, and no user-visible behaviour changes — hence a package changelog entry only, with no dependent-plugin entries.

## Testing instructions

* On a site with My Jetpack, activate or deactivate a Jetpack module, then load any wp-admin page.
* Confirm the module list still updates: `wp option get jetpack_historically_active_modules`.
* Confirm the new key is the one being used during the queued window, e.g. by adding a temporary `error_log()` in `Historically_Active_Modules::queue_historically_active_jetpack_modules_update()`, or by watching `wp_options` for `_transient_jetpack_update_historically_active_modules` between the queueing action and the next admin page load.
* `jp test php packages/my-jetpack` passes.



