### PR TITLE
Backup: fix the file browser preview and restore real per-file details

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-preview-manifest-path-encoding
+++ b/projects/packages/backup/changelog/fix-backup-preview-manifest-path-encoding
@@ -1,3 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: Backup: fix the modernized file browser's preview, which corrupted the manifest path by percent-encoding an already-base64 value, and restore the per-file details pane so it shows each file's real size, hash and modification time. No-op when the modernization filter is off.
+Comment: Backup: fix the modernized file browser's preview, which corrupted the manifest path by percent-encoding an already-base64 value, and restore the per-file details pane so it shows each file's real size, hash and modification time. The manifest path and period are now schema-validated, since the path is interpolated into the upstream URL unescaped. No-op when the modernization filter is off.

--- a/projects/packages/backup/changelog/fix-backup-preview-manifest-path-encoding
+++ b/projects/packages/backup/changelog/fix-backup-preview-manifest-path-encoding
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Backup: fix the modernized file browser's preview, which corrupted the manifest path by percent-encoding an already-base64 value, and restore the per-file details pane so it shows each file's real size, hash and modification time. No-op when the modernization filter is off.

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -4,18 +4,19 @@ import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { Button, Card, Stack, Text } from '@wordpress/ui';
 import { useFileContents } from '../../hooks/use-file-contents';
+import { formatFileSize, usePathInfo } from '../../hooks/use-path-info';
 import './style.scss';
 import type { FileNodeFile } from '../../types/file-tree';
 
 /**
  * Heuristic mime-type lookup by file extension.
  *
- * WPCOM's `/path-info` endpoint, which PR 48859 originally relied on,
- * returns "No file found" for every variant we tried — it appears to
- * query an internal index that isn't populated for every site / file.
- * Deriving mime from the extension keeps the FileInfoCard's preview-or-
- * not decision working without that fetch, and matches the heuristic
- * legacy file managers use.
+ * Deliberately not replaced by `path-info`'s `data_type`: that field is
+ * a small integer type code — the manifest path's second character —
+ * rather than a mime type, and it cannot tell a previewable `.php` from
+ * an opaque binary. Calypso reaches the same conclusion and keeps its
+ * own extension map for exactly this decision, using `data_type` only
+ * to drive granular download.
  */
 const EXT_TO_MIME: Record< string, string > = {
 	css: 'text/css',
@@ -61,11 +62,16 @@ type Props = {
 
 /**
  * Renders the preview slot's body: a spinner while loading, the file
- * contents in a `<pre>` when available, an error-specific muted line
- * when the fetch failed (most commonly because the file's `period`
- * predates available content blobs — VaultPress retains manifest
- * entries longer than blob storage), or a generic "preview unavailable"
- * muted line for non-text mime types.
+ * contents in a `<pre>` when available, a muted line when the fetch
+ * failed, or a generic "preview unavailable" muted line for non-text
+ * mime types.
+ *
+ * The error branch says nothing about *why*, on purpose. It used to
+ * blame blob storage having outlived the manifest entry, which was
+ * never right: upstream reports a genuinely unreadable blob with a
+ * different error entirely, and the failure that prompted that wording
+ * turned out to be this package percent-encoding an already-base64
+ * path. There is no failure mode here specific enough to name.
  *
  * Pulled out as a standalone component to keep `FileInfoCard`'s JSX flat
  * (no nested ternaries) and to give the loading / error / empty branches
@@ -102,10 +108,7 @@ function PreviewBody( {
 	if ( error ) {
 		return (
 			<Text variant="body-sm" className="jpb-text-muted">
-				{ __(
-					'Preview could not be loaded for this file. It may no longer be available in storage.',
-					'jetpack-backup-pkg'
-				) }
+				{ __( 'Preview could not be loaded for this file.', 'jetpack-backup-pkg' ) }
 			</Text>
 		);
 	}
@@ -135,15 +138,20 @@ function isTextual( mime: string ): boolean {
 }
 
 /**
- * Side panel showing details for the currently-open file: modified
- * timestamp, monospace text preview for recognized text mime types,
- * plus per-file Download and Restore buttons.
+ * Side panel showing details for the currently-open file: size, hash,
+ * modified timestamp, and a monospace text preview for recognized text
+ * mime types.
  *
- * `lastModified`, `period`, and `manifestPath` all come from `/ls` and
- * are carried on the FileNode itself — no extra fetch needed. The
- * preview pulls content via the file's own `period` (not the parent
- * backup's rewindId) because VaultPress addresses file blobs by their
- * per-entry snapshot timestamp.
+ * Two fetches back this, both keyed on the file's own `period` from
+ * `/ls` rather than the parent backup's rewindId, because VaultPress
+ * records one row per file version and matches the period exactly.
+ * `path-info` supplies size, hash and the real mtime; `file-content`
+ * supplies the preview body. Neither is fatal on its own — the card
+ * renders whatever resolved.
+ *
+ * `lastModified` from `/ls` is the snapshot the file landed in, which
+ * is close to but not the same as the file's modification time, so
+ * path-info's `mtime` wins when it is available.
  *
  * @param props         - Component props.
  * @param props.file    - The file node clicked in the tree.
@@ -158,6 +166,8 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 		isLoading: contentsLoading,
 		error: contentsError,
 	} = useFileContents( file.period, file.manifestPath, showPreview );
+	const { size, hash, lastModified } = usePathInfo( file.period, file.manifestPath );
+	const modified = lastModified ?? file.lastModified;
 
 	return (
 		<Card.Root className="jpb-file-info-card">
@@ -181,16 +191,28 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 				</Button>
 			</Stack>
 			<dl className="jpb-file-info-card__meta">
-				{ file.lastModified && (
+				{ modified && (
 					<div>
 						<dt>{ __( 'Modified:', 'jetpack-backup-pkg' ) }</dt>
-						<dd>{ dateI18n( 'M j, Y, g:i A', file.lastModified, undefined ) }</dd>
+						<dd>{ dateI18n( 'M j, Y, g:i A', modified, undefined ) }</dd>
+					</div>
+				) }
+				{ size !== null && (
+					<div>
+						<dt>{ __( 'Size:', 'jetpack-backup-pkg' ) }</dt>
+						<dd>{ formatFileSize( size ) }</dd>
 					</div>
 				) }
 				{ mimeType && (
 					<div>
 						<dt>{ __( 'Type:', 'jetpack-backup-pkg' ) }</dt>
 						<dd>{ mimeType }</dd>
+					</div>
+				) }
+				{ hash && (
+					<div>
+						<dt>{ __( 'Hash:', 'jetpack-backup-pkg' ) }</dt>
+						<dd className="jpb-file-info-card__hash">{ hash }</dd>
 					</div>
 				) }
 			</dl>

--- a/projects/packages/backup/src/dashboard/data/api/path-info.ts
+++ b/projects/packages/backup/src/dashboard/data/api/path-info.ts
@@ -1,0 +1,56 @@
+import { apiCall, apiPath } from './_helpers';
+
+/**
+ * WPCOM's raw `/rewind/backup/path-info` payload.
+ *
+ * Every field is optional because upstream answers HTTP 200 with only
+ * an `error` string when the file has no row for the period asked for —
+ * a caller has to branch on `error`, not on the status code.
+ *
+ * Two fields are returned but deliberately unused here. `download_url`
+ * is hardcoded empty upstream behind a TODO, so it carries no signal
+ * about whether the bytes exist. `data_type` is a small integer type
+ * code taken from the manifest path's second character, not a mime
+ * type; it exists to drive granular download, and the info card keeps
+ * deriving previewability from the file extension the way Calypso does.
+ */
+export type PathInfoResponse = {
+	error?: string;
+	size?: number;
+	hash?: string;
+	mtime?: number;
+	data_type?: number;
+	manifest_filter?: string;
+	download_url?: string;
+};
+
+/**
+ * Fetch one file's recorded metadata.
+ *
+ * `filePeriod` is the file's own snapshot timestamp from `/ls`, NOT the
+ * parent backup's rewindId: VaultPress stores one row per file version
+ * and matches the period exactly, so a file that did not change during
+ * the backup being browsed has no row under that backup's id.
+ *
+ * `manifestPath` goes raw — this route carries it in the request body,
+ * unlike the file-content route, which base64-encodes it into a URL
+ * segment.
+ *
+ * @param filePeriod    - The file's own snapshot timestamp (Unix seconds, from /ls's `period`).
+ * @param manifestPath  - The volume-prefixed manifest path, unencoded (e.g. `f5:/wp-config.php`).
+ * @param extensionType - Optional extension filter (`changed` | `unchanged`).
+ * @return The raw path-info payload.
+ */
+export async function fetchPathInfo(
+	filePeriod: string,
+	manifestPath: string,
+	extensionType = ''
+): Promise< PathInfoResponse > {
+	return apiCall< PathInfoResponse >( {
+		path: apiPath( '/rewind/backup/path-info', {
+			file_period: filePeriod,
+			manifest_path: manifestPath,
+			extension_type: extensionType,
+		} ),
+	} );
+}

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -49,6 +49,11 @@ export const keys = {
 		[ 'backup', 'file-tree', rewindId, folderPath ] as const,
 	fileContents: ( rewindId: string, path: string ) =>
 		[ 'backup', 'file-contents', rewindId, path ] as const,
+	// Keyed on the file's own period, not the parent backup's rewindId:
+	// upstream records one row per file version and matches the period
+	// exactly, so two backups sharing a file share this entry.
+	pathInfo: ( filePeriod: string, manifestPath: string ) =>
+		[ 'backup', 'path-info', filePeriod, manifestPath ] as const,
 	downloadStatus: ( rewindId: string, downloadId: number ) =>
 		[ 'backup', 'download-status', rewindId, downloadId ] as const,
 	restoreStatus: ( restoreId: number ) => [ 'backup', 'restore-status', restoreId ] as const,

--- a/projects/packages/backup/src/dashboard/hooks/test/use-path-info.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-path-info.test.ts
@@ -1,5 +1,26 @@
-import { formatFileSize, toFileDetails } from '../use-path-info';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, type ReactNode } from 'react';
+import { formatFileSize, toFileDetails, usePathInfo } from '../use-path-info';
 import type { PathInfoResponse } from '../../data/api/path-info';
+
+jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+/**
+ * Fresh client per test, retries off so failures assert immediately.
+ *
+ * @return A wrapper providing an isolated QueryClient.
+ */
+function makeWrapper() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+	const wrapper = ( { children }: { children: ReactNode } ) =>
+		createElement( QueryClientProvider, { client }, children );
+	return { wrapper };
+}
 
 const payload = ( overrides: Partial< PathInfoResponse > = {} ): PathInfoResponse => ( {
 	size: 3247,
@@ -35,18 +56,29 @@ describe( 'toFileDetails', () => {
 		} );
 	} );
 
-	// Same hazard `toFileNode` guards for: `mtime` is unvalidated upstream
-	// data, and `toISOString()` throws `RangeError` on an unrepresentable
-	// date. A finite-but-out-of-range value — an mtime that arrives in
-	// milliseconds rather than seconds — passes `Number.isFinite` and
-	// still blows up, so the `Date` itself has to be tested.
+	// Two separate hazards, both landing on `lastModified: null`.
+	//
+	// The falsy group is the nastier one. `Number()` turns `null`, `''`
+	// and `false` into `0`, which is a perfectly valid Date — 1 Jan 1970
+	// — and its ISO string is *truthy*, so the card's
+	// `lastModified ?? file.lastModified` fallback would prefer it and
+	// display 1970 for a file whose real date it already had from `/ls`.
+	// An mtime from a nullable upstream column is a plausible payload.
+	//
+	// The unrepresentable group is the `toFileNode` hazard: `Date` is
+	// only defined within ±8.64e15 ms, so a microsecond-scale timestamp
+	// is finite and still throws `RangeError` from `toISOString()`.
 	test.each( [
-		[ 'out-of-range', 1748888135000000 ],
+		[ 'null', null ],
+		[ 'zero', 0 ],
+		[ 'empty string', '' ],
+		[ 'false', false ],
+		[ 'microsecond-scale', 1748888135000000 ],
 		[ 'not a number', NaN ],
-	] )( 'drops lastModified rather than throwing on an %s mtime', ( _label, mtime ) => {
+	] )( 'reports no lastModified for a %s mtime, never 1970', ( _label, mtime ) => {
 		let details;
 		expect( () => {
-			details = toFileDetails( payload( { mtime } ) );
+			details = toFileDetails( payload( { mtime: mtime as unknown as number } ) );
 		} ).not.toThrow();
 
 		expect( details ).toMatchObject( { size: 3247, lastModified: null } );
@@ -76,5 +108,57 @@ describe( 'formatFileSize', () => {
 		[ 5368709120, '5 GB' ],
 	] )( 'formats %i bytes as %s', ( bytes, expected ) => {
 		expect( formatFileSize( bytes ) ).toBe( expected );
+	} );
+} );
+
+describe( 'usePathInfo', () => {
+	beforeEach( () => {
+		mockedApiFetch.mockReset();
+	} );
+
+	test( 'sends the file period and the raw manifest path, and projects the reply', async () => {
+		mockedApiFetch.mockResolvedValue( payload() );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => usePathInfo( '1748888135', 'f5:/wp-config.php' ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		expect( mockedApiFetch ).toHaveBeenCalledWith( {
+			path: '/jetpack/v4/rewind/backup/path-info?file_period=1748888135&manifest_path=f5%3A%2Fwp-config.php',
+		} );
+		expect( result.current ).toMatchObject( {
+			size: 3247,
+			hash: '2b468ca8798605890addf85864109793',
+			lastModified: '2025-06-02T18:15:35.000Z',
+		} );
+	} );
+
+	// The card's hooks run before a file is chosen, and folder rows from
+	// `/ls` carry no manifest path at all. Both params are required
+	// upstream, so firing anyway would spend a request to earn a 400.
+	test.each( [
+		[ 'the period is missing', undefined, 'f5:/wp-config.php' ],
+		[ 'the manifest path is missing', '1748888135', undefined ],
+		[ 'the period is empty', '', 'f5:/wp-config.php' ],
+		[ 'both are missing', undefined, undefined ],
+	] )( 'issues no request when %s', ( _label, period, manifestPath ) => {
+		const { wrapper } = makeWrapper();
+
+		renderHook( () => usePathInfo( period, manifestPath ), { wrapper } );
+
+		expect( mockedApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	// How the card suppresses the fetch for a file it will not render
+	// details for.
+	test( 'issues no request when disabled despite having both params', () => {
+		const { wrapper } = makeWrapper();
+
+		renderHook( () => usePathInfo( '1748888135', 'f5:/wp-config.php', false ), { wrapper } );
+
+		expect( mockedApiFetch ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-path-info.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-path-info.test.ts
@@ -1,0 +1,80 @@
+import { formatFileSize, toFileDetails } from '../use-path-info';
+import type { PathInfoResponse } from '../../data/api/path-info';
+
+const payload = ( overrides: Partial< PathInfoResponse > = {} ): PathInfoResponse => ( {
+	size: 3247,
+	hash: '2b468ca8798605890addf85864109793',
+	mtime: 1748888135,
+	...overrides,
+} );
+
+describe( 'toFileDetails', () => {
+	test( 'reads size, hash and mtime from a resolved row', () => {
+		expect( toFileDetails( payload() ) ).toEqual( {
+			size: 3247,
+			hash: '2b468ca8798605890addf85864109793',
+			lastModified: '2025-06-02T18:15:35.000Z',
+		} );
+	} );
+
+	// Upstream answers HTTP 200 with an `error` string when the file has
+	// no row for that period, so the status code alone never reveals it.
+	// Reading the body regardless would render `0 bytes` and an empty
+	// hash as though they were real measurements of the file.
+	test( 'treats a 200 carrying an error as no details at all', () => {
+		expect(
+			toFileDetails( payload( { error: 'No file found for the given manifest_path' } ) )
+		).toEqual( { size: null, hash: null, lastModified: null } );
+	} );
+
+	test( 'returns nulls when nothing has been fetched yet', () => {
+		expect( toFileDetails( undefined ) ).toEqual( {
+			size: null,
+			hash: null,
+			lastModified: null,
+		} );
+	} );
+
+	// Same hazard `toFileNode` guards for: `mtime` is unvalidated upstream
+	// data, and `toISOString()` throws `RangeError` on an unrepresentable
+	// date. A finite-but-out-of-range value — an mtime that arrives in
+	// milliseconds rather than seconds — passes `Number.isFinite` and
+	// still blows up, so the `Date` itself has to be tested.
+	test.each( [
+		[ 'out-of-range', 1748888135000000 ],
+		[ 'not a number', NaN ],
+	] )( 'drops lastModified rather than throwing on an %s mtime', ( _label, mtime ) => {
+		let details;
+		expect( () => {
+			details = toFileDetails( payload( { mtime } ) );
+		} ).not.toThrow();
+
+		expect( details ).toMatchObject( { size: 3247, lastModified: null } );
+	} );
+
+	test( 'keeps size and hash when only mtime is missing', () => {
+		expect( toFileDetails( payload( { mtime: undefined } ) ) ).toMatchObject( {
+			size: 3247,
+			lastModified: null,
+		} );
+	} );
+
+	// A zero-byte file is a real file, and `0` is falsy — the reason this
+	// is asserted rather than left to a truthiness check.
+	test( 'reports a zero-byte file as 0, not as unknown', () => {
+		expect( toFileDetails( payload( { size: 0 } ) ) ).toMatchObject( { size: 0 } );
+	} );
+} );
+
+describe( 'formatFileSize', () => {
+	test.each( [
+		[ 0, '0 B' ],
+		[ 512, '512 B' ],
+		[ 1024, '1 KB' ],
+		[ 3247, '3.2 KB' ],
+		[ 1048576, '1 MB' ],
+		[ 5368709120, '5 GB' ],
+	] )( 'formats %i bytes as %s', ( bytes, expected ) => {
+		expect( formatFileSize( bytes ) ).toBe( expected );
+	} );
+} );

--- a/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
@@ -66,9 +66,11 @@ export function toFileNode( name: string, raw: WpcomFileNode, parentPath: string
 	// Testing the resulting `Date` rather than the parsed number is what
 	// makes this complete: `Number.isFinite` alone rejects non-numeric
 	// values but happily passes anything inside float range, and `Date` is
-	// only defined within ±8.64e15 ms. A `period` in milliseconds or
-	// microseconds — ordinary upstream drift for an unvalidated field —
-	// is finite and still unrepresentable.
+	// only defined within ±8.64e15 ms. A `period` in microseconds — one
+	// kind of upstream drift for an unvalidated field — is finite and
+	// still unrepresentable. Note a *millisecond*-scale value is not: it
+	// stays in range and renders a far-future date, which nothing here
+	// can distinguish from a genuine one.
 	const periodSeconds = raw.period ? Number.parseInt( raw.period, 10 ) : NaN;
 	const lastModifiedDate = new Date( periodSeconds * 1000 );
 	const lastModified = Number.isNaN( lastModifiedDate.getTime() )

--- a/projects/packages/backup/src/dashboard/hooks/use-path-info.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-path-info.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { _x, sprintf } from '@wordpress/i18n';
 import { fetchPathInfo } from '../data/api/path-info';
 import { keys } from '../data/query-client';
 import type { PathInfoResponse } from '../data/api/path-info';
@@ -20,13 +20,22 @@ const NO_DETAILS: FileDetails = { size: null, hash: null, lastModified: null };
  * value would render `0 bytes` and an empty hash as if they were real
  * measurements.
  *
- * `mtime` gets the same treatment `toFileNode` gives `period`. It is
- * unvalidated upstream data, and `toISOString()` throws `RangeError` on
- * an unrepresentable date from inside the render path. Testing the
- * resulting `Date` rather than the number is what makes the guard
- * complete — `Number.isFinite` passes anything in float range, while
- * `Date` is only defined within ±8.64e15 ms, so an mtime that arrives
- * in milliseconds is finite and still unrepresentable.
+ * `mtime` needs a stricter guard than a bare `Number()` coercion, which
+ * turns `null`, `''` and `false` into `0` — a perfectly valid Date of
+ * 1 Jan 1970 whose ISO string is *truthy*. That would win the card's
+ * `lastModified ?? file.lastModified` fallback and show 1970 for a file
+ * whose real date was already known from `/ls`. Only a positive number
+ * is a usable mtime.
+ *
+ * The resulting `Date` is then checked as well as the number, the way
+ * `toFileNode` checks `period`: `Date` is only defined within ±8.64e15
+ * ms, so a microsecond-scale timestamp is finite and still throws
+ * `RangeError` from `toISOString()` on the render path.
+ *
+ * That pair does not catch every scale error, and deliberately so — a
+ * millisecond-scale mtime stays inside range and renders as year 57390.
+ * Nothing distinguishes it from a genuine far-future timestamp, so it
+ * is left alone rather than guessed at.
  *
  * @param raw - The raw payload, or undefined before the query resolves.
  * @return Normalized details, with nulls wherever a value is unusable.
@@ -36,8 +45,10 @@ export function toFileDetails( raw: PathInfoResponse | undefined ): FileDetails 
 		return NO_DETAILS;
 	}
 
-	const mtimeDate = new Date( Number( raw.mtime ) * 1000 );
-	const lastModified = Number.isNaN( mtimeDate.getTime() ) ? null : mtimeDate.toISOString();
+	const mtime = typeof raw.mtime === 'number' && raw.mtime > 0 ? raw.mtime : null;
+	const mtimeDate = mtime === null ? null : new Date( mtime * 1000 );
+	const lastModified =
+		mtimeDate && ! Number.isNaN( mtimeDate.getTime() ) ? mtimeDate.toISOString() : null;
 
 	return {
 		size: typeof raw.size === 'number' ? raw.size : null,
@@ -53,37 +64,57 @@ export function toFileDetails( raw: PathInfoResponse | undefined ): FileDetails 
  * byte count is unreadable at the top of that range. Whole numbers stay
  * whole — `1 KB`, not `1.0 KB`.
  *
- * The unit list is built per call rather than hoisted to a module
- * constant on purpose: this dashboard's boot downloads its translation
+ * Each unit gets a whole translatable string rather than a shared
+ * `%1$s %2$s` joiner. A two-placeholder msgid tells a translator
+ * nothing about what is being formatted, and locales that lead with the
+ * unit have no way to reorder it.
+ *
+ * The strings are also translated per call rather than hoisted to a
+ * module constant: this dashboard's boot downloads its translation
  * catalogs asynchronously, so anything translated at import time
- * resolves before the catalog lands and freezes the English string in
- * for the life of the page.
+ * resolves before the catalog lands and freezes the English in for the
+ * life of the page.
  *
  * @param bytes - Size in bytes.
  * @return A localized, human-readable size.
  */
 export function formatFileSize( bytes: number ): string {
-	const units = [
-		_x( 'B', 'abbreviation for bytes, a unit of file size', 'jetpack-backup-pkg' ),
-		_x( 'KB', 'abbreviation for kilobytes, a unit of file size', 'jetpack-backup-pkg' ),
-		_x( 'MB', 'abbreviation for megabytes, a unit of file size', 'jetpack-backup-pkg' ),
-		_x( 'GB', 'abbreviation for gigabytes, a unit of file size', 'jetpack-backup-pkg' ),
-	];
-
+	const LARGEST_UNIT = 3;
 	let value = bytes;
 	let unit = 0;
-	while ( value >= 1024 && unit < units.length - 1 ) {
+	while ( value >= 1024 && unit < LARGEST_UNIT ) {
 		value /= 1024;
 		unit++;
 	}
 
-	const rounded = Math.round( value * 10 ) / 10;
-	return sprintf(
-		/* translators: 1: A file size number, e.g. "3.2". 2: An abbreviated unit of file size, e.g. "KB". */
-		__( '%1$s %2$s', 'jetpack-backup-pkg' ),
-		String( rounded ),
-		units[ unit ]
-	);
+	const rounded = String( Math.round( value * 10 ) / 10 );
+
+	switch ( unit ) {
+		case 1:
+			return sprintf(
+				/* translators: %s: a file size number, e.g. "3.2". */
+				_x( '%s KB', 'file size in kilobytes', 'jetpack-backup-pkg' ),
+				rounded
+			);
+		case 2:
+			return sprintf(
+				/* translators: %s: a file size number, e.g. "3.2". */
+				_x( '%s MB', 'file size in megabytes', 'jetpack-backup-pkg' ),
+				rounded
+			);
+		case LARGEST_UNIT:
+			return sprintf(
+				/* translators: %s: a file size number, e.g. "3.2". */
+				_x( '%s GB', 'file size in gigabytes', 'jetpack-backup-pkg' ),
+				rounded
+			);
+		default:
+			return sprintf(
+				/* translators: %s: a file size number, e.g. "512". */
+				_x( '%s B', 'file size in bytes', 'jetpack-backup-pkg' ),
+				rounded
+			);
+	}
 }
 
 /**

--- a/projects/packages/backup/src/dashboard/hooks/use-path-info.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-path-info.ts
@@ -1,0 +1,115 @@
+import { useQuery } from '@tanstack/react-query';
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { fetchPathInfo } from '../data/api/path-info';
+import { keys } from '../data/query-client';
+import type { PathInfoResponse } from '../data/api/path-info';
+
+export type FileDetails = {
+	size: number | null;
+	hash: string | null;
+	lastModified: string | null;
+};
+
+const NO_DETAILS: FileDetails = { size: null, hash: null, lastModified: null };
+
+/**
+ * Project WPCOM's path-info payload onto what the info card renders.
+ *
+ * Upstream reports a missing file as HTTP 200 with an `error` string
+ * rather than a 4xx, so the body has to be inspected: taking it at face
+ * value would render `0 bytes` and an empty hash as if they were real
+ * measurements.
+ *
+ * `mtime` gets the same treatment `toFileNode` gives `period`. It is
+ * unvalidated upstream data, and `toISOString()` throws `RangeError` on
+ * an unrepresentable date from inside the render path. Testing the
+ * resulting `Date` rather than the number is what makes the guard
+ * complete — `Number.isFinite` passes anything in float range, while
+ * `Date` is only defined within ±8.64e15 ms, so an mtime that arrives
+ * in milliseconds is finite and still unrepresentable.
+ *
+ * @param raw - The raw payload, or undefined before the query resolves.
+ * @return Normalized details, with nulls wherever a value is unusable.
+ */
+export function toFileDetails( raw: PathInfoResponse | undefined ): FileDetails {
+	if ( ! raw || raw.error ) {
+		return NO_DETAILS;
+	}
+
+	const mtimeDate = new Date( Number( raw.mtime ) * 1000 );
+	const lastModified = Number.isNaN( mtimeDate.getTime() ) ? null : mtimeDate.toISOString();
+
+	return {
+		size: typeof raw.size === 'number' ? raw.size : null,
+		hash: raw.hash ? raw.hash : null,
+		lastModified,
+	};
+}
+
+/**
+ * Render a byte count for display, one decimal place at most.
+ *
+ * Backed-up files run from empty to multi-gigabyte archives, so a raw
+ * byte count is unreadable at the top of that range. Whole numbers stay
+ * whole — `1 KB`, not `1.0 KB`.
+ *
+ * The unit list is built per call rather than hoisted to a module
+ * constant on purpose: this dashboard's boot downloads its translation
+ * catalogs asynchronously, so anything translated at import time
+ * resolves before the catalog lands and freezes the English string in
+ * for the life of the page.
+ *
+ * @param bytes - Size in bytes.
+ * @return A localized, human-readable size.
+ */
+export function formatFileSize( bytes: number ): string {
+	const units = [
+		_x( 'B', 'abbreviation for bytes, a unit of file size', 'jetpack-backup-pkg' ),
+		_x( 'KB', 'abbreviation for kilobytes, a unit of file size', 'jetpack-backup-pkg' ),
+		_x( 'MB', 'abbreviation for megabytes, a unit of file size', 'jetpack-backup-pkg' ),
+		_x( 'GB', 'abbreviation for gigabytes, a unit of file size', 'jetpack-backup-pkg' ),
+	];
+
+	let value = bytes;
+	let unit = 0;
+	while ( value >= 1024 && unit < units.length - 1 ) {
+		value /= 1024;
+		unit++;
+	}
+
+	const rounded = Math.round( value * 10 ) / 10;
+	return sprintf(
+		/* translators: 1: A file size number, e.g. "3.2". 2: An abbreviated unit of file size, e.g. "KB". */
+		__( '%1$s %2$s', 'jetpack-backup-pkg' ),
+		String( rounded ),
+		units[ unit ]
+	);
+}
+
+/**
+ * Hook reading one file's recorded size, hash and modification time.
+ *
+ * Kept separate from the file tree because `/ls` carries neither size
+ * nor hash, and its `period` is the snapshot the file landed in rather
+ * than the file's own mtime.
+ *
+ * @param filePeriod   - The file's own snapshot timestamp (from /ls `period`).
+ * @param manifestPath - The volume-prefixed manifest path (from /ls `manifest_path`), sent unencoded.
+ * @param enabled      - When false, the query is skipped.
+ * @return Normalized details plus loading state.
+ */
+export function usePathInfo(
+	filePeriod: string | undefined,
+	manifestPath: string | undefined,
+	enabled = true
+): FileDetails & { isLoading: boolean } {
+	const safePeriod = filePeriod ?? '';
+	const safePath = manifestPath ?? '';
+	const query = useQuery( {
+		queryKey: keys.pathInfo( safePeriod, safePath ),
+		queryFn: () => fetchPathInfo( safePeriod, safePath ),
+		enabled: enabled && Boolean( safePeriod ) && Boolean( safePath ),
+	} );
+
+	return { ...toFileDetails( query.data ), isLoading: query.isLoading };
+}

--- a/projects/packages/backup/src/rest/class-file-browser-bridge.php
+++ b/projects/packages/backup/src/rest/class-file-browser-bridge.php
@@ -44,6 +44,24 @@ class File_Browser_Bridge {
 	const PREVIEW_MAX_BYTES = 64 * 1024;
 
 	/**
+	 * Standard base64, with optional padding — the exact alphabet, and
+	 * nothing else.
+	 *
+	 * Notably excludes `%` and `.`, which is what makes it safe to
+	 * interpolate a matching value into a URL path unescaped.
+	 */
+	const BASE64_PATTERN = '^[A-Za-z0-9+/]*={0,2}$';
+
+	/**
+	 * A snapshot period: Unix seconds, digits only.
+	 *
+	 * Matches the upstream route's own `(?P<backup_id>\d+)` capture, so
+	 * a malformed value fails here with a clear 400 instead of an
+	 * opaque upstream 404.
+	 */
+	const PERIOD_PATTERN = '^[0-9]+$';
+
+	/**
 	 * Register routes.
 	 *
 	 * @return void
@@ -80,7 +98,11 @@ class File_Browser_Bridge {
 					'file_period'    => array(
 						'type'     => 'string',
 						'required' => true,
+						'pattern'  => self::PERIOD_PATTERN,
 					),
+					// Unconstrained on purpose: this one is forwarded in
+					// the request body, not the URL, and a manifest path
+					// can legitimately contain any byte a filename can.
 					'manifest_path'  => array(
 						'type'     => 'string',
 						'required' => true,
@@ -105,10 +127,16 @@ class File_Browser_Bridge {
 					'file_period'           => array(
 						'type'     => 'string',
 						'required' => true,
+						'pattern'  => self::PERIOD_PATTERN,
 					),
+					// Both of these land in the WPCOM URL *path*, and the
+					// manifest path deliberately goes in unescaped, so
+					// these patterns are the only guard on it. See
+					// `get_file_content()` for why escaping is not an option.
 					'encoded_manifest_path' => array(
 						'type'     => 'string',
 						'required' => true,
+						'pattern'  => self::BASE64_PATTERN,
 					),
 				),
 			)
@@ -226,6 +254,15 @@ class File_Browser_Bridge {
 		// upstream route captures it as `\S+`, so nothing needs
 		// escaping. `$file_period` is digits, so its encoding is a
 		// no-op either way.
+		//
+		// Because nothing escapes it here, `BASE64_PATTERN` on the arg
+		// definition is the guard. That matters: cURL applies RFC 3986
+		// dot-segment removal before the request leaves the host, so an
+		// unconstrained value containing `../` would climb out of this
+		// route — with a `?` swallowing the trailing `/url` — and turn
+		// a file proxy into an arbitrary authenticated WPCOM GET. The
+		// base64 alphabet contains neither `%` nor `.`, so the pattern
+		// closes that off without re-breaking the preview.
 		$url_response = Client::wpcom_json_api_request_as_user(
 			sprintf(
 				'/sites/%d/rewind/backup/%s/file/%s/url',

--- a/projects/packages/backup/src/rest/class-file-browser-bridge.php
+++ b/projects/packages/backup/src/rest/class-file-browser-bridge.php
@@ -138,12 +138,25 @@ class File_Browser_Bridge {
 		$encoded_manifest_path = (string) $request->get_param( 'encoded_manifest_path' );
 
 		// Step 1: resolve the signed stream URL.
+		//
+		// `$encoded_manifest_path` goes in verbatim. It is already
+		// base64, and WPCOM's stream route runs a plain
+		// `base64_decode()` on this segment, so percent-encoding it
+		// first is silently destructive: PHP's non-strict decoder
+		// discards the `%` and keeps the `3` and the `D`, both valid
+		// base64 characters. `ZjU6L3dwLWNvbmZpZy5waHA%3D` decodes to
+		// `f5:/wp-config.php7`, and VaultPress then correctly reports
+		// `File not found` for a file that is really there. Base64's
+		// `+`, `/` and `=` are all legal in a path segment, and the
+		// upstream route captures it as `\S+`, so nothing needs
+		// escaping. `$file_period` is digits, so its encoding is a
+		// no-op either way.
 		$url_response = Client::wpcom_json_api_request_as_user(
 			sprintf(
 				'/sites/%d/rewind/backup/%s/file/%s/url',
 				$blog_id,
 				rawurlencode( $file_period ),
-				rawurlencode( $encoded_manifest_path )
+				$encoded_manifest_path
 			),
 			'v2',
 			array(),

--- a/projects/packages/backup/src/rest/class-file-browser-bridge.php
+++ b/projects/packages/backup/src/rest/class-file-browser-bridge.php
@@ -20,13 +20,20 @@ if ( ! defined( 'ABSPATH' ) ) {
  * File browser endpoints powering the BackupDetail file tree:
  *   - POST /jetpack/v4/rewind/backup/ls           → list folder children
  *   - GET  /jetpack/v4/rewind/backup/file-content → text preview proxy
+ *   - GET  /jetpack/v4/rewind/backup/path-info    → per-file metadata
  *
- * NOTE: WPCOM's `/sites/{id}/rewind/backup/path-info` endpoint was
- * removed from this bridge in 2026-05. It returned "No file found"
- * for every input variant we could synthesize and there's no working
- * caller of it elsewhere in the monorepo; the React layer derives the
- * `lastModified` field from `/ls`'s `period` and the mime type from
- * the file extension instead.
+ * All three address a file by the *file's own* `period` from `/ls` —
+ * the timestamp at which that file last changed — never by the parent
+ * backup's rewindId. VaultPress records one row per file version and
+ * matches `period` exactly, with no nearest-earlier fallback, so a
+ * file that did not change during the backup the reader is browsing
+ * has no row under the backup's own id.
+ *
+ * Note the two paths take the manifest path in *different* encodings,
+ * because the upstream routes do: `path-info` carries it raw in the
+ * request body, while `file-content` puts standard base64 in a URL
+ * segment that WPCOM `base64_decode()`s. Neither tolerates the other's
+ * form.
  */
 class File_Browser_Bridge {
 
@@ -57,6 +64,31 @@ class File_Browser_Bridge {
 					'path'      => array(
 						'type'     => 'string',
 						'required' => true,
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			'jetpack/v4',
+			'/rewind/backup/path-info',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( __CLASS__, 'get_path_info' ),
+				'permission_callback' => array( Rest_Controller::class, 'permission_check' ),
+				'args'                => array(
+					'file_period'    => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'manifest_path'  => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'extension_type' => array(
+						'type'     => 'string',
+						'required' => false,
+						'default'  => '',
 					),
 				),
 			)
@@ -107,6 +139,49 @@ class File_Browser_Bridge {
 		);
 
 		return self::forward_response( $response, 'backup_ls_fetch_failed', __( 'Could not list backup contents.', 'jetpack-backup-pkg' ) );
+	}
+
+	/**
+	 * Read one file's real metadata. Proxies POST wpcom/v2
+	 * /sites/{id}/rewind/backup/path-info.
+	 *
+	 * Gives the info card the `size`, `hash` and `mtime` VaultPress
+	 * actually recorded, rather than the snapshot `period` `/ls` carries.
+	 * `manifest_filter` comes back too, which is what a future granular
+	 * per-file download needs.
+	 *
+	 * Two fields are deliberately not surfaced. `download_url` is
+	 * hardcoded empty upstream behind a TODO, so it says nothing about
+	 * whether the bytes exist. And `data_type` is a small integer type
+	 * code — the second character of the manifest path — not a mime
+	 * type, so it cannot drive the preview decision; the card keeps
+	 * deriving that from the file extension, as Calypso does.
+	 *
+	 * Upstream answers 200 with an `error` string when the file has no
+	 * row, so a caller must branch on `error` rather than on the status.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public static function get_path_info( WP_REST_Request $request ) {
+		$blog_id = Rest_Controller::get_blog_id_or_error();
+		if ( is_wp_error( $blog_id ) ) {
+			return $blog_id;
+		}
+
+		$response = Client::wpcom_json_api_request_as_user(
+			sprintf( '/sites/%d/rewind/backup/path-info', $blog_id ),
+			'v2',
+			array( 'method' => 'POST' ),
+			array(
+				'backup_id'      => $request->get_param( 'file_period' ),
+				'manifest_path'  => $request->get_param( 'manifest_path' ),
+				'extension_type' => (string) $request->get_param( 'extension_type' ),
+			),
+			'wpcom'
+		);
+
+		return self::forward_response( $response, 'backup_path_info_failed', __( 'Could not read file details.', 'jetpack-backup-pkg' ) );
 	}
 
 	/**

--- a/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
@@ -48,6 +48,7 @@ class Rest_Bridge_Gating_Test extends TestCase {
 		'/jetpack/v4/site/rewindable-activity',
 		'/jetpack/v4/rewind/backup/ls',
 		'/jetpack/v4/rewind/backup/file-content',
+		'/jetpack/v4/rewind/backup/path-info',
 		'/jetpack/v4/backups/download/(?P<rewind_id>[A-Za-z0-9.\-]+)',
 		'/jetpack/v4/backups/download/(?P<rewind_id>[A-Za-z0-9.\-]+)/status',
 		'/jetpack/v4/rewind/to/(?P<rewind_id>[A-Za-z0-9.\-]+)',

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Backup\V0005\REST;
 
 use Automattic\Jetpack\Backup\V0005\Jetpack_Backup;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
@@ -86,9 +87,54 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * Routes are gated on manage_options — a subscriber gets 403.
+	 * Every route in this file, with the params it needs to get past
+	 * validation and reach the permission gate.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: array<string, string>}>
 	 */
-	public function test_routes_require_manage_options() {
+	public static function provide_bridge_routes() {
+		return array(
+			'ls'           => array(
+				'POST',
+				'/jetpack/v4/rewind/backup/ls',
+				array(
+					'rewind_id' => '123',
+					'path'      => '/',
+				),
+			),
+			'file-content' => array(
+				'GET',
+				'/jetpack/v4/rewind/backup/file-content',
+				array(
+					'file_period'           => '123',
+					'encoded_manifest_path' => 'abc',
+				),
+			),
+			'path-info'    => array(
+				'GET',
+				'/jetpack/v4/rewind/backup/path-info',
+				array(
+					'file_period'   => '123',
+					'manifest_path' => 'f5:/wp-config.php',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Routes are gated on manage_options — a subscriber gets 403.
+	 *
+	 * Driven by a provider so the coverage keeps pace as routes are
+	 * added, rather than silently continuing to assert one of them.
+	 *
+	 * @param string                $method Request method.
+	 * @param string                $route  Route to dispatch.
+	 * @param array<string, string> $params Params needed to pass validation.
+	 *
+	 * @dataProvider provide_bridge_routes
+	 */
+	#[DataProvider( 'provide_bridge_routes' )]
+	public function test_routes_require_manage_options( $method, $route, array $params ) {
 		$subscriber_id = wp_insert_user(
 			array(
 				'user_login' => 'subscriber_user',
@@ -98,9 +144,10 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 		);
 		wp_set_current_user( $subscriber_id );
 
-		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/backup/file-content' );
-		$request->set_param( 'file_period', '123' );
-		$request->set_param( 'encoded_manifest_path', 'abc' );
+		$request = new WP_REST_Request( $method, $route );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 403, $response->get_status() );
@@ -123,6 +170,57 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertStringNotContainsString( 'cURL', $response->get_error_message() );
 		$this->assertSame( 502, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * A manifest path that is not base64 is refused before dispatch.
+	 *
+	 * The value is interpolated into the WPCOM URL *path* unescaped —
+	 * it has to be, because percent-encoding it is what broke the
+	 * preview — so the schema is the only thing standing between an
+	 * admin and an arbitrary authenticated WPCOM GET. Dot segments are
+	 * the concrete hazard: cURL applies RFC 3986 dot-segment removal
+	 * before the request leaves the host, so `../` climbs out of the
+	 * intended route and a `?` swallows the trailing `/url`.
+	 *
+	 * `has_valid_params()` runs in `dispatch()` before the permission
+	 * callback is consulted, which is why this returns 400 rather than
+	 * the 403 an unauthenticated caller would otherwise get.
+	 */
+	public function test_file_content_refuses_a_manifest_path_that_is_not_base64() {
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/backup/file-content' );
+		$request->set_param( 'file_period', '1748888135' );
+		$request->set_param( 'encoded_manifest_path', '../../../../../me/sites?f=' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Every character base64 can emit survives that guard.
+	 *
+	 * `+` and `/` only turn up for non-ASCII filenames, which makes them
+	 * easy to leave untested and easy to break — a guard that rejected
+	 * them would make every file with a CJK or accented name
+	 * un-previewable. `/` is also the case where relying on the upstream
+	 * route's `\S+` capture is load-bearing, since it splits the
+	 * outbound path into an extra segment.
+	 *
+	 * Asserted by the absence of a validation failure: a well-formed
+	 * request falls through to the permission gate, which is a 401/403
+	 * here rather than a 400.
+	 */
+	public function test_file_content_accepts_base64_containing_plus_and_slash() {
+		// base64 of `f5:/wp-content/uploads/日本語.jpg`.
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/backup/file-content' );
+		$request->set_param( 'file_period', '1748888135' );
+		$request->set_param( 'encoded_manifest_path', 'ZjU6L3dwLWNvbnRlbnQvdXBsb2Fkcy/ml6XmnKzoqp4uanBn' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotSame( 'rest_invalid_param', $response->get_data()['code'] ?? '' );
 	}
 
 	/**
@@ -188,17 +286,39 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	 * Only paths whose base64 needs no `=` padding and happens to avoid
 	 * `+` and `/` survive the round trip — which is why `readme.html`
 	 * (15 bytes) previewed while `wp-config.php` (17 bytes) did not.
+	 *
+	 * @return array<string, array{0: string}>
 	 */
-	public function test_file_content_sends_the_manifest_path_as_raw_base64() {
+	public static function provide_encoded_manifest_paths() {
+		return array(
+			// `f5:/wp-config.php` — the padded case, 68% of real paths.
+			'padded'         => array( 'ZjU6L3dwLWNvbmZpZy5waHA=' ),
+			// `f5:/wp-content/uploads/日本語.jpg`. `/` inside the base64
+			// splits the outbound path into an extra segment, which is
+			// the case where relying on the upstream route's greedy
+			// `\S+` capture actually carries weight. Non-ASCII filenames
+			// are the only way `+` and `/` arise, so without this the
+			// central claim of the fix goes unexercised.
+			'contains slash' => array( 'ZjU6L3dwLWNvbnRlbnQvdXBsb2Fkcy/ml6XmnKzoqp4uanBn' ),
+		);
+	}
+
+	/**
+	 * @param string $encoded The base64 manifest path to send.
+	 *
+	 * @dataProvider provide_encoded_manifest_paths
+	 */
+	#[DataProvider( 'provide_encoded_manifest_paths' )]
+	public function test_file_content_sends_the_manifest_path_as_raw_base64( $encoded ) {
 		$this->arrange_wpcom( array( 'url' => 'https://public-api.wordpress.com/signed-stream' ) );
 
 		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/backup/file-content' );
 		$request->set_param( 'file_period', '1748888135' );
-		$request->set_param( 'encoded_manifest_path', 'ZjU6L3dwLWNvbmZpZy5waHA=' );
+		$request->set_param( 'encoded_manifest_path', $encoded );
 		File_Browser_Bridge::get_file_content( $request );
 
 		$this->assertStringContainsString(
-			'/rewind/backup/1748888135/file/ZjU6L3dwLWNvbmZpZy5waHA=/url',
+			"/rewind/backup/1748888135/file/{$encoded}/url",
 			$this->captured_urls[0]
 		);
 	}

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -126,6 +126,55 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
+	 * The path-info route registers when the modernization filter is on.
+	 */
+	public function test_path_info_route_registers_when_modernized() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/jetpack/v4/rewind/backup/path-info', $routes );
+	}
+
+	/**
+	 * The path-info leg is addressed by the file's own period and the
+	 * *raw* manifest path.
+	 *
+	 * Both halves are easy to get wrong and neither fails loudly. WPCOM
+	 * names the parameter `backup_id`, but VaultPress hands it straight
+	 * to an exact `period = %d` match against the row for this file
+	 * version — so the parent backup's rewindId, the backup period and
+	 * VaultPress's own id all resolve to nothing. And unlike the stream
+	 * leg, this route takes the manifest path unencoded in the request
+	 * body; base64-ing it here would look for a file literally named
+	 * `ZjU6L3dwLWNvbmZpZy5waHA=`.
+	 */
+	public function test_path_info_sends_the_file_period_and_the_raw_manifest_path() {
+		$this->arrange_wpcom(
+			array(
+				'size'  => 3247,
+				'hash'  => 'abc123',
+				'mtime' => 1748888135,
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/backup/path-info' );
+		$request->set_param( 'file_period', '1748888135' );
+		$request->set_param( 'manifest_path', 'f5:/wp-config.php' );
+		File_Browser_Bridge::get_path_info( $request );
+
+		// Asserted whole rather than key by key: it pins that nothing
+		// extra is sent, and it fails loudly on a null body — the trait
+		// leaves it null when a guard refused before reaching the
+		// network, which per-key assertions would skip in silence.
+		$this->assertSame(
+			array(
+				'backup_id'      => '1748888135',
+				'manifest_path'  => 'f5:/wp-config.php',
+				'extension_type' => '',
+			),
+			$this->captured_body
+		);
+	}
+
+	/**
 	 * The manifest path reaches WPCOM as raw, unescaped base64.
 	 *
 	 * WPCOM's stream route runs a plain `base64_decode()` on this URL

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -126,6 +126,35 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
+	 * The manifest path reaches WPCOM as raw, unescaped base64.
+	 *
+	 * WPCOM's stream route runs a plain `base64_decode()` on this URL
+	 * segment, so percent-encoding it first is silently destructive:
+	 * PHP's non-strict decoder discards the `%` and keeps the `3` and
+	 * the `D`, both of which are valid base64 characters. The segment
+	 * `ZjU6L3dwLWNvbmZpZy5waHA%3D` therefore decodes to the non-empty
+	 * but wrong `f5:/wp-config.php7`, and VaultPress correctly reports
+	 * `File not found` for a file that is really there.
+	 *
+	 * Only paths whose base64 needs no `=` padding and happens to avoid
+	 * `+` and `/` survive the round trip — which is why `readme.html`
+	 * (15 bytes) previewed while `wp-config.php` (17 bytes) did not.
+	 */
+	public function test_file_content_sends_the_manifest_path_as_raw_base64() {
+		$this->arrange_wpcom( array( 'url' => 'https://public-api.wordpress.com/signed-stream' ) );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/backup/file-content' );
+		$request->set_param( 'file_period', '1748888135' );
+		$request->set_param( 'encoded_manifest_path', 'ZjU6L3dwLWNvbmZpZy5waHA=' );
+		File_Browser_Bridge::get_file_content( $request );
+
+		$this->assertStringContainsString(
+			'/rewind/backup/1748888135/file/ZjU6L3dwLWNvbmZpZy5waHA=/url',
+			$this->captured_urls[0]
+		);
+	}
+
+	/**
 	 * The signed-URL leg wraps a transport failure too.
 	 *
 	 * Worth covering separately from the listing: the file-content

--- a/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
+++ b/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
@@ -41,6 +41,18 @@ trait Wpcom_Request_Mock {
 	protected $captured_url = '';
 
 	/**
+	 * URLs of every request a bridge made to WPCOM, in call order.
+	 *
+	 * `get_file_content()` makes two outbound calls — the signed-URL
+	 * lookup and then the stream fetch — so `$captured_url` only ever
+	 * holds the second. A test asserting on how the first one was built
+	 * has to read this instead.
+	 *
+	 * @var string[]
+	 */
+	protected $captured_urls = array();
+
+	/**
 	 * Decoded body of the last request a bridge made to WPCOM.
 	 *
 	 * Stays null when no request was made, which is how a test asserts
@@ -82,8 +94,9 @@ trait Wpcom_Request_Mock {
 		add_filter(
 			'pre_http_request',
 			function ( $preempt, $args, $url ) use ( $body, $status ) {
-				$this->captured_url  = $url;
-				$this->captured_body = isset( $args['body'] ) ? json_decode( $args['body'], true ) : null;
+				$this->captured_url    = $url;
+				$this->captured_urls[] = $url;
+				$this->captured_body   = isset( $args['body'] ) ? json_decode( $args['body'], true ) : null;
 				return array(
 					'response' => array( 'code' => $status ),
 					'body'     => wp_json_encode( $body, JSON_UNESCAPED_SLASHES ),
@@ -127,6 +140,7 @@ trait Wpcom_Request_Mock {
 		wp_set_current_user( 0 );
 
 		$this->captured_url  = '';
+		$this->captured_urls = array();
 		$this->captured_body = null;
 	}
 


### PR DESCRIPTION
Fixes #

Closes task **G** of JETPACK-2243 (G1 + G1b). G2 is removed — its premise is gone.

## Proposed changes

The modernized Backup dashboard's file preview failed for almost every file, returning `400 File not found` from VaultPress even though the signed-URL leg returned 200. This was attributed upstream to VaultPress. It was ours.

**G1 — the 400.** `File_Browser_Bridge::get_file_content()` wrapped the *already-base64* manifest path in `rawurlencode()`, so the `=` padding reached WordPress.com as `%3D`. The upstream stream route runs a plain `base64_decode()` on that URL segment, and PHP's non-strict decoder discards the invalid `%` while keeping the `3` and the `D` — both valid base64 characters:

```php
base64_decode( 'ZjU6L3dwLWNvbmZpZy5waHA%3D' ) === 'f5:/wp-config.php7'
```

VaultPress was asked for a file that genuinely does not exist and answered correctly. Only paths whose base64 needs no `=` padding and happens to avoid `+` and `/` survived, which is why a handful of files worked and nobody spotted the pattern. Base64's `+`, `/` and `=` are all legal in a path segment and the upstream route captures it as `\S+`, so the value needs no escaping — this now matches what Calypso has sent since the endpoint was built.

**G1b — the details pane.** The `path-info` bridge had been removed in 2026-05 on the belief that it "returned 'No file found' for every input variant we could synthesize". That belief was wrong: it resolves a file completely when given the file's own `period` — the identifier `/ls` already hands us — and fails only when given the parent backup's rewindId. Restored, so the info card shows the real `size`, `hash` and `mtime` instead of only a date derived from the snapshot `period`. The orphaned `&__hash` style has a consumer again, and `manifest_filter` comes back in the same payload for a future granular per-file download.

Two upstream fields stay unused, deliberately:

* `download_url` is hardcoded empty behind a TODO, so it carries no signal about whether the bytes exist.
* `data_type` is a small integer type code (the manifest path's second character), **not** a mime type — it cannot tell a previewable `.php` from an opaque binary. `EXT_TO_MIME` stays; Calypso reaches the same conclusion and keeps its own extension map, using `data_type` only for granular download.

**Folklore corrected.** Three comments and one user-facing string blamed the preview failure on blob storage outliving the manifest entry. Upstream reports an unreadable blob with a different error entirely, so that was never the cause. The user-facing string no longer speculates.

**Tests.** Both encodings are now pinned as regressions — `file-content` sends raw base64, `path-info` sends the raw path plus the file's own period — and the shared mock trait records every outbound URL, since `get_file_content()` makes two calls and only the second was previously observable.

## Related product discussion/links

* JETPACK-2243 (task G)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is behind the `rsm_jetpack_ui_modernization_backup` feature flag, which is **off by default** — with the flag off, nothing changes.

1. On a site with Jetpack Backup and at least one completed backup, enable the modernization flag:
   ```php
   add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
   ```
2. Go to **Jetpack → Backup**, open a backup, and expand the file browser.
3. Click **`wp-config.php`**. Before this change the preview pane read "Preview could not be loaded for this file." — it should now render the file's contents.
4. Click **`readme.html`**. This one previewed before the fix too (its base64 needs no padding), so it should keep working — it's the control.
5. Try a few files whose names vary in length, e.g. `license.txt`, `wp-load.php`, `wp-settings.php`, and something under `wp-content/`. All text files should preview.
6. Confirm the info card now shows **Size** and **Hash** rows alongside **Modified** and **Type**, and that Modified is the file's own modification time.
7. Turn the flag back off and confirm the legacy Backup page is unchanged.

Automated checks, all run locally:

* `jp test php packages/backup` — OK (192 tests, 547 assertions)
* `jp test js packages/backup` — 277 tests, 36 suites
* `jp phan packages/backup` — 0 issues
* `pnpm run typecheck` (in `projects/packages/backup`) — clean
* PHPCS — clean
