### PR TITLE
Charts: keep the band time axis dense when it reaches for an anchor

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-band-axis-tick-values
+++ b/projects/js-packages/charts/changelog/fix-charts-band-axis-tick-values
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Charts: choose the tick values for a bar chart's time axis instead of sampling the band domain by index, so the axis stops skipping the tick that names the year or dates the day and no longer repeats a label.
+Charts: keep the year and the day on a bar chart's time axis, which could previously skip the tick that named them, and stop the same label falling on two ticks in a row.

--- a/projects/js-packages/charts/changelog/fix-charts-band-tick-density
+++ b/projects/js-packages/charts/changelog/fix-charts-band-tick-density
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: stop a bar chart's time axis dropping to a couple of ticks when it reaches for the year, and speed up how it picks them.

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -207,6 +207,13 @@ const monthlyPoints: Array< [ Date, number ] > = Array.from( { length: 36 }, ( _
 	Math.round( 60 + 40 * Math.sin( i / 2 ) ),
 ] );
 
+// A span that is neither a whole number of years nor aligned to one: reaching
+// for its single January is what used to cost the rest of the axis.
+const partYearMonthlyPoints: Array< [ Date, number ] > = Array.from( { length: 30 }, ( _, i ) => [
+	new Date( 2023, 3 + i, 1 ),
+	Math.round( 60 + 40 * Math.sin( i / 2 ) ),
+] );
+
 const yearlyPoints: Array< [ Date, number ] > = [ 72, 95, 58, 86 ].map( ( value, i ) => [
 	new Date( 2023 + i, 0, 1 ),
 	value,
@@ -264,6 +271,10 @@ export const TimeAxisTickFormats: Story = {
 				title="Monthly buckets over three years → month ticks, every tick at January"
 				data={ timeAxisSeries( monthlyPoints ) }
 			/>
+			<TimeAxisPanel
+				title="Monthly buckets, two and a half years → month ticks, year at January"
+				data={ timeAxisSeries( partYearMonthlyPoints ) }
+			/>
 			<TimeAxisPanel title="Yearly buckets → year ticks" data={ timeAxisSeries( yearlyPoints ) } />
 		</div>
 	),
@@ -275,7 +286,7 @@ export const TimeAxisTickFormats: Story = {
 		docs: {
 			description: {
 				story:
-					"Date-based series share the time-axis tick formatter with the line and area charts, on the same data — compare these panels with the line chart's `TimeAxisTickFormats`. Month-or-coarser buckets follow the resolution alone — month names with the year at January, or plain years for yearly buckets — since they carry no day to print at any span. Daily-or-finer buckets narrow with the span: hour ticks within a day, hour ticks dated at midnight for sub-daily data spanning up to a week, calendar dates within a year, and years beyond that. The tick values are chosen rather than sampled: a band scale has no ticks of its own, so picking evenly by index would often skip the very bucket that carries the year or the date. Neither monthly panel starts in January, and both still name their years; the week-long and three-year panels step whole days and whole years, since at those spans nothing closer together reaches a boundary at all. Hover any bar: the tooltip names that bar's bucket spelled out in full — `August 2026` for a monthly bar, `2026` for a yearly one, never a day the bucket doesn't carry. It always names the bucket's own granularity, so on the daily panel it stays finer than the ticks once a long span coarsens the axis. An explicit `options.axis.x.tickFormat` still overrides.",
+					"Date-based series share the time-axis tick formatter with the line and area charts, on the same data — compare these panels with the line chart's `TimeAxisTickFormats`. Month-or-coarser buckets follow the resolution alone — month names with the year at January, or plain years for yearly buckets — since they carry no day to print at any span. Daily-or-finer buckets narrow with the span: hour ticks within a day, hour ticks dated at midnight for sub-daily data spanning up to a week, calendar dates within a year, and years beyond that. The tick values are chosen rather than sampled: a band scale has no ticks of its own, so picking evenly by index would often skip the very bucket that carries the year or the date. None of the monthly panels starts in January, and all three still name their years, the shortest of them without thinning the axis to reach one; the week-long and three-year panels step whole days and whole years, since at those spans nothing closer together reaches a boundary at all. Hover any bar: the tooltip names that bar's bucket spelled out in full — `August 2026` for a monthly bar, `2026` for a yearly one, never a day the bucket doesn't carry. It always names the bucket's own granularity, so on the daily panel it stays finer than the ticks once a long span coarsens the axis. An explicit `options.axis.x.tickFormat` still overrides.",
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
+++ b/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
@@ -314,7 +314,7 @@ describe( 'getBandTickValues', () => {
 	} );
 
 	it( 'keeps the dated midnight ticks for sub-daily data spanning days', () => {
-		// Every bare hour tick needs a dated one before it to say which day it is.
+		// Index sampling already lands here; this pins that the steering keeps it.
 		expect( labelsFor( hourlyDomain( new Date( 2026, 7, 2 ), 48 ) ) ).toEqual( [
 			'Aug 2',
 			'12 PM',
@@ -351,9 +351,36 @@ describe( 'getBandTickValues', () => {
 	} );
 
 	it( 'never repeats a label on adjacent ticks', () => {
-		const labels = labelsFor( monthlyDomain( 2024, 0, 36 ) );
+		// 49 buckets put every fourth tick a whole year apart, so sampling by index
+		// spells the same month five times over: Feb, Feb, Feb, Feb, Feb.
+		const labels = labelsFor( monthlyDomain( 2023, 1, 49 ) );
 
 		expect( labels.some( ( label, i ) => i > 0 && label === labels[ i - 1 ] ) ).toBe( false );
+	} );
+
+	it( 'keeps the axis dense when only a sparser one could reach an anchor', () => {
+		// Ranking anchors above everything picked the two ticks that happened to be
+		// Januaries and dropped the rest of the axis with them.
+		expect( labelsFor( monthlyDomain( 2023, 3, 30 ) ) ).toEqual( [ 'Apr', '2024', 'Oct', 'Jul' ] );
+	} );
+
+	it( 'names the single year of a short series without thinning the axis to it', () => {
+		expect( labelsFor( monthlyDomain( 2023, 6, 9 ) ) ).toEqual( [ 'Jul', 'Oct', '2024' ] );
+	} );
+
+	it( 'reaches anchors that sit an uneven number of buckets apart', () => {
+		// A spring-forward day is 23 hourly buckets, not 24, so a fixed stride
+		// slides off midnight and leaves the rest of the week on bare hours.
+		const domain: Date[] = [];
+		for ( let day = 0; day < 7; day++ ) {
+			for ( let hour = 0; hour < 24; hour++ ) {
+				if ( day !== 2 || hour !== 2 ) {
+					domain.push( new Date( 2026, 2, 6 + day, hour ) );
+				}
+			}
+		}
+
+		expect( labelsFor( domain ) ).toEqual( [ 'Mar 6', 'Mar 8', 'Mar 10', 'Mar 12' ] );
 	} );
 
 	it( 'keeps the whole domain when it already fits', () => {

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -33,20 +33,31 @@ export const getCurveType = ( type?: CurveType, smoothing?: boolean ): typeof cu
 	}
 };
 
-const formatYearTick = ( timestamp: number ) => {
-	const date = new Date( timestamp );
-	return date.toLocaleDateString( undefined, { year: 'numeric' } );
+// Built once and reused: these run per bucket over the whole band domain when
+// the axis picks its tick values, and `toLocaleDateString` rebuilds its
+// formatter on every call once an options object is passed.
+const dateTimeFormat = ( options: Intl.DateTimeFormatOptions ) => {
+	let formatter: Intl.DateTimeFormat;
+	return ( timestamp: number ) => {
+		// `Intl.DateTimeFormat` throws on an invalid date where the `Date`
+		// methods it replaces return "Invalid Date", and charts are expected to
+		// render past a bad point rather than fail.
+		// visx hands its tick formatter a `Date`, so coerce before the check.
+		if ( ! Number.isFinite( Number( timestamp ) ) ) {
+			return new Date( timestamp ).toLocaleDateString();
+		}
+		formatter = formatter ?? new Intl.DateTimeFormat( undefined, options );
+		return formatter.format( timestamp );
+	};
 };
 
-const formatDateTick = ( timestamp: number ) => {
-	const date = new Date( timestamp );
-	return date.toLocaleDateString( undefined, { month: 'short', day: 'numeric' } );
-};
+const formatYearTick = dateTimeFormat( { year: 'numeric' } );
 
-const formatHourTick = ( timestamp: number ) => {
-	const date = new Date( timestamp );
-	return date.toLocaleTimeString( undefined, { hour: 'numeric', hour12: true } );
-};
+const formatDateTick = dateTimeFormat( { month: 'short', day: 'numeric' } );
+
+const formatHourTick = dateTimeFormat( { hour: 'numeric', hour12: true } );
+
+const formatMonthTick = dateTimeFormat( { month: 'short' } );
 
 // Hour ticks with the date at midnight boundaries, so multi-day spans of
 // sub-daily data keep their days identifiable.
@@ -61,9 +72,7 @@ const formatDateOrHourTick = ( timestamp: number ) => {
 // buckets where a full "Sep 1" date would misread as a daily point.
 const formatMonthOrYearTick = ( timestamp: number ) => {
 	const date = new Date( timestamp );
-	return date.getMonth() === 0
-		? formatYearTick( timestamp )
-		: date.toLocaleDateString( undefined, { month: 'short' } );
+	return date.getMonth() === 0 ? formatYearTick( timestamp ) : formatMonthTick( timestamp );
 };
 
 // Overall time span of the data. Series with no dated points are dropped rather
@@ -189,14 +198,38 @@ const TICK_ANCHORS = new Map< ( timestamp: number ) => string, ( date: Date ) =>
 	[ formatMonthOrYearTick, date => date.getMonth() === 0 ],
 ] );
 
-// Index distance between consecutive anchor buckets, or null below two of them.
-// The steps that can land on more than one anchor are the ones that divide it
-// and the ones that are whole multiples of it.
-const getAnchorPeriod = ( domain: Date[], isAnchor: ( date: Date ) => boolean ) => {
-	const first = domain.findIndex( isAnchor );
-	const second = domain.findIndex( ( date, index ) => index > first && isAnchor( date ) );
+// Indices of the buckets whose label carries the coarser unit.
+const getAnchorIndices = ( domain: Date[], isAnchor: ( date: Date ) => boolean ) =>
+	domain.reduce< number[] >( ( indices, date, index ) => {
+		if ( isAnchor( date ) ) {
+			indices.push( index );
+		}
+		return indices;
+	}, [] );
 
-	return first < 0 || second < 0 ? null : second - first;
+// Index strides worth sampling the domain at. Both roundings of each tick count
+// are needed: flooring alone skips the stride that fits a mid-series anchor on
+// short domains. Anchors add the strides that can land on more than one of them
+// — those dividing their spacing, and the smallest whole multiple that still
+// fits, which carries spans too long for any divisor to reach.
+const getCandidateSteps = ( length: number, maxTicks: number, anchorSpacing: number | null ) => {
+	const steps = new Set< number >();
+	for ( let count = maxTicks; count > 1; count-- ) {
+		steps.add( Math.max( 1, Math.floor( ( length - 1 ) / ( count - 1 ) ) ) );
+		steps.add( Math.max( 1, Math.ceil( ( length - 1 ) / ( count - 1 ) ) ) );
+	}
+
+	if ( anchorSpacing ) {
+		for ( let divisor = 1; divisor <= anchorSpacing; divisor++ ) {
+			if ( anchorSpacing % divisor === 0 ) {
+				steps.add( anchorSpacing / divisor );
+			}
+		}
+		const minStep = Math.floor( ( length - 1 ) / Math.max( 1, maxTicks ) ) + 1;
+		steps.add( Math.ceil( minStep / anchorSpacing ) * anchorSpacing );
+	}
+
+	return steps;
 };
 
 /**
@@ -205,10 +238,10 @@ const getAnchorPeriod = ( domain: Date[], isAnchor: ( date: Date ) => boolean ) 
  * visx samples a band domain by index from offset zero, blind to which labels
  * carry a boundary and without collapsing repeats — so the tick that prints the
  * year or the date often isn't sampled at all, and a long series can show the
- * same label twice. Choose the values instead: keep the even spacing, but slide
- * the offset onto the anchor buckets — stepping by whole anchor periods once the
- * span is too long to reach them any other way — and reject any step that would
- * put two identical labels side by side.
+ * same label twice. Choose the values instead: sweep the evenly spaced
+ * candidates, including those that step from anchor to anchor, and keep the one
+ * that reaches the most anchors without thinning the axis or putting two
+ * identical labels side by side.
  *
  * @param domain        - Band domain, in axis order.
  * @param tickFormatter - Formatter the axis will render these values with.
@@ -225,58 +258,64 @@ export const getBandTickValues = (
 	}
 
 	const isAnchor = TICK_ANCHORS.get( tickFormatter );
-
-	const steps = new Set< number >();
-	for ( let count = maxTicks; count > 1; count-- ) {
-		steps.add( Math.max( 1, Math.floor( ( domain.length - 1 ) / ( count - 1 ) ) ) );
-	}
-	const anchorPeriod = isAnchor ? getAnchorPeriod( domain, isAnchor ) : null;
-	for ( let divisor = 1; divisor <= ( anchorPeriod ?? 0 ); divisor++ ) {
-		if ( anchorPeriod % divisor === 0 ) {
-			steps.add( anchorPeriod / divisor );
-		}
-	}
-	if ( anchorPeriod ) {
-		// A divisor reaches every anchor but outruns `maxTicks` beyond a few
-		// periods, which would leave a week of hourly buckets naming one day out
-		// of seven. Whole multiples carry those longer spans, and the smallest one
-		// that still fits is the densest, so it reaches the most anchors.
-		const minStep = Math.floor( ( domain.length - 1 ) / Math.max( 1, maxTicks ) ) + 1;
-		steps.add( Math.ceil( minStep / anchorPeriod ) * anchorPeriod );
-	}
+	const anchorIndices = isAnchor ? getAnchorIndices( domain, isAnchor ) : [];
 
 	// Once per bucket rather than once per bucket per candidate: the sweep reads
-	// the same labels back for every step and offset, and these formatters go
-	// through `toLocaleDateString`.
+	// the same labels back for every step and offset.
 	const domainLabels = domain.map( date => tickFormatter( date.getTime() ) );
 
-	let best: { values: Date[]; anchors: number } | null = null;
-	for ( const step of steps ) {
+	const candidates: number[][] = [];
+	const consider = ( indices: number[] ) => {
+		if ( ! indices.length || indices.length > maxTicks ) {
+			return;
+		}
+		const repeats = indices.some(
+			( index, position ) =>
+				position > 0 && domainLabels[ index ] === domainLabels[ indices[ position - 1 ] ]
+		);
+		if ( ! repeats ) {
+			candidates.push( indices );
+		}
+	};
+
+	const anchorSpacing = anchorIndices.length > 1 ? anchorIndices[ 1 ] - anchorIndices[ 0 ] : null;
+	for ( const step of getCandidateSteps( domain.length, maxTicks, anchorSpacing ) ) {
 		for ( let offset = 0; offset < step; offset++ ) {
-			const values: Date[] = [];
-			const labels: string[] = [];
+			const indices: number[] = [];
 			for ( let index = offset; index < domain.length; index += step ) {
-				values.push( domain[ index ] );
-				labels.push( domainLabels[ index ] );
+				indices.push( index );
 			}
-			if ( ! values.length || values.length > maxTicks ) {
-				continue;
-			}
-
-			if ( labels.some( ( label, index ) => index > 0 && label === labels[ index - 1 ] ) ) {
-				continue;
-			}
-
-			// The anchors first, then the denser axis.
-			const anchors = isAnchor ? values.filter( isAnchor ).length : 0;
-			const denser = anchors === best?.anchors && values.length > best.values.length;
-			if ( ! best || anchors > best.anchors || denser ) {
-				best = { values, anchors };
-			}
+			consider( indices );
 		}
 	}
 
-	return best ? best.values : [ domain[ 0 ] ];
+	// Stepping the anchors themselves rather than the domain, so that anchors an
+	// uneven number of buckets apart are still all reachable — a wall-clock day
+	// is 23 buckets of hourly data across a spring-forward DST transition, and a
+	// fixed stride drifts off midnight for the rest of the span.
+	for ( let stride = 1; stride <= anchorIndices.length; stride++ ) {
+		consider( anchorIndices.filter( ( _, position ) => position % stride === 0 ) );
+	}
+
+	if ( ! candidates.length ) {
+		return [ domain[ 0 ] ];
+	}
+
+	// An anchor is worth at most one tick. Ranking anchors above density outright
+	// collapsed ordinary monthly axes to two ticks — worse than sampling by index,
+	// which at least stayed dense — while ignoring anchors leaves the year unnamed.
+	const densest = candidates.reduce( ( most, indices ) => Math.max( most, indices.length ), 0 );
+	const anchorsIn = ( indices: number[] ) =>
+		isAnchor ? indices.filter( index => isAnchor( domain[ index ] ) ).length : 0;
+
+	const best = candidates
+		.filter( indices => indices.length >= densest - 1 )
+		.reduce( ( chosen, indices ) => {
+			const gain = anchorsIn( indices ) - anchorsIn( chosen );
+			return gain > 0 || ( gain === 0 && indices.length > chosen.length ) ? indices : chosen;
+		} );
+
+	return best.map( index => domain[ index ] );
 };
 
 // Estimate the largest number of x-axis ticks that fit without producing

--- a/projects/plugins/jetpack/changelog/fix-charts-band-axis-tick-values
+++ b/projects/plugins/jetpack/changelog/fix-charts-band-axis-tick-values
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Premium Analytics: keep the year and the day on the traffic chart's time axis, which could previously skip the tick that named them and repeat a label instead.
+Premium Analytics: keep the year and the day on the traffic chart's time axis, which could previously skip the tick that named them, and stop the same label falling on two ticks in a row.

--- a/projects/plugins/jetpack/changelog/fix-charts-band-tick-density
+++ b/projects/plugins/jetpack/changelog/fix-charts-band-tick-density
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: keep the full set of ticks on the traffic chart's time axis, which could thin out to two labels on longer date ranges.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-band-axis-tick-values
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-band-axis-tick-values
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: keep the year and the day on the traffic chart's time axis, which could previously skip the tick that named them and repeat a label instead.
+Premium Analytics: keep the year and the day on the traffic chart's time axis, which could previously skip the tick that named them, and stop the same label falling on two ticks in a row.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-band-tick-density
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-band-tick-density
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: keep the full set of ticks on the traffic chart's time axis, which could thin out to two labels on longer date ranges.

--- a/projects/plugins/premium-analytics/changelog/fix-charts-band-axis-tick-values
+++ b/projects/plugins/premium-analytics/changelog/fix-charts-band-axis-tick-values
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Keep the year and the day on bar chart time axes, which could previously skip the tick that named them and repeat a label instead.
+Keep the year and the day on bar chart time axes, which could previously skip the tick that named them, and stop the same label falling on two ticks in a row.

--- a/projects/plugins/premium-analytics/changelog/fix-charts-band-tick-density
+++ b/projects/plugins/premium-analytics/changelog/fix-charts-band-tick-density
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the full set of ticks on bar chart time axes, which could thin out to two labels on longer date ranges.

--- a/projects/plugins/wpcomsh/changelog/fix-charts-band-axis-tick-values
+++ b/projects/plugins/wpcomsh/changelog/fix-charts-band-axis-tick-values
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: keep the year and the day on the traffic chart's time axis, which could previously skip the tick that named them and repeat a label instead.
+Premium Analytics: keep the year and the day on the traffic chart's time axis, which could previously skip the tick that named them, and stop the same label falling on two ticks in a row.

--- a/projects/plugins/wpcomsh/changelog/fix-charts-band-tick-density
+++ b/projects/plugins/wpcomsh/changelog/fix-charts-band-tick-density
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: keep the full set of ticks on the traffic chart's time axis, which could thin out to two labels on longer date ranges.


### PR DESCRIPTION
Fixes #

Follow-up to #51275, found by a local review pass before the code had shipped anywhere.

## Proposed changes

* **The band time axis could collapse to two ticks — sometimes sparser than the index sampling it replaced.** `getBandTickValues` ranked anchor ticks (the year at January, the date at midnight) above tick density with no bound, so a 2-tick axis that happened to name a year beat a 4-tick one that did not. Sweeping monthly domains of length 6–48 across all 12 start months, **38 of 516 collapsed to ≤2 ticks, and 13 of those were strictly worse than plain index sampling** — which had already shown the year *and* carried more ticks. An anchor is now worth at most one tick.
* **A stride that could reach an anchor often wasn't generated at all.** Candidate strides came only from `floor( ( length - 1 ) / ( count - 1 ) )`, which skips the stride that fits a mid-series anchor on short domains. Both roundings are now taken.
* **Anchors spaced unevenly were unreachable.** The old code read the gap between the first two anchors and assumed it held for the rest of the span. A wall-clock day is 23 hourly buckets, not 24, across a spring-forward DST transition, so the stride drifted off midnight and left the rest of the week on bare hours with no day named. The sweep now also steps the anchors themselves, which needs no assumption about their spacing.
* **Tick formatters are built over cached `Intl.DateTimeFormat` instances.** They run once per bucket over the whole domain when the axis picks its values, and `toLocaleDateString` rebuilds its formatter on every call once an options object is passed. A year of daily buckets went from **10.3 ms to 0.2 ms** per call.

No public API change; `getBandTickValues` keeps its signature and its `numTicks` contract.

Also corrects the wording of the five unreleased changelog entries from #51275: they promised the axis "no longer repeats a label", but only *adjacent* repeats are collapsed, and the two-day panel still legitimately shows `12 PM` twice.

## Related product discussion/links

* WOOA7S-1902

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Every panel of the existing `BarChart` → `TimeAxisTickFormats` story renders **identically** before and after — the change only affects domains that were collapsing. Rendered ticks at `numTicks: 4`, `TZ=UTC`:

| Story panel | Before | After |
|---|---|---|
| Hourly, single day | `12 AM \| 7 AM \| 2 PM \| 9 PM` | *(unchanged)* |
| Hourly, two days | `Aug 2 \| 12 PM \| Aug 3 \| 12 PM` | *(unchanged)* |
| Hourly, a week | `Aug 2 \| Aug 4 \| Aug 6 \| Aug 8` | *(unchanged)* |
| Daily buckets | `Jul 1 \| Jul 10 \| Jul 19 \| Jul 28` | *(unchanged)* |
| Monthly over a year | `Sep \| 2026 \| May` | *(unchanged)* |
| Monthly over 3 years | `2024 \| 2025 \| 2026` | *(unchanged)* |
| Yearly buckets | `2021 \| 2023 \| 2025` | *(unchanged)* |

The regressions this fixes are domains no story covered:

| Domain | Before | After |
|---|---|---|
| 9 monthly buckets from Jul 2023 | `Sep \| 2024` | `Jul \| Oct \| 2024` |
| 30 monthly buckets from Apr 2023 | `2024 \| 2025` | `Apr \| 2024 \| Oct \| Jul` |
| 168 hourly buckets over a US spring-forward | `11 PM \| Mar 9 \| Mar 11 \| Mar 13` | `Mar 6 \| Mar 8 \| Mar 10 \| Mar 12` |

To verify:

* `jp test js js-packages/charts` — 1123 tests pass (54 suites).
* Three new unit tests in `src/charts/private/test/time-axis.test.ts` pin the three rows above. **Each one fails on `trunk`** — confirmed by reverting `time-axis.ts` alone and re-running: `3 failed, 40 passed`.
* The existing `never repeats a label on adjacent ticks` test was tautological — its 36-month domain produces no adjacent repeat under naive sampling either. It now uses a 49-bucket domain, where sampling by index spells `Feb` five times in a row.
* In Storybook, open **Charts Library → Charts → Bar Chart → Time Axis Tick Formats** and confirm all seven panels are unchanged.

### Before / after in Storybook

**Charts Library → Charts → Bar Chart → Time Axis Tick Formats**, same panels, same framing. The only panel that changes is the new one; the three either side are pixel-identical, which is the point.

**Before** — the two-and-a-half-year span collapses to `2024 | 2025`, two ticks on a 30-bar chart:

![Before](https://raw.githubusercontent.com/Automattic/jetpack/260e5a98df90211d20df2621e01b65da92445383/before.jpg)

**After** — `Apr | 2024 | Oct | Jul`: the axis keeps its four ticks and still names the year:

![After](https://raw.githubusercontent.com/Automattic/jetpack/260e5a98df90211d20df2621e01b65da92445383/after.jpg)

This PR adds that eighth panel. The seven that existed all land on spans the axis was already choosing well, so none of them showed the regression.

<sub>Note on tooling: Chrome initially refused all connections to `localhost` — there were two Chrome instances paired to this machine and the automation was driving the one that could not see the dev server. Screenshots above are from the correct instance. The tick values were cross-checked against the same code path in jsdom and match exactly.</sub>
