### PR TITLE
Insights: scope the calendar heatmaps to the selected year

### DIFF
--- a/projects/js-packages/charts/changelog/fix-wooa7s-1963-heatmap-window
+++ b/projects/js-packages/charts/changelog/fix-wooa7s-1963-heatmap-window
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Charts: let a calendar heatmap draw a grid wider than its data, filling the extra weeks with cells that report nothing rather than claiming there was no activity on them.

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -103,10 +103,13 @@ $focus-ring-width: var(--wpds-border-width-focus, var(--wp-admin-border-width-fo
 	pointer-events: none;
 }
 
-// Grid filler: keeps the empty-cell track from the base class so the grid reads
-// as continuous, but captures no pointer — it stands for an unmeasured day.
+// Grid filler: keeps its slot so the grid reads as continuous, but stands for a
+// day nothing was measured for — so it captures no pointer, and its track is
+// faded to keep it apart from a measured day that simply scored zero. Mixed
+// towards `transparent` rather than a lighter grey so it holds in either theme.
 .heatmap-chart__cell--placeholder {
 	pointer-events: none;
+	background: color-mix(in sRGB, var(--a8c-charts-color-track) 45%, transparent);
 }
 
 // Floor the mix at 15% so the lowest value stays visibly tinted, distinct from

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -103,6 +103,12 @@ $focus-ring-width: var(--wpds-border-width-focus, var(--wp-admin-border-width-fo
 	pointer-events: none;
 }
 
+// Grid filler: keeps the empty-cell track from the base class so the grid reads
+// as continuous, but captures no pointer — it stands for an unmeasured day.
+.heatmap-chart__cell--placeholder {
+	pointer-events: none;
+}
+
 // Floor the mix at 15% so the lowest value stays visibly tinted, distinct from
 // an empty cell.
 .heatmap-chart__cell--filled {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -136,8 +136,13 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 		hideTooltip();
 	}, [ hideTooltip ] );
 
-	const isCellHidden = useCallback(
-		( col: number, row: number ) => data[ col ]?.data[ row ]?.hidden === true,
+	// Both empty-slot kinds are skipped by navigation: `hidden` paints nothing,
+	// `placeholder` paints an empty cell, and neither has a value to report.
+	const isCellInert = useCallback(
+		( col: number, row: number ) => {
+			const cell = data[ col ]?.data[ row ];
+			return cell?.hidden === true || cell?.placeholder === true;
+		},
 		[ data ]
 	);
 
@@ -163,7 +168,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 				// Start at the first navigable cell (a calendar's leading edge
 				// slots may be hidden).
 				for ( let index = 0; index < columns * rows; index++ ) {
-					if ( ! isCellHidden( Math.floor( index / rows ), index % rows ) ) {
+					if ( ! isCellInert( Math.floor( index / rows ), index % rows ) ) {
 						setSelectedIndex( index );
 						return;
 					}
@@ -191,7 +196,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 			do {
 				col += stepCol;
 				row += stepRow;
-			} while ( col >= 0 && col < columns && row >= 0 && row < rows && isCellHidden( col, row ) );
+			} while ( col >= 0 && col < columns && row >= 0 && row < rows && isCellInert( col, row ) );
 
 			if ( col < 0 || col >= columns || row < 0 || row >= rows ) {
 				return;
@@ -199,7 +204,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 
 			setSelectedIndex( col * rows + row );
 		},
-		[ rows, columns, selectedIndex, hideTooltip, isCellHidden ]
+		[ rows, columns, selectedIndex, hideTooltip, isCellInert ]
 	);
 
 	const handleCellMouseMove = useCallback(
@@ -386,6 +391,24 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 													className={ clsx(
 														styles[ 'heatmap-chart__cell' ],
 														styles[ 'heatmap-chart__cell--hidden' ]
+													) }
+												/>
+											);
+										}
+
+										// Filler: drawn like an empty cell so the grid fills its
+										// container, but it stands for a day nothing was measured
+										// for, so it reports nothing to a pointer or a screen
+										// reader either.
+										if ( cell?.placeholder ) {
+											return (
+												<div
+													key={ `cell-${ columnIndex }-${ rowIndex }` }
+													data-testid="heatmap-cell-placeholder"
+													aria-hidden="true"
+													className={ clsx(
+														styles[ 'heatmap-chart__cell' ],
+														styles[ 'heatmap-chart__cell--placeholder' ]
 													) }
 												/>
 											);

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
@@ -69,8 +69,9 @@ export const buildCalendarHeatmapData = (
 		 * series' own. Days inside the grid but outside the series become
 		 * placeholder cells: painted as empty slots so a short series still
 		 * fills its container, but reporting nothing, since they were never
-		 * measured. Bounds narrower than the series are ignored — the grid
-		 * never drops a day that carries data.
+		 * measured. A start bound is drawn from the beginning of its week, so
+		 * the grid always opens on a whole column. Bounds narrower than the
+		 * series are ignored — the grid never drops a day that carries data.
 		 */
 		gridSpan?: { start?: string; end?: string };
 	} = {}
@@ -109,10 +110,15 @@ export const buildCalendarHeatmapData = (
 	const gridMinDate = widenTo( options.gridSpan?.start, minDate, 'earlier' );
 	const gridMaxDate = widenTo( options.gridSpan?.end, maxDate, 'later' );
 
-	const gridMinDayKey = format( gridMinDate, 'yyyy-MM-dd' );
 	const gridMaxDayKey = format( gridMaxDate, 'yyyy-MM-dd' );
 
 	const gridStart = startOfWeek( gridMinDate, { weekStartsOn } );
+
+	// A start bound rarely lands on a week start, and `gridStart` rounds it down.
+	// The days it rounds past were no more measured than the rest of the widened
+	// span, so they are filler too; treating them as a ragged edge instead would
+	// notch the first column by however far the bound sat into its week.
+	const gridMinDayKey = format( gridMinDate < minDate ? gridStart : gridMinDate, 'yyyy-MM-dd' );
 	const weekCount = differenceInCalendarWeeks( gridMaxDate, gridStart, { weekStartsOn } ) + 1;
 
 	const rowLabels = Array.from( { length: 7 }, ( _, row ) =>

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
@@ -10,6 +10,36 @@ export type CalendarHeatmapResult = {
 /** Rows that get a weekday label (Mon, Wed, Fri with a Monday week start). */
 const LABELLED_ROWS = [ 0, 2, 4 ];
 
+/**
+ * Resolve one grid bound: an unparseable or narrowing value falls back to the
+ * series' own bound, so the grid can only ever be widened.
+ *
+ * @param bound     - Requested bound as `yyyy-MM-dd`, if any.
+ * @param fallback  - The series' own bound on this side.
+ * @param direction - Which way the bound is allowed to move.
+ * @return The bound to draw to.
+ */
+const widenTo = (
+	bound: string | undefined,
+	fallback: Date,
+	direction: 'earlier' | 'later'
+): Date => {
+	if ( ! bound ) {
+		return fallback;
+	}
+
+	const parsed = parseISO( bound );
+	if ( isNaN( parsed.getTime() ) ) {
+		return fallback;
+	}
+
+	if ( direction === 'earlier' ) {
+		return parsed < fallback ? parsed : fallback;
+	}
+
+	return parsed > fallback ? parsed : fallback;
+};
+
 const toDate = ( point: DataPointDate ): Date | null => {
 	if ( point.date instanceof Date && ! isNaN( point.date.getTime() ) ) {
 		return point.date;
@@ -34,6 +64,15 @@ export const buildCalendarHeatmapData = (
 		 * blank cells even when the series has no entry for them.
 		 */
 		hideOutOfRangeDays?: boolean;
+		/**
+		 * Draw the grid over this span (`yyyy-MM-dd` bounds) instead of the
+		 * series' own. Days inside the grid but outside the series become
+		 * placeholder cells: painted as empty slots so a short series still
+		 * fills its container, but reporting nothing, since they were never
+		 * measured. Bounds narrower than the series are ignored — the grid
+		 * never drops a day that carries data.
+		 */
+		gridSpan?: { start?: string; end?: string };
 	} = {}
 ): CalendarHeatmapResult => {
 	const weekStartsOn = options.weekStartsOn ?? 1;
@@ -60,13 +99,21 @@ export const buildCalendarHeatmapData = (
 		}
 	}
 
-	const gridStart = startOfWeek( minDate, { weekStartsOn } );
-	const weekCount = differenceInCalendarWeeks( maxDate, gridStart, { weekStartsOn } ) + 1;
-
 	// Day-key bounds for the ragged-edge option: calendar-day comparison, so
 	// entries carrying a time of day can't shift the span.
 	const minDayKey = format( minDate, 'yyyy-MM-dd' );
 	const maxDayKey = format( maxDate, 'yyyy-MM-dd' );
+
+	// The grid may run wider than the series, never narrower: a bound that would
+	// cut into the data is dropped rather than honoured.
+	const gridMinDate = widenTo( options.gridSpan?.start, minDate, 'earlier' );
+	const gridMaxDate = widenTo( options.gridSpan?.end, maxDate, 'later' );
+
+	const gridMinDayKey = format( gridMinDate, 'yyyy-MM-dd' );
+	const gridMaxDayKey = format( gridMaxDate, 'yyyy-MM-dd' );
+
+	const gridStart = startOfWeek( gridMinDate, { weekStartsOn } );
+	const weekCount = differenceInCalendarWeeks( gridMaxDate, gridStart, { weekStartsOn } ) + 1;
 
 	const rowLabels = Array.from( { length: 7 }, ( _, row ) =>
 		LABELLED_ROWS.includes( row ) ? format( addDays( gridStart, row ), 'EEE' ) : ''
@@ -104,8 +151,15 @@ export const buildCalendarHeatmapData = (
 				label: format( day, 'EEE, MMM d, yyyy' ),
 				value: valueByDay.has( key ) ? ( valueByDay.get( key ) as number | null ) : null,
 			};
-			if ( hideOutOfRangeDays && ( key < minDayKey || key > maxDayKey ) ) {
-				cell.hidden = true;
+			if ( key < gridMinDayKey || key > gridMaxDayKey ) {
+				// The days completing the grid's first/last week: the calendar's
+				// ragged edge.
+				if ( hideOutOfRangeDays ) {
+					cell.hidden = true;
+				}
+			} else if ( key < minDayKey || key > maxDayKey ) {
+				// Inside the grid the caller asked for, outside the series: filler.
+				cell.placeholder = true;
 			}
 			cells.push( cell );
 		}

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
@@ -79,6 +79,13 @@ type HeatmapCell = {
 	 * place so the rest of the grid doesn't shift.
 	 */
 	hidden?: boolean;
+	/**
+	 * Paint the cell as a faded empty slot that carries no claim about the
+	 * day: it is skipped by hover, tooltips, keyboard navigation and the
+	 * accessibility tree. For grid filler — slots drawn only so a short
+	 * range still fills its container, which were never measured.
+	 */
+	placeholder?: boolean;
 };
 ```
 
@@ -112,7 +119,11 @@ Utility function that converts a flat time-series into the `HeatmapColumn[]` / `
 ```typescript
 function buildCalendarHeatmapData(
 	series: DataPointDate[],
-	options?: { weekStartsOn?: 0 | 1; hideOutOfRangeDays?: boolean }
+	options?: {
+		weekStartsOn?: 0 | 1;
+		hideOutOfRangeDays?: boolean;
+		gridSpan?: { start?: string; end?: string };
+	}
 ): CalendarHeatmapResult
 ```
 
@@ -123,6 +134,7 @@ function buildCalendarHeatmapData(
 | `series` | `DataPointDate[]` | - | **Required.** Array of data points with a `date` (or `dateString`) and a numeric `value`. |
 | `options.weekStartsOn` | `0 \| 1` | `1` | Day the week starts on: `0` = Sunday, `1` = Monday. |
 | `options.hideOutOfRangeDays` | `boolean` | `true` | Mark the week-completion days outside the series' date span as hidden cells (empty grid slots) instead of blank cells, giving the calendar ragged edges. Pass `false` to keep them as blank cells. |
+| `options.gridSpan` | `{ start?: string; end?: string }` | - | Draw the grid over this span (`yyyy-MM-dd` bounds) instead of the series' own, so a series too short to fill its container still does. Days inside the grid but outside the series become `placeholder` cells. A `start` is drawn from the beginning of its week, so the grid opens on a whole column. Bounds narrower than the series are ignored. |
 
 **Returns:** `CalendarHeatmapResult`
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
@@ -172,6 +172,7 @@ Use `buildCalendarHeatmapData` to convert a flat `DataPointDate[]` series into t
 
 - **`weekStartsOn`** (`0 | 1`, default `1`): `0` = Sunday, `1` = Monday
 - **`hideOutOfRangeDays`** (`boolean`, default `true`): render the week-completion days outside the series' date span as empty grid slots instead of blank cells, giving the calendar ragged edges. Days inside the span stay blank cells even when the series has no entry for them. Hidden slots keep their grid position but paint nothing, and hover and keyboard navigation skip them. Pass `false` to keep out-of-range days as blank cells.
+- **`gridSpan`** (`{ start?: string; end?: string }`, `yyyy-MM-dd` bounds): draw the grid over this span instead of the series' own, so a series too short to fill its container still does. Days inside the grid but outside the series become `placeholder` cells: faded empty slots that keep the grid continuous but report nothing to a pointer, the keyboard or a screen reader, since they stand for days that were never measured. A `start` is drawn from the beginning of its week, so the grid opens on a whole column. Bounds narrower than the series are ignored — the grid never drops a day that carries data.
 
 ## Fixed Dimensions
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
@@ -223,4 +223,47 @@ describe( 'buildCalendarHeatmapData with a grid wider than the series', () => {
 			buildCalendarHeatmapData( oneWeek, { weekStartsOn: 1, gridSpan: {} } )
 		);
 	} );
+
+	// The caller sizes the grid in whole weeks back from the period's last day, so
+	// the bound lands on that weekday — a Monday only one year in seven.
+	test( 'opens on a whole column when the start bound falls mid-week', () => {
+		const { data } = buildCalendarHeatmapData( oneWeek, {
+			weekStartsOn: 1,
+			gridSpan: { start: '2023-12-07' }, // a Thursday
+		} );
+
+		expect( data ).toHaveLength( 5 );
+
+		// Mon Dec 4 through Wed Dec 6 precede the bound; they are as unmeasured as
+		// the rest of the filler, so they fill the column rather than notching it.
+		expect( data[ 0 ].data.every( cell => cell.placeholder === true ) ).toBe( true );
+		expect( data[ 0 ].data.some( cell => cell.hidden ) ).toBe( false );
+	} );
+
+	test( 'still draws the ragged edge past the grid end', () => {
+		// Wed Jan 3 ends the series, so Thu Jan 4 onward only completes the week.
+		const { data } = buildCalendarHeatmapData( [ { dateString: '2024-01-03', value: 5 } ], {
+			weekStartsOn: 1,
+			gridSpan: { start: '2023-12-20' }, // a Wednesday
+		} );
+
+		expect( data[ 0 ].data.every( cell => cell.placeholder === true ) ).toBe( true );
+
+		const lastColumn = data[ data.length - 1 ];
+		expect( lastColumn.data[ 2 ].value ).toBe( 5 );
+		expect( lastColumn.data[ 3 ].hidden ).toBe( true );
+	} );
+
+	test( 'keeps the ragged start edge when the bound is ignored', () => {
+		// A narrowing bound never applies, so the series' own first week stays
+		// ragged rather than being filled out.
+		const { data } = buildCalendarHeatmapData( [ { dateString: '2024-01-03', value: 5 } ], {
+			weekStartsOn: 1,
+			gridSpan: { start: '2024-01-05' },
+		} );
+
+		expect( data ).toHaveLength( 1 );
+		expect( data[ 0 ].data[ 0 ].hidden ).toBe( true );
+		expect( data[ 0 ].data[ 0 ].placeholder ).toBeUndefined();
+	} );
 } );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
@@ -142,3 +142,85 @@ describe( 'buildCalendarHeatmapData', () => {
 		expect( rowLabels[ 4 ] ).toBe( 'Thu' );
 	} );
 } );
+
+describe( 'buildCalendarHeatmapData with a grid wider than the series', () => {
+	// Mon Jan 1 2024 through Sun Jan 7 — one whole week of data.
+	const oneWeek: DataPointDate[] = [
+		{ dateString: '2024-01-01', value: 3 },
+		{ dateString: '2024-01-07', value: 4 },
+	];
+
+	test( 'draws the extra weeks and marks them placeholders, not blank cells', () => {
+		const { data } = buildCalendarHeatmapData( oneWeek, {
+			weekStartsOn: 1,
+			gridSpan: { start: '2023-12-04' }, // 4 weeks earlier
+		} );
+
+		expect( data ).toHaveLength( 5 );
+
+		// The filler weeks stand for days nothing was measured for.
+		expect( data[ 0 ].data.every( cell => cell.placeholder === true ) ).toBe( true );
+		expect( data[ 3 ].data.every( cell => cell.placeholder === true ) ).toBe( true );
+
+		// The data week is untouched: real values, no placeholder flag.
+		expect( data[ 4 ].data[ 0 ] ).toMatchObject( { value: 3 } );
+		expect( data[ 4 ].data[ 0 ].placeholder ).toBeUndefined();
+		expect( data[ 4 ].data[ 6 ] ).toMatchObject( { value: 4 } );
+	} );
+
+	test( 'labels the filler columns so the grid still reads as a calendar', () => {
+		const { data } = buildCalendarHeatmapData( oneWeek, {
+			weekStartsOn: 1,
+			gridSpan: { start: '2023-12-04' },
+		} );
+
+		expect( data.map( column => column.label ) ).toEqual( [ 'Dec', '', '', '', 'Jan' ] );
+	} );
+
+	test( 'ignores a bound that would cut into the series', () => {
+		const { data } = buildCalendarHeatmapData( oneWeek, {
+			weekStartsOn: 1,
+			gridSpan: { start: '2024-01-04', end: '2024-01-05' },
+		} );
+
+		expect( data ).toHaveLength( 1 );
+		expect( data[ 0 ].data[ 0 ].value ).toBe( 3 );
+		expect( data[ 0 ].data[ 6 ].value ).toBe( 4 );
+	} );
+
+	test( 'falls back to the series span for an unparseable bound', () => {
+		const { data } = buildCalendarHeatmapData( oneWeek, {
+			weekStartsOn: 1,
+			gridSpan: { start: 'not-a-date' },
+		} );
+
+		expect( data ).toHaveLength( 1 );
+	} );
+
+	test( 'separates the ragged edge from the filler', () => {
+		// The grid opens Mon Dec 25 and closes with the series on Wed Jan 3, so
+		// Thu Jan 4 onward only completes the last week.
+		const { data } = buildCalendarHeatmapData( [ { dateString: '2024-01-03', value: 5 } ], {
+			weekStartsOn: 1,
+			gridSpan: { start: '2023-12-25' },
+		} );
+
+		const lastColumn = data[ data.length - 1 ];
+
+		// Inside the requested grid, before the data: filler.
+		expect( lastColumn.data[ 0 ].placeholder ).toBe( true );
+		expect( lastColumn.data[ 0 ].hidden ).toBeUndefined();
+
+		expect( lastColumn.data[ 2 ].value ).toBe( 5 );
+
+		// Past the grid's end: the calendar's ragged edge, painted as nothing.
+		expect( lastColumn.data[ 3 ].hidden ).toBe( true );
+		expect( lastColumn.data[ 3 ].placeholder ).toBeUndefined();
+	} );
+
+	test( 'is a no-op when no grid span is given', () => {
+		expect( buildCalendarHeatmapData( oneWeek, { weekStartsOn: 1 } ) ).toEqual(
+			buildCalendarHeatmapData( oneWeek, { weekStartsOn: 1, gridSpan: {} } )
+		);
+	} );
+} );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
@@ -13,6 +13,13 @@ export type HeatmapCell = {
 	 * days completing the first/last week fall outside the covered range.
 	 */
 	hidden?: boolean;
+	/**
+	 * Paint the cell as an empty slot that carries no claim about the day: it
+	 * looks like a no-value cell but is skipped by hover, tooltips, keyboard
+	 * navigation and the accessibility tree. For grid filler — slots drawn only
+	 * so a short range still fills its container, which were never measured.
+	 */
+	placeholder?: boolean;
 };
 
 /** A heatmap column (rendered left→right); its cells render top→bottom. */

--- a/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
@@ -14,10 +14,11 @@ export type HeatmapCell = {
 	 */
 	hidden?: boolean;
 	/**
-	 * Paint the cell as an empty slot that carries no claim about the day: it
-	 * looks like a no-value cell but is skipped by hover, tooltips, keyboard
-	 * navigation and the accessibility tree. For grid filler — slots drawn only
-	 * so a short range still fills its container, which were never measured.
+	 * Paint the cell as a faded empty slot that carries no claim about the day:
+	 * it is set apart from a measured day that scored zero, and skipped by
+	 * hover, tooltips, keyboard navigation and the accessibility tree. For grid
+	 * filler — slots drawn only so a short range still fills its container,
+	 * which were never measured.
 	 */
 	placeholder?: boolean;
 };

--- a/projects/packages/premium-analytics/changelog/fix-wooa7s-1963-heatmap-window
+++ b/projects/packages/premium-analytics/changelog/fix-wooa7s-1963-heatmap-window
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Insights: scope the calendar heatmaps to the selected period, so the card no longer draws and reports on years outside it.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/__tests__/adaptive-calendar-heatmap.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/__tests__/adaptive-calendar-heatmap.test.tsx
@@ -42,17 +42,19 @@ function chartFor( {
 	width,
 	height,
 	period = PERIOD,
+	valueByDay = VALUE_BY_DAY,
 }: {
 	width: number;
 	height: number;
 	period?: { startDate: string; endDate: string };
+	valueByDay?: Record< string, number | null >;
 } ) {
 	const restoreTileSize = stubTileSize( width, height );
 	let view;
 
 	try {
 		view = render(
-			<AdaptiveCalendarHeatmap valueByDay={ VALUE_BY_DAY } period={ period }>
+			<AdaptiveCalendarHeatmap valueByDay={ valueByDay } period={ period }>
 				{ ( chartProps: AdaptiveCalendarHeatmapChartProps ) => (
 					<div
 						data-testid="chart"
@@ -63,7 +65,7 @@ function chartFor( {
 						data-last-visible-label={
 							chartProps.data
 								.flatMap( column => column.data )
-								.filter( cell => ! cell.hidden )
+								.filter( cell => ! cell.hidden && ! cell.placeholder )
 								.map( cell => cell.label )
 								.slice( -1 )[ 0 ]
 						}
@@ -72,6 +74,16 @@ function chartFor( {
 							.filter( cell => cell.value !== null )
 							.map( cell => `${ cell.label }:${ cell.value }` )
 							.join( '|' ) }
+						data-placeholders={ String(
+							chartProps.data.flatMap( column => column.data ).filter( cell => cell.placeholder )
+								.length
+						) }
+						data-first-real-label={
+							chartProps.data
+								.flatMap( column => column.data )
+								.filter( cell => ! cell.hidden && ! cell.placeholder )
+								.map( cell => cell.label )[ 0 ]
+						}
 					/>
 				) }
 			</AdaptiveCalendarHeatmap>
@@ -89,6 +101,8 @@ function chartFor( {
 		width: chart.getAttribute( 'data-width' ) === 'undefined' ? null : number( 'data-width' ),
 		height: chart.getAttribute( 'data-height' ) === 'undefined' ? null : number( 'data-height' ),
 		lastVisibleLabel: chart.getAttribute( 'data-last-visible-label' ),
+		firstRealLabel: chart.getAttribute( 'data-first-real-label' ),
+		placeholders: number( 'data-placeholders' ),
 		values: chart.getAttribute( 'data-values' ) ?? '',
 	};
 
@@ -136,18 +150,67 @@ describe( 'AdaptiveCalendarHeatmap', () => {
 		expect( tall.columns ).toBeLessThan( short.columns );
 	} );
 
-	it( 'never renders unfetched dates before the period', () => {
+	it( 'fills the tile with filler rather than stretching a short period', () => {
 		const chart = chartFor( {
 			width: 1000,
 			height: ONE_ROW_TILE_HEIGHT,
 			period: ONE_MONTH,
 		} );
 
-		// June spans six week columns. A stale fetch window must not turn earlier,
-		// unfetched dates into interactive no-data cells just to fill the tile.
-		expect( chart.columns ).toBe( 6 );
-		expect( chart.width ).toBeLessThan( 1000 );
+		// June spans six week columns, far short of what this tile draws, so the
+		// grid opens backwards to fill it.
+		expect( chart.columns ).toBeGreaterThan( 6 );
+		expect( chart.width ).toBe( 1000 );
+
+		// The filler carries no data of its own: only June's day is a value, and
+		// June is still where the grid ends.
 		expect( chart.values ).toBe( 'Mon, Jun 2, 2025:120' );
+		expect( chart.lastVisibleLabel ).toBe( 'Mon, Jun 30, 2025' );
+	} );
+
+	it( 'makes the unfetched weeks filler, not no-data cells', () => {
+		const chart = chartFor( {
+			width: 1000,
+			height: ONE_ROW_TILE_HEIGHT,
+			period: ONE_MONTH,
+		} );
+
+		// The regression this guards (WOOA7S-1963): dates drawn only to fill the
+		// tile were interactive no-data cells, so the heatmap told a reader there
+		// was no traffic on days it had never asked about.
+		expect( chart.placeholders ).toBeGreaterThan( 0 );
+		expect( chart.firstRealLabel ).toBe( 'Sun, Jun 1, 2025' );
+	} );
+
+	it( 'trims the filler before the data when the tile shrinks', () => {
+		const wide = chartFor( { width: 1000, height: ONE_ROW_TILE_HEIGHT, period: ONE_MONTH } );
+		const narrow = chartFor( { width: 400, height: ONE_ROW_TILE_HEIGHT, period: ONE_MONTH } );
+
+		expect( narrow.columns ).toBeLessThan( wide.columns );
+
+		// Fewer columns must cost filler weeks, never the month itself.
+		expect( narrow.values ).toBe( 'Mon, Jun 2, 2025:120' );
+		expect( narrow.firstRealLabel ).toBe( 'Sun, Jun 1, 2025' );
+	} );
+
+	it( 'keeps the newest data when the period outruns the tile', () => {
+		// A whole year in a tile whose cells are too big to draw all 53 columns.
+		const chart = chartFor( {
+			width: 1000,
+			height: 300,
+			valueByDay: { '2025-01-06': 5, '2025-12-29': 120 },
+		} );
+
+		expect( chart.columns ).toBeLessThan( 53 );
+
+		// The trim spends its columns on the end of the period, so December
+		// survives and January is what falls off. The regression this guards ran
+		// the grid on past the data instead, leaving the surviving columns empty.
+		expect( chart.values ).toBe( 'Mon, Dec 29, 2025:120' );
+		expect( chart.lastVisibleLabel ).toBe( 'Wed, Dec 31, 2025' );
+
+		// A period longer than the tile needs no filler at all.
+		expect( chart.placeholders ).toBe( 0 );
 	} );
 
 	it( 'ends the grid on the period, not on today', () => {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/adaptive-calendar-heatmap.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/adaptive-calendar-heatmap.tsx
@@ -7,7 +7,10 @@ import { useCallback, useMemo, useState } from 'react';
  * Internal dependencies
  */
 import { computeCalendarHeatmapLayout } from '../../helpers/calendar-heatmap-layout';
-import { buildDenseDaySeries } from '../../helpers/calendar-heatmap-window';
+import {
+	buildDenseDaySeries,
+	resolveCalendarHeatmapGridStart,
+} from '../../helpers/calendar-heatmap-window';
 import { useElementSize } from '../../hooks';
 import styles from './adaptive-calendar-heatmap.module.scss';
 import type { CalendarHeatmapPager } from './calendar-heatmap-pager-overlay';
@@ -46,7 +49,8 @@ export type AdaptiveCalendarHeatmapProps = {
 	/** Value per `yyyy-MM-dd`. Days not present render as empty cells. */
 	valueByDay: Map< string, number | null > | Record< string, number | null >;
 	/**
-	 * The period the values cover. The grid never renders dates outside this range.
+	 * The period the values cover, and the only range the grid reports on. Weeks
+	 * drawn before it to fill the tile are inert filler, never no-data cells.
 	 */
 	period: CalendarHeatmapWindow;
 	/**
@@ -64,12 +68,11 @@ export type AdaptiveCalendarHeatmapProps = {
  * Fits a calendar heatmap to the tile it is given.
  *
  * The tile's height picks the cell size and its width picks how many week columns
- * it shows. The grid spans the columns the width can draw within the supplied
- * period, ending on its last day, and fills the tile when the period contains
- * enough history. A period holding more weeks than the tile draws is paged —
- * the newest page first, a window of whole columns at a time — through the
- * `pager` handed to the children. Both widgets share this, so they stay
- * consistent as the dashboard is resized.
+ * it shows. The grid always ends on the period's last day. A period with fewer
+ * weeks than the width can draw is opened backwards with filler columns so the
+ * tile still fills; one with more is paged — the newest page first, a window of
+ * whole columns at a time — through the `pager` handed to the children. Both
+ * widgets share this, so they stay consistent as the dashboard is resized.
  *
  * It renders the measured tile wrapper and hands the caller the chart props to
  * spread, leaving the widget to own its data, states, and tooltip.
@@ -89,13 +92,38 @@ export function AdaptiveCalendarHeatmap( {
 	// is the space the heatmap has to work with.
 	const [ setRef, size ] = useElementSize< HTMLDivElement >();
 
-	const { data: heatmapData, rowLabels } = useMemo(
-		() =>
-			buildCalendarHeatmapData(
-				buildDenseDaySeries( valueByDay, period.startDate, period.endDate )
-			),
+	const daySeries = useMemo(
+		() => buildDenseDaySeries( valueByDay, period.startDate, period.endDate ),
 		[ valueByDay, period ]
 	);
+
+	// The tile's capacity, settled before the data is considered: the height picks
+	// the cell size and the width divides by it. `dataColumns` is deliberately
+	// omitted — this is how many columns the tile could draw, not how many the
+	// period has.
+	const fitColumns = useMemo(
+		() =>
+			computeCalendarHeatmapLayout( {
+				availWidth: size.width,
+				availHeight: size.height,
+				aspectRatio: CELL_ASPECT_RATIO,
+				legendHeight: 0,
+			} ).columns,
+		[ size.width, size.height ]
+	);
+
+	// A period with fewer weeks than the tile fits opens backwards into filler
+	// columns, so the grid fills its tile without the request reaching outside the
+	// period (WOOA7S-1963). `gridSpan` never narrows the grid, so a period longer
+	// than the tile passes through untouched and is trimmed below instead.
+	const { data: heatmapData, rowLabels } = useMemo( () => {
+		const gridStart = resolveCalendarHeatmapGridStart( period.endDate, fitColumns );
+
+		return buildCalendarHeatmapData(
+			daySeries,
+			gridStart ? { gridSpan: { start: gridStart } } : {}
+		);
+	}, [ daySeries, period.endDate, fitColumns ] );
 
 	// Height picks the cell size, width the column count, and the grid is sized to
 	// the rectangle it occupies — so it fills the tile without ever overflowing it.
@@ -158,8 +186,9 @@ export function AdaptiveCalendarHeatmap( {
 	const offset = Math.min( pageOffset, maxOffset );
 
 	const chartProps = useMemo( () => {
-		// `slice( -0 )` returns the whole array, so an unmeasured or collapsed tile
-		// leaves the period's own columns intact.
+		// Trimming drops the oldest columns — the filler first, and only then the
+		// period's own earliest weeks. `slice( -0 )` returns the whole array, so an
+		// unmeasured or collapsed tile leaves the grid intact.
 		let data = heatmapData.slice( -columns );
 		if ( isPaged && offset > 0 ) {
 			const start = Math.max( 0, total - ( offset + 1 ) * columns );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/stories/adaptive-calendar-heatmap.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/stories/adaptive-calendar-heatmap.stories.tsx
@@ -47,9 +47,19 @@ interface AdaptiveCalendarHeatmapStoryControls {
 	tileWidth: number;
 	/** Height of the mock tile's body, in px. Drives the cell size. */
 	tileHeight: number;
-	/** Use a one-month period to show that the grid stays inside its data window. */
+	/** Use a one-month period to show how a grid shorter than the tile is filled. */
 	shortPeriod: boolean;
 }
+
+// The current year is selected as January through today, so early in the year it is
+// the shortest period Insights can produce. Fixed dates: a story that moved with the
+// clock would render differently on every visual diff.
+const CURRENT_YEAR_AS_OF = [
+	{ label: 'Jan 15 — 2 weeks of data', endDate: '2026-01-15' },
+	{ label: 'Apr 15 — 15 weeks of data', endDate: '2026-04-15' },
+	{ label: 'Aug 19 — 33 weeks of data', endDate: '2026-08-19' },
+	{ label: 'Dec 31 — the whole year', endDate: '2026-12-31' },
+] as const;
 
 /**
  * Mock widget tile. The component measures its parent, so the story has to give it
@@ -177,9 +187,9 @@ export const VeryTallTile: Story = {
 };
 
 /**
- * One month of data in a tile that fits well over a year of columns. The grid stops
- * at the period boundary instead of presenting unfetched earlier dates as no-data
- * cells.
+ * One month of data in a tile that fits well over a year of columns. The month sits
+ * at the right-hand edge and the weeks before it are filler: drawn so the tile fills,
+ * but inert — no tooltip, no keyboard stop, no claim that those days had no traffic.
  */
 export const ShortPeriod: Story = {
 	render: renderAdaptiveCalendarHeatmap,
@@ -194,5 +204,47 @@ export const ShortPeriod: Story = {
 export const NarrowTile: Story = {
 	render: renderAdaptiveCalendarHeatmap,
 	args: { ...SHORT_TILE_ARGS, tileWidth: 420, tileHeight: 320 },
+	decorators: [ withChartTheme ],
+};
+
+/**
+ * The current year, read at four points in it. Every row ends on the day the year has
+ * reached and fills leftwards with filler weeks, so the tile is as full in January as
+ * in December while the request only ever covers days that have happened.
+ */
+export const CurrentYearThroughTheYear: Story = {
+	render: ( { tileWidth, tileHeight } ) => (
+		<div style={ { display: 'flex', flexDirection: 'column', gap: '16px' } }>
+			{ CURRENT_YEAR_AS_OF.map( ( { label, endDate } ) => {
+				const fetched = { startDate: '2026-01-01', endDate };
+
+				return (
+					<div key={ endDate }>
+						<div
+							style={ {
+								marginBlockEnd: '4px',
+								font: 'var(--wpds-typography-body-small)',
+								color: 'var(--wpds-color-foreground-neutral-weak)',
+							} }
+						>
+							{ label }
+						</div>
+						<TileCanvas width={ tileWidth } height={ tileHeight }>
+							<AdaptiveCalendarHeatmap valueByDay={ buildViewsByDay( fetched ) } period={ fetched }>
+								{ chartProps => (
+									<HeatmapChartUnresponsive
+										{ ...chartProps }
+										primaryColor="var(--wp-admin-theme-color, #3858e9)"
+										withTooltips
+									/>
+								) }
+							</AdaptiveCalendarHeatmap>
+						</TileCanvas>
+					</div>
+				);
+			} ) }
+		</div>
+	),
+	args: SHORT_TILE_ARGS,
 	decorators: [ withChartTheme ],
 };

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/calendar-heatmap-window.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/calendar-heatmap-window.test.ts
@@ -1,34 +1,16 @@
 /**
  * Internal dependencies
  */
-import { buildDenseDaySeries, resolveCalendarHeatmapWindow } from '../calendar-heatmap-window';
+import {
+	buildDenseDaySeries,
+	resolveCalendarHeatmapGridStart,
+	resolveCalendarHeatmapWindow,
+} from '../calendar-heatmap-window';
 
 const TODAY = '2026-08-10';
 
 describe( 'resolveCalendarHeatmapWindow', () => {
-	describe( 'minDays — the posting activity floor', () => {
-		it( 'extends a short range backwards to the floor', () => {
-			expect(
-				resolveCalendarHeatmapWindow(
-					{ from: '2026-08-04', to: '2026-08-10' },
-					{ minDays: 366 },
-					TODAY
-				)
-			).toEqual( { startDate: '2025-08-10', endDate: '2026-08-10' } );
-		} );
-
-		it( 'leaves a range that already reaches further back alone', () => {
-			expect(
-				resolveCalendarHeatmapWindow(
-					{ from: '2021-01-01', to: '2026-08-10' },
-					{ minDays: 366 },
-					TODAY
-				)
-			).toEqual( { startDate: '2021-01-01', endDate: '2026-08-10' } );
-		} );
-	} );
-
-	describe( 'maxDays — the traffic views cap', () => {
+	describe( 'maxDays — the shared cap', () => {
 		it( 'caps an all-time range to the most recent year', () => {
 			expect(
 				resolveCalendarHeatmapWindow(
@@ -78,17 +60,6 @@ describe( 'resolveCalendarHeatmapWindow', () => {
 				)
 			).toEqual( { startDate: '2026-08-01', endDate: '2026-08-10' } );
 		} );
-	} );
-
-	it( 'applies both bounds together', () => {
-		const bounds = { minDays: 30, maxDays: 60 };
-
-		expect(
-			resolveCalendarHeatmapWindow( { from: '2026-08-08', to: '2026-08-10' }, bounds, TODAY )
-		).toEqual( { startDate: '2026-07-12', endDate: '2026-08-10' } );
-		expect(
-			resolveCalendarHeatmapWindow( { from: '2020-01-01', to: '2026-08-10' }, bounds, TODAY )
-		).toEqual( { startDate: '2026-06-12', endDate: '2026-08-10' } );
 	} );
 
 	it( 'reads only the calendar day from an offset-bearing timestamp', () => {
@@ -187,5 +158,34 @@ describe( 'buildDenseDaySeries', () => {
 		expect( buildDenseDaySeries( { '2026-08-02': 5 }, '2026-08-05', '2026-08-01' ) ).toEqual( [
 			{ dateString: '2026-08-02', value: 5 },
 		] );
+	} );
+} );
+
+describe( 'resolveCalendarHeatmapGridStart', () => {
+	// The current year is selected as January through today, so for most of the
+	// year it has fewer weeks than a wide tile can draw.
+	it( 'opens the grid back far enough to fill the tile', () => {
+		expect( resolveCalendarHeatmapGridStart( TODAY, 53 ) ).toBe( '2025-08-11' );
+	} );
+
+	it( 'lands on the same weekday, so the span is a whole number of columns', () => {
+		// 2026-08-10 is a Monday; every result must be one too.
+		expect( resolveCalendarHeatmapGridStart( TODAY, 1 ) ).toBe( TODAY );
+		expect( resolveCalendarHeatmapGridStart( TODAY, 2 ) ).toBe( '2026-08-03' );
+		expect( resolveCalendarHeatmapGridStart( TODAY, 3 ) ).toBe( '2026-07-27' );
+	} );
+
+	it( 'crosses a leap day without drifting', () => {
+		expect( resolveCalendarHeatmapGridStart( '2024-03-04', 2 ) ).toBe( '2024-02-26' );
+	} );
+
+	// The caller passes a measured column count, so a collapsed tile reports zero
+	// and must not be turned into a one-column grid.
+	it.each( [ 0, -1, 0.5, NaN, Infinity ] )( 'sizes nothing from %p columns', columns => {
+		expect( resolveCalendarHeatmapGridStart( TODAY, columns ) ).toBeUndefined();
+	} );
+
+	it( 'sizes nothing from a date it cannot parse', () => {
+		expect( resolveCalendarHeatmapGridStart( 'not-a-date', 53 ) ).toBeUndefined();
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/calendar-heatmap-window.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/calendar-heatmap-window.ts
@@ -15,34 +15,31 @@ export type CalendarHeatmapWindow = {
 };
 
 export type CalendarHeatmapWindowBounds = {
-	minDays?: number;
 	maxDays?: number;
 };
 
 /**
- * Clamps a report range to inclusive minimum and maximum day counts.
+ * Caps a report range at an inclusive maximum day count.
+ *
+ * A floor is deliberately not offered: it would reach back past the selection,
+ * and the card would attribute years the user did not choose to the year in its
+ * heading (WOOA7S-1963). A range too short to fill the tile is filled with
+ * filler weeks instead — see `resolveCalendarHeatmapGridStart`.
  */
 export function resolveCalendarHeatmapWindow(
 	params: { from?: string; to?: string },
 	bounds: CalendarHeatmapWindowBounds,
 	todayIso: string
 ): CalendarHeatmapWindow {
-	const { minDays, maxDays } = bounds;
+	const { maxDays } = bounds;
 	const endDate = getDatePart( params.to ) ?? todayIso;
 	const end = parseISO( endDate );
 
 	// ISO date-only strings sort chronologically.
 	let startDate = getDatePart( params.from ) ?? endDate;
 
-	if ( minDays !== undefined ) {
-		// Bounds count inclusive dates, hence the subtraction of one day.
-		const floor = format( subDays( end, minDays - 1 ), 'yyyy-MM-dd' );
-		if ( startDate > floor ) {
-			startDate = floor;
-		}
-	}
-
 	if ( maxDays !== undefined ) {
+		// Bounds count inclusive dates, hence the subtraction of one day.
 		const cap = format( subDays( end, maxDays - 1 ), 'yyyy-MM-dd' );
 		if ( startDate < cap ) {
 			startDate = cap;
@@ -50,6 +47,40 @@ export function resolveCalendarHeatmapWindow(
 	}
 
 	return { startDate: startDate > endDate ? endDate : startDate, endDate };
+}
+
+/**
+ * The date a heatmap grid has to open on to draw `columns` week columns ending
+ * with `endDate`.
+ *
+ * A period shorter than the tile leaves the grid part-filled, so the grid is
+ * opened back far enough to fill it. Those earlier weeks are drawn, not
+ * requested: the chart paints them as filler that reports nothing, and the
+ * fetch window stays inside the period the user selected (WOOA7S-1963).
+ *
+ * Opening backwards rather than running on past `endDate` also keeps trimming
+ * honest — the grid drops its oldest columns first, which are the filler.
+ *
+ * @param endDate - Last day the grid covers, `yyyy-MM-dd`.
+ * @param columns - Week columns the tile can draw.
+ * @return The grid's first day, or `undefined` when the inputs can't size one.
+ */
+export function resolveCalendarHeatmapGridStart(
+	endDate: string,
+	columns: number
+): string | undefined {
+	if ( ! Number.isFinite( columns ) || columns < 1 ) {
+		return undefined;
+	}
+
+	const end = parseISO( endDate );
+	if ( isNaN( end.getTime() ) ) {
+		return undefined;
+	}
+
+	// A whole number of weeks back from `endDate` lands on the same weekday, so
+	// the grid spans exactly `columns` columns whichever day the week starts on.
+	return format( subDays( end, ( Math.floor( columns ) - 1 ) * 7 ), 'yyyy-MM-dd' );
 }
 
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -91,6 +91,7 @@ export {
 export { formatViewCount } from './format-view-count';
 export {
 	buildDenseDaySeries,
+	resolveCalendarHeatmapGridStart,
 	resolveCalendarHeatmapWindow,
 	resolveCalendarHeatmapWindowDays,
 	type CalendarHeatmapWindow,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -206,6 +206,7 @@ export {
 	fitWeekColumns,
 	formatViewCount,
 	buildDenseDaySeries,
+	resolveCalendarHeatmapGridStart,
 	resolveCalendarHeatmapWindow,
 	resolveCalendarHeatmapWindowDays,
 	type CalendarHeatmapLayout,

--- a/projects/packages/premium-analytics/widgets/posting-activity/__tests__/posting-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/__tests__/posting-activity.test.tsx
@@ -21,12 +21,28 @@ jest.mock( '@jetpack-premium-analytics/externals', () => {
 		// Render the widget's own tooltip too: after the shared `CalendarHeatmapTooltip`
 		// landed, the copy each widget passes in is the only part still its own.
 		HeatmapChartUnresponsive: ( {
+			data,
+			width,
 			renderTooltip,
 		}: {
+			data?: { data: { label?: string; value: number | null; placeholder?: boolean }[] }[];
+			width?: number;
 			renderTooltip?: ( data: HeatmapTooltipData ) => ReactNode;
 		} ) => (
 			<>
-				<div data-testid="heatmap" />
+				<div
+					data-testid="heatmap"
+					data-columns={ data?.length }
+					data-width={ String( width ) }
+					data-day-values={ data
+						?.flatMap( column => column.data )
+						.filter( cell => cell.value !== null )
+						.map( cell => `${ cell.label }:${ cell.value }` )
+						.join( '|' ) }
+					data-placeholders={ String(
+						data?.flatMap( column => column.data ).filter( cell => cell.placeholder ).length
+					) }
+				/>
 				<div data-testid="tooltip-empty">
 					{ renderTooltip?.( { value: null, cellLabel: 'Mon, Jun 2, 2025', row: 0, column: 0 } ) }
 				</div>
@@ -69,6 +85,26 @@ function setViewportWidth( width: number ) {
 	Object.defineProperty( window, 'innerWidth', { value: width, configurable: true } );
 }
 
+// jsdom reports every element as 0x0, so the tile has to be faked to reach the
+// trimming and filler paths. Returns a restore callback.
+function stubTileSize( width: number, height: number ) {
+	const original = Element.prototype.getBoundingClientRect;
+
+	Element.prototype.getBoundingClientRect = () => ( { width, height } ) as DOMRect;
+
+	return () => {
+		Element.prototype.getBoundingClientRect = original;
+	};
+}
+
+function renderWidget( reportParams: ReportParams = REPORT_PARAMS ) {
+	return render( <PostingActivityRender attributes={ { reportParams } } /> );
+}
+
+function chartDayValues() {
+	return screen.getByTestId( 'heatmap' ).getAttribute( 'data-day-values' );
+}
+
 describe( 'PostingActivityWidget', () => {
 	const originalInnerWidth = window.innerWidth;
 
@@ -94,18 +130,40 @@ describe( 'PostingActivityWidget', () => {
 		expect( screen.getByTestId( 'tooltip-plural' ) ).toHaveTextContent( '3 postsWed, Jun 4, 2025' );
 	} );
 
-	it( 'shows the empty state when only the fetch window surplus has posts', () => {
-		// June 2025 is selected; the request reaches back a further year, and a
-		// post in that surplus history must not suppress the empty state.
+	it( 'shows the empty state when only days outside the range have posts', () => {
+		// June 2025 is selected; a response still carrying an older day — a stale
+		// one for a wider selection — must not suppress the empty state.
 		mockUseStatsStreak.mockReturnValue( streakResult( { data: { '2024-03-05': 2 } } ) );
 		render( <PostingActivityRender attributes={ { reportParams: REPORT_PARAMS } } /> );
 
 		expect( screen.getByText( 'No posts published in this period.' ) ).toBeInTheDocument();
 	} );
 
-	it( 'updates the shared history window when the viewport is resized', () => {
+	// A request reaching back past the selection would attribute those months to
+	// the card's heading (WOOA7S-1963).
+	it( 'requests the selected period, however wide the viewport gets', () => {
 		render( <PostingActivityRender attributes={ { reportParams: REPORT_PARAMS } } /> );
 
+		expect( mockUseStatsStreak.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
+			startDate: '2025-06-01',
+			endDate: '2025-06-30',
+		} );
+
+		setViewportWidth( 2560 );
+		fireEvent.resize( window );
+
+		const lastCall = mockUseStatsStreak.mock.calls[ mockUseStatsStreak.mock.calls.length - 1 ];
+		expect( lastCall[ 0 ] ).toMatchObject( {
+			startDate: '2025-06-01',
+			endDate: '2025-06-30',
+		} );
+	} );
+
+	it( 'caps a selection longer than the viewport could draw, and lifts the cap as it widens', () => {
+		const allTime = { ...REPORT_PARAMS, from: '2015-01-01' } as unknown as ReportParams;
+		render( <PostingActivityRender attributes={ { reportParams: allTime } } /> );
+
+		// 1024px holds 76 compact columns — 532 days, rounded up to two years.
 		expect( mockUseStatsStreak.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
 			startDate: '2023-06-30',
 			endDate: '2025-06-30',
@@ -118,6 +176,76 @@ describe( 'PostingActivityWidget', () => {
 		expect( lastCall[ 0 ] ).toMatchObject( {
 			startDate: '2021-06-28',
 			endDate: '2025-06-30',
+		} );
+	} );
+
+	describe( 'empty state', () => {
+		it( 'speaks for the whole period when the window covered it', () => {
+			mockUseStatsStreak.mockReturnValue( streakResult( { data: {} } ) );
+
+			renderWidget();
+
+			expect( screen.getByText( 'No posts published in this period.' ) ).toBeInTheDocument();
+		} );
+
+		// The request stops at the history the viewport can draw, so the copy has to
+		// stop there too: the site may well have posts in the years left out.
+		it( 'names the days requested when the period outran the window', () => {
+			mockUseStatsStreak.mockReturnValue( streakResult( { data: {} } ) );
+
+			renderWidget( { ...REPORT_PARAMS, from: '2015-01-01' } as unknown as ReportParams );
+
+			expect(
+				screen.getByText( 'No posts published between Jun 30, 2023 and Jun 30, 2025.' )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'in a measured tile', () => {
+		const currentYear = {
+			...REPORT_PARAMS,
+			from: '2026-01-01',
+			to: '2026-08-10',
+		} as unknown as ReportParams;
+
+		beforeEach( () => {
+			mockUseStatsStreak.mockReturnValue(
+				streakResult( { data: { '2026-01-05': 1, '2026-08-10': 4 } } )
+			);
+		} );
+
+		it.each( [
+			[ 1000, 86 ],
+			[ 700, 86 ],
+			[ 1000, 300 ],
+		] )( 'keeps the year on screen at %ix%i', ( width, height ) => {
+			const restoreTileSize = stubTileSize( width, height );
+
+			try {
+				renderWidget( currentYear );
+			} finally {
+				restoreTileSize();
+			}
+
+			// The regression this guards (WOOA7S-1963): the grid ran on to a December
+			// that had not happened, so a tile too small for all 53 columns kept the
+			// empty future weeks and trimmed the year's own posts away.
+			expect( chartDayValues() ).toContain( 'Mon, Aug 10, 2026:4' );
+		} );
+
+		it( 'fills the tile with filler weeks the reader cannot mistake for data', () => {
+			const restoreTileSize = stubTileSize( 1000, 86 );
+
+			try {
+				renderWidget( currentYear );
+			} finally {
+				restoreTileSize();
+			}
+
+			const heatmap = screen.getByTestId( 'heatmap' );
+
+			expect( heatmap ).toHaveAttribute( 'data-width', '1000' );
+			expect( Number( heatmap.getAttribute( 'data-placeholders' ) ) ).toBeGreaterThan( 0 );
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/widgets/posting-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/render.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { useStatsStreak } from '@jetpack-premium-analytics/data';
+import { parseSiteDateTime } from '@jetpack-premium-analytics/datetime';
+import { formatDate } from '@jetpack-premium-analytics/formatters';
 import { calendar } from '@jetpack-premium-analytics/icons';
 import {
 	AdaptiveCalendarHeatmap,
@@ -60,10 +62,9 @@ function renderCellTooltip( { value, cellLabel }: HeatmapTooltipData ) {
  * The `stats/streak` endpoint returns a `{ 'yyyy-MM-dd': count }` map of posts
  * per day, with no comparison period.
  *
- * The date range comes from the dashboard picker via `reportParams`, but the fetch
- * window spans as much history as the widest possible tile could draw — a calendar
- * heatmap needs a span of weeks, not a 7-day slice, and the grid fills the tile
- * rather than stopping where the period does.
+ * The date range comes from the dashboard picker via `reportParams`. The fetch
+ * window is that range, capped at the history the widest possible tile could draw
+ * so a long selection cannot request years the grid would throw away.
  *
  * `AdaptiveCalendarHeatmap` fits the grid to the tile: the height picks the cell
  * size, the width picks how many week columns are drawn.
@@ -71,56 +72,68 @@ function renderCellTooltip( { value, cellLabel }: HeatmapTooltipData ) {
 function PostingActivityInner() {
 	const { reportParams } = useWidgetRootContext();
 
-	// Same window rule as the other calendar heatmap: floor and cap the picker's
-	// range at the history the viewport could show, so the two widgets request
-	// the same span instead of one running out of data early — and the floored,
-	// year-quantized request stays cacheable across preset changes.
+	// Same window rule as the other calendar heatmap: a ceiling at the history the
+	// viewport could draw, and no floor. A floor would reach back past the selection,
+	// putting years outside the card's heading inside it (WOOA7S-1963).
 	const viewportWidth = useViewportWidth();
 	const windowDays = resolveCalendarHeatmapWindowDays( viewportWidth );
+
+	// One reading for both windows below, so a render across midnight cannot resolve
+	// them against different days.
 	const today = format( new Date(), 'yyyy-MM-dd' );
+
+	// Both the request window and the range the heatmap draws and pages through:
+	// without a floor the two coincide, so paging can never leave the selection.
 	const streakRange = useMemo(
-		() =>
-			resolveCalendarHeatmapWindow(
-				reportParams,
-				{ minDays: windowDays, maxDays: windowDays },
-				today
-			),
+		() => resolveCalendarHeatmapWindow( reportParams, { maxDays: windowDays }, today ),
 		[ reportParams, windowDays, today ]
 	);
+
+	// The period as selected, before the ceiling. All time on a long-lived site
+	// reaches back past the window, and the empty state has to know the response
+	// says nothing about the years left out.
+	const periodWindow = useMemo(
+		() => resolveCalendarHeatmapWindow( reportParams, {}, today ),
+		[ reportParams, today ]
+	);
+	const isWindowClipped = periodWindow.startDate < streakRange.startDate;
 	const streakParams = useMemo(
 		() => ( { ...reportParams, startDate: streakRange.startDate, endDate: streakRange.endDate } ),
 		[ reportParams, streakRange ]
 	);
 
-	// What the heatmap may draw and page through is the picker's range, not the
-	// request window: the floor above fetches history past a short range, and
-	// with the pager those weeks would otherwise be reachable — selecting 2025
-	// must not page into 2024. Only the cap survives (paging never outruns the
-	// fetched data).
-	const displayRange = useMemo(
-		() => resolveCalendarHeatmapWindow( reportParams, { maxDays: windowDays }, today ),
-		[ reportParams, windowDays, today ]
-	);
-
 	const { data, isLoading, isFetching, isError, error, refetch } = useStatsStreak( streakParams );
 
 	// The endpoint returns only days with posts, so an empty response means the
-	// window has none — the component densifies the rest into empty cells. The
-	// check spans the drawn range only: the fetch reaches past a short
-	// selection, and posts in that surplus history must not suppress the empty
-	// state for a selection that has none.
+	// window has none — the component densifies the rest into empty cells. Days
+	// outside the range are still ruled out, so a stale response for a wider
+	// selection cannot suppress the empty state while the new one loads.
 	const postsByDay = data ?? NO_POSTS_BY_DAY;
 	const hasData = useMemo(
 		() =>
 			Object.entries( postsByDay ).some(
 				( [ day, count ] ) =>
-					day >= displayRange.startDate && day <= displayRange.endDate && Number( count ) > 0
+					day >= streakRange.startDate && day <= streakRange.endDate && Number( count ) > 0
 			),
-		[ postsByDay, displayRange ]
+		[ postsByDay, streakRange ]
 	);
 
+	// Where the period outran the window, name the days the request covers rather
+	// than the period: the site may well have posts outside them.
+	const windowStart = parseSiteDateTime( streakRange.startDate );
+	const windowEnd = parseSiteDateTime( streakRange.endDate );
+	const emptyDescription =
+		isWindowClipped && windowStart && windowEnd
+			? sprintf(
+					/* translators: 1: first date the request covers, e.g. "Aug 9, 2024". 2: last date it covers. */
+					__( 'No posts published between %1$s and %2$s.', 'jetpack-premium-analytics-pkg' ),
+					formatDate( windowStart, 'compact' ),
+					formatDate( windowEnd, 'compact' )
+			  )
+			: __( 'No posts published in this period.', 'jetpack-premium-analytics-pkg' );
+
 	return (
-		<AdaptiveCalendarHeatmap valueByDay={ postsByDay } period={ displayRange }>
+		<AdaptiveCalendarHeatmap valueByDay={ postsByDay } period={ streakRange }>
 			{ ( chartProps, pager ) => (
 				<WidgetState
 					isLoading={ isLoading }
@@ -138,10 +151,7 @@ function PostingActivityInner() {
 					} ) }
 					empty={ {
 						icon: calendar,
-						description: __(
-							'No posts published in this period.',
-							'jetpack-premium-analytics-pkg'
-						),
+						description: emptyDescription,
 					} }
 					renderLoading={ <HeatmapSkeleton /> }
 				>

--- a/projects/packages/premium-analytics/widgets/traffic-views-activity/__tests__/traffic-views-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-views-activity/__tests__/traffic-views-activity.test.tsx
@@ -150,13 +150,13 @@ describe( 'TrafficViewsActivityWidget', () => {
 	} );
 
 	describe( 'request parameters', () => {
-		it( 'passes the shared history window as from/to, the fields stats/visits reads', () => {
+		it( 'passes the selected period as from/to, the fields stats/visits reads', () => {
 			renderWidget();
 
 			const params = mockUseStatsVisits.mock.calls[ 0 ][ 0 ] as Record< string, unknown >;
 
 			expect( params ).toMatchObject( {
-				from: '2023-12-31',
+				from: '2025-01-01',
 				to: '2025-12-31',
 				period: 'day',
 				stat_fields: 'views',
@@ -225,7 +225,9 @@ describe( 'TrafficViewsActivityWidget', () => {
 			} );
 		} );
 
-		it( 'floors a shorter selection to the shared history window', () => {
+		// A request reaching back past the selection would attribute those years to
+		// the card's heading (WOOA7S-1963).
+		it( 'leaves a selection shorter than the window where it is', () => {
 			renderWidget( {
 				...REPORT_PARAMS,
 				from: '2024-01-01',
@@ -233,7 +235,24 @@ describe( 'TrafficViewsActivityWidget', () => {
 			} as unknown as ReportParams );
 
 			expect( mockUseStatsVisits.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
-				from: '2022-12-31',
+				from: '2024-01-01',
+				to: '2024-12-31',
+			} );
+		} );
+
+		it( 'holds that selection as the viewport widens', () => {
+			renderWidget( {
+				...REPORT_PARAMS,
+				from: '2024-01-01',
+				to: '2024-12-31',
+			} as unknown as ReportParams );
+
+			setViewportWidth( 2560 );
+			fireEvent.resize( window );
+
+			const lastCall = mockUseStatsVisits.mock.calls[ mockUseStatsVisits.mock.calls.length - 1 ];
+			expect( lastCall[ 0 ] ).toMatchObject( {
+				from: '2024-01-01',
 				to: '2024-12-31',
 			} );
 		} );
@@ -284,14 +303,82 @@ describe( 'TrafficViewsActivityWidget', () => {
 			expect( chartDayValues() ).toContain( 'Tue, Jun 3, 2025:340' );
 		} );
 
-		it( 'spans the selected period even though the payload is sparse', () => {
+		it( 'requests only the part of the current year that has happened', () => {
+			renderWidget( {
+				...REPORT_PARAMS,
+				from: '2026-01-01',
+				to: '2026-08-10',
+			} as unknown as ReportParams );
+
+			expect( mockUseStatsVisits.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
+				from: '2026-01-01',
+				to: '2026-08-10',
+			} );
+		} );
+
+		it( 'spans the whole selected period even though the payload is sparse', () => {
 			renderWidget();
 
-			// The 2025 selection densifies to 53 week columns. Not the fetch
-			// window's 106: the request floors at the shared history window, but
-			// the grid must not draw (or let the pager reach) dates outside the
-			// selection — picking 2025 must not page into 2024.
+			// The 53 week columns 2025 spans, not the two years the viewport could draw.
 			expect( screen.getByTestId( 'heatmap' ) ).toHaveAttribute( 'data-columns', '53' );
+		} );
+
+		// jsdom measures every element as 0x0, which resolves to zero columns and
+		// hands the chart the whole series — so a `data-columns` assertion alone
+		// never exercises trimming. These stub a real tile so it does.
+		describe( 'in a measured tile', () => {
+			const currentYear = {
+				...REPORT_PARAMS,
+				from: '2026-01-01',
+				to: '2026-08-10',
+			} as unknown as ReportParams;
+
+			beforeEach( () => {
+				mockUseStatsVisits.mockReturnValue(
+					visitsResult(
+						report( [
+							[ '2026-01-05', 11 ],
+							[ '2026-08-10', 44 ],
+						] )
+					)
+				);
+			} );
+
+			it.each( [
+				[ 1000, 86 ],
+				[ 700, 86 ],
+				[ 1000, 300 ],
+			] )( 'keeps the year on screen at %ix%i', ( width, height ) => {
+				const restoreTileSize = stubTileSize( width, height );
+
+				try {
+					renderWidget( currentYear );
+				} finally {
+					restoreTileSize();
+				}
+
+				// The regression this guards (WOOA7S-1963): the grid ran on to a
+				// December that had not happened, so the columns a smaller tile kept
+				// were the empty future weeks and the year's own traffic was trimmed
+				// away — at 1000x300 the heatmap came out entirely blank.
+				expect( chartDayValues() ).toContain( 'Mon, Aug 10, 2026:44' );
+			} );
+
+			it( 'fills a wide tile with filler weeks rather than leaving a band', () => {
+				const restoreTileSize = stubTileSize( 1000, 86 );
+
+				try {
+					renderWidget( currentYear );
+				} finally {
+					restoreTileSize();
+				}
+
+				const heatmap = screen.getByTestId( 'heatmap' );
+
+				// 2026 has only reached 33 weeks, but the tile draws more than that.
+				expect( Number( heatmap.getAttribute( 'data-columns' ) ) ).toBeGreaterThan( 33 );
+				expect( heatmap ).toHaveAttribute( 'data-width', '1000' );
+			} );
 		} );
 	} );
 
@@ -304,9 +391,9 @@ describe( 'TrafficViewsActivityWidget', () => {
 			expect( screen.queryByTestId( 'heatmap' ) ).not.toBeInTheDocument();
 		} );
 
-		it( 'shows the empty state when only the fetch window surplus has views', () => {
-			// The 2025 selection draws only 2025, but the request reaches back a
-			// further year; those older views must not suppress the empty state.
+		it( 'shows the empty state when only days outside the range have views', () => {
+			// 2025 is selected; a response still carrying an older day — a stale one
+			// for a wider selection — must not suppress the empty state.
 			mockUseStatsVisits.mockReturnValue( visitsResult( report( [ [ '2024-03-05', 120 ] ] ) ) );
 			renderWidget();
 

--- a/projects/packages/premium-analytics/widgets/traffic-views-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-views-activity/render.tsx
@@ -60,33 +60,23 @@ function TrafficViewsActivityInner() {
 	// them against different days.
 	const today = format( new Date(), 'yyyy-MM-dd' );
 
+	// A ceiling only. A floor would reach back past the selection, putting years
+	// outside the card's heading inside it (WOOA7S-1963). It is equally the range
+	// the heatmap draws and pages through — with no floor the two coincide, so
+	// paging can never leave the selection.
 	const fetchWindow = useMemo(
-		() =>
-			resolveCalendarHeatmapWindow(
-				reportParams,
-				{ minDays: windowDays, maxDays: windowDays },
-				today
-			),
+		() => resolveCalendarHeatmapWindow( reportParams, { maxDays: windowDays }, today ),
 		[ reportParams, windowDays, today ]
 	);
 
-	// The period as selected, before the viewport window, and the only use for it:
-	// All time on a long-dormant site reaches back past the window, and the empty
-	// state has to know the response says nothing about the years left out.
+	// The period as selected, before the ceiling. All time on a long-lived site
+	// reaches back past the window, and the empty state has to know the response
+	// says nothing about the years left out.
 	const periodWindow = useMemo(
 		() => resolveCalendarHeatmapWindow( reportParams, {}, today ),
 		[ reportParams, today ]
 	);
 	const isWindowClipped = periodWindow.startDate < fetchWindow.startDate;
-
-	// What the heatmap may draw and page through is the picker's range, not the
-	// request window: the fetch floor reaches past a short range, and with the
-	// pager those weeks would otherwise be reachable — selecting 2025 must not
-	// page into 2024. Only the cap survives (paging never outruns the fetch).
-	const displayWindow = useMemo(
-		() => resolveCalendarHeatmapWindow( reportParams, { maxDays: windowDays }, today ),
-		[ reportParams, windowDays, today ]
-	);
 
 	// stats/visits reads from/to; startDate/endDate are specific to stats/streak.
 	const params = useMemo(
@@ -117,14 +107,14 @@ function TrafficViewsActivityInner() {
 	);
 
 	// Key the empty state to the response rather than the densified calendar, whose
-	// missing dates are represented by null-valued cells — and to the drawn range
-	// only: the fetch reaches past a short selection, and views in that surplus
-	// history must not suppress the empty state for a selection that has none.
+	// missing dates are represented by null-valued cells. Days outside the window
+	// are still ruled out, so a stale response for a wider selection cannot
+	// suppress the empty state while the new one loads.
 	const hasViews = ( report?.data ?? [] ).some( row => {
 		const day = String( row.time_interval );
 
 		return (
-			Number( row.views ?? 0 ) > 0 && day >= displayWindow.startDate && day <= displayWindow.endDate
+			Number( row.views ?? 0 ) > 0 && day >= fetchWindow.startDate && day <= fetchWindow.endDate
 		);
 	} );
 
@@ -145,7 +135,7 @@ function TrafficViewsActivityInner() {
 			: __( 'No views in this period.', 'jetpack-premium-analytics-pkg' );
 
 	return (
-		<AdaptiveCalendarHeatmap valueByDay={ viewsByDay } period={ displayWindow }>
+		<AdaptiveCalendarHeatmap valueByDay={ viewsByDay } period={ fetchWindow }>
 			{ ( chartProps, pager ) => (
 				<WidgetState
 					isLoading={ isLoading }

--- a/projects/plugins/premium-analytics/changelog/fix-wooa7s-1963-heatmap-window
+++ b/projects/plugins/premium-analytics/changelog/fix-wooa7s-1963-heatmap-window
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Insights: scope the calendar heatmaps to the selected period, so the card no longer draws and reports on years outside it.


### PR DESCRIPTION
Fixes WOOA7S-1963

## Proposed changes

* Request only the selected period: the fetch window keeps its ceiling and loses the equal floor that reached back past the selection.
* The request and the range the grid draws now coincide, so the separate display window — and the helper's `minDays` floor, whose last caller this was — go away.
* Fill a tile wider than the period by opening the grid *backwards*, so it still ends on the period's last day.
* Draw those extra weeks as inert filler: no tooltip, no keyboard stop, and no "No views" for a day nothing was measured for. This needs a `placeholder` cell and a `gridSpan` option in `@automattic/charts` — the chart derived its grid from the series, so a grid wider than the data could not be expressed.
* Give `posting-activity` the clipped-window empty state `traffic-views-activity` already had.

Selecting 2023 at 1440px requested `2021-01-01` to `2023-12-31`, and browser width decided how much history came back. #51437 stopped the grid drawing those extra years, but the request still asks for them. The over-fetch was there to fill the tile; filler weeks fill it instead, and trimming spends them before it touches the period.

## Related product discussion/links

* WOOA7S-1963, found while auditing WOOA7S-1848.

## Does this pull request change what data or activity we track or use?

No. It narrows two existing requests to the period the user selected.

## Testing instructions

* Open Insights and pick a past year, e.g. 2024. Both heatmaps should request that year only, and the grid should end on 31 December.
* Pick the current year. The request stops at today and so does the grid; the weeks drawn before January are filler — hovering one shows no tooltip, and arrow keys skip over them.
* Narrow the browser until the tile can no longer draw the whole period. The columns that drop are the filler first, and only then the period's oldest weeks — the most recent data must stay on screen at every width, and the pager arrows reach the rest.
* Pick All time. Still capped at the years the viewport can draw, and the empty state names the days the request covers.
* Storybook: `Widgets Toolkit / Components / AdaptiveCalendarHeatmap → Current Year Through The Year`.
