### PR TITLE
Enable React 19 on 2% of Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-react-19-segment-exclude-extensions
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-react-19-segment-exclude-extensions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Gutenberg: Enable the React 19 experiment on 2% of Atomic sites, skip sites with incompatible extensions.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -21,6 +21,10 @@ class Jetpack_Mu_Wpcom {
 	const BASE_DIR        = __DIR__ . '/';
 	const BASE_FILE       = __FILE__;
 
+	// Themes (by template slug) and plugins (by basename) known to break with React 19.
+	const REACT_19_INCOMPATIBLE_THEMES  = array( 'divi' );
+	const REACT_19_INCOMPATIBLE_PLUGINS = array( 'wp-table-builder/wp-table-builder.php' );
+
 	/**
 	 * Initialize the class.
 	 */
@@ -919,11 +923,17 @@ class Jetpack_Mu_Wpcom {
 			return true;
 		}
 
-		if ( 'divi' === strtolower( get_template() ) ) {
+		if ( in_array( strtolower( get_template() ), self::REACT_19_INCOMPATIBLE_THEMES, true ) ) {
 			return true;
 		}
 
-		return is_plugin_active( 'wp-table-builder/wp-table-builder.php' );
+		foreach ( self::REACT_19_INCOMPATIBLE_PLUGINS as $plugin_file ) {
+			if ( is_plugin_active( $plugin_file ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -859,7 +859,8 @@ class Jetpack_Mu_Wpcom {
 	 *
 	 * The `disable-gutenberg-react-19` blog sticker force-disables the experiment,
 	 * the `gutenberg-react-19` sticker opts the site in. With neither sticker,
-	 * the experiment is enabled on 1% of Atomic sites.
+	 * the experiment is enabled on a certain percentage of Atomic sites,
+	 * known incompatible plugins and themes are excluded.
 	 *
 	 * @param mixed $experiments The current value of the gutenberg-experiments option.
 	 * @return mixed Original option value or the filtered experiments.
@@ -879,8 +880,10 @@ class Jetpack_Mu_Wpcom {
 			// Don't enable if the site ID is unknown (zero).
 			if ( ! $site_id ) {
 				$is_enabled = false;
+			} elseif ( self::has_react_19_incompatible_extension() ) {
+				$is_enabled = false;
 			} else {
-				$current_segment = 1; // Segment of Atomic sites in the experiment, in %.
+				$current_segment = 2; // Segment of Atomic sites in the experiment, in %.
 				$site_segment    = $site_id % 100;
 
 				/*
@@ -903,6 +906,24 @@ class Jetpack_Mu_Wpcom {
 
 		$experiments['gutenberg-react-19'] = true;
 		return $experiments;
+	}
+
+	/**
+	 * Whether the site runs an extension that's known to break with React 19.
+	 *
+	 * @return bool
+	 */
+	private static function has_react_19_incompatible_extension() {
+		// Outside wp-admin the plugin check is unavailable, and the experiment isn't needed.
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			return true;
+		}
+
+		if ( 'divi' === strtolower( get_template() ) ) {
+			return true;
+		}
+
+		return is_plugin_active( 'wp-table-builder/wp-table-builder.php' );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/changelog/update-error-reporting-react-19-segment
+++ b/projects/plugins/wpcomsh/changelog/update-error-reporting-react-19-segment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enable wp-admin JS error reporting on 2% of sites, to keep up with the React 19 experiment rollout.

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -196,8 +196,7 @@ function wpcomsh_remove_gutenberg_experimental_menu() {
 
 /**
  * Enable wp-admin JS error reporting on sites participating in the `gutenberg-react-19`
- * experiment, and on 1% of all sites, so that errors caused by the React 19 upgrade
- * are captured.
+ * experiment, so that errors caused by the React 19 upgrade are captured.
  *
  * Reporting is enabled only for WP.com-connected users, who have accepted the WP.com
  * terms of service and privacy policy. Local users have made no such agreement.
@@ -223,7 +222,7 @@ function wpcomsh_enable_error_reporting_for_react_19( $is_enabled ) {
 		return false;
 	}
 
-	$current_segment = 1; // Segment of sites that get error reporting, in %.
+	$current_segment = 2; // Segment of sites that get error reporting, in %.
 	$site_segment    = $site_id % 100;
 
 	// Sites whose id ends in digits < $current_segment are in the segment.


### PR DESCRIPTION
## Proposed changes

Enables React 19 on 2% of Atomic sites, increase from previous 1% (#50805), and exclude known incompatible plugins (WP Table Builder, Divi 5).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Install on an Atomic site and verify that it doesn't cause any fatal errors.
