### PR TITLE
Likes: register Settings > Sharing when the Sharing Buttons module is off

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -257,7 +257,6 @@ return [
         'modules/infinite-scroll.php' => ['PhanUndeclaredClassMethod'],
         'modules/infinite-scroll/infinity.php' => ['PhanTypeComparisonToArray', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeMissingReturn'],
         'modules/likes.php' => ['PhanUndeclaredFunction'],
-        'modules/likes/jetpack-likes-settings.php' => ['PhanDeprecatedFunction'],
         'modules/markdown/easy-markdown.php' => ['PhanTypeArraySuspiciousNullable', 'PhanTypeMismatchArgument'],
         'modules/memberships/class-jetpack-memberships.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal', 'PhanUndeclaredMethod'],
         'modules/monitor.php' => ['PhanTypeMismatchReturnProbablyReal'],

--- a/projects/plugins/jetpack/changelog/fix-sharing-block-heading
+++ b/projects/plugins/jetpack/changelog/fix-sharing-block-heading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Likes: rename the settings heading on Settings > Sharing to reflect what it holds when sharing buttons are off.

--- a/projects/plugins/jetpack/changelog/fix-sharing-menu-registration-likes
+++ b/projects/plugins/jetpack/changelog/fix-sharing-menu-registration-likes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Likes: keep Settings > Sharing available when sharing buttons are turned off, so the Likes and Comment Likes settings stay reachable.

--- a/projects/plugins/jetpack/modules/comment-likes.php
+++ b/projects/plugins/jetpack/modules/comment-likes.php
@@ -81,15 +81,23 @@ class Jetpack_Comment_Likes {
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 
 		if ( ! Jetpack::is_module_active( 'likes' ) ) {
-			$active = Jetpack::get_active_modules();
+			$active            = Jetpack::get_active_modules();
+			$sharedaddy_active = in_array( 'sharedaddy', $active, true );
 
-			if ( in_array( 'publicize', $active, true ) && ! in_array( 'sharedaddy', $active, true ) ) {
+			if ( $this->settings->needs_own_sharing_menu( $sharedaddy_active ) ) {
+				/*
+				 * Sharedaddy is what registers Settings > Sharing, and it is off, so we
+				 * register that screen ourselves; the Likes settings that gate comment
+				 * likes are displayed on it.
+				 */
+				add_action( 'admin_menu', array( $this->settings, 'sharing_menu' ) );
+			} elseif ( in_array( 'publicize', $active, true ) && ! $sharedaddy_active ) {
 				// we have a sharing page but not the global options area.
 				add_action( 'pre_admin_screen_sharing', array( $this->settings, 'sharing_block' ), 20 );
 				add_action( 'pre_admin_screen_sharing', array( $this->settings, 'updated_message' ), -10 );
 			}
 
-			if ( ! in_array( 'sharedaddy', $active, true ) ) {
+			if ( ! $sharedaddy_active ) {
 				add_action( 'admin_init', array( $this->settings, 'process_update_requests_if_sharedaddy_not_loaded' ) );
 				add_action( 'sharing_global_options', array( $this->settings, 'admin_settings_showbuttonon_init' ), 19 );
 				add_action( 'sharing_admin_update', array( $this->settings, 'admin_settings_showbuttonon_callback' ), 19 );

--- a/projects/plugins/jetpack/modules/likes.php
+++ b/projects/plugins/jetpack/modules/likes.php
@@ -108,7 +108,13 @@ class Jetpack_Likes {
 		$publicize_active  = Jetpack::is_module_active( 'publicize' );
 		$sharedaddy_active = Jetpack::is_module_active( 'sharedaddy' );
 
-		if ( $publicize_active && ! $sharedaddy_active ) {
+		if ( $this->settings->needs_own_sharing_menu( $sharedaddy_active ) ) {
+			/*
+			 * Sharedaddy is what registers Settings > Sharing, and it is off, so we
+			 * register that screen ourselves; our settings are displayed on it.
+			 */
+			add_action( 'admin_menu', array( $this->settings, 'sharing_menu' ) );
+		} elseif ( $publicize_active && ! $sharedaddy_active ) {
 			// we have a sharing page but not the global options area.
 			add_action( 'pre_admin_screen_sharing', array( $this->settings, 'sharing_block' ), 20 );
 			add_action( 'pre_admin_screen_sharing', array( $this->settings, 'updated_message' ), -10 );

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
@@ -256,8 +256,6 @@ class Jetpack_Likes_Settings {
 
 	/**
 	 * Returns the settings have been saved message.
-	 *
-	 * @deprecated 13.2
 	 */
 	public function updated_message() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- ignoring since we are just displaying that the settings have been saved and not making  any other changes to the site.
@@ -268,8 +266,6 @@ class Jetpack_Likes_Settings {
 
 	/**
 	 * Returns just the "sharing buttons" w/ like option block, so it can be inserted into different sharing page contexts
-	 *
-	 * @deprecated 13.2
 	 */
 	public function sharing_block() {
 		?>

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
@@ -265,11 +265,15 @@ class Jetpack_Likes_Settings {
 	}
 
 	/**
-	 * Returns just the "sharing buttons" w/ like option block, so it can be inserted into different sharing page contexts
+	 * Returns the Likes options block, so it can be inserted into different sharing page contexts.
+	 *
+	 * Only rendered when the Sharing (sharedaddy) module is off, which is why the heading
+	 * does not mention sharing buttons: what lands under it is the Likes settings, the
+	 * "Show buttons on" setting that governs where Likes appear, and the Twitter Site Tag.
 	 */
 	public function sharing_block() {
 		?>
-		<h2><?php esc_html_e( 'Sharing Buttons', 'jetpack' ); ?></h2>
+		<h2><?php esc_html_e( 'Likes and Sharing', 'jetpack' ); ?></h2>
 		<form method="post" action="">
 			<table class="form-table">
 				<tbody>

--- a/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
+++ b/projects/plugins/jetpack/modules/likes/jetpack-likes-settings.php
@@ -207,10 +207,27 @@ class Jetpack_Likes_Settings {
 	}
 
 	/**
-	 * Adds the 'sharing' menu to the settings menu.
-	 * Only ran if sharedaddy and publicize are not already active.
+	 * Should we register the Settings > Sharing screen ourselves?
 	 *
-	 * @deprecated 13.2
+	 * Our settings are displayed on Settings > Sharing, but that screen is registered by
+	 * the Sharing (sharedaddy) module. When that module is off, nothing registers the
+	 * screen and our settings become unreachable.
+	 *
+	 * WordPress.com Simple sites are excluded: the screen is registered elsewhere there.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $sharedaddy_active Whether the Sharing (sharedaddy) module is active.
+	 * @return bool
+	 */
+	public function needs_own_sharing_menu( $sharedaddy_active ) {
+		return ! $sharedaddy_active && $this->in_jetpack;
+	}
+
+	/**
+	 * Adds the 'sharing' menu to the settings menu.
+	 * Only ran when the Sharing (sharedaddy) module is inactive on a Jetpack site,
+	 * since Settings > Sharing is where our settings live. See needs_own_sharing_menu().
 	 */
 	public function sharing_menu() {
 		add_submenu_page( 'options-general.php', esc_html__( 'Sharing Settings', 'jetpack' ), esc_html__( 'Sharing', 'jetpack' ), 'manage_options', 'sharing', array( $this, 'sharing_page' ) );
@@ -219,9 +236,8 @@ class Jetpack_Likes_Settings {
 	/**
 	 * Provides a sharing page with the sharing_global_options hook
 	 * so we can display the setting.
-	 * Only ran if sharedaddy and publicize are not already active.
-	 *
-	 * @deprecated 13.2
+	 * Only ran when the Sharing (sharedaddy) module is inactive on a Jetpack site,
+	 * since Settings > Sharing is where our settings live. See needs_own_sharing_menu().
 	 */
 	public function sharing_page() {
 		$this->updated_message();

--- a/projects/plugins/jetpack/tests/php/modules/comment-likes/Comment_Likes_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/comment-likes/Comment_Likes_Test.php
@@ -41,4 +41,24 @@ class Comment_Likes_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( wp_style_is( 'jetpack_likes' ) );
 	}
+
+	/**
+	 * With the Likes module off and the Sharing module off, nothing registers
+	 * Settings > Sharing, where the settings gating comment likes are displayed.
+	 * Comment Likes carries its own copy of that wiring, so it needs its own test.
+	 */
+	public function test_registers_sharing_menu_when_sharedaddy_is_inactive() {
+		Jetpack_Options::update_option( 'active_modules', array( 'comment-likes' ) );
+
+		// Sidestep the singleton in Jetpack_Comment_Likes::init(), which memoizes the wiring.
+		$class       = new ReflectionClass( 'Jetpack_Comment_Likes' );
+		$instance    = $class->newInstanceWithoutConstructor();
+		$constructor = $class->getConstructor();
+		$constructor->setAccessible( true );
+		$constructor->invoke( $instance );
+
+		Jetpack_Options::delete_option( 'active_modules' );
+
+		$this->assertNotFalse( has_action( 'admin_menu', array( $instance->settings, 'sharing_menu' ) ) );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/comment-likes/Comment_Likes_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/comment-likes/Comment_Likes_Test.php
@@ -54,7 +54,11 @@ class Comment_Likes_Test extends WP_UnitTestCase {
 		$class       = new ReflectionClass( 'Jetpack_Comment_Likes' );
 		$instance    = $class->newInstanceWithoutConstructor();
 		$constructor = $class->getConstructor();
-		$constructor->setAccessible( true );
+		// setAccessible() is a no-op as of PHP 8.1 and deprecated in 8.5; only
+		// needed (and only called) on the older PHP versions Jetpack still supports.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$constructor->setAccessible( true );
+		}
 		$constructor->invoke( $instance );
 
 		Jetpack_Options::delete_option( 'active_modules' );

--- a/projects/plugins/jetpack/tests/php/modules/likes/Likes_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/likes/Likes_Test.php
@@ -1,8 +1,20 @@
 <?php
 require __DIR__ . '/../../../../modules/likes.php';
 
+use Automattic\Jetpack\Constants;
+
 class Likes_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Clean up after the sharing menu tests, which set the active module list.
+	 */
+	public function tear_down() {
+		Jetpack_Options::delete_option( 'active_modules' );
+		Constants::clear_constants();
+
+		parent::tear_down();
+	}
 
 	/**
 	 * Test that the actions are not added if likes are not visible.
@@ -125,5 +137,91 @@ class Likes_Test extends WP_UnitTestCase {
 		remove_filter( 'wpl_is_enabled_sitewide', '__return_true' );
 
 		$this->assertTrue( $likeable );
+	}
+
+	/**
+	 * The Likes settings live on Settings > Sharing, but that screen is registered by
+	 * the Sharing Buttons (sharedaddy) module. With that module off, Likes must register
+	 * the screen itself, or its settings become unreachable.
+	 */
+	public function test_registers_sharing_menu_when_sharedaddy_is_inactive() {
+		Jetpack_Options::update_option( 'active_modules', array( 'likes' ) );
+
+		$instance = new Jetpack_Likes();
+
+		$this->assertNotFalse( has_action( 'admin_menu', array( $instance->settings, 'sharing_menu' ) ) );
+	}
+
+	/**
+	 * Sharedaddy registers Settings > Sharing and the global options area on it,
+	 * so Likes must not register a second menu item.
+	 */
+	public function test_does_not_register_sharing_menu_when_sharedaddy_is_active() {
+		Jetpack_Options::update_option( 'active_modules', array( 'likes', 'sharedaddy' ) );
+
+		$instance = new Jetpack_Likes();
+
+		$this->assertFalse( has_action( 'admin_menu', array( $instance->settings, 'sharing_menu' ) ) );
+	}
+
+	/**
+	 * Publicize no longer registers Settings > Sharing, so Likes has to. When it does,
+	 * it renders the settings block itself and must not also hook it onto
+	 * pre_admin_screen_sharing, which would print the block twice.
+	 */
+	public function test_registers_sharing_menu_once_when_publicize_is_active() {
+		Jetpack_Options::update_option( 'active_modules', array( 'likes', 'publicize' ) );
+
+		$instance = new Jetpack_Likes();
+
+		$this->assertNotFalse( has_action( 'admin_menu', array( $instance->settings, 'sharing_menu' ) ) );
+		$this->assertFalse( has_action( 'pre_admin_screen_sharing', array( $instance->settings, 'sharing_block' ) ) );
+	}
+
+	/**
+	 * The helper shared by the Likes and Comment Likes modules: we only register the
+	 * screen when the module that usually owns it is off.
+	 */
+	public function test_needs_own_sharing_menu() {
+		$settings = new Jetpack_Likes_Settings();
+
+		$this->assertTrue( $settings->needs_own_sharing_menu( false ) );
+		$this->assertFalse( $settings->needs_own_sharing_menu( true ) );
+	}
+
+	/**
+	 * Simple sites get Settings > Sharing from elsewhere, so we have to stay out of the
+	 * way there, or the site ends up with two menu items.
+	 */
+	public function test_does_not_need_own_sharing_menu_on_simple_sites() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$settings = new Jetpack_Likes_Settings();
+
+		$this->assertFalse( $settings->needs_own_sharing_menu( false ) );
+	}
+
+	/**
+	 * The menu item has to land on options-general.php under the `sharing` slug, since
+	 * that is the URL the Likes module's own configuration link points at.
+	 */
+	public function test_sharing_menu_registers_the_sharing_slug() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		// add_submenu_page() writes to all three of these, and WP_UnitTestCase restores none of them.
+		global $submenu, $_registered_pages, $_parent_pages;
+		$submenu_backup          = $submenu;
+		$registered_pages_backup = $_registered_pages;
+		$parent_pages_backup     = $_parent_pages;
+
+		$settings = new Jetpack_Likes_Settings();
+		$settings->sharing_menu();
+
+		$slugs = wp_list_pluck( $submenu['options-general.php'], 2 );
+
+		$submenu           = $submenu_backup;
+		$_registered_pages = $registered_pages_backup;
+		$_parent_pages     = $parent_pages_backup;
+
+		$this->assertContains( 'sharing', $slugs );
 	}
 }


### PR DESCRIPTION
Fixes JETPACK-2273

## Proposed changes

* The Likes and Comment Likes settings render on Settings > Sharing in wp-admin, but the only thing registering that screen is the Sharing Buttons (`sharedaddy`) module. Turn Sharing Buttons off while Likes or Comment Likes are on, and the settings become unreachable. The Likes "Configure" link and the "Configure your sharing buttons" link in Jetpack > Settings > Sharing then both point at a page that does not exist. On a classic theme there is no way around it, since the Like block only helps on block themes.
* Likes and Comment Likes now register that screen themselves when Sharing Buttons is off, everywhere but Simple sites, where the platform provides it. The check lives in a new shared helper, `Jetpack_Likes_Settings::needs_own_sharing_menu()`.
* The Publicize branch becomes an `elseif`. Publicize stopped registering the screen in #35781 as well, so leaving both paths active would hook the settings block onto `pre_admin_screen_sharing` and then render it a second time from `sharing_page()`.
* The `@deprecated 13.2` tags come off `sharing_menu()`, `sharing_page()`, `updated_message()` and `sharing_block()`, since all four are live code again: the first is hooked to `admin_menu`, the second is the page callback, and it calls the other two on every render. The Phan baseline entry for the file goes with them — the `PhanDeprecatedFunction` it recorded was exactly those calls.
* The settings block on that screen is no longer headed "Sharing Buttons". Every path into `sharing_block()` runs with sharedaddy off, so that heading named a feature that is switched off whenever anyone reads it. It now says "Likes and Sharing", which covers the Likes settings, the "Show buttons on" row, and the Twitter Site Tag row that the post-media package hooks in.
* Regression tests in `Likes_Test` and `Comment_Likes_Test` cover the module combinations, the Simple exclusion, and the registered menu slug.

### Why

All four modules used to register the menu item. #35781 removed it from Likes, Comment Likes, Publicize and Sharedaddy; #44706 later restored it in Sharedaddy alone. The gap was raised in the review of #35781 and deferred; the plan then was to drop these settings in favor of the Like block in the editor. That never happened, so the settings are still with us, with no page left to live on.

This brings the page back for the configurations where it is the only way in. It does not redesign it, so one rough edge comes back with it: the screen renders without the Jetpack admin wrapper and styles that sharedaddy loads, so it looks plainer than the same URL does with sharing buttons on. That is how the page behaved before 13.2. The screen is worth a rework (#21566 wants to deprecate it, #41668 wants Likes fully block-based), but not in this PR.

This PR is otherwise deliberately narrow. Reviewing it turned up a handful of pre-existing problems on that page: the "Settings have been saved" notice prints outside the wrap, the submit paragraph is never closed, and the save handler has no capability check. None of them are caused by this change, and all of them are worth a separate PR rather than riding along in this one.

## Related product discussion/links

* JETPACK-2273
* #35781, where the menu registration was removed from all four modules
* #44706, where it came back for Sharing Buttons only
* #21566 and #41668, the longer-term plans for this screen

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a self-hosted site, activate a classic theme (Twenty Twenty-One works well).
* In Jetpack > Settings, turn the Sharing Buttons feature off, and turn Likes and Comment Likes on.
* Go to Settings in wp-admin. Before this PR there is no Sharing item. With this PR, Settings > Sharing is there, showing the Likes settings and "Show buttons on".
* Change a setting, save, and reload: the change sticks, and you get the "Settings have been saved" notice.
* Turn Sharing Buttons back on. There should still be a single Settings > Sharing item, with the sharing services and the Likes settings on it, each rendered once.
* Repeat with Comment Likes on and Likes off, and with Jetpack Social (Publicize) on: same result, no duplicated settings block.
* Automated tests: `jetpack docker phpunit jetpack -- --filter='Likes_Test|Comment_Likes_Test'`.
