### PR TITLE
Stats Admin: enqueue the post list column CSS

### DIFF
--- a/projects/packages/stats-admin/changelog/stats-343-stats-admin-enqueue-column-css
+++ b/projects/packages/stats-admin/changelog/stats-343-stats-admin-enqueue-column-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Load the post list Stats column CSS through the stylesheet queue.

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -47,7 +47,7 @@ class Admin_Post_List_Column {
 	 */
 	public function __construct() {
 		// Add an icon to see stats in WordPress.com for a particular post.
-		add_action( 'admin_print_styles-edit.php', array( $this, 'stats_load_admin_css' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'stats_load_admin_css' ) );
 
 		add_filter( 'manage_posts_columns', array( $this, 'add_stats_post_table' ) );
 		add_filter( 'manage_pages_columns', array( $this, 'add_stats_post_table' ) );
@@ -60,16 +60,18 @@ class Admin_Post_List_Column {
 	 * Load CSS needed for Stats column width in WP-Admin area.
 	 *
 	 * @since 4.7.0
+	 *
+	 * @param string $hook_suffix The current admin page.
 	 */
-	public function stats_load_admin_css() {
-		?>
-		<style type="text/css">
-			.wp-list-table.fixed .column-stats {
-				width: 9em;
-				white-space: nowrap;
-			}
-		</style>
-		<?php
+	public function stats_load_admin_css( $hook_suffix ) {
+		if ( 'edit.php' !== $hook_suffix ) {
+			return;
+		}
+
+		wp_add_inline_style(
+			'common',
+			'.wp-list-table.fixed .column-stats { width: 9em; white-space: nowrap; }'
+		);
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -60,10 +60,11 @@ class Admin_Post_List_Column {
 	 * Load CSS needed for Stats column width in WP-Admin area.
 	 *
 	 * @since 4.7.0
+	 * @since $$next-version$$ Added the `$hook_suffix` parameter.
 	 *
 	 * @param string $hook_suffix The current admin page.
 	 */
-	public function stats_load_admin_css( $hook_suffix ) {
+	public function stats_load_admin_css( $hook_suffix = '' ) {
 		if ( 'edit.php' !== $hook_suffix ) {
 			return;
 		}

--- a/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
+++ b/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
@@ -220,18 +220,33 @@ class Admin_Post_List_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test the CSS output.
+	 * Test that the column CSS is attached to an enqueued stylesheet on the post list screen.
 	 *
 	 * @return void
 	 */
 	public function test_stats_load_admin_css() {
-		// Capture output from the `stats_load_admin_css` method
-		ob_start();
-		Admin_Post_List_Column::register()->stats_load_admin_css();
-		$output = ob_get_clean();
+		wp_styles()->add_inline_style( 'common', '' );
+		wp_styles()->add_data( 'common', 'after', array() );
 
-		// Ensure the correct CSS is outputted for the Stats column width
-		$this->assertStringContainsString( '.fixed .column-stats', $output );
+		Admin_Post_List_Column::register()->stats_load_admin_css( 'edit.php' );
+
+		$this->assertStringContainsString(
+			'.fixed .column-stats',
+			implode( '', wp_styles()->get_data( 'common', 'after' ) )
+		);
+	}
+
+	/**
+	 * Test that the column CSS is not added to admin screens without the post list.
+	 *
+	 * @return void
+	 */
+	public function test_stats_load_admin_css_is_limited_to_the_post_list() {
+		wp_styles()->add_data( 'common', 'after', array() );
+
+		Admin_Post_List_Column::register()->stats_load_admin_css( 'index.php' );
+
+		$this->assertSame( array(), wp_styles()->get_data( 'common', 'after' ) );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
+++ b/projects/packages/stats-admin/tests/php/Admin_Post_List_Test.php
@@ -225,7 +225,7 @@ class Admin_Post_List_Test extends BaseTestCase {
 	 * @return void
 	 */
 	public function test_stats_load_admin_css() {
-		wp_styles()->add_inline_style( 'common', '' );
+		$this->assertTrue( wp_style_is( 'common', 'registered' ), 'The column CSS rides on core\'s common stylesheet.' );
 		wp_styles()->add_data( 'common', 'after', array() );
 
 		Admin_Post_List_Column::register()->stats_load_admin_css( 'edit.php' );
@@ -242,6 +242,7 @@ class Admin_Post_List_Test extends BaseTestCase {
 	 * @return void
 	 */
 	public function test_stats_load_admin_css_is_limited_to_the_post_list() {
+		$this->assertTrue( wp_style_is( 'common', 'registered' ), 'The column CSS rides on core\'s common stylesheet.' );
 		wp_styles()->add_data( 'common', 'after', array() );
 
 		Admin_Post_List_Column::register()->stats_load_admin_css( 'index.php' );


### PR DESCRIPTION
Fixes #

## Proposed changes
* The Stats column width CSS on the post list screen was printed as a `<style>` tag. It now goes through `wp_add_inline_style()` on the core `common` stylesheet, so it is part of the stylesheet queue and can be dequeued, reordered and cached like anything else.
* The hook moves from `admin_print_styles-edit.php` to `admin_enqueue_scripts`, with a check on the hook suffix so the CSS still loads only on the post list screen.

Flagged by the WordPress.org plugin review tooling while the standalone Jetpack Stats plugin was under review. Their guidance is explicit that admin screens are not an exception, and neither are inline styles.

## Related product discussion/links
* WordPress.org plugin review of the standalone Jetpack Stats plugin, second automated round.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Go to Posts, and confirm the Stats column is still one line wide and does not wrap.
* View source on that screen and confirm the rule appears in the `common-inline-css` block rather than in a standalone `<style>` tag.
* Go to Dashboard or another admin screen and confirm the rule is not present there.
