### PR TITLE
Connection: sanitize the request metadata sent with Tracks events

### DIFF
--- a/projects/packages/connection/changelog/stats-343-plugin-review-feedback
+++ b/projects/packages/connection/changelog/stats-343-plugin-review-feedback
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Tracking: sanitize the user agent, IP address, and language recorded with Tracks events.
+Tracking: Sanitize the user agent, IP address, and language recorded with Tracks events.

--- a/projects/packages/connection/changelog/stats-343-plugin-review-feedback
+++ b/projects/packages/connection/changelog/stats-343-plugin-review-feedback
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Tracking: Sanitize the user agent, IP address, and language recorded with Tracks events.
+Tracking: Sanitize the event name, event properties, user agent, IP address, and language recorded with Tracks events.

--- a/projects/packages/connection/changelog/stats-343-plugin-review-feedback
+++ b/projects/packages/connection/changelog/stats-343-plugin-review-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Tracking: sanitize the user agent, IP address, and language recorded with Tracks events.

--- a/projects/packages/connection/src/class-tracking.php
+++ b/projects/packages/connection/src/class-tracking.php
@@ -171,9 +171,9 @@ class Tracking {
 		}
 		$site_url = get_option( 'siteurl' );
 
-		$data['_via_ua']  = isset( $_SERVER['HTTP_USER_AGENT'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
-		$data['_via_ip']  = isset( $_SERVER['REMOTE_ADDR'] ) ? filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
-		$data['_lg']      = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? filter_var( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : '';
+		$data['_via_ua']  = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
+		$data['_via_ip']  = isset( $_SERVER['REMOTE_ADDR'] ) ? (string) filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_VALIDATE_IP ) : '';
+		$data['_lg']      = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : '';
 		$data['blog_url'] = $site_url;
 		$data['blog_id']  = \Jetpack_Options::get_option( 'id' );
 

--- a/projects/packages/connection/src/class-tracking.php
+++ b/projects/packages/connection/src/class-tracking.php
@@ -94,13 +94,17 @@ class Tracking {
 		$tracks_data = array();
 		if ( 'click' === $_REQUEST['tracksEventType'] && isset( $_REQUEST['tracksEventProp'] ) ) {
 			if ( is_array( $_REQUEST['tracksEventProp'] ) ) {
-				$tracks_data = array_map( 'filter_var', wp_unslash( $_REQUEST['tracksEventProp'] ) );
+				// map_deep() rather than array_map(): the request is client-supplied and may nest,
+				// and sanitize_text_field() returns an empty string when handed an array.
+				$tracks_data = map_deep( wp_unslash( $_REQUEST['tracksEventProp'] ), 'sanitize_text_field' );
 			} else {
-				$tracks_data = array( 'clicked' => filter_var( wp_unslash( $_REQUEST['tracksEventProp'] ) ) );
+				$tracks_data = array( 'clicked' => sanitize_text_field( wp_unslash( $_REQUEST['tracksEventProp'] ) ) );
 			}
 		}
 
-		$this->record_user_event( filter_var( wp_unslash( $_REQUEST['tracksEventName'] ) ), $tracks_data, null, false );
+		// Tracks only accepts lowercase alphanumerics and underscores in an event name
+		// (see Jetpack_Tracks_Event::EVENT_NAME_REGEX), which is what sanitize_key() permits.
+		$this->record_user_event( sanitize_key( wp_unslash( $_REQUEST['tracksEventName'] ) ), $tracks_data, null, false );
 
 		wp_send_json_success( null, null, JSON_UNESCAPED_SLASHES );
 	}

--- a/projects/packages/connection/src/class-tracking.php
+++ b/projects/packages/connection/src/class-tracking.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack;
 
+use Automattic\Jetpack\IP\Utils as IP_Utils;
+
 /**
  * The Tracking class, used to record events in wpcom
  */
@@ -172,7 +174,7 @@ class Tracking {
 		$site_url = get_option( 'siteurl' );
 
 		$data['_via_ua']  = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
-		$data['_via_ip']  = isset( $_SERVER['REMOTE_ADDR'] ) ? (string) filter_var( wp_unslash( $_SERVER['REMOTE_ADDR'] ), FILTER_VALIDATE_IP ) : '';
+		$data['_via_ip']  = isset( $_SERVER['REMOTE_ADDR'] ) ? (string) IP_Utils::clean_ip( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- clean_ip() validates the address.
 		$data['_lg']      = isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) : '';
 		$data['blog_url'] = $site_url;
 		$data['blog_id']  = \Jetpack_Options::get_option( 'id' );

--- a/projects/packages/connection/tests/php/Tracking_Test.php
+++ b/projects/packages/connection/tests/php/Tracking_Test.php
@@ -60,6 +60,12 @@ class Tracking_Test extends TestCase {
 	 */
 	public function tearDown(): void {
 		unset( $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_USER_AGENT'], $_SERVER['HTTP_ACCEPT_LANGUAGE'] );
+		unset(
+			$_REQUEST['tracksNonce'],
+			$_REQUEST['tracksEventName'],
+			$_REQUEST['tracksEventType'],
+			$_REQUEST['tracksEventProp']
+		);
 
 		parent::tearDown();
 		Monkey\tearDown();
@@ -175,6 +181,146 @@ class Tracking_Test extends TestCase {
 		$this->assertSame( '', $captured['_via_ua'] );
 		$this->assertSame( '', $captured['_via_ip'] );
 		$this->assertSame( '', $captured['_lg'] );
+	}
+
+	/**
+	 * Build a Tracking object that captures what ajax_tracks() forwards to record_user_event(),
+	 * with the WordPress functions that method reaches stubbed out.
+	 *
+	 * The two sanitizers return distinguishable markers so a test can assert which of them guards a
+	 * given field. map_deep() is given a real recursive implementation, since the point of using it
+	 * is that it reaches nested values.
+	 *
+	 * @param string $event_name Set by reference to the event name passed on.
+	 * @param array  $properties Set by reference to the properties passed on.
+	 * @return Tracking
+	 */
+	private function tracking_capturing_ajax_event( &$event_name, &$properties ) {
+		Monkey\Functions\when( 'wp_unslash' )->returnArg();
+		Monkey\Functions\when( 'wp_verify_nonce' )->justReturn( true );
+		Monkey\Functions\when( 'wp_send_json_error' )->justReturn( null );
+		Monkey\Functions\when( 'wp_send_json_success' )->justReturn( null );
+		Monkey\Functions\when( 'sanitize_key' )->alias(
+			function ( $str ) {
+				return 'key:' . $str;
+			}
+		);
+		Monkey\Functions\when( 'sanitize_text_field' )->alias(
+			function ( $str ) {
+				return 'text:' . $str;
+			}
+		);
+
+		$deep = function ( $value, $callback ) use ( &$deep ) {
+			if ( is_array( $value ) ) {
+				return array_map(
+					function ( $item ) use ( &$deep, $callback ) {
+						return $deep( $item, $callback );
+					},
+					$value
+				);
+			}
+			return $callback( $value );
+		};
+		Monkey\Functions\when( 'map_deep' )->alias( $deep );
+
+		$tracking = $this->getMockBuilder( Tracking::class )
+			->setConstructorArgs( array( 'jetpack', $this->connection ) )
+			->onlyMethods( array( 'record_user_event' ) )
+			->getMock();
+
+		$tracking->method( 'record_user_event' )
+			->willReturnCallback(
+				function ( $name, $data = array() ) use ( &$event_name, &$properties ) {
+					$event_name = $name;
+					$properties = $data;
+					return true;
+				}
+			);
+
+		return $tracking;
+	}
+
+	/**
+	 * The event name reaches Tracks as a key, so it is sanitized with sanitize_key() rather than
+	 * passed through. Tracks itself only accepts lowercase alphanumerics and underscores.
+	 */
+	public function test_ajax_tracks_sanitizes_the_event_name() {
+		$event_name = null;
+		$properties = null;
+		$tracking   = $this->tracking_capturing_ajax_event( $event_name, $properties );
+
+		$_REQUEST['tracksNonce']     = 'nonce';
+		$_REQUEST['tracksEventName'] = 'jetpack_about_click';
+		$_REQUEST['tracksEventType'] = 'view';
+
+		$tracking->ajax_tracks();
+
+		$this->assertSame( 'key:jetpack_about_click', $event_name );
+	}
+
+	/**
+	 * A scalar event property is sanitized as free-form text before it is recorded.
+	 */
+	public function test_ajax_tracks_sanitizes_a_scalar_event_prop() {
+		$event_name = null;
+		$properties = null;
+		$tracking   = $this->tracking_capturing_ajax_event( $event_name, $properties );
+
+		$_REQUEST['tracksNonce']     = 'nonce';
+		$_REQUEST['tracksEventName'] = 'jetpack_about_click';
+		$_REQUEST['tracksEventType'] = 'click';
+		$_REQUEST['tracksEventProp'] = '<script>alert(1)</script>';
+
+		$tracking->ajax_tracks();
+
+		$this->assertSame( array( 'clicked' => 'text:<script>alert(1)</script>' ), $properties );
+	}
+
+	/**
+	 * Array event properties are sanitized at every depth. The request is client-supplied, so it
+	 * can nest even though the shipped JavaScript client only sends a flat object.
+	 */
+	public function test_ajax_tracks_sanitizes_array_event_props_at_any_depth() {
+		$event_name = null;
+		$properties = null;
+		$tracking   = $this->tracking_capturing_ajax_event( $event_name, $properties );
+
+		$_REQUEST['tracksNonce']     = 'nonce';
+		$_REQUEST['tracksEventName'] = 'jetpack_about_click';
+		$_REQUEST['tracksEventType'] = 'click';
+		$_REQUEST['tracksEventProp'] = array(
+			'feature' => 'backups',
+			'nested'  => array( 'inner' => 'value' ),
+		);
+
+		$tracking->ajax_tracks();
+
+		$this->assertSame(
+			array(
+				'feature' => 'text:backups',
+				'nested'  => array( 'inner' => 'text:value' ),
+			),
+			$properties
+		);
+	}
+
+	/**
+	 * Properties are only collected for click events, so another event type records none.
+	 */
+	public function test_ajax_tracks_ignores_props_for_non_click_events() {
+		$event_name = null;
+		$properties = null;
+		$tracking   = $this->tracking_capturing_ajax_event( $event_name, $properties );
+
+		$_REQUEST['tracksNonce']     = 'nonce';
+		$_REQUEST['tracksEventName'] = 'jetpack_about_click';
+		$_REQUEST['tracksEventType'] = 'view';
+		$_REQUEST['tracksEventProp'] = 'ignored';
+
+		$tracking->ajax_tracks();
+
+		$this->assertSame( array(), $properties );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Tracking_Test.php
+++ b/projects/packages/connection/tests/php/Tracking_Test.php
@@ -191,8 +191,8 @@ class Tracking_Test extends TestCase {
 	 * given field. map_deep() is given a real recursive implementation, since the point of using it
 	 * is that it reaches nested values.
 	 *
-	 * @param string $event_name Set by reference to the event name passed on.
-	 * @param array  $properties Set by reference to the properties passed on.
+	 * @param string|null $event_name Set by reference to the event name passed on.
+	 * @param array|null  $properties Set by reference to the properties passed on.
 	 * @return Tracking
 	 */
 	private function tracking_capturing_ajax_event( &$event_name, &$properties ) {

--- a/projects/packages/connection/tests/php/Tracking_Test.php
+++ b/projects/packages/connection/tests/php/Tracking_Test.php
@@ -96,8 +96,9 @@ class Tracking_Test extends TestCase {
 	}
 
 	/**
-	 * REMOTE_ADDR is validated as an IP address, so anything that is not one is sent as an
-	 * empty string rather than passed through verbatim.
+	 * REMOTE_ADDR is normalized and then validated as an IP address, so a decorated address is
+	 * reduced to the address itself and anything that is not one is sent as an empty string
+	 * rather than passed through verbatim.
 	 *
 	 * @param string $remote_addr The REMOTE_ADDR value the request arrives with.
 	 * @param string $expected    The value expected in the Tracks `_via_ip` property.
@@ -123,13 +124,17 @@ class Tracking_Test extends TestCase {
 	 */
 	public static function data_provider_test_via_ip_is_validated() {
 		return array(
-			'IPv4'                    => array( '203.0.113.5', '203.0.113.5' ),
-			'IPv6'                    => array( '2001:db8::1', '2001:db8::1' ),
-			'IPv6 with a zone index'  => array( 'fe80::1%eth0', '' ),
-			'address with a port'     => array( '192.0.2.1:54321', '' ),
-			'bracketed IPv6'          => array( '[2001:db8::1]', '' ),
-			'list from a front proxy' => array( '203.0.113.5, 198.51.100.2', '' ),
-			'not an address at all'   => array( '<script>alert(1)</script>', '' ),
+			'IPv4'                     => array( '203.0.113.5', '203.0.113.5' ),
+			'IPv6'                     => array( '2001:db8::1', '2001:db8::1' ),
+			'IPv6 in upper case'       => array( '2001:DB8::1', '2001:db8::1' ),
+			'surrounding whitespace'   => array( "  203.0.113.5\n", '203.0.113.5' ),
+			'IPv4 with a port'         => array( '192.0.2.1:54321', '192.0.2.1' ),
+			'bracketed IPv6'           => array( '[2001:db8::1]', '2001:db8::1' ),
+			'bracketed IPv6 with port' => array( '[2001:db8::1]:54321', '2001:db8::1' ),
+			'IPv4 mapped into IPv6'    => array( '::ffff:203.0.113.5', '203.0.113.5' ),
+			'IPv6 with a zone index'   => array( 'fe80::1%eth0', '' ),
+			'list from a front proxy'  => array( '203.0.113.5, 198.51.100.2', '' ),
+			'not an address at all'    => array( '<script>alert(1)</script>', '' ),
 		);
 	}
 

--- a/projects/packages/connection/tests/php/Tracking_Test.php
+++ b/projects/packages/connection/tests/php/Tracking_Test.php
@@ -43,6 +43,12 @@ class Tracking_Test extends TestCase {
 		parent::setUp();
 		Monkey\setUp();
 
+		// External_Storage, reached through Jetpack_Options, computes a class constant from this
+		// at load time. Brain Monkey tests run without the WordPress constants defined.
+		if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+			define( 'MINUTE_IN_SECONDS', 60 );
+		}
+
 		$this->connection = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
 			->onlyMethods( array( 'is_user_connected' ) )
 			->getMock();
@@ -53,8 +59,117 @@ class Tracking_Test extends TestCase {
 	 * Test teardown.
 	 */
 	public function tearDown(): void {
+		unset( $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_USER_AGENT'], $_SERVER['HTTP_ACCEPT_LANGUAGE'] );
+
 		parent::tearDown();
 		Monkey\tearDown();
+	}
+
+	/**
+	 * Build a Tracking object that captures the properties it would send to Tracks.
+	 *
+	 * @param array $captured Set by reference to the properties passed to tracks_record_event().
+	 * @return Tracking
+	 */
+	private function tracking_capturing_properties( &$captured ) {
+		Monkey\Functions\when( 'wp_unslash' )->returnArg();
+		Monkey\Functions\when( 'get_option' )->alias(
+			function ( $option ) {
+				return 'siteurl' === $option ? 'https://example.com' : false;
+			}
+		);
+
+		$tracking = $this->getMockBuilder( Tracking::class )
+			->setConstructorArgs( array( 'jetpack', $this->connection ) )
+			->onlyMethods( array( 'tracks_record_event' ) )
+			->getMock();
+
+		$tracking->method( 'tracks_record_event' )
+			->willReturnCallback(
+				function ( $user, $event_name, $properties ) use ( &$captured ) {
+					$captured = $properties;
+					return true;
+				}
+			);
+
+		return $tracking;
+	}
+
+	/**
+	 * REMOTE_ADDR is validated as an IP address, so anything that is not one is sent as an
+	 * empty string rather than passed through verbatim.
+	 *
+	 * @param string $remote_addr The REMOTE_ADDR value the request arrives with.
+	 * @param string $expected    The value expected in the Tracks `_via_ip` property.
+	 *
+	 * @dataProvider data_provider_test_via_ip_is_validated
+	 */
+	#[DataProvider( 'data_provider_test_via_ip_is_validated' )]
+	public function test_via_ip_is_validated( $remote_addr, $expected ) {
+		$captured = array();
+		$tracking = $this->tracking_capturing_properties( $captured );
+
+		$_SERVER['REMOTE_ADDR'] = $remote_addr;
+
+		$tracking->record_user_event( 'test_event', array(), 'test_user' );
+
+		$this->assertSame( $expected, $captured['_via_ip'] );
+	}
+
+	/**
+	 * Data provider for test_via_ip_is_validated.
+	 *
+	 * @return array
+	 */
+	public static function data_provider_test_via_ip_is_validated() {
+		return array(
+			'IPv4'                    => array( '203.0.113.5', '203.0.113.5' ),
+			'IPv6'                    => array( '2001:db8::1', '2001:db8::1' ),
+			'IPv6 with a zone index'  => array( 'fe80::1%eth0', '' ),
+			'address with a port'     => array( '192.0.2.1:54321', '' ),
+			'bracketed IPv6'          => array( '[2001:db8::1]', '' ),
+			'list from a front proxy' => array( '203.0.113.5, 198.51.100.2', '' ),
+			'not an address at all'   => array( '<script>alert(1)</script>', '' ),
+		);
+	}
+
+	/**
+	 * The user agent and the language are free-form strings, so they are sanitized rather than
+	 * validated. The IP address is deliberately excluded, being validated instead.
+	 */
+	public function test_user_agent_and_language_are_sanitized() {
+		$captured = array();
+		$tracking = $this->tracking_capturing_properties( $captured );
+
+		Monkey\Functions\when( 'sanitize_text_field' )->alias(
+			function ( $str ) {
+				return 'sanitized:' . $str;
+			}
+		);
+
+		$_SERVER['HTTP_USER_AGENT']      = 'Mozilla/5.0';
+		$_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'en-US,en;q=0.9';
+		$_SERVER['REMOTE_ADDR']          = '203.0.113.5';
+
+		$tracking->record_user_event( 'test_event', array(), 'test_user' );
+
+		$this->assertSame( 'sanitized:Mozilla/5.0', $captured['_via_ua'] );
+		$this->assertSame( 'sanitized:en-US,en;q=0.9', $captured['_lg'] );
+		$this->assertSame( '203.0.113.5', $captured['_via_ip'] );
+	}
+
+	/**
+	 * Absent request metadata is reported as an empty string, not as a missing property.
+	 */
+	public function test_absent_request_metadata_is_empty() {
+		$captured = array();
+		$tracking = $this->tracking_capturing_properties( $captured );
+
+		$tracking->record_user_event( 'test_event', array(), 'test_user' );
+
+		$this->assertSame( '', $captured['_via_ua'] );
+		$this->assertSame( '', $captured['_via_ip'] );
+		$this->assertSame( '', $captured['_lg'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
`Tracking` passed several request values through `filter_var( $value )` with no filter argument. That is `FILTER_DEFAULT`, which returns its input unchanged — so the values reached the Tracks payload raw.

In `record_user_event()`, from the server:

* `_via_ua` (`HTTP_USER_AGENT`) and `_lg` (`HTTP_ACCEPT_LANGUAGE`) now go through `sanitize_text_field()`.
* `_via_ip` (`REMOTE_ADDR`) now goes through `IP\Utils::clean_ip()`, which normalizes the address and then validates it.

In `ajax_tracks()`, from the browser:

* The event name now goes through `sanitize_key()`. `Jetpack_Tracks_Event::EVENT_NAME_REGEX` only accepts lowercase alphanumerics and underscores, so `sanitize_key()` permits a superset of what Tracks will take and cannot corrupt a valid name.
* Array event properties now go through `map_deep( …, 'sanitize_text_field' )` rather than `array_map( 'filter_var', … )`. The value comes from `$_REQUEST` and can nest, and `sanitize_text_field()` returns an empty string when handed an array, so `array_map()` would silently discard nested data.
* A scalar event property now goes through `sanitize_text_field()`.

These four are arguably the more important half: unlike the `$_SERVER` values, they are supplied directly by the browser and land in the same payload. Thanks @juanmaguitar for catching that they were still outstanding.

Deliberately unchanged: the `$_GET` reads in `class-jetpack-signature.php` and `class-rest-connector.php`. Those are reassembled into the string the HMAC is computed over, so encoding them would break authentication.

Raised in the WordPress.org plugin review of the standalone Jetpack Stats submission, named against the `_via_ip` line with the note: *"filter_var() without a specific filter does not sanitize the IP value before it is placed into the tracking payload."*

### What `clean_ip()` does to `_via_ip`

It normalizes first and validates second, so decorated addresses are reduced to the address rather than discarded. Only values that are not an IP at all become empty:

| `REMOTE_ADDR` | Before | After |
| --- | --- | --- |
| `203.0.113.5` | `203.0.113.5` | `203.0.113.5` |
| `2001:db8::1` | `2001:db8::1` | `2001:db8::1` |
| `2001:DB8::1` | `2001:DB8::1` | `2001:db8::1` |
| `  203.0.113.5\n` | passed through | `203.0.113.5` |
| `192.0.2.1:54321` | passed through | `192.0.2.1` |
| `[2001:db8::1]` | passed through | `2001:db8::1` |
| `[2001:db8::1]:54321` | passed through | `2001:db8::1` |
| `::ffff:203.0.113.5` | passed through | `203.0.113.5` |
| `fe80::1%eth0` | passed through | `''` |
| `203.0.113.5, 198.51.100.2` | passed through | `''` |
| `<script>alert(1)</script>` | passed through | `''` |

Every row is covered by `data_provider_test_via_ip_is_validated`.

One behaviour worth knowing: `sanitize_text_field()` strips percent-encoded sequences outright, so a bot user agent containing `bot%20info` arrives as `botinfo`. Normal browser user agents are unaffected.

### Test environment note

`setUp()` defines `MINUTE_IN_SECONDS` when it is missing. `Jetpack_Options::get_option()` reaches `External_Storage`, which computes a class constant from it at load time, and these Brain Monkey tests run without the WordPress constants. Pre-existing gap, not introduced here.

## Related product discussion/links
* CONNECT-431: https://linear.app/a8c/issue/CONNECT-431/trackingrecord-user-event-sends-the-user-agent-ip-address-and-language

## Does this pull request change what data or activity we track or use?
It changes the shape of data already collected and adds nothing new. Values that were sent raw are now sanitized, and malformed IP addresses that are not recoverable are sent as an empty string rather than verbatim — see the table above. Flagging it here so the label can be added if you read this as privacy-affecting.

## Testing instructions

* `cd projects/packages/connection && vendor/bin/phpunit-select-config phpunit.#.xml.dist` — the full suite passes (914 tests).
* `cd projects/packages/connection && vendor/bin/phpunit tests/php/Tracking_Test.php` — 22 tests.
* To see the delta, swap in the trunk version of the file and re-run that one file:
  ```
  git show origin/trunk:projects/packages/connection/src/class-tracking.php > projects/packages/connection/src/class-tracking.php
  ```
  13 of the 22 fail, each showing the value that used to reach Tracks — including `<script>alert(1)</script>` arriving as the IP address. Restore with `git checkout -- projects/packages/connection/src/class-tracking.php`.
