### PR TITLE
Premium Analytics: pick the chart type from an icon toggle

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-toggle-group-field
+++ b/projects/packages/premium-analytics/changelog/add-toggle-group-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Chart widgets: pick the chart type from an icon toggle instead of a dropdown.

--- a/projects/packages/premium-analytics/eslint.config.mjs
+++ b/projects/packages/premium-analytics/eslint.config.mjs
@@ -67,6 +67,15 @@ export default defineConfig(
 		},
 	},
 	{
+		// `ToggleGroupField` is built on the `__experimental*` ToggleGroupControl
+		// exports from `@wordpress/components`, which have no stable equivalent
+		// yet — the same exemption the widgets-toolkit block carries.
+		files: [ 'packages/fields/**' ],
+		rules: {
+			'@wordpress/no-unsafe-wp-apis': 'off',
+		},
+	},
+	{
 		// The routing port also imports `react` directly (the staged-search
 		// hook), flagged as extraneous because the internal package's deps are
 		// declared on the parent manifest.

--- a/projects/packages/premium-analytics/packages/fields/package.json
+++ b/projects/packages/premium-analytics/packages/fields/package.json
@@ -23,5 +23,11 @@
 		"@wordpress/private-apis": "1.52.0",
 		"date-fns": "4.1.0",
 		"react": "18.3.1"
+	},
+	"devDependencies": {
+		"@jetpack-premium-analytics/icons": "workspace:*",
+		"@storybook/react": "10.4.6",
+		"@testing-library/react": "16.3.2",
+		"@testing-library/user-event": "14.6.1"
 	}
 }

--- a/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/__tests__/toggle-group-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/__tests__/toggle-group-field.test.tsx
@@ -30,12 +30,12 @@ const TEXT_ELEMENTS: Option[] = [
 
 function renderField( {
 	elements,
-	value = 'line',
+	data = { chartType: 'line' },
 	hideLabelFromVision = true,
 	onChange = jest.fn(),
 }: {
 	elements: Option[];
-	value?: string;
+	data?: ChartAttributes;
 	hideLabelFromVision?: boolean;
 	onChange?: jest.Mock;
 } ) {
@@ -50,7 +50,7 @@ function renderField( {
 
 	render(
 		<ToggleGroupField
-			data={ { chartType: value } }
+			data={ data }
 			field={ field }
 			onChange={ onChange }
 			hideLabelFromVision={ hideLabelFromVision }
@@ -81,7 +81,7 @@ describe( 'ToggleGroupField', () => {
 	} );
 
 	it( 'marks the segment matching the current value as selected', () => {
-		renderField( { elements: ICON_ELEMENTS, value: 'bar' } );
+		renderField( { elements: ICON_ELEMENTS, data: { chartType: 'bar' } } );
 
 		expect( screen.getByRole( 'radio', { name: 'Bar chart' } ) ).toBeChecked();
 		expect( screen.getByRole( 'radio', { name: 'Line chart' } ) ).not.toBeChecked();
@@ -94,6 +94,18 @@ describe( 'ToggleGroupField', () => {
 		await userEvent.click( screen.getByRole( 'radio', { name: 'Bar chart' } ) );
 
 		expect( onChange ).toHaveBeenCalledWith( { chartType: 'bar' } );
+	} );
+
+	it( 'selects the first option when the value is absent', () => {
+		renderField( { elements: ICON_ELEMENTS, data: {} } );
+
+		expect( screen.getByRole( 'radio', { name: 'Line chart' } ) ).toBeChecked();
+	} );
+
+	it( 'selects the first option when the value matches none', () => {
+		renderField( { elements: ICON_ELEMENTS, data: { chartType: 'area' } } );
+
+		expect( screen.getByRole( 'radio', { name: 'Line chart' } ) ).toBeChecked();
 	} );
 
 	it( 'labels the control where the label is visible', () => {

--- a/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/__tests__/toggle-group-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/__tests__/toggle-group-field.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+/**
+ * Internal dependencies
+ */
+import ToggleGroupField, { hasIconOptions } from '../toggle-group-field';
+import type { DataFormControlProps, Option } from '@jetpack-premium-analytics/externals';
+import type { ReactElement } from 'react';
+
+type ChartAttributes = { chartType?: string };
+
+// `Option` carries no `icon`, so the icon-bearing fixtures name their own
+// shape, the way `chartTypeAttributeField` builds its elements.
+type IconOption = Option & { icon: ReactElement };
+
+const ICON = <svg />;
+
+const ICON_ELEMENTS = [
+	{ value: 'line', label: 'Line chart', icon: ICON },
+	{ value: 'bar', label: 'Bar chart', icon: ICON },
+] satisfies IconOption[];
+
+const TEXT_ELEMENTS: Option[] = [
+	{ value: 'line', label: 'Line chart' },
+	{ value: 'bar', label: 'Bar chart' },
+];
+
+function renderField( {
+	elements,
+	value = 'line',
+	hideLabelFromVision = true,
+	onChange = jest.fn(),
+}: {
+	elements: Option[];
+	value?: string;
+	hideLabelFromVision?: boolean;
+	onChange?: jest.Mock;
+} ) {
+	const field = {
+		id: 'chartType',
+		label: 'Chart type',
+		elements,
+		getValue: ( { item }: { item: ChartAttributes } ) => item.chartType,
+		setValue: ( { value: next }: { value: unknown } ) => ( { chartType: next } ),
+		isDisabled: () => false,
+	} as unknown as DataFormControlProps< ChartAttributes >[ 'field' ];
+
+	render(
+		<ToggleGroupField
+			data={ { chartType: value } }
+			field={ field }
+			onChange={ onChange }
+			hideLabelFromVision={ hideLabelFromVision }
+		/>
+	);
+}
+
+describe( 'hasIconOptions', () => {
+	it( 'reports icons when every option carries one', () => {
+		expect( hasIconOptions( ICON_ELEMENTS ) ).toBe( true );
+	} );
+
+	it( 'falls back to text when only some options carry an icon', () => {
+		expect( hasIconOptions( [ ICON_ELEMENTS[ 0 ], TEXT_ELEMENTS[ 1 ] ] ) ).toBe( false );
+	} );
+
+	it( 'reports no icons for an empty list', () => {
+		expect( hasIconOptions( [] ) ).toBe( false );
+	} );
+} );
+
+describe( 'ToggleGroupField', () => {
+	it( 'names every icon segment by its option label', () => {
+		renderField( { elements: ICON_ELEMENTS } );
+
+		expect( screen.getByRole( 'radio', { name: 'Line chart' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'radio', { name: 'Bar chart' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'marks the segment matching the current value as selected', () => {
+		renderField( { elements: ICON_ELEMENTS, value: 'bar' } );
+
+		expect( screen.getByRole( 'radio', { name: 'Bar chart' } ) ).toBeChecked();
+		expect( screen.getByRole( 'radio', { name: 'Line chart' } ) ).not.toBeChecked();
+	} );
+
+	it( 'writes the selected option value on click', async () => {
+		const onChange = jest.fn();
+		renderField( { elements: ICON_ELEMENTS, onChange } );
+
+		await userEvent.click( screen.getByRole( 'radio', { name: 'Bar chart' } ) );
+
+		expect( onChange ).toHaveBeenCalledWith( { chartType: 'bar' } );
+	} );
+
+	it( 'labels the control where the label is visible', () => {
+		renderField( { elements: TEXT_ELEMENTS, hideLabelFromVision: false } );
+
+		expect( screen.getByText( 'Chart type' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing without options', () => {
+		const { container } = render(
+			<ToggleGroupField
+				data={ {} }
+				field={
+					{
+						id: 'chartType',
+						label: 'Chart type',
+						elements: [],
+						getValue: () => undefined,
+						setValue: () => ( {} ),
+						isDisabled: () => false,
+					} as unknown as DataFormControlProps< ChartAttributes >[ 'field' ]
+				}
+				onChange={ jest.fn() }
+			/>
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/__tests__/toggle-group-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/__tests__/toggle-group-field.test.tsx
@@ -89,9 +89,11 @@ describe( 'ToggleGroupField', () => {
 
 	it( 'writes the selected option value on click', async () => {
 		const onChange = jest.fn();
+		const user = userEvent.setup();
+
 		renderField( { elements: ICON_ELEMENTS, onChange } );
 
-		await userEvent.click( screen.getByRole( 'radio', { name: 'Bar chart' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'Bar chart' } ) );
 
 		expect( onChange ).toHaveBeenCalledWith( { chartType: 'bar' } );
 	} );

--- a/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/index.ts
+++ b/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/index.ts
@@ -1,0 +1,1 @@
+export { default as ToggleGroupField } from './toggle-group-field';

--- a/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/stories/toggle-group-field.stories.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/stories/toggle-group-field.stories.tsx
@@ -1,0 +1,119 @@
+import { chartLine } from '@jetpack-premium-analytics/icons';
+import { chartBar } from '@wordpress/icons';
+import { useState } from 'react';
+import ToggleGroupField from '../toggle-group-field';
+import type { DataFormControlProps, Option } from '@jetpack-premium-analytics/externals';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ReactElement } from 'react';
+
+type ChartAttributes = { chartType?: string };
+
+// `Option` carries no `icon`, so the icon-bearing options name their own
+// shape, the way `chartTypeAttributeField` builds its elements.
+type IconOption = Option & { icon: ReactElement };
+
+const CHART_TYPES = [
+	{ value: 'line', label: 'Line chart', icon: chartLine },
+	{ value: 'bar', label: 'Bar chart', icon: chartBar },
+] satisfies IconOption[];
+
+const GRANULARITIES: Option[] = [
+	{ value: 'day', label: 'By days' },
+	{ value: 'week', label: 'By weeks' },
+	{ value: 'month', label: 'By months' },
+];
+
+const meta: Meta< typeof ToggleGroupField > = {
+	title: 'Packages/Premium Analytics/Fields/ToggleGroupField',
+	component: ToggleGroupField,
+	tags: [ 'autodocs' ],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'A DataForm edit control that lays a field’s `elements` out as segments ' +
+					'of one row, so every option is visible and one click away. Use it for a ' +
+					'short, stable set of mutually exclusive options; longer or open-ended ones ' +
+					'belong in `SelectField`.\n\n' +
+					'Options that all carry an `icon` render as square icon segments, with the ' +
+					'label as the tooltip and the accessible name; anything else renders as text.',
+			},
+		},
+	},
+};
+
+export default meta;
+
+type Story = StoryObj< typeof ToggleGroupField >;
+
+/**
+ * Stands in for `DataForm`: holds the attribute the control writes, and hands
+ * the field down the way the widget host does.
+ */
+function ToggleGroupFieldWithState( {
+	label,
+	elements,
+	initialValue,
+	hideLabelFromVision,
+}: {
+	label: string;
+	elements: Option[];
+	initialValue: string;
+	hideLabelFromVision?: boolean;
+} ) {
+	const [ chartType, setChartType ] = useState( initialValue );
+
+	const field = {
+		id: 'chartType',
+		label,
+		elements,
+		getValue: ( { item }: { item: ChartAttributes } ) => item.chartType,
+		setValue: ( { value }: { value: unknown } ) => ( { chartType: value } ),
+		isDisabled: () => false,
+	} as unknown as DataFormControlProps< ChartAttributes >[ 'field' ];
+
+	return (
+		<ToggleGroupField
+			data={ { chartType } }
+			field={ field }
+			onChange={ edits => setChartType( String( edits.chartType ) ) }
+			hideLabelFromVision={ hideLabelFromVision }
+		/>
+	);
+}
+
+/**
+ * The `chartType` attribute as the widget host renders it inline in a chart
+ * widget's header: the label is hidden, so the icons carry the meaning and
+ * the control sizes to its content.
+ */
+export const Default: Story = {
+	render: () => (
+		<ToggleGroupFieldWithState
+			label="Chart type"
+			elements={ CHART_TYPES }
+			initialValue="line"
+			hideLabelFromVision
+		/>
+	),
+};
+
+/**
+ * The same control in the widget controls popover, where the host shows the
+ * label above the field.
+ */
+export const WithVisibleLabel: Story = {
+	render: () => (
+		<ToggleGroupFieldWithState label="Chart type" elements={ CHART_TYPES } initialValue="line" />
+	),
+};
+
+/**
+ * Options without icons fall back to text segments, which share the row width
+ * evenly wherever the label is visible.
+ */
+export const TextOptions: Story = {
+	render: () => (
+		<ToggleGroupFieldWithState label="Group by" elements={ GRANULARITIES } initialValue="week" />
+	),
+};

--- a/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/toggle-group-field.module.css
+++ b/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/toggle-group-field.module.css
@@ -1,0 +1,16 @@
+/*
+ * The widget header's other controls are compact WPDS fields — a 32px box with
+ * a resting neutral border — while the core control is 40px and only draws its
+ * border when `isBlock`. Both are restated here so the toggle sits on the same
+ * line as its neighbours. The `[role]` qualifier outranks the component's own
+ * class, which is injected at runtime and would otherwise land last.
+ */
+.control[role="radiogroup"] {
+	block-size: var(--wpds-dimension-size-md);
+	border-color: var(--wpds-color-stroke-interactive-neutral);
+}
+
+/* Icon segments carry a fixed height instead of filling the control. */
+.control[role="radiogroup"] button {
+	block-size: 100%;
+}

--- a/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/toggle-group-field.module.css
+++ b/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/toggle-group-field.module.css
@@ -14,3 +14,22 @@
 .control[role="radiogroup"] button {
 	block-size: 100%;
 }
+
+/*
+ * The selection indicator, which core positions and animates over the active
+ * segment. Filling it and inverting the glyph reads at a glance; core's own
+ * pale fill barely separates the two segments.
+ */
+.control[role="radiogroup"]::before {
+	background: var(--wpds-color-background-interactive-neutral-strong);
+	border-color: transparent;
+}
+
+/*
+ * The `:hover` twin outranks the component's own hover rule, which would
+ * otherwise repaint the glyph dark over the dark fill.
+ */
+.control[role="radiogroup"] button[aria-checked="true"],
+.control[role="radiogroup"] button[aria-checked="true"]:hover {
+	color: var(--wpds-color-foreground-interactive-neutral-strong);
+}

--- a/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/toggle-group-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/toggle-group-field.tsx
@@ -76,6 +76,13 @@ export default function ToggleGroupField< Item >( {
 	}
 
 	const iconOptions = hasIconOptions( elements );
+	// A value matching no option leaves every segment unpressed, while the
+	// consumer keeps drawing its own default. The first option stands in as the
+	// rendered selection, as it does in `SelectField`; nothing is written until
+	// the user picks one.
+	const selectedValue = elements.some( element => element.value === value )
+		? value
+		: elements[ 0 ].value;
 
 	return (
 		<ToggleGroupControl
@@ -87,7 +94,7 @@ export default function ToggleGroupField< Item >( {
 			// reads as text. Icon segments are square, and inline in a widget
 			// header the control sizes to its content.
 			isBlock={ ! iconOptions && ! hideLabelFromVision }
-			value={ value }
+			value={ selectedValue }
 			onChange={ onValueChange }
 		>
 			{ iconOptions

--- a/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/toggle-group-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/toggle-group-field.tsx
@@ -1,0 +1,113 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
+	Spinner,
+} from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import useElements from '../helpers/use-elements';
+import styles from './toggle-group-field.module.css';
+import type { DataFormControlProps, Option } from '@jetpack-premium-analytics/externals';
+import type { ReactElement } from 'react';
+
+/**
+ * An option rendered as an icon segment. `label` still names the option: it
+ * becomes the segment's tooltip and its accessible name.
+ */
+type IconOption = Option & { icon: ReactElement };
+
+/**
+ * Whether the options render as icons, which they do only when every one of
+ * them carries an icon: icon segments are square and text segments are as wide
+ * as their label, so a mixed row would size its segments inconsistently.
+ *
+ * @param elements - The resolved options.
+ * @return Whether every option carries an icon.
+ */
+export function hasIconOptions( elements: Option[] ): elements is IconOption[] {
+	return (
+		elements.length > 0 && elements.every( element => !! ( element as Partial< IconOption > ).icon )
+	);
+}
+
+/**
+ * Edit control for fields with `elements`, rendering the options as segments
+ * of a single row rather than as a dropdown. Suited to a short, stable set of
+ * mutually exclusive options; longer or open-ended ones belong in `SelectField`.
+ */
+export default function ToggleGroupField< Item >( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+}: DataFormControlProps< Item > ) {
+	const { label, description, getValue, setValue } = field;
+	const disabled = field.isDisabled( { item: data, field } );
+	const value = getValue( { item: data } );
+
+	const { elements, isLoading } = useElements( {
+		elements: field.elements,
+		getElements: field.getElements,
+	} );
+
+	const onValueChange = useCallback(
+		( newValue: string | number | undefined ) => {
+			if ( newValue === undefined ) {
+				return;
+			}
+
+			onChange( setValue( { item: data, value: newValue } ) );
+		},
+		[ data, onChange, setValue ]
+	);
+
+	if ( isLoading ) {
+		return <Spinner />;
+	}
+
+	if ( elements.length === 0 ) {
+		return null;
+	}
+
+	const iconOptions = hasIconOptions( elements );
+
+	return (
+		<ToggleGroupControl
+			className={ styles.control }
+			label={ label }
+			help={ description }
+			hideLabelFromVision={ hideLabelFromVision }
+			// Segments stretch only where the control owns a full form row and
+			// reads as text. Icon segments are square, and inline in a widget
+			// header the control sizes to its content.
+			isBlock={ ! iconOptions && ! hideLabelFromVision }
+			value={ value }
+			onChange={ onValueChange }
+		>
+			{ iconOptions
+				? elements.map( element => (
+						<ToggleGroupControlOptionIcon
+							key={ String( element.value ) }
+							value={ element.value }
+							icon={ element.icon }
+							label={ element.label }
+							disabled={ disabled }
+						/>
+				  ) )
+				: elements.map( element => (
+						<ToggleGroupControlOption
+							key={ String( element.value ) }
+							value={ element.value }
+							label={ element.label }
+							disabled={ disabled }
+						/>
+				  ) ) }
+		</ToggleGroupControl>
+	);
+}

--- a/projects/packages/premium-analytics/packages/fields/src/index.ts
+++ b/projects/packages/premium-analytics/packages/fields/src/index.ts
@@ -6,3 +6,5 @@ export {
 export { ArrayCheckboxField } from './field-array-checkbox';
 
 export { SelectField } from './field-select';
+
+export { ToggleGroupField } from './field-toggle-group';

--- a/projects/packages/premium-analytics/packages/icons/src/chart-line/index.tsx
+++ b/projects/packages/premium-analytics/packages/icons/src/chart-line/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+/**
+ * A line chart, as a 24px control glyph. Drawn on the same grid as `chartBar`
+ * from `@wordpress/icons`, at the stroke weight of that icon's bars, so the
+ * two read as one pair when they sit side by side in a control.
+ */
+export const chartLine = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+		<Path
+			d="M5.5 15.75L10 10.25L14 13.75L18.5 7.25"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	</SVG>
+);

--- a/projects/packages/premium-analytics/packages/icons/src/index.ts
+++ b/projects/packages/premium-analytics/packages/icons/src/index.ts
@@ -13,3 +13,4 @@ export { search } from './search';
 export { payment } from './payment';
 export { tag } from './tag';
 export { jetpack } from './jetpack';
+export { chartLine } from './chart-line';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-display-attribute-fields.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-display-attribute-fields.ts
@@ -1,24 +1,33 @@
 /**
  * External dependencies
  */
-import { SelectField } from '@jetpack-premium-analytics/fields';
+import { SelectField, ToggleGroupField } from '@jetpack-premium-analytics/fields';
+import { chartLine } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
+import { chartBar } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
 import type { MetricTabsChartType } from '../components/metric-tabs-chart/metric-tabs-chart';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+import type { ReactElement } from 'react';
 
 /**
- * The chart types the display control offers, in menu order. One list keeps
- * every chart widget's dropdown identical, and `satisfies` ties it to the
+ * The chart types the display control offers, in segment order. One list keeps
+ * every chart widget's control identical, and `satisfies` ties it to the
  * toolkit's own union so a value `MetricTabsChart` cannot draw fails to
- * compile here rather than shipping as a broken dropdown option.
+ * compile here rather than shipping as a broken option. The label names the
+ * type for assistive technology and for the segment's tooltip; the icon is
+ * what the control shows.
  */
 export const CHART_DISPLAY_CHART_TYPES = [
-	{ id: 'line', label: __( 'Line chart', 'jetpack-premium-analytics-pkg' ) },
-	{ id: 'bar', label: __( 'Bar chart', 'jetpack-premium-analytics-pkg' ) },
-] as const satisfies readonly { id: MetricTabsChartType; label: string }[];
+	{ id: 'line', label: __( 'Line chart', 'jetpack-premium-analytics-pkg' ), icon: chartLine },
+	{ id: 'bar', label: __( 'Bar chart', 'jetpack-premium-analytics-pkg' ), icon: chartBar },
+] as const satisfies readonly {
+	id: MetricTabsChartType;
+	label: string;
+	icon: ReactElement;
+}[];
 
 export type ChartDisplayChartType = ( typeof CHART_DISPLAY_CHART_TYPES )[ number ][ 'id' ];
 
@@ -50,8 +59,9 @@ export function granularityAttributeField<
 }
 
 /**
- * The "Chart type" attribute field (`relevance: 'high'`), offering the
- * chart types in `CHART_DISPLAY_CHART_TYPES`.
+ * The "Chart type" attribute field (`relevance: 'high'`), offering the chart
+ * types in `CHART_DISPLAY_CHART_TYPES` as an icon toggle: two mutually
+ * exclusive options both worth showing at a glance.
  */
 export function chartTypeAttributeField<
 	Attributes extends { chartType?: ChartDisplayChartType },
@@ -60,10 +70,11 @@ export function chartTypeAttributeField<
 		id: 'chartType',
 		label: __( 'Chart type', 'jetpack-premium-analytics-pkg' ),
 		type: 'text',
-		Edit: SelectField,
+		Edit: ToggleGroupField,
 		elements: CHART_DISPLAY_CHART_TYPES.map( chartType => ( {
 			value: chartType.id,
 			label: chartType.label,
+			icon: chartType.icon,
 		} ) ),
 		relevance: 'high',
 	} as WidgetAttributeField< Attributes >;


### PR DESCRIPTION
Fixes WOOA7S-1954

## What?

The chart type control in every chart widget header was a two-option dropdown, "Line chart" / "Bar chart". It is now an icon toggle.

Behind it is a new `ToggleGroupField` in the fields package. Nothing about it is chart specific: any field with `elements` can use it.

**Before**

<img width="745" height="516" alt="Screenshot 2026-08-18 at 10 42 11 AM" src="https://github.com/user-attachments/assets/333b6e00-e024-470c-a909-eb245eba6c93" />

**After**

<img width="754" height="511" alt="Screenshot 2026-08-18 at 10 39 29 AM" src="https://github.com/user-attachments/assets/acd29465-265b-48dd-aeee-abd63fc4390c" />

## Why?

A dropdown is heavy for a binary choice. It hides both options behind a click and uses the header width to name the current one.

That header is shared with the "Group by" control, so the width is not free.

## How?

`ToggleGroupField` maps `field.elements` onto `ToggleGroupControl`.

Options that all carry an `icon` render as icon segments, with the label as the tooltip and the accessible name. Anything else renders as text. Mixed rows are not supported because square icons and label-width text would render inconsistently in size.

One control covers both host surfaces: inline in the header with the label hidden, and the controls popover with the label above it.

`chartTypeAttributeField()` now points at it, with `chartBar` from `@wordpress/icons` and a new `chartLine` glyph drawn to match.

Five widgets pick it up unchanged: Traffic chart, Subscribers chart, Post views, Email time series, Video detail views performance.

### Two visual calls

`ToggleGroupControl` is 40px and only draws its border when `isBlock`. Its neighbors are compact WPDS fields, 32px with a resting border. The CSS module restates both so the row lines up.

Core paints the selection with a pale fill that barely separates two segments. The module fills the indicator dark and inverts the glyph.

Each is its own commit, so either can go on its own.

## Testing

Jetpack → Analytics, Traffic chart widget.

1. The chart type control is two icons, the active one filled dark.
2. Click the bar icon. The chart switches, and the fill moves with it.
3. Hover each icon for its tooltip, then tab in and check the arrow keys move between segments.
4. Check it lines up with the "Group by" dropdown beside it.
5. Narrow the widget until the header controls collapse into the popover. The toggle renders there with its label above it.

https://github.com/user-attachments/assets/9b9b31c2-b67c-4fdf-ad91-7c2c645f86e1

Storybook has it under `Packages/Premium Analytics/Fields/ToggleGroupField`.


https://github.com/user-attachments/assets/b9dbf316-7e68-4c39-adb2-ccc802316510

### Automated

`pnpm run test` and `pnpm run typecheck` in `projects/packages/premium-analytics`, plus eslint and stylelint.

New: `toggle-group-field.test.tsx`, eight cases over the icon/text decision, accessible names, selected state, and the value written on click.
