### PR TITLE
Podcast: record when required settings are first filled in

### DIFF
--- a/projects/packages/podcast/changelog/add-podcast-setup-completed-event
+++ b/projects/packages/podcast/changelog/add-podcast-setup-completed-event
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Record a one-time event when a show's required settings have all been filled in.
+Record when each required podcast setting is first filled in, so setup completion can be measured.

--- a/projects/packages/podcast/changelog/add-podcast-setup-completed-event
+++ b/projects/packages/podcast/changelog/add-podcast-setup-completed-event
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Record a one-time event when a show's required settings have all been filled in.

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -27,6 +27,23 @@ use WP_User;
 class Tracks {
 
 	/**
+	 * Settings a show needs before a directory will accept it. Mirrors the
+	 * dashboard's `getValidationIssues()` rule in
+	 * `src/dashboard/hooks/use-validation-issues.ts` — keep the two in step.
+	 *
+	 * @var string[]
+	 */
+	private const SETUP_OPTIONS = array(
+		'podcasting_category_id',
+		'podcasting_title',
+		'podcasting_summary',
+		'podcasting_talent_name',
+		'podcasting_email',
+		'podcasting_category_1',
+		'podcasting_image',
+	);
+
+	/**
 	 * Wire the recorder hooks.
 	 */
 	public static function init(): void {
@@ -41,6 +58,15 @@ class Tracks {
 
 		add_action( 'add_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_added' ), 10, 2 );
 		add_action( 'update_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_updated' ), 10, 3 );
+
+		// Watch every required setting rather than the REST endpoint's
+		// `jetpack_podcast_settings_saved` action, so the milestone lands
+		// whichever path fills the last field — dashboard, Media Settings
+		// form, or WP-CLI.
+		foreach ( self::SETUP_OPTIONS as $option ) {
+			add_action( "add_option_{$option}", array( __CLASS__, 'record_setup_option_added' ), 10, 2 );
+			add_action( "update_option_{$option}", array( __CLASS__, 'record_setup_option_updated' ), 10, 3 );
+		}
 	}
 
 	/**
@@ -259,6 +285,98 @@ class Tracks {
 	}
 
 	/**
+	 * `add_option_{$option}` callback for a required setting.
+	 *
+	 * @param string $option Option name.
+	 * @param mixed  $value  Stored value.
+	 */
+	public static function record_setup_option_added( $option, $value ): void {
+		unset( $option, $value );
+		self::maybe_record_setup_completed();
+	}
+
+	/**
+	 * `update_option_{$option}` callback for a required setting.
+	 *
+	 * @param mixed  $old_value Previous stored value.
+	 * @param mixed  $new_value Newly stored value.
+	 * @param string $option    Option name.
+	 */
+	public static function record_setup_option_updated( $old_value, $new_value, $option ): void {
+		unset( $old_value, $new_value, $option );
+		self::maybe_record_setup_completed();
+	}
+
+	/**
+	 * Emit `wpcom_podcast_setup_completed` the first time every required
+	 * setting holds a value.
+	 *
+	 * Deliberately a milestone, not a per-save event: it answers "did this
+	 * site finish setting up a show", so it fires once and never again — same
+	 * atomic `add_option()` guard as `show_launched`. Which field completed
+	 * the set is not recorded, because a save that fills several at once
+	 * writes them in `Settings::OPTION_NAMES` order and the last one would be
+	 * an artifact of that order rather than a signal.
+	 */
+	private static function maybe_record_setup_completed(): void {
+		try {
+			if ( ! self::is_setup_complete() ) {
+				return;
+			}
+
+			// Atomic INSERT — only one concurrent caller per site wins.
+			if ( ! add_option( 'podcast_setup_completed_tracked', time(), '', false ) ) {
+				return;
+			}
+
+			self::record_event(
+				'wpcom_podcast_setup_completed',
+				array(
+					'user_id'      => (int) get_current_user_id(),
+					'product_slug' => self::current_product_slug(),
+				)
+			);
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Tracks is best-effort — never break a settings save.
+		}
+	}
+
+	/**
+	 * True once every required setting holds a value.
+	 */
+	private static function is_setup_complete(): bool {
+		foreach ( self::SETUP_OPTIONS as $option ) {
+			$value = get_option( $option, '' );
+
+			if ( 'podcasting_category_id' === $option ) {
+				if ( (int) $value < 1 ) {
+					return false;
+				}
+				continue;
+			}
+
+			if ( ! is_string( $value ) || '' === trim( $value ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Current plan slug. `WPCOM_Store_API` on Simple, `Current_Plan` on Atomic
+	 * and self-hosted — same dual pattern as
+	 * `Masterbar\Dashboard_Switcher_Tracking::get_plan()`.
+	 */
+	private static function current_product_slug(): string {
+		$plan = class_exists( '\WPCOM_Store_API' )
+			? \WPCOM_Store_API::get_current_plan( (int) get_current_blog_id() )
+			: ( class_exists( '\Automattic\Jetpack\Current_Plan' ) ? \Automattic\Jetpack\Current_Plan::get() : array() );
+
+		return (string) ( $plan['product_slug'] ?? '' );
+	}
+
+	/**
 	 * Emit `wpcom_podcasting_status_changed` (enabled / disabled / changed)
 	 * when the `podcasting_category_id` option transitions.
 	 *
@@ -278,12 +396,6 @@ class Tracks {
 			$status = 'changed';
 		}
 
-		// `WPCOM_Store_API` on Simple, `Current_Plan` on Atomic — same dual
-		// pattern as `Masterbar\Dashboard_Switcher_Tracking::get_plan()`.
-		$plan = class_exists( '\WPCOM_Store_API' )
-			? \WPCOM_Store_API::get_current_plan( (int) get_current_blog_id() )
-			: ( class_exists( '\Automattic\Jetpack\Current_Plan' ) ? \Automattic\Jetpack\Current_Plan::get() : array() );
-
 		self::record_event(
 			'wpcom_podcasting_status_changed',
 			array(
@@ -292,7 +404,7 @@ class Tracks {
 				'previous_category_id' => $old_value,
 				'new_category_id'      => $new_value,
 				'user_id'              => (int) get_current_user_id(),
-				'product_slug'         => (string) ( $plan['product_slug'] ?? '' ),
+				'product_slug'         => self::current_product_slug(),
 			)
 		);
 

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -27,9 +27,10 @@ use WP_User;
 class Tracks {
 
 	/**
-	 * Settings a show needs before a directory will accept it. Mirrors the
-	 * dashboard's `getValidationIssues()` rule in
+	 * Mirrors `getValidationIssues()` in
 	 * `src/dashboard/hooks/use-validation-issues.ts` — keep the two in step.
+	 * Not the directory-submission bar, which also wants an episode and a
+	 * conforming cover.
 	 *
 	 * @var string[]
 	 */
@@ -59,10 +60,10 @@ class Tracks {
 		add_action( 'add_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_added' ), 10, 2 );
 		add_action( 'update_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_updated' ), 10, 3 );
 
-		// Watch the options themselves rather than the REST endpoint's
-		// `jetpack_podcast_settings_saved` action, so setup progress is
-		// recorded whichever path writes the value — dashboard, Media
-		// Settings form, or WP-CLI.
+		// The options rather than the endpoint's `jetpack_podcast_settings_saved`,
+		// so setup lands whichever path writes it. `podcasting_category_id`
+		// intentionally overlaps `status_changed` above, which stays canonical
+		// for "site enabled podcasting".
 		foreach ( self::SETUP_OPTIONS as $option ) {
 			add_action( "add_option_{$option}", array( __CLASS__, 'record_setting_added' ), 10, 2 );
 			add_action( "update_option_{$option}", array( __CLASS__, 'record_setting_updated' ), 10, 3 );
@@ -296,7 +297,9 @@ class Tracks {
 	}
 
 	/**
-	 * `update_option_{$option}` callback for a required setting.
+	 * `update_option_{$option}` callback for a required setting. Seldom the live
+	 * path: `update_option()` defers to `add_option()` while the stored value
+	 * still equals the registered empty default.
 	 *
 	 * @param mixed  $old_value Previous stored value.
 	 * @param mixed  $new_value Newly stored value.
@@ -310,15 +313,10 @@ class Tracks {
 	 * Emit `wpcom_podcast_setting_first_saved` when a required setting picks up
 	 * a value for the first time.
 	 *
-	 * Only the empty → filled transition is recorded, so this is bounded at one
-	 * event per required setting rather than one per save — later edits to an
-	 * already-populated setting aren't part of setup. `is_complete` marks the
-	 * transition that finished the set, which is the "this site is properly set
-	 * up" milestone; `setting` and `filled_count` describe where sites that
-	 * never get there stopped.
-	 *
-	 * Sites already fully configured before this shipped stay silent, because
-	 * none of their settings are transitioning from empty.
+	 * Recording only the empty → filled transition bounds this at one event per
+	 * setting instead of one per save, and keeps sites configured before it
+	 * shipped silent rather than reporting a false completion. `is_complete`
+	 * marks the transition that finished the set.
 	 *
 	 * @param string $option    Option name.
 	 * @param mixed  $old_value Previous stored value.
@@ -326,12 +324,11 @@ class Tracks {
 	 */
 	private static function maybe_record_setting_first_saved( string $option, $old_value, $new_value ): void {
 		try {
-			if ( self::has_value( $option, $old_value ) || ! self::has_value( $option, $new_value ) ) {
+			if ( self::has_value( $old_value ) || ! self::has_value( $new_value ) ) {
 				return;
 			}
 
-			// Both hooks fire after the write and its cache update, so the
-			// count already includes the setting that triggered this.
+			// Both hooks fire after the write, so this counts the new value too.
 			$filled_count = self::filled_setting_count();
 
 			self::record_event(
@@ -356,7 +353,7 @@ class Tracks {
 		$filled = 0;
 
 		foreach ( self::SETUP_OPTIONS as $option ) {
-			if ( self::has_value( $option, get_option( $option, '' ) ) ) {
+			if ( self::has_value( get_option( $option, '' ) ) ) {
 				++$filled;
 			}
 		}
@@ -365,19 +362,16 @@ class Tracks {
 	}
 
 	/**
-	 * Whether a required setting counts as filled in. The category is an ID, so
-	 * 0 means unset; the rest are strings the dashboard treats as blank when
-	 * they hold nothing but whitespace.
+	 * Whether a required setting counts as filled in. Options read back as
+	 * strings, so one rule covers both shapes: blank for the text fields, `'0'`
+	 * for `podcasting_category_id`, where 0 is the disabled sentinel.
 	 *
-	 * @param string $option Option name.
-	 * @param mixed  $value  Value to test.
+	 * @param mixed $value Value to test.
 	 */
-	private static function has_value( string $option, $value ): bool {
-		if ( 'podcasting_category_id' === $option ) {
-			return (int) $value >= 1;
-		}
+	private static function has_value( $value ): bool {
+		$value = is_scalar( $value ) ? trim( (string) $value ) : '';
 
-		return is_string( $value ) && '' !== trim( $value );
+		return '' !== $value && '0' !== $value;
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -59,13 +59,13 @@ class Tracks {
 		add_action( 'add_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_added' ), 10, 2 );
 		add_action( 'update_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_updated' ), 10, 3 );
 
-		// Watch every required setting rather than the REST endpoint's
-		// `jetpack_podcast_settings_saved` action, so the milestone lands
-		// whichever path fills the last field — dashboard, Media Settings
-		// form, or WP-CLI.
+		// Watch the options themselves rather than the REST endpoint's
+		// `jetpack_podcast_settings_saved` action, so setup progress is
+		// recorded whichever path writes the value — dashboard, Media
+		// Settings form, or WP-CLI.
 		foreach ( self::SETUP_OPTIONS as $option ) {
-			add_action( "add_option_{$option}", array( __CLASS__, 'record_setup_option_added' ), 10, 2 );
-			add_action( "update_option_{$option}", array( __CLASS__, 'record_setup_option_updated' ), 10, 3 );
+			add_action( "add_option_{$option}", array( __CLASS__, 'record_setting_added' ), 10, 2 );
+			add_action( "update_option_{$option}", array( __CLASS__, 'record_setting_updated' ), 10, 3 );
 		}
 	}
 
@@ -285,14 +285,14 @@ class Tracks {
 	}
 
 	/**
-	 * `add_option_{$option}` callback for a required setting.
+	 * `add_option_{$option}` callback for a required setting. No prior row, so
+	 * the previous value is empty by definition.
 	 *
 	 * @param string $option Option name.
 	 * @param mixed  $value  Stored value.
 	 */
-	public static function record_setup_option_added( $option, $value ): void {
-		unset( $option, $value );
-		self::maybe_record_setup_completed();
+	public static function record_setting_added( $option, $value ): void {
+		self::maybe_record_setting_first_saved( (string) $option, '', $value );
 	}
 
 	/**
@@ -302,36 +302,44 @@ class Tracks {
 	 * @param mixed  $new_value Newly stored value.
 	 * @param string $option    Option name.
 	 */
-	public static function record_setup_option_updated( $old_value, $new_value, $option ): void {
-		unset( $old_value, $new_value, $option );
-		self::maybe_record_setup_completed();
+	public static function record_setting_updated( $old_value, $new_value, $option ): void {
+		self::maybe_record_setting_first_saved( (string) $option, $old_value, $new_value );
 	}
 
 	/**
-	 * Emit `wpcom_podcast_setup_completed` the first time every required
-	 * setting holds a value.
+	 * Emit `wpcom_podcast_setting_first_saved` when a required setting picks up
+	 * a value for the first time.
 	 *
-	 * Deliberately a milestone, not a per-save event: it answers "did this
-	 * site finish setting up a show", so it fires once and never again — same
-	 * atomic `add_option()` guard as `show_launched`. Which field completed
-	 * the set is not recorded, because a save that fills several at once
-	 * writes them in `Settings::OPTION_NAMES` order and the last one would be
-	 * an artifact of that order rather than a signal.
+	 * Only the empty → filled transition is recorded, so this is bounded at one
+	 * event per required setting rather than one per save — later edits to an
+	 * already-populated setting aren't part of setup. `is_complete` marks the
+	 * transition that finished the set, which is the "this site is properly set
+	 * up" milestone; `setting` and `filled_count` describe where sites that
+	 * never get there stopped.
+	 *
+	 * Sites already fully configured before this shipped stay silent, because
+	 * none of their settings are transitioning from empty.
+	 *
+	 * @param string $option    Option name.
+	 * @param mixed  $old_value Previous stored value.
+	 * @param mixed  $new_value Newly stored value.
 	 */
-	private static function maybe_record_setup_completed(): void {
+	private static function maybe_record_setting_first_saved( string $option, $old_value, $new_value ): void {
 		try {
-			if ( ! self::is_setup_complete() ) {
+			if ( self::has_value( $option, $old_value ) || ! self::has_value( $option, $new_value ) ) {
 				return;
 			}
 
-			// Atomic INSERT — only one concurrent caller per site wins.
-			if ( ! add_option( 'podcast_setup_completed_tracked', time(), '', false ) ) {
-				return;
-			}
+			// Both hooks fire after the write and its cache update, so the
+			// count already includes the setting that triggered this.
+			$filled_count = self::filled_setting_count();
 
 			self::record_event(
-				'wpcom_podcast_setup_completed',
+				'wpcom_podcast_setting_first_saved',
 				array(
+					'setting'      => $option,
+					'filled_count' => $filled_count,
+					'is_complete'  => count( self::SETUP_OPTIONS ) === $filled_count,
 					'user_id'      => (int) get_current_user_id(),
 					'product_slug' => self::current_product_slug(),
 				)
@@ -342,25 +350,34 @@ class Tracks {
 	}
 
 	/**
-	 * True once every required setting holds a value.
+	 * How many required settings currently hold a value.
 	 */
-	private static function is_setup_complete(): bool {
+	private static function filled_setting_count(): int {
+		$filled = 0;
+
 		foreach ( self::SETUP_OPTIONS as $option ) {
-			$value = get_option( $option, '' );
-
-			if ( 'podcasting_category_id' === $option ) {
-				if ( (int) $value < 1 ) {
-					return false;
-				}
-				continue;
-			}
-
-			if ( ! is_string( $value ) || '' === trim( $value ) ) {
-				return false;
+			if ( self::has_value( $option, get_option( $option, '' ) ) ) {
+				++$filled;
 			}
 		}
 
-		return true;
+		return $filled;
+	}
+
+	/**
+	 * Whether a required setting counts as filled in. The category is an ID, so
+	 * 0 means unset; the rest are strings the dashboard treats as blank when
+	 * they hold nothing but whitespace.
+	 *
+	 * @param string $option Option name.
+	 * @param mixed  $value  Value to test.
+	 */
+	private static function has_value( string $option, $value ): bool {
+		if ( 'podcasting_category_id' === $option ) {
+			return (int) $value >= 1;
+		}
+
+		return is_string( $value ) && '' !== trim( $value );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes
* Add `wpcom_podcast_setting_first_saved`, emitted when one of the seven required podcast settings picks up a value **for the first time** — the same seven the dashboard's `getValidationIssues()` enforces. Only the empty → filled transition is recorded, so this is bounded at one event per setting per site rather than one per save.
* Each event carries `setting`, `filled_count`, and `is_complete`. `is_complete` marks the transition that finished the set, so "this site is properly set up" is `WHERE is_complete = true` — one row per site, no window function. `setting` and `filled_count` show where sites that never get there stopped.
* Hooked on the option writes rather than the endpoint's `jetpack_podcast_settings_saved` action, so progress is recorded whichever path writes the value — dashboard, Media Settings form, or WP-CLI. Matches how `wpcom_podcasting_status_changed` already works.
* Extract the duplicated Simple-vs-Atomic plan lookup into `current_product_slug()`, now that two events need it.

Notes on the shape, since it went through a revision:

* **No new option and no local guard state.** An earlier draft fired a single `wpcom_podcast_setup_completed` milestone guarded by a `podcast_setup_completed_tracked` option. Deriving the milestone from a first-save flag instead means nothing new to store, nothing to add to the Sync whitelist, and no state that a staging clone inherits or an options reset clears.
* **Sites configured before this ships stay silent** rather than emitting a misleading "just completed" on their next settings edit, because none of their settings are transitioning from empty.
* **The rule stays re-derivable.** If what counts as "required" changes later, the milestone can be recomputed from the raw events; a write-time guard would have frozen the current definition permanently.
* If a required setting is cleared and re-filled, that's another empty → filled transition, so `is_complete = true` can appear twice for a site. Arguably useful signal (setup broke, then got repaired); `MIN(timestamp) GROUP BY blog_id` collapses it if not.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
Yes. It adds one new Tracks event, `wpcom_podcast_setting_first_saved`, recorded at most once per required setting per site. Its properties are `setting` (the option name), `filled_count`, `is_complete`, `user_id`, `product_slug`, and the auto-injected `blog_id` — the identity properties are ones existing podcast events already carry. No setting *values* are included, only which option was filled and how many are now complete, so no new category of data is collected.

## Testing instructions

On a Jetpack-connected site (Simple, Atomic or self-hosted) where podcasting is not yet configured:

* Go to **Jetpack → Podcast → Settings** and fill in one required field — podcast category, title, summary, host name, owner email, topic, or cover image. Confirm one `wpcom_podcast_setting_first_saved` fires, with `setting` naming that field, `filled_count: 1`, and `is_complete: false`.
* Edit that same field again. Confirm no second event fires — it's no longer a first save.
* Fill in the rest. Confirm one event per field, `filled_count` climbing, and that the seventh carries `is_complete: true`.
* Edit any settings afterwards and confirm nothing further fires.

Regression check — the existing events should be unchanged:

* Set and then clear the podcast category, and confirm `wpcom_podcasting_status_changed` still fires with the correct `status` and a populated `product_slug` (that lookup moved into a shared helper).
