### PR TITLE
Newsletter: Sandbox the email preview iframe

### DIFF
--- a/projects/plugins/jetpack/changelog/nl-752-sandbox-the-newsletter-email-preview-iframe-xss-hardening
+++ b/projects/plugins/jetpack/changelog/nl-752-sandbox-the-newsletter-email-preview-iframe-xss-hardening
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter: Sandbox the email preview iframe for defense in depth.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.tsx
@@ -619,6 +619,7 @@ export function NewsletterPreviewModal( { isOpen, onClose, postId }: NewsletterP
 					) }
 					{ ! isLoading && ! isError && (
 						<iframe
+							sandbox=""
 							srcDoc={ previewCache?.[ selectedAccess ] }
 							style={ {
 								width: deviceWidth,

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.test.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.test.tsx
@@ -164,6 +164,21 @@ describe( 'Newsletter preview: save before fetching', () => {
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
 	} );
 
+	it( 'renders the preview inside a sandboxed iframe with no script execution', async () => {
+		jest.mocked( useDispatch ).mockReturnValue( {
+			__unstableSaveForPreview: jest.fn().mockResolvedValue( undefined ),
+		} );
+		( select as jest.Mock ).mockReturnValue( { isEditedPostDirty: () => false } );
+		jest.mocked( apiFetch ).mockResolvedValue( { html: '<p>Preview</p>' } );
+
+		render( <NewsletterPreviewModal isOpen postId={ 123 } onClose={ jest.fn() } /> );
+
+		const iframe = await screen.findByTitle( 'Email Preview' );
+		// An empty sandbox strips script execution and same-origin access, so any
+		// markup in the returned HTML stays inert regardless of upstream escaping.
+		expect( iframe ).toHaveAttribute( 'sandbox', '' );
+	} );
+
 	it( 'skips the save and fetches directly when the post is not dirty', async () => {
 		const saveForPreview = jest.fn().mockResolvedValue( undefined );
 		jest.mocked( useDispatch ).mockReturnValue( { __unstableSaveForPreview: saveForPreview } );


### PR DESCRIPTION
Fixes NL-752

## Proposed changes

The newsletter email preview drops the returned HTML into an iframe that had no `sandbox` attribute, so anything in that HTML would run same-origin in the editor. The preview is a static render and never needs to script, so this adds an empty `sandbox` to the iframe; scripts can't run, and the frame can't reach the editor context at all.

It's a small hardening step. The content reaching the preview today is already safe, so nothing you see changes; it just makes the preview safe by construction instead of leaning on every upstream callback escaping its output. An empty `sandbox` still lets images and CSS load, so the email renders exactly as before.

I kept this to the client iframe. The related server-side gap (the preview render path not running `wp_kses`) is tracked separately in NL-753.

## Related product discussion/links

* Fixes NL-752
* Related: NL-753

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with the Newsletter feature, edit a Post and open **Email preview** (the "Email preview" item under the editor's Preview / View menu).
* Confirm the email still renders in the modal exactly as before, images and styles intact.
* Inspect the preview iframe in DevTools; it should carry a `sandbox=""` attribute.
* To see the effect, with the preview open, drop a `<script>` into the frame's `srcdoc` from the console and confirm it doesn't run and the frame is no longer same-origin reachable:
  ```js
  const f = document.querySelector( 'iframe[title="Email Preview"]' );
  f.addEventListener( 'load', () => {
  	try { console.log( 'title:', f.contentDocument.title ); }
  	catch ( e ) { console.log( 'blocked:', e.message ); } // expected: blocked
  }, { once: true } );
  f.srcdoc = '<script>document.title = "ran"<\/script>';
  ```
  Before the change the same probe logs `ran`; after it, the frame is cross-origin and the read is blocked.
