### PR TITLE
Connection: Make connection error gating direction-aware

### DIFF
--- a/projects/packages/connection/changelog/update-connection-should-report-error-transients
+++ b/projects/packages/connection/changelog/update-connection-should-report-error-transients
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Connection error reporting: make the gate direction-aware to avoid suppressing matching codes across directions.

--- a/projects/packages/connection/docs/error-handling.md
+++ b/projects/packages/connection/docs/error-handling.md
@@ -97,7 +97,13 @@ Storage limits and hygiene:
 
 * At most 5 user IDs are kept per error code; the oldest is evicted when a sixth arrives.
 * Errors expire 24 hours after being stored (checked on read).
-* A reporting gate only processes each error code once per hour, protecting both the site and WordPress.com from error storms. The `jetpack_connection_bypass_error_reporting_gate` filter can disable the gate (useful in tests).
+* A reporting gate only processes each error code once per hour, protecting both the site and Word
+Press.com from error storms. The gate is keyed by error code **and direction**: an outgoing error
+of a given code is verified locally and reported immediately, and that must not block an incoming
+error of the same code from independently clearing its own hourly gate to reach the WordPress.com
+verification round-trip (see [Incoming requests](#incoming-requests-wordpresscom--site)) — and vic
+e versa. The `jetpack_connection_bypass_error_reporting_gate` filter can disable the gate (useful
+in tests).
 * Only [supported error codes](#supported-error-codes) are stored — anything else is silently discarded.
 
 ## Displaying errors

--- a/projects/packages/connection/docs/error-handling.md
+++ b/projects/packages/connection/docs/error-handling.md
@@ -97,13 +97,7 @@ Storage limits and hygiene:
 
 * At most 5 user IDs are kept per error code; the oldest is evicted when a sixth arrives.
 * Errors expire 24 hours after being stored (checked on read).
-* A reporting gate only processes each error code once per hour, protecting both the site and Word
-Press.com from error storms. The gate is keyed by error code **and direction**: an outgoing error
-of a given code is verified locally and reported immediately, and that must not block an incoming
-error of the same code from independently clearing its own hourly gate to reach the WordPress.com
-verification round-trip (see [Incoming requests](#incoming-requests-wordpresscom--site)) — and vic
-e versa. The `jetpack_connection_bypass_error_reporting_gate` filter can disable the gate (useful
-in tests).
+* A reporting gate only processes each error code once per hour, protecting both the site and WordPress.com from error storms. The gate is keyed by error code **and direction**: an outgoing error of a given code is verified locally and reported immediately, and that must not block an incoming error of the same code from independently clearing its own hourly gate to reach the WordPress.com verification round-trip (see [Incoming requests](#incoming-requests-wordpresscom--site)) — and vice versa. The `jetpack_connection_bypass_error_reporting_gate` filter can disable the gate (useful in tests).
 * Only [supported error codes](#supported-error-codes) are stored — anything else is silently discarded.
 
 ## Displaying errors

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -964,7 +964,7 @@ class Error_Handler {
 			return true;
 		}
 
-		$transient = self::ERROR_REPORTING_GATE . $error->get_error_code();
+		$transient = self::error_reporting_gate_transient( $error );
 
 		if ( get_transient( $transient ) ) {
 			return false;
@@ -972,6 +972,24 @@ class Error_Handler {
 
 		set_transient( $transient, true, HOUR_IN_SECONDS );
 		return true;
+	}
+
+	/**
+	 * Builds the reporting-gate transient name for an error.
+	 *
+	 * Keyed by code and direction, not code alone: an outgoing error is reported
+	 * immediately and verified locally (no WP.com round trip), while an incoming error of the
+	 * same code still needs to clear the gate to reach the `verify_xml_rpc_error` round trip
+	 * that triggers WP.com-side self-healing (flow 1 in the class docblock).
+	 *
+	 * @param \WP_Error $error the error object.
+	 * @return string
+	 */
+	private static function error_reporting_gate_transient( \WP_Error $error ) {
+		$error_data      = $error->get_error_data();
+		$error_direction = is_array( $error_data ) && ! empty( $error_data['error_direction'] ) ? $error_data['error_direction'] : '';
+
+		return self::ERROR_REPORTING_GATE . $error->get_error_code() . '_' . $error_direction;
 	}
 
 	/**
@@ -1535,8 +1553,11 @@ class Error_Handler {
 
 		// Reopen the reporting gate for this code: deletion means the condition was
 		// positively confirmed cleared, so a recurrence must be reportable immediately
-		// rather than suppressed for up to an hour.
-		delete_transient( self::ERROR_REPORTING_GATE . $error_code );
+		// rather than suppressed for up to an hour. The gate is keyed by code + direction
+		// (see error_reporting_gate_transient()), so every direction variant is cleared.
+		delete_transient( self::ERROR_REPORTING_GATE . $error_code . '_' . self::DIRECTION_INCOMING );
+		delete_transient( self::ERROR_REPORTING_GATE . $error_code . '_' . self::DIRECTION_OUTGOING );
+		delete_transient( self::ERROR_REPORTING_GATE . $error_code . '_' );
 
 		$stored_errors = $this->get_stored_errors();
 		if ( isset( $stored_errors[ $error_code ] ) ) {

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -1426,7 +1426,7 @@ class Error_Handler_Test extends BaseTestCase {
 		);
 
 		// Set a transient to close the gate
-		set_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token', true, HOUR_IN_SECONDS );
+		set_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token_', true, HOUR_IN_SECONDS );
 
 		// Report the error with force=true (should bypass the gate)
 		$this->error_handler->report_error( $error, true );
@@ -1437,7 +1437,7 @@ class Error_Handler_Test extends BaseTestCase {
 		$this->assertArrayHasKey( '3', $stored_errors['invalid_token'] );
 
 		// Clean up transient only (tear_down will handle the rest)
-		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token' );
+		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token_' );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -56,7 +56,13 @@ class Error_Handler_Test extends BaseTestCase {
 		wp_set_current_user( 0 );
 		\Jetpack_Options::delete_option( 'master_user' );
 
-		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'malformed_token' );
+		// The gate is keyed by code + direction; clean every direction variant a test could
+		// have armed (including '' for a WP_Error built with no error_data).
+		foreach ( array( '', 'incoming', 'outgoing' ) as $direction ) {
+			delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'malformed_token_' . $direction );
+			delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token_' . $direction );
+			delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'unknown_user_' . $direction );
+		}
 	}
 
 	/**
@@ -831,8 +837,6 @@ class Error_Handler_Test extends BaseTestCase {
 		);
 
 		$this->assertEmpty( $this->error_handler->get_stored_errors(), 'the gate should suppress a second report within the hour' );
-
-		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token' );
 	}
 
 	/**
@@ -860,6 +864,28 @@ class Error_Handler_Test extends BaseTestCase {
 		$this->assertCount( 2, $stored_errors['unknown_user'] );
 		$this->assertSame( Error_Handler::DIRECTION_INCOMING, $stored_errors['unknown_user']['1']['error_direction'] );
 		$this->assertSame( Error_Handler::DIRECTION_OUTGOING, $stored_errors['unknown_user']['0']['error_direction'] );
+	}
+
+	/**
+	 * Test that an outgoing fault report does not starve a same-code incoming report.
+	 *
+	 * The gate is deliberately NOT bypassed here — that's the whole point of the test.
+	 */
+	public function test_check_xmlrpc_fault_for_errors_does_not_starve_an_incoming_report_of_the_same_code() {
+		// The outgoing fault arrives first and arms the gate for its own direction.
+		$this->error_handler->check_xmlrpc_fault_for_errors(
+			'unknown_user',
+			'The user is unknown',
+			'https://jetpack.wordpress.com/xmlrpc.php',
+			'POST'
+		);
+
+		// The incoming report, for the same code, must still be storable.
+		$this->error_handler->report_error( $this->get_sample_error( 'unknown_user', 1, Error_Handler::ERROR_TYPE_XMLRPC ) );
+
+		$stored_errors = $this->error_handler->get_stored_errors();
+
+		$this->assertCount( 2, $stored_errors['unknown_user'], 'the incoming report must not be suppressed by the outgoing fault sharing the gate' );
 	}
 
 	/**
@@ -1476,14 +1502,14 @@ class Error_Handler_Test extends BaseTestCase {
 	public function test_should_report_error_gate_closed() {
 		$error = new \WP_Error( 'invalid_token', 'Invalid token' );
 
-		// Set a transient to close the gate
-		set_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token', true, HOUR_IN_SECONDS );
+		// Set a transient to close the gate. No error_data, so direction resolves to ''.
+		set_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token_', true, HOUR_IN_SECONDS );
 
 		$result = $this->error_handler->should_report_error( $error );
 		$this->assertFalse( $result );
 
 		// Clean up
-		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token' );
+		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token_' );
 	}
 
 	/**
@@ -1495,11 +1521,11 @@ class Error_Handler_Test extends BaseTestCase {
 		$result = $this->error_handler->should_report_error( $error );
 		$this->assertTrue( $result );
 
-		// Verify the gate was set
-		$this->assertTrue( get_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token' ) );
+		// Verify the gate was set. No error_data, so direction resolves to ''.
+		$this->assertTrue( get_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token_' ) );
 
 		// Clean up
-		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token' );
+		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token_' );
 	}
 
 	/**
@@ -1508,8 +1534,8 @@ class Error_Handler_Test extends BaseTestCase {
 	public function test_should_report_error_bypass_filter() {
 		$error = new \WP_Error( 'invalid_token', 'Invalid token' );
 
-		// Set a transient to close the gate
-		set_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token', true, HOUR_IN_SECONDS );
+		// Set a transient to close the gate. No error_data, so direction resolves to ''.
+		set_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token_', true, HOUR_IN_SECONDS );
 
 		// Add filter to bypass gate
 		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
@@ -1518,7 +1544,7 @@ class Error_Handler_Test extends BaseTestCase {
 		$this->assertTrue( $result );
 
 		// Clean up
-		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token' );
+		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'invalid_token_' );
 		remove_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
 	}
 


### PR DESCRIPTION
Fixes CONNECT-432

## Proposed changes
Reason for the change:
* Currently, the hourly reporting gate in `should_report_error` is keyed by error code and direction, not code alone — an outgoing fault and an incoming (via `report_error`) report of the same code no longer share a gate. This is an issue because incoming reports of certain codes (e.g. `unknown_user`) trigger WP.com-side self-healing via the verification round-trip. When the gate is shared, an outgoing fault would silently block that round-trip for up to an hour.

For more context on outgoing and incoming errors:
* Incoming is via `Manager::verify_xml_rpc_signature()` calls through to `get_access_token` via `internal_verify_xml_rpc_signature`. The user and token id come from parsing the inbound request token. If this errors, it goes o a WPcom round trip for self-healing.
Outgoing is via `Client::build_signed_request()`, also calling get_access_token. But user is is the site's own intended signer. This can also error, but WPcom verification is skipped due to it being local state (no round trip).

Suggested fix:
* The fix as [suggested here](https://github.com/Automattic/jetpack/pull/51208#pullrequestreview-4927066934) is to  key the gate by code + direction.
* Note this should only affect `no_token_for_user`, `user_id_mismatch` and `no_user_tokens` as these fire in both incoming and outgoing directions, however neither are in the displayable list. However the display isn't what matters, it's the self-healing round-trip


## Related product discussion/links

* See the above Linear issue, and https://github.com/Automattic/jetpack/pull/51208#pullrequestreview-4927066934

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions


To verify visually, on a test site with this branch applied (locally or using the Jetpack Beta tester plugin):

* Make sure the filter `add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );` is not added to your test site, as this will bypass the transient checks.
* Apply the following code snippet via a mu-plugin or using the code snippets plugin: 3c4bf-pb/
* `Visit wp-admin/?test_no_token_for_user=1`
* After the fix: you'll see 2 entries — outgoing and incoming both stored, because they're keyed under `_outgoing` and `_incoming` separately. By doing this test,  you're checking that the incoming report reaches `send_error_to_wpcom()` in order for self-healing (or gets stored/counted) instead of being silently gated by an unrelated outgoing fault.

Post-deploy.

* It is expected that there will be a short-term increase in errors due to the invalidation of the existing transient.
* Errors: 182131cdc746093b75cf249677bc2a5f-logstash