### PR TITLE
Forms: retire the jetpack_forms_alpha filter

### DIFF
--- a/projects/packages/forms/changelog/retire-forms-dashboard-gates
+++ b/projects/packages/forms/changelog/retire-forms-dashboard-gates
@@ -1,4 +1,4 @@
 Significance: minor
 Type: deprecated
 
-Dashboard: deprecate the jetpack_forms_alpha and jetpack_forms_dashboard_enable filters, which no longer select anything.
+Dashboard: deprecate the jetpack_forms_alpha filter, which no longer selects anything.

--- a/projects/packages/forms/changelog/retire-forms-dashboard-gates
+++ b/projects/packages/forms/changelog/retire-forms-dashboard-gates
@@ -1,4 +1,4 @@
 Significance: minor
-Type: removed
+Type: deprecated
 
-Dashboard: retire the jetpack_forms_alpha and jetpack_forms_dashboard_enable filters.
+Dashboard: deprecate the jetpack_forms_alpha and jetpack_forms_dashboard_enable filters, which no longer select anything.

--- a/projects/packages/forms/changelog/retire-forms-dashboard-gates
+++ b/projects/packages/forms/changelog/retire-forms-dashboard-gates
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Dashboard: retire the jetpack_forms_alpha and jetpack_forms_dashboard_enable filters.

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -51,10 +51,8 @@ class Jetpack_Forms {
 
 		Util::init();
 
-		if ( self::is_feedback_dashboard_enabled() ) {
-			$dashboard = new Dashboard();
-			$dashboard->init();
-		}
+		$dashboard = new Dashboard();
+		$dashboard->init();
 
 		if ( is_admin() && apply_filters_deprecated( 'tmp_grunion_allow_editor_view', array( true ), '0.30.5', '', 'This functionality will be removed in an upcoming version.' ) ) {
 			add_action( 'current_screen', '\Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks' );
@@ -87,23 +85,6 @@ class Jetpack_Forms {
 	 */
 	public static function assets_url() {
 		return plugin_dir_url( __DIR__ ) . 'assets';
-	}
-
-	/**
-	 * Returns true if the feedback dashboard is enabled.
-	 *
-	 * @return boolean
-	 */
-	public static function is_feedback_dashboard_enabled() {
-		/**
-		 * Enable the new Jetpack Forms dashboard.
-		 *
-		 * @module contact-form
-		 * @since 0.3.0
-		 *
-		 * @param bool false Should the new Jetpack Forms dashboard be enabled? Default to false.
-		 */
-		return apply_filters( 'jetpack_forms_dashboard_enable', true );
 	}
 
 	/**

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -88,6 +88,22 @@ class Jetpack_Forms {
 	}
 
 	/**
+	 * Returns true if the feedback dashboard is enabled.
+	 *
+	 * The `jetpack_forms_dashboard_enable` filter behind this was retired: there is one
+	 * dashboard and it is always enabled. Kept so existing callers keep working.
+	 *
+	 * @deprecated $$next-version$$ The dashboard is always enabled.
+	 *
+	 * @return boolean Always true.
+	 */
+	public static function is_feedback_dashboard_enabled() {
+		_deprecated_function( __METHOD__, 'jetpack-forms-$$next-version$$' );
+
+		return true;
+	}
+
+	/**
 	 * Returns true if the legacy menu item is retired.
 	 *
 	 * @return boolean

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -51,8 +51,10 @@ class Jetpack_Forms {
 
 		Util::init();
 
-		$dashboard = new Dashboard();
-		$dashboard->init();
+		if ( self::is_feedback_dashboard_enabled() ) {
+			$dashboard = new Dashboard();
+			$dashboard->init();
+		}
 
 		if ( is_admin() && apply_filters_deprecated( 'tmp_grunion_allow_editor_view', array( true ), '0.30.5', '', 'This functionality will be removed in an upcoming version.' ) ) {
 			add_action( 'current_screen', '\Automattic\Jetpack\Forms\ContactForm\Editor_View::add_hooks' );
@@ -90,17 +92,21 @@ class Jetpack_Forms {
 	/**
 	 * Returns true if the feedback dashboard is enabled.
 	 *
-	 * The `jetpack_forms_dashboard_enable` filter behind this was retired: there is one
-	 * dashboard and it is always enabled. Kept so existing callers keep working.
-	 *
-	 * @deprecated $$next-version$$ The dashboard is always enabled.
-	 *
-	 * @return boolean Always true.
+	 * @return boolean
 	 */
 	public static function is_feedback_dashboard_enabled() {
-		_deprecated_function( __METHOD__, 'jetpack-forms-$$next-version$$' );
-
-		return true;
+		/**
+		 * Enable the Jetpack Forms dashboard.
+		 *
+		 * Returning false hides the Forms admin menu entry and skips the dashboard
+		 * entirely. Unrelated to which dashboard renders — there is only one.
+		 *
+		 * @module contact-form
+		 * @since 0.3.0
+		 *
+		 * @param bool $enabled Should the Jetpack Forms dashboard be enabled? Default true.
+		 */
+		return apply_filters( 'jetpack_forms_dashboard_enable', true );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -1565,11 +1565,10 @@ class Contact_Form_Plugin {
 			return;
 		}
 		\Automattic\Jetpack\Menu_Badges\Menu_Badges::init(); // idempotent; wires the renderer.
-		$slug = apply_filters( 'jetpack_forms_alpha', true ) ? Dashboard::FORMS_WPBUILD_ADMIN_SLUG : Dashboard::ADMIN_SLUG;
 		\Automattic\Jetpack\Menu_Badges\Notification_Counts::register(
 			'jetpack-forms',
 			array(
-				'menu_slug' => $slug,
+				'menu_slug' => Dashboard::FORMS_WPBUILD_ADMIN_SLUG,
 				'count'     => self::get_unread_count(),
 				'type'      => 'count',
 			)

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -161,12 +161,9 @@ class Dashboard {
 			return;
 		}
 
-		_deprecated_hook(
-			'jetpack_forms_alpha',
-			'jetpack-forms-$$next-version$$',
-			'',
-			'The legacy Forms dashboard has been removed, so this filter no longer selects anything.'
-		);
+		// Kept on one line: replace-next-version-tag.sh only recognises the token in a
+		// single-line deprecation call, and errors the build out otherwise.
+		_deprecated_hook( 'jetpack_forms_alpha', 'jetpack-forms-$$next-version$$', '', 'The legacy Forms dashboard has been removed, so this filter no longer selects anything.' );
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -145,10 +145,19 @@ class Dashboard {
 	 * it, where apply_filters_deprecated() would return a `false` this code can no longer
 	 * act on. Guarded by has_filter() so sites that never used it stay silent.
 	 *
+	 * Admin-only, because this class is loaded on every request but the filter only ever
+	 * affected admin. Without the guard the notice lands in front-end, REST and cron
+	 * output on any site still carrying the filter.
+	 *
+	 * The has_filter() check runs at this class's load time, so a callback registered
+	 * later — on `init`, say — is not seen and no notice is emitted. That covers the
+	 * ordinary case: filters added at the top level of a plugin file, and the WordPress.com
+	 * writer on `plugins_loaded`. It is a missed warning, never a wrong one.
+	 *
 	 * @since $$next-version$$
 	 */
 	private static function announce_retired_filter() {
-		if ( ! has_filter( 'jetpack_forms_alpha' ) ) {
+		if ( ! is_admin() || ! has_filter( 'jetpack_forms_alpha' ) ) {
 			return;
 		}
 

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -129,105 +129,56 @@ class Dashboard {
 		add_action( 'admin_menu', array( $this, 'add_admin_submenu' ), self::MENU_PRIORITY );
 		add_action( 'admin_menu', array( __CLASS__, 'redirect_dashboard_url_cross_variant' ), 1 );
 
-		/**
-		 * Filter to enable or disable the wp-build-based Forms dashboard.
-		 *
-		 * Enabled by default since Central Forms Management is now available for all sites.
-		 * Can be disabled by returning false from this filter.
-		 *
-		 * @since 7.18.0
-		 *
-		 * @param bool $enabled Whether the wp-build dashboard is enabled. Default true.
-		 */
-		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', true );
-
-		if ( $is_wp_build_enabled ) {
-			self::load_wp_build();
-		}
+		self::announce_retired_filter();
+		self::load_wp_build();
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
-
-		// Removed all admin notices on the Jetpack Forms admin page.
-		if ( self::get_admin_query_page() === self::ADMIN_SLUG ) {
-			remove_all_actions( 'admin_notices' );
-		}
 	}
 
 	/**
-	 * Redirect dashboard URLs when the wp-build flag has changed since the link was generated.
+	 * Tell anyone still filtering `jetpack_forms_alpha` that it no longer does anything.
 	 *
-	 * Email links may point to the legacy or wp-build dashboard. If the flag has toggled,
-	 * the requested page may not exist. This redirects to the correct variant.
+	 * The filter gated the wp-build dashboard while it was in development. That dashboard
+	 * is now the only one, so a `false` return has nothing left to select and is ignored.
+	 *
+	 * Announced rather than applied: _deprecated_hook() reports the hook without honouring
+	 * it, where apply_filters_deprecated() would return a `false` this code can no longer
+	 * act on. Guarded by has_filter() so sites that never used it stay silent.
+	 *
+	 * @since $$next-version$$
+	 */
+	private static function announce_retired_filter() {
+		if ( ! has_filter( 'jetpack_forms_alpha' ) ) {
+			return;
+		}
+
+		_deprecated_hook(
+			'jetpack_forms_alpha',
+			'jetpack-forms-$$next-version$$',
+			'',
+			'The legacy Forms dashboard has been removed, so this filter no longer selects anything.'
+		);
+	}
+
+	/**
+	 * Send legacy dashboard URLs to the wp-build dashboard.
+	 *
+	 * Email and masterbar links generated before the legacy dashboard was retired still
+	 * point at its slug, which no longer registers a page. Translate them rather than
+	 * letting them 404.
 	 */
 	public static function redirect_dashboard_url_cross_variant() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
 
-		if ( $page !== self::ADMIN_SLUG && $page !== self::FORMS_WPBUILD_ADMIN_SLUG ) {
+		if ( $page !== self::ADMIN_SLUG ) {
 			return;
 		}
 
-		/** This filter is documented in class-dashboard.php::init */
-		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', true );
-
-		// Legacy URL requested but wp-build is now active → redirect to wp-build.
-		if ( $page === self::ADMIN_SLUG && $is_wp_build_enabled ) {
-			// The hash is never sent to the server. "inbox" used as default tab so we end up specifically in the responses
-			// route, where the client-side router will handle the redirect to the correct status in its beforeLoad hook.
-			$redirect = self::get_forms_admin_url( 'inbox' );
-			wp_safe_redirect( $redirect );
-			exit;
-		}
-
-		// WP-Build URL requested but legacy is now active → redirect to legacy.
-		if ( $page === self::FORMS_WPBUILD_ADMIN_SLUG && ! $is_wp_build_enabled ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$p                = isset( $_GET['p'] ) ? rawurldecode( sanitize_text_field( wp_unslash( $_GET['p'] ) ) ) : '';
-			$tab              = 'inbox';
-			$post_id          = null;
-			$has_mark_as_spam = false;
-
-			// Check if mark_as_spam is a separate query parameter (old email format).
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( isset( $_GET['mark_as_spam'] ) ) {
-				$has_mark_as_spam = true;
-			}
-
-			if ( $p !== '' ) {
-				// Parse path like /responses/inbox?responseIds=["2879"] or /responses/inbox?responseIds=["2879"]&mark_as_spam or /forms.
-				if ( preg_match( '#^/responses/(inbox|spam|trash)(?:\?responseIds=\["(\d+)"\])?(.*)$#', $p, $m ) ) {
-					$tab     = $m[1];
-					$post_id = ! empty( $m[2] ) ? absint( $m[2] ) : null;
-
-					// Check if mark_as_spam parameter is present inside the path.
-					if ( ! empty( $m[3] ) && strpos( $m[3], 'mark_as_spam' ) !== false ) {
-						$has_mark_as_spam = true;
-					}
-				} elseif ( preg_match( '#^/response/(\d+)(?:\?(.*))?$#', $p, $m ) ) {
-					// Standalone single response page (wp-build only) — the legacy
-					// dashboard shows the response in the inbox list instead. The path
-					// is matched whole so trailing junk isn't read as a response ID,
-					// but it may legitimately carry the email's mark_as_spam trigger.
-					$post_id = absint( $m[1] );
-
-					if ( ! empty( $m[2] ) && strpos( $m[2], 'mark_as_spam' ) !== false ) {
-						$has_mark_as_spam = true;
-					}
-				} elseif ( preg_match( '#^/forms#', $p ) ) {
-					$tab = 'forms';
-				}
-			}
-
-			$redirect = self::get_forms_admin_url( $tab, $post_id );
-
-			// Add mark_as_spam parameter if it was present in the original URL (either format).
-			if ( $has_mark_as_spam ) {
-				$redirect .= '&mark_as_spam';
-			}
-
-			wp_safe_redirect( $redirect );
-			exit;
-		}
+		// The hash is never sent to the server. "inbox" used as default tab so we end up specifically in the responses
+		// route, where the client-side router will handle the redirect to the correct status in its beforeLoad hook.
+		wp_safe_redirect( self::get_forms_admin_url( 'inbox' ) );
+		exit;
 	}
 
 	/**
@@ -363,78 +314,46 @@ class Dashboard {
 	}
 
 	/**
-	 * Whether the current request targets the wp-build (script-module) Forms dashboard,
-	 * as opposed to the legacy SPA dashboard.
-	 *
-	 * When true, the legacy dashboard bundle should not be enqueued: the wp-build page
-	 * (build/pages/jetpack-forms-responses/…) provides its own UI and asset loading.
+	 * Whether the current request targets the Forms dashboard page.
 	 *
 	 * @return bool
 	 */
 	public static function is_wp_build_dashboard_page() {
-		/** This filter is documented in class-dashboard.php::init */
-		return apply_filters( 'jetpack_forms_alpha', true )
-			&& self::get_admin_query_page() === self::FORMS_WPBUILD_ADMIN_SLUG;
+		return self::get_admin_query_page() === self::FORMS_WPBUILD_ADMIN_SLUG;
 	}
 
 	/**
 	 * Register the dashboard admin submenu Forms under Jetpack menu.
 	 */
 	public function add_admin_submenu() {
-
-		/** This filter is documented in class-dashboard.php::init */
-		if ( apply_filters( 'jetpack_forms_alpha', true ) ) {
-
-			// Report a missing build here rather than only on the page itself, so a partial
-			// deploy shows up on the first admin request instead of waiting for someone to
-			// open Forms. Keyed on the file and not on the generated callback: load_wp_build()
-			// only requires build.php on the Forms page, so the callback is legitimately
-			// absent on every other admin screen, which runs this method too.
-			if ( ! file_exists( self::wp_build_index_path() ) ) {
-				_doing_it_wrong(
-					__METHOD__,
-					'The Jetpack Forms build output is missing: build/build.php is absent, so the dashboard has nothing to render. The package build did not run for this deploy.',
-					''
-				);
-			}
-
-			// `jetpack_forms_jetpack_forms_responses_wp_admin_render_page` is the callback generated
-			// by the WP build script, named after the page slug. It only exists once `build/build.php`
-			// is loaded. Without it the page has nothing to render, so show an explanation rather
-			// than the legacy mount point, whose bundle load_admin_scripts() does not enqueue here.
-			$callback = function_exists( 'jetpack_forms_jetpack_forms_responses_wp_admin_render_page' )
-				? 'jetpack_forms_jetpack_forms_responses_wp_admin_render_page'
-				: array( $this, 'render_wp_build_unavailable' );
-
-			Admin_Menu::add_menu(
-				/** "Jetpack Forms" and "Forms" are product names, do not translate. */
-				'Jetpack Forms',
-				'Forms',
-				'edit_pages',
-				self::FORMS_WPBUILD_ADMIN_SLUG,
-				$callback
+		// Report a missing build here rather than only on the page itself, so a partial
+		// deploy shows up on the first admin request instead of waiting for someone to
+		// open Forms. Keyed on the file and not on the generated callback: load_wp_build()
+		// only requires build.php on the Forms page, so the callback is legitimately
+		// absent on every other admin screen, which runs this method too.
+		if ( ! file_exists( self::wp_build_index_path() ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				'The Jetpack Forms build output is missing: build/build.php is absent, so the dashboard has nothing to render. The package build did not run for this deploy.',
+				''
 			);
-
-			return;
 		}
 
+		// `jetpack_forms_jetpack_forms_responses_wp_admin_render_page` is the callback generated
+		// by the WP build script, named after the page slug. It only exists once `build/build.php`
+		// is loaded. Without it the page has nothing to render, so show an explanation.
+		$callback = function_exists( 'jetpack_forms_jetpack_forms_responses_wp_admin_render_page' )
+			? 'jetpack_forms_jetpack_forms_responses_wp_admin_render_page'
+			: array( $this, 'render_wp_build_unavailable' );
+
 		Admin_Menu::add_menu(
-			/** "Jetpack Forms" and "Forms" are Product names, do not translate. */
+			/** "Jetpack Forms" and "Forms" are product names, do not translate. */
 			'Jetpack Forms',
 			'Forms',
 			'edit_pages',
-			self::ADMIN_SLUG,
-			array( $this, 'render_dashboard' )
+			self::FORMS_WPBUILD_ADMIN_SLUG,
+			$callback
 		);
-	}
-
-	/**
-	 * Render the dashboard.
-	 */
-	public function render_dashboard() {
-		?>
-		<div id="jp-forms-dashboard"></div>
-		<?php
 	}
 
 	/**
@@ -606,24 +525,9 @@ class Dashboard {
 	 * @return string
 	 */
 	public static function get_forms_admin_url( $tab = null, $post_id = null ) {
-		/** This filter is documented in class-dashboard.php::init */
-		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', true );
-		$url                 = admin_url( 'admin.php' );
-
-		$url .= $is_wp_build_enabled
-			? '?page=' . self::FORMS_WPBUILD_ADMIN_SLUG
-			: '?page=' . self::ADMIN_SLUG;
-
-		if ( $is_wp_build_enabled ) {
-			$path = self::get_forms_admin_path_wp_build( $tab, $post_id );
-			$url .= '&p=' . rawurlencode( $path );
-		} else {
-			$suffix = self::get_forms_admin_suffix_legacy( $tab, $post_id );
-
-			if ( $suffix !== '' ) {
-				$url .= $suffix;
-			}
-		}
+		$url  = admin_url( 'admin.php' );
+		$url .= '?page=' . self::FORMS_WPBUILD_ADMIN_SLUG;
+		$url .= '&p=' . rawurlencode( self::get_forms_admin_path_wp_build( $tab, $post_id ) );
 
 		/**
 		 * Filters the Forms admin page URL.
@@ -696,33 +600,6 @@ class Dashboard {
 		}
 
 		return '/responses/inbox';
-	}
-
-	/**
-	 * Legacy (hash-based) URL suffix for the forms admin page.
-	 *
-	 * @param string|null $tab    Tab to open.
-	 * @param int|null    $post_id Post ID of response.
-	 * @return string URL suffix (e.g. '#/responses?status=inbox&r=123', or '#/forms').
-	 */
-	private static function get_forms_admin_suffix_legacy( $tab, $post_id ) {
-		$post_id    = ! empty( $post_id ) ? absint( $post_id ) : null;
-		$valid_tabs = array( 'spam', 'inbox', 'trash' );
-		$r_param    = ! empty( $post_id ) ? '&r=' . $post_id : '';
-
-		if ( in_array( $tab, $valid_tabs, true ) ) {
-			return '#/responses?status=' . $tab . $r_param;
-		}
-
-		if ( $tab === 'forms' ) {
-			return '#/forms';
-		}
-
-		if ( ! empty( $post_id ) ) {
-			return '#/responses?status=inbox' . $r_param;
-		}
-
-		return '';
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -141,7 +141,7 @@ class Dashboard {
 	 * The filter gated the wp-build dashboard while it was in development. That dashboard
 	 * is now the only one, so a `false` return has nothing left to select and is ignored.
 	 *
-	 * Announced rather than applied: _deprecated_hook() reports the hook without honouring
+	 * Announced rather than applied: _deprecated_hook() reports the hook without honoring
 	 * it, where apply_filters_deprecated() would return a `false` this code can no longer
 	 * act on. Guarded by has_filter() so sites that never used it stay silent.
 	 *
@@ -162,7 +162,7 @@ class Dashboard {
 			return;
 		}
 
-		// Kept on one line: replace-next-version-tag.sh only recognises the token in a
+		// Kept on one line: replace-next-version-tag.sh only recognizes the token in a
 		// single-line deprecation call, and errors the build out otherwise.
 		_deprecated_hook( 'jetpack_forms_alpha', 'jetpack-forms-$$next-version$$', '', 'The legacy Forms dashboard has been removed, so this filter no longer selects anything.' );
 	}
@@ -170,9 +170,8 @@ class Dashboard {
 	/**
 	 * Send legacy dashboard URLs to the wp-build dashboard.
 	 *
-	 * Email and masterbar links generated before the legacy dashboard was retired still
-	 * point at its slug, which no longer registers a page. Translate them rather than
-	 * letting them 404.
+	 * Load-bearing, not a courtesy for stale links: Creative Mail's JITMs and post-install
+	 * redirect, and My Jetpack's fallback URL, still emit the legacy slug today. Keep it.
 	 */
 	public static function redirect_dashboard_url_cross_variant() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -128,8 +128,8 @@ class Dashboard {
 	public function init() {
 		add_action( 'admin_menu', array( $this, 'add_admin_submenu' ), self::MENU_PRIORITY );
 		add_action( 'admin_menu', array( __CLASS__, 'redirect_dashboard_url_cross_variant' ), 1 );
+		add_action( 'admin_notices', array( __CLASS__, 'announce_retired_filter' ) );
 
-		self::announce_retired_filter();
 		self::load_wp_build();
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
@@ -145,19 +145,20 @@ class Dashboard {
 	 * it, where apply_filters_deprecated() would return a `false` this code can no longer
 	 * act on. Guarded by has_filter() so sites that never used it stay silent.
 	 *
-	 * Admin-only, because this class is loaded on every request but the filter only ever
-	 * affected admin. Without the guard the notice lands in front-end, REST and cron
-	 * output on any site still carrying the filter.
+	 * Hooked to `admin_notices` rather than called from init(). This class loads at
+	 * `after_setup_theme` priority -2, so with WP_DEBUG display on the notice would print
+	 * — and send headers — before load_wp_build() and redirect_dashboard_url_cross_variant()
+	 * get to redirect, leaving both on "headers already sent" and a blank page.
 	 *
-	 * The has_filter() check runs at this class's load time, so a callback registered
-	 * later — on `init`, say — is not seen and no notice is emitted. That covers the
-	 * ordinary case: filters added at the top level of a plugin file, and the WordPress.com
-	 * writer on `plugins_loaded`. It is a missed warning, never a wrong one.
+	 * That hook also fires only while an admin screen renders, so the notice stays out of
+	 * admin-ajax and admin-post responses, which `is_admin()` would have let through. And
+	 * it runs late enough that has_filter() sees callbacks registered on `init`, not just
+	 * those added at file scope.
 	 *
 	 * @since $$next-version$$
 	 */
-	private static function announce_retired_filter() {
-		if ( ! is_admin() || ! has_filter( 'jetpack_forms_alpha' ) ) {
+	public static function announce_retired_filter() {
+		if ( ! has_filter( 'jetpack_forms_alpha' ) ) {
 			return;
 		}
 
@@ -628,10 +629,9 @@ class Dashboard {
 	 * Legacy (hash-based) URL suffix for the forms admin page.
 	 *
 	 * Unused since the legacy dashboard was retired: get_forms_admin_url() always builds
-	 * the wp-build URL now. Kept rather than deleted, and still private, so nothing
-	 * outside this class ever depended on it.
-	 *
-	 * @deprecated $$next-version$$ The legacy dashboard was retired.
+	 * the wp-build URL now. Private, so nothing outside this class ever called it, which
+	 * is why it carries no deprecation notice — there is no audience for one. Goes with
+	 * the rest of the legacy tree.
 	 *
 	 * @param string|null $tab    Tab to open.
 	 * @param int|null    $post_id Post ID of response.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -357,6 +357,22 @@ class Dashboard {
 	}
 
 	/**
+	 * Render the legacy dashboard mount point.
+	 *
+	 * Nothing registers this any more — the legacy dashboard was retired and its bundle
+	 * is no longer enqueued, so the container it prints stays empty. Kept, and left
+	 * printing the same markup, so any caller outside this package behaves as before.
+	 *
+	 * @deprecated $$next-version$$ The legacy dashboard was retired.
+	 */
+	public function render_dashboard() {
+		_deprecated_function( __METHOD__, 'jetpack-forms-$$next-version$$' );
+		?>
+		<div id="jp-forms-dashboard"></div>
+		<?php
+	}
+
+	/**
 	 * Render an error notice when the wp-build dashboard cannot render.
 	 *
 	 * The wp-build dashboard renders through a callback generated into `build/build.php`.
@@ -600,6 +616,39 @@ class Dashboard {
 		}
 
 		return '/responses/inbox';
+	}
+
+	/**
+	 * Legacy (hash-based) URL suffix for the forms admin page.
+	 *
+	 * Unused since the legacy dashboard was retired: get_forms_admin_url() always builds
+	 * the wp-build URL now. Kept rather than deleted, and still private, so nothing
+	 * outside this class ever depended on it.
+	 *
+	 * @deprecated $$next-version$$ The legacy dashboard was retired.
+	 *
+	 * @param string|null $tab    Tab to open.
+	 * @param int|null    $post_id Post ID of response.
+	 * @return string URL suffix (e.g. '#/responses?status=inbox&r=123', or '#/forms').
+	 */
+	private static function get_forms_admin_suffix_legacy( $tab, $post_id ) {
+		$post_id    = ! empty( $post_id ) ? absint( $post_id ) : null;
+		$valid_tabs = array( 'spam', 'inbox', 'trash' );
+		$r_param    = ! empty( $post_id ) ? '&r=' . $post_id : '';
+
+		if ( in_array( $tab, $valid_tabs, true ) ) {
+			return '#/responses?status=' . $tab . $r_param;
+		}
+
+		if ( $tab === 'forms' ) {
+			return '#/forms';
+		}
+
+		if ( ! empty( $post_id ) ) {
+			return '#/responses?status=inbox' . $r_param;
+		}
+
+		return '';
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -9,20 +9,15 @@ export const getPath = item => {
 };
 
 /**
- * The Forms wp-admin submenu badge can be registered under either of two
- * slugs, depending on the `jetpack_forms_alpha` filter: the wp-build slug
- * (`jetpack-forms-responses-wp-admin`), or the legacy slug
- * (`jetpack-forms-admin`, i.e. `Dashboard::ADMIN_SLUG`) when the filter
- * returns false. This selector matches whichever one is actually rendered so
- * callers don't have to hardcode (and potentially mismatch) the active slug.
+ * The Forms wp-admin submenu badge is registered under the Forms dashboard
+ * slug. Matched by attribute rather than assumed, so a slug change surfaces as
+ * a missing badge rather than a silent mismatch.
  */
-const FORMS_MENU_BADGE_SELECTOR =
-	'[data-jp-menu-badge="jetpack-forms-responses-wp-admin"],[data-jp-menu-badge="jetpack-forms-admin"]';
+const FORMS_MENU_BADGE_SELECTOR = '[data-jp-menu-badge="jetpack-forms-responses-wp-admin"]';
 
 /**
  * Fallback slug to use when no Forms menu badge is present in the DOM
  * (e.g. the count is already 0, or the badge simply hasn't rendered yet).
- * This matches the default wp-build slug.
  */
 const DEFAULT_FORMS_MENU_BADGE_SLUG = 'jetpack-forms-responses-wp-admin';
 
@@ -44,10 +39,9 @@ export const getMenuBadgeCount = () => {
 /**
  * Resolve the slug the Forms wp-admin submenu badge is currently registered
  * under, by reading it off the rendered `data-jp-menu-badge` attribute rather
- * than assuming a fixed slug. This is needed because the active slug depends
- * on the `jetpack_forms_alpha` filter (see `FORMS_MENU_BADGE_SELECTOR`
- * above), and using the wrong slug means `window.jetpackMenuBadges.setCount()`
- * silently no-ops against a badge element that doesn't exist.
+ * than assuming a fixed slug. Using the wrong slug means
+ * `window.jetpackMenuBadges.setCount()` silently no-ops against a badge
+ * element that doesn't exist.
  *
  * @return {string} The active Forms menu badge slug, or the default wp-build slug if no badge is rendered.
  */

--- a/projects/packages/forms/src/dashboard/inbox/utils.js
+++ b/projects/packages/forms/src/dashboard/inbox/utils.js
@@ -9,9 +9,9 @@ export const getPath = item => {
 };
 
 /**
- * The Forms wp-admin submenu badge is registered under the Forms dashboard
- * slug. Matched by attribute rather than assumed, so a slug change surfaces as
- * a missing badge rather than a silent mismatch.
+ * The Forms wp-admin submenu badge slug, duplicated from PHP
+ * `Dashboard::FORMS_WPBUILD_ADMIN_SLUG`. Keep the two in step: see
+ * getFormsMenuBadgeSlug() below for what drift costs.
  */
 const FORMS_MENU_BADGE_SELECTOR = '[data-jp-menu-badge="jetpack-forms-responses-wp-admin"]';
 
@@ -37,13 +37,14 @@ export const getMenuBadgeCount = () => {
 };
 
 /**
- * Resolve the slug the Forms wp-admin submenu badge is currently registered
- * under, by reading it off the rendered `data-jp-menu-badge` attribute rather
- * than assuming a fixed slug. Using the wrong slug means
- * `window.jetpackMenuBadges.setCount()` silently no-ops against a badge
- * element that doesn't exist.
+ * Resolve the Forms wp-admin submenu badge slug off the rendered
+ * `data-jp-menu-badge` attribute.
  *
- * @return {string} The active Forms menu badge slug, or the default wp-build slug if no badge is rendered.
+ * Constant in practice: selector and fallback are the same literal, so if the PHP slug
+ * changed this returns the stale one and `setCount()` no-ops against nothing. Reading the
+ * attribute does not catch that -- only keeping the literal in step with PHP does.
+ *
+ * @return {string} The Forms menu badge slug.
  */
 export const getFormsMenuBadgeSlug = () => {
 	const badge = document.querySelector( FORMS_MENU_BADGE_SELECTOR );

--- a/projects/packages/forms/tests/js/dashboard/inbox/menu-counter-updates.test.js
+++ b/projects/packages/forms/tests/js/dashboard/inbox/menu-counter-updates.test.js
@@ -8,7 +8,6 @@ import { describe, expect, it, beforeEach } from '@jest/globals';
 import { getFormsMenuBadgeSlug, getMenuBadgeCount } from '../../../../src/dashboard/inbox/utils';
 
 const FORMS_MENU_BADGE_SLUG = 'jetpack-forms-responses-wp-admin';
-const FORMS_LEGACY_MENU_BADGE_SLUG = 'jetpack-forms-admin';
 
 describe( 'getMenuBadgeCount', () => {
 	beforeEach( () => {
@@ -19,12 +18,6 @@ describe( 'getMenuBadgeCount', () => {
 		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }" data-jp-menu-count="5"></span>`;
 
 		expect( getMenuBadgeCount() ).toBe( 5 );
-	} );
-
-	it( 'reads the count when the legacy (jetpack_forms_alpha=false) badge slug is rendered instead', () => {
-		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_LEGACY_MENU_BADGE_SLUG }" data-jp-menu-count="7"></span>`;
-
-		expect( getMenuBadgeCount() ).toBe( 7 );
 	} );
 
 	it( 'returns 0 when the badge is not rendered (e.g. count is already 0)', () => {
@@ -54,12 +47,6 @@ describe( 'getFormsMenuBadgeSlug', () => {
 		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_MENU_BADGE_SLUG }" data-jp-menu-count="5"></span>`;
 
 		expect( getFormsMenuBadgeSlug() ).toBe( FORMS_MENU_BADGE_SLUG );
-	} );
-
-	it( 'returns the legacy slug when jetpack_forms_alpha=false renders that badge instead', () => {
-		document.body.innerHTML = `<span data-jp-menu-badge="${ FORMS_LEGACY_MENU_BADGE_SLUG }" data-jp-menu-count="7"></span>`;
-
-		expect( getFormsMenuBadgeSlug() ).toBe( FORMS_LEGACY_MENU_BADGE_SLUG );
 	} );
 
 	it( 'falls back to the wp-build slug when no badge is rendered', () => {

--- a/projects/packages/forms/tests/php/Jetpack_Forms_Test.php
+++ b/projects/packages/forms/tests/php/Jetpack_Forms_Test.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Tests for the Jetpack_Forms entry point.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms;
+
+use Automattic\Jetpack\Forms\Dashboard\Dashboard;
+use WorDBless\BaseTestCase;
+
+/**
+ * Covers what load_contact_form() decides to wire up.
+ */
+class Jetpack_Forms_Test extends BaseTestCase {
+
+	/**
+	 * The dashboard registers on admin_menu, so ask that hook whether it is there.
+	 *
+	 * Dashboard::init() is the only thing the `jetpack_forms_dashboard_enable` gate
+	 * controls; the menu entry, the redirects and the script enqueue all hang off it.
+	 *
+	 * @return bool
+	 */
+	private function dashboard_is_wired() {
+		global $wp_filter;
+
+		if ( empty( $wp_filter['admin_menu'] ) ) {
+			return false;
+		}
+
+		foreach ( $wp_filter['admin_menu']->callbacks as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				if ( ! is_array( $callback['function'] ) ) {
+					continue;
+				}
+
+				$target = $callback['function'][0];
+
+				if ( $target instanceof Dashboard || $target === Dashboard::class ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * The control half. Without it a broken assertion in the sibling test below would
+	 * pass for the wrong reason — "no dashboard on admin_menu" is also what a test that
+	 * never wired anything reports.
+	 */
+	public function test_dashboard_is_wired_by_default() {
+		Jetpack_Forms::load_contact_form();
+
+		$this->assertTrue( $this->dashboard_is_wired() );
+	}
+
+	/**
+	 * `jetpack_forms_dashboard_enable` gates whether the dashboard is registered at all,
+	 * which is why it survives the retirement of `jetpack_forms_alpha`. That is only
+	 * worth keeping if it still works.
+	 */
+	public function test_dashboard_gate_returning_false_wires_nothing() {
+		add_filter( 'jetpack_forms_dashboard_enable', '__return_false' );
+
+		Jetpack_Forms::load_contact_form();
+
+		$this->assertFalse( $this->dashboard_is_wired() );
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -1423,7 +1423,6 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$post  = $this->post_global_backup;
 		$_POST = $this->post_superglobal_backup;
 		Notification_Counts::reset();
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
 		delete_option( 'jetpack_feedback_unread_count' );
 		wp_set_current_user( 0 );
 		parent::tearDown();
@@ -1448,8 +1447,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 	/**
 	 * Unread_count() should register the unread count with the central
-	 * menu-badges registry, under the Forms wp-build dashboard slug (the
-	 * default, since jetpack_forms_alpha defaults to true).
+	 * menu-badges registry, under the Forms dashboard slug.
 	 */
 	public function test_unread_count_registers_with_menu_badges() {
 		$this->create_admin_user();
@@ -1458,21 +1456,6 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		Contact_Form_Plugin::init()->unread_count();
 
 		$this->assertSame( 3, Notification_Counts::get_for_menu( Dashboard::FORMS_WPBUILD_ADMIN_SLUG ) );
-	}
-
-	/**
-	 * Unread_count() should register against the legacy ADMIN_SLUG instead when
-	 * the jetpack_forms_alpha filter is disabled.
-	 */
-	public function test_unread_count_registers_legacy_slug_when_alpha_disabled() {
-		$this->create_admin_user();
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-		update_option( 'jetpack_feedback_unread_count', 4 );
-
-		Contact_Form_Plugin::init()->unread_count();
-
-		$this->assertSame( 4, Notification_Counts::get_for_menu( Dashboard::ADMIN_SLUG ) );
-		$this->assertSame( 0, Notification_Counts::get_for_menu( Dashboard::FORMS_WPBUILD_ADMIN_SLUG ) );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
@@ -695,7 +695,6 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 	 * confirmation, so pin it here.
 	 */
 	public function test_build_email_content_action_urls_target_single_response_page() {
-		add_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		$post_id = Utility::create_legacy_feedback(
 			array(
@@ -720,8 +719,6 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 		);
 
 		$result = Feedback_Email_Renderer::build_email_content( $post_id, $form, $response, $context_data );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		// "View in dashboard" points at the standalone single response page — and
 		// must NOT carry the trigger. Matched to the closing quote, because the view
@@ -759,7 +756,6 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 	 * already-spam response, leaving the trigger armed in the URL.
 	 */
 	public function test_build_email_content_omits_mark_as_spam_for_spam_submission() {
-		add_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		$post_id = Utility::create_legacy_feedback(
 			array(
@@ -784,8 +780,6 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 		);
 
 		$result = Feedback_Email_Renderer::build_email_content( $post_id, $form, $response, $context_data );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		$this->assertStringNotContainsString(
 			'mark_as_spam',
@@ -821,7 +815,6 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 	 * would leave the button pointing at a page with nothing to confirm.
 	 */
 	public function test_build_email_content_omits_mark_as_spam_for_trashed_submission() {
-		add_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		$post_id = Utility::create_legacy_feedback(
 			array(
@@ -846,8 +839,6 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 		);
 
 		$result = Feedback_Email_Renderer::build_email_content( $post_id, $form, $response, $context_data );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		$this->assertStringNotContainsString( 'mark_as_spam', $result['message'] );
 		$this->assertStringNotContainsString( 'href=""', $result['message'] );

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
@@ -695,7 +695,6 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 	 * confirmation, so pin it here.
 	 */
 	public function test_build_email_content_action_urls_target_single_response_page() {
-
 		$post_id = Utility::create_legacy_feedback(
 			array(
 				'Name'  => 'Test User',
@@ -756,7 +755,6 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 	 * already-spam response, leaving the trigger armed in the URL.
 	 */
 	public function test_build_email_content_omits_mark_as_spam_for_spam_submission() {
-
 		$post_id = Utility::create_legacy_feedback(
 			array(
 				'Name'  => 'Test User',
@@ -815,7 +813,6 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 	 * would leave the button pointing at a page with nothing to confirm.
 	 */
 	public function test_build_email_content_omits_mark_as_spam_for_trashed_submission() {
-
 		$post_id = Utility::create_legacy_feedback(
 			array(
 				'Name'  => 'Test User',

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -42,6 +42,12 @@ class Dashboard_Test extends BaseTestCase {
 	public function tear_down() {
 		$this->reset_wp_build_polyfills();
 		unset( $_GET['page'], $_GET['p'] );
+
+		// Tests that call set_current_screen() would otherwise leave it set for whatever
+		// runs next, which decides is_admin() and is_jetpack_forms_admin_page().
+		global $current_screen;
+		$current_screen = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test teardown.
+
 		parent::tear_down();
 	}
 

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -30,6 +30,13 @@ class Dashboard_Test extends BaseTestCase {
 	private $doing_it_wrong = array();
 
 	/**
+	 * Hook names captured from _deprecated_hook() during a test.
+	 *
+	 * @var string[]
+	 */
+	private $deprecations = array();
+
+	/**
 	 * The Dashboard instance the submenu was registered from.
 	 *
 	 * @var Dashboard|null
@@ -56,7 +63,6 @@ class Dashboard_Test extends BaseTestCase {
 	 * Verifies the responseIds query parameter is correctly encoded in the path.
 	 */
 	public function test_get_forms_admin_url_with_post_id_wp_build() {
-
 		// Tab + post_id: path includes responseIds in the path.
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox?responseIds=["123"]' );
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'inbox', 123 ) );
@@ -73,7 +79,6 @@ class Dashboard_Test extends BaseTestCase {
 	 * Test get_single_response_admin_url points at the standalone response page (wp-build mode).
 	 */
 	public function test_get_single_response_admin_url_wp_build() {
-
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/response/123' );
 		$this->assertEquals( $expected, Dashboard::get_single_response_admin_url( 123 ) );
 
@@ -126,7 +131,6 @@ class Dashboard_Test extends BaseTestCase {
 	 * Test get_forms_admin_url with tab for wp-build dashboard
 	 */
 	public function test_get_forms_admin_url_wp_build_with_tab() {
-
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox' );
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'inbox' ) );
 
@@ -257,64 +261,58 @@ class Dashboard_Test extends BaseTestCase {
 	 * `jetpack_forms_alpha` no longer selects anything, so anyone still filtering it
 	 * is told rather than left wondering why their filter stopped working.
 	 */
-	public function test_init_announces_the_retired_filter() {
-		$announced = array();
-		add_filter( 'deprecated_hook_trigger_error', '__return_false' );
-		add_action(
-			'deprecated_hook_run',
-			function ( $hook ) use ( &$announced ) {
-				$announced[] = $hook;
-			}
-		);
+	public function test_announces_the_retired_filter() {
+		$this->capture_deprecations();
 
-		set_current_screen( 'dashboard' );
 		add_filter( 'jetpack_forms_alpha', '__return_false' );
 		( new Dashboard() )->init();
+		do_action( 'admin_notices' );
 		remove_filter( 'jetpack_forms_alpha', '__return_false' );
 
-		$this->assertContains( 'jetpack_forms_alpha', $announced );
-	}
-
-	/**
-	 * The filter only ever affected wp-admin, and this class loads on every request.
-	 * Announcing outside admin would drop the notice into front-end, REST and cron
-	 * output on any site still carrying the filter.
-	 */
-	public function test_init_does_not_announce_outside_admin() {
-		$announced = array();
-		add_filter( 'deprecated_hook_trigger_error', '__return_false' );
-		add_action(
-			'deprecated_hook_run',
-			function ( $hook ) use ( &$announced ) {
-				$announced[] = $hook;
-			}
-		);
-
-		set_current_screen( 'front' );
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-		( new Dashboard() )->init();
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		$this->assertNotContains( 'jetpack_forms_alpha', $announced );
+		$this->assertContains( 'jetpack_forms_alpha', $this->deprecations );
 	}
 
 	/**
 	 * ...and stays quiet for the overwhelming majority who never used it.
 	 */
-	public function test_init_is_silent_without_the_retired_filter() {
-		$announced = array();
+	public function test_is_silent_without_the_retired_filter() {
+		$this->capture_deprecations();
+
+		( new Dashboard() )->init();
+		do_action( 'admin_notices' );
+
+		$this->assertNotContains( 'jetpack_forms_alpha', $this->deprecations );
+	}
+
+	/**
+	 * Nothing may be emitted while init() runs. This class loads at after_setup_theme
+	 * priority -2, and printing there sends headers before load_wp_build() and
+	 * redirect_dashboard_url_cross_variant() can redirect — both would then die on
+	 * "headers already sent". Waiting for admin_notices also keeps the notice out of
+	 * admin-ajax and admin-post responses.
+	 */
+	public function test_does_not_announce_before_admin_notices() {
+		$this->capture_deprecations();
+
+		add_filter( 'jetpack_forms_alpha', '__return_false' );
+		( new Dashboard() )->init();
+		remove_filter( 'jetpack_forms_alpha', '__return_false' );
+
+		$this->assertNotContains( 'jetpack_forms_alpha', $this->deprecations );
+	}
+
+	/**
+	 * Record deprecated-hook reports instead of letting them raise.
+	 */
+	private function capture_deprecations() {
+		$this->deprecations = array();
 		add_filter( 'deprecated_hook_trigger_error', '__return_false' );
 		add_action(
 			'deprecated_hook_run',
-			function ( $hook ) use ( &$announced ) {
-				$announced[] = $hook;
+			function ( $hook ) {
+				$this->deprecations[] = $hook;
 			}
 		);
-
-		set_current_screen( 'dashboard' );
-		( new Dashboard() )->init();
-
-		$this->assertNotContains( 'jetpack_forms_alpha', $announced );
 	}
 
 	/**
@@ -363,7 +361,6 @@ class Dashboard_Test extends BaseTestCase {
 	 * Test get_forms_admin_url with screen ID equivalents for wp-build dashboard
 	 */
 	public function test_get_forms_admin_url_wp_build_with_screen_id_equivalents() {
-
 		$url_form = Dashboard::get_forms_admin_url( 'forms' );
 		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG, $url_form );
 		$this->assertStringContainsString( '&p=%2Fforms', $url_form );

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -261,11 +261,35 @@ class Dashboard_Test extends BaseTestCase {
 			}
 		);
 
+		set_current_screen( 'dashboard' );
 		add_filter( 'jetpack_forms_alpha', '__return_false' );
 		( new Dashboard() )->init();
 		remove_filter( 'jetpack_forms_alpha', '__return_false' );
 
 		$this->assertContains( 'jetpack_forms_alpha', $announced );
+	}
+
+	/**
+	 * The filter only ever affected wp-admin, and this class loads on every request.
+	 * Announcing outside admin would drop the notice into front-end, REST and cron
+	 * output on any site still carrying the filter.
+	 */
+	public function test_init_does_not_announce_outside_admin() {
+		$announced = array();
+		add_filter( 'deprecated_hook_trigger_error', '__return_false' );
+		add_action(
+			'deprecated_hook_run',
+			function ( $hook ) use ( &$announced ) {
+				$announced[] = $hook;
+			}
+		);
+
+		set_current_screen( 'front' );
+		add_filter( 'jetpack_forms_alpha', '__return_false' );
+		( new Dashboard() )->init();
+		remove_filter( 'jetpack_forms_alpha', '__return_false' );
+
+		$this->assertNotContains( 'jetpack_forms_alpha', $announced );
 	}
 
 	/**
@@ -281,6 +305,7 @@ class Dashboard_Test extends BaseTestCase {
 			}
 		);
 
+		set_current_screen( 'dashboard' );
 		( new Dashboard() )->init();
 
 		$this->assertNotContains( 'jetpack_forms_alpha', $announced );

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -46,80 +46,10 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test get_forms_admin_url without tab parameter (legacy dashboard)
-	 */
-	public function test_get_forms_admin_url_without_tab() {
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin';
-		$this->assertEquals( $expected, Dashboard::get_forms_admin_url() );
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
-	}
-
-	/**
-	 * Test get_forms_admin_url with valid tab parameter (legacy dashboard)
-	 */
-	public function test_get_forms_admin_url_with_valid_tab() {
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox';
-		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'inbox' ) );
-
-		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=spam';
-		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'spam' ) );
-
-		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=trash';
-		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'trash' ) );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
-	}
-
-	/**
-	 * Test get_forms_admin_url with invalid tab parameter (legacy dashboard)
-	 */
-	public function test_get_forms_admin_url_with_invalid_tab() {
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin';
-		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'invalid' ) );
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
-	}
-
-	/**
-	 * Test get_forms_admin_url with forms tab parameter (legacy dashboard)
-	 */
-	public function test_get_forms_admin_url_with_forms_tab() {
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/forms';
-		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'forms' ) );
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
-	}
-
-	/**
-	 * Test get_forms_admin_url with post_id parameter (legacy mode).
-	 * Verifies the r parameter is correctly appended in the hash fragment.
-	 */
-	public function test_get_forms_admin_url_with_post_id_legacy() {
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		// Tab + post_id: appends r and status in hash fragment (client-side handles redirect).
-		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox&r=123';
-		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'inbox', 123 ) );
-
-		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=spam&r=456';
-		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'spam', 456 ) );
-
-		// post_id only (no tab): appends r and status=inbox in hash fragment.
-		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox&r=789';
-		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( null, 789 ) );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
-	}
-
-	/**
 	 * Test get_forms_admin_url with post_id parameter (wp-build mode).
 	 * Verifies the responseIds query parameter is correctly encoded in the path.
 	 */
 	public function test_get_forms_admin_url_with_post_id_wp_build() {
-		add_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		// Tab + post_id: path includes responseIds in the path.
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox?responseIds=["123"]' );
@@ -131,15 +61,12 @@ class Dashboard_Test extends BaseTestCase {
 		// post_id only (no tab): defaults to /responses/inbox with responseIds.
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox?responseIds=["789"]' );
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( null, 789 ) );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 	}
 
 	/**
 	 * Test get_single_response_admin_url points at the standalone response page (wp-build mode).
 	 */
 	public function test_get_single_response_admin_url_wp_build() {
-		add_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/response/123' );
 		$this->assertEquals( $expected, Dashboard::get_single_response_admin_url( 123 ) );
@@ -147,21 +74,6 @@ class Dashboard_Test extends BaseTestCase {
 		// Without a post ID there is no single response to open — fall back to the list.
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox' );
 		$this->assertEquals( $expected, Dashboard::get_single_response_admin_url() );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_true' );
-	}
-
-	/**
-	 * Test get_single_response_admin_url falls back to the responses list on the legacy dashboard,
-	 * which has no standalone single response route.
-	 */
-	public function test_get_single_response_admin_url_legacy() {
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox&r=123';
-		$this->assertEquals( $expected, Dashboard::get_single_response_admin_url( 123 ) );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
 	}
 
 	/**
@@ -197,87 +109,17 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A wp-build single response link must survive jetpack_forms_alpha being turned off.
-	 *
-	 * This is the branch nobody exercises by hand: it only runs against links already
-	 * sitting in people's inboxes after the flag is flipped.
-	 */
-	public function test_redirect_cross_variant_maps_single_response_path_to_legacy() {
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
-		$_GET['p']    = '/response/123';
-
-		$redirect = $this->capture_cross_variant_redirect();
-
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		// The legacy dashboard has no single response route, so the response is
-		// opened in the inbox list instead — and the `/response/` pattern must not be
-		// shadowed by the `/responses/(inbox|spam|trash)` one above it.
-		$this->assertEquals(
-			get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox&r=123',
-			$redirect
-		);
-	}
-
-	/**
-	 * The email's Mark as spam trigger survives the cross-variant redirect.
-	 *
-	 * Losing it here would silently turn the email's Mark as spam button into a
-	 * plain "view" link on the legacy dashboard.
-	 */
-	public function test_redirect_cross_variant_keeps_mark_as_spam_on_single_response_path() {
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
-		$_GET['p']    = '/response/123?mark_as_spam=1';
-
-		$redirect = $this->capture_cross_variant_redirect();
-
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		$this->assertEquals(
-			get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox&r=123&mark_as_spam',
-			$redirect
-		);
-	}
-
-	/**
-	 * The single response path is matched whole — trailing junk is not a response ID.
-	 */
-	public function test_redirect_cross_variant_ignores_malformed_single_response_path() {
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
-		$_GET['p']    = '/response/123junk';
-
-		$redirect = $this->capture_cross_variant_redirect();
-
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		// Falls through to the plain inbox with no response selected.
-		$this->assertEquals(
-			get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox',
-			$redirect
-		);
-	}
-
-	/**
 	 * Test get_forms_admin_url without tab for wp-build dashboard
 	 */
 	public function test_get_forms_admin_url_wp_build_without_tab() {
-		add_filter( 'jetpack_forms_alpha', '__return_true' );
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox' );
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url() );
-		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 	}
 
 	/**
 	 * Test get_forms_admin_url with tab for wp-build dashboard
 	 */
 	public function test_get_forms_admin_url_wp_build_with_tab() {
-		add_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox' );
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'inbox' ) );
@@ -287,8 +129,6 @@ class Dashboard_Test extends BaseTestCase {
 
 		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox' );
 		$this->assertEquals( $expected, Dashboard::get_forms_admin_url( 'responses/inbox' ) );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 	}
 
 	/**
@@ -377,53 +217,91 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The wp-build dashboard page is detected when the alpha flag is on and the
-	 * wp-build slug is requested (so the legacy SPA bundle is skipped there).
+	 * The dashboard page is detected from the slug alone.
 	 */
 	public function test_is_wp_build_dashboard_page_true_on_wpbuild_slug() {
-		add_filter( 'jetpack_forms_alpha', '__return_true' );
 		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
 
 		$this->assertTrue( Dashboard::is_wp_build_dashboard_page() );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 	}
 
 	/**
-	 * The legacy SPA bundle must still load when the alpha flag is off, even on the
-	 * wp-build slug (the cross-variant redirect sends the user to the legacy page).
+	 * Links generated before the legacy dashboard was retired still carry its slug.
+	 * They must land on the dashboard rather than a page that no longer registers.
 	 */
-	public function test_is_wp_build_dashboard_page_false_when_alpha_off() {
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
+	public function test_redirect_cross_variant_sends_legacy_slug_to_wp_build() {
+		$_GET['page'] = Dashboard::ADMIN_SLUG;
+
+		$redirect = $this->capture_cross_variant_redirect();
+
+		$this->assertNotNull( $redirect, 'A legacy dashboard URL must redirect.' );
+		$this->assertStringContainsString( 'page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG, $redirect );
+	}
+
+	/**
+	 * The dashboard slug is already correct, so it must not bounce.
+	 */
+	public function test_redirect_cross_variant_leaves_the_wp_build_slug_alone() {
 		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
 
-		$this->assertFalse( Dashboard::is_wp_build_dashboard_page() );
+		$this->assertNull( $this->capture_cross_variant_redirect() );
+	}
 
+	/**
+	 * `jetpack_forms_alpha` no longer selects anything, so anyone still filtering it
+	 * is told rather than left wondering why their filter stopped working.
+	 */
+	public function test_init_announces_the_retired_filter() {
+		$announced = array();
+		add_filter( 'deprecated_hook_trigger_error', '__return_false' );
+		add_action(
+			'deprecated_hook_run',
+			function ( $hook ) use ( &$announced ) {
+				$announced[] = $hook;
+			}
+		);
+
+		add_filter( 'jetpack_forms_alpha', '__return_false' );
+		( new Dashboard() )->init();
 		remove_filter( 'jetpack_forms_alpha', '__return_false' );
+
+		$this->assertContains( 'jetpack_forms_alpha', $announced );
+	}
+
+	/**
+	 * ...and stays quiet for the overwhelming majority who never used it.
+	 */
+	public function test_init_is_silent_without_the_retired_filter() {
+		$announced = array();
+		add_filter( 'deprecated_hook_trigger_error', '__return_false' );
+		add_action(
+			'deprecated_hook_run',
+			function ( $hook ) use ( &$announced ) {
+				$announced[] = $hook;
+			}
+		);
+
+		( new Dashboard() )->init();
+
+		$this->assertNotContains( 'jetpack_forms_alpha', $announced );
 	}
 
 	/**
 	 * The legacy dashboard slug is not treated as the wp-build page.
 	 */
 	public function test_is_wp_build_dashboard_page_false_on_legacy_slug() {
-		add_filter( 'jetpack_forms_alpha', '__return_true' );
 		$_GET['page'] = Dashboard::ADMIN_SLUG;
 
 		$this->assertFalse( Dashboard::is_wp_build_dashboard_page() );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 	}
 
 	/**
 	 * With no page requested, this is not the wp-build dashboard page.
 	 */
 	public function test_is_wp_build_dashboard_page_false_without_page() {
-		add_filter( 'jetpack_forms_alpha', '__return_true' );
 		unset( $_GET['page'] );
 
 		$this->assertFalse( Dashboard::is_wp_build_dashboard_page() );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 	}
 
 	/**
@@ -451,44 +329,9 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test get_forms_admin_url with screen ID equivalents (legacy dashboard).
-	 */
-	public function test_get_forms_admin_url_with_screen_id_equivalents() {
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		$url_form = Dashboard::get_forms_admin_url( 'forms' );
-		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::ADMIN_SLUG, $url_form );
-		$this->assertStringContainsString( '#/forms', $url_form );
-
-		// For legacy dashboard, edit-feedback equivalent is base URL (no tab).
-		$url_feedback = Dashboard::get_forms_admin_url();
-		$expected     = get_admin_url() . 'admin.php?page=' . Dashboard::ADMIN_SLUG;
-		$this->assertEquals( $expected, $url_feedback );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
-	}
-
-	/**
-	 * Test get_forms_admin_url with invalid tab returns base URL (legacy dashboard).
-	 */
-	public function test_get_forms_admin_url_with_invalid_tab_returns_base_url() {
-		add_filter( 'jetpack_forms_alpha', '__return_false' );
-
-		$url = Dashboard::get_forms_admin_url( 'invalid-screen' );
-		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::ADMIN_SLUG, $url );
-		$this->assertStringNotContainsString( '#/', $url );
-
-		$url = Dashboard::get_forms_admin_url( '' );
-		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::ADMIN_SLUG, $url );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_false' );
-	}
-
-	/**
 	 * Test get_forms_admin_url with screen ID equivalents for wp-build dashboard
 	 */
 	public function test_get_forms_admin_url_wp_build_with_screen_id_equivalents() {
-		add_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		$url_form = Dashboard::get_forms_admin_url( 'forms' );
 		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG, $url_form );
@@ -497,8 +340,6 @@ class Dashboard_Test extends BaseTestCase {
 		$url_feedback = Dashboard::get_forms_admin_url( 'inbox' );
 		$this->assertStringContainsString( 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG, $url_feedback );
 		$this->assertStringContainsString( '&p=%2Fresponses%2Finbox', $url_feedback );
-
-		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 	}
 
 	/**
@@ -510,13 +351,10 @@ class Dashboard_Test extends BaseTestCase {
 	 * @return array|null The registered menu entry.
 	 */
 	private function register_wp_build_submenu() {
-		add_filter( 'jetpack_forms_alpha', '__return_true' );
 		$this->capture_doing_it_wrong();
 
 		$this->dashboard = new Dashboard();
 		$this->dashboard->add_admin_submenu();
-
-		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		return Admin_Menu::remove_menu( Dashboard::FORMS_WPBUILD_ADMIN_SLUG );
 	}

--- a/projects/plugins/jetpack/changelog/retire-forms-dashboard-gates
+++ b/projects/plugins/jetpack/changelog/retire-forms-dashboard-gates
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Forms: deprecate the jetpack_forms_alpha and jetpack_forms_dashboard_enable filters, which no longer select anything.
+Forms: deprecate the jetpack_forms_alpha filter, which no longer selects anything.

--- a/projects/plugins/jetpack/changelog/retire-forms-dashboard-gates
+++ b/projects/plugins/jetpack/changelog/retire-forms-dashboard-gates
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Forms: retire the jetpack_forms_alpha and jetpack_forms_dashboard_enable filters, which no longer select anything.

--- a/projects/plugins/jetpack/changelog/retire-forms-dashboard-gates
+++ b/projects/plugins/jetpack/changelog/retire-forms-dashboard-gates
@@ -1,4 +1,4 @@
 Significance: minor
 Type: other
 
-Forms: retire the jetpack_forms_alpha and jetpack_forms_dashboard_enable filters, which no longer select anything.
+Forms: deprecate the jetpack_forms_alpha and jetpack_forms_dashboard_enable filters, which no longer select anything.


### PR DESCRIPTION
Part of #50712 (step 4a).

## Proposed changes

`jetpack_forms_alpha` selected which of two dashboards rendered. There is now one, so it no longer selects anything and is retired.

It was a development flag — #46206, *"Introduce wp-build on dashboard under feature flag"*. Its default flipped to `true` in #47826, *"Enable Central Forms Management by default for all sites"*, and since then its only remaining job has been a rollback valve. That valve is now empty: the sole writer left is a WordPress.com sticker branch, and `wp blog-stickers get-blogs-with-sticker disable-central-forms-management` returned zero blogs on 2026-08-24. #51397 removes that branch outright, ahead of this PR.

* The wp-build branch of all six `jetpack_forms_alpha` reads becomes the behavior.
* `_deprecated_hook()` announces the retirement, guarded by `has_filter()` so it stays silent for the sites that never used it.

### `jetpack_forms_dashboard_enable` is deliberately kept

An earlier revision of this PR retired it too, on the grounds that it was another unused dashboard gate. That conflated two different things. `jetpack_forms_alpha` chose **which** dashboard rendered; `jetpack_forms_dashboard_enable` gates **whether** the dashboard is registered at all — no menu entry, no dashboard. That capability is untouched by retiring the legacy tree and is worth keeping whether or not anything uses it today.

It is restored unchanged. Its docblock is corrected: it claimed the filter defaults to `false` while the code has always passed `true`, and it now describes what returning `false` actually does.

It is also covered now. Nothing exercised the gate before, which made "worth keeping" an assertion rather than a fact; `Jetpack_Forms_Test` asserts that returning `false` wires no dashboard, with the default-on case as a control.

### Why not `apply_filters_deprecated()`

That helper still applies the filter and returns its value. Once the legacy dashboard is gone a `false` cannot be honoured, so returning it would lie about what happened. `_deprecated_hook()` reports the hook without honouring it.

### Why this lands before the delete

Today a `false` return registers the legacy slug and renders a mount point the legacy bundle fills. Delete that tree (step 4c) with the gate still branching and any site still getting `false` lands on a blank Forms dashboard — the same failure class as #51151, on the other branch.

Retiring the gate first also makes every stale `add_filter( 'jetpack_forms_alpha', '__return_false' )` inert, wherever it is deployed. That removes two scheduling dependencies from 4c: the WordPress.com sticker cleanup, and waiting on the plugin release that carries this code to Atomic.

### Nothing is removed

Three things lost their callers. All stay, with **behavior unchanged**:

* `Dashboard::render_dashboard()` — public, so it announces itself through `_deprecated_function()`. It still prints the same mount point, which stays empty because nothing enqueues the legacy bundle any more — what a caller would get either way.
* `Dashboard::get_forms_admin_suffix_legacy()` — private, so nothing outside the class could ever have called it. It carries neither a notice nor a `@deprecated` tag: visibility already guarantees there is no audience for one.
* The legacy-bundle branch in `load_admin_scripts()`, and `Dashboard::SCRIPT_HANDLE` with it. `ADMIN_SLUG` no longer registers a page, so `is_jetpack_forms_admin_page()` can only be true on the wp-build screen, where `is_wp_build_dashboard_page()` is then unconditionally true — the `else` cannot run, and its "Only enqueue it on the legacy dashboard" comment describes an impossible state. **Deferred to 4c on purpose**, together with the legacy screen `is_jetpack_forms_admin_page()` still lists, so this PR stays a gate retirement and the deletions land in one place.

The reverse leg of `redirect_dashboard_url_cross_variant()` — wp-build URL back to legacy — is gone, since there is nothing to send anyone back to. The forward leg stays, and it is load-bearing rather than a courtesy for stale links: `packages/jitm` emits the legacy slug in both Creative Mail JITM CTAs, `plugins/jetpack/3rd-party/creative-mail.php` uses it for the post-install redirect, and `packages/my-jetpack` falls back to it when the Forms class is not loaded. Nothing breaks today — the redirect catches all of them, and Creative Mail's nonce survives because `try_install()` runs on `admin_init`, ahead of the `admin_menu` priority-1 redirect. **4c must not delete it.**

## Related product discussion/links

* FORMS-733

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Merge after #51397, and not before the 16.2 branch cut.**

#51397 retires the WordPress.com sticker that writes this filter. Until it lands, this PR makes the sticker's `jetpack_forms_alpha` leg inert while its editor-flag leg still runs — on a stickered site that is the wp-build dashboard with `central-form-management` off, so the Forms tab lists `jetpack_form` posts with no `jetpack_form` post type registered. No site carries the sticker today, so nothing is broken in practice; the order removes the hazard from the code rather than from the site list. See the merge-order note on #51397.

The 16.2 gate is separate. This is groundwork for deleting the legacy dashboard; it wants a full cycle of soak rather than landing next to a release.

Every real site already serves the wp-build dashboard, so nothing changes for them. What needs exercising is the deprecation notice, and specifically *when* it is emitted — printing it too early sends headers and breaks the two redirects this class performs.

### Setup

Two host settings hide the failure, and both must be turned off or every check below passes with the bug fully present.

1. **`display_errors`** is off at the PHP level on most hosts, including Atomic and Jurassic Ninja, so `WP_DEBUG` alone never puts the notice on the page.
2. **`output_buffering`** is `4096` by default in PHP-FPM. The notice is ~320 bytes, so it never flushes, `headers_sent()` stays false, and the redirect succeeds anyway.

Force both:

```php
<?php
// mu-plugin. Only needed when testing a branch build rsynced over an existing install.
define( 'JETPACK_AUTOLOAD_DEV', true );

ini_set( 'display_errors', 1 );
add_filter( 'jetpack_forms_alpha', '__return_false' );
```

```bash
printf 'output_buffering = 0\n' > /path/to/docroot/.user.ini
```

`.user.ini` is cached for 300s and FPM workers are long-lived, so pick it up with a graceful reload — `kill -USR2 <fpm master pid>`, not a container restart.

Confirm the copy under test is the one that loads:

```bash
wp eval 'echo (new ReflectionClass("Automattic\Jetpack\Forms\Dashboard\Dashboard"))->getFileName(), PHP_EOL;'
```

### 1. The notice does not leak into non-screen responses — the primary check

```bash
curl -s 'https://<site>/wp-admin/admin-ajax.php?action=nope' | wc -c
```

Must be **1** — the single `0` byte, nothing prepended. `is_admin()` is true for `admin-ajax.php` and `admin-post.php`, so a notice emitted on that basis is prefixed to every Heartbeat poll.

This is the reliable detector: it fails on a bad build whether or not output buffering is on.

### 2. The redirects still work

Load each of these directly, and check the **body as well as the status**:

- `/wp-admin/admin.php?page=jetpack-forms-admin` — the retired legacy slug, redirected by `redirect_dashboard_url_cross_variant()`. Lands on `&p=/responses/inbox`.
- `/wp-admin/admin.php?page=jetpack-forms-responses-wp-admin` — **no `p` parameter**, redirected from inside `load_wp_build()`. Lands on `&p=/forms`, because `central-form-management` is on. `/forms` is the expected tab here, not the inbox.

Both must return `302` with an **empty body**. A `302` carrying ~320 bytes of deprecation notice means the notice printed first and only buffering saved the redirect. A `200` with *"headers already sent"* is the same bug with buffering off.

The wp-admin **Forms** menu entry is registered as the bare slug, with no `p`, so clicking it in the sidebar is the second URL above.

### 3. The notice does appear where it should

Load any normal admin screen. A deprecation notice naming `jetpack_forms_alpha` renders in the page, and the Forms dashboard is still the wp-build one — the filter no longer selects anything.

Remove the filter and the notice goes away. Sites that never used it see nothing.

### Automated

```
jp test php packages/forms      # 1152 pass
jp test js packages/forms
jp phan packages/forms          # 0 issues
jp build packages/forms --deps --production
```

The build matters: `replace-next-version-tag.sh` rejects a `$$next-version$$` token in a multi-line deprecation call, and tests, Phan and PHPCS all pass without noticing.

### What was verified

Run against a local WordPress install at `77cf28e`, with `3e7b0e8` — the revision that called `_deprecated_hook()` from `init()` — as the control. PHP 8.4 FPM, WP 7.1.

| Build | `output_buffering` | legacy slug | wp-build slug, no `p` | `admin-ajax.php?action=nope` |
| --- | --- | --- | --- | --- |
| `3e7b0e8` control | 4096 | `302`, 323 b | `302`, 323 b | 324 b |
| `3e7b0e8` control | 0 | `200`, headers already sent | `200`, headers already sent | 1212 b |
| `77cf28e` | 4096 | `302`, 0 b | `302`, 0 b | 1 b |
| `77cf28e` | 0 | `302`, 0 b | `302`, 0 b | 1 b |

The control's failure is `Cannot modify header information — headers already sent by (wp-includes/functions.php:6131) in pluggable.php:1531`.

Also confirmed at `77cf28e`: the notice renders on `plugins.php` and on the Forms dashboard, which still returns `200`; it is absent from the front end and from `/wp-json/`; and removing the filter silences it everywhere while both redirects keep working.

### Note on the test changes

Twelve PHP tests and two JS tests covered legacy-only behavior that no longer exists; they are deleted rather than rewritten. Added: the legacy slug redirects forward, the dashboard slug does not bounce, the deprecation fires on `admin_notices`, it stays quiet without the filter, and — guarding the bug above — nothing is emitted before `admin_notices` runs. Plus the two `jetpack_forms_dashboard_enable` tests above.

Each of the three new deprecation tests was checked by mutation rather than by reading: moving the announcement back into `init()` fails only `test_does_not_announce_before_admin_notices`, dropping the `has_filter()` guard fails only `test_is_silent_without_the_retired_filter`, and making the gate ignore its filter fails only `test_dashboard_gate_returning_false_wires_nothing`.


