### PR TITLE
Fix WordPress 7.0 test failures in connection, masterbar, search and videopress

### DIFF
--- a/projects/packages/connection/changelog/fix-wp7-test-expectations
+++ b/projects/packages/connection/changelog/fix-wp7-test-expectations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test-only: build a real WP_Screen in the Connectors page path test, which WordPress 7.0 requires.
+
+

--- a/projects/packages/connection/tests/php/Jetpack_Connector_Test.php
+++ b/projects/packages/connection/tests/php/Jetpack_Connector_Test.php
@@ -728,13 +728,15 @@ class Jetpack_Connector_Test extends TestCase {
 	 *
 	 * WordPress auto-prefixes submenu screen IDs (e.g. settings_page_<slug>), so using
 	 * $screen->id directly as the page= parameter would produce an invalid URL.
+	 *
+	 * The screen has to be a real WP_Screen: WP 7.0 made get_current_screen() return null
+	 * for anything else, so a stdClass stub silently takes the core-screen branch instead.
 	 */
 	public function test_connectors_page_path_gutenberg() {
 		$_SERVER['SCRIPT_NAME'] = '/wp-admin/options-general.php';
 
-		$screen                    = new \stdClass();
-		$screen->id                = Jetpack_Connector::GUTENBERG_CONNECTORS_SCREEN_ID;
-		$GLOBALS['current_screen'] = $screen;
+		set_current_screen( Jetpack_Connector::GUTENBERG_CONNECTORS_SCREEN_ID );
+		$this->assertSame( Jetpack_Connector::GUTENBERG_CONNECTORS_SCREEN_ID, get_current_screen()->id );
 
 		$method = new \ReflectionMethod( Jetpack_Connector::class, 'get_connectors_page_path' );
 		if ( PHP_VERSION_ID < 80100 ) {

--- a/projects/packages/masterbar/changelog/fix-wp7-test-expectations
+++ b/projects/packages/masterbar/changelog/fix-wp7-test-expectations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test-only: follow core's default admin color scheme instead of naming it, which changed in WordPress 7.0.
+
+

--- a/projects/packages/masterbar/tests/php/Admin_Color_Schemes_Test.php
+++ b/projects/packages/masterbar/tests/php/Admin_Color_Schemes_Test.php
@@ -84,6 +84,10 @@ class Admin_Color_Schemes_Test extends BaseTestCase {
 
 	/**
 	 * Tests retrieving the color scheme setting for a user.
+	 *
+	 * A user who has never chosen a scheme keeps whatever core stored for them, so the
+	 * expectation follows core's default rather than naming it — it changed from `fresh`
+	 * to `modern` in WordPress 7.0.
 	 */
 	public function test_get_color_scheme() {
 		wp_set_current_user( static::$user_id );
@@ -94,7 +98,7 @@ class Admin_Color_Schemes_Test extends BaseTestCase {
 
 		$this->assertArrayHasKey( 'meta', $data );
 		$this->assertArrayHasKey( 'admin_color', $data['meta'] );
-		$this->assertSame( 'fresh', $data['meta']['admin_color'] );
+		$this->assertSame( get_user_option( 'admin_color', static::$user_id ), $data['meta']['admin_color'] );
 	}
 
 	/**

--- a/projects/packages/search/changelog/fix-wp7-test-expectations
+++ b/projects/packages/search/changelog/fix-wp7-test-expectations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test-only: stop the stray-block test asserting core's paragraph attributes, which WordPress 7.0 adds to.
+
+

--- a/projects/packages/search/tests/php/No_Results_Render_Test.php
+++ b/projects/packages/search/tests/php/No_Results_Render_Test.php
@@ -261,11 +261,13 @@ class No_Results_Render_Test extends TestCase {
 		);
 
 		// The stray sits inside a variant wrapper bound to the unscoped
-		// condition, not loose in the container.
+		// condition, not loose in the container. Only the nesting is asserted:
+		// the paragraph's attributes come from core, and WP 7.0 adds a
+		// `wp-block-paragraph` class to them.
 		$this->assertSame(
 			1,
 			preg_match(
-				'/<div class="jetpack-search-no-results__variant"[^>]*>\s*<p>STRAY COPY<\/p>\s*<\/div>/',
+				'/<div class="jetpack-search-no-results__variant"[^>]*>\s*<p[^>]*>STRAY COPY<\/p>\s*<\/div>/',
 				$markup
 			),
 			'the stray block must be wrapped in an unscoped variant'

--- a/projects/packages/videopress/changelog/fix-wp7-test-expectations
+++ b/projects/packages/videopress/changelog/fix-wp7-test-expectations
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test-only: drop the trailing semicolon from the playlist font preset expectation, which WordPress 7.0 no longer emits.
+
+

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -251,8 +251,10 @@ class Playlist_Block_Test extends BaseTestCase {
 			$this->attributes( array( 'entryTitleFontFamily' => 'grotesk' ) )
 		);
 
+		// No trailing semicolon: get_block_wrapper_attributes() re-serialises the
+		// declarations, and WP 7.0 drops the separator after the last one.
 		$this->assertStringContainsString(
-			'--vpp-entry-title-font:var(--wp--preset--font-family--grotesk);',
+			'--vpp-entry-title-font:var(--wp--preset--font-family--grotesk)',
 			$markup
 		);
 


### PR DESCRIPTION
Fixes JETPACK-2279

## Why

The PHP test environment moved from WordPress 6.9 to 7.0, and four package test suites started failing against it. They fail on **every** PR whose test matrix reaches those packages, including PRs that change no PHP at all, so people see red checks they did not cause. This clears them.

Follow-up to #51375, which fixed the same class of failure in `jetpack-mu-wpcom` and left auditing the other packages out of scope.

### What moved the test environment to WordPress 7.0

Neither a WordPress release nor a commit in this repo. It was a transitive dependency bump:

| Time (UTC) | Event |
| -- | -- |
| 2026-02-24 23:33 | Automattic/wordbless#84 merged, widening `roots/wordpress` from `^6.6` to `^6.6 \|\| ^7.0` |
| 2026-08-18 22:29 | `automattic/wordbless` 0.6.1 published, carrying that constraint |
| 2026-08-18 22:13:41 | Last green `Tests` run on trunk (`c75c111b`) |
| 2026-08-18 22:42:54 | First failing `Tests` run on trunk (`26d685c2`), plus three more within five minutes on unrelated commits |

`tools/php-test-env/composer.json` requires `automattic/wordbless: ^0.6.0` and sets `"lock": false`, so every CI run re-resolves from scratch. WorDBless 0.6.0 required `roots/wordpress: ^6.6`, and that constraint was the only thing holding the environment at 6.9.7. Version 0.6.1 widened it to `^6.6 || ^7.0`, and since `roots/wordpress` 7.0.4 has been on Packagist since 2026-03-22 it was picked up on the very next run.

The widening itself sat unreleased for nearly six months; the 0.6.1 tag is what delivered it. Automattic/wordbless#84 framed the change as opt-in — "so consumers can test against WP 7.0 trunk" — but in this repo it became the default, for the reason below.

Worth recording, because `WP latest` is not what pins the version here: `tools/get-wp-version.php` queries api.wordpress.org, but `select-wordpress-tag.sh`'s output is only used to `composer require` a specific tag when `WP_BRANCH` is `trunk` or `previous`. For `latest`, `tests.yml` runs a plain `composer install` and takes whatever resolves, so the effective version is set by WorDBless's constraint.

## Proposed changes

Following the pattern set in #51375, each expectation is keyed to the thing that actually changed rather than to a version compare. All four suites pass on WordPress 6.9 and 7.0 alike.

* **`connection`** — WP 7.0 hardened `get_current_screen()` to return `null` for anything that is not a `WP_Screen` instance (it previously returned whatever was in the global). The test stubbed the screen with a `stdClass`, so the stub was ignored and `get_connectors_page_path()` fell through to the core-screen branch. The test now builds a real screen with `set_current_screen()`.
* **`masterbar`** — core changed the default admin colour scheme from `fresh` to `modern`, and `wp_insert_user()` stores that default on every new user. The test named the old default; it now asserts that the REST response matches the value core actually stored for the user.
* **`search`** — WP 7.0 adds a `wp-block-paragraph` class to rendered `core/paragraph` blocks (`block_core_paragraph_add_class`), which broke a regex asserting a bare `<p>`. The assertion is about where the stray block is nested, not about core's paragraph attributes, so the pattern now tolerates them.
* **`videopress`** — `get_block_wrapper_attributes()` re-serialises the style declarations and 7.0 no longer emits a trailing `;` after the last one. The assertion drops it.

### Conclusions on the two that could have been product bugs

The issue flagged `connection` and `masterbar` as possible real behaviour changes rather than stale expectations. Both turned out to be **test-only**:

* **`connection`** — `Jetpack_Connector` already handles the WP 7.0 core Connectors screen. `get_connectors_page_path()` returns `options-connectors.php` when the request is served by that file and only falls back to `options-general.php?page=…` for the Gutenberg plugin's submenu page. In production `get_current_screen()` always returns a real `WP_Screen`, so the admin link is correct on 7.0. Only the test's fake screen was affected.
* **`masterbar`** — the package does not choose a scheme; it exposes the `admin_color` user meta over REST and registers its own extra schemes. Core still registers `fresh` in 7.0, so masterbar's `CORE_COLOR_SCHEMES` list stays valid, and a user who has never chosen a scheme keeps whatever core stored for them.

### One thing deliberately left alone

While auditing `masterbar` I found that `register_admin_color_meta()` advertises `'default' => 'fresh'` in the REST schema — a hard-coded copy of core's pre-7.0 default. It is now stale: for a user whose `admin_color` meta is genuinely absent, the REST API reports `fresh` while wp-admin renders `modern`.

I did not change it, because there is no correct way to fix it under this issue's "no version compare" constraint. Core exposes no API for "the default admin colour scheme", and the scheme registry (`$_wp_admin_css_colors`) is only populated on `admin_init`, so it is unavailable at `rest_api_init` where the meta is registered. Every candidate probe fails:

* `modern` ships as a registered scheme in 6.9 as well, so its presence proves nothing.
* The only thing distinguishing the two is which scheme carries the translated `Default` label — not something to key on.
* `$wp_db_version >= 61644` (the threshold gating core's own `fresh` → `modern` migration) would work, but it is a version compare wearing a different hat.

The impact is cosmetic and narrow — core writes `admin_color` on user creation and the 7.0 upgrade routine rewrites existing `fresh` users to `modern`, so absent meta is rare, and `fresh` remains a valid scheme if a client saves it back. Worth its own issue rather than a workaround here.

## Related product discussion/links

* JETPACK-2279
* #51375 — same root cause in `jetpack-mu-wpcom`
* #51370 — raises the minimum supported WordPress version to 7.0

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

CI covers this: the four package suites run against `WP latest`, which is now 7.0.

To check locally against both supported versions:

1. Confirm the test environment is on WordPress 7.0 — `grep wp_version tools/php-test-env/wordpress/wp-includes/version.php`.
2. Run the four suites and confirm they pass:
   ```
   jp test php packages/connection
   jp test php packages/masterbar
   jp test php packages/search
   jp test php packages/videopress
   ```
3. Downgrade the test environment to the minimum supported version:
   ```
   composer --working-dir=tools/php-test-env require --dev "roots/wordpress:~6.9.0" "roots/wordpress-no-content:~6.9.0"
   ```
4. Run the same four suites again and confirm they still pass.
5. Restore the test environment:
   ```
   git checkout -- tools/php-test-env/composer.json
   composer --working-dir=tools/php-test-env update
   ```

I ran exactly this: all four pass on 7.0.4 and on 6.9.7.
