### PR TITLE
Premium Analytics: keep widget numbers on screen while unchanged params revalidate

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -619,10 +619,10 @@ interpolated into a shared frame) so translators see the whole sentence:
 
 ```tsx
 <WidgetState
-	isLoading={ isLoading }            // first load, no data yet
+	isLoading={ isLoading }            // nothing on screen answers the current params
 	isError={ isError }
 	isEmpty={ data.length === 0 }
-	// Optional: draws the delayed skeleton during refetches too.
+	// Optional: marks the widget busy while unchanged params revalidate.
 	isFetching={ isFetching }
 	error={ describeError( error, {
 		retryDescription: __( "We couldn't load search terms. Please try again in a moment.", 'jetpack-premium-analytics-pkg' ),
@@ -640,9 +640,14 @@ area. Notes:
 - Expose `refetch` from the data/view hook so the error state's Retry can re-run the query.
 - The loading state defaults to `GenericSkeleton`. Pass a content-specific shape through
   `renderLoading` when needed, and build new shapes on `SkeletonRoot`.
-- Passing `isFetching` shows a delayed skeleton while keeping children mounted, preserving their
-  state through refetches. Keyboard focus inside the body is captured and restored across that
-  window, so a drill-down activated from the keyboard does not strand the reader.
+- **Pass the hook's `isLoading` straight through — never `isLoading && ! hasData`.** The hooks
+  widen it to "nothing on screen answers the current params", which covers a range change: the
+  queries carry `placeholderData`, so the previous range's numbers stay mounted. A `&& ! hasData`
+  guard sees those and cancels the skeleton, leaving one period's figures under another period's
+  heading.
+- `isFetching` draws nothing — it only marks the widget `aria-busy`. A revalidation of unchanged
+  params leaves the right numbers on screen, and blanking them reports a refresh nobody asked for
+  (WOOA7S-1934).
 - When a view hook masks `isError` (e.g. `rows.length === 0 && isError` to keep placeholder
   rows), gate `error` with the same predicate (`error: showError ? error : null`) so the two
   fields can't disagree.

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -647,7 +647,12 @@ area. Notes:
   heading.
 - `isFetching` draws nothing — it only marks the widget `aria-busy`. A revalidation of unchanged
   params leaves the right numbers on screen, and blanking them reports a refresh nobody asked for
-  (WOOA7S-1934).
+  (WOOA7S-1934). Nothing unmounts, so children keep their own state and keyboard focus.
+- Every other branch *does* unmount the children, and a drill-down reaches the skeleton by
+  definition (it changes the params). `<WidgetState>` catches the focus that would otherwise fall
+  to `<body>` and parks it on its own root, so the next Tab continues from the widget instead of
+  the top of the page. Widgets need do nothing for this, but drill-down rows must be real
+  focusable controls for it to have anything to catch.
 - When a view hook masks `isError` (e.g. `rows.length === 0 && isError` to keep placeholder
   rows), gate `error` with the same predicate (`error: showError ? error : null`) so the two
   fields can't disagree.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1934-revalidation-skeletons
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1934-revalidation-skeletons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep widget numbers on screen while unchanged data is refreshed in the background.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/awaiting-data.test.tsx
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/awaiting-data.test.tsx
@@ -130,5 +130,9 @@ describe( 'isAwaitingData', () => {
 		// placeholder data — already the right answer.
 		expect( read( 'shown' ) ).toBe( 'january' );
 		expect( read( 'awaiting' ) ).toBe( 'false' );
+
+		// The invalidation above leaves a refetch in flight; let it land inside
+		// the test rather than during teardown.
+		await settleOn( 'january' );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/awaiting-data.test.tsx
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/awaiting-data.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+/**
+ * Internal dependencies
+ */
+import { isAwaitingData } from '../awaiting-data';
+import type { ReactNode } from 'react';
+
+// Driven against a real QueryClient, not hand-built flag objects: the point is
+// how React Query itself reports a param change versus a revalidation.
+
+type Row = { range: string };
+
+const STALE_TIME = 5 * 60 * 1000;
+
+function Probe( { range }: { range: string } ) {
+	const query = useQuery< Row >( {
+		queryKey: [ 'report', range ],
+		queryFn: async () => {
+			await new Promise( resolve => setTimeout( resolve, 10 ) );
+			return { range };
+		},
+		placeholderData: previousData => previousData,
+	} );
+
+	return (
+		<>
+			<span data-testid="shown">{ query.data?.range ?? '—' }</span>
+			<span data-testid="awaiting">{ String( isAwaitingData( query ) ) }</span>
+			<span data-testid="fetching">{ String( query.isFetching ) }</span>
+		</>
+	);
+}
+
+function read( testId: string ) {
+	return screen.getByTestId( testId ).textContent;
+}
+
+describe( 'isAwaitingData', () => {
+	let client: QueryClient;
+	let setRange: ( range: string ) => void;
+
+	function Host() {
+		const [ range, set ] = useState( 'january' );
+		setRange = set;
+		return <Probe range={ range } />;
+	}
+
+	function wrap( children: ReactNode ) {
+		return <QueryClientProvider client={ client }>{ children }</QueryClientProvider>;
+	}
+
+	/**
+	 * Wait for a range's rows to land. Polled, not slept through — a fixed delay
+	 * races the query on a loaded runner.
+	 *
+	 * @param range - The range whose rows should be on screen.
+	 */
+	async function settleOn( range: string ) {
+		await waitFor( () => expect( read( 'shown' ) ).toBe( range ) );
+		await waitFor( () => expect( read( 'awaiting' ) ).toBe( 'false' ) );
+	}
+
+	beforeEach( () => {
+		client = new QueryClient( {
+			defaultOptions: { queries: { staleTime: STALE_TIME, retry: false } },
+		} );
+	} );
+
+	it( 'is true on a first load, when there is nothing on screen at all', async () => {
+		render( wrap( <Host /> ) );
+
+		expect( read( 'shown' ) ).toBe( '—' );
+		expect( read( 'awaiting' ) ).toBe( 'true' );
+
+		await settleOn( 'january' );
+	} );
+
+	it( 'is true through a range change, while the previous range is still on screen', async () => {
+		render( wrap( <Host /> ) );
+		await settleOn( 'january' );
+
+		await act( async () => {
+			setRange( 'february' );
+		} );
+
+		// `placeholderData` keeps January mounted, so React Query calls this a
+		// success — but January no longer answers what was asked.
+		expect( read( 'shown' ) ).toBe( 'january' );
+		expect( read( 'awaiting' ) ).toBe( 'true' );
+
+		await settleOn( 'february' );
+	} );
+
+	it( 'stays false through a revalidation of unchanged params (WOOA7S-1934)', async () => {
+		render( wrap( <Host /> ) );
+		await settleOn( 'january' );
+
+		act( () => {
+			client.invalidateQueries( { queryKey: [ 'report', 'january' ] } );
+		} );
+		await waitFor( () => expect( read( 'fetching' ) ).toBe( 'true' ) );
+
+		// What a window refocus past `staleTime` does. `isFetching` here is
+		// indistinguishable from the range change above.
+		expect( read( 'shown' ) ).toBe( 'january' );
+		expect( read( 'awaiting' ) ).toBe( 'false' );
+
+		await settleOn( 'january' );
+	} );
+
+	it( 'stays false when a range change lands on an already cached range', async () => {
+		render( wrap( <Host /> ) );
+		await settleOn( 'january' );
+		await act( async () => {
+			setRange( 'february' );
+		} );
+		await settleOn( 'february' );
+
+		await act( async () => {
+			client.invalidateQueries();
+			setRange( 'january' );
+		} );
+
+		// Cached under its own key, so it is served directly rather than as
+		// placeholder data — already the right answer.
+		expect( read( 'shown' ) ).toBe( 'january' );
+		expect( read( 'awaiting' ) ).toBe( 'false' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-report.test.tsx
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-report.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { QueryClient, QueryClientProvider, type UseQueryOptions } from '@tanstack/react-query';
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 /**
  * Internal dependencies
  */
@@ -84,5 +84,53 @@ describe( 'useReport', () => {
 		] );
 		expect( calls[ 0 ].params ).not.toHaveProperty( 'compare_from' );
 		expect( calls[ 1 ].params ).not.toHaveProperty( 'compare_from' );
+	} );
+
+	it( 'awaits data when only the comparison window moves, leaving primary untouched', async () => {
+		// Deliberate: `isLoading` is the union of both queries, so moving the
+		// comparison window alone (previous period → previous year, or switching
+		// comparison on) takes the whole widget to a skeleton even though the
+		// primary numbers never went stale. The deltas on screen did, and a widget
+		// showing one comparison's deltas under another's label is the bug this
+		// flag exists to prevent.
+		const queryFactory = (
+			params: ReportParams,
+			queryType: string
+		): UseQueryOptions< { summary: Record< string, unknown > } > => ( {
+			queryKey: [ 'test-report', queryType, params.from, params.to ],
+			queryFn: async () => ( { summary: { views: 1 } } ),
+			placeholderData: ( previousData?: { summary: Record< string, unknown > } ) => previousData,
+		} );
+
+		const params = ( compareFrom: string, compareTo: string ): ReportParams => ( {
+			from: '2026-06-01',
+			to: '2026-06-07',
+			compare_from: compareFrom,
+			compare_to: compareTo,
+			compare_preset: 'previous-period',
+			comp: '1',
+			interval: 'day',
+			period: 'day',
+			section: 'stats',
+		} );
+
+		const { result, rerender } = renderHook(
+			( { compare }: { compare: [ string, string ] } ) =>
+				useReport( queryFactory, params( ...compare ) ),
+			{ wrapper, initialProps: { compare: [ '2026-05-01', '2026-05-07' ] as [ string, string ] } }
+		);
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+		expect( result.current.hasData ).toBe( true );
+
+		rerender( { compare: [ '2025-06-01', '2025-06-07' ] } );
+
+		// The primary query key never changed, so its own numbers are still on
+		// screen — `hasData` proves the old `&& ! hasData` guard would have
+		// cancelled this skeleton.
+		expect( result.current.hasData ).toBe( true );
+		expect( result.current.isLoading ).toBe( true );
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/awaiting-data.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/awaiting-data.ts
@@ -1,0 +1,35 @@
+type PlaceholderAwareQuery = {
+	isLoading: boolean;
+	isPlaceholderData: boolean;
+};
+
+/**
+ * Whether nothing on screen answers the current params — what widgets gate
+ * their skeleton on.
+ *
+ * Broader than React Query's `isLoading`, which a range change leaves false:
+ * `placeholderData` keeps the previous params' response mounted, and React
+ * Query calls that a success. `isFetching` is no help either — it is equally
+ * true when unchanged params are revalidated, where the numbers on screen are
+ * still the right answer (WOOA7S-1934).
+ *
+ * @param query - A React Query result.
+ * @return Whether anything on screen answers the current params.
+ */
+export function isAwaitingData( query: PlaceholderAwareQuery ): boolean {
+	return query.isLoading || query.isPlaceholderData;
+}
+
+/**
+ * `isAwaitingData` folded into a result's own `isLoading`, so hooks hand widgets
+ * one flag. `isPlaceholderData` stays on the result for callers that need the
+ * two apart — see `useLocationViews`.
+ *
+ * @param query - A React Query result.
+ * @return The same result with `isLoading` widened.
+ */
+export function withAwaitedDataLoading< TQuery extends PlaceholderAwareQuery >(
+	query: TQuery
+): TQuery {
+	return { ...query, isLoading: isAwaitingData( query ) };
+}

--- a/projects/packages/premium-analytics/packages/data/src/hooks/awaiting-data.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/awaiting-data.ts
@@ -14,7 +14,7 @@ type PlaceholderAwareQuery = {
  * still the right answer (WOOA7S-1934).
  *
  * @param query - A React Query result.
- * @return Whether anything on screen answers the current params.
+ * @return Whether the result has nothing valid for the current params.
  */
 export function isAwaitingData( query: PlaceholderAwareQuery ): boolean {
 	return query.isLoading || query.isPlaceholderData;
@@ -23,7 +23,12 @@ export function isAwaitingData( query: PlaceholderAwareQuery ): boolean {
 /**
  * `isAwaitingData` folded into a result's own `isLoading`, so hooks hand widgets
  * one flag. `isPlaceholderData` stays on the result for callers that need the
- * two apart — see `useLocationViews`.
+ * two apart.
+ *
+ * Spreading costs React Query's tracked-property optimization: reading every key
+ * marks every key as tracked, so the caller also re-renders on fields it never
+ * uses (`isStale` flipping at `staleTime`, for one). Cheap next to a fetch, and
+ * the alternative is handing widgets a flag whose name lies.
  *
  * @param query - A React Query result.
  * @return The same result with `isLoading` widened.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
@@ -7,6 +7,7 @@ import { useCallback } from 'react';
  * Internal dependencies
  */
 import { hasComparisonEnabled, type ReportParams } from '../utils/search';
+import { isAwaitingData } from './awaiting-data';
 
 type UseReportOptions = {
 	enabled?: boolean;
@@ -73,7 +74,9 @@ export function useReport< TData, TParams extends ReportParams = ReportParams >(
 		enabled: queryEnabled && comparisonEnabled && ( comparisonQueryOptions.enabled ?? true ),
 	} );
 
-	const isLoading = primary.isLoading || comparison.isLoading;
+	// Widened past React Query's `isLoading` — see `isAwaitingData`. Its own
+	// flags stay reachable through `primary` and `comparison`.
+	const isLoading = isAwaitingData( primary ) || isAwaitingData( comparison );
 	const isFetching = primary.isFetching || comparison.isFetching;
 
 	/**

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-app-query.ts
@@ -1,4 +1,5 @@
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { withAwaitedDataLoading } from './awaiting-data';
 import { getStatsQueryEnabled } from './use-stats-query';
 import type { UseStatsOptions } from './use-stats-report';
 
@@ -8,8 +9,10 @@ export function useStatsAppQuery< TData = unknown >(
 	queryOptions: UseQueryOptions< TData >,
 	options?: UseStatsAppOptions
 ) {
-	return useQuery( {
-		...queryOptions,
-		enabled: getStatsQueryEnabled( queryOptions, options ),
-	} );
+	return withAwaitedDataLoading(
+		useQuery( {
+			...queryOptions,
+			enabled: getStatsQueryEnabled( queryOptions, options ),
+		} )
+	);
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-query.ts
@@ -1,4 +1,5 @@
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { withAwaitedDataLoading } from './awaiting-data';
 import type { UseStatsOptions } from './use-stats-report';
 
 export function getStatsQueryEnabled< TData = unknown >(
@@ -12,8 +13,10 @@ export function useStatsQuery< TData = unknown >(
 	queryOptions: UseQueryOptions< TData >,
 	options?: UseStatsOptions
 ) {
-	return useQuery( {
-		...queryOptions,
-		enabled: getStatsQueryEnabled( queryOptions, options ),
-	} );
+	return withAwaitedDataLoading(
+		useQuery( {
+			...queryOptions,
+			enabled: getStatsQueryEnabled( queryOptions, options ),
+		} )
+	);
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-metric/report-metric.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-metric/report-metric.tsx
@@ -120,7 +120,7 @@ export function ReportMetricWidget( {
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/__tests__/widget-state.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/__tests__/widget-state.test.tsx
@@ -11,15 +11,6 @@ import { errorStateIcon } from '../error-state-icon';
 import { WidgetState } from '../widget-state';
 import type { ReactElement } from 'react';
 
-// The shared CSS Module stub resolves every stylesheet to `{}`, so class names
-// never reach the DOM. Name the two this file asserts on, rather than swapping
-// the stub package-wide for one test: that would put class names on every
-// component in every suite.
-jest.mock( '../widget-state.module.scss', () => ( {
-	content: 'content',
-	contentHidden: 'contentHidden',
-} ) );
-
 const CONTENT = <div>rows</div>;
 
 function Counter() {
@@ -122,7 +113,7 @@ describe( 'WidgetState', () => {
 		expect( screen.getByRole( 'status' ) ).toBeInTheDocument();
 	} );
 
-	it( 'shows loading, not the empty state, once a refetch over an empty result drags on', () => {
+	it( 'keeps the empty state on screen through a refetch that drags on', () => {
 		render(
 			<WidgetState
 				isLoading={ false }
@@ -137,12 +128,10 @@ describe( 'WidgetState', () => {
 		expect( screen.getByText( 'No posts here.' ) ).toBeInTheDocument();
 
 		elapseFetchDelay();
-		expect( screen.queryByText( 'No posts here.' ) ).not.toBeInTheDocument();
-		// Silent, like the ready branch's overlay: this is still a refetch, and
-		// only a first load announces. Otherwise whether a widget speaks up would
-		// depend on what it happened to be showing beforehand.
-		expect( screen.getByRole( 'status', { hidden: true } ) ).toBeInTheDocument();
-		expect( screen.queryByRole( 'status' ) ).not.toBeInTheDocument();
+		// Still the right answer for these params, so a revalidation has nothing
+		// to correct.
+		expect( screen.getByText( 'No posts here.' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'status', { hidden: true } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the caller loading override instead of the default skeleton', () => {
@@ -155,7 +144,7 @@ describe( 'WidgetState', () => {
 		expect( screen.queryByRole( 'status' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'uses the caller loading override during a refetch too, not just the first load', () => {
+	it( 'keeps the caller loading override out of a refetch, however long it drags on', () => {
 		render(
 			<WidgetState
 				isLoading={ false }
@@ -168,8 +157,8 @@ describe( 'WidgetState', () => {
 			</WidgetState>
 		);
 		elapseFetchDelay();
-		expect( screen.getByText( 'override' ) ).toBeInTheDocument();
-		expect( screen.queryByRole( 'status' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'override' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'rows' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the empty state (not error) when resolved with no rows', () => {
@@ -270,29 +259,59 @@ describe( 'WidgetState', () => {
 		expect( screen.queryAllByRole( 'generic', { busy: true } ) ).toHaveLength( 0 );
 	} );
 
-	it( 'covers the children with a silent skeleton once a refetch drags on, marking the region busy', () => {
+	it( 'marks the region busy once a refetch drags on, without covering the children', () => {
 		render(
 			<WidgetState isLoading={ false } isFetching isError={ false } isEmpty={ false }>
 				{ CONTENT }
 			</WidgetState>
 		);
 		elapseFetchDelay();
-		expect( screen.queryByRole( 'status' ) ).not.toBeInTheDocument();
-		expect( screen.getByRole( 'status', { hidden: true } ) ).toBeInTheDocument();
+		// A long revalidation changes only `aria-busy` — no skeleton at all,
+		// hidden or otherwise.
+		expect( screen.queryByRole( 'status', { hidden: true } ) ).not.toBeInTheDocument();
 		expect( screen.getAllByRole( 'generic', { busy: true } ) ).toHaveLength( 1 );
 		expect( screen.getByText( 'rows' ) ).toBeInTheDocument();
 	} );
 
-	it( 'keeps the children mounted across a refetch, so their own state survives it', () => {
+	it( 'never takes the numbers off screen across a whole revalidation cycle', () => {
+		// The bug lived in the transition, so pinning `isFetching` to one value
+		// cannot catch it. `isLoading` stays false throughout: same params.
 		const props = { isLoading: false, isError: false, isEmpty: false };
-		const { container, rerender } = render(
+		const rowsOnScreen = () => !! screen.queryByText( 'rows' );
+
+		const { rerender } = render(
+			<WidgetState { ...props } isFetching={ false }>
+				{ CONTENT }
+			</WidgetState>
+		);
+		expect( rowsOnScreen() ).toBe( true );
+
+		rerender(
+			<WidgetState { ...props } isFetching>
+				{ CONTENT }
+			</WidgetState>
+		);
+		expect( rowsOnScreen() ).toBe( true );
+
+		elapseFetchDelay();
+		expect( rowsOnScreen() ).toBe( true );
+
+		rerender(
+			<WidgetState { ...props } isFetching={ false }>
+				{ CONTENT }
+			</WidgetState>
+		);
+		expect( rowsOnScreen() ).toBe( true );
+		expect( screen.queryAllByRole( 'generic', { busy: true } ) ).toHaveLength( 0 );
+	} );
+
+	it( 'leaves the children their own state through a revalidation', () => {
+		const props = { isLoading: false, isError: false, isEmpty: false };
+		const { rerender } = render(
 			<WidgetState { ...props } isFetching={ false }>
 				<Counter />
 			</WidgetState>
 		);
-		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the CSS Module class is the behavior under test.
-		const content = container.querySelector( '.content' );
-		expect( content ).not.toHaveClass( 'contentHidden' );
 		// eslint-disable-next-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
 		fireEvent.click( screen.getByRole( 'button' ) );
 		expect( screen.getByRole( 'button' ) ).toHaveTextContent( '1' );
@@ -303,211 +322,15 @@ describe( 'WidgetState', () => {
 			</WidgetState>
 		);
 		elapseFetchDelay();
-		expect( content ).toHaveClass( 'contentHidden' );
+		expect( screen.getByRole( 'button' ) ).toHaveTextContent( '1' );
+
 		rerender(
 			<WidgetState { ...props } isFetching={ false }>
 				<Counter />
 			</WidgetState>
 		);
-		expect( content ).not.toHaveClass( 'contentHidden' );
 		expect( screen.getByRole( 'button' ) ).toHaveTextContent( '1' );
 	} );
-
-	it( 'holds focus in the widget body for the length of the refetch', () => {
-		// Not just on the way out: the browser drops focus to the body as soon as
-		// the children are hidden, and the skeleton window is 400ms at best.
-		const props = { isLoading: false, isError: false, isEmpty: false };
-		const { rerender } = render(
-			<WidgetState { ...props } isFetching={ false }>
-				<button type="button">Taiwan</button>
-			</WidgetState>
-		);
-		const row = screen.getByRole( 'button', { name: 'Taiwan' } );
-		act( () => row.focus() );
-
-		rerender(
-			<WidgetState { ...props } isFetching>
-				<button type="button">Taiwan</button>
-			</WidgetState>
-		);
-		elapseFetchDelay();
-
-		// Parked on the wrapper: not the hidden row, and not the document body,
-		// where the next Tab would jump to the top of the page.
-		expect( row ).not.toHaveFocus();
-		expect( document.body ).not.toHaveFocus();
-		// eslint-disable-next-line @wordpress/no-global-active-element, testing-library/no-node-access -- which element the browser focused is the assertion, and the wrapper is deliberately not queryable.
-		expect( document.activeElement ).toContainElement( row );
-	} );
-
-	it( 'returns focus to the element a refetch took it from', () => {
-		// Keyboard-activating a drill-down row refetches by definition, so this is
-		// the common path, not an edge case.
-		const props = { isLoading: false, isError: false, isEmpty: false };
-		const { rerender } = render(
-			<WidgetState { ...props } isFetching={ false }>
-				<button type="button">Taiwan</button>
-			</WidgetState>
-		);
-		const row = screen.getByRole( 'button', { name: 'Taiwan' } );
-		act( () => row.focus() );
-
-		rerender(
-			<WidgetState { ...props } isFetching>
-				<button type="button">Taiwan</button>
-			</WidgetState>
-		);
-		elapseFetchDelay();
-
-		rerender(
-			<WidgetState { ...props } isFetching={ false }>
-				<button type="button">Taiwan</button>
-			</WidgetState>
-		);
-		expect( row ).toHaveFocus();
-	} );
-
-	it( 'parks focus in the widget body when the refetch replaced that element', () => {
-		// The drill-down case: the row that was activated is not in the new data.
-		// Keyed, so React unmounts it rather than reusing the node for the new row
-		// — reuse would keep the original target connected and miss this path.
-		const props = { isLoading: false, isError: false, isEmpty: false };
-		const { rerender } = render(
-			<WidgetState { ...props } isFetching={ false }>
-				<button type="button" key="tw">
-					Taiwan
-				</button>
-			</WidgetState>
-		);
-		act( () => screen.getByRole( 'button', { name: 'Taiwan' } ).focus() );
-
-		rerender(
-			<WidgetState { ...props } isFetching>
-				<button type="button" key="tw">
-					Taiwan
-				</button>
-			</WidgetState>
-		);
-		elapseFetchDelay();
-
-		rerender(
-			<WidgetState { ...props } isFetching={ false }>
-				<button type="button" key="tp">
-					Taipei
-				</button>
-			</WidgetState>
-		);
-		// Focus sits on the body wrapper, so the next Tab continues from the widget
-		// rather than the top of the document.
-		expect( document.body ).not.toHaveFocus();
-		// eslint-disable-next-line @wordpress/no-global-active-element, testing-library/no-node-access -- which element the browser focused is the assertion, and the body wrapper is deliberately not queryable.
-		expect( document.activeElement ).toContainElement(
-			screen.getByRole( 'button', { name: 'Taipei' } )
-		);
-	} );
-
-	it( 'leaves focus alone when the reader moved on during the refetch', () => {
-		const props = { isLoading: false, isError: false, isEmpty: false };
-		const { rerender } = render(
-			<>
-				<button type="button">Elsewhere</button>
-				<WidgetState { ...props } isFetching={ false }>
-					<button type="button">Taiwan</button>
-				</WidgetState>
-			</>
-		);
-		act( () => screen.getByRole( 'button', { name: 'Taiwan' } ).focus() );
-
-		rerender(
-			<>
-				<button type="button">Elsewhere</button>
-				<WidgetState { ...props } isFetching>
-					<button type="button">Taiwan</button>
-				</WidgetState>
-			</>
-		);
-		elapseFetchDelay();
-		const elsewhere = screen.getByRole( 'button', { name: 'Elsewhere' } );
-		act( () => elsewhere.focus() );
-
-		rerender(
-			<>
-				<button type="button">Elsewhere</button>
-				<WidgetState { ...props } isFetching={ false }>
-					<button type="button">Taiwan</button>
-				</WidgetState>
-			</>
-		);
-		expect( elsewhere ).toHaveFocus();
-	} );
-
-	it( 'leaves focus alone when it reached the document body during the refetch', () => {
-		// Clicking something unfocusable blurs the parked root and drops focus to
-		// the body. jsdom cannot click that way, but the end state is the same —
-		// and since the root now outlives every branch, that click is the only
-		// way focus gets to the body from here. Restoring would haul the reader
-		// back to a widget they just clicked away from.
-		const props = { isLoading: false, isError: false, isEmpty: false };
-		const { rerender } = render(
-			<WidgetState { ...props } isFetching={ false }>
-				<button type="button">Taiwan</button>
-			</WidgetState>
-		);
-		const row = screen.getByRole( 'button', { name: 'Taiwan' } );
-		act( () => row.focus() );
-
-		rerender(
-			<WidgetState { ...props } isFetching>
-				<button type="button">Taiwan</button>
-			</WidgetState>
-		);
-		elapseFetchDelay();
-		// eslint-disable-next-line @wordpress/no-global-active-element, testing-library/no-node-access -- the parked root is deliberately not queryable, and blurring it is the setup.
-		act( () => ( document.activeElement as HTMLElement ).blur() );
-
-		rerender(
-			<WidgetState { ...props } isFetching={ false }>
-				<button type="button">Taiwan</button>
-			</WidgetState>
-		);
-
-		expect( row ).not.toHaveFocus();
-		expect( document.body ).toHaveFocus();
-	} );
-
-	it.each( [
-		[ 'empty', { isEmpty: true, isError: false } ],
-		[ 'an error', { isEmpty: false, isError: true } ],
-	] )( 'keeps focus in the widget when the refetch resolves to %s', ( _label, resolved ) => {
-		// Changing to a range with no data, or losing the connection mid-fetch,
-		// swaps the ready branch for a different one. Parking on anything that
-		// only exists while ready would unmount here and hand focus back to the
-		// document body.
-		const { rerender } = render(
-			<WidgetState isLoading={ false } isError={ false } isEmpty={ false } isFetching={ false }>
-				<button type="button">Taiwan</button>
-			</WidgetState>
-		);
-		act( () => screen.getByRole( 'button', { name: 'Taiwan' } ).focus() );
-
-		rerender(
-			<WidgetState isLoading={ false } isError={ false } isEmpty={ false } isFetching>
-				<button type="button">Taiwan</button>
-			</WidgetState>
-		);
-		elapseFetchDelay();
-
-		rerender(
-			<WidgetState isLoading={ false } { ...resolved } isFetching={ false }>
-				<button type="button">Taiwan</button>
-			</WidgetState>
-		);
-
-		expect( document.body ).not.toHaveFocus();
-		// eslint-disable-next-line @wordpress/no-global-active-element, testing-library/no-node-access -- which element the browser focused is the assertion, and the root is deliberately not queryable.
-		expect( document.activeElement ).toHaveAttribute( 'tabindex', '-1' );
-	} );
-
 	it( 'error wins over loading and empty (retry in flight after a failed fetch)', () => {
 		// The production shape on a failed fetch: isError with isEmpty derived
 		// true, plus loading signals while a retry is in flight. The priority

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/__tests__/widget-state.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/__tests__/widget-state.test.tsx
@@ -3,13 +3,13 @@
  */
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { chartBar } from '@wordpress/icons';
-import { useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 /**
  * Internal dependencies
  */
 import { errorStateIcon } from '../error-state-icon';
 import { WidgetState } from '../widget-state';
-import type { ReactElement } from 'react';
+import type { ReactElement, RefObject } from 'react';
 
 const CONTENT = <div>rows</div>;
 
@@ -44,6 +44,31 @@ function iconPathOf( element: ReactElement ): string | null {
 	const path = svgPathOf( container );
 	unmount();
 	return path;
+}
+
+/**
+ * Stand-in for whatever else claims focus in the same commit that unmounts a
+ * widget's focused element — another widget's own parking effect, a dialog
+ * autofocus. Rendered before the widget so its layout effect runs first.
+ *
+ * @param props        - Component props.
+ * @param props.steal  - Whether to take focus on this commit.
+ * @param props.target - Ref to the element to take focus to.
+ * @return Nothing; the component renders no markup.
+ */
+function StealFocus( {
+	steal,
+	target,
+}: {
+	steal: boolean;
+	target: RefObject< HTMLElement | null >;
+} ) {
+	useLayoutEffect( () => {
+		if ( steal ) {
+			target.current?.focus();
+		}
+	} );
+	return null;
 }
 
 function elapseFetchDelay() {
@@ -445,6 +470,38 @@ describe( 'WidgetState', () => {
 		elapseFetchDelay();
 
 		expect( row ).toHaveFocus();
+	} );
+
+	it( 'forgets a row it did not park focus for, so a later fall to <body> stays put', () => {
+		// Something else claiming focus in the same commit takes the widget out of
+		// the running. Left pointing at the detached row, it would answer the next
+		// unrelated fall to <body> — in tree order, ahead of the widget that
+		// actually lost its focused element.
+		const props = { isError: false, isEmpty: false };
+		const elsewhereRef: RefObject< HTMLButtonElement | null > = { current: null };
+		const tree = ( { steal, isLoading }: { steal: boolean; isLoading: boolean } ) => (
+			<>
+				<StealFocus steal={ steal } target={ elsewhereRef } />
+				<WidgetState { ...props } isLoading={ isLoading }>
+					<button type="button">Taiwan</button>
+				</WidgetState>
+				<button type="button" ref={ elsewhereRef }>
+					Elsewhere
+				</button>
+			</>
+		);
+
+		const { rerender } = render( tree( { steal: false, isLoading: false } ) );
+		act( () => screen.getByRole( 'button', { name: 'Taiwan' } ).focus() );
+
+		rerender( tree( { steal: true, isLoading: true } ) );
+		const elsewhere = screen.getByRole( 'button', { name: 'Elsewhere' } );
+		expect( elsewhere ).toHaveFocus();
+
+		act( () => elsewhere.blur() );
+		rerender( tree( { steal: false, isLoading: false } ) );
+
+		expect( document.body ).toHaveFocus();
 	} );
 
 	it( 'error wins over loading and empty (retry in flight after a failed fetch)', () => {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/__tests__/widget-state.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/__tests__/widget-state.test.tsx
@@ -331,6 +331,122 @@ describe( 'WidgetState', () => {
 		);
 		expect( screen.getByRole( 'button' ) ).toHaveTextContent( '1' );
 	} );
+
+	it.each( [
+		[ 'the skeleton', { isLoading: true, isEmpty: false, isError: false } ],
+		[ 'the empty state', { isLoading: false, isEmpty: true, isError: false } ],
+		[ 'an error', { isLoading: false, isEmpty: false, isError: true } ],
+	] )( 'catches the focus %s takes down with the children', ( _label, resolved ) => {
+		// Keyboard-activating a drill-down row changes the params by definition,
+		// so it lands on the skeleton and unmounts the row that was activated.
+		// Without this the browser drops focus to <body> and the next Tab
+		// restarts at the top of the page.
+		const { rerender } = render(
+			<WidgetState isLoading={ false } isError={ false } isEmpty={ false }>
+				<button type="button">Taiwan</button>
+			</WidgetState>
+		);
+		act( () => screen.getByRole( 'button', { name: 'Taiwan' } ).focus() );
+
+		rerender(
+			<WidgetState { ...resolved }>
+				<button type="button">Taiwan</button>
+			</WidgetState>
+		);
+
+		expect( document.body ).not.toHaveFocus();
+		// eslint-disable-next-line @wordpress/no-global-active-element, testing-library/no-node-access -- which element the browser focused is the assertion, and the root is deliberately not queryable.
+		expect( document.activeElement ).toHaveAttribute( 'tabindex', '-1' );
+	} );
+
+	it( 'catches focus when new rows replace the focused one with no branch change', () => {
+		// A revalidation that comes back reordered unmounts the focused row
+		// without the state ever changing, so there is no branch to key on.
+		// Keyed, so React unmounts the old row rather than reusing the node.
+		const props = { isLoading: false, isError: false, isEmpty: false };
+		const { rerender } = render(
+			<WidgetState { ...props }>
+				<button type="button" key="tw">
+					Taiwan
+				</button>
+			</WidgetState>
+		);
+		act( () => screen.getByRole( 'button', { name: 'Taiwan' } ).focus() );
+
+		rerender(
+			<WidgetState { ...props }>
+				<button type="button" key="tp">
+					Taipei
+				</button>
+			</WidgetState>
+		);
+
+		expect( document.body ).not.toHaveFocus();
+		// eslint-disable-next-line @wordpress/no-global-active-element, testing-library/no-node-access -- which element the browser focused is the assertion, and the root is deliberately not queryable.
+		expect( document.activeElement ).toContainElement(
+			screen.getByRole( 'button', { name: 'Taipei' } )
+		);
+	} );
+
+	it( 'leaves focus alone when the reader had already left the widget', () => {
+		// Clicking something unfocusable drops focus to <body> on its own.
+		// Reclaiming it would haul the reader back to a widget they left.
+		const props = { isError: false, isEmpty: false };
+		const { rerender } = render(
+			<WidgetState { ...props } isLoading={ false }>
+				<button type="button">Taiwan</button>
+			</WidgetState>
+		);
+		const row = screen.getByRole( 'button', { name: 'Taiwan' } );
+		act( () => row.focus() );
+		act( () => row.blur() );
+
+		rerender(
+			<WidgetState { ...props } isLoading>
+				<button type="button">Taiwan</button>
+			</WidgetState>
+		);
+
+		expect( document.body ).toHaveFocus();
+	} );
+
+	it( 'leaves focus alone when it never entered the widget', () => {
+		const props = { isError: false, isEmpty: false };
+		const { rerender } = render(
+			<WidgetState { ...props } isLoading={ false }>
+				<button type="button">Taiwan</button>
+			</WidgetState>
+		);
+
+		rerender(
+			<WidgetState { ...props } isLoading>
+				<button type="button">Taiwan</button>
+			</WidgetState>
+		);
+
+		expect( document.body ).toHaveFocus();
+	} );
+
+	it( 'never moves focus through a revalidation, which unmounts nothing', () => {
+		const props = { isLoading: false, isError: false, isEmpty: false };
+		const { rerender } = render(
+			<WidgetState { ...props } isFetching={ false }>
+				<button type="button">Taiwan</button>
+			</WidgetState>
+		);
+		const row = screen.getByRole( 'button', { name: 'Taiwan' } );
+		act( () => row.focus() );
+
+		rerender(
+			<WidgetState { ...props } isFetching>
+				<button type="button">Taiwan</button>
+			</WidgetState>
+		);
+		elapseFetchDelay();
+
+		expect( row ).toHaveFocus();
+	} );
+
 	it( 'error wins over loading and empty (retry in flight after a failed fetch)', () => {
 		// The production shape on a failed fetch: isError with isEmpty derived
 		// true, plus loading signals while a retry is in flight. The priority

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/stories/widget-state.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/stories/widget-state.stories.tsx
@@ -65,7 +65,7 @@ const meta: Meta< typeof WidgetState > = {
 		docs: {
 			description: {
 				component:
-					'Data-agnostic widget content-area state. Derives one state (error → loading → empty → ready) from four boolean signals and renders it; any fetch in flight shows the loading skeleton, refetches included. Callers map their fetch result to the signals and pass generic `error` / `empty` descriptors. Stories render it inside a mock widget card; the ready state shows a mock bar chart standing in for real widget content.',
+					'Data-agnostic widget content-area state. Derives one state (error → loading → empty → ready) from four boolean signals and renders it. The skeleton is reserved for `isLoading`, meaning nothing on screen answers the current params; a background revalidation (`isFetching` alone) draws nothing and only marks the widget busy. Callers map their fetch result to the signals and pass generic `error` / `empty` descriptors. Stories render it inside a mock widget card; the ready state shows a mock bar chart standing in for real widget content.',
 			},
 		},
 	},
@@ -212,6 +212,10 @@ export const Ready: Story = {
 	},
 };
 
+/**
+ * Unchanged params being revalidated. Identical to `Ready` by design — only
+ * `aria-busy` differs.
+ */
 export const Refetching: Story = {
 	args: {
 		isLoading: false,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
@@ -87,3 +87,19 @@
 .root {
 	min-block-size: 0;
 }
+
+// The root is only focused programmatically, to catch focus a branch change
+// dropped, so it carries no ring by default.
+.root:focus {
+	outline: none;
+}
+
+// `:focus-visible` still separates the two cases: the flag carries across a
+// programmatic focus move, so a reader navigating by keyboard sees where they
+// landed, while a mouse user gets no ring around the whole widget body. Drawn
+// inset for the reason `.reportLink` documents — widgets clip their own
+// overflow, so an outset ring on a full-height element is cut off entirely.
+.root:focus-visible {
+	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus);
+	outline-offset: calc(-1 * var(--wpds-border-width-focus));
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
@@ -87,30 +87,3 @@
 .root {
 	min-block-size: 0;
 }
-
-// Preserve layout measurements during refetches.
-.contentHidden {
-	visibility: hidden;
-}
-
-// The root is only ever focused programmatically, to hold focus while a refetch
-// hides the children, so it carries no ring by default.
-.root:focus {
-	outline: none;
-}
-
-// `:focus-visible` still separates the two cases: the flag carries across a
-// programmatic focus move, so a reader who activated a row from the keyboard
-// sees where they landed, while a mouse user gets no ring around the whole
-// widget body. Drawn inset for the reason `.reportLink` documents — widgets
-// clip their own overflow, so an outset ring on a full-height element is cut
-// off entirely.
-.root:focus-visible {
-	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus);
-	outline-offset: calc(-1 * var(--wpds-border-width-focus));
-}
-
-.skeletonOverlay {
-	position: absolute;
-	inset: 0;
-}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
@@ -3,8 +3,6 @@
  */
 import { Button, Icon, Stack } from '@jetpack-premium-analytics/externals';
 import { __ } from '@wordpress/i18n';
-import clsx from 'clsx';
-import { useLayoutEffect, useRef } from 'react';
 /**
  * Internal dependencies
  */
@@ -29,9 +27,16 @@ export interface WidgetStateEmpty {
 }
 
 export interface WidgetStateProps {
-	/** A fetch is in flight and there is no data yet (React Query `isLoading`). */
+	/**
+	 * Nothing on screen answers the current params: a first load, or a param
+	 * change still showing the previous response. Pass the data hook's
+	 * `isLoading`, which is already widened to cover both.
+	 */
 	isLoading: boolean;
-	/** A refetch is in flight while data is already shown (React Query `isFetching`). */
+	/**
+	 * Unchanged params being revalidated (React Query `isFetching`). Draws
+	 * nothing — the numbers on screen are still the right answer.
+	 */
 	isFetching?: boolean;
 	isError: boolean;
 	isEmpty: boolean;
@@ -52,47 +57,9 @@ export function WidgetState( {
 	renderLoading,
 	children,
 }: WidgetStateProps ) {
-	// React Query also reports `isFetching` on the first load; delay only refetches.
-	const showFetchingState = useDelayedLoading( isFetching && ! isLoading );
-	const rootRef = useRef< HTMLDivElement >( null );
-	const contentRef = useRef< HTMLDivElement >( null );
-	const focusToRestore = useRef< HTMLElement | null >( null );
-
-	// Park focus before hidden content becomes unfocusable, then restore it after the refetch.
-	useLayoutEffect( () => {
-		// Use the widget's document to support rendering in another window or iframe.
-		const ownerDocument = rootRef.current?.ownerDocument;
-		const view = ownerDocument?.defaultView;
-		if ( ! ownerDocument || ! view ) {
-			return;
-		}
-
-		if ( showFetchingState ) {
-			const active = ownerDocument.activeElement;
-			// Elements must be checked against their own document's constructor.
-			const wasInside =
-				active instanceof view.HTMLElement && !! contentRef.current?.contains( active );
-			// Clear stale targets when focus is outside the widget.
-			focusToRestore.current = wasInside ? active : null;
-			if ( wasInside ) {
-				// The root remains mounted and keeps keyboard navigation at the widget.
-				rootRef.current?.focus( { preventScroll: true } );
-			}
-			return;
-		}
-
-		const target = focusToRestore.current;
-		focusToRestore.current = null;
-		if ( ! target ) {
-			return;
-		}
-		// Do not reclaim focus if the user moved it during the refetch.
-		if ( ownerDocument.activeElement !== rootRef.current ) {
-			return;
-		}
-		// Fall back to the root if the original target was removed, without changing the viewport.
-		( target.isConnected ? target : rootRef.current )?.focus( { preventScroll: true } );
-	}, [ showFetchingState ] );
+	// `isFetching` is true on the first load too, and a quick revalidation is not
+	// worth announcing.
+	const isRevalidating = useDelayedLoading( isFetching && ! isLoading );
 
 	const skeleton = renderLoading ?? <GenericSkeleton />;
 	let body: ReactNode;
@@ -129,13 +96,8 @@ export function WidgetState( {
 				) }
 			</Stack>
 		);
-	} else if ( isLoading || ( isEmpty && showFetchingState ) ) {
-		// Announce the skeleton only on first load, not when refetching an empty result.
-		body = (
-			<div className={ styles.loading } aria-hidden={ ! isLoading || undefined }>
-				{ skeleton }
-			</div>
-		);
+	} else if ( isLoading ) {
+		body = <div className={ styles.loading }>{ skeleton }</div>;
 	} else if ( isEmpty ) {
 		body = (
 			<ChartEmptyState
@@ -151,34 +113,15 @@ export function WidgetState( {
 			/>
 		);
 	} else {
-		// Keep children mounted during refetches so their state and layout survive.
-		body = (
-			<>
-				<div
-					ref={ contentRef }
-					className={ clsx( styles.content, showFetchingState && styles.contentHidden ) }
-				>
-					{ children }
-				</div>
-				{ /* Avoid announcing one status message per widget during refetches. */ }
-				{ showFetchingState && (
-					<div className={ styles.skeletonOverlay } aria-hidden="true">
-						{ skeleton }
-					</div>
-				) }
-			</>
-		);
+		body = <div className={ styles.content }>{ children }</div>;
 	}
 
-	// Keep the focus target mounted when a refetch resolves to any state.
 	return (
 		<div
-			ref={ rootRef }
-			// Focused programmatically during refetches, but omitted from the tab order.
-			tabIndex={ -1 }
 			className={ styles.root }
-			// Mark only visible refetch skeletons as busy; the first-load skeleton announces itself.
-			aria-busy={ showFetchingState || undefined }
+			// Nothing on screen moves, so a reader is told the region is updating
+			// rather than shown it.
+			aria-busy={ isRevalidating || undefined }
 		>
 			{ body }
 		</div>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
@@ -3,6 +3,7 @@
  */
 import { Button, Icon, Stack } from '@jetpack-premium-analytics/externals';
 import { __ } from '@wordpress/i18n';
+import { useLayoutEffect, useRef } from 'react';
 /**
  * Internal dependencies
  */
@@ -12,7 +13,7 @@ import { ChartEmptyState } from '../chart-empty-state';
 import { GenericSkeleton } from '../widget-skeleton';
 import { errorStateIcon } from './error-state-icon';
 import styles from './widget-state.module.scss';
-import type { ComponentProps, ReactNode } from 'react';
+import type { ComponentProps, FocusEvent, ReactNode } from 'react';
 
 export interface WidgetStateError {
 	title?: string;
@@ -60,6 +61,51 @@ export function WidgetState( {
 	// `isFetching` is true on the first load too, and a quick revalidation is not
 	// worth announcing.
 	const isRevalidating = useDelayedLoading( isFetching && ! isLoading );
+
+	const rootRef = useRef< HTMLDivElement >( null );
+	// What the reader is standing on inside this widget, so the effect below can
+	// tell "their element was taken away" from "they walked off".
+	const focusedInside = useRef< HTMLElement | null >( null );
+
+	const rememberFocus = ( event: FocusEvent< HTMLDivElement > ) => {
+		focusedInside.current = event.target;
+	};
+
+	const forgetFocus = ( event: FocusEvent< HTMLDivElement > ) => {
+		// An element on its way out fires focusout in some browsers and not in
+		// others. Keep it either way: that is the case the effect below exists for.
+		if ( ! event.target.isConnected ) {
+			return;
+		}
+		// Moving within the widget is not leaving it.
+		if ( ! event.currentTarget.contains( event.relatedTarget ) ) {
+			focusedInside.current = null;
+		}
+	};
+
+	// Every branch but the ready one unmounts the children, and a drill-down or a
+	// range change reaches the skeleton by definition — both take the row the
+	// reader activated with them, and the browser hands focus to <body>, where the
+	// next Tab restarts at the top of the page. Catch it on the root instead.
+	//
+	// Deliberately unconditional: a branch change is the common way to lose the
+	// focused element, but not the only one — new rows arriving under unchanged
+	// params unmount it just the same, without any branch change to key on.
+	useLayoutEffect( () => {
+		const target = focusedInside.current;
+		const root = rootRef.current;
+		// Use the widget's own document to support rendering in another window.
+		const ownerDocument = root?.ownerDocument;
+		if ( ! target || ! root || ! ownerDocument ) {
+			return;
+		}
+		// Step in only for focus this widget just dropped: a target still in the
+		// document, or focus that went anywhere but <body>, is not ours to move.
+		if ( target.isConnected || ownerDocument.activeElement !== ownerDocument.body ) {
+			return;
+		}
+		root.focus( { preventScroll: true } );
+	} );
 
 	const skeleton = renderLoading ?? <GenericSkeleton />;
 	let body: ReactNode;
@@ -118,9 +164,15 @@ export function WidgetState( {
 
 	return (
 		<div
+			ref={ rootRef }
+			// Focused programmatically when a branch change drops the reader's
+			// element, but never in the tab order itself.
+			tabIndex={ -1 }
 			className={ styles.root }
-			// Nothing on screen moves, so a reader is told the region is updating
-			// rather than shown it.
+			onFocus={ rememberFocus }
+			onBlur={ forgetFocus }
+			// A marker, not an announcement: on a roleless container most screen
+			// readers stay quiet, which is the point — nothing on screen moved.
 			aria-busy={ isRevalidating || undefined }
 		>
 			{ body }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
@@ -99,9 +99,17 @@ export function WidgetState( {
 		if ( ! target || ! root || ! ownerDocument ) {
 			return;
 		}
-		// Step in only for focus this widget just dropped: a target still in the
-		// document, or focus that went anywhere but <body>, is not ours to move.
-		if ( target.isConnected || ownerDocument.activeElement !== ownerDocument.body ) {
+		// A target still in the document is not something this widget dropped.
+		if ( target.isConnected ) {
+			return;
+		}
+		// Gone either way, so stop tracking it now. Held past the render that
+		// dropped it, it would let the next fall to <body> anywhere on the page
+		// pull focus in here.
+		focusedInside.current = null;
+		// Step in only for focus this widget just dropped: focus that went
+		// anywhere but <body> is not ours to move.
+		if ( ownerDocument.activeElement !== ownerDocument.body ) {
 			return;
 		}
 		root.focus( { preventScroll: true } );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/bookings-by-attendance/bookings-by-attendance-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/bookings-by-attendance/bookings-by-attendance-widget.tsx
@@ -38,7 +38,7 @@ export function BookingsByAttendanceWidget() {
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/conversion-rate/conversion-rate-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/conversion-rate/conversion-rate-widget.tsx
@@ -61,7 +61,7 @@ export function ConversionRateWidget( {
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/coupon-use/coupon-use-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/coupon-use/coupon-use-widget.tsx
@@ -36,7 +36,7 @@ export function CouponUseWidget() {
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/new-vs-returning-customer/new-vs-returning-customer-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/new-vs-returning-customer/new-vs-returning-customer-widget.tsx
@@ -36,7 +36,7 @@ export function NewVsReturningCustomerWidget() {
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/orders-fulfillment/orders-fulfillment-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/orders-fulfillment/orders-fulfillment-widget.tsx
@@ -83,7 +83,7 @@ export function OrdersFulfillmentWidget() {
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/product-leaderboard/top-performing-product-leaderboard-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/product-leaderboard/top-performing-product-leaderboard-widget.tsx
@@ -162,9 +162,10 @@ export function TopPerformingProductLeaderboardWidget( {
 
 	return (
 		<WidgetState
-			// Images gate only the first paint, so rows never appear with blank
-			// thumbnails; after that they stay put and the thumbnails fill in.
-			isLoading={ isLoading || ( imagesLoading && ! hasData ) }
+			// The images query only starts once the report supplies product IDs, so
+			// rows land first and the thumbnails fill in behind them. That gap is
+			// a refetch, not a missing answer, so it belongs in `isFetching`.
+			isLoading={ isLoading }
 			isFetching={ isFetching || imagesLoading }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/product-leaderboard/top-performing-product-leaderboard-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/product-leaderboard/top-performing-product-leaderboard-widget.tsx
@@ -162,7 +162,9 @@ export function TopPerformingProductLeaderboardWidget( {
 
 	return (
 		<WidgetState
-			isLoading={ ( isLoading || imagesLoading ) && ! hasData }
+			// Images gate only the first paint, so rows never appear with blank
+			// thumbnails; after that they stay put and the thumbnails fill in.
+			isLoading={ isLoading || ( imagesLoading && ! hasData ) }
 			isFetching={ isFetching || imagesLoading }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/revenue-by-customer-type/revenue-by-customer-type-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/revenue-by-customer-type/revenue-by-customer-type-widget.tsx
@@ -48,7 +48,7 @@ function CustomerTypeRevenueWidget( { filter }: CustomerTypeRevenueWidgetProps )
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-coupon/sales-by-coupon-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-coupon/sales-by-coupon-widget.tsx
@@ -35,7 +35,7 @@ export function SalesByCouponWidget() {
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-device/sales-by-device-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-device/sales-by-device-widget.tsx
@@ -60,7 +60,7 @@ export function SalesByDeviceWidget( {
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-utm/sales-by-utm-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-utm/sales-by-utm-widget.tsx
@@ -72,7 +72,7 @@ export function SalesByUtmWidget( { view }: SalesByUtmWidgetProps ) {
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sessions-by-device/sessions-by-device-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sessions-by-device/sessions-by-device-widget.tsx
@@ -36,7 +36,7 @@ export function SessionsByDeviceWidget() {
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/total-returns/total-returns-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/total-returns/total-returns-widget.tsx
@@ -34,7 +34,7 @@ export function TotalReturnsWidget() {
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholders
 			// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.tsx
@@ -106,7 +106,7 @@ export function VisitorsByLocationWidget() {
 				</div>
 
 				<WidgetState
-					isLoading={ isLoading && ! hasData }
+					isLoading={ isLoading }
 					isFetching={ isFetching }
 					// The report queries keep the previous period's data as placeholders
 					// across range changes, so only surface the error when there is

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -229,20 +229,12 @@ function AuthorsReport( { max }: AuthorsReportProps ) {
 	const { reportParams } = useWidgetRootContext();
 	const statsParams = useMemo( () => ( { ...reportParams, max } ), [ reportParams, max ] );
 
-	const {
-		primary,
-		comparisonRows,
-		hasComparison,
-		isLoading,
-		isFetching,
-		hasData,
-		isError,
-		refetch,
-	} = useStatsTopAuthors( statsParams, { maxRows: max } );
+	const { primary, comparisonRows, hasComparison, isLoading, isFetching, isError, refetch } =
+		useStatsTopAuthors( statsParams, { maxRows: max } );
 
 	// `primary.isPending` also covers the brief window where the query is disabled
 	// while the report params resolve (isLoading is false there).
-	const isInitialLoading = ( isLoading || primary.isPending ) && ! hasData;
+	const isInitialLoading = isLoading || primary.isPending;
 
 	const rows = useMemo(
 		() => buildTopAuthorsData( comparisonRows?.rows ?? [] ),

--- a/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
@@ -268,12 +268,9 @@ describe( 'EmailTimeSeriesWidget', () => {
 			jest.advanceTimersByTime( 1000 );
 		} );
 
-		// The skeleton, not the removed spinner — and a silent one: a refetch
-		// must not announce, only a first load does. `hidden: true` widens the
-		// query to include hidden nodes rather than requiring them, so it only
-		// pins the silence paired with the negative assertion above it.
-		expect( screen.queryByRole( 'status' ) ).not.toBeInTheDocument();
-		expect( screen.getByRole( 'status', { hidden: true } ) ).toBeInTheDocument();
+		// The previous range's "no activity" is not an answer about this one, so
+		// it gives way to an announced skeleton.
+		expect( screen.getByRole( 'status' ) ).toBeInTheDocument();
 		expect(
 			screen.queryByText( 'No activity for this email in this period.' )
 		).not.toBeInTheDocument();

--- a/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
@@ -56,7 +56,6 @@ const LOADING_STATE: LocationViewsState = {
 	isFetching: true,
 	hasData: false,
 	isError: false,
-	isPlaceholderData: false,
 	refetch: () => {},
 };
 

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -41,10 +41,6 @@ import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 type LocationsRenderAttributes = LocationsAttributes & Partial< ReportParamsFieldAttributes >;
 type LocationsWidgetProps = WidgetRenderProps< LocationsRenderAttributes >;
 type DrillDownCountry = { code: string; name: string };
-type RenderLocationState = {
-	geoMode: GeoMode;
-	selectedCountry?: DrillDownCountry;
-};
 type GoogleChartsWindow = Window & {
 	google?: {
 		visualization?: {
@@ -115,43 +111,26 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
 	const geoMode: GeoMode =
 		geoGranularity === 'country' && activeSelectedCountry ? 'region' : geoGranularity;
 
-	const { data, hasComparison, isLoading, isFetching, isError, isPlaceholderData, refetch } =
-		useLocationViews( {
-			reportParams,
-			max,
-			geoMode,
-			countryFilter: activeSelectedCountry?.code,
-		} );
-	const [ renderLocationState, setRenderLocationState ] = useState< RenderLocationState >( {
+	const { data, hasComparison, isLoading, isFetching, isError, refetch } = useLocationViews( {
+		reportParams,
+		max,
 		geoMode,
-		selectedCountry: activeSelectedCountry,
+		countryFilter: activeSelectedCountry?.code,
 	} );
 
-	useEffect( () => {
-		if ( isPlaceholderData ) {
-			return;
-		}
-
-		setRenderLocationState( { geoMode, selectedCountry: activeSelectedCountry } );
-	}, [ activeSelectedCountry, geoMode, isPlaceholderData ] );
-
-	const renderGeoMode = isPlaceholderData ? renderLocationState.geoMode : geoMode;
-	const renderSelectedCountry = isPlaceholderData
-		? renderLocationState.selectedCountry
-		: activeSelectedCountry;
-	const selectedCountryCode = renderSelectedCountry?.code.toUpperCase();
+	const selectedCountryCode = activeSelectedCountry?.code.toUpperCase();
 	const useProvinceMap =
-		renderGeoMode === 'region' &&
+		geoMode === 'region' &&
 		!! selectedCountryCode &&
 		! unsupportedProvinceMapCountries.has( selectedCountryCode );
 	const useCountryFallbackMap =
-		renderGeoMode === 'region' && !! renderSelectedCountry && ! useProvinceMap;
-	const fallbackCountry = useCountryFallbackMap ? renderSelectedCountry : undefined;
+		geoMode === 'region' && !! activeSelectedCountry && ! useProvinceMap;
+	const fallbackCountry = useCountryFallbackMap ? activeSelectedCountry : undefined;
 	// Cities, and Regions outside a country drill-down, span the whole world.
 	// Google GeoChart can't place either row type on the world map, so both are
 	// summed back up to their country.
 	const useCountrySummaryMap =
-		renderGeoMode === 'city' || ( renderGeoMode === 'region' && ! renderSelectedCountry );
+		geoMode === 'city' || ( geoMode === 'region' && ! activeSelectedCountry );
 	const countrySummaryRows = useMemo( () => {
 		const countryRows = new Map< string, { countryFull: string; value: number } >();
 
@@ -285,7 +264,7 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
 						country: location.countryFull,
 					},
 					action:
-						renderGeoMode === 'country' && countryCode
+						geoMode === 'country' && countryCode
 							? {
 									kind: 'drillDown',
 									onClick: () =>
@@ -314,9 +293,9 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
 						: undefined,
 			};
 		} ) as LeaderboardChartData;
-	}, [ data, renderGeoMode, hasComparison, selectCountry ] );
+	}, [ data, geoMode, hasComparison, selectCountry ] );
 
-	const backLink = renderSelectedCountry ? (
+	const backLink = activeSelectedCountry ? (
 		<WidgetBackLink
 			label={ __( 'All locations', 'jetpack-premium-analytics-pkg' ) }
 			ariaLabel={ __( 'View all locations', 'jetpack-premium-analytics-pkg' ) }
@@ -374,7 +353,7 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
 							<GeoChart
 								data={ geoData }
 								resizeDebounceTime={ 100 }
-								region={ useProvinceMap ? renderSelectedCountry?.code ?? 'world' : 'world' }
+								region={ useProvinceMap ? activeSelectedCountry?.code ?? 'world' : 'world' }
 								resolution={ useProvinceMap ? 'provinces' : 'countries' }
 								onError={ handleGeoChartError }
 							/>

--- a/projects/packages/premium-analytics/widgets/locations/use-location-views.ts
+++ b/projects/packages/premium-analytics/widgets/locations/use-location-views.ts
@@ -45,7 +45,6 @@ interface LocationViewsState {
 	isFetching: boolean;
 	hasData: boolean;
 	isError: boolean;
-	isPlaceholderData: boolean;
 	refetch: () => void;
 }
 
@@ -90,18 +89,8 @@ export default function useLocationViews( {
 		...( countryFilter ? { filter_by_country: countryFilter } : {} ),
 	} as Parameters< typeof useStatsLocations >[ 0 ];
 
-	const {
-		primary,
-		comparison,
-		comparisonRows,
-		hasComparison,
-		isLoading,
-		isFetching,
-		hasData,
-		isError,
-		refetch,
-	} = useStatsLocations( statsParams, { maxRows: max } );
-	const isPlaceholderData = primary.isPlaceholderData || comparison.isPlaceholderData;
+	const { comparisonRows, hasComparison, isLoading, isFetching, hasData, isError, refetch } =
+		useStatsLocations( statsParams, { maxRows: max } );
 
 	const items = ( comparisonRows?.rows ?? [] )
 		.map( toLocationView )
@@ -118,7 +107,6 @@ export default function useLocationViews( {
 		// flips true. Only surface the error when there's nothing to show, so a transient
 		// refetch failure doesn't replace populated rows with the error state.
 		isError: items.length === 0 && isError,
-		isPlaceholderData,
 		refetch,
 	};
 }

--- a/projects/packages/premium-analytics/widgets/payment-status/payment-status-widget.tsx
+++ b/projects/packages/premium-analytics/widgets/payment-status/payment-status-widget.tsx
@@ -41,7 +41,7 @@ export function PaymentStatusWidget() {
 
 	return (
 		<WidgetState
-			isLoading={ isLoading && ! hasData }
+			isLoading={ isLoading }
 			isFetching={ isFetching }
 			// The report queries keep the previous period's data as placeholder across
 			// range changes, so only surface the error when there is nothing to show.

--- a/projects/packages/premium-analytics/widgets/plan-usage/__tests__/plan-usage.test.tsx
+++ b/projects/packages/premium-analytics/widgets/plan-usage/__tests__/plan-usage.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { queryClient } from '@jetpack-premium-analytics/data';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -139,7 +139,7 @@ describe( 'PlanUsageWidget', () => {
 		expect( screen.queryByRole( 'status' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'replaces the meter with the skeleton during a background refetch', async () => {
+	it( 'leaves the meter on screen through a background refetch (WOOA7S-1934)', async () => {
 		let resolveRefetch: ( value: unknown ) => void = () => {};
 		mockApiFetch.mockResolvedValueOnce( PLAN_USAGE_RESPONSE ).mockImplementationOnce(
 			() =>
@@ -156,8 +156,12 @@ describe( 'PlanUsageWidget', () => {
 			queryClient.refetchQueries();
 		} );
 
-		await expect( screen.findByRole( 'status', { hidden: true } ) ).resolves.toBeInTheDocument();
-		expect( screen.queryByRole( 'status' ) ).not.toBeInTheDocument();
+		// `aria-busy` lands after the same delay the skeleton used to, so waiting
+		// for it proves that window has elapsed.
+		await waitFor( () =>
+			expect( screen.getAllByRole( 'generic', { busy: true } ) ).toHaveLength( 1 )
+		);
+		expect( screen.queryByRole( 'status', { hidden: true } ) ).not.toBeInTheDocument();
 		expect( screen.getByText( '6,200 / 10,000 views' ) ).toBeInTheDocument();
 
 		await act( async () => {

--- a/projects/packages/premium-analytics/widgets/post-comments/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-comments/render.tsx
@@ -59,7 +59,7 @@ function PostCommentsInner() {
 	return (
 		<div className={ styles.root }>
 			<WidgetState
-				isLoading={ isLoading && ! data }
+				isLoading={ isLoading }
 				isFetching={ isFetching }
 				// The query keeps prior data via `placeholderData`, so a transient
 				// refetch failure keeps the comments visible; only surface the error

--- a/projects/packages/premium-analytics/widgets/post-detail-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-detail-highlights/render.tsx
@@ -94,7 +94,7 @@ function PostDetailHighlightsInner() {
 	return (
 		<div className={ styles.root }>
 			<WidgetState
-				isLoading={ isLoading && ! hasData }
+				isLoading={ isLoading }
 				isFetching={ isFetching }
 				// As with `isLoading` above: the highlights stay on screen through a
 				// transient refetch failure, so only surface the error when there is

--- a/projects/packages/premium-analytics/widgets/post-likes/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-likes/render.tsx
@@ -63,7 +63,7 @@ function PostLikesInner() {
 	return (
 		<div className={ styles.root }>
 			<WidgetState
-				isLoading={ isLoading && ! data }
+				isLoading={ isLoading }
 				isFetching={ isFetching }
 				// The query keeps prior data via `placeholderData`, so a transient
 				// refetch failure keeps the likes visible; only surface the error

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -92,7 +92,6 @@ function PostTrafficActivityInner() {
 		isLoading,
 		isFetching,
 		isError,
-		hasData,
 		refetch,
 	} = usePostTrafficActivity( postId, reportParams, weeksForWidth( width ) * 7 );
 
@@ -134,7 +133,7 @@ function PostTrafficActivityInner() {
 		<div ref={ measureRef } className={ styles.root }>
 			<div className={ styles.body }>
 				<WidgetState
-					isLoading={ isLoading && ! hasData }
+					isLoading={ isLoading }
 					isFetching={ isFetching }
 					isError={ isError }
 					isEmpty={ postId <= 0 || heatmapData.length === 0 }

--- a/projects/packages/premium-analytics/widgets/post-views/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/render.tsx
@@ -45,7 +45,7 @@ function PostViewsInner( { granularity, chartType }: PostViewsInnerProps ) {
 	const { reportParams } = useWidgetRootContext();
 	const postId = toPostId( reportParams.post_id );
 
-	const { current, isLoading, isFetching, isError, hasData, refetch } = usePostViews(
+	const { current, isLoading, isFetching, isError, refetch } = usePostViews(
 		postId,
 		reportParams,
 		granularity
@@ -68,7 +68,7 @@ function PostViewsInner( { granularity, chartType }: PostViewsInnerProps ) {
 	return (
 		<div className={ styles.root }>
 			<WidgetState
-				isLoading={ isLoading && ! hasData }
+				isLoading={ isLoading }
 				isFetching={ isFetching }
 				isError={ isError }
 				isEmpty={ postId <= 0 }

--- a/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
@@ -243,9 +243,9 @@ describe( 'SiteOverviewWidget', () => {
 			/>
 		);
 
-		await expect( screen.findByRole( 'status', { hidden: true } ) ).resolves.toBeInTheDocument();
-		expect( screen.queryByRole( 'status' ) ).not.toBeInTheDocument();
-		expect( screen.getByText( '420' ) ).toBeInTheDocument();
+		// March's total is not April's, so it gives way to the skeleton.
+		await expect( screen.findByRole( 'status' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( '420' ) ).not.toBeInTheDocument();
 
 		resolveNextPeriod?.();
 		await expect( screen.findByText( '999' ) ).resolves.toBeInTheDocument();

--- a/projects/packages/premium-analytics/widgets/site-overview/render.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/render.tsx
@@ -144,7 +144,7 @@ function SiteOverviewReport( {
 	return (
 		<div className={ styles.root }>
 			<WidgetState
-				isLoading={ ( isLoading || primary.isPending ) && ! summary }
+				isLoading={ isLoading || primary.isPending }
 				isFetching={ isFetching }
 				isError={ ! summary && isError }
 				isEmpty={ isEmpty }

--- a/projects/packages/premium-analytics/widgets/store-performance/render.tsx
+++ b/projects/packages/premium-analytics/widgets/store-performance/render.tsx
@@ -311,7 +311,7 @@ function StorePerformanceContent() {
 		[ enrichedMetrics, dataSources ]
 	);
 
-	const isInitialLoading = reports.some( report => report.isLoading && ! report.hasData );
+	const isInitialLoading = reports.some( report => report.isLoading );
 	const isFetching = reports.some( report => report.isFetching );
 
 	return (

--- a/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
@@ -336,8 +336,10 @@ describe( 'TopPostsWidget', () => {
 		await waitFor( () =>
 			expect( screen.queryByRole( 'button', { name: /Download CSV/ } ) ).not.toBeInTheDocument()
 		);
-		await expect( screen.findByRole( 'status', { hidden: true } ) ).resolves.toBeInTheDocument();
-		expect( screen.getByRole( 'link', { name: /^Hello World Post$/ } ) ).toBeInTheDocument();
+		// March's rows do not answer a question about May, so they give way to an
+		// announced skeleton.
+		await expect( screen.findByRole( 'status' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: /^Hello World Post$/ } ) ).not.toBeInTheDocument();
 
 		// Once the new range settles, the export returns.
 		resolveSecond( TOP_POSTS_RESPONSE );

--- a/projects/packages/premium-analytics/widgets/video-detail-views-performance/render.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-views-performance/render.tsx
@@ -55,7 +55,7 @@ function VideoDetailViewsPerformanceInner( {
 	const { reportParams } = useWidgetRootContext();
 	const videoId = toPostId( reportParams.post_id );
 
-	const { current, isLoading, isFetching, isError, error, hasData, refetch } = useVideoViews(
+	const { current, isLoading, isFetching, isError, error, refetch } = useVideoViews(
 		videoId,
 		reportParams,
 		granularity
@@ -78,7 +78,7 @@ function VideoDetailViewsPerformanceInner( {
 	return (
 		<div className={ styles.root }>
 			<WidgetState
-				isLoading={ isLoading && ! hasData }
+				isLoading={ isLoading }
 				isFetching={ isFetching }
 				isError={ isError }
 				isEmpty={ videoId <= 0 }

--- a/projects/packages/premium-analytics/widgets/videopress/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/render.tsx
@@ -108,20 +108,12 @@ function VideoPressReport( { max }: VideoPressReportProps ) {
 	// The hook merges comparison rows in the data layer and gates
 	// `hasComparison` on at least one visible row (`maxRows`) having a matching
 	// comparison row, so the chart never fabricates vs-zero deltas.
-	const {
-		primary,
-		comparisonRows,
-		hasComparison,
-		isLoading,
-		isFetching,
-		hasData,
-		isError,
-		refetch,
-	} = useStatsVideoPlays( statsParams, { maxRows: max } );
+	const { primary, comparisonRows, hasComparison, isLoading, isFetching, isError, refetch } =
+		useStatsVideoPlays( statsParams, { maxRows: max } );
 
 	// `primary.isPending` also covers the brief window where the query is disabled
 	// while the report params resolve (isLoading is false there).
-	const isInitialLoading = ( isLoading || primary.isPending ) && ! hasData;
+	const isInitialLoading = isLoading || primary.isPending;
 
 	const rows = useMemo( () => toVideoPlaysRows( comparisonRows?.rows ?? [] ), [ comparisonRows ] );
 	const detailSearch = useMemo( () => pickReportDateParams( reportParams ), [ reportParams ] );


### PR DESCRIPTION
Fixes WOOA7S-1934

## Proposed changes

- `WidgetState` no longer hides the rendered content and paints a skeleton over it during a background revalidation — the numbers stay put and the widget only reports itself `aria-busy`.
- The data hooks widen `isLoading` to "nothing on screen answers the current params", folding in `isPlaceholderData` so a range change still gets a skeleton.
- Drops the `&& ! hasData` guards at the call sites, which would otherwise cancel that skeleton — every `<WidgetState>` now passes the hook's `isLoading` straight through.
- Removes the focus-parking effect and the `contentHidden` / `skeletonOverlay` rules, which only existed to survive content being hidden.
- Adds coverage for the transition itself, plus a contract test pinning how React Query reports a range change versus a revalidation.

Follow-up to @retrofox's review of #51202. The root cause was not a widget feeding the wrong flag: `isFetching` is equally true for a range change and for a revalidation of unchanged params, so `WidgetState` could not tell "these numbers are stale" from "these numbers are fine, we're just checking". `isPlaceholderData` separates them.

## Related product discussion/links

- WOOA7S-1934

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Reproducing the original bug needs the dashboard to go stale, so start there:

- Open the Premium Analytics dashboard and let every widget render.
- Switch to another browser tab for 5+ minutes (past the query client's `staleTime`), then switch back. Throttling to Slow 3G first makes the phase easy to watch.
- **Before this PR:** every widget replaces its numbers with a skeleton at once. **After:** nothing moves — the numbers stay on screen while the refresh runs.

Then confirm the cases that _should_ still show a skeleton:

- Change the date range to one you have not viewed yet: widgets show a skeleton rather than the previous range's numbers. (Switching back to a range you already loaded now shows its numbers immediately instead of flashing a skeleton — the data is cached under its own key.)
- Reload the dashboard cold: first load still shows skeletons.

Storybook covers the component in isolation: `Packages/Premium Analytics/Widgets Toolkit/Components/WidgetState` → **Refetching** is now visually identical to **Ready**, which is the point.
