### PR TITLE
cli: Default build concurrency to num CPUs

### DIFF
--- a/tools/cli/commands/build.js
+++ b/tools/cli/commands/build.js
@@ -1,6 +1,7 @@
 import { constants as fsconstants, createReadStream } from 'fs';
 import fs from 'fs/promises';
 import { once } from 'node:events';
+import os from 'node:os';
 import { createInterface as rlcreateInterface } from 'node:readline';
 import npath from 'path';
 import chalk from 'chalk';
@@ -44,7 +45,7 @@ export function builder( yargs ) {
 		.option( 'concurrency', {
 			type: 'number',
 			description: 'Maximum number of build tasks to run at once.',
-			default: Infinity,
+			default: os.availableParallelism(),
 			coerce: coerceConcurrency,
 		} )
 		.option( 'deps', {


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Back in 2022 this made no difference to the build times. Since then we've added more stuff, and in particular a bunch of memory-hungry wp-build builds. Keeping the concurrency down may help CI avoid RAM contention.

"Num CPUs" as a proxy for RAM isn't a perfect measure, but it seems likely to hold well enough for GitHub Actions CI.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1787074403430719-slack-C0BR4KX9VL4

Also, "back in 2022" refers to p9dueE-4dJ-p2#comment-7303 / #22742

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI build is not slower?