### PR TITLE
Premium Analytics: drop the comparison from the report window

### DIFF
--- a/projects/packages/premium-analytics/changelog/reports-drop-comparison-data
+++ b/projects/packages/premium-analytics/changelog/reports-drop-comparison-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Reports: stop showing period-over-period deltas, which the report header offers no comparison control to explain. A comparison chosen on the dashboard is still kept and restored on the way back.

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -244,6 +244,7 @@ export {
 	shouldRetryApiError,
 	toPostId,
 	useSiteHomeUrl,
+	withoutComparison,
 } from './utils';
 export type { ReportDataMap } from './types';
 export type { ReportQueryParams } from './api';

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/without-comparison.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/without-comparison.test.ts
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { hasComparisonEnabled } from '../search';
 import { withoutComparison } from '../without-comparison';
 import type { ReportParams } from '../search';
 
@@ -36,6 +37,16 @@ describe( 'withoutComparison', () => {
 
 	it( 'leaves params that carry no comparison untouched', () => {
 		expect( withoutComparison( PARAMS ) ).toEqual( PARAMS );
+	} );
+
+	/*
+	 * The two halves of the same notion, and the reason the report pages can
+	 * strip a comparison and trust it is gone. It holds only while the fields
+	 * `hasComparisonEnabled` reads stay a subset of the ones removed here.
+	 */
+	it( 'leaves nothing `hasComparisonEnabled` still recognises', () => {
+		expect( hasComparisonEnabled( COMPARING_PARAMS ) ).toBe( true );
+		expect( hasComparisonEnabled( withoutComparison( COMPARING_PARAMS ) ) ).toBe( false );
 	} );
 
 	it( 'does not mutate the input', () => {

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/without-comparison.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/without-comparison.test.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { withoutComparison } from '../without-comparison';
-import type { ReportParams } from '@jetpack-premium-analytics/data';
+import type { ReportParams } from '../search';
 
 const PARAMS = {
 	from: '2026-07-01',

--- a/projects/packages/premium-analytics/packages/data/src/utils/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/index.ts
@@ -7,6 +7,7 @@ export { computeDateRangeFromPreset } from './preset-date-range';
 export { hasProductFilters } from './product-filters';
 export { saveBlob } from './save-blob';
 export { toPostId } from './to-post-id';
+export { withoutComparison } from './without-comparison';
 export { useSiteHomeUrl } from './use-site-home-url';
 export type { PresetType, ReportParams } from './search';
 export { isSelectablePreset } from '@jetpack-premium-analytics/datetime';

--- a/projects/packages/premium-analytics/packages/data/src/utils/without-comparison.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/without-comparison.ts
@@ -1,7 +1,7 @@
 /**
- * Types
+ * Internal dependencies
  */
-import type { ReportParams } from '@jetpack-premium-analytics/data';
+import type { ReportParams } from './search';
 
 /**
  * Copy report params with the comparison fields removed.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -63,7 +63,6 @@ export { summaryCount } from './summary-count';
 export { toDay } from './to-day';
 export { defaultPeriodForInterval } from './default-period-for-interval';
 export { buildMetricTab, type MetricReport, type BuildMetricTabOptions } from './build-metric-tab';
-export { withoutComparison } from '@jetpack-premium-analytics/data';
 export {
 	CHART_DISPLAY_CHART_TYPES,
 	chartTypeAttributeField,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -63,7 +63,7 @@ export { summaryCount } from './summary-count';
 export { toDay } from './to-day';
 export { defaultPeriodForInterval } from './default-period-for-interval';
 export { buildMetricTab, type MetricReport, type BuildMetricTabOptions } from './build-metric-tab';
-export { withoutComparison } from './without-comparison';
+export { withoutComparison } from '@jetpack-premium-analytics/data';
 export {
 	CHART_DISPLAY_CHART_TYPES,
 	chartTypeAttributeField,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -165,7 +165,6 @@ export {
 	toDay,
 	defaultPeriodForInterval,
 	buildMetricTab,
-	withoutComparison,
 	CHART_DISPLAY_CHART_TYPES,
 	chartTypeAttributeField,
 	granularityAttributeField,

--- a/projects/packages/premium-analytics/routes/reports/authors/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/authors/page.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { normalizeReportParams } from '@jetpack-premium-analytics/data';
 import { useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { StatsBreadcrumbs, StatsPageIcon } from '@jetpack-premium-analytics/ui';
 import {
@@ -16,12 +15,12 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSearch } from '@wordpress/route';
 /**
  * Internal dependencies
  */
 import { route } from '../package.json';
 import { REPORTS } from '../registry';
+import { useReportParams } from '../use-report-params';
 import { getAuthorName, getAuthorsFields, useAuthorsReportRecords, type AuthorRow } from './config';
 
 const ROUTE_FROM = route.path;
@@ -74,11 +73,7 @@ function getAuthorCsvLabel( item: AuthorRow ): string {
  * @return The Authors report page.
  */
 function AuthorsReport(): JSX.Element {
-	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
-	const reportParams = useMemo(
-		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
-		[ search ]
-	);
+	const reportParams = useReportParams();
 
 	const records = useAuthorsReportRecords( reportParams );
 	const retry = useReportRetry( records.refetch );

--- a/projects/packages/premium-analytics/routes/reports/clicks/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/page.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { normalizeReportParams } from '@jetpack-premium-analytics/data';
 import { useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { StatsBreadcrumbs, StatsPageIcon } from '@jetpack-premium-analytics/ui';
 import {
@@ -16,12 +15,12 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSearch } from '@wordpress/route';
 /**
  * Internal dependencies
  */
 import { route } from '../package.json';
 import { REPORTS } from '../registry';
+import { useReportParams } from '../use-report-params';
 import { getClickCsvGroup, getClicksFields, useClicksReportRecords, type ClickRow } from './config';
 
 const ROUTE_FROM = route.path;
@@ -68,11 +67,7 @@ type ClickCsvRow = ClickRow & { group: string };
  * @return The Clicks report page.
  */
 function ClicksReport(): JSX.Element {
-	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
-	const reportParams = useMemo(
-		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
-		[ search ]
-	);
+	const reportParams = useReportParams();
 
 	const records = useClicksReportRecords( reportParams );
 	const retry = useReportRetry( records.refetch );

--- a/projects/packages/premium-analytics/routes/reports/downloads/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/downloads/page.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	normalizeReportParams,
 	type StatsFileDownloadsItem,
 	type StatsFileDownloadsComparisonItem,
 } from '@jetpack-premium-analytics/data';
@@ -20,12 +19,12 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSearch } from '@wordpress/route';
 /**
  * Internal dependencies
  */
 import { route } from '../package.json';
 import { REPORTS } from '../registry';
+import { useReportParams } from '../use-report-params';
 import { getDownloadsFields, useDownloadsReportRecords } from './config';
 
 const ROUTE_FROM = route.path;
@@ -59,11 +58,7 @@ const sortDownloadCsvRows = ( a: StatsFileDownloadsItem, b: StatsFileDownloadsIt
  * @return The rendered report page.
  */
 function DownloadsReport(): JSX.Element {
-	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
-	const reportParams = useMemo(
-		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
-		[ search ]
-	);
+	const reportParams = useReportParams();
 	const records = useDownloadsReportRecords( reportParams );
 	const retry = useReportRetry( records.refetch );
 	const fields = useMemo(

--- a/projects/packages/premium-analytics/routes/reports/locations/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/locations/page.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { normalizeReportParams } from '@jetpack-premium-analytics/data';
 import { useReportDateFilters, useSectionTab } from '@jetpack-premium-analytics/routing';
 import { StatsBreadcrumbs, StatsPageIcon } from '@jetpack-premium-analytics/ui';
 import {
@@ -17,12 +16,12 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSearch } from '@wordpress/route';
 /**
  * Internal dependencies
  */
 import { route } from '../package.json';
 import { REPORTS } from '../registry';
+import { useReportParams } from '../use-report-params';
 import {
 	getLocationFields,
 	getReportLocationsTabs,
@@ -83,11 +82,7 @@ function getCountryFilter( view: View ): string {
  * @return The Locations report page.
  */
 export default function LocationsReportPage(): JSX.Element {
-	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
-	const reportParams = useMemo(
-		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
-		[ search ]
-	);
+	const reportParams = useReportParams();
 	const tabs = useMemo( () => getReportLocationsTabs(), [] );
 	const [ activeTab, setActiveTab ] = useSectionTab( ROUTE_FROM, resolveSection );
 	const [ countryFilter, setCountryFilter ] = useState( '' );

--- a/projects/packages/premium-analytics/routes/reports/posts/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/posts/page.tsx
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	normalizeReportParams,
-	type StatsTopPostsComparisonItem,
-} from '@jetpack-premium-analytics/data';
+import { type StatsTopPostsComparisonItem } from '@jetpack-premium-analytics/data';
 import { useReportDateFilters, useSectionTab } from '@jetpack-premium-analytics/routing';
 import { StatsBreadcrumbs, StatsPageIcon } from '@jetpack-premium-analytics/ui';
 import {
@@ -21,12 +18,12 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSearch } from '@wordpress/route';
 /**
  * Internal dependencies
  */
 import { route } from '../package.json';
 import { REPORTS } from '../registry';
+import { useReportParams } from '../use-report-params';
 import {
 	buildArchiveCsvRows,
 	getArchivesFields,
@@ -109,11 +106,7 @@ function PostsReport(): JSX.Element {
 	// The route guard guarantees the report window params are seeded, so the
 	// URL search is the single source of truth for dates, interval, and
 	// comparison — resolve it with the same normalizer the widgets use.
-	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
-	const reportParams = useMemo(
-		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
-		[ search ]
-	);
+	const reportParams = useReportParams();
 
 	const tabs = useMemo( () => getReportPostsTabs(), [] );
 	const [ activeTab, setActiveTab ] = useSectionTab( ROUTE_FROM, resolveTabId );

--- a/projects/packages/premium-analytics/routes/reports/referrers/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/page.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { normalizeReportParams } from '@jetpack-premium-analytics/data';
 import { useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { StatsBreadcrumbs, StatsPageIcon } from '@jetpack-premium-analytics/ui';
 import {
@@ -16,12 +15,12 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSearch } from '@wordpress/route';
 /**
  * Internal dependencies
  */
 import { route } from '../package.json';
 import { REPORTS } from '../registry';
+import { useReportParams } from '../use-report-params';
 import { getReferrerFields, useReferrersReportRecords, type ReferrerRecord } from './config';
 
 const ROUTE_FROM = route.path;
@@ -65,11 +64,7 @@ const RECORDS_VIEW = {
  * @return {JSX.Element} The Referrers report page.
  */
 function ReferrersReport(): JSX.Element {
-	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
-	const reportParams = useMemo(
-		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
-		[ search ]
-	);
+	const reportParams = useReportParams();
 
 	const records = useReferrersReportRecords( reportParams );
 	const retry = useReportRetry( records.refetch );

--- a/projects/packages/premium-analytics/routes/reports/search-terms/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/page.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { normalizeReportParams } from '@jetpack-premium-analytics/data';
 import { useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { StatsBreadcrumbs, StatsPageIcon } from '@jetpack-premium-analytics/ui';
 import {
@@ -16,12 +15,12 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSearch } from '@wordpress/route';
 /**
  * Internal dependencies
  */
 import { route } from '../package.json';
 import { REPORTS } from '../registry';
+import { useReportParams } from '../use-report-params';
 import { getSearchTermsFields, useSearchTermsReportRecords, type SearchTermRow } from './config';
 
 const ROUTE_FROM = route.path;
@@ -54,11 +53,7 @@ const sortSearchTermCsvRows = ( a: SearchTermRow, b: SearchTermRow ) => b.views 
  * @return The report page.
  */
 export default function SearchTermsReportPage(): JSX.Element {
-	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
-	const reportParams = useMemo(
-		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
-		[ search ]
-	);
+	const reportParams = useReportParams();
 	const records = useSearchTermsReportRecords( reportParams );
 	const retry = useReportRetry( records.refetch );
 	const fields = useMemo(

--- a/projects/packages/premium-analytics/routes/reports/use-report-params.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/use-report-params.test.ts
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { useReportParams } from './use-report-params';
+
+const SEARCH = {
+	from: '2026-06-01T00:00:00+00:00',
+	to: '2026-06-30T23:59:59+00:00',
+	interval: 'day',
+	preset: 'custom',
+	comp: '1',
+	compare_from: '2026-05-02T00:00:00+00:00',
+	compare_to: '2026-05-31T23:59:59+00:00',
+	compare_preset: 'previous-period',
+};
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => SEARCH,
+} ) );
+
+describe( 'useReportParams', () => {
+	/*
+	 * A report offers no comparison control and its header names no compared
+	 * period, so a delta in the table would have no baseline the reader can see.
+	 */
+	it( 'drops the comparison the URL carries in', () => {
+		const { result } = renderHook( () => useReportParams() );
+
+		expect( result.current ).not.toHaveProperty( 'comp' );
+		expect( result.current ).not.toHaveProperty( 'compare_from' );
+		expect( result.current ).not.toHaveProperty( 'compare_to' );
+		expect( result.current ).not.toHaveProperty( 'compare_preset' );
+	} );
+
+	it( 'keeps the window itself', () => {
+		const { result } = renderHook( () => useReportParams() );
+
+		expect( result.current ).toEqual(
+			expect.objectContaining( {
+				from: SEARCH.from,
+				to: SEARCH.to,
+				interval: SEARCH.interval,
+			} )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/use-report-params.ts
+++ b/projects/packages/premium-analytics/routes/reports/use-report-params.ts
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { normalizeReportParams, withoutComparison } from '@jetpack-premium-analytics/data';
+import { useSearch } from '@wordpress/route';
+import { useMemo } from 'react';
+/**
+ * Internal dependencies
+ */
+import { route } from './package.json';
+
+const ROUTE_FROM = route.path;
+
+/**
+ * The window a report's records are fetched for, resolved from the URL with the
+ * same normalizer the widgets use.
+ *
+ * Comparison is stripped. A report offers no control for one and its header
+ * names no compared period, so a delta in the table would have no baseline the
+ * reader could see or change. The params themselves stay on the URL, for the
+ * dashboard to pick back up.
+ *
+ * @return The report params, without comparison.
+ */
+export function useReportParams() {
+	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
+
+	return useMemo(
+		() =>
+			withoutComparison(
+				normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] )
+			),
+		[ search ]
+	);
+}

--- a/projects/packages/premium-analytics/routes/reports/utm/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/utm/page.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { normalizeReportParams } from '@jetpack-premium-analytics/data';
 import { useReportDateFilters, useSectionTab } from '@jetpack-premium-analytics/routing';
 import { StatsBreadcrumbs, StatsPageIcon } from '@jetpack-premium-analytics/ui';
 import {
@@ -17,12 +16,12 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSearch } from '@wordpress/route';
 /**
  * Internal dependencies
  */
 import { route } from '../package.json';
 import { REPORTS } from '../registry';
+import { useReportParams } from '../use-report-params';
 import {
 	getReportUtmTabs,
 	getTabTitle,
@@ -84,11 +83,7 @@ function getUtmCsvLabel( item: UtmReportRow ): string {
  * @return The UTM report page.
  */
 function UtmReport(): JSX.Element {
-	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
-	const reportParams = useMemo(
-		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
-		[ search ]
-	);
+	const reportParams = useReportParams();
 	const tabs = useMemo( () => getReportUtmTabs(), [] );
 	const [ activeTab, setActiveTab ] = useSectionTab( ROUTE_FROM, resolveSection );
 	const records = useUtmReportRecords( activeTab, reportParams );

--- a/projects/packages/premium-analytics/routes/reports/videos/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/page.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	normalizeReportParams,
 	type StatsVideoPlaysItem,
 	type StatsVideoPlaysComparisonItem,
 } from '@jetpack-premium-analytics/data';
@@ -20,12 +19,12 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSearch } from '@wordpress/route';
 /**
  * Internal dependencies
  */
 import { route } from '../package.json';
 import { REPORTS } from '../registry';
+import { useReportParams } from '../use-report-params';
 import { getVideosFields, useVideosReportRecords } from './config';
 
 const ROUTE_FROM = route.path;
@@ -71,11 +70,7 @@ const sortVideoCsvRows = ( a: StatsVideoPlaysItem, b: StatsVideoPlaysItem ) => b
  * @return The Videos report page.
  */
 function VideosReport(): JSX.Element {
-	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
-	const reportParams = useMemo(
-		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
-		[ search ]
-	);
+	const reportParams = useReportParams();
 	const records = useVideosReportRecords( reportParams );
 	const retry = useReportRetry( records.refetch );
 	const fields = useMemo(

--- a/projects/packages/premium-analytics/widgets/popular-days/use-popular-days.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/use-popular-days.ts
@@ -1,11 +1,8 @@
 /**
  * External dependencies
  */
-import { useStatsVisits } from '@jetpack-premium-analytics/data';
-import {
-	useWidgetRootContext,
-	withoutComparison,
-} from '@jetpack-premium-analytics/widgets-toolkit';
+import { useStatsVisits, withoutComparison } from '@jetpack-premium-analytics/data';
+import { useWidgetRootContext } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from 'react';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/widgets/total-views/render.tsx
+++ b/projects/packages/premium-analytics/widgets/total-views/render.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useStatsVisits } from '@jetpack-premium-analytics/data';
+import { useStatsVisits, withoutComparison } from '@jetpack-premium-analytics/data';
 import { Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import {
@@ -10,7 +10,6 @@ import {
 	useWidgetRootContext,
 	WidgetRoot,
 	WidgetState,
-	withoutComparison,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';

--- a/projects/packages/premium-analytics/widgets/total-visitors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/total-visitors/render.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useStatsVisits } from '@jetpack-premium-analytics/data';
+import { useStatsVisits, withoutComparison } from '@jetpack-premium-analytics/data';
 import { Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import {
@@ -10,7 +10,6 @@ import {
 	useWidgetRootContext,
 	WidgetRoot,
 	WidgetState,
-	withoutComparison,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';

--- a/projects/packages/premium-analytics/widgets/traffic-views-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-views-activity/render.tsx
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { useStatsVisits, type StatsVisitsResponse } from '@jetpack-premium-analytics/data';
+import {
+	type StatsVisitsResponse,
+	useStatsVisits,
+	withoutComparison,
+} from '@jetpack-premium-analytics/data';
 import { parseSiteDateTime } from '@jetpack-premium-analytics/datetime';
 import { formatDate } from '@jetpack-premium-analytics/formatters';
 import {
@@ -16,7 +20,6 @@ import {
 	resolveCalendarHeatmapWindowDays,
 	useViewportWidth,
 	useWidgetRootContext,
-	withoutComparison,
 	type HeatmapTooltipData,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';


### PR DESCRIPTION
Closes WOOA7S-1953

## Proposed changes

A report page offers no comparison control and its header names no compared period, but its table still drew period-over-period deltas whenever `comp=1` was in the URL, carried in from the dashboard. The reader saw a delta with no baseline, no way to change it and no way to dismiss it.

The nine reports with a date window now read their window through one hook, `useReportParams`, which strips the comparison out of the derived params with `withoutComparison`. `hasComparison` resolves false, the delta columns drop out, and the comparison period is no longer fetched.

The URL is untouched. `comp`, `compare_from`, `compare_to` and `compare_preset` all survive, so the dashboard still restores the comparison on the way back.

That hook replaces a `useSearch` plus `normalizeReportParams` memo that was repeated in all nine pages.

`withoutComparison` moved from `widgets-toolkit` to `data`, next to `hasComparisonEnabled` — the same question asked the other way — and to the `ReportParams` type it takes. Its reason to exist is a data-layer one: `useReport` folds the comparison query's flags into the primary ones.

The toolkit no longer re-exports it. The four widgets that use it now take it from `data`, which they already depend on, as 240 files under `widgets/` already do. The bridge bought nothing: `data` is a shared script module (`wpScriptModuleExports`) just like the toolkit, so importing from it inlines nothing into a widget's bundle. That rule exists for `@automattic/charts`, which is not one.

## Related product discussion/links

Fixes [WOOA7S-1953](https://linear.app/a8c/issue/WOOA7S-1953/reports-stop-rendering-comparison-data-where-the-report-offers-no), under [WOOA7S-1793](https://linear.app/a8c/issue/WOOA7S-1793/implement-consistent-title-and-date-selection-component). Raised in review on #51309, which this stacks on.

Once [WOOA7S-1952](https://linear.app/a8c/issue/WOOA7S-1952/reports-declare-the-date-filter-options-per-report-from-the-backend) lets a report declare `date_filter_options.with_date_comparison`, the strip should follow that declaration instead of being unconditional.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

```
jetpack build --deps packages/premium-analytics
```

On the dashboard, set a comparison — say *Previous month*. Note `comp`, `compare_from`, `compare_to` and `compare_preset` in the URL.`

<img width="1010" height="728" alt="Screenshot 2026-08-18 at 12 23 01 PM" src="https://github.com/user-attachments/assets/ea912643-646c-44e1-bc3d-4ebc39d52aff" />

Open a report with a date window: Posts & Pages, Referrers, Videos, Locations, Clicks, Search terms, UTM, Top authors, or File downloads on Simple.

The table shows no delta column and no percentages against the previous month. Before this change, it did.

<img width="1019" height="574" alt="Screenshot 2026-08-18 at 12 23 21 PM" src="https://github.com/user-attachments/assets/9609cd31-12f2-4953-b563-ff28fe77f7b4" />

Those four params are still in the URL, unchanged.

Go back to the dashboard with the breadcrumb. The comparison is still on, still *Previous month*, and the widgets show their deltas again.

<img width="357" height="284" alt="Screenshot 2026-08-18 at 12 23 42 PM" src="https://github.com/user-attachments/assets/8f2ca9fd-a55d-4220-b153-7607afe1b415" />

Change the range inside the report first, then go back: the comparison window has followed the new range rather than staying on the old one.
