### PR TITLE
Payment buttons: fix incorrect color variables

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-blocks-payments-color-vars
+++ b/projects/plugins/jetpack/changelog/fix-blocks-payments-color-vars
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Replace invalid --color-gray-* CSS custom properties with Calypso --color-neutral-* tokens in payment button editor styles.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss
@@ -35,14 +35,14 @@
 }
 
 .membership-button__disclaimer {
-	color: var(--color-gray-200);
+	color: var(--color-neutral-20);
 	flex-basis: 100%;
 	margin: 0;
 	font-style: italic;
 }
 
 .membership-button__disclaimer a {
-	color: var(--color-gray-400);
+	color: var(--color-neutral-40);
 	line-height: 36px;
 }
 

--- a/projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss
+++ b/projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss
@@ -58,13 +58,13 @@
 		}
 
 		&__disclaimer {
-			color: var(--color-gray-200);
+			color: var(--color-neutral-20);
 			flex-basis: 100%;
 			margin: 0;
 			font-style: italic;
 
 			a {
-				color: var(--color-gray-400);
+				color: var(--color-neutral-40);
 				line-height: 36px;
 			}
 		}


### PR DESCRIPTION
Found while working on https://github.com/Automattic/jetpack/pull/50108

## Proposed changes
<!--- Explain what functional changes your PR includes -->
Replaced the unsupported/non-existing tokens in:

- `projects/plugins/jetpack/extensions/blocks/premium-content/editor.scss`
- `projects/plugins/jetpack/extensions/blocks/recurring-payments/editor.scss`

Changes:
- `--color-gray-200` → `--color-neutral-20`
- `--color-gray-400` → `--color-neutral-40`

Those map to the same effective gray values from the available token sources:
- `--color-neutral-20` → `var(--studio-gray-20)` → `#a7aaad`
- `--color-neutral-40` → `var(--studio-gray-40)` → `#787c82`

Bundle at `_inc/blocks/editor.css`

#### Before
```css
.membership-button__disclaimer {
  color: var(--color-gray-200);
}
.membership-button__disclaimer a {
  color: var(--color-gray-400);
}
```

#### After
```css
.membership-button__disclaimer {
  color: #a7aaad;
}
.membership-button__disclaimer a {
  color: #787c82;
}
```

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

- No linter errors
- `jetpack build plugins/jetpack` completed successfully

When testing as part of https://github.com/Automattic/jetpack/pull/50108, these tokens now resolve and get fallback injection through the PostCSS pipeline.