### PR TITLE
Admin color: restore Fresh color scheme name back from Default

### DIFF
--- a/projects/packages/masterbar/changelog/admin-color-fresh-default
+++ b/projects/packages/masterbar/changelog/admin-color-fresh-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin color schemes: Stop labelling the Fresh scheme "Default", which duplicated the Default (Modern) entry on WordPress 7.0.

--- a/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php
+++ b/projects/packages/masterbar/src/admin-color-schemes/class-admin-color-schemes.php
@@ -86,6 +86,19 @@ class Admin_Color_Schemes {
 	 * Registers new admin color schemes
 	 */
 	public function register_admin_color_schemes() {
+		global $_wp_admin_css_colors;
+
+		// Adds custom CSS overrides for Fresh
+		if ( isset( $_wp_admin_css_colors['fresh'] ) ) {
+			$fresh = $_wp_admin_css_colors['fresh'];
+			wp_admin_css_color(
+				'fresh',
+				$fresh->name,
+				$this->get_admin_color_scheme_url( 'fresh' ),
+				$fresh->colors,
+				$fresh->icon_colors
+			);
+		}
 
 		wp_admin_css_color(
 			'aquatic',
@@ -143,18 +156,6 @@ class Admin_Color_Schemes {
 			array(
 				'base'    => '#1d2327',
 				'focus'   => '#fff',
-				'current' => '#fff',
-			)
-		);
-
-		wp_admin_css_color(
-			'fresh',
-			__( 'Default', 'jetpack-masterbar' ),
-			$this->get_admin_color_scheme_url( 'fresh' ),
-			array( '#1d2327', '#2c3338', '#2271b1', '#72aee6' ),
-			array(
-				'base'    => '#a7aaad',
-				'focus'   => '#72aee6',
 				'current' => '#fff',
 			)
 		);

--- a/projects/plugins/wpcomsh/changelog/admin-color-fresh-default
+++ b/projects/plugins/wpcomsh/changelog/admin-color-fresh-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin color schemes: Stop labelling the Fresh scheme "Default", which duplicated the Default (Modern) entry on WordPress 7.0.


### PR DESCRIPTION
Fixes DOTSITE-151

## Proposed changes

This PR restores the Fresh admin color scheme name from Default.

Currently, there are two `Default` color schemes in WordPress.com since 7.0. Since that version, Core updated the default one to Modern. However, Fresh stays Default by mistake. This is because we hardcoded the name (unintentionally) in this PR: https://github.com/Automattic/jetpack/pull/39371 to add custom CSS for Fresh.

This PR improves that logic by reusing the existing Fresh entry when updating the CSS file.

Before

<img width="901" height="102" alt="image" src="https://github.com/user-attachments/assets/d3bb4235-ba11-4483-918d-7c6f39ddf901" />

After

<img width="960" height="105" alt="image" src="https://github.com/user-attachments/assets/2d8fa3d1-a010-40df-b320-b87871976c25" />


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Patch this PR.
2. Go to `wp-admin/profile.php`, verify you don't see two Defaults.
3. Retest the linked PR above for regression, particularly this comment: https://github.com/Automattic/jetpack/pull/39371#pullrequestreview-2299774760
    - Select Sunrise color scheme, save.
    - Click Fresh, but don't click Update yet
    - Verify Help Center icon looks good.