### PR TITLE
jetpack-mu-wpcom: retire the disable-central-forms-management gating

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/cleanup-mu-wpcom-forms-alpha-filter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/cleanup-mu-wpcom-forms-alpha-filter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: deprecated
 
-Contact form flags: retire the disable-central-forms-management gating; Central Forms Management is enabled for every site.
+Contact Form Flags: Retire the disable-central-forms-management gating. Central Forms Management is enabled for every site.

--- a/projects/packages/jetpack-mu-wpcom/changelog/cleanup-mu-wpcom-forms-alpha-filter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/cleanup-mu-wpcom-forms-alpha-filter
@@ -1,4 +1,4 @@
-Significance: patch
-Type: removed
+Significance: minor
+Type: deprecated
 
-Contact form flags: stop setting the retired jetpack_forms_alpha filter.
+Contact form flags: retire the disable-central-forms-management gating; Central Forms Management is enabled for every site.

--- a/projects/packages/jetpack-mu-wpcom/changelog/cleanup-mu-wpcom-forms-alpha-filter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/cleanup-mu-wpcom-forms-alpha-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Contact form flags: stop setting the retired jetpack_forms_alpha filter.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -67,7 +67,7 @@ function wpcom_maybe_disable_central_forms_management() {
 /**
  * Pass-through kept so existing callers do not fatal.
  *
- * This set the `central-form-management` block editor feature flag. It is no longer
+ * Previously set the `central-form-management` block editor feature flag. No longer
  * hooked: the Forms package already defaults the flag to true, so filtering here only
  * ever restated the default.
  *

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -2,9 +2,15 @@
 /**
  * WordPress.com Contact Form feature flags.
  *
- * Sets the `central-form-management` block editor feature flag, which the Forms
- * block reads to decide whether the synced-forms UI is available. Works on both
- * Simple and Atomic infrastructure.
+ * Central Forms Management is enabled for every WordPress.com site, so nothing here
+ * gates it any more. The `disable-central-forms-management` sticker is retired: it
+ * was a rollback valve for the CFM rollout, and there is no longer anything to roll
+ * back to. The functions below are kept, deprecated, so existing callers do not
+ * fatal; none of them is wired to anything.
+ *
+ * With no filter on `jetpack_block_editor_feature_flags` from here, the
+ * `central-form-management` flag falls through to the Forms package default, which
+ * is true — see Contact_Form_Block::register_central_form_management_default().
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -32,36 +38,39 @@ function wpcom_forms_has_blog_sticker( $sticker, $blog_id ) {
 /**
  * Check if Central Forms Management is enabled for a given blog.
  *
- * Enabled for all WordPress.com sites, except those that opt out by sticker.
+ * @deprecated $$next-version$$ Central Forms Management is enabled for every site.
  *
- * Scope note: this now decides the block editor feature flag only. It used to
- * pick the Forms dashboard too, via `jetpack_forms_alpha`, but that filter was
- * retired along with the legacy dashboard — every site gets the same one.
- *
- * @param int|null $blog_id Blog ID. Defaults to the current WP.com blog ID.
- * @return bool
+ * @param int|null $blog_id Blog ID. Unused.
+ * @return bool Always true.
  */
-function wpcom_is_central_forms_management_enabled( $blog_id = null ) {
-	if ( null === $blog_id ) {
-		$blog_id = function_exists( 'get_wpcom_blog_id' ) ? get_wpcom_blog_id() : get_current_blog_id();
-	}
-
-	// Allow disabling CFM for individual sites via blog sticker.
-	if ( wpcom_forms_has_blog_sticker( 'disable-central-forms-management', $blog_id ) ) {
-		return false;
-	}
+function wpcom_is_central_forms_management_enabled( $blog_id = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Signature kept for existing callers.
+	_deprecated_function( __FUNCTION__, 'jetpack-mu-wpcom-$$next-version$$' );
 
 	return true;
 }
 
 /**
+ * Disable Central Forms Management for excluded WordPress.com sites.
+ *
+ * @deprecated $$next-version$$ Nothing disables Central Forms Management any more.
+ */
+function wpcom_maybe_disable_central_forms_management() {
+	_deprecated_function( __FUNCTION__, 'jetpack-mu-wpcom-$$next-version$$' );
+}
+
+/**
  * Set the 'central-form-management' block editor feature flag.
  *
+ * No longer hooked: the Forms package already defaults this flag to true, so
+ * filtering it here only ever restated the default.
+ *
+ * @deprecated $$next-version$$ The Forms package supplies the default.
+ *
  * @param array $flags Existing feature flags.
- * @return array Modified feature flags.
+ * @return array Flags, unchanged.
  */
 function wpcom_contact_form_set_editor_feature_flags( $flags ) {
-	$flags['central-form-management'] = wpcom_is_central_forms_management_enabled();
+	_deprecated_function( __FUNCTION__, 'jetpack-mu-wpcom-$$next-version$$' );
+
 	return $flags;
 }
-add_filter( 'jetpack_block_editor_feature_flags', 'wpcom_contact_form_set_editor_feature_flags', 1000 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -2,8 +2,9 @@
 /**
  * WordPress.com Contact Form feature flags.
  *
- * Controls the Central Forms Management rollout and disables the integrations
- * tab on WordPress.com sites. Works on both Simple and Atomic infrastructure.
+ * Sets the `central-form-management` block editor feature flag, which the Forms
+ * block reads to decide whether the synced-forms UI is available. Works on both
+ * Simple and Atomic infrastructure.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -33,6 +34,10 @@ function wpcom_forms_has_blog_sticker( $sticker, $blog_id ) {
  *
  * Enabled for all WordPress.com sites, except those that opt out by sticker.
  *
+ * Scope note: this now decides the block editor feature flag only. It used to
+ * pick the Forms dashboard too, via `jetpack_forms_alpha`, but that filter was
+ * retired along with the legacy dashboard — every site gets the same one.
+ *
  * @param int|null $blog_id Blog ID. Defaults to the current WP.com blog ID.
  * @return bool
  */
@@ -48,25 +53,6 @@ function wpcom_is_central_forms_management_enabled( $blog_id = null ) {
 
 	return true;
 }
-
-/**
- * Disable Central Forms Management for excluded WordPress.com sites.
- *
- * CFM is now enabled by default in the Forms package. This function
- * explicitly disables it for sites that carry the
- * disable-central-forms-management sticker.
- *
- * Called immediately on file load since this file is required during
- * plugins_loaded (priority 10) inside load_wpcom_sites_features().
- */
-function wpcom_maybe_disable_central_forms_management() {
-	if ( wpcom_is_central_forms_management_enabled() ) {
-		return;
-	}
-
-	add_filter( 'jetpack_forms_alpha', '__return_false', 999 );
-}
-wpcom_maybe_disable_central_forms_management();
 
 /**
  * Set the 'central-form-management' block editor feature flag.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -5,7 +5,7 @@
  * Central Forms Management is enabled for every WordPress.com site, so nothing here
  * gates it any more. The `disable-central-forms-management` sticker is retired: it
  * was a rollback valve for the CFM rollout, and there is no longer anything to roll
- * back to. The functions below are kept, deprecated, so existing callers do not
+ * back to. Every function below is kept and deprecated, so existing callers do not
  * fatal; none of them is wired to anything.
  *
  * With no filter on `jetpack_block_editor_feature_flags` from here, the
@@ -21,11 +21,17 @@
  * Uses the appropriate sticker API depending on whether the site is
  * Simple (has_blog_sticker) or Atomic (wpcomsh_is_site_sticker_active).
  *
+ * Served the retired gating, and has no callers left.
+ *
+ * @deprecated $$next-version$$ The gating it served is retired.
+ *
  * @param string $sticker The sticker name to check.
  * @param int    $blog_id The blog ID to check.
  * @return bool
  */
 function wpcom_forms_has_blog_sticker( $sticker, $blog_id ) {
+	_deprecated_function( __FUNCTION__, 'jetpack-mu-wpcom-$$next-version$$' );
+
 	if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC && function_exists( 'wpcomsh_is_site_sticker_active' ) ) {
 		return (bool) wpcomsh_is_site_sticker_active( $sticker );
 	} elseif ( function_exists( 'has_blog_sticker' ) ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -50,7 +50,7 @@ function wpcom_is_central_forms_management_enabled( $blog_id = null ) { // phpcs
 }
 
 /**
- * Disable Central Forms Management for excluded WordPress.com sites.
+ * No-op kept so existing callers do not fatal.
  *
  * @deprecated $$next-version$$ Nothing disables Central Forms Management any more.
  */
@@ -59,10 +59,11 @@ function wpcom_maybe_disable_central_forms_management() {
 }
 
 /**
- * Set the 'central-form-management' block editor feature flag.
+ * Pass-through kept so existing callers do not fatal.
  *
- * No longer hooked: the Forms package already defaults this flag to true, so
- * filtering it here only ever restated the default.
+ * This set the `central-form-management` block editor feature flag. It is no longer
+ * hooked: the Forms package already defaults the flag to true, so filtering here only
+ * ever restated the default.
  *
  * @deprecated $$next-version$$ The Forms package supplies the default.
  *

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -10,7 +10,8 @@
  *
  * With no filter on `jetpack_block_editor_feature_flags` from here, the
  * `central-form-management` flag falls through to the Forms package default, which
- * is true — see Contact_Form_Block::register_central_form_management_default().
+ * is true — see Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block::register_central_form_management_default()
+ * in `packages/forms`, which this package does not depend on.
  *
  * @package automattic/jetpack-mu-wpcom
  */


### PR DESCRIPTION
Part of #50712. Lands before #51395.

## Proposed changes

Retires the `disable-central-forms-management` sticker gating. It was a rollback valve for the CFM rollout; there is nothing left to roll back to.

An earlier revision of this PR removed only the `jetpack_forms_alpha` leg and kept the editor-flag leg. Review on #51395 flagged that as leaving the sticker meaning half of what it says — and the half it kept is worse than odd. `Contact_Form::register_post_type()` is gated on the same `central-form-management` flag, so a stickered site would get the wp-build dashboard, whose **Forms tab lists `jetpack_form` posts**, with **no `jetpack_form` post type registered**. That combination was unreachable before, because the sticker also forced the legacy dashboard, which has no Forms tab.

So the whole gating goes rather than half-working.

Nothing here filters `jetpack_block_editor_feature_flags` any more, so `central-form-management` falls through to the Forms package default of `true` — `Contact_Form_Block::register_central_form_management_default()`. That is the same value every WordPress.com site already had, since no site carries the sticker.

All three functions stay, deprecated and unwired, so existing callers do not fatal.

### The sticker is unused — checked

```bash
wp blog-stickers get-blogs-with-sticker disable-central-forms-management
```

Zero blogs, on **2026-08-24**.

The earlier evidence was a rollout sweep from 2026-08-03 that de-stickered and verified 24 sites. That showed those sites were clean but could not rule out a re-add or a new one, because `get-blog-report-card` is per-blog. The enumerating command closes that gap.

So nothing here is observable for any site, and the package-only changelog is correct. Had any site carried the sticker, merging would have switched its editor to synced forms unannounced, and `wpcomsh` and `mu-wpcom-plugin` would have needed entries too.

### Merge order: before #51395

#51395 makes the sticker's `jetpack_forms_alpha` leg inert while this PR's editor-flag leg still runs. On a stickered site that combination is the wp-build dashboard with `central-form-management` off — a Forms tab listing `jetpack_form` posts, with no `jetpack_form` post type registered.

Landing this PR first means that state cannot occur however the two deploys skew. `packages/forms` reaches sites through `plugins/jetpack`; `packages/jetpack-mu-wpcom` reaches them through `wpcomsh` and `mu-wpcom-plugin`. Those trains do not arrive together, so merging both at once does not make them land together.

This PR has no dependency on #51395: it only removes two `add_filter()` calls and deprecates three functions, none of which #51395 introduces. It also carries no 16.2 gate, which #51395 does.

## Related product discussion/links

* FORMS-733

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Nothing observable should change: no site carries the sticker, and the flag resolves to the same `true` it did before.

**Merge before #51395** — see *Merge order* above.

1. Open the block editor on a WordPress.com site and insert a Form block. The synced-forms UI, variation picker and AI generation behave as before — that path now reads the Forms package default.
2. Load **Jetpack → Forms**. Unchanged.
3. If you can set stickers on a test site: add `disable-central-forms-management` and confirm it now does nothing — dashboard and editor both behave as an unstickered site.

Automated:

```
jp test php packages/jetpack-mu-wpcom
jp phan packages/jetpack-mu-wpcom
```

Both pass.


