### PR TITLE
Forms: fix the first change to a synced form being discarded on save

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-required-not-saving
+++ b/projects/packages/forms/changelog/fix-forms-required-not-saving
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the first change made to a form after opening a page being discarded when saving.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -449,7 +449,7 @@ function JetpackContactFormEdit( {
 	);
 
 	// Sync synced form content INTO the editor (one-time on ref change)
-	const { isSyncingRef } = useSyncedFormLoader( {
+	const { isSyncingRef, syncCompletionCount } = useSyncedFormLoader( {
 		ref,
 		syncedFormBlocks,
 		syncedFormAttributes,
@@ -467,6 +467,7 @@ function JetpackContactFormEdit( {
 		attributes,
 		currentInnerBlocks,
 		isSyncingRef,
+		syncCompletionCount,
 		editEntityRecord,
 	} );
 

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -449,7 +449,7 @@ function JetpackContactFormEdit( {
 	);
 
 	// Sync synced form content INTO the editor (one-time on ref change)
-	const { isSyncingRef, syncCompletionCount } = useSyncedFormLoader( {
+	const { isSyncingRef, syncGeneration } = useSyncedFormLoader( {
 		ref,
 		syncedFormBlocks,
 		syncedFormAttributes,
@@ -467,7 +467,7 @@ function JetpackContactFormEdit( {
 		attributes,
 		currentInnerBlocks,
 		isSyncingRef,
-		syncCompletionCount,
+		syncGeneration,
 		editEntityRecord,
 	} );
 

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
@@ -14,6 +14,13 @@ interface UseSyncedFormAutoSaveParams {
 	attributes: Record< string, unknown >;
 	currentInnerBlocks: Block[];
 	isSyncingRef: React.MutableRefObject< boolean >;
+	/**
+	 * Counter from `useSyncedFormLoader` that changes when a sync finishes. Only used as
+	 * an effect dependency: it gives us a render on which to capture the baseline from
+	 * the loaded-but-unedited form. Without it the first edit after a load would be the
+	 * render that captures the baseline, and so would compare equal and never stage.
+	 */
+	syncCompletionCount: number;
 	editEntityRecord: (
 		kind: string,
 		name: string,
@@ -110,6 +117,7 @@ export function useSyncedFormAutoSave( {
 	attributes,
 	currentInnerBlocks,
 	isSyncingRef,
+	syncCompletionCount,
 	editEntityRecord,
 }: UseSyncedFormAutoSaveParams ): UseSyncedFormAutoSaveResult {
 	const pendingTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
@@ -163,7 +171,17 @@ export function useSyncedFormAutoSave( {
 			clearTimeout( timeoutId );
 			pendingTimeoutRef.current = null;
 		};
-	}, [ currentInnerBlocks, ref, syncedForm, editEntityRecord, attributes, isSyncingRef ] );
+	}, [
+		currentInnerBlocks,
+		ref,
+		syncedForm,
+		editEntityRecord,
+		attributes,
+		isSyncingRef,
+		// Re-runs this effect once syncing ends, so the baseline is captured from the
+		// loaded form rather than from whatever the user changed first.
+		syncCompletionCount,
+	] );
 
 	const flushPendingSave = useCallback( () => {
 		if ( ! ref ) {

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-auto-save.ts
@@ -15,12 +15,11 @@ interface UseSyncedFormAutoSaveParams {
 	currentInnerBlocks: Block[];
 	isSyncingRef: React.MutableRefObject< boolean >;
 	/**
-	 * Counter from `useSyncedFormLoader` that changes when a sync finishes. Only used as
-	 * an effect dependency: it gives us a render on which to capture the baseline from
-	 * the loaded-but-unedited form. Without it the first edit after a load would be the
-	 * render that captures the baseline, and so would compare equal and never stage.
+	 * Changes when `useSyncedFormLoader` finishes a sync — see that hook for why it has
+	 * to be a render-triggering value. Used only as an effect dependency, so the
+	 * baseline below is captured from the loaded-but-unedited form.
 	 */
-	syncCompletionCount: number;
+	syncGeneration: number;
 	editEntityRecord: (
 		kind: string,
 		name: string,
@@ -117,7 +116,7 @@ export function useSyncedFormAutoSave( {
 	attributes,
 	currentInnerBlocks,
 	isSyncingRef,
-	syncCompletionCount,
+	syncGeneration,
 	editEntityRecord,
 }: UseSyncedFormAutoSaveParams ): UseSyncedFormAutoSaveResult {
 	const pendingTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
@@ -136,6 +135,8 @@ export function useSyncedFormAutoSave( {
 		if ( ! ref ) {
 			return;
 		}
+		const hadBaseline = baselineRef.current?.ref === ref;
+
 		// Only capture baseline after sync completes to ensure it reflects synced content
 		const baseline = captureBaseline(
 			ref,
@@ -146,8 +147,9 @@ export function useSyncedFormAutoSave( {
 			baselineRef
 		);
 
-		// Not ready or no changes - don't stage
-		if ( ! baseline ) {
+		// Not ready - don't stage. A baseline captured on this very run was serialized
+		// from the arguments below, so it would compare equal; skip the second pass.
+		if ( ! baseline || ! hadBaseline ) {
 			return;
 		}
 
@@ -178,9 +180,7 @@ export function useSyncedFormAutoSave( {
 		editEntityRecord,
 		attributes,
 		isSyncingRef,
-		// Re-runs this effect once syncing ends, so the baseline is captured from the
-		// loaded form rather than from whatever the user changed first.
-		syncCompletionCount,
+		syncGeneration,
 	] );
 
 	const flushPendingSave = useCallback( () => {

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
@@ -2,7 +2,7 @@
  * Hook to load synced form content into the editor (one-time sync on mount/ref change)
  */
 
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { filterSyncedAttributes } from '../util/form-sync.ts';
 import type { Block } from '@wordpress/blocks';
 
@@ -19,6 +19,13 @@ interface UseSyncedFormLoaderParams {
 
 interface UseSyncedFormLoaderResult {
 	isSyncingRef: React.MutableRefObject< boolean >;
+	/**
+	 * Incremented every time a sync finishes. `isSyncingRef` is a ref because the
+	 * debounced auto-save has to read it at fire time, but ref writes don't re-render —
+	 * so a consumer that skipped work while syncing would never learn that syncing
+	 * ended. Depending on this counter gives them that render.
+	 */
+	syncCompletionCount: number;
 }
 
 /**
@@ -63,6 +70,7 @@ export function useSyncedFormLoader( {
 }: UseSyncedFormLoaderParams ): UseSyncedFormLoaderResult {
 	// Track if we're currently syncing to prevent save-back loops
 	const isSyncingRef = useRef( false );
+	const [ syncCompletionCount, setSyncCompletionCount ] = useState( 0 );
 	const lastLoadedRefId = useRef< number | null >( null );
 	const animationFrameIdRef = useRef< number | null >( null );
 
@@ -97,10 +105,12 @@ export function useSyncedFormLoader( {
 			setActiveStep( clientId, firstStepClientId );
 		}
 
-		// Reset syncing flag after React commits
+		// Reset syncing flag after React commits, and re-render so consumers can act on
+		// the editor's settled, not-yet-edited state.
 		animationFrameIdRef.current = requestAnimationFrame( () => {
 			animationFrameIdRef.current = null;
 			isSyncingRef.current = false;
+			setSyncCompletionCount( count => count + 1 );
 		} );
 
 		// Cleanup: cancel pending rAF if component unmounts or effect re-runs
@@ -123,5 +133,5 @@ export function useSyncedFormLoader( {
 		setActiveStep,
 	] );
 
-	return { isSyncingRef };
+	return { isSyncingRef, syncCompletionCount };
 }

--- a/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
+++ b/projects/packages/forms/src/blocks/contact-form/hooks/use-synced-form-loader.ts
@@ -20,12 +20,12 @@ interface UseSyncedFormLoaderParams {
 interface UseSyncedFormLoaderResult {
 	isSyncingRef: React.MutableRefObject< boolean >;
 	/**
-	 * Incremented every time a sync finishes. `isSyncingRef` is a ref because the
-	 * debounced auto-save has to read it at fire time, but ref writes don't re-render —
-	 * so a consumer that skipped work while syncing would never learn that syncing
-	 * ended. Depending on this counter gives them that render.
+	 * Opaque token that changes every time a sync finishes; depend on it, don't read it.
+	 * `isSyncingRef` is a ref because the debounced auto-save has to read it at fire
+	 * time, but ref writes don't re-render — so a consumer that skipped work while
+	 * syncing would never learn that syncing ended. This gives them that render.
 	 */
-	syncCompletionCount: number;
+	syncGeneration: number;
 }
 
 /**
@@ -70,7 +70,7 @@ export function useSyncedFormLoader( {
 }: UseSyncedFormLoaderParams ): UseSyncedFormLoaderResult {
 	// Track if we're currently syncing to prevent save-back loops
 	const isSyncingRef = useRef( false );
-	const [ syncCompletionCount, setSyncCompletionCount ] = useState( 0 );
+	const [ syncGeneration, setSyncGeneration ] = useState( 0 );
 	const lastLoadedRefId = useRef< number | null >( null );
 	const animationFrameIdRef = useRef< number | null >( null );
 
@@ -105,12 +105,11 @@ export function useSyncedFormLoader( {
 			setActiveStep( clientId, firstStepClientId );
 		}
 
-		// Reset syncing flag after React commits, and re-render so consumers can act on
-		// the editor's settled, not-yet-edited state.
+		// Reset syncing flag after React commits
 		animationFrameIdRef.current = requestAnimationFrame( () => {
 			animationFrameIdRef.current = null;
 			isSyncingRef.current = false;
-			setSyncCompletionCount( count => count + 1 );
+			setSyncGeneration( generation => generation + 1 );
 		} );
 
 		// Cleanup: cancel pending rAF if component unmounts or effect re-runs
@@ -133,5 +132,5 @@ export function useSyncedFormLoader( {
 		setActiveStep,
 	] );
 
-	return { isSyncingRef, syncCompletionCount };
+	return { isSyncingRef, syncGeneration };
 }

--- a/projects/packages/forms/tests/js/contact-form/use-synced-form-auto-save.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-synced-form-auto-save.test.js
@@ -225,52 +225,56 @@ describe( 'useSyncedFormAutoSave', () => {
 	} );
 
 	/**
-	 * Drive the hook through a synced form load, then apply edits.
+	 * Render the hook with everything but the blocks and the sync generation fixed.
 	 *
-	 * The loader flips `isSyncingRef` from a requestAnimationFrame callback — a ref
-	 * write, which renders nothing — and signals the same moment by bumping
-	 * `syncCompletionCount`.
-	 *
-	 * @return {object} The `editEntityRecord` spy and an `edit` helper.
+	 * @param {object} isSyncingRef     - The loader's syncing flag.
+	 * @param {object} editEntityRecord - Spy standing in for the entity store dispatch.
+	 * @return {object} The renderHook result.
 	 */
-	const loadForm = () => {
-		const editEntityRecord = jest.fn();
-		const isSyncingRef = { current: true };
-		let syncCompletionCount = 0;
-		let blocks = [];
-
-		const { rerender } = renderHook(
-			( { currentInnerBlocks, count } ) =>
+	const renderAutoSave = ( isSyncingRef, editEntityRecord ) =>
+		renderHook(
+			( { currentInnerBlocks, syncGeneration } ) =>
 				useSyncedFormAutoSave( {
 					ref: 123,
 					syncedForm: SYNCED_FORM,
 					attributes: FORM_ATTRIBUTES,
 					currentInnerBlocks,
 					isSyncingRef,
-					syncCompletionCount: count,
+					syncGeneration,
 					editEntityRecord,
 				} ),
-			{ initialProps: { currentInnerBlocks: blocks, count: syncCompletionCount } }
+			{ initialProps: { currentInnerBlocks: [], syncGeneration: 0 } }
 		);
 
-		const render = () => rerender( { currentInnerBlocks: blocks, count: syncCompletionCount } );
+	/**
+	 * Drive the hook through a synced form load, leaving it ready for edits.
+	 *
+	 * @return {object} The `editEntityRecord` spy and an `edit` helper.
+	 */
+	const loadForm = () => {
+		const editEntityRecord = jest.fn();
+		const isSyncingRef = { current: true };
+		const { rerender } = renderAutoSave( isSyncingRef, editEntityRecord );
+		// One array, passed to both renders below. The blocks do not change when syncing
+		// ends, so if the generation bump is not what re-runs the effect, nothing is —
+		// a fresh array here would re-run it on identity alone and the test would pass
+		// against the bug it exists to catch.
+		const loadedBlocks = [ field( false ) ];
 
 		// The loader lands the synced inner blocks while syncing is still in progress.
-		blocks = [ field( false ) ];
-		render();
+		rerender( { currentInnerBlocks: loadedBlocks, syncGeneration: 0 } );
 
-		// requestAnimationFrame fires: syncing is done.
+		// requestAnimationFrame fires: the flag clears without a render, and the
+		// generation bump supplies the render it could not.
 		isSyncingRef.current = false;
-		syncCompletionCount++;
-		render();
+		rerender( { currentInnerBlocks: loadedBlocks, syncGeneration: 1 } );
 
 		return {
 			editEntityRecord,
-			edit: nextBlocks => {
-				blocks = nextBlocks;
-				render();
+			edit: currentInnerBlocks => {
+				rerender( { currentInnerBlocks, syncGeneration: 1 } );
 				act( () => {
-					jest.advanceTimersByTime( 2000 );
+					jest.advanceTimersByTime( 1000 );
 				} );
 			},
 		};
@@ -285,7 +289,7 @@ describe( 'useSyncedFormAutoSave', () => {
 
 		expect( editEntityRecord ).toHaveBeenCalledWith(
 			'postType',
-			expect.any( String ),
+			'jetpack_form',
 			123,
 			expect.objectContaining( { content: expect.any( String ) } )
 		);
@@ -303,24 +307,11 @@ describe( 'useSyncedFormAutoSave', () => {
 	it( 'does not stage while the form is still syncing', () => {
 		const editEntityRecord = jest.fn();
 		const isSyncingRef = { current: true };
+		const { rerender } = renderAutoSave( isSyncingRef, editEntityRecord );
 
-		const { rerender } = renderHook(
-			( { currentInnerBlocks } ) =>
-				useSyncedFormAutoSave( {
-					ref: 123,
-					syncedForm: SYNCED_FORM,
-					attributes: FORM_ATTRIBUTES,
-					currentInnerBlocks,
-					isSyncingRef,
-					syncCompletionCount: 0,
-					editEntityRecord,
-				} ),
-			{ initialProps: { currentInnerBlocks: [] } }
-		);
-
-		rerender( { currentInnerBlocks: [ field( false ) ] } );
+		rerender( { currentInnerBlocks: [ field( false ) ], syncGeneration: 0 } );
 		act( () => {
-			jest.advanceTimersByTime( 2000 );
+			jest.advanceTimersByTime( 1000 );
 		} );
 
 		expect( editEntityRecord ).not.toHaveBeenCalled();

--- a/projects/packages/forms/tests/js/contact-form/use-synced-form-auto-save.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-synced-form-auto-save.test.js
@@ -2,8 +2,12 @@
  * Tests for synced form auto-save helper functions
  */
 
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { act, renderHook } from '@testing-library/react';
+
+afterEach( () => {
+	jest.useRealTimers();
+} );
 
 // Mock WordPress dependencies before importing
 const mockCreateBlock = jest.fn();

--- a/projects/packages/forms/tests/js/contact-form/use-synced-form-auto-save.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-synced-form-auto-save.test.js
@@ -3,6 +3,7 @@
  */
 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react';
 
 // Mock WordPress dependencies before importing
 const mockCreateBlock = jest.fn();
@@ -13,7 +14,7 @@ await jest.unstable_mockModule( '@wordpress/blocks', () => ( {
 	serialize: mockSerialize,
 } ) );
 
-const { captureBaseline, stageFormEdits } = await import(
+const { captureBaseline, stageFormEdits, useSyncedFormAutoSave } = await import(
 	'../../../src/blocks/contact-form/hooks/use-synced-form-auto-save.ts'
 );
 
@@ -194,5 +195,134 @@ describe( 'stageFormEdits', () => {
 		expect( edits ).toHaveProperty( 'content', serialized );
 		expect( edits ).toHaveProperty( 'blocks' );
 		expect( edits.blocks ).toEqual( [ mockFormBlock ] );
+	} );
+} );
+
+describe( 'useSyncedFormAutoSave', () => {
+	// Serialize enough of the block for a `required` flip to change the string.
+	const serializeFake = block =>
+		JSON.stringify( ( block.innerBlocks || [] ).map( b => [ b.name, b.attributes ] ) );
+	const field = required => ( {
+		name: 'jetpack/field-name',
+		attributes: { required },
+		innerBlocks: [],
+	} );
+	// Referentially stable across renders, exactly like the real block attributes and
+	// entity record. Fresh literals would re-run the effect on every render and hide
+	// whether it re-runs for the right reason.
+	const FORM_ATTRIBUTES = {};
+	const SYNCED_FORM = { content: { raw: 'x' } };
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.useFakeTimers();
+		mockCreateBlock.mockImplementation( ( name, attributes, innerBlocks ) => ( {
+			name,
+			attributes,
+			innerBlocks,
+		} ) );
+		mockSerialize.mockImplementation( serializeFake );
+	} );
+
+	/**
+	 * Drive the hook through a synced form load, then apply edits.
+	 *
+	 * The loader flips `isSyncingRef` from a requestAnimationFrame callback — a ref
+	 * write, which renders nothing — and signals the same moment by bumping
+	 * `syncCompletionCount`.
+	 *
+	 * @return {object} The `editEntityRecord` spy and an `edit` helper.
+	 */
+	const loadForm = () => {
+		const editEntityRecord = jest.fn();
+		const isSyncingRef = { current: true };
+		let syncCompletionCount = 0;
+		let blocks = [];
+
+		const { rerender } = renderHook(
+			( { currentInnerBlocks, count } ) =>
+				useSyncedFormAutoSave( {
+					ref: 123,
+					syncedForm: SYNCED_FORM,
+					attributes: FORM_ATTRIBUTES,
+					currentInnerBlocks,
+					isSyncingRef,
+					syncCompletionCount: count,
+					editEntityRecord,
+				} ),
+			{ initialProps: { currentInnerBlocks: blocks, count: syncCompletionCount } }
+		);
+
+		const render = () => rerender( { currentInnerBlocks: blocks, count: syncCompletionCount } );
+
+		// The loader lands the synced inner blocks while syncing is still in progress.
+		blocks = [ field( false ) ];
+		render();
+
+		// requestAnimationFrame fires: syncing is done.
+		isSyncingRef.current = false;
+		syncCompletionCount++;
+		render();
+
+		return {
+			editEntityRecord,
+			edit: nextBlocks => {
+				blocks = nextBlocks;
+				render();
+				act( () => {
+					jest.advanceTimersByTime( 2000 );
+				} );
+			},
+		};
+	};
+
+	it( 'stages the first edit made after the form loads', () => {
+		const { editEntityRecord, edit } = loadForm();
+
+		// Flipping "Field is required" is a single atomic change — it used to be
+		// swallowed into the baseline and silently dropped.
+		edit( [ field( true ) ] );
+
+		expect( editEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			expect.any( String ),
+			123,
+			expect.objectContaining( { content: expect.any( String ) } )
+		);
+	} );
+
+	it( 'stages subsequent edits too', () => {
+		const { editEntityRecord, edit } = loadForm();
+
+		edit( [ field( true ) ] );
+		edit( [ field( true ), field( false ) ] );
+
+		expect( editEntityRecord ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'does not stage while the form is still syncing', () => {
+		const editEntityRecord = jest.fn();
+		const isSyncingRef = { current: true };
+
+		const { rerender } = renderHook(
+			( { currentInnerBlocks } ) =>
+				useSyncedFormAutoSave( {
+					ref: 123,
+					syncedForm: SYNCED_FORM,
+					attributes: FORM_ATTRIBUTES,
+					currentInnerBlocks,
+					isSyncingRef,
+					syncCompletionCount: 0,
+					editEntityRecord,
+				} ),
+			{ initialProps: { currentInnerBlocks: [] } }
+		);
+
+		rerender( { currentInnerBlocks: [ field( false ) ] } );
+		act( () => {
+			jest.advanceTimersByTime( 2000 );
+		} );
+
+		expect( editEntityRecord ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/forms/tests/js/contact-form/use-synced-form-loader.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-synced-form-loader.test.js
@@ -8,7 +8,6 @@ import { renderHook } from '@testing-library/react';
 // Mock WordPress dependencies
 const mockUseEffect = jest.fn();
 const mockUseRef = jest.fn();
-const mockSetState = jest.fn();
 
 // Track rAF callbacks and cleanup
 let rafCallback = null;
@@ -25,9 +24,9 @@ await jest.unstable_mockModule( '@wordpress/element', () => ( {
 		mockUseRef( ref );
 		return ref;
 	},
-	// The hook only uses state as a re-render signal, so a stub setter is enough here;
-	// the behaviour it drives is covered in use-synced-form-auto-save.test.js.
-	useState: initialValue => [ initialValue, mockSetState ],
+	// State is only a re-render signal here, so a no-op setter suffices; the behaviour
+	// it drives is covered in use-synced-form-auto-save.test.js.
+	useState: initialValue => [ initialValue, () => {} ],
 } ) );
 
 await jest.unstable_mockModule( '../../../src/blocks/contact-form/util/form-sync.ts', () => ( {

--- a/projects/packages/forms/tests/js/contact-form/use-synced-form-loader.test.js
+++ b/projects/packages/forms/tests/js/contact-form/use-synced-form-loader.test.js
@@ -8,6 +8,7 @@ import { renderHook } from '@testing-library/react';
 // Mock WordPress dependencies
 const mockUseEffect = jest.fn();
 const mockUseRef = jest.fn();
+const mockSetState = jest.fn();
 
 // Track rAF callbacks and cleanup
 let rafCallback = null;
@@ -24,6 +25,9 @@ await jest.unstable_mockModule( '@wordpress/element', () => ( {
 		mockUseRef( ref );
 		return ref;
 	},
+	// The hook only uses state as a re-render signal, so a stub setter is enough here;
+	// the behaviour it drives is covered in use-synced-form-auto-save.test.js.
+	useState: initialValue => [ initialValue, mockSetState ],
 } ) );
 
 await jest.unstable_mockModule( '../../../src/blocks/contact-form/util/form-sync.ts', () => ( {

--- a/projects/plugins/jetpack/changelog/fix-forms-required-not-saving
+++ b/projects/plugins/jetpack/changelog/fix-forms-required-not-saving
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix the first change made to a form after opening a page being discarded when saving.


### PR DESCRIPTION
Fixes FORMS-766

## Proposed changes

* Fix the first change made to a synced form after opening a page being silently discarded.

When a page contains a synced form (a form block with a `ref` to a `jetpack_form` post), `useSyncedFormAutoSave` stages editor changes onto the form entity by comparing the current serialization against a baseline. The baseline was never captured while the form was loading — correctly, since `isSyncing` is true — but nothing re-rendered once loading finished, so the effect that captures it did not run again.

`useSyncedFormLoader` clears its `isSyncing` flag from a `requestAnimationFrame` callback, and that flag lives in a ref, so clearing it renders nothing. The next render came from the user's first edit. The baseline was therefore captured from the already-edited state, compared equal to itself, and no edit was staged: `jetpack_form` never became dirty and the change was dropped on save. `flushPendingSave` had the same hole, so navigating to the form editor did not rescue it either.

The loader now bumps a `syncCompletionCount` alongside clearing the flag, and the auto-save effect depends on it. That gives the effect one render on the loaded-but-unedited form, which is what the baseline should have been all along. The flag stays a ref because the debounced save has to read it at fire time.

This is not specific to `required` — any single atomic edit made first after a load was lost. Typing in a label only appeared to work because the first keystroke became the baseline and the rest staged normally.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with the Forms module active, create or edit a **page** and insert a **Form** block, choosing the *Contact Form* template. This creates a synced form (the block gets a `ref`).
* Save the page, then **reload the editor** — the bug only shows on a fresh load of an existing synced form.
* Select the **Name** field and toggle **Field is required** in the block sidebar. Change nothing else.
* Click **Update**. On the pre-save panel, the form should be listed as having changes alongside the page.
* Reload the editor and check the Name field. The required state should be the one you set.
* On trunk, the form is missing from the save panel and the toggle reverts after reload.
* Worth also checking that the fix did not introduce spurious saves: open a page with a synced form, change nothing, and confirm the form is not reported as dirty.

Verified end-to-end on a Jurassic Ninja site running this branch — the form entity now enters the dirty set and the change survives save and reload in both directions. `use-synced-form-auto-save.test.js` gains two regression tests that fail on trunk and pass here.
