### PR TITLE
VideoPress: add a playlist block

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-playlist-block
+++ b/projects/packages/videopress/changelog/add-videopress-playlist-block
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a Video Playlist block.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -853,15 +853,6 @@ class Initializer {
 
 		$first          = $entries[0];
 		$first_title    = __( 'Video 1', 'jetpack-videopress-pkg' );
-		$first_details  = implode(
-			' · ',
-			array_filter(
-				array(
-					self::playlist_resolution_label( $first['height'] ),
-					self::playlist_timecode( $first['durationMs'] ),
-				)
-			)
-		);
 		$runtime_label  = self::playlist_runtime_label( $total_ms );
 		$runtime_markup = $show_runtime && '' !== $runtime_label
 			? sprintf( '<span class="videopress-playlist__runtime">%s</span>', esc_html( $runtime_label ) )
@@ -874,26 +865,23 @@ class Initializer {
 			$runtime_markup
 		);
 
-		$now_runtime_markup = $show_runtime && '' !== $runtime_label
+		/*
+		 * The player renders its own title overlay, so the stage carries no
+		 * duplicate now-playing text — only the grid layout's runtime line.
+		 */
+		$now_markup = $show_runtime && '' !== $runtime_label
 			? sprintf(
-				'<span class="videopress-playlist__now-runtime">%s</span>',
+				'<div class="videopress-playlist__now"><span class="videopress-playlist__now-runtime">%s</span></div>',
 				esc_html( $count_label . ' · ' . $runtime_label )
 			)
 			: '';
 
 		$stage_markup = sprintf(
 			'<div class="videopress-playlist__stage">' .
-				'<div class="videopress-playlist__player"><iframe class="videopress-playlist__iframe" title="%1$s" src="%2$s" allowfullscreen allow="clipboard-write"></iframe></div>' .
-				'<div class="videopress-playlist__now"><span class="videopress-playlist__now-title">%3$s</span>' .
-				'<span class="videopress-playlist__now-meta"><span class="videopress-playlist__now-position">%4$s</span><span class="videopress-playlist__now-details">%5$s</span></span>%6$s</div>' .
-				'</div>',
+				'<div class="videopress-playlist__player"><iframe class="videopress-playlist__iframe" title="%1$s" src="%2$s" allowfullscreen allow="clipboard-write"></iframe></div>%3$s</div>',
 			esc_attr( $first_title ),
 			esc_url( self::playlist_embed_url( $first['guid'], false ) ),
-			esc_html( $first_title ),
-			/* translators: 1: position of the current video. 2: number of videos in the playlist. */
-			esc_html( sprintf( __( '%1$d of %2$d', 'jetpack-videopress-pkg' ), 1, $count ) ),
-			esc_html( $first_details ),
-			$now_runtime_markup
+			$now_markup
 		);
 
 		$progress_markup = '' !== $total_timecode
@@ -925,7 +913,6 @@ class Initializer {
 		 */
 		$font_style = '';
 		foreach ( array(
-			'nowTitleFontFamily'   => '--vpp-now-title-font',
 			'entryTitleFontFamily' => '--vpp-entry-title-font',
 		) as $font_attribute => $css_variable ) {
 			if ( ! empty( $block_attributes[ $font_attribute ] )

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -930,10 +930,13 @@ class Initializer {
 			}
 		}
 
+		// Looping implies auto-advancing, so it forces the autoplay-next flag on.
+		$loop_playlist = $enabled( 'loopPlaylist', false );
+
 		$wrapper_extra_attributes = array(
 			'class'              => implode( ' ', $classes ),
-			'data-autoplay-next' => $enabled( 'autoplayNext', false ) ? '1' : '0',
-			'data-loop'          => $enabled( 'loopPlaylist', false ) ? '1' : '0',
+			'data-autoplay-next' => $enabled( 'autoplayNext', false ) || $loop_playlist ? '1' : '0',
+			'data-loop'          => $loop_playlist ? '1' : '0',
 		);
 		if ( '' !== $font_style ) {
 			$wrapper_extra_attributes['style'] = $font_style;

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -918,12 +918,33 @@ class Initializer {
 			$items
 		);
 
-		$wrapper_attributes = get_block_wrapper_attributes(
-			array(
-				'class'              => implode( ' ', $classes ),
-				'data-autoplay-next' => $enabled( 'autoplayNext', false ) ? '1' : '0',
-			)
+		/*
+		 * User-selected theme font presets (theme.json slugs) for the
+		 * customizable titles, exposed as CSS custom properties the
+		 * stylesheet reads. Anything but a plain preset slug is dropped.
+		 */
+		$font_style = '';
+		foreach ( array(
+			'nowTitleFontFamily'   => '--vpp-now-title-font',
+			'entryTitleFontFamily' => '--vpp-entry-title-font',
+		) as $font_attribute => $css_variable ) {
+			if ( ! empty( $block_attributes[ $font_attribute ] )
+				&& is_string( $block_attributes[ $font_attribute ] )
+				&& preg_match( '/^[a-zA-Z0-9-]+$/', $block_attributes[ $font_attribute ] )
+			) {
+				$font_style .= $css_variable . ':var(--wp--preset--font-family--' . $block_attributes[ $font_attribute ] . ');';
+			}
+		}
+
+		$wrapper_extra_attributes = array(
+			'class'              => implode( ' ', $classes ),
+			'data-autoplay-next' => $enabled( 'autoplayNext', false ) ? '1' : '0',
 		);
+		if ( '' !== $font_style ) {
+			$wrapper_extra_attributes['style'] = $font_style;
+		}
+
+		$wrapper_attributes = get_block_wrapper_attributes( $wrapper_extra_attributes );
 
 		return sprintf(
 			'<figure %1$s><div class="videopress-playlist__body">%2$s%3$s</div></figure>',

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -269,6 +269,9 @@ class Initializer {
 	public static function register_videopress_blocks() {
 		// Register VideoPress Video block.
 		self::register_videopress_video_block();
+
+		// Register Video Playlist block.
+		self::register_videopress_playlist_block();
 	}
 
 	/**
@@ -550,6 +553,383 @@ class Initializer {
 
 		// Register and enqueue scripts used by the VideoPress video block.
 		Block_Editor_Extensions::init( $script_handle );
+	}
+
+	/**
+	 * Register the Video Playlist block.
+	 *
+	 * @param string|null $metadata_file Path to the block.json metadata file. Defaults to the
+	 *                                   package build output; tests can point it at a fixture.
+	 *
+	 * @return void
+	 */
+	public static function register_videopress_playlist_block( $metadata_file = null ) {
+		/*
+		 * Unlike the video block, the playlist block has no "activate the module"
+		 * placeholder, so it is only registered where VideoPress can play videos.
+		 */
+		if (
+			Status::is_jetpack_plugin_without_videopress_module_active()
+			&& ! Status::is_standalone_plugin_active()
+		) {
+			return;
+		}
+
+		if ( null === $metadata_file ) {
+			$metadata_file = __DIR__ . '/../build/block-editor/blocks/playlist/block.json';
+		}
+
+		if ( ! file_exists( $metadata_file ) ) {
+			return;
+		}
+
+		$metadata = json_decode(
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			file_get_contents( $metadata_file )
+		);
+
+		if ( empty( $metadata->name )
+			|| \WP_Block_Type_Registry::get_instance()->is_registered( $metadata->name )
+		) {
+			return;
+		}
+
+		register_block_type(
+			$metadata_file,
+			array(
+				'render_callback' => array( __CLASS__, 'render_videopress_playlist_block' ),
+			)
+		);
+	}
+
+	/**
+	 * Sanitize the playlist block's videos attribute into rendering-ready entries.
+	 *
+	 * @param mixed $videos Raw attribute value.
+	 *
+	 * @return array Entries with guid, title, durationMs, height and poster keys.
+	 */
+	private static function sanitize_playlist_entries( $videos ) {
+		if ( ! is_array( $videos ) ) {
+			return array();
+		}
+
+		$entries = array();
+		foreach ( $videos as $video ) {
+			if ( ! is_array( $video ) || empty( $video['guid'] ) || ! is_string( $video['guid'] ) ) {
+				continue;
+			}
+
+			// VideoPress GUIDs are 8 alphanumeric characters; drop anything else.
+			if ( ! preg_match( '/^[a-zA-Z0-9]{8}$/', $video['guid'] ) ) {
+				continue;
+			}
+
+			$entries[] = array(
+				'guid'       => $video['guid'],
+				'title'      => isset( $video['title'] ) && is_string( $video['title'] ) ? $video['title'] : '',
+				'durationMs' => isset( $video['durationMs'] ) && is_numeric( $video['durationMs'] ) ? max( 0, (int) $video['durationMs'] ) : 0,
+				'height'     => isset( $video['height'] ) && is_numeric( $video['height'] ) ? max( 0, (int) $video['height'] ) : 0,
+				'poster'     => isset( $video['poster'] ) && is_string( $video['poster'] ) ? $video['poster'] : '',
+			);
+		}
+
+		return $entries;
+	}
+
+	/**
+	 * Build the VideoPress embed URL for a playlist entry.
+	 *
+	 * @param string $guid     Video GUID.
+	 * @param bool   $autoplay Whether the video should start playing once loaded.
+	 *
+	 * @return string Embed URL.
+	 */
+	private static function playlist_embed_url( $guid, $autoplay ) {
+		return add_query_arg(
+			array(
+				'cover'          => 1,
+				'preloadContent' => 'metadata',
+				'autoPlay'       => $autoplay ? 1 : 0,
+			),
+			'https://videopress.com/embed/' . rawurlencode( $guid )
+		);
+	}
+
+	/**
+	 * Format a duration in milliseconds as a timecode, m:ss or h:mm:ss.
+	 *
+	 * @param int $duration_ms Duration in milliseconds.
+	 *
+	 * @return string Timecode, or an empty string when the duration is unknown.
+	 */
+	private static function playlist_timecode( $duration_ms ) {
+		if ( $duration_ms <= 0 ) {
+			return '';
+		}
+
+		$total_seconds = (int) round( $duration_ms / 1000 );
+		$hours         = intdiv( $total_seconds, 3600 );
+		$minutes       = intdiv( $total_seconds % 3600, 60 );
+		$seconds       = $total_seconds % 60;
+
+		if ( $hours > 0 ) {
+			return sprintf( '%d:%02d:%02d', $hours, $minutes, $seconds );
+		}
+
+		return sprintf( '%d:%02d', $minutes, $seconds );
+	}
+
+	/**
+	 * Format a duration in milliseconds as a long runtime, e.g. "1 hr 13 min".
+	 *
+	 * @param int $duration_ms Duration in milliseconds.
+	 *
+	 * @return string Runtime label, or an empty string when the duration is unknown.
+	 */
+	private static function playlist_runtime_label( $duration_ms ) {
+		if ( $duration_ms <= 0 ) {
+			return '';
+		}
+
+		$total_minutes = max( 1, (int) round( $duration_ms / 60000 ) );
+		$hours         = intdiv( $total_minutes, 60 );
+		$minutes       = $total_minutes % 60;
+
+		if ( $hours > 0 && $minutes > 0 ) {
+			/* translators: 1: number of hours. 2: number of minutes. */
+			return sprintf( __( '%1$d hr %2$d min', 'jetpack-videopress-pkg' ), $hours, $minutes );
+		}
+
+		if ( $hours > 0 ) {
+			/* translators: %d: number of hours. */
+			return sprintf( __( '%d hr', 'jetpack-videopress-pkg' ), $hours );
+		}
+
+		/* translators: %d: number of minutes. */
+		return sprintf( __( '%d min', 'jetpack-videopress-pkg' ), $minutes );
+	}
+
+	/**
+	 * Map a video's pixel height to a resolution label, e.g. "1080p" or "4K".
+	 *
+	 * @param int $height Video height in pixels.
+	 *
+	 * @return string Resolution label, or an empty string when the height is unknown.
+	 */
+	private static function playlist_resolution_label( $height ) {
+		if ( $height <= 0 ) {
+			return '';
+		}
+
+		return $height >= 2160 ? '4K' : $height . 'p';
+	}
+
+	/**
+	 * Video Playlist block render callback.
+	 *
+	 * @param array $block_attributes Block attributes.
+	 *
+	 * @return string Block markup, or an empty string when the playlist has no playable entries.
+	 */
+	public static function render_videopress_playlist_block( $block_attributes ) {
+		$entries = self::sanitize_playlist_entries( $block_attributes['videos'] ?? null );
+
+		if ( ! $entries ) {
+			return '';
+		}
+
+		$enabled = function ( $key, $default_value = true ) use ( $block_attributes ) {
+			return isset( $block_attributes[ $key ] ) ? (bool) $block_attributes[ $key ] : $default_value;
+		};
+
+		$layout = isset( $block_attributes['layout'] ) && in_array( $block_attributes['layout'], array( 'side-rail', 'grid', 'strip' ), true )
+			? $block_attributes['layout']
+			: 'side-rail';
+
+		$show_thumbnail = $enabled( 'showThumbnail' );
+		$show_title     = $enabled( 'showTitle' );
+		$show_res       = $enabled( 'showResolution' );
+		$show_duration  = $enabled( 'showDuration' );
+		$show_number    = $enabled( 'showPositionNumber', false );
+		$show_runtime   = $enabled( 'showTotalRuntime' );
+
+		$classes = array( 'videopress-playlist', 'is-layout-' . $layout );
+		if ( $enabled( 'darkPlayer', false ) ) {
+			$classes[] = 'is-dark';
+		}
+		if ( ! $show_thumbnail ) {
+			$classes[] = 'hide-thumbnails';
+		}
+		if ( ! $show_title ) {
+			$classes[] = 'hide-titles';
+		}
+		if ( ! $show_res ) {
+			$classes[] = 'hide-resolutions';
+		}
+		if ( ! $show_duration ) {
+			$classes[] = 'hide-durations';
+		}
+		if ( ! $show_runtime ) {
+			$classes[] = 'hide-runtime';
+		}
+
+		// Lets the embed play private videos for authorized viewers.
+		Jwt_Token_Bridge::enqueue_jwt_token_bridge();
+
+		$count    = count( $entries );
+		$total_ms = 0;
+		foreach ( $entries as $entry ) {
+			$total_ms += $entry['durationMs'];
+		}
+
+		$total_timecode = self::playlist_timecode( $total_ms );
+		/* translators: %d: number of videos in the playlist. */
+		$count_label = sprintf( _n( '%d video', '%d videos', $count, 'jetpack-videopress-pkg' ), $count );
+
+		$items = '';
+		foreach ( $entries as $index => $entry ) {
+			$title = '' !== $entry['title']
+				? $entry['title']
+				/* translators: %d: position of the video in the playlist. */
+				: sprintf( __( 'Video %d', 'jetpack-videopress-pkg' ), $index + 1 );
+
+			$timecode   = self::playlist_timecode( $entry['durationMs'] );
+			$resolution = self::playlist_resolution_label( $entry['height'] );
+			/* translators: 1: position of the video in the playlist. 2: number of videos in the playlist. */
+			$position = sprintf( __( '%1$d of %2$d', 'jetpack-videopress-pkg' ), $index + 1, $count );
+			$details  = implode( ' · ', array_filter( array( $resolution, $timecode ) ) );
+			$progress = '' !== $total_timecode
+				/* translators: 1: position of the video in the playlist. 2: number of videos. 3: total playlist timecode. */
+				? sprintf( __( '%1$d / %2$d · %3$s total', 'jetpack-videopress-pkg' ), $index + 1, $count, $total_timecode )
+				/* translators: 1: position of the video in the playlist. 2: number of videos. */
+				: sprintf( __( '%1$d / %2$d', 'jetpack-videopress-pkg' ), $index + 1, $count );
+
+			$number_markup = $show_number
+				? sprintf(
+					'<span class="videopress-playlist__entry-number">%s</span>',
+					esc_html( str_pad( (string) ( $index + 1 ), 2, '0', STR_PAD_LEFT ) )
+				)
+				: '';
+
+			$poster_markup = '' !== $entry['poster']
+				? sprintf( '<img src="%s" alt="" loading="lazy" />', esc_url( $entry['poster'] ) )
+				: '';
+
+			$time_markup = '' !== $timecode
+				? sprintf( '<span class="videopress-playlist__entry-time">%s</span>', esc_html( $timecode ) )
+				: '';
+
+			$resolution_markup = '' !== $resolution
+				? sprintf( '<span class="videopress-playlist__entry-resolution">%s</span>', esc_html( $resolution ) )
+				: '';
+
+			$duration_markup = '' !== $timecode
+				? sprintf( '<span class="videopress-playlist__entry-duration">%s</span>', esc_html( $timecode ) )
+				: '';
+
+			$items .= sprintf(
+				'<li class="videopress-playlist__entry"><button type="button" class="videopress-playlist__select%1$s"%2$s data-guid="%3$s" data-embed-url="%4$s" data-title="%5$s" data-position="%6$s" data-details="%7$s" data-progress="%8$s">' .
+					'%9$s<span class="videopress-playlist__entry-thumb">%10$s<span class="videopress-playlist__entry-flag">%11$s</span>%12$s</span>' .
+					'<span class="videopress-playlist__entry-body"><span class="videopress-playlist__entry-title">%13$s</span><span class="videopress-playlist__entry-meta">%14$s%15$s</span></span>' .
+					'</button></li>',
+				0 === $index ? ' is-current' : '',
+				0 === $index ? ' aria-current="true"' : '',
+				esc_attr( $entry['guid'] ),
+				esc_url( self::playlist_embed_url( $entry['guid'], true ) ),
+				esc_attr( $title ),
+				esc_attr( $position ),
+				esc_attr( $details ),
+				esc_attr( $progress ),
+				$number_markup,
+				$poster_markup,
+				esc_html__( 'Playing', 'jetpack-videopress-pkg' ),
+				$time_markup,
+				esc_html( $title ),
+				$resolution_markup,
+				$duration_markup
+			);
+		}
+
+		$first          = $entries[0];
+		$first_title    = '' !== $first['title'] ? $first['title'] : __( 'Video 1', 'jetpack-videopress-pkg' );
+		$first_details  = implode(
+			' · ',
+			array_filter(
+				array(
+					self::playlist_resolution_label( $first['height'] ),
+					self::playlist_timecode( $first['durationMs'] ),
+				)
+			)
+		);
+		$runtime_label  = self::playlist_runtime_label( $total_ms );
+		$runtime_markup = $show_runtime && '' !== $runtime_label
+			? sprintf( '<span class="videopress-playlist__runtime">%s</span>', esc_html( $runtime_label ) )
+			: '';
+
+		$header_markup = sprintf(
+			'<header class="videopress-playlist__header"><span class="videopress-playlist__count">%s</span>%s</header>',
+			esc_html( $count_label ),
+			$runtime_markup
+		);
+
+		$now_runtime_markup = $show_runtime && '' !== $runtime_label
+			? sprintf(
+				'<span class="videopress-playlist__now-runtime">%s</span>',
+				esc_html( $count_label . ' · ' . $runtime_label )
+			)
+			: '';
+
+		$stage_markup = sprintf(
+			'<div class="videopress-playlist__stage">' .
+				'<div class="videopress-playlist__player"><iframe class="videopress-playlist__iframe" title="%1$s" src="%2$s" allowfullscreen allow="clipboard-write"></iframe></div>' .
+				'<div class="videopress-playlist__now"><span class="videopress-playlist__now-title">%3$s</span>' .
+				'<span class="videopress-playlist__now-meta"><span class="videopress-playlist__now-position">%4$s</span><span class="videopress-playlist__now-details">%5$s</span></span>%6$s</div>' .
+				'</div>',
+			esc_attr( $first_title ),
+			esc_url( self::playlist_embed_url( $first['guid'], false ) ),
+			esc_html( $first_title ),
+			/* translators: 1: position of the current video. 2: number of videos in the playlist. */
+			esc_html( sprintf( __( '%1$d of %2$d', 'jetpack-videopress-pkg' ), 1, $count ) ),
+			esc_html( $first_details ),
+			$now_runtime_markup
+		);
+
+		$progress_markup = '' !== $total_timecode
+			? sprintf(
+				'<span class="videopress-playlist__list-progress">%s</span>',
+				/* translators: 1: position of the current video. 2: number of videos. 3: total playlist timecode. */
+				esc_html( sprintf( __( '%1$d / %2$d · %3$s total', 'jetpack-videopress-pkg' ), 1, $count, $total_timecode ) )
+			)
+			: '';
+
+		$list_markup = sprintf(
+			'<div class="videopress-playlist__list">' .
+				'<div class="videopress-playlist__list-header">' .
+				'<span class="videopress-playlist__list-label videopress-playlist__list-label--rail">%1$s</span>' .
+				'<span class="videopress-playlist__list-label videopress-playlist__list-label--strip">%2$s</span>%3$s</div>' .
+				'<ol class="videopress-playlist__entries">%4$s</ol></div>',
+			esc_html__( 'Up next', 'jetpack-videopress-pkg' ),
+			/* translators: %s: number of videos in the playlist, e.g. "5 videos". */
+			esc_html( sprintf( __( 'Playlist — %s', 'jetpack-videopress-pkg' ), $count_label ) ),
+			$progress_markup,
+			$items
+		);
+
+		$wrapper_attributes = get_block_wrapper_attributes(
+			array(
+				'class'              => implode( ' ', $classes ),
+				'data-autoplay-next' => $enabled( 'autoplayNext', false ) ? '1' : '0',
+			)
+		);
+
+		return sprintf(
+			'<figure %1$s>%2$s<div class="videopress-playlist__body">%3$s%4$s</div></figure>',
+			$wrapper_attributes,
+			$header_markup,
+			$stage_markup,
+			$list_markup
+		);
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -645,16 +645,22 @@ class Initializer {
 	 *
 	 * @param string $guid     Video GUID.
 	 * @param bool   $autoplay Whether the video should start playing once loaded.
+	 * @param bool   $muted    Whether playback should start muted.
 	 *
 	 * @return string Embed URL.
 	 */
-	private static function playlist_embed_url( $guid, $autoplay ) {
+	private static function playlist_embed_url( $guid, $autoplay, $muted = false ) {
+		$args = array(
+			'cover'          => 1,
+			'preloadContent' => 'metadata',
+			'autoPlay'       => $autoplay ? 1 : 0,
+		);
+		if ( $muted ) {
+			$args['muted'] = 1;
+		}
+
 		return add_query_arg(
-			array(
-				'cover'          => 1,
-				'preloadContent' => 'metadata',
-				'autoPlay'       => $autoplay ? 1 : 0,
-			),
+			$args,
 			'https://videopress.com/embed/' . rawurlencode( $guid )
 		);
 	}
@@ -756,6 +762,7 @@ class Initializer {
 		$show_duration  = $enabled( 'showDuration' );
 		$show_number    = $enabled( 'showPositionNumber', false );
 		$show_runtime   = $enabled( 'showTotalRuntime' );
+		$muted          = $enabled( 'muteByDefault', false );
 
 		$classes = array( 'videopress-playlist', 'is-layout-' . $layout );
 		if ( $enabled( 'darkPlayer', false ) ) {
@@ -837,7 +844,7 @@ class Initializer {
 				0 === $index ? ' is-current' : '',
 				0 === $index ? ' aria-current="true"' : '',
 				esc_attr( $entry['guid'] ),
-				esc_url( self::playlist_embed_url( $entry['guid'], true ) ),
+				esc_url( self::playlist_embed_url( $entry['guid'], true, $muted ) ),
 				esc_attr( $title ),
 				esc_attr( $position ),
 				esc_attr( $details ),
@@ -880,7 +887,7 @@ class Initializer {
 			'<div class="videopress-playlist__stage">' .
 				'<div class="videopress-playlist__player"><iframe class="videopress-playlist__iframe" title="%1$s" src="%2$s" allowfullscreen allow="clipboard-write"></iframe></div>%3$s</div>',
 			esc_attr( $first_title ),
-			esc_url( self::playlist_embed_url( $first['guid'], false ) ),
+			esc_url( self::playlist_embed_url( $first['guid'], false, $muted ) ),
 			$now_markup
 		);
 
@@ -926,6 +933,7 @@ class Initializer {
 		$wrapper_extra_attributes = array(
 			'class'              => implode( ' ', $classes ),
 			'data-autoplay-next' => $enabled( 'autoplayNext', false ) ? '1' : '0',
+			'data-loop'          => $enabled( 'loopPlaylist', false ) ? '1' : '0',
 		);
 		if ( '' !== $font_style ) {
 			$wrapper_extra_attributes['style'] = $font_style;

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -867,8 +867,9 @@ class Initializer {
 			? sprintf( '<span class="videopress-playlist__runtime">%s</span>', esc_html( $runtime_label ) )
 			: '';
 
-		$header_markup = sprintf(
-			'<header class="videopress-playlist__header"><span class="videopress-playlist__count">%s</span>%s</header>',
+		// Count · runtime meta line, shown by the side-rail layout in the list header.
+		$list_meta_markup = sprintf(
+			'<span class="videopress-playlist__list-meta"><span class="videopress-playlist__count">%s</span>%s</span>',
 			esc_html( $count_label ),
 			$runtime_markup
 		);
@@ -907,11 +908,12 @@ class Initializer {
 			'<div class="videopress-playlist__list">' .
 				'<div class="videopress-playlist__list-header">' .
 				'<span class="videopress-playlist__list-label videopress-playlist__list-label--rail">%1$s</span>' .
-				'<span class="videopress-playlist__list-label videopress-playlist__list-label--strip">%2$s</span>%3$s</div>' .
-				'<ol class="videopress-playlist__entries">%4$s</ol></div>',
+				'<span class="videopress-playlist__list-label videopress-playlist__list-label--strip">%2$s</span>%3$s%4$s</div>' .
+				'<ol class="videopress-playlist__entries">%5$s</ol></div>',
 			esc_html__( 'Up next', 'jetpack-videopress-pkg' ),
 			/* translators: %s: number of videos in the playlist, e.g. "5 videos". */
 			esc_html( sprintf( __( 'Playlist — %s', 'jetpack-videopress-pkg' ), $count_label ) ),
+			$list_meta_markup,
 			$progress_markup,
 			$items
 		);
@@ -924,9 +926,8 @@ class Initializer {
 		);
 
 		return sprintf(
-			'<figure %1$s>%2$s<div class="videopress-playlist__body">%3$s%4$s</div></figure>',
+			'<figure %1$s><div class="videopress-playlist__body">%2$s%3$s</div></figure>',
 			$wrapper_attributes,
-			$header_markup,
 			$stage_markup,
 			$list_markup
 		);

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -625,12 +625,15 @@ class Initializer {
 				continue;
 			}
 
+			/*
+			 * Only the video reference and numeric metadata are stored. Display
+			 * metadata (title, poster) is always live: the view script reads it
+			 * from the video data after the page loads.
+			 */
 			$entries[] = array(
 				'guid'       => $video['guid'],
-				'title'      => isset( $video['title'] ) && is_string( $video['title'] ) ? $video['title'] : '',
 				'durationMs' => isset( $video['durationMs'] ) && is_numeric( $video['durationMs'] ) ? max( 0, (int) $video['durationMs'] ) : 0,
 				'height'     => isset( $video['height'] ) && is_numeric( $video['height'] ) ? max( 0, (int) $video['height'] ) : 0,
-				'poster'     => isset( $video['poster'] ) && is_string( $video['poster'] ) ? $video['poster'] : '',
 			);
 		}
 
@@ -789,10 +792,12 @@ class Initializer {
 
 		$items = '';
 		foreach ( $entries as $index => $entry ) {
-			$title = '' !== $entry['title']
-				? $entry['title']
-				/* translators: %d: position of the video in the playlist. */
-				: sprintf( __( 'Video %d', 'jetpack-videopress-pkg' ), $index + 1 );
+			/*
+			 * Positional fallback only: the view script replaces titles (and
+			 * adds posters) with live video data once the page loads.
+			 */
+			/* translators: %d: position of the video in the playlist. */
+			$title = sprintf( __( 'Video %d', 'jetpack-videopress-pkg' ), $index + 1 );
 
 			$timecode   = self::playlist_timecode( $entry['durationMs'] );
 			$resolution = self::playlist_resolution_label( $entry['height'] );
@@ -812,10 +817,6 @@ class Initializer {
 				)
 				: '';
 
-			$poster_markup = '' !== $entry['poster']
-				? sprintf( '<img src="%s" alt="" loading="lazy" />', esc_url( $entry['poster'] ) )
-				: '';
-
 			$time_markup = '' !== $timecode
 				? sprintf( '<span class="videopress-playlist__entry-time">%s</span>', esc_html( $timecode ) )
 				: '';
@@ -830,8 +831,8 @@ class Initializer {
 
 			$items .= sprintf(
 				'<li class="videopress-playlist__entry"><button type="button" class="videopress-playlist__select%1$s"%2$s data-guid="%3$s" data-embed-url="%4$s" data-title="%5$s" data-position="%6$s" data-details="%7$s" data-progress="%8$s">' .
-					'%9$s<span class="videopress-playlist__entry-thumb">%10$s<span class="videopress-playlist__entry-flag">%11$s</span>%12$s</span>' .
-					'<span class="videopress-playlist__entry-body"><span class="videopress-playlist__entry-title">%13$s</span><span class="videopress-playlist__entry-meta">%14$s%15$s</span></span>' .
+					'%9$s<span class="videopress-playlist__entry-thumb"><span class="videopress-playlist__entry-flag">%10$s</span>%11$s</span>' .
+					'<span class="videopress-playlist__entry-body"><span class="videopress-playlist__entry-title">%12$s</span><span class="videopress-playlist__entry-meta">%13$s%14$s</span></span>' .
 					'</button></li>',
 				0 === $index ? ' is-current' : '',
 				0 === $index ? ' aria-current="true"' : '',
@@ -842,7 +843,6 @@ class Initializer {
 				esc_attr( $details ),
 				esc_attr( $progress ),
 				$number_markup,
-				$poster_markup,
 				esc_html__( 'Playing', 'jetpack-videopress-pkg' ),
 				$time_markup,
 				esc_html( $title ),
@@ -852,7 +852,7 @@ class Initializer {
 		}
 
 		$first          = $entries[0];
-		$first_title    = '' !== $first['title'] ? $first['title'] : __( 'Video 1', 'jetpack-videopress-pkg' );
+		$first_title    = __( 'Video 1', 'jetpack-videopress-pkg' );
 		$first_details  = implode(
 			' · ',
 			array_filter(

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
@@ -39,6 +39,14 @@
 			"type": "boolean",
 			"default": false
 		},
+		"muteByDefault": {
+			"type": "boolean",
+			"default": false
+		},
+		"loopPlaylist": {
+			"type": "boolean",
+			"default": false
+		},
 		"showThumbnail": {
 			"type": "boolean",
 			"default": true

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
@@ -6,7 +6,7 @@
 	"title": "Video Playlist",
 	"category": "media",
 	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M4 5.5h9A1.5 1.5 0 0 1 14.5 7v6A1.5 1.5 0 0 1 13 14.5H4A1.5 1.5 0 0 1 2.5 13V7A1.5 1.5 0 0 1 4 5.5Zm3.5 2.6v3.8L10.7 10 7.5 8.1ZM16.5 7H21v1.5h-4.5V7Zm0 4H21v1.5h-4.5V11Zm-14 6H21v1.5H2.5V17Z'></path></svg>",
-	"description": "Play a sequence of VideoPress videos in a single customizable player. Build the list from your VideoPress library or video links, choose a side rail, grid, or strip layout with a light or dark surface, pick which details each entry shows, and let titles and thumbnails stay in sync with your videos automatically.",
+	"description": "VideoPress powered list of videos in a single customizable player. Build the playlist from your VideoPress library or video links.",
 	"keywords": [ "playlist", "video", "videopress", "series" ],
 	"textdomain": "jetpack-videopress-pkg",
 	"supports": {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
@@ -6,7 +6,7 @@
 	"title": "Video Playlist",
 	"category": "media",
 	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M4 5.5h9A1.5 1.5 0 0 1 14.5 7v6A1.5 1.5 0 0 1 13 14.5H4A1.5 1.5 0 0 1 2.5 13V7A1.5 1.5 0 0 1 4 5.5Zm3.5 2.6v3.8L10.7 10 7.5 8.1ZM16.5 7H21v1.5h-4.5V7Zm0 4H21v1.5h-4.5V11Zm-14 6H21v1.5H2.5V17Z'></path></svg>",
-	"description": "Player plus a list of linked videos.",
+	"description": "Play a sequence of VideoPress videos in a single customizable player. Build the list from your VideoPress library or video links, choose a side rail, grid, or strip layout with a light or dark surface, pick which details each entry shows, and let titles and thumbnails stay in sync with your videos automatically.",
 	"keywords": [ "playlist", "video", "videopress", "series" ],
 	"textdomain": "jetpack-videopress-pkg",
 	"supports": {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
@@ -1,0 +1,71 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "videopress/playlist",
+	"version": "0.1.0",
+	"title": "Video Playlist",
+	"category": "media",
+	"icon": "<svg viewBox='0 0 24 24' width='24' height='24' xmlns='http://www.w3.org/2000/svg'><path fill-rule='evenodd' clip-rule='evenodd' d='M4 5.5h9A1.5 1.5 0 0 1 14.5 7v6A1.5 1.5 0 0 1 13 14.5H4A1.5 1.5 0 0 1 2.5 13V7A1.5 1.5 0 0 1 4 5.5Zm3.5 2.6v3.8L10.7 10 7.5 8.1ZM16.5 7H21v1.5h-4.5V7Zm0 4H21v1.5h-4.5V11Zm-14 6H21v1.5H2.5V17Z'></path></svg>",
+	"description": "Player plus a list of linked videos.",
+	"keywords": [ "playlist", "video", "videopress", "series" ],
+	"textdomain": "jetpack-videopress-pkg",
+	"supports": {
+		"html": false,
+		"align": [ "wide", "full" ],
+		"anchor": true,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		}
+	},
+	"attributes": {
+		"videos": {
+			"type": "array",
+			"items": {
+				"type": "object"
+			},
+			"default": []
+		},
+		"layout": {
+			"type": "string",
+			"enum": [ "side-rail", "grid", "strip" ],
+			"default": "side-rail"
+		},
+		"darkPlayer": {
+			"type": "boolean",
+			"default": false
+		},
+		"autoplayNext": {
+			"type": "boolean",
+			"default": false
+		},
+		"showThumbnail": {
+			"type": "boolean",
+			"default": true
+		},
+		"showTitle": {
+			"type": "boolean",
+			"default": true
+		},
+		"showResolution": {
+			"type": "boolean",
+			"default": true
+		},
+		"showDuration": {
+			"type": "boolean",
+			"default": true
+		},
+		"showPositionNumber": {
+			"type": "boolean",
+			"default": false
+		},
+		"showTotalRuntime": {
+			"type": "boolean",
+			"default": true
+		}
+	},
+	"editorScript": "file:./index.js",
+	"editorStyle": [ "file:./index.css", "file:./view.css" ],
+	"viewScript": "file:./view.js",
+	"viewStyle": "file:./view.css"
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
@@ -63,10 +63,6 @@
 			"type": "boolean",
 			"default": true
 		},
-		"nowTitleFontFamily": {
-			"type": "string",
-			"default": ""
-		},
 		"entryTitleFontFamily": {
 			"type": "string",
 			"default": ""

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/block.json
@@ -62,6 +62,14 @@
 		"showTotalRuntime": {
 			"type": "boolean",
 			"default": true
+		},
+		"nowTitleFontFamily": {
+			"type": "string",
+			"default": ""
+		},
+		"entryTitleFontFamily": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"editorScript": "file:./index.js",

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -939,6 +939,7 @@ export default function PlaylistEdit( {
 		<InspectorControls group="styles">
 			<PanelBody title={ __( 'Typography', 'jetpack-videopress-pkg' ) }>
 				<FontFamilyControl
+					className="videopress-playlist-editor__font-control"
 					fontFamilies={ fontFamilies }
 					label={ __( 'Now playing title', 'jetpack-videopress-pkg' ) }
 					value={ fontFamilyValueOf( nowTitleFontFamily ) }
@@ -947,6 +948,7 @@ export default function PlaylistEdit( {
 					}
 				/>
 				<FontFamilyControl
+					className="videopress-playlist-editor__font-control"
 					fontFamilies={ fontFamilies }
 					label={ __( 'Entry titles', 'jetpack-videopress-pkg' ) }
 					value={ fontFamilyValueOf( entryTitleFontFamily ) }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -302,13 +302,6 @@ function PlaylistPreview( {
 					</ol>
 				</div>
 			</div>
-
-			<p className="videopress-playlist-editor__canvas-hint">
-				{ __(
-					'The canvas preview mirrors the sidebar order live — the block is not editable in place.',
-					'jetpack-videopress-pkg'
-				) }
-			</p>
 		</>
 	);
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -88,12 +88,17 @@ function entryFromApiResponse( guid: string, item: Record< string, unknown > ): 
 	if ( typeof item?.title === 'string' && item.title ) {
 		entry.title = decodeEntities( item.title );
 	}
-	if ( typeof item?.duration === 'number' && item.duration > 0 ) {
-		entry.durationMs = item.duration;
+
+	// The API isn't strict about numeric types, so coerce rather than type-check.
+	const duration = Number( item?.duration );
+	if ( Number.isFinite( duration ) && duration > 0 ) {
+		entry.durationMs = duration;
 	}
-	if ( typeof item?.height === 'number' && item.height > 0 ) {
-		entry.height = item.height;
+	const height = Number( item?.height );
+	if ( Number.isFinite( height ) && height > 0 ) {
+		entry.height = height;
 	}
+
 	if ( typeof item?.poster === 'string' && item.poster ) {
 		entry.poster = item.poster;
 	}
@@ -409,6 +414,12 @@ export default function PlaylistEdit( {
 			if ( typeof poster === 'string' && poster ) {
 				entry.poster = poster;
 			}
+			// Attachments know the video height, so the resolution badge
+			// shows for library picks too (240p included).
+			const height = Number( item.height );
+			if ( Number.isFinite( height ) && height > 0 ) {
+				entry.height = height;
+			}
 
 			entries.push( entry );
 		}
@@ -506,12 +517,20 @@ export default function PlaylistEdit( {
 	const notices = (
 		<>
 			{ addError && (
-				<Notice status="error" isDismissible={ false }>
+				<Notice
+					className="videopress-playlist-editor__notice"
+					status="error"
+					isDismissible={ false }
+				>
 					{ addError }
 				</Notice>
 			) }
 			{ duplicateGuid && (
-				<Notice status="warning" isDismissible={ false }>
+				<Notice
+					className="videopress-playlist-editor__notice"
+					status="warning"
+					isDismissible={ false }
+				>
 					{ sprintf(
 						/* translators: %s: title (or GUID) of the video. */
 						__( '“%s” is already in this playlist', 'jetpack-videopress-pkg' ),

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -28,6 +28,7 @@ import { fetchVideoItem } from '../../../lib/fetch-video-item';
 import { isVideoPressGuid, pickGUIDFromUrl } from '../../../lib/url';
 import { VideoPressIcon } from '../video/components/icons';
 import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../video/constants';
+import usePublishTracking from './use-publish-tracking';
 import {
 	formatRuntime,
 	formatTimecode,
@@ -316,11 +317,13 @@ function PlaylistPreview( {
  * @param props               - Block edit props.
  * @param props.attributes    - Block attributes.
  * @param props.setAttributes - Attribute setter.
+ * @param props.clientId      - This block instance's client id.
  * @return Edit component.
  */
 export default function PlaylistEdit( {
 	attributes,
 	setAttributes,
+	clientId,
 }: BlockEditProps< PlaylistAttributes > ) {
 	const {
 		videos,
@@ -408,6 +411,9 @@ export default function PlaylistEdit( {
 	}, [ videos ] );
 
 	const displayTitle = ( guid: string ) => liveMetadata[ guid ]?.title || guid;
+
+	// Records a Tracks event when a post/page is published with the playlist.
+	usePublishTracking( { clientId, layout, videoCount: videos.length } );
 
 	const currentIndex = Math.min( previewIndex, Math.max( 0, videos.length - 1 ) );
 	const isLongPlaylist = videos.length > LONG_PLAYLIST_THRESHOLD;

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -558,7 +558,8 @@ export default function PlaylistEdit( {
 				__next40pxDefaultSize
 				variant="primary"
 				isBusy={ isAdding }
-				aria-disabled={ isAdding }
+				disabled={ isAdding || ! urlInput.trim() }
+				accessibleWhenDisabled
 				onClick={ addFromInput }
 			>
 				{ /* Kept as two expressions so minification can't merge the two

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -844,6 +844,50 @@ export default function PlaylistEdit( {
 				) }
 			</PanelBody>
 
+			<PanelBody title={ __( 'Show on each entry', 'jetpack-videopress-pkg' ) }>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Thumbnail', 'jetpack-videopress-pkg' ) }
+					checked={ showThumbnail }
+					onChange={ ( value: boolean ) => setAttributes( { showThumbnail: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Title', 'jetpack-videopress-pkg' ) }
+					checked={ showTitle }
+					onChange={ ( value: boolean ) => setAttributes( { showTitle: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Resolution', 'jetpack-videopress-pkg' ) }
+					checked={ showResolution }
+					onChange={ ( value: boolean ) => setAttributes( { showResolution: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Duration', 'jetpack-videopress-pkg' ) }
+					checked={ showDuration }
+					onChange={ ( value: boolean ) => setAttributes( { showDuration: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Position number', 'jetpack-videopress-pkg' ) }
+					checked={ showPositionNumber }
+					onChange={ ( value: boolean ) => setAttributes( { showPositionNumber: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Total runtime in header', 'jetpack-videopress-pkg' ) }
+					checked={ showTotalRuntime }
+					onChange={ ( value: boolean ) => setAttributes( { showTotalRuntime: value } ) }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+
+	// In the Styles tab, where WordPress surfaces style settings for core blocks.
+	const stylesControls = (
+		<InspectorControls group="styles">
 			<PanelBody title={ __( 'Layout', 'jetpack-videopress-pkg' ) }>
 				<div
 					className="videopress-playlist-editor__layouts"
@@ -892,71 +936,28 @@ export default function PlaylistEdit( {
 					onChange={ ( value: boolean ) => setAttributes( { autoplayNext: value } ) }
 				/>
 			</PanelBody>
-
-			<PanelBody title={ __( 'Show on each entry', 'jetpack-videopress-pkg' ) }>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ __( 'Thumbnail', 'jetpack-videopress-pkg' ) }
-					checked={ showThumbnail }
-					onChange={ ( value: boolean ) => setAttributes( { showThumbnail: value } ) }
-				/>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ __( 'Title', 'jetpack-videopress-pkg' ) }
-					checked={ showTitle }
-					onChange={ ( value: boolean ) => setAttributes( { showTitle: value } ) }
-				/>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ __( 'Resolution', 'jetpack-videopress-pkg' ) }
-					checked={ showResolution }
-					onChange={ ( value: boolean ) => setAttributes( { showResolution: value } ) }
-				/>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ __( 'Duration', 'jetpack-videopress-pkg' ) }
-					checked={ showDuration }
-					onChange={ ( value: boolean ) => setAttributes( { showDuration: value } ) }
-				/>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ __( 'Position number', 'jetpack-videopress-pkg' ) }
-					checked={ showPositionNumber }
-					onChange={ ( value: boolean ) => setAttributes( { showPositionNumber: value } ) }
-				/>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ __( 'Total runtime in header', 'jetpack-videopress-pkg' ) }
-					checked={ showTotalRuntime }
-					onChange={ ( value: boolean ) => setAttributes( { showTotalRuntime: value } ) }
-				/>
-			</PanelBody>
-		</InspectorControls>
-	);
-
-	// In the Styles tab, where WordPress surfaces typography for core blocks.
-	const typographyControls = fontFamilies.length > 0 && (
-		<InspectorControls group="styles">
-			<PanelBody title={ __( 'Typography', 'jetpack-videopress-pkg' ) }>
-				<FontFamilyControl
-					className="videopress-playlist-editor__font-control"
-					fontFamilies={ fontFamilies }
-					label={ __( 'Now playing title', 'jetpack-videopress-pkg' ) }
-					value={ fontFamilyValueOf( nowTitleFontFamily ) }
-					onChange={ ( value: string ) =>
-						setAttributes( { nowTitleFontFamily: fontFamilySlugOf( value ) } )
-					}
-				/>
-				<FontFamilyControl
-					className="videopress-playlist-editor__font-control"
-					fontFamilies={ fontFamilies }
-					label={ __( 'Entry titles', 'jetpack-videopress-pkg' ) }
-					value={ fontFamilyValueOf( entryTitleFontFamily ) }
-					onChange={ ( value: string ) =>
-						setAttributes( { entryTitleFontFamily: fontFamilySlugOf( value ) } )
-					}
-				/>
-			</PanelBody>
+			{ fontFamilies.length > 0 && (
+				<PanelBody title={ __( 'Typography', 'jetpack-videopress-pkg' ) }>
+					<FontFamilyControl
+						className="videopress-playlist-editor__font-control"
+						fontFamilies={ fontFamilies }
+						label={ __( 'Now playing title', 'jetpack-videopress-pkg' ) }
+						value={ fontFamilyValueOf( nowTitleFontFamily ) }
+						onChange={ ( value: string ) =>
+							setAttributes( { nowTitleFontFamily: fontFamilySlugOf( value ) } )
+						}
+					/>
+					<FontFamilyControl
+						className="videopress-playlist-editor__font-control"
+						fontFamilies={ fontFamilies }
+						label={ __( 'Entry titles', 'jetpack-videopress-pkg' ) }
+						value={ fontFamilyValueOf( entryTitleFontFamily ) }
+						onChange={ ( value: string ) =>
+							setAttributes( { entryTitleFontFamily: fontFamilySlugOf( value ) } )
+						}
+					/>
+				</PanelBody>
+			) }
 		</InspectorControls>
 	);
 
@@ -964,7 +965,7 @@ export default function PlaylistEdit( {
 		return (
 			<div { ...blockProps }>
 				{ inspectorControls }
-				{ typographyControls }
+				{ stylesControls }
 				<Placeholder
 					icon={ VideoPressIcon }
 					label={ __( 'Build a video playlist', 'jetpack-videopress-pkg' ) }
@@ -994,7 +995,7 @@ export default function PlaylistEdit( {
 	return (
 		<figure { ...blockProps }>
 			{ inspectorControls }
-			{ typographyControls }
+			{ stylesControls }
 			<PlaylistPreview
 				attributes={ attributes }
 				currentIndex={ currentIndex }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -161,7 +161,6 @@ function PlaylistPreview( {
 } ) {
 	const { videos, showPositionNumber, showTotalRuntime } = attributes;
 	const current = videos[ currentIndex ];
-	const currentTitle = liveMetadata[ current.guid ]?.title || current.guid;
 
 	/*
 	 * Mirrors the front-end view script: while more entries hide beyond the
@@ -188,13 +187,6 @@ function PlaylistPreview( {
 		_n( '%d video', '%d videos', videos.length, 'jetpack-videopress-pkg' ),
 		videos.length
 	);
-	const nowPosition = sprintf(
-		/* translators: 1: position of the current video. 2: number of videos in the playlist. */
-		__( '%1$d of %2$d', 'jetpack-videopress-pkg' ),
-		currentIndex + 1,
-		videos.length
-	);
-
 	return (
 		<>
 			<div className="videopress-playlist__body">
@@ -211,22 +203,13 @@ function PlaylistPreview( {
 							allow="clipboard-write"
 						/>
 					</div>
-					<div className="videopress-playlist__now">
-						<span className="videopress-playlist__now-title">{ currentTitle }</span>
-						<span className="videopress-playlist__now-meta">
-							<span className="videopress-playlist__now-position">{ nowPosition }</span>
-							{ entryMetaLine( current ) && (
-								<span className="videopress-playlist__now-details">
-									{ entryMetaLine( current ) }
-								</span>
-							) }
-						</span>
-						{ showTotalRuntime && runtime && (
+					{ showTotalRuntime && runtime && (
+						<div className="videopress-playlist__now">
 							<span className="videopress-playlist__now-runtime">
 								{ `${ countLabel } · ${ runtime }` }
 							</span>
-						) }
-					</div>
+						</div>
+					) }
 				</div>
 
 				<div
@@ -357,7 +340,6 @@ export default function PlaylistEdit( {
 		showDuration,
 		showPositionNumber,
 		showTotalRuntime,
-		nowTitleFontFamily,
 		entryTitleFontFamily,
 	} = attributes;
 
@@ -452,11 +434,6 @@ export default function PlaylistEdit( {
 	// The chosen presets reach the stylesheet as CSS custom properties, the
 	// same way the PHP render exposes them on the front end.
 	const fontVariables: Record< string, string > = {};
-	if ( nowTitleFontFamily ) {
-		fontVariables[
-			'--vpp-now-title-font'
-		] = `var(--wp--preset--font-family--${ nowTitleFontFamily })`;
-	}
 	if ( entryTitleFontFamily ) {
 		fontVariables[
 			'--vpp-entry-title-font'
@@ -966,16 +943,6 @@ export default function PlaylistEdit( {
 			</PanelBody>
 			{ fontFamilies.length > 0 && (
 				<PanelBody title={ __( 'Typography', 'jetpack-videopress-pkg' ) }>
-					<div className="videopress-playlist-editor__font-control">
-						<FontFamilyControl
-							fontFamilies={ fontFamilies }
-							label={ __( 'Now playing title', 'jetpack-videopress-pkg' ) }
-							value={ fontFamilyValueOf( nowTitleFontFamily ) }
-							onChange={ ( value: string ) =>
-								setAttributes( { nowTitleFontFamily: fontFamilySlugOf( value ) } )
-							}
-						/>
-					</div>
 					<div className="videopress-playlist-editor__font-control">
 						<FontFamilyControl
 							fontFamilies={ fontFamilies }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -1,0 +1,843 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	InspectorControls,
+	MediaUpload,
+	MediaUploadCheck,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import {
+	Button,
+	Notice,
+	PanelBody,
+	Placeholder,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { closeSmall, dragHandle, Icon } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import { fetchVideoItem } from '../../../lib/fetch-video-item';
+import { isVideoPressGuid, pickGUIDFromUrl } from '../../../lib/url';
+import { VideoPressIcon } from '../video/components/icons';
+import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../video/constants';
+import {
+	formatRuntime,
+	formatTimecode,
+	moveEntry,
+	playlistEmbedUrl,
+	playlistRuntimeMs,
+	resolutionLabel,
+} from './utils';
+import './editor.scss';
+/**
+ * Types
+ */
+import type { PlaylistAttributes, PlaylistEntry, PlaylistLayout } from './types';
+import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../types';
+import type { BlockEditProps } from '@wordpress/blocks';
+
+/**
+ * Playlists longer than this get a filter input and per-row position
+ * numbers in the sidebar manager, matching the long-playlist design.
+ */
+const LONG_PLAYLIST_THRESHOLD = 8;
+
+type LayoutOption = { value: PlaylistLayout; label: string };
+
+const LAYOUT_OPTIONS: LayoutOption[] = [
+	{ value: 'side-rail', label: __( 'Side rail', 'jetpack-videopress-pkg' ) },
+	{ value: 'grid', label: __( 'Grid', 'jetpack-videopress-pkg' ) },
+	{ value: 'strip', label: __( 'Strip', 'jetpack-videopress-pkg' ) },
+];
+
+/**
+ * Resolve raw user input (a VideoPress URL or a bare GUID) to a GUID.
+ *
+ * @param input - Raw user input.
+ * @return The GUID, or null when the input isn't a VideoPress video reference.
+ */
+export function guidFromInput( input: string ): string | null {
+	const value = input.trim();
+	if ( ! value ) {
+		return null;
+	}
+
+	if ( isVideoPressGuid( value ) ) {
+		return value;
+	}
+
+	return pickGUIDFromUrl( value );
+}
+
+/**
+ * Build a playlist entry from a videos API response item.
+ *
+ * @param guid - The video GUID.
+ * @param item - The videos API response.
+ * @return Playlist entry with the metadata the API reported.
+ */
+function entryFromApiResponse( guid: string, item: Record< string, unknown > ): PlaylistEntry {
+	const entry: PlaylistEntry = { guid };
+
+	if ( typeof item?.title === 'string' && item.title ) {
+		entry.title = decodeEntities( item.title );
+	}
+	if ( typeof item?.duration === 'number' && item.duration > 0 ) {
+		entry.durationMs = item.duration;
+	}
+	if ( typeof item?.height === 'number' && item.height > 0 ) {
+		entry.height = item.height;
+	}
+	if ( typeof item?.poster === 'string' && item.poster ) {
+		entry.poster = item.poster;
+	}
+
+	return entry;
+}
+
+/**
+ * Format the "1080p · 12:04" meta line of an entry.
+ *
+ * @param entry - Playlist entry.
+ * @return Meta line; empty when nothing is known.
+ */
+function entryMetaLine( entry: PlaylistEntry ): string {
+	return [ resolutionLabel( entry.height ), formatTimecode( entry.durationMs ) ]
+		.filter( Boolean )
+		.join( ' · ' );
+}
+
+/**
+ * The front-end-mirroring preview rendered in the editor canvas.
+ *
+ * @param props              - Component props.
+ * @param props.attributes   - Block attributes.
+ * @param props.currentIndex - Index of the entry shown in the player.
+ * @param props.onSelect     - Called with an entry index when it is clicked.
+ * @return Preview element.
+ */
+function PlaylistPreview( {
+	attributes,
+	currentIndex,
+	onSelect,
+}: {
+	attributes: PlaylistAttributes;
+	currentIndex: number;
+	onSelect: ( index: number ) => void;
+} ) {
+	const { videos, showPositionNumber, showTotalRuntime } = attributes;
+	const current = videos[ currentIndex ];
+	const runtime = formatRuntime( playlistRuntimeMs( videos ) );
+	const countLabel = sprintf(
+		/* translators: %d: number of videos in the playlist. */
+		_n( '%d video', '%d videos', videos.length, 'jetpack-videopress-pkg' ),
+		videos.length
+	);
+	const nowPosition = sprintf(
+		/* translators: 1: position of the current video. 2: number of videos in the playlist. */
+		__( '%1$d of %2$d', 'jetpack-videopress-pkg' ),
+		currentIndex + 1,
+		videos.length
+	);
+
+	return (
+		<>
+			<header className="videopress-playlist__header">
+				<span className="videopress-playlist__count">{ countLabel }</span>
+				{ showTotalRuntime && runtime && (
+					<span className="videopress-playlist__runtime">{ runtime }</span>
+				) }
+			</header>
+
+			<div className="videopress-playlist__body">
+				<div className="videopress-playlist__stage">
+					<div className="videopress-playlist__player">
+						<iframe
+							className="videopress-playlist__iframe"
+							title={ current.title || __( 'Video Playlist player', 'jetpack-videopress-pkg' ) }
+							src={ playlistEmbedUrl( current.guid, false ) }
+							allowFullScreen
+							allow="clipboard-write"
+						/>
+					</div>
+					<div className="videopress-playlist__now">
+						<span className="videopress-playlist__now-title">
+							{ current.title || current.guid }
+						</span>
+						<span className="videopress-playlist__now-meta">
+							<span className="videopress-playlist__now-position">{ nowPosition }</span>
+							{ entryMetaLine( current ) && (
+								<span className="videopress-playlist__now-details">
+									{ entryMetaLine( current ) }
+								</span>
+							) }
+						</span>
+						{ showTotalRuntime && runtime && (
+							<span className="videopress-playlist__now-runtime">
+								{ `${ countLabel } · ${ runtime }` }
+							</span>
+						) }
+					</div>
+				</div>
+
+				<div className="videopress-playlist__list">
+					<div className="videopress-playlist__list-header">
+						<span className="videopress-playlist__list-label videopress-playlist__list-label--rail">
+							{ __( 'Up next', 'jetpack-videopress-pkg' ) }
+						</span>
+						<span className="videopress-playlist__list-label videopress-playlist__list-label--strip">
+							{ sprintf(
+								/* translators: %d: number of videos in the playlist. */
+								__( 'Playlist — %d videos', 'jetpack-videopress-pkg' ),
+								videos.length
+							) }
+						</span>
+						<span className="videopress-playlist__list-progress">
+							{ sprintf(
+								/* translators: 1: position of the current video. 2: number of videos. 3: total playlist timecode. */
+								__( '%1$d / %2$d · %3$s total', 'jetpack-videopress-pkg' ),
+								currentIndex + 1,
+								videos.length,
+								formatTimecode( playlistRuntimeMs( videos ) )
+							) }
+						</span>
+					</div>
+					<ol className="videopress-playlist__entries">
+						{ videos.map( ( entry, index ) => (
+							<li className="videopress-playlist__entry" key={ `${ entry.guid }-${ index }` }>
+								<button
+									type="button"
+									className={
+										index === currentIndex
+											? 'videopress-playlist__select is-current'
+											: 'videopress-playlist__select'
+									}
+									aria-current={ index === currentIndex ? 'true' : undefined }
+									onClick={ () => onSelect( index ) }
+								>
+									{ showPositionNumber && (
+										<span className="videopress-playlist__entry-number">
+											{ String( index + 1 ).padStart( 2, '0' ) }
+										</span>
+									) }
+									<span className="videopress-playlist__entry-thumb">
+										{ entry.poster && <img src={ entry.poster } alt="" loading="lazy" /> }
+										<span className="videopress-playlist__entry-flag">
+											{ __( 'Playing', 'jetpack-videopress-pkg' ) }
+										</span>
+										{ formatTimecode( entry.durationMs ) && (
+											<span className="videopress-playlist__entry-time">
+												{ formatTimecode( entry.durationMs ) }
+											</span>
+										) }
+									</span>
+									<span className="videopress-playlist__entry-body">
+										<span className="videopress-playlist__entry-title">
+											{ entry.title || entry.guid }
+										</span>
+										<span className="videopress-playlist__entry-meta">
+											{ resolutionLabel( entry.height ) && (
+												<span className="videopress-playlist__entry-resolution">
+													{ resolutionLabel( entry.height ) }
+												</span>
+											) }
+											{ formatTimecode( entry.durationMs ) && (
+												<span className="videopress-playlist__entry-duration">
+													{ formatTimecode( entry.durationMs ) }
+												</span>
+											) }
+										</span>
+									</span>
+								</button>
+							</li>
+						) ) }
+					</ol>
+				</div>
+			</div>
+
+			<p className="videopress-playlist-editor__canvas-hint">
+				{ __(
+					'The canvas preview mirrors the sidebar order live — the block is not editable in place.',
+					'jetpack-videopress-pkg'
+				) }
+			</p>
+		</>
+	);
+}
+
+/**
+ * Video Playlist block edit component.
+ *
+ * The canvas is a live, non-editable preview of the front end; every
+ * playlist operation (add, reorder, remove, display options) lives in the
+ * block settings sidebar.
+ *
+ * @param props               - Block edit props.
+ * @param props.attributes    - Block attributes.
+ * @param props.setAttributes - Attribute setter.
+ * @return Edit component.
+ */
+export default function PlaylistEdit( {
+	attributes,
+	setAttributes,
+}: BlockEditProps< PlaylistAttributes > ) {
+	const {
+		videos,
+		layout,
+		darkPlayer,
+		autoplayNext,
+		showThumbnail,
+		showTitle,
+		showResolution,
+		showDuration,
+		showPositionNumber,
+		showTotalRuntime,
+	} = attributes;
+
+	const [ previewIndex, setPreviewIndex ] = useState( 0 );
+	const [ urlInput, setUrlInput ] = useState( '' );
+	const [ isAdding, setIsAdding ] = useState( false );
+	const [ addError, setAddError ] = useState< string | null >( null );
+	const [ duplicateGuid, setDuplicateGuid ] = useState< string | null >( null );
+	const [ filter, setFilter ] = useState( '' );
+	const [ dragIndex, setDragIndex ] = useState< number | null >( null );
+	const [ dropIndex, setDropIndex ] = useState< number | null >( null );
+
+	const currentIndex = Math.min( previewIndex, Math.max( 0, videos.length - 1 ) );
+	const isLongPlaylist = videos.length > LONG_PLAYLIST_THRESHOLD;
+	const isFiltering = isLongPlaylist && filter.trim() !== '';
+
+	const wrapperClasses = [
+		'videopress-playlist',
+		`is-layout-${ layout }`,
+		darkPlayer ? 'is-dark' : '',
+		showThumbnail ? '' : 'hide-thumbnails',
+		showTitle ? '' : 'hide-titles',
+		showResolution ? '' : 'hide-resolutions',
+		showDuration ? '' : 'hide-durations',
+		showTotalRuntime ? '' : 'hide-runtime',
+	]
+		.filter( Boolean )
+		.join( ' ' );
+
+	const blockProps = useBlockProps( {
+		className: videos.length ? wrapperClasses : 'videopress-playlist is-empty',
+	} );
+
+	const clearFeedback = () => {
+		setAddError( null );
+		setDuplicateGuid( null );
+	};
+
+	const appendVideo = async ( guid: string ) => {
+		setIsAdding( true );
+		clearFeedback();
+
+		try {
+			const item = await fetchVideoItem( { guid, isPrivate: false, skipRatingControl: true } );
+			setAttributes( {
+				videos: [ ...videos, entryFromApiResponse( guid, item as Record< string, unknown > ) ],
+			} );
+			setUrlInput( '' );
+		} catch {
+			setAddError(
+				__(
+					'No video found at that link. Check the URL, or paste the share link of a video in your VideoPress library.',
+					'jetpack-videopress-pkg'
+				)
+			);
+		} finally {
+			setIsAdding( false );
+		}
+	};
+
+	const addFromInput = () => {
+		if ( isAdding ) {
+			return;
+		}
+
+		const guid = guidFromInput( urlInput );
+		if ( ! guid ) {
+			setDuplicateGuid( null );
+			setAddError(
+				__(
+					'No video found at that link. Check the URL, or paste a VideoPress video URL or GUID.',
+					'jetpack-videopress-pkg'
+				)
+			);
+			return;
+		}
+
+		if ( videos.some( entry => entry.guid === guid ) ) {
+			setAddError( null );
+			setDuplicateGuid( guid );
+			return;
+		}
+
+		appendVideo( guid );
+	};
+
+	const addFromLibrary = (
+		selection:
+			| AdminAjaxQueryAttachmentsResponseItemProps
+			| AdminAjaxQueryAttachmentsResponseItemProps[]
+	) => {
+		const items = Array.isArray( selection ) ? selection : [ selection ];
+		const entries: PlaylistEntry[] = [];
+
+		for ( const item of items ) {
+			// Depending on the endpoint, `videopress_guid` is an array or a string.
+			const guid = Array.isArray( item?.videopress_guid )
+				? item.videopress_guid[ 0 ]
+				: item?.videopress_guid;
+
+			if ( ! guid ) {
+				continue;
+			}
+
+			const entry: PlaylistEntry = { guid };
+			if ( typeof item.title === 'string' && item.title ) {
+				entry.title = decodeEntities( item.title );
+			}
+			const poster = item.image?.src || item.thumb?.src;
+			if ( typeof poster === 'string' && poster ) {
+				entry.poster = poster;
+			}
+
+			entries.push( entry );
+		}
+
+		if ( ! entries.length ) {
+			setAddError(
+				__(
+					'None of the selected items are VideoPress videos. Pick videos hosted on VideoPress.',
+					'jetpack-videopress-pkg'
+				)
+			);
+			return;
+		}
+
+		clearFeedback();
+		setAttributes( { videos: [ ...videos, ...entries ] } );
+	};
+
+	const removeVideo = ( index: number ) => {
+		setAttributes( { videos: videos.filter( ( _, i ) => i !== index ) } );
+		if ( currentIndex > index || ( currentIndex === index && currentIndex > 0 ) ) {
+			setPreviewIndex( currentIndex - 1 );
+		}
+	};
+
+	const reorderVideo = ( from: number, to: number ) => {
+		const next = moveEntry( videos, from, to );
+		if ( next === videos ) {
+			return;
+		}
+
+		setAttributes( { videos: next } );
+
+		// Keep the canvas preview on the entry it was showing before the move.
+		if ( currentIndex === from ) {
+			setPreviewIndex( to );
+		} else if ( from < currentIndex && to >= currentIndex ) {
+			setPreviewIndex( currentIndex - 1 );
+		} else if ( from > currentIndex && to <= currentIndex ) {
+			setPreviewIndex( currentIndex + 1 );
+		}
+	};
+
+	const addForm = (
+		<div className="videopress-playlist-editor__add-row">
+			<TextControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'Add a video', 'jetpack-videopress-pkg' ) }
+				hideLabelFromVision
+				placeholder={ __( 'Paste a video URL', 'jetpack-videopress-pkg' ) }
+				value={ urlInput }
+				onChange={ ( value: string ) => {
+					setUrlInput( value );
+					clearFeedback();
+				} }
+				onKeyDown={ ( event: React.KeyboardEvent ) => {
+					if ( event.key === 'Enter' ) {
+						event.preventDefault();
+						addFromInput();
+					}
+				} }
+			/>
+			<Button
+				__next40pxDefaultSize
+				variant="primary"
+				isBusy={ isAdding }
+				aria-disabled={ isAdding }
+				onClick={ addFromInput }
+			>
+				{ /* Kept as two expressions so minification can't merge the two
+				     __() calls into one, which would break string extraction. */ }
+				{ isAdding && __( 'Adding…', 'jetpack-videopress-pkg' ) }
+				{ ! isAdding && __( 'Add', 'jetpack-videopress-pkg' ) }
+			</Button>
+		</div>
+	);
+
+	const mediaLibraryButton = (
+		<MediaUploadCheck>
+			<MediaUpload
+				title={ __( 'Select videos to add', 'jetpack-videopress-pkg' ) }
+				onSelect={ addFromLibrary }
+				allowedTypes={ VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES }
+				multiple
+				render={ ( { open }: { open: () => void } ) => (
+					<Button __next40pxDefaultSize variant="secondary" onClick={ open }>
+						{ __( 'Media Library', 'jetpack-videopress-pkg' ) }
+					</Button>
+				) }
+			/>
+		</MediaUploadCheck>
+	);
+
+	const notices = (
+		<>
+			{ addError && (
+				<Notice status="error" isDismissible={ false }>
+					{ addError }
+				</Notice>
+			) }
+			{ duplicateGuid && (
+				<Notice status="warning" isDismissible={ false }>
+					{ sprintf(
+						/* translators: %s: title (or GUID) of the video. */
+						__( '“%s” is already in this playlist', 'jetpack-videopress-pkg' ),
+						videos.find( entry => entry.guid === duplicateGuid )?.title || duplicateGuid
+					) }
+					<span className="videopress-playlist-editor__duplicate-actions">
+						<Button size="small" variant="secondary" onClick={ () => appendVideo( duplicateGuid ) }>
+							{ __( 'Add anyway', 'jetpack-videopress-pkg' ) }
+						</Button>
+						<Button size="small" variant="tertiary" onClick={ () => setDuplicateGuid( null ) }>
+							{ __( 'Cancel', 'jetpack-videopress-pkg' ) }
+						</Button>
+					</span>
+				</Notice>
+			) }
+		</>
+	);
+
+	const filteredRows = videos
+		.map( ( entry, index ) => ( { entry, index } ) )
+		.filter( ( { entry } ) => {
+			if ( ! isFiltering ) {
+				return true;
+			}
+			return `${ entry.title ?? '' } ${ entry.guid }`
+				.toLowerCase()
+				.includes( filter.trim().toLowerCase() );
+		} );
+
+	const inspectorControls = (
+		<InspectorControls>
+			<PanelBody title={ __( 'Add a video', 'jetpack-videopress-pkg' ) }>
+				{ addForm }
+				<p className="videopress-playlist-editor__help">
+					{ __(
+						'Any VideoPress video URL or GUID. Title, thumbnail, duration and resolution come from the video data.',
+						'jetpack-videopress-pkg'
+					) }
+				</p>
+				{ mediaLibraryButton }
+				{ notices }
+			</PanelBody>
+
+			<PanelBody title={ __( 'Playlist', 'jetpack-videopress-pkg' ) }>
+				<div className="videopress-playlist-editor__list-summary">
+					<span>
+						{ sprintf(
+							/* translators: %d: number of videos in the playlist. */
+							_n( '%d video', '%d videos', videos.length, 'jetpack-videopress-pkg' ),
+							videos.length
+						) }
+					</span>
+					{ formatTimecode( playlistRuntimeMs( videos ) ) && (
+						<span className="videopress-playlist-editor__list-runtime">
+							{ formatTimecode( playlistRuntimeMs( videos ) ) }
+						</span>
+					) }
+				</div>
+
+				{ isLongPlaylist && (
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Filter videos', 'jetpack-videopress-pkg' ) }
+						hideLabelFromVision
+						placeholder={ sprintf(
+							/* translators: %d: number of videos in the playlist. */
+							__( 'Filter %d videos', 'jetpack-videopress-pkg' ),
+							videos.length
+						) }
+						value={ filter }
+						onChange={ setFilter }
+					/>
+				) }
+
+				<ol
+					className="videopress-playlist-editor__rows"
+					aria-label={ __( 'Playlist videos', 'jetpack-videopress-pkg' ) }
+				>
+					{ filteredRows.map( ( { entry, index } ) => {
+						const rowClasses = [ 'videopress-playlist-editor__row' ];
+						if ( dragIndex === index ) {
+							rowClasses.push( 'is-dragging' );
+						}
+						if ( dropIndex === index && dragIndex !== null && dragIndex !== index ) {
+							rowClasses.push( 'is-drop-target' );
+						}
+
+						return (
+							<li
+								key={ `${ entry.guid }-${ index }` }
+								className={ rowClasses.join( ' ' ) }
+								draggable={ ! isFiltering }
+								onDragStart={ ( event: React.DragEvent ) => {
+									setDragIndex( index );
+									event.dataTransfer.effectAllowed = 'move';
+									event.dataTransfer.setData( 'text/plain', String( index ) );
+								} }
+								onDragOver={ ( event: React.DragEvent ) => {
+									event.preventDefault();
+									event.dataTransfer.dropEffect = 'move';
+									if ( dragIndex !== null && dragIndex !== index ) {
+										setDropIndex( index );
+									}
+								} }
+								onDragLeave={ () => {
+									setDropIndex( current => ( current === index ? null : current ) );
+								} }
+								onDrop={ ( event: React.DragEvent ) => {
+									event.preventDefault();
+									if ( dragIndex !== null ) {
+										reorderVideo( dragIndex, index );
+									}
+									setDragIndex( null );
+									setDropIndex( null );
+								} }
+								onDragEnd={ () => {
+									setDragIndex( null );
+									setDropIndex( null );
+								} }
+							>
+								{ ! isFiltering && (
+									<Button
+										className="videopress-playlist-editor__row-handle"
+										icon={ <Icon icon={ dragHandle } size={ 16 } /> }
+										label={ sprintf(
+											/* translators: %s: title (or GUID) of the video. */
+											__( 'Reorder “%s”. Press up or down to move it.', 'jetpack-videopress-pkg' ),
+											entry.title || entry.guid
+										) }
+										onKeyDown={ ( event: React.KeyboardEvent ) => {
+											if ( event.key === 'ArrowUp' ) {
+												event.preventDefault();
+												reorderVideo( index, index - 1 );
+											} else if ( event.key === 'ArrowDown' ) {
+												event.preventDefault();
+												reorderVideo( index, index + 1 );
+											}
+										} }
+									/>
+								) }
+								{ isLongPlaylist && (
+									<span className="videopress-playlist-editor__row-number">
+										{ String( index + 1 ).padStart( 2, '0' ) }
+									</span>
+								) }
+								<span className="videopress-playlist-editor__row-thumb">
+									{ entry.poster && <img src={ entry.poster } alt="" loading="lazy" /> }
+								</span>
+								<span className="videopress-playlist-editor__row-body">
+									<span className="videopress-playlist-editor__row-title">
+										{ entry.title || entry.guid }
+									</span>
+									{ entryMetaLine( entry ) && (
+										<span className="videopress-playlist-editor__row-meta">
+											{ entryMetaLine( entry ) }
+										</span>
+									) }
+								</span>
+								<Button
+									className="videopress-playlist-editor__row-remove"
+									size="small"
+									icon={ closeSmall }
+									label={ sprintf(
+										/* translators: %s: title (or GUID) of the video. */
+										__( 'Remove “%s” from the playlist', 'jetpack-videopress-pkg' ),
+										entry.title || entry.guid
+									) }
+									onClick={ () => removeVideo( index ) }
+								/>
+							</li>
+						);
+					} ) }
+					{ isAdding && (
+						<li
+							className="videopress-playlist-editor__row is-loading"
+							data-testid="playlist-loading-row"
+							aria-hidden="true"
+						>
+							<span className="videopress-playlist-editor__row-thumb" />
+							<span className="videopress-playlist-editor__row-body">
+								<span className="videopress-playlist-editor__row-meta">
+									{ __( 'Reading metadata…', 'jetpack-videopress-pkg' ) }
+								</span>
+							</span>
+						</li>
+					) }
+				</ol>
+				{ videos.length > 1 && (
+					<p className="videopress-playlist-editor__help">
+						{ __(
+							'Drag to reorder, or focus a handle and press ↑ / ↓. × removes the video.',
+							'jetpack-videopress-pkg'
+						) }
+					</p>
+				) }
+			</PanelBody>
+
+			<PanelBody title={ __( 'Layout', 'jetpack-videopress-pkg' ) }>
+				<div
+					className="videopress-playlist-editor__layouts"
+					role="group"
+					aria-label={ __( 'Layout', 'jetpack-videopress-pkg' ) }
+				>
+					{ LAYOUT_OPTIONS.map( option => (
+						<button
+							key={ option.value }
+							type="button"
+							className={
+								layout === option.value
+									? 'videopress-playlist-editor__layout is-selected'
+									: 'videopress-playlist-editor__layout'
+							}
+							aria-pressed={ layout === option.value }
+							onClick={ () => setAttributes( { layout: option.value } ) }
+						>
+							<span
+								className={ `videopress-playlist-editor__layout-sketch is-${ option.value }` }
+								aria-hidden="true"
+							>
+								<i />
+								<i />
+								<i />
+								<i />
+							</span>
+							{ option.label }
+						</button>
+					) ) }
+				</div>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Dark player surface', 'jetpack-videopress-pkg' ) }
+					checked={ darkPlayer }
+					onChange={ ( value: boolean ) => setAttributes( { darkPlayer: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Autoplay next', 'jetpack-videopress-pkg' ) }
+					help={ __(
+						'Play the next video automatically when one ends.',
+						'jetpack-videopress-pkg'
+					) }
+					checked={ autoplayNext }
+					onChange={ ( value: boolean ) => setAttributes( { autoplayNext: value } ) }
+				/>
+			</PanelBody>
+
+			<PanelBody title={ __( 'Show on each entry', 'jetpack-videopress-pkg' ) }>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Thumbnail', 'jetpack-videopress-pkg' ) }
+					checked={ showThumbnail }
+					onChange={ ( value: boolean ) => setAttributes( { showThumbnail: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Title', 'jetpack-videopress-pkg' ) }
+					checked={ showTitle }
+					onChange={ ( value: boolean ) => setAttributes( { showTitle: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Resolution', 'jetpack-videopress-pkg' ) }
+					checked={ showResolution }
+					onChange={ ( value: boolean ) => setAttributes( { showResolution: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Duration', 'jetpack-videopress-pkg' ) }
+					checked={ showDuration }
+					onChange={ ( value: boolean ) => setAttributes( { showDuration: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Position number', 'jetpack-videopress-pkg' ) }
+					checked={ showPositionNumber }
+					onChange={ ( value: boolean ) => setAttributes( { showPositionNumber: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Total runtime in header', 'jetpack-videopress-pkg' ) }
+					checked={ showTotalRuntime }
+					onChange={ ( value: boolean ) => setAttributes( { showTotalRuntime: value } ) }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+
+	if ( ! videos.length ) {
+		return (
+			<div { ...blockProps }>
+				{ inspectorControls }
+				<Placeholder
+					icon={ VideoPressIcon }
+					label={ __( 'Build a video playlist', 'jetpack-videopress-pkg' ) }
+					instructions={ __(
+						'Paste a link, or pick a video already in your media library. Title, thumbnail, duration and resolution are read for you.',
+						'jetpack-videopress-pkg'
+					) }
+				>
+					<div className="videopress-playlist-editor__placeholder">
+						{ addForm }
+						{ notices }
+						{ isAdding && (
+							<p className="videopress-playlist-editor__help" data-testid="playlist-loading-row">
+								{ __( 'Reading metadata…', 'jetpack-videopress-pkg' ) }
+							</p>
+						) }
+						<div className="videopress-playlist-editor__placeholder-divider">
+							<span>{ __( 'or', 'jetpack-videopress-pkg' ) }</span>
+						</div>
+						{ mediaLibraryButton }
+					</div>
+				</Placeholder>
+			</div>
+		);
+	}
+
+	return (
+		<figure { ...blockProps }>
+			{ inspectorControls }
+			<PlaylistPreview
+				attributes={ attributes }
+				currentIndex={ currentIndex }
+				onSelect={ setPreviewIndex }
+			/>
+		</figure>
+	);
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -15,7 +15,7 @@ import {
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
-import { useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { closeSmall, dragHandle, Icon } from '@wordpress/icons';
@@ -38,7 +38,12 @@ import './editor.scss';
 /**
  * Types
  */
-import type { PlaylistAttributes, PlaylistEntry, PlaylistLayout } from './types';
+import type {
+	PlaylistAttributes,
+	PlaylistEntry,
+	PlaylistLayout,
+	PlaylistLiveMetadata,
+} from './types';
 import type { AdminAjaxQueryAttachmentsResponseItemProps } from '../../../types';
 import type { BlockEditProps } from '@wordpress/blocks';
 
@@ -76,7 +81,8 @@ export function guidFromInput( input: string ): string | null {
 }
 
 /**
- * Build a playlist entry from a videos API response item.
+ * Build a stored playlist entry from a videos API response item. Only the
+ * numeric metadata is stored; title and poster stay live-only.
  *
  * @param guid - The video GUID.
  * @param item - The videos API response.
@@ -84,10 +90,6 @@ export function guidFromInput( input: string ): string | null {
  */
 function entryFromApiResponse( guid: string, item: Record< string, unknown > ): PlaylistEntry {
 	const entry: PlaylistEntry = { guid };
-
-	if ( typeof item?.title === 'string' && item.title ) {
-		entry.title = decodeEntities( item.title );
-	}
 
 	// The API isn't strict about numeric types, so coerce rather than type-check.
 	const duration = Number( item?.duration );
@@ -99,11 +101,27 @@ function entryFromApiResponse( guid: string, item: Record< string, unknown > ): 
 		entry.height = height;
 	}
 
+	return entry;
+}
+
+/**
+ * Pick the live display metadata (title, poster) out of a videos API
+ * response item.
+ *
+ * @param item - The videos API response.
+ * @return Live metadata; fields are omitted when the API has none.
+ */
+function liveMetadataFromApiResponse( item: Record< string, unknown > ): PlaylistLiveMetadata {
+	const metadata: PlaylistLiveMetadata = {};
+
+	if ( typeof item?.title === 'string' && item.title ) {
+		metadata.title = decodeEntities( item.title );
+	}
 	if ( typeof item?.poster === 'string' && item.poster ) {
-		entry.poster = item.poster;
+		metadata.poster = item.poster;
 	}
 
-	return entry;
+	return metadata;
 }
 
 /**
@@ -124,20 +142,24 @@ function entryMetaLine( entry: PlaylistEntry ): string {
  * @param props              - Component props.
  * @param props.attributes   - Block attributes.
  * @param props.currentIndex - Index of the entry shown in the player.
+ * @param props.liveMetadata - Live title/poster per GUID, from the video data.
  * @param props.onSelect     - Called with an entry index when it is clicked.
  * @return Preview element.
  */
 function PlaylistPreview( {
 	attributes,
 	currentIndex,
+	liveMetadata,
 	onSelect,
 }: {
 	attributes: PlaylistAttributes;
 	currentIndex: number;
+	liveMetadata: Record< string, PlaylistLiveMetadata >;
 	onSelect: ( index: number ) => void;
 } ) {
 	const { videos, showPositionNumber, showTotalRuntime } = attributes;
 	const current = videos[ currentIndex ];
+	const currentTitle = liveMetadata[ current.guid ]?.title || current.guid;
 	const runtime = formatRuntime( playlistRuntimeMs( videos ) );
 	const countLabel = sprintf(
 		/* translators: %d: number of videos in the playlist. */
@@ -158,16 +180,17 @@ function PlaylistPreview( {
 					<div className="videopress-playlist__player">
 						<iframe
 							className="videopress-playlist__iframe"
-							title={ current.title || __( 'Video Playlist player', 'jetpack-videopress-pkg' ) }
+							title={
+								liveMetadata[ current.guid ]?.title ||
+								__( 'Video Playlist player', 'jetpack-videopress-pkg' )
+							}
 							src={ playlistEmbedUrl( current.guid, false ) }
 							allowFullScreen
 							allow="clipboard-write"
 						/>
 					</div>
 					<div className="videopress-playlist__now">
-						<span className="videopress-playlist__now-title">
-							{ current.title || current.guid }
-						</span>
+						<span className="videopress-playlist__now-title">{ currentTitle }</span>
 						<span className="videopress-playlist__now-meta">
 							<span className="videopress-playlist__now-position">{ nowPosition }</span>
 							{ entryMetaLine( current ) && (
@@ -231,7 +254,9 @@ function PlaylistPreview( {
 										</span>
 									) }
 									<span className="videopress-playlist__entry-thumb">
-										{ entry.poster && <img src={ entry.poster } alt="" loading="lazy" /> }
+										{ liveMetadata[ entry.guid ]?.poster && (
+											<img src={ liveMetadata[ entry.guid ].poster } alt="" loading="lazy" />
+										) }
 										<span className="videopress-playlist__entry-flag">
 											{ __( 'Playing', 'jetpack-videopress-pkg' ) }
 										</span>
@@ -243,7 +268,7 @@ function PlaylistPreview( {
 									</span>
 									<span className="videopress-playlist__entry-body">
 										<span className="videopress-playlist__entry-title">
-											{ entry.title || entry.guid }
+											{ liveMetadata[ entry.guid ]?.title || entry.guid }
 										</span>
 										<span className="videopress-playlist__entry-meta">
 											{ resolutionLabel( entry.height ) && (
@@ -313,6 +338,46 @@ export default function PlaylistEdit( {
 	const [ dragIndex, setDragIndex ] = useState< number | null >( null );
 	const [ dropIndex, setDropIndex ] = useState< number | null >( null );
 
+	/*
+	 * Live display metadata (title, poster) per GUID. It is never written to
+	 * block attributes: the editor reads it fresh from the video data, the
+	 * same way the front-end view script does.
+	 */
+	const [ liveMetadata, setLiveMetadata ] = useState< Record< string, PlaylistLiveMetadata > >(
+		{}
+	);
+	// GUIDs with a lookup already started this session; failed lookups keep the fallback.
+	const metadataFetchesStarted = useRef( new Set< string >() );
+
+	const cacheLiveMetadata = ( guid: string, metadata: PlaylistLiveMetadata ) => {
+		if ( ! Object.keys( metadata ).length ) {
+			return;
+		}
+		setLiveMetadata( cache => ( { ...cache, [ guid ]: { ...cache[ guid ], ...metadata } } ) );
+	};
+
+	useEffect( () => {
+		videos.forEach( ( { guid } ) => {
+			if ( metadataFetchesStarted.current.has( guid ) ) {
+				return;
+			}
+			metadataFetchesStarted.current.add( guid );
+
+			fetchVideoItem( { guid, isPrivate: false, skipRatingControl: true } )
+				.then( item =>
+					cacheLiveMetadata(
+						guid,
+						liveMetadataFromApiResponse( item as Record< string, unknown > )
+					)
+				)
+				.catch( () => {
+					// The entry keeps its GUID fallback when the video data isn't reachable.
+				} );
+		} );
+	}, [ videos ] );
+
+	const displayTitle = ( guid: string ) => liveMetadata[ guid ]?.title || guid;
+
 	const currentIndex = Math.min( previewIndex, Math.max( 0, videos.length - 1 ) );
 	const isLongPlaylist = videos.length > LONG_PLAYLIST_THRESHOLD;
 	const isFiltering = isLongPlaylist && filter.trim() !== '';
@@ -345,6 +410,8 @@ export default function PlaylistEdit( {
 
 		try {
 			const item = await fetchVideoItem( { guid, isPrivate: false, skipRatingControl: true } );
+			metadataFetchesStarted.current.add( guid );
+			cacheLiveMetadata( guid, liveMetadataFromApiResponse( item as Record< string, unknown > ) );
 			setAttributes( {
 				videos: [ ...videos, entryFromApiResponse( guid, item as Record< string, unknown > ) ],
 			} );
@@ -406,19 +473,24 @@ export default function PlaylistEdit( {
 			}
 
 			const entry: PlaylistEntry = { guid };
-			if ( typeof item.title === 'string' && item.title ) {
-				entry.title = decodeEntities( item.title );
-			}
-			const poster = item.image?.src || item.thumb?.src;
-			if ( typeof poster === 'string' && poster ) {
-				entry.poster = poster;
-			}
 			// Attachments know the video height, so the resolution badge
 			// shows for library picks too (240p included).
 			const height = Number( item.height );
 			if ( Number.isFinite( height ) && height > 0 ) {
 				entry.height = height;
 			}
+
+			// Seed the live cache from the attachment; the metadata effect
+			// still refreshes it from the video data.
+			const seed: PlaylistLiveMetadata = {};
+			if ( typeof item.title === 'string' && item.title ) {
+				seed.title = decodeEntities( item.title );
+			}
+			const poster = item.image?.src || item.thumb?.src;
+			if ( typeof poster === 'string' && poster ) {
+				seed.poster = poster;
+			}
+			cacheLiveMetadata( guid, seed );
 
 			entries.push( entry );
 		}
@@ -533,7 +605,7 @@ export default function PlaylistEdit( {
 					{ sprintf(
 						/* translators: %s: title (or GUID) of the video. */
 						__( '“%s” is already in this playlist', 'jetpack-videopress-pkg' ),
-						videos.find( entry => entry.guid === duplicateGuid )?.title || duplicateGuid
+						displayTitle( duplicateGuid )
 					) }
 					<span className="videopress-playlist-editor__duplicate-actions">
 						<Button size="small" variant="secondary" onClick={ () => appendVideo( duplicateGuid ) }>
@@ -554,7 +626,7 @@ export default function PlaylistEdit( {
 			if ( ! isFiltering ) {
 				return true;
 			}
-			return `${ entry.title ?? '' } ${ entry.guid }`
+			return `${ liveMetadata[ entry.guid ]?.title ?? '' } ${ entry.guid }`
 				.toLowerCase()
 				.includes( filter.trim().toLowerCase() );
 		} );
@@ -658,7 +730,7 @@ export default function PlaylistEdit( {
 										label={ sprintf(
 											/* translators: %s: title (or GUID) of the video. */
 											__( 'Reorder “%s”. Press up or down to move it.', 'jetpack-videopress-pkg' ),
-											entry.title || entry.guid
+											displayTitle( entry.guid )
 										) }
 										onKeyDown={ ( event: React.KeyboardEvent ) => {
 											if ( event.key === 'ArrowUp' ) {
@@ -677,11 +749,13 @@ export default function PlaylistEdit( {
 									</span>
 								) }
 								<span className="videopress-playlist-editor__row-thumb">
-									{ entry.poster && <img src={ entry.poster } alt="" loading="lazy" /> }
+									{ liveMetadata[ entry.guid ]?.poster && (
+										<img src={ liveMetadata[ entry.guid ].poster } alt="" loading="lazy" />
+									) }
 								</span>
 								<span className="videopress-playlist-editor__row-body">
 									<span className="videopress-playlist-editor__row-title">
-										{ entry.title || entry.guid }
+										{ displayTitle( entry.guid ) }
 									</span>
 									{ entryMetaLine( entry ) && (
 										<span className="videopress-playlist-editor__row-meta">
@@ -696,7 +770,7 @@ export default function PlaylistEdit( {
 									label={ sprintf(
 										/* translators: %s: title (or GUID) of the video. */
 										__( 'Remove “%s” from the playlist', 'jetpack-videopress-pkg' ),
-										entry.title || entry.guid
+										displayTitle( entry.guid )
 									) }
 									onClick={ () => removeVideo( index ) }
 								/>
@@ -854,6 +928,7 @@ export default function PlaylistEdit( {
 			<PlaylistPreview
 				attributes={ attributes }
 				currentIndex={ currentIndex }
+				liveMetadata={ liveMetadata }
 				onSelect={ setPreviewIndex }
 			/>
 		</figure>

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -335,10 +335,20 @@ export default function PlaylistEdit( {
 
 	/*
 	 * Theme font-family presets, as used by core blocks' typography tools.
-	 * Attributes store the preset slug; the control works in CSS values.
+	 * Queried per origin — the bare `typography.fontFamilies` path returns
+	 * the raw origins object, not a list. Attributes store the preset slug;
+	 * the control works in CSS values.
 	 */
-	const [ fontFamilies = [] ] = useSettings( 'typography.fontFamilies' ) as [
-		Array< { name?: string; slug: string; fontFamily: string } > | undefined,
+	type FontFamilyPreset = { name?: string; slug: string; fontFamily: string };
+	const [ customFontFamilies, themeFontFamilies, defaultFontFamilies ] = useSettings(
+		'typography.fontFamilies.custom',
+		'typography.fontFamilies.theme',
+		'typography.fontFamilies.default'
+	) as Array< FontFamilyPreset[] | undefined >;
+	const fontFamilies: FontFamilyPreset[] = [
+		...( customFontFamilies ?? [] ),
+		...( themeFontFamilies ?? [] ),
+		...( defaultFontFamilies ?? [] ),
 	];
 	const fontFamilyValueOf = ( slug: string ) =>
 		fontFamilies.find( preset => preset.slug === slug )?.fontFamily ?? '';
@@ -929,6 +939,7 @@ export default function PlaylistEdit( {
 		<InspectorControls group="styles">
 			<PanelBody title={ __( 'Typography', 'jetpack-videopress-pkg' ) }>
 				<FontFamilyControl
+					fontFamilies={ fontFamilies }
 					label={ __( 'Now playing title', 'jetpack-videopress-pkg' ) }
 					value={ fontFamilyValueOf( nowTitleFontFamily ) }
 					onChange={ ( value: string ) =>
@@ -936,6 +947,7 @@ export default function PlaylistEdit( {
 					}
 				/>
 				<FontFamilyControl
+					fontFamilies={ fontFamilies }
 					label={ __( 'Entry titles', 'jetpack-videopress-pkg' ) }
 					value={ fontFamilyValueOf( entryTitleFontFamily ) }
 					onChange={ ( value: string ) =>

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -159,7 +159,7 @@ function PlaylistPreview( {
 	liveMetadata: Record< string, PlaylistLiveMetadata >;
 	onSelect: ( index: number ) => void;
 } ) {
-	const { videos, showPositionNumber, showTotalRuntime } = attributes;
+	const { videos, muteByDefault, showPositionNumber, showTotalRuntime } = attributes;
 	const current = videos[ currentIndex ];
 
 	/*
@@ -198,7 +198,7 @@ function PlaylistPreview( {
 								liveMetadata[ current.guid ]?.title ||
 								__( 'Video Playlist player', 'jetpack-videopress-pkg' )
 							}
-							src={ playlistEmbedUrl( current.guid, false ) }
+							src={ playlistEmbedUrl( current.guid, false, muteByDefault ) }
 							allowFullScreen
 							allow="clipboard-write"
 						/>
@@ -327,6 +327,8 @@ export default function PlaylistEdit( {
 		layout,
 		darkPlayer,
 		autoplayNext,
+		muteByDefault,
+		loopPlaylist,
 		showThumbnail,
 		showTitle,
 		showResolution,
@@ -842,6 +844,36 @@ export default function PlaylistEdit( {
 				) }
 			</PanelBody>
 
+			<PanelBody title={ __( 'Playback', 'jetpack-videopress-pkg' ) }>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Autoplay next', 'jetpack-videopress-pkg' ) }
+					help={ __(
+						'Play the next video automatically when one ends.',
+						'jetpack-videopress-pkg'
+					) }
+					checked={ autoplayNext }
+					onChange={ ( value: boolean ) => setAttributes( { autoplayNext: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Mute by default', 'jetpack-videopress-pkg' ) }
+					help={ __( 'Start playback muted.', 'jetpack-videopress-pkg' ) }
+					checked={ muteByDefault }
+					onChange={ ( value: boolean ) => setAttributes( { muteByDefault: value } ) }
+				/>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Loop playlist', 'jetpack-videopress-pkg' ) }
+					help={ __(
+						'Restart from the first video after the last one ends.',
+						'jetpack-videopress-pkg'
+					) }
+					checked={ loopPlaylist }
+					onChange={ ( value: boolean ) => setAttributes( { loopPlaylist: value } ) }
+				/>
+			</PanelBody>
+
 			<PanelBody title={ __( 'Show on each entry', 'jetpack-videopress-pkg' ) }>
 				<ToggleControl
 					__nextHasNoMarginBottom
@@ -922,16 +954,6 @@ export default function PlaylistEdit( {
 					label={ __( 'Dark player surface', 'jetpack-videopress-pkg' ) }
 					checked={ darkPlayer }
 					onChange={ ( value: boolean ) => setAttributes( { darkPlayer: value } ) }
-				/>
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ __( 'Autoplay next', 'jetpack-videopress-pkg' ) }
-					help={ __(
-						'Play the next video automatically when one ends.',
-						'jetpack-videopress-pkg'
-					) }
-					checked={ autoplayNext }
-					onChange={ ( value: boolean ) => setAttributes( { autoplayNext: value } ) }
 				/>
 			</PanelBody>
 			{ fontFamilies.length > 0 && (

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -164,8 +164,9 @@ function PlaylistPreview( {
 	const currentTitle = liveMetadata[ current.guid ]?.title || current.guid;
 
 	/*
-	 * Mirrors the front-end view script: while more entries hide below the
-	 * capped side-rail list's scroll position, the list shows a bottom fade.
+	 * Mirrors the front-end view script: while more entries hide beyond the
+	 * scroll position — below it in the capped side rail, past the trailing
+	 * edge in the horizontal strip — the list shows the matching fade.
 	 */
 	const entriesRef = useRef< HTMLOListElement | null >( null );
 	const [ hasMoreBelow, setHasMoreBelow ] = useState( false );
@@ -174,7 +175,11 @@ function PlaylistPreview( {
 		if ( ! container ) {
 			return;
 		}
-		setHasMoreBelow( container.scrollHeight - container.scrollTop - container.clientHeight > 1 );
+		const moreBelow = container.scrollHeight - container.scrollTop - container.clientHeight > 1;
+		// scrollLeft is negative in right-to-left scrollers.
+		const moreInline =
+			container.scrollWidth - Math.abs( container.scrollLeft ) - container.clientWidth > 1;
+		setHasMoreBelow( moreBelow || moreInline );
 	};
 	useEffect( updateScrollHint, [ videos, attributes.layout, liveMetadata ] );
 	const runtime = formatRuntime( playlistRuntimeMs( videos ) );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -921,25 +921,28 @@ export default function PlaylistEdit( {
 					onChange={ ( value: boolean ) => setAttributes( { showTotalRuntime: value } ) }
 				/>
 			</PanelBody>
+		</InspectorControls>
+	);
 
-			{ fontFamilies.length > 0 && (
-				<PanelBody title={ __( 'Typography', 'jetpack-videopress-pkg' ) }>
-					<FontFamilyControl
-						label={ __( 'Now playing title', 'jetpack-videopress-pkg' ) }
-						value={ fontFamilyValueOf( nowTitleFontFamily ) }
-						onChange={ ( value: string ) =>
-							setAttributes( { nowTitleFontFamily: fontFamilySlugOf( value ) } )
-						}
-					/>
-					<FontFamilyControl
-						label={ __( 'Entry titles', 'jetpack-videopress-pkg' ) }
-						value={ fontFamilyValueOf( entryTitleFontFamily ) }
-						onChange={ ( value: string ) =>
-							setAttributes( { entryTitleFontFamily: fontFamilySlugOf( value ) } )
-						}
-					/>
-				</PanelBody>
-			) }
+	// In the Styles tab, where WordPress surfaces typography for core blocks.
+	const typographyControls = fontFamilies.length > 0 && (
+		<InspectorControls group="styles">
+			<PanelBody title={ __( 'Typography', 'jetpack-videopress-pkg' ) }>
+				<FontFamilyControl
+					label={ __( 'Now playing title', 'jetpack-videopress-pkg' ) }
+					value={ fontFamilyValueOf( nowTitleFontFamily ) }
+					onChange={ ( value: string ) =>
+						setAttributes( { nowTitleFontFamily: fontFamilySlugOf( value ) } )
+					}
+				/>
+				<FontFamilyControl
+					label={ __( 'Entry titles', 'jetpack-videopress-pkg' ) }
+					value={ fontFamilyValueOf( entryTitleFontFamily ) }
+					onChange={ ( value: string ) =>
+						setAttributes( { entryTitleFontFamily: fontFamilySlugOf( value ) } )
+					}
+				/>
+			</PanelBody>
 		</InspectorControls>
 	);
 
@@ -947,6 +950,7 @@ export default function PlaylistEdit( {
 		return (
 			<div { ...blockProps }>
 				{ inspectorControls }
+				{ typographyControls }
 				<Placeholder
 					icon={ VideoPressIcon }
 					label={ __( 'Build a video playlist', 'jetpack-videopress-pkg' ) }
@@ -976,6 +980,7 @@ export default function PlaylistEdit( {
 	return (
 		<figure { ...blockProps }>
 			{ inspectorControls }
+			{ typographyControls }
 			<PlaylistPreview
 				attributes={ attributes }
 				currentIndex={ currentIndex }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -2,10 +2,12 @@
  * WordPress dependencies
  */
 import {
+	__experimentalFontFamilyControl as FontFamilyControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	InspectorControls,
 	MediaUpload,
 	MediaUploadCheck,
 	useBlockProps,
+	useSettings,
 } from '@wordpress/block-editor';
 import {
 	Button,
@@ -327,7 +329,21 @@ export default function PlaylistEdit( {
 		showDuration,
 		showPositionNumber,
 		showTotalRuntime,
+		nowTitleFontFamily,
+		entryTitleFontFamily,
 	} = attributes;
+
+	/*
+	 * Theme font-family presets, as used by core blocks' typography tools.
+	 * Attributes store the preset slug; the control works in CSS values.
+	 */
+	const [ fontFamilies = [] ] = useSettings( 'typography.fontFamilies' ) as [
+		Array< { name?: string; slug: string; fontFamily: string } > | undefined,
+	];
+	const fontFamilyValueOf = ( slug: string ) =>
+		fontFamilies.find( preset => preset.slug === slug )?.fontFamily ?? '';
+	const fontFamilySlugOf = ( value: string ) =>
+		fontFamilies.find( preset => preset.fontFamily === value )?.slug ?? '';
 
 	const [ previewIndex, setPreviewIndex ] = useState( 0 );
 	const [ urlInput, setUrlInput ] = useState( '' );
@@ -395,8 +411,23 @@ export default function PlaylistEdit( {
 		.filter( Boolean )
 		.join( ' ' );
 
+	// The chosen presets reach the stylesheet as CSS custom properties, the
+	// same way the PHP render exposes them on the front end.
+	const fontVariables: Record< string, string > = {};
+	if ( nowTitleFontFamily ) {
+		fontVariables[
+			'--vpp-now-title-font'
+		] = `var(--wp--preset--font-family--${ nowTitleFontFamily })`;
+	}
+	if ( entryTitleFontFamily ) {
+		fontVariables[
+			'--vpp-entry-title-font'
+		] = `var(--wp--preset--font-family--${ entryTitleFontFamily })`;
+	}
+
 	const blockProps = useBlockProps( {
 		className: videos.length ? wrapperClasses : 'videopress-playlist is-empty',
+		style: fontVariables,
 	} );
 
 	const clearFeedback = () => {
@@ -890,6 +921,25 @@ export default function PlaylistEdit( {
 					onChange={ ( value: boolean ) => setAttributes( { showTotalRuntime: value } ) }
 				/>
 			</PanelBody>
+
+			{ fontFamilies.length > 0 && (
+				<PanelBody title={ __( 'Typography', 'jetpack-videopress-pkg' ) }>
+					<FontFamilyControl
+						label={ __( 'Now playing title', 'jetpack-videopress-pkg' ) }
+						value={ fontFamilyValueOf( nowTitleFontFamily ) }
+						onChange={ ( value: string ) =>
+							setAttributes( { nowTitleFontFamily: fontFamilySlugOf( value ) } )
+						}
+					/>
+					<FontFamilyControl
+						label={ __( 'Entry titles', 'jetpack-videopress-pkg' ) }
+						value={ fontFamilyValueOf( entryTitleFontFamily ) }
+						onChange={ ( value: string ) =>
+							setAttributes( { entryTitleFontFamily: fontFamilySlugOf( value ) } )
+						}
+					/>
+				</PanelBody>
+			) }
 		</InspectorControls>
 	);
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -938,24 +938,26 @@ export default function PlaylistEdit( {
 			</PanelBody>
 			{ fontFamilies.length > 0 && (
 				<PanelBody title={ __( 'Typography', 'jetpack-videopress-pkg' ) }>
-					<FontFamilyControl
-						className="videopress-playlist-editor__font-control"
-						fontFamilies={ fontFamilies }
-						label={ __( 'Now playing title', 'jetpack-videopress-pkg' ) }
-						value={ fontFamilyValueOf( nowTitleFontFamily ) }
-						onChange={ ( value: string ) =>
-							setAttributes( { nowTitleFontFamily: fontFamilySlugOf( value ) } )
-						}
-					/>
-					<FontFamilyControl
-						className="videopress-playlist-editor__font-control"
-						fontFamilies={ fontFamilies }
-						label={ __( 'Entry titles', 'jetpack-videopress-pkg' ) }
-						value={ fontFamilyValueOf( entryTitleFontFamily ) }
-						onChange={ ( value: string ) =>
-							setAttributes( { entryTitleFontFamily: fontFamilySlugOf( value ) } )
-						}
-					/>
+					<div className="videopress-playlist-editor__font-control">
+						<FontFamilyControl
+							fontFamilies={ fontFamilies }
+							label={ __( 'Now playing title', 'jetpack-videopress-pkg' ) }
+							value={ fontFamilyValueOf( nowTitleFontFamily ) }
+							onChange={ ( value: string ) =>
+								setAttributes( { nowTitleFontFamily: fontFamilySlugOf( value ) } )
+							}
+						/>
+					</div>
+					<div className="videopress-playlist-editor__font-control">
+						<FontFamilyControl
+							fontFamilies={ fontFamilies }
+							label={ __( 'Entry titles', 'jetpack-videopress-pkg' ) }
+							value={ fontFamilyValueOf( entryTitleFontFamily ) }
+							onChange={ ( value: string ) =>
+								setAttributes( { entryTitleFontFamily: fontFamilySlugOf( value ) } )
+							}
+						/>
+					</div>
 				</PanelBody>
 			) }
 		</InspectorControls>

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -569,7 +569,7 @@ export default function PlaylistEdit( {
 						'jetpack-videopress-pkg'
 					) }
 				</p>
-				{ mediaLibraryButton }
+				<div className="videopress-playlist-editor__library">{ mediaLibraryButton }</div>
 				{ notices }
 			</PanelBody>
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -162,6 +162,21 @@ function PlaylistPreview( {
 	const { videos, showPositionNumber, showTotalRuntime } = attributes;
 	const current = videos[ currentIndex ];
 	const currentTitle = liveMetadata[ current.guid ]?.title || current.guid;
+
+	/*
+	 * Mirrors the front-end view script: while more entries hide below the
+	 * capped side-rail list's scroll position, the list shows a bottom fade.
+	 */
+	const entriesRef = useRef< HTMLOListElement | null >( null );
+	const [ hasMoreBelow, setHasMoreBelow ] = useState( false );
+	const updateScrollHint = () => {
+		const container = entriesRef.current;
+		if ( ! container ) {
+			return;
+		}
+		setHasMoreBelow( container.scrollHeight - container.scrollTop - container.clientHeight > 1 );
+	};
+	useEffect( updateScrollHint, [ videos, attributes.layout, liveMetadata ] );
 	const runtime = formatRuntime( playlistRuntimeMs( videos ) );
 	const countLabel = sprintf(
 		/* translators: %d: number of videos in the playlist. */
@@ -209,7 +224,11 @@ function PlaylistPreview( {
 					</div>
 				</div>
 
-				<div className="videopress-playlist__list">
+				<div
+					className={
+						hasMoreBelow ? 'videopress-playlist__list has-more-videos' : 'videopress-playlist__list'
+					}
+				>
 					<div className="videopress-playlist__list-header">
 						<span className="videopress-playlist__list-label videopress-playlist__list-label--rail">
 							{ __( 'Up next', 'jetpack-videopress-pkg' ) }
@@ -237,7 +256,11 @@ function PlaylistPreview( {
 							) }
 						</span>
 					</div>
-					<ol className="videopress-playlist__entries">
+					<ol
+						className="videopress-playlist__entries"
+						ref={ entriesRef }
+						onScroll={ updateScrollHint }
+					>
 						{ videos.map( ( entry, index ) => (
 							<li className="videopress-playlist__entry" key={ `${ entry.guid }-${ index }` }>
 								<button

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -673,6 +673,17 @@ export default function PlaylistEdit( {
 				.includes( filter.trim().toLowerCase() );
 		} );
 
+	// Kept as separate statements: a shared ternary of __() calls would let
+	// the minifier merge them, breaking translation extraction.
+	const autoplayHelp = __(
+		'Play the next video automatically when one ends.',
+		'jetpack-videopress-pkg'
+	);
+	const autoplayImpliedHelp = __(
+		'Looping the playlist keeps autoplay on.',
+		'jetpack-videopress-pkg'
+	);
+
 	const inspectorControls = (
 		<InspectorControls>
 			<PanelBody title={ __( 'Add a video', 'jetpack-videopress-pkg' ) }>
@@ -848,11 +859,9 @@ export default function PlaylistEdit( {
 				<ToggleControl
 					__nextHasNoMarginBottom
 					label={ __( 'Autoplay next', 'jetpack-videopress-pkg' ) }
-					help={ __(
-						'Play the next video automatically when one ends.',
-						'jetpack-videopress-pkg'
-					) }
-					checked={ autoplayNext }
+					help={ loopPlaylist ? autoplayImpliedHelp : autoplayHelp }
+					checked={ autoplayNext || loopPlaylist }
+					disabled={ loopPlaylist }
 					onChange={ ( value: boolean ) => setAttributes( { autoplayNext: value } ) }
 				/>
 				<ToggleControl

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -153,13 +153,6 @@ function PlaylistPreview( {
 
 	return (
 		<>
-			<header className="videopress-playlist__header">
-				<span className="videopress-playlist__count">{ countLabel }</span>
-				{ showTotalRuntime && runtime && (
-					<span className="videopress-playlist__runtime">{ runtime }</span>
-				) }
-			</header>
-
 			<div className="videopress-playlist__body">
 				<div className="videopress-playlist__stage">
 					<div className="videopress-playlist__player">
@@ -201,6 +194,12 @@ function PlaylistPreview( {
 								/* translators: %d: number of videos in the playlist. */
 								__( 'Playlist — %d videos', 'jetpack-videopress-pkg' ),
 								videos.length
+							) }
+						</span>
+						<span className="videopress-playlist__list-meta">
+							<span className="videopress-playlist__count">{ countLabel }</span>
+							{ showTotalRuntime && runtime && (
+								<span className="videopress-playlist__runtime">{ runtime }</span>
 							) }
 						</span>
 						<span className="videopress-playlist__list-progress">

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -174,7 +174,9 @@
 
 	&__layout-sketch {
 		display: block;
-		block-size: 22px;
+
+		/* Fixed desktop proportions (66.664 × 39 px) at every screen size. */
+		aspect-ratio: 66.664 / 39;
 		position: relative;
 
 		i {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -36,6 +36,12 @@
 		margin-block-start: 12px;
 	}
 
+	/* The font controls bring no outer margin of their own; give stacked
+	   ones the standard control separation. */
+	&__font-control + &__font-control {
+		margin-block-start: 16px;
+	}
+
 	/* Notices render flush against the controls above them without this. */
 	&__notice.components-notice {
 		margin: 12px 0 0;

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -252,6 +252,15 @@
 		flex-direction: column;
 		gap: 10px;
 		max-inline-size: 400px;
+
+		/* Center the form column within the placeholder, per the design. */
+		margin-inline: auto;
+
+		/* The library button keeps its natural width, centered — the
+		   stretch default made it span the whole column. */
+		> .components-button {
+			align-self: center;
+		}
 	}
 
 	&__placeholder-divider {
@@ -281,6 +290,17 @@
 /* The canvas hint is editor chrome: only show it on the selected block. */
 .videopress-playlist:not(.is-selected) .videopress-playlist-editor__canvas-hint {
 	display: none;
+}
+
+/* Empty state: the design centers the icon, title, instructions and form. */
+.videopress-playlist.is-empty .components-placeholder {
+	align-items: center;
+	text-align: center;
+
+	.components-placeholder__label,
+	.components-placeholder__fieldset {
+		justify-content: center;
+	}
 }
 
 @keyframes videopress-playlist-editor-shimmer {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -1,0 +1,284 @@
+/**
+ * Video Playlist block — editor styles.
+ *
+ * The canvas preview reuses the front-end stylesheet (view.scss, loaded as
+ * an additional editorStyle); these rules cover the editor-only chrome: the
+ * sidebar playlist manager, the layout picker, the placeholder form, and
+ * the canvas hint.
+ */
+
+.videopress-playlist-editor {
+
+	&__add-row {
+		display: flex;
+		gap: 6px;
+		align-items: flex-start;
+
+		> :first-child {
+			flex: 1 1 auto;
+		}
+	}
+
+	&__help {
+		margin: 8px 0 0;
+		font-size: 0.75rem;
+		color: rgba(30, 30, 30, 0.62);
+	}
+
+	&__duplicate-actions {
+		display: flex;
+		gap: 8px;
+		margin-block-start: 8px;
+	}
+
+	&__list-summary {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 10px;
+		margin-block-end: 10px;
+		font-size: 0.75rem;
+	}
+
+	&__list-runtime {
+		color: rgba(30, 30, 30, 0.62);
+		font-variant-numeric: tabular-nums;
+	}
+
+	&__rows {
+		list-style: none;
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		margin: 10px 0 0;
+		padding: 0;
+	}
+
+	&__row {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 6px;
+		border: 1px solid #e0e0e0;
+		border-radius: 3px;
+		background: #fff;
+
+		&.is-dragging {
+			opacity: 0.45;
+		}
+
+		&.is-drop-target {
+			border-color: var(--wp-admin-theme-color, #2a78d6);
+			box-shadow: 0 -2px 0 0 var(--wp-admin-theme-color, #2a78d6);
+		}
+
+		&.is-loading &-thumb {
+			animation: videopress-playlist-editor-shimmer 1.2s ease-in-out infinite;
+		}
+	}
+
+	&__row-handle.components-button {
+		padding: 0;
+		min-inline-size: 20px;
+		inline-size: 20px;
+		block-size: 32px;
+		color: #949494;
+		cursor: grab;
+	}
+
+	&__row-number {
+		font-size: 0.65625rem;
+		font-family: monospace;
+		color: #949494;
+	}
+
+	&__row-thumb {
+		flex: none;
+		inline-size: 54px;
+		aspect-ratio: 16 / 9;
+		border-radius: 3px;
+		overflow: hidden;
+		background: #e6e4df;
+
+		img {
+			inline-size: 100%;
+			block-size: 100%;
+			object-fit: cover;
+		}
+	}
+
+	&__row-body {
+		flex: 1 1 auto;
+		min-inline-size: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	&__row-title {
+		font-size: 0.75rem;
+		font-weight: 500;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	&__row-meta {
+		font-size: 0.65625rem;
+		color: #757575;
+		font-variant-numeric: tabular-nums;
+	}
+
+	&__row-remove.components-button {
+		color: #757575;
+	}
+
+	&__layouts {
+		display: flex;
+		gap: 6px;
+		margin-block-end: 14px;
+	}
+
+	&__layout {
+		flex: 1 1 0;
+		display: flex;
+		flex-direction: column;
+		gap: 5px;
+		align-items: stretch;
+		padding: 7px 5px 6px;
+		border: 1px solid #e0e0e0;
+		border-radius: 2px;
+		background: #fff;
+		font-size: 0.65625rem;
+		text-align: center;
+		cursor: pointer;
+
+		&.is-selected {
+			border-color: #1e1e1e;
+			background: #f7f7f7;
+			font-weight: 500;
+		}
+	}
+
+	/* Tiny wireframe sketches for the three layouts. */
+
+	&__layout-sketch {
+		display: block;
+		block-size: 22px;
+		position: relative;
+
+		i {
+			position: absolute;
+			border-radius: 1px;
+			background: #e2e2e2;
+		}
+
+		&.is-side-rail i {
+
+			&:nth-child(1) {
+				inset: 0 35% 0 0;
+				background: #c4c4c4;
+			}
+
+			&:nth-child(2) {
+				inset: 0 0 66% 68%;
+			}
+
+			&:nth-child(3) {
+				inset: 38% 0 33% 68%;
+			}
+
+			&:nth-child(4) {
+				inset: 76% 0 0 68%;
+			}
+		}
+
+		&.is-grid i {
+
+			&:nth-child(1) {
+				inset: 0 0 40% 0;
+				background: #c4c4c4;
+			}
+
+			&:nth-child(2) {
+				inset: 68% 68% 0 0;
+			}
+
+			&:nth-child(3) {
+				inset: 68% 34% 0 34%;
+			}
+
+			&:nth-child(4) {
+				inset: 68% 0 0 68%;
+			}
+		}
+
+		&.is-strip i {
+
+			&:nth-child(1) {
+				inset: 0 0 30% 0;
+				background: #c4c4c4;
+			}
+
+			&:nth-child(2) {
+				inset: 78% 60% 0 0;
+			}
+
+			&:nth-child(3) {
+				inset: 78% 22% 0 44%;
+			}
+
+			&:nth-child(4) {
+				inset: 78% 0 0 82%;
+			}
+		}
+	}
+
+	&__placeholder {
+		inline-size: 100%;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+		max-inline-size: 400px;
+	}
+
+	&__placeholder-divider {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		color: #949494;
+		font-size: 0.71875rem;
+
+		&::before,
+		&::after {
+			content: "";
+			flex: 1 1 auto;
+			block-size: 1px;
+			background: #e0e0e0;
+		}
+	}
+
+	&__canvas-hint {
+		margin: 10px 0 0;
+		font-size: 0.71875rem;
+		color: #757575;
+		text-align: center;
+	}
+}
+
+/* The canvas hint is editor chrome: only show it on the selected block. */
+.videopress-playlist:not(.is-selected) .videopress-playlist-editor__canvas-hint {
+	display: none;
+}
+
+@keyframes videopress-playlist-editor-shimmer {
+
+	0%,
+	100% {
+		opacity: 0.5;
+	}
+
+	50% {
+		opacity: 1;
+	}
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -3,8 +3,7 @@
  *
  * The canvas preview reuses the front-end stylesheet (view.scss, loaded as
  * an additional editorStyle); these rules cover the editor-only chrome: the
- * sidebar playlist manager, the layout picker, the placeholder form, and
- * the canvas hint.
+ * sidebar playlist manager, the layout picker, and the placeholder form.
  */
 
 .videopress-playlist-editor {
@@ -284,18 +283,6 @@
 			background: #e0e0e0;
 		}
 	}
-
-	&__canvas-hint {
-		margin: 10px 0 0;
-		font-size: 0.71875rem;
-		color: #757575;
-		text-align: center;
-	}
-}
-
-/* The canvas hint is editor chrome: only show it on the selected block. */
-.videopress-playlist:not(.is-selected) .videopress-playlist-editor__canvas-hint {
-	display: none;
 }
 
 /* Empty state: the design centers the icon, title, instructions and form. */

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -31,6 +31,11 @@
 		margin-block-start: 8px;
 	}
 
+	/* Separates the library action from the URL form's help text above it. */
+	&__library {
+		margin-block-start: 12px;
+	}
+
 	/* Notices render flush against the controls above them without this. */
 	&__notice.components-notice {
 		margin: 12px 0 0;

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/editor.scss
@@ -31,6 +31,11 @@
 		margin-block-start: 8px;
 	}
 
+	/* Notices render flush against the controls above them without this. */
+	&__notice.components-notice {
+		margin: 12px 0 0;
+	}
+
 	&__list-summary {
 		display: flex;
 		align-items: baseline;

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/index.ts
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+/**
+ * Internal dependencies
+ */
+// Overrides Webpack's publicPath before any lazy chunk loads on wpcom.
+import '../../set-webpack-public-path';
+import { VideoPressIcon as icon } from '../video/components/icons';
+import metadata from './block.json';
+import Edit from './edit';
+/**
+ * Types
+ */
+import type { PlaylistAttributes } from './types';
+
+export const { name, title, description, attributes, category } = metadata;
+
+registerBlockType< PlaylistAttributes >( name, {
+	edit: Edit,
+	category,
+	title,
+	icon,
+	// Dynamic block: the markup is produced by the render callback in
+	// Initializer::render_videopress_playlist_block().
+	save: () => null,
+	attributes,
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -71,7 +71,6 @@ const DEFAULT_ATTRIBUTES: PlaylistAttributes = {
 	showDuration: true,
 	showPositionNumber: false,
 	showTotalRuntime: true,
-	nowTitleFontFamily: '',
 	entryTitleFontFamily: '',
 };
 
@@ -555,38 +554,25 @@ describe( 'PlaylistEdit', () => {
 		renderEdit( { videos: [ { guid: 'aaaaaaaa' } ] }, setAttributes );
 
 		await userEvent.selectOptions(
-			screen.getByRole( 'combobox', { name: 'Now playing title' } ),
-			'"Serif Pro", serif'
-		);
-		expect( setAttributes ).toHaveBeenCalledWith( { nowTitleFontFamily: 'serif-pro' } );
-
-		await userEvent.selectOptions(
 			screen.getByRole( 'combobox', { name: 'Entry titles' } ),
 			'Grotesk, sans-serif'
 		);
 		expect( setAttributes ).toHaveBeenCalledWith( { entryTitleFontFamily: 'grotesk' } );
 
 		// Picking Default resets back to inheriting.
-		await userEvent.selectOptions(
-			screen.getByRole( 'combobox', { name: 'Now playing title' } ),
-			''
-		);
-		expect( setAttributes ).toHaveBeenCalledWith( { nowTitleFontFamily: '' } );
+		await userEvent.selectOptions( screen.getByRole( 'combobox', { name: 'Entry titles' } ), '' );
+		expect( setAttributes ).toHaveBeenCalledWith( { entryTitleFontFamily: '' } );
 	} );
 
 	it( 'exposes the chosen fonts as CSS custom properties on the wrapper', async () => {
 		renderEdit( {
 			videos: [ { guid: 'aaaaaaaa' } ],
-			nowTitleFontFamily: 'serif-pro',
 			entryTitleFontFamily: 'grotesk',
 		} );
 		// Let the live metadata lookup settle.
 		await expect( screen.findAllByText( 'First' ) ).resolves.toBeTruthy();
 
 		const figure = screen.getByRole( 'figure' );
-		expect( figure.style.getPropertyValue( '--vpp-now-title-font' ) ).toBe(
-			'var(--wp--preset--font-family--serif-pro)'
-		);
 		expect( figure.style.getPropertyValue( '--vpp-entry-title-font' ) ).toBe(
 			'var(--wp--preset--font-family--grotesk)'
 		);

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -8,6 +8,12 @@ import type { BlockEditProps } from '@wordpress/blocks';
 // What the mocked media library modal "selects" when the button is clicked.
 let mockMediaSelection: unknown = [];
 
+// The publish-tracking hook has its own isolated test suite.
+jest.mock( '../use-publish-tracking', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: ( props: Record< string, unknown > = {} ) => props,
 	InspectorControls: ( { children }: { children: React.ReactNode } ) => (
@@ -89,6 +95,7 @@ function renderEdit(
 	const props = {
 		attributes: { ...DEFAULT_ATTRIBUTES, ...overrides },
 		setAttributes,
+		clientId: 'playlist-client-1',
 	} as unknown as BlockEditProps< PlaylistAttributes >;
 
 	render( <PlaylistEdit { ...props } /> );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -311,12 +311,13 @@ describe( 'PlaylistEdit', () => {
 		expect( fetchVideoItemMock ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'adds media library selections, reading guid, title and poster', async () => {
+	it( 'adds media library selections, reading guid, title, poster and height', async () => {
 		mockMediaSelection = [
 			{
 				videopress_guid: [ 'aaaaaaaa' ],
 				title: 'From array',
 				image: { src: 'https://example.com/image.jpg' },
+				height: 240,
 			},
 			{
 				videopress_guid: 'bbbbbbbb',
@@ -331,10 +332,33 @@ describe( 'PlaylistEdit', () => {
 
 		expect( setAttributes ).toHaveBeenCalledWith( {
 			videos: [
-				{ guid: 'aaaaaaaa', title: 'From array', poster: 'https://example.com/image.jpg' },
+				{
+					guid: 'aaaaaaaa',
+					title: 'From array',
+					poster: 'https://example.com/image.jpg',
+					height: 240,
+				},
 				{ guid: 'bbbbbbbb', poster: 'https://example.com/thumb.jpg' },
 			],
 		} );
+	} );
+
+	it( 'coerces numeric metadata the API returns as strings', async () => {
+		fetchVideoItemMock.mockResolvedValue( {
+			title: 'Low-res upload',
+			duration: '724000',
+			height: '240',
+		} );
+		const setAttributes = jest.fn();
+		renderEdit( {}, setAttributes );
+
+		await submitUrl( 'abcDEF12' );
+
+		await waitFor( () =>
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				videos: [ { guid: 'abcDEF12', title: 'Low-res upload', durationMs: 724000, height: 240 } ],
+			} )
+		);
 	} );
 
 	it( 'accepts a single media library selection object', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -21,12 +21,18 @@ jest.mock( '@wordpress/block-editor', () => ( {
 		render: ( args: { open: () => void } ) => React.ReactNode;
 	} ) => renderProp( { open: () => onSelect( mockMediaSelection ) } ),
 	MediaUploadCheck: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
-	useSettings: () => [
-		[
-			{ name: 'Serif Pro', slug: 'serif-pro', fontFamily: '"Serif Pro", serif' },
-			{ name: 'Grotesk', slug: 'grotesk', fontFamily: 'Grotesk, sans-serif' },
-		],
-	],
+	// Mirrors core: font families resolve per origin path; the bare
+	// `typography.fontFamilies` path yields the raw origins object.
+	useSettings: ( ...paths: string[] ) =>
+		paths.map( path => {
+			if ( path === 'typography.fontFamilies.theme' ) {
+				return [
+					{ name: 'Serif Pro', slug: 'serif-pro', fontFamily: '"Serif Pro", serif' },
+					{ name: 'Grotesk', slug: 'grotesk', fontFamily: 'Grotesk, sans-serif' },
+				];
+			}
+			return undefined;
+		} ),
 	__experimentalFontFamilyControl: ( {
 		label,
 		value,

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -257,14 +257,25 @@ describe( 'PlaylistEdit', () => {
 		await expect( screen.findAllByText( 'Video 8' ) ).resolves.toBeTruthy();
 	} );
 
-	it( 'shows an error when Add is pressed with an empty input', async () => {
+	it( 'only enables Add once something has been typed into the URL field', async () => {
 		const setAttributes = jest.fn();
 		renderEdit( {}, setAttributes );
 
-		await userEvent.click( screen.getAllByRole( 'button', { name: 'Add' } )[ 0 ] );
+		const addButton = screen.getAllByRole( 'button', { name: 'Add' } )[ 0 ];
+		expect( addButton ).toHaveAttribute( 'aria-disabled', 'true' );
 
-		expect( screen.getAllByText( /No video found at that link/ ).length ).toBeGreaterThan( 0 );
+		// Clicking while empty does nothing.
+		await userEvent.click( addButton );
+		expect( fetchVideoItemMock ).not.toHaveBeenCalled();
 		expect( setAttributes ).not.toHaveBeenCalled();
+
+		// Typing a URL enables the button, and clicking it adds the video.
+		await userEvent.type( screen.getAllByPlaceholderText( 'Paste a video URL' )[ 0 ], 'abcDEF12' );
+		await userEvent.click( addButton );
+
+		await waitFor( () =>
+			expect( setAttributes ).toHaveBeenCalledWith( { videos: [ { guid: 'abcDEF12' } ] } )
+		);
 	} );
 
 	it( 'submits the URL with the Enter key', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -65,6 +65,8 @@ const DEFAULT_ATTRIBUTES: PlaylistAttributes = {
 	layout: 'side-rail',
 	darkPlayer: false,
 	autoplayNext: false,
+	muteByDefault: false,
+	loopPlaylist: false,
 	showThumbnail: true,
 	showTitle: true,
 	showResolution: true,
@@ -423,6 +425,12 @@ describe( 'PlaylistEdit', () => {
 
 		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Autoplay next' } ) );
 		expect( setAttributes ).toHaveBeenCalledWith( { autoplayNext: true } );
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Mute by default' } ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { muteByDefault: true } );
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Loop playlist' } ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { loopPlaylist: true } );
 	} );
 
 	it( 'changes the per-entry display options from the sidebar', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -1,9 +1,12 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { fetchVideoItem } from '../../../../lib/fetch-video-item';
 import PlaylistEdit from '../edit';
 import type { PlaylistAttributes } from '../types';
 import type { BlockEditProps } from '@wordpress/blocks';
+
+// What the mocked media library modal "selects" when the button is clicked.
+let mockMediaSelection: unknown = [];
 
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: ( props: Record< string, unknown > = {} ) => props,
@@ -11,10 +14,12 @@ jest.mock( '@wordpress/block-editor', () => ( {
 		<div data-testid="inspector-controls">{ children }</div>
 	),
 	MediaUpload: ( {
+		onSelect,
 		render: renderProp,
 	}: {
+		onSelect: ( selection: unknown ) => void;
 		render: ( args: { open: () => void } ) => React.ReactNode;
-	} ) => renderProp( { open: () => {} } ),
+	} ) => renderProp( { open: () => onSelect( mockMediaSelection ) } ),
 	MediaUploadCheck: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
 } ) );
 
@@ -67,6 +72,7 @@ async function submitUrl( value: string ) {
 
 beforeEach( () => {
 	jest.clearAllMocks();
+	mockMediaSelection = [];
 } );
 
 describe( 'PlaylistEdit', () => {
@@ -253,5 +259,269 @@ describe( 'PlaylistEdit', () => {
 		} ) );
 		renderEdit( { videos: longList } );
 		expect( screen.getByPlaceholderText( 'Filter 9 videos' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows an error when Add is pressed with an empty input', async () => {
+		const setAttributes = jest.fn();
+		renderEdit( {}, setAttributes );
+
+		await userEvent.click( screen.getAllByRole( 'button', { name: 'Add' } )[ 0 ] );
+
+		expect( screen.getAllByText( /No video found at that link/ ).length ).toBeGreaterThan( 0 );
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'submits the URL with the Enter key', async () => {
+		fetchVideoItemMock.mockResolvedValue( { title: 'Via Enter' } );
+		const setAttributes = jest.fn();
+		renderEdit( {}, setAttributes );
+
+		await userEvent.type(
+			screen.getAllByPlaceholderText( 'Paste a video URL' )[ 0 ],
+			'abcDEF12{enter}'
+		);
+
+		await waitFor( () =>
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				videos: [ { guid: 'abcDEF12', title: 'Via Enter' } ],
+			} )
+		);
+	} );
+
+	it( 'shows the busy state and ignores re-submits while a video is being added', async () => {
+		let resolveFetch: ( value: unknown ) => void = () => {};
+		fetchVideoItemMock.mockReturnValue(
+			new Promise( resolve => {
+				resolveFetch = resolve;
+			} )
+		);
+		const setAttributes = jest.fn();
+		renderEdit( {}, setAttributes );
+
+		await submitUrl( 'abcDEF12' );
+
+		expect( screen.getAllByRole( 'button', { name: 'Adding…' } ).length ).toBeGreaterThan( 0 );
+		expect( screen.getAllByText( 'Reading metadata…' ).length ).toBeGreaterThan( 0 );
+
+		// A second press while busy must not start another add.
+		await userEvent.click( screen.getAllByRole( 'button', { name: 'Adding…' } )[ 0 ] );
+
+		resolveFetch( { title: 'Once' } );
+		await waitFor( () => expect( setAttributes ).toHaveBeenCalledTimes( 1 ) );
+		expect( fetchVideoItemMock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'adds media library selections, reading guid, title and poster', async () => {
+		mockMediaSelection = [
+			{
+				videopress_guid: [ 'aaaaaaaa' ],
+				title: 'From array',
+				image: { src: 'https://example.com/image.jpg' },
+			},
+			{
+				videopress_guid: 'bbbbbbbb',
+				thumb: { src: 'https://example.com/thumb.jpg' },
+			},
+			{ title: 'Not a VideoPress video' },
+		];
+		const setAttributes = jest.fn();
+		renderEdit( {}, setAttributes );
+
+		await userEvent.click( screen.getAllByRole( 'button', { name: 'Media Library' } )[ 0 ] );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			videos: [
+				{ guid: 'aaaaaaaa', title: 'From array', poster: 'https://example.com/image.jpg' },
+				{ guid: 'bbbbbbbb', poster: 'https://example.com/thumb.jpg' },
+			],
+		} );
+	} );
+
+	it( 'accepts a single media library selection object', async () => {
+		mockMediaSelection = { videopress_guid: [ 'cccccccc' ], title: 'Single' };
+		const setAttributes = jest.fn();
+		renderEdit( {}, setAttributes );
+
+		await userEvent.click( screen.getAllByRole( 'button', { name: 'Media Library' } )[ 0 ] );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			videos: [ { guid: 'cccccccc', title: 'Single' } ],
+		} );
+	} );
+
+	it( 'shows an error when no media library selection is a VideoPress video', async () => {
+		mockMediaSelection = [ { title: 'Plain video' } ];
+		const setAttributes = jest.fn();
+		renderEdit( {}, setAttributes );
+
+		await userEvent.click( screen.getAllByRole( 'button', { name: 'Media Library' } )[ 0 ] );
+
+		expect(
+			screen.getAllByText( /None of the selected items are VideoPress videos/ ).length
+		).toBeGreaterThan( 0 );
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'changes the layout and playback options from the sidebar', async () => {
+		const setAttributes = jest.fn();
+		renderEdit( { videos: [ { guid: 'aaaaaaaa', title: 'First' } ] }, setAttributes );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Grid' } ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { layout: 'grid' } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Strip' } ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { layout: 'strip' } );
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Dark player surface' } ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { darkPlayer: true } );
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Autoplay next' } ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { autoplayNext: true } );
+	} );
+
+	it( 'changes the per-entry display options from the sidebar', async () => {
+		const setAttributes = jest.fn();
+		renderEdit( { videos: [ { guid: 'aaaaaaaa', title: 'First' } ] }, setAttributes );
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Thumbnail' } ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { showThumbnail: false } );
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Title' } ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { showTitle: false } );
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Resolution' } ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { showResolution: false } );
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Duration' } ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { showDuration: false } );
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Position number' } ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { showPositionNumber: true } );
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Total runtime in header' } ) );
+		expect( setAttributes ).toHaveBeenCalledWith( { showTotalRuntime: false } );
+	} );
+
+	it( 'reorders entries with drag and drop', async () => {
+		const videos = [
+			{ guid: 'aaaaaaaa', title: 'First' },
+			{ guid: 'bbbbbbbb', title: 'Second' },
+			{ guid: 'cccccccc', title: 'Third' },
+		];
+		const setAttributes = jest.fn();
+		renderEdit( { videos }, setAttributes );
+
+		const list = screen.getByRole( 'list', { name: 'Playlist videos' } );
+		const dataTransfer = { effectAllowed: '', dropEffect: '', setData: jest.fn() };
+		const rows = () => within( list ).getAllByRole( 'listitem' );
+
+		fireEvent.dragStart( rows()[ 0 ], { dataTransfer } );
+		expect( rows()[ 0 ] ).toHaveClass( 'is-dragging' );
+
+		fireEvent.dragOver( rows()[ 2 ], { dataTransfer } );
+		expect( rows()[ 2 ] ).toHaveClass( 'is-drop-target' );
+
+		// Leaving a row clears its drop indicator.
+		fireEvent.dragLeave( rows()[ 2 ] );
+		expect( rows()[ 2 ] ).not.toHaveClass( 'is-drop-target' );
+
+		fireEvent.dragOver( rows()[ 2 ], { dataTransfer } );
+		fireEvent.drop( rows()[ 2 ], { dataTransfer } );
+		fireEvent.dragEnd( rows()[ 0 ], { dataTransfer } );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			videos: [ videos[ 1 ], videos[ 2 ], videos[ 0 ] ],
+		} );
+		expect( rows()[ 0 ] ).not.toHaveClass( 'is-dragging' );
+	} );
+
+	it( 'narrows the sidebar rows while filtering and disables reordering', async () => {
+		const videos = Array.from( { length: 9 }, ( _, i ) => ( {
+			guid: `aaaaaaa${ i }`,
+			title: `Video ${ i }`,
+		} ) );
+		renderEdit( { videos } );
+
+		const list = screen.getByRole( 'list', { name: 'Playlist videos' } );
+		expect( within( list ).getAllByRole( 'listitem' ) ).toHaveLength( 9 );
+
+		await userEvent.type( screen.getByPlaceholderText( 'Filter 9 videos' ), 'Video 3' );
+
+		expect( within( list ).getAllByRole( 'listitem' ) ).toHaveLength( 1 );
+		expect( within( list ).getByText( 'Video 3' ) ).toBeInTheDocument();
+		// Reorder handles disappear while the visible order is filtered.
+		expect( within( list ).queryByRole( 'button', { name: /Reorder/ } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps the preview on the same entry when one is moved from above it', async () => {
+		const videos = [
+			{ guid: 'aaaaaaaa', title: 'First' },
+			{ guid: 'bbbbbbbb', title: 'Second' },
+			{ guid: 'cccccccc', title: 'Third' },
+		];
+		const setAttributes = jest.fn();
+		renderEdit( { videos }, setAttributes );
+
+		// Preview the second entry from the canvas list.
+		await userEvent.click( screen.getByRole( 'button', { name: /Playing.*Second/ } ) );
+		expect( screen.getByTitle( 'Second' ) ).toBeInTheDocument();
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Reorder “First”. Press up or down to move it.' } )
+		);
+		await userEvent.keyboard( '{ArrowDown}' );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			videos: [ videos[ 1 ], videos[ 0 ], videos[ 2 ] ],
+		} );
+	} );
+
+	it( 'keeps the preview on the same entry when one is moved from below it', async () => {
+		const videos = [
+			{ guid: 'aaaaaaaa', title: 'First' },
+			{ guid: 'bbbbbbbb', title: 'Second' },
+		];
+		const setAttributes = jest.fn();
+		renderEdit( { videos }, setAttributes );
+
+		// The default preview is the first entry; move the second above it.
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Reorder “Second”. Press up or down to move it.' } )
+		);
+		await userEvent.keyboard( '{ArrowUp}' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ videos[ 1 ], videos[ 0 ] ] } );
+	} );
+
+	it( 'keeps the preview on the same entry when one is removed above it', async () => {
+		const videos = [
+			{ guid: 'aaaaaaaa', title: 'First' },
+			{ guid: 'bbbbbbbb', title: 'Second' },
+			{ guid: 'cccccccc', title: 'Third' },
+		];
+		const setAttributes = jest.fn();
+		renderEdit( { videos }, setAttributes );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Playing.*Second/ } ) );
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Remove “First” from the playlist' } )
+		);
+
+		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ videos[ 1 ], videos[ 2 ] ] } );
+	} );
+
+	it( 'ignores out-of-range keyboard reorders', async () => {
+		const videos = [
+			{ guid: 'aaaaaaaa', title: 'First' },
+			{ guid: 'bbbbbbbb', title: 'Second' },
+		];
+		const setAttributes = jest.fn();
+		renderEdit( { videos }, setAttributes );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Reorder “First”. Press up or down to move it.' } )
+		);
+		await userEvent.keyboard( '{ArrowUp}' );
+
+		expect( setAttributes ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -1,0 +1,257 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { fetchVideoItem } from '../../../../lib/fetch-video-item';
+import PlaylistEdit from '../edit';
+import type { PlaylistAttributes } from '../types';
+import type { BlockEditProps } from '@wordpress/blocks';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: ( props: Record< string, unknown > = {} ) => props,
+	InspectorControls: ( { children }: { children: React.ReactNode } ) => (
+		<div data-testid="inspector-controls">{ children }</div>
+	),
+	MediaUpload: ( {
+		render: renderProp,
+	}: {
+		render: ( args: { open: () => void } ) => React.ReactNode;
+	} ) => renderProp( { open: () => {} } ),
+	MediaUploadCheck: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
+} ) );
+
+jest.mock( '../../../../lib/fetch-video-item', () => ( {
+	fetchVideoItem: jest.fn(),
+} ) );
+
+const fetchVideoItemMock = fetchVideoItem as unknown as jest.Mock;
+
+const DEFAULT_ATTRIBUTES: PlaylistAttributes = {
+	videos: [],
+	layout: 'side-rail',
+	darkPlayer: false,
+	autoplayNext: false,
+	showThumbnail: true,
+	showTitle: true,
+	showResolution: true,
+	showDuration: true,
+	showPositionNumber: false,
+	showTotalRuntime: true,
+};
+
+/**
+ * Render the edit component with merged attributes.
+ *
+ * @param overrides     - Attribute overrides.
+ * @param setAttributes - setAttributes mock.
+ */
+function renderEdit(
+	overrides: Partial< PlaylistAttributes > = {},
+	setAttributes: jest.Mock = jest.fn()
+) {
+	const props = {
+		attributes: { ...DEFAULT_ATTRIBUTES, ...overrides },
+		setAttributes,
+	} as unknown as BlockEditProps< PlaylistAttributes >;
+
+	render( <PlaylistEdit { ...props } /> );
+}
+
+/**
+ * Type into the URL field and press the Add button.
+ *
+ * @param value - Value to type.
+ */
+async function submitUrl( value: string ) {
+	await userEvent.type( screen.getAllByPlaceholderText( 'Paste a video URL' )[ 0 ], value );
+	await userEvent.click( screen.getAllByRole( 'button', { name: 'Add' } )[ 0 ] );
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'PlaylistEdit', () => {
+	it( 'shows the build-a-playlist placeholder when the playlist is empty', () => {
+		renderEdit();
+
+		expect( screen.getByText( 'Build a video playlist' ) ).toBeInTheDocument();
+		// One in the placeholder, one in the settings sidebar.
+		expect( screen.getAllByRole( 'button', { name: 'Media Library' } ) ).toHaveLength( 2 );
+		expect( screen.queryByTitle( 'Video Playlist player' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'adds a video by GUID with metadata read from the video data', async () => {
+		fetchVideoItemMock.mockResolvedValue( {
+			title: 'Kiln loading, start to finish',
+			duration: 724000,
+			height: 1080,
+			poster: 'https://example.com/poster.jpg',
+		} );
+		const setAttributes = jest.fn();
+		renderEdit( {}, setAttributes );
+
+		await submitUrl( 'abcDEF12' );
+
+		await waitFor( () =>
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				videos: [
+					{
+						guid: 'abcDEF12',
+						title: 'Kiln loading, start to finish',
+						durationMs: 724000,
+						height: 1080,
+						poster: 'https://example.com/poster.jpg',
+					},
+				],
+			} )
+		);
+	} );
+
+	it( 'accepts a VideoPress URL', async () => {
+		fetchVideoItemMock.mockResolvedValue( { title: 'By URL' } );
+		const setAttributes = jest.fn();
+		renderEdit( {}, setAttributes );
+
+		await submitUrl( 'https://videopress.com/v/abcDEF12' );
+
+		await waitFor( () =>
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				videos: [ { guid: 'abcDEF12', title: 'By URL' } ],
+			} )
+		);
+		expect( fetchVideoItemMock ).toHaveBeenCalledWith(
+			expect.objectContaining( { guid: 'abcDEF12' } )
+		);
+	} );
+
+	it( 'shows an error and adds nothing when the input is not a VideoPress link', async () => {
+		const setAttributes = jest.fn();
+		renderEdit( {}, setAttributes );
+
+		await submitUrl( 'https://example.com/watch?v=nope' );
+
+		expect( screen.getAllByText( /No video found at that link/ ).length ).toBeGreaterThan( 0 );
+		expect( fetchVideoItemMock ).not.toHaveBeenCalled();
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows an error and adds nothing when the video data cannot be read', async () => {
+		fetchVideoItemMock.mockRejectedValue( new Error( 'not found' ) );
+		const setAttributes = jest.fn();
+		renderEdit( {}, setAttributes );
+
+		await submitUrl( 'abcDEF12' );
+
+		await waitFor( () =>
+			expect( screen.getAllByText( /No video found at that link/ ).length ).toBeGreaterThan( 0 )
+		);
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'warns about duplicates and only adds after "Add anyway"', async () => {
+		fetchVideoItemMock.mockResolvedValue( { title: 'Existing video' } );
+		const existing = { guid: 'abcDEF12', title: 'Existing video' };
+		const setAttributes = jest.fn();
+		renderEdit( { videos: [ existing ] }, setAttributes );
+
+		await submitUrl( 'abcDEF12' );
+
+		expect(
+			screen.getByText( '“Existing video” is already in this playlist' )
+		).toBeInTheDocument();
+		expect( setAttributes ).not.toHaveBeenCalled();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Add anyway' } ) );
+
+		await waitFor( () =>
+			expect( setAttributes ).toHaveBeenCalledWith( {
+				videos: [ existing, { guid: 'abcDEF12', title: 'Existing video' } ],
+			} )
+		);
+	} );
+
+	it( 'dismisses the duplicate warning on Cancel', async () => {
+		const setAttributes = jest.fn();
+		renderEdit( { videos: [ { guid: 'abcDEF12', title: 'Existing' } ] }, setAttributes );
+
+		await submitUrl( 'abcDEF12' );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		// The a11y live region retains the announcement, so assert on the notice UI itself.
+		expect( screen.queryByRole( 'button', { name: 'Add anyway' } ) ).not.toBeInTheDocument();
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'removes an entry', async () => {
+		const videos = [
+			{ guid: 'aaaaaaaa', title: 'First' },
+			{ guid: 'bbbbbbbb', title: 'Second' },
+		];
+		const setAttributes = jest.fn();
+		renderEdit( { videos }, setAttributes );
+
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Remove “First” from the playlist' } )
+		);
+
+		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ videos[ 1 ] ] } );
+	} );
+
+	it( 'reorders entries with the arrow keys on a drag handle', async () => {
+		const videos = [
+			{ guid: 'aaaaaaaa', title: 'First' },
+			{ guid: 'bbbbbbbb', title: 'Second' },
+		];
+		const setAttributes = jest.fn();
+		renderEdit( { videos }, setAttributes );
+
+		// Clicking the handle focuses it (it has no click action of its own).
+		await userEvent.click(
+			screen.getByRole( 'button', { name: 'Reorder “First”. Press up or down to move it.' } )
+		);
+		await userEvent.keyboard( '{ArrowDown}' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ videos[ 1 ], videos[ 0 ] ] } );
+	} );
+
+	it( 'renders the canvas preview mirroring the playlist', () => {
+		renderEdit( {
+			videos: [
+				{ guid: 'aaaaaaaa', title: 'First', durationMs: 60000, height: 1080 },
+				{ guid: 'bbbbbbbb', title: 'Second', durationMs: 120000, height: 2160 },
+			],
+		} );
+
+		expect( screen.getAllByText( '2 videos' ).length ).toBeGreaterThan( 0 );
+		expect( screen.getByTitle( 'First' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Up next' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'The canvas preview mirrors the sidebar order live — the block is not editable in place.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'only offers the filter input on long playlists', () => {
+		const shortList = Array.from( { length: 3 }, ( _, i ) => ( {
+			guid: `aaaaaaa${ i }`,
+			title: `Video ${ i }`,
+		} ) );
+		const { unmount } = render(
+			<PlaylistEdit
+				{ ...( {
+					attributes: { ...DEFAULT_ATTRIBUTES, videos: shortList },
+					setAttributes: jest.fn(),
+				} as unknown as BlockEditProps< PlaylistAttributes > ) }
+			/>
+		);
+		expect( screen.queryByPlaceholderText( 'Filter 3 videos' ) ).not.toBeInTheDocument();
+		unmount();
+
+		const longList = Array.from( { length: 9 }, ( _, i ) => ( {
+			guid: `aaaaaaa${ i }`,
+			title: `Video ${ i }`,
+		} ) );
+		renderEdit( { videos: longList } );
+		expect( screen.getByPlaceholderText( 'Filter 9 videos' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -433,6 +433,17 @@ describe( 'PlaylistEdit', () => {
 		expect( setAttributes ).toHaveBeenCalledWith( { loopPlaylist: true } );
 	} );
 
+	it( 'locks Autoplay next on while the playlist loops', async () => {
+		renderEdit( { videos: [ { guid: 'aaaaaaaa' } ], loopPlaylist: true, autoplayNext: false } );
+		// Let the live metadata lookup settle.
+		await expect( screen.findAllByText( 'First' ) ).resolves.toBeTruthy();
+
+		const autoplayToggle = screen.getByRole( 'checkbox', { name: 'Autoplay next' } );
+		expect( autoplayToggle ).toBeChecked();
+		expect( autoplayToggle ).toBeDisabled();
+		expect( screen.getByText( 'Looping the playlist keeps autoplay on.' ) ).toBeInTheDocument();
+	} );
+
 	it( 'changes the per-entry display options from the sidebar', async () => {
 		const setAttributes = jest.fn();
 		renderEdit( { videos: [ { guid: 'aaaaaaaa' } ] }, setAttributes );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -70,9 +70,24 @@ async function submitUrl( value: string ) {
 	await userEvent.click( screen.getAllByRole( 'button', { name: 'Add' } )[ 0 ] );
 }
 
+const LIVE_TITLES: Record< string, string > = {
+	aaaaaaaa: 'First',
+	bbbbbbbb: 'Second',
+	cccccccc: 'Third',
+	abcDEF12: 'Existing video',
+};
+
 beforeEach( () => {
 	jest.clearAllMocks();
 	mockMediaSelection = [];
+	// Titles are live data resolved per GUID, never stored in attributes.
+	fetchVideoItemMock.mockImplementation( ( { guid }: { guid: string } ) => {
+		const numbered = guid.match( /^aaaaaaa(\d)$/ );
+		if ( numbered ) {
+			return Promise.resolve( { title: `Video ${ numbered[ 1 ] }` } );
+		}
+		return Promise.resolve( LIVE_TITLES[ guid ] ? { title: LIVE_TITLES[ guid ] } : {} );
+	} );
 } );
 
 describe( 'PlaylistEdit', () => {
@@ -99,15 +114,7 @@ describe( 'PlaylistEdit', () => {
 
 		await waitFor( () =>
 			expect( setAttributes ).toHaveBeenCalledWith( {
-				videos: [
-					{
-						guid: 'abcDEF12',
-						title: 'Kiln loading, start to finish',
-						durationMs: 724000,
-						height: 1080,
-						poster: 'https://example.com/poster.jpg',
-					},
-				],
+				videos: [ { guid: 'abcDEF12', durationMs: 724000, height: 1080 } ],
 			} )
 		);
 	} );
@@ -120,9 +127,7 @@ describe( 'PlaylistEdit', () => {
 		await submitUrl( 'https://videopress.com/v/abcDEF12' );
 
 		await waitFor( () =>
-			expect( setAttributes ).toHaveBeenCalledWith( {
-				videos: [ { guid: 'abcDEF12', title: 'By URL' } ],
-			} )
+			expect( setAttributes ).toHaveBeenCalledWith( { videos: [ { guid: 'abcDEF12' } ] } )
 		);
 		expect( fetchVideoItemMock ).toHaveBeenCalledWith(
 			expect.objectContaining( { guid: 'abcDEF12' } )
@@ -155,29 +160,29 @@ describe( 'PlaylistEdit', () => {
 
 	it( 'warns about duplicates and only adds after "Add anyway"', async () => {
 		fetchVideoItemMock.mockResolvedValue( { title: 'Existing video' } );
-		const existing = { guid: 'abcDEF12', title: 'Existing video' };
+		const existing = { guid: 'abcDEF12' };
 		const setAttributes = jest.fn();
 		renderEdit( { videos: [ existing ] }, setAttributes );
 
 		await submitUrl( 'abcDEF12' );
 
-		expect(
-			screen.getByText( '“Existing video” is already in this playlist' )
-		).toBeInTheDocument();
+		await expect(
+			screen.findByText( '“Existing video” is already in this playlist' )
+		).resolves.toBeInTheDocument();
 		expect( setAttributes ).not.toHaveBeenCalled();
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Add anyway' } ) );
 
 		await waitFor( () =>
 			expect( setAttributes ).toHaveBeenCalledWith( {
-				videos: [ existing, { guid: 'abcDEF12', title: 'Existing video' } ],
+				videos: [ existing, { guid: 'abcDEF12' } ],
 			} )
 		);
 	} );
 
 	it( 'dismisses the duplicate warning on Cancel', async () => {
 		const setAttributes = jest.fn();
-		renderEdit( { videos: [ { guid: 'abcDEF12', title: 'Existing' } ] }, setAttributes );
+		renderEdit( { videos: [ { guid: 'abcDEF12' } ] }, setAttributes );
 
 		await submitUrl( 'abcDEF12' );
 		await userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
@@ -188,47 +193,41 @@ describe( 'PlaylistEdit', () => {
 	} );
 
 	it( 'removes an entry', async () => {
-		const videos = [
-			{ guid: 'aaaaaaaa', title: 'First' },
-			{ guid: 'bbbbbbbb', title: 'Second' },
-		];
+		const videos = [ { guid: 'aaaaaaaa' }, { guid: 'bbbbbbbb' } ];
 		const setAttributes = jest.fn();
 		renderEdit( { videos }, setAttributes );
 
 		await userEvent.click(
-			screen.getByRole( 'button', { name: 'Remove “First” from the playlist' } )
+			await screen.findByRole( 'button', { name: 'Remove “First” from the playlist' } )
 		);
 
 		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ videos[ 1 ] ] } );
 	} );
 
 	it( 'reorders entries with the arrow keys on a drag handle', async () => {
-		const videos = [
-			{ guid: 'aaaaaaaa', title: 'First' },
-			{ guid: 'bbbbbbbb', title: 'Second' },
-		];
+		const videos = [ { guid: 'aaaaaaaa' }, { guid: 'bbbbbbbb' } ];
 		const setAttributes = jest.fn();
 		renderEdit( { videos }, setAttributes );
 
 		// Clicking the handle focuses it (it has no click action of its own).
 		await userEvent.click(
-			screen.getByRole( 'button', { name: 'Reorder “First”. Press up or down to move it.' } )
+			await screen.findByRole( 'button', { name: 'Reorder “First”. Press up or down to move it.' } )
 		);
 		await userEvent.keyboard( '{ArrowDown}' );
 
 		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ videos[ 1 ], videos[ 0 ] ] } );
 	} );
 
-	it( 'renders the canvas preview mirroring the playlist', () => {
+	it( 'renders the canvas preview mirroring the playlist', async () => {
 		renderEdit( {
 			videos: [
-				{ guid: 'aaaaaaaa', title: 'First', durationMs: 60000, height: 1080 },
-				{ guid: 'bbbbbbbb', title: 'Second', durationMs: 120000, height: 2160 },
+				{ guid: 'aaaaaaaa', durationMs: 60000, height: 1080 },
+				{ guid: 'bbbbbbbb', durationMs: 120000, height: 2160 },
 			],
 		} );
 
 		expect( screen.getAllByText( '2 videos' ).length ).toBeGreaterThan( 0 );
-		expect( screen.getByTitle( 'First' ) ).toBeInTheDocument();
+		await expect( screen.findByTitle( 'First' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Up next' ) ).toBeInTheDocument();
 		expect(
 			screen.getByText(
@@ -237,11 +236,8 @@ describe( 'PlaylistEdit', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'only offers the filter input on long playlists', () => {
-		const shortList = Array.from( { length: 3 }, ( _, i ) => ( {
-			guid: `aaaaaaa${ i }`,
-			title: `Video ${ i }`,
-		} ) );
+	it( 'only offers the filter input on long playlists', async () => {
+		const shortList = Array.from( { length: 3 }, ( _, i ) => ( { guid: `aaaaaaa${ i }` } ) );
 		const { unmount } = render(
 			<PlaylistEdit
 				{ ...( {
@@ -251,14 +247,14 @@ describe( 'PlaylistEdit', () => {
 			/>
 		);
 		expect( screen.queryByPlaceholderText( 'Filter 3 videos' ) ).not.toBeInTheDocument();
+		// Let the live metadata lookups settle before unmounting.
+		await expect( screen.findAllByText( 'Video 2' ) ).resolves.toBeTruthy();
 		unmount();
 
-		const longList = Array.from( { length: 9 }, ( _, i ) => ( {
-			guid: `aaaaaaa${ i }`,
-			title: `Video ${ i }`,
-		} ) );
+		const longList = Array.from( { length: 9 }, ( _, i ) => ( { guid: `aaaaaaa${ i }` } ) );
 		renderEdit( { videos: longList } );
 		expect( screen.getByPlaceholderText( 'Filter 9 videos' ) ).toBeInTheDocument();
+		await expect( screen.findAllByText( 'Video 8' ) ).resolves.toBeTruthy();
 	} );
 
 	it( 'shows an error when Add is pressed with an empty input', async () => {
@@ -282,9 +278,7 @@ describe( 'PlaylistEdit', () => {
 		);
 
 		await waitFor( () =>
-			expect( setAttributes ).toHaveBeenCalledWith( {
-				videos: [ { guid: 'abcDEF12', title: 'Via Enter' } ],
-			} )
+			expect( setAttributes ).toHaveBeenCalledWith( { videos: [ { guid: 'abcDEF12' } ] } )
 		);
 	} );
 
@@ -331,15 +325,7 @@ describe( 'PlaylistEdit', () => {
 		await userEvent.click( screen.getAllByRole( 'button', { name: 'Media Library' } )[ 0 ] );
 
 		expect( setAttributes ).toHaveBeenCalledWith( {
-			videos: [
-				{
-					guid: 'aaaaaaaa',
-					title: 'From array',
-					poster: 'https://example.com/image.jpg',
-					height: 240,
-				},
-				{ guid: 'bbbbbbbb', poster: 'https://example.com/thumb.jpg' },
-			],
+			videos: [ { guid: 'aaaaaaaa', height: 240 }, { guid: 'bbbbbbbb' } ],
 		} );
 	} );
 
@@ -356,7 +342,7 @@ describe( 'PlaylistEdit', () => {
 
 		await waitFor( () =>
 			expect( setAttributes ).toHaveBeenCalledWith( {
-				videos: [ { guid: 'abcDEF12', title: 'Low-res upload', durationMs: 724000, height: 240 } ],
+				videos: [ { guid: 'abcDEF12', durationMs: 724000, height: 240 } ],
 			} )
 		);
 	} );
@@ -368,9 +354,7 @@ describe( 'PlaylistEdit', () => {
 
 		await userEvent.click( screen.getAllByRole( 'button', { name: 'Media Library' } )[ 0 ] );
 
-		expect( setAttributes ).toHaveBeenCalledWith( {
-			videos: [ { guid: 'cccccccc', title: 'Single' } ],
-		} );
+		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ { guid: 'cccccccc' } ] } );
 	} );
 
 	it( 'shows an error when no media library selection is a VideoPress video', async () => {
@@ -388,7 +372,7 @@ describe( 'PlaylistEdit', () => {
 
 	it( 'changes the layout and playback options from the sidebar', async () => {
 		const setAttributes = jest.fn();
-		renderEdit( { videos: [ { guid: 'aaaaaaaa', title: 'First' } ] }, setAttributes );
+		renderEdit( { videos: [ { guid: 'aaaaaaaa' } ] }, setAttributes );
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Grid' } ) );
 		expect( setAttributes ).toHaveBeenCalledWith( { layout: 'grid' } );
@@ -405,7 +389,7 @@ describe( 'PlaylistEdit', () => {
 
 	it( 'changes the per-entry display options from the sidebar', async () => {
 		const setAttributes = jest.fn();
-		renderEdit( { videos: [ { guid: 'aaaaaaaa', title: 'First' } ] }, setAttributes );
+		renderEdit( { videos: [ { guid: 'aaaaaaaa' } ] }, setAttributes );
 
 		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Thumbnail' } ) );
 		expect( setAttributes ).toHaveBeenCalledWith( { showThumbnail: false } );
@@ -427,17 +411,16 @@ describe( 'PlaylistEdit', () => {
 	} );
 
 	it( 'reorders entries with drag and drop', async () => {
-		const videos = [
-			{ guid: 'aaaaaaaa', title: 'First' },
-			{ guid: 'bbbbbbbb', title: 'Second' },
-			{ guid: 'cccccccc', title: 'Third' },
-		];
+		const videos = [ { guid: 'aaaaaaaa' }, { guid: 'bbbbbbbb' }, { guid: 'cccccccc' } ];
 		const setAttributes = jest.fn();
 		renderEdit( { videos }, setAttributes );
 
 		const list = screen.getByRole( 'list', { name: 'Playlist videos' } );
 		const dataTransfer = { effectAllowed: '', dropEffect: '', setData: jest.fn() };
 		const rows = () => within( list ).getAllByRole( 'listitem' );
+
+		// Let the live metadata lookups settle before dragging.
+		await expect( within( list ).findByText( 'Third' ) ).resolves.toBeInTheDocument();
 
 		fireEvent.dragStart( rows()[ 0 ], { dataTransfer } );
 		expect( rows()[ 0 ] ).toHaveClass( 'is-dragging' );
@@ -460,14 +443,13 @@ describe( 'PlaylistEdit', () => {
 	} );
 
 	it( 'narrows the sidebar rows while filtering and disables reordering', async () => {
-		const videos = Array.from( { length: 9 }, ( _, i ) => ( {
-			guid: `aaaaaaa${ i }`,
-			title: `Video ${ i }`,
-		} ) );
+		const videos = Array.from( { length: 9 }, ( _, i ) => ( { guid: `aaaaaaa${ i }` } ) );
 		renderEdit( { videos } );
 
 		const list = screen.getByRole( 'list', { name: 'Playlist videos' } );
 		expect( within( list ).getAllByRole( 'listitem' ) ).toHaveLength( 9 );
+		// Titles arrive from the live metadata lookups; wait for the last one.
+		await expect( within( list ).findByText( 'Video 8' ) ).resolves.toBeInTheDocument();
 
 		await userEvent.type( screen.getByPlaceholderText( 'Filter 9 videos' ), 'Video 3' );
 
@@ -478,20 +460,16 @@ describe( 'PlaylistEdit', () => {
 	} );
 
 	it( 'keeps the preview on the same entry when one is moved from above it', async () => {
-		const videos = [
-			{ guid: 'aaaaaaaa', title: 'First' },
-			{ guid: 'bbbbbbbb', title: 'Second' },
-			{ guid: 'cccccccc', title: 'Third' },
-		];
+		const videos = [ { guid: 'aaaaaaaa' }, { guid: 'bbbbbbbb' }, { guid: 'cccccccc' } ];
 		const setAttributes = jest.fn();
 		renderEdit( { videos }, setAttributes );
 
 		// Preview the second entry from the canvas list.
-		await userEvent.click( screen.getByRole( 'button', { name: /Playing.*Second/ } ) );
-		expect( screen.getByTitle( 'Second' ) ).toBeInTheDocument();
+		await userEvent.click( await screen.findByRole( 'button', { name: /Playing.*Second/ } ) );
+		await expect( screen.findByTitle( 'Second' ) ).resolves.toBeInTheDocument();
 
 		await userEvent.click(
-			screen.getByRole( 'button', { name: 'Reorder “First”. Press up or down to move it.' } )
+			await screen.findByRole( 'button', { name: 'Reorder “First”. Press up or down to move it.' } )
 		);
 		await userEvent.keyboard( '{ArrowDown}' );
 		expect( setAttributes ).toHaveBeenCalledWith( {
@@ -500,16 +478,15 @@ describe( 'PlaylistEdit', () => {
 	} );
 
 	it( 'keeps the preview on the same entry when one is moved from below it', async () => {
-		const videos = [
-			{ guid: 'aaaaaaaa', title: 'First' },
-			{ guid: 'bbbbbbbb', title: 'Second' },
-		];
+		const videos = [ { guid: 'aaaaaaaa' }, { guid: 'bbbbbbbb' } ];
 		const setAttributes = jest.fn();
 		renderEdit( { videos }, setAttributes );
 
 		// The default preview is the first entry; move the second above it.
 		await userEvent.click(
-			screen.getByRole( 'button', { name: 'Reorder “Second”. Press up or down to move it.' } )
+			await screen.findByRole( 'button', {
+				name: 'Reorder “Second”. Press up or down to move it.',
+			} )
 		);
 		await userEvent.keyboard( '{ArrowUp}' );
 
@@ -517,32 +494,25 @@ describe( 'PlaylistEdit', () => {
 	} );
 
 	it( 'keeps the preview on the same entry when one is removed above it', async () => {
-		const videos = [
-			{ guid: 'aaaaaaaa', title: 'First' },
-			{ guid: 'bbbbbbbb', title: 'Second' },
-			{ guid: 'cccccccc', title: 'Third' },
-		];
+		const videos = [ { guid: 'aaaaaaaa' }, { guid: 'bbbbbbbb' }, { guid: 'cccccccc' } ];
 		const setAttributes = jest.fn();
 		renderEdit( { videos }, setAttributes );
 
-		await userEvent.click( screen.getByRole( 'button', { name: /Playing.*Second/ } ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: /Playing.*Second/ } ) );
 		await userEvent.click(
-			screen.getByRole( 'button', { name: 'Remove “First” from the playlist' } )
+			await screen.findByRole( 'button', { name: 'Remove “First” from the playlist' } )
 		);
 
 		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ videos[ 1 ], videos[ 2 ] ] } );
 	} );
 
 	it( 'ignores out-of-range keyboard reorders', async () => {
-		const videos = [
-			{ guid: 'aaaaaaaa', title: 'First' },
-			{ guid: 'bbbbbbbb', title: 'Second' },
-		];
+		const videos = [ { guid: 'aaaaaaaa' }, { guid: 'bbbbbbbb' } ];
 		const setAttributes = jest.fn();
 		renderEdit( { videos }, setAttributes );
 
 		await userEvent.click(
-			screen.getByRole( 'button', { name: 'Reorder “First”. Press up or down to move it.' } )
+			await screen.findByRole( 'button', { name: 'Reorder “First”. Press up or down to move it.' } )
 		);
 		await userEvent.keyboard( '{ArrowUp}' );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -21,6 +21,31 @@ jest.mock( '@wordpress/block-editor', () => ( {
 		render: ( args: { open: () => void } ) => React.ReactNode;
 	} ) => renderProp( { open: () => onSelect( mockMediaSelection ) } ),
 	MediaUploadCheck: ( { children }: { children: React.ReactNode } ) => <>{ children }</>,
+	useSettings: () => [
+		[
+			{ name: 'Serif Pro', slug: 'serif-pro', fontFamily: '"Serif Pro", serif' },
+			{ name: 'Grotesk', slug: 'grotesk', fontFamily: 'Grotesk, sans-serif' },
+		],
+	],
+	__experimentalFontFamilyControl: ( {
+		label,
+		value,
+		onChange,
+	}: {
+		label: string;
+		value: string;
+		onChange: ( value: string ) => void;
+	} ) => (
+		<select
+			aria-label={ label }
+			value={ value }
+			onChange={ event => onChange( event.target.value ) }
+		>
+			<option value="">Default</option>
+			<option value='"Serif Pro", serif'>Serif Pro</option>
+			<option value="Grotesk, sans-serif">Grotesk</option>
+		</select>
+	),
 } ) );
 
 jest.mock( '../../../../lib/fetch-video-item', () => ( {
@@ -40,6 +65,8 @@ const DEFAULT_ATTRIBUTES: PlaylistAttributes = {
 	showDuration: true,
 	showPositionNumber: false,
 	showTotalRuntime: true,
+	nowTitleFontFamily: '',
+	entryTitleFontFamily: '',
 };
 
 /**
@@ -515,6 +542,48 @@ describe( 'PlaylistEdit', () => {
 		);
 
 		expect( setAttributes ).toHaveBeenCalledWith( { videos: [ videos[ 1 ], videos[ 2 ] ] } );
+	} );
+
+	it( 'sets the title font families from theme presets', async () => {
+		const setAttributes = jest.fn();
+		renderEdit( { videos: [ { guid: 'aaaaaaaa' } ] }, setAttributes );
+
+		await userEvent.selectOptions(
+			screen.getByRole( 'combobox', { name: 'Now playing title' } ),
+			'"Serif Pro", serif'
+		);
+		expect( setAttributes ).toHaveBeenCalledWith( { nowTitleFontFamily: 'serif-pro' } );
+
+		await userEvent.selectOptions(
+			screen.getByRole( 'combobox', { name: 'Entry titles' } ),
+			'Grotesk, sans-serif'
+		);
+		expect( setAttributes ).toHaveBeenCalledWith( { entryTitleFontFamily: 'grotesk' } );
+
+		// Picking Default resets back to inheriting.
+		await userEvent.selectOptions(
+			screen.getByRole( 'combobox', { name: 'Now playing title' } ),
+			''
+		);
+		expect( setAttributes ).toHaveBeenCalledWith( { nowTitleFontFamily: '' } );
+	} );
+
+	it( 'exposes the chosen fonts as CSS custom properties on the wrapper', async () => {
+		renderEdit( {
+			videos: [ { guid: 'aaaaaaaa' } ],
+			nowTitleFontFamily: 'serif-pro',
+			entryTitleFontFamily: 'grotesk',
+		} );
+		// Let the live metadata lookup settle.
+		await expect( screen.findAllByText( 'First' ) ).resolves.toBeTruthy();
+
+		const figure = screen.getByRole( 'figure' );
+		expect( figure.style.getPropertyValue( '--vpp-now-title-font' ) ).toBe(
+			'var(--wp--preset--font-family--serif-pro)'
+		);
+		expect( figure.style.getPropertyValue( '--vpp-entry-title-font' ) ).toBe(
+			'var(--wp--preset--font-family--grotesk)'
+		);
 	} );
 
 	it( 'ignores out-of-range keyboard reorders', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -261,11 +261,6 @@ describe( 'PlaylistEdit', () => {
 		expect( screen.getAllByText( '2 videos' ).length ).toBeGreaterThan( 0 );
 		await expect( screen.findByTitle( 'First' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Up next' ) ).toBeInTheDocument();
-		expect(
-			screen.getByText(
-				'The canvas preview mirrors the sidebar order live — the block is not editable in place.'
-			)
-		).toBeInTheDocument();
 	} );
 
 	it( 'only offers the filter input on long playlists', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/index.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/index.test.ts
@@ -1,0 +1,31 @@
+import { registerBlockType } from '@wordpress/blocks';
+import '../index';
+
+jest.mock( '@wordpress/blocks', () => ( {
+	registerBlockType: jest.fn(),
+} ) );
+
+// Keep the registration test from dragging in the whole block editor.
+jest.mock( '../edit', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+const registerBlockTypeMock = registerBlockType as jest.Mock;
+
+describe( 'playlist block registration', () => {
+	it( 'registers videopress/playlist as a dynamic block', () => {
+		expect( registerBlockTypeMock ).toHaveBeenCalledTimes( 1 );
+
+		const [ name, settings ] = registerBlockTypeMock.mock.calls[ 0 ];
+		expect( name ).toBe( 'videopress/playlist' );
+		expect( settings.title ).toBe( 'Video Playlist' );
+		expect( settings.category ).toBe( 'media' );
+		expect( typeof settings.edit ).toBe( 'function' );
+		expect( settings.icon ).toBeDefined();
+		expect( settings.attributes.videos.default ).toEqual( [] );
+
+		// Dynamic block: the front end comes from the PHP render callback.
+		expect( settings.save() ).toBeNull();
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/use-publish-tracking.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/use-publish-tracking.test.ts
@@ -1,0 +1,87 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { renderHook } from '@testing-library/react';
+import usePublishTracking from '../use-publish-tracking';
+
+// Editor-store state driving the hook.
+let mockIsPublishing = false;
+let mockPlaylistClientIds: string[] = [ 'playlist-client-1' ];
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: { tracks: { recordEvent: jest.fn() } },
+} ) );
+
+jest.mock( '@wordpress/editor', () => ( { store: 'core/editor' } ) );
+jest.mock( '@wordpress/block-editor', () => ( { store: 'core/block-editor' } ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: ( selector: ( select: unknown ) => unknown ) =>
+		selector( () => ( {
+			isPublishingPost: () => mockIsPublishing,
+			getCurrentPostType: () => 'post',
+			getBlocksByName: () => mockPlaylistClientIds,
+		} ) ),
+} ) );
+
+const recordEventMock = jetpackAnalytics.tracks.recordEvent as jest.Mock;
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockIsPublishing = false;
+	mockPlaylistClientIds = [ 'playlist-client-1' ];
+} );
+
+describe( 'usePublishTracking', () => {
+	it( 'records one event when the post is being published', () => {
+		mockIsPublishing = true;
+
+		const { rerender } = renderHook( () =>
+			usePublishTracking( { clientId: 'playlist-client-1', layout: 'grid', videoCount: 2 } )
+		);
+		// Publishing spans several renders; the event must not repeat.
+		rerender();
+
+		expect( recordEventMock ).toHaveBeenCalledTimes( 1 );
+		expect( recordEventMock ).toHaveBeenCalledWith( 'jetpack_videopress_playlist_block_published', {
+			post_type: 'post',
+			layout: 'grid',
+			video_count: 2,
+			playlist_count: 1,
+		} );
+	} );
+
+	it( 'does nothing while the post is not being published', () => {
+		renderHook( () =>
+			usePublishTracking( { clientId: 'playlist-client-1', layout: 'side-rail', videoCount: 1 } )
+		);
+
+		expect( recordEventMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'leaves reporting to the first playlist block in the post', () => {
+		mockIsPublishing = true;
+		mockPlaylistClientIds = [ 'another-playlist', 'playlist-client-1' ];
+
+		renderHook( () =>
+			usePublishTracking( { clientId: 'playlist-client-1', layout: 'strip', videoCount: 3 } )
+		);
+
+		expect( recordEventMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'counts every playlist block in the post', () => {
+		mockIsPublishing = true;
+		mockPlaylistClientIds = [ 'playlist-client-1', 'another-playlist' ];
+
+		renderHook( () =>
+			usePublishTracking( { clientId: 'playlist-client-1', layout: 'side-rail', videoCount: 5 } )
+		);
+
+		expect( recordEventMock ).toHaveBeenCalledWith( 'jetpack_videopress_playlist_block_published', {
+			post_type: 'post',
+			layout: 'side-rail',
+			video_count: 5,
+			playlist_count: 2,
+		} );
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/utils.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/utils.test.ts
@@ -1,0 +1,114 @@
+import {
+	formatRuntime,
+	formatTimecode,
+	moveEntry,
+	playlistEmbedUrl,
+	playlistRuntimeMs,
+	resolutionLabel,
+} from '../utils';
+
+describe( 'formatTimecode', () => {
+	it( 'formats minutes and seconds', () => {
+		expect( formatTimecode( 724000 ) ).toBe( '12:04' );
+	} );
+
+	it( 'formats hours', () => {
+		expect( formatTimecode( 4430000 ) ).toBe( '1:13:50' );
+	} );
+
+	it( 'pads seconds and minutes', () => {
+		expect( formatTimecode( 3601000 ) ).toBe( '1:00:01' );
+	} );
+
+	it( 'returns an empty string for unknown durations', () => {
+		expect( formatTimecode( undefined ) ).toBe( '' );
+		expect( formatTimecode( 0 ) ).toBe( '' );
+		expect( formatTimecode( -5 ) ).toBe( '' );
+		expect( formatTimecode( NaN ) ).toBe( '' );
+	} );
+} );
+
+describe( 'formatRuntime', () => {
+	it( 'formats hours and minutes', () => {
+		expect( formatRuntime( 4380000 ) ).toBe( '1 hr 13 min' );
+	} );
+
+	it( 'formats whole hours', () => {
+		expect( formatRuntime( 7200000 ) ).toBe( '2 hr' );
+	} );
+
+	it( 'formats minutes only', () => {
+		expect( formatRuntime( 300000 ) ).toBe( '5 min' );
+	} );
+
+	it( 'rounds very short durations up to one minute', () => {
+		expect( formatRuntime( 10000 ) ).toBe( '1 min' );
+	} );
+
+	it( 'returns an empty string for unknown durations', () => {
+		expect( formatRuntime( undefined ) ).toBe( '' );
+		expect( formatRuntime( 0 ) ).toBe( '' );
+	} );
+} );
+
+describe( 'resolutionLabel', () => {
+	it( 'labels common heights', () => {
+		expect( resolutionLabel( 1080 ) ).toBe( '1080p' );
+		expect( resolutionLabel( 720 ) ).toBe( '720p' );
+	} );
+
+	it( 'labels 4K from 2160 up', () => {
+		expect( resolutionLabel( 2160 ) ).toBe( '4K' );
+		expect( resolutionLabel( 4320 ) ).toBe( '4K' );
+	} );
+
+	it( 'returns an empty string for unknown heights', () => {
+		expect( resolutionLabel( undefined ) ).toBe( '' );
+		expect( resolutionLabel( 0 ) ).toBe( '' );
+	} );
+} );
+
+describe( 'playlistRuntimeMs', () => {
+	it( 'sums known durations and ignores unknown ones', () => {
+		expect(
+			playlistRuntimeMs( [
+				{ guid: 'aaaaaaaa', durationMs: 1000 },
+				{ guid: 'bbbbbbbb' },
+				{ guid: 'cccccccc', durationMs: 500 },
+			] )
+		).toBe( 1500 );
+	} );
+
+	it( 'returns 0 for an empty playlist', () => {
+		expect( playlistRuntimeMs( [] ) ).toBe( 0 );
+	} );
+} );
+
+describe( 'moveEntry', () => {
+	it( 'moves an entry forward', () => {
+		expect( moveEntry( [ 'a', 'b', 'c' ], 0, 2 ) ).toEqual( [ 'b', 'c', 'a' ] );
+	} );
+
+	it( 'moves an entry backward', () => {
+		expect( moveEntry( [ 'a', 'b', 'c' ], 2, 0 ) ).toEqual( [ 'c', 'a', 'b' ] );
+	} );
+
+	it( 'returns the same list for no-op or out-of-range moves', () => {
+		const list = [ 'a', 'b' ];
+		expect( moveEntry( list, 0, 0 ) ).toBe( list );
+		expect( moveEntry( list, 0, 5 ) ).toBe( list );
+		expect( moveEntry( list, -1, 0 ) ).toBe( list );
+	} );
+} );
+
+describe( 'playlistEmbedUrl', () => {
+	it( 'builds the embed URL', () => {
+		expect( playlistEmbedUrl( 'abcDEF12', false ) ).toBe(
+			'https://videopress.com/embed/abcDEF12?cover=1&preloadContent=metadata&autoPlay=0'
+		);
+	} );
+
+	it( 'toggles autoplay', () => {
+		expect( playlistEmbedUrl( 'abcDEF12', true ) ).toContain( 'autoPlay=1' );
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -228,6 +228,24 @@ describe( 'initPlaylistBlock', () => {
 		);
 	} );
 
+	it( 'shows the more-videos fade only while entries hide below the scroll', () => {
+		const root = setUpPlaylist();
+		const list = root.querySelector< HTMLElement >( '.videopress-playlist__list' );
+		const entriesContainer = root.querySelector< HTMLElement >( '.videopress-playlist__entries' );
+
+		// jsdom has no layout; give the list a scrollable geometry.
+		Object.defineProperty( entriesContainer, 'scrollHeight', { configurable: true, value: 400 } );
+		Object.defineProperty( entriesContainer, 'clientHeight', { configurable: true, value: 200 } );
+
+		entriesContainer.scrollTop = 0;
+		entriesContainer.dispatchEvent( new Event( 'scroll' ) );
+		expect( list ).toHaveClass( 'has-more-videos' );
+
+		entriesContainer.scrollTop = 200;
+		entriesContainer.dispatchEvent( new Event( 'scroll' ) );
+		expect( list ).not.toHaveClass( 'has-more-videos' );
+	} );
+
 	it( 'ignores clicks on entries without an embed URL', () => {
 		const root = setUpPlaylist();
 		const entries = root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -39,13 +39,6 @@ function setUpPlaylist( autoplayNext = true ): HTMLElement {
 					'autoPlay=1',
 					'autoPlay=0'
 				) }" title="First"></iframe>
-				<div class="videopress-playlist__now">
-					<span class="videopress-playlist__now-title">First</span>
-					<span class="videopress-playlist__now-meta">
-						<span class="videopress-playlist__now-position">1 of 3</span>
-						<span class="videopress-playlist__now-details">1080p · 12:04</span>
-					</span>
-				</div>
 			</div>
 			<div class="videopress-playlist__list">
 				<div class="videopress-playlist__list-header">
@@ -105,18 +98,11 @@ describe( 'initPlaylistBlock', () => {
 		expect( entries[ 0 ] ).not.toHaveAttribute( 'aria-current' );
 	} );
 
-	it( 'updates the now-playing text and progress counter', () => {
+	it( 'updates the progress counter', () => {
 		const root = setUpPlaylist();
 
 		root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' )[ 2 ].click();
 
-		expect( root.querySelector( '.videopress-playlist__now-title' ) ).toHaveTextContent( 'Third' );
-		expect( root.querySelector( '.videopress-playlist__now-position' ) ).toHaveTextContent(
-			'3 of 3'
-		);
-		expect( root.querySelector( '.videopress-playlist__now-details' ) ).toHaveTextContent(
-			'720p · 6:15'
-		);
 		expect( root.querySelector( '.videopress-playlist__list-progress' ) ).toHaveTextContent(
 			'3 / 3 · 25:00 total'
 		);
@@ -210,11 +196,6 @@ describe( 'initPlaylistBlock', () => {
 		expect( entries[ 0 ].querySelector( '.videopress-playlist__entry-thumb img' ) ).toHaveAttribute(
 			'src',
 			'https://example.com/first.jpg'
-		);
-
-		// The current entry's live title also lands in the now-playing row.
-		expect( root.querySelector( '.videopress-playlist__now-title' ) ).toHaveTextContent(
-			'Live first'
 		);
 
 		expect( entries[ 1 ].querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -1,4 +1,23 @@
-import { initPlaylistBlock } from '../view';
+import { hydratePlaylistMetadata, initPlaylistBlock } from '../view';
+
+// Live metadata the mocked videos API returns, keyed by GUID.
+let mockLiveMetadata: Record< string, { title?: string; poster?: string } > = {};
+
+beforeEach( () => {
+	mockLiveMetadata = {};
+	const fetchMock = jest.fn( ( url: string ) => {
+		const guid = String( url ).split( '/' ).pop();
+		const metadata = guid ? mockLiveMetadata[ guid ] : undefined;
+		if ( ! metadata ) {
+			return Promise.resolve( { ok: false } as Response );
+		}
+		return Promise.resolve( {
+			ok: true,
+			json: () => Promise.resolve( metadata ),
+		} as Response );
+	} );
+	( global as { fetch: unknown } ).fetch = fetchMock;
+} );
 
 const EMBED_A = 'https://videopress.com/embed/aaaaaaaa?cover=1&preloadContent=metadata&autoPlay=1';
 const EMBED_B = 'https://videopress.com/embed/bbbbbbbb?cover=1&preloadContent=metadata&autoPlay=1';
@@ -35,13 +54,22 @@ function setUpPlaylist( autoplayNext = true ): HTMLElement {
 				<ol class="videopress-playlist__entries">
 					<li><button type="button" class="videopress-playlist__select is-current" aria-current="true"
 						data-guid="aaaaaaaa" data-embed-url="${ EMBED_A }" data-title="First"
-						data-position="1 of 3" data-details="1080p · 12:04" data-progress="1 / 3 · 25:00 total"></button></li>
+						data-position="1 of 3" data-details="1080p · 12:04" data-progress="1 / 3 · 25:00 total">
+						<span class="videopress-playlist__entry-thumb"></span>
+						<span class="videopress-playlist__entry-title">First</span>
+					</button></li>
 					<li><button type="button" class="videopress-playlist__select"
 						data-guid="bbbbbbbb" data-embed-url="${ EMBED_B }" data-title="Second"
-						data-position="2 of 3" data-details="4K · 6:41" data-progress="2 / 3 · 25:00 total"></button></li>
+						data-position="2 of 3" data-details="4K · 6:41" data-progress="2 / 3 · 25:00 total">
+						<span class="videopress-playlist__entry-thumb"></span>
+						<span class="videopress-playlist__entry-title">Second</span>
+					</button></li>
 					<li><button type="button" class="videopress-playlist__select"
 						data-guid="cccccccc" data-embed-url="${ EMBED_C }" data-title="Third"
-						data-position="3 of 3" data-details="720p · 6:15" data-progress="3 / 3 · 25:00 total"></button></li>
+						data-position="3 of 3" data-details="720p · 6:15" data-progress="3 / 3 · 25:00 total">
+						<span class="videopress-playlist__entry-thumb"></span>
+						<span class="videopress-playlist__entry-title">Third</span>
+					</button></li>
 				</ol>
 			</div>
 		</figure>
@@ -162,6 +190,41 @@ describe( 'initPlaylistBlock', () => {
 		postPlayerMessage( 'https://videopress.com', { event: 'videopress_ended', id: 'aaaaaaaa' } );
 		expect( root.querySelector< HTMLIFrameElement >( '.videopress-playlist__iframe' ).src ).toBe(
 			'about:blank'
+		);
+	} );
+
+	it( 'hydrates titles and posters from live video data', async () => {
+		const root = setUpPlaylist();
+		mockLiveMetadata = {
+			aaaaaaaa: { title: 'Live first', poster: 'https://example.com/first.jpg' },
+			bbbbbbbb: { title: 'Live second' },
+		};
+
+		await hydratePlaylistMetadata( root );
+
+		const entries = root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' );
+		expect( entries[ 0 ].querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
+			'Live first'
+		);
+		expect( entries[ 0 ].dataset.title ).toBe( 'Live first' );
+		expect( entries[ 0 ].querySelector( '.videopress-playlist__entry-thumb img' ) ).toHaveAttribute(
+			'src',
+			'https://example.com/first.jpg'
+		);
+
+		// The current entry's live title also lands in the now-playing row.
+		expect( root.querySelector( '.videopress-playlist__now-title' ) ).toHaveTextContent(
+			'Live first'
+		);
+
+		expect( entries[ 1 ].querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
+			'Live second'
+		);
+		expect( entries[ 1 ].querySelector( 'img' ) ).toBeNull();
+
+		// Unreachable video data keeps the server-rendered fallback.
+		expect( entries[ 2 ].querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
+			'Third'
 		);
 	} );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -1,0 +1,150 @@
+import { initPlaylistBlock } from '../view';
+
+const EMBED_A = 'https://videopress.com/embed/aaaaaaaa?cover=1&preloadContent=metadata&autoPlay=1';
+const EMBED_B = 'https://videopress.com/embed/bbbbbbbb?cover=1&preloadContent=metadata&autoPlay=1';
+const EMBED_C = 'https://videopress.com/embed/cccccccc?cover=1&preloadContent=metadata&autoPlay=1';
+
+/**
+ * Render a playlist block's front-end markup and initialize it.
+ *
+ * @param autoplayNext - Value of the wrapper's data-autoplay-next flag.
+ * @return The block root element.
+ */
+function setUpPlaylist( autoplayNext = true ): HTMLElement {
+	document.body.innerHTML = `
+		<figure class="wp-block-videopress-playlist videopress-playlist is-layout-side-rail" data-autoplay-next="${
+			autoplayNext ? '1' : '0'
+		}">
+			<div class="videopress-playlist__stage">
+				<iframe class="videopress-playlist__iframe" src="${ EMBED_A.replace(
+					'autoPlay=1',
+					'autoPlay=0'
+				) }" title="First"></iframe>
+				<div class="videopress-playlist__now">
+					<span class="videopress-playlist__now-title">First</span>
+					<span class="videopress-playlist__now-meta">
+						<span class="videopress-playlist__now-position">1 of 3</span>
+						<span class="videopress-playlist__now-details">1080p · 12:04</span>
+					</span>
+				</div>
+			</div>
+			<div class="videopress-playlist__list">
+				<div class="videopress-playlist__list-header">
+					<span class="videopress-playlist__list-progress">1 / 3 · 25:00 total</span>
+				</div>
+				<ol class="videopress-playlist__entries">
+					<li><button type="button" class="videopress-playlist__select is-current" aria-current="true"
+						data-guid="aaaaaaaa" data-embed-url="${ EMBED_A }" data-title="First"
+						data-position="1 of 3" data-details="1080p · 12:04" data-progress="1 / 3 · 25:00 total"></button></li>
+					<li><button type="button" class="videopress-playlist__select"
+						data-guid="bbbbbbbb" data-embed-url="${ EMBED_B }" data-title="Second"
+						data-position="2 of 3" data-details="4K · 6:41" data-progress="2 / 3 · 25:00 total"></button></li>
+					<li><button type="button" class="videopress-playlist__select"
+						data-guid="cccccccc" data-embed-url="${ EMBED_C }" data-title="Third"
+						data-position="3 of 3" data-details="720p · 6:15" data-progress="3 / 3 · 25:00 total"></button></li>
+				</ol>
+			</div>
+		</figure>
+	`;
+
+	const root = document.querySelector< HTMLElement >( '.wp-block-videopress-playlist' );
+	initPlaylistBlock( root );
+	return root;
+}
+
+/**
+ * Dispatch a player message event on the window.
+ *
+ * @param origin - Message origin.
+ * @param data   - Message payload.
+ */
+function postPlayerMessage( origin: string, data: Record< string, unknown > ) {
+	window.dispatchEvent( new MessageEvent( 'message', { origin, data } ) );
+}
+
+describe( 'initPlaylistBlock', () => {
+	it( 'loads the clicked entry into the player and moves the current markers', () => {
+		const root = setUpPlaylist();
+		const entries = root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' );
+
+		entries[ 1 ].click();
+
+		const iframe = root.querySelector< HTMLIFrameElement >( '.videopress-playlist__iframe' );
+		expect( iframe.src ).toBe( EMBED_B );
+		expect( entries[ 1 ] ).toHaveClass( 'is-current' );
+		expect( entries[ 1 ] ).toHaveAttribute( 'aria-current', 'true' );
+		expect( entries[ 0 ] ).not.toHaveClass( 'is-current' );
+		expect( entries[ 0 ] ).not.toHaveAttribute( 'aria-current' );
+	} );
+
+	it( 'updates the now-playing text and progress counter', () => {
+		const root = setUpPlaylist();
+
+		root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' )[ 2 ].click();
+
+		expect( root.querySelector( '.videopress-playlist__now-title' ) ).toHaveTextContent( 'Third' );
+		expect( root.querySelector( '.videopress-playlist__now-position' ) ).toHaveTextContent(
+			'3 of 3'
+		);
+		expect( root.querySelector( '.videopress-playlist__now-details' ) ).toHaveTextContent(
+			'720p · 6:15'
+		);
+		expect( root.querySelector( '.videopress-playlist__list-progress' ) ).toHaveTextContent(
+			'3 / 3 · 25:00 total'
+		);
+	} );
+
+	it( 'advances to the next entry when the current video ends', () => {
+		const root = setUpPlaylist();
+
+		postPlayerMessage( 'https://videopress.com', { event: 'videopress_ended', id: 'aaaaaaaa' } );
+
+		const iframe = root.querySelector< HTMLIFrameElement >( '.videopress-playlist__iframe' );
+		expect( iframe.src ).toBe( EMBED_B );
+	} );
+
+	it( 'ignores ended events for videos other than the current one', () => {
+		const root = setUpPlaylist();
+		const iframe = root.querySelector< HTMLIFrameElement >( '.videopress-playlist__iframe' );
+		const initialSrc = iframe.src;
+
+		postPlayerMessage( 'https://videopress.com', { event: 'videopress_ended', id: 'cccccccc' } );
+
+		expect( iframe.src ).toBe( initialSrc );
+	} );
+
+	it( 'ignores ended events from untrusted origins', () => {
+		const root = setUpPlaylist();
+		const iframe = root.querySelector< HTMLIFrameElement >( '.videopress-playlist__iframe' );
+		const initialSrc = iframe.src;
+
+		postPlayerMessage( 'https://evil.example.com', {
+			event: 'videopress_ended',
+			id: 'aaaaaaaa',
+		} );
+
+		expect( iframe.src ).toBe( initialSrc );
+	} );
+
+	it( 'stops after the last entry instead of looping', () => {
+		const root = setUpPlaylist();
+		const entries = root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' );
+		const iframe = root.querySelector< HTMLIFrameElement >( '.videopress-playlist__iframe' );
+
+		entries[ 2 ].click();
+		postPlayerMessage( 'https://videopress.com', { event: 'videopress_ended', id: 'cccccccc' } );
+
+		expect( iframe.src ).toBe( EMBED_C );
+		expect( entries[ 2 ] ).toHaveClass( 'is-current' );
+	} );
+
+	it( 'does not auto-advance when autoplay next is off', () => {
+		const root = setUpPlaylist( false );
+		const iframe = root.querySelector< HTMLIFrameElement >( '.videopress-playlist__iframe' );
+		const initialSrc = iframe.src;
+
+		postPlayerMessage( 'https://videopress.com', { event: 'videopress_ended', id: 'aaaaaaaa' } );
+
+		expect( iframe.src ).toBe( initialSrc );
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -27,13 +27,14 @@ const EMBED_C = 'https://videopress.com/embed/cccccccc?cover=1&preloadContent=me
  * Render a playlist block's front-end markup and initialize it.
  *
  * @param autoplayNext - Value of the wrapper's data-autoplay-next flag.
+ * @param loop         - Value of the wrapper's data-loop flag.
  * @return The block root element.
  */
-function setUpPlaylist( autoplayNext = true ): HTMLElement {
+function setUpPlaylist( autoplayNext = true, loop = false ): HTMLElement {
 	document.body.innerHTML = `
 		<figure class="wp-block-videopress-playlist videopress-playlist is-layout-side-rail" data-autoplay-next="${
 			autoplayNext ? '1' : '0'
-		}">
+		}" data-loop="${ loop ? '1' : '0' }">
 			<div class="videopress-playlist__stage">
 				<iframe class="videopress-playlist__iframe" src="${ EMBED_A.replace(
 					'autoPlay=1',
@@ -150,6 +151,18 @@ describe( 'initPlaylistBlock', () => {
 
 		expect( iframe.src ).toBe( EMBED_C );
 		expect( entries[ 2 ] ).toHaveClass( 'is-current' );
+	} );
+
+	it( 'loops back to the first entry when looping is on', () => {
+		const root = setUpPlaylist( true, true );
+		const entries = root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' );
+		const iframe = root.querySelector< HTMLIFrameElement >( '.videopress-playlist__iframe' );
+
+		entries[ 2 ].click();
+		postPlayerMessage( 'https://videopress.com', { event: 'videopress_ended', id: 'cccccccc' } );
+
+		expect( iframe.src ).toBe( EMBED_A );
+		expect( entries[ 0 ] ).toHaveClass( 'is-current' );
 	} );
 
 	it( 'does not auto-advance when autoplay next is off', () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -246,6 +246,24 @@ describe( 'initPlaylistBlock', () => {
 		expect( list ).not.toHaveClass( 'has-more-videos' );
 	} );
 
+	it( 'shows the fade for horizontal strip overflow too', () => {
+		const root = setUpPlaylist();
+		const list = root.querySelector< HTMLElement >( '.videopress-playlist__list' );
+		const entriesContainer = root.querySelector< HTMLElement >( '.videopress-playlist__entries' );
+
+		// jsdom has no layout; give the strip a horizontally scrollable geometry.
+		Object.defineProperty( entriesContainer, 'scrollWidth', { configurable: true, value: 800 } );
+		Object.defineProperty( entriesContainer, 'clientWidth', { configurable: true, value: 400 } );
+
+		entriesContainer.scrollLeft = 0;
+		entriesContainer.dispatchEvent( new Event( 'scroll' ) );
+		expect( list ).toHaveClass( 'has-more-videos' );
+
+		entriesContainer.scrollLeft = 400;
+		entriesContainer.dispatchEvent( new Event( 'scroll' ) );
+		expect( list ).not.toHaveClass( 'has-more-videos' );
+	} );
+
 	it( 'ignores clicks on entries without an embed URL', () => {
 		const root = setUpPlaylist();
 		const entries = root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -147,4 +147,35 @@ describe( 'initPlaylistBlock', () => {
 
 		expect( iframe.src ).toBe( initialSrc );
 	} );
+
+	it( 'does nothing on a block without playable entries', () => {
+		document.body.innerHTML = `
+			<figure class="wp-block-videopress-playlist" data-autoplay-next="1">
+				<iframe class="videopress-playlist__iframe" src="about:blank" title="Empty"></iframe>
+				<ol class="videopress-playlist__entries"></ol>
+			</figure>
+		`;
+		const root = document.querySelector< HTMLElement >( '.wp-block-videopress-playlist' );
+
+		expect( () => initPlaylistBlock( root ) ).not.toThrow();
+
+		postPlayerMessage( 'https://videopress.com', { event: 'videopress_ended', id: 'aaaaaaaa' } );
+		expect( root.querySelector< HTMLIFrameElement >( '.videopress-playlist__iframe' ).src ).toBe(
+			'about:blank'
+		);
+	} );
+
+	it( 'ignores clicks on entries without an embed URL', () => {
+		const root = setUpPlaylist();
+		const entries = root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' );
+		entries[ 1 ].removeAttribute( 'data-embed-url' );
+		const iframe = root.querySelector< HTMLIFrameElement >( '.videopress-playlist__iframe' );
+		const initialSrc = iframe.src;
+
+		entries[ 1 ].click();
+
+		expect( iframe.src ).toBe( initialSrc );
+		expect( entries[ 1 ] ).not.toHaveClass( 'is-current' );
+		expect( entries[ 0 ] ).toHaveClass( 'is-current' );
+	} );
 } );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
@@ -1,0 +1,24 @@
+import type { VideoGUID } from '../video/types';
+
+export type PlaylistEntry = {
+	guid: VideoGUID;
+	title?: string;
+	durationMs?: number;
+	height?: number;
+	poster?: string;
+};
+
+export type PlaylistLayout = 'side-rail' | 'grid' | 'strip';
+
+export type PlaylistAttributes = {
+	videos: PlaylistEntry[];
+	layout: PlaylistLayout;
+	darkPlayer: boolean;
+	autoplayNext: boolean;
+	showThumbnail: boolean;
+	showTitle: boolean;
+	showResolution: boolean;
+	showDuration: boolean;
+	showPositionNumber: boolean;
+	showTotalRuntime: boolean;
+};

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
@@ -34,4 +34,11 @@ export type PlaylistAttributes = {
 	showDuration: boolean;
 	showPositionNumber: boolean;
 	showTotalRuntime: boolean;
+
+	/*
+	 * Theme font-family preset slugs (theme.json) for the customizable UI
+	 * parts; an empty string inherits the surrounding font.
+	 */
+	nowTitleFontFamily: string;
+	entryTitleFontFamily: string;
 };

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
@@ -36,9 +36,8 @@ export type PlaylistAttributes = {
 	showTotalRuntime: boolean;
 
 	/*
-	 * Theme font-family preset slugs (theme.json) for the customizable UI
-	 * parts; an empty string inherits the surrounding font.
+	 * Theme font-family preset slug (theme.json) for the entry titles; an
+	 * empty string inherits the surrounding font.
 	 */
-	nowTitleFontFamily: string;
 	entryTitleFontFamily: string;
 };

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
@@ -1,10 +1,23 @@
 import type { VideoGUID } from '../video/types';
 
+/**
+ * A stored playlist entry. Only the video reference and numeric metadata
+ * (used for server-rendered totals) are persisted; display metadata —
+ * title and poster — is always read live from the video data, by the
+ * editor and by the front-end view script alike.
+ */
 export type PlaylistEntry = {
 	guid: VideoGUID;
-	title?: string;
 	durationMs?: number;
 	height?: number;
+};
+
+/**
+ * Live display metadata for one video, fetched from the videos API and
+ * never persisted in block attributes.
+ */
+export type PlaylistLiveMetadata = {
+	title?: string;
 	poster?: string;
 };
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
@@ -28,6 +28,8 @@ export type PlaylistAttributes = {
 	layout: PlaylistLayout;
 	darkPlayer: boolean;
 	autoplayNext: boolean;
+	muteByDefault: boolean;
+	loopPlaylist: boolean;
 	showThumbnail: boolean;
 	showTitle: boolean;
 	showResolution: boolean;

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/use-publish-tracking.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/use-publish-tracking.ts
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+/**
+ * WordPress dependencies
+ */
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useEffect, useRef } from '@wordpress/element';
+
+type PublishTrackingProps = {
+	clientId: string;
+	layout: string;
+	videoCount: number;
+};
+
+type EditorSelectors = {
+	isPublishingPost?: () => boolean;
+	getCurrentPostType?: () => string;
+	getBlocksByName?: ( name: string ) => string[];
+};
+
+/**
+ * Record a Tracks event when a post or page is published containing the
+ * playlist block. The first playlist block in the post is the designated
+ * reporter, so multi-playlist posts still record exactly one event per
+ * publish.
+ *
+ * @param props            - Hook props.
+ * @param props.clientId   - This block instance's client id.
+ * @param props.layout     - The block's current layout.
+ * @param props.videoCount - Number of videos in this playlist.
+ */
+export default function usePublishTracking( {
+	clientId,
+	layout,
+	videoCount,
+}: PublishTrackingProps ) {
+	const { isPublishing, postType, playlistClientIds } = useSelect( select => {
+		const editorSelectors = select( editorStore ) as EditorSelectors;
+		const blockEditorSelectors = select( blockEditorStore ) as EditorSelectors;
+
+		return {
+			isPublishing: editorSelectors?.isPublishingPost?.() ?? false,
+			postType: editorSelectors?.getCurrentPostType?.() ?? '',
+			playlistClientIds: blockEditorSelectors?.getBlocksByName?.( 'videopress/playlist' ) ?? [],
+		};
+	}, [] );
+
+	const publishTracked = useRef( false );
+
+	useEffect( () => {
+		if ( ! isPublishing ) {
+			publishTracked.current = false;
+			return;
+		}
+		if (
+			publishTracked.current ||
+			( playlistClientIds.length > 0 && playlistClientIds[ 0 ] !== clientId )
+		) {
+			return;
+		}
+		publishTracked.current = true;
+
+		jetpackAnalytics.tracks.recordEvent( 'jetpack_videopress_playlist_block_published', {
+			post_type: postType,
+			layout,
+			video_count: videoCount,
+			playlist_count: Math.max( 1, playlistClientIds.length ),
+		} );
+	}, [ isPublishing, playlistClientIds, clientId, postType, layout, videoCount ] );
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/utils.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/utils.ts
@@ -117,14 +117,18 @@ export function moveEntry< T >( list: T[], from: number, to: number ): T[] {
  *
  * @param guid     - Video GUID.
  * @param autoplay - Whether the video should start playing once loaded.
+ * @param muted    - Whether playback should start muted.
  * @return Embed URL.
  */
-export function playlistEmbedUrl( guid: string, autoplay: boolean ): string {
+export function playlistEmbedUrl( guid: string, autoplay: boolean, muted = false ): string {
 	const params = new URLSearchParams( {
 		cover: '1',
 		preloadContent: 'metadata',
 		autoPlay: autoplay ? '1' : '0',
 	} );
+	if ( muted ) {
+		params.set( 'muted', '1' );
+	}
 
 	return `https://videopress.com/embed/${ encodeURIComponent( guid ) }?${ params.toString() }`;
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/utils.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/utils.ts
@@ -1,0 +1,130 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+/**
+ * Types
+ */
+import type { PlaylistEntry } from './types';
+
+/**
+ * Format a duration in milliseconds as a timecode, m:ss or h:mm:ss.
+ *
+ * @param durationMs - Duration in milliseconds.
+ * @return Timecode string, or an empty string when the duration is unknown.
+ */
+export function formatTimecode( durationMs?: number ): string {
+	if ( typeof durationMs !== 'number' || ! Number.isFinite( durationMs ) || durationMs <= 0 ) {
+		return '';
+	}
+
+	const totalSeconds = Math.round( durationMs / 1000 );
+	const hours = Math.floor( totalSeconds / 3600 );
+	const minutes = Math.floor( ( totalSeconds % 3600 ) / 60 );
+	const seconds = String( totalSeconds % 60 ).padStart( 2, '0' );
+
+	if ( hours > 0 ) {
+		return `${ hours }:${ String( minutes ).padStart( 2, '0' ) }:${ seconds }`;
+	}
+
+	return `${ minutes }:${ seconds }`;
+}
+
+/**
+ * Format a duration in milliseconds as a long runtime, e.g. "1 hr 13 min".
+ *
+ * @param durationMs - Duration in milliseconds.
+ * @return Runtime string, or an empty string when the duration is unknown.
+ */
+export function formatRuntime( durationMs?: number ): string {
+	if ( typeof durationMs !== 'number' || ! Number.isFinite( durationMs ) || durationMs <= 0 ) {
+		return '';
+	}
+
+	const totalMinutes = Math.max( 1, Math.round( durationMs / 60000 ) );
+	const hours = Math.floor( totalMinutes / 60 );
+	const minutes = totalMinutes % 60;
+
+	if ( hours > 0 && minutes > 0 ) {
+		return sprintf(
+			/* translators: 1: number of hours. 2: number of minutes. */
+			__( '%1$d hr %2$d min', 'jetpack-videopress-pkg' ),
+			hours,
+			minutes
+		);
+	}
+
+	if ( hours > 0 ) {
+		return sprintf(
+			/* translators: %d: number of hours. */
+			__( '%d hr', 'jetpack-videopress-pkg' ),
+			hours
+		);
+	}
+
+	return sprintf(
+		/* translators: %d: number of minutes. */
+		__( '%d min', 'jetpack-videopress-pkg' ),
+		minutes
+	);
+}
+
+/**
+ * Map a video's pixel height to a resolution label, e.g. "1080p" or "4K".
+ *
+ * @param height - Video height in pixels.
+ * @return Resolution label, or an empty string when the height is unknown.
+ */
+export function resolutionLabel( height?: number ): string {
+	if ( typeof height !== 'number' || ! Number.isFinite( height ) || height <= 0 ) {
+		return '';
+	}
+
+	return height >= 2160 ? '4K' : `${ Math.round( height ) }p`;
+}
+
+/**
+ * Sum the known durations of the playlist entries.
+ *
+ * @param videos - Playlist entries.
+ * @return Total duration in milliseconds; 0 when no entry has a known duration.
+ */
+export function playlistRuntimeMs( videos: PlaylistEntry[] ): number {
+	return videos.reduce( ( total, video ) => total + Math.max( 0, video.durationMs ?? 0 ), 0 );
+}
+
+/**
+ * Return a copy of the list with one entry moved to a new position.
+ *
+ * @param list - Source list.
+ * @param from - Index of the entry to move.
+ * @param to   - Destination index.
+ * @return Reordered copy, or the original list when the move is a no-op or out of range.
+ */
+export function moveEntry< T >( list: T[], from: number, to: number ): T[] {
+	if ( from === to || from < 0 || to < 0 || from >= list.length || to >= list.length ) {
+		return list;
+	}
+
+	const next = [ ...list ];
+	const [ moved ] = next.splice( from, 1 );
+	next.splice( to, 0, moved );
+	return next;
+}
+
+/**
+ * Build the VideoPress embed URL for a playlist entry.
+ *
+ * @param guid     - Video GUID.
+ * @param autoplay - Whether the video should start playing once loaded.
+ * @return Embed URL.
+ */
+export function playlistEmbedUrl( guid: string, autoplay: boolean ): string {
+	const params = new URLSearchParams( {
+		cover: '1',
+		preloadContent: 'metadata',
+		autoPlay: autoplay ? '1' : '0',
+	} );
+
+	return `https://videopress.com/embed/${ encodeURIComponent( guid ) }?${ params.toString() }`;
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -103,6 +103,9 @@ $vpp-mono: ui-monospace, menlo, monospace;
 		font-size: 0.9375rem;
 		flex: 1 1 auto;
 		min-inline-size: 0;
+
+		/* User-selected theme font preset; inherits when none is chosen. */
+		font-family: var(--vpp-now-title-font, inherit);
 	}
 
 	&__now-meta {
@@ -242,6 +245,9 @@ $vpp-mono: ui-monospace, menlo, monospace;
 		-webkit-line-clamp: 2;
 		-webkit-box-orient: vertical;
 		overflow: hidden;
+
+		/* User-selected theme font preset; inherits when none is chosen. */
+		font-family: var(--vpp-entry-title-font, inherit);
 	}
 
 	&.hide-titles &__entry-title {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -466,11 +466,38 @@ $vpp-mono: ui-monospace, menlo, monospace;
 		display: none;
 	}
 
+	&.is-layout-strip &__list {
+		position: relative;
+	}
+
 	&.is-layout-strip &__entries {
 		display: flex;
 		gap: 10px;
 		overflow-x: auto;
 		padding-block-end: 4px;
+	}
+
+	/*
+	 * Fades the strip's trailing edge while more entries hide beyond the
+	 * horizontal scroll position. Sticky keeps it pinned to the scrollport
+	 * edge; the negative margin keeps it out of the layout flow.
+	 */
+
+	&.is-layout-strip &__entries::after {
+		content: "";
+		position: sticky;
+		inset-inline-end: 0;
+		flex: none;
+		inline-size: 52px;
+		margin-inline-start: -52px;
+		background: linear-gradient(to right, transparent, var(--vpp-list-fade));
+		opacity: 0;
+		transition: opacity 0.2s;
+		pointer-events: none;
+	}
+
+	&.is-layout-strip &__list.has-more-videos &__entries::after {
+		opacity: 1;
 	}
 
 	&.is-layout-strip &__entry {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -31,27 +31,23 @@
 		padding: 24px;
 	}
 
-	/* Header (count · total runtime) */
-
 	/*
-	 * One right-aligned meta line, "5 videos · 1 hr 13 min", per the side-rail
-	 * design; the separator lives on the runtime so the count stands alone
-	 * when the total runtime is toggled off.
+	 * Count · total runtime meta line, "5 videos · 1 hr 13 min". It lives in
+	 * the list header and only the side rail shows it, to the right of the
+	 * "Up next" label; the separator lives on the runtime so the count stands
+	 * alone when the total runtime is toggled off.
 	 */
 
-	&__header {
-		display: flex;
-		align-items: baseline;
-		justify-content: flex-end;
-		margin-block-end: 14px;
+	&__list-meta {
+		display: none;
 		font-family: ui-monospace, Menlo, monospace;
-		font-size: 0.75rem;
+		font-size: 0.71875rem;
 	}
 
 	&__count + &__runtime::before {
 		content: " · ";
 
-		/* The spans are flex items; keep the separator spaces intact. */
+		/* Keep the separator's spaces from collapsing. */
 		white-space: pre;
 	}
 
@@ -305,6 +301,10 @@
 		display: none;
 	}
 
+	&.is-layout-side-rail &__list-meta {
+		display: inline;
+	}
+
 	&.is-layout-side-rail &__select {
 		padding: 10px 12px;
 		border-inline-start: 3px solid transparent;
@@ -335,7 +335,6 @@
 	 * Grid: player on top, meta row, thumbnails in a grid below.
 	 */
 
-	&.is-layout-grid &__header,
 	&.is-layout-grid &__list-header {
 		display: none;
 	}
@@ -394,7 +393,6 @@
 	 * Strip: player on top, compact horizontal scroller below.
 	 */
 
-	&.is-layout-strip &__header,
 	&.is-layout-strip &__now {
 		display: none;
 	}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -92,37 +92,14 @@ $vpp-mono: ui-monospace, menlo, monospace;
 		border: 0;
 	}
 
+	/* The player renders its own title overlay; this row only carries the
+	   grid layout's playlist runtime line. */
+
 	&__now {
-		display: flex;
-		flex-wrap: wrap;
-		column-gap: 12px;
-		align-items: baseline;
-		margin-block-start: 10px;
-	}
-
-	&__now-title {
-		font-weight: 500;
-		font-size: 0.9375rem;
-		flex: 1 1 auto;
-		min-inline-size: 0;
-
-		/* User-selected theme font preset; inherits when none is chosen. */
-		font-family: var(--vpp-now-title-font, inherit);
-	}
-
-	&__now-meta {
-		font-size: 0.75rem;
-		color: var(--vpp-muted);
-		flex-basis: 100%;
-		margin-block-start: 3px;
-	}
-
-	&__now-position + &__now-details::before {
-		content: " · ";
+		display: none;
 	}
 
 	&__now-runtime {
-		display: none;
 		font-family: $vpp-mono;
 
 		/* 11.5px per the design's grid meta row. */
@@ -298,14 +275,6 @@ $vpp-mono: ui-monospace, menlo, monospace;
 		min-inline-size: 0;
 	}
 
-	&.is-layout-side-rail &__now-position {
-		display: none;
-	}
-
-	&.is-layout-side-rail &__now-position + &__now-details::before {
-		content: "";
-	}
-
 	/*
 	 * The rail never grows past the player column: zero natural height keeps
 	 * it out of the grid row sizing, min-block-size stretches it back to the
@@ -397,13 +366,11 @@ $vpp-mono: ui-monospace, menlo, monospace;
 	}
 
 	&.is-layout-grid &__now {
+		display: flex;
+		justify-content: flex-end;
+		margin-block-start: 10px;
 		padding-block-end: 12px;
 		border-block-end: 1px solid var(--vpp-border);
-	}
-
-	&.is-layout-grid &__now-runtime {
-		display: block;
-		flex: none;
 	}
 
 	&.is-layout-grid &__list {
@@ -449,10 +416,6 @@ $vpp-mono: ui-monospace, menlo, monospace;
 	/*
 	 * Strip: player on top, compact horizontal scroller below.
 	 */
-
-	&.is-layout-strip &__now {
-		display: none;
-	}
 
 	&.is-layout-strip &__list {
 		margin-block-start: 16px;

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -1,0 +1,464 @@
+/**
+ * Video Playlist block — front-end styles.
+ *
+ * One markup structure, restyled per layout via the wrapper classes
+ * `is-layout-side-rail`, `is-layout-grid` and `is-layout-strip`, with an
+ * `is-dark` surface variant and `hide-*` classes for the display toggles.
+ */
+
+.videopress-playlist {
+	--vpp-text: #1e1e1e;
+	--vpp-muted: #6f6f6f;
+	--vpp-border: #e6e4df;
+	--vpp-border-soft: #f2f0eb;
+	--vpp-accent: #2a78d6;
+	--vpp-accent-tint: rgba(42, 120, 214, 0.08);
+	--vpp-thumb-bg: #e6e4df;
+
+	margin: 0;
+	color: var(--vpp-text);
+
+	&.is-dark {
+		--vpp-text: #f2f1ee;
+		--vpp-muted: #8f8d88;
+		--vpp-border: #2a2a30;
+		--vpp-border-soft: #232329;
+		--vpp-accent-tint: rgba(42, 120, 214, 0.18);
+		--vpp-thumb-bg: #2c2c31;
+
+		background: #131315;
+		border-radius: 8px;
+		padding: 24px;
+	}
+
+	/* Header (count · total runtime) */
+
+	&__header {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 12px;
+		margin-block-end: 14px;
+		font-size: 0.8125rem;
+	}
+
+	&__runtime,
+	&__now-runtime,
+	&__count {
+		color: var(--vpp-muted);
+	}
+
+	&.hide-runtime &__runtime,
+	&.hide-runtime &__now-runtime,
+	&.hide-runtime &__list-progress {
+		display: none;
+	}
+
+	/* Player stage */
+
+	&__player {
+		position: relative;
+		aspect-ratio: 16 / 9;
+		border-radius: 6px;
+		overflow: hidden;
+		background: #1c1c20;
+	}
+
+	&__iframe {
+		position: absolute;
+		inset: 0;
+		inline-size: 100%;
+		block-size: 100%;
+		border: 0;
+	}
+
+	&__now {
+		display: flex;
+		flex-wrap: wrap;
+		column-gap: 12px;
+		align-items: baseline;
+		margin-block-start: 10px;
+	}
+
+	&__now-title {
+		font-weight: 500;
+		font-size: 0.9375rem;
+		flex: 1 1 auto;
+		min-inline-size: 0;
+	}
+
+	&__now-meta {
+		font-size: 0.75rem;
+		color: var(--vpp-muted);
+		flex-basis: 100%;
+		margin-block-start: 3px;
+	}
+
+	&__now-position + &__now-details::before {
+		content: " · ";
+	}
+
+	&__now-runtime {
+		font-size: 0.75rem;
+		display: none;
+	}
+
+	/* Entry list */
+
+	&__list-header {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 12px;
+	}
+
+	&__list-label {
+		font-size: 0.6875rem;
+		font-weight: 600;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--vpp-muted);
+	}
+
+	&__list-progress {
+		font-size: 0.71875rem;
+		color: var(--vpp-muted);
+	}
+
+	&__entries {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	&__entry {
+		margin: 0;
+	}
+
+	&__select {
+		appearance: none;
+		display: flex;
+		inline-size: 100%;
+		gap: 10px;
+		align-items: flex-start;
+		padding: 0;
+		border: 0;
+		background: none;
+		font: inherit;
+		color: inherit;
+		text-align: start;
+		cursor: pointer;
+	}
+
+	&__entry-number {
+		font-size: 0.65625rem;
+		font-variant-numeric: tabular-nums;
+		color: var(--vpp-muted);
+	}
+
+	&__entry-thumb {
+		position: relative;
+		flex: none;
+		aspect-ratio: 16 / 9;
+		border-radius: 4px;
+		overflow: hidden;
+		background: var(--vpp-thumb-bg);
+
+		img {
+			position: absolute;
+			inset: 0;
+			inline-size: 100%;
+			block-size: 100%;
+			object-fit: cover;
+		}
+	}
+
+	&.hide-thumbnails &__entry-thumb {
+		display: none;
+	}
+
+	&__entry-time {
+		position: absolute;
+		inset-inline-end: 4px;
+		inset-block-end: 4px;
+		padding: 1px 4px;
+		border-radius: 2px;
+		background: rgba(0, 0, 0, 0.7);
+		color: #fff;
+		font-size: 0.59375rem;
+		font-variant-numeric: tabular-nums;
+	}
+
+	&__entry-flag {
+		position: absolute;
+		inset-inline-start: 4px;
+		inset-block-start: 4px;
+		padding: 2px 4px;
+		border-radius: 2px;
+		background: var(--vpp-accent);
+		color: #fff;
+		font-size: 0.59375rem;
+		font-weight: 600;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		display: none;
+	}
+
+	&__entry-body {
+		min-inline-size: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+	}
+
+	&__entry-title {
+		font-size: 0.78125rem;
+		line-height: 1.3;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	&.hide-titles &__entry-title {
+		display: none;
+	}
+
+	&__entry-meta {
+		font-size: 0.65625rem;
+		color: var(--vpp-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	&__entry-resolution + &__entry-duration::before {
+		content: " · ";
+	}
+
+	&.hide-resolutions &__entry-resolution {
+		display: none;
+	}
+
+	&.hide-resolutions &__entry-resolution + &__entry-duration::before {
+		content: "";
+	}
+
+	&.hide-durations &__entry-duration,
+	&.hide-durations &__entry-time {
+		display: none;
+	}
+
+	&__select.is-current &__entry-title {
+		font-weight: 600;
+	}
+
+	/*
+	 * Side rail: player on the reading side, "Up next" rail beside it.
+	 */
+
+	&.is-layout-side-rail &__body {
+		display: flex;
+		gap: 18px;
+		align-items: flex-start;
+	}
+
+	&.is-layout-side-rail &__stage {
+		flex: 1 1 auto;
+		min-inline-size: 0;
+	}
+
+	&.is-layout-side-rail &__now-position {
+		display: none;
+	}
+
+	&.is-layout-side-rail &__now-position + &__now-details::before {
+		content: "";
+	}
+
+	&.is-layout-side-rail &__list {
+		flex: none;
+		inline-size: min(296px, 38%);
+		border: 1px solid var(--vpp-border);
+		border-radius: 6px;
+		overflow: hidden;
+	}
+
+	&.is-layout-side-rail &__list-header {
+		padding: 9px 12px;
+		border-block-end: 1px solid var(--vpp-border-soft);
+	}
+
+	&.is-layout-side-rail &__list-progress,
+	&.is-layout-side-rail &__list-label--strip {
+		display: none;
+	}
+
+	&.is-layout-side-rail &__select {
+		padding: 10px 12px;
+		border-inline-start: 3px solid transparent;
+	}
+
+	&.is-layout-side-rail &__entry:not(:first-child) &__select {
+		border-block-start: 1px solid var(--vpp-border-soft);
+	}
+
+	&.is-layout-side-rail &__select.is-current {
+		background: var(--vpp-accent-tint);
+		border-inline-start-color: var(--vpp-accent);
+	}
+
+	&.is-layout-side-rail &__select.is-current &__entry-meta {
+		color: var(--vpp-accent);
+	}
+
+	&.is-layout-side-rail &__entry-thumb {
+		inline-size: 76px;
+	}
+
+	&.is-layout-side-rail &__entry-number {
+		align-self: center;
+	}
+
+	/*
+	 * Grid: player on top, meta row, thumbnails in a grid below.
+	 */
+
+	&.is-layout-grid &__header,
+	&.is-layout-grid &__list-header {
+		display: none;
+	}
+
+	&.is-layout-grid &__now {
+		padding-block-end: 12px;
+		border-block-end: 1px solid var(--vpp-border);
+	}
+
+	&.is-layout-grid &__now-runtime {
+		display: block;
+		flex: none;
+	}
+
+	&.is-layout-grid &__list {
+		margin-block-start: 16px;
+	}
+
+	&.is-layout-grid &__entries {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+		gap: 14px;
+	}
+
+	&.is-layout-grid &__select {
+		position: relative;
+		flex-direction: column;
+		gap: 7px;
+	}
+
+	&.is-layout-grid &__entry-thumb {
+		inline-size: 100%;
+	}
+
+	&.is-layout-grid &__select.is-current &__entry-thumb {
+		outline: 2px solid var(--vpp-accent);
+		outline-offset: -2px;
+	}
+
+	&.is-layout-grid &__select.is-current &__entry-flag {
+		display: block;
+	}
+
+	&.is-layout-grid &__entry-number {
+		position: absolute;
+		inset-inline-start: 4px;
+		inset-block-start: 4px;
+		z-index: 1;
+		padding: 1px 4px;
+		border-radius: 2px;
+		background: rgba(255, 255, 255, 0.85);
+		color: #1e1e1e;
+	}
+
+	/*
+	 * Strip: player on top, compact horizontal scroller below.
+	 */
+
+	&.is-layout-strip &__header,
+	&.is-layout-strip &__now {
+		display: none;
+	}
+
+	&.is-layout-strip &__list {
+		margin-block-start: 16px;
+	}
+
+	&.is-layout-strip &__list-header {
+		margin-block-end: 10px;
+	}
+
+	&.is-layout-strip &__list-label--rail {
+		display: none;
+	}
+
+	&.is-layout-strip &__entries {
+		display: flex;
+		gap: 10px;
+		overflow-x: auto;
+		padding-block-end: 4px;
+	}
+
+	&.is-layout-strip &__entry {
+		flex: none;
+		inline-size: 176px;
+	}
+
+	&.is-layout-strip &__select {
+		position: relative;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	&.is-layout-strip &__entry-thumb {
+		inline-size: 100%;
+	}
+
+	&.is-layout-strip &__select.is-current &__entry-thumb {
+		outline: 2px solid var(--vpp-accent);
+		outline-offset: -2px;
+	}
+
+	&.is-layout-strip &__select.is-current &__entry-flag {
+		display: block;
+	}
+
+	&.is-layout-strip &__entry-number {
+		position: absolute;
+		inset-inline-start: 4px;
+		inset-block-start: 4px;
+		z-index: 1;
+		padding: 1px 4px;
+		border-radius: 2px;
+		background: rgba(255, 255, 255, 0.85);
+		color: #1e1e1e;
+	}
+
+	/* The number/flag overlays only make sense with the thumbnail visible. */
+
+	&.hide-thumbnails.is-layout-grid &__entry-number,
+	&.hide-thumbnails.is-layout-strip &__entry-number {
+		position: static;
+		background: none;
+		color: var(--vpp-muted);
+	}
+
+	/* Narrow containers: the side rail stacks under the player. */
+
+	@media ( max-width: 599px ) {
+
+		&.is-layout-side-rail &__body {
+			flex-direction: column;
+		}
+
+		&.is-layout-side-rail &__list {
+			inline-size: 100%;
+		}
+	}
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -33,13 +33,26 @@
 
 	/* Header (count · total runtime) */
 
+	/*
+	 * One right-aligned meta line, "5 videos · 1 hr 13 min", per the side-rail
+	 * design; the separator lives on the runtime so the count stands alone
+	 * when the total runtime is toggled off.
+	 */
+
 	&__header {
 		display: flex;
 		align-items: baseline;
-		justify-content: space-between;
-		gap: 12px;
+		justify-content: flex-end;
 		margin-block-end: 14px;
-		font-size: 0.8125rem;
+		font-family: ui-monospace, Menlo, monospace;
+		font-size: 0.75rem;
+	}
+
+	&__count + &__runtime::before {
+		content: " · ";
+
+		/* The spans are flex items; keep the separator spaces intact. */
+		white-space: pre;
 	}
 
 	&__runtime,

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -17,6 +17,7 @@ $vpp-mono: ui-monospace, menlo, monospace;
 	--vpp-accent: #2a78d6;
 	--vpp-accent-tint: rgba(42, 120, 214, 0.08);
 	--vpp-thumb-bg: #e6e4df;
+	--vpp-list-fade: #fff;
 
 	margin: 0;
 	color: var(--vpp-text);
@@ -28,6 +29,7 @@ $vpp-mono: ui-monospace, menlo, monospace;
 		--vpp-border-soft: #232329;
 		--vpp-accent-tint: rgba(42, 120, 214, 0.18);
 		--vpp-thumb-bg: #2c2c31;
+		--vpp-list-fade: #131315;
 
 		background: #131315;
 		border-radius: 8px;
@@ -286,13 +288,13 @@ $vpp-mono: ui-monospace, menlo, monospace;
 	 */
 
 	&.is-layout-side-rail &__body {
-		display: flex;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) min(296px, 38%);
 		gap: 18px;
-		align-items: flex-start;
+		align-items: stretch;
 	}
 
 	&.is-layout-side-rail &__stage {
-		flex: 1 1 auto;
 		min-inline-size: 0;
 	}
 
@@ -304,15 +306,49 @@ $vpp-mono: ui-monospace, menlo, monospace;
 		content: "";
 	}
 
+	/*
+	 * The rail never grows past the player column: zero natural height keeps
+	 * it out of the grid row sizing, min-block-size stretches it back to the
+	 * row, and the entry list scrolls the overflow.
+	 */
+
 	&.is-layout-side-rail &__list {
-		flex: none;
-		inline-size: min(296px, 38%);
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		block-size: 0;
+		min-block-size: 100%;
 		border: 1px solid var(--vpp-border);
 		border-radius: 6px;
 		overflow: hidden;
 	}
 
+	&.is-layout-side-rail &__entries {
+		flex: 1 1 auto;
+		min-block-size: 0;
+		overflow-y: auto;
+	}
+
+	/* Fades the list bottom while more entries hide below the scroll. */
+
+	&.is-layout-side-rail &__list::after {
+		content: "";
+		position: absolute;
+		inset-inline: 0;
+		inset-block-end: 0;
+		block-size: 52px;
+		background: linear-gradient(transparent, var(--vpp-list-fade));
+		opacity: 0;
+		transition: opacity 0.2s;
+		pointer-events: none;
+	}
+
+	&.is-layout-side-rail &__list.has-more-videos::after {
+		opacity: 1;
+	}
+
 	&.is-layout-side-rail &__list-header {
+		flex: none;
 		padding: 9px 12px;
 		border-block-end: 1px solid var(--vpp-border-soft);
 	}
@@ -486,11 +522,12 @@ $vpp-mono: ui-monospace, menlo, monospace;
 	@media ( max-width: 599px ) {
 
 		&.is-layout-side-rail &__body {
-			flex-direction: column;
+			grid-template-columns: 1fr;
 		}
 
 		&.is-layout-side-rail &__list {
-			inline-size: 100%;
+			block-size: auto;
+			min-block-size: 0;
 		}
 	}
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -6,6 +6,9 @@
  * `is-dark` surface variant and `hide-*` classes for the display toggles.
  */
 
+// Numeric/meta text stack, as specified by the design.
+$vpp-mono: ui-monospace, menlo, monospace;
+
 .videopress-playlist {
 	--vpp-text: #1e1e1e;
 	--vpp-muted: #6f6f6f;
@@ -40,8 +43,14 @@
 
 	&__list-meta {
 		display: none;
-		font-family: ui-monospace, Menlo, monospace;
-		font-size: 0.71875rem;
+		color: var(--vpp-muted);
+		font-family: $vpp-mono;
+
+		/* 12px per the design's count · duration meta line. */
+		font-size: 0.75rem;
+		font-weight: 400;
+		letter-spacing: normal;
+		text-transform: none;
 	}
 
 	&__count + &__runtime::before {
@@ -108,8 +117,11 @@
 	}
 
 	&__now-runtime {
-		font-size: 0.75rem;
 		display: none;
+		font-family: $vpp-mono;
+
+		/* 11.5px per the design's grid meta row. */
+		font-size: 0.71875rem;
 	}
 
 	/* Entry list */
@@ -130,8 +142,11 @@
 	}
 
 	&__list-progress {
-		font-size: 0.71875rem;
 		color: var(--vpp-muted);
+		font-family: $vpp-mono;
+
+		/* 11.5px per the design's strip header counter. */
+		font-size: 0.71875rem;
 	}
 
 	&__entries {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -13,13 +13,97 @@ type PlayerEventMessage = {
 	id?: string;
 };
 
+type LiveVideoMetadata = {
+	title?: string;
+	poster?: string;
+};
+
+/**
+ * Fetch a video's live display metadata from the public videos API.
+ *
+ * Lookups are anonymous: private videos (and API failures) return null and
+ * the entry keeps its server-rendered fallback.
+ *
+ * @param guid - The video GUID.
+ * @return The metadata, or null when it can't be read.
+ */
+async function fetchLiveMetadata( guid: string ): Promise< LiveVideoMetadata | null > {
+	try {
+		const response = await fetch(
+			`https://public-api.wordpress.com/rest/v1.1/videos/${ encodeURIComponent( guid ) }`
+		);
+		if ( ! response.ok ) {
+			return null;
+		}
+		return ( await response.json() ) as LiveVideoMetadata;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Replace the server-rendered fallbacks with live video data: each entry's
+ * title and poster (and the now-playing title) always reflect the videos'
+ * current metadata rather than anything stored with the block.
+ *
+ * @param root - The block wrapper element.
+ * @return Promise resolving once every entry has been processed.
+ */
+export function hydratePlaylistMetadata( root: HTMLElement ): Promise< void[] > {
+	const nowTitle = root.querySelector( '.videopress-playlist__now-title' );
+	const entries = Array.from(
+		root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' )
+	);
+
+	return Promise.all(
+		entries.map( async entry => {
+			const guid = entry.dataset.guid;
+			if ( ! guid ) {
+				return;
+			}
+
+			const metadata = await fetchLiveMetadata( guid );
+			if ( ! metadata ) {
+				return;
+			}
+
+			if ( typeof metadata.title === 'string' && metadata.title ) {
+				entry.dataset.title = metadata.title;
+				const titleElement = entry.querySelector( '.videopress-playlist__entry-title' );
+				if ( titleElement ) {
+					titleElement.textContent = metadata.title;
+				}
+				if ( nowTitle && entry.classList.contains( 'is-current' ) ) {
+					nowTitle.textContent = metadata.title;
+				}
+			}
+
+			if ( typeof metadata.poster === 'string' && metadata.poster ) {
+				const thumb = entry.querySelector( '.videopress-playlist__entry-thumb' );
+				if ( thumb ) {
+					let image = thumb.querySelector( 'img' );
+					if ( ! image ) {
+						image = document.createElement( 'img' );
+						image.alt = '';
+						image.loading = 'lazy';
+						thumb.prepend( image );
+					}
+					if ( image.src !== metadata.poster ) {
+						image.src = metadata.poster;
+					}
+				}
+			}
+		} )
+	);
+}
+
 /**
  * Wire up one Video Playlist block on the front end.
  *
  * Clicking an entry loads its video into the player; when "Autoplay next"
  * is on, a `videopress_ended` message from the player advances to the
- * following entry. All entry text (titles, meta lines, counters) is
- * server-rendered — this script only moves it around.
+ * following entry. Titles and posters are hydrated from live video data;
+ * the numeric meta lines and counters are server-rendered.
  *
  * @param root - The block wrapper element.
  */
@@ -32,6 +116,10 @@ export function initPlaylistBlock( root: HTMLElement ) {
 	if ( ! player || ! entries.length ) {
 		return;
 	}
+
+	// Fire-and-forget: the list is usable with the server-rendered fallbacks
+	// while (or if) the live metadata lookups are still pending.
+	hydratePlaylistMetadata( root );
 
 	const nowTitle = root.querySelector( '.videopress-playlist__now-title' );
 	const nowPosition = root.querySelector( '.videopress-playlist__now-position' );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -201,6 +201,8 @@ export function initPlaylistBlock( root: HTMLElement ) {
 
 		if ( currentIndex + 1 < entries.length ) {
 			activate( currentIndex + 1, true );
+		} else if ( root.dataset.loop === '1' ) {
+			activate( 0, true );
 		}
 	} );
 }

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -1,0 +1,119 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+/**
+ * Internal dependencies
+ */
+import { isAllowedOrigin } from '../../../lib/videopress-allowed-origins';
+import './view.scss';
+
+type PlayerEventMessage = {
+	event?: string;
+	id?: string;
+};
+
+/**
+ * Wire up one Video Playlist block on the front end.
+ *
+ * Clicking an entry loads its video into the player; when "Autoplay next"
+ * is on, a `videopress_ended` message from the player advances to the
+ * following entry. All entry text (titles, meta lines, counters) is
+ * server-rendered — this script only moves it around.
+ *
+ * @param root - The block wrapper element.
+ */
+export function initPlaylistBlock( root: HTMLElement ) {
+	const player = root.querySelector< HTMLIFrameElement >( '.videopress-playlist__iframe' );
+	const entries = Array.from(
+		root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' )
+	);
+
+	if ( ! player || ! entries.length ) {
+		return;
+	}
+
+	const nowTitle = root.querySelector( '.videopress-playlist__now-title' );
+	const nowPosition = root.querySelector( '.videopress-playlist__now-position' );
+	const nowDetails = root.querySelector( '.videopress-playlist__now-details' );
+	const listProgress = root.querySelector( '.videopress-playlist__list-progress' );
+
+	let currentIndex = Math.max(
+		0,
+		entries.findIndex( entry => entry.classList.contains( 'is-current' ) )
+	);
+
+	const activate = ( index: number, autoplay: boolean ) => {
+		const entry = entries[ index ];
+		if ( ! entry || ! entry.dataset.embedUrl ) {
+			return;
+		}
+
+		currentIndex = index;
+		player.src = autoplay
+			? entry.dataset.embedUrl
+			: entry.dataset.embedUrl.replace( 'autoPlay=1', 'autoPlay=0' );
+
+		entries.forEach( ( other, i ) => {
+			other.classList.toggle( 'is-current', i === index );
+			if ( i === index ) {
+				other.setAttribute( 'aria-current', 'true' );
+			} else {
+				other.removeAttribute( 'aria-current' );
+			}
+		} );
+
+		if ( nowTitle ) {
+			nowTitle.textContent = entry.dataset.title ?? '';
+		}
+		if ( nowPosition && entry.dataset.position ) {
+			nowPosition.textContent = entry.dataset.position;
+		}
+		if ( nowDetails ) {
+			nowDetails.textContent = entry.dataset.details ?? '';
+		}
+		if ( listProgress && entry.dataset.progress ) {
+			listProgress.textContent = entry.dataset.progress;
+		}
+	};
+
+	entries.forEach( ( entry, index ) => {
+		entry.addEventListener( 'click', () => activate( index, true ) );
+	} );
+
+	if ( root.dataset.autoplayNext !== '1' ) {
+		return;
+	}
+
+	window.addEventListener( 'message', ( event: MessageEvent< PlayerEventMessage > ) => {
+		if ( ! isAllowedOrigin( event.origin ) ) {
+			return;
+		}
+
+		const { event: eventName, id } = event.data || {};
+
+		// React only to the end of the video this playlist is showing.
+		if (
+			eventName !== 'videopress_ended' ||
+			! id ||
+			id !== entries[ currentIndex ]?.dataset.guid
+		) {
+			return;
+		}
+
+		if ( currentIndex + 1 < entries.length ) {
+			activate( currentIndex + 1, true );
+		}
+	} );
+}
+
+/**
+ * Initialize every Video Playlist block on the page.
+ */
+export function initAllPlaylistBlocks() {
+	document
+		.querySelectorAll< HTMLElement >( '.wp-block-videopress-playlist' )
+		.forEach( initPlaylistBlock );
+}
+
+domReady( initAllPlaylistBlocks );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -118,9 +118,9 @@ export function initPlaylistBlock( root: HTMLElement ) {
 	}
 
 	/*
-	 * The side rail caps the list at the player column's height; while more
-	 * entries hide below the scroll position, the list carries a class that
-	 * shows the bottom fade.
+	 * While more entries hide beyond the scroll position — below it in the
+	 * capped side rail, past its trailing edge in the horizontal strip — the
+	 * list carries a class that shows the matching fade.
 	 */
 	const list = root.querySelector< HTMLElement >( '.videopress-playlist__list' );
 	const entriesContainer = root.querySelector< HTMLElement >( '.videopress-playlist__entries' );
@@ -128,10 +128,16 @@ export function initPlaylistBlock( root: HTMLElement ) {
 		if ( ! list || ! entriesContainer ) {
 			return;
 		}
-		list.classList.toggle(
-			'has-more-videos',
-			entriesContainer.scrollHeight - entriesContainer.scrollTop - entriesContainer.clientHeight > 1
-		);
+		const moreBelow =
+			entriesContainer.scrollHeight - entriesContainer.scrollTop - entriesContainer.clientHeight >
+			1;
+		// scrollLeft is negative in right-to-left scrollers.
+		const moreInline =
+			entriesContainer.scrollWidth -
+				Math.abs( entriesContainer.scrollLeft ) -
+				entriesContainer.clientWidth >
+			1;
+		list.classList.toggle( 'has-more-videos', moreBelow || moreInline );
 	};
 	entriesContainer?.addEventListener( 'scroll', updateScrollHint, { passive: true } );
 	updateScrollHint();

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -117,9 +117,29 @@ export function initPlaylistBlock( root: HTMLElement ) {
 		return;
 	}
 
+	/*
+	 * The side rail caps the list at the player column's height; while more
+	 * entries hide below the scroll position, the list carries a class that
+	 * shows the bottom fade.
+	 */
+	const list = root.querySelector< HTMLElement >( '.videopress-playlist__list' );
+	const entriesContainer = root.querySelector< HTMLElement >( '.videopress-playlist__entries' );
+	const updateScrollHint = () => {
+		if ( ! list || ! entriesContainer ) {
+			return;
+		}
+		list.classList.toggle(
+			'has-more-videos',
+			entriesContainer.scrollHeight - entriesContainer.scrollTop - entriesContainer.clientHeight > 1
+		);
+	};
+	entriesContainer?.addEventListener( 'scroll', updateScrollHint, { passive: true } );
+	updateScrollHint();
+
 	// Fire-and-forget: the list is usable with the server-rendered fallbacks
-	// while (or if) the live metadata lookups are still pending.
-	hydratePlaylistMetadata( root );
+	// while (or if) the live metadata lookups are still pending. Hydrated
+	// posters can change entry heights, so refresh the scroll hint after.
+	hydratePlaylistMetadata( root ).then( updateScrollHint );
 
 	const nowTitle = root.querySelector( '.videopress-playlist__now-title' );
 	const nowPosition = root.querySelector( '.videopress-playlist__now-position' );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -50,7 +50,6 @@ async function fetchLiveMetadata( guid: string ): Promise< LiveVideoMetadata | n
  * @return Promise resolving once every entry has been processed.
  */
 export function hydratePlaylistMetadata( root: HTMLElement ): Promise< void[] > {
-	const nowTitle = root.querySelector( '.videopress-playlist__now-title' );
 	const entries = Array.from(
 		root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' )
 	);
@@ -72,9 +71,6 @@ export function hydratePlaylistMetadata( root: HTMLElement ): Promise< void[] > 
 				const titleElement = entry.querySelector( '.videopress-playlist__entry-title' );
 				if ( titleElement ) {
 					titleElement.textContent = metadata.title;
-				}
-				if ( nowTitle && entry.classList.contains( 'is-current' ) ) {
-					nowTitle.textContent = metadata.title;
 				}
 			}
 
@@ -147,9 +143,6 @@ export function initPlaylistBlock( root: HTMLElement ) {
 	// posters can change entry heights, so refresh the scroll hint after.
 	hydratePlaylistMetadata( root ).then( updateScrollHint );
 
-	const nowTitle = root.querySelector( '.videopress-playlist__now-title' );
-	const nowPosition = root.querySelector( '.videopress-playlist__now-position' );
-	const nowDetails = root.querySelector( '.videopress-playlist__now-details' );
 	const listProgress = root.querySelector( '.videopress-playlist__list-progress' );
 
 	let currentIndex = Math.max(
@@ -177,15 +170,6 @@ export function initPlaylistBlock( root: HTMLElement ) {
 			}
 		} );
 
-		if ( nowTitle ) {
-			nowTitle.textContent = entry.dataset.title ?? '';
-		}
-		if ( nowPosition && entry.dataset.position ) {
-			nowPosition.textContent = entry.dataset.position;
-		}
-		if ( nowDetails ) {
-			nowDetails.textContent = entry.dataset.details ?? '';
-		}
 		if ( listProgress && entry.dataset.progress ) {
 			listProgress.textContent = entry.dataset.progress;
 		}

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * Tests for the Video Playlist block registration and render callback.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack;
+
+use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Initializer;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test suite for Initializer::register_videopress_playlist_block and
+ * Initializer::render_videopress_playlist_block.
+ *
+ * Runs in separate processes because rendering loads Jwt_Token_Bridge, which
+ * other suites (Uploader_Test) replace with a Mockery alias mock that requires
+ * the real class to not be loaded yet.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
+class Playlist_Block_Test extends BaseTestCase {
+
+	/**
+	 * Directory holding the block.json fixture written for registration tests.
+	 *
+	 * @var string|null
+	 */
+	private $fixture_dir = null;
+
+	/**
+	 * Give render calls a block context, as do_blocks() would.
+	 */
+	protected function set_up() {
+		\WP_Block_Supports::$block_to_render = array(
+			'blockName' => 'videopress/playlist',
+			'attrs'     => array(),
+		);
+	}
+
+	/**
+	 * Clean up any block registration and fixture the test created.
+	 */
+	protected function tear_down() {
+		\WP_Block_Supports::$block_to_render = null;
+
+		$registry = \WP_Block_Type_Registry::get_instance();
+		if ( $registry->is_registered( 'videopress/playlist' ) ) {
+			unregister_block_type( 'videopress/playlist' );
+		}
+
+		if ( $this->fixture_dir && file_exists( $this->fixture_dir . '/block.json' ) ) {
+			wp_delete_file( $this->fixture_dir . '/block.json' );
+			rmdir( $this->fixture_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+			$this->fixture_dir = null;
+		}
+	}
+
+	/**
+	 * Build block attributes with the given overrides applied.
+	 *
+	 * @param array $overrides Attribute overrides.
+	 *
+	 * @return array Attributes.
+	 */
+	private function attributes( $overrides = array() ) {
+		return array_merge(
+			array(
+				'videos' => array(
+					array(
+						'guid'       => 'abcDEF12',
+						'title'      => 'Kiln loading, start to finish',
+						'durationMs' => 724000,
+						'height'     => 1080,
+						'poster'     => 'https://example.com/poster.jpg',
+					),
+					array(
+						'guid'       => 'ghiJKL34',
+						'title'      => 'Wedging clay by hand',
+						'durationMs' => 401000,
+						'height'     => 2160,
+						'poster'     => '',
+					),
+				),
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Rendering without playable entries returns an empty string.
+	 */
+	public function test_render_returns_empty_without_videos() {
+		$this->assertSame( '', VideoPress_Initializer::render_videopress_playlist_block( array() ) );
+		$this->assertSame(
+			'',
+			VideoPress_Initializer::render_videopress_playlist_block( array( 'videos' => array() ) )
+		);
+		$this->assertSame(
+			'',
+			VideoPress_Initializer::render_videopress_playlist_block( array( 'videos' => 'nope' ) )
+		);
+	}
+
+	/**
+	 * Entries without a valid 8-character alphanumeric GUID are dropped.
+	 */
+	public function test_render_drops_invalid_guids() {
+		$attributes = array(
+			'videos' => array(
+				array( 'guid' => 'has spaces' ),
+				array( 'guid' => '"><script>' ),
+				array( 'guid' => 'short' ),
+				array( 'title' => 'No GUID at all' ),
+			),
+		);
+
+		$this->assertSame( '', VideoPress_Initializer::render_videopress_playlist_block( $attributes ) );
+
+		$attributes['videos'][] = array( 'guid' => 'abcDEF12' );
+		$markup                 = VideoPress_Initializer::render_videopress_playlist_block( $attributes );
+
+		$this->assertStringContainsString( 'data-guid="abcDEF12"', $markup );
+		$this->assertSame( 1, substr_count( $markup, 'data-guid=' ) );
+		$this->assertStringContainsString( '1 video<', $markup );
+	}
+
+	/**
+	 * The happy path renders the player, the entry list and the metadata.
+	 */
+	public function test_render_outputs_player_and_entries() {
+		$markup = VideoPress_Initializer::render_videopress_playlist_block( $this->attributes() );
+
+		// Player: first entry loaded without autoplay.
+		$this->assertStringContainsString( 'videopress.com/embed/abcDEF12', $markup );
+		$this->assertStringContainsString( 'autoPlay=0', $markup );
+
+		// Entries carry the data the view script needs.
+		$this->assertStringContainsString( 'data-guid="abcDEF12"', $markup );
+		$this->assertStringContainsString( 'data-guid="ghiJKL34"', $markup );
+		$this->assertStringContainsString( 'autoPlay=1', $markup );
+		$this->assertStringContainsString( 'data-position="2 of 2"', $markup );
+
+		// First entry is marked current.
+		$this->assertStringContainsString( 'videopress-playlist__select is-current', $markup );
+		$this->assertStringContainsString( 'aria-current="true"', $markup );
+
+		// Header and metadata.
+		$this->assertStringContainsString( '2 videos', $markup );
+		$this->assertStringContainsString( '19 min', $markup );
+		$this->assertStringContainsString( '1080p', $markup );
+		$this->assertStringContainsString( '4K', $markup );
+		$this->assertStringContainsString( '12:04', $markup );
+		$this->assertStringContainsString( 'https://example.com/poster.jpg', $markup );
+	}
+
+	/**
+	 * Attribute-controlled text is escaped.
+	 */
+	public function test_render_escapes_titles() {
+		$attributes = array(
+			'videos' => array(
+				array(
+					'guid'  => 'abcDEF12',
+					'title' => '<script>alert(1)</script>',
+				),
+			),
+		);
+
+		$markup = VideoPress_Initializer::render_videopress_playlist_block( $attributes );
+
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $markup );
+		$this->assertStringContainsString( '&lt;script&gt;', $markup );
+	}
+
+	/**
+	 * Poster URLs that aren't URLs don't survive escaping into an img tag.
+	 */
+	public function test_render_escapes_poster_url() {
+		$attributes = array(
+			'videos' => array(
+				array(
+					'guid'   => 'abcDEF12',
+					// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+					'poster' => '"><script src="https://evil.example/x.js"></script>',
+				),
+			),
+		);
+
+		$markup = VideoPress_Initializer::render_videopress_playlist_block( $attributes );
+
+		$this->assertStringNotContainsString( '<script', $markup );
+		$this->assertStringNotContainsString( 'evil.example', $markup );
+	}
+
+	/**
+	 * Layout and dark-surface options map to wrapper classes.
+	 */
+	public function test_render_layout_and_dark_classes() {
+		$default = VideoPress_Initializer::render_videopress_playlist_block( $this->attributes() );
+		$this->assertStringContainsString( 'is-layout-side-rail', $default );
+		$this->assertStringNotContainsString( 'is-dark', $default );
+
+		$grid_dark = VideoPress_Initializer::render_videopress_playlist_block(
+			$this->attributes(
+				array(
+					'layout'     => 'grid',
+					'darkPlayer' => true,
+				)
+			)
+		);
+		$this->assertStringContainsString( 'is-layout-grid', $grid_dark );
+		$this->assertStringContainsString( 'is-dark', $grid_dark );
+
+		$bogus = VideoPress_Initializer::render_videopress_playlist_block(
+			$this->attributes( array( 'layout' => 'sideways' ) )
+		);
+		$this->assertStringContainsString( 'is-layout-side-rail', $bogus );
+	}
+
+	/**
+	 * Display toggles map to hide-* classes and the position-number markup.
+	 */
+	public function test_render_display_toggles() {
+		$defaults = VideoPress_Initializer::render_videopress_playlist_block( $this->attributes() );
+		$this->assertStringNotContainsString( 'hide-thumbnails', $defaults );
+		$this->assertStringNotContainsString( 'videopress-playlist__entry-number', $defaults );
+
+		$markup = VideoPress_Initializer::render_videopress_playlist_block(
+			$this->attributes(
+				array(
+					'showThumbnail'      => false,
+					'showTitle'          => false,
+					'showResolution'     => false,
+					'showDuration'       => false,
+					'showTotalRuntime'   => false,
+					'showPositionNumber' => true,
+				)
+			)
+		);
+
+		$this->assertStringContainsString( 'hide-thumbnails', $markup );
+		$this->assertStringContainsString( 'hide-titles', $markup );
+		$this->assertStringContainsString( 'hide-resolutions', $markup );
+		$this->assertStringContainsString( 'hide-durations', $markup );
+		$this->assertStringContainsString( 'hide-runtime', $markup );
+		$this->assertStringContainsString( '<span class="videopress-playlist__entry-number">01</span>', $markup );
+	}
+
+	/**
+	 * The autoplay-next flag is exposed to the view script as a data attribute.
+	 */
+	public function test_render_autoplay_next_flag() {
+		$off = VideoPress_Initializer::render_videopress_playlist_block( $this->attributes() );
+		$this->assertStringContainsString( 'data-autoplay-next="0"', $off );
+
+		$on = VideoPress_Initializer::render_videopress_playlist_block(
+			$this->attributes( array( 'autoplayNext' => true ) )
+		);
+		$this->assertStringContainsString( 'data-autoplay-next="1"', $on );
+	}
+
+	/**
+	 * Registration reads the metadata file and registers the block once.
+	 */
+	public function test_register_videopress_playlist_block() {
+		// register_block_type() only accepts metadata files named block.json.
+		$this->fixture_dir = get_temp_dir() . 'playlist-block-' . wp_generate_password( 8, false );
+		mkdir( $this->fixture_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			$this->fixture_dir . '/block.json',
+			wp_json_encode(
+				array(
+					'apiVersion' => 3,
+					'name'       => 'videopress/playlist',
+					'title'      => 'Video Playlist',
+				),
+				JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+			)
+		);
+
+		VideoPress_Initializer::register_videopress_playlist_block( $this->fixture_dir . '/block.json' );
+
+		$registry = \WP_Block_Type_Registry::get_instance();
+		$this->assertTrue( $registry->is_registered( 'videopress/playlist' ) );
+
+		$block_type = $registry->get_registered( 'videopress/playlist' );
+		$this->assertSame(
+			array( VideoPress_Initializer::class, 'render_videopress_playlist_block' ),
+			$block_type->render_callback
+		);
+
+		// A second call must not fatal on the already-registered block.
+		VideoPress_Initializer::register_videopress_playlist_block( $this->fixture_dir . '/block.json' );
+		$this->assertTrue( $registry->is_registered( 'videopress/playlist' ) );
+	}
+
+	/**
+	 * Registration bails quietly when the metadata file is missing.
+	 */
+	public function test_register_without_metadata_file_is_a_noop() {
+		VideoPress_Initializer::register_videopress_playlist_block( '/nonexistent/block.json' );
+
+		$this->assertFalse(
+			\WP_Block_Type_Registry::get_instance()->is_registered( 'videopress/playlist' )
+		);
+	}
+}

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -388,7 +388,9 @@ class Playlist_Block_Test extends BaseTestCase {
 	 * Runs in this test's separate process, so the fake Jetpack class doesn't leak.
 	 */
 	public function test_register_skips_when_videopress_module_is_inactive() {
-		class_alias( \stdClass::class, 'Jetpack' );
+		// An anonymous class stands in for the plugin: class_alias() (and Phan)
+		// require a user-defined class, and internal ones only work on PHP 8.3+.
+		class_alias( get_class( new class() {} ), 'Jetpack' );
 
 		$this->fixture_dir = get_temp_dir() . 'playlist-block-' . wp_generate_password( 8, false );
 		mkdir( $this->fixture_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -151,9 +151,12 @@ class Playlist_Block_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'videopress-playlist__select is-current', $markup );
 		$this->assertStringContainsString( 'aria-current="true"', $markup );
 
-		// Header and metadata.
-		$this->assertStringContainsString( '2 videos', $markup );
-		$this->assertStringContainsString( '19 min', $markup );
+		// The count · runtime meta line lives in the list header, next to "Up next".
+		$this->assertStringContainsString(
+			'<span class="videopress-playlist__list-meta"><span class="videopress-playlist__count">2 videos</span><span class="videopress-playlist__runtime">19 min</span></span>',
+			$markup
+		);
+		$this->assertStringNotContainsString( 'videopress-playlist__header', $markup );
 		$this->assertStringContainsString( '1080p', $markup );
 		$this->assertStringContainsString( '4K', $markup );
 		$this->assertStringContainsString( '12:04', $markup );

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -291,6 +291,18 @@ class Playlist_Block_Test extends BaseTestCase {
 
 		// Muted playback rides on every embed URL: the player and the entries.
 		$this->assertSame( 3, substr_count( $markup, 'muted=1' ) );
+
+		// Looping implies auto-advancing even with autoplay-next toggled off.
+		$loop_only = VideoPress_Initializer::render_videopress_playlist_block(
+			$this->attributes(
+				array(
+					'autoplayNext' => false,
+					'loopPlaylist' => true,
+				)
+			)
+		);
+		$this->assertStringContainsString( 'data-autoplay-next="1"', $loop_only );
+		$this->assertStringContainsString( 'data-loop="1"', $loop_only );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -75,17 +75,13 @@ class Playlist_Block_Test extends BaseTestCase {
 				'videos' => array(
 					array(
 						'guid'       => 'abcDEF12',
-						'title'      => 'Kiln loading, start to finish',
 						'durationMs' => 724000,
 						'height'     => 1080,
-						'poster'     => 'https://example.com/poster.jpg',
 					),
 					array(
 						'guid'       => 'ghiJKL34',
-						'title'      => 'Wedging clay by hand',
 						'durationMs' => 401000,
 						'height'     => 2160,
-						'poster'     => '',
 					),
 				),
 			),
@@ -160,36 +156,23 @@ class Playlist_Block_Test extends BaseTestCase {
 		$this->assertStringContainsString( '1080p', $markup );
 		$this->assertStringContainsString( '4K', $markup );
 		$this->assertStringContainsString( '12:04', $markup );
-		$this->assertStringContainsString( 'https://example.com/poster.jpg', $markup );
+
+		// Titles are positional fallbacks; the view script hydrates live data.
+		$this->assertStringContainsString( 'data-title="Video 1"', $markup );
+		$this->assertStringContainsString( '>Video 2<', $markup );
+		$this->assertStringNotContainsString( '<img', $markup );
 	}
 
 	/**
-	 * Attribute-controlled text is escaped.
+	 * Display metadata is live-only: stored title/poster values (including
+	 * hostile ones) never reach the markup.
 	 */
-	public function test_render_escapes_titles() {
-		$attributes = array(
-			'videos' => array(
-				array(
-					'guid'  => 'abcDEF12',
-					'title' => '<script>alert(1)</script>',
-				),
-			),
-		);
-
-		$markup = VideoPress_Initializer::render_videopress_playlist_block( $attributes );
-
-		$this->assertStringNotContainsString( '<script>alert(1)</script>', $markup );
-		$this->assertStringContainsString( '&lt;script&gt;', $markup );
-	}
-
-	/**
-	 * Poster URLs that aren't URLs don't survive escaping into an img tag.
-	 */
-	public function test_render_escapes_poster_url() {
+	public function test_render_ignores_stored_display_metadata() {
 		$attributes = array(
 			'videos' => array(
 				array(
 					'guid'   => 'abcDEF12',
+					'title'  => '<script>alert(1)</script>',
 					// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 					'poster' => '"><script src="https://evil.example/x.js"></script>',
 				),
@@ -199,7 +182,10 @@ class Playlist_Block_Test extends BaseTestCase {
 		$markup = VideoPress_Initializer::render_videopress_playlist_block( $attributes );
 
 		$this->assertStringNotContainsString( '<script', $markup );
+		$this->assertStringNotContainsString( 'alert(1)', $markup );
 		$this->assertStringNotContainsString( 'evil.example', $markup );
+		$this->assertStringNotContainsString( '<img', $markup );
+		$this->assertStringContainsString( '>Video 1<', $markup );
 	}
 
 	/**
@@ -324,7 +310,6 @@ class Playlist_Block_Test extends BaseTestCase {
 				'videos' => array(
 					array(
 						'guid'       => 'abcDEF12',
-						'title'      => 'Full workshop recording',
 						'durationMs' => 4384000, // 1:13:04.
 					),
 				),
@@ -339,7 +324,6 @@ class Playlist_Block_Test extends BaseTestCase {
 				'videos' => array(
 					array(
 						'guid'       => 'abcDEF12',
-						'title'      => 'Two hours of throwing',
 						'durationMs' => 7200000, // 2:00:00.
 					),
 				),

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -311,4 +311,103 @@ class Playlist_Block_Test extends BaseTestCase {
 			\WP_Block_Type_Registry::get_instance()->is_registered( 'videopress/playlist' )
 		);
 	}
+
+	/**
+	 * Hour-long playlists format both timecodes and the long runtime with hours.
+	 */
+	public function test_render_formats_hour_long_durations() {
+		$markup = VideoPress_Initializer::render_videopress_playlist_block(
+			array(
+				'videos' => array(
+					array(
+						'guid'       => 'abcDEF12',
+						'title'      => 'Full workshop recording',
+						'durationMs' => 4384000, // 1:13:04.
+					),
+				),
+			)
+		);
+
+		$this->assertStringContainsString( '1:13:04', $markup );
+		$this->assertStringContainsString( '1 hr 13 min', $markup );
+
+		$markup = VideoPress_Initializer::render_videopress_playlist_block(
+			array(
+				'videos' => array(
+					array(
+						'guid'       => 'abcDEF12',
+						'title'      => 'Two hours of throwing',
+						'durationMs' => 7200000, // 2:00:00.
+					),
+				),
+			)
+		);
+
+		$this->assertStringContainsString( '2:00:00', $markup );
+		$this->assertStringContainsString( '2 hr', $markup );
+	}
+
+	/**
+	 * Without an argument, registration reads the package build output.
+	 */
+	public function test_register_defaults_to_build_metadata() {
+		VideoPress_Initializer::register_videopress_playlist_block();
+
+		$initializer_dir = dirname( ( new \ReflectionClass( VideoPress_Initializer::class ) )->getFileName() );
+		$build_metadata  = $initializer_dir . '/../build/block-editor/blocks/playlist/block.json';
+
+		// Registered exactly when the package build output exists.
+		$this->assertSame(
+			file_exists( $build_metadata ),
+			\WP_Block_Type_Registry::get_instance()->is_registered( 'videopress/playlist' )
+		);
+	}
+
+	/**
+	 * Metadata without a block name is not registered.
+	 */
+	public function test_register_skips_metadata_without_name() {
+		$this->fixture_dir = get_temp_dir() . 'playlist-block-' . wp_generate_password( 8, false );
+		mkdir( $this->fixture_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			$this->fixture_dir . '/block.json',
+			'{}'
+		);
+
+		VideoPress_Initializer::register_videopress_playlist_block( $this->fixture_dir . '/block.json' );
+
+		$this->assertFalse(
+			\WP_Block_Type_Registry::get_instance()->is_registered( 'videopress/playlist' )
+		);
+	}
+
+	/**
+	 * With the Jetpack plugin active but the VideoPress module off (and no
+	 * standalone plugin), the block is not registered at all.
+	 *
+	 * Runs in this test's separate process, so the fake Jetpack class doesn't leak.
+	 */
+	public function test_register_skips_when_videopress_module_is_inactive() {
+		class_alias( \stdClass::class, 'Jetpack' );
+
+		$this->fixture_dir = get_temp_dir() . 'playlist-block-' . wp_generate_password( 8, false );
+		mkdir( $this->fixture_dir ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_mkdir
+		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			$this->fixture_dir . '/block.json',
+			wp_json_encode(
+				array(
+					'apiVersion' => 3,
+					'name'       => 'videopress/playlist',
+					'title'      => 'Video Playlist',
+				),
+				JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+			)
+		);
+
+		VideoPress_Initializer::register_videopress_playlist_block( $this->fixture_dir . '/block.json' );
+
+		$this->assertFalse(
+			\WP_Block_Type_Registry::get_instance()->is_registered( 'videopress/playlist' )
+		);
+	}
 }

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -269,16 +269,28 @@ class Playlist_Block_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The autoplay-next flag is exposed to the view script as a data attribute.
+	 * The playback flags are exposed to the view script and embed URLs.
 	 */
-	public function test_render_autoplay_next_flag() {
-		$off = VideoPress_Initializer::render_videopress_playlist_block( $this->attributes() );
-		$this->assertStringContainsString( 'data-autoplay-next="0"', $off );
+	public function test_render_playback_options() {
+		$defaults = VideoPress_Initializer::render_videopress_playlist_block( $this->attributes() );
+		$this->assertStringContainsString( 'data-autoplay-next="0"', $defaults );
+		$this->assertStringContainsString( 'data-loop="0"', $defaults );
+		$this->assertStringNotContainsString( 'muted=1', $defaults );
 
-		$on = VideoPress_Initializer::render_videopress_playlist_block(
-			$this->attributes( array( 'autoplayNext' => true ) )
+		$markup = VideoPress_Initializer::render_videopress_playlist_block(
+			$this->attributes(
+				array(
+					'autoplayNext'  => true,
+					'loopPlaylist'  => true,
+					'muteByDefault' => true,
+				)
+			)
 		);
-		$this->assertStringContainsString( 'data-autoplay-next="1"', $on );
+		$this->assertStringContainsString( 'data-autoplay-next="1"', $markup );
+		$this->assertStringContainsString( 'data-loop="1"', $markup );
+
+		// Muted playback rides on every embed URL: the player and the entries.
+		$this->assertSame( 3, substr_count( $markup, 'muted=1' ) );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -248,18 +248,9 @@ class Playlist_Block_Test extends BaseTestCase {
 	 */
 	public function test_render_title_font_presets() {
 		$markup = VideoPress_Initializer::render_videopress_playlist_block(
-			$this->attributes(
-				array(
-					'nowTitleFontFamily'   => 'serif-pro',
-					'entryTitleFontFamily' => 'grotesk',
-				)
-			)
+			$this->attributes( array( 'entryTitleFontFamily' => 'grotesk' ) )
 		);
 
-		$this->assertStringContainsString(
-			'--vpp-now-title-font:var(--wp--preset--font-family--serif-pro);',
-			$markup
-		);
 		$this->assertStringContainsString(
 			'--vpp-entry-title-font:var(--wp--preset--font-family--grotesk);',
 			$markup
@@ -267,14 +258,13 @@ class Playlist_Block_Test extends BaseTestCase {
 
 		// No selection, no style attribute payload.
 		$default_markup = VideoPress_Initializer::render_videopress_playlist_block( $this->attributes() );
-		$this->assertStringNotContainsString( '--vpp-now-title-font', $default_markup );
 		$this->assertStringNotContainsString( '--vpp-entry-title-font', $default_markup );
 
 		// Hostile "slugs" never reach the style attribute.
 		$hostile_markup = VideoPress_Initializer::render_videopress_playlist_block(
-			$this->attributes( array( 'nowTitleFontFamily' => 'x);}body{display:none' ) )
+			$this->attributes( array( 'entryTitleFontFamily' => 'x);}body{display:none' ) )
 		);
-		$this->assertStringNotContainsString( '--vpp-now-title-font', $hostile_markup );
+		$this->assertStringNotContainsString( '--vpp-entry-title-font', $hostile_markup );
 		$this->assertStringNotContainsString( 'display:none', $hostile_markup );
 	}
 

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -243,6 +243,42 @@ class Playlist_Block_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Title font presets render as CSS custom properties; anything that isn't
+	 * a plain preset slug is dropped.
+	 */
+	public function test_render_title_font_presets() {
+		$markup = VideoPress_Initializer::render_videopress_playlist_block(
+			$this->attributes(
+				array(
+					'nowTitleFontFamily'   => 'serif-pro',
+					'entryTitleFontFamily' => 'grotesk',
+				)
+			)
+		);
+
+		$this->assertStringContainsString(
+			'--vpp-now-title-font:var(--wp--preset--font-family--serif-pro);',
+			$markup
+		);
+		$this->assertStringContainsString(
+			'--vpp-entry-title-font:var(--wp--preset--font-family--grotesk);',
+			$markup
+		);
+
+		// No selection, no style attribute payload.
+		$default_markup = VideoPress_Initializer::render_videopress_playlist_block( $this->attributes() );
+		$this->assertStringNotContainsString( '--vpp-now-title-font', $default_markup );
+		$this->assertStringNotContainsString( '--vpp-entry-title-font', $default_markup );
+
+		// Hostile "slugs" never reach the style attribute.
+		$hostile_markup = VideoPress_Initializer::render_videopress_playlist_block(
+			$this->attributes( array( 'nowTitleFontFamily' => 'x);}body{display:none' ) )
+		);
+		$this->assertStringNotContainsString( '--vpp-now-title-font', $hostile_markup );
+		$this->assertStringNotContainsString( 'display:none', $hostile_markup );
+	}
+
+	/**
 	 * The autoplay-next flag is exposed to the view script as a data attribute.
 	 */
 	public function test_render_autoplay_next_flag() {

--- a/projects/packages/videopress/webpack.config.js
+++ b/projects/packages/videopress/webpack.config.js
@@ -67,6 +67,10 @@ module.exports = [
 			'block-editor/blocks/video/index': './src/client/block-editor/blocks/video/index.ts',
 			'block-editor/blocks/video/view': './src/client/block-editor/blocks/video/view.ts',
 
+			// Video Playlist block
+			'block-editor/blocks/playlist/index': './src/client/block-editor/blocks/playlist/index.ts',
+			'block-editor/blocks/playlist/view': './src/client/block-editor/blocks/playlist/view.ts',
+
 			'lib/token-bridge': './src/client/lib/token-bridge/index.ts',
 			'lib/player-bridge': './src/client/lib/player-bridge/index.ts',
 


### PR DESCRIPTION
Fixes #17402
Fixes VIDP-370

## Proposed changes

Adds a new dynamic block, **Video Playlist** (`videopress/playlist`), to the videopress package (shipping through both the Jetpack and standalone VideoPress plugins): a VideoPress-powered list of videos in a single customizable player, built from your VideoPress library or video links.

### Features included

**Editor**
* The canvas is a live, non-editable preview mirroring the front end exactly (same markup and stylesheet); clicking an entry switches the previewed video. All management lives in the block sidebar.
* **Adding videos**: paste a VideoPress URL or GUID (Enter or the Add button, which stays disabled until the field has content) or pick several videos at once from the Media Library. Title, thumbnail, duration and resolution are read from the video data — nothing is hand-edited.
* **Failure states**: unrecognized links and unreadable video data show a "No video found at that link" error and add nothing; adding a duplicate asks first with explicit "Add anyway" / "Cancel"; an "Adding…" busy state shows a "Reading metadata…" skeleton row.
* **Playlist manager**: drag-and-drop reordering with a drop indicator, keyboard reordering (focus a handle, press ↑ / ↓), per-entry remove, entry count and total duration; playlists over 8 entries gain a filter input and position numbers.
* **Settings tab**: Add a video, Playlist, **Playback** — Autoplay next, Mute by default, Loop playlist (looping implies autoplay: the toggle shows checked and locked) — and Show on each entry (Thumbnail, Title, Resolution, Duration, Position number, Total runtime).
* **Styles tab**: a three-way **Layout** picker with fixed-aspect mini wireframes (Side rail / Grid / Strip) plus a Dark player surface toggle, and a **Typography** panel selecting the entry-title font from the theme's `theme.json` presets (hidden on themes without font presets).
* Centered empty-state placeholder with the URL form, an "or" divider, and the Media Library button.

**Front end**
* **Dynamic PHP render**: GUIDs validated, everything escaped, stored display fields ignored, empty playlists render nothing; the JWT token bridge is enqueued for private-video playback.
* **Three layouts** from one markup structure:
  * *Side rail*: player beside an "Up next" rail (count · total duration in its header) that never grows past the player column — the entry list scrolls internally.
  * *Grid*: thumbnail grid with a "Playing" badge and outline on the current card, plus a right-aligned playlist runtime row.
  * *Strip*: compact numbered horizontal scroller with a "1 / 24 · 5:47:10 total" progress counter, built for long playlists.
* **Scroll-hint fades**: a gradient at the side rail's bottom and the strip's trailing edge (RTL-aware) appears only while more entries hide beyond the scroll position — mirrored in the editor preview.
* **Playback**: clicking an entry loads it into the player; the player's origin-checked `videopress_ended` message advances to the next entry, loops back to the first when looping is on, and "Mute by default" rides on every embed URL.
* **Live display metadata**: block attributes persist only the video reference and numeric metadata (`guid`, `durationMs`, `height`). Titles and posters are never stored — the editor caches them per session from the videos API and the view script hydrates each entry (and falls back to "Video N" for e.g. private videos), so editor and page always reflect the videos' current metadata. The player renders its own title overlay, so no duplicate now-playing text is rendered.
* **Theme typography integration**: the chosen font preset slug is emitted as a CSS custom property pointing at the theme's `--wp--preset--font-family--*` variable, identically in the editor and the render.

Covered by 62 Jest tests (editor flows, view-script playback/hydration/scroll behavior, formatting utilities, block registration) and 14 PHPUnit tests (registration, rendering, sanitization, escaping, playback flags).

## Related product discussion/links

* VIDP-370
* #17402 — VideoPress: support multiple videos (playlists) in a single player

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Use a site with VideoPress active (Jetpack with the VideoPress module, or the standalone VideoPress plugin) and a few videos uploaded to VideoPress.
* Add a "Video Playlist" block: in the centered placeholder or the "Add a video" panel, paste a VideoPress URL or GUID (the Add button enables once you type) — the entry appears with title, thumbnail, duration and resolution read from the video data. Also add several at once via Media Library.
* Paste a non-VideoPress URL — a "No video found at that link" error appears and nothing is added. Add the same video twice — "Add anyway" / "Cancel" is offered.
* In the "Playlist" panel, reorder by dragging and with ↑ / ↓ on a handle; remove with ×; with more than 8 videos, a filter input and position numbers appear. The canvas preview mirrors every change.
* In the **Styles** tab, switch between Side rail, Grid and Strip, toggle "Dark player surface", and pick an entry-title font from the Typography panel (theme with `theme.json` fonts required). In **Settings → Playback**, try Autoplay next, Mute by default, and Loop playlist (note it locks Autoplay on). In "Show on each entry", flip each display toggle.
* With many videos in the side rail, confirm the rail stays capped at the player's height, scrolls internally, and shows a bottom fade until you reach the end; in the strip layout, the same fade appears at the trailing edge horizontally.
* Publish and view the post: entry titles/thumbnails load from live video data; clicking an entry plays it; with autoplay on, the next video starts when one ends (looping back to the first when Loop playlist is on; muted when Mute by default is on).
* Rename a video in VideoPress, then reload the editor and the published post — both show the new title without re-saving the post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
