### PR TITLE
Stats: enqueue the rule that hides the tracking pixel

### DIFF
--- a/projects/packages/stats/changelog/stats-343-stats-enqueue-hide-smile-css
+++ b/projects/packages/stats/changelog/stats-343-stats-enqueue-hide-smile-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Load the rule that hides the tracking pixel through the stylesheet queue.

--- a/projects/packages/stats/src/class-main.php
+++ b/projects/packages/stats/src/class-main.php
@@ -69,8 +69,7 @@ class Main {
 		// Generate the tracking code after wp() has queried for posts.
 		add_action( 'template_redirect', array( __CLASS__, 'template_redirect' ), 1 );
 
-		add_action( 'wp_head', array( __CLASS__, 'hide_smile_css' ) );
-		add_action( 'embed_head', array( __CLASS__, 'hide_smile_css' ) );
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'hide_smile_css' ) );
 
 		// Map stats caps.
 		add_filter( 'map_meta_cap', array( __CLASS__, 'map_meta_caps' ), 10, 3 );
@@ -188,9 +187,12 @@ class Main {
 		if ( ! self::should_track() ) {
 			return;
 		}
-		?>
-	<style>img#wpstats{display:none}</style>
-		<?php
+
+		// This one rule is the whole stylesheet, so the handle carries no file.
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- There is no file to version.
+		wp_register_style( 'jetpack-stats', false, array(), null );
+		wp_enqueue_style( 'jetpack-stats' );
+		wp_add_inline_style( 'jetpack-stats', 'img#wpstats{display:none}' );
 	}
 
 	/**

--- a/projects/packages/stats/src/class-main.php
+++ b/projects/packages/stats/src/class-main.php
@@ -188,9 +188,7 @@ class Main {
 			return;
 		}
 
-		// This one rule is the whole stylesheet, so the handle carries no file.
-		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- There is no file to version.
-		wp_register_style( 'jetpack-stats', false, array(), null );
+		wp_register_style( 'jetpack-stats', false, array(), Package_Version::PACKAGE_VERSION );
 		wp_enqueue_style( 'jetpack-stats' );
 		wp_add_inline_style( 'jetpack-stats', 'img#wpstats{display:none}' );
 	}

--- a/projects/packages/stats/tests/php/Main_Test.php
+++ b/projects/packages/stats/tests/php/Main_Test.php
@@ -50,6 +50,11 @@ class Main_Test extends StatsBaseTestCase {
 
 		unset( $_SERVER['HTTP_DNT'] );
 
+		// wp_styles() is a global that outlives each test, so a handle enqueued by one would
+		// otherwise be seen by the next.
+		wp_dequeue_style( 'jetpack-stats' );
+		wp_deregister_style( 'jetpack-stats' );
+
 		// Reset the REST server so the lazy-registration test below does not leak its
 		// populated server (with the stats route registered) into later tests in the suite.
 		global $wp_rest_server;
@@ -150,32 +155,22 @@ class Main_Test extends StatsBaseTestCase {
 	}
 
 	/**
-	 * Drop the stylesheet between tests. wp_styles() is a global that outlives each test, so a
-	 * handle enqueued by one would otherwise be seen by the next.
-	 *
-	 * @return void
-	 */
-	private function forget_hide_smile_css_style() {
-		wp_dequeue_style( 'jetpack-stats' );
-		wp_deregister_style( 'jetpack-stats' );
-	}
-
-	/**
 	 * The rule that hides the tracking pixel goes through the stylesheet queue rather than
 	 * being printed into the page.
 	 */
 	public function test_hide_smile_css_is_enqueued() {
-		$this->forget_hide_smile_css_style();
-
 		add_filter( 'jetpack_active_modules', array( __CLASS__, 'filter_jetpack_active_modules_add_stats' ), 10, 2 );
 		Stats::hide_smile_css();
 		remove_filter( 'jetpack_active_modules', array( __CLASS__, 'filter_jetpack_active_modules_add_stats' ), 10 );
 
 		$this->assertTrue( wp_style_is( 'jetpack-stats', 'enqueued' ) );
-		$this->assertStringContainsString(
-			'img#wpstats',
-			implode( '', (array) wp_styles()->get_data( 'jetpack-stats', 'after' ) )
-		);
+
+		ob_start();
+		wp_styles()->do_items( 'jetpack-stats' );
+		$output = ob_get_clean();
+
+		$this->assertMatchesRegularExpression( '/<style id=["\']jetpack-stats-inline-css["\']/', $output );
+		$this->assertStringContainsString( 'img#wpstats{display:none}', $output );
 	}
 
 	/**
@@ -183,8 +178,6 @@ class Main_Test extends StatsBaseTestCase {
 	 * module being inactive means here.
 	 */
 	public function test_hide_smile_css_is_not_enqueued_when_not_tracking() {
-		$this->forget_hide_smile_css_style();
-
 		Stats::hide_smile_css();
 
 		$this->assertFalse( wp_style_is( 'jetpack-stats', 'enqueued' ) );

--- a/projects/packages/stats/tests/php/Main_Test.php
+++ b/projects/packages/stats/tests/php/Main_Test.php
@@ -133,37 +133,61 @@ class Main_Test extends StatsBaseTestCase {
 	}
 
 	/**
-	 * Test Main::init does not add the `wp_head` hook if an older version of the
+	 * Test Main::init does not add the stylesheet hook if an older version of the
 	 * Jetpack plugin is active.
 	 */
-	public function test_wp_head_hook_not_added_with_jp_version_lt_11_5_a_2() {
-		$has_action = has_action( 'wp_head', array( 'Automattic\Jetpack\Stats\Main', 'hide_smile_css' ) );
+	public function test_hide_smile_css_hook_not_added_with_jp_version_lt_11_5_a_2() {
+		$has_action = has_action( 'wp_enqueue_scripts', array( 'Automattic\Jetpack\Stats\Main', 'hide_smile_css' ) );
 		$this->assertFalse( $has_action );
 	}
 
 	/**
-	 * Test Main::init adds the `wp_head` hook.
+	 * Test Main::init adds the stylesheet hook.
 	 */
-	public function test_wp_head_hook() {
-		$has_action = has_action( 'wp_head', array( 'Automattic\Jetpack\Stats\Main', 'hide_smile_css' ) );
+	public function test_hide_smile_css_hook() {
+		$has_action = has_action( 'wp_enqueue_scripts', array( 'Automattic\Jetpack\Stats\Main', 'hide_smile_css' ) );
 		$this->assertEquals( 10, $has_action );
 	}
 
 	/**
-	 * Test Main::init does not add the `wp_head` hook if an older version of the
-	 * Jetpack plugin is active.
+	 * Drop the stylesheet between tests. wp_styles() is a global that outlives each test, so a
+	 * handle enqueued by one would otherwise be seen by the next.
+	 *
+	 * @return void
 	 */
-	public function test_embed_head_hook_not_added_with_jp_version_lt_11_5_a_2() {
-		$has_action = has_action( 'embed_head', array( 'Automattic\Jetpack\Stats\Main', 'hide_smile_css' ) );
-		$this->assertFalse( $has_action );
+	private function forget_hide_smile_css_style() {
+		wp_dequeue_style( 'jetpack-stats' );
+		wp_deregister_style( 'jetpack-stats' );
 	}
 
 	/**
-	 * Test Main::init adds the `embed_head` hook.
+	 * The rule that hides the tracking pixel goes through the stylesheet queue rather than
+	 * being printed into the page.
 	 */
-	public function test_embed_head_hook() {
-		$has_action = has_action( 'embed_head', array( 'Automattic\Jetpack\Stats\Main', 'hide_smile_css' ) );
-		$this->assertEquals( 10, $has_action );
+	public function test_hide_smile_css_is_enqueued() {
+		$this->forget_hide_smile_css_style();
+
+		add_filter( 'jetpack_active_modules', array( __CLASS__, 'filter_jetpack_active_modules_add_stats' ), 10, 2 );
+		Stats::hide_smile_css();
+		remove_filter( 'jetpack_active_modules', array( __CLASS__, 'filter_jetpack_active_modules_add_stats' ), 10 );
+
+		$this->assertTrue( wp_style_is( 'jetpack-stats', 'enqueued' ) );
+		$this->assertStringContainsString(
+			'img#wpstats',
+			implode( '', (array) wp_styles()->get_data( 'jetpack-stats', 'after' ) )
+		);
+	}
+
+	/**
+	 * Nothing is enqueued on a request that is not being tracked, which is what the stats
+	 * module being inactive means here.
+	 */
+	public function test_hide_smile_css_is_not_enqueued_when_not_tracking() {
+		$this->forget_hide_smile_css_style();
+
+		Stats::hide_smile_css();
+
+		$this->assertFalse( wp_style_is( 'jetpack-stats', 'enqueued' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes
* `img#wpstats{display:none}` was printed as a `<style>` tag on `wp_head`. It now goes through `wp_add_inline_style()` on `wp_enqueue_scripts`, behind the same `should_track()` gate as before, so it still only loads on a tracked request.
* The rule hides the tracking pixel image that the `stats.wp.com` script injects into the page. Nothing in this package emits that element, so the rule is purely defensive.
* The `embed_head` hook goes away with it. `should_track()` returns false for embeds, so that hook could never produce anything.
* The stylesheet handle carries no file, since this one rule is the whole stylesheet.

Flagged by the WordPress.org plugin review tooling while the standalone Jetpack Stats plugin was under review. Their guidance is explicit that inline styles are not an exception.

## Related product discussion/links
* WordPress.org plugin review of the standalone Jetpack Stats plugin, second automated round.

## Does this pull request change what data or activity we track or use?
No. The pixel and the conditions under which it fires are unchanged; only how the rule that hides it reaches the page.

## Testing instructions
* On a connected site with Stats active, load a front-end page and confirm no stats pixel is visible anywhere on the page.
* View source and confirm the rule appears in a `jetpack-stats-inline-css` block rather than a bare `<style>` tag.
* Confirm the page view is still recorded in the Stats dashboard.
* Load a page with Do Not Track enabled, or with the site disconnected, and confirm neither the rule nor the pixel is present.

