### PR TITLE
Build: Lower build timeouts after fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       CHANGED: ${{ fromJson( needs.prepare.outputs.build_matrix ).all.changed }}
       # Hard-code a specific directory to avoid paths in vendor/composer/installed.json changing every build.
       BUILD_BASE: /tmp/jetpack-build
-    timeout-minutes: 40  # 2026-08-04: PRs that rebuild every project take ~26 minutes.
+    timeout-minutes: 30  # 2026-08-18: Successful runs take ~18 minutes.
 
     steps: &build_steps
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -193,7 +193,7 @@ jobs:
       CHANGED: ${{ fromJson( needs.prepare.outputs.build_matrix ).wpcom.changed }}
       # Hard-code a specific directory to avoid paths in vendor/composer/installed.json changing every build.
       BUILD_BASE: /tmp/jetpack-build
-    timeout-minutes: 40  # 2026-08-05: Trunk pushes build the full wpcom half, which now takes over 25 minutes.
+    timeout-minutes: 25  # 2026-08-18: Successful runs take ~13 minutes.
     steps: *build_steps
 
   build_nonwpcom:
@@ -206,7 +206,7 @@ jobs:
       CHANGED: ${{ fromJson( needs.prepare.outputs.build_matrix ).nonwpcom.changed }}
       # Hard-code a specific directory to avoid paths in vendor/composer/installed.json changing every build.
       BUILD_BASE: /tmp/jetpack-build
-    timeout-minutes: 25  # 2026-04-07: Successful runs seem to take ~15 minutes.
+    timeout-minutes: 25  # 2026-08-18: Successful runs seem to take ~13 minutes.
     steps: *build_steps
 
   merge_artifacts:


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
PR #50762 caused a significant rise in build times, which was fixed by #51086. Let's turn the build times back down after the fix.

This effectively reverts #51029. As for #51059, the progression is 25 before → 40 during the rise → 30 now, to leave some leeway since full builds are up to ~18 minutes now.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
See the referenced PRs.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* You can get the `build_wpcom` and `build_nonwpcom` numbers from Grafana. You'd have to do your own analysis for the `build_all` runs.