### PR TITLE
Fix jetpack-mu-wpcom for WP core change

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wp-core-breakage-in-verbum
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wp-core-breakage-in-verbum
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Unregister hook in Verbum_Block_Utils_Test to account for a WP Core change.
+
+

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/verbum-comments/Verbum_Block_Utils_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/verbum-comments/Verbum_Block_Utils_Test.php
@@ -18,6 +18,21 @@ require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/verbum-comments/assets/cl
  */
 #[CoversClass( Verbum_Block_Utils::class )]
 class Verbum_Block_Utils_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Runs the routine before each test is executed.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// `wp_render_layout_support_flag()` (since WP 7.1) calls `wp_get_global_settings()`,
+		// which winds up in our `wpcom_block_global_styles_frontend()` which tries to call wpcom-only
+		// functions (wpcom_site_has_feature et al.) that aren't defined in the test env,
+		// Detach the incidental filter so that doesn't break.
+		// `\WorDBless\BaseTestCase::tear_down()` will restore the hook for future tests.
+		remove_filter( 'wp_theme_json_data_user', 'wpcom_block_global_styles_frontend' );
+	}
+
 	/**
 	 * Ensure string comments are not modified when 'render_verbum_blocks' is applied
 	 */


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
WordPress/wordpress-develop@d6dd2e55c241f4d00e5662f24c6c6c70d684ab0d added a call to a function that triggers a hook that the test isn't ready for. Unhook the filter to avoid it being called.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?