### PR TITLE
Site purchases: sync the billing-state cache from wpcom

### DIFF
--- a/projects/plugins/wpcomsh/changelog/dotcom-18246-cache-billing-state-lookups
+++ b/projects/plugins/wpcomsh/changelog/dotcom-18246-cache-billing-state-lookups
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Mirrors a WordPress.com-side performance change; the cached path is inert on Atomic.
+
+

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php
@@ -24,6 +24,41 @@
  */
 class WPCOM_Site_Purchase {
 	/**
+	 * Object-cache group for billing-derived state. Shared with the site's purchases, which the
+	 * same two hooks already invalidate, and registered as a global group in object-cache.php --
+	 * the keys carry their own blog ID and are read from whichever blog is current.
+	 */
+	private const BILLING_STATES_CACHE_GROUP = 'site_purchases';
+
+	/**
+	 * How long billing-derived state stays cached. See billing_states_for_blog() for why this is
+	 * minutes rather than the day the neighbouring purchases get.
+	 */
+	private const BILLING_STATES_CACHE_TTL = 5 * MINUTE_IN_SECONDS;
+
+	/**
+	 * How long a *failed* lookup stays cached.
+	 *
+	 * Much shorter than a successful one. Caching the failure at all is what stops a persistently
+	 * broken billing stack from being asked again on every pageview, but a momentary blip should
+	 * not outlive itself by minutes: while it is cached, both accessors answer null and consumers
+	 * fall back to the raw auto-renew flag -- the very value they exist to distrust.
+	 */
+	private const BILLING_STATES_FAILURE_TTL = 30;
+
+	/**
+	 * MC stat name under which billing-state lookups are counted, and the bins broken out of it.
+	 *
+	 * Static strings, and within the 32-character limit MC imposes on both a name and a bin.
+	 * Visible at https://mc.a8c.com/s/wpcom-site-purchase/stat-total/ -- and only there until it
+	 * clears 100 hits a day, which is the threshold for the searchable stat list.
+	 */
+	private const BILLING_STATES_STAT_NAME   = 'wpcom-site-purchase';
+	private const BILLING_STATES_STAT_LOOKUP = 'billing-lookup';
+	private const BILLING_STATES_STAT_HIT    = 'billing-cache-hit';
+	private const BILLING_STATES_STAT_ERROR  = 'billing-error';
+
+	/**
 	 * The blog the purchase belongs to.
 	 *
 	 * @var int
@@ -198,6 +233,12 @@ class WPCOM_Site_Purchase {
 	 * The raw auto-renew flag stays true for subscriptions that cannot renew — one with no
 	 * chargeable payment method attached, for instance — so only billing can answer this.
 	 * Null wherever billing cannot be reached.
+	 *
+	 * NOT A FREE GETTER. On a Simple site whose purchase carries no stored answer this reaches
+	 * billing: a store query, and the whole billing code-base loaded into a request that may
+	 * never have needed it. Cached for a few minutes, so the repeat cost is a memcache get, but
+	 * the first one is real. Don't call it on a path that runs for every site regardless of
+	 * expiry; gate it on the site actually being close enough to expiry for the answer to matter.
 	 */
 	public function might_still_auto_renew(): ?bool {
 		return $this->might_still_auto_renew ?? $this->billing_state()?->might_still_auto_renew;
@@ -212,6 +253,12 @@ class WPCOM_Site_Purchase {
 	 * nor that it runs at this time of day. Null either because nothing is scheduled -- no
 	 * meaningful expiry to schedule against, e.g. a VIP domain or a one-time product -- or
 	 * because billing could not be reached; a consumer cannot tell the two apart.
+	 *
+	 * NOT A FREE GETTER. On a Simple site whose purchase carries no stored answer this reaches
+	 * billing: a store query, and the whole billing code-base loaded into a request that may
+	 * never have needed it. Cached for a few minutes, so the repeat cost is a memcache get, but
+	 * the first one is real. Don't call it on a path that runs for every site regardless of
+	 * expiry; gate it on the site actually being close enough to expiry for the answer to matter.
 	 */
 	public function first_auto_renew_attempt_date(): ?string {
 		return $this->first_auto_renew_attempt_date ?? $this->billing_state()?->first_auto_renew_attempt_date;
@@ -233,8 +280,16 @@ class WPCOM_Site_Purchase {
 	 * yield an empty map, so every value must be treated as optional.
 	 *
 	 * Memoized per request, so that a site with many purchases costs one lookup rather than one
-	 * per purchase. Deliberately not cached beyond the request: these values track the passage of
-	 * time, while the `site_purchases` cache lives for a day.
+	 * per purchase, and cached in the object cache for a few minutes on top, so that a careless
+	 * caller costs a memcache get rather than the query and the load. Cleared on
+	 * `subscription_changed` and `wpcom_site_purchases_cleared`, alongside the other
+	 * `site_purchases` entries.
+	 *
+	 * The TTL is short, and much shorter than the day-long `site_purchases` cache, because
+	 * `might_still_auto_renew` can stop being true without any subscription event to hang an
+	 * invalidation on -- a card reaching its own expiry date, say. The hooks cover everything a
+	 * user does; the TTL is the backstop for what merely happens. `first_auto_renew_attempt_date`
+	 * needs no such care: it is a date, and callers compare it against their own clock.
 	 *
 	 * @param int $blog_id Blog ID to look up.
 	 *
@@ -251,10 +306,26 @@ class WPCOM_Site_Purchase {
 
 		// The whole loader rather than just the class file, as get_site_billing_upgrades() also
 		// reaches for store_logger(). Unreadable wherever the billing code-base does not ship.
+		// Checked before the cache is consulted, so that Atomic -- where this is never readable
+		// -- pays nothing at all, not even a memcache round trip.
 		$billing_loader = WP_CONTENT_DIR . '/admin-plugins/wpcom-billing.php';
 		if ( ! is_readable( $billing_loader ) ) {
 			return $states[ $blog_id ];
 		}
+
+		$cache_key = self::billing_states_cache_key( $blog_id );
+		$cached    = wp_cache_get( $cache_key, self::BILLING_STATES_CACHE_GROUP );
+		if ( is_array( $cached ) ) {
+			self::bump_billing_stat( self::BILLING_STATES_STAT_HIT );
+			$states[ $blog_id ] = $cached;
+			return $states[ $blog_id ];
+		}
+
+		// Bumped where the work actually happens, so that a consumer which has wandered onto a
+		// hot path shows up in MC as a spike rather than as a billing incident.
+		self::bump_billing_stat( self::BILLING_STATES_STAT_LOOKUP );
+
+		$failed = false;
 
 		try {
 			require_once $billing_loader;
@@ -269,8 +340,68 @@ class WPCOM_Site_Purchase {
 			}
 		} catch ( \Throwable $e ) {
 			$states[ $blog_id ] = array();
+			$failed             = true;
+			self::bump_billing_stat( self::BILLING_STATES_STAT_ERROR );
 		}
 
+		// The empty map is cached too. Reaching billing and coming back with nothing costs the
+		// same as reaching it and finding something, and a site that has just thrown is exactly
+		// the one that should not be asked again on the next pageview -- but only briefly, so a
+		// blip does not keep answering null long after it has passed.
+		wp_cache_set(
+			$cache_key,
+			$states[ $blog_id ],
+			self::BILLING_STATES_CACHE_GROUP,
+			$failed ? self::BILLING_STATES_FAILURE_TTL : self::BILLING_STATES_CACHE_TTL
+		);
+
 		return $states[ $blog_id ];
+	}
+
+	/**
+	 * Object-cache key for a blog's billing-derived state.
+	 *
+	 * Carries the store-subscriptions table name, as the neighbouring `site_purchases` entries
+	 * do, to keep the production and test stores from reading each other's answers.
+	 *
+	 * Kept public so that the invalidation wired up in wpcom-features.php builds the same key
+	 * this does, rather than a copy of it that can drift.
+	 *
+	 * WPCOM ONLY, despite living in a class that is otherwise safe on Atomic: there are no store
+	 * tables there, so `$wpdb->store_subscriptions` is not a property and there is nothing to key
+	 * on. Nothing calls this on Atomic today -- billing_states_for_blog() bails before reaching
+	 * it, and the other caller is a wpcom-only mu-plugin -- and nothing should start.
+	 *
+	 * @param int $blog_id Blog ID to look up.
+	 */
+	public static function billing_states_cache_key( int $blog_id ): string {
+		global $wpdb;
+
+		return "billing_states_$blog_id-{$wpdb->store_subscriptions}";
+	}
+
+	/**
+	 * Count a billing-state lookup in MC.
+	 *
+	 * A counter rather than a log line: this sits behind a feature-check path, where per-event
+	 * logging would be a firehose, and the question worth asking is how often it runs, not which
+	 * request ran it. Best-effort -- stats must never be the reason a page fails to render.
+	 *
+	 * @param string $bin Stat bin to bump.
+	 */
+	private static function bump_billing_stat( string $bin ): void {
+		if ( ! function_exists( 'require_lib' ) ) {
+			return;
+		}
+
+		try {
+			require_lib( 'mc-stats' );
+
+			if ( function_exists( 'bump_stats_extras' ) ) {
+				bump_stats_extras( self::BILLING_STATES_STAT_NAME, $bin );
+			}
+		} catch ( \Throwable $e ) {
+			return;
+		}
 	}
 }

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php
@@ -31,18 +31,19 @@ class WPCOM_Site_Purchase {
 	private const BILLING_STATES_CACHE_GROUP = 'site_purchases';
 
 	/**
-	 * How long billing-derived state stays cached. See billing_states_for_blog() for why this is
-	 * minutes rather than the day the neighbouring purchases get.
+	 * How long billing-derived state stays cached. See billing_states_for_blog() for what the TTL
+	 * is actually covering, which is less than it first appears.
 	 */
-	private const BILLING_STATES_CACHE_TTL = 5 * MINUTE_IN_SECONDS;
+	private const BILLING_STATES_CACHE_TTL = HOUR_IN_SECONDS;
 
 	/**
 	 * How long a *failed* lookup stays cached.
 	 *
-	 * Much shorter than a successful one. Caching the failure at all is what stops a persistently
-	 * broken billing stack from being asked again on every pageview, but a momentary blip should
-	 * not outlive itself by minutes: while it is cached, both accessors answer null and consumers
-	 * fall back to the raw auto-renew flag -- the very value they exist to distrust.
+	 * Far shorter than a successful one. Caching the failure at all is what stops a persistently
+	 * broken billing stack from being asked again on every pageview, but a blip lasting one request
+	 * should not go on being answered for the rest of the hour: while it is cached, both accessors
+	 * answer null and consumers fall back to the raw auto-renew flag -- the very value they exist
+	 * to distrust.
 	 */
 	private const BILLING_STATES_FAILURE_TTL = 30;
 
@@ -280,16 +281,28 @@ class WPCOM_Site_Purchase {
 	 * yield an empty map, so every value must be treated as optional.
 	 *
 	 * Memoized per request, so that a site with many purchases costs one lookup rather than one
-	 * per purchase, and cached in the object cache for a few minutes on top, so that a careless
-	 * caller costs a memcache get rather than the query and the load. Cleared on
-	 * `subscription_changed` and `wpcom_site_purchases_cleared`, alongside the other
-	 * `site_purchases` entries.
+	 * per purchase, and cached in the object cache for an hour on top, so that a careless caller
+	 * costs a memcache get rather than the query and the load. Cleared on `subscription_changed`
+	 * and `wpcom_site_purchases_cleared`, alongside the other `site_purchases` entries -- though
+	 * those two are one signal rather than two, since every caller of the latter is itself hooked
+	 * to the former.
 	 *
-	 * The TTL is short, and much shorter than the day-long `site_purchases` cache, because
-	 * `might_still_auto_renew` can stop being true without any subscription event to hang an
-	 * invalidation on -- a card reaching its own expiry date, say. The hooks cover everything a
-	 * user does; the TTL is the backstop for what merely happens. `first_auto_renew_attempt_date`
-	 * needs no such care: it is a date, and callers compare it against their own clock.
+	 * That signal is scoped to the subscription row, which covers more of `might_still_auto_renew`
+	 * than it looks: both the subscription's status and the `auto_renew` column live there, so
+	 * everything a user actively does is reflected at once -- including the case that would
+	 * otherwise be a support ticket, "I re-enabled auto-renew, why is it still nagging me?".
+	 *
+	 * The TTL therefore only has to cover what no subscription event announces, which is two
+	 * things. `is_past_last_auto_renew_attempt_date()` is a clock comparison, but against a
+	 * timestamp pinned to the start of a UTC day, so it flips once, on a day boundary -- a shorter
+	 * TTL would be measuring a day-granular signal to the minute. And the payment method reached
+	 * through `will_auto_renew()` lives in Billingdaddy ownerships rather than on the subscription,
+	 * so a card being replaced, removed, or reaching its own expiry never touches the row and never
+	 * fires the hook. There is no Billingdaddy action to subscribe to for that today; an hour is
+	 * the bound on how stale a notice can be because of it.
+	 *
+	 * `first_auto_renew_attempt_date` needs none of this care: it is a date, and callers compare it
+	 * against their own clock.
 	 *
 	 * @param int $blog_id Blog ID to look up.
 	 *

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php
@@ -237,9 +237,9 @@ class WPCOM_Site_Purchase {
 	 *
 	 * NOT A FREE GETTER. On a Simple site whose purchase carries no stored answer this reaches
 	 * billing: a store query, and the whole billing code-base loaded into a request that may
-	 * never have needed it. Cached for a few minutes, so the repeat cost is a memcache get, but
-	 * the first one is real. Don't call it on a path that runs for every site regardless of
-	 * expiry; gate it on the site actually being close enough to expiry for the answer to matter.
+	 * never have needed it. Cached for an hour, so the repeat cost is a memcache get, but the
+	 * first one is real. Don't call it on a path that runs for every site regardless of expiry;
+	 * gate it on the site actually being close enough to expiry for the answer to matter.
 	 */
 	public function might_still_auto_renew(): ?bool {
 		return $this->might_still_auto_renew ?? $this->billing_state()?->might_still_auto_renew;
@@ -257,9 +257,9 @@ class WPCOM_Site_Purchase {
 	 *
 	 * NOT A FREE GETTER. On a Simple site whose purchase carries no stored answer this reaches
 	 * billing: a store query, and the whole billing code-base loaded into a request that may
-	 * never have needed it. Cached for a few minutes, so the repeat cost is a memcache get, but
-	 * the first one is real. Don't call it on a path that runs for every site regardless of
-	 * expiry; gate it on the site actually being close enough to expiry for the answer to matter.
+	 * never have needed it. Cached for an hour, so the repeat cost is a memcache get, but the
+	 * first one is real. Don't call it on a path that runs for every site regardless of expiry;
+	 * gate it on the site actually being close enough to expiry for the answer to matter.
 	 */
 	public function first_auto_renew_attempt_date(): ?string {
 		return $this->first_auto_renew_attempt_date ?? $this->billing_state()?->first_auto_renew_attempt_date;
@@ -283,14 +283,13 @@ class WPCOM_Site_Purchase {
 	 * Memoized per request, so that a site with many purchases costs one lookup rather than one
 	 * per purchase, and cached in the object cache for an hour on top, so that a careless caller
 	 * costs a memcache get rather than the query and the load. Cleared on `subscription_changed`
-	 * and `wpcom_site_purchases_cleared`, alongside the other `site_purchases` entries -- though
-	 * those two are one signal rather than two, since every caller of the latter is itself hooked
-	 * to the former.
+	 * and `wpcom_site_purchases_cleared`, alongside the other `site_purchases` entries.
 	 *
-	 * That signal is scoped to the subscription row, which covers more of `might_still_auto_renew`
-	 * than it looks: both the subscription's status and the `auto_renew` column live there, so
-	 * everything a user actively does is reflected at once -- including the case that would
-	 * otherwise be a support ticket, "I re-enabled auto-renew, why is it still nagging me?".
+	 * `subscription_changed` is the one that carries the weight, and it is scoped to the
+	 * subscription row -- which covers more of `might_still_auto_renew` than it looks, since both
+	 * the subscription's status and the `auto_renew` column live there. Everything a user actively
+	 * does is therefore reflected at once, including the case that would otherwise be a support
+	 * ticket: "I re-enabled auto-renew, why is it still nagging me?".
 	 *
 	 * The TTL therefore only has to cover what no subscription event announces, which is two
 	 * things. `is_past_last_auto_renew_attempt_date()` is a clock comparison, but against a
@@ -377,8 +376,9 @@ class WPCOM_Site_Purchase {
 	 * Carries the store-subscriptions table name, as the neighbouring `site_purchases` entries
 	 * do, to keep the production and test stores from reading each other's answers.
 	 *
-	 * Kept public so that the invalidation wired up in wpcom-features.php builds the same key
-	 * this does, rather than a copy of it that can drift.
+	 * Public for inspection -- reading the entry by hand while debugging, or asserting on it in a
+	 * test. Invalidation goes through forget_billing_states() instead, so that the group name does
+	 * not have to travel with the key.
 	 *
 	 * WPCOM ONLY, despite living in a class that is otherwise safe on Atomic: there are no store
 	 * tables there, so `$wpdb->store_subscriptions` is not a property and there is nothing to key
@@ -391,6 +391,21 @@ class WPCOM_Site_Purchase {
 		global $wpdb;
 
 		return "billing_states_$blog_id-{$wpdb->store_subscriptions}";
+	}
+
+	/**
+	 * Drop a blog's cached billing-derived state.
+	 *
+	 * The whole of the invalidation, so that a caller needs neither the key nor the group and
+	 * cannot drift from either. `clear_wp_cache_site_purchases()` in wpcom-features.php is the
+	 * one that matters; it runs on `subscription_changed` and `wpcom_site_purchases_cleared`.
+	 *
+	 * WPCOM ONLY, for the same reason as the key it builds.
+	 *
+	 * @param int $blog_id Blog whose entry should be forgotten.
+	 */
+	public static function forget_billing_states( int $blog_id ): void {
+		wp_cache_delete( self::billing_states_cache_key( $blog_id ), self::BILLING_STATES_CACHE_GROUP );
 	}
 
 	/**


### PR DESCRIPTION
Fixes DOTCOM-18246

## Proposed changes

* Mirror into wpcomsh the WordPress.com-side change to `WPCOM_Site_Purchase`. That file carries a "THIS FILE EXISTS VERBATIM IN WPCOM AND WPCOMSH / DANGER DANGER DANGER" banner, so it is copied across whether or not the change does anything here.
  * `billing_states_for_blog()` now caches its per-blog result in the object cache (one hour; thirty seconds when the lookup threw) on top of the existing per-request memoization, and counts lookups in MC.
  * `might_still_auto_renew()` and `first_auto_renew_attempt_date()` gain docblocks saying outright that they are **not free getters** and should be gated on the site being close enough to expiry for the answer to matter.
  * New `billing_states_cache_key()` helper, marked WPCOM-only — there are no store tables on Atomic to key on.
* Changelog entry is `Comment:`-only, since nothing here is user-observable.

**This is inert on Atomic**, by design. Reaching billing needs the billing code-base, which is not deployed to Atomic sites, and the `is_readable()` bail that has always guarded that comes *before* the new cache access — so those sites pay nothing, not even a memcache round trip. The docblocks are the part that actually carries over.

## Related product discussion/links

* Linear: DOTCOM-18246
* WordPress.com counterpart (merge first): 235204-ghe-Automattic/wpcom
* Consumer-side gate that motivated it: #49304

## Why are these changes being made?

Team Atomic reviewed the site-purchase work and flagged the risk of introducing load and DB work into a very hot path (wpcom features). The hot path itself turned out clean — `wpcom_site_has_feature()` never touches these accessors — but the review surfaced a real hazard just behind it: two methods that read like getters but, on a Simple site, reach billing for a store query plus the whole billing code-base.

The WordPress.com PR makes that cheap and visible so safety doesn't depend on every future consumer being careful. This PR exists only to keep the two copies of the file from drifting.

The TTL is an hour because most of what it looks like it is guarding is already covered by the invalidation hooks: two of the four components of `might_still_auto_renew()` live on the subscription row, so `subscription_changed` clears them the moment a user acts. What remains is a schedule check pinned to a UTC day boundary, and the payment method — neither of which wants minute-level precision. The full reasoning is in the counterpart PR; none of it is reachable on Atomic in any case.

## Does this pull request change what data or activity we track or use?

No — not on Atomic. The MC counters added to this file (`wpcom-site-purchase` / `billing-lookup`, `billing-cache-hit`, `billing-error`) can only fire where the billing code-base is deployed, which is WordPress.com Simple and not here. No user data is read, stored, or transmitted.

## Testing instructions

The behavioural change is not reachable on an Atomic site, so this is a no-regression check plus a drift check.

1. Confirm the file is byte-identical to its WordPress.com twin — that is the entire point of the PR:
   `diff <path-to-wpcom>/wp-content/mu-plugins/wpcom-features/class-wpcom-site-purchase.php projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php`
2. `jp docker phpunit wpcomsh -- --filter WpcomSitePurchaseTest` — 3 tests pass. These cover the Atomic half (purchases synced into Atomic Persistent Data), which is the half that executes here.
3. On an Atomic site, confirm plan/feature checks still behave: a site with a plan still reports its features, and `wpcom_get_site_purchases()` still returns purchases in the declared shape.

The caching itself is verified on the WordPress.com side, where it actually runs — see the counterpart PR for the measurements (292ms → 0ms across two processes).
