### PR TITLE
Stats Admin: enqueue the dashboard bootstrap script

### DIFF
--- a/projects/packages/stats-admin/changelog/stats-343-stats-admin-enqueue-dashboard-script
+++ b/projects/packages/stats-admin/changelog/stats-343-stats-admin-enqueue-dashboard-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Load the Stats dashboard bootstrap script through the script queue.

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -170,8 +170,7 @@ JS;
 		// The bootstrap runs on jQuery, which the Odyssey bundle does not depend on. It gets its own
 		// handle rather than jQuery being added to that bundle, which the dashboard widget shares
 		// and which has no use for it.
-		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- The handle carries an inline script only, so there is no file to version.
-		wp_register_script( 'jp-stats-dashboard-bootstrap', false, array( 'jquery' ), null, true );
+		wp_register_script( 'jp-stats-dashboard-bootstrap', false, array( 'jquery' ), Main::VERSION, true );
 		wp_enqueue_script( 'jp-stats-dashboard-bootstrap' );
 		wp_add_inline_script( 'jp-stats-dashboard-bootstrap', $this->get_bootstrap_script() );
 

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -124,26 +124,34 @@ class Dashboard {
 				/>
 			</div>
 		</div>
-		<script>
-			jQuery(document).ready(function($) {
-				// Load SVG sprite.
-				$.get("https://widgets.wp.com/odyssey-stats/common/gridicons-506499ddac13811fee8e.svg", function(data) {
-					var div = document.createElement("div");
-					div.innerHTML = new XMLSerializer().serializeToString(data.documentElement);
-					div.style = 'display: none';
-					document.body.insertBefore(div, document.body.childNodes[0]);
-				});
-				// we intercept on all anchor tags and change it to hashbang style.
-				$("#wpcom").on('click', 'a', function (e) {
-					const link = e && e.currentTarget && e.currentTarget.attributes && e.currentTarget.attributes.href && e.currentTarget.attributes.href.value;
-					if( link && link.startsWith( '/stats' ) ) {
-						location.hash = `#!${link}`;
-						return false;
-					}
-				});
-			});
-		</script>
 		<?php
+	}
+
+	/**
+	 * The dashboard bootstrap: load the icon sprite, and keep in-app links inside the dashboard.
+	 *
+	 * @return string
+	 */
+	private function get_bootstrap_script() {
+		return <<<'JS'
+jQuery(document).ready(function($) {
+	// Load SVG sprite.
+	$.get("https://widgets.wp.com/odyssey-stats/common/gridicons-506499ddac13811fee8e.svg", function(data) {
+		var div = document.createElement("div");
+		div.innerHTML = new XMLSerializer().serializeToString(data.documentElement);
+		div.style = 'display: none';
+		document.body.insertBefore(div, document.body.childNodes[0]);
+	});
+	// we intercept on all anchor tags and change it to hashbang style.
+	$("#wpcom").on('click', 'a', function (e) {
+		const link = e && e.currentTarget && e.currentTarget.attributes && e.currentTarget.attributes.href && e.currentTarget.attributes.href.value;
+		if( link && link.startsWith( '/stats' ) ) {
+			location.hash = `#!${link}`;
+			return false;
+		}
+	});
+});
+JS;
 	}
 
 	/**
@@ -158,6 +166,14 @@ class Dashboard {
 	 */
 	public function load_admin_scripts() {
 		( new Odyssey_Assets() )->load_admin_scripts( 'jp-stats-dashboard', 'build.min', array( 'config_variable_name' => 'jetpackStatsOdysseyAppConfigData' ) );
+
+		// The bootstrap runs on jQuery, which the Odyssey bundle does not depend on. It gets its own
+		// handle rather than jQuery being added to that bundle, which the dashboard widget shares
+		// and which has no use for it.
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- The handle carries an inline script only, so there is no file to version.
+		wp_register_script( 'jp-stats-dashboard-bootstrap', false, array( 'jquery' ), null, true );
+		wp_enqueue_script( 'jp-stats-dashboard-bootstrap' );
+		wp_add_inline_script( 'jp-stats-dashboard-bootstrap', $this->get_bootstrap_script() );
 
 		// The app is served from our CDN and so cannot bundle the connection package. Print the
 		// state Search and Protect print on their own pages, so it can read the connection status

--- a/projects/packages/stats-admin/tests/php/Dashboard_Test.php
+++ b/projects/packages/stats-admin/tests/php/Dashboard_Test.php
@@ -81,6 +81,40 @@ class Dashboard_Test extends Stats_TestCase {
 	}
 
 	/**
+	 * The bootstrap that loads the icon sprite is no longer part of the page markup, so it has to
+	 * reach the page through the script queue.
+	 */
+	public function test_load_admin_scripts_enqueues_the_bootstrap() {
+		( new Dashboard() )->load_admin_scripts();
+
+		$inline_scripts = implode( '', (array) wp_scripts()->get_data( 'jp-stats-dashboard-bootstrap', 'after' ) );
+
+		$this->assertTrue( wp_script_is( 'jp-stats-dashboard-bootstrap', 'enqueued' ) );
+		$this->assertStringContainsString( 'gridicons', $inline_scripts );
+	}
+
+	/**
+	 * The bootstrap runs on jQuery, which the Odyssey bundle does not depend on, so it has to say
+	 * so itself rather than rely on another admin feature having loaded it.
+	 */
+	public function test_bootstrap_declares_its_jquery_dependency() {
+		( new Dashboard() )->load_admin_scripts();
+
+		$this->assertContains( 'jquery', wp_scripts()->registered['jp-stats-dashboard-bootstrap']->deps );
+	}
+
+	/**
+	 * The dashboard markup carries no script tag of its own.
+	 */
+	public function test_render_prints_no_script_tag() {
+		ob_start();
+		( new Dashboard() )->render();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( '<script', $output );
+	}
+
+	/**
 	 * Once connected the dashboard is a reporting page, open to anyone allowed to see stats.
 	 */
 	public function test_capability_when_connected() {

--- a/projects/packages/stats-admin/tests/php/Dashboard_Test.php
+++ b/projects/packages/stats-admin/tests/php/Dashboard_Test.php
@@ -17,6 +17,8 @@ class Dashboard_Test extends Stats_TestCase {
 	public function tearDown(): void {
 		wp_dequeue_script( 'jp-stats-dashboard' );
 		wp_deregister_script( 'jp-stats-dashboard' );
+		wp_dequeue_script( 'jp-stats-dashboard-bootstrap' );
+		wp_deregister_script( 'jp-stats-dashboard-bootstrap' );
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
## Proposed changes
* The Stats dashboard printed a `<script>` tag in its own markup to load the gridicons SVG sprite and to keep in-app links inside the dashboard. That now goes through `wp_add_inline_script()`.
* It gets its own handle rather than riding on `jp-stats-dashboard`, because it runs on jQuery and the Odyssey bundle does not depend on jQuery. Adding jQuery to that bundle's dependencies would also load it for the WP dashboard widget, which shares the bundle and has no use for it.
* The script itself is unchanged.

Flagged by the WordPress.org plugin review tooling while the standalone Jetpack Stats plugin was under review. Their guidance is explicit that admin screens are not an exception for inline scripts.

## Related product discussion/links
* WordPress.org plugin review of the standalone Jetpack Stats plugin, second automated round.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open Jetpack → Stats and confirm the dashboard renders as before, with icons present rather than blank squares — that proves the sprite still loads.
* Click through to a sub-view, for example Traffic → Posts & Pages, and confirm the URL becomes a `#!` hash and the view changes without a full page load.
* View source on the Stats page and confirm the sprite loader appears in a `jp-stats-dashboard-bootstrap-js-after` block rather than a bare `<script>` tag in the body.
* Open Dashboard → Home with the Stats widget enabled and confirm it still renders, and that jQuery is not being pulled in for it.

