### PR TITLE
Backup: refuse malformed rewind ids, keep failure reasons through a retry, and report the activity list as busy

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-invalid-rewind-id-and-list-loading
+++ b/projects/packages/backup/changelog/fix-backup-invalid-rewind-id-and-list-loading
@@ -1,5 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: Backup: refuse a malformed rewind id in the modernized restore and download screens instead of arming a form that cannot succeed, keep a failed request's reason on screen while it is being retried, and report the activity list as busy while a page change is in flight. No-op when the modernization filter is off.
-
-
+Comment: Backup: refuse a malformed rewind id in the modernized restore and download screens instead of arming a form that cannot succeed, keep a failed request's reason on screen while it is being retried, report the activity list as busy while a page change is in flight, and pin the page footer to the bottom of the viewport on the restore and download routes. No-op when the modernization filter is off.

--- a/projects/packages/backup/changelog/fix-backup-invalid-rewind-id-and-list-loading
+++ b/projects/packages/backup/changelog/fix-backup-invalid-rewind-id-and-list-loading
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: refuse a malformed rewind id in the modernized restore and download screens instead of arming a form that cannot succeed, keep a failed request's reason on screen while it is being retried, and report the activity list as busy while a page change is in flight. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/routes/dashboard/style.scss
+++ b/projects/packages/backup/routes/dashboard/style.scss
@@ -4,7 +4,7 @@
 
 @use "sass:meta";
 @use "@wordpress/base-styles/breakpoints";
-@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+@use "../../src/dashboard/admin-shell" as *;
 
 // Pull in the bundled DataViews stylesheet. `@wordpress/dataviews` ships
 // its CSS in `build-style/style.css` rather than auto-injecting it from
@@ -15,64 +15,10 @@
 @include meta.load-css("@wordpress/dataviews/build-style/style.css");
 
 // Pin the wp-admin content column to the viewport and turn its inner
-// flex chain into "fixed header + scrollable middle + pinned footer"
-// — matches the modernized VideoPress / Forms dashboards (see
-// `projects/packages/videopress/src/dashboard/admin-shell.scss`).
-// Without this, JetpackFooter scrolls with the body when the activity
-// list grows past the viewport. Scoped to the backup admin body so it
-// can't leak onto other Jetpack pages.
-body.jetpack_page_jetpack-backup {
-
-	@include jetpack-admin-page-layout-wp-build;
-
-	// `<Page>` from `@wordpress/admin-ui` puts the page title and the
-	// caller-supplied actions on the same flex row inside the header
-	// content slot. The row doesn't wrap by default, so on narrow
-	// viewports the action buttons overflow the page width (the "Back up
-	// now" button is clipped on mobile). Allow the content row and the
-	// actions group to wrap so the actions drop onto a new row instead
-	// of escaping the viewport. admin-ui's emotion-hashed classnames
-	// follow a stable `<hash>__semantic-name` pattern that we can match
-	// on without depending on the hash.
-	.jpb-dashboard-layout {
-
-		[class*="__header-content"],
-		[class*="__header-actions"] {
-			flex-wrap: wrap;
-		}
-	}
-
-	// The shared mixin assumes `<AdminPage>` from `@automattic/jetpack-components`
-	// (which stamps `.jp-admin-page` AND admin-ui's `.admin-ui-page` /
-	// `.admin-ui-page__header` classes verbatim). Our DashboardLayout uses
-	// `<Page>` from `@wordpress/admin-ui` 2.x, whose root + header classes
-	// are emotion-hashed (`_<hash>__page`, `_<hash>__header`) and don't
-	// match the mixin's selectors. We add `.jp-admin-page` to the Page so
-	// the mixin's outer flex chain still attaches, and reproduce the
-	// page-internal "header / middle / footer" sticky layout here using
-	// our own stable class names (`.jpb-dev-mode-banner`,
-	// `.jpb-dashboard-body`, `.jetpack-footer`).
-	.jp-admin-page {
-
-		> header {
-			flex-shrink: 0;
-		}
-
-		> .jpb-dev-mode-banner {
-			flex-shrink: 0;
-		}
-
-		> .jpb-dashboard-body {
-			flex: 1 1 auto;
-			min-height: 0;
-			overflow: auto;
-		}
-
-		> .jetpack-footer {
-			flex-shrink: 0;
-		}
-	}
-}
+// flex chain into "fixed header + scrollable middle + pinned footer".
+// Shared with every other route — see `admin-shell.scss` for why it
+// cannot live in one route's stylesheet.
+@include backup-admin-shell;
 
 .jpb-overview {
 	display: grid;

--- a/projects/packages/backup/routes/download/style.scss
+++ b/projects/packages/backup/routes/download/style.scss
@@ -1,3 +1,11 @@
+@use "../../src/dashboard/admin-shell" as *;
+
+// The admin shell is per-route: this stylesheet is inlined into this
+// route's own bundle, so without this include a cold load of
+// `/download/$rewindId` gets none of the viewport layout and the footer
+// stops short of the bottom of the page.
+@include backup-admin-shell;
+
 .jpb-download {
 	max-width: 700px;
 	margin-inline: auto;

--- a/projects/packages/backup/routes/restore/style.scss
+++ b/projects/packages/backup/routes/restore/style.scss
@@ -1,3 +1,11 @@
+@use "../../src/dashboard/admin-shell" as *;
+
+// The admin shell is per-route: this stylesheet is inlined into this
+// route's own bundle, so without this include a cold load of
+// `/restore/$rewindId` gets none of the viewport layout and the footer
+// stops short of the bottom of the page.
+@include backup-admin-shell;
+
 .jpb-restore {
 	max-width: 700px;
 	margin-inline: auto;

--- a/projects/packages/backup/src/dashboard/admin-shell.scss
+++ b/projects/packages/backup/src/dashboard/admin-shell.scss
@@ -1,0 +1,75 @@
+// The modernized Backup dashboard's admin shell: the chain that pins the
+// wp-admin content column to the viewport and lays the page out as
+// "fixed header + scrollable middle + pinned footer".
+
+// Lives here, as a mixin every route includes, because each wp-build
+// route is its own bundle with its own inlined CSS. A route that does
+// not include this gets none of it: `#wpbody-content` stays static and
+// the footer sits wherever the content happens to end, which is what
+// cold-loading `/restore/$id` or `/download/$id` used to do.
+
+// Matches the modernized VideoPress / Forms dashboards — see
+// `projects/packages/videopress/src/dashboard/admin-shell.scss`.
+
+@use "@automattic/jetpack-base-styles/admin-page-layout" as *;
+
+@mixin backup-admin-shell {
+
+	// Scoped to the backup admin body so it can't leak onto other
+	// Jetpack pages.
+	body.jetpack_page_jetpack-backup {
+
+		@include jetpack-admin-page-layout-wp-build;
+
+		// `<Page>` from `@wordpress/admin-ui` puts the page title and
+		// the caller-supplied actions on the same flex row inside the
+		// header content slot. The row doesn't wrap by default, so on
+		// narrow viewports the action buttons overflow the page width
+		// (the "Back up now" button is clipped on mobile). Allow the
+		// content row and the actions group to wrap so the actions drop
+		// onto a new row instead of escaping the viewport. admin-ui's
+		// emotion-hashed classnames follow a stable
+		// `<hash>__semantic-name` pattern that we can match on without
+		// depending on the hash.
+		.jpb-dashboard-layout {
+
+			[class*="__header-content"],
+			[class*="__header-actions"] {
+				flex-wrap: wrap;
+			}
+		}
+
+		// The shared mixin assumes `<AdminPage>` from
+		// `@automattic/jetpack-components` (which stamps
+		// `.jp-admin-page` AND admin-ui's `.admin-ui-page` /
+		// `.admin-ui-page__header` classes verbatim). Our
+		// DashboardLayout uses `<Page>` from `@wordpress/admin-ui` 2.x,
+		// whose root + header classes are emotion-hashed
+		// (`_<hash>__page`, `_<hash>__header`) and don't match the
+		// mixin's selectors. We add `.jp-admin-page` to the Page so the
+		// mixin's outer flex chain still attaches, and reproduce the
+		// page-internal "header / middle / footer" sticky layout here
+		// using our own stable class names (`.jpb-dev-mode-banner`,
+		// `.jpb-dashboard-body`, `.jetpack-footer`).
+		.jp-admin-page {
+
+			> header {
+				flex-shrink: 0;
+			}
+
+			> .jpb-dev-mode-banner {
+				flex-shrink: 0;
+			}
+
+			> .jpb-dashboard-body {
+				flex: 1 1 auto;
+				min-height: 0;
+				overflow: auto;
+			}
+
+			> .jetpack-footer {
+				flex-shrink: 0;
+			}
+		}
+	}
+}

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -170,8 +170,22 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 		[ selectedId ]
 	);
 
+	// `isLoading` alone is only ever true on the very first load: the query
+	// sets `placeholderData: keepPreviousData`, so a page change keeps the
+	// previous rows and leaves React Query "not pending". Reporting it by
+	// itself told DataViews nothing was happening while the reader looked
+	// at rows from the page they had just left.
+	//
+	// This cannot swallow `emptyState`: DataViews initialises
+	// `hasInitiallyLoaded` to `!isLoading` and latches it true on the first
+	// non-loading render, and the spinner branch that would replace the
+	// `empty` slot is gated on `!hasInitiallyLoaded`. Past the first load a
+	// truthy `isLoading` only reaches the footer, which marks itself inert
+	// while the next page is fetched.
+	const isBusy = isLoading || isFetching;
+
 	return (
-		<Card.Root className="jpb-activity-list" aria-busy={ isLoading }>
+		<Card.Root className="jpb-activity-list" aria-busy={ isBusy }>
 			<DataViews< ActivityItem >
 				data={ items }
 				fields={ fields }
@@ -182,7 +196,7 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 				getItemId={ getRowId }
 				selection={ selection }
 				onChangeSelection={ onChangeSelection }
-				isLoading={ isLoading }
+				isLoading={ isBusy }
 				search={ false }
 				empty={ emptyState }
 			/>

--- a/projects/packages/backup/src/dashboard/components/invalid-rewind-id/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/invalid-rewind-id/index.tsx
@@ -1,0 +1,57 @@
+import { __ } from '@wordpress/i18n';
+import { Icon, arrowLeft } from '@wordpress/icons';
+import { Link } from '@wordpress/route';
+import { Card, Stack, Text } from '@wordpress/ui';
+import DashboardLayout from '../dashboard-layout';
+
+type Props = {
+	/**
+	 * Block class the calling screen uses for its own layout — `jpb-restore`
+	 * or `jpb-download`. The card borrows the screen's width, padding and
+	 * back-link styles rather than defining its own.
+	 */
+	prefix: string;
+	title: string;
+	body: string;
+};
+
+/**
+ * Shown in place of the restore or download form when the rewind id in
+ * the URL isn't one.
+ *
+ * A malformed id can only produce a failed operation, so the screen
+ * offers the way back and nothing else — no checklist, and above all no
+ * submit button. Both screens rendered a fully armed form here, with the
+ * only sign of trouble being a missing "Restore point:" line.
+ *
+ * Shared rather than duplicated because the two screens are twins: they
+ * differ in the block class and in two strings.
+ *
+ * @param props        - Component props.
+ * @param props.prefix - Block class of the calling screen.
+ * @param props.title  - What is wrong, in the reader's terms.
+ * @param props.body   - What to do about it.
+ * @return The rendered fallback.
+ */
+export default function InvalidRewindId( { prefix, title, body }: Props ) {
+	return (
+		<DashboardLayout>
+			<div className={ prefix }>
+				<Link to="/" className={ `${ prefix }__back` }>
+					<Icon icon={ arrowLeft } size={ 18 } />
+					{ __( 'Back to overview', 'jetpack-backup-pkg' ) }
+				</Link>
+				<Card.Root className={ `${ prefix }__card` }>
+					<Stack direction="column" gap="xs">
+						<Text variant="heading-md" render={ <h3 /> }>
+							{ title }
+						</Text>
+						<Text variant="body-sm" className="jpb-text-muted">
+							{ body }
+						</Text>
+					</Stack>
+				</Card.Root>
+			</div>
+		</DashboardLayout>
+	);
+}

--- a/projects/packages/backup/src/dashboard/data/api/_helpers.ts
+++ b/projects/packages/backup/src/dashboard/data/api/_helpers.ts
@@ -35,23 +35,19 @@ export function apiPath(
  * `'1777035492.615'` → `'1777035492'`).
  *
  * Truncating is a WPCOM-side requirement, not a local one — no route in
- * this package matches the id against `\d+`. Where the two remaining
- * callers stand:
+ * this package matches the id against `\d+`.
  *
- * `fetchFileTree` needs it. It sends the id in the body as `rewind_id`,
- * and the bridge forwards that to WPCOM as `backup_id`, which is an
- * integer identifier there.
+ * `fetchFileTree` is the only caller left, and it needs this: it sends
+ * the id in the body as `rewind_id`, and the bridge forwards that to
+ * WPCOM as `backup_id`, which is an integer identifier there.
  *
- * `initiateRestore` still calls it, but only because it targets the v1
- * activity-log route with the id in the *path*. That is a temporary
- * arrangement: the v2 restore route takes the id in the body, in full,
- * and the call moves with it when it is repointed. Note the Jetpack
- * route it goes through already accepts a decimal, so the truncation is
- * not protecting anything.
+ * Neither mutation calls it any more. Both `/rewind/downloads` and
+ * `/rewind/restores` take the id in the body in full, and truncating it
+ * for either addresses a different backup than the reader picked —
+ * download stopped in #51295, restore in #51338.
  *
- * Download no longer calls it at all: `/rewind/downloads` takes the id
- * in the body and truncating it there addresses a different backup than
- * the reader picked.
+ * Use `isValidRewindId` in `types/rewind-id` to check an id from the
+ * URL; this one assumes a well-formed id and only reshapes it.
  *
  * @param rewindId - Raw rewind id, possibly with a decimal suffix.
  * @return The integer-seconds portion only.

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -8,6 +8,7 @@ import {
 import { normalizeActivityLog } from '../data/normalize/activity-log';
 import { keys } from '../data/query-client';
 import { useCanQueryWpcom } from './use-connection';
+import { useStickyError } from './use-sticky-error';
 import type { ActivityItem } from '../types/activity';
 
 type Args = {
@@ -82,6 +83,10 @@ function useActivityPageQuery( page: number, pageSize: number ) {
 export function useActivityLog( { page, pageSize }: Args ): Result {
 	const query = useActivityPageQuery( page, pageSize );
 	const { refetch } = query;
+	// Held across the retry: React Query rewinds this query to `pending`
+	// when it refetches after a failure, so without this the reason
+	// disappears the moment the reader clicks the retry button.
+	const error = useStickyError( query.error, query.isFetching );
 
 	const items = useMemo(
 		() => normalizeActivityLog( query.data?.current?.orderedItems ),
@@ -100,7 +105,7 @@ export function useActivityLog( { page, pageSize }: Args ): Result {
 		totalPages: query.data?.totalPages ?? Math.max( 1, Math.ceil( items.length / pageSize ) ),
 		isLoading: query.isLoading,
 		isFetching: query.isFetching,
-		error: query.error ?? null,
+		error,
 		refetch: retry,
 	};
 }

--- a/projects/packages/backup/src/dashboard/hooks/use-backups.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backups.ts
@@ -4,6 +4,7 @@ import { fetchBackups, type RawBackupEntry } from '../data/api/backups';
 import { normalizeBackups } from '../data/normalize/backups';
 import { keys } from '../data/query-client';
 import { useCanQueryWpcom } from './use-connection';
+import { useStickyError } from './use-sticky-error';
 import type { Backup, BackupsState } from '../types/backup';
 
 /**
@@ -209,7 +210,14 @@ export function useBackups( { forcePoll = false }: Args = {} ): Result {
 		refetchInterval: ( { state } ) => pollInterval( state.data, forcePoll ),
 	} );
 
-	const { data, error, refetch } = query;
+	const { data, refetch } = query;
+	// Held across the retry: React Query rewinds this query to `pending`
+	// when it refetches after a *rejection*, so without this both `error`
+	// and the derived `'error'` state evaporate the moment the reader
+	// clicks the retry button — taking the only control that can ask
+	// again with them. The route's other failure mode, a `null` body
+	// served as HTTP 200, resolves and so is unaffected.
+	const error = useStickyError( query.error, query.isFetching );
 
 	const backups = useMemo(
 		() => normalizeBackups( Array.isArray( data ) ? data : undefined ),
@@ -243,8 +251,13 @@ export function useBackups( { forcePoll = false }: Args = {} ): Result {
 	return {
 		...summary,
 		backups,
-		error: error ?? null,
-		isRefetching: query.isRefetching,
+		error,
+		// Not `query.isRefetching`: that is `isFetching && ! isPending`,
+		// and the rewind above makes a retry pending again, so it stays
+		// false for the whole round trip — the hole this field's docblock
+		// describes, in the field meant to close it. "Something is already
+		// on screen and we are fetching" is the honest test.
+		isRefetching: query.isFetching && ( error !== null || data !== undefined ),
 		refetch: retry,
 	};
 }

--- a/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useCallback, useMemo } from '@wordpress/element';
 import { fetchFileTree, type WpcomFileNode } from '../data/api/file-tree';
 import { keys } from '../data/query-client';
+import { useStickyError } from './use-sticky-error';
 import type { FileNode } from '../types/file-tree';
 
 const BASE_FOLDER_PATH = '/';
@@ -125,11 +126,16 @@ export function useFileTree( rewindId: string, folderPath: string | null ): Resu
 		refetch();
 	}, [ refetch ] );
 
+	// Held across the retry: React Query rewinds this query to `pending`
+	// when it refetches after a failure, so without this the reason
+	// disappears the moment the reader clicks the retry button.
+	const error = useStickyError( query.error, query.isFetching );
+
 	return {
 		children,
 		isLoading: query.isLoading,
 		isFetching: query.isFetching,
-		error: query.error ?? null,
+		error,
 		refetch: retry,
 	};
 }

--- a/projects/packages/backup/src/dashboard/hooks/use-sticky-error.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-sticky-error.ts
@@ -1,0 +1,41 @@
+import { useRef } from 'react';
+
+/**
+ * Hold a query's error across its own retry.
+ *
+ * React Query v5 rewinds an errored query *that holds no data* back to
+ * `status: 'pending'` when it refetches: a retry on a query that has
+ * never succeeded is treated as a fresh first load. For the whole
+ * duration of that retry `error` is null and `isLoading` is true.
+ *
+ * Every failure surface in this dashboard is written as
+ * `error ? <QueryError/> : …`, so without this the reason vanished the
+ * instant the reader clicked "Try again" — the activity list fell back
+ * to DataViews' own "No results", which is the misleading empty state
+ * D3 removed, and `QueryError`'s own `isRetrying` state could never
+ * render because the component was already unmounted.
+ *
+ * Queries that hold data don't need this — they keep `status: 'success'`
+ * across a refetch — but applying it uniformly costs nothing and means
+ * a caller doesn't have to know which kind it has.
+ *
+ * @param error      - The error the query is reporting right now, if any.
+ * @param isFetching - Whether a request is in flight.
+ * @return The error to show: the current one, or the last one while its retry runs.
+ */
+export function useStickyError( error: Error | null, isFetching: boolean ): Error | null {
+	// A ref rather than state: this derives a render-time value from the
+	// arguments and must not schedule a render of its own. The assignment
+	// is idempotent for a given pair, so a double render leaves it where
+	// a single render would.
+	const lastError = useRef< Error | null >( null );
+
+	if ( error ) {
+		lastError.current = error;
+	} else if ( ! isFetching ) {
+		// Settled without an error: the failure is genuinely over.
+		lastError.current = null;
+	}
+
+	return error ?? lastError.current;
+}

--- a/projects/packages/backup/src/dashboard/hooks/use-sticky-error.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-sticky-error.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef } from '@wordpress/element';
 
 /**
  * Hold a query's error across its own retry.

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -9,21 +9,7 @@ import DashboardLayout from '../components/dashboard-layout';
 import RestoreItemsChecklist from '../components/restore-items-checklist';
 import { useDownload } from '../hooks/use-download';
 import { DEFAULT_RESTORE_ITEMS, hasSelectedItems } from '../types/restore';
-
-/**
- * Derive an ISO timestamp for the download-point label from the WPCOM
- * rewind id (unix seconds, possibly suffixed with a decimal).
- *
- * @param rewindId - The rewind id from the URL.
- * @return ISO timestamp or null when the id isn't numeric.
- */
-function rewindIdToIso( rewindId: string ): string | null {
-	const seconds = Number.parseInt( rewindId, 10 );
-	if ( ! Number.isFinite( seconds ) || seconds <= 0 ) {
-		return null;
-	}
-	return new Date( seconds * 1000 ).toISOString();
-}
+import { isValidRewindId, rewindIdToIso } from '../types/rewind-id';
 
 // Stable so the submit button can point at the hint with
 // `aria-describedby`. A module constant rather than `useInstanceId`
@@ -40,13 +26,46 @@ const SELECTION_HINT_ID = 'jpb-download__selection-hint';
  */
 export default function DownloadScreen() {
 	const { rewindId } = useParams( { from: '/download/$rewindId' } );
-	const downloadPoint = rewindIdToIso( rewindId );
 	const [ items, setItems ] = useState( DEFAULT_RESTORE_ITEMS );
 	const { state, submit, reset } = useDownload( rewindId );
 	const handleGenerate = useCallback( () => submit( items ), [ submit, items ] );
 	// An empty checklist would ask WPCOM for the *whole* archive, not for
 	// nothing — see `hasSelectedItems`.
 	const hasSelection = hasSelectedItems( items );
+
+	// A malformed id can only produce a failed download, so there is
+	// nothing here for the reader to do but go back. Before this, the id
+	// changed only whether the download-point line appeared: the button
+	// stayed live, and an id like `123abc` parsed to `123` and put a
+	// January 1970 download point above it. Only the shape is checked —
+	// whether the backup exists is upstream's answer.
+	if ( ! isValidRewindId( rewindId ) ) {
+		return (
+			<DashboardLayout>
+				<div className="jpb-download">
+					<Link to="/" className="jpb-download__back">
+						<Icon icon={ arrowLeft } size={ 18 } />
+						{ __( 'Back to overview', 'jetpack-backup-pkg' ) }
+					</Link>
+					<Card.Root className="jpb-download__card">
+						<Stack direction="column" gap="xs">
+							<Text variant="heading-md" render={ <h3 /> }>
+								{ __( "This download link isn't valid.", 'jetpack-backup-pkg' ) }
+							</Text>
+							<Text variant="body-sm" className="jpb-text-muted">
+								{ __(
+									'The address is missing a valid restore point. Go back to the overview and choose a backup to download.',
+									'jetpack-backup-pkg'
+								) }
+							</Text>
+						</Stack>
+					</Card.Root>
+				</div>
+			</DashboardLayout>
+		);
+	}
+
+	const downloadPoint = rewindIdToIso( rewindId );
 
 	return (
 		<DashboardLayout>
@@ -62,12 +81,10 @@ export default function DownloadScreen() {
 							<Text variant="heading-md" render={ <h3 /> }>
 								{ __( 'Download backup', 'jetpack-backup-pkg' ) }
 							</Text>
-							{ downloadPoint && (
-								<Text variant="body-sm" className="jpb-text-muted">
-									{ __( 'Download point:', 'jetpack-backup-pkg' ) }{ ' ' }
-									{ dateI18n( 'M j, Y, g:i A', downloadPoint, undefined ) }
-								</Text>
-							) }
+							<Text variant="body-sm" className="jpb-text-muted">
+								{ __( 'Download point:', 'jetpack-backup-pkg' ) }{ ' ' }
+								{ dateI18n( 'M j, Y, g:i A', downloadPoint, undefined ) }
+							</Text>
 						</Stack>
 					</Stack>
 					{ ( state.phase === 'idle' || state.phase === 'submitting' ) && (

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -6,6 +6,7 @@ import { Icon, cloud, download as downloadIcon, arrowLeft } from '@wordpress/ico
 import { Link, useParams } from '@wordpress/route';
 import { Button, Card, Stack, Text } from '@wordpress/ui';
 import DashboardLayout from '../components/dashboard-layout';
+import InvalidRewindId from '../components/invalid-rewind-id';
 import RestoreItemsChecklist from '../components/restore-items-checklist';
 import { useDownload } from '../hooks/use-download';
 import { DEFAULT_RESTORE_ITEMS, hasSelectedItems } from '../types/restore';
@@ -33,35 +34,18 @@ export default function DownloadScreen() {
 	// nothing — see `hasSelectedItems`.
 	const hasSelection = hasSelectedItems( items );
 
-	// A malformed id can only produce a failed download, so there is
-	// nothing here for the reader to do but go back. Before this, the id
-	// changed only whether the download-point line appeared: the button
-	// stayed live, and an id like `123abc` parsed to `123` and put a
-	// January 1970 download point above it. Only the shape is checked —
-	// whether the backup exists is upstream's answer.
+	// A malformed id can only produce a failed download, so the screen
+	// offers the way back and nothing else — see `InvalidRewindId`.
 	if ( ! isValidRewindId( rewindId ) ) {
 		return (
-			<DashboardLayout>
-				<div className="jpb-download">
-					<Link to="/" className="jpb-download__back">
-						<Icon icon={ arrowLeft } size={ 18 } />
-						{ __( 'Back to overview', 'jetpack-backup-pkg' ) }
-					</Link>
-					<Card.Root className="jpb-download__card">
-						<Stack direction="column" gap="xs">
-							<Text variant="heading-md" render={ <h3 /> }>
-								{ __( "This download link isn't valid.", 'jetpack-backup-pkg' ) }
-							</Text>
-							<Text variant="body-sm" className="jpb-text-muted">
-								{ __(
-									'The address is missing a valid restore point. Go back to the overview and choose a backup to download.',
-									'jetpack-backup-pkg'
-								) }
-							</Text>
-						</Stack>
-					</Card.Root>
-				</div>
-			</DashboardLayout>
+			<InvalidRewindId
+				prefix="jpb-download"
+				title={ __( "This download link isn't valid.", 'jetpack-backup-pkg' ) }
+				body={ __(
+					'The address is missing a valid download point. Go back to the overview and choose a backup to download.',
+					'jetpack-backup-pkg'
+				) }
+			/>
 		);
 	}
 

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -6,6 +6,7 @@ import { Icon, backup as backupIcon, arrowLeft } from '@wordpress/icons';
 import { Link, useParams } from '@wordpress/route';
 import { Button, Card, Stack, Text } from '@wordpress/ui';
 import DashboardLayout from '../components/dashboard-layout';
+import InvalidRewindId from '../components/invalid-rewind-id';
 import RestoreItemsChecklist from '../components/restore-items-checklist';
 import { useRestore } from '../hooks/use-restore';
 import { DEFAULT_RESTORE_ITEMS, hasSelectedItems } from '../types/restore';
@@ -32,35 +33,18 @@ export default function RestoreScreen() {
 	// see `hasSelectedItems`. On this screen that is unrecoverable.
 	const hasSelection = hasSelectedItems( items );
 
-	// A malformed id can only produce a failed restore, so there is
-	// nothing here for the reader to do but go back. Before this, the id
-	// changed only whether the restore-point line appeared: the Confirm
-	// button stayed live, and an id like `123abc` parsed to `123` and put
-	// a January 1970 restore point above it. Only the shape is checked —
-	// whether the backup exists is upstream's answer.
+	// A malformed id can only produce a failed restore, so the screen
+	// offers the way back and nothing else — see `InvalidRewindId`.
 	if ( ! isValidRewindId( rewindId ) ) {
 		return (
-			<DashboardLayout>
-				<div className="jpb-restore">
-					<Link to="/" className="jpb-restore__back">
-						<Icon icon={ arrowLeft } size={ 18 } />
-						{ __( 'Back to overview', 'jetpack-backup-pkg' ) }
-					</Link>
-					<Card.Root className="jpb-restore__card">
-						<Stack direction="column" gap="xs">
-							<Text variant="heading-md" render={ <h3 /> }>
-								{ __( "This restore link isn't valid.", 'jetpack-backup-pkg' ) }
-							</Text>
-							<Text variant="body-sm" className="jpb-text-muted">
-								{ __(
-									'The address is missing a valid restore point. Go back to the overview and choose a backup to restore.',
-									'jetpack-backup-pkg'
-								) }
-							</Text>
-						</Stack>
-					</Card.Root>
-				</div>
-			</DashboardLayout>
+			<InvalidRewindId
+				prefix="jpb-restore"
+				title={ __( "This restore link isn't valid.", 'jetpack-backup-pkg' ) }
+				body={ __(
+					'The address is missing a valid restore point. Go back to the overview and choose a backup to restore.',
+					'jetpack-backup-pkg'
+				) }
+			/>
 		);
 	}
 

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -9,23 +9,7 @@ import DashboardLayout from '../components/dashboard-layout';
 import RestoreItemsChecklist from '../components/restore-items-checklist';
 import { useRestore } from '../hooks/use-restore';
 import { DEFAULT_RESTORE_ITEMS, hasSelectedItems } from '../types/restore';
-
-/**
- * Derive an ISO timestamp for the restore-point label from the WPCOM
- * rewind id. WPCOM rewind ids are unix-seconds (with an optional decimal
- * suffix), so we don't need to look the activity row up in cache just
- * to render "Restore point: …".
- *
- * @param rewindId - The rewind id from the URL.
- * @return ISO timestamp or null when the id isn't numeric.
- */
-function rewindIdToIso( rewindId: string ): string | null {
-	const seconds = Number.parseInt( rewindId, 10 );
-	if ( ! Number.isFinite( seconds ) || seconds <= 0 ) {
-		return null;
-	}
-	return new Date( seconds * 1000 ).toISOString();
-}
+import { isValidRewindId, rewindIdToIso } from '../types/rewind-id';
 
 // Stable so the submit button can point at the hint with
 // `aria-describedby`. A module constant rather than `useInstanceId`
@@ -41,13 +25,46 @@ const SELECTION_HINT_ID = 'jpb-restore__selection-hint';
  */
 export default function RestoreScreen() {
 	const { rewindId } = useParams( { from: '/restore/$rewindId' } );
-	const restorePoint = rewindIdToIso( rewindId );
 	const [ items, setItems ] = useState( DEFAULT_RESTORE_ITEMS );
 	const { state, submit, reset } = useRestore( rewindId );
 	const handleConfirm = useCallback( () => submit( items ), [ submit, items ] );
 	// An empty checklist would restore *everything* rather than nothing —
 	// see `hasSelectedItems`. On this screen that is unrecoverable.
 	const hasSelection = hasSelectedItems( items );
+
+	// A malformed id can only produce a failed restore, so there is
+	// nothing here for the reader to do but go back. Before this, the id
+	// changed only whether the restore-point line appeared: the Confirm
+	// button stayed live, and an id like `123abc` parsed to `123` and put
+	// a January 1970 restore point above it. Only the shape is checked —
+	// whether the backup exists is upstream's answer.
+	if ( ! isValidRewindId( rewindId ) ) {
+		return (
+			<DashboardLayout>
+				<div className="jpb-restore">
+					<Link to="/" className="jpb-restore__back">
+						<Icon icon={ arrowLeft } size={ 18 } />
+						{ __( 'Back to overview', 'jetpack-backup-pkg' ) }
+					</Link>
+					<Card.Root className="jpb-restore__card">
+						<Stack direction="column" gap="xs">
+							<Text variant="heading-md" render={ <h3 /> }>
+								{ __( "This restore link isn't valid.", 'jetpack-backup-pkg' ) }
+							</Text>
+							<Text variant="body-sm" className="jpb-text-muted">
+								{ __(
+									'The address is missing a valid restore point. Go back to the overview and choose a backup to restore.',
+									'jetpack-backup-pkg'
+								) }
+							</Text>
+						</Stack>
+					</Card.Root>
+				</div>
+			</DashboardLayout>
+		);
+	}
+
+	const restorePoint = rewindIdToIso( rewindId );
 
 	return (
 		<DashboardLayout>
@@ -63,12 +80,10 @@ export default function RestoreScreen() {
 							<Text variant="heading-md" render={ <h3 /> }>
 								{ __( 'Restore backup', 'jetpack-backup-pkg' ) }
 							</Text>
-							{ restorePoint && (
-								<Text variant="body-sm" className="jpb-text-muted">
-									{ __( 'Restore point:', 'jetpack-backup-pkg' ) }{ ' ' }
-									{ dateI18n( 'M j, Y, g:i A', restorePoint, undefined ) }
-								</Text>
-							) }
+							<Text variant="body-sm" className="jpb-text-muted">
+								{ __( 'Restore point:', 'jetpack-backup-pkg' ) }{ ' ' }
+								{ dateI18n( 'M j, Y, g:i A', restorePoint, undefined ) }
+							</Text>
 						</Stack>
 					</Stack>
 					{ ( state.phase === 'idle' || state.phase === 'submitting' ) && (

--- a/projects/packages/backup/src/dashboard/types/rewind-id.ts
+++ b/projects/packages/backup/src/dashboard/types/rewind-id.ts
@@ -21,14 +21,23 @@
  * is accepted; rejecting it would mean choosing an arbitrary horizon,
  * and a horizon that is wrong turns away real backups.
  *
+ * Every check runs against the same `seconds`, deliberately. Reading the
+ * id twice with two different parsers is what let `0.5` through: the
+ * positivity test used `Number.parseFloat`, which sees `0.5`, while the
+ * date came from `Number.parseInt`, which sees `0` — so an id the `0`
+ * case was written to stop arrived at `rewindIdToIso` and rendered
+ * "Jan 1, 1970" above a live Confirm button. The gate has to judge the
+ * number the caller will actually use.
+ *
  * @param rewindId - Candidate id, straight from the URL.
  * @return True when the id is shaped like a rewind id and names a representable date.
  */
 export function isValidRewindId( rewindId: string ): boolean {
-	if ( ! /^\d+(\.\d+)?$/.test( rewindId ) || Number.parseFloat( rewindId ) <= 0 ) {
+	if ( ! /^\d+(\.\d+)?$/.test( rewindId ) ) {
 		return false;
 	}
-	return ! Number.isNaN( new Date( Number.parseInt( rewindId, 10 ) * 1000 ).getTime() );
+	const seconds = Number.parseInt( rewindId, 10 );
+	return seconds > 0 && ! Number.isNaN( new Date( seconds * 1000 ).getTime() );
 }
 
 /**

--- a/projects/packages/backup/src/dashboard/types/rewind-id.ts
+++ b/projects/packages/backup/src/dashboard/types/rewind-id.ts
@@ -11,11 +11,24 @@
  * 1970 restore point above a live Confirm button. A believable wrong
  * screen is worse than an obviously broken one.
  *
+ * Digits alone are not enough, which is why the resulting `Date` is
+ * tested rather than the parsed number: `Date` is only defined within
+ * ±8.64e15 ms, so an id past that ceiling is well-formed and still makes
+ * `rewindIdToIso` throw. `toFileNode` in `hooks/use-file-tree` guards a
+ * WPCOM timestamp the same way and for the same reason.
+ *
+ * It stops at representable, not plausible. A far-future but valid date
+ * is accepted; rejecting it would mean choosing an arbitrary horizon,
+ * and a horizon that is wrong turns away real backups.
+ *
  * @param rewindId - Candidate id, straight from the URL.
- * @return True when the id is shaped like a rewind id.
+ * @return True when the id is shaped like a rewind id and names a representable date.
  */
 export function isValidRewindId( rewindId: string ): boolean {
-	return /^\d+(\.\d+)?$/.test( rewindId ) && Number.parseFloat( rewindId ) > 0;
+	if ( ! /^\d+(\.\d+)?$/.test( rewindId ) || Number.parseFloat( rewindId ) <= 0 ) {
+		return false;
+	}
+	return ! Number.isNaN( new Date( Number.parseInt( rewindId, 10 ) * 1000 ).getTime() );
 }
 
 /**
@@ -24,6 +37,9 @@ export function isValidRewindId( rewindId: string ): boolean {
  * Rewind ids are unix seconds, so the date is readable from the id alone
  * — no need to look the activity row up in cache just to render
  * "Restore point: …".
+ *
+ * Total for any id `isValidRewindId` accepts, which is the only way it
+ * is called — that check is what makes the date representable.
  *
  * @param rewindId - A rewind id that has passed `isValidRewindId`.
  * @return ISO timestamp.

--- a/projects/packages/backup/src/dashboard/types/rewind-id.ts
+++ b/projects/packages/backup/src/dashboard/types/rewind-id.ts
@@ -1,0 +1,33 @@
+/**
+ * Whether a string is a well-formed WPCOM rewind id.
+ *
+ * Rewind ids are unix seconds with an optional decimal suffix
+ * (`1786644531`, `1786644531.9425`). This is a check on the *shape* of
+ * the id only — a well-formed id for a backup that does not exist still
+ * passes, and is caught upstream.
+ *
+ * Matched against a pattern rather than parsed: `Number.parseInt` accepts
+ * a numeric prefix, so `123abc` came back as `123` and rendered a January
+ * 1970 restore point above a live Confirm button. A believable wrong
+ * screen is worse than an obviously broken one.
+ *
+ * @param rewindId - Candidate id, straight from the URL.
+ * @return True when the id is shaped like a rewind id.
+ */
+export function isValidRewindId( rewindId: string ): boolean {
+	return /^\d+(\.\d+)?$/.test( rewindId ) && Number.parseFloat( rewindId ) > 0;
+}
+
+/**
+ * Derive an ISO timestamp from a rewind id, for the restore-point label.
+ *
+ * Rewind ids are unix seconds, so the date is readable from the id alone
+ * — no need to look the activity row up in cache just to render
+ * "Restore point: …".
+ *
+ * @param rewindId - A rewind id that has passed `isValidRewindId`.
+ * @return ISO timestamp.
+ */
+export function rewindIdToIso( rewindId: string ): string {
+	return new Date( Number.parseInt( rewindId, 10 ) * 1000 ).toISOString();
+}

--- a/projects/packages/backup/tests/error-persists-during-retry.test.tsx
+++ b/projects/packages/backup/tests/error-persists-during-retry.test.tsx
@@ -33,7 +33,7 @@ jest.mock( '@wordpress/route', () => ( {
 // Imports must come after the jest.mock factories above.
 import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 import ActivityList from '../src/dashboard/components/activity-list';
 import FileBrowser, { EMPTY_FILE_SELECTION } from '../src/dashboard/components/file-browser';
 import { queryClient } from '../src/dashboard/data/query-client';

--- a/projects/packages/backup/tests/error-persists-during-retry.test.tsx
+++ b/projects/packages/backup/tests/error-persists-during-retry.test.tsx
@@ -1,0 +1,296 @@
+// Regression tests for JETPACK-2243: the reason for a failure must not
+// disappear the moment the reader asks to try again.
+//
+// React Query v5 rewinds an errored query *that holds no data* back to
+// `status: 'pending'` when it refetches — a retry is treated as a fresh
+// first load. So mid-retry `error` is null and `isLoading` is true, and
+// every `error ? <QueryError/> : …` branch in the dashboard unmounted on
+// click. The activity list fell back to DataViews' own "No results",
+// which is precisely the copy D3 (#51294) existed to remove; the file
+// browser fell through to a tree it had failed to load.
+//
+// It also made `QueryError`'s `isRetrying` prop (#51336) unreachable in
+// every one of its three call sites: the component was gone before it
+// could render its busy state.
+//
+// The fix keeps the last error until the refetch settles, at the hook
+// layer so all three surfaces inherit it.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+	useNavigate: () => () => {},
+	useParams: () => ( { rewindId: '1786644531.123' } ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import ActivityList from '../src/dashboard/components/activity-list';
+import FileBrowser, { EMPTY_FILE_SELECTION } from '../src/dashboard/components/file-browser';
+import { queryClient } from '../src/dashboard/data/query-client';
+import { ACTIVITY_LOG_DEFAULT_PER_PAGE } from '../src/dashboard/hooks/use-activity-log';
+import { useBackups } from '../src/dashboard/hooks/use-backups';
+import { useStickyError } from '../src/dashboard/hooks/use-sticky-error';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import type { View } from '@wordpress/dataviews';
+
+const noop = () => {};
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+const INITIAL_VIEW: View = {
+	type: 'list',
+	page: 1,
+	perPage: ACTIVITY_LOG_DEFAULT_PER_PAGE,
+	filters: [],
+	titleField: 'title',
+	mediaField: 'icon',
+	descriptionField: 'description',
+	fields: [],
+};
+
+/**
+ * One raw rewindable-activity row, so a successful retry has something
+ * to render.
+ *
+ * @return A raw activity entry.
+ */
+function activityEntry() {
+	return {
+		activity_id: 'act-1',
+		gridicon: 'cloud',
+		summary: 'Backup complete',
+		published: '2026-08-13T18:08:56+00:00',
+		rewind_id: '1786644531.123',
+		actor: { type: 'Application', name: 'Jetpack' },
+		content: { text: '46 plugins, 23 themes' },
+		name: 'rewind__backup_complete_full',
+	};
+}
+
+/**
+ * A promise whose settlement the test controls, so a retry can be held
+ * in flight while assertions run against the rendered output.
+ *
+ * @return The promise and its resolver.
+ */
+function deferred< T >() {
+	let resolve!: ( value: T ) => void;
+	const promise = new Promise< T >( res => {
+		resolve = res;
+	} );
+	return { promise, resolve };
+}
+
+/**
+ * `ActivityList` with the controlled view state it expects.
+ *
+ * @return The rendered harness.
+ */
+function Harness() {
+	const [ view, setView ] = useState< View >( INITIAL_VIEW );
+	return (
+		<QueryClientProvider>
+			<ActivityList selectedId={ null } onSelect={ noop } view={ view } onChangeView={ setView } />
+		</QueryClientProvider>
+	);
+}
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'useStickyError', () => {
+	it( 'reports the error the query is currently carrying', () => {
+		const error = new Error( 'boom' );
+		const { result } = renderHook( () => useStickyError( error, false ) );
+
+		expect( result.current ).toBe( error );
+	} );
+
+	it( 'holds the last error while the retry is still in flight', () => {
+		const error = new Error( 'boom' );
+		const { result, rerender } = renderHook(
+			( { error: e, isFetching }: { error: Error | null; isFetching: boolean } ) =>
+				useStickyError( e, isFetching ),
+			{ initialProps: { error: error as Error | null, isFetching: false } }
+		);
+
+		// React Query nulls the error and starts fetching in the same tick.
+		rerender( { error: null, isFetching: true } );
+
+		expect( result.current ).toBe( error );
+	} );
+
+	it( 'clears once the retry succeeds', () => {
+		const error = new Error( 'boom' );
+		const { result, rerender } = renderHook(
+			( { error: e, isFetching }: { error: Error | null; isFetching: boolean } ) =>
+				useStickyError( e, isFetching ),
+			{ initialProps: { error: error as Error | null, isFetching: false } }
+		);
+
+		rerender( { error: null, isFetching: true } );
+		rerender( { error: null, isFetching: false } );
+
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'replaces the held error when the retry fails differently', () => {
+		const first = new Error( 'boom' );
+		const second = new Error( 'still boom' );
+		const { result, rerender } = renderHook(
+			( { error: e, isFetching }: { error: Error | null; isFetching: boolean } ) =>
+				useStickyError( e, isFetching ),
+			{ initialProps: { error: first as Error | null, isFetching: false } }
+		);
+
+		rerender( { error: null, isFetching: true } );
+		rerender( { error: second, isFetching: false } );
+
+		expect( result.current ).toBe( second );
+	} );
+
+	it( 'reports nothing during a first load that has not failed', () => {
+		const { result } = renderHook( () => useStickyError( null, true ) );
+
+		expect( result.current ).toBeNull();
+	} );
+} );
+
+describe( 'activity list', () => {
+	it( 'keeps the reason and shows the retry as busy while it runs', async () => {
+		mockApiFetch.mockRejectedValue( {
+			code: 'activity_log_fetch_failed',
+			message: 'Service unavailable',
+		} );
+
+		render( <Harness /> );
+
+		await expect(
+			screen.findByText( "We couldn't load your site's activity." )
+		).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Service unavailable' ) ).toBeInTheDocument();
+
+		const retry = deferred< unknown >();
+		mockApiFetch.mockImplementation( () => retry.promise );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+
+		// The regression: this is where "No results" used to take over.
+		expect( screen.getByText( 'Service unavailable' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'No results' ) ).not.toBeInTheDocument();
+		// `isRetrying` finally reaches the button it was written for.
+		// Asserted as `aria-disabled`: the design-system Button keeps a
+		// disabled control focusable rather than using the native
+		// attribute, so `toBeDisabled()` does not see it.
+		expect( screen.getByRole( 'button', { name: 'Try again' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+
+		retry.resolve( {
+			current: { orderedItems: [ activityEntry() ] },
+			totalItems: 1,
+			totalPages: 1,
+		} );
+
+		await expect( screen.findByText( 'Backup complete' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Service unavailable' ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'file browser', () => {
+	it( 'keeps the reason on screen while its retry runs', async () => {
+		mockApiFetch.mockRejectedValue( {
+			code: 'file_browser_fetch_failed',
+			message: 'Backup host unreachable',
+		} );
+
+		render(
+			<QueryClientProvider>
+				<FileBrowser
+					rewindId="1786644531.123"
+					selection={ EMPTY_FILE_SELECTION }
+					onSelectionChange={ noop }
+				/>
+			</QueryClientProvider>
+		);
+
+		await expect(
+			screen.findByText( "We couldn't load this backup's files." )
+		).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Backup host unreachable' ) ).toBeInTheDocument();
+
+		const retry = deferred< unknown >();
+		mockApiFetch.mockImplementation( () => retry.promise );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+
+		// The regression: the early return stopped firing mid-retry and the
+		// browser fell through to a tree it had failed to load.
+		expect( screen.getByText( "We couldn't load this backup's files." ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Backup host unreachable' ) ).toBeInTheDocument();
+
+		retry.resolve( { contents: [] } );
+		await waitFor( () =>
+			expect( screen.queryByText( 'Backup host unreachable' ) ).not.toBeInTheDocument()
+		);
+	} );
+} );
+
+describe( 'backups', () => {
+	// Only the transport-rejection path is at risk here. The route's other
+	// failure mode — a `null` body served as HTTP 200 — resolves, so the
+	// query stays a success across a refetch and `state` is derived from
+	// the retained `data` rather than from `error`.
+	it( 'stays in the error state while its retry runs', async () => {
+		mockApiFetch.mockRejectedValue( {
+			code: 'backups_fetch_failed',
+			message: 'Gateway timeout',
+		} );
+
+		const { result } = renderHook( () => useBackups(), { wrapper: QueryClientProvider } );
+
+		await waitFor( () => expect( result.current.state ).toBe( 'error' ) );
+		expect( result.current.error ).not.toBeNull();
+
+		const retry = deferred< unknown >();
+		mockApiFetch.mockImplementation( () => retry.promise );
+		act( () => result.current.refetch() );
+
+		// The regression: `state` flipped back to 'loading' and the
+		// Overview's QueryError — the only control that can ask again —
+		// unmounted with it.
+		await waitFor( () => expect( result.current.isRefetching ).toBe( true ) );
+		expect( result.current.state ).toBe( 'error' );
+		expect( result.current.error ).not.toBeNull();
+
+		await act( async () => {
+			retry.resolve( [] );
+		} );
+		await waitFor( () => expect( result.current.error ).toBeNull() );
+	} );
+} );

--- a/projects/packages/backup/tests/invalid-rewind-id.test.tsx
+++ b/projects/packages/backup/tests/invalid-rewind-id.test.tsx
@@ -1,0 +1,156 @@
+// Regression tests for JETPACK-2243 B5.
+//
+// `/restore/not-a-real-id` rendered a fully armed Confirm restore button.
+// The only thing the bad id changed was that the "Restore point:" line
+// was silently omitted — a detail nobody would read as a warning — and
+// the button beside it would have sent the malformed id upstream.
+//
+// The screens already had the signal and were only half-using it:
+// `rewindIdToIso()` returned null for an id it could not parse, and both
+// screens used that solely to hide the date.
+//
+// The check is deliberately about the *shape* of the id, not whether the
+// backup exists. `parseInt` accepts a numeric prefix, so `123abc` parsed
+// to `123` and rendered "Jan 1, 1970" as a restore point above a live
+// button — a plausible-looking screen rather than an obviously broken
+// one, which is the worse of the two failures.
+
+const mockApiFetch = jest.fn();
+const mockParams = jest.fn< { rewindId: string }, [] >();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+	useNavigate: () => () => {},
+	useParams: () => mockParams(),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import { queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import DownloadScreen from '../src/dashboard/screens/download';
+import RestoreScreen from '../src/dashboard/screens/restore';
+import { isValidRewindId, rewindIdToIso } from '../src/dashboard/types/rewind-id';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const CAPABILITIES = { hasBackupPlan: true, hasScan: false };
+
+// A real WPCOM rewind id: unix seconds with a decimal suffix.
+const VALID_ID = '1786644531.123';
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	// Both screens render behind `<Gates>`, which resolves capabilities
+	// before it mounts the body under test.
+	mockApiFetch.mockResolvedValue( CAPABILITIES );
+	mockParams.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'isValidRewindId', () => {
+	it.each( [ '1786644531', '1786644531.123', '1786644531.9425' ] )(
+		'accepts the WPCOM id %s',
+		id => {
+			expect( isValidRewindId( id ) ).toBe( true );
+		}
+	);
+
+	it.each( [
+		[ 'a word', 'not-a-real-id' ],
+		[ 'a numeric prefix, which parseInt would have accepted', '123abc' ],
+		[ 'the empty string', '' ],
+		[ 'zero', '0' ],
+		[ 'a negative number', '-1786644531' ],
+		[ 'a trailing dot', '1786644531.' ],
+		[ 'whitespace', ' 1786644531' ],
+	] )( 'rejects %s', ( _label, id ) => {
+		expect( isValidRewindId( id ) ).toBe( false );
+	} );
+} );
+
+describe( 'rewindIdToIso', () => {
+	it( 'converts unix seconds to an ISO timestamp', () => {
+		expect( rewindIdToIso( '1786644531.123' ) ).toBe( new Date( 1786644531000 ).toISOString() );
+	} );
+} );
+
+describe.each( [
+	{
+		name: 'restore',
+		Screen: RestoreScreen,
+		heading: 'Restore backup',
+		submit: 'Confirm restore',
+		notFound: "This restore link isn't valid.",
+	},
+	{
+		name: 'download',
+		Screen: DownloadScreen,
+		heading: 'Download backup',
+		submit: 'Generate download',
+		notFound: "This download link isn't valid.",
+	},
+] )( '$name screen', ( { Screen, heading, submit, notFound } ) => {
+	it( 'refuses to arm the form for a malformed rewind id', async () => {
+		mockParams.mockReturnValue( { rewindId: 'not-a-real-id' } );
+
+		render(
+			<QueryClientProvider>
+				<Screen />
+			</QueryClientProvider>
+		);
+
+		await expect( screen.findByText( notFound ) ).resolves.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: new RegExp( submit ) } )
+		).not.toBeInTheDocument();
+		// The way back is the whole recovery affordance, so it has to
+		// survive. Matched by text: the `Link` mock renders an anchor with
+		// no `href`, which carries no implicit `link` role.
+		expect( screen.getByText( 'Back to overview' ) ).toBeInTheDocument();
+	} );
+
+	it( 'refuses an id that only starts with digits', async () => {
+		// This is the one that rendered a believable screen: `parseInt`
+		// took `123`, so the card showed a January 1970 restore point
+		// above a live button.
+		mockParams.mockReturnValue( { rewindId: '123abc' } );
+
+		render(
+			<QueryClientProvider>
+				<Screen />
+			</QueryClientProvider>
+		);
+
+		await expect( screen.findByText( notFound ) ).resolves.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: new RegExp( submit ) } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'arms the form for a real rewind id', async () => {
+		mockParams.mockReturnValue( { rewindId: VALID_ID } );
+
+		render(
+			<QueryClientProvider>
+				<Screen />
+			</QueryClientProvider>
+		);
+
+		await expect( screen.findByText( heading ) ).resolves.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: new RegExp( submit ) } ) ).toBeInTheDocument();
+		expect( screen.queryByText( notFound ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/invalid-rewind-id.test.tsx
+++ b/projects/packages/backup/tests/invalid-rewind-id.test.tsx
@@ -76,6 +76,18 @@ describe( 'isValidRewindId', () => {
 		[ 'a negative number', '-1786644531' ],
 		[ 'a trailing dot', '1786644531.' ],
 		[ 'whitespace', ' 1786644531' ],
+		// Digits are not enough. `Date` is only defined within ±8.64e15 ms,
+		// so an id past that ceiling is well-formed and still throws in
+		// `rewindIdToIso` — which put the route's error boundary on screen,
+		// with a "Reload the page" button that reloads into the same throw,
+		// in place of the card this gate exists to show.
+		//
+		// The gate stops there: it does not judge whether a representable
+		// date is a *plausible* one. `8640000000000` is accepted and renders
+		// "Sep 13, +275760", which is odd but harmless and unreachable
+		// except by typing it. Rejecting it means picking an arbitrary
+		// horizon, which risks turning away genuinely old backups.
+		[ 'an unrepresentable date', '8640000000001' ],
 	] )( 'rejects %s', ( _label, id ) => {
 		expect( isValidRewindId( id ) ).toBe( false );
 	} );

--- a/projects/packages/backup/tests/invalid-rewind-id.test.tsx
+++ b/projects/packages/backup/tests/invalid-rewind-id.test.tsx
@@ -88,6 +88,14 @@ describe( 'isValidRewindId', () => {
 		// except by typing it. Rejecting it means picking an arbitrary
 		// horizon, which risks turning away genuinely old backups.
 		[ 'an unrepresentable date', '8640000000001' ],
+		// `0` is rejected and `0.5` was not, which is the same hole
+		// `123abc` came through: the positivity check reads
+		// `Number.parseFloat` while the date is built from
+		// `Number.parseInt`, so any id whose integer part is zero passes a
+		// gate that its own `0` case proves was meant to stop it — and
+		// renders "Jan 1, 1970" above a live Confirm button.
+		[ 'a fraction of the first second', '0.5' ],
+		[ 'a fraction written with leading zeros', '00.5' ],
 	] )( 'rejects %s', ( _label, id ) => {
 		expect( isValidRewindId( id ) ).toBe( false );
 	} );

--- a/projects/packages/backup/tests/route-styles-include-admin-shell.test.ts
+++ b/projects/packages/backup/tests/route-styles-include-admin-shell.test.ts
@@ -1,0 +1,40 @@
+// Every wp-build route must pull in the dashboard's admin shell.
+//
+// Each route is its own bundle and its SCSS is inlined into its own
+// `content.js`, so a route that does not include the shell gets *none*
+// of it — not the `jetpack-admin-page-layout-wp-build` mixin that pins
+// `#wpbody-content` to the viewport, and not the page-internal
+// header / body / footer flex chain.
+//
+// That is not a theoretical gap. The mixin lived only in the dashboard
+// route, so cold-loading `/restore/$id` or `/download/$id` left
+// `#wpbody-content` static and the footer wherever the content happened
+// to end — measured live at 168px above the viewport bottom on the
+// restore form, against the correct 8px page inset on the overview.
+//
+// This is a structural check rather than a layout one: jsdom does no
+// layout, so the only honest automated guard is that each route asks
+// for the shell. Confirming it *works* means measuring in a browser.
+
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+const ROUTES_DIR = join( __dirname, '..', 'routes' );
+
+const routes = readdirSync( ROUTES_DIR ).filter( entry =>
+	statSync( join( ROUTES_DIR, entry ) ).isDirectory()
+);
+
+it( 'has routes to check', () => {
+	// Guards the guard: a bad path would otherwise make `it.each` below
+	// vacuous and the suite would pass having asserted nothing.
+	expect( routes.length ).toBeGreaterThan( 0 );
+} );
+
+describe.each( routes )( 'routes/%s', route => {
+	it( 'includes the shared admin shell in its stylesheet', () => {
+		const style = readFileSync( join( ROUTES_DIR, route, 'style.scss' ), 'utf8' );
+
+		expect( style ).toMatch( /@include\s+backup-admin-shell\b/ );
+	} );
+} );

--- a/projects/packages/backup/tests/stale-rows-feedback.test.tsx
+++ b/projects/packages/backup/tests/stale-rows-feedback.test.tsx
@@ -1,0 +1,173 @@
+// Regression tests for JETPACK-2243 F2.
+//
+// `useActivityPageQuery` sets `placeholderData: keepPreviousData`, which
+// is what makes pagination feel smooth: the previous page stays on
+// screen while the next one is fetched. React Query expresses that as
+// `isLoading === false` — the query is not *pending*, it is holding
+// placeholder rows — so the list was handing DataViews `isLoading` and
+// telling it "not loading" over rows that belong to the page the reader
+// just left. Clicking to page 2 changed nothing on screen until the
+// response landed.
+//
+// The fix reports `isLoading || isFetching`. That it cannot swallow the
+// error state is not obvious and is worth stating: DataViews 17.3.0
+// initialises `hasInitiallyLoaded` to `!isLoading` and latches it true
+// on the first non-loading render, and the spinner branch that would
+// replace the `empty` slot — where `QueryError` lives — is gated on
+// `!hasInitiallyLoaded`. After the first load that branch is dead, so a
+// truthy `isLoading` only reaches the footer. What the error slot does
+// across a retry is held by `error-persists-during-retry.test.tsx`.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useCallback, useState } from 'react';
+import ActivityList from '../src/dashboard/components/activity-list';
+import { queryClient } from '../src/dashboard/data/query-client';
+import { ACTIVITY_LOG_DEFAULT_PER_PAGE } from '../src/dashboard/hooks/use-activity-log';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import type { View } from '@wordpress/dataviews';
+
+const noop = () => {};
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+const INITIAL_VIEW: View = {
+	type: 'list',
+	page: 1,
+	perPage: ACTIVITY_LOG_DEFAULT_PER_PAGE,
+	filters: [],
+	titleField: 'title',
+	mediaField: 'icon',
+	descriptionField: 'description',
+	fields: [],
+};
+
+/**
+ * One raw rewindable-activity row for the page under test.
+ *
+ * @param page - Page number, woven into the ids so each page is distinguishable on screen.
+ * @return A raw activity entry.
+ */
+function activityEntry( page: number ) {
+	return {
+		activity_id: `act-page-${ page }`,
+		gridicon: 'cloud',
+		summary: `Backup complete (page ${ page })`,
+		published: '2026-08-13T18:08:56+00:00',
+		rewind_id: `178664453${ page }.123`,
+		actor: { type: 'Application', name: 'Jetpack' },
+		content: { text: '46 plugins, 23 themes' },
+		name: 'rewind__backup_complete_full',
+	};
+}
+
+/**
+ * A promise whose settlement the test controls, so a request can be held
+ * in flight while assertions run against the rendered output.
+ *
+ * @return The promise and its resolver.
+ */
+function deferred< T >() {
+	let resolve!: ( value: T ) => void;
+	let reject!: ( reason?: unknown ) => void;
+	const promise = new Promise< T >( ( res, rej ) => {
+		resolve = res;
+		reject = rej;
+	} );
+	return { promise, resolve, reject };
+}
+
+/**
+ * Harness giving `ActivityList` the controlled view state it expects,
+ * plus a button the test uses to advance the page the way DataViews'
+ * footer would.
+ *
+ * @return The rendered harness.
+ */
+function Harness() {
+	const [ view, setView ] = useState< View >( INITIAL_VIEW );
+	const goToPageTwo = useCallback( () => setView( v => ( { ...v, page: 2 } ) ), [] );
+	return (
+		<QueryClientProvider>
+			<button onClick={ goToPageTwo }>Go to page 2</button>
+			<ActivityList selectedId={ null } onSelect={ noop } view={ view } onChangeView={ setView } />
+		</QueryClientProvider>
+	);
+}
+
+/**
+ * The element carrying the list's busy state.
+ *
+ * @return The activity list container.
+ */
+function list() {
+	return document.querySelector( '.jpb-activity-list' ) as HTMLElement;
+}
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+it( 'reports the list as busy while the next page is still in flight', async () => {
+	const secondPage = deferred< unknown >();
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( 'page=2' ) ) {
+			return secondPage.promise;
+		}
+		return Promise.resolve( {
+			current: { orderedItems: [ activityEntry( 1 ) ] },
+			totalItems: 20,
+			totalPages: 2,
+		} );
+	} );
+
+	render( <Harness /> );
+
+	await expect( screen.findByText( 'Backup complete (page 1)' ) ).resolves.toBeInTheDocument();
+	expect( list() ).toHaveAttribute( 'aria-busy', 'false' );
+
+	await userEvent.click( screen.getByRole( 'button', { name: 'Go to page 2' } ) );
+
+	// The page-1 rows are still on screen — that is the whole point of
+	// `keepPreviousData` — so the busy flag is the only thing that can
+	// tell the reader their click was received.
+	await waitFor( () => expect( list() ).toHaveAttribute( 'aria-busy', 'true' ) );
+	expect( screen.getByText( 'Backup complete (page 1)' ) ).toBeInTheDocument();
+
+	secondPage.resolve( {
+		current: { orderedItems: [ activityEntry( 2 ) ] },
+		totalItems: 20,
+		totalPages: 2,
+	} );
+
+	await expect( screen.findByText( 'Backup complete (page 2)' ) ).resolves.toBeInTheDocument();
+	expect( list() ).toHaveAttribute( 'aria-busy', 'false' );
+} );

--- a/projects/packages/backup/tests/stale-rows-feedback.test.tsx
+++ b/projects/packages/backup/tests/stale-rows-feedback.test.tsx
@@ -32,7 +32,7 @@ jest.mock( '@wordpress/route', () => ( {
 // Imports must come after the jest.mock factories above.
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useCallback, useState } from 'react';
+import { useCallback, useState } from '@wordpress/element';
 import ActivityList from '../src/dashboard/components/activity-list';
 import { queryClient } from '../src/dashboard/data/query-client';
 import { ACTIVITY_LOG_DEFAULT_PER_PAGE } from '../src/dashboard/hooks/use-activity-log';


### PR DESCRIPTION
## Proposed changes

Four fixes in the modernized Backup dashboard, all behind `rsm_jetpack_ui_modernization_backup` (default off). The legacy page is untouched.

* **Refuse a malformed rewind id instead of arming the form (B5).** `/restore/not-a-real-id` rendered a fully live **Confirm restore** button — the only thing the bad id changed was that the "Restore point:" line was silently omitted. `/download/$id` had the same defect. Worse than filed: `Number.parseInt` accepts a numeric prefix, so `/restore/123abc` took `123`, rendered "Jan 1, 1970" as the restore point, and armed the button beneath it — a believable wrong screen rather than an obviously broken one. Both screens now share one `isValidRewindId`, and a malformed id renders a card saying so with the way back. The check is on the *shape* of the id only; whether the backup exists is upstream's answer, and is filed separately.
* **Keep a failure's reason on screen while it is retried.** Clicking "Try again" replaced the failure with the very empty state the error surfacing was added to remove: the activity list fell back to DataViews' own "No results", the file browser fell through to a tree it had just failed to load. React Query v5 rewinds an errored query *that holds no data* back to `status: 'pending'` on refetch — a retry on a query that never succeeded is treated as a fresh first load — so `error` was null and `isLoading` true for the whole round trip, and every `error ? <QueryError/> : …` branch unmounted on click. `useStickyError` holds the last error until the refetch settles, wired in at the hook layer so all three surfaces inherit it. This also makes `QueryError`'s `isRetrying` prop reachable for the first time, and fixes the same hole in `use-backups`' `isRefetching`.
* **Tell the activity list it is busy during a page change (F2).** `placeholderData: keepPreviousData` keeps the previous page on screen while the next is fetched, which React Query reports as `isLoading === false`. DataViews was told nothing was happening while the reader looked at rows from the page they had just left. It now gets `isLoading || isFetching`, as does `aria-busy`.
* **Give every route the admin shell (F9, cold-load half).** Cold-loading `/restore/$rewindId` or `/download/$rewindId` left the footer wherever the content ended, with the viewport blank below it. Each wp-build route is its own bundle with its own inlined SCSS, but the layout mixin lived only in `routes/dashboard/style.scss`. It moves to `src/dashboard/admin-shell.scss` as a mixin every route includes — where VideoPress and Forms keep theirs. Measured live as the gap between footer and viewport bottom, where 8px is the correct page inset:

  | Page | `#wpbody-content` | Gap (before) | Gap (after) |
  |---|---|---|---|
  | overview | `fixed` | 8px | 8px |
  | `/restore/<valid id>` | `static` → `fixed` | 168px | 8px |
  | `/restore/not-a-real-id` | `static` → `fixed` | 674px | 8px |

Also corrects `toIntRewindId`'s docblock, which still described `initiateRestore` as a caller — #51338 repointed restore at a route that takes the id in full, leaving `fetchFileTree` as the only caller.

Two of these were not on the task list. The retry defect was found while writing the F2 tests and is pre-existing on trunk, in code merged by #51294/#51336. The footer gap is the cold-load half of **F9** and likewise predates this branch — the restore form has always had it, as the table shows; the short not-found card only made it impossible to miss.

**Tests:** 294 jest, up from 264. The layout fix is verified by measurement in a browser, not by jest — jsdom does no layout, so its automated guard asserts only the structural invariant that every route asks for the shell.

## Related product discussion/links

* [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243/backup-modernized-dashboard-work-needed-before-the-flag-can-flip) — items **F2**, **B5** and **F9** (cold-load half), plus one item the task list did not have.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Everything here is behind the modernization flag. Turn it on with a mu-plugin or snippet:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

Then go to **Jetpack → Backup** on a site with a Backup plan.

**A malformed restore/download link no longer arms the form**

* Visit `…&p=/restore/not-a-real-id`, then `…&p=/restore/123abc`.
* Both should render "This restore link isn't valid." with a working **Back to overview** link, and **no** Confirm restore button.
* Before this PR, `123abc` showed a "Restore point: Jan 1, 1970" line above a live Confirm button.
* Repeat for `/download/not-a-real-id` and `/download/123abc` — same behaviour, "This download link isn't valid."
* Visit a real one, e.g. `…&p=/restore/<rewindId>` taken from a row in the activity list. The form should be armed as before, with the restore point rendered.

**The footer sits at the bottom on every route**

* Load `…&p=/restore/<rewindId>` and `…&p=/download/<rewindId>` **directly** (a fresh page load, not by clicking through from the overview — the bug only appears on a cold load).
* The Jetpack footer should sit at the bottom of the viewport, as it does on the overview, rather than partway up with blank space beneath.
* Also click through from the overview to confirm nothing regressed on the dashboard route: the activity list should still scroll inside its own pane with the footer pinned.

**A failed request keeps its reason while retrying**

* Easiest with DevTools → Network → offline, or by blocking `/jetpack/v4/site/rewindable-activity`.
* Load the Overview. The list should show "We couldn't load your site's activity." with the upstream reason beneath it.
* Click **Try again** while the request is still failing or slow. The reason must stay on screen and the button must show as busy.
* Before this PR the reason was replaced by "No results" for the duration of the retry.
* Same check for the file browser (block `/rewind/backup/ls`) and for the backup-status card (block `/jetpack/v4/backups` — note only the transport-failure case, not the null-body one).

**Page changes give feedback**

* With at least two pages of activity, throttle the network and click to page 2.
* The pagination footer should go inert while the request is in flight, instead of the page appearing to do nothing until it lands.

**Flag off**

* Turn the filter off and confirm the legacy Backup page renders exactly as before. No PHP changed in this PR.

