### PR TITLE
Charts: resolve the XY theme's five roles from one style snapshot

### DIFF
--- a/projects/js-packages/charts/changelog/charts-256-one-style-snapshot-per-xy-theme-build
+++ b/projects/js-packages/charts/changelog/charts-256-one-style-snapshot-per-xy-theme-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Resolve an XY chart theme's colour roles from a single computed-style snapshot instead of one per role.

--- a/projects/js-packages/charts/changelog/charts-256-one-style-snapshot-per-xy-theme-build
+++ b/projects/js-packages/charts/changelog/charts-256-one-style-snapshot-per-xy-theme-build
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Resolve an XY chart theme's colour roles from a single computed-style snapshot instead of one per role.
+Resolve an XY chart theme's color roles from a single computed-style snapshot, and rebuild the theme only when a series color changes rather than on every render.

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
@@ -27,7 +27,7 @@ import {
 	useGlobalChartsContext,
 	useGlobalChartsTheme,
 } from '../../providers';
-import { attachSubComponents, resolveCssVariable } from '../../utils';
+import { attachSubComponents } from '../../utils';
 import { renderDefaultTooltip } from '../line-chart';
 import { useChartChildren } from '../private/chart-composition';
 import { ChartLayout } from '../private/chart-layout';
@@ -482,10 +482,8 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 														stacked={ stacked }
 														stackOffset={ stackOffset }
 														getElementStyles={ getElementStyles }
-														strokeColor={
-															resolveCssVariable( providerTheme.backgroundColor ) ??
-															providerTheme.backgroundColor
-														}
+														// useXYChartTheme resolved this role inside its memo; reading it back avoids a getComputedStyle on every render.
+														strokeColor={ theme.backgroundColor ?? providerTheme.backgroundColor }
 													/>
 												</>
 											) }

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -29,7 +29,7 @@ import {
 	useGlobalChartsContext,
 	useGlobalChartsTheme,
 } from '../../providers';
-import { attachSubComponents, resolveCssVariable } from '../../utils';
+import { attachSubComponents } from '../../utils';
 import { useChartChildren } from '../private/chart-composition';
 import { ChartLayout } from '../private/chart-layout';
 import { DefaultGlyph } from '../private/default-glyph';
@@ -192,11 +192,9 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 		const legendPosition = legend.position ?? 'bottom';
 
 		const providerTheme = useGlobalChartsTheme();
-		// Gradient stops apply this as an SVG attribute, where CSS var() cannot
-		// resolve, so resolve the WPDS token to a concrete value first.
-		const resolvedBackgroundColor =
-			resolveCssVariable( providerTheme.backgroundColor ) ?? providerTheme.backgroundColor;
 		const theme = useXYChartTheme( data );
+		// Gradient stops apply this as an SVG attribute, where CSS var() cannot resolve. useXYChartTheme has already resolved the same role inside its memo, so read it back rather than paying another getComputedStyle on every render.
+		const resolvedBackgroundColor = theme.backgroundColor ?? providerTheme.backgroundColor;
 		const chartId = useChartId( providedChartId );
 		const chartRef = useRef< HTMLDivElement >( null );
 		const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );

--- a/projects/js-packages/charts/src/hooks/test/use-xychart-theme-style-reads.test.tsx
+++ b/projects/js-packages/charts/src/hooks/test/use-xychart-theme-style-reads.test.tsx
@@ -1,0 +1,58 @@
+import { renderHook } from '@testing-library/react';
+import { useXYChartTheme } from '../use-xychart-theme';
+import type { SeriesData } from '../../types';
+
+// The theme resolves five catalog roles — background, grid, axis, tick and axis label. Each `getComputedStyle` call can force the browser to flush pending style, and this memo re-runs whenever `data` changes identity, so a dashboard mounting N charts pays the count below N times over.
+const STABLE_DATA: SeriesData[] = [];
+
+describe( 'useXYChartTheme style reads', () => {
+	let getComputedStyleSpy: jest.SpyInstance;
+
+	beforeEach( () => {
+		document.documentElement.style.setProperty( '--a8c-charts-color-grid', '#00ff00' );
+		getComputedStyleSpy = jest.spyOn( window, 'getComputedStyle' );
+	} );
+
+	afterEach( () => {
+		getComputedStyleSpy.mockRestore();
+		document.documentElement.style.removeProperty( '--a8c-charts-color-grid' );
+		document.documentElement.style.removeProperty( '--a8c-charts-color-background' );
+		document.documentElement.style.removeProperty( '--a8c-charts-color-axis' );
+	} );
+
+	const renderTheme = ( data: SeriesData[] = STABLE_DATA ) =>
+		renderHook( ( { series }: { series: SeriesData[] } ) => useXYChartTheme( series ), {
+			initialProps: { series: data },
+		} );
+
+	it( 'reads every role from one computed-style snapshot, not one per role', () => {
+		document.documentElement.style.setProperty( '--a8c-charts-color-background', '#111111' );
+		document.documentElement.style.setProperty( '--a8c-charts-color-axis', '#222222' );
+
+		const { result } = renderTheme();
+
+		expect( getComputedStyleSpy ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.backgroundColor ).toBe( '#111111' );
+		expect( result.current.gridStyles.stroke ).toBe( '#00ff00' );
+		expect( result.current.axisStyles.x.bottom.axisLine.stroke ).toBe( '#222222' );
+	} );
+
+	it( 'does not re-read styles when the hook re-renders with the same inputs', () => {
+		const { rerender } = renderTheme();
+
+		getComputedStyleSpy.mockClear();
+		rerender( { series: STABLE_DATA } );
+
+		expect( getComputedStyleSpy ).not.toHaveBeenCalled();
+	} );
+
+	// A caller passing an inline array literal — `<LineChart data={ [ … ] } />` — gives the memo a new identity on every render, so the theme rebuilds each time. That costs one style query now; before the roles shared a snapshot it cost five.
+	it( 'rebuilds once per render when the caller passes a fresh data array', () => {
+		const { rerender } = renderTheme( [] );
+
+		getComputedStyleSpy.mockClear();
+		rerender( { series: [] } );
+
+		expect( getComputedStyleSpy ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/projects/js-packages/charts/src/hooks/test/use-xychart-theme-style-reads.test.tsx
+++ b/projects/js-packages/charts/src/hooks/test/use-xychart-theme-style-reads.test.tsx
@@ -46,13 +46,38 @@ describe( 'useXYChartTheme style reads', () => {
 		expect( getComputedStyleSpy ).not.toHaveBeenCalled();
 	} );
 
-	// A caller passing an inline array literal — `<LineChart data={ [ … ] } />` — gives the memo a new identity on every render, so the theme rebuilds each time. That costs one style query now; before the roles shared a snapshot it cost five.
-	it( 'rebuilds once per render when the caller passes a fresh data array', () => {
+	// A caller passing an inline array literal — `<LineChart data={ [ … ] } />` — hands the hook a new array identity on every render. The memo keys on the series strokes instead, so the theme is not rebuilt and no style is read. Keyed on `data` this cost one query per render, and before the roles shared a snapshot it cost five.
+	it( 'does not rebuild when the caller passes a fresh data array of the same strokes', () => {
 		const { rerender } = renderTheme( [] );
 
 		getComputedStyleSpy.mockClear();
 		rerender( { series: [] } );
 
+		expect( getComputedStyleSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'rebuilds when a series stroke actually changes', () => {
+		const withStroke = ( stroke: string ) =>
+			[ { label: 'A', options: { stroke }, data: [] } ] as unknown as SeriesData[];
+		const { result, rerender } = renderTheme( withStroke( 'rgba(0, 0, 0, 0.5)' ) );
+
+		getComputedStyleSpy.mockClear();
+		rerender( { series: withStroke( 'rebeccapurple' ) } );
+
 		expect( getComputedStyleSpy ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.colors[ 0 ] ).toBe( 'rebeccapurple' );
+	} );
+
+	// The memo key serialises the strokes rather than joining them, so a colour containing a comma or a space survives the round-trip intact.
+	it( 'keeps a stroke that contains separators intact', () => {
+		const { result } = renderTheme( [
+			{ label: 'A', options: { stroke: 'rgba(0, 0, 0, 0.5)' }, data: [] },
+			{ label: 'B', options: { stroke: 'var(--brand, #fff)' }, data: [] },
+		] as unknown as SeriesData[] );
+
+		expect( result.current.colors.slice( 0, 2 ) ).toEqual( [
+			'rgba(0, 0, 0, 0.5)',
+			'var(--brand, #fff)',
+		] );
 	} );
 } );

--- a/projects/js-packages/charts/src/hooks/use-xychart-theme.ts
+++ b/projects/js-packages/charts/src/hooks/use-xychart-theme.ts
@@ -1,19 +1,20 @@
 import { buildChartTheme } from '@visx/xychart';
 import { useMemo } from 'react';
 import { useGlobalChartsTheme } from '../providers';
-import { resolveCssVariable } from '../utils';
+import { createCssVariableResolver } from '../utils';
 import type { SeriesData } from '../types';
-
-// visx applies grid, axis, and tick-label colors as SVG presentation attributes,
-// where CSS var() cannot resolve. Resolve WPDS tokens to concrete values (or their
-// fallbacks) before handing the theme to buildChartTheme.
-const resolveColor = ( value?: string ): string | undefined =>
-	value ? resolveCssVariable( value ) ?? value : value;
 
 export const useXYChartTheme = ( data: SeriesData[] ) => {
 	const theme = useGlobalChartsTheme();
 
 	return useMemo( () => {
+		// visx applies grid, axis, and tick-label colours as SVG presentation attributes, where CSS var() cannot resolve. Resolve them to concrete values before handing the theme to buildChartTheme.
+		//
+		// One resolver per theme build, so the five roles below share a single getComputedStyle call rather than taking one each.
+		const resolve = createCssVariableResolver();
+		const resolveColor = ( value?: string ): string | undefined =>
+			value ? resolve( value ) ?? value : value;
+
 		const seriesColors = ( data ?? [] )
 			.map( series => series.options?.stroke )
 			.filter( ( color ): color is string => Boolean( color ) );

--- a/projects/js-packages/charts/src/hooks/use-xychart-theme.ts
+++ b/projects/js-packages/charts/src/hooks/use-xychart-theme.ts
@@ -7,17 +7,22 @@ import type { SeriesData } from '../types';
 export const useXYChartTheme = ( data: SeriesData[] ) => {
 	const theme = useGlobalChartsTheme();
 
+	// The only thing the theme takes from `data` is the series strokes, so key the memo on those rather than on the array's identity. A caller passing an inline literal — `<LineChart data={ [ … ] } />`, which the stories and several consumers do — otherwise rebuilds the whole theme on every render. Serialised rather than joined: a stroke can be `rgba(0, 0, 0, 0.5)` or `var(--brand, #fff)`, and any separator that reads naturally inside a colour cannot round-trip.
+	const seriesColorKey = JSON.stringify(
+		( data ?? [] )
+			.map( series => series.options?.stroke )
+			.filter( ( color ): color is string => Boolean( color ) )
+	);
+
 	return useMemo( () => {
-		// visx applies grid, axis, and tick-label colours as SVG presentation attributes, where CSS var() cannot resolve. Resolve them to concrete values before handing the theme to buildChartTheme.
+		// visx applies grid, axis, and tick-label colors as SVG presentation attributes, where CSS var() cannot resolve. Resolve them to concrete values before handing the theme to buildChartTheme.
 		//
 		// One resolver per theme build, so the five roles below share a single getComputedStyle call rather than taking one each.
 		const resolve = createCssVariableResolver();
 		const resolveColor = ( value?: string ): string | undefined =>
 			value ? resolve( value ) ?? value : value;
 
-		const seriesColors = ( data ?? [] )
-			.map( series => series.options?.stroke )
-			.filter( ( color ): color is string => Boolean( color ) );
+		const seriesColors: string[] = JSON.parse( seriesColorKey );
 
 		return buildChartTheme( {
 			...theme,
@@ -40,5 +45,5 @@ export const useXYChartTheme = ( data: SeriesData[] ) => {
 				fill: resolveColor( theme.svgLabelSmall.fill ),
 			},
 		} );
-	}, [ theme, data ] );
+	}, [ theme, seriesColorKey ] );
 };

--- a/projects/js-packages/charts/src/utils/index.ts
+++ b/projects/js-packages/charts/src/utils/index.ts
@@ -30,7 +30,7 @@ export { mergeThemes } from './merge-themes';
 export * from './color-utils';
 
 // CSS utilities
-export { resolveCssVariable } from './resolve-css-var';
+export { resolveCssVariable, createCssVariableResolver } from './resolve-css-var';
 
 // Font sizing utilities
 export { resolveFontSize } from './resolve-font-size';

--- a/projects/js-packages/charts/src/utils/resolve-css-var.ts
+++ b/projects/js-packages/charts/src/utils/resolve-css-var.ts
@@ -4,6 +4,21 @@
 const CSS_VAR_NAME_PATTERN = /^--[\w-]+$/;
 
 /**
+ * Resolves a CSS custom property (variable) to its computed value.
+ * Handles multiple formats:
+ * - Plain variable names: '--my-color'
+ * - CSS var() syntax: 'var(--my-color)'
+ * - CSS var() with fallback: 'var(--my-color, #ffffff)'
+ * - Regular values (returned as-is): '#ffffff', 'red'
+ *
+ * @param value   - A CSS variable name, var() expression, or regular value
+ * @param element - Optional DOM element to resolve the variable from (defaults to document.documentElement)
+ * @return The resolved value, fallback value, or null if unresolvable
+ */
+export const resolveCssVariable = ( value: string, element?: HTMLElement | null ): string | null =>
+	createCssVariableResolver( element )( value );
+
+/**
  * Builds a resolver that reads every value from one `getComputedStyle` snapshot.
  *
  * `getComputedStyle` is the expensive half of resolving a token: each call can force the browser to flush pending style, and a chart theme resolves five roles at once. Taking the snapshot once per build turns that into a single query. The reads that share a snapshot happen synchronously inside one memo body, so no style change can land between them — the resolver is single-pass by design and is not meant to be held across renders.
@@ -11,9 +26,9 @@ const CSS_VAR_NAME_PATTERN = /^--[\w-]+$/;
  * @param element - The element to resolve against, or null/undefined for the document root.
  * @return A resolver that resolves each value exactly as `resolveCssVariable` does.
  */
-export const createCssVariableResolver = (
+export function createCssVariableResolver(
 	element?: HTMLElement | null
-): ( ( value: string ) => string | null ) => {
+): ( value: string ) => string | null {
 	let styles: CSSStyleDeclaration | null = null;
 
 	// Deferred so a resolver for a theme that turns out to hold only literals costs nothing. Only a successful read is kept: caching the null would leave a resolver built before its element is in the document dead for the rest of its life.
@@ -25,7 +40,7 @@ export const createCssVariableResolver = (
 		return styles;
 	};
 
-	return value => {
+	return ( value: string ): string | null => {
 		if ( ! value ) {
 			return null;
 		}
@@ -50,22 +65,7 @@ export const createCssVariableResolver = (
 		// Return regular values as-is (e.g., '#ffffff', 'red')
 		return value;
 	};
-};
-
-/**
- * Resolves a CSS custom property (variable) to its computed value.
- * Handles multiple formats:
- * - Plain variable names: '--my-color'
- * - CSS var() syntax: 'var(--my-color)'
- * - CSS var() with fallback: 'var(--my-color, #ffffff)'
- * - Regular values (returned as-is): '#ffffff', 'red'
- *
- * @param value   - A CSS variable name, var() expression, or regular value
- * @param element - Optional DOM element to resolve the variable from (defaults to document.documentElement)
- * @return The resolved value, fallback value, or null if unresolvable
- */
-export const resolveCssVariable = ( value: string, element?: HTMLElement | null ): string | null =>
-	createCssVariableResolver( element )( value );
+}
 
 /**
  * Parses a var() expression into its variable name and optional fallback.

--- a/projects/js-packages/charts/src/utils/resolve-css-var.ts
+++ b/projects/js-packages/charts/src/utils/resolve-css-var.ts
@@ -15,10 +15,42 @@ const CSS_VAR_NAME_PATTERN = /^--[\w-]+$/;
  * @param element - Optional DOM element to resolve the variable from (defaults to document.documentElement)
  * @return The resolved value, fallback value, or null if unresolvable
  */
-export const resolveCssVariable = (
-	value: string,
+export const resolveCssVariable = ( value: string, element?: HTMLElement | null ): string | null =>
+	resolveWith( value, () => computedStyleFor( element ) );
+
+/**
+ * Builds a resolver that reads every value from one `getComputedStyle` snapshot.
+ *
+ * `getComputedStyle` is the expensive half of resolving a token: each call can force the browser to flush pending style, and a chart theme resolves five roles at once. Taking the snapshot once per theme build turns that into a single query — the returned styles object stays live, so later reads still see current values.
+ *
+ * @param element - The element to resolve against, or null/undefined for the document root.
+ * @return A resolver with the same contract as `resolveCssVariable`.
+ */
+export const createCssVariableResolver = (
 	element?: HTMLElement | null
-): string | null => {
+): ( ( value: string ) => string | null ) => {
+	let styles: CSSStyleDeclaration | null | undefined;
+
+	// Deferred so a resolver built for a theme that turns out to hold only literals costs nothing.
+	const getStyles = () => {
+		if ( styles === undefined ) {
+			styles = computedStyleFor( element );
+		}
+
+		return styles;
+	};
+
+	return value => resolveWith( value, getStyles );
+};
+
+/**
+ * The shared resolution contract, over a lazily-obtained computed-style snapshot.
+ *
+ * @param value     - A CSS variable name, var() expression, or regular value.
+ * @param getStyles - Returns the computed styles to read custom properties from.
+ * @return The resolved value, fallback value, or null if unresolvable.
+ */
+function resolveWith( value: string, getStyles: () => CSSStyleDeclaration | null ): string | null {
 	if ( ! value ) {
 		return null;
 	}
@@ -29,7 +61,7 @@ export const resolveCssVariable = (
 		const parsed = parseVarExpression( value );
 
 		if ( parsed ) {
-			const resolved = resolveVariableName( parsed.varName, element );
+			const resolved = readCustomProperty( parsed.varName, getStyles() );
 
 			return resolved || parsed.fallback;
 		}
@@ -37,12 +69,12 @@ export const resolveCssVariable = (
 
 	// Check if it's a plain variable name (starts with --)
 	if ( value.startsWith( '--' ) ) {
-		return resolveVariableName( value, element );
+		return readCustomProperty( value, getStyles() );
 	}
 
 	// Return regular values as-is (e.g., '#ffffff', 'red')
 	return value;
-};
+}
 
 /**
  * Parses a var() expression into its variable name and optional fallback.
@@ -87,24 +119,42 @@ function parseVarExpression( expr: string ): { varName: string; fallback: string
 }
 
 /**
- * Resolves a plain CSS variable name to its computed value.
+ * Takes one computed-style snapshot, or null where there is nothing to read (SSR, or a detached element).
  *
- * @param varName - A CSS variable name like '--my-color'
- * @param element - Optional DOM element to resolve from
- * @return The computed value or null
+ * @param element - The element to read from, or null/undefined for the document root.
+ * @return The computed styles, or null.
  */
-function resolveVariableName( varName: string, element?: HTMLElement | null ): string | null {
+function computedStyleFor( element?: HTMLElement | null ): CSSStyleDeclaration | null {
 	if ( typeof window === 'undefined' || typeof document === 'undefined' ) {
 		return null;
 	}
 
 	try {
-		const targetElement = element || document.documentElement;
-		const computedValue = getComputedStyle( targetElement ).getPropertyValue( varName ).trim();
+		return getComputedStyle( element || document.documentElement );
+	} catch {
+		// getComputedStyle throws on a detached element.
+		return null;
+	}
+}
+
+/**
+ * Reads one custom property from a computed-style snapshot.
+ *
+ * @param varName - A CSS variable name like '--my-color'
+ * @param styles  - The snapshot to read from, or null
+ * @return The computed value or null
+ */
+function readCustomProperty( varName: string, styles: CSSStyleDeclaration | null ): string | null {
+	if ( ! styles ) {
+		return null;
+	}
+
+	try {
+		const computedValue = styles.getPropertyValue( varName ).trim();
 
 		return computedValue || null;
 	} catch {
-		// Return null if getComputedStyle throws (e.g., detached element)
+		// A snapshot can outlive what it describes: reading a property off a stale CSSStyleDeclaration throws in some engines.
 		return null;
 	}
 }

--- a/projects/js-packages/charts/src/utils/resolve-css-var.ts
+++ b/projects/js-packages/charts/src/utils/resolve-css-var.ts
@@ -4,6 +4,55 @@
 const CSS_VAR_NAME_PATTERN = /^--[\w-]+$/;
 
 /**
+ * Builds a resolver that reads every value from one `getComputedStyle` snapshot.
+ *
+ * `getComputedStyle` is the expensive half of resolving a token: each call can force the browser to flush pending style, and a chart theme resolves five roles at once. Taking the snapshot once per build turns that into a single query. The reads that share a snapshot happen synchronously inside one memo body, so no style change can land between them — the resolver is single-pass by design and is not meant to be held across renders.
+ *
+ * @param element - The element to resolve against, or null/undefined for the document root.
+ * @return A resolver that resolves each value exactly as `resolveCssVariable` does.
+ */
+export const createCssVariableResolver = (
+	element?: HTMLElement | null
+): ( ( value: string ) => string | null ) => {
+	let styles: CSSStyleDeclaration | null = null;
+
+	// Deferred so a resolver for a theme that turns out to hold only literals costs nothing. Only a successful read is kept: caching the null would leave a resolver built before its element is in the document dead for the rest of its life.
+	const getStyles = () => {
+		if ( ! styles ) {
+			styles = computedStyleFor( element );
+		}
+
+		return styles;
+	};
+
+	return value => {
+		if ( ! value ) {
+			return null;
+		}
+
+		// Check if it's a var() expression: var(--name) or var(--name, fallback)
+		// Parse manually to avoid regex backtracking vulnerabilities
+		if ( value.startsWith( 'var(' ) && value.endsWith( ')' ) ) {
+			const parsed = parseVarExpression( value );
+
+			if ( parsed ) {
+				const resolved = readCustomProperty( parsed.varName, getStyles() );
+
+				return resolved || parsed.fallback;
+			}
+		}
+
+		// Check if it's a plain variable name (starts with --)
+		if ( value.startsWith( '--' ) ) {
+			return readCustomProperty( value, getStyles() );
+		}
+
+		// Return regular values as-is (e.g., '#ffffff', 'red')
+		return value;
+	};
+};
+
+/**
  * Resolves a CSS custom property (variable) to its computed value.
  * Handles multiple formats:
  * - Plain variable names: '--my-color'
@@ -16,65 +65,7 @@ const CSS_VAR_NAME_PATTERN = /^--[\w-]+$/;
  * @return The resolved value, fallback value, or null if unresolvable
  */
 export const resolveCssVariable = ( value: string, element?: HTMLElement | null ): string | null =>
-	resolveWith( value, () => computedStyleFor( element ) );
-
-/**
- * Builds a resolver that reads every value from one `getComputedStyle` snapshot.
- *
- * `getComputedStyle` is the expensive half of resolving a token: each call can force the browser to flush pending style, and a chart theme resolves five roles at once. Taking the snapshot once per theme build turns that into a single query — the returned styles object stays live, so later reads still see current values.
- *
- * @param element - The element to resolve against, or null/undefined for the document root.
- * @return A resolver with the same contract as `resolveCssVariable`.
- */
-export const createCssVariableResolver = (
-	element?: HTMLElement | null
-): ( ( value: string ) => string | null ) => {
-	let styles: CSSStyleDeclaration | null | undefined;
-
-	// Deferred so a resolver built for a theme that turns out to hold only literals costs nothing.
-	const getStyles = () => {
-		if ( styles === undefined ) {
-			styles = computedStyleFor( element );
-		}
-
-		return styles;
-	};
-
-	return value => resolveWith( value, getStyles );
-};
-
-/**
- * The shared resolution contract, over a lazily-obtained computed-style snapshot.
- *
- * @param value     - A CSS variable name, var() expression, or regular value.
- * @param getStyles - Returns the computed styles to read custom properties from.
- * @return The resolved value, fallback value, or null if unresolvable.
- */
-function resolveWith( value: string, getStyles: () => CSSStyleDeclaration | null ): string | null {
-	if ( ! value ) {
-		return null;
-	}
-
-	// Check if it's a var() expression: var(--name) or var(--name, fallback)
-	// Parse manually to avoid regex backtracking vulnerabilities
-	if ( value.startsWith( 'var(' ) && value.endsWith( ')' ) ) {
-		const parsed = parseVarExpression( value );
-
-		if ( parsed ) {
-			const resolved = readCustomProperty( parsed.varName, getStyles() );
-
-			return resolved || parsed.fallback;
-		}
-	}
-
-	// Check if it's a plain variable name (starts with --)
-	if ( value.startsWith( '--' ) ) {
-		return readCustomProperty( value, getStyles() );
-	}
-
-	// Return regular values as-is (e.g., '#ffffff', 'red')
-	return value;
-}
+	createCssVariableResolver( element )( value );
 
 /**
  * Parses a var() expression into its variable name and optional fallback.
@@ -154,7 +145,7 @@ function readCustomProperty( varName: string, styles: CSSStyleDeclaration | null
 
 		return computedValue || null;
 	} catch {
-		// A snapshot can outlive what it describes: reading a property off a stale CSSStyleDeclaration throws in some engines.
+		// Belt and braces — no engine is known to throw here. Kept because a caller may hand in a stand-in for CSSStyleDeclaration; `resolve-css-var.test.ts` covers exactly that.
 		return null;
 	}
 }

--- a/projects/js-packages/charts/src/utils/test/create-css-variable-resolver.test.ts
+++ b/projects/js-packages/charts/src/utils/test/create-css-variable-resolver.test.ts
@@ -1,0 +1,83 @@
+import { createCssVariableResolver } from '../resolve-css-var';
+
+describe( 'createCssVariableResolver', () => {
+	let originalGetComputedStyle: typeof window.getComputedStyle;
+
+	beforeEach( () => {
+		originalGetComputedStyle = window.getComputedStyle;
+	} );
+
+	afterEach( () => {
+		window.getComputedStyle = originalGetComputedStyle;
+	} );
+
+	const mockStyles = ( values: Record< string, string > ) => {
+		const spy = jest.fn( () => ( {
+			getPropertyValue: ( prop: string ) => values[ prop ] ?? '',
+		} ) );
+		window.getComputedStyle = spy as unknown as typeof window.getComputedStyle;
+
+		return spy;
+	};
+
+	it( 'reads many values from a single snapshot', () => {
+		const spy = mockStyles( { '--a': '#111', '--b': '#222' } );
+		const resolve = createCssVariableResolver();
+
+		expect( resolve( '--a' ) ).toBe( '#111' );
+		expect( resolve( 'var(--b)' ) ).toBe( '#222' );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'takes no snapshot at all for values that need no lookup', () => {
+		const spy = mockStyles( {} );
+		const resolve = createCssVariableResolver();
+
+		expect( resolve( '#ffffff' ) ).toBe( '#ffffff' );
+		expect( resolve( '' ) ).toBeNull();
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'resolves against the element it was built for', () => {
+		const element = document.createElement( 'div' );
+		const spy = jest.fn( ( target: Element ) => ( {
+			getPropertyValue: () => ( target === element ? '#c029dc' : '#000000' ),
+		} ) );
+		window.getComputedStyle = spy as unknown as typeof window.getComputedStyle;
+
+		expect( createCssVariableResolver( element )( '--accent' ) ).toBe( '#c029dc' );
+		expect( spy ).toHaveBeenCalledWith( element );
+	} );
+
+	it( 'falls back to the var() fallback when the property is unset', () => {
+		mockStyles( {} );
+
+		expect( createCssVariableResolver()( 'var(--missing, #dbdbdb)' ) ).toBe( '#dbdbdb' );
+	} );
+
+	// A failed read is not cached: a resolver built before its element is in the document would otherwise stay dead for the rest of its life, which is the shape CHARTS-255 introduces.
+	it( 'retries after a snapshot that could not be taken', () => {
+		const failing = jest.fn( () => {
+			throw new Error( 'not attached' );
+		} );
+		window.getComputedStyle = failing as unknown as typeof window.getComputedStyle;
+
+		const resolve = createCssVariableResolver();
+		expect( resolve( '--a' ) ).toBeNull();
+
+		mockStyles( { '--a': '#111' } );
+		expect( resolve( '--a' ) ).toBe( '#111' );
+	} );
+
+	it( 'matches resolveCssVariable for the values it is given', () => {
+		mockStyles( { '--a': '#111' } );
+		const resolve = createCssVariableResolver();
+
+		expect( [
+			resolve( '--a' ),
+			resolve( 'var(--a)' ),
+			resolve( 'var(--z, red)' ),
+			resolve( 'red' ),
+		] ).toEqual( [ '#111', '#111', 'red', 'red' ] );
+	} );
+} );


### PR DESCRIPTION
Fixes CHARTS-256

## Why

`useXYChartTheme()` resolved each of the theme's five color roles — background, grid, axis line, tick line, small SVG label — with its own `resolveCssVariable()` call, and each of those took its own `getComputedStyle` snapshot. Five style queries to build one theme.

`getComputedStyle` can force the browser to flush pending style, so this is not a nominal cost, and the memo rebuilt whenever `data` changed identity. A caller passing an inline array literal — `<LineChart data={ [ … ] } />`, which the stories and several consumers do — rebuilt on every render, so a dashboard of N charts was paying 5N style queries per render pass.

Split out of #51308 so the theming-architecture change can be reviewed on its own. This fix is independent of it and applies to trunk as it stands.

## Proposed changes

Two independent wins, both in `useXYChartTheme`:

* **The multiplier.** Add `createCssVariableResolver( element )` beside `resolveCssVariable` in `src/utils/resolve-css-var.ts` and build one per theme memo, so all five roles share a snapshot instead of taking one each. 5 → 1 per build.
* **The frequency.** Key the memo on the series strokes rather than on `data`'s identity — they are the only thing the theme takes from it. The inline-array-literal case now costs **zero** style reads per render and skips `buildChartTheme` too, rather than one read.

Three details worth a look:

* **The snapshot is deferred**, so a theme that turns out to hold only literals — the SSR and jsdom paths — still costs nothing. Only a *successful* read is cached: keeping the `null` would leave a resolver built before its element is in the document dead for the rest of its life, which is exactly the shape CHARTS-255 introduces.
* **The memo key is serialised, not joined.** A series stroke is arbitrary consumer CSS: `rgba(0, 0, 0, 0.5)` and `var(--brand, #fff)` both contain spaces and commas, so a join/split round-trip would shred one color into several. There is a test for this.
* **Two adjacent reads went with it.** `line-chart.tsx` and `area-chart.tsx` each resolved `providerTheme.backgroundColor` in the render path for a role the theme had already resolved a line earlier. Reading it back off the theme removes a `getComputedStyle` per render on every LineChart and AreaChart — a bigger steady-state win than the batching itself.

`resolveCssVariable` keeps its signature and behaviour for its other callers, including the SSR, detached-element and throwing-`getPropertyValue` guards; it is now a one-line call through the factory rather than a second path.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

`projects/js-packages/charts`: `pnpm test` (56 suites, 1131 tests), `pnpm typecheck` and `pnpm run build` are clean.

`src/hooks/test/use-xychart-theme-style-reads.test.tsx` spies on `window.getComputedStyle` and asserts:

1. One call per theme build, with all five roles still resolving from that one snapshot. *(Fails with `Expected 1, Received 5` if the batching is reverted.)*
2. No call at all when the hook re-renders with unchanged inputs. *(This one passes on trunk too — it guards the memo, not this change.)*
3. No call at all when the caller passes a fresh `data` array of the same strokes — the inline-literal case. *(Fails if the memo key is reverted to `data`.)*
4. One call when a series stroke actually changes, and colors containing commas and spaces surviving the key round-trip.

`src/utils/test/create-css-variable-resolver.test.ts` covers the resolver directly: one snapshot across many reads, no snapshot for literal-only themes, the `element` argument, `var()` fallbacks, and the retry after a snapshot that could not be taken.

In Storybook (`pnpm run storybook`), the XY charts — area, bar, line, sparkline — should render exactly as before; this changes when the style read happens, not what it returns.

## Related product discussion/links

* CHARTS-256 — this issue
* #51308 — the theming-architecture PR this was split out of
* CHARTS-255 — will add a second resolution pass once a chart's own root mounts; batching first keeps that from doubling the cost

