### PR TITLE
Premium Analytics: unify the no-comparison surfaces on one declaration

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1964-report-scope-unification
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1964-report-scope-unification
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Date controls: derive both the comparison control and the comparison params from one declaration per surface, instead of each page answering the same question twice.
+Comment: Unify the no-comparison surfaces on one report-scope declaration. Pure refactor, no behavior change.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1964-report-scope-unification
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1964-report-scope-unification
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Date controls: derive both the comparison control and the comparison params from one declaration per surface, instead of each page answering the same question twice.

--- a/projects/packages/premium-analytics/packages/ui/package.json
+++ b/projects/packages/premium-analytics/packages/ui/package.json
@@ -11,6 +11,7 @@
 		"*.scss"
 	],
 	"dependencies": {
+		"@jetpack-premium-analytics/data": "workspace:*",
 		"@jetpack-premium-analytics/datetime": "workspace:*",
 		"@jetpack-premium-analytics/externals": "workspace:*",
 		"@jetpack-premium-analytics/formatters": "workspace:*",

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
@@ -1,4 +1,4 @@
-import { ReportScopeProvider } from '@jetpack-premium-analytics/routing';
+import { ReportScopeProvider } from '@jetpack-premium-analytics/data';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DateFiltersPanel } from '../date-filters-panel';

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
@@ -1,3 +1,4 @@
+import { ReportScopeProvider } from '@jetpack-premium-analytics/routing';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DateFiltersPanel } from '../date-filters-panel';
@@ -72,6 +73,20 @@ function renderPanel( props: Partial< ComponentProps< typeof DateFiltersPanel > 
 }
 
 describe( 'DateFiltersPanel', () => {
+	// The control follows the surface's declared scope rather than a prop, so a
+	// header can never offer a comparison the widgets below are stripping.
+	it( 'offers the comparison control by default', () => {
+		renderPanel();
+
+		expect( screen.getByRole( 'button', { name: 'Compare' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the comparison control on a surface that offers none', () => {
+		render( <ReportScopeProvider offersComparison={ false }>{ panel() }</ReportScopeProvider> );
+
+		expect( screen.queryByRole( 'button', { name: 'Compare' } ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'publishes the full-labels row width on its root', () => {
 		mockContainerResize();
 		const { container } = renderPanel();

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useReportScope } from '@jetpack-premium-analytics/data';
 import {
 	getQuickSurfacePresets,
 	canStepForward,
@@ -13,7 +14,6 @@ import {
 } from '@jetpack-premium-analytics/datetime';
 import { Stack } from '@jetpack-premium-analytics/externals';
 import { formatDateRangeMinimal } from '@jetpack-premium-analytics/formatters';
-import { useReportScope } from '@jetpack-premium-analytics/routing';
 import { BaseControl } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { flushSync } from '@wordpress/element';

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
@@ -13,6 +13,7 @@ import {
 } from '@jetpack-premium-analytics/datetime';
 import { Stack } from '@jetpack-premium-analytics/externals';
 import { formatDateRangeMinimal } from '@jetpack-premium-analytics/formatters';
+import { useReportScope } from '@jetpack-premium-analytics/routing';
 import { BaseControl } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { flushSync } from '@wordpress/element';
@@ -117,14 +118,6 @@ export type DateFiltersPanelProps = {
 	timeZone: string;
 
 	/**
-	 * Whether to render the period-over-period Compare control. Pages whose
-	 * design has no comparison (the post/email detail page) opt out; their
-	 * widgets ignore comparison params, and hiding the control keeps the UI
-	 * honest about it.
-	 */
-	showComparison?: boolean;
-
-	/**
 	 * Element to measure for the responsive layout instead of the panel's own
 	 * root. Required when the panel sits in a shrink-to-fit slot (e.g. sharing
 	 * a header row with a title): there the root's width follows the panel's
@@ -174,10 +167,16 @@ export function DateFiltersPanel( {
 	onCancel,
 	canApply = true,
 	timeZone,
-	showComparison = true,
 	containerElement,
 	reservedInlineSize = 0,
 }: DateFiltersPanelProps ) {
+	/*
+	 * Read rather than taken as a prop: the same declaration keeps the params
+	 * away from the widgets, so a header can never offer a comparison nothing
+	 * below will read, or hide one the widgets are still fetching.
+	 */
+	const { offersComparison } = useReportScope();
+
 	// Unknown values (e.g. garbage from the URL) become undefined, which
 	// DateRangePopover reads as the custom preset.
 	const validatedPresetId = useMemo( () => {
@@ -434,7 +433,7 @@ export function DateFiltersPanel( {
 
 				{ /* Comparison before the interval: it qualifies the range the
 				     presets just set, while the interval only buckets the charts. */ }
-				{ showComparison && (
+				{ offersComparison && (
 					<BaseControl
 						className="date-filters-panel__comparison"
 						help={ comparisonControlProps.help }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/__tests__/report-page-layout.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/__tests__/report-page-layout.test.tsx
@@ -117,7 +117,10 @@ describe( 'ReportPageLayout', () => {
 		expect( subtitle ).not.toHaveTextContent( /vs\.|Previous period|Previous month/ );
 	} );
 
-	it( 'offers no comparison control, without disturbing the comparison state', () => {
+	// Whether the panel draws the comparison control is the report route's
+	// declared scope, not this layout's business — it only has to leave the
+	// comparison state alone on its way through.
+	it( 'passes the comparison state through without disturbing it', () => {
 		const dateFilters = buildDateFilters();
 
 		render(
@@ -128,7 +131,6 @@ describe( 'ReportPageLayout', () => {
 
 		const panelProps = dateFiltersPanelMock.mock.calls[ 0 ][ 0 ];
 
-		expect( panelProps.showComparison ).toBe( false );
 		expect( panelProps.withIntervalControl ).toBeUndefined();
 
 		// Hidden, not cleared: both ride along for the dashboard.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-layout.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-layout.tsx
@@ -47,7 +47,7 @@ export function ReportPageLayout( { title, dateFilters, tabs, children }: Report
 		<div className={ styles.root }>
 			{ tabs }
 			<SectionHeader title={ title } subtitle={ subtitle }>
-				{ dateFilters ? <DateFiltersPanel { ...dateFilters } showComparison={ false } /> : null }
+				{ dateFilters ? <DateFiltersPanel { ...dateFilters } /> : null }
 			</SectionHeader>
 			<div className={ styles.sections }>{ children }</div>
 		</div>

--- a/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
@@ -34,9 +34,7 @@ jest.mock( '@jetpack-premium-analytics/routing', () => ( {
 } ) );
 
 jest.mock( '@jetpack-premium-analytics/ui', () => ( {
-	DateFiltersPanel: ( { showComparison }: { showComparison?: boolean } ) => (
-		<span>{ showComparison ? 'header offers comparison' : 'header offers no comparison' }</span>
-	),
+	DateFiltersPanel: () => <MockHeaderScopeProbe />,
 	DateIntervalDropdown: () => null,
 	DateYearFilter: () => null,
 	SectionHeader: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
@@ -57,6 +55,21 @@ jest.mock( '@wordpress/components', () => ( {
 jest.mock( '@wordpress/core-data', () => ( { store: {} } ) );
 
 jest.mock( '@wordpress/data', () => ( { useSelect: () => [] } ) );
+
+/**
+ * Reads the scope the dashboard declares, from where the header's date controls
+ * render. Both halves derive from the one declaration, so the header reads it
+ * rather than being handed a prop.
+ *
+ * @return The declared scope, as text.
+ */
+function MockHeaderScopeProbe() {
+	const { offersComparison } = useReportScope();
+
+	return (
+		<span>{ offersComparison ? 'header offers comparison' : 'header offers no comparison' }</span>
+	);
+}
 
 /**
  * Reads the scope the dashboard declares, from where the widgets actually render.

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -189,7 +189,7 @@ function Dashboard(): JSX.Element {
 			 * report pages mount this same panel over records tables, which are
 			 * not, so the control is asked for rather than implied by the props.
 			 */
-			<DateFiltersPanel { ...dateFilters } withIntervalControl showComparison={ showComparison } />
+			<DateFiltersPanel { ...dateFilters } withIntervalControl />
 		);
 
 	return (

--- a/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.test.tsx
@@ -95,31 +95,25 @@ describe( 'usePostDetailTabs', () => {
 		mockRouteSearch = {};
 	} );
 
-	it( 'injects comparison-stripped report params into every layout entry', () => {
+	/*
+	 * The page's no-comparison invariant is declared once by the stage, as a
+	 * report scope, and enforced in `WidgetRoot`. The layout this hook returns
+	 * is the fixed one, carrying no injected report params — see
+	 * `stage.test.tsx` for the scope the widgets actually read.
+	 */
+	it( 'returns the tab’s fixed layout untouched', () => {
 		mockSearch( 'post-traffic' );
 		mockRouteSearch = {
 			from: '2026-07-01',
 			to: '2026-07-07',
-			interval: 'day',
-			post_id: String( POST_ID ),
 			comp: '1',
 			compare_from: '2026-06-24',
-			compare_to: '2026-06-30',
-			compare_preset: 'previous-period',
 		};
 
 		const { result } = renderHook( () => usePostDetailTabs( POST_ID ) );
 
 		expect( result.current.layout.length ).toBeGreaterThan( 0 );
-		for ( const widget of result.current.layout ) {
-			const attributes = widget.attributes as { reportParams?: unknown } | undefined;
-			expect( attributes?.reportParams ).toEqual( {
-				from: '2026-07-01',
-				to: '2026-07-07',
-				interval: 'day',
-				post_id: String( POST_ID ),
-			} );
-		}
+		expect( result.current.layout ).toEqual( POST_DETAIL_TAB_LAYOUTS[ 'post-traffic' ] );
 	} );
 
 	it( 'falls back from a hidden tab and replaces the URL', async () => {
@@ -158,17 +152,7 @@ describe( 'usePostDetailTabs', () => {
 			'email-clicks',
 		] );
 		expect( result.current.activeTab ).toBe( 'email-clicks' );
-		// The hook overlays each fixed entry with the comparison-stripped
-		// reportParams (empty here — the mocked route search is empty).
-		expect( result.current.layout ).toEqual(
-			POST_DETAIL_TAB_LAYOUTS[ 'email-clicks' ].map( widget => ( {
-				...widget,
-				attributes: {
-					...( widget.attributes as Record< string, unknown > | undefined ),
-					reportParams: {},
-				},
-			} ) )
-		);
+		expect( result.current.layout ).toEqual( POST_DETAIL_TAB_LAYOUTS[ 'email-clicks' ] );
 		expect( stage ).not.toHaveBeenCalled();
 		expect( commit ).not.toHaveBeenCalled();
 	} );

--- a/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.ts
@@ -5,12 +5,10 @@ import {
 	useStatsEmailOpensBreakdown,
 	type StatsEmailBreakdown,
 } from '@jetpack-premium-analytics/data';
-import { omitComparisonReportParams } from '@jetpack-premium-analytics/routing';
 /**
  * WordPress dependencies
  */
 import { useEffect, useMemo } from '@wordpress/element';
-import { useSearch } from '@wordpress/route';
 /**
  * Internal dependencies
  */
@@ -80,26 +78,9 @@ export function usePostDetailTabs( postId: number ) {
 		}
 	}, [ canNormalize, storedTab, activeTab, setActiveTab ] );
 
-	/*
-	 * The page has no period-over-period comparison by design, but the
-	 * comparison params stay in the URL so the breadcrumb carries the
-	 * dashboard's state back out. Without explicit `reportParams`, every
-	 * `WidgetRoot` falls back to reading the raw URL search — comparison
-	 * included — so comparison-capable widgets (UTM, highlights) would render
-	 * deltas. Injecting the stripped params into each layout entry makes the
-	 * page-wide no-comparison invariant hold by construction.
-	 */
-	const search = useSearch( { strict: false } ) as Record< string, unknown > | undefined;
-	const layout = useMemo( () => {
-		const reportParams = omitComparisonReportParams( search );
-		return POST_DETAIL_TAB_LAYOUTS[ activeTab ].map( widget => ( {
-			...widget,
-			attributes: {
-				...( widget.attributes as Record< string, unknown > | undefined ),
-				reportParams,
-			},
-		} ) );
-	}, [ activeTab, search ] );
+	// The page's no-comparison invariant is the report scope the stage declares,
+	// so the layout is the tab's fixed one.
+	const layout = POST_DETAIL_TAB_LAYOUTS[ activeTab ];
 
 	return {
 		tabs,

--- a/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
@@ -21,9 +21,7 @@ jest.mock( '@jetpack-premium-analytics/routing', () => ( {
 
 // Avoid loading DataViews while keeping the real breadcrumbs for these assertions.
 jest.mock( '@jetpack-premium-analytics/ui', () => ( {
-	DateFiltersPanel: ( { showComparison }: { showComparison?: boolean } ) => (
-		<div>{ showComparison === false ? 'Date filters without comparison' : 'Date filters' }</div>
-	),
+	DateFiltersPanel: () => <div>Date filters</div>,
 	SectionTabPanel: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
 	StatsBreadcrumbs: jest.requireActual( '../../packages/ui/src/stats-breadcrumbs' )
 		.StatsBreadcrumbs,
@@ -217,14 +215,9 @@ describe( 'post detail stage', () => {
 		expect( screen.queryByRole( 'link', { name: /^View (post|page)$/ } ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders the date filters without the comparison control', () => {
-		mockSummary();
-
-		render( stage() );
-
-		expect( screen.getByText( 'Date filters without comparison' ) ).toBeInTheDocument();
-	} );
-
+	// One declaration drives both halves: the panel reads it to drop the Compare
+	// control (covered in the ui package) and `WidgetRoot` reads it to strip the
+	// params. This asserts the declaration the page makes.
 	it( 'declares no comparison for the widgets it renders', () => {
 		mockSummary();
 

--- a/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
@@ -1,4 +1,4 @@
-import { useReportScope } from '@jetpack-premium-analytics/routing';
+import { useReportScope } from '@jetpack-premium-analytics/data';
 import { render, screen, within } from '@testing-library/react';
 import { usePostSummary } from './hooks';
 import { stage } from './stage';
@@ -7,6 +7,7 @@ import type { ReactNode } from 'react';
 let mockSearch: Record< string, unknown > = {};
 
 jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
 	AnalyticsQueryClientProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
 	GlobalErrorProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
 } ) );

--- a/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
@@ -1,3 +1,4 @@
+import { useReportScope } from '@jetpack-premium-analytics/routing';
 import { render, screen, within } from '@testing-library/react';
 import { usePostSummary } from './hooks';
 import { stage } from './stage';
@@ -55,9 +56,20 @@ jest.mock(
 		)
 );
 
+/**
+ * Reads the scope from where the page's widgets render.
+ *
+ * @return The declared scope, as text.
+ */
+function MockScopeProbe() {
+	const { offersComparison } = useReportScope();
+
+	return <div>{ offersComparison ? 'Post widgets' : 'Post widgets without comparison' }</div>;
+}
+
 jest.mock( '@wordpress/widget-dashboard', () => {
 	const WidgetDashboard = ( { children }: { children: ReactNode } ) => <>{ children }</>;
-	WidgetDashboard.Widgets = () => <div>Post widgets</div>;
+	WidgetDashboard.Widgets = () => <MockScopeProbe />;
 
 	return {
 		WidgetDashboard,
@@ -122,7 +134,8 @@ jest.mock( './components', () => ( {
 jest.mock( './hooks', () => ( {
 	usePostSummary: jest.fn(),
 	usePostDetailTabs: () => ( {
-		tabs: [],
+		// One tab, so the panel carrying the widget grid actually mounts.
+		tabs: [ { id: 'traffic', label: 'Traffic' } ],
 		activeTab: 'traffic',
 		setActiveTab: jest.fn(),
 		layout: [],
@@ -210,6 +223,14 @@ describe( 'post detail stage', () => {
 		render( stage() );
 
 		expect( screen.getByText( 'Date filters without comparison' ) ).toBeInTheDocument();
+	} );
+
+	it( 'declares no comparison for the widgets it renders', () => {
+		mockSummary();
+
+		render( stage() );
+
+		expect( screen.getByText( 'Post widgets without comparison' ) ).toBeInTheDocument();
 	} );
 
 	it( 'keeps the two-crumb trail when no report origin is present', () => {

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -1,6 +1,10 @@
-import { AnalyticsQueryClientProvider, GlobalErrorProvider } from '@jetpack-premium-analytics/data';
+import {
+	AnalyticsQueryClientProvider,
+	GlobalErrorProvider,
+	ReportScopeProvider,
+} from '@jetpack-premium-analytics/data';
 import { Button } from '@jetpack-premium-analytics/externals';
-import { ReportScopeProvider, useReportDateFilters } from '@jetpack-premium-analytics/routing';
+import { useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import {
 	DateFiltersPanel,
 	SectionTabPanel,

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -173,15 +173,14 @@ function PostDetail(): JSX.Element {
 								<div className={ styles.dateFilters }>
 									{ /*
 									 * The design has no period-over-period comparison on
-									 * this page, so the Compare control is opted out;
-									 * comparison params stay in the URL so the breadcrumb
-									 * carries them back to the dashboard. What keeps the
-									 * widgets from reading them is the report scope the
-									 * stage declares, not this prop.
+									 * this page. The panel reads that from the scope the
+									 * stage declares, which is the same declaration that
+									 * keeps the params away from the widgets; the params
+									 * themselves stay in the URL so the breadcrumb carries
+									 * them back to the dashboard.
 									 */ }
 									<DateFiltersPanel
 										{ ...dateFilters }
-										showComparison={ false }
 										containerElement={ headerElement }
 										reservedInlineSize={ HEADER_RESERVED_INLINE_SIZE }
 									/>

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -1,6 +1,6 @@
 import { AnalyticsQueryClientProvider, GlobalErrorProvider } from '@jetpack-premium-analytics/data';
 import { Button } from '@jetpack-premium-analytics/externals';
-import { useReportDateFilters } from '@jetpack-premium-analytics/routing';
+import { ReportScopeProvider, useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import {
 	DateFiltersPanel,
 	SectionTabPanel,
@@ -174,9 +174,10 @@ function PostDetail(): JSX.Element {
 									{ /*
 									 * The design has no period-over-period comparison on
 									 * this page, so the Compare control is opted out;
-									 * comparison params stay in the URL (stripped from the
-									 * widgets' injected reportParams) so the breadcrumb
-									 * carries them back to the dashboard.
+									 * comparison params stay in the URL so the breadcrumb
+									 * carries them back to the dashboard. What keeps the
+									 * widgets from reading them is the report scope the
+									 * stage declares, not this prop.
 									 */ }
 									<DateFiltersPanel
 										{ ...dateFilters }
@@ -213,7 +214,14 @@ function PostDetail(): JSX.Element {
 export function stage(): JSX.Element {
 	return (
 		<AnalyticsQueryClientProvider>
-			<PostDetail />
+			{ /*
+			 * The page names no compared period and offers no control for one, so
+			 * nothing below may fetch or draw a comparison. The params stay on the
+			 * URL so the breadcrumb carries the dashboard's state back out.
+			 */ }
+			<ReportScopeProvider offersComparison={ false }>
+				<PostDetail />
+			</ReportScopeProvider>
 		</AnalyticsQueryClientProvider>
 	);
 }

--- a/projects/packages/premium-analytics/routes/reports/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/stage.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { useReportScope } from '@jetpack-premium-analytics/routing';
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { stage as ReportStage } from './stage';
+import type { ReactNode } from 'react';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	AnalyticsQueryClientProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
+	GlobalErrorProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
+} ) );
+
+jest.mock( '@jetpack-premium-analytics/externals', () => ( {
+	Stack: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
+	GlobalChartsProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
+	useChartTheme: () => ( {} ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Spinner: () => null,
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useParams: () => ( { report: 'posts' } ),
+} ) );
+
+/**
+ * Reads the scope from where a report page renders.
+ *
+ * @return The declared scope, as text.
+ */
+function MockScopeProbe() {
+	const { offersComparison } = useReportScope();
+
+	return <span>{ offersComparison ? 'offers comparison' : 'no comparison' }</span>;
+}
+
+jest.mock( './registry', () => ( {
+	getReportDefinition: () => ( {
+		load: () => Promise.resolve( { default: MockScopeProbe } ),
+	} ),
+} ) );
+
+describe( 'Report stage report scope', () => {
+	it( 'declares no comparison for every report page', async () => {
+		render( <ReportStage /> );
+
+		await expect( screen.findByText( 'no comparison' ) ).resolves.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/stage.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useReportScope } from '@jetpack-premium-analytics/routing';
+import { useReportScope } from '@jetpack-premium-analytics/data';
 import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
@@ -10,6 +10,7 @@ import { stage as ReportStage } from './stage';
 import type { ReactNode } from 'react';
 
 jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
 	AnalyticsQueryClientProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
 	GlobalErrorProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
 } ) );

--- a/projects/packages/premium-analytics/routes/reports/stage.tsx
+++ b/projects/packages/premium-analytics/routes/reports/stage.tsx
@@ -1,9 +1,12 @@
 /**
  * External dependencies
  */
-import { AnalyticsQueryClientProvider, GlobalErrorProvider } from '@jetpack-premium-analytics/data';
+import {
+	AnalyticsQueryClientProvider,
+	GlobalErrorProvider,
+	ReportScopeProvider,
+} from '@jetpack-premium-analytics/data';
 import { Stack } from '@jetpack-premium-analytics/externals';
-import { ReportScopeProvider } from '@jetpack-premium-analytics/routing';
 import { GlobalChartsProvider, useChartTheme } from '@jetpack-premium-analytics/widgets-toolkit';
 import { Spinner } from '@wordpress/components';
 import { lazy, Suspense, useMemo } from '@wordpress/element';

--- a/projects/packages/premium-analytics/routes/reports/stage.tsx
+++ b/projects/packages/premium-analytics/routes/reports/stage.tsx
@@ -3,6 +3,7 @@
  */
 import { AnalyticsQueryClientProvider, GlobalErrorProvider } from '@jetpack-premium-analytics/data';
 import { Stack } from '@jetpack-premium-analytics/externals';
+import { ReportScopeProvider } from '@jetpack-premium-analytics/routing';
 import { GlobalChartsProvider, useChartTheme } from '@jetpack-premium-analytics/widgets-toolkit';
 import { Spinner } from '@wordpress/components';
 import { lazy, Suspense, useMemo } from '@wordpress/element';
@@ -87,7 +88,14 @@ function ReportProviders( { children }: { children: ReactNode } ): JSX.Element {
 	return (
 		<AnalyticsQueryClientProvider>
 			<GlobalErrorProvider>
-				<GlobalChartsProvider theme={ chartTheme }>{ children }</GlobalChartsProvider>
+				<GlobalChartsProvider theme={ chartTheme }>
+					{ /*
+					 * A report names no compared period and offers no control for
+					 * one, so nothing below may fetch or draw a comparison. The
+					 * params stay on the URL for the dashboard to pick back up.
+					 */ }
+					<ReportScopeProvider offersComparison={ false }>{ children }</ReportScopeProvider>
+				</GlobalChartsProvider>
 			</GlobalErrorProvider>
 		</AnalyticsQueryClientProvider>
 	);

--- a/projects/packages/premium-analytics/routes/reports/use-report-params.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/use-report-params.test.tsx
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
+import { ReportScopeProvider } from '@jetpack-premium-analytics/routing';
 import { renderHook } from '@testing-library/react';
 /**
  * Internal dependencies
  */
 import { useReportParams } from './use-report-params';
+import type { ReactNode } from 'react';
 
 const SEARCH = {
 	from: '2026-06-01T00:00:00+00:00',
@@ -22,13 +24,24 @@ jest.mock( '@wordpress/route', () => ( {
 	useSearch: () => SEARCH,
 } ) );
 
+/**
+ * The scope the report route declares, which is what makes the strip happen.
+ *
+ * @param props          - Wrapper props.
+ * @param props.children - The hook under test.
+ * @return The wrapped tree.
+ */
+function noComparison( { children }: { children: ReactNode } ) {
+	return <ReportScopeProvider offersComparison={ false }>{ children }</ReportScopeProvider>;
+}
+
 describe( 'useReportParams', () => {
 	/*
 	 * A report offers no comparison control and its header names no compared
 	 * period, so a delta in the table would have no baseline the reader can see.
 	 */
 	it( 'drops the comparison the URL carries in', () => {
-		const { result } = renderHook( () => useReportParams() );
+		const { result } = renderHook( () => useReportParams(), { wrapper: noComparison } );
 
 		expect( result.current ).not.toHaveProperty( 'comp' );
 		expect( result.current ).not.toHaveProperty( 'compare_from' );
@@ -37,7 +50,7 @@ describe( 'useReportParams', () => {
 	} );
 
 	it( 'keeps the window itself', () => {
-		const { result } = renderHook( () => useReportParams() );
+		const { result } = renderHook( () => useReportParams(), { wrapper: noComparison } );
 
 		expect( result.current ).toEqual(
 			expect.objectContaining( {
@@ -46,5 +59,16 @@ describe( 'useReportParams', () => {
 				interval: SEARCH.interval,
 			} )
 		);
+	} );
+
+	// Guards the hook against re-hardcoding the strip: the surface decides, so a
+	// surface that offers a comparison must get one.
+	it( 'keeps the comparison where the surface offers one', () => {
+		const { result } = renderHook( () => useReportParams() );
+
+		expect( result.current ).toMatchObject( {
+			comp: '1',
+			compare_from: SEARCH.compare_from,
+		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/use-report-params.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/use-report-params.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { ReportScopeProvider } from '@jetpack-premium-analytics/routing';
+import { ReportScopeProvider } from '@jetpack-premium-analytics/data';
 import { renderHook } from '@testing-library/react';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/routes/reports/use-report-params.ts
+++ b/projects/packages/premium-analytics/routes/reports/use-report-params.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { normalizeReportParams, withoutComparison } from '@jetpack-premium-analytics/data';
+import { useReportScope } from '@jetpack-premium-analytics/routing';
 import { useSearch } from '@wordpress/route';
 import { useMemo } from 'react';
 /**
@@ -15,21 +16,23 @@ const ROUTE_FROM = route.path;
  * The window a report's records are fetched for, resolved from the URL with the
  * same normalizer the widgets use.
  *
- * Comparison is stripped. A report offers no control for one and its header
- * names no compared period, so a delta in the table would have no baseline the
- * reader could see or change. The params themselves stay on the URL, for the
- * dashboard to pick back up.
+ * Comparison follows the surface's declared scope, which the report route sets
+ * to none: a report offers no control for one and its header names no compared
+ * period, so a delta in the table would have no baseline the reader could see
+ * or change. The params themselves stay on the URL, for the dashboard to pick
+ * back up.
  *
- * @return The report params, without comparison.
+ * @return The report params, carrying a comparison only where one is offered.
  */
 export function useReportParams() {
 	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
+	const { offersComparison } = useReportScope();
 
-	return useMemo(
-		() =>
-			withoutComparison(
-				normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] )
-			),
-		[ search ]
-	);
+	return useMemo( () => {
+		const params = normalizeReportParams(
+			search as Parameters< typeof normalizeReportParams >[ 0 ]
+		);
+
+		return offersComparison ? params : withoutComparison( params );
+	}, [ search, offersComparison ] );
 }

--- a/projects/packages/premium-analytics/routes/reports/use-report-params.ts
+++ b/projects/packages/premium-analytics/routes/reports/use-report-params.ts
@@ -1,8 +1,11 @@
 /**
  * External dependencies
  */
-import { normalizeReportParams, withoutComparison } from '@jetpack-premium-analytics/data';
-import { useReportScope } from '@jetpack-premium-analytics/routing';
+import {
+	normalizeReportParams,
+	useReportScope,
+	withoutComparison,
+} from '@jetpack-premium-analytics/data';
 import { useSearch } from '@wordpress/route';
 import { useMemo } from 'react';
 /**

--- a/projects/packages/premium-analytics/routes/video-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.test.tsx
@@ -1,3 +1,4 @@
+import { useReportScope } from '@jetpack-premium-analytics/routing';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { useVideoSummary } from './hooks';
 import { stage } from './stage';
@@ -56,15 +57,31 @@ jest.mock(
 		)
 );
 
-// Captures each render's `layout` prop so tests can assert the reportParams
-// the page injects into its widget entries.
+/**
+ * Reads the scope from where the page's widgets render.
+ *
+ * @return The declared scope, as text.
+ */
+function MockScopeProbe() {
+	const { offersComparison } = useReportScope();
+
+	return (
+		<>
+			<div>Video widgets</div>
+			<div>{ offersComparison ? 'Scope offers comparison' : 'Scope offers no comparison' }</div>
+		</>
+	);
+}
+
+// Captures each render's `layout` prop so tests can assert what the page hands
+// the dashboard.
 const mockDashboardLayouts: unknown[] = [];
 jest.mock( '@wordpress/widget-dashboard', () => {
 	const WidgetDashboard = ( { children, layout }: { children: ReactNode; layout?: unknown } ) => {
 		mockDashboardLayouts.push( layout );
 		return <>{ children }</>;
 	};
-	WidgetDashboard.Widgets = () => <div>Video widgets</div>;
+	WidgetDashboard.Widgets = () => <MockScopeProbe />;
 
 	return { WidgetDashboard, DEFAULT_GRID: {}, ROW_HEIGHT_PRESETS: { small: 200 } };
 } );
@@ -320,7 +337,7 @@ describe( 'video detail stage', () => {
 		expect( screen.getByText( 'Date filters without comparison' ) ).toBeInTheDocument();
 	} );
 
-	it( 'injects comparison-stripped report params into every layout entry', () => {
+	it( 'declares no comparison for the widgets it renders', () => {
 		mockSummary( { title: 'Launch recap' } );
 		mockSearch = {
 			from: '2026-06-01',
@@ -334,16 +351,22 @@ describe( 'video detail stage', () => {
 
 		render( stage() );
 
+		expect( screen.getByText( 'Scope offers no comparison' ) ).toBeInTheDocument();
+	} );
+
+	// The layout the page hands the dashboard is the fixed composition; the
+	// no-comparison invariant is the scope above, not injected attributes.
+	it( 'hands the dashboard its fixed layout', () => {
+		mockSummary( { title: 'Launch recap' } );
+
+		render( stage() );
+
 		const layout = mockDashboardLayouts.at( -1 ) as Array< {
-			attributes?: { reportParams?: Record< string, unknown > };
+			attributes?: { reportParams?: unknown };
 		} >;
 		expect( layout.length ).toBeGreaterThan( 0 );
 		for ( const widget of layout ) {
-			expect( widget.attributes?.reportParams ).toEqual( {
-				from: '2026-06-01',
-				to: '2026-06-16',
-				post_id: '42',
-			} );
+			expect( widget.attributes ?? {} ).not.toHaveProperty( 'reportParams' );
 		}
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/video-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.test.tsx
@@ -1,4 +1,4 @@
-import { useReportScope } from '@jetpack-premium-analytics/routing';
+import { useReportScope } from '@jetpack-premium-analytics/data';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { useVideoSummary } from './hooks';
 import { stage } from './stage';
@@ -7,6 +7,7 @@ import type { ReactNode } from 'react';
 let mockSearch: Record< string, unknown > = {};
 
 jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
 	AnalyticsQueryClientProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
 	GlobalErrorProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
 } ) );

--- a/projects/packages/premium-analytics/routes/video-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.test.tsx
@@ -25,9 +25,7 @@ jest.mock( '@jetpack-premium-analytics/routing', () => ( {
 
 // Avoid loading DataViews while keeping the real breadcrumbs for these assertions.
 jest.mock( '@jetpack-premium-analytics/ui', () => ( {
-	DateFiltersPanel: ( { showComparison }: { showComparison?: boolean } ) => (
-		<div>{ showComparison === false ? 'Date filters without comparison' : 'Date filters' }</div>
-	),
+	DateFiltersPanel: () => <div>Date filters</div>,
 	StatsBreadcrumbs: jest.requireActual( '../../packages/ui/src/stats-breadcrumbs' )
 		.StatsBreadcrumbs,
 	StatsPageIcon: () => null,
@@ -329,14 +327,9 @@ describe( 'video detail stage', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'renders the date filters without the comparison control', () => {
-		mockSummary( { title: 'Launch recap' } );
-
-		render( stage() );
-
-		expect( screen.getByText( 'Date filters without comparison' ) ).toBeInTheDocument();
-	} );
-
+	// One declaration drives both halves: the panel reads it to drop the Compare
+	// control (covered in the ui package) and `WidgetRoot` reads it to strip the
+	// params. This asserts the declaration the page makes.
 	it( 'declares no comparison for the widgets it renders', () => {
 		mockSummary( { title: 'Launch recap' } );
 		mockSearch = {

--- a/projects/packages/premium-analytics/routes/video-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.tsx
@@ -166,13 +166,12 @@ function VideoDetail(): JSX.Element {
 						<div className={ styles.dateFilters }>
 							{ /*
 							 * The design has no period-over-period comparison on this
-							 * page, so the Compare control is opted out. What keeps the
-							 * widgets from reading the params is the report scope the
-							 * stage declares, not this prop.
+							 * page. The panel reads that from the scope the stage
+							 * declares, which is the same declaration that keeps the
+							 * params away from the widgets.
 							 */ }
 							<DateFiltersPanel
 								{ ...dateFilters }
-								showComparison={ false }
 								containerElement={ headerElement }
 								reservedInlineSize={ HEADER_RESERVED_INLINE_SIZE }
 							/>

--- a/projects/packages/premium-analytics/routes/video-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.tsx
@@ -4,15 +4,15 @@
 import { AnalyticsQueryClientProvider, GlobalErrorProvider } from '@jetpack-premium-analytics/data';
 import { Button, Stack, Text } from '@jetpack-premium-analytics/externals';
 import {
-	omitComparisonReportParams,
 	pickReportDateParams,
+	ReportScopeProvider,
 	useReportDateFilters,
 } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel, StatsBreadcrumbs, StatsPageIcon } from '@jetpack-premium-analytics/ui';
 import { Page } from '@wordpress/admin-ui';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useMemo, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link, useParams, useSearch } from '@wordpress/route';
 import { DEFAULT_GRID, ROW_HEIGHT_PRESETS, WidgetDashboard } from '@wordpress/widget-dashboard';
@@ -90,28 +90,9 @@ function VideoDetail(): JSX.Element {
 	const search = useSearch( { strict: false } ) as Record< string, unknown > | undefined;
 	const reportSearch = pickReportDateParams( search );
 
-	/*
-	 * Same construction as post detail: the page has no period-over-period
-	 * comparison by design, but the comparison params stay in the URL so the
-	 * breadcrumb carries the dashboard's state back out. Without explicit
-	 * `reportParams`, every `WidgetRoot` falls back to reading the raw URL
-	 * search — comparison included. Today's three widgets all ignore the
-	 * comparison params in their own query mapping, so this is defensive:
-	 * injecting the stripped params into each layout entry makes the
-	 * page-wide no-comparison invariant hold by construction (matching post
-	 * detail), instead of relying on every current and future widget to keep
-	 * ignoring them.
-	 */
-	const layout = useMemo( () => {
-		const reportParams = omitComparisonReportParams( search );
-		return VIDEO_DETAIL_LAYOUT.map( widget => ( {
-			...widget,
-			attributes: {
-				...( widget.attributes as Record< string, unknown > | undefined ),
-				reportParams,
-			},
-		} ) );
-	}, [ search ] );
+	// The page's no-comparison invariant is the report scope the stage declares,
+	// so the layout is the fixed composition.
+	const layout = VIDEO_DETAIL_LAYOUT;
 
 	// Error and not-found responses have no trustworthy title, so only resolved
 	// videos add the title crumb or render the heading.
@@ -185,9 +166,9 @@ function VideoDetail(): JSX.Element {
 						<div className={ styles.dateFilters }>
 							{ /*
 							 * The design has no period-over-period comparison on this
-							 * page, so the Compare control is opted out; the layout memo
-							 * above strips the comparison params before they reach the
-							 * widgets.
+							 * page, so the Compare control is opted out. What keeps the
+							 * widgets from reading the params is the report scope the
+							 * stage declares, not this prop.
 							 */ }
 							<DateFiltersPanel
 								{ ...dateFilters }
@@ -217,7 +198,15 @@ export function stage(): JSX.Element {
 	return (
 		<AnalyticsQueryClientProvider>
 			<GlobalErrorProvider>
-				<VideoDetail />
+				{ /*
+				 * The page names no compared period and offers no control for one,
+				 * so nothing below may fetch or draw a comparison. The params stay
+				 * on the URL so the breadcrumb carries the dashboard's state back
+				 * out.
+				 */ }
+				<ReportScopeProvider offersComparison={ false }>
+					<VideoDetail />
+				</ReportScopeProvider>
 			</GlobalErrorProvider>
 		</AnalyticsQueryClientProvider>
 	);

--- a/projects/packages/premium-analytics/routes/video-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.tsx
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { AnalyticsQueryClientProvider, GlobalErrorProvider } from '@jetpack-premium-analytics/data';
-import { Button, Stack, Text } from '@jetpack-premium-analytics/externals';
 import {
-	pickReportDateParams,
+	AnalyticsQueryClientProvider,
+	GlobalErrorProvider,
 	ReportScopeProvider,
-	useReportDateFilters,
-} from '@jetpack-premium-analytics/routing';
+} from '@jetpack-premium-analytics/data';
+import { Button, Stack, Text } from '@jetpack-premium-analytics/externals';
+import { pickReportDateParams, useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel, StatsBreadcrumbs, StatsPageIcon } from '@jetpack-premium-analytics/ui';
 import { Page } from '@wordpress/admin-ui';
 import { store as coreStore } from '@wordpress/core-data';


### PR DESCRIPTION
Stacked on #51381 — **review that one first**; this PR targets its branch, so the diff here is only the refactor.

Related to WOOA7S-1964.

## Proposed changes

Every analytics surface answers the same question twice: does the header show the comparison control, and do the comparison params reach the things that fetch? Each route hardcoded both answers separately, which is how the dashboard came to answer the first and forget the second (the defect #51381 fixes). This collapses all of them onto the one declaration that PR introduced.

- Mount `ReportScopeProvider` once per route: the `/reports/$report` dispatcher, post detail, video detail.
- `DateFiltersPanel` reads the scope; the `showComparison` prop is gone, along with its four call sites.
- `useReportParams` reads the scope instead of calling `withoutComparison()` unconditionally.
- Delete the layout-attribute injection in both detail pages — `WidgetRoot` already strips from the scope, and injected attributes travelling with a layout was a standing hazard.

No behavior change. Comparison params stay on the URL on every surface, exactly as before.

## Related product discussion/links

- Follow-up to #51381.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a pure refactor, so the interesting check is that nothing moved:

- On **Reports**, **post detail**, and **video detail**: confirm no Compare control in the header, and no period-over-period deltas in any widget or table.
- Pick a comparison on the dashboard's Traffic section, then visit each of those three pages and come back. The comparison should still be applied — the params ride along on the URL.
- On the dashboard's Traffic section, confirm the Compare control still works and widgets still render deltas.
- On **Insights**, confirm there is still no Compare control and no deltas.
