### PR TITLE
Jetpack AI: add the SEO feature option and point its surfaces at it

### DIFF
--- a/projects/packages/seo/changelog/add-jetpack-ai-seo-option
+++ b/projects/packages/seo/changelog/add-jetpack-ai-seo-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Follow the site's SEO entitlement when reporting whether AI SEO is available.

--- a/projects/packages/seo/src/class-ai-seo.php
+++ b/projects/packages/seo/src/class-ai-seo.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * The AI SEO Enhancer's availability gate. This package owns the
- * `ai_seo_enhancer_enabled` option, so the shared predicate lives here.
+ * The AI SEO feature's availability gate. This package owns the SEO surfaces
+ * the feature writes to, so the shared predicate lives here.
  *
  * @package automattic/jetpack-seo-package
  */
@@ -12,14 +12,17 @@ use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Modules;
 
 /**
- * Whether the AI SEO Enhancer is offered on this site.
+ * Whether AI SEO is offered on this site.
  */
-class AI_SEO_Enhancer {
+class Ai_Seo {
 
 	/**
-	 * Whether the site can offer the enhancer, independent of the admin's
-	 * toggle. Callers own the outer AI master and host gates. The AI sidebar's
-	 * SEO suggestions intentionally use a different plan slug — do not unify.
+	 * Whether the site can offer AI SEO, independent of the admin's toggle.
+	 * Callers own the outer AI master and host gates.
+	 *
+	 * The plan term is `advanced-seo`, the entitlement for the SEO title and
+	 * meta description fields every AI SEO surface writes to. Automatic
+	 * generation needs `ai-seo-enhancer` on top, checked where it runs.
 	 *
 	 * @since 0.8.2
 	 *
@@ -31,6 +34,6 @@ class AI_SEO_Enhancer {
 			/** This filter is documented in projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-utils.php */
 			&& ! apply_filters( 'jetpack_disable_seo_tools', false )
 			&& ( new Modules() )->is_active( 'seo-tools' )
-			&& Current_Plan::supports( 'ai-seo-enhancer' );
+			&& Current_Plan::supports( 'advanced-seo' );
 	}
 }

--- a/projects/packages/seo/tests/php/AiSeoTest.php
+++ b/projects/packages/seo/tests/php/AiSeoTest.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * Tests for the AI SEO Enhancer gate: each availability term falsified on its
- * own. The Simple behavior is pinned plugin-side in Jetpack_AI_Sidebar_Test
+ * Tests for the AI SEO availability gate: each term falsified on its own. The Simple behavior is pinned plugin-side in Jetpack_AI_Sidebar_Test
  * (IS_WPCOM needs process isolation, broken here under PHP 8.5).
  *
  * @package automattic/jetpack-seo
@@ -12,10 +11,10 @@ namespace Automattic\Jetpack\SEO;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
- * @covers \Automattic\Jetpack\SEO\AI_SEO_Enhancer
+ * @covers \Automattic\Jetpack\SEO\Ai_Seo
  */
-#[CoversClass( AI_SEO_Enhancer::class )]
-class AiSeoEnhancerTest extends SeoTestCase {
+#[CoversClass( Ai_Seo::class )]
+class AiSeoTest extends SeoTestCase {
 
 	/**
 	 * Reset the option, filters and plan pin every test touches.
@@ -32,13 +31,13 @@ class AiSeoEnhancerTest extends SeoTestCase {
 	}
 
 	/**
-	 * All four terms satisfied: available.
+	 * Every term satisfied: available.
 	 */
 	public function test_is_available_when_all_inputs_true() {
 		self::set_plan( 'jetpack_business' );
 		self::set_seo_tools_active( true );
 
-		$this->assertTrue( AI_SEO_Enhancer::is_available() );
+		$this->assertTrue( Ai_Seo::is_available() );
 	}
 
 	/**
@@ -49,7 +48,7 @@ class AiSeoEnhancerTest extends SeoTestCase {
 		self::set_seo_tools_active( true );
 		add_filter( 'ai_seo_enhancer_enabled', '__return_false' );
 
-		$this->assertFalse( AI_SEO_Enhancer::is_available() );
+		$this->assertFalse( Ai_Seo::is_available() );
 	}
 
 	/**
@@ -59,17 +58,24 @@ class AiSeoEnhancerTest extends SeoTestCase {
 		self::set_plan( 'jetpack_business' );
 		self::set_seo_tools_active( false );
 
-		$this->assertFalse( AI_SEO_Enhancer::is_available() );
+		$this->assertFalse( Ai_Seo::is_available() );
 	}
 
 	/**
-	 * The plan vetoes on its own.
+	 * `advanced-seo` sits in the free plan's supports list, so every self-hosted
+	 * plan is entitled — AI SEO is offered on a free site with SEO tools on.
+	 * Automatic generation is the part that needs a higher tier, and it checks
+	 * `ai-seo-enhancer` where it runs, not here.
+	 *
+	 * The entitlement can only be falsified on WordPress.com, where
+	 * Current_Plan::supports() hijacks to wpcom_site_has_feature(); pinning a
+	 * purchase there would couple this test to wpcomsh's schema.
 	 */
-	public function test_is_not_available_when_plan_lacks_feature() {
+	public function test_is_available_on_a_free_plan() {
 		self::set_plan( 'jetpack_free' );
 		self::set_seo_tools_active( true );
 
-		$this->assertFalse( AI_SEO_Enhancer::is_available() );
+		$this->assertTrue( Ai_Seo::is_available() );
 	}
 
 	/**
@@ -80,6 +86,6 @@ class AiSeoEnhancerTest extends SeoTestCase {
 		self::set_seo_tools_active( true );
 		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
 
-		$this->assertFalse( AI_SEO_Enhancer::is_available() );
+		$this->assertFalse( Ai_Seo::is_available() );
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -79,7 +79,7 @@ const SECTIONS = [
 		title: __( 'SEO', 'jetpack' ),
 		features: [
 			{
-				key: 'seo_enhancer',
+				key: 'ai_seo',
 				label: __( 'AI SEO', 'jetpack' ),
 				description: __(
 					'AI recommendations to optimize titles, meta descriptions, and content for search engines.',

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -91,6 +91,20 @@ describe( 'AiFeatures rendering', () => {
 		).not.toBeInTheDocument();
 	} );
 
+	test( 'the AI SEO row renders from the ai_seo feature key inside the SEO group', () => {
+		renderFeatures( {
+			features: {
+				writing_assistant: { enabled: true },
+				ai_seo: { enabled: true },
+			},
+		} );
+
+		const seoGroup = screen.getByRole( 'region', { name: 'SEO' } );
+		const toggle = within( seoGroup ).getByRole( 'checkbox', { name: /AI SEO/ } );
+		expect( toggle ).toBeChecked();
+		expect( toggle ).toBeEnabled();
+	} );
+
 	test( 'the upgrade badge sits inside the Search group', () => {
 		renderFeatures();
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -56,8 +56,9 @@ class Jetpack_AI_Settings {
 	/**
 	 * Feature key => option name for every toggle on the AI settings page.
 	 *
-	 * `seo_enhancer` and `ai_search` reuse options owned by the SEO/Search
-	 * surfaces; the rest are registered by this class.
+	 * `ai_search` reuses an option owned by the Search surface; the rest are
+	 * registered by this class. The automatic-generation option is deliberately
+	 * absent: the Traffic page and the SEO dashboard own it.
 	 *
 	 * @var array
 	 */
@@ -66,13 +67,12 @@ class Jetpack_AI_Settings {
 		'image_editor'      => 'jetpack_ai_image_editor_enabled',
 		'feature_clip'      => 'jetpack_ai_feature_clip_enabled',
 		'ai_seo'            => 'jetpack_ai_seo_enabled',
-		'seo_enhancer'      => 'ai_seo_enhancer_enabled',
 		'ai_search'         => 'jetpack_search_ai_answers_enabled',
 	);
 
 	/**
-	 * Option defaults. The reused SEO/Search options keep their established
-	 * opt-in defaults; the new per-feature toggles default to on.
+	 * Option defaults. The reused Search option keeps its established opt-in
+	 * default; the new per-feature toggles default to on.
 	 *
 	 * @var array
 	 */
@@ -81,13 +81,12 @@ class Jetpack_AI_Settings {
 		'image_editor'      => true,
 		'feature_clip'      => true,
 		'ai_seo'            => true,
-		'seo_enhancer'      => false,
 		'ai_search'         => false,
 	);
 
 	/**
 	 * Feature keys whose options this class registers and syncs (the reused
-	 * SEO/Search options are registered by their owning surfaces).
+	 * Search option is registered by its owning surface).
 	 *
 	 * @var array
 	 */
@@ -202,17 +201,17 @@ class Jetpack_AI_Settings {
 	public static function apply_site_wide_gates( $enabled ) {
 		return (bool) $enabled
 			&& self::host_allows_ai()
-			&& ( ! self::is_master_rollout_active() || self::is_master_enabled() );
+			&& ( ! self::should_enforce_ai_controls() || self::is_master_enabled() );
 	}
 
 	/**
-	 * Whether master enforcement has rolled out here: the AI controls are still
-	 * limited to internal testing environments, so the master only enforces
-	 * there; Simple keeps its option contract. Remove at public launch.
+	 * Whether the AI controls — the master switch and the toggles this class owns
+	 * — take effect here. They are not publicly launched, so off Simple they apply
+	 * on internal testing environments only. Remove at public launch.
 	 *
 	 * @return bool
 	 */
-	private static function is_master_rollout_active() {
+	private static function should_enforce_ai_controls() {
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			return true;
 		}
@@ -318,6 +317,9 @@ class Jetpack_AI_Settings {
 	 * carries host + master). Only the matching option is read: a code-level
 	 * override belongs on the option itself, through core's own option filters.
 	 *
+	 * Not {@see self::is_ai_seo_enabled()}, which is this check for the `ai_seo`
+	 * key plus its filter and the site-wide gates. Use that one at load points.
+	 *
 	 * @param string $feature Feature key (see FEATURE_OPTIONS).
 	 * @return bool False for unknown features.
 	 */
@@ -326,12 +328,12 @@ class Jetpack_AI_Settings {
 			return false;
 		}
 
-		// WordPress.com Simple has no per-feature toggles. It keeps the existing
-		// wp.com settings contract, so the features Jetpack owns stay on there and
-		// the host and master gates remain the only controls. The reused SEO and
-		// Search options are deliberately excluded: they have their own settings
-		// surfaces on Simple and must keep honoring their stored values.
-		if ( in_array( $feature, self::OWNED_FEATURES, true ) && ( new Host() )->is_wpcom_simple() ) {
+		// The toggles this class owns stay on wherever they do not apply: Simple keeps
+		// the existing wp.com settings contract, and elsewhere they are not publicly
+		// launched. The reused Search option ships today with its own settings
+		// surface, so it always honors its stored value.
+		if ( in_array( $feature, self::OWNED_FEATURES, true )
+			&& ( ( new Host() )->is_wpcom_simple() || ! self::should_enforce_ai_controls() ) ) {
 			return true;
 		}
 
@@ -345,6 +347,9 @@ class Jetpack_AI_Settings {
 	 * is effectively enabled: its own toggle (gate 4) through the filter, with
 	 * the host and master gates ANDed after the chain so no late-priority
 	 * callback can turn the feature back on — same finality as is_ai_enabled().
+	 *
+	 * Not {@see self::is_feature_enabled()} with `ai_seo`, which is the stored
+	 * toggle alone. This is the one load points and payloads should read.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -65,6 +65,7 @@ class Jetpack_AI_Settings {
 		'writing_assistant' => 'jetpack_ai_writing_assistant_enabled',
 		'image_editor'      => 'jetpack_ai_image_editor_enabled',
 		'feature_clip'      => 'jetpack_ai_feature_clip_enabled',
+		'ai_seo'            => 'jetpack_ai_seo_enabled',
 		'seo_enhancer'      => 'ai_seo_enhancer_enabled',
 		'ai_search'         => 'jetpack_search_ai_answers_enabled',
 	);
@@ -79,6 +80,7 @@ class Jetpack_AI_Settings {
 		'writing_assistant' => true,
 		'image_editor'      => true,
 		'feature_clip'      => true,
+		'ai_seo'            => true,
 		'seo_enhancer'      => false,
 		'ai_search'         => false,
 	);
@@ -89,7 +91,7 @@ class Jetpack_AI_Settings {
 	 *
 	 * @var array
 	 */
-	const OWNED_FEATURES = array( 'writing_assistant', 'image_editor', 'feature_clip' );
+	const OWNED_FEATURES = array( 'writing_assistant', 'image_editor', 'feature_clip', 'ai_seo' );
 
 	/**
 	 * Whether init() has already run.
@@ -123,6 +125,7 @@ class Jetpack_AI_Settings {
 		// AI surfaces that do not flow through jetpack_ai_enabled.
 		add_filter( 'jetpack_search_ai_answers_enabled', array( __CLASS__, 'apply_master_gates' ) );
 		add_filter( 'jetpack_ai_sidebar_enabled', array( __CLASS__, 'apply_master_gates' ) );
+		add_filter( 'jetpack_ai_seo_enabled', array( __CLASS__, 'apply_master_gates' ) );
 	}
 
 	/**
@@ -138,6 +141,7 @@ class Jetpack_AI_Settings {
 			self::FEATURE_OPTIONS['writing_assistant'] => __( 'Whether the Jetpack AI writing assistant is enabled.', 'jetpack' ),
 			self::FEATURE_OPTIONS['image_editor']      => __( 'Whether the Jetpack AI image editor is enabled.', 'jetpack' ),
 			self::FEATURE_OPTIONS['feature_clip']      => __( 'Whether Jetpack AI video clip generation is enabled.', 'jetpack' ),
+			self::FEATURE_OPTIONS['ai_seo']            => __( 'Whether the Jetpack AI SEO features are enabled.', 'jetpack' ),
 		);
 
 		foreach ( $options as $option => $description ) {
@@ -317,6 +321,29 @@ class Jetpack_AI_Settings {
 		$option = self::FEATURE_OPTIONS[ $feature ];
 
 		return (bool) get_option( $option, self::FEATURE_DEFAULTS[ $feature ] );
+	}
+
+	/**
+	 * Whether the AI SEO feature (metadata generation, manual and automatic)
+	 * is effectively enabled: its own toggle (gate 4) through the filter, with
+	 * the host and master gates ANDed after the chain so no late-priority
+	 * callback can turn the feature back on — same finality as is_ai_enabled().
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	public static function is_ai_seo_enabled() {
+		/**
+		 * Filter whether the Jetpack AI SEO feature is enabled.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $enabled Whether the SEO feature toggle is on.
+		 */
+		$enabled = (bool) apply_filters( 'jetpack_ai_seo_enabled', self::is_feature_enabled( 'ai_seo' ) );
+
+		return $enabled && self::host_allows_ai() && self::is_master_enabled();
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -120,12 +120,12 @@ class Jetpack_AI_Settings {
 		// the package consumers that cannot reference this plugin class
 		// (external-media, my-jetpack): there the gates keep their pre-helper,
 		// priority-10 behavior.
-		add_filter( 'jetpack_ai_enabled', array( __CLASS__, 'apply_master_gates' ) );
+		add_filter( 'jetpack_ai_enabled', array( __CLASS__, 'apply_site_wide_gates' ) );
 
 		// AI surfaces that do not flow through jetpack_ai_enabled.
-		add_filter( 'jetpack_search_ai_answers_enabled', array( __CLASS__, 'apply_master_gates' ) );
-		add_filter( 'jetpack_ai_sidebar_enabled', array( __CLASS__, 'apply_master_gates' ) );
-		add_filter( 'jetpack_ai_seo_enabled', array( __CLASS__, 'apply_master_gates' ) );
+		add_filter( 'jetpack_search_ai_answers_enabled', array( __CLASS__, 'apply_site_wide_gates' ) );
+		add_filter( 'jetpack_ai_sidebar_enabled', array( __CLASS__, 'apply_site_wide_gates' ) );
+		add_filter( 'jetpack_ai_seo_enabled', array( __CLASS__, 'apply_site_wide_gates' ) );
 	}
 
 	/**
@@ -199,8 +199,25 @@ class Jetpack_AI_Settings {
 	 * @param bool $enabled The value the call site computed so far.
 	 * @return bool
 	 */
-	public static function apply_master_gates( $enabled ) {
-		return (bool) $enabled && self::host_allows_ai() && self::is_master_enabled();
+	public static function apply_site_wide_gates( $enabled ) {
+		return (bool) $enabled
+			&& self::host_allows_ai()
+			&& ( ! self::is_master_rollout_active() || self::is_master_enabled() );
+	}
+
+	/**
+	 * Whether master enforcement has rolled out here: the AI controls are still
+	 * limited to internal testing environments, so the master only enforces
+	 * there; Simple keeps its option contract. Remove at public launch.
+	 *
+	 * @return bool
+	 */
+	private static function is_master_rollout_active() {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return true;
+		}
+
+		return function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment();
 	}
 
 	/**
@@ -217,7 +234,7 @@ class Jetpack_AI_Settings {
 	 * @since 16.2
 	 *
 	 * @param bool $default The call site's computed default. Defaults differ
-	 *                      between call sites — see apply_master_gates().
+	 *                      between call sites — see apply_site_wide_gates().
 	 * @return bool
 	 */
 	public static function is_ai_enabled( $default = true ) {
@@ -230,7 +247,7 @@ class Jetpack_AI_Settings {
 		 */
 		$enabled = (bool) apply_filters( 'jetpack_ai_enabled', $default );
 
-		return $enabled && self::host_allows_ai() && self::is_master_enabled();
+		return self::apply_site_wide_gates( $enabled );
 	}
 
 	/**
@@ -343,7 +360,7 @@ class Jetpack_AI_Settings {
 		 */
 		$enabled = (bool) apply_filters( 'jetpack_ai_seo_enabled', self::is_feature_enabled( 'ai_seo' ) );
 
-		return $enabled && self::host_allows_ai() && self::is_master_enabled();
+		return self::apply_site_wide_gates( $enabled );
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -119,12 +119,12 @@ class Jetpack_AI_Settings {
 		// the package consumers that cannot reference this plugin class
 		// (external-media, my-jetpack): there the gates keep their pre-helper,
 		// priority-10 behavior.
-		add_filter( 'jetpack_ai_enabled', array( __CLASS__, 'apply_site_wide_gates' ) );
+		add_filter( 'jetpack_ai_enabled', array( __CLASS__, 'apply_master_gates' ) );
 
 		// AI surfaces that do not flow through jetpack_ai_enabled.
-		add_filter( 'jetpack_search_ai_answers_enabled', array( __CLASS__, 'apply_site_wide_gates' ) );
-		add_filter( 'jetpack_ai_sidebar_enabled', array( __CLASS__, 'apply_site_wide_gates' ) );
-		add_filter( 'jetpack_ai_seo_enabled', array( __CLASS__, 'apply_site_wide_gates' ) );
+		add_filter( 'jetpack_search_ai_answers_enabled', array( __CLASS__, 'apply_master_gates' ) );
+		add_filter( 'jetpack_ai_sidebar_enabled', array( __CLASS__, 'apply_master_gates' ) );
+		add_filter( 'jetpack_ai_seo_enabled', array( __CLASS__, 'apply_master_gates' ) );
 	}
 
 	/**
@@ -198,7 +198,7 @@ class Jetpack_AI_Settings {
 	 * @param bool $enabled The value the call site computed so far.
 	 * @return bool
 	 */
-	public static function apply_site_wide_gates( $enabled ) {
+	public static function apply_master_gates( $enabled ) {
 		return (bool) $enabled
 			&& self::host_allows_ai()
 			&& ( ! self::should_enforce_ai_controls() || self::is_master_enabled() );
@@ -233,7 +233,7 @@ class Jetpack_AI_Settings {
 	 * @since 16.2
 	 *
 	 * @param bool $default The call site's computed default. Defaults differ
-	 *                      between call sites — see apply_site_wide_gates().
+	 *                      between call sites — see apply_master_gates().
 	 * @return bool
 	 */
 	public static function is_ai_enabled( $default = true ) {
@@ -246,7 +246,7 @@ class Jetpack_AI_Settings {
 		 */
 		$enabled = (bool) apply_filters( 'jetpack_ai_enabled', $default );
 
-		return self::apply_site_wide_gates( $enabled );
+		return self::apply_master_gates( $enabled );
 	}
 
 	/**
@@ -365,7 +365,7 @@ class Jetpack_AI_Settings {
 		 */
 		$enabled = (bool) apply_filters( 'jetpack_ai_seo_enabled', self::is_feature_enabled( 'ai_seo' ) );
 
-		return self::apply_site_wide_gates( $enabled );
+		return self::apply_master_gates( $enabled );
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -219,8 +219,8 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 					'enabled'   => $stored['feature_clip'],
 					'available' => $this->is_feature_clip_available(),
 				),
-				'seo_enhancer'      => array(
-					'enabled'   => $stored['seo_enhancer'],
+				'ai_seo'            => array(
+					'enabled'   => $stored['ai_seo'],
 					'available' => $this->is_seo_enhancer_available(),
 				),
 				'ai_search'         => array(
@@ -232,9 +232,9 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 	}
 
 	/**
-	 * Whether the AI SEO enhancer is available on this site, so the settings
-	 * page can hide its row. Defers to the SEO package's shared gate; the
-	 * terms are unchanged.
+	 * Whether the SEO feature row is available, so the settings page can hide
+	 * it. Reuses the SEO enhancer's shared gate (kill filter, seo-tools
+	 * module, ai-seo-enhancer plan slug) as the feature's availability.
 	 *
 	 * @return bool
 	 */

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -24,7 +24,7 @@
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Search\Plan as Search_Plan;
-use Automattic\Jetpack\SEO\AI_SEO_Enhancer;
+use Automattic\Jetpack\SEO\Ai_Seo;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
@@ -221,7 +221,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 				),
 				'ai_seo'            => array(
 					'enabled'   => $stored['ai_seo'],
-					'available' => $this->is_seo_enhancer_available(),
+					'available' => $this->is_ai_seo_available(),
 				),
 				'ai_search'         => array(
 					'enabled'          => $stored['ai_search'],
@@ -232,14 +232,22 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 	}
 
 	/**
-	 * Whether the SEO feature row is available, so the settings page can hide
-	 * it. Reuses the SEO enhancer's shared gate (kill filter, seo-tools
-	 * module, ai-seo-enhancer plan slug) as the feature's availability.
+	 * Whether the AI SEO row is available, so the settings page can hide it.
+	 * The row governs user-initiated suggestions as well as automatic
+	 * generation, so it follows the package's shared AI SEO gate.
+	 *
+	 * Guarded with class_exists: the autoloader can pick an older jetpack-seo
+	 * copy from another plugin, predating this class. Without the gate's verdict
+	 * the row is hidden rather than offered.
 	 *
 	 * @return bool
 	 */
-	private function is_seo_enhancer_available() {
-		return AI_SEO_Enhancer::is_available();
+	private function is_ai_seo_available() {
+		if ( ! class_exists( Ai_Seo::class ) ) {
+			return false;
+		}
+
+		return Ai_Seo::is_available();
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-seo-option
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-seo-option
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Jetpack AI: Add a jetpack_ai_seo_enabled option as the AI SEO feature control. The AI settings page's SEO row and the AI sidebar's user-initiated SEO suggestions now follow it instead of the automatic-generation option, so switching automatic generation off no longer removes user-initiated suggestions, and the saved choice is preserved while site-wide AI is off.
+Jetpack AI: Add a jetpack_ai_seo_enabled option as the AI SEO feature control. The AI settings page's SEO row and the AI sidebar's user-initiated SEO suggestions now follow it instead of the automatic-generation option, so switching automatic generation off no longer removes user-initiated suggestions, and the saved choice is preserved while site-wide AI is off. The site-wide AI switch enforces only on internal testing environments while its controls remain limited to them.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-seo-option
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-seo-option
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Jetpack AI: Add an AI SEO control that governs SEO generation as a whole. The AI settings page's SEO row and the sidebar's SEO suggestions follow it, so turning automatic generation off no longer removes the suggestions.
+Jetpack AI: Add an AI SEO control to the AI settings page. The AI sidebar's SEO suggestions follow it, separately from the automatic-generation setting.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-seo-option
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-seo-option
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Jetpack AI: Add a jetpack_ai_seo_enabled option as the AI SEO feature control. The AI settings page's SEO row and the AI sidebar's user-initiated SEO suggestions now follow it instead of the automatic-generation option, so switching automatic generation off no longer removes user-initiated suggestions, and the saved choice is preserved while site-wide AI is off. The site-wide AI switch enforces only on internal testing environments while its controls remain limited to them.
+Jetpack AI: Add an AI SEO control that governs SEO generation as a whole. The AI settings page's SEO row and the sidebar's SEO suggestions follow it, so turning automatic generation off no longer removes the suggestions.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-seo-option
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-seo-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack AI: Add a jetpack_ai_seo_enabled option as the AI SEO feature control. The AI settings page's SEO row and the AI sidebar's user-initiated SEO suggestions now follow it instead of the automatic-generation option, so switching automatic generation off no longer removes user-initiated suggestions, and the saved choice is preserved while site-wide AI is off.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -353,7 +353,7 @@ class Jetpack_AI_Sidebar {
 		// sidebar whose features are all off, or one blocked by the host or
 		// master gates — the gates are final, as with is_ai_enabled().
 		return $enabled
-			&& \Jetpack_AI_Settings::apply_site_wide_gates( true )
+			&& \Jetpack_AI_Settings::apply_master_gates( true )
 			&& self::has_enabled_sidebar_features();
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -385,7 +385,7 @@ class Jetpack_AI_Sidebar {
 		// sidebar whose features are all off, or one blocked by the host or
 		// master gates — the gates are final, as with is_ai_enabled().
 		return $enabled
-			&& \Jetpack_AI_Settings::apply_master_gates( true )
+			&& \Jetpack_AI_Settings::apply_site_wide_gates( true )
 			&& self::has_enabled_sidebar_features();
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -299,16 +299,16 @@ class Jetpack_AI_Sidebar {
 	 * of the Optimize Title suggestion: SEO suggestions target the SEO meta fields,
 	 * not the visible post title.
 	 *
-	 * The user-facing ai_seo_enhancer_enabled *option* is consulted since the AI
-	 * settings page surfaced it as the SEO feature toggle: a switched-off feature
-	 * must not offer suggestions, even user-initiated ones, and even when an
-	 * external host (Big Sky, Woo) draws the sidebar.
+	 * The SEO *feature* option is consulted — the AI settings page surfaces it
+	 * as the SEO toggle, and a switched-off feature must not offer suggestions,
+	 * even user-initiated ones. The automatic-generation option governs only
+	 * automatic runs and is deliberately not consulted here.
 	 *
 	 * @return bool
 	 */
 	private static function is_seo_suggestions_enabled(): bool {
 		return (bool) apply_filters( 'ai_seo_enhancer_enabled', true )
-			&& \Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' )
+			&& \Jetpack_AI_Settings::is_ai_seo_enabled()
 			&& self::has_seo_feature()
 			&& self::is_seo_tools_usable();
 	}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -14,8 +14,7 @@ namespace Automattic\Jetpack\Extensions\AiAssistantPlugin;
 
 use Automattic\Jetpack\Agents_Manager\Agents_Manager;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Current_Plan;
-use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\SEO\Ai_Seo;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
@@ -290,59 +289,28 @@ class Jetpack_AI_Sidebar {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * UI feature flag for the SEO Enhancer suggestions (SEO title and meta description).
+	 * UI feature flag for the SEO suggestions (SEO title and meta description).
 	 *
-	 * Exposed only where the suggestions can actually be used: the SEO Enhancer
-	 * is not killed via its filter, the site's plan includes the Jetpack SEO
-	 * feature (the suggestions write to the plan-gated SEO title and meta
-	 * description fields), and SEO tools are usable on the site. Kept independent
-	 * of the Optimize Title suggestion: SEO suggestions target the SEO meta fields,
-	 * not the visible post title.
+	 * Two halves: the site can offer AI SEO at all — the package's shared gate,
+	 * the same one the AI settings row uses, so the control and the surface it
+	 * governs cannot drift — and the feature's own toggle is on. Kept independent
+	 * of the Optimize Title suggestion: SEO suggestions target the SEO meta
+	 * fields, not the visible post title.
 	 *
-	 * The SEO *feature* option is consulted — the AI settings page surfaces it
-	 * as the SEO toggle, and a switched-off feature must not offer suggestions,
-	 * even user-initiated ones. The automatic-generation option governs only
-	 * automatic runs and is deliberately not consulted here.
+	 * The SEO *feature* option is consulted, not the automatic-generation one:
+	 * a switched-off feature must not offer suggestions, even user-initiated
+	 * ones, while automatic generation governs only automatic runs.
+	 *
+	 * Guarded with class_exists: the autoloader can pick an older jetpack-seo
+	 * copy from another plugin, predating the shared gate. Suggestions stay off
+	 * without it.
 	 *
 	 * @return bool
 	 */
 	private static function is_seo_suggestions_enabled(): bool {
-		return (bool) apply_filters( 'ai_seo_enhancer_enabled', true )
-			&& \Jetpack_AI_Settings::is_ai_seo_enabled()
-			&& self::has_seo_feature()
-			&& self::is_seo_tools_usable();
-	}
-
-	/**
-	 * Whether the site's plan includes the Jetpack SEO feature.
-	 *
-	 * Same predicate the SEO editor panel uses to decide between the SEO fields and
-	 * the "Optimize SEO" upgrade nudge: extensions/plugins/seo/seo.php registers
-	 * availability via Jetpack_Gutenberg::set_availability_for_plan( 'advanced-seo' ),
-	 * which resolves through Current_Plan::supports(). On WordPress.com Simple and
-	 * Atomic this delegates to wpcom_site_has_feature( 'advanced-seo' ) — Business
-	 * and higher plans; on self-hosted sites every plan includes the feature.
-	 *
-	 * @return bool
-	 */
-	private static function has_seo_feature(): bool {
-		return Current_Plan::supports( 'advanced-seo' );
-	}
-
-	/**
-	 * Whether Jetpack SEO tools are usable on this site: SEO is not disabled via the
-	 * jetpack_disable_seo_tools filter — which the seo-tools module enables itself
-	 * when a conflicting SEO plugin (Yoast, AIOSEO, Rank Math, …) owns the site's
-	 * SEO — and the seo-tools module is active, since the module registers the SEO
-	 * meta fields the suggestions write to. On WordPress.com Simple the module always
-	 * reports active, so there this reduces to the filter check.
-	 *
-	 * @return bool
-	 */
-	private static function is_seo_tools_usable(): bool {
-		/** This filter is documented in modules/seo-tools/class-jetpack-seo-utils.php */
-		return ! apply_filters( 'jetpack_disable_seo_tools', false )
-			&& ( new Modules() )->is_active( 'seo-tools' );
+		return class_exists( Ai_Seo::class )
+			&& Ai_Seo::is_available()
+			&& \Jetpack_AI_Settings::is_ai_seo_enabled();
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -46,7 +46,7 @@ const ASSET_TRANSIENT        = 'jetpack_image_studio_asset';
 function is_image_studio_environment_available() {
 	// The host and master switches win over every environment-based enable
 	// below: off must mean Jetpack loads nothing, even in Big Sky or CIAB.
-	if ( ! \Jetpack_AI_Settings::apply_master_gates( true ) ) {
+	if ( ! \Jetpack_AI_Settings::apply_site_wide_gates( true ) ) {
 		return false;
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -46,7 +46,7 @@ const ASSET_TRANSIENT        = 'jetpack_image_studio_asset';
 function is_image_studio_environment_available() {
 	// The host and master switches win over every environment-based enable
 	// below: off must mean Jetpack loads nothing, even in Big Sky or CIAB.
-	if ( ! \Jetpack_AI_Settings::apply_site_wide_gates( true ) ) {
+	if ( ! \Jetpack_AI_Settings::apply_master_gates( true ) ) {
 		return false;
 	}
 

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
@@ -209,14 +209,12 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	 * satisfied the row is available.
 	 *
 	 * Positive-entitlement is asserted on the self-hosted flavor only. On
-	 * WordPress.com Atomic (wpcomsh) `ai-seo-enhancer` is a registered wpcom
+	 * WordPress.com Atomic (wpcomsh) `advanced-seo` is a registered wpcom
 	 * feature, so Current_Plan::supports() resolves it through the real
 	 * wpcom_site_has_feature() purchase lookup rather than the
 	 * `jetpack_active_plan` filter set here; forcing a matching purchase would
-	 * couple this test to wpcomsh's purchase schema. The three unavailable
-	 * cases below still run on both flavors, and the unentitled path — the one
-	 * a self-hosted site without the feature actually hits — is covered by
-	 * test_seo_row_unavailable_when_plan_lacks_feature everywhere.
+	 * couple this test to wpcomsh's purchase schema. The two unavailable cases
+	 * below still run on both flavors.
 	 */
 	public function test_seo_row_available_when_all_inputs_true() {
 		if ( getenv( 'JETPACK_TEST_WPCOMSH' ) ) {
@@ -264,18 +262,18 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	}
 
 	/**
-	 * Input 3 falsified alone: the plan does not grant `ai-seo-enhancer`.
-	 *
-	 * This is the branch a free site lands on, and the one that hides the row
-	 * on an unentitled site with SEO tools switched on.
+	 * Input 3 on a free plan: the row follows `advanced-seo`, which sits in the
+	 * free plan's supports list, so it is offered wherever SEO tools run. The
+	 * row governs user-initiated suggestions as well as automatic generation,
+	 * and only the automatic half needs the higher `ai-seo-enhancer` tier.
 	 */
-	public function test_seo_row_unavailable_when_plan_lacks_feature() {
+	public function test_seo_row_available_on_a_free_plan() {
 		wp_set_current_user( self::$admin_id );
 
 		self::set_seo_tools_active( true );
 		self::set_plan( 'jetpack_free' );
 
-		$this->assertFalse( $this->get_seo_available() );
+		$this->assertTrue( $this->get_seo_available() );
 	}
 
 	/**
@@ -336,6 +334,9 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 		wp_set_current_user( self::$admin_id );
 		self::connect_owner();
 		self::set_ai_module_active( true );
+
+		// The owned toggles only apply on internal testing environments.
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		update_option( Jetpack_AI_Settings::FEATURE_OPTIONS['image_editor'], false );
 
@@ -437,7 +438,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 		$this->assertArrayNotHasKey( 'excerpt', $features );
 		$this->assertTrue( $features['ai_seo']['enabled'] );
 		// The automatic-generation option keeps its own surfaces; the settings
-		// page only carries the SEO feature row.
+		// page only carries the AI SEO row.
 		$this->assertArrayNotHasKey( 'seo_enhancer', $features );
 		$this->assertFalse( $features['ai_search']['enabled'] );
 		// No paid Search product in the test environment.
@@ -561,15 +562,17 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	public function test_post_partial_update() {
 		wp_set_current_user( self::$admin_id );
 
+		// The owned toggles only apply on internal testing environments.
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
 		$data = $this->dispatch(
 			'POST',
 			array(
 				'features' => array(
 					'writing_assistant' => false,
 					'ai_seo'            => false,
-					// Still writable for the auto option, though no longer echoed.
+					// A stale client may still send removed keys. They are ignored.
 					'seo_enhancer'      => array( 'enabled' => true ),
-					// A stale client may still send the removed excerpt key. It is ignored.
 					'excerpt'           => false,
 				),
 			)
@@ -583,7 +586,10 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 		// The options actually changed — this is what the load points read.
 		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' ) );
 		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'ai_seo' ) );
-		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' ) );
+
+		// The automatic-generation option is owned by the Traffic page and the SEO
+		// dashboard: this endpoint no longer writes it.
+		$this->assertFalse( (bool) get_option( 'ai_seo_enhancer_enabled', false ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
@@ -195,12 +195,12 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	}
 
 	/**
-	 * Read `features.seo_enhancer.available` off a fresh GET.
+	 * Read `features.seo.available` off a fresh GET.
 	 *
 	 * @return bool
 	 */
-	private function get_seo_enhancer_available() {
-		return $this->dispatch( 'GET' )->get_data()['features']['seo_enhancer']['available'];
+	private function get_seo_available() {
+		return $this->dispatch( 'GET' )->get_data()['features']['ai_seo']['available'];
 	}
 
 	/**
@@ -215,9 +215,9 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	 * couple this test to wpcomsh's purchase schema. The three unavailable
 	 * cases below still run on both flavors, and the unentitled path — the one
 	 * a self-hosted site without the feature actually hits — is covered by
-	 * test_seo_enhancer_unavailable_when_plan_lacks_feature everywhere.
+	 * test_seo_row_unavailable_when_plan_lacks_feature everywhere.
 	 */
-	public function test_seo_enhancer_available_when_all_inputs_true() {
+	public function test_seo_row_available_when_all_inputs_true() {
 		if ( getenv( 'JETPACK_TEST_WPCOMSH' ) ) {
 			$this->markTestSkipped( 'Entitlement resolves through the wpcom purchase gate on Atomic; the positive case is covered on the self-hosted flavor.' );
 		}
@@ -228,20 +228,20 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 		self::set_seo_tools_active( true );   // 2.
 		self::set_plan( 'jetpack_business' ); // 3.
 
-		$this->assertTrue( $this->get_seo_enhancer_available() );
+		$this->assertTrue( $this->get_seo_available() );
 	}
 
 	/**
 	 * Input 1 falsified alone: the `ai_seo_enhancer_enabled` kill switch is off.
 	 */
-	public function test_seo_enhancer_unavailable_when_filter_off() {
+	public function test_seo_row_unavailable_when_filter_off() {
 		wp_set_current_user( self::$admin_id );
 
 		self::set_seo_tools_active( true );
 		self::set_plan( 'jetpack_business' );
 		add_filter( 'ai_seo_enhancer_enabled', '__return_false' );
 
-		$this->assertFalse( $this->get_seo_enhancer_available() );
+		$this->assertFalse( $this->get_seo_available() );
 	}
 
 	/**
@@ -253,13 +253,13 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	 * therefore covers the self-hosted and Atomic paths only; it is not a claim
 	 * about Simple.
 	 */
-	public function test_seo_enhancer_unavailable_when_module_inactive() {
+	public function test_seo_row_unavailable_when_module_inactive() {
 		wp_set_current_user( self::$admin_id );
 
 		self::set_seo_tools_active( false );
 		self::set_plan( 'jetpack_business' );
 
-		$this->assertFalse( $this->get_seo_enhancer_available() );
+		$this->assertFalse( $this->get_seo_available() );
 	}
 
 	/**
@@ -268,13 +268,13 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	 * This is the branch a free site lands on, and the one that hides the row
 	 * on an unentitled site with SEO tools switched on.
 	 */
-	public function test_seo_enhancer_unavailable_when_plan_lacks_feature() {
+	public function test_seo_row_unavailable_when_plan_lacks_feature() {
 		wp_set_current_user( self::$admin_id );
 
 		self::set_seo_tools_active( true );
 		self::set_plan( 'jetpack_free' );
 
-		$this->assertFalse( $this->get_seo_enhancer_available() );
+		$this->assertFalse( $this->get_seo_available() );
 	}
 
 	/**
@@ -431,7 +431,10 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 		$this->assertArrayNotHasKey( 'sub', $features['image_editor'] );
 		$this->assertArrayNotHasKey( 'image_label', $features );
 		$this->assertArrayNotHasKey( 'excerpt', $features );
-		$this->assertFalse( $features['seo_enhancer']['enabled'] );
+		$this->assertTrue( $features['ai_seo']['enabled'] );
+		// The automatic-generation option keeps its own surfaces; the settings
+		// page only carries the SEO feature row.
+		$this->assertArrayNotHasKey( 'seo_enhancer', $features );
 		$this->assertFalse( $features['ai_search']['enabled'] );
 		// No paid Search product in the test environment.
 		$this->assertTrue( $features['ai_search']['requires_upgrade'] );
@@ -559,6 +562,8 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 			array(
 				'features' => array(
 					'writing_assistant' => false,
+					'ai_seo'            => false,
+					// Still writable for the auto option, though no longer echoed.
 					'seo_enhancer'      => array( 'enabled' => true ),
 					// A stale client may still send the removed excerpt key. It is ignored.
 					'excerpt'           => false,
@@ -567,12 +572,13 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 		)->get_data();
 
 		$this->assertFalse( $data['features']['writing_assistant']['enabled'] );
-		$this->assertTrue( $data['features']['seo_enhancer']['enabled'] );
+		$this->assertFalse( $data['features']['ai_seo']['enabled'] );
 		// Untouched keys keep their defaults.
 		$this->assertTrue( $data['features']['image_editor']['enabled'] );
 
 		// The options actually changed — this is what the load points read.
 		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' ) );
+		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'ai_seo' ) );
 		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' ) );
 	}
 

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
@@ -82,6 +82,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	 * Reset the options and filters this test touches.
 	 */
 	public function tear_down() {
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		delete_option( Jetpack_AI_Settings::MASTER_OPTION );
 		foreach ( Jetpack_AI_Settings::FEATURE_OPTIONS as $option ) {
 			delete_option( $option );
@@ -316,6 +317,9 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	public function test_feature_clip_unavailable_when_environment_gate_fails() {
 		wp_set_current_user( self::$admin_id );
 		self::connect_owner();
+
+		// Master enforcement only runs on internal testing environments.
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		// Off-Simple the master is the `ai` module; turn it off.
 		self::set_ai_module_active( false );
@@ -588,6 +592,9 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	 */
 	public function test_post_master_switch() {
 		wp_set_current_user( self::$admin_id );
+
+		// Master enforcement only runs on internal testing environments.
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		// Off-Simple the master is the `ai` module; start it active so the write
 		// actually flips state and we exercise the setter's module routing.

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_Assistant_Block_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_Assistant_Block_Test.php
@@ -31,6 +31,11 @@ class AI_Assistant_Block_Test extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		// The AI controls only take effect on internal testing environments while
+		// they are unlaunched. These tests are about what the toggles do, so put
+		// the suite where they apply; the scoping itself is pinned in
+		// Jetpack_AI_Settings_Test.
+		$this->force_master_enforcement_for_test();
 
 		Jetpack_Gutenberg::reset();
 		add_filter( 'jetpack_offline_mode', '__return_false' );
@@ -53,6 +58,7 @@ class AI_Assistant_Block_Test extends WP_UnitTestCase {
 	 * Clean up after each test.
 	 */
 	public function tear_down() {
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		if ( Blocks::is_registered( self::BLOCK_NAME ) ) {
 			unregister_block_type( self::BLOCK_NAME );
 		}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_Assistant_Block_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_Assistant_Block_Test.php
@@ -61,6 +61,7 @@ class AI_Assistant_Block_Test extends WP_UnitTestCase {
 		}
 
 		$this->deactivate_ai_module_for_test();
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		delete_option( 'jetpack_ai_enabled' );
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
 		delete_option( 'jetpack_ai_image_editor_enabled' );
@@ -100,6 +101,7 @@ class AI_Assistant_Block_Test extends WP_UnitTestCase {
 	 */
 	public function test_block_and_extensions_not_registered_when_master_disabled() {
 		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->force_master_enforcement_for_test();
 		$this->deactivate_ai_module_for_test();
 
 		AIAssistant\register_block();

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/ai-chat/AI_Chat_Block_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/ai-chat/AI_Chat_Block_Test.php
@@ -60,6 +60,7 @@ class AI_Chat_Block_Test extends \WP_UnitTestCase {
 		}
 
 		$this->deactivate_ai_module_for_test();
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		remove_filter( 'jetpack_ai_enabled', '__return_false' );
 		remove_filter( 'jetpack_offline_mode', '__return_false' );
 		delete_option( 'jetpack_ai_enabled' );
@@ -111,6 +112,7 @@ class AI_Chat_Block_Test extends \WP_UnitTestCase {
 	 */
 	public function test_not_registered_when_master_option_off() {
 		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->force_master_enforcement_for_test();
 		$this->deactivate_ai_module_for_test();
 
 		AIChat\register_block();

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/AI_Assistant_Plugin_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/AI_Assistant_Plugin_Test.php
@@ -32,6 +32,7 @@ class AI_Assistant_Plugin_Test extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		$this->deactivate_ai_module_for_test();
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		unregister_setting( 'general', 'jetpack_ai_agents_enabled' );
 		Constants::clear_single_constant( 'IS_WPCOM' );
 
@@ -161,6 +162,7 @@ class AI_Assistant_Plugin_Test extends WP_UnitTestCase {
 		$this->reset_availability();
 		$this->simulate_connected_owner();
 		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->force_master_enforcement_for_test();
 		$this->deactivate_ai_module_for_test();
 
 		AiAssistantPlugin\register_plugin();

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/AI_Assistant_Plugin_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/AI_Assistant_Plugin_Test.php
@@ -22,6 +22,11 @@ class AI_Assistant_Plugin_Test extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		// The AI controls only take effect on internal testing environments while
+		// they are unlaunched. These tests are about what the toggles do, so put
+		// the suite where they apply; the scoping itself is pinned in
+		// Jetpack_AI_Settings_Test.
+		$this->force_master_enforcement_for_test();
 		// Off-Simple the `ai` module is the AI master switch; activate it so the
 		// legacy panel's jetpack_ai_enabled gate reads on.
 		$this->activate_ai_module_for_test();
@@ -31,6 +36,7 @@ class AI_Assistant_Plugin_Test extends WP_UnitTestCase {
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		$this->deactivate_ai_module_for_test();
 		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		unregister_setting( 'general', 'jetpack_ai_agents_enabled' );

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-content-lens/AI_Content_Lens_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-content-lens/AI_Content_Lens_Test.php
@@ -25,6 +25,11 @@ class AI_Content_Lens_Test extends \WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		// The AI controls only take effect on internal testing environments while
+		// they are unlaunched. These tests are about what the toggles do, so put
+		// the suite where they apply; the scoping itself is pinned in
+		// Jetpack_AI_Settings_Test.
+		$this->force_master_enforcement_for_test();
 		$this->reset_availability();
 		$this->simulate_connected_owner();
 		// Off-Simple the `ai` module is the AI master switch; activate it so the
@@ -36,6 +41,7 @@ class AI_Content_Lens_Test extends \WP_UnitTestCase {
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		$this->deactivate_ai_module_for_test();
 		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		remove_filter( 'jetpack_ai_enabled', '__return_false' );

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-content-lens/AI_Content_Lens_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-content-lens/AI_Content_Lens_Test.php
@@ -37,6 +37,7 @@ class AI_Content_Lens_Test extends \WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		$this->deactivate_ai_module_for_test();
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		remove_filter( 'jetpack_ai_enabled', '__return_false' );
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
 		delete_option( 'jetpack_ai_enabled' );
@@ -90,6 +91,7 @@ class AI_Content_Lens_Test extends \WP_UnitTestCase {
 	 */
 	public function test_not_registered_when_master_option_off() {
 		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->force_master_enforcement_for_test();
 		$this->deactivate_ai_module_for_test();
 
 		Content_Lens\register_plugin();

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -699,7 +699,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 	/**
 	 * Master interplay, both directions. The master gate keeps flowing through
-	 * apply_site_wide_gates on the jetpack_ai_sidebar_enabled filter (re-attached
+	 * apply_master_gates on the jetpack_ai_sidebar_enabled filter (re-attached
 	 * here because set_up() strips the filter): master off hides the sidebar
 	 * regardless of the feature toggles, and master on cannot save a sidebar
 	 * whose features are both off.
@@ -707,7 +707,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_preview_master_gate_composes_with_feature_toggles() {
 		// Run the master gate after set_up()'s __return_true override so it
 		// narrows the forced-open base gate, as it does in production.
-		add_filter( 'jetpack_ai_sidebar_enabled', array( \Jetpack_AI_Settings::class, 'apply_site_wide_gates' ), 11 );
+		add_filter( 'jetpack_ai_sidebar_enabled', array( \Jetpack_AI_Settings::class, 'apply_master_gates' ), 11 );
 
 		// Master off + features on: hidden (existing rule, no regression).
 		// Off-Simple the master is the `ai` module; turn it off there.

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -95,6 +95,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		delete_option( 'big_sky_enable' );
 		delete_option( \Jetpack_AI_Settings::MASTER_OPTION );
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 		delete_option( 'ai_seo_enhancer_enabled' );
 		Constants::clear_single_constant( 'IS_WPCOM' );
 		Constants::clear_single_constant( 'ATOMIC_SITE_ID' );
@@ -546,12 +547,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		foreach ( $combinations as list( $writing, $seo, $expected ) ) {
 			update_option( 'jetpack_ai_writing_assistant_enabled', $writing );
-			update_option( 'ai_seo_enhancer_enabled', $seo );
+			update_option( 'jetpack_ai_seo_enabled', $seo );
 
 			$open = $this->gate_open();
 
 			delete_option( 'jetpack_ai_writing_assistant_enabled' );
-			delete_option( 'ai_seo_enhancer_enabled' );
+			delete_option( 'jetpack_ai_seo_enabled' );
 
 			$this->assertSame(
 				$expected,
@@ -569,12 +570,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_preview_stays_open_on_simple_even_with_every_toggle_off() {
 		$this->simulate_wpcom_simple();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 0 );
+		update_option( 'jetpack_ai_seo_enabled', 0 );
 
 		$open = $this->gate_open();
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertTrue(
 			$open,
@@ -588,12 +589,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_preview_disabled_when_seo_enhancer_cannot_run() {
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 1 );
+		update_option( 'jetpack_ai_seo_enabled', 1 );
 
 		$open = $this->gate_open();
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertFalse( $open, 'A switched-on SEO enhancer whose seo-tools module is inactive must not hold the sidebar open.' );
 	}
@@ -605,13 +606,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_preview_disabled_when_seo_tools_are_disabled_by_filter() {
 		$this->activate_seo_tools_module();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 1 );
+		update_option( 'jetpack_ai_seo_enabled', 1 );
 		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
 
 		$open = $this->gate_open();
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertFalse( $open, 'A site whose SEO is owned by another plugin must not get a sidebar holding only SEO suggestions.' );
 	}
@@ -622,31 +623,33 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_preview_enabled_when_writing_on_regardless_of_seo() {
 		update_option( 'jetpack_ai_writing_assistant_enabled', 1 );
-		update_option( 'ai_seo_enhancer_enabled', 0 );
+		update_option( 'jetpack_ai_seo_enabled', 0 );
 		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
 
 		$open = $this->gate_open();
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertTrue( $open, 'The writing assistant alone should keep the sidebar available whatever the SEO state.' );
 	}
 
 	/**
-	 * On an untouched site the SEO enhancer option is absent and defaults off,
-	 * so turning the writing assistant off alone hides the sidebar. This is the
-	 * agreed behavior, not an accident — pinned here on purpose.
+	 * On an untouched site the SEO feature option is absent and defaults on,
+	 * so with SEO tools usable the sidebar survives the writing assistant
+	 * being switched off. The default flip from the automatic-generation
+	 * option (off) to the feature option (on) is deliberate — pinned on purpose.
 	 */
-	public function test_preview_disabled_when_writing_off_and_seo_option_absent() {
-		delete_option( 'ai_seo_enhancer_enabled' );
+	public function test_preview_stays_open_when_writing_off_and_seo_option_absent() {
+		$this->activate_seo_tools_module();
+		delete_option( 'jetpack_ai_seo_enabled' );
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
 
 		$open = $this->gate_open();
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
 
-		$this->assertFalse( $open, 'Writing off with SEO at its default (off) should hide the sidebar.' );
+		$this->assertTrue( $open, 'Writing off with SEO at its default (on) keeps the sidebar while SEO tools are usable.' );
 	}
 
 	/**
@@ -658,13 +661,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_preview_disabled_when_seo_filter_kills_enabled_option() {
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 1 );
+		update_option( 'jetpack_ai_seo_enabled', 1 );
 		add_filter( 'ai_seo_enhancer_enabled', '__return_false' );
 
 		$open = $this->gate_open();
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertFalse( $open, 'A filter-killed SEO enhancer must not hold the sidebar open when writing is off.' );
 	}
@@ -677,13 +680,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_preview_stays_disabled_when_late_filter_forces_on() {
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 0 );
+		update_option( 'jetpack_ai_seo_enabled', 0 );
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true', 999 );
 
 		$open = $this->gate_open();
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertFalse( $open, 'A late jetpack_ai_sidebar_enabled filter must not resurrect a featureless sidebar.' );
 	}
@@ -704,13 +707,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		// Off-Simple the master is the `ai` module; turn it off there.
 		$this->deactivate_ai_module_for_test();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 1 );
-		update_option( 'ai_seo_enhancer_enabled', 1 );
+		update_option( 'jetpack_ai_seo_enabled', 1 );
 		$master_off_features_on = $this->gate_open();
 
 		// Master on + both features off: hidden (the new rule).
 		$this->activate_ai_module_for_test();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 0 );
+		update_option( 'jetpack_ai_seo_enabled', 0 );
 		$master_on_features_off = $this->gate_open();
 
 		// Master on + a feature on: shown (sanity).
@@ -718,7 +721,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$master_on_writing_on = $this->gate_open();
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertFalse( $master_off_features_on, 'Master off must hide the sidebar even with features on.' );
 		$this->assertFalse( $master_on_features_off, 'Master on must not save a sidebar whose features are both off.' );
@@ -754,12 +757,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_init_does_nothing_when_sidebar_features_are_off() {
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 0 );
+		update_option( 'jetpack_ai_seo_enabled', 0 );
 
 		Jetpack_AI_Sidebar::init();
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertFalse(
 			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
@@ -812,7 +815,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->set_block_editor_screen();
 		$this->activate_seo_tools_module();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 1 );
+		update_option( 'jetpack_ai_seo_enabled', 1 );
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			static function ( $features ) {
@@ -824,7 +827,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$enabled = Jetpack_AI_Sidebar::is_toolbar_button_enabled();
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertFalse( $enabled );
 	}
@@ -934,12 +937,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->enable_sidebar_extension_availability_checks();
 		$this->activate_seo_tools_module();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 1 );
+		update_option( 'jetpack_ai_seo_enabled', 1 );
 
 		Jetpack_AI_Sidebar::register_toolbar_button_extension();
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ) );
 		$availability = \Jetpack_Gutenberg::get_availability()[ AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ];
@@ -1093,24 +1096,61 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 	/**
 	 * Released suggestions are exposed to eligible users. The test plan supports
-	 * advanced-seo, the seo-tools module is activated, and the SEO enhancer
-	 * toggle from the AI settings page is switched on (it defaults off) so the
-	 * SEO suggestions gate is satisfied.
+	 * advanced-seo, the seo-tools module is activated, and the SEO feature
+	 * toggle from the AI settings page is switched on so the SEO suggestions
+	 * gate is satisfied.
 	 */
 	public function test_add_agents_manager_data_exposes_released_features() {
 		$this->set_block_editor_screen();
 		$this->activate_seo_tools_module();
-		update_option( 'ai_seo_enhancer_enabled', 1 );
+		update_option( 'jetpack_ai_seo_enabled', 1 );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['generateFeedback'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['proofreadContent'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
+	}
+
+	/**
+	 * The automatic-generation option no longer gates the sidebar's
+	 * user-initiated SEO suggestions: those follow the SEO feature option.
+	 */
+	public function test_add_agents_manager_data_seo_suggestions_survive_auto_option_off() {
+		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->activate_seo_tools_module();
+		update_option( 'ai_seo_enhancer_enabled', 0 );
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
+
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['proofreadContent'] );
+	}
+
+	/**
+	 * The SEO feature option is the listed control for the sidebar's
+	 * user-initiated SEO suggestions: switched off, they leave the payload
+	 * while the sidebar itself stays available through the writing assistant.
+	 */
+	public function test_add_agents_manager_data_seo_suggestions_follow_seo_option() {
+		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->activate_seo_tools_module();
+		update_option( 'jetpack_ai_seo_enabled', 0 );
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
+
+		delete_option( 'jetpack_ai_seo_enabled' );
+
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['proofreadContent'] );
 	}
 
 	/**
@@ -1128,12 +1168,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->set_block_editor_screen();
 		$this->activate_seo_tools_module();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 1 );
+		update_option( 'jetpack_ai_seo_enabled', 1 );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['proofreadContent'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
@@ -1155,7 +1195,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->activate_seo_tools_module();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 1 );
+		update_option( 'jetpack_ai_seo_enabled', 1 );
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			function ( $features ) {
@@ -1167,7 +1207,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['blockTransformations'] );
 	}
@@ -1182,7 +1222,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->activate_seo_tools_module();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 1 );
+		update_option( 'jetpack_ai_seo_enabled', 1 );
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			function ( $features ) {
@@ -1194,7 +1234,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 	}
@@ -1208,11 +1248,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->set_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->activate_seo_tools_module();
-		update_option( 'ai_seo_enhancer_enabled', 0 );
+		update_option( 'jetpack_ai_seo_enabled', 0 );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
-		delete_option( 'ai_seo_enhancer_enabled' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['proofreadContent'] );

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -80,6 +80,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		$this->deactivate_ai_module_for_test();
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		delete_transient( AiAssistantPlugin\AI_SIDEBAR_ASSET_TRANSIENT );
 		$this->reset_sidebar_hooks();
 		remove_all_filters( 'pre_http_request' );
@@ -693,7 +694,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 	/**
 	 * Master interplay, both directions. The master gate keeps flowing through
-	 * apply_master_gates on the jetpack_ai_sidebar_enabled filter (re-attached
+	 * apply_site_wide_gates on the jetpack_ai_sidebar_enabled filter (re-attached
 	 * here because set_up() strips the filter): master off hides the sidebar
 	 * regardless of the feature toggles, and master on cannot save a sidebar
 	 * whose features are both off.
@@ -701,10 +702,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_preview_master_gate_composes_with_feature_toggles() {
 		// Run the master gate after set_up()'s __return_true override so it
 		// narrows the forced-open base gate, as it does in production.
-		add_filter( 'jetpack_ai_sidebar_enabled', array( \Jetpack_AI_Settings::class, 'apply_master_gates' ), 11 );
+		add_filter( 'jetpack_ai_sidebar_enabled', array( \Jetpack_AI_Settings::class, 'apply_site_wide_gates' ), 11 );
 
 		// Master off + features on: hidden (existing rule, no regression).
 		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->force_master_enforcement_for_test();
 		$this->deactivate_ai_module_for_test();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 1 );
 		update_option( 'jetpack_ai_seo_enabled', 1 );
@@ -736,6 +738,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_init_does_nothing_when_master_off_despite_late_filter() {
 		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->force_master_enforcement_for_test();
 		$this->deactivate_ai_module_for_test();
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true', 999 );
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -68,6 +68,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		// Off-Simple the `ai` module is the AI master switch; activate it so the
 		// AI-features gate behind these surfaces reads on.
 		$this->activate_ai_module_for_test();
+		// The AI controls only take effect on internal testing environments while
+		// they are unlaunched. These tests are about what the toggles do, so put
+		// the suite where they apply; the scoping itself is pinned in
+		// Jetpack_AI_Settings_Test.
+		$this->force_master_enforcement_for_test();
 		// Enable the sidebar by default via the override filter so the behaviour
 		// tests exercise the downstream wiring. has_ai_features() stays on the
 		// self-hosted connection path. The wpcom/Big Sky gating itself is covered

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -569,7 +569,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that a later jetpack_ai_enabled filter cannot re-enable Image Studio
 	 * once the master switch is off — the contract's "off must stay off" state
-	 * test. This is why the environment gate calls apply_site_wide_gates() directly
+	 * test. This is why the environment gate calls apply_master_gates() directly
 	 * instead of re-applying the filter: apply_filters() would let any
 	 * later-priority callback overturn the master switch.
 	 */

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -64,6 +64,11 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		// The AI controls only take effect on internal testing environments while
+		// they are unlaunched. These tests are about what the toggles do, so put
+		// the suite where they apply; the scoping itself is pinned in
+		// Jetpack_AI_Settings_Test.
+		$this->force_master_enforcement_for_test();
 		delete_transient( ImageStudio\ASSET_TRANSIENT );
 		$this->saved_wp_scripts = $GLOBALS['wp_scripts'] ?? null;
 		$this->saved_wp_styles  = $GLOBALS['wp_styles'] ?? null;
@@ -85,6 +90,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		$this->deactivate_ai_module_for_test();
 		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		delete_transient( ImageStudio\ASSET_TRANSIENT );

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -86,6 +86,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		$this->deactivate_ai_module_for_test();
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		delete_transient( ImageStudio\ASSET_TRANSIENT );
 		remove_all_filters( 'jetpack_image_studio_enabled' );
 		remove_all_filters( 'jetpack_image_studio_can_generate_video_clips' );
@@ -524,6 +525,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 */
 	public function test_master_option_off_disables_image_studio() {
 		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->force_master_enforcement_for_test();
 		$this->deactivate_ai_module_for_test();
 
 		$this->assertFalse( ImageStudio\is_image_studio_enabled() );
@@ -537,6 +539,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$this->assertTrue( ImageStudio\is_image_studio_enabled() );
 
 		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->force_master_enforcement_for_test();
 		$this->deactivate_ai_module_for_test();
 		$this->set_block_editor_screen();
 		ImageStudio\register_plugin();
@@ -560,13 +563,14 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	/**
 	 * Test that a later jetpack_ai_enabled filter cannot re-enable Image Studio
 	 * once the master switch is off — the contract's "off must stay off" state
-	 * test. This is why the environment gate calls apply_master_gates() directly
+	 * test. This is why the environment gate calls apply_site_wide_gates() directly
 	 * instead of re-applying the filter: apply_filters() would let any
 	 * later-priority callback overturn the master switch.
 	 */
 	public function test_master_off_cannot_be_reenabled_by_late_filter() {
 		$this->enable_big_sky();
 		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->force_master_enforcement_for_test();
 		$this->deactivate_ai_module_for_test();
 		add_filter( 'jetpack_ai_enabled', '__return_true', 99 );
 

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
@@ -389,25 +389,76 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Per-feature defaults: the new toggles default on; the reused SEO/Search
-	 * options keep their established opt-in (off) defaults; unknown keys are off.
+	 * Per-feature defaults: the new toggles default on; the reused Search option
+	 * keeps its established opt-in (off) default; unknown keys are off.
 	 */
 	public function test_feature_defaults() {
 		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' ) );
 		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'image_editor' ) );
 		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'ai_seo' ) );
-		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' ) );
 		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'ai_search' ) );
+		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' ), 'The automatic-generation option is not a key here.' );
 		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'no_such_feature' ) );
+	}
+
+	/**
+	 * The controls this class owns are not publicly launched, so a stored-off
+	 * toggle is inert outside internal testing environments: the feature keeps
+	 * the behavior the released version has.
+	 */
+	public function test_owned_toggles_are_inert_outside_internal_testing() {
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'jetpack_ai_image_editor_enabled', 0 );
+		update_option( 'jetpack_ai_feature_clip_enabled', 0 );
+		update_option( 'jetpack_ai_seo_enabled', 0 );
+
+		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' ) );
+		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'image_editor' ) );
+		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'feature_clip' ) );
+		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'ai_seo' ) );
+	}
+
+	/**
+	 * On an internal testing environment the same stored values apply, so the
+	 * settings page can be exercised end to end there.
+	 */
+	public function test_owned_toggles_apply_on_internal_testing() {
+		$this->force_internal_testing_env();
+
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'jetpack_ai_image_editor_enabled', 0 );
+		update_option( 'jetpack_ai_feature_clip_enabled', 0 );
+		update_option( 'jetpack_ai_seo_enabled', 0 );
+
+		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' ) );
+		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'image_editor' ) );
+		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'feature_clip' ) );
+		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'ai_seo' ) );
+	}
+
+	/**
+	 * The reused Search option is not one of the controls this class owns: it
+	 * ships today with its own settings surface, so it applies everywhere and
+	 * the rollout scoping must not touch it.
+	 */
+	public function test_reused_toggles_apply_outside_internal_testing() {
+		update_option( 'jetpack_search_ai_answers_enabled', 1 );
+
+		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'ai_search' ) );
+
+		update_option( 'jetpack_search_ai_answers_enabled', 0 );
+
+		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'ai_search' ) );
 	}
 
 	/**
 	 * The SEO feature (AI SEO metadata generation, manual and automatic) is a
 	 * listed control: its own option switches it off while every outer gate is
-	 * open.
+	 * open. Internal testing environment, where the owned toggles apply.
 	 */
 	public function test_seo_feature_follows_its_option() {
 		$this->force_ai_module_active();
+		$this->force_internal_testing_env();
 
 		$this->assertTrue( Jetpack_AI_Settings::is_ai_seo_enabled(), 'Defaults on with every gate open.' );
 
@@ -469,9 +520,11 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * A feature's option turns it off.
+	 * A feature's option turns it off where the owned toggles apply.
 	 */
 	public function test_feature_option_off() {
+		$this->force_internal_testing_env();
+
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
 
 		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' ) );
@@ -508,23 +561,22 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 		update_option( 'ai_seo_enhancer_enabled', 0 );
 		update_option( 'jetpack_search_ai_answers_enabled', 0 );
 
-		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' ) );
 		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'ai_search' ) );
 
 		// ...and on must stay on, so the value is genuinely read rather than
 		// hardcoded in either direction.
-		update_option( 'ai_seo_enhancer_enabled', 1 );
 		update_option( 'jetpack_search_ai_answers_enabled', 1 );
 
-		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' ) );
 		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'ai_search' ) );
 	}
 
 	/**
-	 * Off Simple the same option still switches the feature off.
+	 * Off Simple the same option still switches the feature off, where the
+	 * owned toggles apply.
 	 */
 	public function test_owned_features_honor_their_option_off_wpcom_simple() {
 		Constants::set_constant( 'IS_WPCOM', false );
+		$this->force_internal_testing_env();
 
 		update_option( 'jetpack_ai_image_editor_enabled', 0 );
 

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
@@ -88,7 +88,7 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 * Loading the settings class registers every master-gate filter.
 	 */
 	public function test_class_self_initializes_on_load() {
-		$callback = array( Jetpack_AI_Settings::class, 'apply_site_wide_gates' );
+		$callback = array( Jetpack_AI_Settings::class, 'apply_master_gates' );
 
 		$this->assertNotFalse( has_filter( 'jetpack_ai_enabled', $callback ) );
 		$this->assertNotFalse( has_filter( 'jetpack_search_ai_answers_enabled', $callback ) );

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
@@ -49,9 +49,19 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Master enforcement only runs on internal testing environments while the
+	 * AI controls are not publicly launched. The predicate treats a proxied
+	 * A8C request as internal, so that is the lever the enforcement tests pull.
+	 */
+	private function force_internal_testing_env() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+	}
+
+	/**
 	 * Reset the options and filters this test touches.
 	 */
 	public function tear_down() {
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		delete_option( Jetpack_AI_Settings::MASTER_OPTION );
 		foreach ( Jetpack_AI_Settings::FEATURE_OPTIONS as $option ) {
 			delete_option( $option );
@@ -78,7 +88,7 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 * Loading the settings class registers every master-gate filter.
 	 */
 	public function test_class_self_initializes_on_load() {
-		$callback = array( Jetpack_AI_Settings::class, 'apply_master_gates' );
+		$callback = array( Jetpack_AI_Settings::class, 'apply_site_wide_gates' );
 
 		$this->assertNotFalse( has_filter( 'jetpack_ai_enabled', $callback ) );
 		$this->assertNotFalse( has_filter( 'jetpack_search_ai_answers_enabled', $callback ) );
@@ -101,9 +111,12 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Master off (off-Simple: the `ai` module inactive) turns off every AI filter
-	 * the settings class guards.
+	 * the settings class guards — on an internal testing environment, where
+	 * master enforcement is live.
 	 */
 	public function test_master_off_disables_ai_filters() {
+		$this->force_internal_testing_env();
+
 		// Off-Simple, the module is the master and is inactive by default here.
 		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled() );
 		$this->assertFalse( apply_filters( 'jetpack_ai_enabled', true ) );
@@ -113,12 +126,58 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Until the AI controls ship publicly, the master gate is waived outside
+	 * internal testing environments: an inactive `ai` module must not turn AI
+	 * off for the public.
+	 */
+	public function test_master_not_enforced_outside_internal_testing_env() {
+		// Plain test env: not internal, module inactive.
+		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled(), 'Precondition: the stored master state reads off.' );
+
+		$this->assertTrue( apply_filters( 'jetpack_ai_enabled', true ) );
+		$this->assertTrue( apply_filters( 'jetpack_search_ai_answers_enabled', true ) );
+		$this->assertTrue( apply_filters( 'jetpack_ai_sidebar_enabled', true ) );
+		$this->assertTrue( apply_filters( 'jetpack_ai_seo_enabled', true ) );
+		$this->assertTrue( Jetpack_AI_Settings::is_ai_enabled() );
+		$this->assertTrue( Jetpack_AI_Settings::is_ai_seo_enabled() );
+	}
+
+	/**
+	 * The waiver covers only the master gate: the host gate (a server-owner
+	 * decision) keeps enforcing everywhere.
+	 */
+	public function test_host_gate_enforced_outside_internal_testing_env() {
+		if ( ! function_exists( 'wp_supports_ai' ) ) {
+			$this->markTestSkipped( 'wp_supports_ai() is not available in this WordPress version.' );
+		}
+
+		add_filter( 'wp_supports_ai', '__return_false' );
+
+		$this->assertFalse( Jetpack_AI_Settings::is_ai_enabled() );
+		$this->assertFalse( Jetpack_AI_Settings::is_ai_seo_enabled() );
+	}
+
+	/**
+	 * The waiver is an off-Simple concern: WordPress.com Simple keeps its
+	 * existing contract, where the master option enforces regardless of the
+	 * internal-testing predicate.
+	 */
+	public function test_master_option_enforced_on_wpcom_simple_regardless_of_env() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		update_option( Jetpack_AI_Settings::MASTER_OPTION, 0 );
+
+		$this->assertFalse( Jetpack_AI_Settings::is_ai_enabled() );
+		$this->assertFalse( Jetpack_AI_Settings::is_ai_seo_enabled() );
+	}
+
+	/**
 	 * The master gate is final in is_ai_enabled(). A callback registered at the
 	 * latest possible priority can override the in-chain gate callback — that
 	 * bypass is exactly why the helper exists — but it must not get past the
 	 * helper's hard AND.
 	 */
 	public function test_is_ai_enabled_master_gate_is_final() {
+		$this->force_internal_testing_env();
 		update_option( Jetpack_AI_Settings::MASTER_OPTION, 0 );
 		add_filter( 'jetpack_ai_enabled', '__return_true', PHP_INT_MAX );
 
@@ -363,6 +422,8 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 * so the choice returns when the master does.
 	 */
 	public function test_seo_feature_master_off_preserves_saved_value() {
+		$this->force_internal_testing_env();
+
 		// Seed off first so the row exists: a write equal to the registered
 		// default is short-circuited by update_option and stores nothing.
 		update_option( 'jetpack_ai_seo_enabled', 0 );
@@ -383,6 +444,7 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 * override the in-chain gate callback, but not the helper's hard AND.
 	 */
 	public function test_seo_feature_late_filter_cannot_beat_master() {
+		$this->force_internal_testing_env();
 		add_filter( 'jetpack_ai_seo_enabled', '__return_true', 999 );
 
 		// Off-Simple the `ai` module is the master and is inactive by default here.

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
@@ -83,6 +83,7 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 		$this->assertNotFalse( has_filter( 'jetpack_ai_enabled', $callback ) );
 		$this->assertNotFalse( has_filter( 'jetpack_search_ai_answers_enabled', $callback ) );
 		$this->assertNotFalse( has_filter( 'jetpack_ai_sidebar_enabled', $callback ) );
+		$this->assertNotFalse( has_filter( 'jetpack_ai_seo_enabled', $callback ) );
 	}
 
 	/**
@@ -108,6 +109,7 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 		$this->assertFalse( apply_filters( 'jetpack_ai_enabled', true ) );
 		$this->assertFalse( apply_filters( 'jetpack_search_ai_answers_enabled', true ) );
 		$this->assertFalse( apply_filters( 'jetpack_ai_sidebar_enabled', true ) );
+		$this->assertFalse( apply_filters( 'jetpack_ai_seo_enabled', true ) );
 	}
 
 	/**
@@ -334,9 +336,74 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	public function test_feature_defaults() {
 		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' ) );
 		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'image_editor' ) );
+		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'ai_seo' ) );
 		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' ) );
 		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'ai_search' ) );
 		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'no_such_feature' ) );
+	}
+
+	/**
+	 * The SEO feature (AI SEO metadata generation, manual and automatic) is a
+	 * listed control: its own option switches it off while every outer gate is
+	 * open.
+	 */
+	public function test_seo_feature_follows_its_option() {
+		$this->force_ai_module_active();
+
+		$this->assertTrue( Jetpack_AI_Settings::is_ai_seo_enabled(), 'Defaults on with every gate open.' );
+
+		update_option( 'jetpack_ai_seo_enabled', 0 );
+
+		$this->assertFalse( Jetpack_AI_Settings::is_ai_seo_enabled() );
+	}
+
+	/**
+	 * The master gate rides the SEO feature filter: master off means the
+	 * feature is effectively off while the saved option value is preserved,
+	 * so the choice returns when the master does.
+	 */
+	public function test_seo_feature_master_off_preserves_saved_value() {
+		// Seed off first so the row exists: a write equal to the registered
+		// default is short-circuited by update_option and stores nothing.
+		update_option( 'jetpack_ai_seo_enabled', 0 );
+		update_option( 'jetpack_ai_seo_enabled', 1 );
+
+		// Off-Simple the `ai` module is the master and is inactive by default here.
+		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled() );
+		$this->assertFalse( Jetpack_AI_Settings::is_ai_seo_enabled(), 'Master off must turn the SEO feature off.' );
+		$this->assertTrue( (bool) get_option( 'jetpack_ai_seo_enabled', false ), 'The saved value must survive the master.' );
+
+		// The saved choice returns when the master does.
+		$this->force_ai_module_active();
+		$this->assertTrue( Jetpack_AI_Settings::is_ai_seo_enabled() );
+	}
+
+	/**
+	 * The gates are final in is_ai_seo_enabled() too: a late-priority filter can
+	 * override the in-chain gate callback, but not the helper's hard AND.
+	 */
+	public function test_seo_feature_late_filter_cannot_beat_master() {
+		add_filter( 'jetpack_ai_seo_enabled', '__return_true', 999 );
+
+		// Off-Simple the `ai` module is the master and is inactive by default here.
+		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled() );
+		$late_filter_wins = Jetpack_AI_Settings::is_ai_seo_enabled();
+
+		remove_filter( 'jetpack_ai_seo_enabled', '__return_true', 999 );
+
+		$this->assertFalse( $late_filter_wins, 'A late filter must not resurrect the SEO feature past the master.' );
+	}
+
+	/**
+	 * On WordPress.com Simple the owned features have no per-feature toggles,
+	 * so a stored off value cannot switch the SEO feature off there.
+	 */
+	public function test_seo_feature_forced_on_for_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		update_option( Jetpack_AI_Settings::MASTER_OPTION, 1 );
+		update_option( 'jetpack_ai_seo_enabled', 0 );
+
+		$this->assertTrue( Jetpack_AI_Settings::is_ai_seo_enabled() );
 	}
 
 	/**
@@ -413,6 +480,7 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 		$this->assertNotContains( 'jetpack_ai_enabled', $whitelist );
 		$this->assertContains( 'jetpack_ai_writing_assistant_enabled', $whitelist );
 		$this->assertContains( 'jetpack_ai_image_editor_enabled', $whitelist );
+		$this->assertContains( 'jetpack_ai_seo_enabled', $whitelist );
 		$this->assertNotContains( 'jetpack_ai_image_label_enabled', $whitelist );
 	}
 
@@ -430,6 +498,7 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'jetpack_ai_enabled', $registered );
 		$this->assertArrayHasKey( 'jetpack_ai_writing_assistant_enabled', $registered );
 		$this->assertArrayHasKey( 'jetpack_ai_image_editor_enabled', $registered );
+		$this->assertArrayHasKey( 'jetpack_ai_seo_enabled', $registered );
 		$this->assertArrayNotHasKey( 'jetpack_ai_image_label_enabled', $registered );
 
 		$this->assertFalse( $registered['jetpack_ai_enabled']['show_in_rest'], 'The master option is never exposed over core settings REST.' );

--- a/projects/plugins/jetpack/tests/php/lib/trait-activates-ai-module.php
+++ b/projects/plugins/jetpack/tests/php/lib/trait-activates-ai-module.php
@@ -64,4 +64,16 @@ trait Activates_Ai_Module {
 		remove_filter( 'jetpack_active_modules', $this->activates_ai_module_filter );
 		$this->activates_ai_module_filter = null;
 	}
+
+	/**
+	 * Master enforcement only runs on internal testing environments while the
+	 * AI controls are gated; tests asserting master-off behavior must opt in.
+	 * The predicate treats a proxied A8C request as internal — callers unset
+	 * $_SERVER['A8C_PROXIED_REQUEST'] in tear_down().
+	 *
+	 * @return void
+	 */
+	protected function force_master_enforcement_for_test() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+	}
 }

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
@@ -280,6 +280,7 @@ class Jetpack_Sync_Options_Test extends Jetpack_Sync_TestBase {
 			'jetpack_ai_writing_assistant_enabled'         => false,
 			'jetpack_ai_image_editor_enabled'              => false,
 			'jetpack_ai_feature_clip_enabled'              => false,
+			'jetpack_ai_seo_enabled'                       => false,
 			'jetpack_ai_agents_enabled'                    => false,
 			'wpcom_classic_early_release'                  => true,
 			'jetpack_newsletters_publishing_default_frequency' => 'weekly',


### PR DESCRIPTION
## Proposed changes

- Add `jetpack_ai_seo_enabled` (feature key ai_seo, default on) as the listed AI SEO feature control — registered, synced, and under the site-wide AI switch (module), with `Jetpack_AI_Settings::is_ai_seo_enabled()` applying the host and master gates as well after the filter chain.
- Update the toggle/option used by the WordPress Agent capabilities "AI SEO" row: replace `ai_seo_enhancer_enabled` with `jetpack_ai_seo_enabled`.
- Update the option gating the AI sidebar's user-initiated SEO suggestions to follow `jetpack_ai_seo_enabled`, leaving `ai_seo_enhancer_enabled` unchanged (governs only automatic generation).
- Scope master-switch enforcement to internal testing environments while its controls remain limited to them: everywhere else the master gate is waived, so public sites keep the released (16.1) behavior until the controls ship. The predicate is per-request, so a proxied a11n sees enforcement the site owner doesn't.
- Scope the owned per-feature toggles (writing assistant, image editor, feature clip, AI SEO) the same way: outside internal testing environments a stored-off value is inert, so public sites keep released behavior. This also closes a gap where the options were writable over core settings REST (`show_in_rest`) before their UI shipped.
- Follow the SEO entitlement for the row and the sidebar (review feedback): `AI_SEO_Enhancer` → `Ai_Seo`, its availability check moves from `ai-seo-enhancer` to `advanced-seo` — the entitlement every surface the row governs actually needs — and the settings endpoint and the sidebar's suggestions now share that one predicate instead of two copies.
- Stop the settings endpoint writing `ai_seo_enhancer_enabled`: the row was rekeyed to `ai_seo`, and the automatic-generation option keeps the Traffic page and the SEO dashboard as its only writers.

## Screenshots

The "AI SEO" row bound to the new option, captured live on a Jurassic Ninja site (1440×900):

| Default (on) | Toggled off |
|---|---|
| ![AI SEO on](https://github.com/Automattic/jetpack/raw/screenshots/add/jetpack-ai-seo-option/hub-ai-seo-on.png) | ![AI SEO off](https://github.com/Automattic/jetpack/raw/screenshots/add/jetpack-ai-seo-option/hub-ai-seo-off.png) |

## Related product discussion/links
* pcO4xN-3ih-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Full manual test runbook (states, per-screen expectations, way in/out commands): 3c54e-pb
* On an internal testing env (JN, or proxied) running this branch, with the `ai` module active — master enforcement only runs there:
* `wp option get jetpack_ai_seo_enabled` reports `1` with no stored row (registered default).
* Open the AI settings page (`wp-admin/admin.php?page=jetpack-ai`, WordPress Agent view): the SEO row shows one "AI SEO" row bound to the new option. Toggle it off and back on; the saved value round-trips.
* With the option off and seo-tools active, `Jetpack_AI_Sidebar::add_agents_manager_data()` reports `seoSuggestions: false` while `proofreadContent` stays true; with the option at its default, suggestions survive `wp option update ai_seo_enhancer_enabled 0`.
* `wp jetpack module deactivate ai`: the hub rows grey out at their saved values, and `Jetpack_AI_Settings::is_ai_seo_enabled()` reads false while the stored option is preserved.
* The same deactivate on a non-internal site (or unproxied) leaves `is_ai_seo_enabled()` true — the master gate is waived outside internal testing environments.
* PHP: `jp docker phpunit jetpack -- --filter='Jetpack_AI_Settings_Test|WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test|Jetpack_AI_Sidebar_Test'` plus `jp test php packages/seo` (the `Ai_Seo` gate). JS: `pnpm run test-gui --testPathPatterns='ai'` in `projects/plugins/jetpack`.
* Editor enforcement (the panel honoring the option) lands in the follow-up PR stacked on this one.

🤖 AI Assisted



