### PR TITLE
ci: Post-Build: Handle undocumented `needs.*.result`

### DIFF
--- a/.github/workflows/post-build.yml
+++ b/.github/workflows/post-build.yml
@@ -401,7 +401,7 @@ jobs:
         uses: ./.github/actions/check-run
         with:
           id: ${{ needs.setup.outputs.upgrade_check }}
-          conclusion: ${{ needs.upgrade_test.result }}
+          conclusion: ${{ case( needs.upgrade_test.result == 'abandoned', 'cancelled', needs.upgrade_test.result ) }}
           title: ${{ case( needs.upgrade_test.result == 'success', 'Tests passed', needs.upgrade_test.result == 'cancelled', 'Cancelled', 'Tests failed' ) }}
           summary: |
             ${{ env.SUMMARY }}


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
PR #50368 did the same thing for `job.status`, turns out the same can happen here.

While GitHub documents that `needs.*.result` can have values `success`, `failure`, `cancelled`, and 'skipped', apparently there's also `abandoned`. Handle that when setting the check run status, which doesn't accept "abandoned".

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1787082903543249-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷