### PR TITLE
Newsletter: explain the paywall constraint in the Audience panel

### DIFF
--- a/projects/plugins/jetpack/changelog/update-newsletter-audience-paywall-notice
+++ b/projects/plugins/jetpack/changelog/update-newsletter-audience-paywall-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Newsletter: explain why the Everyone audience is unavailable when a post has a paywall block, instead of linking to the block.

--- a/projects/plugins/jetpack/extensions/blocks/paywall/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/paywall/edit.jsx
@@ -154,6 +154,9 @@ function PaywallEdit() {
 						stripeConnectUrl={ stripeConnectUrl }
 						hasTierPlans={ hasTierPlans }
 						postHasPaywallBlock={ true }
+						// The block card above this panel already explains the paywall, so the
+						// notice would only repeat the heading it sits under.
+						explainPaywallConstraint={ false }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.jsx
@@ -174,7 +174,7 @@ function NewsletterPrePublishSettingsPanel( { accessLevel, showPreviewModal } ) 
 						{ __( 'Audience:', 'jetpack' ) }
 						{ accessLevel && (
 							<span className={ 'jetpack-subscribe-post-publish-panel__heading' }>
-								{ accessOptions[ accessLevel ].panelHeading }
+								{ accessOptions[ accessLevel ].label }
 							</span>
 						) }
 					</>

--- a/projects/plugins/jetpack/extensions/shared/memberships/constants.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/constants.js
@@ -7,16 +7,13 @@ export const accessOptions = {
 	everybody: {
 		key: 'everybody',
 		label: __( 'Everyone', 'jetpack' ),
-		panelHeading: __( 'Everyone', 'jetpack' ),
 	},
 	subscribers: {
 		key: 'subscribers',
 		label: __( 'Subscribers', 'jetpack' ),
-		panelHeading: __( 'Subscribers', 'jetpack' ),
 	},
 	paid_subscribers: {
 		key: 'paid_subscribers',
 		label: __( 'Paid subscribers', 'jetpack' ),
-		panelHeading: __( 'Paid subscribers', 'jetpack' ),
 	},
 };

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
@@ -1,21 +1,21 @@
-import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-utils';
 import { formatNumberCompact } from '@automattic/number-formatters';
 import {
-	Button,
+	BaseControl,
 	Flex,
 	FlexBlock,
+	Notice,
 	RadioControl,
 	Spinner,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { useInstanceId, useViewportMatch } from '@wordpress/compose';
+import { useInstanceId } from '@wordpress/compose';
 import { useEntityId, useEntityProp, store as coreDataStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PostVisibilityCheck, store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-import { Icon } from '@wordpress/icons';
 import { Link as ExternalLink } from '@wordpress/ui';
+import clsx from 'clsx';
 import paywallBlockMetadata from '../../blocks/paywall/block.json';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import './settings.scss';
@@ -26,8 +26,6 @@ import {
 	META_NAME_FOR_POST_TIER_ID_SETTINGS,
 } from './constants';
 import { getPaidPlanLink, getShowMisconfigurationWarning, MisconfigurationWarning } from './utils';
-
-const paywallIcon = getBlockIconComponent( paywallBlockMetadata );
 
 export function Link( { href, children } ) {
 	return (
@@ -166,6 +164,67 @@ function TierSelector() {
 	);
 }
 
+/**
+ * A single audience option, rendered with Gutenberg's own RadioControl classes so it
+ * looks identical to a stock radio group.
+ *
+ * The group is built by hand rather than with RadioControl because an unavailable
+ * option has to stay visible in its natural position — "Everyone" sits above the
+ * options that remain selectable, which is a place RadioControl gives no way to reach.
+ *
+ * Unavailable options use aria-disabled rather than the native disabled attribute: a
+ * disabled input leaves the tab order and is skipped by screen readers, which would
+ * hide the option from exactly the people its explanation is there to inform. They are
+ * also left out of the shared group name, so arrow-key navigation — which selects as it
+ * moves — cannot land on one and choose it.
+ *
+ * @param {object}   props               - Component props.
+ * @param {string}   props.id            - Unique id tying the input to its label.
+ * @param {string}   props.groupName     - Shared name for the selectable options.
+ * @param {string}   props.value         - Access level key this option sets.
+ * @param {string}   props.label         - Visible label.
+ * @param {boolean}  props.checked       - Whether this option is the current value.
+ * @param {boolean}  props.disabled      - Whether this option cannot be chosen.
+ * @param {string}   [props.describedBy] - Id of the element explaining why it is unavailable.
+ * @param {Function} props.onChange      - Called with the new access level key.
+ * @return {import('react').ReactElement} The option.
+ */
+function AccessOption( { id, groupName, value, label, checked, disabled, describedBy, onChange } ) {
+	return (
+		<div
+			className={ clsx( 'components-radio-control__option', {
+				'jetpack-newsletter-access-radio-buttons__disabled-option': disabled,
+			} ) }
+		>
+			<input
+				type="radio"
+				className="components-radio-control__input"
+				id={ id }
+				name={ disabled ? undefined : groupName }
+				value={ value }
+				checked={ checked }
+				aria-disabled={ disabled || undefined }
+				aria-describedby={ describedBy }
+				readOnly={ disabled }
+				onChange={ disabled ? undefined : event => onChange( event.target.value ) }
+				onClick={ disabled ? event => event.preventDefault() : undefined }
+				onKeyDown={
+					disabled
+						? event => {
+								if ( event.key === ' ' ) {
+									event.preventDefault();
+								}
+						  }
+						: undefined
+				}
+			/>
+			<label className="components-radio-control__label" htmlFor={ id }>
+				{ label }
+			</label>
+		</div>
+	);
+}
+
 export function NewsletterAccessRadioButtons( {
 	accessLevel,
 	hasTierPlans,
@@ -186,6 +245,15 @@ export function NewsletterAccessRadioButtons( {
 	// paid before Stripe was disconnected does not end up with nothing selected.
 	const showPaidAsDisabled = ! isPaidAvailable && ! isPaidSelected;
 
+	// A paywall block splits the post, so "the whole post is public" stops being an
+	// option it can express. The option stays visible and disabled — the same treatment
+	// paid subscribers gets — with a notice saying why, rather than the panel silently
+	// changing shape. The saved-value guard is the same as above: the paywall block
+	// moves the post off "everybody" when it is inserted, but until that lands we must
+	// not leave the group with nothing selected.
+	const isEverybodySelected = accessLevel === accessOptions.everybody.key;
+	const showEverybodyAsDisabled = !! postHasPaywallBlock && ! isEverybodySelected;
+
 	const setAccess = useSetAccess();
 	// The count beside each option is the size of the audience that can read it, which
 	// is what distinguishes the options from one another. postHasPaywallBlock is
@@ -203,78 +271,79 @@ export function NewsletterAccessRadioButtons( {
 		paidSubscribers,
 	} );
 
-	const paidOptionLabel = `${ accessOptions.paid_subscribers.label } (${ formatNumberCompact(
-		paidSubscribersReach
-	) })`;
-	const disabledPaidOptionId = useInstanceId(
-		NewsletterAccessRadioButtons,
-		'jetpack-newsletter-access-paid-subscribers-disabled'
-	);
-	const setupLinkId = `${ disabledPaidOptionId }-setup-link`;
+	const instanceId = useInstanceId( NewsletterAccessRadioButtons, 'jetpack-newsletter-access' );
+	const groupName = `${ instanceId }-group`;
+	const paywallNoticeId = `${ instanceId }-paywall-notice`;
+	const setupLinkId = `${ instanceId }-paid-setup-link`;
+
+	const options = [
+		{
+			value: accessOptions.everybody.key,
+			label: accessOptions.everybody.label,
+			disabled: showEverybodyAsDisabled,
+			describedBy: showEverybodyAsDisabled ? paywallNoticeId : undefined,
+		},
+		{
+			value: accessOptions.subscribers.key,
+			label: `${ accessOptions.subscribers.label } (${ formatNumberCompact( subscribersReach ) })`,
+		},
+		{
+			value: accessOptions.paid_subscribers.key,
+			label: `${ accessOptions.paid_subscribers.label } (${ formatNumberCompact(
+				paidSubscribersReach
+			) })`,
+			disabled: showPaidAsDisabled,
+			describedBy: showPaidAsDisabled ? setupLinkId : undefined,
+		},
+	];
 
 	return (
 		<div className="jetpack-newsletter-access-radio-buttons">
-			<RadioControl
-				label={ __( 'Who can read this post?', 'jetpack' ) }
-				onChange={ setAccess }
-				options={ [
-					...( ! postHasPaywallBlock
-						? [
-								{
-									label: accessOptions.everybody.label,
-									value: accessOptions.everybody.key,
-								},
-						  ]
-						: [] ),
-					{
-						label: `${ accessOptions.subscribers.label } (${ formatNumberCompact(
-							subscribersReach
-						) })`,
-						value: accessOptions.subscribers.key,
-					},
-					...( ! showPaidAsDisabled
-						? [
-								{
-									label: paidOptionLabel,
-									value: accessOptions.paid_subscribers.key,
-								},
-						  ]
-						: [] ),
-				] }
-				selected={ accessLevel }
-			/>
-			{ showPaidAsDisabled && (
-				<>
-					<div className="components-radio-control__option jetpack-newsletter-access-radio-buttons__disabled-option">
-						{ /*
-						 * aria-disabled rather than disabled: a disabled input leaves the tab
-						 * order and is skipped by screen readers, which would hide the paid
-						 * option from exactly the people the setup link is there to inform.
-						 * It stays focusable and announced, but cannot be selected.
-						 */ }
-						<input
-							type="radio"
-							className="components-radio-control__input"
-							aria-disabled="true"
-							aria-describedby={ setupLinkId }
-							checked={ false }
-							readOnly
-							onClick={ event => event.preventDefault() }
-							onKeyDown={ event => {
-								if ( event.key === ' ' ) {
-									event.preventDefault();
-								}
-							} }
-							id={ disabledPaidOptionId }
+			{ showEverybodyAsDisabled && (
+				<Notice
+					status="info"
+					isDismissible={ false }
+					className="jetpack-newsletter-access-radio-buttons__paywall-notice"
+				>
+					{ /*
+					 * Notice does not forward arbitrary props, so the id that "Everyone" points
+					 * at lives on a wrapper. It covers only the copy, which keeps the visually
+					 * hidden "Information notice" label out of the option's description.
+					 */ }
+					<span id={ paywallNoticeId }>
+						<strong>{ __( 'Paywall active', 'jetpack' ) }</strong>
+						<br />
+						{ __(
+							'Choose who can read the full post. Everyone can still read the content above the paywall.',
+							'jetpack'
+						) }
+					</span>
+				</Notice>
+			) }
+			<fieldset role="radiogroup" className="components-radio-control">
+				<BaseControl.VisualLabel as="legend">
+					{ __( 'Who can read this post?', 'jetpack' ) }
+				</BaseControl.VisualLabel>
+				<div className="components-radio-control__group-wrapper">
+					{ options.map( option => (
+						<AccessOption
+							key={ option.value }
+							id={ `${ instanceId }-${ option.value }` }
+							groupName={ groupName }
+							value={ option.value }
+							label={ option.label }
+							checked={ ! option.disabled && accessLevel === option.value }
+							disabled={ !! option.disabled }
+							describedBy={ option.describedBy }
+							onChange={ setAccess }
 						/>
-						<label className="components-radio-control__label" htmlFor={ disabledPaidOptionId }>
-							{ paidOptionLabel }
-						</label>
-					</div>
-					<ExternalLink id={ setupLinkId } openInNewTab href={ getPaidPlanLink( hasTierPlans ) }>
-						{ __( 'Turn on paid subscribers', 'jetpack' ) }
-					</ExternalLink>
-				</>
+					) ) }
+				</div>
+			</fieldset>
+			{ showPaidAsDisabled && (
+				<ExternalLink id={ setupLinkId } openInNewTab href={ getPaidPlanLink( hasTierPlans ) }>
+					{ __( 'Turn on paid subscribers', 'jetpack' ) }
+				</ExternalLink>
 			) }
 			{ isPaidSelected && isPaidAvailable && <TierSelector></TierSelector> }
 			<p className="jetpack-newsletter-access-radio-buttons__description">
@@ -285,7 +354,7 @@ export function NewsletterAccessRadioButtons( {
 }
 
 export function NewsletterAccessDocumentSettings( { accessLevel } ) {
-	const { hasTierPlans, stripeConnectUrl, isLoading, foundPaywallBlock } = useSelect( select => {
+	const { hasTierPlans, stripeConnectUrl, isLoading, postHasPaywallBlock } = useSelect( select => {
 		const { getNewsletterTierProducts, getConnectUrl, isApiStateLoading } = select(
 			'jetpack/membership-products'
 		);
@@ -295,15 +364,11 @@ export function NewsletterAccessDocumentSettings( { accessLevel } ) {
 			isLoading: isApiStateLoading(),
 			stripeConnectUrl: getConnectUrl(),
 			hasTierPlans: getNewsletterTierProducts()?.length !== 0,
-			foundPaywallBlock: getBlocks().find( block => block.name === paywallBlockMetadata.name ),
+			postHasPaywallBlock: getBlocks().some( block => block.name === paywallBlockMetadata.name ),
 		};
 	} );
 
 	const postVisibility = useSelect( select => select( editorStore ).getEditedPostVisibility() );
-	const { selectBlock } = useDispatch( 'core/block-editor' );
-	const { closeGeneralSidebar } = useDispatch( 'core/edit-post' );
-
-	const isMobileViewport = useViewportMatch( 'medium', '<' );
 
 	if ( isLoading ) {
 		return (
@@ -321,54 +386,22 @@ export function NewsletterAccessDocumentSettings( { accessLevel } ) {
 	return (
 		<PostVisibilityCheck
 			render={ ( { canEdit } ) => (
-				<>
-					{ foundPaywallBlock && (
-						<>
-							<div className="block-editor-block-card">
-								<span className="block-editor-block-icon has-colors">
-									<Icon icon={ paywallIcon } />
-								</span>
-								<div className="block-editor-block-card__content">
-									<h2 className="block-editor-block-card__title">{ __( 'Paywall', 'jetpack' ) }</h2>
-									<span className="block-editor-block-card__description">
-										{ __(
-											'The content below the paywall block is exclusive to the selected audience.',
-											'jetpack'
-										) }{ ' ' }
-										<Button
-											className="edit-post-paywall-toolbar-button"
-											onClick={ () => {
-												selectBlock( foundPaywallBlock.clientId );
-												if ( isMobileViewport ) {
-													closeGeneralSidebar();
-												}
-											} }
-											variant={ 'link' }
-										>
-											{ __( 'Edit the block.', 'jetpack' ) }
-										</Button>
-									</span>
-								</div>
-							</div>
-						</>
-					) }
-					<Flex direction="column">
-						{ showMisconfigurationWarning && <MisconfigurationWarning /> }
-						<FlexBlock direction="row" justify="flex-start">
-							{ canEdit && (
-								<NewsletterAccessRadioButtons
-									accessLevel={ _accessLevel }
-									stripeConnectUrl={ stripeConnectUrl }
-									hasTierPlans={ hasTierPlans }
-									postHasPaywallBlock={ foundPaywallBlock }
-								/>
-							) }
+				<Flex direction="column">
+					{ showMisconfigurationWarning && <MisconfigurationWarning /> }
+					<FlexBlock direction="row" justify="flex-start">
+						{ canEdit && (
+							<NewsletterAccessRadioButtons
+								accessLevel={ _accessLevel }
+								stripeConnectUrl={ stripeConnectUrl }
+								hasTierPlans={ hasTierPlans }
+								postHasPaywallBlock={ postHasPaywallBlock }
+							/>
+						) }
 
-							{ /* Display the uneditable access level when the user doesn't have edit privileges*/ }
-							{ ! canEdit && <span>{ accessLabel }</span> }
-						</FlexBlock>
-					</Flex>
-				</>
+						{ /* Display the uneditable access level when the user doesn't have edit privileges*/ }
+						{ ! canEdit && <span>{ accessLabel }</span> }
+					</FlexBlock>
+				</Flex>
 			) }
 		/>
 	);

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
@@ -3,7 +3,6 @@ import {
 	BaseControl,
 	Flex,
 	FlexBlock,
-	Notice,
 	RadioControl,
 	Spinner,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -14,7 +13,7 @@ import { useEntityId, useEntityProp, store as coreDataStore } from '@wordpress/c
 import { useDispatch, useSelect } from '@wordpress/data';
 import { PostVisibilityCheck, store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-import { Link as ExternalLink } from '@wordpress/ui';
+import { Link as ExternalLink, Notice } from '@wordpress/ui';
 import clsx from 'clsx';
 import paywallBlockMetadata from '../../blocks/paywall/block.json';
 import { store as membershipProductsStore } from '../../store/membership-products';
@@ -300,25 +299,17 @@ export function NewsletterAccessRadioButtons( {
 	return (
 		<div className="jetpack-newsletter-access-radio-buttons">
 			{ showEverybodyAsDisabled && (
-				<Notice
-					status="info"
-					isDismissible={ false }
-					className="jetpack-newsletter-access-radio-buttons__paywall-notice"
-				>
-					{ /*
-					 * Notice does not forward arbitrary props, so the id that "Everyone" points
-					 * at lives on a wrapper. It covers only the copy, which keeps the visually
-					 * hidden "Information notice" label out of the option's description.
-					 */ }
-					<span id={ paywallNoticeId }>
-						<strong>{ __( 'Paywall active', 'jetpack' ) }</strong>
-						<br />
+				// icon={ null } matches the mockup, which shows the notice without the
+				// intent icon @wordpress/ui would otherwise render for "info".
+				<Notice.Root intent="info" icon={ null } id={ paywallNoticeId }>
+					<Notice.Title>{ __( 'Paywall active', 'jetpack' ) }</Notice.Title>
+					<Notice.Description>
 						{ __(
 							'Choose who can read the full post. Everyone can still read the content above the paywall.',
 							'jetpack'
 						) }
-					</span>
-				</Notice>
+					</Notice.Description>
+				</Notice.Root>
 			) }
 			<fieldset role="radiogroup" className="components-radio-control">
 				<BaseControl.VisualLabel as="legend">

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.jsx
@@ -229,6 +229,7 @@ export function NewsletterAccessRadioButtons( {
 	hasTierPlans,
 	stripeConnectUrl,
 	postHasPaywallBlock: postHasPaywallBlock = false,
+	explainPaywallConstraint = true,
 } ) {
 	const isStripeConnected = stripeConnectUrl === null;
 	const { totalSubscribers, paidSubscribers } = useSelect( select =>
@@ -252,6 +253,13 @@ export function NewsletterAccessRadioButtons( {
 	// not leave the group with nothing selected.
 	const isEverybodySelected = accessLevel === accessOptions.everybody.key;
 	const showEverybodyAsDisabled = !! postHasPaywallBlock && ! isEverybodySelected;
+
+	// The paywall block's own inspector opts out: it sits directly under Gutenberg's
+	// block card, which already says what a paywall does, so the notice repeats the
+	// heading above it. Both the notice and the option's aria-describedby derive from
+	// this one flag — gating only the notice would leave the option pointing at an id
+	// that is no longer in the DOM, which reads as no description at all.
+	const showPaywallNotice = showEverybodyAsDisabled && explainPaywallConstraint;
 
 	const setAccess = useSetAccess();
 	// The count beside each option is the size of the audience that can read it, which
@@ -280,7 +288,7 @@ export function NewsletterAccessRadioButtons( {
 			value: accessOptions.everybody.key,
 			label: accessOptions.everybody.label,
 			disabled: showEverybodyAsDisabled,
-			describedBy: showEverybodyAsDisabled ? paywallNoticeId : undefined,
+			describedBy: showPaywallNotice ? paywallNoticeId : undefined,
 		},
 		{
 			value: accessOptions.subscribers.key,
@@ -298,7 +306,7 @@ export function NewsletterAccessRadioButtons( {
 
 	return (
 		<div className="jetpack-newsletter-access-radio-buttons">
-			{ showEverybodyAsDisabled && (
+			{ showPaywallNotice && (
 				// icon={ null } matches the mockup, which shows the notice without the
 				// intent icon @wordpress/ui would otherwise render for "info".
 				<Notice.Root intent="info" icon={ null } id={ paywallNoticeId }>

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
@@ -39,6 +39,20 @@
 		}
 	}
 
+	// The notice explains why "Everyone" is not selectable, so it reads as an
+	// introduction to the group rather than a banner floating above it.
+	&__paywall-notice {
+		margin: 0;
+	}
+
+	// The group is built by hand rather than by RadioControl (see AccessOption),
+	// so it supplies the spacing RadioControl would get from its own VStack.
+	.components-radio-control__group-wrapper {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
 	// Two tiers of spacing: the options sit close together, while the legend, the
 	// setup link and the description are each set apart from the group by a wider
 	// gap. Gutenberg gives the legend 8px of its own, so it needs half as much.

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.scss
@@ -39,12 +39,6 @@
 		}
 	}
 
-	// The notice explains why "Everyone" is not selectable, so it reads as an
-	// introduction to the group rather than a banner floating above it.
-	&__paywall-notice {
-		margin: 0;
-	}
-
 	// The group is built by hand rather than by RadioControl (see AccessOption),
 	// so it supplies the spacing RadioControl would get from its own VStack.
 	.components-radio-control__group-wrapper {

--- a/projects/plugins/jetpack/extensions/shared/memberships/test/settings-test.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/test/settings-test.jsx
@@ -8,6 +8,7 @@ import {
 	Link,
 	getAccessDescription,
 	getReachForAccessLevelKey,
+	NewsletterAccessDocumentSettings,
 	NewsletterAccessRadioButtons,
 	NewsletterEmailDocumentSettings,
 } from '../settings';
@@ -334,11 +335,95 @@ describe( 'NewsletterAccessRadioButtons', () => {
 		} );
 	} );
 
-	test( 'omits Everyone when the post has a paywall block', () => {
-		renderPanel( { postHasPaywallBlock: true, accessLevel: 'subscribers' } );
+	describe( 'when the post has a paywall block', () => {
+		const renderPaywalled = ( props = {}, selectOptions = {} ) =>
+			renderPanel(
+				{ postHasPaywallBlock: true, accessLevel: 'subscribers', ...props },
+				selectOptions
+			);
 
-		expect( screen.queryByRole( 'radio', { name: 'Everyone' } ) ).not.toBeInTheDocument();
-		expect( screen.getByRole( 'radio', { name: /^Subscribers/ } ) ).toBeInTheDocument();
+		// Removing the option instead would make the panel silently change shape. Keeping
+		// it visible and disabled matches how paid subscribers behaves when it is unavailable.
+		test( 'keeps Everyone visible but not selectable', () => {
+			renderPaywalled();
+
+			const everyone = screen.getByRole( 'radio', { name: 'Everyone' } );
+			expect( everyone ).toHaveAttribute( 'aria-disabled', 'true' );
+			expect( everyone ).not.toBeChecked();
+		} );
+
+		test( 'does not save the everybody level when the disabled option is clicked', async () => {
+			renderPaywalled();
+
+			await userEvent.click( screen.getByRole( 'radio', { name: 'Everyone' } ) );
+			expect( mockSetPostMeta ).not.toHaveBeenCalled();
+		} );
+
+		// The notice only helps a screen reader user if the option points at it, so the
+		// copy is asserted through the description as it is actually computed from
+		// aria-describedby rather than by reading the notice on its own.
+		test( 'explains why Everyone is unavailable, in a way the option points at', () => {
+			renderPaywalled();
+
+			expect( screen.getByText( 'Paywall active' ) ).toBeInTheDocument();
+
+			const everyone = screen.getByRole( 'radio', { name: 'Everyone' } );
+			expect( everyone ).toHaveAccessibleDescription( /^Paywall active/ );
+			expect( everyone ).toHaveAccessibleDescription(
+				/Choose who can read the full post\. Everyone can still read the content above the paywall\.$/
+			);
+		} );
+
+		// A native `disabled` attribute would drop the option out of the tab order and hide
+		// it from screen readers, taking the explanation with it.
+		test( 'keeps the disabled option focusable', () => {
+			renderPaywalled();
+
+			const everyone = screen.getByRole( 'radio', { name: 'Everyone' } );
+			expect( everyone ).toBeEnabled();
+
+			everyone.focus();
+			expect( everyone ).toHaveFocus();
+		} );
+
+		// Arrow keys select as they move within a native radio group, so an unselectable
+		// option must not share the group's name or it could be chosen by keyboard.
+		test( 'leaves the disabled option out of the keyboard group', () => {
+			renderPaywalled();
+
+			expect( screen.getByRole( 'radio', { name: 'Everyone' } ) ).not.toHaveAttribute( 'name' );
+			expect( screen.getByRole( 'radio', { name: /^Subscribers/ } ) ).toHaveAttribute( 'name' );
+		} );
+
+		test( 'still lets the remaining audiences be chosen', async () => {
+			renderPaywalled();
+
+			await userEvent.click( screen.getByRole( 'radio', { name: /^Paid subscribers/ } ) );
+			expect( mockSetPostMeta ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					[ META_NAME_FOR_POST_LEVEL_ACCESS_SETTINGS ]: 'paid_subscribers',
+				} )
+			);
+		} );
+
+		// Inserting a paywall block moves the post off "everybody". Until that lands, the
+		// option has to stay selectable or the group would show nothing selected at all.
+		test( 'leaves Everyone selectable while it is still the saved value', () => {
+			renderPaywalled( { accessLevel: 'everybody' } );
+
+			const everyone = screen.getByRole( 'radio', { name: 'Everyone' } );
+			expect( everyone ).toBeChecked();
+			expect( everyone ).not.toHaveAttribute( 'aria-disabled' );
+		} );
+	} );
+
+	test( 'offers Everyone without explanation when there is no paywall block', () => {
+		renderPanel( { accessLevel: 'everybody' } );
+
+		const everyone = screen.getByRole( 'radio', { name: 'Everyone' } );
+		expect( everyone ).toBeChecked();
+		expect( everyone ).not.toHaveAttribute( 'aria-disabled' );
+		expect( screen.queryByText( 'Paywall active' ) ).not.toBeInTheDocument();
 	} );
 
 	// The counts report how many people can read each level. Switching the paid count to
@@ -352,6 +437,77 @@ describe( 'NewsletterAccessRadioButtons', () => {
 
 		expect( screen.getByRole( 'radio', { name: 'Subscribers (21)' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'radio', { name: 'Paid subscribers (2)' } ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'NewsletterAccessDocumentSettings', () => {
+	const PAYWALL_BLOCK = { name: 'jetpack/paywall', clientId: 'paywall-1' };
+
+	const createMockSelect =
+		( { blocks = [] } = {} ) =>
+		store => {
+			if ( store === 'jetpack/membership-products' ) {
+				return {
+					isApiStateLoading: () => false,
+					getConnectUrl: () => null,
+					getNewsletterTierProducts: () => [],
+				};
+			}
+			if ( store === 'core/block-editor' ) {
+				return { getBlocks: () => blocks };
+			}
+			if ( store === membershipProductsStore ) {
+				return {
+					getSubscriberCounts: () => ( { totalSubscribers: 10, paidSubscribers: 2 } ),
+					getNewsletterTierProducts: () => [],
+				};
+			}
+			if ( store === editorStore ) {
+				return {
+					getCurrentPostType: () => 'post',
+					getEditedPostVisibility: () => 'public',
+				};
+			}
+			return {};
+		};
+
+	const renderSettings = ( { blocks = [], accessLevel = 'subscribers' } = {} ) => {
+		mockUseSelect.mockImplementation( selector => selector( createMockSelect( { blocks } ) ) );
+		return render( <NewsletterAccessDocumentSettings accessLevel={ accessLevel } /> );
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseEntityProp.mockReturnValue( [ {}, jest.fn() ] );
+		jest.spyOn( wpData, 'useSelect' ).mockImplementation( selector => mockUseSelect( selector ) );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	// The card used to sit above the radio group with an "Edit the block." button that
+	// selected the paywall block without switching the sidebar to the Block tab, so it
+	// looked inert. The notice explains the constraint instead. Asserting the notice is
+	// present is what makes the card's absence meaningful: it proves the paywall block
+	// was detected in this render, rather than the card being missing for some other reason.
+	test( 'explains the paywall in the panel instead of linking out to the block', () => {
+		renderSettings( { blocks: [ PAYWALL_BLOCK ] } );
+
+		expect( screen.getByText( 'Paywall active' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /edit the block/i } ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( /content below the paywall block is exclusive/i )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'leaves Everyone selectable when the post has no paywall block', () => {
+		renderSettings( { blocks: [ { name: 'core/paragraph', clientId: 'p-1' } ] } );
+
+		expect( screen.getByRole( 'radio', { name: 'Everyone' } ) ).not.toHaveAttribute(
+			'aria-disabled'
+		);
+		expect( screen.queryByText( 'Paywall active' ) ).not.toBeInTheDocument();
 	} );
 } );
 

--- a/projects/plugins/jetpack/extensions/shared/memberships/test/settings-test.jsx
+++ b/projects/plugins/jetpack/extensions/shared/memberships/test/settings-test.jsx
@@ -414,6 +414,41 @@ describe( 'NewsletterAccessRadioButtons', () => {
 			const everyone = screen.getByRole( 'radio', { name: 'Everyone' } );
 			expect( everyone ).toBeChecked();
 			expect( everyone ).not.toHaveAttribute( 'aria-disabled' );
+			expect( screen.queryByText( 'Paywall active' ) ).not.toBeInTheDocument();
+		} );
+
+		// The paywall block's own inspector opts out, because Gutenberg's block card
+		// directly above it already explains the paywall.
+		describe( 'when the caller opts out of the explanation', () => {
+			const renderOptedOut = () => renderPaywalled( { explainPaywallConstraint: false } );
+
+			test( 'hides the notice but keeps Everyone visible and disabled', () => {
+				renderOptedOut();
+
+				expect( screen.queryByText( 'Paywall active' ) ).not.toBeInTheDocument();
+				expect( screen.getByRole( 'radio', { name: 'Everyone' } ) ).toHaveAttribute(
+					'aria-disabled',
+					'true'
+				);
+			} );
+
+			// Gating the notice without gating aria-describedby would leave the option
+			// pointing at an id that is no longer rendered, which assistive tech reports as
+			// no description at all — worse than deliberately having none.
+			test( 'leaves no dangling description reference behind', () => {
+				renderOptedOut();
+
+				const everyone = screen.getByRole( 'radio', { name: 'Everyone' } );
+				expect( everyone ).not.toHaveAttribute( 'aria-describedby' );
+				expect( everyone ).toHaveAccessibleDescription( '' );
+			} );
+
+			test( 'still refuses to save the everybody level', async () => {
+				renderOptedOut();
+
+				await userEvent.click( screen.getByRole( 'radio', { name: 'Everyone' } ) );
+				expect( mockSetPostMeta ).not.toHaveBeenCalled();
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes NL-832

## Proposed changes

When a post contains a paywall block, the Audience panel used to drop **Everyone** from the radio group and render a Paywall card above it:

> The content below the paywall block is exclusive to the selected audience. **Edit the block.**

That button called `selectBlock()` but nothing switched the settings sidebar from the Document tab to the Block tab, so on desktop it looked inert. 

Rather than fix the link, this replaces the card with a new design discussed in p1787001127697179/1786626588.168549-slack-C03NLNTPZ2T

* **Everyone stays visible and disabled** when a paywall block is present, instead of disappearing. This is the treatment **Paid subscribers** already gets when paid subscriptions aren't set up — visible but not selectable, so the constraint is discoverable.
* **A notice above the radio group** says why it can't be chosen: *"Paywall active — Choose who can read the full post. Everyone can still read the content above the paywall."* It uses `@wordpress/ui`'s `Notice`, whose `Title` / `Description` slots are exactly this shape, and which is bundled here so it renders identically regardless of the site's WordPress version. (`@wordpress/components`' `Notice` is an external and resolves to whatever WP core ships — on WP 7.0 that is still the older left-bar style, not the design.) `icon={ null }` suppresses the intent icon to match the mockup — say the word if the default info icon is wanted instead.
* **The "Edit the block." link is gone**, along with the card it lived in.
* `accessOptions` carried a `panelHeading` field identical, character for character, to `label` on all three entries. It had one consumer — the pre-publish panel header — which now reads `label`. No translation churn: `label` carries the same strings, so this removes three duplicate `__()` call sites and no message ids.

The radio group is now built by hand rather than by `RadioControl`. A disabled **Everyone** has to sit between the legend and the remaining options, which `RadioControl` gives no way to reach — it has no per-option `disabled`. 

Before | After
---- | ----
<img width="262" height="263" alt="Screenshot 2026-08-19 at 2 08 54 PM" src="https://github.com/user-attachments/assets/d685af65-51f6-4c27-9fa2-da0ee8bb827b" /> | <img width="274" height="379" alt="Screenshot 2026-08-19 at 1 26 02 PM" src="https://github.com/user-attachments/assets/c2a8e395-8b2b-466a-97e9-b54a4fafa30a" />
<img width="267" height="262" alt="Screenshot 2026-08-19 at 2 08 59 PM" src="https://github.com/user-attachments/assets/7c192286-912a-4bc3-a6b7-bccf95ccacc7" /> | <img width="271" height="381" alt="Screenshot 2026-08-19 at 1 25 57 PM" src="https://github.com/user-attachments/assets/daa6d4b9-6c7e-43fb-98df-34936d0b6a58" />


## Related product discussion/links

* NL-832

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires a Jetpack-connected site (the paywall block renders a connect banner otherwise) with the `blocks` and `subscriptions` modules active.

1. Create a new post and open the **Audience** panel in the Post sidebar. Confirm **Everyone**, **Subscribers** and **Paid subscribers** all appear, with **Everyone** selected and selectable.
2. Add a **Paywall** block to the post (type `/paywall`).
3. Back on the **Post** tab, look at the **Audience** panel:
   * **Everyone** is still listed, greyed out and not selectable, and the selection has moved to **Subscribers**.
   * A notice above the group reads **Paywall active** / "Choose who can read the full post. Everyone can still read the content above the paywall."
   * The old Paywall card and its **Edit the block.** button are gone.
4. Click **Everyone** — nothing should happen, and the selection should stay on **Subscribers**.
5. Focus **Subscribers** and press <kbd>↑</kbd> — focus should stay on **Subscribers** rather than moving to, and selecting, **Everyone**. Then <kbd>Tab</kbd> to **Everyone** to confirm it's still reachable by keyboard.
6. Select the paywall block and open its Content access panel. Everyone is listed and disabled there too, but the notice is not repeated — the block card above already explains the paywall.
7. Click **Publish** to open the pre-publish panel. The same notice and disabled **Everyone** appear there, and the panel header still reads **Audience: Subscribers**.
8. Save, reload the editor, and confirm the panel comes back in the same state.
9. Delete the paywall block. **Everyone** becomes selectable again, the notice disappears, and the access level resets to **Everyone**.
