### PR TITLE
Guidelines AI: Enable AI guideline generation on WordPress VIP sites

### DIFF
--- a/projects/plugins/jetpack/_inc/content-guidelines-ai.php
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai.php
@@ -29,11 +29,12 @@ function jetpack_content_guidelines_ai_enqueue_scripts( $hook_suffix ) {
 	}
 
 	// Content Guidelines AI is only offered on WordPress.com platform sites
-	// (Simple and Atomic) — a hard gate the jetpack_ai_enabled filter below
-	// cannot widen. Free-tier Simple/Atomic sites still load the bundle so
-	// the upgrade path can be shown — the paid-plan requirement is enforced
-	// by the suggest-guidelines API.
-	if ( ! ( new Host() )->is_wpcom_platform() ) {
+	// (Simple and Atomic) and WordPress VIP sites — a hard gate the
+	// jetpack_ai_enabled filter below cannot widen. Free-tier sites still load
+	// the bundle so the upgrade path can be shown — the paid-plan requirement
+	// is enforced by the suggest-guidelines API.
+	$host = new Host();
+	if ( ! $host->is_wpcom_platform() && ! $host->is_vip_site() ) {
 		return;
 	}
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -124,6 +124,35 @@ class Jetpack_AI_Helper {
 	}
 
 	/**
+	 * Return true if the Content Guidelines AI surfaces should be active on the
+	 * current site.
+	 *
+	 * Same platforms as is_enabled() (WPCOM Simple and Atomic), plus WordPress
+	 * VIP sites. Kept separate from is_enabled() so widening Content Guidelines
+	 * to VIP does not also open the general AI proxy endpoint there.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled_for_content_guidelines() {
+		$default = false;
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$default = true;
+		} else {
+			$host = new Automattic\Jetpack\Status\Host();
+			if ( $host->is_woa_site() || $host->is_vip_site() ) {
+				$default = true;
+			}
+		}
+
+		// The jetpack_ai_enabled filter runs inside the helper; the host and
+		// master gates apply after the chain and cannot be filtered back on.
+		return Jetpack_AI_Settings::is_ai_enabled( $default );
+	}
+
+	/**
 	 * Whether the current user has dismissed the Content Guidelines AI
 	 * empty-state banner.
 	 *

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-agent-guidelines-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-agent-guidelines-ai.php
@@ -57,10 +57,10 @@ class WPCOM_REST_API_V2_Endpoint_Agent_Guidelines_AI extends WP_REST_Controller 
 			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php';
 		}
 
-		// Intentionally gated to Simple and Atomic sites only.
-		// Self-hosted Jetpack support is deferred — we want to roll out
-		// on WordPress.com platforms first before opening to all connected sites.
-		if ( ! \Jetpack_AI_Helper::is_enabled() ) {
+		// Intentionally gated to Simple, Atomic, and WordPress VIP sites only.
+		// Broader self-hosted Jetpack support is deferred — we want to roll out
+		// on these platforms first before opening to all connected sites.
+		if ( ! \Jetpack_AI_Helper::is_enabled_for_content_guidelines() ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-guidelines-banner-dismissed.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-guidelines-banner-dismissed.php
@@ -60,8 +60,9 @@ class WPCOM_REST_API_V2_Endpoint_Guidelines_Banner_Dismissed extends WP_REST_Con
 		$this->is_wpcom                     = true;
 		$this->wpcom_is_wpcom_only_endpoint = true;
 
-		// Match the suggest-guidelines endpoint: register on Simple/Atomic only.
-		if ( ! \Jetpack_AI_Helper::is_enabled() ) {
+		// Match the suggest-guidelines endpoint: register on Simple, Atomic,
+		// and WordPress VIP sites only.
+		if ( ! \Jetpack_AI_Helper::is_enabled_for_content_guidelines() ) {
 			return;
 		}
 

--- a/projects/plugins/jetpack/changelog/add-content-guidelines-ai-vip-sites
+++ b/projects/plugins/jetpack/changelog/add-content-guidelines-ai-vip-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Content Guidelines AI: Enable AI guideline suggestions on WordPress VIP sites.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Agent_Guidelines_AI_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Agent_Guidelines_AI_Test.php
@@ -10,6 +10,7 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 require_once dirname( __DIR__, 2 ) . '/lib/Jetpack_REST_TestCase.php';
@@ -47,6 +48,7 @@ class WPCOM_REST_API_V2_Endpoint_Agent_Guidelines_AI_Test extends Jetpack_REST_T
 		$this->deactivate_ai_module_for_test();
 		remove_filter( 'jetpack_ai_enabled', '__return_false' );
 		remove_filter( 'jetpack_ai_enabled', '__return_true' );
+		Constants::clear_single_constant( 'WPCOM_IS_VIP_ENV' );
 
 		parent::tear_down();
 	}
@@ -129,6 +131,41 @@ class WPCOM_REST_API_V2_Endpoint_Agent_Guidelines_AI_Test extends Jetpack_REST_T
 			self::ROUTE,
 			$routes,
 			'The suggest-guidelines route must not register when Jetpack AI is disabled.'
+		);
+	}
+
+	public function test_route_registers_on_vip_site() {
+		/*
+		 * WordPress VIP sites define WPCOM_IS_VIP_ENV, which
+		 * is_enabled_for_content_guidelines() accepts as a supported platform —
+		 * no jetpack_ai_enabled filter needed.
+		 */
+		Constants::set_constant( 'WPCOM_IS_VIP_ENV', true );
+
+		$routes = $this->register_routes_on_fresh_server();
+
+		$this->assertArrayHasKey(
+			self::ROUTE,
+			$routes,
+			'The suggest-guidelines route must register on a WordPress VIP site by default.'
+		);
+	}
+
+	public function test_route_absent_on_vip_site_when_ai_disabled() {
+		/*
+		 * VIP forces jetpack_ai_enabled off in Jetpack Private Mode (default on
+		 * non-production environments) — the platform default must not override
+		 * that site-wide disable.
+		 */
+		Constants::set_constant( 'WPCOM_IS_VIP_ENV', true );
+		add_filter( 'jetpack_ai_enabled', '__return_false' );
+
+		$routes = $this->register_routes_on_fresh_server();
+
+		$this->assertArrayNotHasKey(
+			self::ROUTE,
+			$routes,
+			'The suggest-guidelines route must not register on a VIP site when Jetpack AI is disabled.'
 		);
 	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes

* Content Guidelines AI now loads on WordPress VIP sites, not only on WordPress.com Simple and Atomic. VIP is detected with `Host::is_vip_site()` (`WPCOM_IS_VIP_ENV`).
* New `Jetpack_AI_Helper::is_enabled_for_content_guidelines()` gates the `jetpack-ai/suggest-guidelines` and `jetpack-ai/guidelines-banner-dismissed` endpoints. `is_enabled()` is unchanged, so the general AI endpoints stay Simple/Atomic-only.
* The `jetpack_ai_enabled` filter and the `ai` module master switch still apply, so VIP Private Mode and the AI toggles keep working.

## Related product discussion/links

* pcO4xN-3n4-p2 (comment 4405)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Tested end to end on an internal VIP test site, including working generation. To reproduce:

* Use a VIP site, or simulate one by defining `WPCOM_IS_VIP_ENV` as `true` on a Jetpack-connected test site.
* Install Gutenberg 23.6+ and enable the `gutenberg-guidelines` experiment.
* Make sure the `ai` module is active and your admin user is connected to WordPress.com.
* Go to Settings → Guidelines. The AI generate buttons should appear.
* Generating needs a plan with the `ai-assistant` feature; without it the API returns 403.
* On a non-VIP self-hosted site nothing changes: no script, no endpoints.
* PHP tests: `jp docker phpunit jetpack -- --filter=WPCOM_REST_API_V2_Endpoint_Agent_Guidelines_AI_Test`
