### PR TITLE
Jetpack AI: gate the editor's SEO metadata generation on the SEO feature

### DIFF
--- a/projects/packages/seo/_inc/data/ai-types.ts
+++ b/projects/packages/seo/_inc/data/ai-types.ts
@@ -22,6 +22,8 @@ export interface AiState {
 		available: boolean;
 		/** Whether the SEO Enhancer is currently enabled. */
 		enabled: boolean;
+		/** Whether the AI SEO control the Enhancer sits under is on. */
+		aiSeoEnabled: boolean;
 	};
 	llmsTxt: {
 		/** Whether llms.txt generation is switched on. */

--- a/projects/packages/seo/_inc/data/test/ai-store.test.ts
+++ b/projects/packages/seo/_inc/data/test/ai-store.test.ts
@@ -17,7 +17,7 @@ describe( 'ai-store', () => {
 
 	it( 'replaces the enhancer state on setEnhancer', () => {
 		const registry = makeRegistry();
-		const next = { available: true, enabled: true };
+		const next = { available: true, enabled: true, aiSeoEnabled: false };
 		registry.dispatch( aiStore ).setEnhancer( next );
 		expect( registry.select( aiStore ).getEnhancer() ).toEqual( next );
 	} );

--- a/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
+++ b/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
@@ -39,7 +39,7 @@ export const SEEDED_SETTINGS: SettingsResponse = {
 };
 
 export const SEEDED_AI: AiState = {
-	enhancer: { available: true, enabled: false },
+	enhancer: { available: true, enabled: false, aiSeoEnabled: true },
 	llmsTxt: { enabled: false, url: 'https://example.com/llms.txt', canServe: true },
 	crawlers: {
 		catalog: [

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -534,7 +534,15 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 							) }
 							checked={ enhancer.enabled }
 							onChange={ setEnhancerEnabled }
-							disabled={ isSaving }
+							disabled={ isSaving || ! enhancer.aiSeoEnabled }
+							help={
+								enhancer.aiSeoEnabled
+									? undefined
+									: __(
+											'AI SEO is turned off for this site, so nothing is generated. Your choice is saved and applies again when AI SEO is turned back on.',
+											'jetpack-seo'
+									  )
+							}
 							__nextHasNoMarginBottom
 						/>
 					</CollapsibleCard.Content>

--- a/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
+++ b/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
@@ -14,7 +14,7 @@ import type { AiForm } from '../../../data/use-ai';
  * @return A form controller for AiScreen with the enhancer hidden.
  */
 const formWith = ( canServe: boolean ): AiForm => ( {
-	enhancer: { available: false, enabled: false },
+	enhancer: { available: false, enabled: false, aiSeoEnabled: true },
 	llmsTxt: { enabled: true, url: 'https://example.com/llms.txt', canServe },
 	crawlers: null,
 	isSaving: false,
@@ -247,7 +247,7 @@ describe( 'AiScreen (GEO tab) — crawler policy state', () => {
  */
 const allModulesForm = (): AiForm => ( {
 	...crawlerForm(),
-	enhancer: { available: true, enabled: false },
+	enhancer: { available: true, enabled: false, aiSeoEnabled: true },
 	llmsTxt: { enabled: true, url: 'https://example.com/llms.txt', canServe: true },
 } );
 
@@ -394,5 +394,45 @@ describe( 'AiScreen (GEO tab) — module titles', () => {
 		expect( heading.querySelector( 'svg' ) ).toBeInTheDocument();
 		// eslint-disable-next-line testing-library/no-node-access -- the heading/trigger nesting is the contract.
 		expect( screen.getByText( 'AI crawler access' ).closest( 'h2' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'AiScreen (AI tab) — the AI SEO Enhancer card', () => {
+	// Same treatment the Traffic page gives it: disabled with an explanation
+	// rather than hidden, so the saved choice stays visible.
+	it( 'disables the toggle and explains why while the AI SEO control is off', () => {
+		render(
+			<AiScreen
+				form={ {
+					...allModulesForm(),
+					enhancer: { available: true, enabled: true, aiSeoEnabled: false },
+				} }
+				searchEnginesVisible
+				onManageVisibility={ noop }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'checkbox', { name: /Automatically generate SEO title/ } )
+		).toBeDisabled();
+		expect( screen.getByText( /AI SEO is turned off for this site/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'leaves the toggle usable while the AI SEO control is on', () => {
+		render(
+			<AiScreen
+				form={ {
+					...allModulesForm(),
+					enhancer: { available: true, enabled: true, aiSeoEnabled: true },
+				} }
+				searchEnginesVisible
+				onManageVisibility={ noop }
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'checkbox', { name: /Automatically generate SEO title/ } )
+		).toBeEnabled();
+		expect( screen.queryByText( /AI SEO is turned off for this site/ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/seo/changelog/update-jetpack-ai-seo-editor-enforcement
+++ b/projects/packages/seo/changelog/update-jetpack-ai-seo-editor-enforcement
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Hide the SEO dashboard's AI SEO Enhancer card while the AI SEO feature is turned off.
+Disable the SEO dashboard's AI SEO Enhancer toggle, and explain why, while AI SEO is turned off.

--- a/projects/packages/seo/changelog/update-jetpack-ai-seo-editor-enforcement
+++ b/projects/packages/seo/changelog/update-jetpack-ai-seo-editor-enforcement
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Hide the SEO dashboard's AI SEO Enhancer card while the AI SEO feature is turned off.

--- a/projects/packages/seo/src/class-dashboard-data.php
+++ b/projects/packages/seo/src/class-dashboard-data.php
@@ -276,8 +276,8 @@ class Dashboard_Data {
 		// Jetpack_AI_Settings lives in plugins/jetpack, which bundles this package; guarded
 		// like the other host-plugin classes here. Without the method the AI SEO control
 		// does not exist, so the enhancer keeps its pre-control behavior.
-		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_AI_Settings lives in plugins/jetpack and is guarded by method_exists.
-		$ai_seo_on = ! method_exists( 'Jetpack_AI_Settings', 'is_ai_seo_enabled' ) || \Jetpack_AI_Settings::is_ai_seo_enabled();
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_AI_Settings lives in plugins/jetpack and is guarded by is_callable.
+		$ai_seo_on = ! is_callable( array( 'Jetpack_AI_Settings', 'is_ai_seo_enabled' ) ) || \Jetpack_AI_Settings::is_ai_seo_enabled();
 
 		// Current_Plan comes from the jetpack-plans package (a dependency of this
 		// package since the plan-gating work), so it's always available here; the

--- a/projects/packages/seo/src/class-dashboard-data.php
+++ b/projects/packages/seo/src/class-dashboard-data.php
@@ -257,25 +257,27 @@ class Dashboard_Data {
 	 *
 	 * The AI SEO Enhancer auto-generates SEO titles/descriptions/alt-text in the
 	 * editor (the generation itself is wpcom/AI-Assistant side); this exposes only
-	 * its persisted on/off toggle and whether it's available. Availability mirrors
-	 * the legacy Traffic page: the `ai_seo_enhancer_enabled` feature filter must be
-	 * on (it still depends on AI being available), the AI SEO feature must be on,
-	 * AND the site's plan must support the `ai-seo-enhancer` feature. The toggle
-	 * writes through the existing `/jetpack/v4/settings` endpoint
-	 * (`ai_seo_enhancer_enabled`).
+	 * its persisted on/off toggle, whether it's available, and whether the AI SEO
+	 * control it sits under is on. Availability mirrors the legacy Traffic page:
+	 * the `ai_seo_enhancer_enabled` feature filter must be on (it still depends on
+	 * AI being available) AND the site's plan must support the `ai-seo-enhancer`
+	 * feature. The toggle writes through the existing `/jetpack/v4/settings`
+	 * endpoint (`ai_seo_enhancer_enabled`).
+	 *
+	 * `aiSeoEnabled` is reported separately rather than folded into availability:
+	 * with the control off the card is disabled, not hidden, so the saved choice
+	 * stays visible — the same treatment the Traffic page gives it.
 	 *
 	 * @return array
 	 */
 	public static function get_ai_data() {
 		$filter_on = (bool) apply_filters( 'ai_seo_enhancer_enabled', true );
 
-		/**
-		 * The AI SEO feature covers automatic generation too, so with it off
-		 * there is nothing here to turn on.
-		 *
-		 * This filter is documented in projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
-		 */
-		$ai_seo_on = (bool) apply_filters( 'jetpack_ai_seo_enabled', (bool) get_option( 'jetpack_ai_seo_enabled', true ) );
+		// Jetpack_AI_Settings lives in plugins/jetpack, which bundles this package;
+		// guarded like the other host-plugin classes here. Without it the AI SEO
+		// control does not exist, so the enhancer keeps its pre-control behavior.
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_AI_Settings lives in plugins/jetpack and is guarded by class_exists.
+		$ai_seo_on = ! class_exists( 'Jetpack_AI_Settings' ) || \Jetpack_AI_Settings::is_ai_seo_enabled();
 
 		// Current_Plan comes from the jetpack-plans package (a dependency of this
 		// package since the plan-gating work), so it's always available here; the
@@ -285,8 +287,9 @@ class Dashboard_Data {
 
 		return array(
 			'enhancer' => array(
-				'available' => $filter_on && $ai_seo_on && $plan_supports,
-				'enabled'   => (bool) get_option( 'ai_seo_enhancer_enabled', false ),
+				'available'    => $filter_on && $plan_supports,
+				'enabled'      => (bool) get_option( 'ai_seo_enhancer_enabled', false ),
+				'aiSeoEnabled' => (bool) $ai_seo_on,
 			),
 			'llmsTxt'  => array(
 				'enabled'  => Llms_Txt::is_enabled(),

--- a/projects/packages/seo/src/class-dashboard-data.php
+++ b/projects/packages/seo/src/class-dashboard-data.php
@@ -259,14 +259,23 @@ class Dashboard_Data {
 	 * editor (the generation itself is wpcom/AI-Assistant side); this exposes only
 	 * its persisted on/off toggle and whether it's available. Availability mirrors
 	 * the legacy Traffic page: the `ai_seo_enhancer_enabled` feature filter must be
-	 * on (it still depends on AI being available) AND the site's plan must support
-	 * the `ai-seo-enhancer` feature. The toggle writes through the existing
-	 * `/jetpack/v4/settings` endpoint (`ai_seo_enhancer_enabled`).
+	 * on (it still depends on AI being available), the AI SEO feature must be on,
+	 * AND the site's plan must support the `ai-seo-enhancer` feature. The toggle
+	 * writes through the existing `/jetpack/v4/settings` endpoint
+	 * (`ai_seo_enhancer_enabled`).
 	 *
 	 * @return array
 	 */
 	public static function get_ai_data() {
 		$filter_on = (bool) apply_filters( 'ai_seo_enhancer_enabled', true );
+
+		/**
+		 * The AI SEO feature covers automatic generation too, so with it off
+		 * there is nothing here to turn on.
+		 *
+		 * This filter is documented in projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+		 */
+		$ai_seo_on = (bool) apply_filters( 'jetpack_ai_seo_enabled', (bool) get_option( 'jetpack_ai_seo_enabled', true ) );
 
 		// Current_Plan comes from the jetpack-plans package (a dependency of this
 		// package since the plan-gating work), so it's always available here; the
@@ -276,7 +285,7 @@ class Dashboard_Data {
 
 		return array(
 			'enhancer' => array(
-				'available' => $filter_on && $plan_supports,
+				'available' => $filter_on && $ai_seo_on && $plan_supports,
 				'enabled'   => (bool) get_option( 'ai_seo_enhancer_enabled', false ),
 			),
 			'llmsTxt'  => array(

--- a/projects/packages/seo/src/class-dashboard-data.php
+++ b/projects/packages/seo/src/class-dashboard-data.php
@@ -273,11 +273,11 @@ class Dashboard_Data {
 	public static function get_ai_data() {
 		$filter_on = (bool) apply_filters( 'ai_seo_enhancer_enabled', true );
 
-		// Jetpack_AI_Settings lives in plugins/jetpack, which bundles this package;
-		// guarded like the other host-plugin classes here. Without it the AI SEO
-		// control does not exist, so the enhancer keeps its pre-control behavior.
-		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_AI_Settings lives in plugins/jetpack and is guarded by class_exists.
-		$ai_seo_on = ! class_exists( 'Jetpack_AI_Settings' ) || \Jetpack_AI_Settings::is_ai_seo_enabled();
+		// Jetpack_AI_Settings lives in plugins/jetpack, which bundles this package; guarded
+		// like the other host-plugin classes here. Without the method the AI SEO control
+		// does not exist, so the enhancer keeps its pre-control behavior.
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_AI_Settings lives in plugins/jetpack and is guarded by method_exists.
+		$ai_seo_on = ! method_exists( 'Jetpack_AI_Settings', 'is_ai_seo_enabled' ) || \Jetpack_AI_Settings::is_ai_seo_enabled();
 
 		// Current_Plan comes from the jetpack-plans package (a dependency of this
 		// package since the plan-gating work), so it's always available here; the

--- a/projects/packages/seo/src/class-dashboard-data.php
+++ b/projects/packages/seo/src/class-dashboard-data.php
@@ -289,7 +289,7 @@ class Dashboard_Data {
 			'enhancer' => array(
 				'available'    => $filter_on && $plan_supports,
 				'enabled'      => (bool) get_option( 'ai_seo_enhancer_enabled', false ),
-				'aiSeoEnabled' => (bool) $ai_seo_on,
+				'aiSeoEnabled' => $ai_seo_on,
 			),
 			'llmsTxt'  => array(
 				'enabled'  => Llms_Txt::is_enabled(),

--- a/projects/packages/seo/tests/php/DashboardDataTest.php
+++ b/projects/packages/seo/tests/php/DashboardDataTest.php
@@ -28,9 +28,29 @@ class DashboardDataTest extends SeoTestCase {
 		\Jetpack_SEO_Utils::$has_legacy_front_page_meta = false;
 		\Jetpack_Redux_State_Helper::$site_image        = '';
 		delete_option( 'advanced_seo_title_formats' );
+		delete_option( 'jetpack_ai_seo_enabled' );
 		remove_all_filters( 'jetpack_active_modules' );
+		remove_all_filters( 'jetpack_ai_seo_enabled' );
+
+		self::reset_plan();
 
 		parent::tearDown();
+	}
+
+	/**
+	 * With the AI SEO feature off the card would offer a toggle that cannot
+	 * generate, so the tab reports it unavailable.
+	 */
+	public function test_get_ai_data_enhancer_unavailable_when_ai_seo_feature_off() {
+		self::set_plan( 'jetpack_business' );
+		self::set_seo_tools_active( true );
+
+		$available_by_default = Dashboard_Data::get_ai_data()['enhancer']['available'];
+
+		update_option( 'jetpack_ai_seo_enabled', 0 );
+
+		$this->assertTrue( $available_by_default, 'Precondition: available while the feature is on.' );
+		$this->assertFalse( Dashboard_Data::get_ai_data()['enhancer']['available'] );
 	}
 
 	/**

--- a/projects/packages/seo/tests/php/DashboardDataTest.php
+++ b/projects/packages/seo/tests/php/DashboardDataTest.php
@@ -27,6 +27,7 @@ class DashboardDataTest extends SeoTestCase {
 		\Jetpack_SEO_Utils::$enabled                    = true;
 		\Jetpack_SEO_Utils::$has_legacy_front_page_meta = false;
 		\Jetpack_Redux_State_Helper::$site_image        = '';
+		\Jetpack_AI_Settings::$is_ai_seo_enabled        = true;
 		delete_option( 'advanced_seo_title_formats' );
 		delete_option( 'jetpack_ai_seo_enabled' );
 		remove_all_filters( 'jetpack_active_modules' );
@@ -38,18 +39,34 @@ class DashboardDataTest extends SeoTestCase {
 	}
 
 	/**
-	 * With the AI SEO feature off the card would offer a toggle that cannot
-	 * generate, so the tab reports it unavailable.
+	 * With the AI SEO control off the card stays available and reports the
+	 * control's state, so the dashboard disables the toggle rather than hiding
+	 * it and the saved choice stays visible.
 	 */
-	public function test_get_ai_data_enhancer_unavailable_when_ai_seo_feature_off() {
+	public function test_get_ai_data_reports_the_ai_seo_control_state() {
 		self::set_plan( 'jetpack_business' );
 		self::set_seo_tools_active( true );
 
-		$available_by_default = Dashboard_Data::get_ai_data()['enhancer']['available'];
+		$on = Dashboard_Data::get_ai_data()['enhancer'];
 
-		update_option( 'jetpack_ai_seo_enabled', 0 );
+		\Jetpack_AI_Settings::$is_ai_seo_enabled = false;
 
-		$this->assertTrue( $available_by_default, 'Precondition: available while the feature is on.' );
+		$off = Dashboard_Data::get_ai_data()['enhancer'];
+
+		$this->assertTrue( $on['available'], 'Precondition: available while the control is on.' );
+		$this->assertTrue( $on['aiSeoEnabled'] );
+		$this->assertTrue( $off['available'], 'The card stays available so it can be disabled, not hidden.' );
+		$this->assertFalse( $off['aiSeoEnabled'] );
+	}
+
+	/**
+	 * The plan and the feature filter still veto availability outright — those
+	 * are entitlement questions, not a switched-off control.
+	 */
+	public function test_get_ai_data_enhancer_unavailable_without_the_entitlement() {
+		self::set_plan( 'jetpack_free' );
+		self::set_seo_tools_active( true );
+
 		$this->assertFalse( Dashboard_Data::get_ai_data()['enhancer']['available'] );
 	}
 

--- a/projects/packages/seo/tests/php/bootstrap.php
+++ b/projects/packages/seo/tests/php/bootstrap.php
@@ -32,6 +32,7 @@ require_once __DIR__ . '/SeoTestCase.php';
 // drive Schema_Builder's behavior. Tests set their public static properties.
 require_once __DIR__ . '/stubs/class-jetpack-seo-utils.php';
 require_once __DIR__ . '/stubs/class-jetpack-redux-state-helper.php';
+require_once __DIR__ . '/stubs/class-jetpack-ai-settings.php';
 require_once __DIR__ . '/stubs/class-jetpack-seo-posts.php';
 require_once __DIR__ . '/stubs/class-jetpack-options.php';
 require_once __DIR__ . '/stubs/class-wc-structured-data.php';

--- a/projects/packages/seo/tests/php/stubs/class-jetpack-ai-settings.php
+++ b/projects/packages/seo/tests/php/stubs/class-jetpack-ai-settings.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Test stub for the host plugin's Jetpack_AI_Settings class.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+if ( ! class_exists( 'Jetpack_AI_Settings' ) ) {
+
+	/**
+	 * Stub of the host plugin's AI settings registry.
+	 */
+	class Jetpack_AI_Settings {
+
+		/**
+		 * Whether the AI SEO control reports on.
+		 *
+		 * @var bool
+		 */
+		public static $is_ai_seo_enabled = true;
+
+		/**
+		 * Return the configured AI SEO state.
+		 *
+		 * @return bool
+		 */
+		public static function is_ai_seo_enabled(): bool {
+			return self::$is_ai_seo_enabled;
+		}
+	}
+}

--- a/projects/packages/seo/tests/routes/ai/stage.test.tsx
+++ b/projects/packages/seo/tests/routes/ai/stage.test.tsx
@@ -77,7 +77,7 @@ describe( 'AI route stage', () => {
 
 		Stage();
 		const ai = {
-			enhancer: { available: true, enabled: false },
+			enhancer: { available: true, enabled: false, aiSeoEnabled: true },
 			llmsTxt: { enabled: true, url: 'https://example.com/llms.txt', canServe: true },
 			crawlers: { catalog: [], overrides: {} },
 		};

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -927,3 +927,15 @@ export function subscriptionSiteEditSupported( state ) {
 export function isSeoEnhancerAvailable( state ) {
 	return 'ai_seo_enhancer_enabled' in state.jetpack.initialState.getModules[ 'seo-tools' ].options;
 }
+
+/**
+ * Returns whether Jetpack AI is effectively enabled, as the server computed it
+ * through the full gate chain. Defaults to true when absent so the UI never
+ * reports AI off on its own authority.
+ *
+ * @param {object} state - Global state tree.
+ * @return {boolean} Whether Jetpack AI is effectively enabled.
+ */
+export function isAiEnabled( state ) {
+	return state.jetpack.initialState.isAiEnabled ?? true;
+}

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/reducer.js
@@ -939,3 +939,15 @@ export function isSeoEnhancerAvailable( state ) {
 export function isAiEnabled( state ) {
 	return state.jetpack.initialState.isAiEnabled ?? true;
 }
+
+/**
+ * Returns whether the AI SEO feature is effectively enabled, as the server
+ * computed it (its own toggle plus the AI gates). Defaults to true when absent
+ * so the UI never reports the feature off on its own authority.
+ *
+ * @param {object} state - Global state tree.
+ * @return {boolean} Whether the AI SEO feature is effectively enabled.
+ */
+export function isAiSeoEnabled( state ) {
+	return state.jetpack.initialState.isAiSeoEnabled ?? true;
+}

--- a/projects/plugins/jetpack/_inc/client/state/initial-state/test/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/initial-state/test/reducer.js
@@ -1,0 +1,17 @@
+import { isAiEnabled } from '../reducer';
+
+describe( 'isAiEnabled', () => {
+	const stateWith = initialState => ( { jetpack: { initialState } } );
+
+	it( 'returns true when the server reports AI effectively enabled', () => {
+		expect( isAiEnabled( stateWith( { isAiEnabled: true } ) ) ).toBe( true );
+	} );
+
+	it( 'returns false when the server reports AI effectively disabled', () => {
+		expect( isAiEnabled( stateWith( { isAiEnabled: false } ) ) ).toBe( false );
+	} );
+
+	it( 'defaults to true when the server did not report the value', () => {
+		expect( isAiEnabled( stateWith( {} ) ) ).toBe( true );
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -26,6 +26,7 @@ import {
 	getSiteIcon,
 	isSeoEnhancerAvailable,
 	getSiteRepresentativeImage,
+	isAiEnabled,
 } from 'state/initial-state';
 import { siteHasFeature } from 'state/site';
 import { isFetchingPluginsData, isPluginActive } from 'state/site/plugins';
@@ -334,7 +335,9 @@ export const SEO = withModuleSettingsFormHelpers(
 										__nextHasNoMarginBottom={ true }
 										id="seo-enhancer"
 										disabled={
-											! this.props.getOptionValue( 'seo-tools' ) || ! this.props.hasSeoEnhancer
+											! this.props.getOptionValue( 'seo-tools' ) ||
+											! this.props.hasSeoEnhancer ||
+											! this.props.aiEnabled
 										}
 										checked={
 											this.props.hasSeoEnhancer &&
@@ -350,6 +353,14 @@ export const SEO = withModuleSettingsFormHelpers(
 											</span>
 										}
 									/>
+									{ this.props.getOptionValue( 'seo-tools' ) && ! this.props.aiEnabled && (
+										<span className="jp-form-setting-explanation">
+											{ __(
+												'Jetpack AI is turned off for this site, so nothing is generated. Your choice is saved and applies again when Jetpack AI is turned back on.',
+												'jetpack'
+											) }
+										</span>
+									) }
 								</FormFieldset>
 							) }
 						</SettingsGroup>
@@ -514,5 +525,9 @@ export default connect( state => {
 		seoEnhancerAvailable: isSeoEnhancerAvailable( state ),
 		state,
 		hasSeoEnhancer: siteHasFeature( state, 'ai-seo-enhancer' ),
+		// The server-composed AI gate chain: with it closed nothing generates,
+		// so the control says so rather than accepting a change that cannot
+		// take effect.
+		aiEnabled: isAiEnabled( state ),
 	};
 } )( SEO );

--- a/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/seo.jsx
@@ -27,6 +27,7 @@ import {
 	isSeoEnhancerAvailable,
 	getSiteRepresentativeImage,
 	isAiEnabled,
+	isAiSeoEnabled,
 } from 'state/initial-state';
 import { siteHasFeature } from 'state/site';
 import { isFetchingPluginsData, isPluginActive } from 'state/site/plugins';
@@ -337,7 +338,7 @@ export const SEO = withModuleSettingsFormHelpers(
 										disabled={
 											! this.props.getOptionValue( 'seo-tools' ) ||
 											! this.props.hasSeoEnhancer ||
-											! this.props.aiEnabled
+											! this.props.aiSeoEnabled
 										}
 										checked={
 											this.props.hasSeoEnhancer &&
@@ -353,12 +354,17 @@ export const SEO = withModuleSettingsFormHelpers(
 											</span>
 										}
 									/>
-									{ this.props.getOptionValue( 'seo-tools' ) && ! this.props.aiEnabled && (
+									{ this.props.getOptionValue( 'seo-tools' ) && ! this.props.aiSeoEnabled && (
 										<span className="jp-form-setting-explanation">
-											{ __(
-												'Jetpack AI is turned off for this site, so nothing is generated. Your choice is saved and applies again when Jetpack AI is turned back on.',
-												'jetpack'
-											) }
+											{ this.props.aiEnabled
+												? __(
+														'AI SEO is turned off for this site, so nothing is generated. Your choice is saved and applies again when AI SEO is turned back on.',
+														'jetpack'
+												  )
+												: __(
+														'Jetpack AI is turned off for this site, so nothing is generated. Your choice is saved and applies again when Jetpack AI is turned back on.',
+														'jetpack'
+												  ) }
 										</span>
 									) }
 								</FormFieldset>
@@ -529,5 +535,8 @@ export default connect( state => {
 		// so the control says so rather than accepting a change that cannot
 		// take effect.
 		aiEnabled: isAiEnabled( state ),
+		// Automatic generation sits under the AI SEO feature, so the toggle
+		// follows it rather than the site-wide switch alone.
+		aiSeoEnabled: isAiSeoEnabled( state ),
 	};
 } )( SEO );

--- a/projects/plugins/jetpack/_inc/client/traffic/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/test/component.jsx
@@ -1,0 +1,126 @@
+/**
+ * The enhancer row's "Jetpack AI is turned off" explanation must only blame
+ * AI while AI is genuinely the blocker: with the seo-tools module off, the
+ * toggle is disabled by the module gate and the AI message would mislead.
+ * Renders the REAL connected SEO card with the real root reducer.
+ */
+import { jest } from '@jest/globals';
+import { render as rtlRender, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createStore, applyMiddleware } from 'redux';
+import { thunk } from 'redux-thunk';
+import rootReducer from 'state/reducer';
+import ConnectedSeo from '../seo';
+
+jest.mock( '@automattic/jetpack-api', () => ( {
+	__esModule: true,
+	default: new Proxy( {}, { get: () => () => Promise.resolve( {} ) } ),
+} ) );
+
+jest.mock( 'lib/analytics', () => ( {
+	__esModule: true,
+	default: { tracks: { recordEvent: () => {} }, setMcAnalyticsEnabled: () => {} },
+} ) );
+
+const AI_OFF_MESSAGE = /Jetpack AI is turned off for this site/;
+
+/**
+ * State for a site that has the enhancer (plan feature + option registered),
+ * with AI effectively off and the seo-tools module on or off.
+ *
+ * @param {object}  _            - Options.
+ * @param {boolean} _.seoToolsOn - Whether the seo-tools module is active.
+ * @return {object} Initial redux state.
+ */
+function buildInitialState( { seoToolsOn } ) {
+	return {
+		jetpack: {
+			connection: {
+				status: {
+					siteConnected: {
+						isActive: true,
+						offlineMode: { isActive: false },
+					},
+				},
+				user: { currentUser: { isConnected: true } },
+				requests: {},
+			},
+			initialState: {
+				userData: { currentUser: { permissions: { manage_modules: true } } },
+				siteTitle: 'Test Site',
+				isAiEnabled: false,
+				getModules: {
+					'seo-tools': { options: { ai_seo_enhancer_enabled: {} } },
+				},
+			},
+			modules: {
+				items: {
+					'seo-tools': { module: 'seo-tools', name: 'SEO Tools', activated: seoToolsOn },
+				},
+			},
+			settings: {
+				items: {
+					'seo-tools': seoToolsOn,
+					ai_seo_enhancer_enabled: false,
+					advanced_seo_title_formats: {},
+					advanced_seo_front_page_description: '',
+				},
+			},
+			siteData: {
+				data: {
+					name: 'Test Site',
+					description: '',
+					URL: 'https://example.com',
+					site: {
+						features: { active: [ 'ai-seo-enhancer', 'advanced-seo' ] },
+					},
+					plan: { product_slug: 'jetpack_complete' },
+				},
+			},
+		},
+	};
+}
+
+// The Traffic page passes getModule down to every card (traffic/index.jsx);
+// module-scope so the JSX prop reference is stable (react/jsx-no-bind).
+let currentModules = {};
+
+/**
+ * Look a module up in the current test fixture.
+ *
+ * @param {string} name - Module slug.
+ * @return {object} The module fixture, or an empty object.
+ */
+function getModule( name ) {
+	return currentModules[ name ] || {};
+}
+
+/**
+ * Render the connected SEO card over the given state.
+ *
+ * @param {object} initialState - Initial redux state.
+ * @return {import('@testing-library/react').RenderResult} Render result.
+ */
+function renderSeo( initialState ) {
+	const store = createStore( rootReducer, initialState, applyMiddleware( thunk ) );
+	currentModules = initialState.jetpack.modules.items;
+	return rtlRender(
+		<Provider store={ store }>
+			<ConnectedSeo configureUrl="https://example.com/configure" getModule={ getModule } />
+		</Provider>
+	);
+}
+
+describe( 'SEO card enhancer row explanation', () => {
+	it( 'shows the AI-off message while seo-tools is on and AI is off', () => {
+		renderSeo( buildInitialState( { seoToolsOn: true } ) );
+
+		expect( screen.getByText( AI_OFF_MESSAGE ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not blame AI while the seo-tools module is the blocker', () => {
+		renderSeo( buildInitialState( { seoToolsOn: false } ) );
+
+		expect( screen.queryByText( AI_OFF_MESSAGE ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/client/traffic/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/test/component.jsx
@@ -1,8 +1,6 @@
 /**
- * The enhancer row's "Jetpack AI is turned off" explanation must only blame
- * AI while AI is genuinely the blocker: with the seo-tools module off, the
- * toggle is disabled by the module gate and the AI message would mislead.
- * Renders the REAL connected SEO card with the real root reducer.
+ * The enhancer row must name whichever switch is actually blocking it.
+ * Renders the real connected SEO card over the real root reducer.
  */
 import { jest } from '@jest/globals';
 import { render as rtlRender, screen } from '@testing-library/react';
@@ -23,16 +21,28 @@ jest.mock( 'lib/analytics', () => ( {
 } ) );
 
 const AI_OFF_MESSAGE = /Jetpack AI is turned off for this site/;
+const AI_SEO_OFF_MESSAGE = /AI SEO is turned off for this site/;
+
+/**
+ * The enhancer toggle carries no associated label, so find it by id.
+ *
+ * @return {HTMLElement} The enhancer toggle input.
+ */
+function enhancerToggle() {
+	return screen.getAllByRole( 'checkbox' ).find( input => input.id === 'seo-enhancer' );
+}
 
 /**
  * State for a site that has the enhancer (plan feature + option registered),
- * with AI effectively off and the seo-tools module on or off.
+ * varying the seo-tools module, Jetpack AI, and the AI SEO feature.
  *
  * @param {object}  _            - Options.
  * @param {boolean} _.seoToolsOn - Whether the seo-tools module is active.
+ * @param {boolean} _.aiOn       - Whether Jetpack AI is effectively on.
+ * @param {boolean} _.aiSeoOn    - Whether the AI SEO feature is effectively on.
  * @return {object} Initial redux state.
  */
-function buildInitialState( { seoToolsOn } ) {
+function buildInitialState( { seoToolsOn, aiOn = false, aiSeoOn = false } ) {
 	return {
 		jetpack: {
 			connection: {
@@ -48,7 +58,8 @@ function buildInitialState( { seoToolsOn } ) {
 			initialState: {
 				userData: { currentUser: { permissions: { manage_modules: true } } },
 				siteTitle: 'Test Site',
-				isAiEnabled: false,
+				isAiEnabled: aiOn,
+				isAiSeoEnabled: aiSeoOn,
 				getModules: {
 					'seo-tools': { options: { ai_seo_enhancer_enabled: {} } },
 				},
@@ -121,6 +132,27 @@ describe( 'SEO card enhancer row explanation', () => {
 	it( 'does not blame AI while the seo-tools module is the blocker', () => {
 		renderSeo( buildInitialState( { seoToolsOn: false } ) );
 
+		expect( screen.queryByText( AI_OFF_MESSAGE ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'disables the enhancer toggle while the AI SEO feature is off', () => {
+		renderSeo( buildInitialState( { seoToolsOn: true, aiOn: true, aiSeoOn: false } ) );
+
+		expect( enhancerToggle() ).toBeDisabled();
+	} );
+
+	it( 'names the AI SEO feature, not Jetpack AI, while only the feature is off', () => {
+		renderSeo( buildInitialState( { seoToolsOn: true, aiOn: true, aiSeoOn: false } ) );
+
+		expect( screen.getByText( AI_SEO_OFF_MESSAGE ) ).toBeInTheDocument();
+		expect( screen.queryByText( AI_OFF_MESSAGE ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'leaves the enhancer toggle alone while both AI and the feature are on', () => {
+		renderSeo( buildInitialState( { seoToolsOn: true, aiOn: true, aiSeoOn: true } ) );
+
+		expect( enhancerToggle() ).toBeEnabled();
+		expect( screen.queryByText( AI_SEO_OFF_MESSAGE ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( AI_OFF_MESSAGE ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -244,6 +244,9 @@ class Jetpack_Redux_State_Helper {
 			// is active) — what the editor enforces, for settings UI that must
 			// not contradict it.
 			'isAiEnabled'                          => Jetpack_AI_Settings::is_ai_enabled(),
+			// The AI SEO feature, gates folded in: controls that drive only its
+			// automatic half must follow it too.
+			'isAiSeoEnabled'                       => Jetpack_AI_Settings::is_ai_seo_enabled(),
 			'isSubscriptionSiteEnabled'            => apply_filters( 'jetpack_subscription_site_enabled', false ),
 			'newsletterDateExample'                => gmdate( get_option( 'date_format' ), time() ),
 			'subscriptionSiteEditSupported'        => $current_theme->is_block_theme(),

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-redux-state-helper.php
@@ -240,6 +240,10 @@ class Jetpack_Redux_State_Helper {
 			'isOdysseyStatsEnabled'                => Stats_Options::get_option( 'enable_odyssey_stats' ),
 			'shouldInitializeBlaze'                => Blaze::should_initialize(),
 			'isBlazeDashboardEnabled'              => Blaze::is_dashboard_enabled(),
+			// The composed AI gate chain (host, and the master where its rollout
+			// is active) — what the editor enforces, for settings UI that must
+			// not contradict it.
+			'isAiEnabled'                          => Jetpack_AI_Settings::is_ai_enabled(),
 			'isSubscriptionSiteEnabled'            => apply_filters( 'jetpack_subscription_site_enabled', false ),
 			'newsletterDateExample'                => gmdate( get_option( 'date_format' ), time() ),
 			'subscriptionSiteEditSupported'        => $current_theme->is_block_theme(),

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-editor-enforcement
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-editor-enforcement
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack AI: Make the editor honor the AI SEO feature control — switching it off removes the Metadata AI Generator section, automatic generation at publish, and automatic image alt text, with saved choices returning when it is switched back on. Also disable the Traffic card's enhancer toggle while site-wide AI is off, and hide the enhancer setting on sites running an outdated copy of the SEO package.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-editor-enforcement
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-editor-enforcement
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Jetpack AI: Make the editor honor the AI SEO feature control — switching it off removes the Metadata AI Generator section, automatic generation at publish, and automatic image alt text, with saved choices returning when it is switched back on. The automatic-generation toggle follows it too, on both the Traffic settings page and the SEO dashboard. Also hide the enhancer setting on sites running an outdated copy of the SEO package.
+Jetpack AI: Make the editor and the automatic-generation toggles follow the AI SEO control — switching it off stops metadata generation and disables its controls, with saved choices returning when it is switched back on.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-editor-enforcement
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-editor-enforcement
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Jetpack AI: Make the editor honor the AI SEO feature control — switching it off removes the Metadata AI Generator section, automatic generation at publish, and automatic image alt text, with saved choices returning when it is switched back on. Also disable the Traffic card's enhancer toggle while site-wide AI is off, and hide the enhancer setting on sites running an outdated copy of the SEO package.
+Jetpack AI: Make the editor honor the AI SEO feature control — switching it off removes the Metadata AI Generator section, automatic generation at publish, and automatic image alt text, with saved choices returning when it is switched back on. The automatic-generation toggle follows it too, on both the Traffic settings page and the SEO dashboard. Also hide the enhancer setting on sites running an outdated copy of the SEO package.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -884,7 +884,8 @@ class Jetpack_Gutenberg {
 		}
 		// AI Assistant
 		$ai_assistant_state = array(
-			'is-enabled' => Jetpack_AI_Settings::is_ai_enabled(),
+			'is-enabled'     => Jetpack_AI_Settings::is_ai_enabled(),
+			'is-seo-enabled' => Jetpack_AI_Settings::is_ai_seo_enabled(),
 		);
 
 		$screen_base = null;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/can-auto-enhance-metadata.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/can-auto-enhance-metadata.ts
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { isSimpleSite } from '@automattic/jetpack-script-data';
+/**
+ * Internal dependencies
+ */
+import { isAiSeoEnabled } from './is-ai-seo-enabled';
+
+/**
+ * Whether automatic metadata generation may run on this site: never on Simple
+ * sites, and only while the AI SEO feature is effectively on.
+ *
+ * @return {boolean} Whether the automatic paths may run.
+ */
+export function canAutoEnhanceMetadata(): boolean {
+	return ! isSimpleSite() && isAiSeoEnabled();
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/is-ai-seo-enabled.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/is-ai-seo-enabled.ts
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { getJetpackData } from '@automattic/jetpack-shared-extension-utils';
+
+/**
+ * Whether the AI SEO feature — metadata generation, manual and automatic —
+ * may run: the feature's effective state, computed server-side with the host
+ * and master gates folded in. A missing state reads as on (pre-feature payload).
+ *
+ * @return {boolean} Whether the AI SEO feature is on.
+ */
+export function isAiSeoEnabled(): boolean {
+	return getJetpackData()?.[ 'ai-assistant' ]?.[ 'is-seo-enabled' ] !== false;
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -114,7 +114,7 @@ export function SeoEnhancer( {
 							) }
 						/>
 					) }
-					{ ( ! isEnabled || disableAutoEnhance ) && (
+					{ ! isEnabled && (
 						<div className="feature-checkboxes-container">
 							{ FEATURES.map( feature => (
 								<CheckboxControl
@@ -137,7 +137,7 @@ export function SeoEnhancer( {
 					) }
 				</BaseControl>
 			</PanelRow>
-			{ ( ! isEnabled || disableAutoEnhance ) && (
+			{ ! isEnabled && (
 				<PanelRow className="jetpack-seo-sidebar__feature-section">
 					<BaseControl __nextHasNoMarginBottom={ true } className="ai-seo-enhancer-toggle">
 						<Button

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -137,7 +137,7 @@ export function SeoEnhancer( {
 					) }
 				</BaseControl>
 			</PanelRow>
-			{ ! isEnabled && (
+			{ ( ! isEnabled || disableAutoEnhance ) && (
 				<PanelRow className="jetpack-seo-sidebar__feature-section">
 					<BaseControl __nextHasNoMarginBottom={ true } className="ai-seo-enhancer-toggle">
 						<Button

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/test/can-auto-enhance-metadata.test.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/test/can-auto-enhance-metadata.test.ts
@@ -1,0 +1,45 @@
+import { isSimpleSite } from '@automattic/jetpack-script-data';
+import { canAutoEnhanceMetadata } from '../can-auto-enhance-metadata';
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	isSimpleSite: jest.fn(),
+} ) );
+
+const setSeoState = ( isEnabled: boolean ) => {
+	window.Jetpack_Editor_Initial_State = {
+		'ai-assistant': { 'is-seo-enabled': isEnabled },
+	} as unknown as Window[ 'Jetpack_Editor_Initial_State' ];
+};
+
+describe( 'canAutoEnhanceMetadata', () => {
+	afterEach( () => {
+		delete window.Jetpack_Editor_Initial_State;
+	} );
+
+	it( 'is false on Simple sites regardless of the SEO feature', () => {
+		( isSimpleSite as jest.Mock ).mockReturnValue( true );
+		setSeoState( true );
+
+		expect( canAutoEnhanceMetadata() ).toBe( false );
+	} );
+
+	it( 'is false when the SEO feature is effectively off', () => {
+		( isSimpleSite as jest.Mock ).mockReturnValue( false );
+		setSeoState( false );
+
+		expect( canAutoEnhanceMetadata() ).toBe( false );
+	} );
+
+	it( 'is true off-Simple when the SEO feature is on', () => {
+		( isSimpleSite as jest.Mock ).mockReturnValue( false );
+		setSeoState( true );
+
+		expect( canAutoEnhanceMetadata() ).toBe( true );
+	} );
+
+	it( 'treats a missing state as enabled', () => {
+		( isSimpleSite as jest.Mock ).mockReturnValue( false );
+
+		expect( canAutoEnhanceMetadata() ).toBe( true );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/test/is-ai-seo-enabled.test.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/test/is-ai-seo-enabled.test.ts
@@ -1,0 +1,29 @@
+import { isAiSeoEnabled } from '../is-ai-seo-enabled';
+
+const setSeoState = ( isEnabled: boolean ) => {
+	window.Jetpack_Editor_Initial_State = {
+		'ai-assistant': { 'is-seo-enabled': isEnabled },
+	} as unknown as Window[ 'Jetpack_Editor_Initial_State' ];
+};
+
+describe( 'isAiSeoEnabled', () => {
+	afterEach( () => {
+		delete window.Jetpack_Editor_Initial_State;
+	} );
+
+	it( 'is false when the SEO feature is effectively off', () => {
+		setSeoState( false );
+
+		expect( isAiSeoEnabled() ).toBe( false );
+	} );
+
+	it( 'is true when the SEO feature is on', () => {
+		setSeoState( true );
+
+		expect( isAiSeoEnabled() ).toBe( true );
+	} );
+
+	it( 'treats a missing state as enabled', () => {
+		expect( isAiSeoEnabled() ).toBe( true );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/test/seo-enhancer.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/test/seo-enhancer.test.tsx
@@ -65,15 +65,7 @@ jest.mock( '@wordpress/data', () => {
 } );
 
 describe( 'SeoEnhancer', () => {
-	it( 'keeps the manual Generate metadata button in manual-only mode even while auto-generation is on', () => {
-		mockIsEnabled = true;
-
-		render( <SeoEnhancer disableAutoEnhance={ true } /> );
-
-		expect( screen.getByRole( 'button', { name: 'Generate metadata' } ) ).toBeInTheDocument();
-	} );
-
-	it( 'hides the auto-generate toggle in manual-only mode', () => {
+	it( 'hides the auto-generate toggle where automatic generation cannot run', () => {
 		mockIsEnabled = true;
 
 		render( <SeoEnhancer disableAutoEnhance={ true } /> );
@@ -81,12 +73,12 @@ describe( 'SeoEnhancer', () => {
 		expect( screen.queryByLabelText( 'Auto-generate metadata' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'shows the feature checkboxes in manual-only mode', () => {
-		mockIsEnabled = true;
+	it( 'shows the manual button while automatic generation is switched off', () => {
+		mockIsEnabled = false;
 
-		render( <SeoEnhancer disableAutoEnhance={ true } /> );
+		render( <SeoEnhancer disableAutoEnhance={ false } /> );
 
-		expect( screen.getByLabelText( 'SEO title' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Generate metadata' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'hides the manual button while automatic mode is available and on', () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/test/seo-enhancer.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/test/seo-enhancer.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import { SeoEnhancer } from '../seo-enhancer';
+
+let mockIsEnabled = false;
+
+jest.mock( '../store', () => ( {
+	store: 'jetpack/seo-enhancer-test-store',
+} ) );
+
+jest.mock( '../use-seo-module-settings', () => ( {
+	useSeoModuleSettings: () => ( {
+		isEnabled: mockIsEnabled,
+		toggleEnhancer: jest.fn(),
+		isToggling: false,
+	} ),
+} ) );
+
+jest.mock( '../use-seo-requests', () => ( {
+	useSeoRequests: () => ( {
+		updateSeoData: jest.fn(),
+		isBusy: false,
+	} ),
+} ) );
+
+jest.mock( '../seo-enhancer-task-list', () => ( {
+	SeoEnhancerTaskList: () => null,
+} ) );
+
+jest.mock( '@automattic/jetpack-ai-client', () => ( {
+	getAllBlocks: () => [],
+} ) );
+
+jest.mock( '@automattic/jetpack-shared-extension-utils', () => {
+	const analytics = { tracks: { recordEvent: jest.fn() } };
+	return { useAnalytics: () => analytics };
+} );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: 'core/block-editor',
+} ) );
+
+jest.mock( '@wordpress/data', () => {
+	const actual = jest.requireActual( '@wordpress/data' );
+	const stores: Record< string, unknown > = {
+		'jetpack/seo-enhancer-test-store': {
+			isBusy: () => false,
+			isAnyImageBusy: () => false,
+			getEnabledFeatures: () => [],
+		},
+		'core/block-editor': {
+			getBlocks: () => [],
+		},
+	};
+	const mocks = {
+		useSelect: ( selector: ( select: ( store: string ) => unknown ) => unknown ) =>
+			selector( ( store: string ) => stores[ store ] ),
+		useDispatch: () => ( { setFeatureEnabled: jest.fn() } ),
+	};
+	// Keep the real registry so @wordpress/components' own stores still work.
+	return new Proxy( actual, {
+		get( target, property ) {
+			return mocks[ property ] ?? target[ property ];
+		},
+	} );
+} );
+
+describe( 'SeoEnhancer', () => {
+	it( 'keeps the manual Generate metadata button in manual-only mode even while auto-generation is on', () => {
+		mockIsEnabled = true;
+
+		render( <SeoEnhancer disableAutoEnhance={ true } /> );
+
+		expect( screen.getByRole( 'button', { name: 'Generate metadata' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the auto-generate toggle in manual-only mode', () => {
+		mockIsEnabled = true;
+
+		render( <SeoEnhancer disableAutoEnhance={ true } /> );
+
+		expect( screen.queryByLabelText( 'Auto-generate metadata' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the feature checkboxes in manual-only mode', () => {
+		mockIsEnabled = true;
+
+		render( <SeoEnhancer disableAutoEnhance={ true } /> );
+
+		expect( screen.getByLabelText( 'SEO title' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the manual button while automatic mode is available and on', () => {
+		mockIsEnabled = true;
+
+		render( <SeoEnhancer disableAutoEnhance={ false } /> );
+
+		expect( screen.queryByRole( 'button', { name: 'Generate metadata' } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/with-seo-auto-generation.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/with-seo-auto-generation.tsx
@@ -1,7 +1,6 @@
 /*
  * External dependencies
  */
-import { isSimpleSite } from '@automattic/jetpack-script-data';
 import {
 	getJetpackExtensionAvailability,
 	useModuleStatus,
@@ -13,6 +12,7 @@ import { addFilter } from '@wordpress/hooks';
 /*
  * Internal dependencies
  */
+import { canAutoEnhanceMetadata } from './can-auto-enhance-metadata';
 import { store } from './store';
 import { useSeoModuleSettings } from './use-seo-module-settings';
 import { useSeoRequests } from './use-seo-requests';
@@ -22,7 +22,8 @@ import { useSeoRequests } from './use-seo-requests';
 import type { Block } from '@automattic/jetpack-ai-client';
 
 const isSeoEnhancerEnabled =
-	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true && ! isSimpleSite();
+	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true &&
+	canAutoEnhanceMetadata();
 
 function isPossibleToExtendImageBlock( blockName: string ): boolean {
 	return blockName === 'core/image' && isSeoEnhancerEnabled;

--- a/projects/plugins/jetpack/extensions/plugins/seo/index.jsx
+++ b/projects/plugins/jetpack/extensions/plugins/seo/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { LinkPreviewModalWithTrigger } from '@automattic/jetpack-publicize/link-preview';
-import { isWpcomPlatformSite, isSimpleSite } from '@automattic/jetpack-script-data';
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import {
 	useModuleStatus,
 	getJetpackExtensionAvailability,
@@ -26,6 +26,8 @@ import clsx from 'clsx';
  */
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import { SeoEnhancer } from '../ai-assistant-plugin/components/seo-enhancer';
+import { canAutoEnhanceMetadata } from '../ai-assistant-plugin/components/seo-enhancer/can-auto-enhance-metadata';
+import { isAiSeoEnabled } from '../ai-assistant-plugin/components/seo-enhancer/is-ai-seo-enabled';
 import { SeoSummary } from '../ai-assistant-plugin/components/seo-enhancer/seo-summary';
 import { useSeoModuleSettings } from '../ai-assistant-plugin/components/seo-enhancer/use-seo-module-settings';
 import { useSeoRequests } from '../ai-assistant-plugin/components/seo-enhancer/use-seo-requests';
@@ -45,11 +47,18 @@ export const name = 'seo';
 const supportsPublishSidebar =
 	typeof globalSelect( editorStore ).isPublishSidebarOpened === 'function';
 
-const isSeoEnhancerEnabled =
+const isSeoEnhancerAvailable =
 	getJetpackExtensionAvailability( 'ai-seo-enhancer' )?.available === true &&
 	supportsPublishSidebar;
 
-const canHaveAutoEnhance = ! isSimpleSite();
+// Automatic generation never runs on Simple sites and follows the AI SEO
+// feature everywhere else.
+const canHaveAutoEnhance = canAutoEnhanceMetadata();
+
+// The AI SEO feature covers manual and automatic generation alike (host and
+// master gates folded in server-side); with it off the enhancer is not
+// rendered at all.
+const isAiSeoFeatureEnabled = isAiSeoEnabled();
 
 const Seo = () => {
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
@@ -72,7 +81,7 @@ const Seo = () => {
 
 	useEffect( () => {
 		if (
-			isSeoEnhancerEnabled &&
+			isSeoEnhancerAvailable &&
 			isPrePublishPanelOpen &&
 			! previousIsOpenRef.current &&
 			! isBusy &&
@@ -162,7 +171,7 @@ const Seo = () => {
 	const jetpackSeoPublishPanelsProps = {
 		icon: <JetpackEditorPanelLogo />,
 		title: __( 'SEO', 'jetpack' ),
-		initialOpen: isSeoEnhancerEnabled,
+		initialOpen: isSeoEnhancerAvailable && isAiSeoFeatureEnabled,
 	};
 
 	// TODO: remove all code related to the SeoAssistantWizard if it's a no-go
@@ -170,31 +179,46 @@ const Seo = () => {
 		<>
 			<JetpackPluginSidebar>
 				<PanelBody title={ __( 'Optimize SEO', 'jetpack' ) } className="jetpack-seo-panel">
-					{ isSeoEnhancerEnabled && hasRequiredPlanForEnhancer && (
+					{ isSeoEnhancerAvailable && hasRequiredPlanForEnhancer && isAiSeoFeatureEnabled && (
 						<SeoEnhancer placement="jetpack-sidebar" disableAutoEnhance={ ! canHaveAutoEnhance } />
 					) }
 					<PanelRow
-						className={ clsx( { 'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled } ) }
+						className={ clsx( {
+							'jetpack-seo-sidebar__feature-section':
+								isSeoEnhancerAvailable && isAiSeoFeatureEnabled,
+						} ) }
 					>
 						<SeoTitlePanel />
 					</PanelRow>
 					<PanelRow
-						className={ clsx( { 'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled } ) }
+						className={ clsx( {
+							'jetpack-seo-sidebar__feature-section':
+								isSeoEnhancerAvailable && isAiSeoFeatureEnabled,
+						} ) }
 					>
 						<SeoDescriptionPanel />
 					</PanelRow>
 					<PanelRow
-						className={ clsx( { 'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled } ) }
+						className={ clsx( {
+							'jetpack-seo-sidebar__feature-section':
+								isSeoEnhancerAvailable && isAiSeoFeatureEnabled,
+						} ) }
 					>
 						<LinkPreviewModalWithTrigger />
 					</PanelRow>
 					<PanelRow
-						className={ clsx( { 'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled } ) }
+						className={ clsx( {
+							'jetpack-seo-sidebar__feature-section':
+								isSeoEnhancerAvailable && isAiSeoFeatureEnabled,
+						} ) }
 					>
 						<SeoNoindexPanel />
 					</PanelRow>
 					<PanelRow
-						className={ clsx( { 'jetpack-seo-sidebar__feature-section': isSeoEnhancerEnabled } ) }
+						className={ clsx( {
+							'jetpack-seo-sidebar__feature-section':
+								isSeoEnhancerAvailable && isAiSeoFeatureEnabled,
+						} ) }
 					>
 						<SeoSchemaPanel />
 					</PanelRow>
@@ -207,7 +231,7 @@ const Seo = () => {
 				name="jetpack-seo"
 				icon={ <JetpackEditorPanelLogo /> }
 			>
-				{ isSeoEnhancerEnabled && hasRequiredPlanForEnhancer && (
+				{ isSeoEnhancerAvailable && hasRequiredPlanForEnhancer && isAiSeoFeatureEnabled && (
 					<SeoEnhancer placement="document-settings" disableAutoEnhance={ ! canHaveAutoEnhance } />
 				) }
 				<PanelRow>
@@ -229,7 +253,7 @@ const Seo = () => {
 
 			<PluginPrePublishPanel { ...jetpackSeoPublishPanelsProps }>
 				<div className="jetpack-seo-panel">
-					{ isSeoEnhancerEnabled && hasRequiredPlanForEnhancer && (
+					{ isSeoEnhancerAvailable && hasRequiredPlanForEnhancer && isAiSeoFeatureEnabled && (
 						<SeoEnhancer
 							placement="jetpack-prepublish-sidebar"
 							disableAutoEnhance={ ! canHaveAutoEnhance }
@@ -253,7 +277,7 @@ const Seo = () => {
 				</div>
 			</PluginPrePublishPanel>
 
-			{ isSeoEnhancerEnabled && (
+			{ isSeoEnhancerAvailable && isAiSeoFeatureEnabled && (
 				<PluginPostPublishPanel { ...jetpackSeoPublishPanelsProps }>
 					<div className="jetpack-seo-panel">
 						<SeoSummary onEdit={ handleSummaryEdit } />

--- a/projects/plugins/jetpack/tests/jest.config.gui.js
+++ b/projects/plugins/jetpack/tests/jest.config.gui.js
@@ -14,6 +14,7 @@ module.exports = {
 		'<rootDir>/_inc/client/ai/overview/test/component.jsx',
 		'<rootDir>/_inc/client/ai/test/main.jsx',
 		'<rootDir>/_inc/client/sharing/test/component.jsx',
+		'<rootDir>/_inc/client/traffic/test/component.jsx',
 		'<rootDir>/_inc/client/at-a-glance/stats/test/chart-bar-range.js',
 	],
 	setupFilesAfterEnv: [ ...baseConfig.setupFilesAfterEnv, '<rootDir>/tests/jest-globals.gui.js' ],

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Redux_State_Helper_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Redux_State_Helper_Test.php
@@ -42,6 +42,7 @@ class Jetpack_Redux_State_Helper_Test extends WP_UnitTestCase {
 		global $_wp_theme_features;
 
 		$_wp_theme_features = $this->theme_features;
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		parent::tear_down();
 	}
 
@@ -63,5 +64,20 @@ class Jetpack_Redux_State_Helper_Test extends WP_UnitTestCase {
 
 		$redux_state = Jetpack_Redux_State_Helper::get_initial_state();
 		$this->assertSame( false, $redux_state['themeData']['support']['widgets'] );
+	}
+
+	/**
+	 * The initial state reports the effective AI state through the same gate
+	 * chain the editor enforces: waived master outside internal testing
+	 * environments, enforced master (the inactive `ai` module) inside them.
+	 */
+	public function test_ai_effectively_enabled_reflects_the_ai_gates() {
+		$redux_state = Jetpack_Redux_State_Helper::get_initial_state();
+		$this->assertTrue( $redux_state['isAiEnabled'], 'Outside internal testing envs the master is waived, so AI reads on.' );
+
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$redux_state                    = Jetpack_Redux_State_Helper::get_initial_state();
+
+		$this->assertFalse( $redux_state['isAiEnabled'], 'On internal testing envs the inactive ai module reads as master off.' );
 	}
 }


### PR DESCRIPTION
Related to FORNO-468

## Proposed changes
* Make the editor honor the AI SEO feature control from the parent PR: with `jetpack_ai_seo_enabled` effectively off, the Metadata AI Generator section (auto toggle included), automatic generation at publish, automatic image alt text, and the post-publish summary are all gone — the non-AI SEO fields remain.
* Disable the auto-generation toggle while the AI SEO control (or Jetpack AI as a whole) is effectively off — on the Traffic card and on the SEO dashboard's AI page — keeping the saved choice, with a note explaining why.

### Screenshots (JN, 1440×900)

<details>

**Feature on, auto off** (defaults) — manual mode:

![manual mode](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-editor-enforcement/row1-editor-manual.png)

**Feature on, auto on** — auto mode:

![auto mode](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-editor-enforcement/row2-editor-auto.png)

**Feature off** — generator gone; Improve with AI and the non-AI SEO fields remain:

![feature off](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-editor-enforcement/row3-editor-gone.png)

**Master off** — all AI panels gone, plain SEO fields remain:

![master off](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-editor-enforcement/row4-editor-master-off.png)

**Feature back on** — manual mode returns (byte-identical to the first capture):

![restored](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-editor-enforcement/row5-editor-restored.png)

**AI SEO off — the automatic-generation toggles disable, saved choice kept:**

| Traffic page | SEO dashboard |
|---|---|
| ![traffic toggle disabled](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-editor-enforcement/row6-traffic-toggle-disabled.png) | ![seo dashboard toggle disabled](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-editor-enforcement/row7-seo-dashboard-toggle-disabled.png) |

The hub control driving the feature-off rows:

![hub AI SEO off](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-editor-enforcement/row3-hub-toggle-off.png)

</details>

## Related product discussion/links
* pcO4xN-3ih-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Full manual test runbook (states, per-screen expectations, way in/out commands): 3c54e-pb

Sync this branch to an internal testing env (JN, or proxied) whose plan grants `ai-seo-enhancer`, with the `ai` and `seo-tools` modules active — master enforcement only runs there. Hard-reload the editor after every settings change.

1. Create a new post, defaults untouched, and expand the Jetpack sidebar's "Optimize SEO" panel. Expect: the Metadata AI Generator section in manual mode, auto toggle off — released behavior, unchanged.
2. Turn on the auto toggle inside the Metadata AI Generator section. Expect: the section switches to auto mode.
3. Turn off the "AI SEO" toggle in the SEO group of the AI settings page (wp-admin → Jetpack → AI). Expect: the Metadata AI Generator section is gone, and no `jetpack-ai` requests fire on publish or image insert.
4. Turn the "AI SEO" toggle back on. Expect: manual mode returns as before.
5. With the "AI SEO" toggle off (or after `wp jetpack module deactivate ai`): the auto-generation row in Jetpack → Settings → Traffic → Search engine optimization is disabled, with a saved-choice note. Same on the SEO dashboard's AI page (`admin.php?page=jetpack-seo&p=%2Fai`): the AI SEO Enhancer toggle is disabled with the same note.
   - The SEO dashboard is a wpcom staged rollout (`seo-admin-ui` feature); on a site outside the cohort, force it: `echo '<?php add_filter( "rsm_jetpack_seo", "__return_true" );' > wp-content/mu-plugins/rsm-seo-flag.php`. While that flag is on, the Traffic card shows a "Jetpack SEO has its own dashboard" pointer instead of its toggle — test the two surfaces with the flag off and on respectively.
   - On Atomic, `wp jetpack module deactivate ai` may not take effect if the fleet still carries the temporary force-on filter from the #51488/#51491 incident. Probe with `wp eval 'var_export( function_exists( "Automattic\\Jetpack\\Jetpack_Mu_Wpcom\\Jetpack_AI_Module\\keep_module_active" ) );'` — if `true`, add a priority-999 `jetpack_active_modules` filter removing `ai` in a mu-plugin for the master-off checks, and delete it afterwards.
6. Run the parent PR's PHP/JS suites plus `pnpm run test-extensions --testPathPatterns='seo-enhancer|plugins/seo'`. Expect: green.

🤖 AI Assisted




