### PR TITLE
My Jetpack: replace commercial-use framing on Add Stats with the real paid differentiators

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/products/stats.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/products/stats.tsx
@@ -22,6 +22,7 @@ export function getStatsConfig(): ProductConfig {
 		SPAM_FILTERING,
 		INSTANT_SITE_SEARCH,
 		VIDEO_HOSTING_1TB,
+		SOCIAL_TOOLS,
 		PRIORITY_SUPPORT,
 	} = getTranslatableFeatureLabels();
 
@@ -55,16 +56,22 @@ export function getStatsConfig(): ProductConfig {
 				bundle: { included: true, label: SPAM_FILTERING },
 			},
 			{
-				name: __( 'Access to upcoming advanced features', 'jetpack-my-jetpack' ),
+				name: __( 'UTM tracking', 'jetpack-my-jetpack' ),
 				free: { included: false, label: NOT_INCLUDED },
 				paid: { included: true, label: INCLUDED },
 				bundle: { included: true, label: INSTANT_SITE_SEARCH },
 			},
 			{
-				name: __( 'Commercial use', 'jetpack-my-jetpack' ),
+				name: __( 'Device stats', 'jetpack-my-jetpack' ),
 				free: { included: false, label: NOT_INCLUDED },
 				paid: { included: true, label: INCLUDED },
 				bundle: { included: true, label: VIDEO_HOSTING_1TB },
+			},
+			{
+				name: __( 'Locations', 'jetpack-my-jetpack' ),
+				free: { included: true, label: __( 'Country-level', 'jetpack-my-jetpack' ) },
+				paid: { included: true, label: __( 'Region and city', 'jetpack-my-jetpack' ) },
+				bundle: { included: true, label: SOCIAL_TOOLS },
 			},
 			{
 				name: PRIORITY_SUPPORT,
@@ -80,7 +87,7 @@ export function getStatsConfig(): ProductConfig {
 			},
 			paid: {
 				name: 'Stats',
-				cta: __( 'Get Stats', 'jetpack-my-jetpack' ),
+				cta: __( 'Get Paid Stats', 'jetpack-my-jetpack' ),
 			},
 			bundle: {
 				name: COMPLETE,

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/products/stats.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/products/stats.tsx
@@ -66,13 +66,13 @@ export function getStatsConfig(): ProductConfig {
 				name: __( 'Device stats', 'jetpack-my-jetpack' ),
 				free: { included: false, label: NOT_INCLUDED },
 				paid: { included: true, label: INCLUDED },
-				bundle: { included: true, label: VIDEO_HOSTING_1TB },
+				bundle: { included: true, label: SOCIAL_TOOLS },
 			},
 			{
 				name: __( 'Locations', 'jetpack-my-jetpack' ),
 				free: { included: true, label: __( 'Country-level', 'jetpack-my-jetpack' ) },
 				paid: { included: true, label: __( 'Region and city', 'jetpack-my-jetpack' ) },
-				bundle: { included: true, label: SOCIAL_TOOLS },
+				bundle: { included: true, label: VIDEO_HOSTING_1TB },
 			},
 			{
 				name: PRIORITY_SUPPORT,

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/products/stats.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/products/stats.tsx
@@ -56,6 +56,7 @@ export function getStatsConfig(): ProductConfig {
 				bundle: { included: true, label: SPAM_FILTERING },
 			},
 			{
+				/* translators: UTM refers to the Urchin Tracking Module campaign parameters appended to a URL. */
 				name: __( 'UTM tracking', 'jetpack-my-jetpack' ),
 				free: { included: false, label: NOT_INCLUDED },
 				paid: { included: true, label: INCLUDED },
@@ -87,6 +88,7 @@ export function getStatsConfig(): ProductConfig {
 			},
 			paid: {
 				name: 'Stats',
+				/* translators: "Stats" here shouldn't be translated as it's the name of the product */
 				cta: __( 'Get Paid Stats', 'jetpack-my-jetpack' ),
 			},
 			bundle: {

--- a/projects/packages/my-jetpack/changelog/stats-447-add-stats-differentiators
+++ b/projects/packages/my-jetpack/changelog/stats-447-add-stats-differentiators
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats: Replace the commercial-use row on the Add Stats screen with UTM tracking, device stats, and location detail.

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -132,9 +132,10 @@ class Stats extends Module_Product {
 			__( 'Traffic stats and trends for post and pages', 'jetpack-my-jetpack' ),
 			__( 'Detailed statistics about links leading to your site', 'jetpack-my-jetpack' ),
 			__( 'GDPR compliant', 'jetpack-my-jetpack' ),
-			__( 'Access to upcoming advanced features', 'jetpack-my-jetpack' ),
+			__( 'UTM tracking', 'jetpack-my-jetpack' ),
+			__( 'Device stats', 'jetpack-my-jetpack' ),
+			__( 'Region and city locations', 'jetpack-my-jetpack' ),
 			__( 'Priority support', 'jetpack-my-jetpack' ),
-			__( 'Commercial use', 'jetpack-my-jetpack' ),
 		);
 	}
 

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -132,6 +132,7 @@ class Stats extends Module_Product {
 			__( 'Traffic stats and trends for post and pages', 'jetpack-my-jetpack' ),
 			__( 'Detailed statistics about links leading to your site', 'jetpack-my-jetpack' ),
 			__( 'GDPR compliant', 'jetpack-my-jetpack' ),
+			/* translators: UTM refers to the Urchin Tracking Module campaign parameters appended to a URL. */
 			__( 'UTM tracking', 'jetpack-my-jetpack' ),
 			__( 'Device stats', 'jetpack-my-jetpack' ),
 			__( 'Region and city locations', 'jetpack-my-jetpack' ),

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -124,7 +124,7 @@ class Stats extends Module_Product {
 	/**
 	 * Get the internationalized features list
 	 *
-	 * @return array CRM features list
+	 * @return array Stats features list
 	 */
 	public static function get_features() {
 		return array(

--- a/projects/plugins/backup/changelog/stats-447-add-stats-differentiators
+++ b/projects/plugins/backup/changelog/stats-447-add-stats-differentiators
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Show what Paid Stats actually adds — UTM tracking, device stats, and region & city locations — instead of commercial use.

--- a/projects/plugins/boost/changelog/stats-447-add-stats-differentiators
+++ b/projects/plugins/boost/changelog/stats-447-add-stats-differentiators
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Show what Paid Stats actually adds — UTM tracking, device stats, and region & city locations — instead of commercial use.

--- a/projects/plugins/jetpack/changelog/stats-447-add-stats-differentiators
+++ b/projects/plugins/jetpack/changelog/stats-447-add-stats-differentiators
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+My Jetpack: Show what Paid Stats actually adds — UTM tracking, device stats, and region & city locations — instead of commercial use.

--- a/projects/plugins/protect/changelog/stats-447-add-stats-differentiators
+++ b/projects/plugins/protect/changelog/stats-447-add-stats-differentiators
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Show what Paid Stats actually adds — UTM tracking, device stats, and region & city locations — instead of commercial use.

--- a/projects/plugins/search/changelog/stats-447-add-stats-differentiators
+++ b/projects/plugins/search/changelog/stats-447-add-stats-differentiators
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Show what Paid Stats actually adds — UTM tracking, device stats, and region & city locations — instead of commercial use.

--- a/projects/plugins/social/changelog/stats-447-add-stats-differentiators
+++ b/projects/plugins/social/changelog/stats-447-add-stats-differentiators
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Show what Paid Stats actually adds — UTM tracking, device stats, and region & city locations — instead of commercial use.

--- a/projects/plugins/starter-plugin/changelog/stats-447-add-stats-differentiators
+++ b/projects/plugins/starter-plugin/changelog/stats-447-add-stats-differentiators
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Show what Paid Stats actually adds — UTM tracking, device stats, and region & city locations — instead of commercial use.

--- a/projects/plugins/stats/changelog/stats-447-add-stats-differentiators
+++ b/projects/plugins/stats/changelog/stats-447-add-stats-differentiators
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Show what Paid Stats actually adds — UTM tracking, device stats, and region & city locations — instead of commercial use.

--- a/projects/plugins/videopress/changelog/stats-447-add-stats-differentiators
+++ b/projects/plugins/videopress/changelog/stats-447-add-stats-differentiators
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: Show what Paid Stats actually adds — UTM tracking, device stats, and region & city locations — instead of commercial use.


### PR DESCRIPTION
Fixes STATS-447

## Why

A site owner who opens **My Jetpack → Add Stats** is asked to choose between Free and Paid Stats, and the only reasons the screen gives them to pay are **"Commercial use"** and **"Access to upcoming advanced features"**. The first is a paywall we stopped enforcing; the second names nothing at all. So the one moment in wp-admin where someone decides whether Paid Stats is worth it argues from a rule that no longer exists — while the three things paying actually unlocks (UTM tracking, device stats, and region & city locations) appear nowhere on the page.

This swaps that pitch for what Paid Stats genuinely adds, using the grid copy already signed off in STATS-366 and shipped in Automattic/wp-calypso#113366, so a customer sees the same promise wherever they meet it.

## Proposed changes

* Replace the two paid-only rows — "Access to upcoming advanced features" and "Commercial use" — with the real differentiators: **UTM tracking**, **Device stats**, and **Locations**.
* The Locations row shows **Country-level** for Free and **Region and city** for Paid, rather than a bare cross, so free users aren't told they get no location data at all.
* Rename the paid CTA from "Get Stats" to **"Get Paid Stats"**, matching the Calypso grid.
* Give the Complete column an eighth bundle feature ("Social tools") to fill the new row, ordered to match `boost.ts` and `videopress.ts`; its labels are positional, one Complete feature per row.
* Apply the same edit to `Stats::get_features()` in PHP, so "Commercial use" also leaves the My Jetpack products REST payload.

The four shared rows above the differentiators are untouched, as is the price, the view tier, and the Complete bundle pitch.

## Screenshots

![Add Stats interstitial, before and after](https://github.com/user-attachments/assets/58f090f3-ffe0-486a-bf61-62d910a4d7ac)

## Related product discussion/links

* STATS-447 · STATS-366 (grid spec) · STATS-388 (align in-product content with stopped enforcement)
* Automattic/wp-calypso#113366 — the same grid in Odyssey/Calypso, whose copy this matches

## Does this pull request change what data or activity we track or use?

No new tracking. One existing property changes value: `trackProductOrBundleClick` records the paid CTA's label as `cta_text`, which becomes `"Get Paid Stats"` instead of `"Get Stats"`. Worth knowing if you segment on that string (cc STATS-423).

## Testing instructions

Go to **Jetpack → My Jetpack** on a site without a Stats plan, then open `admin.php?page=my-jetpack#/add-stats`.

- [ ] The screen shows no "Commercial use" row and no "Access to upcoming advanced features" row.
- [ ] The paid column's differentiators are exactly: **UTM tracking**, **Device stats**, **Locations** (Region and city), **Priority support**.
- [ ] The Free column shows **Country-level** on the Locations row — free users are not told they get no location data at all.
- [ ] The four shared rows above the differentiators are unchanged.
- [ ] The paid CTA reads **Get Paid Stats**; the column heading stays `Stats`.
- [ ] The Complete column still lists eight distinct Complete features, one per row.
- [ ] `wp eval 'echo json_encode( Automattic\Jetpack\My_Jetpack\Products\Stats::get_features() );'` no longer mentions commercial use or upcoming advanced features, and names the three real differentiators.
- [ ] No visual regression in the 3-column table at desktop.

Verified live on a local docker WP install at 1728px — see the screenshot above.

The stacked card layout below the `xlarge` breakpoint was **not** separately screenshotted (the test window would not leave fullscreen); it was checked by reading `PricingTableItem`, where an explicit `label` wins in both modes (`label || defaultLabel`) and the row count is data-driven. Every My Jetpack row already passes an explicit label, so the stacked cards have never shown feature names — the Free card will read "✓ Country-level" and the Paid card "✓ Region and city" with no "Locations" antecedent, which is the pattern `videopress.ts` already ships ("One video" / "1TB of storage"). Consistent with the existing design rather than a regression, but still worth a glance on a narrow viewport during review.
