### PR TITLE
Stats: point the readme at the Stats packages and the Calypso dashboard source

### DIFF
--- a/projects/plugins/stats/changelog/stats-343-readme-review-followup
+++ b/projects/plugins/stats/changelog/stats-343-readme-review-followup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Link the Stats packages and the Odyssey Stats dashboard source in the readme.

--- a/projects/plugins/stats/readme.txt
+++ b/projects/plugins/stats/readme.txt
@@ -136,7 +136,15 @@ Service privacy policy: [Privacy Policy](https://automattic.com/privacy/)
 Jetpack Stats is developed in the open. The plugin, every bundled `automattic/jetpack-*` package, and the build tools that produce the released package are all in the Jetpack monorepo:
 
 * Plugin source: [Automattic/jetpack/projects/plugins/stats](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/stats)
+* Stats collection and reporting: [projects/packages/stats](https://github.com/Automattic/jetpack/tree/trunk/projects/packages/stats)
+* Stats dashboard integration: [projects/packages/stats-admin](https://github.com/Automattic/jetpack/tree/trunk/projects/packages/stats-admin)
 * Monorepo and build tools: [Automattic/jetpack](https://github.com/Automattic/jetpack)
+
+The dashboard interface itself is a React application called Odyssey Stats. It is served as a prebuilt bundle from `widgets.wp.com`, and its source is in a second public repository:
+
+* Odyssey Stats application: [Automattic/wp-calypso/apps/odyssey-stats](https://github.com/Automattic/wp-calypso/tree/trunk/apps/odyssey-stats)
+* Shared Stats interface it is built from: [Automattic/wp-calypso/client/my-sites/stats](https://github.com/Automattic/wp-calypso/tree/trunk/client/my-sites/stats)
+* Repository and build tools: [Automattic/wp-calypso](https://github.com/Automattic/wp-calypso)
 
 To build the plugin from source, follow the instructions in the monorepo [development guide](https://github.com/Automattic/jetpack/blob/trunk/docs/development-environment.md).
 


### PR DESCRIPTION
Fixes #

## Proposed changes
Follow-up to #51314. That PR added a `== Source code ==` section pointing at the plugin directory and the monorepo. This fills in the two parts it left out:

* Link the Stats packages directly — `projects/packages/stats` (collection and reporting) and `projects/packages/stats-admin` (dashboard integration) — rather than only the plugin shell that wraps them.
* Link the dashboard's own source. The interface is a React app, Odyssey Stats, served as a **prebuilt bundle** from `widgets.wp.com` and built from a second repository: [`wp-calypso/apps/odyssey-stats`](https://github.com/Automattic/wp-calypso/tree/trunk/apps/odyssey-stats), itself built on [`client/my-sites/stats`](https://github.com/Automattic/wp-calypso/tree/trunk/client/my-sites/stats).

The second one closes a real gap for the WordPress.org review. Guideline 1/4 asks for public access to source **and build tools**, and the readme already discloses `widgets.wp.com/odyssey-stats/` as an external service serving the dashboard. Without this, a reviewer could reasonably ask where that bundle is built from — most of what a user actually sees is not in this repository at all. Saying so plainly, and pointing at Calypso, answers it before it is asked.

All four paths were verified against the live repositories before being written.

## Related product discussion/links
* Follow-up to #51314

## Does this pull request change what data or activity we track or use?
No. Documentation only — no code changes.

## Testing instructions

* Read the `== Source code ==` section of `projects/plugins/stats/readme.txt`.
* Confirm the six links resolve, in particular the two Calypso ones:
  * https://github.com/Automattic/wp-calypso/tree/trunk/apps/odyssey-stats
  * https://github.com/Automattic/wp-calypso/tree/trunk/client/my-sites/stats
* Confirm the wording makes clear the dashboard ships prebuilt and is not built from this repository.
