### PR TITLE
Subscriptions: check the Reader follow matrix, not just email subscriptions

### DIFF
--- a/projects/plugins/jetpack/.phan/config.php
+++ b/projects/plugins/jetpack/.phan/config.php
@@ -23,6 +23,9 @@ $config = make_phan_config(
 			'tests/php/lib/class-wpcom-features.php',
 			'tests/php/lib/class-email-verification.php',
 			'tests/php/lib/mock-functions.php',
+			'tests/php/extensions/blocks/premium-content/mocks/class-blog-subscriber.php',
+			'tests/php/extensions/blocks/premium-content/mocks/class-blog-subscription.php',
+			'tests/php/extensions/blocks/premium-content/mocks/wpcom-subs-is-subscribed.php',
 			// Temporary duplicated defintions of classes.
 			'_inc/lib/class.color.php',
 			// We have a stub for this because the real file has duplicate trait definitions.

--- a/projects/plugins/jetpack/changelog/update-nl-428
+++ b/projects/plugins/jetpack/changelog/update-nl-428
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Fix subscribe prompts and paywalled content incorrectly showing or blocking for readers who follow the site but have no active email subscription.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
@@ -74,7 +74,7 @@ class WPCOM_Online_Subscription_Service extends Jetpack_Token_Subscription_Servi
 			$has_active_email_sub = 'active' === $subscription_status;
 		}
 
-		$is_following = function_exists( 'wpcom_subs_is_subscribed' ) && wpcom_subs_is_subscribed(
+		$is_following = ! $has_active_email_sub && function_exists( 'wpcom_subs_is_subscribed' ) && wpcom_subs_is_subscribed(
 			array(
 				'user_id' => get_current_user_id(),
 				'blog_id' => $blog_id,

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
@@ -37,16 +37,7 @@ class WPCOM_Online_Subscription_Service extends Jetpack_Token_Subscription_Servi
 	 * @return bool
 	 */
 	public function visitor_can_view_content( $valid_plan_ids, $access_level ) {
-		include_once WP_CONTENT_DIR . '/mu-plugins/email-subscriptions/subscriptions.php';
-		$email             = wp_get_current_user()->user_email;
-		$subscriber_object = \Blog_Subscriber::get( $email );
-
-		$is_blog_subscriber = false;
-		if ( $subscriber_object ) {
-			$blog_id             = $this->get_site_id();
-			$subscription_status = \Blog_Subscription::get_subscription_status_for_blog( $subscriber_object, $blog_id );
-			$is_blog_subscriber  = 'active' === $subscription_status;
-		}
+		$is_blog_subscriber = $this->is_current_user_subscribed();
 
 		return $this->user_can_view_content( $valid_plan_ids, $access_level, $is_blog_subscriber, get_the_ID() );
 	}
@@ -67,23 +58,30 @@ class WPCOM_Online_Subscription_Service extends Jetpack_Token_Subscription_Servi
 	}
 
 	/**
-	 * Returns true if the current authenticated user is subscribed to the current site.
+	 * Returns true if the current authenticated user is subscribed to the current site,
+	 * either via an active email subscription or by following it in the Reader.
 	 *
 	 * @return bool
 	 */
 	public function is_current_user_subscribed(): bool {
 		include_once WP_CONTENT_DIR . '/mu-plugins/email-subscriptions/subscriptions.php';
-		$email             = wp_get_current_user()->user_email;
-		$subscriber_object = \Blog_Subscriber::get( $email );
-		if ( empty( $subscriber_object ) ) {
-			return false;
+		$email              = wp_get_current_user()->user_email;
+		$subscriber_object  = \Blog_Subscriber::get( $email );
+		$blog_id            = $this->get_site_id();
+		$has_active_email_sub = false;
+		if ( ! empty( $subscriber_object ) ) {
+			$subscription_status  = \Blog_Subscription::get_subscription_status_for_blog( $subscriber_object, $blog_id );
+			$has_active_email_sub = 'active' === $subscription_status;
 		}
-		$blog_id             = $this->get_site_id();
-		$subscription_status = \Blog_Subscription::get_subscription_status_for_blog( $subscriber_object, $blog_id );
-		if ( 'active' !== $subscription_status ) {
-			return false;
-		}
-		return true;
+
+		$is_following = function_exists( 'wpcom_subs_is_subscribed' ) && wpcom_subs_is_subscribed(
+			array(
+				'user_id' => get_current_user_id(),
+				'blog_id' => $blog_id,
+			)
+		);
+
+		return $has_active_email_sub || $is_following;
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-wpcom-online-subscription-service.php
@@ -65,9 +65,9 @@ class WPCOM_Online_Subscription_Service extends Jetpack_Token_Subscription_Servi
 	 */
 	public function is_current_user_subscribed(): bool {
 		include_once WP_CONTENT_DIR . '/mu-plugins/email-subscriptions/subscriptions.php';
-		$email              = wp_get_current_user()->user_email;
-		$subscriber_object  = \Blog_Subscriber::get( $email );
-		$blog_id            = $this->get_site_id();
+		$email                = wp_get_current_user()->user_email;
+		$subscriber_object    = \Blog_Subscriber::get( $email );
+		$blog_id              = $this->get_site_id();
 		$has_active_email_sub = false;
 		if ( ! empty( $subscriber_object ) ) {
 			$subscription_status  = \Blog_Subscription::get_subscription_status_for_blog( $subscriber_object, $blog_id );

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/WPCOM_Online_Subscription_Service_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/WPCOM_Online_Subscription_Service_Test.php
@@ -77,7 +77,7 @@ class WPCOM_Online_Subscription_Service_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	private function make_email_subscriber_active( string $status = 'active' ) {
-		Blog_Subscriber::$subscribers_by_email = array( self::SUBSCRIBER_EMAIL => (object) array() );
+		Blog_Subscriber::$subscribers_by_email = array( self::SUBSCRIBER_EMAIL => new Blog_Subscriber() );
 		Blog_Subscription::$status             = $status;
 	}
 

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/WPCOM_Online_Subscription_Service_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/WPCOM_Online_Subscription_Service_Test.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Tests for WPCOM_Online_Subscription_Service::is_current_user_subscribed().
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/subscription-service/include.php';
+require_once __DIR__ . '/mocks/class-blog-subscriber.php';
+require_once __DIR__ . '/mocks/class-blog-subscription.php';
+require_once __DIR__ . '/mocks/wpcom-subs-is-subscribed.php';
+
+use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\WPCOM_Online_Subscription_Service;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @covers \Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\WPCOM_Online_Subscription_Service
+ */
+#[CoversClass( WPCOM_Online_Subscription_Service::class )]
+class WPCOM_Online_Subscription_Service_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Email used for both the current user and the Blog_Subscriber mock.
+	 */
+	const SUBSCRIBER_EMAIL = 'reader@example.org';
+
+	/**
+	 * The logged-in user for the test, matched against Blog_Subscriber::$subscribers_by_email.
+	 *
+	 * @var integer
+	 */
+	private $user_id;
+
+	/**
+	 * The site being checked, matched against wpcom_subs_is_subscribed()'s blog_id arg.
+	 *
+	 * @var integer
+	 */
+	private $blog_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->user_id = self::factory()->user->create( array( 'user_email' => self::SUBSCRIBER_EMAIL ) );
+		wp_set_current_user( $this->user_id );
+		$this->blog_id = get_current_blog_id();
+
+		Blog_Subscriber::$subscribers_by_email           = array();
+		Blog_Subscription::$status                       = '';
+		$GLOBALS['wpcom_subs_is_subscribed_mock_return'] = false;
+		$GLOBALS['wpcom_subs_is_subscribed_mock_calls']  = array();
+	}
+
+	public function tear_down() {
+		Blog_Subscriber::$subscribers_by_email = array();
+		Blog_Subscription::$status             = '';
+		unset( $GLOBALS['wpcom_subs_is_subscribed_mock_return'], $GLOBALS['wpcom_subs_is_subscribed_mock_calls'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Marks the current user as an active email subscriber to the current blog.
+	 *
+	 * @param string $status The subscription status to simulate.
+	 *
+	 * @return void
+	 */
+	private function make_email_subscriber_active( string $status = 'active' ) {
+		Blog_Subscriber::$subscribers_by_email = array( self::SUBSCRIBER_EMAIL => (object) array() );
+		Blog_Subscription::$status             = $status;
+	}
+
+	/**
+	 * Calls is_current_user_subscribed(), silencing the "failed to open stream" warning
+	 * from the method's include_once() of a WPCOM-only file that doesn't exist in the
+	 * Jetpack test environment. This suite fails on any warning, so the expected one
+	 * needs to be swallowed rather than left to bubble up.
+	 *
+	 * @return boolean
+	 */
+	private function is_current_user_subscribed() {
+		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_set_error_handler
+			static function ( $errno, $errstr ) {
+				return (bool) str_contains( $errstr, 'email-subscriptions/subscriptions.php' );
+			},
+			E_WARNING
+		);
+		try {
+			return ( new WPCOM_Online_Subscription_Service() )->is_current_user_subscribed();
+		} finally {
+			restore_error_handler();
+		}
+	}
+
+	public function test_returns_false_when_neither_email_subscribed_nor_following() {
+		$this->assertFalse( $this->is_current_user_subscribed() );
+	}
+
+	public function test_returns_true_for_active_email_subscriber_who_does_not_follow() {
+		$this->make_email_subscriber_active();
+
+		$this->assertTrue( $this->is_current_user_subscribed() );
+	}
+
+	public function test_returns_false_for_inactive_email_subscription_and_no_follow() {
+		$this->make_email_subscriber_active( 'cancelled' );
+
+		$this->assertFalse( $this->is_current_user_subscribed() );
+	}
+
+	public function test_returns_true_for_reader_follower_with_no_email_subscription() {
+		$GLOBALS['wpcom_subs_is_subscribed_mock_return'] = true;
+
+		$this->assertTrue( $this->is_current_user_subscribed() );
+	}
+
+	public function test_returns_true_when_both_email_subscribed_and_following() {
+		$this->make_email_subscriber_active();
+		$GLOBALS['wpcom_subs_is_subscribed_mock_return'] = true;
+
+		$this->assertTrue( $this->is_current_user_subscribed() );
+	}
+
+	public function test_checks_reader_follow_status_for_current_user_and_site() {
+		$this->is_current_user_subscribed();
+
+		$this->assertSame(
+			array(
+				array(
+					'user_id' => $this->user_id,
+					'blog_id' => $this->blog_id,
+				),
+			),
+			$GLOBALS['wpcom_subs_is_subscribed_mock_calls']
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/WPCOM_Online_Subscription_Service_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/WPCOM_Online_Subscription_Service_Test.php
@@ -52,15 +52,20 @@ class WPCOM_Online_Subscription_Service_Test extends WP_UnitTestCase {
 		wp_set_current_user( $this->user_id );
 		$this->blog_id = get_current_blog_id();
 
-		Blog_Subscriber::$subscribers_by_email           = array();
-		Blog_Subscription::$status                       = '';
+		// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Mock-only property, not on the real wpcom class/stub.
+		Blog_Subscriber::$subscribers_by_email = array();
+		// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Mock-only property, not on the real wpcom class/stub.
+		Blog_Subscription::$status = '';
+
 		$GLOBALS['wpcom_subs_is_subscribed_mock_return'] = false;
 		$GLOBALS['wpcom_subs_is_subscribed_mock_calls']  = array();
 	}
 
 	public function tear_down() {
+		// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Mock-only property, not on the real wpcom class/stub.
 		Blog_Subscriber::$subscribers_by_email = array();
-		Blog_Subscription::$status             = '';
+		// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Mock-only property, not on the real wpcom class/stub.
+		Blog_Subscription::$status = '';
 		unset(
 			$GLOBALS['wpcom_subs_is_subscribed_mock_return'],
 			$GLOBALS['wpcom_subs_is_subscribed_mock_calls'],
@@ -77,8 +82,10 @@ class WPCOM_Online_Subscription_Service_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	private function make_email_subscriber_active( string $status = 'active' ) {
+		// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Mock-only property, not on the real wpcom class/stub.
 		Blog_Subscriber::$subscribers_by_email = array( self::SUBSCRIBER_EMAIL => new Blog_Subscriber() );
-		Blog_Subscription::$status             = $status;
+		// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Mock-only property, not on the real wpcom class/stub.
+		Blog_Subscription::$status = $status;
 	}
 
 	/**
@@ -94,7 +101,7 @@ class WPCOM_Online_Subscription_Service_Test extends WP_UnitTestCase {
 	private function without_wpcom_include_warning( callable $callback ) {
 		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_set_error_handler
 			static function ( $errno, $errstr ) {
-				return (bool) str_contains( $errstr, 'email-subscriptions/subscriptions.php' );
+				return str_contains( $errstr, 'email-subscriptions/subscriptions.php' );
 			},
 			E_WARNING
 		);

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/WPCOM_Online_Subscription_Service_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/WPCOM_Online_Subscription_Service_Test.php
@@ -10,6 +10,7 @@ require_once __DIR__ . '/mocks/class-blog-subscriber.php';
 require_once __DIR__ . '/mocks/class-blog-subscription.php';
 require_once __DIR__ . '/mocks/wpcom-subs-is-subscribed.php';
 
+use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
 use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\WPCOM_Online_Subscription_Service;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -42,7 +43,12 @@ class WPCOM_Online_Subscription_Service_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->user_id = self::factory()->user->create( array( 'user_email' => self::SUBSCRIBER_EMAIL ) );
+		$this->user_id = self::factory()->user->create(
+			array(
+				'user_email' => self::SUBSCRIBER_EMAIL,
+				'role'       => 'subscriber',
+			)
+		);
 		wp_set_current_user( $this->user_id );
 		$this->blog_id = get_current_blog_id();
 
@@ -55,7 +61,11 @@ class WPCOM_Online_Subscription_Service_Test extends WP_UnitTestCase {
 	public function tear_down() {
 		Blog_Subscriber::$subscribers_by_email = array();
 		Blog_Subscription::$status             = '';
-		unset( $GLOBALS['wpcom_subs_is_subscribed_mock_return'], $GLOBALS['wpcom_subs_is_subscribed_mock_calls'] );
+		unset(
+			$GLOBALS['wpcom_subs_is_subscribed_mock_return'],
+			$GLOBALS['wpcom_subs_is_subscribed_mock_calls'],
+			$GLOBALS['post']
+		);
 		parent::tear_down();
 	}
 
@@ -72,14 +82,16 @@ class WPCOM_Online_Subscription_Service_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Calls is_current_user_subscribed(), silencing the "failed to open stream" warning
-	 * from the method's include_once() of a WPCOM-only file that doesn't exist in the
-	 * Jetpack test environment. This suite fails on any warning, so the expected one
-	 * needs to be swallowed rather than left to bubble up.
+	 * Runs a callback while silencing the "failed to open stream" warning from
+	 * include_once()'ing a WPCOM-only file that doesn't exist in the Jetpack test
+	 * environment. This suite fails on any warning, so the expected one needs to
+	 * be swallowed rather than left to bubble up.
 	 *
-	 * @return boolean
+	 * @param callable $callback The code to run.
+	 *
+	 * @return mixed
 	 */
-	private function is_current_user_subscribed() {
+	private function without_wpcom_include_warning( callable $callback ) {
 		set_error_handler( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.prevent_path_disclosure_set_error_handler
 			static function ( $errno, $errstr ) {
 				return (bool) str_contains( $errstr, 'email-subscriptions/subscriptions.php' );
@@ -87,10 +99,23 @@ class WPCOM_Online_Subscription_Service_Test extends WP_UnitTestCase {
 			E_WARNING
 		);
 		try {
-			return ( new WPCOM_Online_Subscription_Service() )->is_current_user_subscribed();
+			return $callback();
 		} finally {
 			restore_error_handler();
 		}
+	}
+
+	/**
+	 * Calls is_current_user_subscribed() on a fresh service instance.
+	 *
+	 * @return boolean
+	 */
+	private function is_current_user_subscribed() {
+		return $this->without_wpcom_include_warning(
+			static function () {
+				return ( new WPCOM_Online_Subscription_Service() )->is_current_user_subscribed();
+			}
+		);
 	}
 
 	public function test_returns_false_when_neither_email_subscribed_nor_following() {
@@ -133,6 +158,44 @@ class WPCOM_Online_Subscription_Service_Test extends WP_UnitTestCase {
 				),
 			),
 			$GLOBALS['wpcom_subs_is_subscribed_mock_calls']
+		);
+	}
+
+	/**
+	 * Following in the Reader makes is_current_user_subscribed() true, but that must only
+	 * unlock the free "subscribers" access level. Paid tiers are gated by a fully separate
+	 * check (the user's actual paid subscriptions), so a Reader follower with no paid
+	 * subscription must still be denied paid_subscribers content.
+	 *
+	 * @return void
+	 */
+	public function test_reader_follower_cannot_access_paid_subscribers_post_without_a_paid_subscription() {
+		$GLOBALS['wpcom_subs_is_subscribed_mock_return'] = true;
+
+		$author_id       = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$post_id         = self::factory()->post->create( array( 'post_author' => $author_id ) );
+		$GLOBALS['post'] = get_post( $post_id );
+		$service         = new WPCOM_Online_Subscription_Service();
+
+		$this->assertTrue(
+			$this->without_wpcom_include_warning(
+				static function () use ( $service ) {
+					return $service->is_current_user_subscribed();
+				}
+			),
+			'Sanity check: the reader should be considered subscribed via the Reader follow.'
+		);
+
+		$this->assertFalse(
+			$this->without_wpcom_include_warning(
+				static function () use ( $service ) {
+					return $service->visitor_can_view_content(
+						array( 999999 ),
+						Abstract_Token_Subscription_Service::POST_ACCESS_LEVEL_PAID_SUBSCRIBERS
+					);
+				}
+			),
+			'Following in the Reader must not unlock paid-tier content.'
 		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/mocks/class-blog-subscriber.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/mocks/class-blog-subscriber.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Mock Blog_Subscriber class for testing.
+ *
+ * On WPCOM this class is provided by
+ * wp-content/mu-plugins/email-subscriptions/subscriptions.php, which isn't available
+ * when running the Jetpack plugin's own PHPUnit suite.
+ *
+ * @package automattic/jetpack
+ */
+
+if ( ! class_exists( 'Blog_Subscriber' ) ) {
+	/**
+	 * Mock Blog_Subscriber for testing.
+	 */
+	class Blog_Subscriber {
+
+		/**
+		 * Subscribers keyed by email, set by tests.
+		 *
+		 * @var array<string, mixed>
+		 */
+		public static $subscribers_by_email = array();
+
+		/**
+		 * Mirrors the real Blog_Subscriber::get(), returning a falsy value when unknown.
+		 *
+		 * @param string $email The subscriber's email.
+		 *
+		 * @return mixed
+		 */
+		public static function get( string $email ) {
+			return self::$subscribers_by_email[ $email ] ?? false;
+		}
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/mocks/class-blog-subscription.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/mocks/class-blog-subscription.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Mock Blog_Subscription class for testing.
+ *
+ * On WPCOM this class is provided by
+ * wp-content/mu-plugins/email-subscriptions/subscriptions.php, which isn't available
+ * when running the Jetpack plugin's own PHPUnit suite.
+ *
+ * @package automattic/jetpack
+ */
+
+if ( ! class_exists( 'Blog_Subscription' ) ) {
+	/**
+	 * Mock Blog_Subscription for testing.
+	 */
+	class Blog_Subscription {
+
+		/**
+		 * Status to return from get_subscription_status_for_blog(), set by tests.
+		 *
+		 * @var string
+		 */
+		public static $status = '';
+
+		/**
+		 * Mirrors the real Blog_Subscription::get_subscription_status_for_blog().
+		 *
+		 * @param Blog_Subscriber $subscriber The subscriber.
+		 * @param integer         $blog_id    The blog ID.
+		 * @param boolean         $use_cache  Whether to use the cache.
+		 *
+		 * @return string
+		 */
+		public static function get_subscription_status_for_blog( Blog_Subscriber $subscriber, int $blog_id = 0, bool $use_cache = true ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			return self::$status;
+		}
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/mocks/wpcom-subs-is-subscribed.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/mocks/wpcom-subs-is-subscribed.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Mock wpcom_subs_is_subscribed() for testing.
+ *
+ * On WPCOM this function is provided by wp-content/mu-plugins/subscriptions.php, which
+ * isn't available when running the Jetpack plugin's own PHPUnit suite.
+ *
+ * @package automattic/jetpack
+ */
+
+if ( ! function_exists( 'wpcom_subs_is_subscribed' ) ) {
+	/**
+	 * Mocks the WPCOM Reader follow-matrix lookup.
+	 *
+	 * Tests control the return value via $GLOBALS['wpcom_subs_is_subscribed_mock_return']
+	 * and can inspect the args they were called with via
+	 * $GLOBALS['wpcom_subs_is_subscribed_mock_calls'].
+	 *
+	 * @param array $args The lookup args (user_id, blog_id).
+	 *
+	 * @return boolean
+	 */
+	function wpcom_subs_is_subscribed( array $args = array() ) {
+		$GLOBALS['wpcom_subs_is_subscribed_mock_calls'][] = $args;
+		return ! empty( $GLOBALS['wpcom_subs_is_subscribed_mock_return'] );
+	}
+}


### PR DESCRIPTION
Fixes NL-428

## Proposed changes
* `WPCOM_Online_Subscription_Service::is_current_user_subscribed()` only checked the email subscription store (`Blog_Subscriber`/`Blog_Subscription`), so a logged-in reader who follows a Simple site through the Reader — but has no *active email* subscription row — was treated as "not subscribed."
* This caused two symptoms: subscribe prompts (popup, floating button, overlay, comment-form modal) kept showing to readers who already follow the site, and free subscribers-only posts were incorrectly blocked for them (via `visitor_can_view_content()`, which reused the same incomplete check).
* Now `is_current_user_subscribed()` also checks the Reader follow matrix via `wpcom_subs_is_subscribed()`, mirroring the pattern already used elsewhere in the codebase (e.g. the blogroll block). `visitor_can_view_content()` now reuses `is_current_user_subscribed()` directly instead of re-deriving the same (previously incomplete) check.
* Scope: Simple sites only — `WPCOM_Online_Subscription_Service` is only used when `IS_WPCOM` is true.

## Related product discussion/links
* NL-428

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a Simple site, as a logged-in WordPress.com user with no active email subscription to the site, follow the site in the Reader.
* Visit a post on that site and scroll — confirm no subscribe modal/overlay/floating-button prompt appears, and the comment-form subscribe modal doesn't show either.
* Visit a post marked "Subscribers-only" (free tier) on that site — confirm it opens normally instead of being paywalled.
* As a control, verify a user with an *active email* subscription (but not following in the Reader) still sees the same behavior (no prompts, no paywall) — this path was already working and shouldn't regress.
* As a second control, verify a user who neither follows nor has an email subscription still sees the subscribe prompts and paywall as expected.
