### PR TITLE
Premium Analytics: share the peak-distribution card through the widgets toolkit

### DIFF
--- a/projects/packages/premium-analytics/changelog/refactor-peak-distribution
+++ b/projects/packages/premium-analytics/changelog/refactor-peak-distribution
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Extract the shared peak-distribution card into the widgets toolkit.
+
+

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
@@ -2,6 +2,7 @@ export { MetricDelta } from './metric-delta';
 export { MetricTileGrid } from './metric-tile';
 export { MetricValue } from './metric-value';
 export { MetricWithComparison } from './metric-with-comparison';
+export { PeakDistribution, type PeakDistributionProps } from './peak-distribution';
 export {
 	ComparativeLineChart,
 	type ComparativeLineChartSeries,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/peak-distribution/__tests__/peak-distribution.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/peak-distribution/__tests__/peak-distribution.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { PeakDistribution } from '../peak-distribution';
+
+// Keep visx out of jsdom and make the series the component passes assertable.
+jest.mock( '@jetpack-premium-analytics/externals', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/externals' ),
+	Sparkline: ( { data }: { data: number[] } ) => (
+		<div data-testid="sparkline" data-points={ data.join( ',' ) } />
+	),
+} ) );
+
+describe( 'PeakDistribution', () => {
+	it( 'abbreviates a value at or above 1000 but keeps the exact figure available', () => {
+		render( <PeakDistribution label="Tuesday" value={ 166900 } points={ [ 166900 ] } /> );
+
+		expect( screen.getByText( '166.9K views' ) ).toBeInTheDocument();
+		expect( screen.getByTitle( '166,900' ) ).toBeInTheDocument();
+		// `title` is not reliably announced, so the abbreviation is hidden from
+		// assistive tech and the exact figure is read in its place.
+		expect( screen.getByText( '166.9K views' ) ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( screen.getByText( '166,900 views' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a single node, with no hidden duplicate, for a value below 1000', () => {
+		render( <PeakDistribution label="Monday" value={ 25 } points={ [ 25 ] } /> );
+
+		expect( screen.getAllByText( '25 views' ) ).toHaveLength( 1 );
+		expect( screen.getByText( '25 views' ) ).not.toHaveAttribute( 'aria-hidden' );
+	} );
+
+	it( 'passes the points to the chart in order', () => {
+		render(
+			<PeakDistribution label="Tuesday" value={ 25 } points={ [ 10, 25, 0, 0, 0, 0, 0 ] } />
+		);
+
+		expect( screen.getByTestId( 'sparkline' ) ).toHaveAttribute( 'data-points', '10,25,0,0,0,0,0' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/peak-distribution/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/peak-distribution/index.ts
@@ -1,0 +1,2 @@
+export { PeakDistribution } from './peak-distribution';
+export type { PeakDistributionProps } from './peak-distribution';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/peak-distribution/peak-distribution.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/peak-distribution/peak-distribution.module.scss
@@ -1,0 +1,30 @@
+.body {
+	display: flex;
+	flex-direction: column;
+	block-size: 100%;
+	min-block-size: 0;
+	gap: var(--wpds-dimension-gap-sm);
+}
+
+/* The label and its view count sit on one line in the prototype, with the
+   count riding the label's baseline. `baseline` alignment keeps that true as
+   the two font sizes change. */
+.headline {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: var(--wpds-dimension-gap-sm);
+}
+
+.views {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
+/* `Sparkline` is the responsive variant, so it fills this box: let the box take
+   whatever the headline leaves, rather than pinning it to a fixed band that
+   strands empty space as the card grows. `min-block-size: 0` is what lets a
+   flex child shrink below its content size. */
+.chart {
+	flex: 1 1 auto;
+	min-block-size: 0;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/peak-distribution/peak-distribution.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/peak-distribution/peak-distribution.tsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { Sparkline, Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
+import { __, sprintf } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import styles from './peak-distribution.module.scss';
+
+export type PeakDistributionProps = {
+	label: string;
+	value: number;
+	points: number[];
+};
+
+// `decimals: 0` would round 166,900 to "167K"; the prototype's secondary figure
+// keeps the digit ("166.9K").
+const ABBREVIATED_VIEWS_OPTIONS = { useMultipliers: true, decimals: 1 };
+const PLAIN_VIEWS_OPTIONS = { decimals: 0 };
+
+/**
+ * Display a peak label and view count above its distribution.
+ */
+export function PeakDistribution( { label, value, points }: PeakDistributionProps ) {
+	const exactViews = formatMetricValue( value, 'number', PLAIN_VIEWS_OPTIONS );
+	const formattedViews = formatMetricValue(
+		value,
+		'number',
+		value >= 1000 ? ABBREVIATED_VIEWS_OPTIONS : PLAIN_VIEWS_OPTIONS
+	);
+
+	/* translators: %s is a number of views, e.g. "166.9K". */
+	const viewsTemplate = __( '%s views', 'jetpack-premium-analytics-pkg' );
+	const viewsLabel = sprintf( viewsTemplate, formattedViews );
+	const exactViewsLabel = sprintf( viewsTemplate, exactViews );
+
+	return (
+		<div className={ styles.body }>
+			<div className={ styles.headline }>
+				{ /* Not `MetricValue`: it pins a 20px line-height at any font size, which
+				    clips 32px glyphs. `heading-2xl` pairs 32px with 40px. */ }
+				<Text variant="heading-2xl">{ label }</Text>
+				<Text variant="body-md" className={ styles.views } title={ exactViews }>
+					{ viewsLabel === exactViewsLabel ? (
+						viewsLabel
+					) : (
+						<>
+							{ /* `title` is not reliably announced, so the abbreviation is hidden
+							    from assistive tech and the exact figure read in its place. */ }
+							<span aria-hidden="true">{ viewsLabel }</span>
+							<VisuallyHidden>{ exactViewsLabel }</VisuallyHidden>
+						</>
+					) }
+				</Text>
+			</div>
+			<div className={ styles.chart }>
+				{ /* `withResponsive` caps width at 1200px by default, stranding space on a
+				    wider card. */ }
+				<Sparkline data={ points } maxWidth={ Infinity } />
+			</div>
+		</div>
+	);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -6,6 +6,8 @@ export {
 	MetricTileGrid,
 	MetricValue,
 	MetricWithComparison,
+	PeakDistribution,
+	type PeakDistributionProps,
 	ComparativeLineChart,
 	type ComparativeLineChartSeries,
 	ComparativeBarChart,

--- a/projects/packages/premium-analytics/widgets/popular-days/package.json
+++ b/projects/packages/premium-analytics/widgets/popular-days/package.json
@@ -6,7 +6,6 @@
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/datetime": "link:../../packages/datetime",
-		"@jetpack-premium-analytics/externals": "link:../../packages/externals",
 		"@jetpack-premium-analytics/formatters": "link:../../packages/formatters",
 		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",

--- a/projects/packages/premium-analytics/widgets/popular-days/render.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-days/render.tsx
@@ -1,17 +1,15 @@
 /**
  * External dependencies
  */
-import { Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
-import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { calendar } from '@jetpack-premium-analytics/icons';
 import {
 	describeError,
-	Sparkline,
+	PeakDistribution,
 	WidgetRoot,
 	WidgetState,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 /**
  * Internal dependencies
@@ -30,11 +28,6 @@ type PopularDaysWidgetProps = WidgetRenderProps< PopularDaysRenderAttributes > &
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
-// `decimals: 0` would round 166,900 to "167K"; the prototype's secondary figure
-// keeps the digit ("166.9k").
-const ABBREVIATED_VIEWS_OPTIONS = { useMultipliers: true, decimals: 1 };
-const PLAIN_VIEWS_OPTIONS = { decimals: 0 };
-
 function PopularDaysReport() {
 	const { buckets, peak, isLoading, isFetching, isError, error, refetch } = usePopularDays();
 
@@ -46,19 +39,6 @@ function PopularDaysReport() {
 	// so the error only surfaces when there is nothing left to show. `error` is
 	// gated on the same predicate so the two cannot disagree.
 	const showError = isError && ! peak;
-
-	const views = peak?.average ?? 0;
-	const exactViews = formatMetricValue( views, 'number', PLAIN_VIEWS_OPTIONS );
-	const formattedViews = formatMetricValue(
-		views,
-		'number',
-		views >= 1000 ? ABBREVIATED_VIEWS_OPTIONS : PLAIN_VIEWS_OPTIONS
-	);
-
-	/* translators: %s is a number of views, e.g. "166.9k". */
-	const viewsTemplate = __( '%s views', 'jetpack-premium-analytics-pkg' );
-	const viewsLabel = sprintf( viewsTemplate, formattedViews );
-	const exactViewsLabel = sprintf( viewsTemplate, exactViews );
 
 	return (
 		<div className={ styles.root }>
@@ -83,30 +63,11 @@ function PopularDaysReport() {
 					description: __( 'No views in this period.', 'jetpack-premium-analytics-pkg' ),
 				} }
 			>
-				<div className={ styles.body }>
-					<div className={ styles.headline }>
-						{ /* Not `MetricValue`: it pins a 20px line-height at any font size, which
-						    clips 32px glyphs. `heading-2xl` pairs 32px with 40px. */ }
-						<Text variant="heading-2xl">{ peak?.label }</Text>
-						<Text variant="body-md" className={ styles.views } title={ exactViews }>
-							{ viewsLabel === exactViewsLabel ? (
-								viewsLabel
-							) : (
-								<>
-									{ /* `title` is not reliably announced, so the abbreviation is hidden
-									    from assistive tech and the exact figure read in its place. */ }
-									<span aria-hidden="true">{ viewsLabel }</span>
-									<VisuallyHidden>{ exactViewsLabel }</VisuallyHidden>
-								</>
-							) }
-						</Text>
-					</div>
-					<div className={ styles.chart }>
-						{ /* `withResponsive` caps width at 1200px by default, stranding space on a
-						    wider card. */ }
-						<Sparkline data={ points } maxWidth={ Infinity } />
-					</div>
-				</div>
+				<PeakDistribution
+					label={ peak?.label ?? '' }
+					value={ peak?.average ?? 0 }
+					points={ points }
+				/>
 			</WidgetState>
 		</div>
 	);

--- a/projects/packages/premium-analytics/widgets/popular-days/style.module.css
+++ b/projects/packages/premium-analytics/widgets/popular-days/style.module.css
@@ -5,34 +5,3 @@
 	block-size: 100%;
 	min-block-size: 0;
 }
-
-.body {
-	display: flex;
-	flex-direction: column;
-	block-size: 100%;
-	min-block-size: 0;
-	gap: var(--wpds-dimension-gap-sm);
-}
-
-/* The weekday and its view count sit on one line in the prototype, with the
-   count riding the weekday's baseline. `baseline` alignment keeps that true as
-   the two font sizes change. */
-.headline {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: baseline;
-	gap: var(--wpds-dimension-gap-sm);
-}
-
-.views {
-	color: var(--wpds-color-foreground-content-neutral-weak);
-}
-
-/* `Sparkline` is the responsive variant, so it fills this box: let the box take
-   whatever the headline leaves, rather than pinning it to a fixed band that
-   strands empty space as the card grows. `min-block-size: 0` is what lets a
-   flex child shrink below its content size. */
-.chart {
-	flex: 1 1 auto;
-	min-block-size: 0;
-}


### PR DESCRIPTION
**Pure refactoring**. Part of WOOA7S-1897, split out of #51239 so the feature PR only carries the new widget.

## Proposed changes

- Move the peak label + sparkline card out of Popular days into the widgets toolkit as `PeakDistribution`.
- Leave Popular days its data, icon, and copy; the layout it was carrying was never weekday-specific.
- No behavior change: same markup, same styles, same accessible names.

## Related product discussion/links

- WOOA7S-1897

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Run `jetpack build --deps packages/premium-analytics`.
2. Run `pnpm run storybook` from `projects/packages/premium-analytics`.
3. Open _Packages/Premium Analytics/Widgets/PopularDays_ and verify the default, empty, error, retryable error, and loading states are unchanged.
