### PR TITLE
Backup: fix inverted file icons, a contradictory detail heading, and an RTL indent

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-dashboard-ui-correctness
+++ b/projects/packages/backup/changelog/fix-backup-dashboard-ui-correctness
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Backup dashboard: show each restore point's own status, draw the correct file and folder icons, and indent the restore checklist helper text correctly in RTL.

--- a/projects/packages/backup/changelog/fix-backup-dashboard-ui-correctness
+++ b/projects/packages/backup/changelog/fix-backup-dashboard-ui-correctness
@@ -1,4 +1,3 @@
 Significance: patch
 Type: fixed
-
-Backup dashboard: show each restore point's own status, draw the correct file and folder icons, and indent the restore checklist helper text correctly in RTL.
+Comment: Backup: draw the correct file and folder icons in the modernized dashboard's file browser, head the detail pane with the selected row's own title, and indent the restore checklist helper text logically for RTL. No-op when the modernization filter is off.

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -92,7 +92,6 @@ export default function BackupDetail( { item }: Props ) {
 						align="center"
 					>
 						<Icon icon={ cloud } />
-						{ /* No per-backup scan signal reaches this component. */ }
 						<Text variant="heading-md" render={ <h3 /> }>
 							{ item.title }
 						</Text>

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -92,15 +92,7 @@ export default function BackupDetail( { item }: Props ) {
 						align="center"
 					>
 						<Icon icon={ cloud } />
-						{ /*
-						 * The row's own title, the same string the list shows
-						 * for it — the two panes sit side by side, so a fixed
-						 * header contradicted the selected row (list: "Initial
-						 * backup complete", detail: "Backup and scan
-						 * complete"). It also claimed a scan that may not have
-						 * run: scanning is a plan capability, and no per-backup
-						 * scan signal reaches this component.
-						 */ }
+						{ /* No per-backup scan signal reaches this component. */ }
 						<Text variant="heading-md" render={ <h3 /> }>
 							{ item.title }
 						</Text>

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -54,7 +54,7 @@ function restoreLabel( count: number ): string {
 /**
  * Right-pane detail card for a selected backup activity item.
  *
- * Shows the status header with Download / Restore actions linking to the
+ * Shows the item's title header with Download / Restore actions linking to the
  * matching sibling routes, the backup's summary line, a timestamp by-line,
  * and the file browser. File selection state lives here so the header
  * actions can switch between "Download backup" and "Download N selected
@@ -92,8 +92,17 @@ export default function BackupDetail( { item }: Props ) {
 						align="center"
 					>
 						<Icon icon={ cloud } />
+						{ /*
+						 * The row's own title, the same string the list shows
+						 * for it — the two panes sit side by side, so a fixed
+						 * header contradicted the selected row (list: "Initial
+						 * backup complete", detail: "Backup and scan
+						 * complete"). It also claimed a scan that may not have
+						 * run: scanning is a plan capability, and no per-backup
+						 * scan signal reaches this component.
+						 */ }
 						<Text variant="heading-md" render={ <h3 /> }>
-							{ __( 'Backup and scan complete', 'jetpack-backup-pkg' ) }
+							{ item.title }
 						</Text>
 					</Stack>
 					<Stack

--- a/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
@@ -1,12 +1,19 @@
 import { CheckboxControl, Spinner } from '@wordpress/components';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+// The upstream icon names don't describe what they draw. In
+// `@wordpress/icons` 15.3.0, `file` draws a folder (a folder shape with a
+// tab), `page` draws a document with text lines, and `category` draws a
+// 2x2 grid of squares. There is no `folder` icon in that version. The
+// aliases below are named for the glyph rather than the export, so the
+// rows render what they say — please don't "correct" them back to
+// matching names.
 import {
 	Icon,
 	chevronRight,
 	chevronDown,
-	file as fileIcon,
-	category as folderIcon,
+	file as folderIcon,
+	page as fileIcon,
 } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
 import { useFileTree } from '../../hooks/use-file-tree';

--- a/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
@@ -1,13 +1,9 @@
 import { CheckboxControl, Spinner } from '@wordpress/components';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-// The upstream icon names don't describe what they draw. In
-// `@wordpress/icons` 15.3.0, `file` draws a folder (a folder shape with a
-// tab), `page` draws a document with text lines, and `category` draws a
-// 2x2 grid of squares. There is no `folder` icon in that version. The
-// aliases below are named for the glyph rather than the export, so the
-// rows render what they say — please don't "correct" them back to
-// matching names.
+// The upstream names don't describe what they draw: `file` is a folder
+// glyph, `page` is a document one, and there is no `folder` export.
+// `tests/file-browser-icons.test.tsx` holds these aliases in place.
 import {
 	Icon,
 	chevronRight,

--- a/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
@@ -600,13 +600,34 @@ function NodeRow( {
 					__nextHasNoMarginBottom
 				/>
 				{ nodeIsFolder ? (
-					<button type="button" className="jpb-file-browser__toggle" onClick={ handleToggleOpen }>
+					// The glyphs are `aria-hidden`, so the folder/file distinction they
+					// carry visually has to be spelled out for assistive tech.
+					<button
+						type="button"
+						className="jpb-file-browser__toggle"
+						aria-expanded={ open }
+						aria-label={ sprintf(
+							/* translators: %s: folder name. */
+							__( 'Folder: %s', 'jetpack-backup-pkg' ),
+							node.name
+						) }
+						onClick={ handleToggleOpen }
+					>
 						<Icon icon={ open ? chevronDown : chevronRight } size={ 16 } />
 						<Icon icon={ folderIcon } size={ 18 } />
 						<span>{ node.name }</span>
 					</button>
 				) : (
-					<button type="button" className="jpb-file-browser__file" onClick={ handleOpenFile }>
+					<button
+						type="button"
+						className="jpb-file-browser__file"
+						aria-label={ sprintf(
+							/* translators: %s: file name. */
+							__( 'File: %s', 'jetpack-backup-pkg' ),
+							node.name
+						) }
+						onClick={ handleOpenFile }
+					>
 						<Icon icon={ fileIcon } size={ 18 } />
 						<span>{ node.name }</span>
 					</button>

--- a/projects/packages/backup/src/dashboard/components/restore-items-checklist/style.scss
+++ b/projects/packages/backup/src/dashboard/components/restore-items-checklist/style.scss
@@ -6,7 +6,7 @@
 	// `color: #1e1e1e` wins over the layered token), so set the color
 	// explicitly here.
 	&__desc {
-		padding-left: 28px;
+		padding-inline-start: 28px;
 		color: var(--wp-components-color-foreground-muted, #757575);
 	}
 }

--- a/projects/packages/backup/tests/backup-detail-title.test.tsx
+++ b/projects/packages/backup/tests/backup-detail-title.test.tsx
@@ -1,0 +1,98 @@
+// The backup detail pane must head itself with the selected row's own
+// title.
+//
+// It used to render a fixed, translated "Backup and scan complete". The
+// list and the detail pane sit side by side, so that string contradicted
+// the row the reader had just clicked — the list said "Initial backup
+// complete" while the pane beside it said something else.
+//
+// The string also asserted a scan had run. Scanning is a plan capability
+// (`hasScan` on `/site/capabilities`), not a per-backup field, and no
+// per-backup scan signal reaches this component — so there is nothing
+// here that could ever have backed that claim.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import BackupDetail from '../src/dashboard/components/backup-detail';
+import { queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import type { BackupActivityItem } from '../src/dashboard/types/activity';
+
+/**
+ * One backup row in the dashboard's normalized shape. `title` is what
+ * `normalizeActivityLog` copies out of WPCOM's `summary`, and it is the
+ * same field the activity list renders as each row's title.
+ *
+ * @param title - The row's title.
+ * @return A backup activity item.
+ */
+function backupItem( title: string ): BackupActivityItem {
+	return {
+		id: 'act-cloud',
+		kind: 'backup',
+		title,
+		publishedAt: '2026-08-13T18:08:56+00:00',
+		actor: { type: 'Application', name: 'Jetpack' },
+		rewindId: '1786644531.123',
+		stats: '46 plugins, 23 themes',
+		isComplete: true,
+	};
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	// The file browser fetches the backup's root listing on mount. An
+	// empty response is enough — this suite is about the header.
+	mockApiFetch.mockResolvedValue( {} );
+} );
+
+describe( 'BackupDetail header', () => {
+	it( "renders the item's own title", () => {
+		render(
+			<QueryClientProvider>
+				<BackupDetail item={ backupItem( 'Initial backup complete' ) } />
+			</QueryClientProvider>
+		);
+
+		expect(
+			screen.getByRole( 'heading', { name: 'Initial backup complete' } )
+		).toBeInTheDocument();
+	} );
+
+	// Two different rows must not head the pane with the same string.
+	// A fixed header passes the assertion above by accident whenever the
+	// hardcoded text happens to match one row.
+	it( 'follows the selected row rather than a fixed string', () => {
+		const { rerender } = render(
+			<QueryClientProvider>
+				<BackupDetail item={ backupItem( 'Initial backup complete' ) } />
+			</QueryClientProvider>
+		);
+
+		rerender(
+			<QueryClientProvider>
+				<BackupDetail item={ backupItem( 'Backup complete' ) } />
+			</QueryClientProvider>
+		);
+
+		expect( screen.getByRole( 'heading', { name: 'Backup complete' } ) ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'heading', { name: 'Initial backup complete' } )
+		).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Backup and scan complete' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/backup-detail-title.test.tsx
+++ b/projects/packages/backup/tests/backup-detail-title.test.tsx
@@ -1,15 +1,4 @@
-// The backup detail pane must head itself with the selected row's own
-// title.
-//
-// It used to render a fixed, translated "Backup and scan complete". The
-// list and the detail pane sit side by side, so that string contradicted
-// the row the reader had just clicked — the list said "Initial backup
-// complete" while the pane beside it said something else.
-//
-// The string also asserted a scan had run. Scanning is a plan capability
-// (`hasScan` on `/site/capabilities`), not a per-backup field, and no
-// per-backup scan signal reaches this component — so there is nothing
-// here that could ever have backed that claim.
+// The pane sits beside the list, so its header must match the clicked row.
 
 const mockApiFetch = jest.fn();
 

--- a/projects/packages/backup/tests/file-browser-icons.test.tsx
+++ b/projects/packages/backup/tests/file-browser-icons.test.tsx
@@ -1,8 +1,6 @@
 // `@wordpress/icons` export names do not describe what they draw, so the
 // file-browser aliases look inverted and invite a "correction". These
-// tests cross-check each row against the package's own artwork instead of
-// a copied path string, so they survive an icons upgrade but fail if the
-// aliases are swapped back.
+// tests cross-check the rows against the package's own artwork.
 
 const mockApiFetch = jest.fn();
 

--- a/projects/packages/backup/tests/file-browser-icons.test.tsx
+++ b/projects/packages/backup/tests/file-browser-icons.test.tsx
@@ -68,8 +68,8 @@ async function renderRows(): Promise< { folderRow: HTMLElement; fileRow: HTMLEle
 	);
 
 	return {
-		folderRow: await screen.findByRole( 'button', { name: 'wp-content' } ),
-		fileRow: screen.getByRole( 'button', { name: 'wp-config.php' } ),
+		folderRow: await screen.findByRole( 'button', { name: 'Folder: wp-content' } ),
+		fileRow: screen.getByRole( 'button', { name: 'File: wp-config.php' } ),
 	};
 }
 
@@ -117,5 +117,21 @@ describe( 'file browser row icons', () => {
 
 		expect( shapesIn( fileRow ) ).toContain( shapeOf( page ) );
 		expect( shapesIn( fileRow ) ).not.toContain( shapeOf( file ) );
+	} );
+
+	// The glyphs render `aria-hidden`, so nothing above reaches a screen
+	// reader. Without these the two row types are indistinguishable.
+	it( 'names the row type for assistive tech', async () => {
+		const { folderRow, fileRow } = await renderRows();
+
+		expect( folderRow ).toHaveAccessibleName( 'Folder: wp-content' );
+		expect( fileRow ).toHaveAccessibleName( 'File: wp-config.php' );
+	} );
+
+	it( 'reports the folder disclosure state', async () => {
+		const { folderRow, fileRow } = await renderRows();
+
+		expect( folderRow ).toHaveAttribute( 'aria-expanded', 'false' );
+		expect( fileRow ).not.toHaveAttribute( 'aria-expanded' );
 	} );
 } );

--- a/projects/packages/backup/tests/file-browser-icons.test.tsx
+++ b/projects/packages/backup/tests/file-browser-icons.test.tsx
@@ -1,0 +1,123 @@
+// `@wordpress/icons` export names do not describe what they draw, so the
+// file-browser aliases look inverted and invite a "correction". These
+// tests cross-check each row against the package's own artwork instead of
+// a copied path string, so they survive an icons upgrade but fail if the
+// aliases are swapped back.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import { Icon, file, page } from '@wordpress/icons';
+import FileBrowser, { EMPTY_FILE_SELECTION } from '../src/dashboard/components/file-browser';
+import { queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import type { ReactElement } from 'react';
+
+/** Selection is irrelevant here; the rows render regardless. */
+const noop = () => {};
+
+/**
+ * Every `<svg>` under `root`, reduced to its drawn shape: the `d` data of
+ * its paths, in order. Two icons are the same glyph when their shapes are
+ * equal, whatever the export is called.
+ *
+ * @param root - Element to scan.
+ * @return One shape string per `<svg>`, in DOM order.
+ */
+function shapesIn( root: Element ): string[] {
+	return Array.from( root.querySelectorAll( 'svg' ) ).map( svg =>
+		Array.from( svg.querySelectorAll( 'path' ) )
+			.map( path => path.getAttribute( 'd' ) ?? '' )
+			.join( '|' )
+	);
+}
+
+/**
+ * Shape of one `@wordpress/icons` export, taken from the package itself
+ * rather than a path literal copied into this file. That is what keeps
+ * these assertions correct when upstream redraws the artwork.
+ *
+ * @param icon - The icon element to render.
+ * @return Its shape string.
+ */
+function shapeOf( icon: ReactElement ): string {
+	const { container, unmount } = render( <Icon icon={ icon } size={ 18 } /> );
+	const [ shape ] = shapesIn( container );
+	unmount();
+	return shape;
+}
+
+/**
+ * Render the browser over a backup root holding one folder and one file.
+ *
+ * @return The two row buttons, once the root listing has resolved.
+ */
+async function renderRows(): Promise< { folderRow: HTMLElement; fileRow: HTMLElement } > {
+	render(
+		<QueryClientProvider>
+			<FileBrowser
+				rewindId="1786644531.123"
+				selection={ EMPTY_FILE_SELECTION }
+				onSelectionChange={ noop }
+			/>
+		</QueryClientProvider>
+	);
+
+	return {
+		folderRow: await screen.findByRole( 'button', { name: 'wp-content' } ),
+		fileRow: screen.getByRole( 'button', { name: 'wp-config.php' } ),
+	};
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockApiFetch.mockResolvedValue( {
+		contents: {
+			'wp-content': { type: 'dir', has_children: true },
+			'wp-config.php': { type: 'file', period: '1786644531' },
+		},
+	} );
+} );
+
+describe( 'file browser row icons', () => {
+	// A cross-check against two identical glyphs would pass no matter how
+	// the rows were wired, so state the premise as its own assertion.
+	it( 'draws `file` and `page` as different glyphs', () => {
+		expect( shapeOf( file ) ).not.toBe( '' );
+		expect( shapeOf( page ) ).not.toBe( '' );
+		expect( shapeOf( file ) ).not.toBe( shapeOf( page ) );
+	} );
+
+	it( 'draws a different glyph on a folder row than on a file row', async () => {
+		const { folderRow, fileRow } = await renderRows();
+
+		// The folder row also carries an expand chevron, so compare the
+		// file row's single icon against everything the folder row draws.
+		const [ fileRowShape ] = shapesIn( fileRow );
+		expect( fileRowShape ).not.toBe( '' );
+		expect( shapesIn( folderRow ) ).not.toContain( fileRowShape );
+	} );
+
+	it( 'draws the `file` export — the folder glyph — on a folder row', async () => {
+		const { folderRow } = await renderRows();
+
+		expect( shapesIn( folderRow ) ).toContain( shapeOf( file ) );
+		expect( shapesIn( folderRow ) ).not.toContain( shapeOf( page ) );
+	} );
+
+	it( 'draws the `page` export — the document glyph — on a file row', async () => {
+		const { fileRow } = await renderRows();
+
+		expect( shapesIn( fileRow ) ).toContain( shapeOf( page ) );
+		expect( shapesIn( fileRow ) ).not.toContain( shapeOf( file ) );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes

Three small, independent correctness fixes in the modernized Backup dashboard. All behind `rsm_jetpack_ui_modernization_backup`, **default off** — the legacy dashboard is untouched, and `src/js/` is not modified.

Grouped into one PR because each is a few lines; they are separate commits and can be split if a reviewer prefers.

### 1. File and folder icons were inverted

The upstream icon names do not describe what they draw. In `@wordpress/icons` 15.3.0:

| Export | What it actually draws |
|---|---|
| `file` | a **folder** — folder shape with a tab |
| `page` | a **document** — rectangle with text lines |
| `category` | a 2×2 grid of squares |

There is no `folder` icon in that version. The file browser imported `file as fileIcon, category as folderIcon`, so directories got a grid glyph and files got a folder glyph. Now `file as folderIcon, page as fileIcon`, with a comment explaining why the aliases look wrong, so nobody "corrects" them back. No dependency added — Calypso solves this with Gridicons, which is not worth pulling in for two glyphs.

### 2. The detail pane contradicted the row you clicked

`backup-detail` hardcoded `Backup and scan complete`. The list and the detail pane sit side by side, so this was visible: the row read "Initial backup complete" while the pane beside it said otherwise.

It also claimed a scan that may never have run. Scanning is a **plan capability** (`hasScan` on the capabilities response, which has no UI consumers) — there is no per-backup scan signal reaching this component at all, so nothing could have backed that string.

Now renders `item.title`. That is the same field the list row shows (`normalizeActivityLog` sets it from the entry summary, and the DataViews config uses `titleField: 'title'`), so the two panes now agree by construction rather than by coincidence. It is also what the sibling `ActivityDetail` already renders, in an identical `<Text variant="heading-md" render={ <h3 /> }>` — so this removes a divergence rather than adding a pattern.

### 3. Physical CSS property in a JS-injected stylesheet

`restore-items-checklist/style.scss` used `padding-left`. Route CSS is injected by JS, so WordPress's automatic RTL replacement never runs on it — the property had to be logical to be correct in RTL. Now `padding-inline-start`.

This was the last physical-direction property in `src/dashboard` + `routes`; re-swept after the change and there are zero remaining.

## Related product discussion/links

* [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243/backup-modernized-dashboard-work-needed-before-the-flag-can-flip) — tasks **F5**, **F7**, **F10**
* Follows #51292, #51294, #51295, #51336, #51338

## Does this pull request change what data or activity we track or use?

No.

## Open questions / caveats for review

1. **The activity summaries were never localized.** The PR originally claimed this change *lost* localization. It did not: `class-activity-log-bridge.php` forwarded only `number` and `page`, so both panes always showed English. Fixed separately in #51433, which appends `_locale` — the v2 spelling, which is why searching for a `locale` param turned up nothing.

2. **A pre-existing Prettier complaint on the touched SCSS file.** It wants two-space indent where the file uses tabs. It complains identically at the base commit, so this PR did not introduce it, and I did not reformat unrelated lines to silence it. Stylelint passes. The pre-commit hook may rewrite that file on someone else's machine — expect a whitespace diff that is not mine.

3. **No screenshots.** Both visual changes need a site with a Backup plan, completed backups, *and* a working file tree to photograph, and the file preview endpoint is currently broken upstream (a VaultPress issue tracked separately on JETPACK-2243). Happy to add them if a reviewer wants to set that up, but I did not want to gate three one-line fixes on it. The icon change in particular is easier to verify by reading the SVG sources than by squinting at a screenshot.

## Testing instructions

### Automated — no site needed, and this is real coverage for two of the three fixes

```bash
jp test js packages/backup     # 37 suites, 270 tests. Was 35/264 on trunk.
```

The 6 new tests cover the detail-pane title (including that it *follows* the selected row, so it cannot pass by matching one string) and lock the icon aliases by cross-checking the rendered `d` against the `@wordpress/icons` exports at run time — swap the aliases back and 2 of 4 fail. F10 has no test; it is a one-line physical→logical property change.

`pnpm run typecheck`, `pnpm run lint-changed`, `pnpm run lint-style` all clean. Note bare `pnpm run lint-style` fails on trunk too (the root script passes no glob, so stylelint reads empty stdin) — scope it: `pnpm run lint-style 'projects/packages/backup/**/*.scss'`.

### Manual — needs a connected site with a paid Backup plan

**A plain local install will not show any of this.** `<Gates>` (`src/dashboard/components/gates/index.tsx:30-65`) is a first-match-wins chain:

`not fully connected → secondary admin → capabilities loading → capabilities error → no Backup plan → the dashboard`

The capabilities bridge signs **as user** against WordPress.com, so an unconnected site stops at "Connect Jetpack to get started" and a connected site without a plan stops at "This site doesn't have an active Backup plan". Neither reaches the file browser or the detail pane. Use a Jurassic Ninja or WoA site with Backup, and at least two completed restore points.

Then:

1. **The standalone Backup plugin must be active.** `Jetpack_Backup::initialize()` is only called from it — a Jetpack-connected site without it has no `page=jetpack-backup` at all.
2. **Build first:** `jp build packages/backup`. `build/` is gitignored and `git checkout` does not refresh it; with the flag on and no build you get a blank page, which is #51436, not this PR.
3. Turn the dashboard on, as an mu-plugin so it reverts by deleting the file:
   ```php
   <?php // wp-content/mu-plugins/backup-modernize.php
   add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
   ```

### What to expect

| # | Where | Expect | On trunk |
|---|---|---|---|
| **F5** | **Jetpack → VaultPress Backup**, open a restore point, expand the file tree | Directories draw a **folder**; files draw a **document** | Directories draw a 2×2 grid, files draw a folder — swapped |
| **F7** | Same screen. Click one restore point, then another | The detail-pane heading matches the row you clicked, and **changes** between rows | Always reads "Backup and scan complete", contradicting the row |
| **F10** | Open **Restore** on a restore point, in an RTL locale (Settings → Site Language → العربية) | Helper text under **"WordPress root"** and **"WP-content directory"** indents from the **right** | Indents from the left |

F10 only shows on those two rows — they are the only checklist items with helper text, so checking "WordPress themes" will show you nothing either way.

The file **preview** pane still fails for every file. That is a VaultPress-side bug tracked separately on JETPACK-2243 (G1); it is not this PR and the file *tree* is unaffected.
