### PR TITLE
Backup: repoint restore at the v2 rewind routes and rebuild its state machine

### DIFF
--- a/projects/packages/backup/changelog/add-backup-repoint-restore
+++ b/projects/packages/backup/changelog/add-backup-repoint-restore
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: repoint the modernized restore flow at the v2 rewind routes, map WordPress.com's real status vocabulary, and keep a restore observable when it is queued without an id. Also refuses a `types` supplied as null, which both rewind bridges read as a whole-site operation. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/dashboard-layout/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/dashboard-layout/index.tsx
@@ -3,6 +3,7 @@ import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 import { Page } from '@wordpress/admin-ui';
 import { __ } from '@wordpress/i18n';
 import Gates from '../gates';
+import '../../utilities.scss';
 import './style.scss';
 import type { ReactNode } from 'react';
 

--- a/projects/packages/backup/src/dashboard/components/dashboard-layout/style.scss
+++ b/projects/packages/backup/src/dashboard/components/dashboard-layout/style.scss
@@ -15,37 +15,3 @@
 		padding: 24px;
 	}
 }
-
-// De-emphasized caption text. `@wordpress/ui`'s `Text` has no muted/color
-// prop, so the dimmed treatment lives here and is applied via className
-// alongside `variant="body-sm"`.
-.jpb-text-muted {
-	color: var(--wpds-color-foreground-content-neutral-weak);
-}
-
-// Keeps an element in the accessibility tree while taking it out of the
-// visual layout. Used for a live region that has to stay mounted before
-// it has anything to say: assistive tech needs the region present in the
-// tree *before* its content changes, so a region that appears together
-// with its first message is unreliable — VoiceOver in particular often
-// misses it.
-
-// `position: absolute` is doing more work than hiding here. These regions
-// sit inside flex columns with a `gap`, and a gap applies between all
-// in-flow children no matter how small — so a zero-height placeholder
-// would still cost a full 16px of dead space on every render where the
-// message is absent, which is most of them. Taking it out of flow costs
-// nothing. `display: none` and `visibility: hidden` are both wrong: they
-// remove it from the accessibility tree too, which is the one thing this
-// has to preserve.
-.jpb-visually-hidden {
-	position: absolute;
-	inline-size: 1px;
-	block-size: 1px;
-	margin: -1px;
-	padding: 0;
-	border: 0;
-	overflow: hidden;
-	clip-path: inset(50%);
-	white-space: nowrap;
-}

--- a/projects/packages/backup/src/dashboard/data/api/_helpers.ts
+++ b/projects/packages/backup/src/dashboard/data/api/_helpers.ts
@@ -62,40 +62,6 @@ export function toIntRewindId( rewindId: string ): string {
 }
 
 /**
- * Serialize a restore/download category checklist for WPCOM.
- *
- * WPCOM selects the enabled categories with a **loose** comparison, so a
- * JSON array of names does not mean what it looks like: every name
- * compares equal, and what comes back out is the array's own integer
- * indices. `[ "themes" ]` becomes `[ 0 ]` and `[ "themes", "plugins" ]`
- * becomes `[ 0, 1 ]`, which are then treated as category names. An
- * emptiness check would never catch it, because the list is not empty.
- *
- * The object form is therefore the only safe spelling, and this is the
- * single place that builds it. Only `true` entries are included, so the
- * result never depends on that loose comparison.
- *
- * Returns `undefined` when nothing is selected, which is a signal to the
- * caller rather than a payload. Do not resolve it by omitting the key:
- * see `requireTypes`, which is what the mutations use and which explains
- * why omission is the most dangerous option available here.
- *
- * @param items - The category checklist.
- * @return The object form, or undefined when no category is selected.
- */
-export function serializeTypes(
-	items: Record< string, boolean >
-): Record< string, true > | undefined {
-	const selected: Record< string, true > = {};
-	for ( const key of Object.keys( items ) ) {
-		if ( items[ key ] ) {
-			selected[ key ] = true;
-		}
-	}
-	return Object.keys( selected ).length ? selected : undefined;
-}
-
-/**
  * Error thrown by the data-layer fetchers when WPCOM (via the bridge)
  * responds with a known error code. Consumers branch on `code` to pick
  * the right user-facing message.
@@ -113,15 +79,28 @@ export class ApiError extends Error {
 }
 
 /**
- * Serialize a checklist for a mutation, refusing an empty one.
+ * Serialize a restore/download category checklist for WPCOM, refusing an
+ * empty one.
  *
- * The restore and download bodies must always *name* what they want.
- * An absent `types` is not a request for nothing — it is WPCOM's
- * shorthand for all six categories ("omit it for everything", in the
- * contract's words), so a checklist with every box cleared would submit
- * the full archive on the download side and a full destructive restore
- * on the other. That is the exact inverse of what the reader asked for,
- * and it is silent: the request succeeds.
+ * Two hazards, and the single place both are answered.
+ *
+ * **The shape.** WPCOM selects the enabled categories with a **loose**
+ * comparison, so a JSON array of names does not mean what it looks like:
+ * every name compares equal, and what comes back out is the array's own
+ * integer indices. `[ "themes" ]` becomes `[ 0 ]` and `[ "themes",
+ * "plugins" ]` becomes `[ 0, 1 ]`, which are then treated as category
+ * names. An emptiness check would never catch it, because the list is not
+ * empty. The object form is therefore the only safe spelling, and only
+ * `true` entries are included so the result never depends on that loose
+ * comparison.
+ *
+ * **The empty case.** The bodies must always *name* what they want. An
+ * absent `types` is not a request for nothing — it is WPCOM's shorthand
+ * for all six categories ("omit it for everything", in the contract's
+ * words), so a checklist with every box cleared would submit the full
+ * archive on the download side and a full destructive restore on the
+ * other. That is the exact inverse of what the reader asked for, and it
+ * is silent: the request succeeds.
  *
  * The v2 restore route rejects a supplied-but-empty `types` and the
  * downloads route does not, so this cannot be left to the server. Both
@@ -134,13 +113,20 @@ export class ApiError extends Error {
  * @return The object form, always naming at least one category.
  */
 export function requireTypes( items: Record< string, boolean > ): Record< string, true > {
-	const selected = serializeTypes( items );
-	if ( ! selected ) {
+	const selected: Record< string, true > = {};
+	for ( const key of Object.keys( items ) ) {
+		if ( items[ key ] ) {
+			selected[ key ] = true;
+		}
+	}
+
+	if ( ! Object.keys( selected ).length ) {
 		throw new ApiError(
 			'no_types_selected',
 			__( 'Select at least one item to continue.', 'jetpack-backup-pkg' )
 		);
 	}
+
 	return selected;
 }
 

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -1,17 +1,55 @@
-import { apiCall, apiPath, requireTypes, toIntRewindId } from './_helpers';
+import { apiCall, apiPath, requireTypes } from './_helpers';
 import type { RestoreItems } from '../../types/restore';
 
+/**
+ * Lifecycle of a restore, as the bridge reports it.
+ *
+ * Deliberately not WPCOM's own vocabulary. Upstream says
+ * `running | success | fail | aborted | success-with-errors`; the bridge
+ * maps those to these, reports a not-yet-visible restore as `queued`, and
+ * anything it does not recognise as `unknown` rather than guessing. See
+ * `Restore_Bridge::STATUS_MAP`.
+ *
+ * `unknown` exists so a status WPCOM adds later degrades into "keep
+ * asking for a while" instead of a progress bar frozen at whatever
+ * percentage happened to arrive first.
+ */
+export type RestoreStatus =
+	| 'queued'
+	| 'running'
+	| 'finished'
+	| 'finished-with-errors'
+	| 'failed'
+	| 'aborted'
+	| 'unknown';
+
 export type InitiateRestoreResponse = {
-	id: number;
+	/**
+	 * Null when WPCOM accepted the restore without echoing an id back,
+	 * which is a normal outcome rather than a failure — VaultPress does
+	 * not reliably return one. The id is then recovered from the restores
+	 * collection; see `fetchRecentRestores`.
+	 */
+	id: number | null;
+	rewind_id: string;
 };
 
 export type RestoreStatusResponse = {
 	id: number;
-	status: 'queued' | 'in-progress' | 'finished' | 'failed' | string;
+	status: RestoreStatus;
+	/** 0–100. */
 	progress: number;
 	rewind_id: string;
+	/** Machine identifier such as `checksum_mismatch`. Never shown to users. */
 	error_code: string;
 	message: string;
+};
+
+/** One row of `GET /jetpack/v4/restores` — the last ten restores, any state. */
+export type RecentRestore = {
+	restore_id: number;
+	rewind_id: string;
+	status: string;
 };
 
 /**
@@ -21,25 +59,22 @@ export type RestoreStatusResponse = {
  * form; see that helper for why a JSON array is never safe here, and why
  * an empty checklist is refused rather than sent as an omitted key.
  *
- * That refusal matters most on this call. An absent `types` means all six
- * categories upstream, so a cleared checklist would overwrite the live
- * site with exactly the parts the reader excluded — the one mistake here
- * that cannot be undone.
+ * The rewind id goes in the body, in full. It is not truncated and not
+ * carried in the upstream path: WPCOM passes it to VaultPress as the
+ * backup's timestamp, so dropping the decimal addresses a different
+ * backup than the reader picked. It stays in *our* route's path only
+ * because the client keys its poll cache on it.
  *
- * Note this still targets the v1 activity-log route, which discards
- * Jetpack user tokens and therefore always answers 401. Repointing it at
- * the v2 restore routes is separate work.
- *
- * @param rewindId - The backup's rewind id.
+ * @param rewindId - The backup's rewind id, in full.
  * @param types    - Which categories to restore (themes/plugins/roots/contents/sqls/uploads).
- * @return The restore id.
+ * @return The restore id, which may be null while WPCOM has not named one.
  */
 export async function initiateRestore(
 	rewindId: string,
 	types: RestoreItems
 ): Promise< InitiateRestoreResponse > {
 	return apiCall< InitiateRestoreResponse >( {
-		path: apiPath( `/rewind/to/${ toIntRewindId( rewindId ) }` ),
+		path: apiPath( `/rewind/to/${ rewindId }` ),
 		method: 'POST',
 		data: { types: requireTypes( types ) },
 	} );
@@ -48,11 +83,45 @@ export async function initiateRestore(
 /**
  * Poll restore status.
  *
- * @param restoreId - The restore id returned by `initiateRestore`.
+ * @param restoreId - The restore id.
  * @return The current restore state.
  */
 export async function fetchRestoreStatus( restoreId: number ): Promise< RestoreStatusResponse > {
 	return apiCall< RestoreStatusResponse >( {
 		path: apiPath( `/rewind/restore/${ restoreId }/status` ),
 	} );
+}
+
+/**
+ * The site's ten most recent restores, in any state.
+ *
+ * Reads `GET /jetpack/v4/restores`, which is registered unconditionally
+ * and signed with the blog token — so it answers for any admin, not only
+ * the one who started the restore.
+ *
+ * Used to recover a restore id that WPCOM accepted but did not return.
+ * Note the route follows the legacy convention of answering a non-200
+ * from WPCOM with a bare `null`, which WordPress serves as HTTP 200 — so
+ * this resolves rather than rejecting, and the empty list it returns in
+ * that case means "could not read", not "no restores".
+ *
+ * @return The recent restores, or an empty list when the read failed.
+ */
+export async function fetchRecentRestores(): Promise< RecentRestore[] > {
+	const data = await apiCall< unknown >( {
+		path: apiPath( '/restores' ),
+	} );
+
+	if ( ! Array.isArray( data ) ) {
+		return [];
+	}
+
+	return data
+		.filter( ( row ): row is Record< string, unknown > => !! row && typeof row === 'object' )
+		.map( row => ( {
+			restore_id: Number( row.restore_id ) || 0,
+			rewind_id: typeof row.rewind_id === 'string' ? row.rewind_id : String( row.rewind_id ?? '' ),
+			status: typeof row.status === 'string' ? row.status : '',
+		} ) )
+		.filter( row => row.restore_id > 0 );
 }

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -45,11 +45,19 @@ export type RestoreStatusResponse = {
 	message: string;
 };
 
-/** One row of `GET /jetpack/v4/restores` — the last ten restores, any state. */
+/**
+ * One row of `GET /jetpack/v4/restores` — the last ten restores, any state.
+ *
+ * Deliberately only the two fields the recovery match needs. The rows
+ * also carry a `status`, and it is not the status route's vocabulary:
+ * WordPress.com's docblock for the collection claims `finished/started/
+ * fail` while its own consumer matches `running`. Nothing here reads it,
+ * and mapping a second, differently-spelled status enum would invite
+ * something to.
+ */
 export type RecentRestore = {
 	restore_id: number;
 	rewind_id: string;
-	status: string;
 };
 
 /**
@@ -121,7 +129,6 @@ export async function fetchRecentRestores(): Promise< RecentRestore[] > {
 		.map( row => ( {
 			restore_id: Number( row.restore_id ) || 0,
 			rewind_id: typeof row.rewind_id === 'string' ? row.rewind_id : String( row.rewind_id ?? '' ),
-			status: typeof row.status === 'string' ? row.status : '',
 		} ) )
 		.filter( row => row.restore_id > 0 );
 }

--- a/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
@@ -1,4 +1,4 @@
-import { ApiError, requireTypes, serializeTypes, toIntRewindId } from '../_helpers';
+import { ApiError, requireTypes, toIntRewindId } from '../_helpers';
 
 describe( 'toIntRewindId', () => {
 	test( 'returns the input unchanged when there is no decimal suffix', () => {
@@ -14,51 +14,32 @@ describe( 'toIntRewindId', () => {
 	} );
 } );
 
-describe( 'serializeTypes', () => {
-	test( 'emits the object form, keeping only the selected categories', () => {
-		expect( serializeTypes( { themes: true, plugins: false, sqls: true } ) ).toEqual( {
-			themes: true,
-			sqls: true,
-		} );
-	} );
-
-	// The whole reason this helper exists. WPCOM selects the enabled
-	// categories with a loose comparison, so a JSON array of names yields
-	// its own integer indices — `[ "themes" ]` becomes `[ 0 ]` — and
-	// those get treated as category names. An emptiness check would never
-	// catch it, because the list is not empty.
-	test( 'never produces an array', () => {
-		const result = serializeTypes( { themes: true, plugins: true } );
-
-		expect( Array.isArray( result ) ).toBe( false );
-		expect( result ).toEqual( { themes: true, plugins: true } );
-	} );
-
-	test( 'returns undefined when nothing is selected', () => {
-		// `{}` is not a safe stand-in: the v2 restore route rejects a
-		// `types` value that names nothing. Note that omitting the key is
-		// not safe either — see `requireTypes` below, which is what
-		// mutations use.
-		expect( serializeTypes( { themes: false, plugins: false } ) ).toBeUndefined();
-		expect( serializeTypes( {} ) ).toBeUndefined();
-	} );
-} );
-
 describe( 'requireTypes', () => {
-	test( 'passes a populated selection straight through', () => {
+	test( 'emits the object form, keeping only the selected categories', () => {
 		expect( requireTypes( { themes: true, plugins: false, sqls: true } ) ).toEqual( {
 			themes: true,
 			sqls: true,
 		} );
 	} );
 
-	// The reason this exists rather than the mutations calling
-	// `serializeTypes` directly. Omitting `types` is not "ask for
-	// nothing" — WPCOM reads an absent `types` as all six categories, so
-	// an unticked checklist submitted a *full* download, and a full
-	// destructive restore. Refusing is the only safe reading of an empty
-	// selection, and it has to happen below the UI: the screens disable
-	// their buttons, but the danger is in the request, not the button.
+	// Half the reason this helper exists. WPCOM selects the enabled
+	// categories with a loose comparison, so a JSON array of names yields
+	// its own integer indices — `[ "themes" ]` becomes `[ 0 ]` — and
+	// those get treated as category names. An emptiness check would never
+	// catch it, because the list is not empty.
+	test( 'never produces an array', () => {
+		const result = requireTypes( { themes: true, plugins: true } );
+
+		expect( Array.isArray( result ) ).toBe( false );
+		expect( result ).toEqual( { themes: true, plugins: true } );
+	} );
+
+	// The other half. Omitting `types` is not "ask for nothing" — WPCOM
+	// reads an absent `types` as all six categories, so an unticked
+	// checklist submitted a *full* download, and a full destructive
+	// restore. Refusing is the only safe reading of an empty selection,
+	// and it has to happen below the UI: the screens disable their
+	// buttons, but the danger is in the request, not the button.
 	test( 'refuses an empty selection rather than letting the key be omitted', () => {
 		expect( () => requireTypes( { themes: false, plugins: false } ) ).toThrow( ApiError );
 		expect( () => requireTypes( {} ) ).toThrow( ApiError );

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -52,4 +52,7 @@ export const keys = {
 	downloadStatus: ( rewindId: string, downloadId: number ) =>
 		[ 'backup', 'download-status', rewindId, downloadId ] as const,
 	restoreStatus: ( restoreId: number ) => [ 'backup', 'restore-status', restoreId ] as const,
+	// The site's recent restores, not one restore's status: read to
+	// recover an id WordPress.com accepted but did not return.
+	recentRestores: () => [ 'backup', 'recent-restores' ] as const,
 };

--- a/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
@@ -252,6 +252,10 @@ describe( 'useRestore — failing safe', () => {
 		expect( result.current.state.phase ).not.toBe( 'success' );
 	} );
 
+	// Losing the connection is not the same as the restore failing: it
+	// was accepted and is very likely still running. Reporting it as an
+	// error would offer a retry, and the retry starts a second concurrent
+	// restore — so it reports what is true, that we can no longer watch.
 	it( 'surfaces a mid-poll network failure rather than sitting at the last percent', async () => {
 		mockedApiFetch.mockImplementation( ( options: { method?: string } ) => {
 			if ( options?.method === 'POST' ) {
@@ -264,8 +268,22 @@ describe( 'useRestore — failing safe', () => {
 		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
 		submitAll( result );
 
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'lost-track' ) );
+		// The transport's own text is kept, beneath the message rather
+		// than replacing it.
+		expect( result.current.state ).toMatchObject( { detail: 'Could not reach WordPress.com.' } );
+	} );
+
+	// The property the phase exists for, asserted on the state machine as
+	// well as on the screen: `error` is reserved for "nothing is running".
+	it( 'reserves the error phase for restores that definitely are not running', async () => {
+		respondWith( { status: statusPayload( { status: 'failed', message: 'Restore aborted.' } ) } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
 		await waitFor( () => expect( result.current.state.phase ).toBe( 'error' ) );
-		expect( result.current.state ).toMatchObject( { message: 'Could not reach WordPress.com.' } );
 	} );
 
 	it( 'reports a refused submission and can be reset back to idle', async () => {
@@ -294,8 +312,6 @@ describe( 'useRestore — the silence deadline', () => {
 	afterEach( () => {
 		jest.useRealTimers();
 	} );
-
-	const LOST_TRACK = /lost track of this restore/;
 
 	/**
 	 * Advance fake timers inside `act`, letting queued promises settle.
@@ -347,10 +363,10 @@ describe( 'useRestore — the silence deadline', () => {
 		expect( result.current.state.phase ).toBe( 'queued' );
 
 		await advance( 5 * 60_000 );
-		expect( result.current.state.phase ).toBe( 'error' );
-		expect( result.current.state ).toMatchObject( {
-			message: expect.stringMatching( LOST_TRACK ),
-		} );
+		// `lost-track`, never `error`: the screen offers "Try again" on
+		// `error`, and here that would start a second concurrent restore.
+		expect( result.current.state.phase ).toBe( 'lost-track' );
+		expect( result.current.state ).toMatchObject( { detail: null } );
 	} );
 
 	it( 'gives up on a restore whose status never leaves queued', async () => {
@@ -363,10 +379,8 @@ describe( 'useRestore — the silence deadline', () => {
 		await settleAt( result, 'queued' );
 
 		await advance( 5 * 60_000 + 1000 );
-		expect( result.current.state.phase ).toBe( 'error' );
-		expect( result.current.state ).toMatchObject( {
-			message: expect.stringMatching( LOST_TRACK ),
-		} );
+		expect( result.current.state.phase ).toBe( 'lost-track' );
+		expect( result.current.state ).toMatchObject( { detail: null } );
 	} );
 
 	// The half that matters as much as firing: a long restore that keeps
@@ -395,7 +409,7 @@ describe( 'useRestore — the silence deadline', () => {
 
 		await settleAt( result, 'queued' );
 		await advance( 5 * 60_000 + 1000 );
-		expect( result.current.state.phase ).toBe( 'error' );
+		expect( result.current.state.phase ).toBe( 'lost-track' );
 
 		const before = mockedApiFetch.mock.calls.length;
 		await advance( 60_000 );
@@ -413,7 +427,7 @@ describe( 'useRestore — the silence deadline', () => {
 
 		await settleAt( result, 'queued' );
 		await advance( 5 * 60_000 + 1000 );
-		expect( result.current.state.phase ).toBe( 'error' );
+		expect( result.current.state.phase ).toBe( 'lost-track' );
 
 		act( () => result.current.reset() );
 		expect( result.current.state.phase ).toBe( 'idle' );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
@@ -76,6 +76,7 @@ function respondWith( {
 }
 
 type RenderedRestore = { current: { submit: ( items: typeof DEFAULT_RESTORE_ITEMS ) => void } };
+type PhaseResult = { current: { state: { phase: string } } };
 
 /**
  * Start a restore with every category selected.
@@ -202,7 +203,7 @@ describe( 'useRestore — a restore WordPress.com accepted without naming', () =
 	it( 'recovers the id from the restores collection and resumes polling', async () => {
 		respondWith( {
 			initiate: { id: null, rewind_id: REWIND_ID },
-			restores: [ { restore_id: 912682, rewind_id: REWIND_ID, status: 'running' } ],
+			restores: [ { restore_id: 912682, rewind_id: REWIND_ID } ],
 			status: statusPayload( { status: 'running', progress: 17 } ),
 		} );
 		const { wrapper } = makeWrapper();
@@ -217,7 +218,7 @@ describe( 'useRestore — a restore WordPress.com accepted without naming', () =
 	it( 'ignores a restore of a different backup', async () => {
 		respondWith( {
 			initiate: { id: null, rewind_id: REWIND_ID },
-			restores: [ { restore_id: 111, rewind_id: '1700000000.1', status: 'running' } ],
+			restores: [ { restore_id: 111, rewind_id: '1700000000.1' } ],
 		} );
 		const { wrapper } = makeWrapper();
 
@@ -278,5 +279,181 @@ describe( 'useRestore — failing safe', () => {
 
 		act( () => result.current.reset() );
 		expect( result.current.state.phase ).toBe( 'idle' );
+	} );
+} );
+
+describe( 'useRestore — the silence deadline', () => {
+	// The deadline is enforced by a timer, not by comparing the clock
+	// while rendering, and these are the cases that tell the difference.
+	// Fake timers here rather than in the file-wide setup: every other
+	// suite depends on React Query's real polling.
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	const LOST_TRACK = /lost track of this restore/;
+
+	/**
+	 * Advance fake timers inside `act`, letting queued promises settle.
+	 *
+	 * @param ms - How far to advance.
+	 */
+	async function advance( ms: number ) {
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( ms );
+		} );
+	}
+
+	/**
+	 * Wait for the hook to reach a phase before jumping the clock.
+	 *
+	 * Required rather than tidy: the deadline timer is scheduled when the
+	 * restore is accepted, so a single large `advance()` from a standing
+	 * start moves the clock past the point the timer is armed at, and it
+	 * is then scheduled to fire five minutes after a `now` the test has
+	 * already left behind. Real time does not jump.
+	 *
+	 * @param result - The rendered hook result.
+	 * @param phase  - The phase to wait for.
+	 */
+	async function settleAt( result: PhaseResult, phase: string ) {
+		await waitFor( () => expect( result.current.state.phase ).toBe( phase ) );
+	}
+
+	// The case with no safety net before: the status query is disabled
+	// while the id is unknown, so the recovery poll is the only thing
+	// running — and a refetch that keeps returning the same empty list is
+	// structurally shared into the same array, so the observer never
+	// notifies and nothing re-renders. A deadline evaluated during render
+	// is never reached, and the reader is left on "queued and will begin
+	// shortly…" indefinitely, having just been told a destructive
+	// operation was about to start.
+	it( 'gives up on a restore accepted without an id that never appears in the collection', async () => {
+		respondWith( { initiate: { id: null, rewind_id: REWIND_ID }, restores: [] } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'queued' );
+
+		// Still queued a minute in — the deadline caps silence, it does
+		// not cap the restore.
+		await advance( 60_000 );
+		expect( result.current.state.phase ).toBe( 'queued' );
+
+		await advance( 5 * 60_000 );
+		expect( result.current.state.phase ).toBe( 'error' );
+		expect( result.current.state ).toMatchObject( {
+			message: expect.stringMatching( LOST_TRACK ),
+		} );
+	} );
+
+	it( 'gives up on a restore whose status never leaves queued', async () => {
+		respondWith( { status: statusPayload( { status: 'queued' } ) } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'queued' );
+
+		await advance( 5 * 60_000 + 1000 );
+		expect( result.current.state.phase ).toBe( 'error' );
+		expect( result.current.state ).toMatchObject( {
+			message: expect.stringMatching( LOST_TRACK ),
+		} );
+	} );
+
+	// The half that matters as much as firing: a long restore that keeps
+	// reporting progress must never be cut off. Each `running` reading
+	// restarts the deadline.
+	it( 'never cuts off a restore that keeps reporting progress', async () => {
+		respondWith( { status: statusPayload( { status: 'running', progress: 12 } ) } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'progress' );
+
+		// Twenty minutes of steady progress, four times the deadline.
+		await advance( 20 * 60_000 );
+		expect( result.current.state.phase ).toBe( 'progress' );
+	} );
+
+	it( 'stops polling once it has given up', async () => {
+		respondWith( { initiate: { id: null, rewind_id: REWIND_ID }, restores: [] } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'queued' );
+		await advance( 5 * 60_000 + 1000 );
+		expect( result.current.state.phase ).toBe( 'error' );
+
+		const before = mockedApiFetch.mock.calls.length;
+		await advance( 60_000 );
+		// A request in flight behind an error notice is a request nobody
+		// will ever read the answer to.
+		expect( mockedApiFetch.mock.calls ).toHaveLength( before );
+	} );
+
+	it( 'starts over after a reset', async () => {
+		respondWith( { initiate: { id: null, rewind_id: REWIND_ID }, restores: [] } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'queued' );
+		await advance( 5 * 60_000 + 1000 );
+		expect( result.current.state.phase ).toBe( 'error' );
+
+		act( () => result.current.reset() );
+		expect( result.current.state.phase ).toBe( 'idle' );
+	} );
+} );
+
+describe( 'useRestore — matching the restore we started', () => {
+	it( 'matches a rewind id the collection formatted differently', async () => {
+		// The value in `recent_restores[]` has been round-tripped through
+		// VaultPress rather than echoed back, so a trailing zero gained or
+		// lost is the same instant spelled two ways. A strict string
+		// comparison would miss it and leave the restore unrecoverable.
+		respondWith( {
+			initiate: { id: null, rewind_id: REWIND_ID },
+			restores: [ { restore_id: 912682, rewind_id: `${ REWIND_ID }0` } ],
+			status: statusPayload( { status: 'running', progress: 33 } ),
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'progress' ) );
+		expect( result.current.state ).toMatchObject( { percent: 33 } );
+	} );
+
+	it( 'still refuses a different backup taken in the same second', async () => {
+		respondWith( {
+			initiate: { id: null, rewind_id: REWIND_ID },
+			restores: [ { restore_id: 111, rewind_id: '1786663613.1111' } ],
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'queued' ) );
+		const polled = mockedApiFetch.mock.calls.some( ( [ o ] ) =>
+			( o?.path ?? '' ).includes( '/rewind/restore/111/status' )
+		);
+		expect( polled ).toBe( false );
 	} );
 } );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
@@ -1,0 +1,282 @@
+// The restore state machine — the only place in this dashboard where a
+// bug costs someone their site rather than their patience.
+//
+// It had no test at all, and was dead on arrival: the client tested for
+// `in-progress`, `queued`, `finished` and `failed`, and WordPress.com has
+// never returned any of those. Nothing noticed because the v1 route it
+// called answered 401 before a status could come back, so the whole
+// machine was unreachable rather than merely wrong.
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, type ReactNode } from 'react';
+import { DEFAULT_RESTORE_ITEMS } from '../../types/restore';
+import { useRestore } from '../use-restore';
+
+jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+const REWIND_ID = '1786663613.9425';
+
+/**
+ * Fresh client per test, retries off so failures assert immediately.
+ *
+ * @return A wrapper providing an isolated QueryClient.
+ */
+function makeWrapper() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	const wrapper = ( { children }: { children: ReactNode } ) =>
+		createElement( QueryClientProvider, { client }, children );
+	return { wrapper };
+}
+
+/**
+ * A projected status payload, in the shape the bridge returns.
+ *
+ * @param over - Fields to override on the default running payload.
+ * @return The payload.
+ */
+function statusPayload( over: Record< string, unknown > = {} ) {
+	return {
+		id: 912682,
+		status: 'running',
+		progress: 0,
+		rewind_id: REWIND_ID,
+		error_code: '',
+		message: '',
+		...over,
+	};
+}
+
+/**
+ * Answer the initiate call, then every status poll.
+ *
+ * @param options          - Overrides.
+ * @param options.initiate - What the initiate call resolves with.
+ * @param options.status   - What each status poll resolves with.
+ * @param options.restores - What `/jetpack/v4/restores` resolves with.
+ */
+function respondWith( {
+	initiate = { id: 912682, rewind_id: REWIND_ID } as unknown,
+	status = statusPayload() as unknown,
+	restores = [] as unknown,
+} = {} ) {
+	mockedApiFetch.mockImplementation( ( options: { path?: string; method?: string } ) => {
+		if ( options?.method === 'POST' ) {
+			return Promise.resolve( initiate );
+		}
+		if ( ( options?.path ?? '' ).includes( '/restores' ) ) {
+			return Promise.resolve( restores );
+		}
+		return Promise.resolve( status );
+	} );
+}
+
+type RenderedRestore = { current: { submit: ( items: typeof DEFAULT_RESTORE_ITEMS ) => void } };
+
+/**
+ * Start a restore with every category selected.
+ *
+ * @param result - The rendered hook result.
+ */
+function submitAll( result: RenderedRestore ) {
+	act( () => result.current.submit( DEFAULT_RESTORE_ITEMS ) );
+}
+
+beforeEach( () => {
+	mockedApiFetch.mockReset();
+} );
+
+describe( 'useRestore — the request', () => {
+	it( 'sends the rewind id in full, and never in the upstream path', async () => {
+		respondWith();
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( mockedApiFetch ).toHaveBeenCalled() );
+		const [ initiate ] = mockedApiFetch.mock.calls[ 0 ];
+		// Truncating it addresses a different backup than the reader picked.
+		expect( initiate.path ).toContain( REWIND_ID );
+		expect( initiate.path ).not.toContain( '1786663613/' );
+	} );
+
+	it( 'sends types as an object, never as an array', async () => {
+		respondWith();
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		act( () => result.current.submit( { ...DEFAULT_RESTORE_ITEMS, plugins: false } ) );
+
+		await waitFor( () => expect( mockedApiFetch ).toHaveBeenCalled() );
+		const [ initiate ] = mockedApiFetch.mock.calls[ 0 ];
+		expect( Array.isArray( initiate.data.types ) ).toBe( false );
+		expect( initiate.data.types.plugins ).toBeUndefined();
+		expect( initiate.data.types.themes ).toBe( true );
+	} );
+} );
+
+describe( 'useRestore — terminal states', () => {
+	// Each of these was unreachable before: the client was checking for
+	// status strings WordPress.com does not emit.
+	it( 'reaches success on finished', async () => {
+		respondWith( { status: statusPayload( { status: 'finished', progress: 100 } ) } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'success' ) );
+	} );
+
+	it( 'reaches its own state on finished-with-errors, not success', async () => {
+		respondWith( {
+			status: statusPayload( {
+				status: 'finished-with-errors',
+				message: '3 files could not be written.',
+			} ),
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'success-with-errors' ) );
+		expect( result.current.state ).toMatchObject( { message: '3 files could not be written.' } );
+	} );
+
+	it( 'reaches error on failed, and on aborted', async () => {
+		respondWith( { status: statusPayload( { status: 'failed', message: 'Restore aborted.' } ) } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'error' ) );
+		expect( result.current.state ).toMatchObject( { message: 'Restore aborted.' } );
+	} );
+
+	it( 'never shows the machine error code to the reader', async () => {
+		respondWith( {
+			status: statusPayload( { status: 'failed', message: '', error_code: 'checksum_mismatch' } ),
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'error' ) );
+		expect( JSON.stringify( result.current.state ) ).not.toContain( 'checksum_mismatch' );
+	} );
+
+	it( 'reports progress while running', async () => {
+		respondWith( { status: statusPayload( { status: 'running', progress: 42 } ) } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'progress' ) );
+		expect( result.current.state ).toMatchObject( { percent: 42 } );
+	} );
+} );
+
+describe( 'useRestore — a restore WordPress.com accepted without naming', () => {
+	// VaultPress does not reliably echo an id back, so `restore_id: null`
+	// is a queued restore rather than a failure. The old bridge reported
+	// it as a 500.
+	it( 'stays queued rather than failing when no id comes back', async () => {
+		respondWith( { initiate: { id: null, rewind_id: REWIND_ID } } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'queued' ) );
+	} );
+
+	it( 'recovers the id from the restores collection and resumes polling', async () => {
+		respondWith( {
+			initiate: { id: null, rewind_id: REWIND_ID },
+			restores: [ { restore_id: 912682, rewind_id: REWIND_ID, status: 'running' } ],
+			status: statusPayload( { status: 'running', progress: 17 } ),
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'progress' ) );
+		expect( result.current.state ).toMatchObject( { percent: 17 } );
+	} );
+
+	it( 'ignores a restore of a different backup', async () => {
+		respondWith( {
+			initiate: { id: null, rewind_id: REWIND_ID },
+			restores: [ { restore_id: 111, rewind_id: '1700000000.1', status: 'running' } ],
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'queued' ) );
+		// Adopting the wrong id would report someone else's restore as this one.
+		const polled = mockedApiFetch.mock.calls.some( ( [ o ] ) =>
+			( o?.path ?? '' ).includes( '/rewind/restore/111/status' )
+		);
+		expect( polled ).toBe( false );
+	} );
+} );
+
+describe( 'useRestore — failing safe', () => {
+	// The bug this replaces: the poll stopped on any status it did not
+	// recognise, which was all of them, freezing the bar at its first
+	// reading with no timeout and no escape.
+	it( 'keeps polling through an unrecognised status instead of freezing', async () => {
+		respondWith( { status: statusPayload( { status: 'unknown', progress: 5 } ) } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		// Reported as queued rather than as a stalled progress bar...
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'queued' ) );
+		// ...and it has not given up: no terminal state was reached.
+		expect( result.current.state.phase ).not.toBe( 'error' );
+		expect( result.current.state.phase ).not.toBe( 'success' );
+	} );
+
+	it( 'surfaces a mid-poll network failure rather than sitting at the last percent', async () => {
+		mockedApiFetch.mockImplementation( ( options: { method?: string } ) => {
+			if ( options?.method === 'POST' ) {
+				return Promise.resolve( { id: 912682, rewind_id: REWIND_ID } );
+			}
+			return Promise.reject( new Error( 'Could not reach WordPress.com.' ) );
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'error' ) );
+		expect( result.current.state ).toMatchObject( { message: 'Could not reach WordPress.com.' } );
+	} );
+
+	it( 'reports a refused submission and can be reset back to idle', async () => {
+		mockedApiFetch.mockRejectedValue( new Error( 'Could not start the backup restore.' ) );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'error' ) );
+
+		act( () => result.current.reset() );
+		expect( result.current.state.phase ).toBe( 'idle' );
+	} );
+} );

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/el
 import { __ } from '@wordpress/i18n';
 import { fetchRecentRestores, fetchRestoreStatus, initiateRestore } from '../data/api/restore';
 import { keys } from '../data/query-client';
-import type { RestoreStatus } from '../data/api/restore';
+import type { RestoreStatus, RestoreStatusResponse } from '../data/api/restore';
 import type { RestoreItems, RestoreState } from '../types/restore';
 
 type Result = {
@@ -12,15 +12,24 @@ type Result = {
 	reset: () => void;
 };
 
+/**
+ * How often to ask, both for status and — while the id is unknown — for
+ * the restores collection.
+ *
+ * Raised from the 1.5s the download flow uses. A restore is a long
+ * operation reported as a coarse percentage, so a sub-second cadence buys
+ * no responsiveness and costs a WordPress.com round trip per tick for its
+ * whole duration.
+ */
 const POLL_INTERVAL_MS = 5000;
 
 /**
  * How long the screen will go without a recognisable sign of life before
  * it admits it has lost track of the restore.
  *
- * Measured from the last `running` reading, not from the start, so this
- * does not cap the restore itself: a two-hour restore of a large site
- * keeps polling for as long as it keeps reporting progress. It caps only
+ * Measured from the last sign of life, not from the start, so this does
+ * not cap the restore itself: a two-hour restore of a large site keeps
+ * polling for as long as it keeps reporting progress. It caps only
  * silence.
  *
  * Something has to cap it. The state machine this replaces stopped
@@ -32,6 +41,147 @@ const QUIET_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Statuses that mean the restore is still going, or might be. */
 const LIVE_STATUSES: RestoreStatus[] = [ 'queued', 'running', 'unknown' ];
+
+/**
+ * Whether a status reading counts as a sign of life, restarting the
+ * silence deadline.
+ *
+ * Only `running` does, and deliberately not `queued` — which looks like
+ * positive information and is not. WordPress.com's status enum is exactly
+ * `running | success | fail | aborted | success-with-errors`; there is no
+ * `queued` in it. Every `queued` the client sees is minted by our own
+ * bridge, and overwhelmingly means *404 — that restore is not visible to
+ * this route*. Treating it as a sign of life would mean a restore that
+ * never materialises upstream answers 404 forever, resets the deadline
+ * every time it does, and polls until the tab closes. That is precisely
+ * the frozen-forever failure this hook exists to end.
+ *
+ * @param status - The status the bridge reported, if any.
+ * @return True when the restore has demonstrably moved.
+ */
+function isSignOfLife( status: RestoreStatus | undefined ): boolean {
+	return status === 'running';
+}
+
+/**
+ * Whether a status reading ends the poll.
+ *
+ * @param status - The status the bridge reported, if any.
+ * @return True when there is nothing left to wait for.
+ */
+function isTerminal( status: RestoreStatus | undefined ): boolean {
+	return status !== undefined && ! LIVE_STATUSES.includes( status );
+}
+
+/**
+ * Whether two rewind ids name the same backup.
+ *
+ * Adopting the wrong id would report someone else's restore as this one,
+ * so this stays an equality test and never a prefix or integer-part
+ * match: two restores of the same backup share an integer part.
+ *
+ * What it does tolerate is formatting. A rewind id is a unix timestamp
+ * with a decimal suffix, and the value in `recent_restores[]` has been
+ * round-tripped through VaultPress rather than echoed back by
+ * WordPress.com — so a trailing zero gained or lost (`…613.9425` vs
+ * `…613.94250`) would defeat a strict string comparison for two
+ * representations of the same instant. Comparing them as numbers as well
+ * closes that without widening what counts as a match.
+ *
+ * @param candidate - A rewind id from the restores collection.
+ * @param target    - The rewind id this screen submitted.
+ * @return True when both name the same backup.
+ */
+function sameRewindId( candidate: string, target: string ): boolean {
+	if ( ! candidate || ! target ) {
+		return false;
+	}
+	if ( candidate === target ) {
+		return true;
+	}
+	const a = Number( candidate );
+	const b = Number( target );
+	return Number.isFinite( a ) && Number.isFinite( b ) && a === b;
+}
+
+type DeriveInput = {
+	errorMessage: string | null;
+	isPending: boolean;
+	startedRewindId: string | null;
+	restoreId: number | null;
+	statusError: Error | null;
+	data: RestoreStatusResponse | undefined;
+	lostTrack: boolean;
+};
+
+/**
+ * Collapse the queries into the one thing the screen renders.
+ *
+ * A pure function of its inputs, at module scope rather than inside the
+ * hook: the phase is derived, never sampled. An earlier version read
+ * `Date.now()` here to decide whether the silence deadline had passed,
+ * which only worked while something else happened to be re-rendering —
+ * see `lostTrack` for what replaced it.
+ *
+ * @param input - Everything the phase depends on.
+ * @return The current phase.
+ */
+function deriveState( input: DeriveInput ): RestoreState {
+	const { errorMessage, isPending, startedRewindId, restoreId, statusError, data, lostTrack } =
+		input;
+
+	if ( errorMessage ) {
+		return { phase: 'error', message: errorMessage };
+	}
+	if ( isPending ) {
+		return { phase: 'submitting' };
+	}
+	if ( startedRewindId === null ) {
+		return { phase: 'idle' };
+	}
+	// A network failure mid-poll, surfaced rather than left sitting at
+	// the last known percent with no way out.
+	if ( restoreId !== null && statusError ) {
+		return {
+			phase: 'error',
+			message:
+				statusError.message || __( 'Lost connection while restoring.', 'jetpack-backup-pkg' ),
+		};
+	}
+
+	switch ( data?.status ) {
+		case 'finished':
+			return { phase: 'success' };
+		case 'finished-with-errors':
+			return { phase: 'success-with-errors', message: data.message };
+		case 'failed':
+		case 'aborted':
+			// `error_code` is a machine identifier (e.g.
+			// `checksum_mismatch`) — never surface it; fall through to
+			// the translated generic when `message` is empty.
+			return {
+				phase: 'error',
+				message: data.message || __( 'Restore failed.', 'jetpack-backup-pkg' ),
+			};
+		case 'running':
+			return { phase: 'progress', percent: Math.round( data.progress ?? 0 ) };
+		default:
+			// `queued`, `unknown`, or nothing yet. All the same to the
+			// reader: accepted, nothing to show. Unless it has been that
+			// way long enough that we should stop implying something is
+			// about to happen.
+			if ( lostTrack ) {
+				return {
+					phase: 'error',
+					message: __(
+						"We've lost track of this restore. It may still be running — you'll get an email when it finishes.",
+						'jetpack-backup-pkg'
+					),
+				};
+			}
+			return { phase: 'queued' };
+	}
+}
 
 /**
  * Drives the modernized Restore screen.
@@ -63,9 +213,24 @@ export function useRestore( rewindId: string ): Result {
 	// Set once the restore is accepted, whether or not it came with an id.
 	// Distinguishes "queued, id unknown" from "not started".
 	const [ startedRewindId, setStartedRewindId ] = useState< string | null >( null );
-	// When we last had a recognisable sign of life. A ref because it is a
-	// deadline, not something the UI renders — see QUIET_TIMEOUT_MS.
-	const lastAliveAt = useRef< number | null >( null );
+	// When we last had a recognisable sign of life, and whether the
+	// deadline measured from it has passed.
+	//
+	// Both are state rather than a ref, and the deadline is enforced by a
+	// timer rather than compared against the clock while rendering. That
+	// distinction is the whole point: in the no-id case nothing else is
+	// re-rendering. The status query is disabled, the recovery query is
+	// the only poller, and a refetch that keeps returning the same empty
+	// list is structurally shared into the same array — so React Query's
+	// observer never notifies, no render happens, and any deadline
+	// evaluated during render is never reached. The screen would sit on
+	// "queued and will begin shortly…" for as long as the tab stayed
+	// open, which is the one scenario this recovery path exists for.
+	const [ aliveAt, setAliveAt ] = useState< number | null >( null );
+	const [ lostTrack, setLostTrack ] = useState( false );
+	// Guards the sign-of-life effect against re-bumping the deadline for
+	// a reading it has already seen.
+	const lastSeenUpdateAt = useRef( 0 );
 
 	// Destructure to keep stable references for useCallback deps —
 	// passing the whole `mutation` object trips
@@ -79,7 +244,10 @@ export function useRestore( rewindId: string ): Result {
 		onSuccess: result => {
 			setErrorMessage( null );
 			setStartedRewindId( result.rewind_id || rewindId );
-			lastAliveAt.current = Date.now();
+			// Acceptance starts the clock: it is the last thing we know
+			// for certain until a status reading says otherwise.
+			setAliveAt( Date.now() );
+			setLostTrack( false );
 			if ( result.id !== null ) {
 				setSubmittedId( result.id );
 			}
@@ -93,18 +261,21 @@ export function useRestore( rewindId: string ): Result {
 	// collection; the matching is derived below, so nothing here depends
 	// on state that would have to be mirrored into the query key.
 	const needsId = startedRewindId !== null && submittedId === null;
+	// Once the deadline has passed there is nothing left to recover, and
+	// polling on would keep a request in flight behind an error notice.
+	const recovering = needsId && ! lostTrack;
 	const restoresQuery = useQuery( {
 		queryKey: keys.recentRestores(),
 		queryFn: fetchRecentRestores,
-		enabled: needsId,
-		refetchInterval: needsId ? POLL_INTERVAL_MS : false,
+		enabled: recovering,
+		refetchInterval: recovering ? POLL_INTERVAL_MS : false,
 	} );
 
 	const recoveredId = useMemo( () => {
-		if ( ! needsId ) {
+		if ( ! needsId || startedRewindId === null ) {
 			return null;
 		}
-		const match = restoresQuery.data?.find( row => row.rewind_id === startedRewindId );
+		const match = restoresQuery.data?.find( row => sameRewindId( row.rewind_id, startedRewindId ) );
 		return match ? match.restore_id : null;
 	}, [ needsId, restoresQuery.data, startedRewindId ] );
 
@@ -118,14 +289,9 @@ export function useRestore( rewindId: string ): Result {
 		queryFn: () => fetchRestoreStatus( effectiveRestoreId ),
 		enabled: restoreId !== null,
 		refetchInterval: query => {
-			const status = query.state.data?.status;
-			const isLive = status === undefined || LIVE_STATUSES.includes( status );
-			if ( ! isLive ) {
-				return false;
-			}
-			// Keep asking through anything unrecognised — stopping there is
-			// what froze this before — but not forever.
-			if ( lastAliveAt.current !== null && Date.now() - lastAliveAt.current > QUIET_TIMEOUT_MS ) {
+			// Keep asking through anything unrecognised — stopping there
+			// is what froze this before — but not past the deadline.
+			if ( isTerminal( query.state.data?.status ) || lostTrack ) {
 				return false;
 			}
 			return POLL_INTERVAL_MS;
@@ -135,81 +301,49 @@ export function useRestore( rewindId: string ): Result {
 	// A running restore is the only unambiguous sign of life. Recorded in
 	// an effect rather than during render so the render stays pure.
 	const observedStatus = statusQuery.data?.status;
+	const statusUpdatedAt = statusQuery.dataUpdatedAt;
 	useEffect( () => {
-		if ( observedStatus === 'running' ) {
-			lastAliveAt.current = Date.now();
+		if ( isSignOfLife( observedStatus ) && statusUpdatedAt > lastSeenUpdateAt.current ) {
+			lastSeenUpdateAt.current = statusUpdatedAt;
+			setAliveAt( Date.now() );
 		}
-	}, [ observedStatus, statusQuery.dataUpdatedAt ] );
+	}, [ observedStatus, statusUpdatedAt ] );
+
+	// The deadline, enforced by a timer so that it fires whether or not
+	// anything else is happening. Restarted whenever a sign of life moves
+	// `aliveAt`, cleared once there is nothing left to wait for.
+	const settled = isTerminal( observedStatus );
+	useEffect( () => {
+		if ( aliveAt === null || lostTrack || settled ) {
+			return;
+		}
+		const timer = setTimeout(
+			() => setLostTrack( true ),
+			Math.max( 0, QUIET_TIMEOUT_MS - ( Date.now() - aliveAt ) )
+		);
+		return () => clearTimeout( timer );
+	}, [ aliveAt, lostTrack, settled ] );
 
 	const submit = useCallback( ( items: RestoreItems ) => kickOff( items ), [ kickOff ] );
 	const reset = useCallback( () => {
 		setSubmittedId( null );
 		setErrorMessage( null );
 		setStartedRewindId( null );
-		lastAliveAt.current = null;
+		setAliveAt( null );
+		setLostTrack( false );
+		lastSeenUpdateAt.current = 0;
 		resetMutation();
 	}, [ resetMutation ] );
 
-	return { state: deriveState(), submit, reset };
+	const state = deriveState( {
+		errorMessage,
+		isPending,
+		startedRewindId,
+		restoreId,
+		statusError: statusQuery.error,
+		data: statusQuery.data,
+		lostTrack,
+	} );
 
-	/**
-	 * Collapse the queries into the one thing the screen renders.
-	 *
-	 * @return The current phase.
-	 */
-	function deriveState(): RestoreState {
-		if ( errorMessage ) {
-			return { phase: 'error', message: errorMessage };
-		}
-		if ( isPending ) {
-			return { phase: 'submitting' };
-		}
-		if ( startedRewindId === null ) {
-			return { phase: 'idle' };
-		}
-		// A network failure mid-poll, surfaced rather than left sitting at
-		// the last known percent with no way out.
-		if ( restoreId !== null && statusQuery.error ) {
-			return {
-				phase: 'error',
-				message:
-					statusQuery.error.message ||
-					__( 'Lost connection while restoring.', 'jetpack-backup-pkg' ),
-			};
-		}
-
-		const data = statusQuery.data;
-		switch ( data?.status ) {
-			case 'finished':
-				return { phase: 'success' };
-			case 'finished-with-errors':
-				return { phase: 'success-with-errors', message: data.message };
-			case 'failed':
-			case 'aborted':
-				// `error_code` is a machine identifier (e.g.
-				// `checksum_mismatch`) — never surface it; fall through to
-				// the translated generic when `message` is empty.
-				return {
-					phase: 'error',
-					message: data.message || __( 'Restore failed.', 'jetpack-backup-pkg' ),
-				};
-			case 'running':
-				return { phase: 'progress', percent: Math.round( data.progress ?? 0 ) };
-			default:
-				// `queued`, `unknown`, or nothing yet. All the same to the
-				// reader: accepted, nothing to show. Unless it has been
-				// that way long enough that we should stop implying
-				// something is about to happen.
-				if ( lastAliveAt.current !== null && Date.now() - lastAliveAt.current > QUIET_TIMEOUT_MS ) {
-					return {
-						phase: 'error',
-						message: __(
-							"We've lost track of this restore. It may still be running — you'll get an email when it finishes.",
-							'jetpack-backup-pkg'
-						),
-					};
-				}
-				return { phase: 'queued' };
-		}
-	}
+	return { state, submit, reset };
 }

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -141,12 +141,13 @@ function deriveState( input: DeriveInput ): RestoreState {
 	}
 	// A network failure mid-poll, surfaced rather than left sitting at
 	// the last known percent with no way out.
+	//
+	// `lost-track` and not `error`: the restore was accepted and is very
+	// likely still running — we just cannot watch it any more. Reporting
+	// that as an error offers a retry, and the retry starts a second
+	// concurrent restore of the same site.
 	if ( restoreId !== null && statusError ) {
-		return {
-			phase: 'error',
-			message:
-				statusError.message || __( 'Lost connection while restoring.', 'jetpack-backup-pkg' ),
-		};
+		return { phase: 'lost-track', detail: statusError.message || null };
 	}
 
 	switch ( data?.status ) {
@@ -170,14 +171,11 @@ function deriveState( input: DeriveInput ): RestoreState {
 			// reader: accepted, nothing to show. Unless it has been that
 			// way long enough that we should stop implying something is
 			// about to happen.
+			//
+			// The copy for that lives on the screen, like every other
+			// phase's: this one is entirely ours, with no upstream part.
 			if ( lostTrack ) {
-				return {
-					phase: 'error',
-					message: __(
-						"We've lost track of this restore. It may still be running — you'll get an email when it finishes.",
-						'jetpack-backup-pkg'
-					),
-				};
+				return { phase: 'lost-track', detail: null };
 			}
 			return { phase: 'queued' };
 	}

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -1,8 +1,9 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { fetchRestoreStatus, initiateRestore } from '../data/api/restore';
+import { fetchRecentRestores, fetchRestoreStatus, initiateRestore } from '../data/api/restore';
 import { keys } from '../data/query-client';
+import type { RestoreStatus } from '../data/api/restore';
 import type { RestoreItems, RestoreState } from '../types/restore';
 
 type Result = {
@@ -11,22 +12,60 @@ type Result = {
 	reset: () => void;
 };
 
-const POLL_INTERVAL_MS = 1500;
+const POLL_INTERVAL_MS = 5000;
 
 /**
- * Real `useRestore` driving the modernized Restore screen via the
- * `/jetpack/v4/rewind/to/$rewindId` bridge.
+ * How long the screen will go without a recognisable sign of life before
+ * it admits it has lost track of the restore.
  *
- * Submit kicks off the WPCOM rewind initiate and stores the restore id;
- * a polled status query then advances the state machine
- * idle → submitting → progress → success | error.
+ * Measured from the last `running` reading, not from the start, so this
+ * does not cap the restore itself: a two-hour restore of a large site
+ * keeps polling for as long as it keeps reporting progress. It caps only
+ * silence.
  *
- * @param rewindId - The backup's rewind id.
+ * Something has to cap it. The state machine this replaces stopped
+ * polling on any status it did not recognise — and it recognised none of
+ * the real ones — so the progress bar froze at its first reading with no
+ * timeout and no way out.
+ */
+const QUIET_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Statuses that mean the restore is still going, or might be. */
+const LIVE_STATUSES: RestoreStatus[] = [ 'queued', 'running', 'unknown' ];
+
+/**
+ * Drives the modernized Restore screen.
+ *
+ * Submit starts the restore, then a polled status query advances
+ * idle → submitting → queued → progress → one of the terminal states.
+ *
+ * Two things make this more than a request and a poll.
+ *
+ * WordPress.com may accept a restore without returning an id for it —
+ * VaultPress does not reliably echo one, and the documented response for
+ * the underlying call is only `{ ok, error }`. That is a success, not a
+ * failure, so when it happens the id is recovered by matching the rewind
+ * id we submitted against the restores collection. Until it is found the
+ * screen sits in `queued`, which is the truth: the restore is under way
+ * and we cannot yet say how far along.
+ *
+ * And the poll fails safe in the direction that matters. An unrecognised
+ * status keeps the poll alive under a silence timeout rather than
+ * stopping it, because the failure this replaces was a bar frozen
+ * forever at its first reading.
+ *
+ * @param rewindId - The backup's rewind id, in full.
  * @return state + submit + reset.
  */
 export function useRestore( rewindId: string ): Result {
-	const [ restoreId, setRestoreId ] = useState< number | null >( null );
+	const [ submittedId, setSubmittedId ] = useState< number | null >( null );
 	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
+	// Set once the restore is accepted, whether or not it came with an id.
+	// Distinguishes "queued, id unknown" from "not started".
+	const [ startedRewindId, setStartedRewindId ] = useState< string | null >( null );
+	// When we last had a recognisable sign of life. A ref because it is a
+	// deadline, not something the UI renders — see QUIET_TIMEOUT_MS.
+	const lastAliveAt = useRef< number | null >( null );
 
 	// Destructure to keep stable references for useCallback deps —
 	// passing the whole `mutation` object trips
@@ -38,13 +77,38 @@ export function useRestore( rewindId: string ): Result {
 	} = useMutation( {
 		mutationFn: ( items: RestoreItems ) => initiateRestore( rewindId, items ),
 		onSuccess: result => {
-			setRestoreId( result.id );
 			setErrorMessage( null );
+			setStartedRewindId( result.rewind_id || rewindId );
+			lastAliveAt.current = Date.now();
+			if ( result.id !== null ) {
+				setSubmittedId( result.id );
+			}
 		},
 		onError: ( err: Error ) => {
 			setErrorMessage( err.message );
 		},
 	} );
+
+	// Recovery for the no-id case. The query stays a plain read of the
+	// collection; the matching is derived below, so nothing here depends
+	// on state that would have to be mirrored into the query key.
+	const needsId = startedRewindId !== null && submittedId === null;
+	const restoresQuery = useQuery( {
+		queryKey: keys.recentRestores(),
+		queryFn: fetchRecentRestores,
+		enabled: needsId,
+		refetchInterval: needsId ? POLL_INTERVAL_MS : false,
+	} );
+
+	const recoveredId = useMemo( () => {
+		if ( ! needsId ) {
+			return null;
+		}
+		const match = restoresQuery.data?.find( row => row.rewind_id === startedRewindId );
+		return match ? match.restore_id : null;
+	}, [ needsId, restoresQuery.data, startedRewindId ] );
+
+	const restoreId = submittedId ?? recoveredId;
 
 	// Always-defined query key so @tanstack/query/exhaustive-deps stays
 	// happy; the `enabled` flag keeps the placeholder query from firing.
@@ -53,50 +117,99 @@ export function useRestore( rewindId: string ): Result {
 		queryKey: keys.restoreStatus( effectiveRestoreId ),
 		queryFn: () => fetchRestoreStatus( effectiveRestoreId ),
 		enabled: restoreId !== null,
-		refetchInterval: query =>
-			query.state.data?.status === 'in-progress' || query.state.data?.status === 'queued'
-				? POLL_INTERVAL_MS
-				: false,
+		refetchInterval: query => {
+			const status = query.state.data?.status;
+			const isLive = status === undefined || LIVE_STATUSES.includes( status );
+			if ( ! isLive ) {
+				return false;
+			}
+			// Keep asking through anything unrecognised — stopping there is
+			// what froze this before — but not forever.
+			if ( lastAliveAt.current !== null && Date.now() - lastAliveAt.current > QUIET_TIMEOUT_MS ) {
+				return false;
+			}
+			return POLL_INTERVAL_MS;
+		},
 	} );
+
+	// A running restore is the only unambiguous sign of life. Recorded in
+	// an effect rather than during render so the render stays pure.
+	const observedStatus = statusQuery.data?.status;
+	useEffect( () => {
+		if ( observedStatus === 'running' ) {
+			lastAliveAt.current = Date.now();
+		}
+	}, [ observedStatus, statusQuery.dataUpdatedAt ] );
 
 	const submit = useCallback( ( items: RestoreItems ) => kickOff( items ), [ kickOff ] );
 	const reset = useCallback( () => {
-		setRestoreId( null );
+		setSubmittedId( null );
 		setErrorMessage( null );
+		setStartedRewindId( null );
+		lastAliveAt.current = null;
 		resetMutation();
 	}, [ resetMutation ] );
 
-	let state: RestoreState = { phase: 'idle' };
-	if ( errorMessage ) {
-		state = { phase: 'error', message: errorMessage };
-	} else if ( isPending ) {
-		state = { phase: 'submitting' };
-	} else if ( statusQuery.data?.status === 'finished' ) {
-		state = { phase: 'success' };
-	} else if ( statusQuery.data?.status === 'failed' ) {
-		// `error_code` is a machine identifier (e.g. `"checksum_mismatch"`)
-		// — never surface it to users; fall straight through to the
-		// translated generic message when `message` is empty.
-		state = {
-			phase: 'error',
-			message: statusQuery.data.message || __( 'Restore failed.', 'jetpack-backup-pkg' ),
-		};
-	} else if ( restoreId !== null && statusQuery.error ) {
-		// Network/HTTP failure mid-poll: surface so the UI doesn't sit
-		// in `progress` at the last known percent with no way out.
-		state = {
-			phase: 'error',
-			message:
-				statusQuery.error.message || __( 'Lost connection while restoring.', 'jetpack-backup-pkg' ),
-		};
-	} else if ( restoreId !== null && statusQuery.data ) {
-		state = {
-			phase: 'progress',
-			percent: Math.round( statusQuery.data.progress ?? 0 ),
-		};
-	} else if ( restoreId !== null ) {
-		state = { phase: 'progress', percent: 0 };
-	}
+	return { state: deriveState(), submit, reset };
 
-	return { state, submit, reset };
+	/**
+	 * Collapse the queries into the one thing the screen renders.
+	 *
+	 * @return The current phase.
+	 */
+	function deriveState(): RestoreState {
+		if ( errorMessage ) {
+			return { phase: 'error', message: errorMessage };
+		}
+		if ( isPending ) {
+			return { phase: 'submitting' };
+		}
+		if ( startedRewindId === null ) {
+			return { phase: 'idle' };
+		}
+		// A network failure mid-poll, surfaced rather than left sitting at
+		// the last known percent with no way out.
+		if ( restoreId !== null && statusQuery.error ) {
+			return {
+				phase: 'error',
+				message:
+					statusQuery.error.message ||
+					__( 'Lost connection while restoring.', 'jetpack-backup-pkg' ),
+			};
+		}
+
+		const data = statusQuery.data;
+		switch ( data?.status ) {
+			case 'finished':
+				return { phase: 'success' };
+			case 'finished-with-errors':
+				return { phase: 'success-with-errors', message: data.message };
+			case 'failed':
+			case 'aborted':
+				// `error_code` is a machine identifier (e.g.
+				// `checksum_mismatch`) — never surface it; fall through to
+				// the translated generic when `message` is empty.
+				return {
+					phase: 'error',
+					message: data.message || __( 'Restore failed.', 'jetpack-backup-pkg' ),
+				};
+			case 'running':
+				return { phase: 'progress', percent: Math.round( data.progress ?? 0 ) };
+			default:
+				// `queued`, `unknown`, or nothing yet. All the same to the
+				// reader: accepted, nothing to show. Unless it has been
+				// that way long enough that we should stop implying
+				// something is about to happen.
+				if ( lastAliveAt.current !== null && Date.now() - lastAliveAt.current > QUIET_TIMEOUT_MS ) {
+					return {
+						phase: 'error',
+						message: __(
+							"We've lost track of this restore. It may still be running — you'll get an email when it finishes.",
+							'jetpack-backup-pkg'
+						),
+					};
+				}
+				return { phase: 'queued' };
+		}
+	}
 }

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -124,6 +124,21 @@ export default function RestoreScreen() {
 							</Button>
 						</>
 					) }
+					{ /*
+					 * Accepted, but nothing to report yet — either WordPress.com has
+					 * not started publishing progress, or it queued the restore
+					 * without naming an id we can poll. Indeterminate rather than a
+					 * determinate bar pinned at 0%, which reads as a stall during the
+					 * opening seconds of every restore.
+					 */ }
+					{ state.phase === 'queued' && (
+						<Stack direction="column" gap="sm">
+							<Text>
+								{ __( 'Your restore is queued and will begin shortly…', 'jetpack-backup-pkg' ) }
+							</Text>
+							<ProgressBar />
+						</Stack>
+					) }
 					{ state.phase === 'progress' && (
 						<Stack direction="column" gap="sm">
 							<Text>{ __( 'Restoring…', 'jetpack-backup-pkg' ) }</Text>
@@ -135,6 +150,28 @@ export default function RestoreScreen() {
 							<Notice status="success" isDismissible={ false }>
 								{ __( 'Restore complete.', 'jetpack-backup-pkg' ) }
 							</Notice>
+							<Link to="/">{ __( 'Back to overview', 'jetpack-backup-pkg' ) }</Link>
+						</Stack>
+					) }
+					{ /*
+					 * Finished, but not cleanly. Warning rather than success or error:
+					 * the site has been restored, so treating it as a failure invites a
+					 * pointless retry — but parts of it did not land, and "Restore
+					 * complete." would be a lie the reader discovers later.
+					 */ }
+					{ state.phase === 'success-with-errors' && (
+						<Stack direction="column" gap="sm">
+							<Notice status="warning" isDismissible={ false }>
+								{ __(
+									'Restore finished, but some items could not be restored.',
+									'jetpack-backup-pkg'
+								) }
+							</Notice>
+							{ state.message && (
+								<Text variant="body-sm" className="jpb-text-muted">
+									{ state.message }
+								</Text>
+							) }
 							<Link to="/">{ __( 'Back to overview', 'jetpack-backup-pkg' ) }</Link>
 						</Stack>
 					) }

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -175,6 +175,41 @@ export default function RestoreScreen() {
 							<Link to="/">{ __( 'Back to overview', 'jetpack-backup-pkg' ) }</Link>
 						</Stack>
 					) }
+					{ /*
+					 * Accepted, and then out of sight — the silence deadline passed, or
+					 * the status poll stopped answering. Deliberately not the error
+					 * branch below, which offers "Try again": that resets to an armed
+					 * Confirm button, so the only control on screen would start a second
+					 * concurrent restore of the same site directly beneath a notice
+					 * saying the first may still be running. Nothing upstream is known
+					 * to refuse that.
+					 *
+					 * Warning rather than error for the same reason the copy says "may":
+					 * we have no evidence the restore failed, only that we cannot see
+					 * it. There is nothing for the reader to do here, so the only way
+					 * out is the way out.
+					 */ }
+					{ state.phase === 'lost-track' && (
+						<Stack direction="column" gap="sm">
+							<Notice status="warning" isDismissible={ false }>
+								{ __(
+									"We've lost track of this restore. It may still be running — you'll get an email when it finishes.",
+									'jetpack-backup-pkg'
+								) }
+							</Notice>
+							{ state.detail && (
+								<Text variant="body-sm" className="jpb-text-muted">
+									{ state.detail }
+								</Text>
+							) }
+							<Link to="/">{ __( 'Back to overview', 'jetpack-backup-pkg' ) }</Link>
+						</Stack>
+					) }
+					{ /*
+					 * Nothing is running: the submission was refused, or the restore
+					 * reached `failed`/`aborted`. That is what makes "Try again" safe
+					 * here and nowhere else.
+					 */ }
 					{ state.phase === 'error' && (
 						<Stack direction="column" gap="sm">
 							<Notice status="error" isDismissible={ false }>

--- a/projects/packages/backup/src/dashboard/types/restore.ts
+++ b/projects/packages/backup/src/dashboard/types/restore.ts
@@ -36,9 +36,25 @@ export function hasSelectedItems( items: RestoreItems ): boolean {
 	return Object.values( items ).some( Boolean );
 }
 
+/**
+ * What the Restore screen is showing.
+ *
+ * `queued` is separate from `progress` because they are different
+ * promises to the reader: one says the restore is under way and here is
+ * how far, the other says WordPress.com has accepted it and has not
+ * started reporting yet. Collapsing them means rendering a progress bar
+ * pinned at 0% for the opening seconds of every restore, which reads as
+ * a stall.
+ *
+ * `success-with-errors` is its own terminal state rather than a shade of
+ * either neighbour. A restore that finished but not cleanly should not
+ * be dismissed as done, and should not be retried as if nothing landed.
+ */
 export type RestoreState =
 	| { phase: 'idle' }
 	| { phase: 'submitting' }
+	| { phase: 'queued' }
 	| { phase: 'progress'; percent: number }
 	| { phase: 'success' }
+	| { phase: 'success-with-errors'; message: string }
 	| { phase: 'error'; message: string };

--- a/projects/packages/backup/src/dashboard/types/restore.ts
+++ b/projects/packages/backup/src/dashboard/types/restore.ts
@@ -49,6 +49,25 @@ export function hasSelectedItems( items: RestoreItems ): boolean {
  * `success-with-errors` is its own terminal state rather than a shade of
  * either neighbour. A restore that finished but not cleanly should not
  * be dismissed as done, and should not be retried as if nothing landed.
+ *
+ * `lost-track` is separate from `error` for the same reason, and it
+ * matters more. The two say opposite things about the live site: `error`
+ * means nothing is running, `lost-track` means something probably is and
+ * we can no longer see it — either the silence deadline passed or the
+ * status poll stopped answering. Folding them together is not a wording
+ * problem. The screen offers "Try again" on `error`, which resets to an
+ * armed Confirm button, so a reader following the only control on screen
+ * would start a *second concurrent restore* of the same site, directly
+ * beneath a notice telling them the first may still be running. Nothing
+ * upstream is known to refuse that.
+ *
+ * The rule the split encodes: a retry is offered only when we know
+ * nothing is running.
+ *
+ * `detail` carries a transport failure's own text when there is one,
+ * shown beneath the shared message rather than replacing it — why we
+ * stopped seeing the restore is worth reporting, but it is not the
+ * headline.
  */
 export type RestoreState =
 	| { phase: 'idle' }
@@ -57,4 +76,5 @@ export type RestoreState =
 	| { phase: 'progress'; percent: number }
 	| { phase: 'success' }
 	| { phase: 'success-with-errors'; message: string }
+	| { phase: 'lost-track'; detail: string | null }
 	| { phase: 'error'; message: string };

--- a/projects/packages/backup/src/dashboard/utilities.scss
+++ b/projects/packages/backup/src/dashboard/utilities.scss
@@ -1,0 +1,41 @@
+// App-wide utility classes for the modernized Backup dashboard.
+// These are not the layout's own styles — the screens use them directly
+// (`jpb-text-muted` on captions, `jpb-visually-hidden` on the selection
+// live regions). They live in one file named for what they are rather
+// than inside a component folder, and `DashboardLayout` imports it
+// because it is the shell every screen renders inside: one mount point,
+// loaded once, wherever the class is used.
+
+// De-emphasized caption text. `@wordpress/ui`'s `Text` has no muted/color
+// prop, so the dimmed treatment lives here and is applied via className
+// alongside `variant="body-sm"`.
+.jpb-text-muted {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
+// Keeps an element in the accessibility tree while taking it out of the
+// visual layout. Used for a live region that has to stay mounted before
+// it has anything to say: assistive tech needs the region present in the
+// tree *before* its content changes, so a region that appears together
+// with its first message is unreliable — VoiceOver in particular often
+// misses it.
+
+// `position: absolute` is doing more work than hiding here. These regions
+// sit inside flex columns with a `gap`, and a gap applies between all
+// in-flow children no matter how small — so a zero-height placeholder
+// would still cost a full 16px of dead space on every render where the
+// message is absent, which is most of them. Taking it out of flow costs
+// nothing. `display: none` and `visibility: hidden` are both wrong: they
+// remove it from the accessibility tree too, which is the one thing this
+// has to preserve.
+.jpb-visually-hidden {
+	position: absolute;
+	inline-size: 1px;
+	block-size: 1px;
+	margin: -1px;
+	padding: 0;
+	border: 0;
+	overflow: hidden;
+	clip-path: inset(50%);
+	white-space: nowrap;
+}

--- a/projects/packages/backup/src/rest/class-download-bridge.php
+++ b/projects/packages/backup/src/rest/class-download-bridge.php
@@ -110,7 +110,7 @@ class Download_Bridge {
 		// empty selection as an omission would hand back the full archive
 		// the caller had just excluded. `/rewind/downloads` has no
 		// server-side guard of its own, unlike the v2 restore route.
-		if ( Rest_Controller::types_name_nothing( $types ) ) {
+		if ( Rest_Controller::request_names_no_types( $request ) ) {
 			return new WP_Error(
 				'no_types_selected',
 				__( 'Select at least one item to download.', 'jetpack-backup-pkg' ),

--- a/projects/packages/backup/src/rest/class-rest-controller.php
+++ b/projects/packages/backup/src/rest/class-rest-controller.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Backup\V0005\Jetpack_Backup;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Jetpack_Options;
 use WP_Error;
+use WP_REST_Request;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -30,11 +31,19 @@ class Rest_Controller {
 	 * Every category WPCOM's rewind endpoints recognize in a `types` map.
 	 *
 	 * The first six are the whole-site checklist the Restore and Download
-	 * screens render. `paths` is the granular selector, paired with
-	 * `include_path_list` / `exclude_path_list` — nothing sends it yet,
-	 * but it is part of the same documented contract and leaving it out
-	 * would make the file browser's granular download fail closed with a
-	 * confusing 400 the day it is wired up.
+	 * screens render.
+	 *
+	 * `paths` covers the granular *download* shape only — `types: { paths:
+	 * true }`, paired with `include_path_list` / `exclude_path_list`.
+	 * Nothing sends it yet (C3), but leaving it out would make the file
+	 * browser's granular download fail closed with a confusing 400 the day
+	 * it is wired up.
+	 *
+	 * It does not carry over to granular *restore*, whatever that ends up
+	 * spelling: the v1 route took `types: 'paths'` as a bare string, which
+	 * is not a map at all and would never reach this allowlist. Granular
+	 * restore has to establish its own shape against the v2 route before
+	 * anything here can claim to cover it.
 	 *
 	 * This list has to grow if VaultPress adds a category. WPCOM's own
 	 * route deliberately does not allowlist, so that it stays open to new
@@ -122,7 +131,7 @@ class Rest_Controller {
 	/**
 	 * Rebuild a restore/download `types` parameter as a named map.
 	 *
-	 * The PHP counterpart of the client's `serializeTypes`, and the reason
+	 * The PHP counterpart of the client's `requireTypes`, and the reason
 	 * it exists here rather than being trusted from the request: WordPress
 	 * validates `'type' => 'object'` with `rest_is_object()`, which is
 	 * `is_array()`. A JSON list therefore passes validation and arrives as
@@ -137,7 +146,7 @@ class Rest_Controller {
 	 * skip rather than select.
 	 *
 	 * Unknown keys are dropped rather than forwarded, which is what makes
-	 * `types_name_nothing()` a total guard: without it a payload naming
+	 * `request_names_no_types()` a total guard: without it a payload naming
 	 * only categories WPCOM does not recognize would satisfy the guard and
 	 * be sent on, and what WPCOM does with a `types` that matches nothing
 	 * is not characterized. Dropping them means such a payload names
@@ -165,7 +174,7 @@ class Rest_Controller {
 	}
 
 	/**
-	 * Whether a `types` parameter was supplied but names no category.
+	 * Whether the request supplied a `types` parameter that names no category.
 	 *
 	 * The distinction this draws is the whole point of the helper, and it
 	 * is the opposite of what it looks like. An **absent** `types` is a
@@ -177,15 +186,26 @@ class Rest_Controller {
 	 * omission would quietly upgrade "restore nothing" into "restore
 	 * everything", against a live site.
 	 *
+	 * It takes the request rather than the value because the value cannot
+	 * answer the question. `{"types": null}` is supplied and names nothing,
+	 * but arrives as the same `null` an omitted key does — and the schema
+	 * never sees it, since `WP_REST_Request::has_valid_params()` skips
+	 * `validate_callback` for a null param. `has_param()` is the only thing
+	 * that knows the key was on the wire.
+	 *
 	 * Nothing upstream catches it on both routes. The v2 restore route
 	 * rejects a `types` naming nothing, but `/rewind/downloads` does not,
 	 * so the guarantee has to be made here for the pair to behave alike.
 	 *
-	 * @param mixed $types Raw `types` parameter from the request, or null when absent.
+	 * @param WP_REST_Request $request The REST request.
 	 * @return bool True when the caller supplied a `types` that names no category.
 	 */
-	public static function types_name_nothing( $types ) {
-		return null !== $types && ! self::named_types( $types );
+	public static function request_names_no_types( WP_REST_Request $request ) {
+		if ( ! $request->has_param( 'types' ) ) {
+			return false;
+		}
+
+		return ! self::named_types( $request->get_param( 'types' ) );
 	}
 
 	/**

--- a/projects/packages/backup/src/rest/class-restore-bridge.php
+++ b/projects/packages/backup/src/rest/class-restore-bridge.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Restore REST bridge — proxies /activity-log/{site}/rewind/to and /rewind/{id}/restore-status.
+ * Restore REST bridge — proxies wpcom/v2 /sites/{site}/rewind/restores.
  *
  * @package automattic/jetpack-backup-plugin
  */
@@ -104,12 +104,10 @@ class Restore_Bridge {
 		// empty selection as an omission would overwrite the live site
 		// with exactly the parts the caller excluded.
 		//
-		// This bridge is currently the only guard on that: the call below
-		// still targets the v1 activity-log route, which has no such
-		// check. The v2 restore route does reject it, so once B1 repoints
-		// this there will be a second line of defence — but it will always
-		// be the slower one, since it only fires after the request leaves.
-		if ( Rest_Controller::types_name_nothing( $types ) ) {
+		// The v2 route this now calls rejects it too, so there are two
+		// lines of defence — but this is the one that matters, since the
+		// other only fires after the request has left the site.
+		if ( Rest_Controller::request_names_no_types( $request ) ) {
 			return new WP_Error(
 				'no_types_selected',
 				__( 'Select at least one item to restore.', 'jetpack-backup-pkg' ),

--- a/projects/packages/backup/src/rest/class-restore-bridge.php
+++ b/projects/packages/backup/src/rest/class-restore-bridge.php
@@ -72,14 +72,20 @@ class Restore_Bridge {
 	/**
 	 * Initiate a restore.
 	 *
-	 * Proxies POST rest/v1 /activity-log/{site}/rewind/to/{rewindId}.
+	 * Proxies POST wpcom/v2 /sites/{blog_id}/rewind/restores.
 	 *
-	 * Sign as the user: rewind is a destructive admin action and
-	 * WPCOM's audit log identifies the actor by their wpcom user.
-	 * (We tried as_blog v1.1 to side-step user-permission
-	 * requirements; WPCOM rejects it with `That API call is not
-	 * allowed for this account.` — the rewind endpoint refuses
-	 * blog-token auth entirely.)
+	 * This route exists because the v1 activity-log endpoint this used to
+	 * call could never work from wp-admin: the v1 JSON API discards
+	 * Jetpack user tokens by design, so `can_rewind()` evaluated an empty
+	 * user and every request came back 401. The permission rule is the
+	 * same on both — v1 simply had nobody logged in.
+	 *
+	 * Signed as the user, and that is not incidental: the guard upstream
+	 * is `can_rewind()`, which needs `upload_files` and `delete_users`
+	 * for a specific user id, so a bare blog token has no capabilities to
+	 * evaluate and is rejected. It is also the right answer on its own
+	 * terms — a restore is destructive and the activity log names the
+	 * person who started it.
 	 *
 	 * @param WP_REST_Request $request The REST request.
 	 * @return \WP_REST_Response|WP_Error
@@ -111,24 +117,33 @@ class Restore_Bridge {
 			);
 		}
 
-		$body = array( 'force_rewind' => true );
+		// The rewind id travels in the body, in full. The decimal suffix is
+		// significant — it is passed straight to VaultPress as the backup's
+		// timestamp, and truncating it addresses a different backup than
+		// the reader picked. (`toIntRewindId` belongs to the file-browser
+		// URL family only, whose route regex really is `\d+`.)
+		$request_body = array(
+			'rewindId'     => $rewind_id,
+			// Optional upstream, and it now defaults to false — but both
+			// this dashboard and Calypso have always sent true, so omitting
+			// it would be a silent behaviour change for existing callers.
+			'force_rewind' => true,
+		);
+
 		// Absent when the caller named no categories at all, which is how
 		// a whole-site restore is spelled upstream. Rebuilt as a named map
 		// otherwise — the same contract the download bridge follows.
 		$named_types = Rest_Controller::named_types( $types );
 		if ( ! empty( $named_types ) ) {
-			$body['types'] = $named_types;
+			$request_body['types'] = $named_types;
 		}
 
-		// `base_api_path` defaults to 'wpcom' on `as_user`, but the
-		// activity-log endpoints live under `rest/v1/...`
-		// (https://public-api.wordpress.com/rest/v1/activity-log/...).
 		$response = Client::wpcom_json_api_request_as_user(
-			sprintf( '/activity-log/%d/rewind/to/%s', $blog_id, rawurlencode( $rewind_id ) ),
-			'1',
+			sprintf( '/sites/%d/rewind/restores', $blog_id ),
+			'v2',
 			array( 'method' => 'POST' ),
-			$body,
-			'rest'
+			$request_body,
+			'wpcom'
 		);
 
 		if ( is_wp_error( $response ) ) {
@@ -144,22 +159,86 @@ class Restore_Bridge {
 			);
 		}
 
-		$body          = json_decode( wp_remote_retrieve_body( $response ), true );
-		$restore_id_in = is_array( $body ) && isset( $body['restore_id'] ) ? (int) $body['restore_id'] : 0;
-		if ( ! $restore_id_in ) {
+		$decoded = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $decoded ) ) {
+			$decoded = array();
+		}
+
+		// `ok` is the success signal, not the presence of an id.
+		//
+		// VaultPress does not reliably echo a restore id back — the
+		// underlying call's documented response is only `{ ok, error }` —
+		// so `restore_id: null` means "queued, id not known yet", which is
+		// a perfectly good outcome. Reading the id as the signal reported
+		// a successfully queued restore as a 500, and could not have
+		// distinguished the two cases anyway: `(int) null` and `(int) 0`
+		// are both `0`.
+		if ( empty( $decoded['ok'] ) ) {
 			return new WP_Error(
 				'restore_initiate_failed',
 				__( 'Could not start the backup restore.', 'jetpack-backup-pkg' ),
 				array( 'status' => 500 )
 			);
 		}
-		return rest_ensure_response( array( 'id' => $restore_id_in ) );
+
+		$restore_id_in = isset( $decoded['restore_id'] ) && null !== $decoded['restore_id']
+			? (int) $decoded['restore_id']
+			: null;
+
+		return rest_ensure_response(
+			array(
+				// Null is meaningful here and the client branches on it:
+				// the restore is running, and its id has to be recovered
+				// from the restores collection before progress can be
+				// polled.
+				'id'        => $restore_id_in,
+				'rewind_id' => isset( $decoded['rewind_id'] ) ? (string) $decoded['rewind_id'] : $rewind_id,
+			)
+		);
 	}
+
+	/**
+	 * WPCOM's restore statuses, mapped to the vocabulary the client uses.
+	 *
+	 * The client used to test for `in-progress`, `queued`, `finished` and
+	 * `failed`, none of which WPCOM has ever returned — so the poll never
+	 * recognised a live restore and no terminal state was reachable. That
+	 * went unnoticed because the v1 call this bridge used to make answered
+	 * 401 before any status could come back.
+	 *
+	 * Mapped here rather than in the client for the same reason the
+	 * download bridge derives its own status: the wire vocabulary is
+	 * WPCOM's to change, and one place to change it is better than three
+	 * string comparisons scattered through a state machine.
+	 *
+	 * `success-with-errors` is deliberately kept distinct instead of being
+	 * folded into either neighbour. A restore that completed but not
+	 * cleanly is neither a success the reader should walk away from nor a
+	 * failure they should retry blindly.
+	 *
+	 * @var array<string, string>
+	 */
+	private const STATUS_MAP = array(
+		'running'             => 'running',
+		'success'             => 'finished',
+		'success-with-errors' => 'finished-with-errors',
+		'fail'                => 'failed',
+		'aborted'             => 'aborted',
+	);
 
 	/**
 	 * Poll restore status.
 	 *
-	 * Proxies GET rest/v1 /activity-log/{site}/rewind/{restore_id}/restore-status.
+	 * Proxies GET wpcom/v2 /sites/{blog_id}/rewind/restores/{restore_id}.
+	 *
+	 * Signed `as_blog`, unlike its sibling. Starting a restore is
+	 * user-attributed and needs a user token; *watching* one does not —
+	 * this route falls through to `is_jetpack_authorized_for_site()`, the
+	 * same check the already-registered `GET /jetpack/v4/restores` relies
+	 * on. That is a real capability gain rather than a shortcut: progress
+	 * now survives the initiating user's session and is visible to any
+	 * admin, which is exactly the failure mode where someone closes the
+	 * tab mid-restore and can never see the outcome again.
 	 *
 	 * @param WP_REST_Request $request The REST request.
 	 * @return \WP_REST_Response|WP_Error
@@ -171,12 +250,12 @@ class Restore_Bridge {
 		}
 		$restore_id = (int) $request->get_param( 'restore_id' );
 
-		$response = Client::wpcom_json_api_request_as_user(
-			sprintf( '/activity-log/%d/rewind/%d/restore-status', $blog_id, $restore_id ),
-			'1',
+		$response = Client::wpcom_json_api_request_as_blog(
+			sprintf( '/sites/%d/rewind/restores/%d', $blog_id, $restore_id ),
+			'v2',
 			array(),
 			null,
-			'rest'
+			'wpcom'
 		);
 
 		if ( is_wp_error( $response ) ) {
@@ -184,6 +263,21 @@ class Restore_Bridge {
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );
+
+		// A 404 is the normal first answer, not a failure. A restore that
+		// has just been queued is not visible to this route yet, and the
+		// id may not even exist on our side (see `initiate_restore`, where
+		// VaultPress can decline to echo one). Reporting it as an error
+		// would turn the ordinary opening seconds of every restore into a
+		// user-visible failure.
+		//
+		// Safe to treat softly only because the upstream route now
+		// answers 502 for an unparseable VaultPress reply — before that, a
+		// 404 could quietly have meant "upstream is down".
+		if ( 404 === $status_code ) {
+			return rest_ensure_response( self::project_status( array(), $restore_id, 'queued' ) );
+		}
+
 		if ( 200 !== $status_code ) {
 			return new WP_Error(
 				'restore_status_fetch_failed',
@@ -192,20 +286,49 @@ class Restore_Bridge {
 			);
 		}
 
-		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		// The v2 payload is flat. The old nested `restore_status` unwrap is
+		// kept because it is what makes the flat shape work too — the
+		// fallback branch is the live path now, not the defensive one.
 		$status = is_array( $body ) && isset( $body['restore_status'] ) && is_array( $body['restore_status'] )
 			? $body['restore_status']
 			: ( is_array( $body ) ? $body : array() );
 
-		return rest_ensure_response(
-			array(
-				'id'         => isset( $status['restore_id'] ) ? (int) $status['restore_id'] : $restore_id,
-				'status'     => isset( $status['status'] ) ? (string) $status['status'] : 'queued',
-				'progress'   => isset( $status['percent'] ) ? (float) $status['percent'] : 0,
-				'rewind_id'  => isset( $status['rewind_id'] ) ? (string) $status['rewind_id'] : '',
-				'error_code' => isset( $status['error_code'] ) ? (string) $status['error_code'] : '',
-				'message'    => isset( $status['message'] ) ? (string) $status['message'] : '',
-			)
+		return rest_ensure_response( self::project_status( $status, $restore_id ) );
+	}
+
+	/**
+	 * Shape a restore-status payload for the client.
+	 *
+	 * @param array       $status   Upstream status fields, possibly empty.
+	 * @param int         $fallback Restore id to report when upstream names none.
+	 * @param string|null $force    Status to report regardless of the payload.
+	 * @return array
+	 */
+	private static function project_status( array $status, $fallback, $force = null ) {
+		$raw = isset( $status['status'] ) ? (string) $status['status'] : '';
+
+		if ( null !== $force ) {
+			$mapped = $force;
+		} elseif ( '' === $raw ) {
+			// Present but silent about status: the restore exists and has
+			// not started reporting yet.
+			$mapped = 'queued';
+		} else {
+			// Anything unrecognised is reported as such rather than
+			// guessed at. The client keeps polling through `unknown` under
+			// a bounded cap, so a status WPCOM adds later degrades into a
+			// slower answer instead of a frozen progress bar.
+			$mapped = self::STATUS_MAP[ $raw ] ?? 'unknown';
+		}
+
+		return array(
+			'id'         => isset( $status['restore_id'] ) ? (int) $status['restore_id'] : (int) $fallback,
+			'status'     => $mapped,
+			'progress'   => isset( $status['percent'] ) ? (float) $status['percent'] : 0,
+			'rewind_id'  => isset( $status['rewind_id'] ) ? (string) $status['rewind_id'] : '',
+			'error_code' => isset( $status['error_code'] ) ? (string) $status['error_code'] : '',
+			'message'    => isset( $status['message'] ) ? (string) $status['message'] : '',
 		);
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WP_Error;
+use WP_REST_Request;
 use WP_REST_Server;
 use function add_action;
 use function add_filter;
@@ -173,7 +174,7 @@ class Rest_Bridge_Gating_Test extends TestCase {
 				array(),
 			),
 			// Unknown keys are dropped rather than forwarded, which is what
-			// makes `types_name_nothing()` total: a payload naming only
+			// makes `request_names_no_types()` total: a payload naming only
 			// categories WPCOM does not know would otherwise satisfy the
 			// guard and be sent on, and what WPCOM does with a `types` that
 			// matches nothing is uncharacterized.
@@ -210,7 +211,7 @@ class Rest_Bridge_Gating_Test extends TestCase {
 	}
 
 	/**
-	 * `types_name_nothing()` separates "asked for everything" from
+	 * `request_names_no_types()` separates "asked for everything" from
 	 * "asked for nothing", which are one byte apart on the wire and
 	 * opposite in effect.
 	 *
@@ -220,37 +221,51 @@ class Rest_Bridge_Gating_Test extends TestCase {
 	 * that as an omission turns "restore nothing" into "restore
 	 * everything" against a live site.
 	 *
+	 * Driven through a real request rather than a bare value because the
+	 * value alone cannot tell the two apart for `null`.
+	 *
 	 * @param string $label    Case description.
+	 * @param bool   $supplied Whether the request carries a `types` key at all.
 	 * @param mixed  $input    Raw `types` parameter.
-	 * @param bool   $expected Whether the parameter names nothing.
+	 * @param bool   $expected Whether the request names nothing.
 	 * @dataProvider provide_empty_type_selections
 	 */
 	#[DataProvider( 'provide_empty_type_selections' )]
-	public function test_types_name_nothing( $label, $input, $expected ) {
-		$this->assertSame( $expected, Rest_Controller::types_name_nothing( $input ), $label );
+	public function test_request_names_no_types( $label, $supplied, $input, $expected ) {
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/to/1786663613.9425' );
+		if ( $supplied ) {
+			$request->set_param( 'types', $input );
+		}
+
+		$this->assertSame( $expected, Rest_Controller::request_names_no_types( $request ), $label );
 	}
 
 	/**
-	 * @return array<string, array{0: string, 1: mixed, 2: bool}>
+	 * @return array<string, array{0: string, 1: bool, 2: mixed, 3: bool}>
 	 */
 	public static function provide_empty_type_selections() {
 		return array(
 			// The one case that must NOT be refused.
-			'absent'             => array( 'absent', null, false ),
-			'names one category' => array( 'names one', array( 'themes' => true ), false ),
-			'empty object'       => array( 'empty object', array(), true ),
+			'absent'             => array( 'absent', false, null, false ),
+			// Supplied as null, which is the case a value-only helper
+			// cannot see. WordPress skips `validate_callback` for a null
+			// param, so the schema passes it through and `get_param()`
+			// answers exactly what an omitted key answers.
+			'supplied as null'   => array( 'supplied as null', true, null, true ),
+			'names one category' => array( 'names one', true, array( 'themes' => true ), false ),
+			'empty object'       => array( 'empty object', true, array(), true ),
 			// The case the allowlist exists for. A future client-side typo
 			// — a checklist key renamed `sqls` to `sql` — names nothing
 			// WPCOM recognizes, and is refused rather than forwarded.
-			'only unknown names' => array( 'only unknown names', array( 'sql' => true ), true ),
-			'granular paths'     => array( 'granular paths', array( 'paths' => true ), false ),
-			'every value false'  => array( 'every value false', array( 'themes' => false ), true ),
-			'form-encoded false' => array( 'form-encoded false', array( 'themes' => '0' ), true ),
+			'only unknown names' => array( 'only unknown names', true, array( 'sql' => true ), true ),
+			'granular paths'     => array( 'granular paths', true, array( 'paths' => true ), false ),
+			'every value false'  => array( 'every value false', true, array( 'themes' => false ), true ),
+			'form-encoded false' => array( 'form-encoded false', true, array( 'themes' => '0' ), true ),
 			// The shape the route schema cannot reject, because it
 			// constrains values rather than shape.
-			'list of booleans'   => array( 'list of booleans', array( true, false ), true ),
-			'list of names'      => array( 'list of names', array( 'themes' ), true ),
-			'scalar'             => array( 'scalar', 'themes', true ),
+			'list of booleans'   => array( 'list of booleans', true, array( true, false ), true ),
+			'list of names'      => array( 'list of names', true, array( 'themes' ), true ),
+			'scalar'             => array( 'scalar', true, 'themes', true ),
 		);
 	}
 

--- a/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
@@ -196,6 +196,12 @@ class Rest_Download_Bridge_Test extends TestCase {
 			'empty array'      => array( 'empty array', array() ),
 			'all false'        => array( 'all false', array( 'themes' => false ) ),
 			'list of booleans' => array( 'list of booleans', array( true, false ) ),
+			// Supplied as null, which the guard used to miss: WordPress
+			// skips `validate_callback` for a null param, so the schema
+			// passes it and `get_param()` answers exactly what an omitted
+			// key answers. Only `has_param()` can tell them apart.
+			'supplied as null' => array( 'supplied as null', null ),
+			'unknown names'    => array( 'unknown names', array( 'sql' => true ) ),
 		);
 	}
 

--- a/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
@@ -208,4 +208,219 @@ class Rest_Restore_Bridge_Test extends TestCase {
 		$this->assertSame( 'restore_status_fetch_failed', $response->get_error_code() );
 		$this->assertSame( 502, $response->get_error_data()['status'] );
 	}
+
+	/**
+	 * The rewind id goes in the body, in full, and the target is the v2
+	 * restores collection.
+	 *
+	 * The old target was the v1 activity-log route, which discards Jetpack
+	 * user tokens by design and answered 401 for every restore ever
+	 * attempted from wp-admin.
+	 */
+	public function test_initiate_targets_v2_with_the_full_rewind_id_in_the_body() {
+		$this->arrange_wpcom(
+			array(
+				'ok'         => true,
+				'restore_id' => 912682,
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/to/1786663613.9425' );
+		$request->set_param( 'rewind_id', '1786663613.9425' );
+		$request->set_param( 'types', array( 'themes' => true ) );
+		$response = Restore_Bridge::initiate_restore( $request );
+
+		$sent = (array) $this->captured_body;
+
+		$this->assertStringContainsString( '/sites/999/rewind/restores', $this->captured_url );
+		$this->assertStringNotContainsString( 'activity-log', $this->captured_url );
+		// In full: truncating the decimal addresses a different backup.
+		$this->assertSame( '1786663613.9425', $sent['rewindId'] );
+		$this->assertSame( array( 'themes' => true ), $sent['types'] );
+		$this->assertSame( 912682, $response->get_data()['id'] );
+	}
+
+	/**
+	 * `force_rewind` is sent explicitly.
+	 *
+	 * It is optional upstream and now defaults to false, so omitting it
+	 * would silently change behaviour for a caller that has always sent
+	 * true.
+	 */
+	public function test_initiate_sends_force_rewind_explicitly() {
+		$this->arrange_wpcom(
+			array(
+				'ok'         => true,
+				'restore_id' => 1,
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/to/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'types', array( 'sqls' => true ) );
+		Restore_Bridge::initiate_restore( $request );
+
+		$this->assertTrue( ( (array) $this->captured_body )['force_rewind'] );
+	}
+
+	/**
+	 * A null `restore_id` is a queued restore, not a failure.
+	 *
+	 * VaultPress does not reliably echo an id back — the documented
+	 * response for the underlying call is only `{ ok, error }`. Reading
+	 * the id as the success signal reported a successfully queued restore
+	 * as a 500, and could not tell null from zero in any case.
+	 */
+	public function test_initiate_treats_a_null_restore_id_as_queued() {
+		$this->arrange_wpcom(
+			array(
+				'ok'         => true,
+				'restore_id' => null,
+				'rewind_id'  => '1786663613.9425',
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/to/1786663613.9425' );
+		$request->set_param( 'rewind_id', '1786663613.9425' );
+		$request->set_param( 'types', array( 'themes' => true ) );
+		$response = Restore_Bridge::initiate_restore( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertNull( $response->get_data()['id'] );
+		// Echoed back so the client can find the restore in the collection.
+		$this->assertSame( '1786663613.9425', $response->get_data()['rewind_id'] );
+	}
+
+	/**
+	 * `ok: false` is the failure, whatever else the payload carries.
+	 */
+	public function test_initiate_reports_a_falsey_ok_as_failure() {
+		$this->arrange_wpcom(
+			array(
+				'ok'         => false,
+				'restore_id' => 42,
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/to/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'types', array( 'themes' => true ) );
+		$response = Restore_Bridge::initiate_restore( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'restore_initiate_failed', $response->get_error_code() );
+	}
+
+	/**
+	 * The status poll targets the v2 route and is signed with the blog
+	 * token.
+	 *
+	 * Watching a restore does not need a user, unlike starting one — which
+	 * is what lets progress survive the initiating user's session.
+	 */
+	public function test_status_targets_the_v2_route() {
+		$this->arrange_wpcom(
+			array(
+				'restore_id' => 912682,
+				'status'     => 'running',
+				'percent'    => 42,
+				'rewind_id'  => '1786663613.9425',
+				'message'    => 'Restoring wp-content/uploads',
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/912682/status' );
+		$request->set_param( 'restore_id', 912682 );
+		$data = Restore_Bridge::get_restore_status( $request )->get_data();
+
+		$this->assertStringContainsString( '/sites/999/rewind/restores/912682', $this->captured_url );
+		$this->assertSame( 'running', $data['status'] );
+		$this->assertSame( 42.0, $data['progress'] );
+		$this->assertSame( '1786663613.9425', $data['rewind_id'] );
+		$this->assertSame( 'Restoring wp-content/uploads', $data['message'] );
+	}
+
+	/**
+	 * WPCOM's status vocabulary is mapped to the client's.
+	 *
+	 * The client used to test for `in-progress`, `queued`, `finished` and
+	 * `failed` — none of which WPCOM returns — so no terminal state was
+	 * ever reachable and the poll stopped after one response.
+	 *
+	 * @param string $upstream WPCOM's status value.
+	 * @param string $expected What the bridge should report.
+	 * @dataProvider provide_statuses
+	 */
+	#[DataProvider( 'provide_statuses' )]
+	public function test_status_is_mapped( $upstream, $expected ) {
+		$this->arrange_wpcom(
+			array(
+				'restore_id' => 1,
+				'status'     => $upstream,
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/1/status' );
+		$request->set_param( 'restore_id', 1 );
+		$data = Restore_Bridge::get_restore_status( $request )->get_data();
+
+		$this->assertSame( $expected, $data['status'], "upstream: $upstream" );
+	}
+
+	/**
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public static function provide_statuses() {
+		return array(
+			'running'                 => array( 'running', 'running' ),
+			'success'                 => array( 'success', 'finished' ),
+			// Kept distinct rather than folded into either neighbour: a
+			// restore that completed but not cleanly is neither.
+			'success-with-errors'     => array( 'success-with-errors', 'finished-with-errors' ),
+			'fail'                    => array( 'fail', 'failed' ),
+			'aborted'                 => array( 'aborted', 'aborted' ),
+			// Anything WPCOM adds later is reported as unknown, which the
+			// client keeps polling through rather than freezing on.
+			'a status we do not know' => array( 'paused-for-lunch', 'unknown' ),
+			'absent'                  => array( '', 'queued' ),
+		);
+	}
+
+	/**
+	 * A 404 means "queued, not visible yet" — the normal first answer for
+	 * a restore that has only just been accepted.
+	 *
+	 * Mapping every non-200 to a hard error, as the v1 code did, turns the
+	 * opening seconds of every restore into a user-visible failure. Safe
+	 * to treat softly only because the route now answers 502 when
+	 * VaultPress returns nothing parseable, so a 404 can no longer
+	 * secretly mean "upstream is down".
+	 */
+	public function test_status_treats_404_as_queued() {
+		$this->arrange_wpcom( array( 'error' => 'not_found' ), 404 );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/7/status' );
+		$request->set_param( 'restore_id', 7 );
+		$response = Restore_Bridge::get_restore_status( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'queued', $response->get_data()['status'] );
+		$this->assertSame( 7, $response->get_data()['id'] );
+	}
+
+	/**
+	 * A 5xx is still a hard error — that is the half of the old behaviour
+	 * worth keeping.
+	 */
+	public function test_status_still_hard_errors_on_5xx() {
+		$this->arrange_wpcom( array( 'error' => 'rewind_error' ), 502 );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/7/status' );
+		$request->set_param( 'restore_id', 7 );
+		$response = Restore_Bridge::get_restore_status( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'restore_status_fetch_failed', $response->get_error_code() );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
+	}
 }

--- a/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
@@ -142,11 +142,6 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	 * once every category is named.
 	 */
 	public function test_initiate_allows_an_absent_types() {
-		// `restore_id` is what this bridge still reads as its success
-		// signal. That is wrong against the v2 contract, where `ok` is the
-		// signal and a null id means "queued" — but repointing the bridge
-		// is B1/B9, and this test only cares that the `types` guard stays
-		// out of the way.
 		$this->arrange_wpcom(
 			array(
 				'ok'         => true,
@@ -172,6 +167,13 @@ class Rest_Restore_Bridge_Test extends TestCase {
 			'empty array'      => array( 'empty array', array() ),
 			'all false'        => array( 'all false', array( 'themes' => false ) ),
 			'list of booleans' => array( 'list of booleans', array( true, false ) ),
+			// Supplied as null, which is the case the guard used to miss:
+			// WordPress skips `validate_callback` for a null param, so the
+			// schema passes it and `get_param()` answers exactly what an
+			// omitted key answers. Only `has_param()` can tell them apart,
+			// and getting it wrong means a whole-site restore.
+			'supplied as null' => array( 'supplied as null', null ),
+			'unknown names'    => array( 'unknown names', array( 'sql' => true ) ),
 		);
 	}
 

--- a/projects/packages/backup/tests/restore-lost-track.test.tsx
+++ b/projects/packages/backup/tests/restore-lost-track.test.tsx
@@ -1,0 +1,187 @@
+// A restore we can no longer see must not offer to start another one.
+//
+// The state machine reports two situations the reader cannot act on: the
+// silence deadline passing, and the status poll failing after the restore
+// was accepted. Both mean the same thing — WordPress.com took the
+// restore, it is very likely still running, and we have lost sight of it.
+//
+// Both used to land in the generic `error` phase, whose branch renders a
+// "Try again" button that resets the screen to an armed "Confirm
+// restore". So the only control beneath *"It may still be running —
+// you'll get an email when it finishes"* was one that starts a second
+// concurrent restore of the same site. Nothing upstream is known to
+// refuse that: `queue_restore()` calls `site_queue_rewind()` directly and
+// no in-flight check is visible from either repo.
+//
+// The rule these tests pin: a retry is offered only when we know nothing
+// is running.
+
+const mockApiFetch = jest.fn();
+const mockSearch = jest.fn< Record< string, unknown >, [] >();
+const mockNavigate = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => mockSearch(),
+	useNavigate: () => mockNavigate,
+	useParams: () => ( { rewindId: '1786663613.9425' } ),
+	Link: ( { children, to, ...rest }: { children: React.ReactNode; to: string } ) => (
+		<a href={ to } { ...rest }>
+			{ children }
+		</a>
+	),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { stage as RestoreStage } from '../routes/restore/stage';
+import { queryClient } from '../src/dashboard/data/query-client';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+const SETTLE = { timeout: 10000 };
+
+const RESTORE_ID = 912682;
+
+/**
+ * Answer capabilities and the initiate POST, then let the status poll do
+ * whatever the case under test needs.
+ *
+ * @param status - What each status poll does.
+ */
+function arrange( status: () => Promise< unknown > ) {
+	mockApiFetch.mockImplementation( ( o: { path?: string; method?: string } ) => {
+		const path = o?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		if ( o?.method === 'POST' ) {
+			return Promise.resolve( { id: RESTORE_ID, rewind_id: '1786663613.9425' } );
+		}
+		if ( path.includes( '/status' ) ) {
+			return status();
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockSearch.mockReset();
+	mockSearch.mockReturnValue( {} );
+	mockNavigate.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+/**
+ * Wait for the lost-track message.
+ *
+ * `findAllBy` rather than `findBy`: `Notice` mirrors its content into
+ * `@wordpress/a11y`'s live region, so the text is legitimately in the
+ * document twice and a single-match query throws.
+ */
+async function findMessage() {
+	await expect(
+		screen.findAllByText( /We've lost track of this restore/, undefined, SETTLE )
+	).resolves.not.toHaveLength( 0 );
+}
+
+/**
+ * Start a restore with the default six-of-six checklist.
+ */
+async function startRestore() {
+	await userEvent.click( await screen.findByRole( 'button', { name: /Confirm restore/ }, SETTLE ) );
+}
+
+describe( 'a restore that has gone out of sight', () => {
+	it( 'offers a way out, not a way to start another one', async () => {
+		arrange( () => Promise.reject( new Error( 'Could not reach WordPress.com.' ) ) );
+		render( <RestoreStage /> );
+
+		await startRestore();
+
+		await findMessage();
+
+		// The whole point. Either control would start a second restore:
+		// "Try again" resets to an armed Confirm, and Confirm submits.
+		expect( screen.queryByRole( 'button', { name: /Try again/ } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /Confirm restore/ } ) ).not.toBeInTheDocument();
+		// Not merely the button: the whole form is gone, so there is
+		// nothing left on screen that could submit.
+		expect(
+			screen.queryByRole( 'checkbox', { name: 'WordPress themes' } )
+		).not.toBeInTheDocument();
+
+		// Two: the back link that sits above the card on every phase, and
+		// the one this branch renders where "Try again" used to be. The
+		// count is what pins the second one.
+		expect( screen.getAllByRole( 'link', { name: /Back to overview/ } ) ).toHaveLength( 2 );
+	} );
+
+	it( 'reports why it lost sight, beneath the message rather than instead of it', async () => {
+		arrange( () => Promise.reject( new Error( 'Could not reach WordPress.com.' ) ) );
+		render( <RestoreStage /> );
+
+		await startRestore();
+
+		await findMessage();
+		expect( screen.getByText( 'Could not reach WordPress.com.' ) ).toBeInTheDocument();
+	} );
+
+	// Not an error notice: we have no evidence the restore failed, only
+	// that we cannot see it, and red would assert a failure we cannot
+	// observe. Asserted through the status label `Notice` renders
+	// visually-hidden — what a screen reader is actually told — rather
+	// than through its `is-warning` class, which is that package's
+	// implementation detail rather than a contract.
+	it( 'warns rather than reporting a failure', async () => {
+		arrange( () => Promise.reject( new Error( 'Could not reach WordPress.com.' ) ) );
+		render( <RestoreStage /> );
+
+		await startRestore();
+		await findMessage();
+
+		expect( screen.getByText( 'Warning notice' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Error notice' ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'a restore that definitely is not running', () => {
+	// The other side of the rule: when the restore reached a terminal
+	// failure there is nothing in flight, so a retry is the right offer.
+	it( 'still offers Try again when the restore failed', async () => {
+		arrange( () =>
+			Promise.resolve( {
+				id: RESTORE_ID,
+				status: 'failed',
+				progress: 0,
+				rewind_id: '1786663613.9425',
+				error_code: '',
+				message: 'Restore aborted.',
+			} )
+		);
+		render( <RestoreStage /> );
+
+		await startRestore();
+
+		// `findAllBy` for the same reason as `findMessage`: `Notice` mirrors
+		// its text into the live region.
+		await expect(
+			screen.findAllByText( 'Restore aborted.', undefined, SETTLE )
+		).resolves.not.toHaveLength( 0 );
+		expect( screen.getByRole( 'button', { name: /Try again/ } ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Error notice' ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
> **#51336 has merged and this is now rebased on trunk.** That PR contained B6, a hard prerequisite: repointing restore while an empty checklist still omits `types` turns "restore nothing" into a full destructive restore.

## Proposed changes

**B1, B2, B4** (restore half), **B8**, and the two remaining **B9** bridge fixes. Behind `rsm_jetpack_ui_modernization_backup`, default off; `src/js/` untouched.

### Why restore has never worked from wp-admin

Not a bug in the request — a structural one. The flow called the v1 activity-log route, and **the v1 JSON API discards Jetpack user tokens by design**: `wp_set_current_user(0)` has already run by the time the permission check evaluates `can_rewind()`, so it short-circuits on an empty user id and every attempt came back `401`. The permission rule is identical on v2; v1 simply had nobody logged in. Calypso's byte-identical v1 request succeeds only because OAuth2 sets a real user.

A1/A2 shipped the v2 routes that fix that. This moves both calls onto them.

### Repointing the URLs would not have been enough

Four things break on day one, and they are the substance of this PR.

**1. The client's status vocabulary was wrong in every value.** It tested for `in-progress`, `queued`, `finished`, `failed`. WordPress.com says `running | success | fail | aborted | success-with-errors`. **None of the four appear in the real enum**, so no terminal state was reachable and the poll stopped after a single response. It went unnoticed only because the v1 call 401'd before a status could ever come back — the whole state machine was unreachable rather than merely wrong.

The bridge now maps the real enum to a closed union, for the same reason the download bridge derives its own status: the wire vocabulary is WordPress.com's to change, and one place to change it beats three string comparisons scattered through a state machine.

`success-with-errors` gets **its own state** rather than being folded into either neighbour. A restore that completed but not cleanly should not be dismissed as done, and should not be retried as though nothing landed.

**2. `ok` is the success signal, not the presence of an id.** VaultPress does not reliably echo a `restore_id` — the documented response for the underlying call is only `{ ok, error }`. The old check was `! (int) $body['restore_id']`, which reported a **successfully queued restore as a 500**, and could not have told `null` from `0` in any case. A null id now means "queued"; the client recovers the real one by matching the rewind id against `GET /jetpack/v4/restores`.

**3. A 404 from the status route is the normal first answer.** A restore that was just accepted is not visible to that route yet. The old code mapped every non-200 to a hard error, which would have turned the opening seconds of every restore into a user-visible failure. It is safe to soften this *only* because the route now answers `502` for an unparseable VaultPress reply — before that, a 404 could quietly have meant "upstream is down".

The poll interval also goes from **1.5s to 5s**, and sets the recovery poll's cadence as well. A restore is a long operation reported as a coarse percentage, so a sub-second cadence buys no responsiveness and costs a WordPress.com round trip per tick for its whole duration.

**4. The poll now fails safe in the opposite direction.** It stops on a terminal status, and keeps going through anything unrecognised under a **five-minute silence timeout measured from the last `running` reading** — so a two-hour restore of a large site is never cut off, but nothing sits forever either. The behaviour this replaces was a progress bar frozen at its first value with no timeout and no escape.

### One capability gain worth calling out

The status poll is signed **`as_blog`**. Starting a restore is user-attributed and needs a user token — correctly, since it drives the activity-log entry and the completion email. *Watching* one does not: that route falls through to `is_jetpack_authorized_for_site()`, the same check the already-registered `GET /jetpack/v4/restores` uses.

So restore progress now survives the initiating user's session and is visible to any admin — which is exactly the failure mode where someone closes the tab mid-restore and can never see the outcome again.

### Tests

`use-restore.ts` had **no test at all** — the only stateful logic in the app, and the one place a bug costs someone their site rather than their patience (J2). Adds 13 cases covering every terminal state, the no-id recovery path, the unrecognised-status case, and mid-poll network failure.

The bridge gains 12 cases: the v2 target and full rewind id in the body, explicit `force_rewind`, null-id-as-queued, `ok: false` as failure, the full status mapping table, 404-as-queued, and 5xx still hard-erroring.

**264 jest** (up from 241), **189 phpunit** (up from 170). tsgo, ESLint, stylelint, PHPCS, PHP 7.2+ compatibility, Phan `0 issues`.

### Review round

`09f8991` answers the review, and fixes a blocker in the state machine above.

**The silence deadline never fired in the no-id case** — the scenario the recovery path exists for. It was evaluated during render, which only works while something is re-rendering, and with `restoreId === null` nothing is: the status query is disabled, the recovery poll is the only thing running, and a refetch that keeps returning the same empty list is structurally shared into the same array, so React Query's observer never notifies. The screen sat on *"queued and will begin shortly…"* indefinitely, right after telling the reader a destructive operation was about to start. It is enforced by a timer now, restarted by each sign of life. Four new cases cover it, three of which fail against the previous commit.

`queued` deliberately does **not** count as a sign of life. WordPress.com's enum is `running | success | fail | aborted | success-with-errors` — there is no `queued` in it, so every `queued` the client sees is minted by our own bridge and overwhelmingly means *404, not visible to this route*. Resetting the deadline on it would poll forever.

`533255` answers the second round, which found that the new state reused the generic `error` phase — and so inherited a **"Try again" button that starts a second concurrent restore**, directly beneath a notice saying the first may still be running. `lost-track` is its own phase now, offering the way out instead of the retry. The mid-poll transport failure moves with it, for the same reason and with the stronger claim: losing the connection says nothing about the restore. The rule, stated on the type: *a retry is offered only when we know nothing is running.*

Also in that commit, from #51336's review: **`{"types": null}` no longer reads as an absent `types`** on either rewind bridge. WordPress skips `validate_callback` for a null param, so the schema passed it and `get_param()` answered exactly what an omitted key answers — a whole-site operation. The guard takes the request now, since only `has_param()` can tell the two apart. Plus a rewind-id match that tolerates decimal formatting drift, a `CATEGORIES` docblock that no longer over-promises `paths` for granular *restore*, and three small cleanups.

### Deliberately not in scope

- **B3** — adopting a restore already running when the screen mounts. The plumbing this PR adds (`fetchRecentRestores`) is most of what it needs, but mount-time adoption changes observable behaviour and deserves its own review.
- **B5** — validating the rewind id before arming the form. `/restore/not-a-real-id` still renders a live Confirm button with the restore-point line silently omitted.
- **D2** — mapping WordPress.com's error codes to translated messages. The codes to map are known (`412 no_connected_jetpack`, `401 authorization_required`, `500`/`502 rewind_error`) but `ApiError.code` has no consumer yet, so the mapping buys nothing until a client-side branch exists.

## Related product discussion/links

* [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243/backup-modernized-dashboard-work-needed-before-the-flag-can-flip) — B1, B2, B4 (restore half), B8, B9
* Depends on #51336 (B6) — see the note at the top
* wpcom A1/A2 are merged and deployed

## Does this pull request change what data or activity we track or use?

No new tracking. One access change worth noting for the record: restore *progress* is now readable with a blog token rather than requiring the initiating user's token. That matches the sibling route the plugin already calls the same way, and the progress `message` can contain file paths from the site's own backup — so a site token can read paths belonging to that same site, and nothing else.

## Testing instructions

Restore genuinely runs against WordPress.com, so the honest test needs a site with an active Backup plan and a real restore point. Turn the flag on first:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

**Flag off — confirm nothing changed.** The legacy Backup page should be identical.

**1. A real restore.** From **Jetpack → Backup**, pick a restore point → **Restore to this point** → leave all six ticked → **Confirm restore**.

* The screen shows *"Your restore is queued and will begin shortly…"* with an indeterminate bar, then switches to *"Restoring…"* with a real percentage.
* It reaches **Restore complete.** Before this change it 401'd immediately and showed *"Could not start the backup restore."*
* Check the request in the network tab: it should go to `/jetpack/v4/rewind/to/<id>`, and the bridge should target `wpcom/v2 /sites/<blog>/rewind/restores` with the **full** rewind id in the body.

**2. Progress survives the tab.** While a restore is running, reload the page and navigate back to the restore screen from a different browser — progress is readable with the blog token now.

**3. The states that are hard to reach naturally.** Intercept the outbound call and answer as WordPress.com would:

```php
add_filter( 'pre_http_request', function ( $pre, $args, $url ) {
	if ( false === strpos( $url, '/rewind/restores/' ) ) {
		return $pre;
	}
	$body = array( 'restore_id' => 1, 'status' => 'success-with-errors', 'percent' => 100, 'message' => '3 files could not be written.' );
	// 404 instead, to see the queued state:
	// return array( 'response' => array( 'code' => 404 ), 'body' => '{}' );
	return array( 'response' => array( 'code' => 200 ), 'body' => wp_json_encode( $body ) );
}, 10, 3 );
```

* `success-with-errors` → an amber *"Restore finished, but some items could not be restored."* with the detail beneath — **not** a success notice, and **not** an error offering a pointless retry.
* `404` → stays in the queued state and keeps polling, rather than reporting a failure.
* An unrecognised status (`"paused-for-lunch"`) → also stays queued and keeps polling, instead of freezing.

**4. Empty checklist still refused** (from #51336): clear all six, and the Confirm button stays disabled with a reason.


