### PR TITLE
Boost: update readme.txt module list and swap FID for INP

### DIFF
--- a/projects/plugins/boost/changelog/update-boost-readme-modules-inp
+++ b/projects/plugins/boost/changelog/update-boost-readme-modules-inp
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: WordPress.org readme-only update (module list and FID→INP); no Boost release note needed.

--- a/projects/plugins/boost/readme.txt
+++ b/projects/plugins/boost/readme.txt
@@ -26,7 +26,7 @@ Increase your website performance and speed up your website with one-click optim
 Improving Core Web Vitals helps you rank higher on Google. A faster website also improves your SEO, helps you reduce your bounce rate and increase your ecommerce conversion rate.
 
 - Largest Contentful Paint (LCP): Measures loading performance. Improve your LCP and improve your website loading speed.
-- First Input Delay (FID): Measures interactivity. To improve user experience pages should have a low FID.
+- Interaction to Next Paint (INP): Measures responsiveness. To improve user experience pages should have a low INP.
 - Cumulative Layout Shift (CLS): Measures visual stability. Lowering your CLS helps improve your user experience.
 
 ### Performance Modules
@@ -35,7 +35,7 @@ Optimize your website with the same techniques used on the world's most successf
 
 Each technique that is used to increase website performance is packaged up as a module that you can activate and try out.
 
-Currently, the plugin has 6 performance modules available:
+Currently, the plugin has 8 performance modules available:
 
 1. *Optimize CSS Loading* generates Critical CSS for your homepage, posts and pages. This can allow your content to show up on the screen much faster, particularly for viewers using mobile devices.
 
@@ -56,6 +56,10 @@ Currently, the plugin has 6 performance modules available:
 6. *Concatenate and Minify CSS and JS* combines and shrinks your JavaScript and CSS resources to reduce the number and size of requests to your server, ensuring your content loads faster.
 
    Read more about minifying files at [web.dev](https://web.dev/minify-css/)
+
+7. *Optimize LCP Images* improves the Largest Contentful Paint (LCP) of your Cornerstone Pages by optimizing their key image, so your most important content shows up sooner.
+
+8. *Prerender Cornerstone Pages* loads your Cornerstone Pages in the background before visitors click a link to them, so your most important pages appear almost instantly.
 
 Don’t want to have to manually generate your critical CSS each time you update your site? Let us do the heavy lifting for you with automated critical CSS – each time you update your site we will automatically regenerate your critical CSS and update your performance scores. Upgrading also gives you dedicated email support access.
 


### PR DESCRIPTION
## Proposed changes

* Update the performance module count in `readme.txt` from 6 to 8, adding the two modules missing from the list: *Optimize LCP Images* and *Prerender Cornerstone Pages*.
* Replace First Input Delay (FID) with Interaction to Next Paint (INP) in the Core Web Vitals list. Google retired FID as a Core Web Vital in favor of INP.

## Related product discussion/links

* https://linear.app/a8c/issue/JPHDOC-829/boost-470-documentation-updates (the readme.txt checklist item)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Review the `readme.txt` diff.
* Confirm the two new list entries match the module names shown in the Boost dashboard (*Optimize LCP Images*, *Prerender Cornerstone Pages*) and that their descriptions match how the features behave.
* No functional changes; the copy appears on the WordPress.org plugin page after the next release.
