### PR TITLE
js-packages: expand api and idc package READMEs

### DIFF
--- a/projects/js-packages/api/README.md
+++ b/projects/js-packages/api/README.md
@@ -2,3 +2,74 @@ API Package
 =========
 
 The package includes the API class for communicating with Jetpack's internal APIs.
+
+It exports a singleton REST API client used by Jetpack's admin apps to talk to the `jetpack/v4` (and related) endpoints, covering connection management, modules, settings, plans, recommendations, and more.
+
+## Usage
+
+Install the package:
+
+```bash
+pnpm add @automattic/jetpack-api
+```
+
+Initialize the client with the API root and nonce (usually provided by the consuming plugin via an initial state object), then call any of its methods:
+
+```js
+import restApi from '@automattic/jetpack-api';
+
+restApi.setApiRoot( 'https://example.org/wp-json/' );
+restApi.setApiNonce( '12345' );
+
+const status = await restApi.fetchSiteConnectionStatus();
+```
+
+All methods return promises. Responses with non-2xx status codes are rejected with one of the exported custom error classes, so consumers can handle specific failure modes:
+
+```js
+import restApi, {
+	JsonParseError,
+	JsonParseAfterRedirectError,
+	Api404Error,
+	Api404AfterRedirectError,
+	FetchNetworkError,
+} from '@automattic/jetpack-api';
+```
+
+### Consumer slug
+
+Some endpoints (such as site registration) identify the calling plugin via the `consumer_slug` value from the [`@automattic/jetpack-config`](https://github.com/Automattic/jetpack/tree/trunk/projects/js-packages/config) package. Make sure your app's webpack configuration declares it via the `externals` property:
+
+```js
+externals: {
+	...baseConfig.externals,
+	jetpackConfig: JSON.stringify( {
+		consumer_slug: 'my-plugin-slug',
+	} ),
+},
+```
+
+## Development
+
+From the monorepo root:
+
+```bash
+jetpack install js-packages/api   # Install dependencies
+jetpack test js js-packages/api   # Run the Jest test suite
+```
+
+## Contribute
+
+We welcome contributions from the community. Please submit your pull requests on the GitHub repository.
+
+## Get Help
+
+If you encounter any issues or have any questions, please open an issue on the GitHub repository.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+The API package is licensed under the GNU General Public License v2 (or later).

--- a/projects/js-packages/api/changelog/update-js-packages-api-idc-readmes
+++ b/projects/js-packages/api/changelog/update-js-packages-api-idc-readmes
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Expand the package README with usage and development instructions. Docs-only, no code changes.

--- a/projects/js-packages/idc/README.md
+++ b/projects/js-packages/idc/README.md
@@ -2,3 +2,67 @@ IDC Package
 =========
 
 The Identity Crisis UI.
+
+An identity crisis (IDC) happens when the URL of a site no longer matches the URL registered with WordPress.com — typically after cloning a site to a new domain or setting up a staging copy. This package provides the React components Jetpack plugins render in that state, letting the user either move their Jetpack connection and stats to the new URL, treat the site as a brand-new one and start fresh, or stay in Safe Mode.
+
+## Usage
+
+Install the package:
+
+```bash
+pnpm add @automattic/jetpack-idc
+```
+
+Render the `IDCScreen` component:
+
+```jsx
+import { IDCScreen } from '@automattic/jetpack-idc';
+
+<IDCScreen
+	wpcomHomeUrl="site-original.example.org"
+	currentUrl="site-cloned.example.org"
+	apiRoot="https://example.org/wp-json/"
+	apiNonce="12345"
+	redirectUri="admin.php?page=my-plugin"
+	isAdmin={ true }
+/>;
+```
+
+### Properties
+
+- *wpcomHomeUrl* - string (required), the original site URL registered with WordPress.com.
+- *currentUrl* - string (required), the current site URL.
+- *apiRoot* - string (required), API root URL.
+- *apiNonce* - string (required), API nonce.
+- *redirectUri* - string (required), wp-admin URI to redirect users back to after connecting.
+- *isAdmin* - bool (required), whether to display the "admin" or "non-admin" version of the screen.
+- *logo* - the screen logo, defaults to the Jetpack logo.
+- *customContent* - object, custom text content to override the defaults.
+- *tracksUserData* - object, WordPress.com user's Tracks identity.
+- *tracksEventData* - object, WordPress.com event tracking information.
+- *possibleDynamicSiteUrlDetected* - bool, whether potentially dynamic `HTTP_HOST` usage was detected for site URLs in `wp-config.php`.
+- *isDevelopmentSite* - bool, whether the site is in development mode.
+
+## Development
+
+From the monorepo root:
+
+```bash
+jetpack install js-packages/idc   # Install dependencies
+```
+
+## Contribute
+
+We welcome contributions from the community. Please submit your pull requests on the GitHub repository.
+
+## Get Help
+
+If you encounter any issues or have any questions, please open an issue on the GitHub repository.
+
+## Security
+
+Need to report a security vulnerability? Go to [https://automattic.com/security/](https://automattic.com/security/) or directly to our security bug bounty site [https://hackerone.com/automattic](https://hackerone.com/automattic).
+
+## License
+
+The IDC package is licensed under the GNU General Public License v2 (or later).

--- a/projects/js-packages/idc/changelog/update-js-packages-api-idc-readmes
+++ b/projects/js-packages/idc/changelog/update-js-packages-api-idc-readmes
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Expand the package README with usage and development instructions. Docs-only, no code changes.


### PR DESCRIPTION
## Proposed changes

* Docs-only change, no functional impact.
* Expands the stub README for `projects/js-packages/api` (previously a single sentence) with usage, error handling, the `consumer_slug` webpack configuration requirement, and development commands.
* Expands the stub README for `projects/js-packages/idc` (previously a single sentence) with an explanation of what an identity crisis is, an `IDCScreen` usage example, its documented properties, and development commands.
* Content follows the structure used by sibling js-package READMEs (e.g. `scan`, `licensing`, `connection`) and was derived from each package's `package.json`, entry points, and prop types.

## Related product discussion/links

* N/A — documentation backfill.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Review `projects/js-packages/api/README.md` and `projects/js-packages/idc/README.md` for accuracy.
* Verify the `IDCScreen` properties against `projects/js-packages/idc/components/idc-screen/index.jsx` and the API client behavior against `projects/js-packages/api/index.jsx`.
* No code changes — changelog entries are comment-only (no user-facing entry).


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: docs-backfill:/Users/miguel/dev/a8c/jetpack
task-type: docs-backfill
task-title: Documentation Backfiller
provider: claude
score: 8.0
cost-tier: Low (10-50k)
iterations: 1
duration: 6m52s
run-started: 2026-08-18T03:00:03-03:00
nightshift:metadata -->
