### PR TITLE
RTC: gate collaboration behind the Gutenberg 23.8 experiment

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-18214-rtc-experiment-defaults
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-18214-rtc-experiment-defaults
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: changed
 
 RTC: Document how collaboration is gated behind the Gutenberg 23.8 experiment.

--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-18214-rtc-experiment-defaults
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-18214-rtc-experiment-defaults
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+RTC: Document how collaboration is gated behind the Gutenberg 23.8 experiment.

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/AGENTS.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/AGENTS.md
@@ -48,15 +48,69 @@ A site has RTC running only when **both** are true:
 
 `RTC::is_enabled()` (`projects/packages/rtc/src/class-rtc.php`) = `is_allowed()`
 **AND** `get_option( 'wp_collaboration_enabled' )` **AND** not in the Site Editor.
+`RTC::is_turned_on()` is the same minus the Site Editor check — use it when you
+mean "how is this site configured" rather than "what is this request doing".
 
-The option **defaults to OFF**. When a site is *not* allowed, the Writing field
-is unregistered (hidden) and the option value is forced to `0`. So a missing
-"Enable real-time collaboration" checkbox means the site is not allowed — not
-that the admin forgot to check it.
+When a site is *not* allowed, the Writing field is unregistered (hidden) and the
+option value is forced to `0`. So a missing "Enable real-time collaboration"
+checkbox means the site is not allowed — not that the admin forgot to check it.
 
 > Gotcha — super admins who are **not members** of the blog get the option
 > forced off everywhere except the Writing settings page (`pre_rtc_option`),
 > so HEs/support don't silently broadcast presence on customer sites.
+
+## Gutenberg 23.8+ — the experiment gate
+
+Gutenberg [PR #80658](https://github.com/WordPress/gutenberg/pull/80658) moved
+collaboration and its bundled HTTP polling provider behind a single
+`gutenberg-real-time-collaboration` experiment. On those builds Gutenberg:
+
+- reads `wp_is_collaboration_enabled()` from the experiment, not from an option,
+- **removes** its own collaboration field from Settings → Writing,
+- **deletes** the `wp_collaboration_enabled` option in a one-time migration,
+- drops `WP_ALLOW_COLLABORATION` / `wp_is_collaboration_allowed()`.
+
+`RTC::uses_experiment()` feature-detects those builds (it checks that
+`wp_is_collaboration_enabled()` exists while `wp_is_collaboration_allowed()` does
+not; override with the `jetpack_rtc_uses_experiment` filter). On them the package:
+
+- registers its **own** Writing field (`register_rtc_setting`), since the
+  Gutenberg Experiments page is hidden on WP.com Simple sites and is the wrong
+  level of exposure for a hosted product anyway;
+- **defaults the option to OFF** (`default_rtc_option`), per DOTCOM-18214;
+- toggles the experiment to match the option (`filter_experiments` on
+  `option_gutenberg-experiments`), keeping the setting the single source of truth
+  so collaboration is never on without a provider registered.
+
+On older Gutenberg every one of those callbacks no-ops and the option still
+**defaults to ON**, so behaviour changes exactly when Gutenberg does.
+
+### Carrying over existing opt-ins
+
+Gutenberg's migration deletes `wp_collaboration_enabled` outright, so on its own
+every site would come back with RTC off — including sites that had deliberately
+switched it on. `carry_over_opt_in()` runs on `init` priority 0, ahead of that
+migration at priority 20, and records the answer in
+`jetpack_rtc_pre_experiment_opt_in` ('1' or '0'). `restore_opt_in()` then runs at
+priority 30 — after the migration — and writes `wp_collaboration_enabled` back as a
+**real stored value**, consuming the flag so it only ever happens once.
+
+> Why a stored value and not a default: unchecking the box on Settings → Writing
+> does not store '0', it **removes the option row**. Expressing the carried opt-in
+> as a default therefore re-applied it on the very next request, leaving those
+> sites permanently unable to switch collaboration off. `default_rtc_option()` is
+> unconditionally '0' under the experiment for exactly this reason.
+
+The signal is whether the option was **stored**, not its effective value: it only
+exists in the database when something wrote it (saving Settings → Writing, WP-CLI,
+REST). An absent option means the site was only ever on because the old default
+was on, which is exactly the group we want to switch off.
+
+Sites that are not allowed are skipped, so we do not write an option platform-wide.
+
+> Ordering caveat — this only works if the package ships **before** Gutenberg 23.8
+> reaches a site. If the migration runs first the stored values are already gone
+> and there is nothing left to carry.
 
 ## Layer 1 — this directory (`wpcom_enable_rtc`, priority 10)
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/AGENTS.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/gutenberg-rtc/AGENTS.md
@@ -77,13 +77,18 @@ not; override with the `jetpack_rtc_uses_experiment` filter). On them the packag
 - registers its **own** Writing field (`register_rtc_setting`), since the
   Gutenberg Experiments page is hidden on WP.com Simple sites and is the wrong
   level of exposure for a hosted product anyway;
-- **defaults the option to OFF** (`default_rtc_option`), per DOTCOM-18214;
 - toggles the experiment to match the option (`filter_experiments` on
   `option_gutenberg-experiments`), keeping the setting the single source of truth
   so collaboration is never on without a provider registered.
 
-On older Gutenberg every one of those callbacks no-ops and the option still
-**defaults to ON**, so behaviour changes exactly when Gutenberg does.
+On older Gutenberg those callbacks no-op — Gutenberg still registers its own field
+there, so there is nothing for us to add.
+
+**The option defaults to OFF on every Gutenberg version** (`default_rtc_option`),
+per DOTCOM-18214. That is deliberately not gated on the experiment: there is no
+longer a reason for collaboration to be on by default anywhere. Sites that turned
+it on have a stored value, and `get_option()` returns that without ever consulting
+the default.
 
 ### Carrying over existing opt-ins
 

--- a/projects/packages/rtc/changelog/dotcom-18214-rtc-experiment-defaults
+++ b/projects/packages/rtc/changelog/dotcom-18214-rtc-experiment-defaults
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+RTC: Drive the Gutenberg 23.8 real-time collaboration experiment from the Settings > Writing toggle, default that toggle to off, and preserve the choice of sites that had already opted in.

--- a/projects/packages/rtc/changelog/dotcom-18214-rtc-experiment-defaults
+++ b/projects/packages/rtc/changelog/dotcom-18214-rtc-experiment-defaults
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-RTC: Drive the Gutenberg 23.8 real-time collaboration experiment from the Settings > Writing toggle, default that toggle to off, and preserve the choice of sites that had already opted in.
+RTC: Default collaboration to off, drive the Gutenberg 23.8 experiment from the Settings > Writing toggle, and preserve the choice of sites that had already opted in.

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -30,6 +30,27 @@ class RTC {
 	const OPTION_NEW = 'wp_collaboration_enabled';
 
 	/**
+	 * The Gutenberg experiment that gates real-time collaboration.
+	 *
+	 * Added by Gutenberg PR #80658 (Gutenberg 23.8), which moved collaboration and its
+	 * bundled HTTP polling provider behind a single experiment.
+	 */
+	const EXPERIMENT = 'gutenberg-real-time-collaboration';
+
+	/**
+	 * The option Gutenberg stores its experiments in.
+	 */
+	const EXPERIMENTS_OPTION = 'gutenberg-experiments';
+
+	/**
+	 * Records whether this site had explicitly opted into collaboration before the
+	 * Gutenberg experiment existed.
+	 *
+	 * '1' when it had, '0' when it had not. Absent until we have looked.
+	 */
+	const OPTION_PRE_EXPERIMENT_OPT_IN = 'jetpack_rtc_pre_experiment_opt_in';
+
+	/**
 	 * Whether the hooks have been initialized.
 	 *
 	 * @var bool
@@ -52,6 +73,18 @@ class RTC {
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'load_notices' ) );
 		add_action( 'load-options-writing.php', array( __CLASS__, 'unregister_rtc_setting' ) );
 		add_action( 'load-options-writing.php', array( __CLASS__, 'override_rtc_setting_default' ) );
+
+		/*
+		 * Gutenberg 23.8+ only. Both callbacks no-op on older Gutenberg, and the
+		 * experiment filters are registered on `init` rather than here because
+		 * resolving `is_allowed()` runs the `jetpack_rtc_enabled` filter, whose
+		 * WP.com callbacks are not dependable while plugins are still loading.
+		 */
+		add_action( 'init', array( __CLASS__, 'carry_over_opt_in' ), 0 );
+		add_action( 'init', array( __CLASS__, 'register_experiment_filters' ), 1 );
+		// Priority 30 so it lands after Gutenberg's migration deletes the option at 20.
+		add_action( 'init', array( __CLASS__, 'restore_opt_in' ), 30 );
+		add_action( 'admin_init', array( __CLASS__, 'register_rtc_setting' ) );
 
 		// Hook into both old and new option names for backwards compatibility.
 		foreach ( array( self::OPTION_OLD, self::OPTION_NEW ) as $option ) {
@@ -76,6 +109,20 @@ class RTC {
 	}
 
 	/**
+	 * Determine whether RTC is allowed and switched on for this site.
+	 *
+	 * Unlike is_enabled(), this ignores the current admin screen, so it describes the
+	 * site's configuration rather than the current request. The experiment gate uses
+	 * it for that reason: registering the sync storage post type and REST routes must
+	 * not depend on which admin page happens to be loading.
+	 *
+	 * @return bool
+	 */
+	public static function is_turned_on() {
+		return self::is_allowed() && (bool) get_option( self::OPTION_NEW );
+	}
+
+	/**
 	 * Determine whether RTC is enabled.
 	 *
 	 * @return bool
@@ -91,7 +138,36 @@ class RTC {
 			return false;
 		}
 
-		return self::is_allowed() && (bool) get_option( 'wp_collaboration_enabled' );
+		return self::is_turned_on();
+	}
+
+	/**
+	 * Determine whether the loaded Gutenberg gates RTC behind the experiment.
+	 *
+	 * Gutenberg PR #80658 (Gutenberg 23.8) repointed `wp_is_collaboration_enabled()` at
+	 * the `gutenberg-real-time-collaboration` experiment, removed
+	 * `wp_is_collaboration_allowed()`, dropped the collaboration field from
+	 * Settings > Writing, and deleted the `wp_collaboration_enabled` option in a
+	 * migration.
+	 *
+	 * This feature-detects that pair of functions instead of comparing version numbers,
+	 * because what matters is the shape of the API rather than the release string, and
+	 * WordPress.com can load `dev` and `-fuzz` builds whose versions do not sort
+	 * meaningfully.
+	 *
+	 * @return bool
+	 */
+	public static function uses_experiment() {
+		$uses_experiment = function_exists( 'wp_is_collaboration_enabled' ) && ! function_exists( 'wp_is_collaboration_allowed' );
+
+		/**
+		 * Filter whether RTC is gated by the Gutenberg experiment.
+		 *
+		 * An escape hatch for builds the detection above cannot classify.
+		 *
+		 * @param bool $uses_experiment Whether the loaded Gutenberg gates RTC behind the experiment.
+		 */
+		return (bool) apply_filters( 'jetpack_rtc_uses_experiment', $uses_experiment );
 	}
 
 	/**
@@ -245,6 +321,23 @@ class RTC {
 		if ( ! self::is_allowed() ) {
 			return '0';
 		}
+
+		/*
+		 * Gutenberg 23.8+ makes collaboration opt-in and deliberately does not migrate
+		 * existing sites onto the experiment, so default the setting off to match. This
+		 * is the behaviour DOTCOM-18214 asks for: RTC inactive by default, one checkbox
+		 * away in Settings > Writing.
+		 *
+		 * Sites that had already opted in keep collaboration, but that is handled by
+		 * `restore_opt_in()` storing a real value rather than by bending this default.
+		 * Unchecking the box on Settings > Writing removes the option row, so a default
+		 * of '1' here would immediately switch collaboration back on and leave those
+		 * sites unable to turn it off at all.
+		 */
+		if ( self::uses_experiment() ) {
+			return '0';
+		}
+
 		// RTC allowed and option is not stored yet
 		if ( $option === self::OPTION_NEW ) {
 			// If the old option is set, use that.
@@ -286,6 +379,15 @@ class RTC {
 			return;
 		}
 
+		/*
+		 * Gutenberg 23.8+ no longer registers a collaboration setting for us to adjust;
+		 * `register_rtc_setting` registers our own, already defaulting to off. Bail so we
+		 * do not immediately re-register it here with a default of enabled.
+		 */
+		if ( self::uses_experiment() ) {
+			return;
+		}
+
 		foreach ( array( self::OPTION_OLD, self::OPTION_NEW ) as $option ) {
 			// Only re-register the option if Gutenberg already registered it.
 			if ( ! isset( $wp_registered_settings[ $option ] ) ) {
@@ -306,6 +408,242 @@ class RTC {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Preserve an explicit opt-in across Gutenberg's collaboration migration.
+	 *
+	 * Gutenberg 23.8's `_gutenberg_migrate_remove_legacy_collaboration_options()` deletes
+	 * `wp_collaboration_enabled` outright on `init` priority 20, without migrating it. For
+	 * sites that never touched the setting that is exactly right — they were only ever on
+	 * because the old default was on. But it also discards the choice of sites that
+	 * deliberately switched collaboration on, and those we want to keep.
+	 *
+	 * The distinction is that the option only exists in the database when something
+	 * actually wrote it: saving Settings > Writing, or a WP-CLI/REST update. An absent
+	 * option means "never chosen", so reading the stored value — rather than the effective
+	 * one — separates the two groups cleanly.
+	 *
+	 * Runs on `init` priority 0, so on the first request under Gutenberg 23.8 we read the
+	 * value before the migration at priority 20 removes it.
+	 *
+	 * Note this only works if this package is deployed before Gutenberg 23.8 reaches the
+	 * site. If the migration runs first the stored values are already gone and there is
+	 * nothing left to carry.
+	 *
+	 * @return void
+	 */
+	public static function carry_over_opt_in() {
+		if ( ! self::uses_experiment() ) {
+			return;
+		}
+
+		// Already looked. Recorded as '1' or '0', so anything but false means done.
+		if ( false !== get_option( self::OPTION_PRE_EXPERIMENT_OPT_IN, false ) ) {
+			return;
+		}
+
+		/*
+		 * Skip sites that cannot run RTC anyway. Their stored value was forced to '0' by
+		 * `filter_rtc_option`, so there is nothing meaningful to preserve, and this keeps
+		 * us from writing an option to every site on the platform.
+		 */
+		if ( ! self::is_allowed() ) {
+			return;
+		}
+
+		update_option( self::OPTION_PRE_EXPERIMENT_OPT_IN, self::had_explicit_opt_in() ? '1' : '0' );
+	}
+
+	/**
+	 * Re-apply a carried opt-in after Gutenberg's migration has removed the option.
+	 *
+	 * Deliberately writes a real option value instead of leaning on
+	 * `default_rtc_option()`. Unchecking the box on Settings > Writing does not store a
+	 * '0' — it removes the row entirely — so anything expressed as a default would
+	 * re-apply itself on the next request and make the setting impossible to switch off.
+	 *
+	 * The carried flag is consumed here so this runs once. From then on the stored option
+	 * is the only thing that decides, exactly as it is for a site that never opted in.
+	 *
+	 * @return void
+	 */
+	public static function restore_opt_in() {
+		if ( ! self::uses_experiment() ) {
+			return;
+		}
+
+		if ( '1' !== get_option( self::OPTION_PRE_EXPERIMENT_OPT_IN ) ) {
+			return;
+		}
+
+		// Consume first, so a failure below cannot leave this re-applying every request.
+		update_option( self::OPTION_PRE_EXPERIMENT_OPT_IN, '0' );
+
+		// Only restore into the gap the migration left. Never overwrite a real choice.
+		if ( null === self::get_stored_option( self::OPTION_NEW ) ) {
+			update_option( self::OPTION_NEW, '1' );
+		}
+	}
+
+	/**
+	 * Whether collaboration was explicitly switched on before the experiment existed.
+	 *
+	 * @return bool
+	 */
+	private static function had_explicit_opt_in() {
+		foreach ( array( self::OPTION_NEW, self::OPTION_OLD ) as $option ) {
+			$stored = self::get_stored_option( $option );
+
+			if ( null !== $stored ) {
+				// (bool) '0' is false, so a stored opt-out correctly reads as no opt-in.
+				return (bool) $stored;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Read an option's stored value, or null when nothing is stored.
+	 *
+	 * `get_option()` cannot answer "is this stored?" on its own here, because this class
+	 * filters the option to a value whether or not one exists. Lifting our own filters for
+	 * the duration of the read lets the missing-option default come through untouched.
+	 *
+	 * @param string $option Option name.
+	 * @return mixed The stored value, or null when the option does not exist.
+	 */
+	private static function get_stored_option( $option ) {
+		$filters = array(
+			array( 'pre_option_' . $option, 'pre_rtc_option', 10, 1 ),
+			array( 'option_' . $option, 'filter_rtc_option', 10, 1 ),
+			array( 'default_option_' . $option, 'default_rtc_option', 20, 2 ),
+		);
+
+		// Restore only what was actually hooked, so this cannot add filters of its own.
+		$hooked = array();
+		foreach ( $filters as $filter ) {
+			list( $hook, $method, $priority ) = $filter;
+
+			$hooked[ $hook ] = has_filter( $hook, array( __CLASS__, $method ) ) === $priority;
+			if ( $hooked[ $hook ] ) {
+				remove_filter( $hook, array( __CLASS__, $method ), $priority );
+			}
+		}
+
+		$stored = get_option( $option, null );
+
+		foreach ( $filters as $filter ) {
+			list( $hook, $method, $priority, $args ) = $filter;
+
+			if ( $hooked[ $hook ] ) {
+				add_filter( $hook, array( __CLASS__, $method ), $priority, $args );
+			}
+		}
+
+		return $stored;
+	}
+
+	/**
+	 * Register the filters that drive the Gutenberg RTC experiment.
+	 *
+	 * Runs on `init` so that resolving `is_allowed()` — which fires the
+	 * `jetpack_rtc_enabled` filter, and on WP.com reads site features and stickers —
+	 * happens after plugins have finished loading. Everything in Gutenberg that reads
+	 * the experiment does so on `init`, `admin_init`, `rest_api_init` or
+	 * `block_editor_settings_all`, all of which run later.
+	 *
+	 * @return void
+	 */
+	public static function register_experiment_filters() {
+		if ( ! self::uses_experiment() ) {
+			return;
+		}
+
+		// 'option_' fires when the option exists in the DB, 'default_option_' when it does not.
+		add_filter( 'option_' . self::EXPERIMENTS_OPTION, array( __CLASS__, 'filter_experiments' ) );
+		add_filter( 'default_option_' . self::EXPERIMENTS_OPTION, array( __CLASS__, 'filter_experiments' ) );
+	}
+
+	/**
+	 * Toggle the RTC experiment to match the site's collaboration setting.
+	 *
+	 * Keeping the setting as the single source of truth avoids the "collaboration on,
+	 * no provider registered" state that Gutenberg PR #80658 was written to eliminate.
+	 *
+	 * @param mixed $experiments The `gutenberg-experiments` option value.
+	 * @return array The experiments, with RTC toggled to match the setting.
+	 */
+	public static function filter_experiments( $experiments ) {
+		if ( ! is_array( $experiments ) ) {
+			$experiments = array();
+		}
+
+		if ( self::is_turned_on() ) {
+			$experiments[ self::EXPERIMENT ] = true;
+		} else {
+			// Unset rather than leave alone, so the setting still wins if the experiment
+			// was enabled directly through the Gutenberg Experiments page.
+			unset( $experiments[ self::EXPERIMENT ] );
+		}
+
+		return $experiments;
+	}
+
+	/**
+	 * Register the collaboration setting on Settings > Writing.
+	 *
+	 * Gutenberg 23.8+ removed its own field, leaving the Experiments page as the only
+	 * way to turn RTC on. That page is hidden on WP.com Simple sites, and asking people
+	 * to toggle an experiment is the wrong level of exposure for a hosted product, so we
+	 * register a replacement. The wording matches the checkbox Gutenberg removed.
+	 *
+	 * @return void
+	 */
+	public static function register_rtc_setting() {
+		if ( ! self::uses_experiment() || ! self::is_allowed() ) {
+			return;
+		}
+
+		register_setting(
+			'writing',
+			self::OPTION_NEW,
+			array(
+				'type'              => 'boolean',
+				'description'       => __( 'Enable Real-Time Collaboration', 'jetpack-rtc' ),
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'default'           => false,
+				'show_in_rest'      => true,
+			)
+		);
+
+		add_settings_field(
+			self::OPTION_NEW,
+			__( 'Collaboration', 'jetpack-rtc' ),
+			array( __CLASS__, 'render_rtc_setting_field' ),
+			'writing'
+		);
+	}
+
+	/**
+	 * Render the collaboration checkbox on Settings > Writing.
+	 *
+	 * @return void
+	 */
+	public static function render_rtc_setting_field() {
+		?>
+		<label for="<?php echo esc_attr( self::OPTION_NEW ); ?>">
+			<input
+				name="<?php echo esc_attr( self::OPTION_NEW ); ?>"
+				type="checkbox"
+				id="<?php echo esc_attr( self::OPTION_NEW ); ?>"
+				value="1"
+				<?php checked( (bool) get_option( self::OPTION_NEW ) ); ?>
+			/>
+			<?php esc_html_e( "Enable early access to real-time collaboration. Real-time collaboration may affect your website's performance.", 'jetpack-rtc' ); ?>
+		</label>
+		<?php
 	}
 
 	/**

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -72,7 +72,6 @@ class RTC {
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'register_providers' ) );
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'load_notices' ) );
 		add_action( 'load-options-writing.php', array( __CLASS__, 'unregister_rtc_setting' ) );
-		add_action( 'load-options-writing.php', array( __CLASS__, 'override_rtc_setting_default' ) );
 
 		/*
 		 * Gutenberg 23.8+ only. Both callbacks no-op on older Gutenberg, and the
@@ -304,47 +303,17 @@ class RTC {
 	}
 
 	/**
-	 * When RTC is allowed and the option is NOT stored yet,
-	 * default the option to enabled (1), unless the old option
-	 * has a stored value to migrate from.
+	 * Default the collaboration setting to off.
 	 *
-	 * This handles the Gutenberg upgrade path: e.g. a site on 22.7 stored
-	 * wp_enable_real_time_collaboration, then upgraded to 22.8 which reads
-	 * wp_collaboration_enabled — the new option inherits the old value.
+	 * Real-time collaboration is opt-in: Gutenberg 23.8 made it an experiment that sites
+	 * must enable explicitly, and on earlier versions there is no longer a reason to have
+	 * it on by default either. Sites that turned it on have a stored value, which
+	 * `get_option()` returns without ever consulting this filter.
 	 *
-	 * @param mixed  $default The default value.
-	 * @param string $option  The option name.
-	 * @return mixed
+	 * @return string Always '0'.
 	 */
-	public static function default_rtc_option( $default = '', $option = '' ) {
-		// RTC not allowed: keep default disabled.
-		if ( ! self::is_allowed() ) {
-			return '0';
-		}
-
-		/*
-		 * Gutenberg 23.8+ makes collaboration opt-in and deliberately does not migrate
-		 * existing sites onto the experiment, so default the setting off to match. This
-		 * is the behaviour DOTCOM-18214 asks for: RTC inactive by default, one checkbox
-		 * away in Settings > Writing.
-		 *
-		 * Sites that had already opted in keep collaboration, but that is handled by
-		 * `restore_opt_in()` storing a real value rather than by bending this default.
-		 * Unchecking the box on Settings > Writing removes the option row, so a default
-		 * of '1' here would immediately switch collaboration back on and leave those
-		 * sites unable to turn it off at all.
-		 */
-		if ( self::uses_experiment() ) {
-			return '0';
-		}
-
-		// RTC allowed and option is not stored yet
-		if ( $option === self::OPTION_NEW ) {
-			// If the old option is set, use that.
-			return get_option( self::OPTION_OLD );
-		}
-		// Default to enabled.
-		return '1';
+	public static function default_rtc_option() {
+		return '0';
 	}
 
 	/**
@@ -363,51 +332,6 @@ class RTC {
 
 		// Returning false to let `get_option` proceed normally.
 		return false;
-	}
-
-	/**
-	 * Override the default for the Gutenberg RTC setting so it defaults to enabled in the UI.
-	 *
-	 * @return void
-	 */
-	public static function override_rtc_setting_default() {
-		global $wp_registered_settings;
-
-		// No need to override the setting when RTC is not allowed, since we unregister it
-		// in `unregister_rtc_setting`.
-		if ( ! self::is_allowed() ) {
-			return;
-		}
-
-		/*
-		 * Gutenberg 23.8+ no longer registers a collaboration setting for us to adjust;
-		 * `register_rtc_setting` registers our own, already defaulting to off. Bail so we
-		 * do not immediately re-register it here with a default of enabled.
-		 */
-		if ( self::uses_experiment() ) {
-			return;
-		}
-
-		foreach ( array( self::OPTION_OLD, self::OPTION_NEW ) as $option ) {
-			// Only re-register the option if Gutenberg already registered it.
-			if ( ! isset( $wp_registered_settings[ $option ] ) ) {
-				continue;
-			}
-
-			unregister_setting( 'writing', $option );
-
-			register_setting(
-				'writing',
-				$option,
-				array(
-					'type'              => 'boolean',
-					'description'       => __( 'Enable Real-Time Collaboration', 'jetpack-rtc' ),
-					'sanitize_callback' => 'rest_sanitize_boolean',
-					'default'           => true,
-					'show_in_rest'      => true,
-				)
-			);
-		}
 	}
 
 	/**
@@ -444,14 +368,12 @@ class RTC {
 		}
 
 		/*
-		 * Skip sites that cannot run RTC anyway. Their stored value was forced to '0' by
-		 * `filter_rtc_option`, so there is nothing meaningful to preserve, and this keeps
-		 * us from writing an option to every site on the platform.
+		 * Record an answer for every site, including ones that cannot run RTC. Writing the
+		 * marker unconditionally is what lets the check above short-circuit on subsequent
+		 * requests; skipping disallowed sites would leave them re-evaluating this on every
+		 * admin request forever. Whether RTC is allowed is still enforced at read time by
+		 * `is_turned_on()`.
 		 */
-		if ( ! self::is_allowed() ) {
-			return;
-		}
-
 		update_option( self::OPTION_PRE_EXPERIMENT_OPT_IN, self::had_explicit_opt_in() ? '1' : '0' );
 	}
 
@@ -563,7 +485,18 @@ class RTC {
 
 		// 'option_' fires when the option exists in the DB, 'default_option_' when it does not.
 		add_filter( 'option_' . self::EXPERIMENTS_OPTION, array( __CLASS__, 'filter_experiments' ) );
-		add_filter( 'default_option_' . self::EXPERIMENTS_OPTION, array( __CLASS__, 'filter_experiments' ) );
+
+		/*
+		 * Priority 20 because Gutenberg registers `gutenberg-experiments` with a default
+		 * of array() on `rest_api_init`. register_setting() hooks core's
+		 * filter_default_option() onto `default_option_gutenberg-experiments` at priority
+		 * 10, and that callback ignores the value it is handed and returns the registered
+		 * default. At the same priority ours runs first and its result is thrown away, so
+		 * the experiment would read as disabled on every REST request no matter what the
+		 * setting says. Running after core's callback is the same reason default_rtc_option
+		 * is registered at 20.
+		 */
+		add_filter( 'default_option_' . self::EXPERIMENTS_OPTION, array( __CLASS__, 'filter_experiments' ), 20 );
 	}
 
 	/**

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -759,6 +759,54 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Renders the Writing settings field and returns the markup.
+	 *
+	 * @return string
+	 */
+	private function render_setting_field() {
+		ob_start();
+		RTC::render_rtc_setting_field();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Tests that the field renders unchecked when collaboration is off.
+	 */
+	public function test_render_rtc_setting_field_unchecked_by_default() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+
+		$markup = $this->render_setting_field();
+
+		$this->assertStringContainsString( 'name="' . RTC::OPTION_NEW . '"', $markup );
+		$this->assertStringContainsString( 'type="checkbox"', $markup );
+		$this->assertStringNotContainsString( "checked='checked'", $markup );
+	}
+
+	/**
+	 * Tests that the field renders checked once collaboration is switched on.
+	 */
+	public function test_render_rtc_setting_field_checked_when_enabled() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
+
+		$markup = $this->render_setting_field();
+
+		$this->assertStringContainsString( "checked='checked'", $markup );
+	}
+
+	/**
+	 * Tests that the field describes what it does.
+	 */
+	public function test_render_rtc_setting_field_includes_description() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+
+		$this->assertStringContainsString( 'real-time collaboration', $this->render_setting_field() );
+	}
+
+	/**
 	 * Tests that init hooks the experiment filter registration and the setting.
 	 */
 	public function test_init_hooks_experiment_setup() {
@@ -863,6 +911,25 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 		RTC::carry_over_opt_in();
 
 		$this->assertSame( '0', get_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN ) );
+	}
+
+	/**
+	 * Tests that reading the stored value adds no filters when none were hooked.
+	 *
+	 * The carry-over lifts this class's option filters to read the raw value. If it
+	 * restored them unconditionally it would register filters on a site where init() had
+	 * never run.
+	 */
+	public function test_carry_over_adds_no_filters_when_none_were_hooked() {
+		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		add_filter( 'jetpack_rtc_uses_experiment', '__return_true' );
+
+		// Deliberately no RTC::init(), so none of the option filters are registered.
+		RTC::carry_over_opt_in();
+
+		$this->assertFalse( has_filter( 'option_' . RTC::OPTION_NEW, array( RTC::class, 'filter_rtc_option' ) ) );
+		$this->assertFalse( has_filter( 'default_option_' . RTC::OPTION_NEW, array( RTC::class, 'default_rtc_option' ) ) );
+		$this->assertFalse( has_filter( 'pre_option_' . RTC::OPTION_NEW, array( RTC::class, 'pre_rtc_option' ) ) );
 	}
 
 	/**

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -26,6 +26,13 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	private $original_wp_settings_fields;
 
 	/**
+	 * Original value of $wp_registered_settings to restore after each test.
+	 *
+	 * @var mixed
+	 */
+	private $original_wp_registered_settings;
+
+	/**
 	 * Original WP_Scripts instance to restore after each test.
 	 *
 	 * @var \WP_Scripts|null
@@ -51,24 +58,34 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function set_up(): void {
 		parent::set_up();
-		global $wp_settings_fields, $wp_scripts, $wp_styles, $pagenow;
-		$this->original_wp_settings_fields = $wp_settings_fields;
-		$this->original_wp_scripts         = $wp_scripts;
-		$this->original_wp_styles          = $wp_styles;
-		$this->original_pagenow            = $pagenow;
+		global $wp_settings_fields, $wp_registered_settings, $wp_scripts, $wp_styles, $pagenow;
+		$this->original_wp_settings_fields     = $wp_settings_fields;
+		$this->original_wp_registered_settings = $wp_registered_settings;
+		$this->original_wp_scripts             = $wp_scripts;
+		$this->original_wp_styles              = $wp_styles;
+		$this->original_pagenow                = $pagenow;
 	}
 
 	/**
 	 * Clean up filters and restore global state after each test.
 	 */
 	public function tear_down(): void {
-		global $wp_settings_fields, $wp_scripts, $wp_styles, $pagenow;
-		$wp_settings_fields = $this->original_wp_settings_fields;
-		$wp_scripts         = $this->original_wp_scripts;
-		$wp_styles          = $this->original_wp_styles;
-		$pagenow            = $this->original_pagenow;
+		global $wp_settings_fields, $wp_registered_settings, $wp_scripts, $wp_styles, $pagenow;
+		$wp_settings_fields     = $this->original_wp_settings_fields;
+		$wp_registered_settings = $this->original_wp_registered_settings;
+		$wp_scripts             = $this->original_wp_scripts;
+		$wp_styles              = $this->original_wp_styles;
+		$pagenow                = $this->original_pagenow;
 		remove_all_filters( 'jetpack_rtc_enabled' );
 		remove_all_filters( 'jetpack_rtc_providers' );
+		remove_all_filters( 'jetpack_rtc_uses_experiment' );
+		delete_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN );
+
+		// The pre_rtc_option tests log a user in; leaving them logged in makes
+		// pre_rtc_option short-circuit get_option() in every test that follows.
+		wp_set_current_user( 0 );
+		remove_all_filters( 'option_' . RTC::EXPERIMENTS_OPTION );
+		remove_all_filters( 'default_option_' . RTC::EXPERIMENTS_OPTION );
 		foreach ( array( RTC::OPTION_OLD, RTC::OPTION_NEW ) as $option ) {
 			remove_all_filters( 'option_' . $option );
 			remove_all_filters( 'default_option_' . $option );
@@ -562,5 +579,418 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 		$pagenow = 'options-writing.php';
 
 		$this->assertFalse( RTC::pre_rtc_option() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Gutenberg experiment tests (Gutenberg 23.8+)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Allowed site running a Gutenberg that gates RTC behind the experiment.
+	 */
+	private function use_experiment_and_allow() {
+		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		add_filter( 'jetpack_rtc_uses_experiment', '__return_true' );
+	}
+
+	/**
+	 * Tests that the experiment is not detected without Gutenberg 23.8+ loaded.
+	 */
+	public function test_uses_experiment_defaults_false() {
+		$this->assertFalse( RTC::uses_experiment() );
+	}
+
+	/**
+	 * Tests that experiment detection can be overridden by filter.
+	 */
+	public function test_uses_experiment_respects_filter() {
+		add_filter( 'jetpack_rtc_uses_experiment', '__return_true' );
+		$this->assertTrue( RTC::uses_experiment() );
+	}
+
+	/**
+	 * Tests that is_turned_on describes the site, ignoring the current admin screen.
+	 */
+	public function test_is_turned_on_ignores_site_editor() {
+		global $pagenow;
+
+		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '1' );
+
+		$pagenow = 'site-editor.php';
+
+		$this->assertTrue( RTC::is_turned_on() );
+		$this->assertFalse( RTC::is_enabled() );
+	}
+
+	/**
+	 * Tests that the setting defaults to off once RTC is gated by the experiment.
+	 */
+	public function test_default_rtc_option_returns_0_when_using_experiment() {
+		$this->use_experiment_and_allow();
+
+		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_NEW ) );
+		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_OLD ) );
+	}
+
+	/**
+	 * Tests that the experiment is enabled when the setting is on.
+	 */
+	public function test_filter_experiments_enables_when_turned_on() {
+		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '1' );
+
+		$this->assertSame(
+			array( RTC::EXPERIMENT => true ),
+			RTC::filter_experiments( array() )
+		);
+	}
+
+	/**
+	 * Tests that the experiment is removed when the setting is off.
+	 */
+	public function test_filter_experiments_removes_when_turned_off() {
+		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '0' );
+
+		$this->assertSame(
+			array(),
+			RTC::filter_experiments( array( RTC::EXPERIMENT => true ) )
+		);
+	}
+
+	/**
+	 * Tests that unrelated experiments are left untouched.
+	 */
+	public function test_filter_experiments_preserves_other_experiments() {
+		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		update_option( RTC::OPTION_NEW, '1' );
+
+		$this->assertSame(
+			array(
+				'gutenberg-guidelines' => true,
+				RTC::EXPERIMENT        => true,
+			),
+			RTC::filter_experiments( array( 'gutenberg-guidelines' => true ) )
+		);
+	}
+
+	/**
+	 * Tests that a missing option (passed as false) is handled.
+	 */
+	public function test_filter_experiments_handles_non_array() {
+		$this->assertSame( array(), RTC::filter_experiments( false ) );
+	}
+
+	/**
+	 * Tests that a stored setting cannot enable the experiment on a site that is not allowed.
+	 */
+	public function test_filter_experiments_ignores_setting_when_not_allowed() {
+		add_filter( 'jetpack_rtc_uses_experiment', '__return_true' );
+		update_option( RTC::OPTION_NEW, '1' );
+
+		$this->assertSame( array(), RTC::filter_experiments( array() ) );
+	}
+
+	/**
+	 * Tests that the experiment filters are not registered on older Gutenberg.
+	 */
+	public function test_register_experiment_filters_skips_on_legacy_gutenberg() {
+		RTC::register_experiment_filters();
+
+		$this->assertFalse( has_filter( 'option_' . RTC::EXPERIMENTS_OPTION ) );
+		$this->assertFalse( has_filter( 'default_option_' . RTC::EXPERIMENTS_OPTION ) );
+	}
+
+	/**
+	 * Tests that the experiment filters are registered on Gutenberg 23.8+.
+	 */
+	public function test_register_experiment_filters_registers_on_new_gutenberg() {
+		add_filter( 'jetpack_rtc_uses_experiment', '__return_true' );
+
+		RTC::register_experiment_filters();
+
+		$this->assertNotFalse( has_filter( 'option_' . RTC::EXPERIMENTS_OPTION, array( RTC::class, 'filter_experiments' ) ) );
+		$this->assertNotFalse( has_filter( 'default_option_' . RTC::EXPERIMENTS_OPTION, array( RTC::class, 'filter_experiments' ) ) );
+	}
+
+	/**
+	 * Tests that we do not re-register Gutenberg's setting back to a default of enabled.
+	 */
+	public function test_override_rtc_setting_default_bails_when_using_experiment() {
+		global $wp_registered_settings;
+
+		$this->use_experiment_and_allow();
+		$wp_registered_settings = array( RTC::OPTION_NEW => array( 'default' => false ) );
+
+		RTC::override_rtc_setting_default();
+
+		$this->assertFalse( $wp_registered_settings[ RTC::OPTION_NEW ]['default'] );
+	}
+
+	/**
+	 * Tests that no replacement setting is registered when RTC is not allowed.
+	 */
+	public function test_register_rtc_setting_skips_when_not_allowed() {
+		global $wp_settings_fields;
+
+		add_filter( 'jetpack_rtc_uses_experiment', '__return_true' );
+		$wp_settings_fields = array();
+
+		RTC::register_rtc_setting();
+
+		$this->assertSame( array(), $wp_settings_fields );
+	}
+
+	/**
+	 * Tests that the replacement setting is registered, defaulting to off.
+	 */
+	public function test_register_rtc_setting_registers_field_when_allowed() {
+		global $wp_settings_fields, $wp_registered_settings;
+
+		$this->use_experiment_and_allow();
+		$wp_settings_fields = array();
+
+		RTC::register_rtc_setting();
+
+		$this->assertArrayHasKey( RTC::OPTION_NEW, $wp_settings_fields['writing']['default'] );
+		$this->assertFalse( $wp_registered_settings[ RTC::OPTION_NEW ]['default'] );
+	}
+
+	/**
+	 * Tests that init hooks the experiment filter registration and the setting.
+	 */
+	public function test_init_hooks_experiment_setup() {
+		RTC::init();
+
+		$this->assertNotFalse( has_action( 'init', array( RTC::class, 'register_experiment_filters' ) ) );
+		$this->assertNotFalse( has_action( 'admin_init', array( RTC::class, 'register_rtc_setting' ) ) );
+		// Must land after Gutenberg's migration, which runs at priority 20.
+		$this->assertSame( 30, has_action( 'init', array( RTC::class, 'restore_opt_in' ) ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Opt-in carry-over tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that a site that explicitly turned collaboration on keeps it.
+	 */
+	public function test_carry_over_records_explicit_opt_in() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
+
+		RTC::carry_over_opt_in();
+
+		$this->assertSame( '1', get_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN ) );
+	}
+
+	/**
+	 * Tests that a site that never touched the setting is not opted in.
+	 */
+	public function test_carry_over_records_no_opt_in_when_nothing_stored() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+
+		RTC::carry_over_opt_in();
+
+		$this->assertSame( '0', get_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN ) );
+	}
+
+	/**
+	 * Tests that an explicit opt-out is not read as an opt-in.
+	 */
+	public function test_carry_over_records_no_opt_in_when_explicitly_disabled() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		update_option( RTC::OPTION_NEW, '0' );
+
+		RTC::carry_over_opt_in();
+
+		$this->assertSame( '0', get_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN ) );
+	}
+
+	/**
+	 * Tests that an opt-in stored under the pre-rename option name is still found.
+	 */
+	public function test_carry_over_falls_back_to_legacy_option() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		update_option( RTC::OPTION_OLD, '1' );
+
+		RTC::carry_over_opt_in();
+
+		$this->assertSame( '1', get_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN ) );
+	}
+
+	/**
+	 * Tests that sites which cannot run RTC are not written to.
+	 */
+	public function test_carry_over_skips_when_not_allowed() {
+		add_filter( 'jetpack_rtc_uses_experiment', '__return_true' );
+		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
+
+		RTC::carry_over_opt_in();
+
+		$this->assertFalse( get_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, false ) );
+	}
+
+	/**
+	 * Tests that nothing is recorded on Gutenberg versions without the experiment.
+	 */
+	public function test_carry_over_skips_on_legacy_gutenberg() {
+		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
+
+		RTC::carry_over_opt_in();
+
+		$this->assertFalse( get_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, false ) );
+	}
+
+	/**
+	 * Tests that the carry-over runs once and does not revisit its answer.
+	 */
+	public function test_carry_over_is_idempotent() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '0' );
+		update_option( RTC::OPTION_NEW, '1' );
+
+		RTC::carry_over_opt_in();
+
+		$this->assertSame( '0', get_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN ) );
+	}
+
+	/**
+	 * Tests that reading the stored value leaves this class's option filters intact.
+	 */
+	public function test_carry_over_leaves_option_filters_intact() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
+
+		RTC::carry_over_opt_in();
+
+		$this->assertSame( 10, has_filter( 'option_' . RTC::OPTION_NEW, array( RTC::class, 'filter_rtc_option' ) ) );
+		$this->assertSame( 20, has_filter( 'default_option_' . RTC::OPTION_NEW, array( RTC::class, 'default_rtc_option' ) ) );
+		$this->assertSame( 10, has_filter( 'pre_option_' . RTC::OPTION_NEW, array( RTC::class, 'pre_rtc_option' ) ) );
+	}
+
+	/**
+	 * Tests that the default stays off even for a site that had opted in.
+	 *
+	 * The opt-in is re-applied as a stored value by restore_opt_in(), never as a default.
+	 */
+	public function test_default_rtc_option_is_off_regardless_of_carried_flag() {
+		$this->use_experiment_and_allow();
+
+		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '1' );
+		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_NEW ) );
+
+		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '0' );
+		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_NEW ) );
+	}
+
+	/**
+	 * Tests that a carried opt-in turns the experiment back on end to end.
+	 */
+	public function test_carried_opt_in_enables_the_experiment() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '1' );
+
+		// Gutenberg's migration has removed the option by this point.
+		delete_option( RTC::OPTION_NEW );
+		RTC::restore_opt_in();
+
+		$this->assertSame(
+			array( RTC::EXPERIMENT => true ),
+			RTC::filter_experiments( array() )
+		);
+	}
+
+	/**
+	 * Tests that restoring writes a real stored value, not just a default.
+	 */
+	public function test_restore_opt_in_stores_a_real_value() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '1' );
+		delete_option( RTC::OPTION_NEW );
+
+		RTC::restore_opt_in();
+
+		$this->assertSame( '1', get_option( RTC::OPTION_NEW ) );
+		// The flag is consumed, so this only ever happens once.
+		$this->assertSame( '0', get_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN ) );
+	}
+
+	/**
+	 * Tests that a site which never opted in is left alone.
+	 */
+	public function test_restore_opt_in_skips_when_nothing_carried() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '0' );
+		delete_option( RTC::OPTION_NEW );
+
+		RTC::restore_opt_in();
+
+		$this->assertFalse( RTC::is_turned_on() );
+	}
+
+	/**
+	 * Tests that restoring never overwrites a choice the site already has stored.
+	 */
+	public function test_restore_opt_in_does_not_overwrite_a_stored_choice() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '1' );
+		// add_option, not update_option: the default is already '0', so update_option
+		// would see no change and write nothing.
+		add_option( RTC::OPTION_NEW, '0' );
+
+		RTC::restore_opt_in();
+
+		$this->assertSame( '0', get_option( RTC::OPTION_NEW ) );
+	}
+
+	/**
+	 * Tests that a carried-over site can still switch collaboration off.
+	 *
+	 * Regression test: unchecking the box on Settings > Writing deletes the option row
+	 * rather than storing '0'. While the carried opt-in was expressed as a default, that
+	 * default re-applied on the next request and the setting could never be turned off.
+	 */
+	public function test_carried_site_can_turn_collaboration_off() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '1' );
+		delete_option( RTC::OPTION_NEW );
+
+		RTC::restore_opt_in();
+		$this->assertTrue( RTC::is_turned_on(), 'collaboration should be restored' );
+
+		// The user unchecks the box, which removes the row.
+		delete_option( RTC::OPTION_NEW );
+		RTC::restore_opt_in();
+
+		$this->assertFalse( RTC::is_turned_on(), 'collaboration should stay off' );
+		$this->assertSame( array(), RTC::filter_experiments( array() ) );
+	}
+
+	/**
+	 * Tests that init hooks the carry-over ahead of Gutenberg's migration.
+	 */
+	public function test_init_hooks_carry_over_before_migration() {
+		RTC::init();
+
+		$priority = has_action( 'init', array( RTC::class, 'carry_over_opt_in' ) );
+
+		$this->assertSame( 0, $priority );
+		$this->assertLessThan( 20, $priority );
 	}
 }

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -618,16 +618,6 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the setting defaults to off once RTC is gated by the experiment.
-	 */
-	public function test_default_rtc_option_returns_0_when_using_experiment() {
-		$this->use_experiment_and_allow();
-
-		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_NEW ) );
-		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_OLD ) );
-	}
-
-	/**
 	 * Tests that the experiment is enabled when the setting is on.
 	 */
 	public function test_filter_experiments_enables_when_turned_on() {
@@ -972,10 +962,10 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 		$this->use_experiment_and_allow();
 
 		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '1' );
-		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_NEW ) );
+		$this->assertSame( '0', RTC::default_rtc_option() );
 
 		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '0' );
-		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_NEW ) );
+		$this->assertSame( '0', RTC::default_rtc_option() );
 	}
 
 	/**

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -131,14 +131,6 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that init always hooks override_rtc_setting_default.
-	 */
-	public function test_init_hooks_override_rtc_setting_default() {
-		RTC::init();
-		$this->assertSame( 10, has_action( 'load-options-writing.php', array( RTC::class, 'override_rtc_setting_default' ) ) );
-	}
-
-	/**
 	 * Tests that init hooks filter_rtc_option on both old and new option filters.
 	 */
 	public function test_init_hooks_filter_rtc_option() {
@@ -202,6 +194,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_is_enabled_returns_true_when_allowed_and_option_enabled() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
 		$this->assertTrue( RTC::is_enabled() );
 	}
 
@@ -222,6 +215,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
 
 		$pagenow = 'site-editor.php';
 		$this->assertFalse( RTC::is_enabled() );
@@ -258,6 +252,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_get_providers_returns_providers_when_enabled() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -274,6 +269,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_get_providers_filters_unknown_providers() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -290,6 +286,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_get_providers_handles_non_array_filter() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -306,6 +303,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_get_providers_reindexes_after_filtering() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -325,6 +323,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_get_providers_handles_empty_filter() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -341,6 +340,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_get_providers_default_passes_allowlist() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
 
 		$this->assertSame( array( 'pinghub' ), RTC::get_providers() );
 	}
@@ -355,6 +355,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_register_providers_skips_http_polling_only() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -373,6 +374,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_register_providers_enqueues_when_pinghub() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -391,6 +393,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_register_providers_enqueues_with_multiple_providers() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -409,6 +412,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	public function test_register_providers_does_not_include_jwt_token() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 		RTC::init();
+		update_option( RTC::OPTION_NEW, '1' );
 		add_filter(
 			'jetpack_rtc_providers',
 			function () {
@@ -521,22 +525,12 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that default_rtc_option returns '1' when RTC is allowed and no option is stored.
+	 * Tests that the setting defaults to off even when RTC is allowed.
 	 */
-	public function test_default_rtc_option_returns_1_when_allowed() {
+	public function test_default_rtc_option_returns_0_when_allowed() {
 		add_filter( 'jetpack_rtc_enabled', '__return_true' );
 
-		$this->assertSame( '1', RTC::default_rtc_option( '', RTC::OPTION_OLD ) );
-	}
-
-	/**
-	 * Tests that the new option falls back to the old option's stored value on upgrade.
-	 */
-	public function test_default_rtc_option_migrates_old_to_new() {
-		add_filter( 'jetpack_rtc_enabled', '__return_true' );
-		update_option( RTC::OPTION_OLD, '0' );
-
-		$this->assertSame( '0', RTC::default_rtc_option( '', RTC::OPTION_NEW ) );
+		$this->assertSame( '0', RTC::default_rtc_option() );
 	}
 
 	// -------------------------------------------------------------------------
@@ -715,17 +709,35 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that we do not re-register Gutenberg's setting back to a default of enabled.
+	 * Tests that our experiment filter still wins when the option has a registered default.
+	 *
+	 * Regression test: Gutenberg registers `gutenberg-experiments` with a default of
+	 * array() on rest_api_init. register_setting() hooks core's filter_default_option()
+	 * onto `default_option_gutenberg-experiments` at priority 10, and that callback
+	 * discards the value it is handed and returns the registered default. At the same
+	 * priority ours ran first and its result was thrown away, so the experiment read as
+	 * disabled on every REST request regardless of the setting.
 	 */
-	public function test_override_rtc_setting_default_bails_when_using_experiment() {
-		global $wp_registered_settings;
+	public function test_filter_experiments_wins_over_a_registered_default() {
+		add_filter( 'jetpack_rtc_enabled', '__return_true' );
+		add_filter( 'jetpack_rtc_uses_experiment', '__return_true' );
+		RTC::init();
+		RTC::register_experiment_filters();
+		update_option( RTC::OPTION_NEW, '1' );
+		delete_option( RTC::EXPERIMENTS_OPTION );
 
-		$this->use_experiment_and_allow();
-		$wp_registered_settings = array( RTC::OPTION_NEW => array( 'default' => false ) );
+		// Stand in for core's filter_default_option(): ignore the input, return the default.
+		add_filter(
+			'default_option_' . RTC::EXPERIMENTS_OPTION,
+			function () {
+				return array();
+			},
+			10
+		);
 
-		RTC::override_rtc_setting_default();
+		$experiments = get_option( RTC::EXPERIMENTS_OPTION );
 
-		$this->assertFalse( $wp_registered_settings[ RTC::OPTION_NEW ]['default'] );
+		$this->assertArrayHasKey( RTC::EXPERIMENT, (array) $experiments );
 	}
 
 	/**
@@ -874,16 +886,20 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that sites which cannot run RTC are not written to.
+	 * Tests that sites which cannot run RTC still record an answer.
+	 *
+	 * The marker is what lets the carry-over short-circuit on later requests. Skipping
+	 * disallowed sites would leave them re-evaluating it on every admin request.
 	 */
-	public function test_carry_over_skips_when_not_allowed() {
+	public function test_carry_over_records_an_answer_when_not_allowed() {
 		add_filter( 'jetpack_rtc_uses_experiment', '__return_true' );
 		RTC::init();
-		update_option( RTC::OPTION_NEW, '1' );
 
 		RTC::carry_over_opt_in();
 
-		$this->assertFalse( get_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, false ) );
+		$this->assertSame( '0', get_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN ) );
+		// Being allowed is still enforced when the value is read.
+		$this->assertFalse( RTC::is_turned_on() );
 	}
 
 	/**

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -749,7 +749,8 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 		global $wp_settings_fields, $wp_registered_settings;
 
 		$this->use_experiment_and_allow();
-		$wp_settings_fields = array();
+		// Seed the group rather than an empty array, so the shape is unambiguous.
+		$wp_settings_fields = array( 'writing' => array( 'default' => array() ) );
 
 		RTC::register_rtc_setting();
 


### PR DESCRIPTION
## Proposed changes

Gutenberg 23.8 ([WordPress/gutenberg#80658](https://github.com/WordPress/gutenberg/pull/80658), merged 2026-08-18) moves real-time collaboration and its bundled HTTP polling provider behind a single `gutenberg-real-time-collaboration` experiment. It also:

- **removes** the collaboration field from Settings → Writing,
- **deletes** the `wp_collaboration_enabled` option in a migration, deliberately without migrating it,
- drops `WP_ALLOW_COLLABORATION` / `wp_is_collaboration_allowed()`.

The Gutenberg Experiments page is hidden on WP.com Simple sites (`remove_action( 'admin_menu', 'gutenberg_menu', 9 )` in the wpcom repo), so once 23.8 ships those users would have no way to turn RTC on or off at all — and every site would silently lose it.

Collaboration now **defaults to off on every Gutenberg version**, and `jetpack-rtc` owns the toggle on 23.8+:

* Default the setting to off (per DOTCOM-18214). This is deliberately *not* gated on the experiment — there is no longer a reason for collaboration to be on by default on 23.7 either, so it takes effect when this deploys rather than when 23.8 lands. Sites that explicitly turned it on have a stored value, which `get_option()` returns without ever consulting the default.
* Register our own **Collaboration** field on Settings → Writing for 23.8+, reusing Gutenberg's original wording, since Gutenberg removed its own.
* Derive the experiment from that setting (`filter_experiments` on `option_gutenberg-experiments`), so the setting stays the single source of truth and collaboration is never enabled without a provider registered — the inconsistent state #80658 was written to eliminate.
* **Carry over sites that had already opted in** (`carry_over_opt_in` at `init:0`, ahead of Gutenberg's migration at `init:20`; `restore_opt_in` at `init:30`). Defaulting off is about not opting people in, not about overriding a choice they had already made.

Two notes on the implementation:

- **`uses_experiment()` feature-detects** (`wp_is_collaboration_enabled()` exists while `wp_is_collaboration_allowed()` does not) rather than comparing version strings, because WP.com also loads `dev` and `-fuzz` Gutenberg builds whose versions don't sort meaningfully. The experiment-specific parts no-op on older Gutenberg; the off-by-default does not, by design.
- **`filter_experiments()` runs on `default_option_gutenberg-experiments` at priority 20.** Gutenberg registers that option with a default of `array()` on `rest_api_init`, and `register_setting()` hooks core's `filter_default_option()` at priority 10 — which discards the value it is handed and returns the registered default. At the same priority ours ran first and was thrown away, so the experiment read as disabled on every REST request regardless of the setting. Caught in review by @mmtr; covered by a regression test that fails without the priority.
- **The carry-over writes a real stored value, not a default.** Unchecking the box on Settings → Writing removes the option row rather than storing `'0'`, so expressing it as a default re-applied on the next request and left those sites unable to switch collaboration off. This was caught in sandbox testing, not by the unit tests — there's now a regression test for it.

`is_enabled()` is also split: `is_turned_on()` is the same check minus the Site Editor condition, so the experiment gate describes the site's configuration rather than whatever admin page happens to be loading. Otherwise `wp_sync_storage` registration would flap per-request.

> [!IMPORTANT]
> **Ordering constraint:** this needs to ship *before* Gutenberg 23.8 reaches sites. If the migration runs first, the stored values are already gone and there is nothing left to carry over.

## Related product discussion/links

* Linear: [DOTCOM-18214](https://linear.app/a8c/issue/DOTCOM-18214/configure-wpcom-rtc-defaults-after-experiment-launch)
* Upstream: [WordPress/gutenberg#80658](https://github.com/WordPress/gutenberg/pull/80658)
* Prior art: #49607 disabled RTC by default, reverted in #49915 to keep gathering data. That request has since been withdrawn, so this re-lands the default — this time via the experiment.

## Does this pull request change what data or activity we track or use?

No. It adds one option (`jetpack_rtc_pre_experiment_opt_in`) that records whether the site had opted into collaboration before the experiment existed, so the choice is not lost. It is consumed after one use and holds no user data.

## Testing instructions

Requires a **Gutenberg 23.8+** build (23.8.0-rc.1 does *not* contain the experiment) and an RTC-allowed site (Personal plan or higher, or a P2).

**Setup on a wpcom sandbox:**

1. Point Gutenberg at 23.8.0 in `wp-content/mu-plugins/wpcom-gutenberg-load.php` — set **both** `$__autogen_gutenberg_plugin_version_prod` and `..._edge` to `'v23.8.0'` (a site with the `gutenberg-edge` sticker uses the edge value).
2. Deploy this branch: copy `wp-content/mu-plugins/jetpack-mu-wpcom-plugin/sun` to `.../dev` (the loader prefers `dev`), then drop this branch's `class-rtc.php` over `dev/jetpack_vendor/automattic/jetpack-rtc/src/class-rtc.php`.
3. Confirm you're on the right build — `bin/wp eval` is disabled, so use `bin/wpsh` (single line via stdin; its wrapper strips backslashes, so build namespaced class names with `chr(92)`):

```
GB=23.8.0 uses_exp=true allowed=true
```

**Default is off, and the setting works:**

4. Go to **Settings → Writing**. The **Collaboration** row should be present and **unchecked**.
5. Tick it and click **Save Changes**. Confirm `gutenberg_is_experiment_enabled( 'gutenberg-real-time-collaboration' )` and `wp_is_collaboration_enabled()` are both `true`. Note `gutenberg-experiments` is *never written to the DB* — it's derived.
6. Open a post in the editor. `window.__experimentalEnableRealTimeCollaboration` should be `true` and `window.jetpackRTC.providers` should be `["pinghub"]`.
7. Untick it and save. Both flags back to `false`, `RTC::get_providers()` returns `[]`.

**Carry-over (the important part):**

8. Reset to a pre-upgrade state: `delete_option( 'jetpack_rtc_pre_experiment_opt_in' )`, `update_option( 'gutenberg_version_migration', '22.8.0' )`, and `add_option( 'wp_collaboration_enabled', '1' )` — i.e. a site that had explicitly opted in and has not yet run Gutenberg's migration.
9. Simulate the first request under 23.8 by calling, in order: `RTC::carry_over_opt_in()`, `_gutenberg_migrate_database()`, `RTC::restore_opt_in()`.
10. **Expected:** the migration deletes `wp_collaboration_enabled`, but `restore_opt_in()` writes it back as `'1'` and `wp_is_collaboration_enabled()` is `true`. The site keeps RTC.
11. Repeat from step 8 but with `add_option( 'wp_collaboration_enabled', '0' )`, and again with the option absent entirely. **Expected:** both come back **off**.
12. Regression check — from the carried-over state in step 10, untick the box in **Settings → Writing**, save, and reload the page. **Expected:** it stays unchecked. (It previously came back checked, making RTC impossible to disable.)

**No-op on older Gutenberg:**

13. Point Gutenberg back at `v23.7.2` and reload Settings → Writing. Gutenberg's own collaboration field should appear, still defaulting to **on** — this change must be invisible there.

## Test matrix

Tested on Simple, Personal plan, RTC-allowed against a real **Gutenberg 23.8.0** build on a wpcom sandbox. Gutenberg's actual `_gutenberg_migrate_database()` was invoked in the upgrade scenarios — not simulated (the site's `gutenberg_version_migration` was genuinely still `22.8.0`).

| # | Scenario | Expected | Result |
|---|----------|----------|--------|
| 1 | Version detection on 23.8.0 | `uses_experiment()` true | ✅ `uses_exp=true`, `wp_is_collaboration_allowed` absent |
| 2 | Older build (23.8.0-rc.1) | legacy path untouched | ⚠️ **needs re-testing** — see note below |
| 3 | Site never touched the setting | comes back **off** | ✅ `carried='0'` → experiment off |
| 4 | **Site explicitly opted in** | **preserved** | ✅ migration deleted the option, RTC still on |
| 5 | Site explicitly opted out | stays off | ✅ `carried='0'` → off |
| 6 | Settings → Writing field | present, unchecked | ✅ |
| 7 | Tick + Save | experiment on | ✅ `wp_is_collaboration_enabled=true` |
| 8 | Experiment state not persisted | derived only | ✅ `gutenberg-experiments` row stays `NULL` |
| 9 | Post editor | RTC flag injected | ✅ `__experimentalEnableRealTimeCollaboration=true` |
| 10 | jetpack-rtc provider | PingHub active | ✅ `providers=["pinghub"]`; `[]` when off |
| 11 | Untick + Save, then reload | stays off | ✅ (regression from the default-based approach) |

> [!WARNING]
> **Row 2 predates review feedback and no longer reflects intended behaviour.** It was verified when off-by-default was gated on the experiment, so it observed Gutenberg's own field still defaulting to on. Now that the default applies to every version, a 23.7 site should come back **off** instead. The unit tests cover this (`test_default_rtc_option_returns_0_when_allowed`), but it has not been re-verified on a real 23.7 site since the change. Worth doing before merge, given it changes behaviour on current production.

**Not covered:**

- A genuine two-user live collaboration session (presence/cursors). The provider registration and injected flags were verified, but not multi-user sync.
- WoW / Atomic. The change keys off Gutenberg version rather than environment, but Gutenberg 23.8 isn't readily installable there yet.

**Unit tests:** `projects/packages/rtc` — 86 tests, 127 assertions, all passing; `phpcs` clean.

This PR also resets the current user between tests. The `pre_rtc_option` tests left one logged in, which made `pre_rtc_option()` short-circuit `get_option()` in every test that followed — it masked the failure that led to finding the bug in step 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
