### PR TITLE
STATS-345: Leave the pre-connection Stats menu to the stats-admin package

### DIFF
--- a/projects/plugins/stats/changelog/stats-345-drop-plugin-menu-redirect
+++ b/projects/plugins/stats/changelog/stats-345-drop-plugin-menu-redirect
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Show the Stats dashboard on a site with no connection instead of redirecting to My Jetpack.

--- a/projects/plugins/stats/src/class-jetpack-stats-plugin.php
+++ b/projects/plugins/stats/src/class-jetpack-stats-plugin.php
@@ -28,14 +28,6 @@ class Jetpack_Stats_Plugin {
 	const ADMIN_PAGE_SLUG = 'stats';
 
 	/**
-	 * My Jetpack's admin page slug.
-	 *
-	 * Landing on this page with no connection makes My Jetpack redirect to its own
-	 * onboarding step. See `My_Jetpack\Initializer::get_onboarding_redirect_args()`.
-	 */
-	const MY_JETPACK_PAGE_SLUG = 'my-jetpack';
-
-	/**
 	 * Register hooks to initialize the plugin.
 	 */
 	public static function bootstrap() {
@@ -92,54 +84,18 @@ class Jetpack_Stats_Plugin {
 		My_Jetpack_Initializer::init();
 
 		/**
-		 * `Config::ensure( 'stats_admin' )` starts the package but does not register the
-		 * dashboard page — the Jetpack plugin does that itself in `modules/stats.php`.
-		 * Register it here only when the Jetpack plugin is absent, so the two never
-		 * register the same `stats` menu slug.
+		 * Three places can register the `stats` menu slug, and only one of them may run.
+		 * `Stats_Admin\Main` registers the dashboard itself while the site has no connection,
+		 * and the Jetpack plugin registers it from `modules/stats.php` once the Stats module
+		 * loads. That leaves the connected site without the Jetpack plugin to this plugin.
 		 */
 		if ( self::is_jetpack_plugin_active() ) {
 			return;
 		}
 
-		// Every figure in the dashboard is read back from the WordPress.com API, which
-		// needs a connection token.
 		if ( ( new Connection_Manager() )->is_connected() ) {
 			Stats_Dashboard::init();
-		} else {
-			add_action( 'admin_menu', array( self::class, 'register_disconnected_menu' ), 999 );
 		}
-	}
-
-	/**
-	 * Register a Stats menu that routes to the connection flow.
-	 *
-	 * Runs at priority 999 to match `Stats_Admin\Dashboard`, which places itself between
-	 * the Jetpack plugin (998) and Admin_Menu (1000).
-	 */
-	public static function register_disconnected_menu() {
-		$page_suffix = add_menu_page(
-			__( 'Stats', 'jetpack-stats' ),
-			_x( 'Stats', 'product name shown in menu', 'jetpack-stats' ),
-			'view_stats',
-			self::ADMIN_PAGE_SLUG,
-			'__return_null',
-			'dashicons-chart-bar',
-			2
-		);
-
-		if ( $page_suffix ) {
-			add_action( 'load-' . $page_suffix, array( self::class, 'redirect_to_connection_flow' ) );
-		}
-	}
-
-	/**
-	 * Send the current request to My Jetpack, which redirects on to its onboarding step.
-	 *
-	 * @return never
-	 */
-	public static function redirect_to_connection_flow() {
-		wp_safe_redirect( admin_url( 'admin.php?page=' . self::MY_JETPACK_PAGE_SLUG ) );
-		exit( 0 );
 	}
 
 	/**
@@ -180,8 +136,9 @@ class Jetpack_Stats_Plugin {
 		// connection this is a no-op.
 		self::activate_stats_module();
 
-		// The stand-in menu forwards an unconnected site on to My Jetpack onboarding, so this
-		// redirect does not branch on the connection state.
+		// The Stats page is registered in both connection states, so this redirect does not
+		// branch on one. Without a connection the dashboard offers a plan and drives the
+		// connection itself.
 		if ( ( new Paths() )->is_current_request_activating_plugin_from_plugins_screen( JETPACK_STATS_PLUGIN__FILE_RELATIVE_PATH ) ) {
 			wp_safe_redirect( esc_url( admin_url( 'admin.php?page=' . self::ADMIN_PAGE_SLUG ) ) );
 			exit( 0 );

--- a/projects/plugins/stats/tests/php/Jetpack_Stats_Plugin_Test.php
+++ b/projects/plugins/stats/tests/php/Jetpack_Stats_Plugin_Test.php
@@ -6,9 +6,8 @@
  */
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Stats\Main as Stats_Main;
-use Automattic\Jetpack\Stats\Options as Stats_Options;
 use Automattic\Jetpack\Stats_Admin\Dashboard as Stats_Dashboard;
+use Automattic\Jetpack\Stats_Admin\Main as Stats_Admin_Main;
 use Automattic\Jetpack\Stats_Plugin\Jetpack_Stats_Plugin;
 use WorDBless\BaseTestCase;
 
@@ -18,11 +17,41 @@ use WorDBless\BaseTestCase;
 class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 
 	/**
+	 * The Stats packages record their initialization in statics that outlive the per-test
+	 * database and hook reset, and each one registers its hooks on the first call only. Any
+	 * test that walks `plugins_loaded` would otherwise leave the next one initializing
+	 * nothing, so clear them before every test rather than in the tests that notice.
+	 */
+	public function set_up() {
+		$this->reset_static( Stats_Dashboard::class, 'initialized', false );
+		$this->reset_static( Stats_Admin_Main::class, 'instance', null );
+	}
+
+	/**
 	 * `Connection_Manager::is_connected()` caches its answer in a static, which survives
 	 * the per-test database reset. Clear it so a faked connection cannot leak.
 	 */
 	public function tear_down() {
 		( new Connection_Manager() )->reset_connection_status();
+	}
+
+	/**
+	 * Write a private static property the packages use to guard their initialization.
+	 *
+	 * @param string $class    Class holding the property.
+	 * @param string $property Property name.
+	 * @param mixed  $value    Value to write.
+	 */
+	private function reset_static( $class, $property, $value ) {
+		$reflected = new ReflectionProperty( $class, $property );
+
+		// Reflection cannot write a private property before PHP 8.1 without this, and the
+		// method is deprecated from PHP 8.5. The plugin supports 7.2, so both ends apply.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflected->setAccessible( true );
+		}
+
+		$reflected->setValue( null, $value );
 	}
 
 	/**
@@ -86,20 +115,24 @@ class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * `Stats_Admin\Dashboard` records its initialization in a static that survives the
-	 * per-test hook restore, and it registers the menu only on the first call. Clear it so a
-	 * test that expects the dashboard to register controls its own precondition.
+	 * Whether the plugin hooked a menu of its own onto `admin_menu`.
+	 *
+	 * @return bool
 	 */
-	private function reset_dashboard_initialization() {
-		$initialized = new ReflectionProperty( Stats_Dashboard::class, 'initialized' );
-
-		// Reflection cannot write a private property before PHP 8.1 without this, and the
-		// method is deprecated from PHP 8.5. The plugin supports 7.2, so both ends apply.
-		if ( PHP_VERSION_ID < 80100 ) {
-			$initialized->setAccessible( true );
+	private function plugin_registered_an_admin_menu() {
+		if ( ! isset( $GLOBALS['wp_filter']['admin_menu'] ) ) {
+			return false;
 		}
 
-		$initialized->setValue( null, false );
+		foreach ( $GLOBALS['wp_filter']['admin_menu']->callbacks as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				if ( is_array( $callback['function'] ) && Jetpack_Stats_Plugin::class === $callback['function'][0] ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -212,61 +245,44 @@ class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * On an unconnected site the Stats menu is still registered, but it is the stand-in
-	 * that redirects to the connection flow, not the Odyssey dashboard.
+	 * `Stats_Admin\Main` registers the dashboard while the site has no connection, where the
+	 * app offers a plan and drives the connection itself. A second registration here would
+	 * claim the same `stats` slug and hide that screen.
 	 */
-	public function test_disconnected_site_registers_the_stand_in_menu() {
+	public function test_disconnected_site_leaves_the_menu_to_the_stats_admin_package() {
+		$this->assertFalse( ( new Connection_Manager() )->is_connected(), 'Test environment is expected to be unconnected.' );
+
 		Jetpack_Stats_Plugin::initialize_other_packages();
 
-		$this->assertSame(
-			999,
-			has_action( 'admin_menu', array( Jetpack_Stats_Plugin::class, 'register_disconnected_menu' ) )
-		);
+		$this->assertFalse( $this->dashboard_menu_is_registered() );
+		$this->assertFalse( $this->plugin_registered_an_admin_menu() );
 	}
 
 	/**
-	 * The stand-in menu keeps the `stats` slug so the plugin action link, the post-activation
-	 * redirect and any bookmark stay valid across a connection. Opening it without a
-	 * connection forwards to My Jetpack onboarding.
+	 * The other half: leaving the menu to the package is only safe while the package really
+	 * registers one. Walk the plugin's own wiring — `configure_packages()` and then the
+	 * `Config` initializer — so a lost `Config::ensure( 'stats_admin' )` and a package that
+	 * stopped registering both surface here rather than as a site with no Stats menu at all.
 	 */
-	public function test_stand_in_menu_uses_the_dashboard_slug() {
-		$GLOBALS['menu'] = array();
+	public function test_disconnected_site_gets_its_menu_from_the_stats_admin_package() {
+		$this->assertFalse( ( new Connection_Manager() )->is_connected(), 'Test environment is expected to be unconnected.' );
 
-		// `add_menu_page()` checks `view_stats`, which `Stats\Main` maps to `read` for any
-		// role listed in the Stats `roles` option.
-		Stats_Main::init();
-		Stats_Options::set_option( 'roles', array( 'administrator' ) );
-		$user_id = wp_insert_user(
-			array(
-				'user_login' => 'stats_admin',
-				'user_pass'  => 'password',
-				'role'       => 'administrator',
-			)
-		);
-		wp_set_current_user( $user_id );
+		Jetpack_Stats_Plugin::configure_packages();
+		do_action( 'plugins_loaded' );
 
-		Jetpack_Stats_Plugin::register_disconnected_menu();
-
-		$this->assertContains( 'stats', array_column( $GLOBALS['menu'], 2 ) );
-		$this->assertNotFalse(
-			has_action( 'load-toplevel_page_stats', array( Jetpack_Stats_Plugin::class, 'redirect_to_connection_flow' ) )
-		);
+		$this->assertTrue( $this->dashboard_menu_is_registered() );
 	}
 
 	/**
-	 * The connected counterpart of the two tests above. Both menus claim the `stats` slug, so
-	 * the dashboard must take it and the stand-in must stay out of the way.
+	 * The connected counterpart: nothing else registers the Stats menu for a connected site
+	 * running without the Jetpack plugin, so this plugin has to.
 	 */
 	public function test_connected_site_initializes_the_dashboard() {
 		$this->fake_connection();
-		$this->reset_dashboard_initialization();
 
 		Jetpack_Stats_Plugin::initialize_other_packages();
 
 		$this->assertTrue( $this->dashboard_menu_is_registered() );
-		$this->assertFalse(
-			has_action( 'admin_menu', array( Jetpack_Stats_Plugin::class, 'register_disconnected_menu' ) )
-		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes STATS-345

## Proposed changes
* #51200 moved the pre-connection Stats menu into `Stats_Admin\Main`, which now registers the dashboard whenever the site has no connection so the app can offer a plan and drive the connection itself. The standalone plugin still registered a stand-in menu on the same `stats` slug, and its `load-` handler redirected to My Jetpack — which hid that screen.
* Remove the stand-in menu and the redirect, and leave the unconnected case to the package. The plugin keeps registering the dashboard for a connected site running without the Jetpack plugin, which nothing else covers.
* Tests now assert both halves: the plugin adds no menu of its own when unconnected, and the package really does add one. Clearing the package initialization statics in `set_up()` also fixes pre-existing cross-test pollution — the packages guard on statics that outlive WorDBless's per-test reset, so any test walking `plugins_loaded` left the next one initializing nothing.

## Related product discussion/links
* #51200

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Testing needs the standalone Stats plugin on a site that is **not** connected to WordPress.com, without the Jetpack plugin active.

* Build a zip of `projects/plugins/stats` from this branch and install it on a fresh site. Leave the site unconnected.
* Activate the plugin. You land on **Stats**.
* Confirm the page shows the Odyssey Stats screen offering a plan, and that you are **not** bounced to My Jetpack. On trunk you are.
* Confirm the sidebar has a single **Stats** entry, not two.
* Connect the site, then reload **Stats**. The dashboard loads as before on the same `stats` slug.
* Activate the Jetpack plugin alongside this one and confirm there is still only one **Stats** menu entry.
