### PR TITLE
Connection: sanitize nonces before verification

### DIFF
--- a/projects/packages/connection/changelog/stats-343-connection-sanitize-nonces
+++ b/projects/packages/connection/changelog/stats-343-connection-sanitize-nonces
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sanitize nonce values before passing them to wp_verify_nonce().

--- a/projects/packages/connection/src/class-tracking.php
+++ b/projects/packages/connection/src/class-tracking.php
@@ -72,7 +72,7 @@ class Tracking {
 		// Check for nonce.
 		if (
 			empty( $_REQUEST['tracksNonce'] )
-			|| ! wp_verify_nonce( $_REQUEST['tracksNonce'], 'jp-tracks-ajax-nonce' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- WP core doesn't pre-sanitize nonces either.
+			|| ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['tracksNonce'] ) ), 'jp-tracks-ajax-nonce' )
 		) {
 			wp_send_json_error(
 				__( 'You aren’t authorized to do that.', 'jetpack-connection' ),

--- a/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
+++ b/projects/packages/connection/src/identity-crisis/class-identity-crisis.php
@@ -179,7 +179,7 @@ class Identity_Crisis {
 		if ( current_user_can( 'jetpack_disconnect' ) ) {
 			if (
 				isset( $_GET['jetpack_idc_clear_confirmation'] ) && isset( $_GET['_wpnonce'] ) &&
-				wp_verify_nonce( $_GET['_wpnonce'], 'jetpack_idc_clear_confirmation' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- WordPress core doesn't unslash or verify nonces either.
+				wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'jetpack_idc_clear_confirmation' )
 			) {
 				Jetpack_Options::delete_option( 'safe_mode_confirmed' );
 				self::$is_safe_mode_confirmed = false;

--- a/projects/packages/connection/tests/php/Tracking_Test.php
+++ b/projects/packages/connection/tests/php/Tracking_Test.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack;
 
 use Brain\Monkey;
+use Brain\Monkey\Functions;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -135,5 +136,85 @@ class Tracking_Test extends TestCase {
 				false,
 			),
 		);
+	}
+
+	/**
+	 * Tests that the Tracks nonce is unslashed and sanitized before it is verified.
+	 *
+	 * Nonce verification is pluggable, so the value handed to wp_verify_nonce() has to be
+	 * cleaned first.
+	 *
+	 * @param string $raw      Raw $_REQUEST value.
+	 * @param string $expected Value wp_verify_nonce() is expected to receive.
+	 * @dataProvider data_provider_test_nonce_is_sanitized
+	 */
+	#[DataProvider( 'data_provider_test_nonce_is_sanitized' )]
+	public function test_ajax_tracks_sanitizes_the_nonce( $raw, $expected ) {
+		$received = null;
+		Functions\when( 'wp_verify_nonce' )->alias(
+			function ( $nonce ) use ( &$received ) {
+				$received = $nonce;
+				return false;
+			}
+		);
+		Functions\when( 'wp_send_json_error' )->alias(
+			function () {
+				throw new \RuntimeException( 'wp_send_json_error' );
+			}
+		);
+
+		$_REQUEST['tracksNonce'] = $raw;
+
+		try {
+			$this->tracking->ajax_tracks();
+		} catch ( \RuntimeException $e ) {
+			unset( $e );
+		}
+
+		unset( $_REQUEST['tracksNonce'] );
+
+		$this->assertSame( $expected, $received );
+	}
+
+	/**
+	 * Data provider for 'test_ajax_tracks_sanitizes_the_nonce'.
+	 *
+	 * @return array
+	 */
+	public static function data_provider_test_nonce_is_sanitized() {
+		return array(
+			'a real nonce is unchanged' => array( 'a1b2c3d4e5', 'a1b2c3d4e5' ),
+			'markup is stripped'        => array( '<b>a1b2c3d4e5</b>', 'a1b2c3d4e5' ),
+			'whitespace is trimmed'     => array( "  a1b2c3d4e5\n", 'a1b2c3d4e5' ),
+			'slashes are removed'       => array( "a1b2\\'c3d4", "a1b2'c3d4" ),
+		);
+	}
+
+	/**
+	 * Tests that sanitizing the nonce does not stop a valid one from verifying.
+	 *
+	 * The handler bails on the event name rather than the nonce, which only happens once
+	 * nonce verification has passed.
+	 */
+	public function test_ajax_tracks_still_accepts_a_valid_nonce() {
+		$message = null;
+		Functions\when( 'wp_send_json_error' )->alias(
+			function ( $error ) use ( &$message ) {
+				$message = $error;
+				throw new \RuntimeException( 'wp_send_json_error' );
+			}
+		);
+
+		$_REQUEST['tracksNonce'] = wp_create_nonce( 'jp-tracks-ajax-nonce' );
+
+		try {
+			$this->tracking->ajax_tracks();
+		} catch ( \RuntimeException $e ) {
+			unset( $e );
+		}
+
+		unset( $_REQUEST['tracksNonce'] );
+
+		$this->assertSame( 'No valid event name or type.', $message );
 	}
 }

--- a/projects/packages/connection/tests/php/Tracking_Test.php
+++ b/projects/packages/connection/tests/php/Tracking_Test.php
@@ -157,11 +157,13 @@ class Tracking_Test extends TestCase {
 				return false;
 			}
 		);
-		Functions\when( 'wp_send_json_error' )->alias(
-			function () {
-				throw new \RuntimeException( 'wp_send_json_error' );
-			}
-		);
+		/**
+		 * @return never
+		 */
+		$bail = function () {
+			throw new \RuntimeException( 'wp_send_json_error' );
+		};
+		Functions\when( 'wp_send_json_error' )->alias( $bail );
 
 		$_REQUEST['tracksNonce'] = $raw;
 
@@ -198,12 +200,15 @@ class Tracking_Test extends TestCase {
 	 */
 	public function test_ajax_tracks_still_accepts_a_valid_nonce() {
 		$message = null;
-		Functions\when( 'wp_send_json_error' )->alias(
-			function ( $error ) use ( &$message ) {
-				$message = $error;
-				throw new \RuntimeException( 'wp_send_json_error' );
-			}
-		);
+		/**
+		 * @param string $error Message passed to wp_send_json_error().
+		 * @return never
+		 */
+		$bail = function ( $error ) use ( &$message ) {
+			$message = $error;
+			throw new \RuntimeException( 'wp_send_json_error' );
+		};
+		Functions\when( 'wp_send_json_error' )->alias( $bail );
 
 		$_REQUEST['tracksNonce'] = wp_create_nonce( 'jp-tracks-ajax-nonce' );
 

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -21,6 +21,13 @@ class Identity_Crisis_Test extends BaseTestCase {
 	const TEST_URL = 'https://www.example.org/test';
 
 	/**
+	 * Capability filter registered by set_up_disconnect_user(), so it can be removed again.
+	 *
+	 * @var callable|null
+	 */
+	private $disconnect_cap_filter = null;
+
+	/**
 	 * Set up tests.
 	 */
 	public function set_up() {
@@ -35,6 +42,12 @@ class Identity_Crisis_Test extends BaseTestCase {
 	 * Tear down tests.
 	 */
 	public function tear_down() {
+		if ( $this->disconnect_cap_filter !== null ) {
+			remove_filter( 'user_has_cap', $this->disconnect_cap_filter );
+			$this->disconnect_cap_filter = null;
+			wp_set_current_user( 0 );
+		}
+
 		Constants::clear_constants();
 		StatusCache::clear();
 
@@ -1791,5 +1804,80 @@ class Identity_Crisis_Test extends BaseTestCase {
 		$this->assertGreaterThan( $initial_sync_error['last_checked'], $stored_option['last_checked'] );
 		// next_check_delay should be doubled (exponential backoff).
 		$this->assertEquals( 7200, $stored_option['next_check_delay'] );
+	}
+
+	/**
+	 * Grants the current user the capability wordpress_init() gates on.
+	 *
+	 * @return void
+	 */
+	private function set_up_disconnect_user() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'idc_nonce_user',
+				'user_pass'  => 'password',
+				'user_email' => 'idc_nonce_user@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$this->disconnect_cap_filter = function ( $allcaps ) {
+			$allcaps['jetpack_disconnect'] = true;
+			return $allcaps;
+		};
+		add_filter( 'user_has_cap', $this->disconnect_cap_filter );
+	}
+
+	/**
+	 * Tests that a valid confirmation nonce still clears safe mode after sanitization.
+	 *
+	 * @param string $nonce_wrapper Sprintf pattern applied to the generated nonce.
+	 * @dataProvider data_provider_valid_confirmation_nonce
+	 */
+	#[DataProvider( 'data_provider_valid_confirmation_nonce' )]
+	public function test_wordpress_init_clears_safe_mode_with_a_valid_nonce( $nonce_wrapper ) {
+		$this->set_up_disconnect_user();
+		Jetpack_Options::update_option( 'safe_mode_confirmed', true );
+
+		$_GET['jetpack_idc_clear_confirmation'] = '1';
+		$_GET['_wpnonce']                       = sprintf( $nonce_wrapper, wp_create_nonce( 'jetpack_idc_clear_confirmation' ) );
+
+		Identity_Crisis::init()->wordpress_init();
+
+		unset( $_GET['jetpack_idc_clear_confirmation'], $_GET['_wpnonce'] );
+
+		$this->assertFalse( Identity_Crisis::$is_safe_mode_confirmed );
+		$this->assertFalse( Jetpack_Options::get_option( 'safe_mode_confirmed' ) );
+	}
+
+	/**
+	 * Data provider for 'test_wordpress_init_clears_safe_mode_with_a_valid_nonce'.
+	 *
+	 * @return array
+	 */
+	public static function data_provider_valid_confirmation_nonce() {
+		return array(
+			'as sent by the browser' => array( '%s' ),
+			'padded with whitespace' => array( "  %s\n" ),
+		);
+	}
+
+	/**
+	 * Tests that safe mode survives a confirmation link carrying a nonce that does not verify.
+	 */
+	public function test_wordpress_init_keeps_safe_mode_with_an_invalid_nonce() {
+		$this->set_up_disconnect_user();
+		Jetpack_Options::update_option( 'safe_mode_confirmed', true );
+
+		$_GET['jetpack_idc_clear_confirmation'] = '1';
+		$_GET['_wpnonce']                       = '<b>not-a-nonce</b>';
+
+		Identity_Crisis::init()->wordpress_init();
+
+		unset( $_GET['jetpack_idc_clear_confirmation'], $_GET['_wpnonce'] );
+
+		$this->assertTrue( Identity_Crisis::$is_safe_mode_confirmed );
+		$this->assertTrue( (bool) Jetpack_Options::get_option( 'safe_mode_confirmed' ) );
 	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
* `wp_verify_nonce()` is pluggable, so a caller cannot assume its input has already been unslashed and sanitized. The two nonce reads in this package now do that at the call site: one in the Tracks AJAX handler, one in the Identity Crisis safe-mode confirmation.
* This removes the two `phpcs:ignore` lines that argued WordPress core does not pre-sanitize nonces either. The sniff passes without them.

Flagged by the WordPress.org plugin review tooling while the standalone Jetpack Stats plugin was under review. The same code ships in every plugin that bundles this package, so the fix belongs here rather than in the plugin.

## Related product discussion/links
* WordPress.org plugin review of the standalone Jetpack Stats plugin, second automated round.

## Does this pull request change what data or activity we track or use?
No. Nonces are alphanumeric, so `sanitize_text_field()` returns them unchanged. Only malformed input behaves differently, and that would have failed verification anyway.

## Testing instructions
* Open a Jetpack admin screen and confirm Tracks events are still recorded — nonce verification has to keep passing for the AJAX handler to run.
* Put a site into safe mode, then use the confirmation link in the admin bar and confirm safe mode is still cleared.
