### PR TITLE
Forms: preserve line breaks in multi-line answers in the responses dashboard

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-textarea-newlines
+++ b/projects/packages/forms/changelog/fix-forms-textarea-newlines
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Responses: Preserve line breaks in multi-line answers.

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
@@ -44,6 +44,9 @@
 	font-weight: 300;
 }
 
-.jp-forms__inbox-response-data-value {
+.jp-forms__inbox-response-data-value,
+.jp-forms__field-preview-value {
+	// Answers to multi-line fields are stored with their newlines; without this
+	// they collapse into a single run-on paragraph.
 	white-space: pre-wrap;
 }

--- a/projects/plugins/jetpack/changelog/fix-forms-textarea-newlines
+++ b/projects/plugins/jetpack/changelog/fix-forms-textarea-newlines
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Preserve line breaks in multi-line answers in the responses dashboard.


### PR DESCRIPTION
Fixes #

## Proposed changes

* Answers to multi-line (textarea) fields lost their line breaks in the Forms responses dashboard — a message submitted as several paragraphs rendered as one run-on block of text.
* The value itself was never the problem. `Contact_Form_Plugin`'s field compiler calls the same `$field->get_render_value( $context )` for both the legacy `key-value` shape and the newer `collection` shape, so the newlines reach the browser intact either way. Only the CSS differed:
  * the legacy renderer wraps the value in `.jp-forms__inbox-response-data-value`, which has `white-space: pre-wrap`;
  * `FieldPreview` (the collection-format renderer, which is what every new response uses) wraps it in `.jp-forms__field-preview-value`, which had no `white-space` rule at all and so inherited `normal`.
* The `pre-wrap` declaration was simply not carried over when `FieldPreview` was introduced. This adds `.jp-forms__field-preview-value` to that existing rule.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with Jetpack Forms, add a form with a **Multi-line text field**, and publish it.
* Submit the form from the front end, entering an answer in the multi-line field that spans several lines — include a blank line between two of them, e.g.

  ```
  Line one of the message.
  Line two after a single newline.

  Line four after a blank line.
  ```
* Go to **Jetpack → Forms** and open that response.
* **Before this change:** the answer renders as a single run-on paragraph — `Line one of the message. Line two after a single newline. Line four after a blank line.`
* **After this change:** the answer renders on four lines, with the blank line preserved.
* Confirm nothing else regressed in the response inspector — checkbox/radio/select answers still render as badges, file uploads and image-select answers still render normally, and email/phone/URL answers are still linked.

### Before / after

Verified on a Jurassic Ninja site running this branch. Measured on the rendered value element:

| | `white-space` | rendered height | `innerText` |
|---|---|---|---|
| before | `normal` | 40px (2 wrapped lines) | `Line one of the message. Line two after a single newline. Line four after a blank line.` |
| after | `pre-wrap` | 80px (4 lines) | line breaks preserved |
