### PR TITLE
Backup: enqueue Tracks on the modernized dashboard and cover the admin wiring

### DIFF
--- a/projects/packages/backup/changelog/add-backup-modernized-tracks
+++ b/projects/packages/backup/changelog/add-backup-modernized-tracks
@@ -1,4 +1,3 @@
 Significance: patch
 Type: added
-
-Register the Tracks client on the modernized dashboard.
+Comment: Backup: register the Tracks client on the modernized dashboard and cover the flag → menu → enqueue chain. No-op when the modernization filter is off.

--- a/projects/packages/backup/changelog/add-backup-modernized-tracks
+++ b/projects/packages/backup/changelog/add-backup-modernized-tracks
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Send Tracks analytics from the modernized dashboard.
+Register the Tracks client on the modernized dashboard.

--- a/projects/packages/backup/changelog/add-backup-modernized-tracks
+++ b/projects/packages/backup/changelog/add-backup-modernized-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Send Tracks analytics from the modernized dashboard.

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -250,9 +250,17 @@ class Jetpack_Backup {
 				wp_enqueue_script( 'wp-jp-i18n-loader' );
 			}
 
-			// wp-build manages its own enqueue pipeline. The legacy script,
-			// initial state, and tracking are intentionally skipped for the
-			// wp-build dashboard.
+			// Tracks needs its client callables (`jpTracks.recordEvent`) on the
+			// page before any dashboard component can record an event. The
+			// esbuild bundles don't declare them as a dependency either, so
+			// enqueue them here, before the early return, on the same
+			// `can_use_analytics()` gate the legacy path uses below.
+			if ( self::can_use_analytics() ) {
+				Tracking::register_tracks_functions_scripts( true );
+			}
+
+			// wp-build manages its own enqueue pipeline. The legacy script and
+			// its initial state are skipped for the wp-build dashboard.
 			return;
 		}
 

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -250,11 +250,8 @@ class Jetpack_Backup {
 				wp_enqueue_script( 'wp-jp-i18n-loader' );
 			}
 
-			// Tracks needs its client callables (`jpTracks.recordEvent`) on the
-			// page before any dashboard component can record an event. The
-			// esbuild bundles don't declare them as a dependency either, so
-			// enqueue them here, before the early return, on the same
-			// `can_use_analytics()` gate the legacy path uses below.
+			// The esbuild bundles don't declare the Tracks client as a dependency
+			// either, so it never reaches the page on its own.
 			if ( self::can_use_analytics() ) {
 				Tracking::register_tracks_functions_scripts( true );
 			}

--- a/projects/packages/backup/tests/php/Admin_Modernization_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Admin_Modernization_Gating_Test.php
@@ -20,6 +20,7 @@ use function remove_all_filters;
 use function wp_dequeue_script;
 use function wp_deregister_script;
 use function wp_script_is;
+use function wp_scripts;
 
 require_once __DIR__ . '/mock-wp-build-render-page.php';
 
@@ -99,6 +100,9 @@ class Admin_Modernization_Gating_Test extends TestCase {
 
 		$this->assertTrue( wp_script_is( 'jp-tracks', 'registered' ) );
 		$this->assertTrue( wp_script_is( 'jp-tracks-functions', 'enqueued' ) );
+
+		// The dependency edge, not the registration, is what puts //stats.wp.com/w.js on the page.
+		$this->assertContains( 'jp-tracks', wp_scripts()->registered['jp-tracks-functions']->deps );
 	}
 
 	public function test_enqueue_admin_scripts_skips_tracks_when_analytics_denied() {

--- a/projects/packages/backup/tests/php/Admin_Modernization_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Admin_Modernization_Gating_Test.php
@@ -15,8 +15,11 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use function add_filter;
+use function has_action;
+use function remove_action;
 use function remove_all_actions;
 use function remove_all_filters;
+use function set_current_screen;
 use function wp_dequeue_script;
 use function wp_deregister_script;
 use function wp_script_is;
@@ -38,6 +41,12 @@ class Admin_Modernization_Gating_Test extends TestCase {
 	/** @var string[] Handles registered elsewhere that the code under test only enqueues. */
 	private const BORROWED_SCRIPT_HANDLES = array( 'wp-jp-i18n-loader' );
 
+	/** @var array The `current_screen` callback `maybe_load_wp_build()` adds. */
+	private const SCREEN_ALIAS_CALLBACK = array( Jetpack_Backup::class, 'alias_screen_id_for_wp_build' );
+
+	/** @var array The `admin_print_scripts` callback `maybe_load_wp_build()` adds. */
+	private const INITIAL_STATE_CALLBACK = array( Jetpack_Backup::class, 'render_connection_initial_state' );
+
 	public function setUp(): void {
 		parent::setUp();
 
@@ -50,6 +59,7 @@ class Admin_Modernization_Gating_Test extends TestCase {
 		remove_all_filters( 'jetpack_offline_mode' );
 		remove_all_actions( 'load-jetpack_page_jetpack-backup' );
 		remove_all_actions( 'jetpack_use_iframe_authorization_flow' );
+		$this->leave_backup_admin_request();
 
 		$this->reset_scripts();
 		$this->set_admin_menu_items( array() );
@@ -139,11 +149,66 @@ class Admin_Modernization_Gating_Test extends TestCase {
 		$this->assertSame( 'VaultPress Backup', $items[0]['menu_title'] );
 	}
 
+	public function test_maybe_load_wp_build_does_nothing_when_not_modernized() {
+		$this->enter_backup_admin_request();
+
+		Jetpack_Backup::maybe_load_wp_build();
+
+		$this->assertFalse( has_action( 'current_screen', self::SCREEN_ALIAS_CALLBACK ) );
+		$this->assertFalse( has_action( 'admin_print_scripts', self::INITIAL_STATE_CALLBACK ) );
+	}
+
+	public function test_maybe_load_wp_build_does_nothing_off_the_backup_admin_page() {
+		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
+		$this->enter_backup_admin_request();
+		$_GET['page'] = 'jetpack';
+
+		Jetpack_Backup::maybe_load_wp_build();
+
+		$this->assertFalse( has_action( 'current_screen', self::SCREEN_ALIAS_CALLBACK ) );
+		$this->assertFalse( has_action( 'admin_print_scripts', self::INITIAL_STATE_CALLBACK ) );
+	}
+
+	public function test_maybe_load_wp_build_hooks_the_page_when_modernized() {
+		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
+		$this->enter_backup_admin_request();
+
+		Jetpack_Backup::maybe_load_wp_build();
+
+		$this->assertNotFalse( has_action( 'current_screen', self::SCREEN_ALIAS_CALLBACK ) );
+		$this->assertNotFalse( has_action( 'admin_print_scripts', self::INITIAL_STATE_CALLBACK ) );
+	}
+
+	public function test_render_connection_initial_state_emits_the_connection_global() {
+		ob_start();
+		Jetpack_Backup::render_connection_initial_state();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<script id="jetpack-backup-connection-initial-state">', $output );
+		// render() declares a bare `var`; that is a window global only in a classic script tag.
+		$this->assertStringContainsString( 'JP_CONNECTION_INITIAL_STATE', $output );
+	}
+
 	/** `can_use_analytics()` needs offline mode off and the terms of service agreed. */
 	private function allow_analytics() {
 		add_filter( 'jetpack_offline_mode', '__return_false' );
 		Status_Cache::clear();
 		Jetpack_Options::update_option( 'tos_agreed', true );
+	}
+
+	/** `is_backup_admin_request()` reads `is_admin()` and `$_GET['page']`. */
+	private function enter_backup_admin_request() {
+		set_current_screen( 'jetpack_page_jetpack-backup' );
+		$_GET['page'] = Jetpack_Backup::JETPACK_BACKUP_SLUG;
+	}
+
+	/** Undo `enter_backup_admin_request()` and the hooks a successful load adds. */
+	private function leave_backup_admin_request() {
+		remove_action( 'current_screen', self::SCREEN_ALIAS_CALLBACK );
+		remove_action( 'admin_print_scripts', self::INITIAL_STATE_CALLBACK, 1 );
+
+		unset( $_GET['page'] );
+		set_current_screen( 'front' );
 	}
 
 	/** Undo every registration and enqueue these tests trigger. */

--- a/projects/packages/backup/tests/php/Admin_Modernization_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Admin_Modernization_Gating_Test.php
@@ -86,6 +86,7 @@ class Admin_Modernization_Gating_Test extends TestCase {
 		Jetpack_Backup::enqueue_admin_scripts();
 
 		$this->assertFalse( wp_script_is( 'jetpack-backup', 'registered' ) );
+		$this->assertTrue( wp_script_is( 'wp-jp-i18n-loader', 'enqueued' ) );
 	}
 
 	public function test_enqueue_admin_scripts_enqueues_tracks_when_modernized() {

--- a/projects/packages/backup/tests/php/Admin_Modernization_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Admin_Modernization_Gating_Test.php
@@ -1,11 +1,7 @@
 <?php
 /**
- * Unit tests for the modernization gating around the admin UI.
- *
- * The companion of `Rest_Bridge_Gating_Test`, which covers the same guarantee
- * for the REST routes: with the filter off, nothing about the admin page
- * changes; with it on, the legacy assets stay off the page and the wp-build
- * dashboard gets what it needs.
+ * Unit tests for the modernization gating around the admin UI. The REST-side
+ * companion is `Rest_Bridge_Gating_Test`.
  *
  * @package automattic/jetpack-backup-plugin
  */
@@ -35,23 +31,12 @@ require_once __DIR__ . '/mock-wp-build-render-page.php';
 #[CoversClass( Jetpack_Backup::class )]
 class Admin_Modernization_Gating_Test extends TestCase {
 
-	/**
-	 * Handles the code under test registers itself.
-	 *
-	 * @var string[]
-	 */
+	/** @var string[] Handles the code under test registers itself. */
 	private const OWNED_SCRIPT_HANDLES = array( 'jetpack-backup', 'jp-tracks', 'jp-tracks-functions' );
 
-	/**
-	 * Handles registered elsewhere that the code under test only enqueues.
-	 *
-	 * @var string[]
-	 */
+	/** @var string[] Handles registered elsewhere that the code under test only enqueues. */
 	private const BORROWED_SCRIPT_HANDLES = array( 'wp-jp-i18n-loader' );
 
-	/**
-	 * Start from a clean script registry and an empty menu queue.
-	 */
 	public function setUp(): void {
 		parent::setUp();
 
@@ -59,9 +44,6 @@ class Admin_Modernization_Gating_Test extends TestCase {
 		$this->set_admin_menu_items( array() );
 	}
 
-	/**
-	 * Reset everything a test may have installed.
-	 */
 	public function tearDown(): void {
 		remove_all_filters( Jetpack_Backup::MODERNIZATION_FILTER );
 		remove_all_filters( 'jetpack_offline_mode' );
@@ -77,16 +59,10 @@ class Admin_Modernization_Gating_Test extends TestCase {
 		parent::tearDown();
 	}
 
-	/**
-	 * The flag is off unless a filter turns it on.
-	 */
 	public function test_is_modernized_defaults_to_false() {
 		$this->assertFalse( Jetpack_Backup::is_modernized() );
 	}
 
-	/**
-	 * The flag follows the filter in both directions.
-	 */
 	public function test_is_modernized_follows_the_filter() {
 		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
 		$this->assertTrue( Jetpack_Backup::is_modernized() );
@@ -96,10 +72,6 @@ class Admin_Modernization_Gating_Test extends TestCase {
 		$this->assertFalse( Jetpack_Backup::is_modernized() );
 	}
 
-	/**
-	 * With the flag off, the legacy React bundle is still registered and
-	 * enqueued — the path the shipped plugin takes today.
-	 */
 	public function test_enqueue_admin_scripts_registers_legacy_script_when_not_modernized() {
 		Jetpack_Backup::enqueue_admin_scripts();
 
@@ -107,10 +79,7 @@ class Admin_Modernization_Gating_Test extends TestCase {
 		$this->assertTrue( wp_script_is( 'jetpack-backup', 'enqueued' ) );
 	}
 
-	/**
-	 * With the flag on, the legacy bundle must not reach the page: wp-build
-	 * runs its own enqueue pipeline and would render a second dashboard.
-	 */
+	/** With the flag on, wp-build enqueues its own bundle; a second one renders a second dashboard. */
 	public function test_enqueue_admin_scripts_skips_legacy_script_when_modernized() {
 		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
 
@@ -119,10 +88,6 @@ class Admin_Modernization_Gating_Test extends TestCase {
 		$this->assertFalse( wp_script_is( 'jetpack-backup', 'registered' ) );
 	}
 
-	/**
-	 * The modernized page still gets the Tracks callables, so the dashboard
-	 * can record events. Without this the product's telemetry is blank.
-	 */
 	public function test_enqueue_admin_scripts_enqueues_tracks_when_modernized() {
 		$this->allow_analytics();
 		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
@@ -135,11 +100,6 @@ class Admin_Modernization_Gating_Test extends TestCase {
 		$this->assertTrue( wp_script_is( 'jp-tracks-functions', 'enqueued' ) );
 	}
 
-	/**
-	 * The Tracks enqueue stays behind `can_use_analytics()`, same as the
-	 * legacy path: a site that has not agreed to the terms of service gets
-	 * no tracking script.
-	 */
 	public function test_enqueue_admin_scripts_skips_tracks_when_analytics_denied() {
 		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
 
@@ -150,10 +110,6 @@ class Admin_Modernization_Gating_Test extends TestCase {
 		$this->assertFalse( wp_script_is( 'jp-tracks-functions', 'registered' ) );
 	}
 
-	/**
-	 * With the flag off, the menu points at the legacy settings page and
-	 * keeps the current labels.
-	 */
 	public function test_add_wp_admin_submenu_uses_legacy_callback_when_not_modernized() {
 		Jetpack_Backup::add_wp_admin_submenu();
 
@@ -165,10 +121,6 @@ class Admin_Modernization_Gating_Test extends TestCase {
 		$this->assertSame( 'Backup', $items[0]['menu_title'] );
 	}
 
-	/**
-	 * With the flag on, the same slug renders through the wp-build callback
-	 * and picks up the VaultPress Backup labels.
-	 */
 	public function test_add_wp_admin_submenu_uses_wp_build_callback_when_modernized() {
 		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
 
@@ -182,19 +134,14 @@ class Admin_Modernization_Gating_Test extends TestCase {
 		$this->assertSame( 'VaultPress Backup', $items[0]['menu_title'] );
 	}
 
-	/**
-	 * Make `can_use_analytics()` return true: the site is not in offline
-	 * mode and has agreed to the terms of service.
-	 */
+	/** `can_use_analytics()` needs offline mode off and the terms of service agreed. */
 	private function allow_analytics() {
 		add_filter( 'jetpack_offline_mode', '__return_false' );
 		Status_Cache::clear();
 		Jetpack_Options::update_option( 'tos_agreed', true );
 	}
 
-	/**
-	 * Undo every registration and enqueue these tests trigger.
-	 */
+	/** Undo every registration and enqueue these tests trigger. */
 	private function reset_scripts() {
 		// `wp_deregister_script()` only unsets the handle from `registered`; it
 		// never touches `queue`. Without an explicit dequeue an enqueued handle
@@ -212,26 +159,20 @@ class Admin_Modernization_Gating_Test extends TestCase {
 	}
 
 	/**
-	 * Read the Admin_Menu package's queued menu items.
-	 *
-	 * @return array
+	 * @return array The Admin_Menu package's queued menu items.
 	 */
 	private function get_admin_menu_items() {
 		return $this->accessible_property( Admin_Menu::class, 'menu_items' )->getValue();
 	}
 
 	/**
-	 * Overwrite the Admin_Menu package's queued menu items.
-	 *
-	 * @param array $items The items to set.
+	 * @param array $items The Admin_Menu package's queued menu items to set.
 	 */
 	private function set_admin_menu_items( $items ) {
 		$this->accessible_property( Admin_Menu::class, 'menu_items' )->setValue( null, $items );
 	}
 
 	/**
-	 * Get an accessible reflection of a non-public property.
-	 *
 	 * @param string $class_name    The class owning the property.
 	 * @param string $property_name The property name.
 	 * @return \ReflectionProperty

--- a/projects/packages/backup/tests/php/Admin_Modernization_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Admin_Modernization_Gating_Test.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Unit tests for the modernization gating around the admin UI.
+ *
+ * The companion of `Rest_Bridge_Gating_Test`, which covers the same guarantee
+ * for the REST routes: with the filter off, nothing about the admin page
+ * changes; with it on, the legacy assets stay off the page and the wp-build
+ * dashboard gets what it needs.
+ *
+ * @package automattic/jetpack-backup-plugin
+ */
+
+namespace Automattic\Jetpack\Backup\V0005;
+
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
+use Automattic\Jetpack\Status\Cache as Status_Cache;
+use Jetpack_Options;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use function add_filter;
+use function remove_all_actions;
+use function remove_all_filters;
+use function wp_deregister_script;
+use function wp_script_is;
+
+require_once __DIR__ . '/mock-wp-build-render-page.php';
+
+/**
+ * Tests the flag -> menu callback -> enqueue chain.
+ *
+ * @covers \Automattic\Jetpack\Backup\V0005\Jetpack_Backup
+ */
+#[CoversClass( Jetpack_Backup::class )]
+class Admin_Modernization_Gating_Test extends TestCase {
+
+	/**
+	 * Every script handle these tests may leave behind.
+	 *
+	 * @var string[]
+	 */
+	private const SCRIPT_HANDLES = array( 'jetpack-backup', 'jp-tracks', 'jp-tracks-functions' );
+
+	/**
+	 * Start from a clean script registry and an empty menu queue.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->reset_scripts();
+		$this->set_admin_menu_items( array() );
+	}
+
+	/**
+	 * Reset everything a test may have installed.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( Jetpack_Backup::MODERNIZATION_FILTER );
+		remove_all_filters( 'jetpack_offline_mode' );
+		remove_all_actions( 'load-jetpack_page_jetpack-backup' );
+		remove_all_actions( 'jetpack_use_iframe_authorization_flow' );
+
+		$this->reset_scripts();
+		$this->set_admin_menu_items( array() );
+
+		Status_Cache::clear();
+		WorDBless_Options::init()->clear_options();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The flag is off unless a filter turns it on.
+	 */
+	public function test_is_modernized_defaults_to_false() {
+		$this->assertFalse( Jetpack_Backup::is_modernized() );
+	}
+
+	/**
+	 * The flag follows the filter in both directions.
+	 */
+	public function test_is_modernized_follows_the_filter() {
+		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
+		$this->assertTrue( Jetpack_Backup::is_modernized() );
+
+		remove_all_filters( Jetpack_Backup::MODERNIZATION_FILTER );
+		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_false' );
+		$this->assertFalse( Jetpack_Backup::is_modernized() );
+	}
+
+	/**
+	 * With the flag off, the legacy React bundle is still registered and
+	 * enqueued — the path the shipped plugin takes today.
+	 */
+	public function test_enqueue_admin_scripts_registers_legacy_script_when_not_modernized() {
+		Jetpack_Backup::enqueue_admin_scripts();
+
+		$this->assertTrue( wp_script_is( 'jetpack-backup', 'registered' ) );
+		$this->assertTrue( wp_script_is( 'jetpack-backup', 'enqueued' ) );
+	}
+
+	/**
+	 * With the flag on, the legacy bundle must not reach the page: wp-build
+	 * runs its own enqueue pipeline and would render a second dashboard.
+	 */
+	public function test_enqueue_admin_scripts_skips_legacy_script_when_modernized() {
+		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
+
+		Jetpack_Backup::enqueue_admin_scripts();
+
+		$this->assertFalse( wp_script_is( 'jetpack-backup', 'registered' ) );
+	}
+
+	/**
+	 * The modernized page still gets the Tracks callables, so the dashboard
+	 * can record events. Without this the product's telemetry is blank.
+	 */
+	public function test_enqueue_admin_scripts_enqueues_tracks_when_modernized() {
+		$this->allow_analytics();
+		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
+
+		$this->assertTrue( Jetpack_Backup::can_use_analytics() );
+
+		Jetpack_Backup::enqueue_admin_scripts();
+
+		$this->assertTrue( wp_script_is( 'jp-tracks', 'registered' ) );
+		$this->assertTrue( wp_script_is( 'jp-tracks-functions', 'enqueued' ) );
+	}
+
+	/**
+	 * The Tracks enqueue stays behind `can_use_analytics()`, same as the
+	 * legacy path: a site that has not agreed to the terms of service gets
+	 * no tracking script.
+	 */
+	public function test_enqueue_admin_scripts_skips_tracks_when_analytics_denied() {
+		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
+
+		$this->assertFalse( Jetpack_Backup::can_use_analytics() );
+
+		Jetpack_Backup::enqueue_admin_scripts();
+
+		$this->assertFalse( wp_script_is( 'jp-tracks-functions', 'registered' ) );
+	}
+
+	/**
+	 * With the flag off, the menu points at the legacy settings page and
+	 * keeps the current labels.
+	 */
+	public function test_add_wp_admin_submenu_uses_legacy_callback_when_not_modernized() {
+		Jetpack_Backup::add_wp_admin_submenu();
+
+		$items = $this->get_admin_menu_items();
+		$this->assertCount( 1, $items );
+		$this->assertSame( Jetpack_Backup::JETPACK_BACKUP_SLUG, $items[0]['menu_slug'] );
+		$this->assertSame( array( Jetpack_Backup::class, 'plugin_settings_page' ), $items[0]['function'] );
+		$this->assertSame( 'Jetpack Backup', $items[0]['page_title'] );
+		$this->assertSame( 'Backup', $items[0]['menu_title'] );
+	}
+
+	/**
+	 * With the flag on, the same slug renders through the wp-build callback
+	 * and picks up the VaultPress Backup labels.
+	 */
+	public function test_add_wp_admin_submenu_uses_wp_build_callback_when_modernized() {
+		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
+
+		Jetpack_Backup::add_wp_admin_submenu();
+
+		$items = $this->get_admin_menu_items();
+		$this->assertCount( 1, $items );
+		$this->assertSame( Jetpack_Backup::JETPACK_BACKUP_SLUG, $items[0]['menu_slug'] );
+		$this->assertSame( 'jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page', $items[0]['function'] );
+		$this->assertSame( 'Jetpack VaultPress Backup', $items[0]['page_title'] );
+		$this->assertSame( 'VaultPress Backup', $items[0]['menu_title'] );
+	}
+
+	/**
+	 * Make `can_use_analytics()` return true: the site is not in offline
+	 * mode and has agreed to the terms of service.
+	 */
+	private function allow_analytics() {
+		add_filter( 'jetpack_offline_mode', '__return_false' );
+		Status_Cache::clear();
+		Jetpack_Options::update_option( 'tos_agreed', true );
+	}
+
+	/**
+	 * Deregister every script handle these tests touch.
+	 */
+	private function reset_scripts() {
+		foreach ( self::SCRIPT_HANDLES as $handle ) {
+			wp_deregister_script( $handle );
+		}
+	}
+
+	/**
+	 * Read the Admin_Menu package's queued menu items.
+	 *
+	 * @return array
+	 */
+	private function get_admin_menu_items() {
+		return $this->accessible_property( Admin_Menu::class, 'menu_items' )->getValue();
+	}
+
+	/**
+	 * Overwrite the Admin_Menu package's queued menu items.
+	 *
+	 * @param array $items The items to set.
+	 */
+	private function set_admin_menu_items( $items ) {
+		$this->accessible_property( Admin_Menu::class, 'menu_items' )->setValue( null, $items );
+	}
+
+	/**
+	 * Get an accessible reflection of a non-public property.
+	 *
+	 * @param string $class_name    The class owning the property.
+	 * @param string $property_name The property name.
+	 * @return \ReflectionProperty
+	 */
+	private function accessible_property( $class_name, $property_name ) {
+		$property = new \ReflectionProperty( $class_name, $property_name );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			// Required to access non-public members before PHP 8.1; deprecated no-op since PHP 8.5.
+			$property->setAccessible( true );
+		}
+		return $property;
+	}
+}

--- a/projects/packages/backup/tests/php/Admin_Modernization_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Admin_Modernization_Gating_Test.php
@@ -21,6 +21,7 @@ use WorDBless\Options as WorDBless_Options;
 use function add_filter;
 use function remove_all_actions;
 use function remove_all_filters;
+use function wp_dequeue_script;
 use function wp_deregister_script;
 use function wp_script_is;
 
@@ -35,11 +36,18 @@ require_once __DIR__ . '/mock-wp-build-render-page.php';
 class Admin_Modernization_Gating_Test extends TestCase {
 
 	/**
-	 * Every script handle these tests may leave behind.
+	 * Handles the code under test registers itself.
 	 *
 	 * @var string[]
 	 */
-	private const SCRIPT_HANDLES = array( 'jetpack-backup', 'jp-tracks', 'jp-tracks-functions' );
+	private const OWNED_SCRIPT_HANDLES = array( 'jetpack-backup', 'jp-tracks', 'jp-tracks-functions' );
+
+	/**
+	 * Handles registered elsewhere that the code under test only enqueues.
+	 *
+	 * @var string[]
+	 */
+	private const BORROWED_SCRIPT_HANDLES = array( 'wp-jp-i18n-loader' );
 
 	/**
 	 * Start from a clean script registry and an empty menu queue.
@@ -185,10 +193,20 @@ class Admin_Modernization_Gating_Test extends TestCase {
 	}
 
 	/**
-	 * Deregister every script handle these tests touch.
+	 * Undo every registration and enqueue these tests trigger.
 	 */
 	private function reset_scripts() {
-		foreach ( self::SCRIPT_HANDLES as $handle ) {
+		// `wp_deregister_script()` only unsets the handle from `registered`; it
+		// never touches `queue`. Without an explicit dequeue an enqueued handle
+		// stays queued for every later test, and `wp_script_is( $h, 'enqueued' )`
+		// reads `queue` alone.
+		foreach ( array_merge( self::OWNED_SCRIPT_HANDLES, self::BORROWED_SCRIPT_HANDLES ) as $handle ) {
+			wp_dequeue_script( $handle );
+		}
+
+		// Borrowed handles stay registered: jetpack-assets adds `wp-jp-i18n-loader`
+		// once on `wp_default_scripts`, so nothing puts it back for later tests.
+		foreach ( self::OWNED_SCRIPT_HANDLES as $handle ) {
 			wp_deregister_script( $handle );
 		}
 	}

--- a/projects/packages/backup/tests/php/mock-wp-build-render-page.php
+++ b/projects/packages/backup/tests/php/mock-wp-build-render-page.php
@@ -1,20 +1,12 @@
 <?php
 /**
- * Stand-in for the render callback the wp-build dashboard generates.
- *
- * `Jetpack_Backup::add_wp_admin_submenu()` picks the wp-build callback only
- * when `build/build.php` has been generated and loaded, which never happens
- * in a unit test run. Defining the same function here lets the menu tests
- * exercise the modernized branch of that choice.
+ * Stand-in for the render callback the wp-build dashboard generates. `build/build.php`
+ * is never generated in a unit test run, so the menu tests could not otherwise reach
+ * the modernized branch of `Jetpack_Backup::add_wp_admin_submenu()`.
  *
  * @package automattic/jetpack-backup-plugin
  */
 
 if ( ! function_exists( 'jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page' ) ) {
-	/**
-	 * Render the modernized Backup dashboard page. No-op in tests.
-	 *
-	 * @return void
-	 */
 	function jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page() {}
 }

--- a/projects/packages/backup/tests/php/mock-wp-build-render-page.php
+++ b/projects/packages/backup/tests/php/mock-wp-build-render-page.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Stand-in for the render callback the wp-build dashboard generates.
+ *
+ * `Jetpack_Backup::add_wp_admin_submenu()` picks the wp-build callback only
+ * when `build/build.php` has been generated and loaded, which never happens
+ * in a unit test run. Defining the same function here lets the menu tests
+ * exercise the modernized branch of that choice.
+ *
+ * @package automattic/jetpack-backup-plugin
+ */
+
+if ( ! function_exists( 'jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page' ) ) {
+	/**
+	 * Render the modernized Backup dashboard page. No-op in tests.
+	 *
+	 * @return void
+	 */
+	function jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page() {}
+}


### PR DESCRIPTION
## Proposed changes

Part of the work needed before `rsm_jetpack_ui_modernization_backup` can flip. Everything here is behind that flag, **default off** — the legacy dashboard is untouched.

Two related pieces of admin wiring, in one PR because the second tests the first.

### 1. The modernized dashboard sent no Tracks events at all

`enqueue_admin_scripts()` returns early on the modernized path, and `Tracking::register_tracks_functions_scripts()` sat *after* that return. So the wp-build dashboard loaded without `jpTracks.recordEvent` on the page — flipping the flag would have blanked the product's telemetry at exactly the moment we most want to watch it.

The registration now happens inside the modernized branch, before the return, on the same `can_use_analytics()` gate the legacy path uses. This mirrors the `wp-jp-i18n-loader` handling four lines above, which is in that position for the same reason: the esbuild bundles do not declare either dependency, so neither arrives on its own.

`window.jpTracksContext.blog_id` was already being emitted via `render_connection_initial_state()`, so no context work was needed.

**This PR only puts the callables on the page.** Porting the 12 legacy `recordEvent()` call sites into the React components is separate and still open.

### 2. The flag → menu → enqueue chain had no test coverage

`Rest_Bridge_Gating_Test` asserts the "flag-off is byte-identical" guarantee well, but only for REST routes. Nothing covered the admin UI half, so the early return above could have been broken silently.

New `Admin_Modernization_Gating_Test.php`, 8 tests, adapted from VideoPress's `Admin_UI_Test.php`:

- `is_modernized()` defaults to **false** and follows the filter both ways
- flag off → the legacy `jetpack-backup` script is registered and enqueued
- flag on → it is not
- flag on + analytics permitted → `jp-tracks` registered, `jp-tracks-functions` enqueued
- flag on + analytics denied → not registered
- the menu callback and labels differ by flag

Mutation-checked: removing the new Tracks block fails exactly one of the eight, and the other seven still pass.

## Related product discussion/links

* [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243/backup-modernized-dashboard-work-needed-before-the-flag-can-flip) — tasks **H1a** and **J3**
* Follows #51292, #51294, #51295, #51336, #51338

## Does this pull request change what data or activity we track or use?

**Yes, and it needs a look.** No new events are defined and no new data is collected — this restores the *existing* Tracks client to a page that was silently missing it, so the modernized dashboard behaves like the legacy one. But it does mean a page that previously sent nothing will now be able to send events, so flagging it rather than letting it pass quietly.

## Open questions / caveats for review

1. **This reverses a decision the code documented.** The comment said the legacy script, initial state and tracking were *"intentionally skipped"* for wp-build. Initial state was already walked back (`render_connection_initial_state()` exists for exactly that reason); this walks back tracking too. @dhasilva — if skipping tracking was deliberate for a reason not captured in that comment, say so and I will drop the first commit.

2. **The test mock defines the function production checks with `function_exists()`.** `add_wp_admin_submenu()` picks the wp-build callback via an inline `function_exists( 'jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page' )`. `build/build.php` never loads in a unit run, so the only way to reach that branch without a production seam is to define the function — which `tests/php/mock-wp-build-render-page.php` does.

   Two consequences worth a reviewer's opinion:
   - Once loaded, the function exists for the whole PHPUnit process. Nothing else in the suite touches it today, so it is contained, but it is process-global state.
   - It forecloses ever testing the real fallback branch — flag **on**, build **absent** → legacy callback. That branch exists in production and is now untestable without a refactor.

   The alternative is extracting the callback choice into a seam in production purely for testability. I did not do that because it adds an abstraction for no runtime benefit, but I would rather be told than assume. Happy to switch.

3. **No `#[RunInSeparateProcess]`.** VideoPress uses it for one test; it fatals on PHP 7.x, and it was not needed here.

## Testing instructions

### Automated

* `jp test php packages/backup` → **201 tests, 565+ assertions**. Was 189 on trunk.
* `jp phan packages/backup` → 0 issues.

### Manual

Three preconditions. Skip any one and you will see nothing, for reasons unrelated to this PR.

**1. The standalone Backup plugin must be active.** `Jetpack_Backup::initialize()` is only called from it — a Jetpack-connected site without it has no `page=jetpack-backup` at all.

**2. Build the package first.**

```bash
jp build packages/backup
```

`build/` is gitignored and `git checkout` does not refresh it. With the flag on and no build you get a blank page — that is #51436, not this PR.

**3. `can_use_analytics()` must be true, and on a local site it is false by default.**

It resolves to `Tracking::should_enable_tracking()`, which returns false whenever `Status::is_offline_mode()` is true — and `is_local_site()` makes that true for any localhost/`.test`/`.local` install. It then also needs TOS agreed or a connected user. So on a local Docker site the Tracks block is skipped **by design**, with or without this PR.

Drop this in as an mu-plugin. It sets the flag and both analytics preconditions, and reverts by deleting the file:

```php
<?php
// wp-content/mu-plugins/backup-tracks-test.php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
add_filter( 'jetpack_offline_mode', '__return_false' );
add_filter( 'jetpack_options', function ( $value, $name ) {
	return 'tos_agreed' === $name ? true : $value;
}, 10, 2 );
```

Confirm the precondition before opening the page:

```bash
wp eval 'var_dump( Automattic\Jetpack\Backup\V0005\Jetpack_Backup::can_use_analytics() );'
# must print bool(true)
```

On a Jetpack-connected non-local site (Jurassic Ninja, WoA) only the first filter is needed — a connected user satisfies the rest.

### What to expect

Open **Jetpack → VaultPress Backup**. In the page source:

| Look for | Expect |
|---|---|
| `<script … id="jp-tracks-functions-js" src="…/jetpack_vendor/automattic/jetpack-connection/dist/tracks-callables.js…">` | **present** — this is the whole change |
| `<script … id="jp-tracks-js" src="//stats.wp.com/w.js…">` | present, pulled in as a declared dependency of the above |

In the console:

| Run | Expect |
|---|---|
| `typeof window.analytics.tracks.recordEvent` | `"function"` |
| `window._tkq` | exists |
| `window.jpTracksContext.blog_id` | your blog id |

**On trunk, the same page has no `jp-tracks-functions-js` tag and `window.analytics` is undefined.** That is the before/after.

### Two things that will mislead you

* **w.js on its own proves nothing.** `plugins/protect/src/class-jetpack-protect.php:206` and `plugins/jetpack/class.jetpack-gutenberg.php:819` both `wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js' )` directly, so it can already be on the page from Protect or the block editor. The signal is the `jp-tracks-functions-js` tag.
* **There is no `window.jpTracks`.** No such global exists anywhere in `projects/`. `tracks-callables.js` sets `window.analytics`.

### What this PR does not do

It puts the Tracks client on the page. It does not add any `recordEvent()` call sites — that is H1b, still open. So no events fire yet from the modernized dashboard; `window.analytics.tracks.recordEvent` being callable is the deliverable.
