### PR TITLE
Newsletter: Fix paid panel selection due to a race condition

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nl-467-paywall-paid-access-reset
+++ b/projects/plugins/jetpack/changelog/fix-nl-467-paywall-paid-access-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Paywall Block: Preserve paid post access after reloading the editor.

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.jsx
@@ -1,6 +1,11 @@
 import './editor.scss';
 import { JetpackEditorPanelLogo } from '@automattic/jetpack-shared-extension-utils/components';
-import { BlockControls, InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	InspectorControls,
+	useBlockProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { MenuGroup, MenuItem, PanelBody, ToolbarDropdownMenu } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -14,22 +19,22 @@ import { useAccessLevel } from '../../shared/memberships/edit';
 import { NewsletterAccessRadioButtons, useSetAccess } from '../../shared/memberships/settings';
 import useIsUserConnected from '../../shared/use-is-user-connected';
 
-function PaywallEdit() {
+function PaywallEdit( { clientId } ) {
 	const blockProps = useBlockProps();
 	const postType = useSelect( select => select( editorStore ).getCurrentPostType(), [] );
 	const accessLevel = useAccessLevel( postType );
 	const isUserConnected = useIsUserConnected();
 	const setAccess = useSetAccess();
+	const { getBlock } = useSelect( blockEditorStore );
 
-	// Add cleanup effect to reset access level when paywall is removed
+	// Reset access level to "everybody" when the paywall block is removed.
 	useEffect( () => {
-		// This function will run when the component unmounts
 		return () => {
-			// Reset access level to "everybody" when the paywall block is removed
-			setAccess( accessOptions.everybody.key );
+			if ( ! getBlock( clientId ) ) {
+				setAccess( accessOptions.everybody.key );
+			}
 		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ clientId, getBlock, setAccess ] );
 
 	const { stripeConnectUrl, hasTierPlans } = useSelect( select => {
 		const { getNewsletterTierProducts, getConnectUrl } = select( 'jetpack/membership-products' );
@@ -43,7 +48,8 @@ function PaywallEdit() {
 	const closeDialog = () => setShowDialog( false );
 
 	useEffect( () => {
-		if ( ! accessLevel || accessLevel === accessOptions.everybody.key ) {
+		// Change the access level from "everybody" to "subscribers" if the user adds a paywall block to a post.
+		if ( accessLevel === accessOptions.everybody.key ) {
 			setAccess( accessOptions.subscribers.key );
 		}
 	}, [ accessLevel, setAccess ] );

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.jsx
@@ -9,7 +9,7 @@ import {
 import { MenuGroup, MenuItem, PanelBody, ToolbarDropdownMenu } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { arrowDown, Icon, people, check } from '@wordpress/icons';
 import ConnectBanner from '../../shared/components/connect-banner';
@@ -27,14 +27,17 @@ function PaywallEdit( { clientId } ) {
 	const setAccess = useSetAccess();
 	const { getBlock } = useSelect( blockEditorStore );
 
-	// Reset access level to "everybody" when the paywall block is removed.
+	// useSetAccess returns a new function every render; the ref keeps the cleanup on unmount only.
+	const setAccessRef = useRef( setAccess );
+	setAccessRef.current = setAccess;
 	useEffect( () => {
+		// Reset access level to "everybody" when the paywall block is removed.
 		return () => {
 			if ( ! getBlock( clientId ) ) {
-				setAccess( accessOptions.everybody.key );
+				setAccessRef.current( accessOptions.everybody.key );
 			}
 		};
-	}, [ clientId, getBlock, setAccess ] );
+	}, [ clientId, getBlock ] );
 
 	const { stripeConnectUrl, hasTierPlans } = useSelect( select => {
 		const { getNewsletterTierProducts, getConnectUrl } = select( 'jetpack/membership-products' );

--- a/projects/plugins/jetpack/extensions/blocks/paywall/test/edit.test.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/test/edit.test.tsx
@@ -1,0 +1,100 @@
+import { render } from '@testing-library/react';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+import { accessOptions } from '../../../shared/memberships/constants';
+import PaywallEdit from '../edit';
+
+const CLIENT_ID = 'paywall-client-id';
+
+const mockSetAccess = jest.fn();
+let mockAccessLevel: string;
+let mockPaywallBlock: { clientId: string } | undefined;
+
+// The block reads the access level from post meta and writes it back through these two hooks.
+// Standing in for them is what lets the test say what the post's access is, and see what the
+// block does about it.
+jest.mock( '../../../shared/memberships/edit', () => ( {
+	useAccessLevel: () => mockAccessLevel,
+} ) );
+
+jest.mock( '../../../shared/memberships/settings', () => ( {
+	useSetAccess: () => mockSetAccess,
+	NewsletterAccessRadioButtons: () => null,
+} ) );
+
+// Editor chrome the block renders but these tests never look at. Stubbed because the real
+// modules need a mounted block and a connected user to render at all.
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: { name: 'core/block-editor' },
+	useBlockProps: () => ( {} ),
+	BlockControls: () => null,
+	InspectorControls: () => null,
+} ) );
+
+jest.mock( '@wordpress/editor', () => ( { store: { name: 'core/editor' } } ) );
+jest.mock( '../../../shared/components/plans-setup-dialog', () => () => null );
+jest.mock( '../../../shared/use-is-user-connected', () => () => true );
+
+// Everything the block looks up through useSelect, in one place.
+const registry = createRegistry();
+registry.registerStore( 'core/editor', {
+	reducer: () => ( {} ),
+	selectors: { getCurrentPostType: () => 'post' },
+} );
+registry.registerStore( 'core/block-editor', {
+	reducer: () => ( {} ),
+	selectors: { getBlock: () => mockPaywallBlock },
+} );
+registry.registerStore( 'jetpack/membership-products', {
+	reducer: () => ( {} ),
+	selectors: {
+		getConnectUrl: () => null,
+		getNewsletterTierProducts: () => [ { id: 1 } ],
+	},
+} );
+
+const renderPaywall = ( options = {} ) =>
+	render(
+		<RegistryProvider value={ registry }>
+			<PaywallEdit clientId={ CLIENT_ID } />
+		</RegistryProvider>,
+		options
+	);
+
+describe( 'PaywallEdit', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockAccessLevel = accessOptions.paid_subscribers.key;
+		mockPaywallBlock = { clientId: CLIENT_ID };
+	} );
+
+	test( 'reopens the post to everyone once the block has been removed from it', () => {
+		const { unmount } = renderPaywall();
+		mockPaywallBlock = undefined;
+		unmount();
+
+		expect( mockSetAccess ).toHaveBeenCalledWith( accessOptions.everybody.key );
+	} );
+
+	test( 'raises a post everyone can read to subscribers', () => {
+		mockAccessLevel = accessOptions.everybody.key;
+		renderPaywall();
+
+		expect( mockSetAccess ).toHaveBeenCalledWith( accessOptions.subscribers.key );
+	} );
+
+	test( 'leaves a subscriber-only post alone', () => {
+		mockAccessLevel = accessOptions.subscribers.key;
+		renderPaywall();
+
+		expect( mockSetAccess ).not.toHaveBeenCalled();
+	} );
+
+	// The editor renders under StrictMode, which on development builds of React mounts, unmounts
+	// and remounts every component. Treating that unmount as a removal downgraded a paid post to
+	// subscribers on nothing more than a page load.
+	test( 'keeps a paid post paid across a StrictMode remount', () => {
+		renderPaywall( { reactStrictMode: true } );
+
+		expect( mockSetAccess ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Closes: [NL-467](https://linear.app/a8c/issue/NL-467/paid-subscriber-setting-reverts-to-subscribers-in-editor)
Previous Try: https://github.com/Automattic/jetpack/pull/47469

## Proposed changes
  * Only reset the post's access level when the Paywall block is actually removed from the post, instead of on any unmount.
  * Drop the unreachable `! accessLevel` check — `useAccessLevel` never returns a falsy value (unknown meta already reads as "Everyone"). No behavior change.


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->

View issue.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Note: The root cause of the bug is a race condition so it is hard to test.

1. Go to Jurassic Ninja site.
1. Create a new post with Paywall block. Set access level as "paid_subscribers".
1. Publish the post.
1. Refresh the editor and note the status is now "subscribers". (can be "paid_subscribers" as well due to race condition. In production it was difficult to reproduce this case but while doing development via "Jurassic Tube" site this issue was always reproducible)
1. Checkout this PR.
1. Repeat 2,3,4 and verify the access level value is appearing correctly now.
1. Remove Paywall block and verify the post access value is correctly setting as "everybody".
1. Add the block again to verify that it starts from scratch instead of some previous saved state.
