### PR TITLE
Charts: derive the bar chart's band domain from the axis it ticks

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-bar-options-cleanup
+++ b/projects/js-packages/charts/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Charts: choose a bar chart's time-axis tick values from the buckets the axis actually renders, so a mix of dated and labelled points can no longer place a tick off the scale.
+Charts: keep a bar chart's time axis on the buckets it actually draws, so a labelled bar or a comparison series can no longer strand a tick at the axis origin.

--- a/projects/js-packages/charts/changelog/fix-charts-bar-options-cleanup
+++ b/projects/js-packages/charts/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Charts: keep a bar chart's time axis on the buckets it actually draws, so a labelled bar, a comparison series, or a series hidden from the legend can no longer strand a tick at the axis origin.
+Charts: keep a bar chart's time axis on the buckets it actually draws, so a labelled bar, a comparison series, or a series hidden from the legend can no longer strand a tick at the axis origin, and label such a bar by its label in both the axis and the tooltip.

--- a/projects/js-packages/charts/changelog/fix-charts-bar-options-cleanup
+++ b/projects/js-packages/charts/changelog/fix-charts-bar-options-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: choose a bar chart's time-axis tick values from the buckets the axis actually renders, so a mix of dated and labelled points can no longer place a tick off the scale.

--- a/projects/js-packages/charts/changelog/fix-charts-bar-options-cleanup
+++ b/projects/js-packages/charts/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Charts: keep a bar chart's time axis on the buckets it actually draws, so a labelled bar or a comparison series can no longer strand a tick at the axis origin.
+Charts: keep a bar chart's time axis on the buckets it actually draws, so a labelled bar, a comparison series, or a series hidden from the legend can no longer strand a tick at the axis origin.

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -118,8 +118,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	legend = {},
 	gridVisibility: gridVisibilityProp,
 	renderTooltip,
-	// Left undefined so `useBarChartOptions` can apply its shared default.
-	options,
+	options = {},
 	orientation = 'vertical',
 	withPatterns = false,
 	showZeroValues = false,

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -118,7 +118,10 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	legend = {},
 	gridVisibility: gridVisibilityProp,
 	renderTooltip,
-	options = {},
+	// Deliberately undefined rather than `{}`: the value reaches
+	// `useBarChartOptions` memo dependencies, where a fresh literal per render
+	// would defeat them. That hook supplies a shared default.
+	options,
 	orientation = 'vertical',
 	withPatterns = false,
 	showZeroValues = false,

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -118,9 +118,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	legend = {},
 	gridVisibility: gridVisibilityProp,
 	renderTooltip,
-	// Deliberately undefined rather than `{}`: the value reaches
-	// `useBarChartOptions` memo dependencies, where a fresh literal per render
-	// would defeat them. That hook supplies a shared default.
+	// Left undefined so `useBarChartOptions` can apply its shared default.
 	options,
 	orientation = 'vertical',
 	withPatterns = false,

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -148,7 +148,23 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		[ legendCollapseGroups ]
 	);
 	const legendItems = useChartLegendItems( dataSorted, legendOptions );
-	const chartOptions = useBarChartOptions( dataWithVisibleZeros, horizontal, options );
+
+	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
+
+	// A hidden series is unmounted, so it is not on the band scale either — the
+	// axis has to choose its tick values from what is left.
+	const isSeriesRendered = useCallback(
+		( series: SeriesData ) =>
+			! chartId || ! legendInteractive || isSeriesVisible( chartId, series.label ),
+		[ chartId, legendInteractive, isSeriesVisible ]
+	);
+
+	const chartOptions = useBarChartOptions(
+		dataWithVisibleZeros,
+		horizontal,
+		options,
+		isSeriesRendered
+	);
 	const defaultMargin = useChartMargin( height, chartOptions, dataSorted, theme, horizontal );
 	const chartRef = useRef< HTMLDivElement >( null );
 
@@ -183,23 +199,16 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		totalPoints,
 	} );
 
-	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
-
 	// Add visibility information to series when using interactive legends
-	const seriesWithVisibility = useMemo( () => {
-		if ( ! chartId || ! legendInteractive ) {
-			return dataWithVisibleZeros.map( ( series, index ) => ( {
+	const seriesWithVisibility = useMemo(
+		() =>
+			dataWithVisibleZeros.map( ( series, index ) => ( {
 				series,
 				index,
-				isVisible: true,
-			} ) );
-		}
-		return dataWithVisibleZeros.map( ( series, index ) => ( {
-			series,
-			index,
-			isVisible: isSeriesVisible( chartId, series.label ),
-		} ) );
-	}, [ dataWithVisibleZeros, chartId, isSeriesVisible, legendInteractive ] );
+				isVisible: isSeriesRendered( series ),
+			} ) ),
+		[ dataWithVisibleZeros, isSeriesRendered ]
+	);
 
 	// Check if all series are hidden
 	const allSeriesHidden = useMemo( () => {

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -1,6 +1,7 @@
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from 'react';
+import { useDeepMemo } from '../../../hooks';
 import { getBandTickValues, getBucketResolution, getFormatter } from '../../private/time-axis';
 import { TruncatedXTickComponent, TruncatedYTickComponent } from './truncated-tick-component';
 import type { EnhancedDataPoint } from '../../../hooks/use-zero-value-display';
@@ -16,9 +17,7 @@ const DEFAULT_NUM_TICKS = 4;
 
 // Shared rather than a fresh literal: this lands in the dependencies of every
 // memo below, so defaulting inline recomputed all of them on every render.
-const NO_OPTIONS: BaseChartProps[ 'options' ] = {};
-
-// Same reason as NO_OPTIONS: a stable reference for callers that do not hide series.
+// A stable reference for callers that hide no series, so the memos below hold.
 const ALL_RENDERED = () => true;
 
 // The axis abbreviates to fit a tick; a tooltip has room to spell the same
@@ -149,9 +148,13 @@ const getGroupPadding = ( scale: Record< string, unknown > ): number => {
 export function useBarChartOptions(
 	data: SeriesData[],
 	horizontal: boolean,
-	options: BaseChartProps[ 'options' ] = NO_OPTIONS,
+	options: BaseChartProps[ 'options' ] = {},
 	isSeriesRendered: ( series: SeriesData ) => boolean = ALL_RENDERED
 ) {
+	// Callers reasonably pass an object literal, which is a fresh reference every
+	// render and would defeat every memo below.
+	const stableOptions = useDeepMemo( options );
+
 	// `labelOverflow` and `tickResolution` are consumed by this hook rather than
 	// forwarded — visx has an axis prop for neither — so they are split off the
 	// caller's axis options once, here, and only the rest reaches visx below.
@@ -160,12 +163,12 @@ export function useBarChartOptions(
 			labelOverflow: xLabelOverflow,
 			tickResolution: xTickResolution,
 			...xAxisOptions
-		} = options.axis?.x || {};
+		} = stableOptions.axis?.x || {};
 		const {
 			labelOverflow: yLabelOverflow,
 			tickResolution: yTickResolution,
 			...yAxisOptions
-		} = options.axis?.y || {};
+		} = stableOptions.axis?.y || {};
 
 		return {
 			xLabelOverflow,
@@ -176,7 +179,7 @@ export function useBarChartOptions(
 			// chart is horizontal, so the hint follows them.
 			tickResolution: horizontal ? yTickResolution : xTickResolution,
 		};
-	}, [ options, horizontal ] );
+	}, [ stableOptions, horizontal ] );
 	const { tickResolution } = axisConfig;
 
 	const defaultOptions = useMemo( () => {
@@ -259,7 +262,7 @@ export function useBarChartOptions(
 		const hasComparisonSeries = data.some( s => s.options?.type === 'comparison' );
 		if ( hasComparisonSeries ) {
 			const valueAxisIsY = ! horizontal;
-			const userDomain = valueAxisIsY ? options.yScale?.domain : options.xScale?.domain;
+			const userDomain = valueAxisIsY ? stableOptions.yScale?.domain : stableOptions.xScale?.domain;
 			if ( ! userDomain ) {
 				const allValues: number[] = [];
 				data.forEach( series => {
@@ -285,12 +288,12 @@ export function useBarChartOptions(
 
 		const xScale = {
 			...baseXScale,
-			...( options.xScale || {} ),
+			...( stableOptions.xScale || {} ),
 			...( horizontal ? valueScaleDomainOverride : {} ),
 		};
 		const yScale = {
 			...baseYScale,
-			...( options.yScale || {} ),
+			...( stableOptions.yScale || {} ),
 			...( ! horizontal ? valueScaleDomainOverride : {} ),
 		};
 		const { xLabelOverflow, yLabelOverflow, xAxisOptions, yAxisOptions } = axisConfig;
@@ -347,5 +350,5 @@ export function useBarChartOptions(
 				labelFormatter: providedToolTipLabelFormatter || defaultTooltipLabelFormatter,
 			},
 		};
-	}, [ defaultOptions, axisConfig, options, horizontal, data ] );
+	}, [ defaultOptions, axisConfig, stableOptions, horizontal, data ] );
 }

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -66,14 +66,23 @@ const getTooltipFormatter = ( data: SeriesData[], tickResolution?: TickResolutio
 	return ( timestamp: number ) => new Date( timestamp ).toLocaleString( undefined, format );
 };
 
+const identity = ( label: string ) => label;
+
+// `hasLabels` only samples the first point of the first series, so a labelled
+// bucket can still reach a formatter that was chosen for timestamps. It arrives
+// as its own string; only a dated bucket has a timestamp to format.
+const byBucket =
+	( format: ( timestamp: number ) => string ) => ( bucket: Date | string | number ) =>
+		typeof bucket === 'string' ? bucket : format( Number( bucket ) );
+
 // Shared with the domain below so both read a bucket the same way.
 const bucketAccessor = ( d: DataPointDate ) => d?.label || d?.date;
 
 /**
  * The buckets the band axis can put a tick on.
  *
- * Built from the accessor visx is given, in the order visx concatenates it, so
- * that a tick value is a key the scale actually holds; `scaleBand` returns
+ * Built from the accessor visx is given, over the same series in the same order,
+ * so that a tick value is a key the scale actually holds; `scaleBand` returns
  * `undefined` for one it does not, which parks the tick at the origin. Null
  * rather than a partial list when any bucket is labelled instead of dated.
  *
@@ -85,7 +94,11 @@ const getBandDomain = (
 	data: SeriesData[],
 	isSeriesRendered: ( series: SeriesData ) => boolean
 ): Date[] | null => {
-	const byTimestamp = new Map< number, Date >();
+	// visx keys its data registry on the series label and reads it back with
+	// `Object.keys`, so a plain object reproduces both of the things that follow
+	// from that: two series sharing a label collapse to the later one, and an
+	// integer-like label sorts ahead of the rest whatever order it arrived in.
+	const registry: Record< string, SeriesData > = {};
 
 	for ( const series of data ) {
 		// Comparison series register nothing with visx — `comparison-bars.tsx` draws
@@ -94,8 +107,13 @@ const getBandDomain = (
 		if ( series.options?.type === 'comparison' || ! isSeriesRendered( series ) ) {
 			continue;
 		}
+		registry[ series.label ] = series;
+	}
 
-		for ( const point of series.data ) {
+	const byTimestamp = new Map< number, Date >();
+
+	for ( const key of Object.keys( registry ) ) {
+		for ( const point of registry[ key ].data ) {
 			const bucket = bucketAccessor( point as DataPointDate );
 			if ( ! ( bucket instanceof Date ) ) {
 				return null;
@@ -178,15 +196,10 @@ export function useBarChartOptions(
 		// size; the tooltip stays at the bucket's own granularity.
 		const hasLabels = Boolean( data?.[ 0 ]?.data?.[ 0 ]?.label );
 		const timeTickFormatter = hasLabels ? null : getFormatter( data, tickResolution );
-		// `hasLabels` only samples the first point, so a later labelled bucket still
-		// reaches the axis — as its own string, not a timestamp.
-		const labelFormatter = timeTickFormatter
-			? ( bucket: Date | string | number ) =>
-					typeof bucket === 'string' ? bucket : timeTickFormatter( Number( bucket ) )
-			: ( label: string ) => label;
+		const labelFormatter = timeTickFormatter ? byBucket( timeTickFormatter ) : identity;
 		const tooltipDatumFormatter = hasLabels
 			? labelFormatter
-			: getTooltipFormatter( data, tickResolution );
+			: byBucket( getTooltipFormatter( data, tickResolution ) );
 		const valueFormatter = formatNumberCompact as TickFormatter< unknown >;
 
 		const bandDomain = timeTickFormatter ? getBandDomain( data, isSeriesRendered ) : null;

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -15,8 +15,6 @@ export const BASE_BAND_PADDING_INNER = 0.1;
 /** Ticks each axis carries unless the caller asks for a different count. */
 const DEFAULT_NUM_TICKS = 4;
 
-// Shared rather than a fresh literal: this lands in the dependencies of every
-// memo below, so defaulting inline recomputed all of them on every render.
 // A stable reference for callers that hide no series, so the memos below hold.
 const ALL_RENDERED = () => true;
 

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -14,9 +14,8 @@ export const BASE_BAND_PADDING_INNER = 0.1;
 /** Ticks each axis carries unless the caller asks for a different count. */
 const DEFAULT_NUM_TICKS = 4;
 
-// Shared rather than a fresh literal per call: it is in the dependencies of
-// every memo below, so defaulting inline recomputed all of them on every render
-// for the callers that pass no options at all.
+// Shared rather than a fresh literal: this lands in the dependencies of every
+// memo below, so defaulting inline recomputed all of them on every render.
 const NO_OPTIONS: BaseChartProps[ 'options' ] = {};
 
 // The axis abbreviates to fit a tick; a tooltip has room to spell the same
@@ -64,29 +63,34 @@ const getTooltipFormatter = ( data: SeriesData[], tickResolution?: TickResolutio
 	return ( timestamp: number ) => new Date( timestamp ).toLocaleString( undefined, format );
 };
 
-// The bucket a point sits on, as handed to visx for the band axis. Module-level
-// so the domain below is read through the same function the scale is, and so
-// the reference stays stable across renders.
+// Shared with the domain below so both read a bucket the same way.
 const bucketAccessor = ( d: DataPointDate ) => d?.label || d?.date;
 
 /**
- * The band scale's domain: the buckets the axis can put a tick on, as visx will
- * build them.
+ * The buckets the band axis can put a tick on.
  *
- * Reads the same accessor visx does and keeps its order — series concatenated,
- * first occurrence winning — rather than re-deriving from `date` and sorting.
- * Tick values are chosen as positions in this domain, so anything but the same
- * list can place a tick on a bucket that is not on screen. Null when any bucket
- * is labelled rather than dated: a `Date` tick value would not be in the domain
- * at all, and `scaleBand` returns `undefined` for a key it does not hold.
+ * Built from the accessor visx is given, in the order visx concatenates it, so
+ * that a tick value is a key the scale actually holds; `scaleBand` returns
+ * `undefined` for one it does not, which parks the tick at the origin. Null
+ * rather than a partial list when any bucket is labelled instead of dated.
+ *
+ * Still wider than what visx registers when the legend hides a series, since
+ * this runs before visibility is known — see CHARTS follow-up in the PR.
  *
  * @param data - The series the chart will render.
- * @return Distinct bucket dates in axis order, or null if any bucket is labelled.
+ * @return Bucket dates in axis order, or null if the axis cannot be ticked by date.
  */
 const getBandDomain = ( data: SeriesData[] ): Date[] | null => {
 	const byTimestamp = new Map< number, Date >();
 
 	for ( const series of data ) {
+		// Comparison series register nothing with visx — `comparison-bars.tsx` draws
+		// onto the scales the primary series established — so their buckets are not
+		// keys of the band scale.
+		if ( series.options?.type === 'comparison' ) {
+			continue;
+		}
+
 		for ( const point of series.data ) {
 			const bucket = bucketAccessor( point as DataPointDate );
 			if ( ! ( bucket instanceof Date ) ) {
@@ -98,7 +102,7 @@ const getBandDomain = ( data: SeriesData[] ): Date[] | null => {
 		}
 	}
 
-	return [ ...byTimestamp.values() ];
+	return byTimestamp.size ? [ ...byTimestamp.values() ] : null;
 };
 
 /**
@@ -168,14 +172,17 @@ export function useBarChartOptions(
 		// size; the tooltip stays at the bucket's own granularity.
 		const hasLabels = Boolean( data?.[ 0 ]?.data?.[ 0 ]?.label );
 		const timeTickFormatter = hasLabels ? null : getFormatter( data, tickResolution );
-		const labelFormatter = timeTickFormatter ?? ( ( label: string ) => label );
+		// `hasLabels` only samples the first point, so a later labelled bucket still
+		// reaches the axis — as its own string, not a timestamp.
+		const labelFormatter = timeTickFormatter
+			? ( bucket: Date | string | number ) =>
+					typeof bucket === 'string' ? bucket : timeTickFormatter( Number( bucket ) )
+			: ( label: string ) => label;
 		const tooltipDatumFormatter = hasLabels
 			? labelFormatter
 			: getTooltipFormatter( data, tickResolution );
 		const valueFormatter = formatNumberCompact as TickFormatter< unknown >;
 
-		// Only for a dated axis, and only when every bucket is dated: without a
-		// domain there is nothing to choose tick values from.
 		const bandDomain = timeTickFormatter ? getBandDomain( data ) : null;
 
 		const valueAccessor = ( d: DataPointDate | EnhancedDataPoint ) => {

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -14,6 +14,11 @@ export const BASE_BAND_PADDING_INNER = 0.1;
 /** Ticks each axis carries unless the caller asks for a different count. */
 const DEFAULT_NUM_TICKS = 4;
 
+// Shared rather than a fresh literal per call: it is in the dependencies of
+// every memo below, so defaulting inline recomputed all of them on every render
+// for the callers that pass no options at all.
+const NO_OPTIONS: BaseChartProps[ 'options' ] = {};
+
 // The axis abbreviates to fit a tick; a tooltip has room to spell the same
 // bucket out in full.
 const TOOLTIP_FORMAT_BY_RESOLUTION: Record<
@@ -59,28 +64,41 @@ const getTooltipFormatter = ( data: SeriesData[], tickResolution?: TickResolutio
 	return ( timestamp: number ) => new Date( timestamp ).toLocaleString( undefined, format );
 };
 
-/**
- * The band scale's domain, as the dates the axis can put a tick on. Series are
- * individually sorted already, so a merge on the timestamp restores axis order
- * across all of them.
- *
- * @param data - Date-based series.
- * @return Distinct dates, earliest first.
- */
-const getBandDomain = ( data: SeriesData[] ): Date[] => {
-	const byTimestamp = new Map< number, Date >();
-	data.forEach( series =>
-		series.data.forEach( point => {
-			const { date } = point as DataPointDate;
-			if ( date && ! byTimestamp.has( date.getTime() ) ) {
-				byTimestamp.set( date.getTime(), date );
-			}
-		} )
-	);
+// The bucket a point sits on, as handed to visx for the band axis. Module-level
+// so the domain below is read through the same function the scale is, and so
+// the reference stays stable across renders.
+const bucketAccessor = ( d: DataPointDate ) => d?.label || d?.date;
 
-	return [ ...byTimestamp.keys() ]
-		.sort( ( a, b ) => a - b )
-		.map( timestamp => byTimestamp.get( timestamp ) );
+/**
+ * The band scale's domain: the buckets the axis can put a tick on, as visx will
+ * build them.
+ *
+ * Reads the same accessor visx does and keeps its order — series concatenated,
+ * first occurrence winning — rather than re-deriving from `date` and sorting.
+ * Tick values are chosen as positions in this domain, so anything but the same
+ * list can place a tick on a bucket that is not on screen. Null when any bucket
+ * is labelled rather than dated: a `Date` tick value would not be in the domain
+ * at all, and `scaleBand` returns `undefined` for a key it does not hold.
+ *
+ * @param data - The series the chart will render.
+ * @return Distinct bucket dates in axis order, or null if any bucket is labelled.
+ */
+const getBandDomain = ( data: SeriesData[] ): Date[] | null => {
+	const byTimestamp = new Map< number, Date >();
+
+	for ( const series of data ) {
+		for ( const point of series.data ) {
+			const bucket = bucketAccessor( point as DataPointDate );
+			if ( ! ( bucket instanceof Date ) ) {
+				return null;
+			}
+			if ( ! byTimestamp.has( bucket.getTime() ) ) {
+				byTimestamp.set( bucket.getTime(), bucket );
+			}
+		}
+	}
+
+	return [ ...byTimestamp.values() ];
 };
 
 /**
@@ -104,7 +122,7 @@ const getGroupPadding = ( scale: Record< string, unknown > ): number => {
 export function useBarChartOptions(
 	data: SeriesData[],
 	horizontal: boolean,
-	options: BaseChartProps[ 'options' ] = {}
+	options: BaseChartProps[ 'options' ] = NO_OPTIONS
 ) {
 	// `labelOverflow` and `tickResolution` are consumed by this hook rather than
 	// forwarded — visx has an axis prop for neither — so they are split off the
@@ -156,7 +174,10 @@ export function useBarChartOptions(
 			: getTooltipFormatter( data, tickResolution );
 		const valueFormatter = formatNumberCompact as TickFormatter< unknown >;
 
-		const labelAccessor = ( d: DataPointDate ) => d?.label || d?.date;
+		// Only for a dated axis, and only when every bucket is dated: without a
+		// domain there is nothing to choose tick values from.
+		const bandDomain = timeTickFormatter ? getBandDomain( data ) : null;
+
 		const valueAccessor = ( d: DataPointDate | EnhancedDataPoint ) => {
 			// Use visualValue for bar rendering if available (for zero values), otherwise use value
 			const enhancedPoint = d as EnhancedDataPoint;
@@ -164,15 +185,16 @@ export function useBarChartOptions(
 		};
 
 		return {
-			timeAxis: timeTickFormatter && {
-				domain: getBandDomain( data ),
-				tickFormatter: timeTickFormatter,
-			},
+			timeAxis: bandDomain &&
+				timeTickFormatter && {
+					domain: bandDomain,
+					tickFormatter: timeTickFormatter,
+				},
 			vertical: {
 				xTickFormat: labelFormatter,
 				yTickFormat: valueFormatter,
 				tooltipLabelFormatter: tooltipDatumFormatter,
-				xAccessor: labelAccessor,
+				xAccessor: bucketAccessor,
 				yAccessor: valueAccessor,
 				gridVisibility: 'x',
 				xScale: bandScale,
@@ -183,7 +205,7 @@ export function useBarChartOptions(
 				yTickFormat: labelFormatter,
 				tooltipLabelFormatter: tooltipDatumFormatter,
 				xAccessor: valueAccessor,
-				yAccessor: labelAccessor,
+				yAccessor: bucketAccessor,
 				gridVisibility: 'y',
 				xScale: linearScale,
 				yScale: bandScale,

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -18,6 +18,9 @@ const DEFAULT_NUM_TICKS = 4;
 // memo below, so defaulting inline recomputed all of them on every render.
 const NO_OPTIONS: BaseChartProps[ 'options' ] = {};
 
+// Same reason as NO_OPTIONS: a stable reference for callers that do not hide series.
+const ALL_RENDERED = () => true;
+
 // The axis abbreviates to fit a tick; a tooltip has room to spell the same
 // bucket out in full.
 const TOOLTIP_FORMAT_BY_RESOLUTION: Record<
@@ -74,20 +77,21 @@ const bucketAccessor = ( d: DataPointDate ) => d?.label || d?.date;
  * `undefined` for one it does not, which parks the tick at the origin. Null
  * rather than a partial list when any bucket is labelled instead of dated.
  *
- * Still wider than what visx registers when the legend hides a series, since
- * this runs before visibility is known — see CHARTS follow-up in the PR.
- *
- * @param data - The series the chart will render.
+ * @param data             - Every series handed to the chart.
+ * @param isSeriesRendered - Whether visx mounts a series, i.e. the legend shows it.
  * @return Bucket dates in axis order, or null if the axis cannot be ticked by date.
  */
-const getBandDomain = ( data: SeriesData[] ): Date[] | null => {
+const getBandDomain = (
+	data: SeriesData[],
+	isSeriesRendered: ( series: SeriesData ) => boolean
+): Date[] | null => {
 	const byTimestamp = new Map< number, Date >();
 
 	for ( const series of data ) {
 		// Comparison series register nothing with visx — `comparison-bars.tsx` draws
-		// onto the scales the primary series established — so their buckets are not
-		// keys of the band scale.
-		if ( series.options?.type === 'comparison' ) {
+		// onto the scales the primary series established — and a hidden series is
+		// unmounted, so neither contributes a key to the band scale.
+		if ( series.options?.type === 'comparison' || ! isSeriesRendered( series ) ) {
 			continue;
 		}
 
@@ -118,15 +122,17 @@ const getGroupPadding = ( scale: Record< string, unknown > ): number => {
 /**
  * Returns the merged options for the bar chart, including axis and scale configuration based on the orientation.
  *
- * @param data       - The data to be displayed in the chart.
- * @param horizontal - Whether the chart is horizontal or vertical.
- * @param options    - The options for the chart.
+ * @param data             - The data to be displayed in the chart.
+ * @param horizontal       - Whether the chart is horizontal or vertical.
+ * @param options          - The options for the chart.
+ * @param isSeriesRendered - Whether visx mounts a series, i.e. the legend shows it.
  * @return The merged options for the chart.
  */
 export function useBarChartOptions(
 	data: SeriesData[],
 	horizontal: boolean,
-	options: BaseChartProps[ 'options' ] = NO_OPTIONS
+	options: BaseChartProps[ 'options' ] = NO_OPTIONS,
+	isSeriesRendered: ( series: SeriesData ) => boolean = ALL_RENDERED
 ) {
 	// `labelOverflow` and `tickResolution` are consumed by this hook rather than
 	// forwarded — visx has an axis prop for neither — so they are split off the
@@ -183,7 +189,7 @@ export function useBarChartOptions(
 			: getTooltipFormatter( data, tickResolution );
 		const valueFormatter = formatNumberCompact as TickFormatter< unknown >;
 
-		const bandDomain = timeTickFormatter ? getBandDomain( data ) : null;
+		const bandDomain = timeTickFormatter ? getBandDomain( data, isSeriesRendered ) : null;
 
 		const valueAccessor = ( d: DataPointDate | EnhancedDataPoint ) => {
 			// Use visualValue for bar rendering if available (for zero values), otherwise use value
@@ -218,7 +224,7 @@ export function useBarChartOptions(
 				yScale: bandScale,
 			},
 		};
-	}, [ data, tickResolution ] );
+	}, [ data, tickResolution, isSeriesRendered ] );
 
 	return useMemo( () => {
 		const orientationKey = horizontal ? 'horizontal' : 'vertical';

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { GlobalChartsProvider } from '../../../providers';
 import BarChart from '../bar-chart';
 import { useBarChartOptions } from '../private';
+import type { SeriesData } from '../../../types';
 
 // Mock useElementSize to return non-zero dimensions in jsdom so charts render
 const mockRefCallback = jest.fn();
@@ -215,6 +216,87 @@ describe( 'BarChart', () => {
 			// Query for tspan elements that contain the formatted date.
 			const tspansWithDate = screen.getAllByText( '1/3/24' );
 			expect( tspansWithDate.length ).toBeGreaterThan( 0 );
+		} );
+	} );
+
+	describe( 'Bar chart options memoization', () => {
+		const stableData: SeriesData[] = [
+			{
+				label: 'Views',
+				data: [
+					{ date: new Date( 2026, 0, 1 ), value: 1 },
+					{ date: new Date( 2026, 0, 2 ), value: 2 },
+				],
+				options: {},
+			},
+		];
+
+		test( 'returns the same options when nothing changed and no options were passed', () => {
+			const { result, rerender } = renderHook( () => useBarChartOptions( stableData, false ) );
+			const first = result.current;
+
+			rerender();
+
+			expect( result.current ).toBe( first );
+		} );
+	} );
+
+	describe( 'Band domain', () => {
+		const dated = ( year: number, month: number, day: number, value: number ) => ( {
+			date: new Date( year, month, day ),
+			value,
+		} );
+
+		test( 'leaves tick values alone when a bucket is labelled rather than dated', () => {
+			// visx builds the band domain from `label || date`, so a labelled bucket
+			// is not a `Date` on the axis at all. Choosing `Date` tick values for a
+			// domain like that puts a tick on a key `scaleBand` does not hold.
+			const { result } = renderHook( () =>
+				useBarChartOptions(
+					[
+						{
+							label: 'Views',
+							data: [
+								dated( 2026, 0, 1, 1 ),
+								{ ...dated( 2026, 0, 2, 2 ), label: 'Launch day' },
+								dated( 2026, 0, 3, 3 ),
+							],
+							options: {},
+						},
+					],
+					false
+				)
+			);
+
+			expect( result.current.axis.x.tickValues ).toBeUndefined();
+		} );
+
+		test( 'keeps every dated bucket across series, in the order visx concatenates them', () => {
+			const { result } = renderHook( () =>
+				useBarChartOptions(
+					[
+						{
+							label: 'A',
+							data: [ dated( 2026, 0, 1, 1 ), dated( 2026, 0, 3, 3 ) ],
+							options: {},
+						},
+						{
+							label: 'B',
+							data: [ dated( 2026, 0, 1, 4 ), dated( 2026, 0, 2, 5 ) ],
+							options: {},
+						},
+					],
+					false
+				)
+			);
+
+			// Jan 1 is shared, so the domain is Jan 1, Jan 3, Jan 2 — first
+			// occurrence wins and the second series appends what it adds.
+			expect( result.current.axis.x.tickValues ).toEqual( [
+				new Date( 2026, 0, 1 ),
+				new Date( 2026, 0, 3 ),
+				new Date( 2026, 0, 2 ),
+			] );
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -326,6 +326,39 @@ describe( 'BarChart', () => {
 			warn.mockRestore();
 		} );
 
+		test( 'drops the buckets of a series the legend has hidden', async () => {
+			const user = userEvent.setup();
+			renderWithTheme( {
+				chartId: 'hidden-series',
+				showLegend: true,
+				legend: { interactive: true },
+				data: [
+					{
+						label: 'Long',
+						data: [
+							dated( 2026, 0, 1, 1 ),
+							dated( 2026, 0, 3, 2 ),
+							dated( 2026, 0, 5, 3 ),
+							dated( 2026, 0, 7, 4 ),
+						],
+						options: {},
+					},
+					{
+						label: 'Short',
+						data: [ dated( 2026, 0, 1, 5 ), dated( 2026, 0, 3, 6 ) ],
+						options: {},
+					},
+				],
+			} );
+
+			await user.click( screen.getByText( 'Long' ) );
+
+			// Jan 5 and Jan 7 belong only to the hidden series, so they are no longer
+			// keys of the band scale; ticking them parks a label at the axis origin.
+			expect( inChart().queryByText( 'Jan 5' ) ).not.toBeInTheDocument();
+			expect( inChart().queryByText( 'Jan 7' ) ).not.toBeInTheDocument();
+		} );
+
 		test( 'keeps every dated bucket across series, in the order visx concatenates them', () => {
 			const { result } = renderHook( () =>
 				useBarChartOptions(

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -231,6 +231,33 @@ describe( 'BarChart', () => {
 			},
 		];
 
+		test( 'returns the same options when the caller passes an equal object literal', () => {
+			// The literal is rebuilt on every render, so only a deep comparison can
+			// keep the memos below it from recomputing.
+			const { result, rerender } = renderHook( () =>
+				useBarChartOptions( stableData, false, { axis: { x: { numTicks: 6 } } } )
+			);
+			const first = result.current;
+
+			rerender();
+
+			expect( result.current ).toBe( first );
+		} );
+
+		test( 'still recomputes when the options actually change', () => {
+			const { result, rerender } = renderHook(
+				( { numTicks }: { numTicks: number } ) =>
+					useBarChartOptions( stableData, false, { axis: { x: { numTicks } } } ),
+				{ initialProps: { numTicks: 6 } }
+			);
+			const first = result.current;
+
+			rerender( { numTicks: 3 } );
+
+			expect( result.current ).not.toBe( first );
+			expect( result.current.axis.x.numTicks ).toBe( 3 );
+		} );
+
 		test( 'returns the same options when nothing changed and no options were passed', () => {
 			const { result, rerender } = renderHook( () => useBarChartOptions( stableData, false ) );
 			const first = result.current;

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -247,6 +247,10 @@ describe( 'BarChart', () => {
 			value,
 		} );
 
+		// Scoped to the chart: @visx/text parks a measuring node on document.body,
+		// which a negative assertion would otherwise match.
+		const inChart = () => within( screen.getByRole( 'grid', { name: /bar chart/i } ) );
+
 		test( 'leaves tick values alone when a bucket is labelled rather than dated', () => {
 			// visx builds the band domain from `label || date`, so a labelled bucket
 			// is not a `Date` on the axis at all. Choosing `Date` tick values for a
@@ -269,6 +273,57 @@ describe( 'BarChart', () => {
 			);
 
 			expect( result.current.axis.x.tickValues ).toBeUndefined();
+		} );
+
+		test( 'labels a bucket that carries a label, on an otherwise dated axis', () => {
+			// `hasLabels` samples only the first point, so this axis keeps the time
+			// formatter; the labelled bucket still has to render as itself rather
+			// than as a date parsed out of its label.
+			renderWithTheme( {
+				data: [
+					{
+						label: 'Views',
+						data: [
+							dated( 2026, 0, 1, 1 ),
+							{ ...dated( 2026, 0, 2, 2 ), label: 'Launch day' },
+							dated( 2026, 0, 3, 3 ),
+						],
+						options: {},
+					},
+				],
+			} );
+
+			expect( inChart().getByText( 'Launch day' ) ).toBeInTheDocument();
+			expect( inChart().queryByText( /Invalid Date/ ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'ignores comparison series, which visx never puts on the band scale', () => {
+			// A comparison series carrying its own dates is a misuse the chart already
+			// warns about; the point here is that it does not also break the axis.
+			const warn = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+
+			renderWithTheme( {
+				data: [
+					{
+						label: 'This period',
+						data: [ dated( 2026, 0, 1, 1 ), dated( 2026, 0, 4, 2 ) ],
+						options: {},
+					},
+					{
+						label: 'Prior period',
+						data: [ dated( 2025, 11, 26, 1 ), dated( 2025, 11, 29, 2 ) ],
+						options: { type: 'comparison' },
+					},
+				],
+			} );
+
+			// Dec 26/29 are buckets of a series the band scale never saw; ticking
+			// them parks a label at the axis origin.
+			expect( inChart().queryByText( 'Dec 26' ) ).not.toBeInTheDocument();
+			expect( inChart().queryByText( 'Dec 29' ) ).not.toBeInTheDocument();
+			expect( inChart().getByText( 'Jan 1' ) ).toBeInTheDocument();
+
+			warn.mockRestore();
 		} );
 
 		test( 'keeps every dated bucket across series, in the order visx concatenates them', () => {

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -302,28 +302,28 @@ describe( 'BarChart', () => {
 			// warns about; the point here is that it does not also break the axis.
 			const warn = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
 
-			renderWithTheme( {
-				data: [
-					{
-						label: 'This period',
-						data: [ dated( 2026, 0, 1, 1 ), dated( 2026, 0, 4, 2 ) ],
-						options: {},
-					},
-					{
-						label: 'Prior period',
-						data: [ dated( 2025, 11, 26, 1 ), dated( 2025, 11, 29, 2 ) ],
-						options: { type: 'comparison' },
-					},
-				],
-			} );
+			try {
+				renderWithTheme( {
+					data: [
+						{
+							label: 'This period',
+							data: [ dated( 2026, 0, 1, 1 ), dated( 2026, 0, 4, 2 ) ],
+							options: {},
+						},
+						{
+							label: 'Prior period',
+							data: [ dated( 2025, 11, 26, 1 ), dated( 2025, 11, 29, 2 ) ],
+							options: { type: 'comparison' },
+						},
+					],
+				} );
 
-			// Dec 26/29 are buckets of a series the band scale never saw; ticking
-			// them parks a label at the axis origin.
-			expect( inChart().queryByText( 'Dec 26' ) ).not.toBeInTheDocument();
-			expect( inChart().queryByText( 'Dec 29' ) ).not.toBeInTheDocument();
-			expect( inChart().getByText( 'Jan 1' ) ).toBeInTheDocument();
-
-			warn.mockRestore();
+				expect( inChart().queryByText( 'Dec 26' ) ).not.toBeInTheDocument();
+				expect( inChart().queryByText( 'Dec 29' ) ).not.toBeInTheDocument();
+				expect( inChart().getByText( 'Jan 1' ) ).toBeInTheDocument();
+			} finally {
+				warn.mockRestore();
+			}
 		} );
 
 		test( 'drops the buckets of a series the legend has hidden', async () => {
@@ -353,10 +353,69 @@ describe( 'BarChart', () => {
 
 			await user.click( screen.getByText( 'Long' ) );
 
-			// Jan 5 and Jan 7 belong only to the hidden series, so they are no longer
-			// keys of the band scale; ticking them parks a label at the axis origin.
 			expect( inChart().queryByText( 'Jan 5' ) ).not.toBeInTheDocument();
 			expect( inChart().queryByText( 'Jan 7' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'labels a bucket that carries a label in the tooltip too', () => {
+			const { result } = renderHook( () =>
+				useBarChartOptions(
+					[
+						{
+							label: 'Views',
+							data: [ dated( 2026, 0, 1, 1 ), { ...dated( 2026, 0, 2, 2 ), label: 'Launch day' } ],
+							options: {},
+						},
+					],
+					false
+				)
+			);
+
+			// visx calls a tick formatter with (value, index, values).
+			const format = result.current.tooltip.labelFormatter;
+			expect( format( 'Launch day', 0, [] ) ).toBe( 'Launch day' );
+			expect( format( new Date( 2026, 0, 1 ), 0, [] ) ).toMatch( /2026/ );
+		} );
+
+		test( 'keeps only the later of two series sharing a label, as the registry does', () => {
+			const warn = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+			try {
+				const { result } = renderHook( () =>
+					useBarChartOptions(
+						[
+							{ label: 'Dup', data: [ dated( 2026, 0, 1, 1 ) ], options: {} },
+							{ label: 'Dup', data: [ dated( 2026, 0, 5, 2 ) ], options: {} },
+						],
+						false
+					)
+				);
+
+				expect( result.current.axis.x.tickValues ).toEqual( [ new Date( 2026, 0, 5 ) ] );
+			} finally {
+				warn.mockRestore();
+			}
+		} );
+
+		test( 'puts the band tick values on the y axis when horizontal', () => {
+			const { result } = renderHook( () =>
+				useBarChartOptions(
+					[
+						{
+							label: 'Views',
+							data: [ dated( 2026, 0, 1, 1 ), dated( 2026, 0, 2, 2 ) ],
+							options: {},
+						},
+					],
+					true
+				)
+			);
+
+			expect( result.current.axis.y.tickValues ).toEqual( [
+				new Date( 2026, 0, 1 ),
+				new Date( 2026, 0, 2 ),
+			] );
+			expect( result.current.axis.x.tickValues ).toBeUndefined();
 		} );
 
 		test( 'keeps every dated bucket across series, in the order visx concatenates them', () => {
@@ -378,8 +437,6 @@ describe( 'BarChart', () => {
 				)
 			);
 
-			// Jan 1 is shared, so the domain is Jan 1, Jan 3, Jan 2 — first
-			// occurrence wins and the second series appends what it adds.
 			expect( result.current.axis.x.tickValues ).toEqual( [
 				new Date( 2026, 0, 1 ),
 				new Date( 2026, 0, 3 ),

--- a/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
+++ b/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
@@ -289,6 +289,31 @@ describe( 'getBucketResolution', () => {
 	} );
 } );
 
+describe( 'tick format anchors', () => {
+	// The band axis steers ticks onto boundaries using the predicate the format
+	// hangs off itself. If the two ever disagree, the axis aims at buckets that
+	// do not actually print the coarser label.
+	it( 'marks exactly the buckets whose label carries the coarser unit', () => {
+		const hourly = Array.from( { length: 48 }, ( _, i ) => new Date( 2026, 7, 2, i ) );
+		const hourFormat = getFormatter( toSeries( hourly ) );
+
+		expect( hourFormat.isAnchor ).toBeDefined();
+		hourly.forEach( date => {
+			const isDateLabel = ! /(AM|PM)/.test( hourFormat( date.getTime() ) );
+			expect( hourFormat.isAnchor( date ) ).toBe( isDateLabel );
+		} );
+
+		const monthly = Array.from( { length: 36 }, ( _, i ) => new Date( 2023, 6 + i, 1 ) );
+		const monthFormat = getFormatter( toSeries( monthly ) );
+
+		expect( monthFormat.isAnchor ).toBeDefined();
+		monthly.forEach( date => {
+			const isYearLabel = /^\d{4}$/.test( monthFormat( date.getTime() ) );
+			expect( monthFormat.isAnchor( date ) ).toBe( isYearLabel );
+		} );
+	} );
+} );
+
 describe( 'getBandTickValues', () => {
 	const monthlyDomain = ( year: number, month: number, months: number ) =>
 		Array.from( { length: months }, ( _, i ) => new Date( year, month + i, 1 ) );

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -62,11 +62,9 @@ const formatMonthTick = dateTimeFormat( { month: 'short' } );
 /**
  * A tick format, carrying the boundary test that decides its coarser label.
  *
- * A format that prints a coarser unit at a boundary — the date at midnight, the
- * year at January — says what its neighbours leave out. A time scale always
- * lands on those boundaries; a band scale samples by index and has to be
- * steered onto them, so `getBandTickValues` needs the same test the format
- * itself branches on. Hanging it off the format keeps the two from drifting.
+ * A band scale samples by index, so `getBandTickValues` has to steer ticks onto
+ * the boundaries a format prints the date or the year at. Hanging the test off
+ * the format that branches on it keeps the two from drifting apart.
  */
 export type TickFormat = ( ( timestamp: number ) => string ) & {
 	isAnchor?: ( date: Date ) => boolean;

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -59,21 +59,45 @@ const formatHourTick = dateTimeFormat( { hour: 'numeric', hour12: true } );
 
 const formatMonthTick = dateTimeFormat( { month: 'short' } );
 
+/**
+ * A tick format, carrying the boundary test that decides its coarser label.
+ *
+ * A format that prints a coarser unit at a boundary — the date at midnight, the
+ * year at January — says what its neighbours leave out. A time scale always
+ * lands on those boundaries; a band scale samples by index and has to be
+ * steered onto them, so `getBandTickValues` needs the same test the format
+ * itself branches on. Hanging it off the format keeps the two from drifting.
+ */
+export type TickFormat = ( ( timestamp: number ) => string ) & {
+	isAnchor?: ( date: Date ) => boolean;
+};
+
+const boundaryFormat = (
+	isAnchor: ( date: Date ) => boolean,
+	atBoundary: ( timestamp: number ) => string,
+	between: ( timestamp: number ) => string
+): TickFormat => {
+	const format: TickFormat = ( timestamp: number ) =>
+		isAnchor( new Date( timestamp ) ) ? atBoundary( timestamp ) : between( timestamp );
+	format.isAnchor = isAnchor;
+	return format;
+};
+
 // Hour ticks with the date at midnight boundaries, so multi-day spans of
 // sub-daily data keep their days identifiable.
-const formatDateOrHourTick = ( timestamp: number ) => {
-	const date = new Date( timestamp );
-	return date.getHours() === 0 && date.getMinutes() === 0
-		? formatDateTick( timestamp )
-		: formatHourTick( timestamp );
-};
+const formatDateOrHourTick = boundaryFormat(
+	date => date.getHours() === 0 && date.getMinutes() === 0,
+	formatDateTick,
+	formatHourTick
+);
 
 // Month ticks with the year at January boundaries, for month-or-coarser
 // buckets where a full "Sep 1" date would misread as a daily point.
-const formatMonthOrYearTick = ( timestamp: number ) => {
-	const date = new Date( timestamp );
-	return date.getMonth() === 0 ? formatYearTick( timestamp ) : formatMonthTick( timestamp );
-};
+const formatMonthOrYearTick = boundaryFormat(
+	date => date.getMonth() === 0,
+	formatYearTick,
+	formatMonthTick
+);
 
 // Overall time span of the data. Series with no dated points are dropped rather
 // than folded in: an empty comparison series is legitimate, and one undefined
@@ -154,7 +178,7 @@ export const getBucketResolution = (
 export const getFormatter = (
 	sortedData: ReturnType< typeof useChartDataTransform >,
 	tickResolution?: TickResolution
-) => {
+): TickFormat => {
 	const resolution = getBucketResolution( sortedData, tickResolution );
 
 	// The month regime only prints the year at January boundaries, so yearly
@@ -188,15 +212,6 @@ export const getFormatter = (
 		? formatDateTick
 		: formatYearTick;
 };
-
-// Tick formats that print a coarser unit at a boundary — the date at midnight,
-// the year at January — say what their neighbours leave out. A time scale
-// always lands on those boundaries; a band scale samples by index and has to be
-// steered onto them.
-const TICK_ANCHORS = new Map< ( timestamp: number ) => string, ( date: Date ) => boolean >( [
-	[ formatDateOrHourTick, date => date.getHours() === 0 && date.getMinutes() === 0 ],
-	[ formatMonthOrYearTick, date => date.getMonth() === 0 ],
-] );
 
 // Indices of the buckets whose label carries the coarser unit.
 const getAnchorIndices = ( domain: Date[], isAnchor: ( date: Date ) => boolean ) =>
@@ -250,14 +265,14 @@ const getCandidateSteps = ( length: number, maxTicks: number, anchorSpacing: num
  */
 export const getBandTickValues = (
 	domain: Date[],
-	tickFormatter: ( timestamp: number ) => string,
+	tickFormatter: TickFormat,
 	maxTicks: number
 ): Date[] => {
 	if ( ! domain.length ) {
 		return [];
 	}
 
-	const isAnchor = TICK_ANCHORS.get( tickFormatter );
+	const { isAnchor } = tickFormatter;
 	const anchorIndices = isAnchor ? getAnchorIndices( domain, isAnchor ) : [];
 
 	// Once per bucket rather than once per bucket per candidate: the sweep reads

--- a/projects/plugins/jetpack/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/jetpack/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis when the chart mixes labelled bars with dated ones, or compares two periods.
+Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis after hiding a series from the legend, or when the chart mixes labelled bars with dated ones or compares two periods.

--- a/projects/plugins/jetpack/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/jetpack/changelog/fix-charts-bar-options-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: fix a misplaced tick on charts that mix dated and labelled bars, and cut redundant work when a chart re-renders.

--- a/projects/plugins/jetpack/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/jetpack/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis after hiding a series from the legend, or when the chart mixes labelled bars with dated ones or compares two periods.
+Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis after hiding a series from the legend, or when the chart mixes labelled bars with dated ones or compares two periods, and stop a labelled bar's tooltip reading "Invalid Date".

--- a/projects/plugins/jetpack/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/jetpack/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Premium Analytics: fix a misplaced tick on charts that mix dated and labelled bars, and cut redundant work when a chart re-renders.
+Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis when the chart mixes labelled bars with dated ones, or compares two periods.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: fix a misplaced tick on charts that mix dated and labelled bars, and cut redundant work when a chart re-renders.
+Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis when the chart mixes labelled bars with dated ones, or compares two periods.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis after hiding a series from the legend, or when the chart mixes labelled bars with dated ones or compares two periods.
+Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis after hiding a series from the legend, or when the chart mixes labelled bars with dated ones or compares two periods, and stop a labelled bar's tooltip reading "Invalid Date".

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis when the chart mixes labelled bars with dated ones, or compares two periods.
+Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis after hiding a series from the legend, or when the chart mixes labelled bars with dated ones or compares two periods.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-charts-bar-options-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: fix a misplaced tick on charts that mix dated and labelled bars, and cut redundant work when a chart re-renders.

--- a/projects/plugins/premium-analytics/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/premium-analytics/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix a stray label stacked at the left edge of a bar chart's time axis after hiding a series from the legend, or when the chart mixes labelled bars with dated ones or compares two periods.
+Fix a stray label stacked at the left edge of a bar chart's time axis after hiding a series from the legend, or when the chart mixes labelled bars with dated ones or compares two periods, and stop a labelled bar's tooltip reading "Invalid Date".

--- a/projects/plugins/premium-analytics/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/premium-analytics/changelog/fix-charts-bar-options-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a misplaced tick on bar charts that mix dated and labelled bars, and cut redundant work when a chart re-renders.

--- a/projects/plugins/premium-analytics/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/premium-analytics/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix a stray label stacked at the left edge of a bar chart's time axis when the chart mixes labelled bars with dated ones, or compares two periods.
+Fix a stray label stacked at the left edge of a bar chart's time axis after hiding a series from the legend, or when the chart mixes labelled bars with dated ones or compares two periods.

--- a/projects/plugins/premium-analytics/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/premium-analytics/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix a misplaced tick on bar charts that mix dated and labelled bars, and cut redundant work when a chart re-renders.
+Fix a stray label stacked at the left edge of a bar chart's time axis when the chart mixes labelled bars with dated ones, or compares two periods.

--- a/projects/plugins/wpcomsh/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/wpcomsh/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: fix a misplaced tick on charts that mix dated and labelled bars, and cut redundant work when a chart re-renders.
+Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis when the chart mixes labelled bars with dated ones, or compares two periods.

--- a/projects/plugins/wpcomsh/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/wpcomsh/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis after hiding a series from the legend, or when the chart mixes labelled bars with dated ones or compares two periods.
+Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis after hiding a series from the legend, or when the chart mixes labelled bars with dated ones or compares two periods, and stop a labelled bar's tooltip reading "Invalid Date".

--- a/projects/plugins/wpcomsh/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/wpcomsh/changelog/fix-charts-bar-options-cleanup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis when the chart mixes labelled bars with dated ones, or compares two periods.
+Premium Analytics: fix a stray label stacked at the left edge of a chart's time axis after hiding a series from the legend, or when the chart mixes labelled bars with dated ones or compares two periods.

--- a/projects/plugins/wpcomsh/changelog/fix-charts-bar-options-cleanup
+++ b/projects/plugins/wpcomsh/changelog/fix-charts-bar-options-cleanup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: fix a misplaced tick on charts that mix dated and labelled bars, and cut redundant work when a chart re-renders.


### PR DESCRIPTION
Fixes #

Follow-up to #51339, which merged while this was being written; rebased onto `trunk` so the diff is only the new work.

Clears the remaining findings from the local review of #51275. None are regressions; all pre-date it, and all are reachable today.

## Proposed changes

* **The band domain was rebuilt from the wrong accessor, in the wrong order.** visx builds a band scale from the values its `xAccessor` returns — here `label || date` — concatenated across series, with d3's `InternMap` keeping first occurrences in insertion order ([`useScales.js`](https://github.com/airbnb/visx) takes `xDomain = xValues` verbatim for a discrete scale). `getBandDomain` instead re-derived the domain from `date` alone and sorted it. Two consequences: a series mixing dated and labelled points yields tick values that are **not keys of the scale**, and `scaleBand` returns `undefined` for a key it does not hold — a tick at a NaN position; and series holding disjoint dates would tick against a different order than the one on screen. It now reads the same accessor object visx is handed, keeps visx's order, and returns null — skipping tick selection entirely — as soon as any bucket is labelled rather than dated.
* **`BarChart` defaulted `options` to a fresh object literal**, and that value reaches the dependency array of all three memos in `useBarChartOptions`. Every consumer that omits the prop — which is exactly the consumer that gets chosen tick values, since the feature is gated on `! tickFormat` — therefore recomputed all three on every render. Both defaults now point at one shared object.
* **The anchor predicates were duplicated** beside a `Map` keyed on formatter identity. A change to either format would have drifted from its predicate silently, and any wrapped or memoized formatter would have disabled anchoring with no signal. The predicate now hangs off the format that branches on it, so there is one definition and no identity lookup.
* Also folds the three-pass `getBandDomain` into one pass. As written it built keys, sorted them, then re-`get`-ed each — and the re-`get` returned `Date | undefined` widening into a declared `Date[]`, invisible only because the package sets `strict: false`.

No public API change. `getFormatter` gains an exported `TickFormat` return type — a plain call signature with one optional property — so existing call sites in `LineChart` and `AreaChart` are unaffected.

## Related product discussion/links

* WOOA7S-1902

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `jp test js js-packages/charts` — **1127 tests pass** (54 suites), up from 1123.
* Four new tests, and **each fails without the corresponding fix** — verified by reverting the three source files and re-running: `3 failed, 74 passed`.
  * `returns the same options when nothing changed and no options were passed` — asserts referential stability of the hook result across a re-render.
  * `leaves tick values alone when a bucket is labelled rather than dated` — a three-point series whose middle point carries a label; `axis.x.tickValues` must be absent.
  * `keeps every dated bucket across series, in the order visx concatenates them` — two overlapping series; the domain must be `Jan 1, Jan 3, Jan 2`, not the sorted `Jan 1, Jan 2, Jan 3`.
  * `marks exactly the buckets whose label carries the coarser unit` — walks every bucket of an hourly and a monthly domain and asserts the anchor predicate agrees with what the format actually prints. This is the invariant the third change exists to protect.
* No visual change is expected: every panel of `BarChart` → `TimeAxisTickFormats` renders identically, since none of them mixes labelled and dated buckets.
