### PR TITLE
Newsletter: fix settings page fatal on Gutenberg trunk

### DIFF
--- a/projects/packages/newsletter/changelog/update-jetpack-2277
+++ b/projects/packages/newsletter/changelog/update-jetpack-2277
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newsletter: Fix a fatal error on the settings page caused by Gutenberg removing a private API that DataViews toggle and radio fields relied on.

--- a/projects/packages/newsletter/src/settings/components/radio.tsx
+++ b/projects/packages/newsletter/src/settings/components/radio.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { RadioControl } from '@automattic/jetpack-components';
+import { RadioControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 /**
  * Internal dependencies

--- a/projects/packages/newsletter/src/settings/components/radio.tsx
+++ b/projects/packages/newsletter/src/settings/components/radio.tsx
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { RadioControl } from '@automattic/jetpack-components';
+import { useCallback } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import type { NewsletterSettings } from '../types';
+import type { DataFormControlProps } from '@wordpress/dataviews';
+
+/**
+ * Generic `Edit` control for DataForm fields with `elements`, rendering
+ * Jetpack's public `RadioControl` instead of DataViews' bundled
+ * `Edit: 'radio'` shorthand. The bundled control resolves the same
+ * `ValidatedToggleControl` private API as `Edit: 'toggle'`, which breaks
+ * once Gutenberg stops exposing it (see
+ * https://github.com/WordPress/gutenberg/pull/81492).
+ *
+ * @param {DataFormControlProps<NewsletterSettings>} props - DataForm edit control props.
+ * @return {JSX.Element} The radio control.
+ */
+export function Radio( {
+	field,
+	onChange,
+	data,
+}: DataFormControlProps< NewsletterSettings > ): JSX.Element {
+	const handleChange = useCallback(
+		( value: string ) => {
+			onChange( field.setValue( { item: data, value } ) );
+		},
+		[ onChange, field, data ]
+	);
+
+	return (
+		<RadioControl
+			label={ field.label }
+			help={ field.description }
+			selected={ String( field.getValue( { item: data } ) ) }
+			options={ ( field.elements ?? [] ).map( ( { value, label } ) => ( {
+				value: String( value ),
+				label,
+			} ) ) }
+			onChange={ handleChange }
+		/>
+	);
+}

--- a/projects/packages/newsletter/src/settings/components/radio.tsx
+++ b/projects/packages/newsletter/src/settings/components/radio.tsx
@@ -11,11 +11,10 @@ import type { DataFormControlProps } from '@wordpress/dataviews';
 
 /**
  * Generic `Edit` control for DataForm fields with `elements`, rendering
- * Jetpack's public `RadioControl` instead of DataViews' bundled
- * `Edit: 'radio'` shorthand. The bundled control resolves the same
- * `ValidatedToggleControl` private API as `Edit: 'toggle'`, which breaks
- * once Gutenberg stops exposing it (see
- * https://github.com/WordPress/gutenberg/pull/81492).
+ * Core's public `RadioControl` instead of DataViews' bundled `Edit: 'radio'`
+ * shorthand. The bundled control resolves the same `ValidatedToggleControl`
+ * private API as `Edit: 'toggle'`, which breaks once Gutenberg stops
+ * exposing it (see https://github.com/WordPress/gutenberg/pull/81492).
  *
  * @param {DataFormControlProps<NewsletterSettings>} props - DataForm edit control props.
  * @return {JSX.Element} The radio control.

--- a/projects/packages/newsletter/src/settings/components/toggle.tsx
+++ b/projects/packages/newsletter/src/settings/components/toggle.tsx
@@ -11,30 +11,34 @@ import { Link } from '@wordpress/ui';
 import { addQueryArgs } from '@wordpress/url';
 import type { NewsletterSettings } from '../types';
 
-interface ToggleWithLinkProps {
+interface ToggleProps {
 	data: NewsletterSettings;
 	field: NormalizedField< NewsletterSettings >;
 	onChange: ( value: DeepPartial< NewsletterSettings > ) => void;
-	url: string;
-	linkText: string;
+	url?: string;
+	linkText?: string;
 	isExternal?: boolean;
 	onLinkClick?: () => void;
 }
 
 /**
- * Generic toggle control with a link in the label
+ * `Edit` control for DataForm boolean fields, optionally with a link in the
+ * label. Renders the public `ToggleControl` in place of the bundled
+ * `Edit: 'toggle'` shorthand, which resolves `ValidatedToggleControl` through
+ * `@wordpress/components` private APIs and breaks once Gutenberg stops
+ * exposing it there (see https://github.com/WordPress/gutenberg/pull/81492).
  *
  * @param {object}   props             - Component props
  * @param {object}   props.data        - The data object
  * @param {object}   props.field       - The field definition
  * @param {Function} props.onChange    - Change handler
- * @param {string}   props.url         - URL for the link
- * @param {string}   props.linkText    - Text for the link
+ * @param {string}   props.url         - URL for the link. Omit for a plain toggle.
+ * @param {string}   props.linkText    - Text for the link. Omit for a plain toggle.
  * @param {boolean}  props.isExternal  - Whether the link is external (default: true)
  * @param {Function} props.onLinkClick - Optional callback when link is clicked
- * @return {JSX.Element} The toggle control with link
+ * @return {JSX.Element} The toggle control, with a link in the label when `url`/`linkText` are set.
  */
-export function ToggleWithLink( {
+export function Toggle( {
 	data,
 	field,
 	onChange,
@@ -42,7 +46,7 @@ export function ToggleWithLink( {
 	linkText,
 	isExternal = true,
 	onLinkClick,
-}: ToggleWithLinkProps ): JSX.Element {
+}: ToggleProps ): JSX.Element {
 	const handleChange = useCallback( () => {
 		onChange( {
 			[ field.id ]: ! ( data as Record< string, unknown > )[ field.id ],
@@ -55,18 +59,22 @@ export function ToggleWithLink( {
 			checked={ !! ( data as Record< string, unknown > )[ field.id ] }
 			onChange={ handleChange }
 			label={
-				<span>
-					{ field.label }{ ' ' }
-					{ isExternal ? (
-						<Link openInNewTab href={ url } onClick={ onLinkClick }>
-							{ linkText }
-						</Link>
-					) : (
-						<a href={ url } onClick={ onLinkClick }>
-							{ linkText }
-						</a>
-					) }
-				</span>
+				url && linkText ? (
+					<span>
+						{ field.label }{ ' ' }
+						{ isExternal ? (
+							<Link openInNewTab href={ url } onClick={ onLinkClick }>
+								{ linkText }
+							</Link>
+						) : (
+							<a href={ url } onClick={ onLinkClick }>
+								{ linkText }
+							</a>
+						) }
+					</span>
+				) : (
+					field.label
+				)
 			}
 			help={ field.description }
 		/>
@@ -121,7 +129,7 @@ export function ToggleWithEditorLink( {
 	}, [ siteType, templateId ] );
 
 	return (
-		<ToggleWithLink
+		<Toggle
 			data={ data }
 			field={ field }
 			onChange={ onChange }

--- a/projects/packages/newsletter/src/settings/components/toggle.tsx
+++ b/projects/packages/newsletter/src/settings/components/toggle.tsx
@@ -67,9 +67,9 @@ export function Toggle( {
 								{ linkText }
 							</Link>
 						) : (
-							<a href={ url } onClick={ onLinkClick }>
+							<Link href={ url } onClick={ onLinkClick }>
 								{ linkText }
-							</a>
+							</Link>
 						) }
 					</span>
 				) : (

--- a/projects/packages/newsletter/src/settings/sections/email-byline-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-byline-section.tsx
@@ -9,7 +9,7 @@ import { Card, Stack, Text } from '@wordpress/ui';
  * Internal dependencies
  */
 import { BylinePreview } from '../components/byline-preview';
-import { ToggleWithLink } from '../components/toggle-with-link';
+import { Toggle } from '../components/toggle';
 import { getNewsletterScriptData } from '../script-data';
 import type { NewsletterSettings } from '../types';
 
@@ -40,7 +40,7 @@ export function EmailBylineSection( {
 			type: 'boolean' as const,
 			Edit: newsletterScriptData?.email
 				? ( { data: fieldData, field, onChange: fieldOnChange } ) => (
-						<ToggleWithLink
+						<Toggle
 							data={ fieldData }
 							field={ field }
 							onChange={ fieldOnChange }
@@ -48,7 +48,7 @@ export function EmailBylineSection( {
 							linkText={ __( 'Update your Gravatar', 'jetpack-newsletter' ) }
 						/>
 				  )
-				: ( 'toggle' as const ),
+				: Toggle,
 			description: __(
 				'We use Gravatar, a service that associates an avatar image with your primary email address.',
 				'jetpack-newsletter'
@@ -58,14 +58,14 @@ export function EmailBylineSection( {
 			id: 'jetpack_author_in_email',
 			label: __( 'Show author display name', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
-			Edit: 'toggle' as const,
+			Edit: Toggle,
 		},
 		{
 			id: 'jetpack_post_date_in_email',
 			label: __( 'Add the post date', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
 			Edit: ( { data: fieldData, field, onChange: fieldOnChange } ) => (
-				<ToggleWithLink
+				<Toggle
 					data={ fieldData }
 					field={ field }
 					onChange={ fieldOnChange }

--- a/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-content-section.tsx
@@ -7,6 +7,8 @@ import { Card, Fieldset, Notice, Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
+import { Radio } from '../components/radio';
+import { Toggle } from '../components/toggle';
 import { getNewsletterScriptData } from '../script-data';
 import type { NewsletterSettings } from '../types';
 
@@ -35,13 +37,13 @@ export function EmailContentSection( {
 			id: 'wpcom_featured_image_in_email',
 			label: __( "Include the post's featured image in the new post emails", 'jetpack-newsletter' ),
 			type: 'boolean' as const,
-			Edit: 'toggle' as const,
+			Edit: Toggle,
 		},
 		{
 			id: 'wpcom_subscription_emails_use_excerpt',
 			label: __( 'For each new post email, include', 'jetpack-newsletter' ),
 			type: 'text' as const,
-			Edit: 'radio' as const,
+			Edit: Radio,
 			elements: [
 				{
 					value: '0',

--- a/projects/packages/newsletter/src/settings/sections/email-reply-to-settings-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/email-reply-to-settings-section.tsx
@@ -7,6 +7,7 @@ import { Card } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
+import { Radio } from '../components/radio';
 import type { NewsletterSettings } from '../types';
 
 interface EmailReplyToSettingsSectionProps {
@@ -33,7 +34,7 @@ export function EmailReplyToSettingsSection( {
 			id: 'jetpack_subscriptions_reply_to',
 			label: __( 'Reply-to settings', 'jetpack-newsletter' ),
 			type: 'text' as const,
-			Edit: 'radio' as const,
+			Edit: Radio,
 			elements: [
 				{
 					value: 'comment',

--- a/projects/packages/newsletter/src/settings/sections/legacy-subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/legacy-subscriptions-section.tsx
@@ -11,7 +11,7 @@ import { Card, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
-import { ToggleWithEditorLink } from '../components/toggle-with-link';
+import { Toggle, ToggleWithEditorLink } from '../components/toggle';
 import { getNewsletterScriptData } from '../script-data';
 import type { NewsletterSettings } from '../types';
 
@@ -80,7 +80,7 @@ export function LegacySubscriptionsSection( {
 							siteType={ siteType }
 						/>
 				  )
-				: ( 'toggle' as const ),
+				: Toggle,
 		},
 		{
 			id: 'sm_enabled',
@@ -98,7 +98,7 @@ export function LegacySubscriptionsSection( {
 							siteType={ siteType }
 						/>
 				  )
-				: ( 'toggle' as const ),
+				: Toggle,
 		},
 		{
 			id: 'jetpack_subscribe_overlay_enabled',
@@ -116,7 +116,7 @@ export function LegacySubscriptionsSection( {
 							siteType={ siteType }
 						/>
 				  )
-				: ( 'toggle' as const ),
+				: Toggle,
 		},
 		{
 			id: 'jetpack_subscribe_floating_button_enabled',
@@ -134,7 +134,7 @@ export function LegacySubscriptionsSection( {
 							siteType={ siteType }
 						/>
 				  )
-				: ( 'toggle' as const ),
+				: Toggle,
 		},
 		{
 			id: 'jetpack_subscriptions_subscribe_navigation_enabled',
@@ -152,7 +152,7 @@ export function LegacySubscriptionsSection( {
 							siteType={ siteType }
 						/>
 				  )
-				: ( 'toggle' as const ),
+				: Toggle,
 		},
 		{
 			id: 'jetpack_subscriptions_login_navigation_enabled',
@@ -170,7 +170,7 @@ export function LegacySubscriptionsSection( {
 							siteType={ siteType }
 						/>
 				  )
-				: ( 'toggle' as const ),
+				: Toggle,
 		},
 		{
 			id: 'stb_enabled',
@@ -179,7 +179,7 @@ export function LegacySubscriptionsSection( {
 				'jetpack-newsletter'
 			),
 			type: 'boolean' as const,
-			Edit: 'toggle' as const,
+			Edit: Toggle,
 		},
 		{
 			id: 'stc_enabled',
@@ -188,7 +188,7 @@ export function LegacySubscriptionsSection( {
 				'jetpack-newsletter'
 			),
 			type: 'boolean' as const,
-			Edit: 'toggle' as const,
+			Edit: Toggle,
 		},
 	];
 

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -18,6 +18,7 @@ import { Button, Card, Fieldset, Link, Notice, Stack, Text } from '@wordpress/ui
  * Internal dependencies
  */
 import { fetchCategories } from '../api';
+import { Toggle } from '../components/toggle';
 import {
 	CreatableCategoriesControl,
 	CreatableCategoryContext,
@@ -121,7 +122,7 @@ export function NewsletterCategoriesSection( {
 			id: 'wpcom_newsletter_categories_enabled',
 			label: __( 'Enable newsletter categories', 'jetpack-newsletter' ),
 			type: 'boolean' as const,
-			Edit: 'toggle' as const,
+			Edit: Toggle,
 		},
 		{
 			id: 'wpcom_newsletter_categories',

--- a/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-section.tsx
@@ -12,6 +12,7 @@ import { Card, Link } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
+import { Toggle } from '../components/toggle';
 import { getNewsletterScriptData } from '../script-data';
 import type { NewsletterSettings } from '../types';
 
@@ -74,7 +75,7 @@ export function NewsletterSection( { data, onChange }: NewsletterSectionProps ):
 							'jetpack-newsletter'
 						),
 						type: 'boolean' as const,
-						Edit: 'toggle' as const,
+						Edit: Toggle,
 					},
 			  ]
 			: [] ),

--- a/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
@@ -68,6 +68,26 @@ jest.mock( '@wordpress/components', () => ( {
 		);
 	},
 	Icon: () => null,
+	// Minimal stand-in for the "enable newsletter categories" toggle field's
+	// `Edit` control (`Toggle`, which renders the real `ToggleControl`).
+	// Toggle behavior isn't under test here, just that it renders.
+	ToggleControl: ( {
+		label,
+		checked,
+		onChange,
+	}: {
+		label?: string;
+		checked?: boolean;
+		onChange: ( checked: boolean ) => void;
+	} ) => (
+		<input
+			type="checkbox"
+			aria-label={ label }
+			checked={ !! checked }
+			// eslint-disable-next-line react/jsx-no-bind
+			onChange={ () => onChange( ! checked ) }
+		/>
+	),
 } ) );
 
 interface StubField {
@@ -78,9 +98,10 @@ interface StubField {
 
 jest.mock( '@wordpress/dataviews', () => ( {
 	__esModule: true,
-	// Render each field's real custom `Edit` control (the categories field), so
-	// tests drive the actual create/search behavior. Non-custom fields (the
-	// enable toggle) render nothing — they aren't under test here.
+	// Render each field's real custom `Edit` control, so tests drive the
+	// actual create/search behavior for the categories field. The enable
+	// toggle's `Edit` also renders (via the stubbed `ToggleControl` above)
+	// but isn't under test here.
 	DataForm: ( {
 		data,
 		fields,

--- a/projects/packages/newsletter/tests/radio.test.tsx
+++ b/projects/packages/newsletter/tests/radio.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Tests for the `Radio` DataForm `Edit` control (JETPACK-2277).
+ *
+ * Renders the real, public `@wordpress/components` `RadioControl` — not
+ * DataViews' bundled `Edit: 'radio'` shorthand, which resolves the same
+ * private `ValidatedToggleControl` API as `Edit: 'toggle'` and breaks once
+ * Gutenberg stops exposing it there.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Radio } from '../src/settings/components/radio';
+import type { NewsletterSettings } from '../src/settings/types';
+import type { NormalizedField } from '@wordpress/dataviews';
+
+/**
+ * Build a minimal `NormalizedField` stand-in for `jetpack_subscriptions_reply_to`.
+ *
+ * @param overrides - Field properties to override.
+ * @return A field object cast to `NormalizedField<NewsletterSettings>`.
+ */
+function createField(
+	overrides: Partial< NormalizedField< NewsletterSettings > > = {}
+): NormalizedField< NewsletterSettings > {
+	return {
+		id: 'jetpack_subscriptions_reply_to',
+		label: 'Reply-to settings',
+		getValue: ( { item }: { item: NewsletterSettings } ) => item.jetpack_subscriptions_reply_to,
+		setValue: ( { value }: { item: NewsletterSettings; value: unknown } ) => ( {
+			jetpack_subscriptions_reply_to: value,
+		} ),
+		elements: [
+			{ value: 'comment', label: 'Replies will be a public comment on the post' },
+			{ value: 'author', label: "Replies will be sent to the post author's email" },
+			{ value: 'no-reply', label: 'Replies are not allowed' },
+		],
+		...overrides,
+	} as NormalizedField< NewsletterSettings >;
+}
+
+describe( 'Radio', () => {
+	it( 'renders one option per field.elements entry', () => {
+		render(
+			<Radio
+				data={ { jetpack_subscriptions_reply_to: 'comment' } as NewsletterSettings }
+				field={ createField() }
+				onChange={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'radio', { name: 'Replies will be a public comment on the post' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'radio', { name: "Replies will be sent to the post author's email" } )
+		).toBeInTheDocument();
+		expect( screen.getByRole( 'radio', { name: 'Replies are not allowed' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'checks the option matching field.getValue', () => {
+		render(
+			<Radio
+				data={ { jetpack_subscriptions_reply_to: 'author' } as NewsletterSettings }
+				field={ createField() }
+				onChange={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'radio', { name: "Replies will be sent to the post author's email" } )
+		).toBeChecked();
+		expect(
+			screen.getByRole( 'radio', { name: 'Replies will be a public comment on the post' } )
+		).not.toBeChecked();
+	} );
+
+	it( 'calls onChange with field.setValue applied to the newly selected option', () => {
+		const onChange = jest.fn();
+
+		render(
+			<Radio
+				data={ { jetpack_subscriptions_reply_to: 'comment' } as NewsletterSettings }
+				field={ createField() }
+				onChange={ onChange }
+			/>
+		);
+
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.click( screen.getByRole( 'radio', { name: 'Replies are not allowed' } ) );
+
+		expect( onChange ).toHaveBeenCalledWith( { jetpack_subscriptions_reply_to: 'no-reply' } );
+	} );
+
+	it( 'renders no options when field.elements is empty', () => {
+		render(
+			<Radio
+				data={ { jetpack_subscriptions_reply_to: 'comment' } as NewsletterSettings }
+				field={ createField( { elements: [] } ) }
+				onChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.queryAllByRole( 'radio' ) ).toHaveLength( 0 );
+	} );
+
+	it( 'renders the field label and description', () => {
+		render(
+			<Radio
+				data={ { jetpack_subscriptions_reply_to: 'comment' } as NewsletterSettings }
+				field={ createField( { description: 'Choose who receives replies.' } ) }
+				onChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'Reply-to settings' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Choose who receives replies.' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/newsletter/tests/toggle.test.tsx
+++ b/projects/packages/newsletter/tests/toggle.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * Tests for the `Toggle` and `ToggleWithEditorLink` DataForm `Edit` controls
+ * (JETPACK-2277).
+ *
+ * These render the real, public `@wordpress/components` `ToggleControl` —
+ * not DataViews' bundled `Edit: 'toggle'` shorthand, which resolves
+ * `ValidatedToggleControl` through `@wordpress/components` private APIs and
+ * breaks once Gutenberg stops exposing it there. `@wordpress/ui`'s `Link` is
+ * stubbed to a plain anchor, matching the mocking convention used by the
+ * other section tests in this package.
+ */
+
+const mockRecordEvent = jest.fn();
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		tracks: { recordEvent: ( ...args: unknown[] ) => mockRecordEvent( ...args ) },
+	},
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getAdminUrl: ( path: string ) => `https://example.com/wp-admin/${ path }`,
+} ) );
+
+jest.mock( '@wordpress/ui', () => ( {
+	__esModule: true,
+	Link: ( {
+		children,
+		href,
+		onClick,
+		openInNewTab,
+	}: {
+		children: React.ReactNode;
+		href: string;
+		onClick?: () => void;
+		openInNewTab?: boolean;
+	} ) => (
+		<a
+			href={ href }
+			onClick={ onClick }
+			target={ openInNewTab ? '_blank' : undefined }
+			rel="noreferrer"
+		>
+			{ children }
+		</a>
+	),
+} ) );
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Toggle, ToggleWithEditorLink } from '../src/settings/components/toggle';
+import type { NewsletterSettings } from '../src/settings/types';
+import type { NormalizedField } from '@wordpress/dataviews';
+
+/**
+ * Build a minimal `NormalizedField` stand-in — `Toggle`/`ToggleWithEditorLink`
+ * only read `id`, `label`, and `description` off it, never `getValue`/`setValue`
+ * (the toggled value is derived straight from `data[field.id]`).
+ *
+ * @param overrides - Field properties to override.
+ * @return A field object cast to `NormalizedField<NewsletterSettings>`.
+ */
+function createField(
+	overrides: Partial< NormalizedField< NewsletterSettings > > = {}
+): NormalizedField< NewsletterSettings > {
+	return {
+		id: 'jetpack_author_in_email',
+		label: 'Show author display name',
+		...overrides,
+	} as NormalizedField< NewsletterSettings >;
+}
+
+describe( 'Toggle', () => {
+	it( 'reflects the checked state from data[field.id]', () => {
+		render(
+			<Toggle
+				data={ { jetpack_author_in_email: true } as NewsletterSettings }
+				field={ createField() }
+				onChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByRole( 'checkbox', { name: 'Show author display name' } ) ).toBeChecked();
+	} );
+
+	it( 'calls onChange with the flipped value when clicked', () => {
+		const onChange = jest.fn();
+
+		render(
+			<Toggle
+				data={ { jetpack_author_in_email: false } as NewsletterSettings }
+				field={ createField() }
+				onChange={ onChange }
+			/>
+		);
+
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.click( screen.getByRole( 'checkbox' ) );
+
+		expect( onChange ).toHaveBeenCalledWith( { jetpack_author_in_email: true } );
+	} );
+
+	it( 'renders a plain label when url/linkText are omitted', () => {
+		render(
+			<Toggle
+				data={ { jetpack_author_in_email: false } as NewsletterSettings }
+				field={ createField() }
+				onChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'Show author display name' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a link in the label when url and linkText are set', () => {
+		render(
+			<Toggle
+				data={ { jetpack_gravatar_in_email: false } as NewsletterSettings }
+				field={ createField( {
+					id: 'jetpack_gravatar_in_email',
+					label: 'Show author avatar on your emails',
+				} ) }
+				onChange={ jest.fn() }
+				url="https://gravatar.com/profile/avatars"
+				linkText="Update your Gravatar"
+			/>
+		);
+
+		expect( screen.getByText( 'Show author avatar on your emails' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Update your Gravatar' } ) ).toHaveAttribute(
+			'href',
+			'https://gravatar.com/profile/avatars'
+		);
+	} );
+
+	it( 'calls onLinkClick, not onChange, when the label link is clicked', () => {
+		const onChange = jest.fn();
+		const onLinkClick = jest.fn();
+
+		render(
+			<Toggle
+				data={ {} as NewsletterSettings }
+				field={ createField() }
+				onChange={ onChange }
+				url="https://example.com"
+				linkText="Learn more"
+				onLinkClick={ onLinkClick }
+			/>
+		);
+
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.click( screen.getByRole( 'link', { name: 'Learn more' } ) );
+
+		expect( onLinkClick ).toHaveBeenCalledTimes( 1 );
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'ToggleWithEditorLink', () => {
+	const field = createField( { id: 'stb_enabled', label: 'Enable subscribe block' } );
+
+	beforeEach( () => {
+		mockRecordEvent.mockClear();
+	} );
+
+	it( 'links to the site editor for the given template', () => {
+		render(
+			<ToggleWithEditorLink
+				data={ {} as NewsletterSettings }
+				field={ field }
+				onChange={ jest.fn() }
+				themeStylesheet="twentytwentyfour"
+				postType="wp_template"
+				templateId="single"
+			/>
+		);
+
+		const href = screen.getByRole( 'link', { name: 'Preview and edit' } ).getAttribute( 'href' );
+		expect( href ).toContain( 'site-editor.php' );
+		expect( href ).toContain( 'postType=wp_template' );
+		expect( href ).toContain( encodeURIComponent( 'twentytwentyfour//single' ) );
+	} );
+
+	it( 'tracks an analytics event with the site type when the link is clicked', () => {
+		render(
+			<ToggleWithEditorLink
+				data={ {} as NewsletterSettings }
+				field={ field }
+				onChange={ jest.fn() }
+				themeStylesheet="twentytwentyfour"
+				postType="wp_template"
+				templateId="single"
+				siteType="simple"
+			/>
+		);
+
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.click( screen.getByRole( 'link', { name: 'Preview and edit' } ) );
+
+		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_newsletter_edit_link_click', {
+			site_type: 'simple',
+			template: 'single',
+		} );
+	} );
+
+	it( 'does not track an analytics event without a site type', () => {
+		render(
+			<ToggleWithEditorLink
+				data={ {} as NewsletterSettings }
+				field={ field }
+				onChange={ jest.fn() }
+				themeStylesheet="twentytwentyfour"
+				postType="wp_template"
+				templateId="single"
+			/>
+		);
+
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.click( screen.getByRole( 'link', { name: 'Preview and edit' } ) );
+
+		expect( mockRecordEvent ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/update-jetpack-2277
+++ b/projects/plugins/jetpack/changelog/update-jetpack-2277
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: Fix a fatal error on the settings page caused by Gutenberg removing a private API that DataViews toggle and radio fields relied on.


### PR DESCRIPTION
Fixes JETPACK-2277

## Proposed changes
* Replace the `Edit: 'toggle'`/`Edit: 'radio'` DataForm shorthand in the Newsletter settings page with custom `Edit` controls built on the public `ToggleControl`/`RadioControl` APIs. The shorthand resolves to DataViews' bundled `Toggle`/`Radio` controls, which `unlock(privateApis)` to pull `ValidatedToggleControl` out of `@wordpress/components`. Gutenberg PR [#81492](https://github.com/WordPress/gutenberg/pull/81492) (13 Aug 2026) removed that private API (moving it into `@wordpress/dataviews` itself, a release not yet published to npm), so against a recent Gutenberg trunk build the lookup returns `undefined` and React fatals the whole Settings panel rendering `Toggle`.
* Rename the existing `ToggleWithLink` component to `Toggle` (making `url`/`linkText` optional) and reuse it for every plain-toggle field instead of adding a duplicate component; `ToggleWithEditorLink` is unchanged.
* Add a new `Radio` component (built on `@automattic/jetpack-components`' `RadioControl`, itself a thin public wrapper over `@wordpress/components`) for the two radio fields.
* Update `newsletter-categories-section.test.tsx`'s `@wordpress/components` mock to include `ToggleControl`, since its field now renders the real control instead of the bundled shorthand.

Production is currently unaffected — this only breaks against a Gutenberg trunk/nightly build from after 13 Aug 2026 — so this is a proactive fix rather than an active incident.

## Related product discussion/links
* JETPACK-2277

## Does this pull request change what data or activity we track or use?


## Testing instructions
* Prerequisite: a Jurassic Ninja (or similar) site with the **Gutenberg Nightly** feature enabled, on a build from after 13 Aug 2026.
* Before this fix: open `wp-admin/admin.php?page=jetpack-newsletter`, note the page fatals with `Element type is invalid ... got: undefined. Check the render method of Toggle.` in the console.
* After this fix (this branch): reload the same page — it should load normally.
* Click through and verify each converted field still reads/writes its setting correctly:
  * Email content: "Include the post's featured image" toggle, "Full text"/"Excerpt" radio
  * Reply-to settings radio
  * Email byline: "Show author display name" toggle, gravatar toggle (with/without the Gravatar link, depending on site email)
  * Newsletter categories: "Enable newsletter categories" toggle
  * Legacy subscriptions page (flag off): master toggle, "Subscribe to site"/"Subscribe to comments" toggles, and the placement toggles (with and without the "Preview and edit" editor link, depending on theme support)
* `pnpm jetpack test js packages/newsletter` — 181/181 tests pass.
* `pnpm jetpack build --deps packages/newsletter` — builds clean.
