### PR TITLE
CODEOWNERS: give the Stats team the Stats plugin and packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,6 +59,8 @@
 
 # Packages
 /projects/packages/premium-analytics @Automattic/jetpack-stats 
+/projects/packages/stats @Automattic/jetpack-stats
+/projects/packages/stats-admin @Automattic/jetpack-stats
 /projects/packages/search/src/wpes @Automattic/prometheus
 /projects/packages/connection/src @Automattic/jetpack-connection
 /projects/packages/connection/legacy @Automattic/jetpack-connection
@@ -71,6 +73,7 @@
 # Plugins
 
 /projects/plugins/premium-analytics @Automattic/jetpack-stats 
+/projects/plugins/stats @Automattic/jetpack-stats
 /projects/plugins/boost @Automattic/jetpack-boost
 
 # Functionality that is important to our partners


### PR DESCRIPTION
Fixes #

## Proposed changes
* The standalone Stats plugin (`projects/plugins/stats`) and the `stats` and `stats-admin` packages have no CODEOWNERS entry, so PRs touching them request no team review. Add them to `@Automattic/jetpack-stats`, which already owns the Premium Analytics plugin and package.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Nothing to test by hand. GitHub applies CODEOWNERS from the base branch, so the effect shows up on the next PR that touches one of these paths: `@Automattic/jetpack-stats` is requested as a reviewer when that PR is opened, or when a draft is marked ready for review.
