### PR TITLE
PCG: bucket the percentage rollout on the WP.com blog ID

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-pcg-rollout-bucket-wpcom-blog-id
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-pcg-rollout-bucket-wpcom-blog-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Plugin Conflicts Guardian: bucket the staged rollout on the WP.com blog ID so partial percentages enroll a real sample of sites.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -38,10 +38,9 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/common/fatal-error-signature.php';
 		require_once __DIR__ . '/utils.php';
 
-		// The Plugin Conflicts Guardian only applies where plugins can be
-		// installed, which is Atomic. Its confirmation probe wires a
-		// `pre_option_active_plugins` filter at mu-plugin time, before WP
-		// loads active plugins.
+		// Atomic only — Simple sites can't install plugins. The confirmation
+		// probe wires its `pre_option_active_plugins` filter at mu-plugin
+		// time, before WP loads active plugins.
 		if ( Constants::is_true( 'IS_ATOMIC' ) ) {
 			require_once __DIR__ . '/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php';
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -38,9 +38,13 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/common/fatal-error-signature.php';
 		require_once __DIR__ . '/utils.php';
 
-		// PCG confirmation probe wires its `pre_option_active_plugins`
-		// filter at mu-plugin time, before WP loads active plugins.
-		require_once __DIR__ . '/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php';
+		// The Plugin Conflicts Guardian only applies where plugins can be
+		// installed, which is Atomic. Its confirmation probe wires a
+		// `pre_option_active_plugins` filter at mu-plugin time, before WP
+		// loads active plugins.
+		if ( Constants::is_true( 'IS_ATOMIC' ) ) {
+			require_once __DIR__ . '/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php';
+		}
 
 		/*
 		 * Feature flag overrides answer the jetpack-feature-flags resolution
@@ -319,7 +323,9 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/logo-tool/logo-tool.php';
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';
-		require_once __DIR__ . '/features/plugin-conflicts-guardian/plugin-conflicts-guardian.php';
+		if ( Constants::is_true( 'IS_ATOMIC' ) ) {
+			require_once __DIR__ . '/features/plugin-conflicts-guardian/plugin-conflicts-guardian.php';
+		}
 		require_once __DIR__ . '/features/post-categories/quick-actions.php';
 		require_once __DIR__ . '/features/post-like-from-email/post-like-from-email.php';
 		require_once __DIR__ . '/features/site-editor-dashboard-link/site-editor-dashboard-link.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/README.md
@@ -90,11 +90,15 @@ Update mode never confirms — the candidate is already loaded by WP's normal bo
 
 ## Percentage rollout
 
-`PCG_Rollout` narrows `pcg_guard_activation` / `pcg_guard_updates` per blog. Default is **5%** — the `pcg_rollout_percentage` filter overrides it per environment:
+`PCG_Rollout` narrows `pcg_guard_activation` / `pcg_guard_updates` per blog. It defaults to **0%** here — this package rides a weekly release train, so the live percentage is owned by wpcomsh (`plugin-conflicts-guardian-rollout.php`), which can be deployed on demand when a ramp or a rollback is needed.
+
+Override it per environment with the `pcg_rollout_percentage` filter:
 
 ```php
 add_filter( 'pcg_rollout_percentage', fn () => 10 ); // 10% cohort
 ```
+
+Only Atomic sites are eligible — Simple sites can't install plugins, so the feature isn't loaded there at all.
 
 Bucketing is `crc32(blog_id) % 100`, so ramping from 10% → 50% strictly adds blogs (no reshuffling between tiers). The gate only narrows — emergency-override filters at priority > 100 on `pcg_guard_activation` / `pcg_guard_updates` can still re-enable or disable a blog.
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
@@ -30,34 +30,7 @@ class PCG_Rollout {
 		if ( ! $enabled ) {
 			return $enabled;
 		}
-		return self::is_enabled_for_blog( self::resolve_blog_id() );
-	}
-
-	/**
-	 * Resolve the WP.com blog ID to bucket on.
-	 *
-	 * On Atomic, `get_current_blog_id()` returns the *local* blog ID, which is
-	 * 1 on every single-site install — bucketing on it gives the whole fleet
-	 * one shared bucket, so any percentage below that bucket enrolls nobody and
-	 * any percentage above it enrolls everybody. The WP.com blog ID lives in
-	 * the `jetpack_options` option; read it directly (no `Jetpack_Options`
-	 * dependency) and return 0 when it's absent, so a site we can't attribute
-	 * stays out of the cohort instead of piling into bucket 0.
-	 *
-	 * @return int WP.com blog ID, or 0 when it can't be determined.
-	 */
-	public static function resolve_blog_id() {
-		// WP.com Simple: the current blog ID *is* the WP.com blog ID.
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			return (int) get_current_blog_id();
-		}
-
-		$jetpack_options = get_option( 'jetpack_options' );
-		if ( is_array( $jetpack_options ) && ! empty( $jetpack_options['id'] ) ) {
-			return (int) $jetpack_options['id'];
-		}
-
-		return 0;
+		return self::is_enabled_for_blog( (int) get_wpcom_blog_id() );
 	}
 
 	/**
@@ -67,17 +40,20 @@ class PCG_Rollout {
 	 * @return bool
 	 */
 	public static function is_enabled_for_blog( $blog_id ) {
-		$blog_id = (int) $blog_id;
-		if ( $blog_id <= 0 ) {
-			return false;
-		}
-
 		$percentage = (int) apply_filters( 'pcg_rollout_percentage', self::DEFAULT_PERCENTAGE );
 		if ( $percentage <= 0 ) {
 			return false;
 		}
 		if ( $percentage >= 100 ) {
 			return true;
+		}
+
+		// A partial rollout has to bucket on something; a site we can't
+		// identify stays out rather than sharing one bucket with every
+		// other unidentified site.
+		$blog_id = (int) $blog_id;
+		if ( $blog_id <= 0 ) {
+			return false;
 		}
 
 		return self::blog_bucket( $blog_id ) < $percentage;

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
@@ -10,7 +10,13 @@
  */
 class PCG_Rollout {
 
-	const DEFAULT_PERCENTAGE = 5;
+	/**
+	 * Off unless the host platform opts in. This package ships on a weekly
+	 * release train, so the live percentage is set by wpcomsh via
+	 * `pcg_rollout_percentage` — that's the piece that can be deployed when
+	 * a ramp (or a rollback) actually needs to happen.
+	 */
+	const DEFAULT_PERCENTAGE = 0;
 
 	/**
 	 * Priority 100 leaves room for emergency overrides at higher priorities.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
@@ -30,6 +30,12 @@ class PCG_Rollout {
 		if ( ! $enabled ) {
 			return $enabled;
 		}
+		// Simple sites can't install or activate plugins, so there's nothing
+		// to guard — and including them would swamp the cohort with sites the
+		// feature never runs on.
+		if ( ! \Automattic\Jetpack\Constants::is_true( 'IS_ATOMIC' ) ) {
+			return false;
+		}
 		return self::is_enabled_for_blog( (int) get_wpcom_blog_id() );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
@@ -11,10 +11,7 @@
 class PCG_Rollout {
 
 	/**
-	 * Off unless the host platform opts in. This package ships on a weekly
-	 * release train, so the live percentage is set by wpcomsh via
-	 * `pcg_rollout_percentage` — that's the piece that can be deployed when
-	 * a ramp (or a rollback) actually needs to happen.
+	 * Off by default; wpcomsh sets the live percentage.
 	 */
 	const DEFAULT_PERCENTAGE = 0;
 
@@ -36,9 +33,7 @@ class PCG_Rollout {
 		if ( ! $enabled ) {
 			return $enabled;
 		}
-		// Simple sites can't install or activate plugins, so there's nothing
-		// to guard — and including them would swamp the cohort with sites the
-		// feature never runs on.
+		// Simple sites can't install plugins, so there's nothing to guard.
 		if ( ! \Automattic\Jetpack\Constants::is_true( 'IS_ATOMIC' ) ) {
 			return false;
 		}
@@ -60,9 +55,7 @@ class PCG_Rollout {
 			return true;
 		}
 
-		// A partial rollout has to bucket on something; a site we can't
-		// identify stays out rather than sharing one bucket with every
-		// other unidentified site.
+		// A partial rollout needs a real ID to bucket on.
 		$blog_id = (int) $blog_id;
 		if ( $blog_id <= 0 ) {
 			return false;

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
@@ -10,7 +10,7 @@
  */
 class PCG_Rollout {
 
-	const DEFAULT_PERCENTAGE = 20;
+	const DEFAULT_PERCENTAGE = 5;
 
 	/**
 	 * Priority 100 leaves room for emergency overrides at higher priorities.

--- a/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/plugin-conflicts-guardian/class-pcg-rollout.php
@@ -30,14 +30,40 @@ class PCG_Rollout {
 		if ( ! $enabled ) {
 			return $enabled;
 		}
-		return self::is_enabled_for_blog( get_current_blog_id() );
+		return self::is_enabled_for_blog( self::resolve_blog_id() );
 	}
 
 	/**
-	 * On single-site, `get_current_blog_id()` is always 1, so the site is
-	 * wholly in or wholly out at any given percentage.
+	 * Resolve the WP.com blog ID to bucket on.
 	 *
-	 * @param int $blog_id Blog ID under test.
+	 * On Atomic, `get_current_blog_id()` returns the *local* blog ID, which is
+	 * 1 on every single-site install — bucketing on it gives the whole fleet
+	 * one shared bucket, so any percentage below that bucket enrolls nobody and
+	 * any percentage above it enrolls everybody. The WP.com blog ID lives in
+	 * the `jetpack_options` option; read it directly (no `Jetpack_Options`
+	 * dependency) and return 0 when it's absent, so a site we can't attribute
+	 * stays out of the cohort instead of piling into bucket 0.
+	 *
+	 * @return int WP.com blog ID, or 0 when it can't be determined.
+	 */
+	public static function resolve_blog_id() {
+		// WP.com Simple: the current blog ID *is* the WP.com blog ID.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return (int) get_current_blog_id();
+		}
+
+		$jetpack_options = get_option( 'jetpack_options' );
+		if ( is_array( $jetpack_options ) && ! empty( $jetpack_options['id'] ) ) {
+			return (int) $jetpack_options['id'];
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Bucketing is stable, so raising the percentage only ever adds blogs.
+	 *
+	 * @param int $blog_id WP.com blog ID under test.
 	 * @return bool
 	 */
 	public static function is_enabled_for_blog( $blog_id ) {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -5,6 +5,7 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -40,6 +41,16 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	private $tmp_dir = null;
 
 	/**
+	 * The rollout gate only runs on Atomic, where plugins can be installed.
+	 * `Constants` (rather than a bare `defined()`) is what makes that
+	 * testable without defining IS_ATOMIC across the whole suite.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Constants::set_constant( 'IS_ATOMIC', true );
+	}
+
+	/**
 	 * Clean up any temp directory and guard filter after each test.
 	 */
 	public function tear_down() {
@@ -57,6 +68,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 		remove_all_filters( 'pcg_guard_updates' );
 		remove_all_filters( 'pcg_backup_root' );
 		remove_all_filters( 'pcg_rollout_percentage' );
+		Constants::clear_single_constant( 'IS_ATOMIC' );
 		// PCG_Rollout::init() registers itself on require_once. We tear
 		// the gate callbacks down by name (not via remove_all_filters,
 		// which would also drop any test-local pcg_guard_* filters set
@@ -1312,6 +1324,18 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 		// Roughly 20% of 200 blogs, with generous slack for crc32 clumping.
 		$this->assertGreaterThan( 20, $in );
 		$this->assertLessThan( 60, $in );
+	}
+
+	/**
+	 * Simple sites can't install plugins, so they're never in the cohort —
+	 * not even at 100%, which otherwise means every site.
+	 */
+	public function test_rollout_gate_excludes_simple_sites() {
+		Constants::clear_single_constant( 'IS_ATOMIC' );
+		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
+
+		$this->assertFalse( apply_filters( 'pcg_guard_activation', true ) );
+		$this->assertFalse( apply_filters( 'pcg_guard_updates', true ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -40,6 +40,21 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	private $tmp_dir = null;
 
 	/**
+	 * WP.com blog ID seeded for tests, so the rollout gate has something to
+	 * bucket on. `PCG_Rollout::resolve_blog_id()` reads `jetpack_options`
+	 * off WP.com Simple and keeps an unattributable site out of the cohort.
+	 */
+	private const TEST_WPCOM_BLOG_ID = 240190614;
+
+	/**
+	 * Seed the WP.com blog ID the rollout gate resolves against.
+	 */
+	public function set_up() {
+		parent::set_up();
+		update_option( 'jetpack_options', array( 'id' => self::TEST_WPCOM_BLOG_ID ) );
+	}
+
+	/**
 	 * Clean up any temp directory and guard filter after each test.
 	 */
 	public function tear_down() {
@@ -57,6 +72,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 		remove_all_filters( 'pcg_guard_updates' );
 		remove_all_filters( 'pcg_backup_root' );
 		remove_all_filters( 'pcg_rollout_percentage' );
+		delete_option( 'jetpack_options' );
 		// PCG_Rollout::init() registers itself on require_once. We tear
 		// the gate callbacks down by name (not via remove_all_filters,
 		// which would also drop any test-local pcg_guard_* filters set
@@ -1287,5 +1303,82 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
 		add_filter( 'pcg_guard_activation', static fn() => false, 1 );
 		$this->assertFalse( apply_filters( 'pcg_guard_activation', true ) );
+	}
+
+	/**
+	 * Off WP.com Simple the cohort must be keyed on the WP.com blog ID from
+	 * `jetpack_options`, not the local blog ID — the latter is 1 on every
+	 * Atomic single-site install, which collapses the whole fleet into one
+	 * bucket.
+	 */
+	public function test_rollout_resolves_wpcom_blog_id_on_atomic() {
+		$this->assertSame( self::TEST_WPCOM_BLOG_ID, PCG_Rollout::resolve_blog_id() );
+		$this->assertNotSame( get_current_blog_id(), PCG_Rollout::resolve_blog_id() );
+	}
+
+	/**
+	 * An unattributable site stays out of the cohort rather than falling back
+	 * to the local blog ID (or to bucket 0, which would enroll it at any
+	 * non-zero percentage).
+	 */
+	public function test_rollout_resolves_zero_without_wpcom_blog_id() {
+		delete_option( 'jetpack_options' );
+		$this->assertSame( 0, PCG_Rollout::resolve_blog_id() );
+		$this->assertFalse( PCG_Rollout::is_enabled_for_blog( PCG_Rollout::resolve_blog_id() ) );
+	}
+
+	/**
+	 * `jetpack_options` without a usable `id` is treated the same as missing.
+	 */
+	public function test_rollout_resolves_zero_for_malformed_jetpack_options() {
+		update_option( 'jetpack_options', array( 'id' => 0 ) );
+		$this->assertSame( 0, PCG_Rollout::resolve_blog_id() );
+
+		update_option( 'jetpack_options', 'not-an-array' );
+		$this->assertSame( 0, PCG_Rollout::resolve_blog_id() );
+	}
+
+	/**
+	 * The regression this guards: bucketing on the local blog ID gives every
+	 * Atomic single-site the same bucket, so a partial rollout is all-or-nothing
+	 * across the fleet. Bucketing on distinct WP.com blog IDs must spread.
+	 */
+	public function test_rollout_partial_percentage_spreads_across_wpcom_blog_ids() {
+		add_filter( 'pcg_rollout_percentage', static fn() => 20 );
+
+		$in       = 0;
+		$blog_ids = range( 200000000, 200000199 );
+		foreach ( $blog_ids as $blog_id ) {
+			if ( PCG_Rollout::is_enabled_for_blog( $blog_id ) ) {
+				++$in;
+			}
+		}
+
+		// Roughly 20% of 200 blogs, with generous slack for crc32 clumping.
+		$this->assertGreaterThan( 0, $in );
+		$this->assertLessThan( count( $blog_ids ), $in );
+		$this->assertGreaterThan( 20, $in );
+		$this->assertLessThan( 60, $in );
+	}
+
+	/**
+	 * The gate reads the resolved WP.com blog ID, so a site whose bucket falls
+	 * under the percentage is enrolled even though its local blog ID is 1.
+	 */
+	public function test_rollout_gate_uses_resolved_wpcom_blog_id() {
+		$in_cohort = null;
+		foreach ( range( 200000000, 200000199 ) as $blog_id ) {
+			if ( PCG_Rollout::blog_bucket( $blog_id ) < 20 ) {
+				$in_cohort = $blog_id;
+				break;
+			}
+		}
+		$this->assertNotNull( $in_cohort, 'no blog ID bucketed under 20%' );
+
+		update_option( 'jetpack_options', array( 'id' => $in_cohort ) );
+		add_filter( 'pcg_rollout_percentage', static fn() => 20 );
+
+		$this->assertTrue( apply_filters( 'pcg_guard_activation', true ) );
+		$this->assertTrue( apply_filters( 'pcg_guard_updates', true ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -41,9 +41,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	private $tmp_dir = null;
 
 	/**
-	 * The rollout gate only runs on Atomic, where plugins can be installed.
-	 * `Constants` (rather than a bare `defined()`) is what makes that
-	 * testable without defining IS_ATOMIC across the whole suite.
+	 * The rollout gate only runs on Atomic.
 	 */
 	public function set_up() {
 		parent::set_up();
@@ -1238,9 +1236,8 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * A partial rollout has to bucket on a real ID, so a site whose WP.com
-	 * blog ID can't be resolved stays out. `get_wpcom_blog_id()` returns
-	 * false off WP.com, and 0/-1 stand in for that here.
+	 * A site whose WP.com blog ID can't be resolved stays out of a partial
+	 * rollout. `get_wpcom_blog_id()` returns false off WP.com.
 	 */
 	public function test_rollout_rejects_non_positive_blog_ids() {
 		add_filter( 'pcg_rollout_percentage', static fn() => 50 );
@@ -1305,10 +1302,9 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * The regression this guards: the gate used to bucket on the local blog
-	 * ID, which is 1 on every Atomic single-site install — one shared bucket
-	 * for the whole fleet, so a partial rollout was all-or-nothing. Distinct
-	 * WP.com blog IDs must actually spread across buckets.
+	 * The regression this guards: bucketing on the local blog ID gave every
+	 * Atomic single-site the same bucket, making a partial rollout
+	 * all-or-nothing across the fleet.
 	 */
 	public function test_rollout_partial_percentage_spreads_across_wpcom_blog_ids() {
 		add_filter( 'pcg_rollout_percentage', static fn() => 20 );
@@ -1327,8 +1323,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Simple sites can't install plugins, so they're never in the cohort —
-	 * not even at 100%, which otherwise means every site.
+	 * Simple sites are never in the cohort, not even at 100%.
 	 */
 	public function test_rollout_gate_excludes_simple_sites() {
 		Constants::clear_single_constant( 'IS_ATOMIC' );
@@ -1339,8 +1334,7 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Full rollout doesn't need attribution — 100% means every site, including
-	 * one whose WP.com blog ID can't be resolved.
+	 * 100% means every site, including one we can't identify.
 	 */
 	public function test_rollout_full_includes_unresolvable_blog_ids() {
 		add_filter( 'pcg_rollout_percentage', static fn() => 100 );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/plugin-conflicts-guardian/Plugin_Conflicts_Guardian_Test.php
@@ -40,21 +40,6 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	private $tmp_dir = null;
 
 	/**
-	 * WP.com blog ID seeded for tests, so the rollout gate has something to
-	 * bucket on. `PCG_Rollout::resolve_blog_id()` reads `jetpack_options`
-	 * off WP.com Simple and keeps an unattributable site out of the cohort.
-	 */
-	private const TEST_WPCOM_BLOG_ID = 240190614;
-
-	/**
-	 * Seed the WP.com blog ID the rollout gate resolves against.
-	 */
-	public function set_up() {
-		parent::set_up();
-		update_option( 'jetpack_options', array( 'id' => self::TEST_WPCOM_BLOG_ID ) );
-	}
-
-	/**
 	 * Clean up any temp directory and guard filter after each test.
 	 */
 	public function tear_down() {
@@ -72,7 +57,6 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 		remove_all_filters( 'pcg_guard_updates' );
 		remove_all_filters( 'pcg_backup_root' );
 		remove_all_filters( 'pcg_rollout_percentage' );
-		delete_option( 'jetpack_options' );
 		// PCG_Rollout::init() registers itself on require_once. We tear
 		// the gate callbacks down by name (not via remove_all_filters,
 		// which would also drop any test-local pcg_guard_* filters set
@@ -1242,12 +1226,15 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Invalid or non-positive blog IDs are never enabled, even at 100%.
+	 * A partial rollout has to bucket on a real ID, so a site whose WP.com
+	 * blog ID can't be resolved stays out. `get_wpcom_blog_id()` returns
+	 * false off WP.com, and 0/-1 stand in for that here.
 	 */
 	public function test_rollout_rejects_non_positive_blog_ids() {
-		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
+		add_filter( 'pcg_rollout_percentage', static fn() => 50 );
 		$this->assertFalse( PCG_Rollout::is_enabled_for_blog( 0 ) );
 		$this->assertFalse( PCG_Rollout::is_enabled_for_blog( -1 ) );
+		$this->assertFalse( PCG_Rollout::is_enabled_for_blog( (int) false ) );
 	}
 
 	/**
@@ -1306,48 +1293,16 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Off WP.com Simple the cohort must be keyed on the WP.com blog ID from
-	 * `jetpack_options`, not the local blog ID — the latter is 1 on every
-	 * Atomic single-site install, which collapses the whole fleet into one
-	 * bucket.
-	 */
-	public function test_rollout_resolves_wpcom_blog_id_on_atomic() {
-		$this->assertSame( self::TEST_WPCOM_BLOG_ID, PCG_Rollout::resolve_blog_id() );
-		$this->assertNotSame( get_current_blog_id(), PCG_Rollout::resolve_blog_id() );
-	}
-
-	/**
-	 * An unattributable site stays out of the cohort rather than falling back
-	 * to the local blog ID (or to bucket 0, which would enroll it at any
-	 * non-zero percentage).
-	 */
-	public function test_rollout_resolves_zero_without_wpcom_blog_id() {
-		delete_option( 'jetpack_options' );
-		$this->assertSame( 0, PCG_Rollout::resolve_blog_id() );
-		$this->assertFalse( PCG_Rollout::is_enabled_for_blog( PCG_Rollout::resolve_blog_id() ) );
-	}
-
-	/**
-	 * `jetpack_options` without a usable `id` is treated the same as missing.
-	 */
-	public function test_rollout_resolves_zero_for_malformed_jetpack_options() {
-		update_option( 'jetpack_options', array( 'id' => 0 ) );
-		$this->assertSame( 0, PCG_Rollout::resolve_blog_id() );
-
-		update_option( 'jetpack_options', 'not-an-array' );
-		$this->assertSame( 0, PCG_Rollout::resolve_blog_id() );
-	}
-
-	/**
-	 * The regression this guards: bucketing on the local blog ID gives every
-	 * Atomic single-site the same bucket, so a partial rollout is all-or-nothing
-	 * across the fleet. Bucketing on distinct WP.com blog IDs must spread.
+	 * The regression this guards: the gate used to bucket on the local blog
+	 * ID, which is 1 on every Atomic single-site install — one shared bucket
+	 * for the whole fleet, so a partial rollout was all-or-nothing. Distinct
+	 * WP.com blog IDs must actually spread across buckets.
 	 */
 	public function test_rollout_partial_percentage_spreads_across_wpcom_blog_ids() {
 		add_filter( 'pcg_rollout_percentage', static fn() => 20 );
 
-		$in       = 0;
 		$blog_ids = range( 200000000, 200000199 );
+		$in       = 0;
 		foreach ( $blog_ids as $blog_id ) {
 			if ( PCG_Rollout::is_enabled_for_blog( $blog_id ) ) {
 				++$in;
@@ -1355,30 +1310,17 @@ class Plugin_Conflicts_Guardian_Test extends \WorDBless\BaseTestCase {
 		}
 
 		// Roughly 20% of 200 blogs, with generous slack for crc32 clumping.
-		$this->assertGreaterThan( 0, $in );
-		$this->assertLessThan( count( $blog_ids ), $in );
 		$this->assertGreaterThan( 20, $in );
 		$this->assertLessThan( 60, $in );
 	}
 
 	/**
-	 * The gate reads the resolved WP.com blog ID, so a site whose bucket falls
-	 * under the percentage is enrolled even though its local blog ID is 1.
+	 * Full rollout doesn't need attribution — 100% means every site, including
+	 * one whose WP.com blog ID can't be resolved.
 	 */
-	public function test_rollout_gate_uses_resolved_wpcom_blog_id() {
-		$in_cohort = null;
-		foreach ( range( 200000000, 200000199 ) as $blog_id ) {
-			if ( PCG_Rollout::blog_bucket( $blog_id ) < 20 ) {
-				$in_cohort = $blog_id;
-				break;
-			}
-		}
-		$this->assertNotNull( $in_cohort, 'no blog ID bucketed under 20%' );
-
-		update_option( 'jetpack_options', array( 'id' => $in_cohort ) );
-		add_filter( 'pcg_rollout_percentage', static fn() => 20 );
-
-		$this->assertTrue( apply_filters( 'pcg_guard_activation', true ) );
-		$this->assertTrue( apply_filters( 'pcg_guard_updates', true ) );
+	public function test_rollout_full_includes_unresolvable_blog_ids() {
+		add_filter( 'pcg_rollout_percentage', static fn() => 100 );
+		$this->assertTrue( PCG_Rollout::is_enabled_for_blog( 0 ) );
+		$this->assertTrue( PCG_Rollout::is_enabled_for_blog( (int) false ) );
 	}
 }

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-pcg-rollout-bucket-wpcom-blog-id
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-pcg-rollout-bucket-wpcom-blog-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Plugin Conflicts Guardian: fix the staged rollout so the pre-flight plugin check reaches its intended share of sites.

--- a/projects/plugins/wpcomsh/changelog/fix-pcg-rollout-bucket-wpcom-blog-id
+++ b/projects/plugins/wpcomsh/changelog/fix-pcg-rollout-bucket-wpcom-blog-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Plugin Conflicts Guardian: fix the staged rollout so the pre-flight plugin check reaches its intended share of sites.

--- a/projects/plugins/wpcomsh/changelog/pcg-rollout-percentage-control
+++ b/projects/plugins/wpcomsh/changelog/pcg-rollout-percentage-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Plugin Conflicts Guardian: control the rollout percentage from wpcomsh.

--- a/projects/plugins/wpcomsh/plugin-conflicts-guardian-rollout.php
+++ b/projects/plugins/wpcomsh/plugin-conflicts-guardian-rollout.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Rollout percentage for the Plugin Conflicts Guardian.
+ *
+ * The guardian itself lives in the jetpack-mu-wpcom package, which ships on a
+ * weekly release train. Its cohort size lives here instead so a ramp — or a
+ * rollback — can be deployed when it's needed rather than when the train runs.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Percentage of Atomic sites the guardian is active on, 0-100.
+ *
+ * Bucketing is stable, so raising this only ever adds sites. Set to 0 to turn
+ * the guardian off everywhere.
+ */
+const WPCOMSH_PCG_ROLLOUT_PERCENTAGE = 1;
+
+add_filter(
+	'pcg_rollout_percentage',
+	function () {
+		return WPCOMSH_PCG_ROLLOUT_PERCENTAGE;
+	}
+);

--- a/projects/plugins/wpcomsh/plugin-conflicts-guardian-rollout.php
+++ b/projects/plugins/wpcomsh/plugin-conflicts-guardian-rollout.php
@@ -1,19 +1,14 @@
 <?php
 /**
- * Rollout percentage for the Plugin Conflicts Guardian.
- *
- * The guardian itself lives in the jetpack-mu-wpcom package, which ships on a
- * weekly release train. Its cohort size lives here instead so a ramp — or a
- * rollback — can be deployed when it's needed rather than when the train runs.
+ * Rollout percentage for the Plugin Conflicts Guardian, which ships in
+ * jetpack-mu-wpcom. It lives here so it can be deployed on demand.
  *
  * @package wpcomsh
  */
 
 /**
- * Percentage of Atomic sites the guardian is active on, 0-100.
- *
- * Bucketing is stable, so raising this only ever adds sites. Set to 0 to turn
- * the guardian off everywhere.
+ * Percentage of Atomic sites the guardian runs on, 0-100. Raising it only
+ * ever adds sites; 0 turns it off.
  */
 const WPCOMSH_PCG_ROLLOUT_PERCENTAGE = 1;
 

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -51,6 +51,7 @@ require_once __DIR__ . '/customizer-fixes/customizer-fixes.php';
 
 require_once __DIR__ . '/class-wpcomsh-log.php';
 require_once __DIR__ . '/safeguard/plugins.php';
+require_once __DIR__ . '/plugin-conflicts-guardian-rollout.php';
 require_once __DIR__ . '/jetpack-token-error-header/class-atomic-record-jetpack-token-errors.php';
 
 /**


### PR DESCRIPTION
## Proposed changes

The Plugin Conflicts Guardian's staged rollout has never enrolled a single production site.

The rollout gate picks a cohort by hashing a blog ID into a bucket. It was hashing the *local* blog ID, which is always `1` on an Atomic single-site install. Every Atomic site therefore landed in the same bucket — 83 — so the percentage was never a sample of the fleet. It was one global on/off switch sitting at 84%:

| Configured | Intended | Actual |
| --- | --- | --- |
| 5% (#49451) | ~5% of sites | 0 sites |
| 10% (#49605) | ~10% of sites | 0 sites |
| 20% (#49649) | ~20% of sites | 0 sites |
| 84%+ | ~84% of sites | 100% of sites, in one step |

Four changes:

* **Bucket on the WP.com blog ID**, via the package's existing `get_wpcom_blog_id()` helper.
* **Run the percentage checks before the blog-ID check**, so a full rollout doesn't depend on attribution. 100% now means every site; a partial rollout still needs a real ID to bucket on and excludes a site it can't identify.
* **Skip Simple sites entirely.** They can't install or activate plugins, so there's nothing to guard.
* **Move the cohort size to wpcomsh**, defaulting the package to 0%.

### Why Simple sites are excluded

Simple sites can't install plugins — that needs a Business plan, which transfers the site to Atomic. But they bucket normally on their WP.com blog ID, and the Simple fleet dwarfs Atomic, so leaving them in would fill the cohort with sites the guardian never runs on. A ramp could reach 20%, report no incidents and no log volume, and have barely touched Atomic — the same false-confidence signal that hid the original bug through three ramps.

The feature is now gated at load, so it isn't required on Simple at all. That also drops the per-request work it used to do there: `probe-endpoint.php` ran a `$_GET` check on every request, and the confirmation probe registered a `pre_option_active_plugins` filter at mu-plugin time.

### Why the percentage moved to wpcomsh

jetpack-mu-wpcom ships on a weekly release train, so a percentage baked into the package can't be ramped — or rolled back — at the moment it's needed. `plugin-conflicts-guardian-rollout.php` in wpcomsh now owns it and deploys on demand:

```php
const WPCOMSH_PCG_ROLLOUT_PERCENTAGE = 1;
```

The package defaults to 0%, so the release train can never enable the guardian on its own, and setting the constant to 0 is a kill switch that doesn't wait for a train either.

### Why this went unnoticed

The gate short-circuits any percentage of 100 or more to `true` before it reaches the bucket check, and test sites force the rollout to 100%. So the feature looked healthy everywhere it was exercised by hand, while production ran entirely dark.

The missing guardian entries in logstash were the symptom that led here. Logging itself was fine.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No new data is collected. This changes which sites the guardian runs on, which does mean its existing logstash events will start arriving from production for the first time.

## Testing instructions

```
jp test php packages/jetpack-mu-wpcom
```

Note: the suite has one pre-existing failure unrelated to this PR — `Verbum_Block_Utils_Test::test_comment_text_block_sanitization`, `Call to undefined function wpcom_site_has_feature()`. It reproduces on trunk. The rollout tests are green:

```
composer phpunit -- --filter test_rollout   # OK (10 tests, 35 assertions)
```

To sanity-check against a real Atomic site, compare the two IDs it can be bucketed on. The local ID is `1` on any single-site install and lands in bucket 83 — excluded at every percentage below 84 — while the WP.com blog ID distributes. Verified on a connected test site:

```
old id 1          -> bucket 83
new id 2257xxxxx  -> bucket 8

at  5%:  before=false  after=false
at 10%:  before=false  after=true
at 20%:  before=false  after=true
```

At the 1% this ships with, that site sits outside the cohort and joins once the ramp passes 9%.

## Considerations

**Starting at 1%.** This is the guardian's genuine first production exposure — the earlier 5/10/20% ramps enrolled nobody — and it blocks plugin activations, so it's worth watching a small cohort before ramping.

**Gated in two places, deliberately.** The load-time gate is what removes the work from Simple. The rollout gate keeps its own platform check because tests require the feature files directly, bypassing `init()` — that's the layer where cohort membership stays coverable, and it's a backstop if the feature is ever loaded through another path.

**The platform check goes through `Constants`, not `defined()`.** A bare `defined( 'IS_ATOMIC' )` isn't testable without defining the constant across the whole suite, and ~20 source files in this package read it. `Constants::is_true()` keeps the gate coverable per-test, matching how `Wpcom_Feature_Flags` handles `AT_PROXIED_REQUEST`. `IS_ATOMIC` is available at mu-plugin time — wpcomsh's own loader gates on it and loads successfully — so guarding the `require_once` calls is safe.

**Unidentified sites are excluded below 100%.** `get_wpcom_blog_id()` returns false off-platform, and falls back to the local blog ID on an Atomic site whose Jetpack options aren't readable. Neither gives a usable bucket, so those sites stay out of a partial rollout. The fallback still puts them all in bucket 83 together, so they'd enrol as a group somewhere above 84% — the ramp is unaffected, but that's the one corner where the old behaviour survives.

**Two existing tests changed meaning.** Both used `pcg_rollout_percentage => 100` purely to switch the guard on, and broke once the gate started resolving a WP.com ID the test environment doesn't have. Reordering the checks fixed them without defining `IS_ATOMIC` suite-wide. The trade is that `test_rollout_rejects_non_positive_blog_ids` now asserts at 50% rather than 100%, with a new test pinning the 100%-includes-everyone half.
