### PR TITLE
My Jetpack: tell the Stats dashboard when Start for Free was chosen

### DIFF
--- a/projects/packages/my-jetpack/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Tell the Stats dashboard when Start for Free was chosen, so it does not ask which plan you want a second time.

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -352,6 +352,17 @@ class Stats extends Module_Product {
 	}
 
 	/**
+	 * Get the URL the user is taken to after activating the product
+	 *
+	 * @return ?string
+	 */
+	public static function get_post_activation_url() {
+		// Says the Free-vs-Paid question was already answered here, so the Stats dashboard's own
+		// pricing grid renders the dashboard instead of asking it a second time.
+		return add_query_arg( 'stats_plan_chosen', '1', static::get_manage_url() );
+	}
+
+	/**
 	 * Get the URL where the user manages the product
 	 *
 	 * @return ?string

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -357,9 +357,10 @@ class Stats extends Module_Product {
 	 * @return ?string
 	 */
 	public static function get_post_activation_url() {
-		// Says the Free-vs-Paid question was already answered here, so the Stats dashboard's own
-		// pricing grid renders the dashboard instead of asking it a second time.
-		return add_query_arg( 'stats_plan_chosen', '1', static::get_manage_url() );
+		// Names the plan the Free-vs-Paid question was already answered with here, so the Stats
+		// dashboard's own pricing grid renders the dashboard instead of asking it a second time,
+		// and records the choice as free rather than as one it cannot name.
+		return add_query_arg( 'stats_plan_chosen', 'free', static::get_manage_url() );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/Stats_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Stats_Product_Test.php
@@ -106,7 +106,7 @@ class Stats_Product_Test extends TestCase {
 		$this->set_premium_analytics_enabled( false );
 
 		$this->assertSame(
-			admin_url( 'admin.php?page=stats&stats_plan_chosen=1' ),
+			admin_url( 'admin.php?page=stats&stats_plan_chosen=free' ),
 			Stats::get_post_activation_url()
 		);
 	}

--- a/projects/packages/my-jetpack/tests/php/Stats_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Stats_Product_Test.php
@@ -102,6 +102,21 @@ class Stats_Product_Test extends TestCase {
 		$this->assertStringNotContainsString( 'page=stats', (string) $manage_url );
 	}
 
+	public function test_post_activation_url_reports_the_plan_choice_to_the_stats_dashboard() {
+		$this->set_premium_analytics_enabled( false );
+
+		$this->assertSame(
+			admin_url( 'admin.php?page=stats&stats_plan_chosen=1' ),
+			Stats::get_post_activation_url()
+		);
+	}
+
+	public function test_manage_url_does_not_report_the_plan_choice() {
+		$this->set_premium_analytics_enabled( false );
+
+		$this->assertStringNotContainsString( 'stats_plan_chosen', Stats::get_manage_url() );
+	}
+
 	public function test_purchase_url_points_at_the_stats_purchase_screen_by_default() {
 		$this->set_premium_analytics_enabled( false );
 

--- a/projects/packages/my-jetpack/tests/php/Stats_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Stats_Product_Test.php
@@ -111,12 +111,6 @@ class Stats_Product_Test extends TestCase {
 		);
 	}
 
-	public function test_manage_url_does_not_report_the_plan_choice() {
-		$this->set_premium_analytics_enabled( false );
-
-		$this->assertStringNotContainsString( 'stats_plan_chosen', Stats::get_manage_url() );
-	}
-
 	public function test_purchase_url_points_at_the_stats_purchase_screen_by_default() {
 		$this->set_premium_analytics_enabled( false );
 

--- a/projects/plugins/backup/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/backup/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.
+My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/backup/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/backup/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/boost/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/boost/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.
+My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/boost/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/boost/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/jetpack/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/jetpack/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.
+My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/jetpack/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/jetpack/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/protect/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/protect/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.
+My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/protect/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/protect/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/search/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/search/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.
+My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/search/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/search/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/social/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/social/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.
+My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/social/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/social/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/starter-plugin/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/starter-plugin/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.
+My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/starter-plugin/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/starter-plugin/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/stats/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/stats/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.
+My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/stats/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/stats/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/videopress/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/videopress/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.
+My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/videopress/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/videopress/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop the Stats dashboard asking which plan you want again after Start for Free was already chosen.


### PR DESCRIPTION
Fixes STATS-448

## Why

Someone who opens **My Jetpack → Add Stats** and clicks **Start for Free** has just answered the Free-vs-Paid question. They open Jetpack Stats and get asked it again — the pricing grid replaces their whole dashboard with the same choice they made a moment ago.

Nothing was recording the answer. Stats has no free product slug in its pricing payload, so "Start for Free" runs no checkout; all it writes is a local My Jetpack option that the Stats dashboard has no reason to read. The dashboard checks for a Stats plan and for its own `pricing_grid` notice, finds neither, and asks.

This carries the answer across in the URL, using the arg Odyssey already reads.

## Proposed changes

Override `Stats::get_post_activation_url()` to append `stats_plan_chosen=free`. That is the whole change — 11 lines, most of them comment.

`get_manage_url()` is deliberately left alone, so the Stats menu item and the "Manage" links stay clean; only the URL a user is redirected to *after activating from My Jetpack* carries the marker. The paid path is unaffected for a second reason too: it calls checkout with `postCheckoutUrl`, which overwrites `redirect_to` and resolves to the My Jetpack page for Stats, so a purchase never carries the arg. Bundle checkout uses Complete's own post-activation URL.

Odyssey needs no functional change: its gate reads `stats_plan_chosen`, renders the dashboard on first paint, and records the `pricing_grid` dismissal itself. Keeping the decision to dismiss with the dashboard that owns the notice is the reason this is a query arg rather than a REST call from My Jetpack. The Calypso counterpart — Automattic/wp-calypso#113697 — only generalises naming and docs now that a second surface sends the arg.

The value names the plan rather than being a bare `1`. Automattic/wp-calypso#113672 taught the gate to read `free`/`paid` and demoted `1` to a choice it cannot name, so `1` here would report this flow's plan as `unknown` on `stats_pre_connection_plan_completed` for no reason — "Start for Free" is unambiguously the free choice. One ordering note: the Odyssey bundle on the CDN today (`widgets.wp.com/odyssey-stats/v1/build.min.js`, last modified 18 August) predates that reader and matches only `1`, so suppression starts working once the Odyssey deploy carrying #113672 goes out. That precedes every channel this plugin change reaches — Simple on deploy after merge, WoA weekly, self-hosted on 7 September — and until then the grid simply still asks, exactly as it does on trunk today.

## Related product discussion/links

* STATS-448 · STATS-366 (the grid spec) · Automattic/wp-calypso#113366 (the grid)
* Calypso counterpart: Automattic/wp-calypso#113697

## Does this pull request change what data or activity we track or use?

No new tracking. Choosing Start for Free now results in one `POST` to the existing `/jetpack-stats-dashboard/notices` endpoint recording the `pricing_grid` dismissal — the same call the Stats dashboard already makes for its own "Start for free" button.

## Testing instructions

On a site with no Stats plan, go to **Jetpack → My Jetpack**, open `admin.php?page=my-jetpack#/add-stats`, and click **Start for Free**.

- [ ] You land on the Stats dashboard and the URL carries `stats_plan_chosen=free`.
- [ ] The dashboard renders immediately — no pricing grid, no loading state.
- [ ] A `POST` to `…/jetpack-stats-dashboard/notices` returns 200 (the `pricing_grid` dismissal).
- [ ] Loading `admin.php?page=stats` **without** the arg fires no such POST.
- [ ] **Get Stats** / **Get Complete** still go to checkout, and their redirect URLs carry no `stats_plan_chosen`.
- [ ] The Stats menu item and the card's **Manage** link still point at `admin.php?page=stats` with no extra arg.
- [ ] **Get Stats** / **Get Complete** still go to checkout.

Verified end to end against a local docker WordPress, on the CDN bundle current at the time, which is why the capture below shows the earlier `stats_plan_chosen=1`. The gate's own tests cover the value this now sends (`client/my-sites/stats/pricing-grid/test/gate.test.ts`, the `free`/`paid` cases). The control test is what establishes causation:

<details>
<summary>Network capture</summary>

```text
# admin.php?page=stats&stats_plan_chosen=1
GET  /wp-json/jetpack/v4/stats-app/sites/…/jetpack-stats-dashboard/notices  200
POST /wp-json/jetpack/v4/stats-app/sites/…/jetpack-stats-dashboard/notices  200   <-- dismissal
GET  /wp-json/jetpack/v4/stats-app/sites/…/jetpack-stats-dashboard/notices  200

# admin.php?page=stats   (control, no arg)
GET  /wp-json/jetpack/v4/stats-app/sites/…/jetpack-stats-dashboard/notices  200
# no POST
```

</details>

Clicking **Start for Free** in My Jetpack produced the same POST, landing on
`admin.php?page=stats#!/stats/day/…?page=stats&stats_plan_chosen=1`.

Local checks: PHPCS clean, 164 PHPUnit tests / 398 assertions passing (2 new, covering the arg on `get_post_activation_url()` and its absence from `get_manage_url()`).

