### PR TITLE
Boost: Remove the "Upgraded" pill from the settings page

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/cornerstone-pages.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/cornerstone-pages/cornerstone-pages.tsx
@@ -1,18 +1,13 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import Meta, { CornerstonePagesUpgradeCTA } from './meta/meta';
 import { Panel, PanelBody, PanelRow } from '@wordpress/components';
-import Upgraded from '$features/ui/upgraded/upgraded';
 import styles from './cornerstone-pages.module.scss';
-import { usePremiumFeatures } from '$lib/stores/premium-features';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import { useCustomCornerstonePages } from './lib/stores/cornerstone-pages';
 import Prerender from './prerender/prerender';
 import { useSingleModuleState } from '$features/module/lib/stores';
 
 const CornerstonePages = () => {
-	const premiumFeatures = usePremiumFeatures();
-	const isPremium = premiumFeatures.includes( 'cornerstone-10-pages' );
-
 	const [ moduleState ] = useSingleModuleState( 'speculation_rules' );
 	const isSpeculationRulesAvailable = moduleState?.available ?? false;
 
@@ -22,10 +17,7 @@ const CornerstonePages = () => {
 				<PanelBody
 					title={
 						<div>
-							<h3>
-								{ __( 'Cornerstone Pages', 'jetpack-boost' ) }
-								{ isPremium && <Upgraded /> }
-							</h3>
+							<h3>{ __( 'Cornerstone Pages', 'jetpack-boost' ) }</h3>
 							<CornerstoneTitleSummary />
 						</div>
 					}

--- a/projects/plugins/boost/app/assets/src/js/features/ui/upgraded/upgraded.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/upgraded/upgraded.tsx
@@ -1,6 +1,0 @@
-import { __ } from '@wordpress/i18n';
-import Pill from '$features/ui/pill/pill';
-
-const Upgraded = () => <Pill text={ __( 'Upgraded', 'jetpack-boost' ) } variant="gray" />;
-
-export default Upgraded;

--- a/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/index/index.tsx
@@ -11,7 +11,6 @@ import Module from '$features/module/module';
 import PageCacheModule from '$features/page-cache/page-cache';
 import RenderBlockingJsMeta from '$features/render-blocking-js/render-blocking-js-meta';
 import PremiumTooltip from '$features/premium-tooltip/premium-tooltip';
-import Upgraded from '$features/ui/upgraded/upgraded';
 import InterstitialModalCTA from '$features/upgrade-cta/interstitial-modal-cta';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import { getRedirectUrl } from '@automattic/jetpack-components';
@@ -91,12 +90,7 @@ const Index = () => {
 			</Module>
 			<Module
 				slug="cloud_css"
-				title={
-					<>
-						{ __( 'Automatically Optimize CSS Loading', 'jetpack-boost' ) }
-						<Upgraded />
-					</>
-				}
+				title={ __( 'Automatically Optimize CSS Loading', 'jetpack-boost' ) }
 				worksOffline={ false }
 				onEnable={ requestRegenerateCriticalCss }
 				description={
@@ -161,12 +155,7 @@ const Index = () => {
 			<MinifyCss />
 			<Module
 				slug="image_cdn"
-				title={
-					<>
-						{ __( 'Image CDN', 'jetpack-boost' ) }
-						{ hasPremiumCdnFeatures && <Upgraded /> }
-					</>
-				}
+				title={ __( 'Image CDN', 'jetpack-boost' ) }
 				worksOffline={ false }
 				description={
 					<p>

--- a/projects/plugins/boost/changelog/remove-upgraded-pill
+++ b/projects/plugins/boost/changelog/remove-upgraded-pill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove the Upgraded pill from module titles on the settings page.

--- a/projects/plugins/boost/tests/e2e/specs/cornerstone/cornerstone.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/cornerstone/cornerstone.test.ts
@@ -145,9 +145,9 @@ test.describe( 'Cornerstone Pages', () => {
 
 		// Verify that premium features are detected
 		await expect(
-			page.getByRole( 'button', { name: 'Cornerstone Pages Upgraded' } ),
-			'Premium features should be detected by the frontend'
-		).toBeVisible();
+			page.getByText( 'Premium users can add up to' ),
+			'Upgrade CTA should be hidden when premium features are active'
+		).toBeHidden();
 
 		// Add 10 pages
 		const tenPages = Array.from( { length: 10 }, ( _, i ) => `/page-${ i + 1 }` ).join( '\n' );


### PR DESCRIPTION
## Proposed changes

* Remove the gray "Upgraded" pill from module titles on the Boost settings page. It appeared next to "Automatically Optimize CSS Loading", next to "Image CDN" on sites with premium CDN features, and next to "Cornerstone Pages" on premium sites.
* Delete the now-unused `Upgraded` component. The underlying `Pill` component stays, since the module toggles still use it.

The pill was meant to remind people what their upgrade unlocked, but in practice it reads as noise once the upgrade is no longer new.

## Related product discussion/links

* BOOST-627
* p1786710048013889-slack-C0BP9G9HP28

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with a premium Boost plan (or a premium CDN / Cornerstone Pages feature), open Jetpack Boost → Settings.
* Before this change, an "Upgraded" pill appeared next to "Automatically Optimize CSS Loading", "Image CDN", and the "Cornerstone Pages" panel title. Confirm the pills are gone and the titles render normally.
* On a free site, confirm the settings page is unchanged: the premium tooltip next to "Optimize CSS Loading" and the Image CDN upgrade prompt still show.

## Real-screen before / after

Captured on a live Jurassic Ninja site at `/wp-admin/admin.php?page=jetpack-boost` (premium features forced via the `jetpack_boost_has_feature_*` filters so the pills render). Before is Boost 4.7.0 from wp.org; after is this branch.

### Cornerstone Pages and Automatically Optimize CSS Loading

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/LiamSarsfield/linear-ticket-slack-thread/before-boost-settings-top.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/LiamSarsfield/linear-ticket-slack-thread/after-boost-settings-top.png) |

### Image CDN

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/LiamSarsfield/linear-ticket-slack-thread/before-boost-settings-image-cdn.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/LiamSarsfield/linear-ticket-slack-thread/after-boost-settings-image-cdn.png) |
