### PR TITLE
Backup: refuse an empty restore/download selection, and report the failures the dashboard hid

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-empty-selection-and-failure-states
+++ b/projects/packages/backup/changelog/fix-backup-empty-selection-and-failure-states
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Backup: refuse a restore or download that selects no categories, tell the reader when the backup-state read failed or their backups are failing, and stop forwarding raw transport errors to the browser. No-op when the modernization filter is off.

--- a/projects/packages/backup/src/dashboard/components/backup-status/banner.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/banner.tsx
@@ -1,7 +1,9 @@
 import { ProgressBar } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
+import { ContactSupportLine } from './index';
 import './style.scss';
+import type { BackupsState } from '../../types/backup';
 
 type Props = {
 	/** Completion of the running backup, 0–100. */
@@ -44,6 +46,65 @@ export default function BackupStatusBanner( { progress }: Props ) {
 					__( '%d%%', 'jetpack-backup-pkg' ),
 					progress
 				) }
+			</Text>
+		</Stack>
+	);
+}
+
+/**
+ * Strip shown when the site's backups are failing but the takeover panel
+ * has stood down.
+ *
+ * `replacesOverview()` was quietly doing two jobs: deciding whether the
+ * panel takes the body over, *and* — because only that panel carries the
+ * support link — deciding whether the reader is told their backups are
+ * failing at all. Every case where the takeover correctly steps aside
+ * therefore also dropped the message. Two of those exist: restore points
+ * are still listed from earlier in the retention window, and the activity
+ * request failed so we cannot know either way. In both, "we can't back
+ * your site up" is exactly what the reader came to find out.
+ *
+ * Splitting the two jobs keeps the takeover conservative — the short
+ * `/backups` window really can be wrong about `no-good-backups` — without
+ * paying for that caution in silence.
+ *
+ * @param props       - Component props.
+ * @param props.state - Derived backup state.
+ * @return The rendered banner, or null when the state needs no report.
+ */
+export function BackupTroubleBanner( { state }: { state: BackupsState } ) {
+	// Written as two whole returns rather than one banner with ternaries
+	// inside it. Partly because they say different things — `will-retry`
+	// is not yet a problem the reader has to solve, since WPCOM retries on
+	// its own, while `no-good-backups` is the state where nothing arrives
+	// unless someone intervenes — and partly because a `__()` call chosen
+	// by a ternary is a msgid-extraction hazard: the minifier factors the
+	// shared call out of the conditional and leaves `__( cond ? a : b )`,
+	// which is no longer a string literal.
+	if ( state === 'will-retry' ) {
+		return (
+			<Stack className="jpb-backup-trouble-banner" direction="column" gap="xs" role="status">
+				<Text variant="body-sm">
+					{ __(
+						"Your latest backup didn't complete. We'll try again shortly.",
+						'jetpack-backup-pkg'
+					) }
+				</Text>
+			</Stack>
+		);
+	}
+
+	if ( state !== 'no-good-backups' ) {
+		return null;
+	}
+
+	return (
+		<Stack className="jpb-backup-trouble-banner" direction="column" gap="xs" role="status">
+			<Text variant="body-sm">
+				{ __( "We're having trouble backing up your site.", 'jetpack-backup-pkg' ) }
+			</Text>
+			<Text variant="body-sm">
+				<ContactSupportLine />
 			</Text>
 		</Stack>
 	);

--- a/projects/packages/backup/src/dashboard/components/backup-status/banner.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/banner.tsx
@@ -101,7 +101,10 @@ export function BackupTroubleBanner( { state }: { state: BackupsState } ) {
 	return (
 		<Stack className="jpb-backup-trouble-banner" direction="column" gap="xs" role="status">
 			<Text variant="body-sm">
-				{ __( "We're having trouble backing up your site.", 'jetpack-backup-pkg' ) }
+				{
+					/* translators: sentence form of the takeover panel's heading, which is the same words without the full stop. The two render in mutually exclusive situations — this one is a line of body copy, that one a title — so both spellings are wanted. */
+					__( "We're having trouble backing up your site.", 'jetpack-backup-pkg' )
+				}
 			</Text>
 			<Text variant="body-sm">
 				<ContactSupportLine />

--- a/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
@@ -54,6 +54,33 @@ export function replacesOverview(
 }
 
 /**
+ * The one line that turns "your backups are failing" into something the
+ * reader can act on.
+ *
+ * Shared by the takeover panel and the banner rather than duplicated,
+ * because the two render in mutually exclusive situations and a reader
+ * who lands in either needs the same next step. Keeping one msgid also
+ * stops the two copies drifting apart in translation.
+ *
+ * @return The rendered support line.
+ */
+export function ContactSupportLine() {
+	const siteSuffix = useSiteSuffix();
+
+	return createInterpolateElement(
+		__( '<a>Get in touch with us</a> to get your site backups going again.', 'jetpack-backup-pkg' ),
+		{
+			a: (
+				<Link
+					openInNewTab
+					href={ getRedirectUrl( 'jetpack-contact-support', { site: siteSuffix } ) }
+				/>
+			),
+		}
+	);
+}
+
+/**
  * Full-width panel shown in place of the Overview body while the site
  * has no restore point to show.
  *
@@ -85,20 +112,7 @@ export default function BackupStatusPanel( { state, progress }: Props ) {
 					{ __( "We're having trouble backing up your site", 'jetpack-backup-pkg' ) }
 				</EmptyState.Title>
 				<EmptyState.Description>
-					{ createInterpolateElement(
-						__(
-							'<a>Get in touch with us</a> to get your site backups going again.',
-							'jetpack-backup-pkg'
-						),
-						{
-							a: (
-								<Link
-									openInNewTab
-									href={ getRedirectUrl( 'jetpack-contact-support', { site: siteSuffix } ) }
-								/>
-							),
-						}
-					) }
+					<ContactSupportLine />
 				</EmptyState.Description>
 			</EmptyState.Root>
 		);

--- a/projects/packages/backup/src/dashboard/components/backup-status/style.scss
+++ b/projects/packages/backup/src/dashboard/components/backup-status/style.scss
@@ -55,16 +55,24 @@
 	}
 }
 
-// The in-progress strip sits above the two-pane grid rather than inside
-// it: `.jpb-overview` is a two-column grid at >= 961px, so a third child
+// Both strips sit above the two-pane grid rather than inside it:
+// `.jpb-overview` is a two-column grid at >= 961px, so a third child
 // would be auto-placed into the layout and push the detail pane onto its
-// own row. Wrapping it here keeps that grid untouched.
-.jpb-backup-status-banner {
+// own row. Wrapping them here keeps that grid untouched.
+
+// They are deliberately the same box in the same slot and differ only in
+// tint, so the shared half is written once — otherwise the two drift and
+// the sameness stops being true.
+.jpb-backup-status-banner,
+.jpb-backup-trouble-banner {
 	box-sizing: border-box;
 	inline-size: 100%;
 	margin-block-end: 16px;
 	padding: 12px 16px;
 	border-radius: 8px;
+}
+
+.jpb-backup-status-banner {
 	// `--wp-components-color-background-secondary` is used elsewhere in
 	// this dashboard but is declared by nothing — not by
 	// `@wordpress/components`, `/ui`, `/theme` or `/base-styles` — so it
@@ -91,15 +99,8 @@
 	}
 }
 
-// Same slot and same box as the in-progress strip — see above for why it
-// sits outside `.jpb-overview` — but tinted as a warning, because this
-// one is reporting that something is wrong rather than that something is
-// happening.
+// Tinted as a warning rather than neutral: this one reports that
+// something is wrong, not that something is happening.
 .jpb-backup-trouble-banner {
-	box-sizing: border-box;
-	inline-size: 100%;
-	margin-block-end: 16px;
-	padding: 12px 16px;
-	border-radius: 8px;
 	background-color: var(--wpds-color-background-surface-warning-weak);
 }

--- a/projects/packages/backup/src/dashboard/components/backup-status/style.scss
+++ b/projects/packages/backup/src/dashboard/components/backup-status/style.scss
@@ -90,3 +90,16 @@
 		}
 	}
 }
+
+// Same slot and same box as the in-progress strip — see above for why it
+// sits outside `.jpb-overview` — but tinted as a warning, because this
+// one is reporting that something is wrong rather than that something is
+// happening.
+.jpb-backup-trouble-banner {
+	box-sizing: border-box;
+	inline-size: 100%;
+	margin-block-end: 16px;
+	padding: 12px 16px;
+	border-radius: 8px;
+	background-color: var(--wpds-color-background-surface-warning-weak);
+}

--- a/projects/packages/backup/src/dashboard/components/dashboard-layout/style.scss
+++ b/projects/packages/backup/src/dashboard/components/dashboard-layout/style.scss
@@ -22,3 +22,30 @@
 .jpb-text-muted {
 	color: var(--wpds-color-foreground-content-neutral-weak);
 }
+
+// Keeps an element in the accessibility tree while taking it out of the
+// visual layout. Used for a live region that has to stay mounted before
+// it has anything to say: assistive tech needs the region present in the
+// tree *before* its content changes, so a region that appears together
+// with its first message is unreliable — VoiceOver in particular often
+// misses it.
+
+// `position: absolute` is doing more work than hiding here. These regions
+// sit inside flex columns with a `gap`, and a gap applies between all
+// in-flow children no matter how small — so a zero-height placeholder
+// would still cost a full 16px of dead space on every render where the
+// message is absent, which is most of them. Taking it out of flow costs
+// nothing. `display: none` and `visibility: hidden` are both wrong: they
+// remove it from the accessibility tree too, which is the one thing this
+// has to preserve.
+.jpb-visually-hidden {
+	position: absolute;
+	inline-size: 1px;
+	block-size: 1px;
+	margin: -1px;
+	padding: 0;
+	border: 0;
+	overflow: hidden;
+	clip-path: inset(50%);
+	white-space: nowrap;
+}

--- a/projects/packages/backup/src/dashboard/components/query-error/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/query-error/index.tsx
@@ -18,6 +18,12 @@ type Props = {
 	onRetry?: () => void;
 	/** Whether a retry is in flight. */
 	isRetrying?: boolean;
+	/**
+	 * Extra class for the notice. The base rule zeroes its margin because
+	 * its original two slots are boxes that size it themselves; a caller
+	 * that drops it into ordinary flow has to pay for its own spacing.
+	 */
+	className?: string;
 };
 
 /**
@@ -45,11 +51,22 @@ type Props = {
  * @param props.error      - The query's error.
  * @param props.onRetry    - Refetches the failed query, when the caller can.
  * @param props.isRetrying - Whether a retry is currently in flight.
+ * @param props.className  - Extra class for the notice.
  * @return The rendered error.
  */
-export default function QueryError( { title, error, onRetry, isRetrying = false }: Props ) {
+export default function QueryError( {
+	title,
+	error,
+	onRetry,
+	isRetrying = false,
+	className,
+}: Props ) {
 	return (
-		<Notice status="error" isDismissible={ false } className="jpb-query-error">
+		<Notice
+			status="error"
+			isDismissible={ false }
+			className={ [ 'jpb-query-error', className ].filter( Boolean ).join( ' ' ) }
+		>
 			<Stack direction="column" gap="sm" align="flex-start">
 				<Text>{ title }</Text>
 				{ error?.message && (

--- a/projects/packages/backup/src/dashboard/components/query-error/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/query-error/index.tsx
@@ -6,7 +6,14 @@ import './style.scss';
 type Props = {
 	/** What failed, in the reader's terms. */
 	title: string;
-	error: Error;
+	/**
+	 * The query's error, when there is one. Nullable because not every
+	 * failure produces one: a route that answers a non-200 with a bare
+	 * `null` body is served as HTTP 200, so the request resolves and the
+	 * caller's only evidence is its own derived state. Those callers still
+	 * need to report the failure — they just have no detail line to add.
+	 */
+	error?: Error | null;
 	/** Refetches the failed query. Omitted when the caller has no way to retry. */
 	onRetry?: () => void;
 	/** Whether a retry is in flight. */
@@ -45,7 +52,7 @@ export default function QueryError( { title, error, onRetry, isRetrying = false 
 		<Notice status="error" isDismissible={ false } className="jpb-query-error">
 			<Stack direction="column" gap="sm" align="flex-start">
 				<Text>{ title }</Text>
-				{ error.message && (
+				{ error?.message && (
 					<Text variant="body-sm" className="jpb-text-muted">
 						{ error.message }
 					</Text>

--- a/projects/packages/backup/src/dashboard/components/query-error/style.scss
+++ b/projects/packages/backup/src/dashboard/components/query-error/style.scss
@@ -3,6 +3,13 @@
 // takes the width it is given and left-aligns its own contents rather
 // than inheriting the container's text alignment.
 .jpb-query-error {
+	// `inline-size: 100%` with the notice's own padding and its 4px status
+	// border overflows a content-box by exactly those extra pixels — enough
+	// to put a horizontal scrollbar across the whole dashboard once this is
+	// rendered in ordinary flow rather than inside a box that sizes it.
+	// Measured on a live site at 1440px: 1261px of content in a 1257px
+	// container, gone with this line.
+	box-sizing: border-box;
 	inline-size: 100%;
 	margin: 0;
 	text-align: start;

--- a/projects/packages/backup/src/dashboard/components/query-error/style.scss
+++ b/projects/packages/backup/src/dashboard/components/query-error/style.scss
@@ -7,3 +7,13 @@
 	margin: 0;
 	text-align: start;
 }
+
+// Both original slots are boxes that space the notice themselves, so the
+// rule above zeroes its margin. A caller that drops it into ordinary flow
+// — the Overview renders one directly above the two-pane grid, which
+// declares no block margin of its own — has to add that back, or the red
+// notice's border lands flush on the activity card's. 16px matches
+// `.jpb-backup-status-banner`, the sibling that occupies the same slot.
+.jpb-query-error--standalone {
+	margin-block-end: 16px;
+}

--- a/projects/packages/backup/src/dashboard/data/api/_helpers.ts
+++ b/projects/packages/backup/src/dashboard/data/api/_helpers.ts
@@ -1,4 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import type { APIFetchOptions } from '@wordpress/api-fetch';
 
@@ -74,10 +75,10 @@ export function toIntRewindId( rewindId: string ): string {
  * single place that builds it. Only `true` entries are included, so the
  * result never depends on that loose comparison.
  *
- * Returns `undefined` when nothing is selected. Callers must omit the
- * key entirely in that case rather than sending `{}` — the restore route
- * rejects any `types` value that names no type, and on the download side
- * an empty list would silently ask for nothing.
+ * Returns `undefined` when nothing is selected, which is a signal to the
+ * caller rather than a payload. Do not resolve it by omitting the key:
+ * see `requireTypes`, which is what the mutations use and which explains
+ * why omission is the most dangerous option available here.
  *
  * @param items - The category checklist.
  * @return The object form, or undefined when no category is selected.
@@ -109,6 +110,38 @@ export class ApiError extends Error {
 		this.code = code;
 		this.data = data;
 	}
+}
+
+/**
+ * Serialize a checklist for a mutation, refusing an empty one.
+ *
+ * The restore and download bodies must always *name* what they want.
+ * An absent `types` is not a request for nothing — it is WPCOM's
+ * shorthand for all six categories ("omit it for everything", in the
+ * contract's words), so a checklist with every box cleared would submit
+ * the full archive on the download side and a full destructive restore
+ * on the other. That is the exact inverse of what the reader asked for,
+ * and it is silent: the request succeeds.
+ *
+ * The v2 restore route rejects a supplied-but-empty `types` and the
+ * downloads route does not, so this cannot be left to the server. Both
+ * screens also disable their submit button, but the button is not where
+ * the danger is — a future caller reaching these functions directly gets
+ * the same protection here.
+ *
+ * @param  items - The category checklist.
+ * @throws {ApiError} When no category is selected.
+ * @return The object form, always naming at least one category.
+ */
+export function requireTypes( items: Record< string, boolean > ): Record< string, true > {
+	const selected = serializeTypes( items );
+	if ( ! selected ) {
+		throw new ApiError(
+			'no_types_selected',
+			__( 'Select at least one item to continue.', 'jetpack-backup-pkg' )
+		);
+	}
+	return selected;
 }
 
 /**

--- a/projects/packages/backup/src/dashboard/data/api/download.ts
+++ b/projects/packages/backup/src/dashboard/data/api/download.ts
@@ -1,4 +1,4 @@
-import { apiCall, apiPath, serializeTypes } from './_helpers';
+import { apiCall, apiPath, requireTypes } from './_helpers';
 import type { RestoreItems } from '../../types/restore';
 
 export type InitiateDownloadResponse = {
@@ -33,6 +33,10 @@ export type DownloadStatusResponse = {
 /**
  * Initiate a backup download.
  *
+ * Always names at least one category — `requireTypes` throws instead of
+ * letting the key be dropped, because an absent `types` asks WPCOM for
+ * the *whole* archive rather than for nothing.
+ *
  * @param rewindId - The backup's rewind id, in full — the decimal suffix is significant.
  * @param types    - Which categories to include in the download.
  * @return The download id.
@@ -44,9 +48,7 @@ export async function initiateDownload(
 	return apiCall< InitiateDownloadResponse >( {
 		path: apiPath( `/backups/download/${ rewindId }` ),
 		method: 'POST',
-		// Omitted entirely when nothing is selected: an empty `types`
-		// asks WPCOM for a download containing nothing.
-		data: { types: serializeTypes( types ) },
+		data: { types: requireTypes( types ) },
 	} );
 }
 

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -1,4 +1,4 @@
-import { apiCall, apiPath, serializeTypes, toIntRewindId } from './_helpers';
+import { apiCall, apiPath, requireTypes, toIntRewindId } from './_helpers';
 import type { RestoreItems } from '../../types/restore';
 
 export type InitiateRestoreResponse = {
@@ -17,14 +17,18 @@ export type RestoreStatusResponse = {
 /**
  * Start a restore for the given backup point.
  *
- * Shares `serializeTypes` with the download call so both emit the object
- * form; see that helper for why a JSON array is never safe here. An
- * unselected checklist sends no `types` at all rather than an empty one.
+ * Shares `requireTypes` with the download call so both emit the object
+ * form; see that helper for why a JSON array is never safe here, and why
+ * an empty checklist is refused rather than sent as an omitted key.
+ *
+ * That refusal matters most on this call. An absent `types` means all six
+ * categories upstream, so a cleared checklist would overwrite the live
+ * site with exactly the parts the reader excluded — the one mistake here
+ * that cannot be undone.
  *
  * Note this still targets the v1 activity-log route, which discards
  * Jetpack user tokens and therefore always answers 401. Repointing it at
- * the v2 restore routes is separate work — only the `types` serialization
- * is changed here, so restore and download share one spelling.
+ * the v2 restore routes is separate work.
  *
  * @param rewindId - The backup's rewind id.
  * @param types    - Which categories to restore (themes/plugins/roots/contents/sqls/uploads).
@@ -37,7 +41,7 @@ export async function initiateRestore(
 	return apiCall< InitiateRestoreResponse >( {
 		path: apiPath( `/rewind/to/${ toIntRewindId( rewindId ) }` ),
 		method: 'POST',
-		data: { types: serializeTypes( types ) },
+		data: { types: requireTypes( types ) },
 	} );
 }
 

--- a/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
@@ -1,4 +1,4 @@
-import { serializeTypes, toIntRewindId } from '../_helpers';
+import { ApiError, requireTypes, serializeTypes, toIntRewindId } from '../_helpers';
 
 describe( 'toIntRewindId', () => {
 	test( 'returns the input unchanged when there is no decimal suffix', () => {
@@ -34,11 +34,48 @@ describe( 'serializeTypes', () => {
 		expect( result ).toEqual( { themes: true, plugins: true } );
 	} );
 
-	test( 'returns undefined when nothing is selected, so the key can be omitted', () => {
-		// `{}` is not a safe stand-in: the restore route rejects a `types`
-		// value that names nothing, and the download side would build an
-		// archive containing nothing.
+	test( 'returns undefined when nothing is selected', () => {
+		// `{}` is not a safe stand-in: the v2 restore route rejects a
+		// `types` value that names nothing. Note that omitting the key is
+		// not safe either — see `requireTypes` below, which is what
+		// mutations use.
 		expect( serializeTypes( { themes: false, plugins: false } ) ).toBeUndefined();
 		expect( serializeTypes( {} ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'requireTypes', () => {
+	test( 'passes a populated selection straight through', () => {
+		expect( requireTypes( { themes: true, plugins: false, sqls: true } ) ).toEqual( {
+			themes: true,
+			sqls: true,
+		} );
+	} );
+
+	// The reason this exists rather than the mutations calling
+	// `serializeTypes` directly. Omitting `types` is not "ask for
+	// nothing" — WPCOM reads an absent `types` as all six categories, so
+	// an unticked checklist submitted a *full* download, and a full
+	// destructive restore. Refusing is the only safe reading of an empty
+	// selection, and it has to happen below the UI: the screens disable
+	// their buttons, but the danger is in the request, not the button.
+	test( 'refuses an empty selection rather than letting the key be omitted', () => {
+		expect( () => requireTypes( { themes: false, plugins: false } ) ).toThrow( ApiError );
+		expect( () => requireTypes( {} ) ).toThrow( ApiError );
+	} );
+
+	test( 'throws a branchable code', () => {
+		// Captured rather than asserted inside the `catch`, which
+		// `jest/no-conditional-expect` rejects: an assertion that only runs
+		// when the throw happens passes silently when it does not.
+		let thrown: unknown;
+		try {
+			requireTypes( {} );
+		} catch ( error ) {
+			thrown = error;
+		}
+
+		expect( thrown ).toBeInstanceOf( ApiError );
+		expect( ( thrown as ApiError ).code ).toBe( 'no_types_selected' );
 	} );
 } );

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -199,9 +199,20 @@ export function useDefaultBackupRewindId(): string | null {
  * is paginated over the full retention window and does not have that
  * blind spot.
  *
- * @return Whether a restore point is visible, and whether the answer has loaded.
+ * `isError` is reported separately from `isLoading` because callers must
+ * treat the two the same way and React Query does not. A failed query is
+ * not loading and holds no rows, so `hasRestorePoints` comes back a
+ * confident `false` for a question that was never actually answered —
+ * which is indistinguishable, to a caller reading only the first two
+ * values, from a site that genuinely has no restore points.
+ *
+ * @return Whether a restore point is visible, whether the answer has loaded, and whether asking failed.
  */
-export function useHasRestorePoints(): { hasRestorePoints: boolean; isLoading: boolean } {
+export function useHasRestorePoints(): {
+	hasRestorePoints: boolean;
+	isLoading: boolean;
+	isError: boolean;
+} {
 	const query = useActivityPageQuery( 1, ACTIVITY_LOG_DEFAULT_PER_PAGE );
 	const hasRestorePoints = useMemo(
 		() =>
@@ -210,7 +221,7 @@ export function useHasRestorePoints(): { hasRestorePoints: boolean; isLoading: b
 			),
 		[ query.data ]
 	);
-	return { hasRestorePoints, isLoading: query.isLoading };
+	return { hasRestorePoints, isLoading: query.isLoading, isError: query.isError };
 }
 
 /**

--- a/projects/packages/backup/src/dashboard/hooks/use-backups.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backups.ts
@@ -170,6 +170,13 @@ type Result = BackupsSummary & {
 	 * `state === 'error'`, which covers both.
 	 */
 	error: Error | null;
+	/**
+	 * Whether a request is in flight, including a manual retry. Distinct
+	 * from the `loading` state: a query that already resolved is never
+	 * pending again, so refetching after a failure leaves every
+	 * loading-shaped flag false for the whole round trip.
+	 */
+	isFetching: boolean;
 	refetch: () => void;
 };
 
@@ -236,6 +243,7 @@ export function useBackups( { forcePoll = false }: Args = {} ): Result {
 		...summary,
 		backups,
 		error: error ?? null,
+		isFetching: query.isFetching,
 		refetch: retry,
 	};
 }

--- a/projects/packages/backup/src/dashboard/hooks/use-backups.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backups.ts
@@ -171,12 +171,13 @@ type Result = BackupsSummary & {
 	 */
 	error: Error | null;
 	/**
-	 * Whether a request is in flight, including a manual retry. Distinct
-	 * from the `loading` state: a query that already resolved is never
-	 * pending again, so refetching after a failure leaves every
-	 * loading-shaped flag false for the whole round trip.
+	 * Whether a *re*fetch is in flight — a manual retry or a poll tick,
+	 * but never the first load. Distinct from the `loading` state: a query
+	 * that already resolved is never pending again, so refetching after a
+	 * failure leaves every loading-shaped flag false for the whole round
+	 * trip, and a retry control driven by them never changes.
 	 */
-	isFetching: boolean;
+	isRefetching: boolean;
 	refetch: () => void;
 };
 
@@ -243,7 +244,7 @@ export function useBackups( { forcePoll = false }: Args = {} ): Result {
 		...summary,
 		backups,
 		error: error ?? null,
-		isFetching: query.isFetching,
+		isRefetching: query.isRefetching,
 		refetch: retry,
 	};
 }

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -25,6 +25,11 @@ function rewindIdToIso( rewindId: string ): string | null {
 	return new Date( seconds * 1000 ).toISOString();
 }
 
+// Stable so the submit button can point at the hint with
+// `aria-describedby`. A module constant rather than `useInstanceId`
+// because only one of these renders per page.
+const SELECTION_HINT_ID = 'jpb-download__selection-hint';
+
 /**
  * Download screen — same narrow layout as the Restore screen minus the
  * warning notice. Submission runs through a real state machine via the
@@ -74,8 +79,17 @@ export default function DownloadScreen() {
 								) }
 							</Text>
 							<RestoreItemsChecklist value={ items } onChange={ setItems } />
+							{ /*
+							 * `role="status"` so clearing the last box is announced, and
+							 * `aria-describedby` so the reason travels with the control.
+							 * Without both, the guard whose whole purpose is telling the
+							 * reader before they click tells nobody who cannot see it:
+							 * `@wordpress/ui` renders a disabled button as `aria-disabled`
+							 * and keeps it focusable, so it is reachable but silent about
+							 * why.
+							 */ }
 							{ ! hasSelection && (
-								<Text variant="body-sm" className="jpb-text-muted">
+								<Text id={ SELECTION_HINT_ID } variant="body-sm" role="status">
 									{ __( 'Select at least one item to download.', 'jetpack-backup-pkg' ) }
 								</Text>
 							) }
@@ -83,6 +97,7 @@ export default function DownloadScreen() {
 								className="jpb-download__confirm"
 								variant="solid"
 								disabled={ ! hasSelection || state.phase === 'submitting' }
+								aria-describedby={ hasSelection ? undefined : SELECTION_HINT_ID }
 								onClick={ handleGenerate }
 							>
 								{ state.phase === 'submitting' ? (

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -8,7 +8,7 @@ import { Button, Card, Stack, Text } from '@wordpress/ui';
 import DashboardLayout from '../components/dashboard-layout';
 import RestoreItemsChecklist from '../components/restore-items-checklist';
 import { useDownload } from '../hooks/use-download';
-import { DEFAULT_RESTORE_ITEMS } from '../types/restore';
+import { DEFAULT_RESTORE_ITEMS, hasSelectedItems } from '../types/restore';
 
 /**
  * Derive an ISO timestamp for the download-point label from the WPCOM
@@ -39,6 +39,9 @@ export default function DownloadScreen() {
 	const [ items, setItems ] = useState( DEFAULT_RESTORE_ITEMS );
 	const { state, submit, reset } = useDownload( rewindId );
 	const handleGenerate = useCallback( () => submit( items ), [ submit, items ] );
+	// An empty checklist would ask WPCOM for the *whole* archive, not for
+	// nothing — see `hasSelectedItems`.
+	const hasSelection = hasSelectedItems( items );
 
 	return (
 		<DashboardLayout>
@@ -71,10 +74,15 @@ export default function DownloadScreen() {
 								) }
 							</Text>
 							<RestoreItemsChecklist value={ items } onChange={ setItems } />
+							{ ! hasSelection && (
+								<Text variant="body-sm" className="jpb-text-muted">
+									{ __( 'Select at least one item to download.', 'jetpack-backup-pkg' ) }
+								</Text>
+							) }
 							<Button
 								className="jpb-download__confirm"
 								variant="solid"
-								disabled={ state.phase === 'submitting' }
+								disabled={ ! hasSelection || state.phase === 'submitting' }
 								onClick={ handleGenerate }
 							>
 								{ state.phase === 'submitting' ? (

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -80,24 +80,37 @@ export default function DownloadScreen() {
 							</Text>
 							<RestoreItemsChecklist value={ items } onChange={ setItems } />
 							{ /*
-							 * `role="status"` so clearing the last box is announced, and
-							 * `aria-describedby` so the reason travels with the control.
-							 * Without both, the guard whose whole purpose is telling the
-							 * reader before they click tells nobody who cannot see it:
-							 * `@wordpress/ui` renders a disabled button as `aria-disabled`
-							 * and keeps it focusable, so it is reachable but silent about
-							 * why.
+							 * The live region is mounted unconditionally and only its text
+							 * changes. A region that appears together with its first message
+							 * is unreliable — assistive tech generally needs it in the tree
+							 * before the content changes, and VoiceOver in particular often
+							 * misses the simultaneous case. `jpb-visually-hidden` takes it out
+							 * of flow while empty rather than unmounting it, because this card
+							 * is a flex column with a gap and an in-flow empty node would cost
+							 * 16px of dead space on every render where there is nothing to say.
+							 *
+							 * `aria-describedby` is likewise unconditional: it resolves to the
+							 * same element either way, and an empty target contributes nothing
+							 * to the accessible description. Between them the reader is told
+							 * both when they clear the last box and when they reach the button
+							 * — @wordpress/ui renders a disabled button as focusable
+							 * `aria-disabled`, so it is reachable but silent about why.
 							 */ }
-							{ ! hasSelection && (
-								<Text id={ SELECTION_HINT_ID } variant="body-sm" role="status">
-									{ __( 'Select at least one item to download.', 'jetpack-backup-pkg' ) }
-								</Text>
-							) }
+							<Text
+								id={ SELECTION_HINT_ID }
+								variant="body-sm"
+								role="status"
+								className={ hasSelection ? 'jpb-visually-hidden' : undefined }
+							>
+								{ hasSelection
+									? ''
+									: __( 'Select at least one item to download.', 'jetpack-backup-pkg' ) }
+							</Text>
 							<Button
 								className="jpb-download__confirm"
 								variant="solid"
 								disabled={ ! hasSelection || state.phase === 'submitting' }
-								aria-describedby={ hasSelection ? undefined : SELECTION_HINT_ID }
+								aria-describedby={ SELECTION_HINT_ID }
 								onClick={ handleGenerate }
 							>
 								{ state.phase === 'submitting' ? (

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -9,6 +9,7 @@ import BackupNowButton from '../components/backup-now-button';
 import BackupStatusPanel, { replacesOverview } from '../components/backup-status';
 import BackupStatusBanner from '../components/backup-status/banner';
 import DashboardLayout from '../components/dashboard-layout';
+import QueryError from '../components/query-error';
 import {
 	ACTIVITY_LOG_DEFAULT_PER_PAGE,
 	useActivityById,
@@ -69,13 +70,31 @@ export default function OverviewScreen() {
 	// `/site/rewindable-activity` only lists completed restore points, so
 	// on its own it cannot tell "no backups yet" from "the first one is
 	// running" from "they're all failing". This second query answers that.
-	const { state: backupsState, progress, isInitialBackup } = useBackups();
+	const {
+		state: backupsState,
+		progress,
+		isInitialBackup,
+		error: backupsError,
+		isFetching: backupsFetching,
+		refetch: refetchBackups,
+	} = useBackups();
 	// A second opinion on whether anything is restorable, from the
 	// paginated activity log rather than the short `/backups` window.
 	// While it is still unknown, assume there *are* restore points:
 	// briefly showing the two-pane view is a milder error than briefly
 	// telling an established customer they have no backups.
-	const { hasRestorePoints, isLoading: restorePointsLoading } = useHasRestorePoints();
+	//
+	// A failed request is "still unknown" too, and that is the whole
+	// point of reading `isError` here. React Query reports an errored
+	// query as not-loading with no rows, so without this the veto lifts
+	// on a question nobody managed to ask: the first-run panel takes the
+	// body over and takes the activity log's own error report down with
+	// it, and a 5xx reads as "your first backup is on its way".
+	const {
+		hasRestorePoints,
+		isLoading: restorePointsLoading,
+		isError: restorePointsError,
+	} = useHasRestorePoints();
 
 	const setSelected = useCallback(
 		( id: string ) => {
@@ -88,7 +107,11 @@ export default function OverviewScreen() {
 	);
 
 	if (
-		replacesOverview( backupsState, isInitialBackup, restorePointsLoading || hasRestorePoints )
+		replacesOverview(
+			backupsState,
+			isInitialBackup,
+			restorePointsLoading || restorePointsError || hasRestorePoints
+		)
 	) {
 		return (
 			<DashboardLayout actions={ <BackupNowButton /> }>
@@ -107,6 +130,29 @@ export default function OverviewScreen() {
 			 * child would be auto-placed into it.
 			 */ }
 			{ backupsState === 'in-progress' && <BackupStatusBanner progress={ progress } /> }
+			{ /*
+			 * The backup-state read failed. Reported here rather than as a
+			 * takeover for the same reason as the banner: whatever the
+			 * activity log managed to load is still worth showing, and this
+			 * failure says nothing about it.
+			 *
+			 * `error` is very often null on this path and that is not a bug.
+			 * The route answers a non-200 from WPCOM with a bare `null`
+			 * body, which WordPress serves as HTTP 200 — so the request
+			 * resolves, React Query records a success, and the only signal
+			 * left is the derived state. That is also why the retry button
+			 * matters more here than elsewhere: nothing else will ask again.
+			 * The poll stops deliberately on an unreadable response rather
+			 * than hammering a failing upstream.
+			 */ }
+			{ backupsState === 'error' && (
+				<QueryError
+					title={ __( "We couldn't check your site's backup status.", 'jetpack-backup-pkg' ) }
+					error={ backupsError }
+					onRetry={ refetchBackups }
+					isRetrying={ backupsFetching }
+				/>
+			) }
 			<div className="jpb-overview">
 				<ActivityList
 					selectedId={ selectedId }

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -7,7 +7,7 @@ import ActivityList from '../components/activity-list';
 import BackupDetail from '../components/backup-detail';
 import BackupNowButton from '../components/backup-now-button';
 import BackupStatusPanel, { replacesOverview } from '../components/backup-status';
-import BackupStatusBanner from '../components/backup-status/banner';
+import BackupStatusBanner, { BackupTroubleBanner } from '../components/backup-status/banner';
 import DashboardLayout from '../components/dashboard-layout';
 import QueryError from '../components/query-error';
 import {
@@ -75,7 +75,7 @@ export default function OverviewScreen() {
 		progress,
 		isInitialBackup,
 		error: backupsError,
-		isFetching: backupsFetching,
+		isRefetching: backupsRefetching,
 		refetch: refetchBackups,
 	} = useBackups();
 	// A second opinion on whether anything is restorable, from the
@@ -147,12 +147,20 @@ export default function OverviewScreen() {
 			 */ }
 			{ backupsState === 'error' && (
 				<QueryError
+					className="jpb-query-error--standalone"
 					title={ __( "We couldn't check your site's backup status.", 'jetpack-backup-pkg' ) }
 					error={ backupsError }
 					onRetry={ refetchBackups }
-					isRetrying={ backupsFetching }
+					isRetrying={ backupsRefetching }
 				/>
 			) }
+			{ /*
+			 * The takeover panel has stood down but the site's backups are
+			 * still failing, so the report moves here rather than vanishing
+			 * with it. See `BackupTroubleBanner` for why those were two jobs
+			 * in one predicate.
+			 */ }
+			<BackupTroubleBanner state={ backupsState } />
 			<div className="jpb-overview">
 				<ActivityList
 					selectedId={ selectedId }

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -159,8 +159,19 @@ export default function OverviewScreen() {
 			 * still failing, so the report moves here rather than vanishing
 			 * with it. See `BackupTroubleBanner` for why those were two jobs
 			 * in one predicate.
+			 *
+			 * Held back while the activity log is still loading. Both
+			 * queries start together and `/jetpack/v4/backups` is one round
+			 * trip against the activity log's paginated one, so it normally
+			 * wins — and during that window the veto is still up, which puts
+			 * us here. On a site that turns out to have no restore points
+			 * the veto then lifts and the takeover panel replaces the body,
+			 * saying the same thing the banner just said. Waiting costs
+			 * nothing and avoids announcing the most alarming state in the
+			 * dashboard twice in two different shapes. `isError` is not
+			 * loading, so the terminal case still reports immediately.
 			 */ }
-			<BackupTroubleBanner state={ backupsState } />
+			{ ! restorePointsLoading && <BackupTroubleBanner state={ backupsState } /> }
 			<div className="jpb-overview">
 				<ActivityList
 					selectedId={ selectedId }

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -27,6 +27,11 @@ function rewindIdToIso( rewindId: string ): string | null {
 	return new Date( seconds * 1000 ).toISOString();
 }
 
+// Stable so the submit button can point at the hint with
+// `aria-describedby`. A module constant rather than `useInstanceId`
+// because only one of these renders per page.
+const SELECTION_HINT_ID = 'jpb-restore__selection-hint';
+
 /**
  * Restore screen — narrow centered layout with the warning notice, the
  * shared item checklist, and a Confirm button. Submit drives a real
@@ -76,8 +81,17 @@ export default function RestoreScreen() {
 							</Notice>
 							<Text>{ __( 'Choose the items you wish to restore:', 'jetpack-backup-pkg' ) }</Text>
 							<RestoreItemsChecklist value={ items } onChange={ setItems } />
+							{ /*
+							 * `role="status"` so clearing the last box is announced, and
+							 * `aria-describedby` so the reason travels with the control.
+							 * Without both, the guard whose whole purpose is telling the
+							 * reader before they click tells nobody who cannot see it:
+							 * `@wordpress/ui` renders a disabled button as `aria-disabled`
+							 * and keeps it focusable, so it is reachable but silent about
+							 * why.
+							 */ }
 							{ ! hasSelection && (
-								<Text variant="body-sm" className="jpb-text-muted">
+								<Text id={ SELECTION_HINT_ID } variant="body-sm" role="status">
 									{ __( 'Select at least one item to restore.', 'jetpack-backup-pkg' ) }
 								</Text>
 							) }
@@ -85,6 +99,7 @@ export default function RestoreScreen() {
 								className="jpb-restore__confirm"
 								variant="solid"
 								disabled={ ! hasSelection || state.phase === 'submitting' }
+								aria-describedby={ hasSelection ? undefined : SELECTION_HINT_ID }
 								onClick={ handleConfirm }
 							>
 								{ state.phase === 'submitting' ? (

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -8,7 +8,7 @@ import { Button, Card, Stack, Text } from '@wordpress/ui';
 import DashboardLayout from '../components/dashboard-layout';
 import RestoreItemsChecklist from '../components/restore-items-checklist';
 import { useRestore } from '../hooks/use-restore';
-import { DEFAULT_RESTORE_ITEMS } from '../types/restore';
+import { DEFAULT_RESTORE_ITEMS, hasSelectedItems } from '../types/restore';
 
 /**
  * Derive an ISO timestamp for the restore-point label from the WPCOM
@@ -40,6 +40,9 @@ export default function RestoreScreen() {
 	const [ items, setItems ] = useState( DEFAULT_RESTORE_ITEMS );
 	const { state, submit, reset } = useRestore( rewindId );
 	const handleConfirm = useCallback( () => submit( items ), [ submit, items ] );
+	// An empty checklist would restore *everything* rather than nothing —
+	// see `hasSelectedItems`. On this screen that is unrecoverable.
+	const hasSelection = hasSelectedItems( items );
 
 	return (
 		<DashboardLayout>
@@ -73,10 +76,15 @@ export default function RestoreScreen() {
 							</Notice>
 							<Text>{ __( 'Choose the items you wish to restore:', 'jetpack-backup-pkg' ) }</Text>
 							<RestoreItemsChecklist value={ items } onChange={ setItems } />
+							{ ! hasSelection && (
+								<Text variant="body-sm" className="jpb-text-muted">
+									{ __( 'Select at least one item to restore.', 'jetpack-backup-pkg' ) }
+								</Text>
+							) }
 							<Button
 								className="jpb-restore__confirm"
 								variant="solid"
-								disabled={ state.phase === 'submitting' }
+								disabled={ ! hasSelection || state.phase === 'submitting' }
 								onClick={ handleConfirm }
 							>
 								{ state.phase === 'submitting' ? (

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -82,24 +82,37 @@ export default function RestoreScreen() {
 							<Text>{ __( 'Choose the items you wish to restore:', 'jetpack-backup-pkg' ) }</Text>
 							<RestoreItemsChecklist value={ items } onChange={ setItems } />
 							{ /*
-							 * `role="status"` so clearing the last box is announced, and
-							 * `aria-describedby` so the reason travels with the control.
-							 * Without both, the guard whose whole purpose is telling the
-							 * reader before they click tells nobody who cannot see it:
-							 * `@wordpress/ui` renders a disabled button as `aria-disabled`
-							 * and keeps it focusable, so it is reachable but silent about
-							 * why.
+							 * The live region is mounted unconditionally and only its text
+							 * changes. A region that appears together with its first message
+							 * is unreliable — assistive tech generally needs it in the tree
+							 * before the content changes, and VoiceOver in particular often
+							 * misses the simultaneous case. `jpb-visually-hidden` takes it out
+							 * of flow while empty rather than unmounting it, because this card
+							 * is a flex column with a gap and an in-flow empty node would cost
+							 * 16px of dead space on every render where there is nothing to say.
+							 *
+							 * `aria-describedby` is likewise unconditional: it resolves to the
+							 * same element either way, and an empty target contributes nothing
+							 * to the accessible description. Between them the reader is told
+							 * both when they clear the last box and when they reach the button
+							 * — @wordpress/ui renders a disabled button as focusable
+							 * `aria-disabled`, so it is reachable but silent about why.
 							 */ }
-							{ ! hasSelection && (
-								<Text id={ SELECTION_HINT_ID } variant="body-sm" role="status">
-									{ __( 'Select at least one item to restore.', 'jetpack-backup-pkg' ) }
-								</Text>
-							) }
+							<Text
+								id={ SELECTION_HINT_ID }
+								variant="body-sm"
+								role="status"
+								className={ hasSelection ? 'jpb-visually-hidden' : undefined }
+							>
+								{ hasSelection
+									? ''
+									: __( 'Select at least one item to restore.', 'jetpack-backup-pkg' ) }
+							</Text>
 							<Button
 								className="jpb-restore__confirm"
 								variant="solid"
 								disabled={ ! hasSelection || state.phase === 'submitting' }
-								aria-describedby={ hasSelection ? undefined : SELECTION_HINT_ID }
+								aria-describedby={ SELECTION_HINT_ID }
 								onClick={ handleConfirm }
 							>
 								{ state.phase === 'submitting' ? (

--- a/projects/packages/backup/src/dashboard/types/restore.ts
+++ b/projects/packages/backup/src/dashboard/types/restore.ts
@@ -16,6 +16,26 @@ export const DEFAULT_RESTORE_ITEMS: RestoreItems = {
 	uploads: true,
 };
 
+/**
+ * Whether the checklist names at least one category.
+ *
+ * Both screens gate their submit button on this, and they have to: an
+ * empty checklist does not ask WPCOM for nothing. The request omits
+ * `types` entirely, and an absent `types` is upstream's shorthand for all
+ * six categories — so an unticked list submits a full download, or a full
+ * destructive restore, which is the opposite of what it shows.
+ *
+ * The request layer refuses the same state independently; see
+ * `requireTypes` in `data/api/_helpers`. This one exists so the reader is
+ * told before they click rather than after.
+ *
+ * @param items - The category checklist.
+ * @return True when at least one category is selected.
+ */
+export function hasSelectedItems( items: RestoreItems ): boolean {
+	return Object.values( items ).some( Boolean );
+}
+
 export type RestoreState =
 	| { phase: 'idle' }
 	| { phase: 'submitting' }

--- a/projects/packages/backup/src/rest/class-activity-log-bridge.php
+++ b/projects/packages/backup/src/rest/class-activity-log-bridge.php
@@ -107,7 +107,7 @@ class Activity_Log_Bridge {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return $response;
+			return Rest_Controller::transport_error( $response, 'activity_log_fetch_failed' );
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );

--- a/projects/packages/backup/src/rest/class-capabilities-bridge.php
+++ b/projects/packages/backup/src/rest/class-capabilities-bridge.php
@@ -66,7 +66,7 @@ class Capabilities_Bridge {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return $response;
+			return Rest_Controller::transport_error( $response, 'capabilities_fetch_failed' );
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );

--- a/projects/packages/backup/src/rest/class-download-bridge.php
+++ b/projects/packages/backup/src/rest/class-download-bridge.php
@@ -104,10 +104,23 @@ class Download_Bridge {
 		$rewind_id = (string) $request->get_param( 'rewind_id' );
 		$types     = $request->get_param( 'types' );
 
+		// A supplied `types` that names nothing is refused rather than
+		// dropped. Omitting the key is not "download nothing" — WPCOM
+		// reads an absent `types` as every category, so forwarding an
+		// empty selection as an omission would hand back the full archive
+		// the caller had just excluded. `/rewind/downloads` has no
+		// server-side guard of its own, unlike the v2 restore route.
+		if ( Rest_Controller::types_name_nothing( $types ) ) {
+			return new WP_Error(
+				'no_types_selected',
+				__( 'Select at least one item to download.', 'jetpack-backup-pkg' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		$body = array( 'rewindId' => $rewind_id );
-		// Omit `types` rather than defaulting it to an empty object.
-		// WPCOM selects the enabled categories loosely, so an empty
-		// value names no category and asks for a download of nothing.
+		// Absent when the caller named no categories at all, which is how
+		// a whole-archive download is spelled upstream.
 		$named_types = Rest_Controller::named_types( $types );
 		if ( ! empty( $named_types ) ) {
 			$body['types'] = $named_types;
@@ -122,7 +135,7 @@ class Download_Bridge {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return $response;
+			return Rest_Controller::transport_error( $response, 'download_initiate_failed' );
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );
@@ -183,7 +196,7 @@ class Download_Bridge {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return $response;
+			return Rest_Controller::transport_error( $response, 'download_status_fetch_failed' );
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );

--- a/projects/packages/backup/src/rest/class-file-browser-bridge.php
+++ b/projects/packages/backup/src/rest/class-file-browser-bridge.php
@@ -152,7 +152,7 @@ class File_Browser_Bridge {
 		);
 
 		if ( is_wp_error( $url_response ) ) {
-			return $url_response;
+			return Rest_Controller::transport_error( $url_response, 'backup_file_content_url_failed' );
 		}
 
 		$url_status = wp_remote_retrieve_response_code( $url_response );
@@ -194,7 +194,7 @@ class File_Browser_Bridge {
 		);
 
 		if ( is_wp_error( $stream_response ) ) {
-			return $stream_response;
+			return Rest_Controller::transport_error( $stream_response, 'backup_file_content_stream_failed' );
 		}
 
 		$stream_status = wp_remote_retrieve_response_code( $stream_response );
@@ -211,17 +211,18 @@ class File_Browser_Bridge {
 
 	/**
 	 * Shared response forwarder for the bridges that just pass through
-	 * WPCOM JSON. Wraps WP_Error / non-200 responses with bridge-level
-	 * error codes the front-end branches on.
+	 * WPCOM JSON. Wraps transport failures and non-200 responses alike
+	 * with bridge-level error codes the front-end branches on, so cURL's
+	 * own text never reaches the reader.
 	 *
 	 * @param array|\WP_Error $response The wp_remote_* response.
-	 * @param string          $code     Error code for non-200.
-	 * @param string          $message  Translated error message.
+	 * @param string          $code     Error code for a transport failure or a non-200.
+	 * @param string          $message  Translated error message for a non-200.
 	 * @return \WP_REST_Response|WP_Error
 	 */
 	private static function forward_response( $response, $code, $message ) {
 		if ( is_wp_error( $response ) ) {
-			return $response;
+			return Rest_Controller::transport_error( $response, $code );
 		}
 		$status_code = wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {

--- a/projects/packages/backup/src/rest/class-rest-controller.php
+++ b/projects/packages/backup/src/rest/class-rest-controller.php
@@ -124,4 +124,66 @@ class Rest_Controller {
 		}
 		return $named;
 	}
+
+	/**
+	 * Whether a `types` parameter was supplied but names no category.
+	 *
+	 * The distinction this draws is the whole point of the helper, and it
+	 * is the opposite of what it looks like. An **absent** `types` is a
+	 * valid, deliberate request for every category — WPCOM's contract is
+	 * "omit it for everything" — so the mutations leave the key out for a
+	 * whole-site restore or a full archive. A **supplied** `types` that
+	 * survives into nothing is the other thing entirely: the caller tried
+	 * to name categories and named none, and forwarding that as an
+	 * omission would quietly upgrade "restore nothing" into "restore
+	 * everything", against a live site.
+	 *
+	 * Nothing upstream catches it on both routes. The v2 restore route
+	 * rejects a `types` naming nothing, but `/rewind/downloads` does not,
+	 * so the guarantee has to be made here for the pair to behave alike.
+	 *
+	 * @param mixed $types Raw `types` parameter from the request, or null when absent.
+	 * @return bool True when the caller supplied a `types` that names no category.
+	 */
+	public static function types_name_nothing( $types ) {
+		return null !== $types && ! self::named_types( $types );
+	}
+
+	/**
+	 * Convert a transport-level failure into a bridge error.
+	 *
+	 * `Client::wpcom_json_api_request_as_*` answers with a `WP_Error` when
+	 * the request never reached WPCOM at all — DNS, TLS, or the cURL
+	 * timeout behind JETPACK-2173's "cURL error 28". Returning that error
+	 * unchanged hands cURL's own text to the browser, where the dashboard
+	 * renders the message verbatim in a notice; it also carries no
+	 * `status`, so core answers 500 for what is really a reachability
+	 * problem rather than a server fault.
+	 *
+	 * The raw text is preserved under `transport` rather than discarded.
+	 * It is the only part a support agent can act on, and it is the same
+	 * reason the non-200 branches forward WPCOM's status instead of
+	 * flattening it.
+	 *
+	 * Always 502: telling a timeout from a refused connection would mean
+	 * matching on cURL's English message text, and no caller reads the
+	 * difference.
+	 *
+	 * @param WP_Error $error Transport error from the HTTP client.
+	 * @param string   $code  Bridge error code for the operation that failed.
+	 * @return WP_Error
+	 */
+	public static function transport_error( WP_Error $error, $code ) {
+		return new WP_Error(
+			$code,
+			__( 'Could not reach WordPress.com. Check your connection and try again.', 'jetpack-backup-pkg' ),
+			array(
+				'status'    => 502,
+				'transport' => array(
+					'code'    => $error->get_error_code(),
+					'message' => $error->get_error_message(),
+				),
+			)
+		);
+	}
 }

--- a/projects/packages/backup/src/rest/class-rest-controller.php
+++ b/projects/packages/backup/src/rest/class-rest-controller.php
@@ -27,6 +27,34 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Rest_Controller {
 
 	/**
+	 * Every category WPCOM's rewind endpoints recognize in a `types` map.
+	 *
+	 * The first six are the whole-site checklist the Restore and Download
+	 * screens render. `paths` is the granular selector, paired with
+	 * `include_path_list` / `exclude_path_list` — nothing sends it yet,
+	 * but it is part of the same documented contract and leaving it out
+	 * would make the file browser's granular download fail closed with a
+	 * confusing 400 the day it is wired up.
+	 *
+	 * This list has to grow if VaultPress adds a category. WPCOM's own
+	 * route deliberately does not allowlist, so that it stays open to new
+	 * types; we can afford to be stricter because we also own the UI that
+	 * produces the values, and here a value that names nothing is the
+	 * dangerous case rather than merely a useless one.
+	 *
+	 * @var string[]
+	 */
+	private const CATEGORIES = array(
+		'themes',
+		'plugins',
+		'roots',
+		'contents',
+		'sqls',
+		'uploads',
+		'paths',
+	);
+
+	/**
 	 * Hook entry point. Registers all bridge routes if the modernization
 	 * filter is enabled.
 	 *
@@ -103,10 +131,21 @@ class Rest_Controller {
 	 * the members fail a boolean check — shape itself is never asserted —
 	 * so the guarantee is made here, where the payload is actually built.
 	 *
-	 * Only string keys with a truthy value survive, and every surviving
-	 * value is normalized to `true`. Values are read with
+	 * Only known categories with a truthy value survive, and every
+	 * surviving value is normalized to `true`. Values are read with
 	 * `rest_sanitize_boolean()` so a form-encoded `"false"` or `"0"` means
 	 * skip rather than select.
+	 *
+	 * Unknown keys are dropped rather than forwarded, which is what makes
+	 * `types_name_nothing()` a total guard: without it a payload naming
+	 * only categories WPCOM does not recognize would satisfy the guard and
+	 * be sent on, and what WPCOM does with a `types` that matches nothing
+	 * is not characterized. Dropping them means such a payload names
+	 * nothing, and is refused. The realistic way to get there is not an
+	 * attacker — an admin who can craft the request can already omit
+	 * `types` for a whole-site operation — but a future client-side typo:
+	 * renaming a checklist key `sqls` to `sql` would otherwise go through
+	 * silently.
 	 *
 	 * @param mixed $types Raw `types` parameter from the request.
 	 * @return array<string, true> Named types, empty when none are selected.
@@ -118,7 +157,7 @@ class Rest_Controller {
 
 		$named = array();
 		foreach ( (array) $types as $key => $value ) {
-			if ( is_string( $key ) && '' !== $key && rest_sanitize_boolean( $value ) ) {
+			if ( in_array( $key, self::CATEGORIES, true ) && rest_sanitize_boolean( $value ) ) {
 				$named[ $key ] = true;
 			}
 		}

--- a/projects/packages/backup/src/rest/class-restore-bridge.php
+++ b/projects/packages/backup/src/rest/class-restore-bridge.php
@@ -92,13 +92,24 @@ class Restore_Bridge {
 		$rewind_id = (string) $request->get_param( 'rewind_id' );
 		$types     = $request->get_param( 'types' );
 
+		// A supplied `types` that names nothing is refused rather than
+		// dropped, and this is the screen where that matters most: an
+		// absent `types` means every category upstream, so forwarding an
+		// empty selection as an omission would overwrite the live site
+		// with exactly the parts the caller excluded. The v2 restore route
+		// rejects this too, but only once the request has left us.
+		if ( Rest_Controller::types_name_nothing( $types ) ) {
+			return new WP_Error(
+				'no_types_selected',
+				__( 'Select at least one item to restore.', 'jetpack-backup-pkg' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		$body = array( 'force_rewind' => true );
-		// Omit `types` entirely when nothing is named, and rebuild it as a
-		// named map otherwise — the same contract the download bridge and
-		// the client's `serializeTypes` follow. Defaulting to `{}` sent the
-		// one value that names no category, which the v2 restore route
-		// rejects outright and which the client had already been careful to
-		// leave out.
+		// Absent when the caller named no categories at all, which is how
+		// a whole-site restore is spelled upstream. Rebuilt as a named map
+		// otherwise — the same contract the download bridge follows.
 		$named_types = Rest_Controller::named_types( $types );
 		if ( ! empty( $named_types ) ) {
 			$body['types'] = $named_types;
@@ -116,7 +127,7 @@ class Restore_Bridge {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return $response;
+			return Rest_Controller::transport_error( $response, 'restore_initiate_failed' );
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );
@@ -164,7 +175,7 @@ class Restore_Bridge {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return $response;
+			return Rest_Controller::transport_error( $response, 'restore_status_fetch_failed' );
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );

--- a/projects/packages/backup/src/rest/class-restore-bridge.php
+++ b/projects/packages/backup/src/rest/class-restore-bridge.php
@@ -96,8 +96,13 @@ class Restore_Bridge {
 		// dropped, and this is the screen where that matters most: an
 		// absent `types` means every category upstream, so forwarding an
 		// empty selection as an omission would overwrite the live site
-		// with exactly the parts the caller excluded. The v2 restore route
-		// rejects this too, but only once the request has left us.
+		// with exactly the parts the caller excluded.
+		//
+		// This bridge is currently the only guard on that: the call below
+		// still targets the v1 activity-log route, which has no such
+		// check. The v2 restore route does reject it, so once B1 repoints
+		// this there will be a second line of defence — but it will always
+		// be the slower one, since it only fires after the request leaves.
 		if ( Rest_Controller::types_name_nothing( $types ) ) {
 			return new WP_Error(
 				'no_types_selected',

--- a/projects/packages/backup/tests/empty-selection.test.tsx
+++ b/projects/packages/backup/tests/empty-selection.test.tsx
@@ -1,0 +1,168 @@
+// An empty category checklist must never submit.
+//
+// This is a safety guard, not a politeness one, and the reason is
+// counter-intuitive enough to be worth stating where the tests live.
+//
+// WPCOM reads an *absent* `types` as "all six categories" — the wpcom
+// contract's words are "omit it for everything". The client omits the key
+// when nothing is ticked, and both bridges drop it from the upstream body
+// when it names nothing. So unticking every box did not ask for nothing:
+// on the Download screen it asked for the full archive, and on the
+// Restore screen it asked for a full destructive restore of precisely the
+// categories the reader had just deselected.
+//
+// The comments in the tree said the opposite ("an empty `types` asks
+// WPCOM for a download containing nothing"), which is how it survived
+// review — the code read as safe while behaving the other way. That
+// belief was true against the v1 route; the v2 restore route added in
+// A1/A2 rejects a supplied-but-empty `types` outright, which pushed the
+// client toward omitting the key, and omission is the "everything"
+// sentinel. Fixing one side moved the danger to the other.
+
+const mockApiFetch = jest.fn();
+const mockSearch = jest.fn< Record< string, unknown >, [] >();
+const mockNavigate = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => mockSearch(),
+	useNavigate: () => mockNavigate,
+	useParams: () => ( { rewindId: '1786663613.9425' } ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { stage as DownloadStage } from '../routes/download/stage';
+import { stage as RestoreStage } from '../routes/restore/stage';
+import { queryClient } from '../src/dashboard/data/query-client';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+const SETTLE = { timeout: 10000 };
+
+/** Every box in the shared checklist, by its accessible name. */
+const ITEM_LABELS = [
+	'WordPress themes',
+	'WordPress plugins',
+	'WordPress root',
+	'WP-content directory',
+	'Site database',
+	'Media uploads',
+];
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockApiFetch.mockImplementation( ( o: { path?: string } ) => {
+		const path = o?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		return Promise.resolve( {} );
+	} );
+	mockSearch.mockReset();
+	mockSearch.mockReturnValue( {} );
+	mockNavigate.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+/**
+ * Untick every category. The checklist starts with all six selected, so
+ * this is the state a reader reaches by deliberately clearing the list.
+ */
+async function untickEverything() {
+	for ( const label of ITEM_LABELS ) {
+		await userEvent.click( await screen.findByRole( 'checkbox', { name: label }, SETTLE ) );
+	}
+}
+
+/**
+ * Every POST the dashboard issued. The mutations are the only POSTs
+ * either screen makes, so an empty list here means nothing was submitted.
+ *
+ * @return The matching apiFetch option objects.
+ */
+function postCalls() {
+	return mockApiFetch.mock.calls
+		.map( ( [ options ] ) => options as { method?: string } | undefined )
+		.filter( options => options?.method === 'POST' );
+}
+
+/**
+ * `@wordpress/ui`'s Button marks a disabled control with `aria-disabled`
+ * rather than the native attribute, so it stays focusable and a screen
+ * reader still reaches it. `toBeDisabled()` only reads the native one.
+ *
+ * @param name - Accessible name of the button.
+ * @return The button element.
+ */
+function button( name: RegExp ) {
+	return screen.getByRole( 'button', { name } );
+}
+
+describe( 'Download screen with nothing selected', () => {
+	it( 'says what is wrong instead of leaving the button armed', async () => {
+		render( <DownloadStage /> );
+		await untickEverything();
+
+		expect( screen.getByText( 'Select at least one item to download.' ) ).toBeInTheDocument();
+		expect( button( /Generate download/ ) ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'issues no request when the button is clicked anyway', async () => {
+		render( <DownloadStage /> );
+		await untickEverything();
+
+		await userEvent.click( button( /Generate download/ ) );
+
+		expect( postCalls() ).toHaveLength( 0 );
+		// Nothing was submitted *and* nothing was attempted: the request
+		// layer's own refusal would have surfaced as an error phase, so its
+		// absence is what proves the button itself is inert. Both guards
+		// are wanted, but the reader should never reach the second one.
+		expect( screen.queryByText( /Select at least one item to continue/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 're-arms as soon as one category comes back', async () => {
+		render( <DownloadStage /> );
+		await untickEverything();
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Site database' } ) );
+
+		expect( screen.queryByText( 'Select at least one item to download.' ) ).not.toBeInTheDocument();
+		expect( button( /Generate download/ ) ).not.toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+} );
+
+describe( 'Restore screen with nothing selected', () => {
+	// The destructive half. An unticked restore that reached WPCOM would
+	// overwrite the live site with everything the reader excluded.
+	it( 'says what is wrong instead of leaving the button armed', async () => {
+		render( <RestoreStage /> );
+		await untickEverything();
+
+		expect( screen.getByText( 'Select at least one item to restore.' ) ).toBeInTheDocument();
+		expect( button( /Confirm restore/ ) ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'issues no request when the button is clicked anyway', async () => {
+		render( <RestoreStage /> );
+		await untickEverything();
+
+		await userEvent.click( button( /Confirm restore/ ) );
+
+		expect( postCalls() ).toHaveLength( 0 );
+		expect( screen.queryByText( /Select at least one item to continue/ ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/empty-selection.test.tsx
+++ b/projects/packages/backup/tests/empty-selection.test.tsx
@@ -121,6 +121,28 @@ describe( 'Download screen with nothing selected', () => {
 		expect( button( /Generate download/ ) ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
+	// The reason has to reach someone who cannot see it. Both halves of
+	// that depend on `@wordpress/ui`'s `Text` forwarding arbitrary props,
+	// which that package does not promise — so if a release stopped
+	// forwarding `id`, `aria-describedby` would dangle and every other
+	// assertion here would stay green.
+	it( 'points the button at the hint, and keeps the live region mounted', async () => {
+		render( <DownloadStage /> );
+
+		// Mounted and empty before anything is wrong: a live region that
+		// appears together with its first message is unreliable.
+		const hint = await screen.findByRole( 'status', undefined, SETTLE );
+		expect( hint ).toBeEmptyDOMElement();
+		expect( button( /Generate download/ ) ).toHaveAttribute( 'aria-describedby', hint.id );
+
+		await untickEverything();
+
+		// The same element, now carrying the message — an update to a
+		// region already in the tree, not an insertion.
+		expect( screen.getByRole( 'status' ) ).toBe( hint );
+		expect( hint ).toHaveTextContent( 'Select at least one item to download.' );
+	} );
+
 	it( 'issues no request when the button is clicked anyway', async () => {
 		render( <DownloadStage /> );
 		await untickEverything();

--- a/projects/packages/backup/tests/jest.config.js
+++ b/projects/packages/backup/tests/jest.config.js
@@ -5,4 +5,14 @@ module.exports = {
 	...baseConfig,
 	rootDir: path.join( __dirname, '..' ),
 	setupFilesAfterEnv: [ ...baseConfig.setupFilesAfterEnv, '<rootDir>/tests/jest.setup.js' ],
+	// Raised above Jest's 5s default so the `SETTLE` windows the route-stage
+	// suites pass to `findBy*` can actually elapse. Those stages render
+	// behind several sequential requests and have taken well over a second
+	// on a loaded runner under coverage, which is why they ask for a longer
+	// deadline than Testing Library's 1s default — but Jest's own timeout
+	// fires first when it is lower, killing the test with a bare "Exceeded
+	// timeout" instead of Testing Library's "Unable to find an element with
+	// the text …" plus the rendered DOM. Losing that dump is losing the one
+	// thing that says what actually went wrong on CI.
+	testTimeout: 20000,
 };

--- a/projects/packages/backup/tests/overview-takeover.test.tsx
+++ b/projects/packages/backup/tests/overview-takeover.test.tsx
@@ -202,6 +202,36 @@ describe( 'Overview takeover', () => {
 	} );
 } );
 
+// Suppressing the takeover must not also suppress the *message*. Only the
+// panel carried "your backups are failing" and its support link, so every
+// case where the panel correctly stands down used to drop that too — which
+// the veto widening above would have made worse, not better.
+describe( 'Failing backups with the takeover suppressed', () => {
+	it( 'still reports the failure when restore points are listed', async () => {
+		mockEndpoints( { backups: [ UNUSABLE_BACKUP ], activity: [ activityEntry( 'cloud' ) ] } );
+
+		render( <OverviewStage /> );
+
+		// The list is kept...
+		await expect(
+			screen.findByText( 'Backup complete', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+		// ...and the reader is told anyway, with a way to get help.
+		expect( screen.getByText( "We're having trouble backing up your site." ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: /Get in touch with us/ } ) ).toBeInTheDocument();
+	} );
+
+	it( 'still reports the failure when the activity request failed', async () => {
+		mockEndpoints( { backups: [ UNUSABLE_BACKUP ], activityFails: true } );
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByText( "We're having trouble backing up your site.", undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+	} );
+} );
+
 describe( 'Backup-state read failure', () => {
 	// `/jetpack/v4/backups` answers a non-200 from WPCOM with a bare
 	// `null` body, which WordPress serves as HTTP 200 — so the request
@@ -225,9 +255,14 @@ describe( 'Backup-state read failure', () => {
 		render( <OverviewStage /> );
 
 		// The notice is a report, not a takeover: the restore points the
-		// reader came for are still listed beside it.
+		// reader came for are still listed beside it. Both halves are
+		// asserted — the row alone renders on trunk too, so without the
+		// notice assertion this test would pass with the fix reverted.
 		await expect(
 			screen.findByText( 'Backup complete', undefined, SETTLE )
 		).resolves.toBeInTheDocument();
+		expect(
+			screen.getByText( "We couldn't check your site's backup status." )
+		).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/overview-takeover.test.tsx
+++ b/projects/packages/backup/tests/overview-takeover.test.tsx
@@ -29,6 +29,11 @@ import { queryClient } from '../src/dashboard/data/query-client';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
+// Testing Library's default `findBy` window is one second. These stages
+// render behind several sequential requests, and a loaded CI runner under
+// coverage has taken well over that for the same work locally-green here.
+const SETTLE = { timeout: 10000 };
+
 // jsdom implements no scrolling, and DataViews' list layout calls
 // `scrollIntoView` on the selected row — which only happens here because
 // these are the first tests to render the list with a row in it.
@@ -65,22 +70,32 @@ function activityEntry( gridicon: string ) {
 /**
  * Answer every endpoint the Overview reads.
  *
- * @param options          - Overrides.
- * @param options.backups  - What `/jetpack/v4/backups` returns.
- * @param options.activity - Rewindable-activity entries.
+ * @param options               - Overrides.
+ * @param options.backups       - What `/jetpack/v4/backups` resolves with. `null` is the
+ *                              shape a non-200 from WPCOM actually takes — the legacy
+ *                              route returns a bare `null`, which WordPress serves as
+ *                              HTTP 200, so the request resolves rather than rejecting.
+ * @param options.activity      - Rewindable-activity entries.
+ * @param options.activityFails - Make `/site/rewindable-activity` reject.
  */
-function mockEndpoints( { backups = [] as unknown[], activity = [] as unknown[] } = {} ) {
+function mockEndpoints( {
+	backups = [] as unknown[] | null,
+	activity = [] as unknown[],
+	activityFails = false,
+} = {} ) {
 	mockApiFetch.mockImplementation( ( o: { path?: string } ) => {
 		const path = o?.path ?? '';
 		if ( path.includes( '/site/capabilities' ) ) {
 			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
 		}
 		if ( path.includes( '/site/rewindable-activity' ) ) {
-			return Promise.resolve( {
-				current: { orderedItems: activity },
-				totalItems: activity.length,
-				totalPages: 1,
-			} );
+			return activityFails
+				? Promise.reject( new Error( 'Could not fetch the activity log.' ) )
+				: Promise.resolve( {
+						current: { orderedItems: activity },
+						totalItems: activity.length,
+						totalPages: 1,
+				  } );
 		}
 		if ( path.includes( '/site/backup/size' ) ) {
 			return Promise.resolve( { ok: true, backups_stopped: false } );
@@ -161,6 +176,58 @@ describe( 'Overview takeover', () => {
 
 		await expect(
 			screen.findByText( "We're having trouble backing up your site" )
+		).resolves.toBeInTheDocument();
+	} );
+
+	// The cell where the first-run panel and the activity-log error
+	// boundary were each individually right and jointly blind. An errored
+	// query is neither loading nor holding rows, so `hasRestorePoints`
+	// came back false with `isLoading` false — the veto lifted, the panel
+	// took the body over, and the error `<ActivityList>` was about to
+	// render went down with it. A failed request read as "your first
+	// backup is on its way".
+	it( 'does not take over when the activity request failed', async () => {
+		mockEndpoints( { backups: [], activityFails: true } );
+
+		render( <OverviewStage /> );
+
+		// The activity log says what went wrong...
+		await expect(
+			screen.findByText( "We couldn't load your site's activity.", undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+		// ...instead of the panel claiming a first backup is coming.
+		expect(
+			screen.queryByText( 'Your first cloud backup will be ready soon' )
+		).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'Backup-state read failure', () => {
+	// `/jetpack/v4/backups` answers a non-200 from WPCOM with a bare
+	// `null` body, which WordPress serves as HTTP 200 — so the request
+	// *resolves*, React Query records a success, and neither `error` nor
+	// a retry ever fires. The state was computed and documented
+	// ("we couldn't ask" must never be rendered as "you have none") and
+	// then rendered nowhere at all.
+	it( 'reports a null backups response instead of staying silent', async () => {
+		mockEndpoints( { backups: null, activity: [ activityEntry( 'cloud' ) ] } );
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByText( "We couldn't check your site's backup status.", undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'leaves the activity list usable while the backup state is unreadable', async () => {
+		mockEndpoints( { backups: null, activity: [ activityEntry( 'cloud' ) ] } );
+
+		render( <OverviewStage /> );
+
+		// The notice is a report, not a takeover: the restore points the
+		// reader came for are still listed beside it.
+		await expect(
+			screen.findByText( 'Backup complete', undefined, SETTLE )
 		).resolves.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
 use function add_action;
@@ -21,6 +22,8 @@ use function remove_filter;
 use function wp_insert_user;
 use function wp_set_current_user;
 
+require_once __DIR__ . '/trait-wpcom-request-mock.php';
+
 /**
  * Tests for the GET /jetpack/v4/site/rewindable-activity route.
  *
@@ -28,6 +31,8 @@ use function wp_set_current_user;
  */
 #[CoversClass( Activity_Log_Bridge::class )]
 class Rest_Activity_Log_Bridge_Test extends TestCase {
+
+	use Wpcom_Request_Mock;
 
 	/**
 	 * REST Server.
@@ -56,7 +61,7 @@ class Rest_Activity_Log_Bridge_Test extends TestCase {
 	 */
 	public function tearDown(): void {
 		remove_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
-		wp_set_current_user( 0 );
+		$this->reset_wpcom_request_mock();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
@@ -89,5 +94,23 @@ class Rest_Activity_Log_Bridge_Test extends TestCase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 403, $response->get_status() );
+	}
+	/**
+	 * A transport failure surfaces as the bridge's own error rather than
+	 * cURL's text, which the activity list renders verbatim beneath its
+	 * "We couldn't load your site's activity." heading.
+	 */
+	public function test_wraps_a_transport_failure() {
+		$this->arrange_wpcom_unreachable();
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/site/rewindable-activity' );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'number', 10 );
+		$response = Activity_Log_Bridge::get_activity_log( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'activity_log_fetch_failed', $response->get_error_code() );
+		$this->assertStringNotContainsString( 'cURL', $response->get_error_message() );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
@@ -172,6 +172,32 @@ class Rest_Bridge_Gating_Test extends TestCase {
 				array( true, false ),
 				array(),
 			),
+			// Unknown keys are dropped rather than forwarded, which is what
+			// makes `types_name_nothing()` total: a payload naming only
+			// categories WPCOM does not know would otherwise satisfy the
+			// guard and be sent on, and what WPCOM does with a `types` that
+			// matches nothing is uncharacterized.
+			'drops an unknown category'        => array(
+				'drops an unknown category',
+				array( 'bogus' => true ),
+				array(),
+			),
+			'keeps known, drops unknown'       => array(
+				'keeps known, drops unknown',
+				array(
+					'sqls' => true,
+					'sql'  => true,
+				),
+				array( 'sqls' => true ),
+			),
+			// The granular selector, paired with include/exclude path
+			// lists. Nothing sends it yet (C3), but it is part of the same
+			// contract and must not be filtered out when it is wired up.
+			'keeps paths'                      => array(
+				'keeps paths',
+				array( 'paths' => true ),
+				array( 'paths' => true ),
+			),
 			'empty array'                      => array( 'empty array', array(), array() ),
 			'null'                             => array( 'null', null, array() ),
 			'scalar'                           => array( 'scalar', 'themes', array() ),
@@ -213,6 +239,11 @@ class Rest_Bridge_Gating_Test extends TestCase {
 			'absent'             => array( 'absent', null, false ),
 			'names one category' => array( 'names one', array( 'themes' => true ), false ),
 			'empty object'       => array( 'empty object', array(), true ),
+			// The case the allowlist exists for. A future client-side typo
+			// — a checklist key renamed `sqls` to `sql` — names nothing
+			// WPCOM recognizes, and is refused rather than forwarded.
+			'only unknown names' => array( 'only unknown names', array( 'sql' => true ), true ),
+			'granular paths'     => array( 'granular paths', array( 'paths' => true ), false ),
 			'every value false'  => array( 'every value false', array( 'themes' => false ), true ),
 			'form-encoded false' => array( 'form-encoded false', array( 'themes' => '0' ), true ),
 			// The shape the route schema cannot reject, because it

--- a/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
@@ -16,6 +16,7 @@ use Automattic\Jetpack\Backup\V0005\Jetpack_Backup;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use WP_Error;
 use WP_REST_Server;
 use function add_action;
 use function add_filter;
@@ -180,5 +181,82 @@ class Rest_Bridge_Gating_Test extends TestCase {
 				array( 'themes' => true ),
 			),
 		);
+	}
+
+	/**
+	 * `types_name_nothing()` separates "asked for everything" from
+	 * "asked for nothing", which are one byte apart on the wire and
+	 * opposite in effect.
+	 *
+	 * An absent `types` is upstream's spelling of every category, so it
+	 * must stay allowed. A supplied `types` that survives into nothing is
+	 * a caller who tried to name categories and named none — forwarding
+	 * that as an omission turns "restore nothing" into "restore
+	 * everything" against a live site.
+	 *
+	 * @param string $label    Case description.
+	 * @param mixed  $input    Raw `types` parameter.
+	 * @param bool   $expected Whether the parameter names nothing.
+	 * @dataProvider provide_empty_type_selections
+	 */
+	#[DataProvider( 'provide_empty_type_selections' )]
+	public function test_types_name_nothing( $label, $input, $expected ) {
+		$this->assertSame( $expected, Rest_Controller::types_name_nothing( $input ), $label );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: mixed, 2: bool}>
+	 */
+	public static function provide_empty_type_selections() {
+		return array(
+			// The one case that must NOT be refused.
+			'absent'             => array( 'absent', null, false ),
+			'names one category' => array( 'names one', array( 'themes' => true ), false ),
+			'empty object'       => array( 'empty object', array(), true ),
+			'every value false'  => array( 'every value false', array( 'themes' => false ), true ),
+			'form-encoded false' => array( 'form-encoded false', array( 'themes' => '0' ), true ),
+			// The shape the route schema cannot reject, because it
+			// constrains values rather than shape.
+			'list of booleans'   => array( 'list of booleans', array( true, false ), true ),
+			'list of names'      => array( 'list of names', array( 'themes' ), true ),
+			'scalar'             => array( 'scalar', 'themes', true ),
+		);
+	}
+
+	/**
+	 * A transport failure is reported as a bridge error, not forwarded.
+	 *
+	 * The HTTP client answers with a `WP_Error` when the request never
+	 * reached WPCOM. Returning that unchanged put cURL's own text on
+	 * screen — the dashboard renders `error.message` verbatim — and left
+	 * it without a `status`, so core called a reachability problem a 500.
+	 */
+	public function test_transport_error_replaces_the_raw_message() {
+		$raw = new WP_Error(
+			'http_request_failed',
+			'cURL error 28: Operation timed out after 10001 milliseconds with 0 bytes received'
+		);
+
+		$wrapped = Rest_Controller::transport_error( $raw, 'capabilities_fetch_failed' );
+
+		$this->assertSame( 'capabilities_fetch_failed', $wrapped->get_error_code() );
+		$this->assertStringNotContainsString( 'cURL', $wrapped->get_error_message() );
+		$this->assertSame( 502, $wrapped->get_error_data()['status'] );
+	}
+
+	/**
+	 * The raw text survives for support, one level down.
+	 *
+	 * It is the only part of a transport failure anyone can act on, so it
+	 * is moved rather than dropped — the same reason the non-200 branches
+	 * forward WPCOM's status instead of flattening it.
+	 */
+	public function test_transport_error_keeps_the_original_for_support() {
+		$raw = new WP_Error( 'http_request_failed', 'cURL error 6: Could not resolve host' );
+
+		$data = Rest_Controller::transport_error( $raw, 'activity_log_fetch_failed' )->get_error_data();
+
+		$this->assertSame( 'http_request_failed', $data['transport']['code'] );
+		$this->assertSame( 'cURL error 6: Could not resolve host', $data['transport']['message'] );
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
 use function add_action;
@@ -21,6 +22,8 @@ use function remove_filter;
 use function wp_insert_user;
 use function wp_set_current_user;
 
+require_once __DIR__ . '/trait-wpcom-request-mock.php';
+
 /**
  * Tests for the GET /jetpack/v4/site/capabilities route.
  *
@@ -28,6 +31,8 @@ use function wp_set_current_user;
  */
 #[CoversClass( Capabilities_Bridge::class )]
 class Rest_Capabilities_Bridge_Test extends TestCase {
+
+	use Wpcom_Request_Mock;
 
 	/**
 	 * REST Server.
@@ -56,7 +61,7 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 	 */
 	public function tearDown(): void {
 		remove_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
-		wp_set_current_user( 0 );
+		$this->reset_wpcom_request_mock();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
@@ -89,5 +94,23 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 403, $response->get_status() );
+	}
+	/**
+	 * A transport failure surfaces as the bridge's own error rather than
+	 * cURL's text.
+	 *
+	 * This is the callback behind `<Gates>`, so its message is the first
+	 * thing a reader sees when WPCOM is unreachable — the capabilities
+	 * error screen renders it verbatim.
+	 */
+	public function test_wraps_a_transport_failure() {
+		$this->arrange_wpcom_unreachable();
+
+		$response = Capabilities_Bridge::get_capabilities();
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'capabilities_fetch_failed', $response->get_error_code() );
+		$this->assertStringNotContainsString( 'cURL', $response->get_error_message() );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
@@ -19,12 +19,11 @@ use WP_REST_Server;
 use function add_action;
 use function add_filter;
 use function do_action;
-use function get_current_user_id;
-use function remove_all_filters;
 use function remove_filter;
 use function wp_insert_user;
-use function wp_json_encode;
 use function wp_set_current_user;
+
+require_once __DIR__ . '/trait-wpcom-request-mock.php';
 
 /**
  * Tests for the /jetpack/v4/backups/download/* routes.
@@ -41,19 +40,7 @@ class Rest_Download_Bridge_Test extends TestCase {
 	 */
 	private $server;
 
-	/**
-	 * URL of the last request the bridge made to WPCOM.
-	 *
-	 * @var string
-	 */
-	private $captured_url = '';
-
-	/**
-	 * Decoded body of the last request the bridge made to WPCOM.
-	 *
-	 * @var array|null
-	 */
-	private $captured_body = null;
+	use Wpcom_Request_Mock;
 
 	/**
 	 * Enable modernization, register routes, and prepare a fresh REST server.
@@ -75,12 +62,7 @@ class Rest_Download_Bridge_Test extends TestCase {
 	 */
 	public function tearDown(): void {
 		remove_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
-		remove_all_filters( 'pre_http_request' );
-		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10 );
-		wp_set_current_user( 0 );
-
-		$this->captured_url  = '';
-		$this->captured_body = null;
+		$this->reset_wpcom_request_mock();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
@@ -128,66 +110,6 @@ class Rest_Download_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * Stand in for a connected site so `Client` can sign a request.
-	 *
-	 * @param mixed  $value Original option value.
-	 * @param string $name  Option name.
-	 * @return mixed
-	 */
-	public function mock_jetpack_connection_options( $value, $name ) {
-		switch ( $name ) {
-			case 'blog_token':
-				return 'test.blogtoken';
-			case 'id':
-				return '999';
-			case 'user_tokens':
-				$user_id = get_current_user_id();
-				if ( $user_id ) {
-					return array( $user_id => sprintf( 'token%d.secret%d.%d', $user_id, $user_id, $user_id ) );
-				}
-		}
-		return $value;
-	}
-
-	/**
-	 * Sign in as an administrator and intercept the bridge's WPCOM call.
-	 *
-	 * The callbacks below are invoked directly rather than dispatched
-	 * through the REST server, because `Rest_Controller::permission_check()`
-	 * additionally requires a user-level WPCOM connection that WorDBless
-	 * cannot stand up. The permission boundary itself is covered by
-	 * `test_routes_require_manage_options`.
-	 *
-	 * @param array $body   Payload WPCOM should answer with.
-	 * @param int   $status HTTP status WPCOM should answer with.
-	 */
-	private function arrange_wpcom( array $body, $status = 200 ) {
-		$admin_id = wp_insert_user(
-			array(
-				'user_login' => 'admin_user_' . wp_rand( 1, PHP_INT_MAX ),
-				'user_pass'  => 'dummy_pass',
-				'role'       => 'administrator',
-			)
-		);
-		wp_set_current_user( $admin_id );
-
-		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10, 2 );
-		add_filter(
-			'pre_http_request',
-			function ( $preempt, $args, $url ) use ( $body, $status ) {
-				$this->captured_url  = $url;
-				$this->captured_body = isset( $args['body'] ) ? json_decode( $args['body'], true ) : null;
-				return array(
-					'response' => array( 'code' => $status ),
-					'body'     => wp_json_encode( $body, JSON_UNESCAPED_SLASHES ),
-				);
-			},
-			10,
-			3
-		);
-	}
-
-	/**
 	 * The rewind id goes in the body, in full, and the target is the
 	 * downloads collection.
 	 *
@@ -213,45 +135,104 @@ class Rest_Download_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * An empty `types` is omitted rather than sent as `{}`.
+	 * An absent `types` is forwarded as an omission, because that is how
+	 * a whole-archive download is spelled upstream.
 	 *
-	 * WPCOM selects the enabled categories loosely, so an empty value
-	 * names no category — it asks for a download containing nothing.
-	 *
-	 * @param string $label Case description.
-	 * @param mixed  $types The `types` parameter to send, or null to omit it.
-	 * @dataProvider provide_types_that_name_nothing
+	 * The only empty-looking case that stays allowed, and the distinction
+	 * is load-bearing — see the refusal test below.
 	 */
-	#[DataProvider( 'provide_types_that_name_nothing' )]
-	public function test_initiate_omits_types_that_name_nothing( $label, $types ) {
+	public function test_initiate_omits_an_absent_types() {
 		$this->arrange_wpcom( array( 'downloadId' => 1 ) );
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
 		$request->set_param( 'rewind_id', '123' );
-		if ( null !== $types ) {
-			$request->set_param( 'types', $types );
-		}
 		Download_Bridge::initiate_download( $request );
 
-		$this->assertArrayNotHasKey( 'types', (array) $this->captured_body, $label );
+		$this->assertArrayNotHasKey( 'types', (array) $this->captured_body );
 	}
 
 	/**
-	 * Every shape that names no category.
+	 * A supplied `types` that names nothing is refused, not omitted.
 	 *
-	 * `absent` is what the client actually sends when the checklist is
-	 * empty; `list of booleans` is the shape the route schema cannot
-	 * reject, since it constrains values rather than shape.
+	 * This test asserted the opposite until now, and the reasoning
+	 * recorded with it was wrong: an omitted `types` does not ask WPCOM
+	 * for a download containing nothing, it asks for **all six
+	 * categories**. Dropping an empty selection therefore handed back the
+	 * full archive the caller had just excluded — and the same code path
+	 * on the restore bridge overwrote a live site with it.
+	 * `/rewind/downloads` has no server-side guard of its own, unlike the
+	 * v2 restore route, so this one has to hold.
+	 *
+	 * @param string $label Case description.
+	 * @param mixed  $types The `types` parameter to send.
+	 * @dataProvider provide_types_that_name_nothing
+	 */
+	#[DataProvider( 'provide_types_that_name_nothing' )]
+	public function test_initiate_refuses_types_that_name_nothing( $label, $types ) {
+		$this->arrange_wpcom( array( 'downloadId' => 1 ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'types', $types );
+		$response = Download_Bridge::initiate_download( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response, $label );
+		$this->assertSame( 'no_types_selected', $response->get_error_code(), $label );
+		$this->assertSame( 400, $response->get_error_data()['status'], $label );
+		// And nothing was asked of WPCOM at all.
+		$this->assertNull( $this->captured_body, $label );
+	}
+
+	/**
+	 * Every supplied shape that names no category.
+	 *
+	 * `list of booleans` is the shape the route schema cannot reject,
+	 * since it constrains values rather than shape.
 	 *
 	 * @return array<string, array{0: string, 1: mixed}>
 	 */
 	public static function provide_types_that_name_nothing() {
 		return array(
 			'empty array'      => array( 'empty array', array() ),
-			'absent'           => array( 'absent', null ),
 			'all false'        => array( 'all false', array( 'themes' => false ) ),
 			'list of booleans' => array( 'list of booleans', array( true, false ) ),
 		);
+	}
+
+	/**
+	 * A transport failure surfaces as the bridge's own error rather than
+	 * cURL's text, which the dashboard renders to the reader verbatim.
+	 */
+	public function test_initiate_wraps_a_transport_failure() {
+		$this->arrange_wpcom_unreachable();
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'types', array( 'themes' => true ) );
+		$response = Download_Bridge::initiate_download( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'download_initiate_failed', $response->get_error_code() );
+		$this->assertStringNotContainsString( 'cURL', $response->get_error_message() );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * The status poll wraps a transport failure too. Worth its own case:
+	 * this is the call that runs on a timer, so it is the one most likely
+	 * to meet a flaky network.
+	 */
+	public function test_status_wraps_a_transport_failure() {
+		$this->arrange_wpcom_unreachable();
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/backups/download/123/status' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'download_id', 4321 );
+		$response = Download_Bridge::get_download_status( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'download_status_fetch_failed', $response->get_error_code() );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
 	}
 
 	/**

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
 use function add_action;
@@ -21,6 +22,8 @@ use function remove_filter;
 use function wp_insert_user;
 use function wp_set_current_user;
 
+require_once __DIR__ . '/trait-wpcom-request-mock.php';
+
 /**
  * Tests for the /jetpack/v4/rewind/backup/* routes.
  *
@@ -28,6 +31,8 @@ use function wp_set_current_user;
  */
 #[CoversClass( File_Browser_Bridge::class )]
 class Rest_File_Browser_Bridge_Test extends TestCase {
+
+	use Wpcom_Request_Mock;
 
 	/**
 	 * REST Server.
@@ -56,7 +61,7 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	 */
 	public function tearDown(): void {
 		remove_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
-		wp_set_current_user( 0 );
+		$this->reset_wpcom_request_mock();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
@@ -99,5 +104,45 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 403, $response->get_status() );
+	}
+	/**
+	 * A transport failure on the directory listing surfaces as the
+	 * bridge's own error rather than cURL's text.
+	 *
+	 * This one goes through `forward_response()`, which every
+	 * pass-through bridge shares, so it covers the shared path.
+	 */
+	public function test_list_directory_wraps_a_transport_failure() {
+		$this->arrange_wpcom_unreachable();
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/backups/123/ls' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'path', '/' );
+		$response = File_Browser_Bridge::list_directory( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertStringNotContainsString( 'cURL', $response->get_error_message() );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * The signed-URL leg wraps a transport failure too.
+	 *
+	 * Worth covering separately from the listing: the file-content
+	 * callback makes two outbound calls, and only the first is reached
+	 * when WPCOM is unreachable.
+	 */
+	public function test_file_content_wraps_a_transport_failure() {
+		$this->arrange_wpcom_unreachable();
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/backups/123/file-content' );
+		$request->set_param( 'file_period', '1748888135' );
+		$request->set_param( 'encoded_manifest_path', 'ZjU6L3dwLWNvbmZpZy5waHA=' );
+		$response = File_Browser_Bridge::get_file_content( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'backup_file_content_url_failed', $response->get_error_code() );
+		$this->assertStringNotContainsString( 'cURL', $response->get_error_message() );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
@@ -9,9 +9,11 @@ namespace Automattic\Jetpack\Backup\V0005\REST;
 
 use Automattic\Jetpack\Backup\V0005\Jetpack_Backup;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
 use function add_action;
@@ -21,6 +23,8 @@ use function remove_filter;
 use function wp_insert_user;
 use function wp_set_current_user;
 
+require_once __DIR__ . '/trait-wpcom-request-mock.php';
+
 /**
  * Tests for the /jetpack/v4/rewind/* routes.
  *
@@ -28,6 +32,8 @@ use function wp_set_current_user;
  */
 #[CoversClass( Restore_Bridge::class )]
 class Rest_Restore_Bridge_Test extends TestCase {
+
+	use Wpcom_Request_Mock;
 
 	/**
 	 * REST Server.
@@ -56,7 +62,7 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	 */
 	public function tearDown(): void {
 		remove_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
-		wp_set_current_user( 0 );
+		$this->reset_wpcom_request_mock();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
@@ -100,5 +106,106 @@ class Rest_Restore_Bridge_Test extends TestCase {
 		$status_request  = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/1/status' );
 		$status_response = $this->server->dispatch( $status_request );
 		$this->assertSame( 403, $status_response->get_status() );
+	}
+	/**
+	 * A supplied `types` that names nothing is refused, not omitted.
+	 *
+	 * The destructive half of the guard. An omitted `types` means every
+	 * category upstream, so forwarding an empty selection as an omission
+	 * would overwrite the live site with exactly the parts the caller
+	 * excluded. The v2 restore route rejects this too, but only after the
+	 * request has left us.
+	 *
+	 * @param string $label Case description.
+	 * @param mixed  $types The `types` parameter to send.
+	 * @dataProvider provide_types_that_name_nothing
+	 */
+	#[DataProvider( 'provide_types_that_name_nothing' )]
+	public function test_initiate_refuses_types_that_name_nothing( $label, $types ) {
+		$this->arrange_wpcom( array( 'ok' => true ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/to/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'types', $types );
+		$response = Restore_Bridge::initiate_restore( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response, $label );
+		$this->assertSame( 'no_types_selected', $response->get_error_code(), $label );
+		$this->assertSame( 400, $response->get_error_data()['status'], $label );
+		// Nothing was asked of WPCOM at all.
+		$this->assertNull( $this->captured_body, $label );
+	}
+
+	/**
+	 * An absent `types` still means a whole-site restore, and must stay
+	 * allowed — it is what the default six-of-six checklist collapses to
+	 * once every category is named.
+	 */
+	public function test_initiate_allows_an_absent_types() {
+		// `restore_id` is what this bridge still reads as its success
+		// signal. That is wrong against the v2 contract, where `ok` is the
+		// signal and a null id means "queued" — but repointing the bridge
+		// is B1/B9, and this test only cares that the `types` guard stays
+		// out of the way.
+		$this->arrange_wpcom(
+			array(
+				'ok'         => true,
+				'restore_id' => 42,
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/to/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$response = Restore_Bridge::initiate_restore( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertArrayNotHasKey( 'types', (array) $this->captured_body );
+	}
+
+	/**
+	 * Every supplied shape that names no category.
+	 *
+	 * @return array<string, array{0: string, 1: mixed}>
+	 */
+	public static function provide_types_that_name_nothing() {
+		return array(
+			'empty array'      => array( 'empty array', array() ),
+			'all false'        => array( 'all false', array( 'themes' => false ) ),
+			'list of booleans' => array( 'list of booleans', array( true, false ) ),
+		);
+	}
+
+	/**
+	 * A transport failure surfaces as the bridge's own error rather than
+	 * cURL's text.
+	 */
+	public function test_initiate_wraps_a_transport_failure() {
+		$this->arrange_wpcom_unreachable();
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/to/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'types', array( 'themes' => true ) );
+		$response = Restore_Bridge::initiate_restore( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'restore_initiate_failed', $response->get_error_code() );
+		$this->assertStringNotContainsString( 'cURL', $response->get_error_message() );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * The status poll wraps a transport failure too — the call that runs
+	 * on a timer, and so the one most likely to meet a flaky network.
+	 */
+	public function test_status_wraps_a_transport_failure() {
+		$this->arrange_wpcom_unreachable();
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/1/status' );
+		$request->set_param( 'restore_id', 1 );
+		$response = Restore_Bridge::get_restore_status( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'restore_status_fetch_failed', $response->get_error_code() );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
 	}
 }

--- a/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
+++ b/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Shared scaffolding for exercising a bridge callback against a faked WPCOM.
+ *
+ * @package automattic/jetpack-backup-plugin
+ */
+
+namespace Automattic\Jetpack\Backup\V0005\REST;
+
+use WP_Error;
+use function add_filter;
+use function get_current_user_id;
+use function remove_all_filters;
+use function remove_filter;
+use function wp_insert_user;
+use function wp_rand;
+use function wp_set_current_user;
+
+/**
+ * Signs in an administrator, stands in for a connected site, and lets a
+ * test decide how WPCOM answers.
+ *
+ * Every bridge callback needs the same three things before it will run,
+ * and each was being rebuilt per test file. Consumers must call
+ * `reset_wpcom_request_mock()` from their own `tearDown()`.
+ *
+ * One thing worth knowing before adding tests with this: the callbacks
+ * are invoked directly rather than dispatched through the REST server.
+ * `Rest_Controller::permission_check()` additionally requires a
+ * user-level WPCOM connection that WorDBless cannot stand up, so a
+ * dispatch never reaches the callback body. The permission boundary
+ * itself is covered separately, by each file's `manage_options` test.
+ */
+trait Wpcom_Request_Mock {
+
+	/**
+	 * URL of the last request a bridge made to WPCOM.
+	 *
+	 * @var string
+	 */
+	protected $captured_url = '';
+
+	/**
+	 * Decoded body of the last request a bridge made to WPCOM.
+	 *
+	 * Stays null when no request was made, which is how a test asserts
+	 * that a guard refused before reaching the network.
+	 *
+	 * @var array|null
+	 */
+	protected $captured_body = null;
+
+	/**
+	 * Sign in as an administrator and make `Client` able to sign a request.
+	 *
+	 * @return int The administrator's user id.
+	 */
+	protected function sign_in_as_admin() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'admin_user_' . wp_rand( 1, PHP_INT_MAX ),
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10, 2 );
+
+		return $admin_id;
+	}
+
+	/**
+	 * Sign in and have WPCOM answer with a body and status.
+	 *
+	 * @param array $body   Payload WPCOM should answer with.
+	 * @param int   $status HTTP status WPCOM should answer with.
+	 */
+	protected function arrange_wpcom( array $body, $status = 200 ) {
+		$this->sign_in_as_admin();
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( $body, $status ) {
+				$this->captured_url  = $url;
+				$this->captured_body = isset( $args['body'] ) ? json_decode( $args['body'], true ) : null;
+				return array(
+					'response' => array( 'code' => $status ),
+					'body'     => wp_json_encode( $body, JSON_UNESCAPED_SLASHES ),
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Sign in and make the request fail in transport.
+	 *
+	 * `pre_http_request` returning a `WP_Error` is what the HTTP client
+	 * itself does when the request never leaves the host — DNS, TLS, or
+	 * the cURL timeout behind JETPACK-2173. It is a different failure
+	 * from a non-200 and has to be tested separately: there is no
+	 * response to read a status or a WPCOM error envelope out of, so the
+	 * bridges' non-200 branch never runs.
+	 */
+	protected function arrange_wpcom_unreachable() {
+		$this->sign_in_as_admin();
+
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return new WP_Error(
+					'http_request_failed',
+					'cURL error 28: Operation timed out after 10001 milliseconds with 0 bytes received'
+				);
+			}
+		);
+	}
+
+	/**
+	 * Undo everything this trait installed. Call from `tearDown()`.
+	 */
+	protected function reset_wpcom_request_mock() {
+		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10 );
+		wp_set_current_user( 0 );
+
+		$this->captured_url  = '';
+		$this->captured_body = null;
+	}
+
+	/**
+	 * Stand in for a connected site so `Client` can sign a request.
+	 *
+	 * Public because it is registered as a filter callback.
+	 *
+	 * @param mixed  $value Original option value.
+	 * @param string $name  Option name.
+	 * @return mixed
+	 */
+	public function mock_jetpack_connection_options( $value, $name ) {
+		switch ( $name ) {
+			case 'blog_token':
+				return 'test.blogtoken';
+			case 'id':
+				return '999';
+			case 'user_tokens':
+				$user_id = get_current_user_id();
+				if ( $user_id ) {
+					return array( $user_id => sprintf( 'token%d.secret%d.%d', $user_id, $user_id, $user_id ) );
+				}
+		}
+		return $value;
+	}
+}


### PR DESCRIPTION
## Proposed changes

Follow-up to #51292, #51294 and #51295. All of this is behind `rsm_jetpack_ui_modernization_backup`, **default off** — the legacy dashboard is untouched and `src/js/` is not modified.

A post-merge audit of those three PRs turned up four defects in the code they landed. Three of them are about the same thing: **a failure that reads as a success.** The fourth is the one that matters most, and it sits directly in front of the restore work (B1).

### 1. An empty category checklist asked for *everything*

This is the important one, and it is the opposite of what it looks like.

WordPress.com reads an **absent** `types` as "all six categories" — omitting the key is how a whole-site operation is spelled. The client omitted `types` when nothing was ticked, and both bridges dropped it from the outgoing body when it named nothing. So clearing every box did not request nothing:

- **Download** — returns the full archive. Live on trunk today (behind the flag).
- **Restore** — latent only because that call still 401s on the v1 route. **The moment B1 repoints it, an empty checklist becomes a full destructive restore of precisely the categories the reader deselected.**

Nothing disabled the button, and the comments in the tree asserted the opposite ("an empty `types` asks WPCOM for a download containing nothing"), so the code read as safe while behaving the other way. That belief was true against the v1 route; the v2 restore route added in A1/A2 rejects a *supplied* `types` that names nothing, which pushed the client toward omitting the key — and omission is the "everything" sentinel. Fixing one side moved the danger to the other.

Guarded at three layers, because the consequence is unrecoverable:

| Layer | Guard |
|---|---|
| UI | `hasSelectedItems()` disables both submit buttons and explains why |
| Request | `requireTypes()` throws instead of letting the key be dropped |
| Endpoint | `Rest_Controller::types_name_nothing()` → `400` from both bridges |

An **absent** `types` stays allowed throughout — that is still a legitimate whole-site request. The download side needs the local guard most: the downloads route has no server-side check of its own, unlike the v2 restore route.

### 2. The `/jetpack/v4/backups` error state was computed and rendered nowhere

The state existed, and the type that defines it says *"'we couldn't ask' must never be rendered as 'you have none'"* — but `replacesOverview` left `'error'` out of its list and the Overview dropped `error`/`refetch` from its destructure.

It was also unrecoverable without a page reload. That route answers a non-200 from WordPress.com with a bare `null` body, which WordPress serves as **HTTP 200** — so the request *resolves*, React Query records a success, `retry` never applies, `error` stays null, and the poll deliberately stops rather than hammering a failing upstream. Nothing in the UI ever asked again.

Now reported as a notice with a working retry, rendered *beside* the activity list rather than over it — whatever loaded is still worth showing.

### 3. #51292 and #51294 were individually correct and jointly blind in one cell

If the activity request fails while `/jetpack/v4/backups` legitimately reports no records, `useHasRestorePoints` returned `{ hasRestorePoints: false, isLoading: false }` — an errored query is neither loading nor holding rows. The first-run panel's veto lifted, the panel took the body over, and the `QueryError` the activity list was about to render went down with it. **A failed request read as "your first backup is on its way."**

The hook now reports `isError` separately, and the Overview treats it the way it already treats `isLoading`. That extends a principle the code had already written down — *"while it is still unknown, assume there **are** restore points"* — to the case it always covered in spirit.

### 3b. …which exposed that suppressing the takeover also suppressed the *message*

Fixing 3 surfaced a second problem, and it's the more interesting one. `replacesOverview()` was quietly doing two jobs: deciding whether the panel takes the body over, **and** — because only that panel carries "we're having trouble backing up your site" and its support link — deciding whether the reader is told their backups are failing at all.

So every case where the takeover *correctly* stands down also dropped the message. That was already true on trunk when restore points are listed from earlier in the retention window; widening the veto in 3 would have added a second such case.

The two jobs are now split. The takeover stays conservative — the short `/backups` window really can be wrong about `no-good-backups` — and a banner beside the list carries the report, sharing the support-link copy with the panel so there's one msgid. **That closes E4**, whose remaining piece the audit had described as exactly this strip.

### 4. D3 turned D1 into a copy bug on screen

`QueryError` renders `error.message` verbatim, so after #51294 a transport failure printed `cURL error 28: Operation timed out…` in a notice on the Overview and in the file browser. Transport failures also carry no `status`, so core answered 500 for what is really a reachability problem.

All **nine** sites across the five bridges now go through one `Rest_Controller::transport_error()` wrapper: a translated message, `502`, and the raw text kept in the error data for support rather than shown to the reader.

### Tests

- New `Wpcom_Request_Mock` trait replaces per-file scaffolding and gives the other four bridges their **first callback-body coverage** — a down-payment on J1, which was 2-of-8 callbacks before this.
- New `tests/empty-selection.test.tsx`; new cases in `tests/overview-takeover.test.tsx`, `_helpers.test.ts` and all five PHP bridge test files.
- 240 jest (up from 230), 165 phpunit (up from 155).
- `testTimeout` raised in the package's jest config. The route-stage suites pass a 10s `SETTLE` window to `findBy*`, but Jest's own 5s default fired first and killed the test with a bare "Exceeded timeout" instead of Testing Library's "Unable to find an element with the text…" plus the rendered DOM — losing the only thing that says what went wrong on CI. Pre-existing on trunk in `error-surfacing.test.tsx`; fixed for all of them at the config.

### Accessibility

`@wordpress/ui` renders a disabled Button as focusable `aria-disabled`, so the empty-checklist hint was reachable but silent about *why* the control was dead — in the one guard whose entire purpose is telling the reader before they click. The hint now has `role="status"` so clearing the last box is announced, and the button points at it with `aria-describedby`.

(Worth knowing for tests: `expect(btn).toBeDisabled()` **fails** against these buttons, because jest-dom only reads the native attribute. Assert `aria-disabled`.)

### Two things a reviewer should push back on if they disagree

1. **The endpoint guard is slightly beyond the literal task.** B6 was filed as a client-side checklist guard. I added the `400` in both bridges too, because the downloads route has no upstream guard and the UI is not where the danger is. Say so if you'd rather keep it client-only.
2. **One existing PHP test now asserts the opposite of what it did.** `test_initiate_omits_types_that_name_nothing` became `test_initiate_refuses_types_that_name_nothing`, and its `absent` provider case was split out into its own test, which still asserts omission. The old test encoded the wrong belief; the reasoning is in its docblock.

## Related product discussion/links

* [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243/backup-modernized-dashboard-work-needed-before-the-flag-can-flip) — tasks **B6**, **D1**, **E4**, plus two newly filed items **D4** and **D5**. The post-merge audit comment on that issue has the full findings.
* Follows #51292 (E1/E2/E3), #51294 (D3), #51295 (C1/C2/C5/C6)
* **B6 is a prerequisite for B1** — repointing restore without it makes the empty-checklist case destructive.

## Does this pull request change what data or activity we track or use?

No. No new tracking, and no new data leaves the site. The change *reduces* what reaches the browser: the raw transport error text is moved out of the user-facing message into the error data.

## Testing instructions

Everything is behind the modernization filter, so start by turning it on:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

**Flag off — confirm nothing changed.** Load **Jetpack → Backup**. The legacy dashboard should be identical: same first-run states, same "Back up now", same activity list.

**1. The empty checklist (the important one).** Flag on, go to a backup's **Download** screen and untick all six categories.

* The "Generate download" button goes disabled and *"Select at least one item to download."* appears above it.
* Clicking it does nothing — no request is issued.
* Tick any one category back: the hint disappears and the button re-arms.
* Repeat on the **Restore** screen; the copy reads *"…to restore."*
* Before this change, submitting an empty checklist here returned the **whole** archive.

**2. The endpoint refuses it too.** With the flag on, as an admin:

```
POST /wp-json/jetpack/v4/backups/download/<rewindId>   body: { "types": {} }
```

Expect `400 no_types_selected`. Sending **no** `types` key at all must still work — that is a whole-site download.

**3, 4 and 5 all use one lever** — intercept the outbound WordPress.com call, so you exercise the real path rather than faking the REST response. Drop this in an mu-plugin and edit the `$fail` line per case:

```php
add_filter( 'pre_http_request', function ( $pre, $args, $url ) {
	$fail = '/rewind/backups';          // case 3
	// $fail = '/activity/rewindable';  // case 4
	if ( false === strpos( $url, $fail ) ) {
		return $pre;
	}
	return array( 'response' => array( 'code' => 503 ), 'body' => '' );   // cases 3 and 4
	// return new WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out' ); // case 5
}, 10, 3 );
```

**3. Backup-state failure.** Fail `/rewind/backups`. The route answers a non-200 by returning a bare `null`, which WordPress serves as HTTP 200 — that resolved-but-failed response is the whole point.

* Overview shows *"We couldn't check your site's backup status."* with a **Try again** button.
* The activity list beside it still renders normally — the notice reports, it does not take over.
* Remove the filter and click **Try again**: the notice clears with no page reload. Before this change the query was frozen for the life of the page, with nothing on screen.

**4. Activity failure on a site with no backups.** Fail `/activity/rewindable` on a site whose backup list is legitimately empty (a fresh site, or fail both and let `/rewind/backups` return `[]`).

* You get the activity list's *"We couldn't load your site's activity."*
* You do **not** get "Your first cloud backup will be ready soon" — that was the bug.

**4b. Failing backups, list still usable.** On a site whose recent attempts all failed but whose activity log still lists older restore points (the `no-good-backups` state with restore points present):

* The list is **kept** — the takeover panel correctly stays away.
* A banner above it reads *"We're having trouble backing up your site."* with a **Get in touch with us** link. Before this change the reader saw the list and was told nothing.

**5. Transport errors.** Return the `WP_Error` line instead, for any of the paths.

* Notices read *"Could not reach WordPress.com. Check your connection and try again."*
* No `cURL error 28…` text anywhere on screen.
* The response is `502`, and the original text is still in the error's `data.transport` — visible in the network tab, not in the UI.
