### PR TITLE
Forms: address conditional logic review feedback on checkbox naming and rule status

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-conditional-logic-feedback
+++ b/projects/packages/forms/changelog/fix-forms-conditional-logic-feedback
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Conditional logic: name a checkbox by its own label in the conditions dropdown, and show an unanswered checkbox as "No" rather than a blank.
+Conditional logic: name a checkbox by its own label in the conditions dropdown, keep a value typed before the field was chosen, and show an unanswered checkbox as "No" rather than a blank.

--- a/projects/packages/forms/changelog/fix-forms-conditional-logic-feedback
+++ b/projects/packages/forms/changelog/fix-forms-conditional-logic-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Conditional logic: name a checkbox by its own label in the conditions dropdown, and show an unanswered checkbox as "No" rather than a blank.

--- a/projects/packages/forms/changelog/fix-forms-conditional-logic-feedback
+++ b/projects/packages/forms/changelog/fix-forms-conditional-logic-feedback
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Conditional logic: name a checkbox by its own label in the conditions dropdown, keep a value typed before the field was chosen, and show an unanswered checkbox as "No" rather than a blank.
+Conditional logic: Name a checkbox by its own label in the conditions dropdown, keep a value typed before the field was chosen, and show an unticked checkbox as "No" rather than a blank.

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/controls/field-value/edit.jsx
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/controls/field-value/edit.jsx
@@ -148,8 +148,8 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 			const nextSubject = fields.find( field => selectionValue( field ) === selection );
 
 			if ( ! nextSubject ) {
-				// The value is left alone; whether it still applies is decided by the next
-				// subject the author picks.
+				// The value is carried, normalized: whether it still applies is decided by
+				// the next subject the author picks.
 				onChange( index, { field: '', operator: OPERATORS.IS, value: rule.value ?? '' } );
 				return;
 			}
@@ -204,7 +204,15 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 
 	// The builder opens with one empty row, which is not a mistake -- so amber is kept for a
 	// condition begun and left unfinished, the only case where a field silently will not react.
+	// A complete rule is necessarily a started one, which is why three states need two flags.
 	const isStarted = isRuleStarted( rule );
+
+	let statusIcon = drafts;
+	if ( isComplete ) {
+		statusIcon = published;
+	} else if ( isStarted ) {
+		statusIcon = caution;
+	}
 
 	const activeReason = __( 'This condition is active.', 'jetpack-forms' );
 
@@ -214,7 +222,7 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 	let inactiveReason = __( 'Choose a field to compare against.', 'jetpack-forms' );
 	if ( missingSubject ) {
 		inactiveReason = __( 'The field this condition refers to no longer exists.', 'jetpack-forms' );
-	} else if ( isRuleStarted( rule ) ) {
+	} else if ( isStarted ) {
 		inactiveReason = __( 'Give this condition a value.', 'jetpack-forms' );
 	}
 
@@ -263,16 +271,12 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 					<span
 						className={ clsx( 'jetpack-contact-form__conditional-logic-rule-status', {
 							'is-active': isComplete,
-							'is-unstarted': ! isComplete && ! isStarted,
+							'is-unstarted': ! isStarted,
 						} ) }
 						role="img"
 						aria-label={ isComplete ? activeReason : inactiveReason }
 					>
-						{ isComplete || isStarted ? (
-							<Icon icon={ isComplete ? published : caution } size={ 20 } />
-						) : (
-							<Icon icon={ drafts } size={ 20 } />
-						) }
+						<Icon icon={ statusIcon } size={ 20 } />
 					</span>
 				</Tooltip>
 

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/controls/field-value/edit.jsx
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/controls/field-value/edit.jsx
@@ -9,7 +9,7 @@ import { useEnsureFieldId } from '../../hooks/use-subject-fields.js';
 import { getFieldDisplayName } from '../../util/field-label.js';
 import {
 	OPERATORS,
-	canValueCarryOver,
+	getCarriedOverValue,
 	getOperatorsForTypeKey,
 	getValueInputForTypeKey,
 	operatorNeedsValue,
@@ -178,11 +178,11 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 			// The value box is offered before a subject is chosen, so a value typed first is
 			// kept. Dropped when the new subject cannot represent it, which would otherwise
 			// leave an empty-looking box the evaluators were still comparing against.
-			const keepsValue =
-				operatorNeedsValue( operator ) &&
-				canValueCarryOver( rule.value, nextSubject.typeKey, nextSubject.options );
+			const carried = operatorNeedsValue( operator )
+				? getCarriedOverValue( rule.value, nextSubject.typeKey, nextSubject.options )
+				: null;
 
-			onChange( index, { field: fieldId, operator, value: keepsValue ? rule.value : '' } );
+			onChange( index, { field: fieldId, operator, value: carried ?? '' } );
 		},
 		[ ensureFieldId, fields, ownFieldId, index, onChange, rule.operator, rule.value ]
 	);

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/controls/field-value/edit.jsx
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/controls/field-value/edit.jsx
@@ -9,6 +9,7 @@ import { useEnsureFieldId } from '../../hooks/use-subject-fields.js';
 import { getFieldDisplayName } from '../../util/field-label.js';
 import {
 	OPERATORS,
+	canValueCarryOver,
 	getOperatorsForTypeKey,
 	getValueInputForTypeKey,
 	operatorNeedsValue,
@@ -147,7 +148,9 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 			const nextSubject = fields.find( field => selectionValue( field ) === selection );
 
 			if ( ! nextSubject ) {
-				onChange( index, { field: '', operator: OPERATORS.IS, value: '' } );
+				// The value survives clearing the subject: the author did not touch it, and
+				// whether it still applies is decided when they pick the next subject.
+				onChange( index, { field: '', operator: OPERATORS.IS, value: rule.value ?? '' } );
 				return;
 			}
 
@@ -172,9 +175,18 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 				? rule.operator
 				: defaultOperatorFor( nextSubject.typeKey );
 
-			onChange( index, { field: fieldId, operator, value: '' } );
+			// The value box is offered before a subject has been chosen, so filling it in
+			// first is a natural order to work in -- and this used to throw that away. It is
+			// kept whenever the new subject can still represent it, and dropped when it
+			// cannot, which would otherwise leave an empty-looking box the evaluators were
+			// still comparing against.
+			const keepsValue =
+				operatorNeedsValue( operator ) &&
+				canValueCarryOver( rule.value, nextSubject.typeKey, nextSubject.options );
+
+			onChange( index, { field: fieldId, operator, value: keepsValue ? rule.value : '' } );
 		},
-		[ ensureFieldId, fields, ownFieldId, index, onChange, rule.operator ]
+		[ ensureFieldId, fields, ownFieldId, index, onChange, rule.operator, rule.value ]
 	);
 
 	const handleOperatorChange = useCallback(

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/controls/field-value/edit.jsx
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/controls/field-value/edit.jsx
@@ -148,8 +148,8 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 			const nextSubject = fields.find( field => selectionValue( field ) === selection );
 
 			if ( ! nextSubject ) {
-				// The value survives clearing the subject: the author did not touch it, and
-				// whether it still applies is decided when they pick the next subject.
+				// The value is left alone; whether it still applies is decided by the next
+				// subject the author picks.
 				onChange( index, { field: '', operator: OPERATORS.IS, value: rule.value ?? '' } );
 				return;
 			}
@@ -175,11 +175,9 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 				? rule.operator
 				: defaultOperatorFor( nextSubject.typeKey );
 
-			// The value box is offered before a subject has been chosen, so filling it in
-			// first is a natural order to work in -- and this used to throw that away. It is
-			// kept whenever the new subject can still represent it, and dropped when it
-			// cannot, which would otherwise leave an empty-looking box the evaluators were
-			// still comparing against.
+			// The value box is offered before a subject is chosen, so a value typed first is
+			// kept. Dropped when the new subject cannot represent it, which would otherwise
+			// leave an empty-looking box the evaluators were still comparing against.
 			const keepsValue =
 				operatorNeedsValue( operator ) &&
 				canValueCarryOver( rule.value, nextSubject.typeKey, nextSubject.options );
@@ -204,10 +202,8 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 	const operators = getOperatorsForTypeKey( subject?.typeKey || 'string' );
 	const isComplete = isRuleComplete( rule, subject );
 
-	// A row nobody has touched yet is not a mistake: the builder opens with one waiting, and
-	// showing it in amber greeted an author with a warning about something they had not done.
-	// Amber is kept for the case it was meant for -- a condition begun and left unfinished,
-	// which is the only one where a field will silently not react and nothing says why.
+	// The builder opens with one empty row, which is not a mistake -- so amber is kept for a
+	// condition begun and left unfinished, the only case where a field silently will not react.
 	const isStarted = isRuleStarted( rule );
 
 	const activeReason = __( 'This condition is active.', 'jetpack-forms' );
@@ -272,9 +268,6 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 						role="img"
 						aria-label={ isComplete ? activeReason : inactiveReason }
 					>
-						{ /* An untouched row gets the draft icon: the same thing it says of a
-						     post nobody has finished, and it keeps the column aligned without
-						     passing judgement on a row yet. */ }
 						{ isComplete || isStarted ? (
 							<Icon icon={ isComplete ? published : caution } size={ 20 } />
 						) : (

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/controls/field-value/edit.jsx
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/controls/field-value/edit.jsx
@@ -1,7 +1,7 @@
 import { Icon, Notice, SelectControl, TextControl, Tooltip } from '@wordpress/components';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { caution, check, plus, trash } from '@wordpress/icons';
+import { caution, drafts, plus, published, trash } from '@wordpress/icons';
 import { Button, IconButton, Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { RULE_TYPE_FIELD_VALUE } from '../../constants.js';
@@ -192,6 +192,12 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 	const operators = getOperatorsForTypeKey( subject?.typeKey || 'string' );
 	const isComplete = isRuleComplete( rule, subject );
 
+	// A row nobody has touched yet is not a mistake: the builder opens with one waiting, and
+	// showing it in amber greeted an author with a warning about something they had not done.
+	// Amber is kept for the case it was meant for -- a condition begun and left unfinished,
+	// which is the only one where a field will silently not react and nothing says why.
+	const isStarted = isRuleStarted( rule );
+
 	const activeReason = __( 'This condition is active.', 'jetpack-forms' );
 
 	// Why the condition will be skipped, phrased as the thing to do about it. The three cases
@@ -249,11 +255,19 @@ const RuleRow = ( { rule, index, fields, ownFieldId, shouldFocus, onChange, onRe
 					<span
 						className={ clsx( 'jetpack-contact-form__conditional-logic-rule-status', {
 							'is-active': isComplete,
+							'is-unstarted': ! isComplete && ! isStarted,
 						} ) }
 						role="img"
 						aria-label={ isComplete ? activeReason : inactiveReason }
 					>
-						<Icon icon={ isComplete ? check : caution } size={ 20 } />
+						{ /* An untouched row gets the draft icon: the same thing it says of a
+						     post nobody has finished, and it keeps the column aligned without
+						     passing judgement on a row yet. */ }
+						{ isComplete || isStarted ? (
+							<Icon icon={ isComplete ? published : caution } size={ 20 } />
+						) : (
+							<Icon icon={ drafts } size={ 20 } />
+						) }
 					</span>
 				</Tooltip>
 

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/editor.scss
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/editor.scss
@@ -123,8 +123,9 @@
 		}
 	}
 
-	// Reads down the left edge of a long list. Amber says the condition will be
-	// skipped and the tooltip says why; green says it will be acted on.
+	// Reads down the left edge of a long list. The draft icon says the condition
+	// has not been started, amber says it will be skipped and the tooltip says
+	// why, and green says it will be acted on.
 	// The `-weak` tokens are the ones that carry the hue. Their unsuffixed
 	// counterparts are text-on-light colours, dark enough (near-black green and
 	// brown) that neither icon read as its status.
@@ -136,6 +137,10 @@
 
 		&.is-active {
 			color: var(--wpds-color-foreground-content-success-weak);
+		}
+
+		&.is-unstarted {
+			color: var(--wpds-color-foreground-content-neutral-weak);
 		}
 	}
 

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/hooks/use-subject-fields.js
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/hooks/use-subject-fields.js
@@ -26,19 +26,10 @@ const toFieldIdBase = label => {
 };
 
 /**
- * The placeholder standing in for a field that has not been named.
- *
- * @return {string} The placeholder label.
- */
-const untitledLabel = () => __( 'Untitled field', 'jetpack-forms' );
-
-/**
  * Read a field block's visible label.
  *
- * Two blocks keep their label somewhere other than a `jetpack/label` inner block: a checkbox
- * and a consent field each write their inline label onto the standalone `jetpack/option`
- * their template inserts. Reading only `jetpack/label` reported both as "Untitled field"
- * however carefully they had been named, which is unusable in a form holding more than one.
+ * A checkbox and a consent field keep theirs on the standalone `jetpack/option` their
+ * template inserts rather than on a `jetpack/label` block.
  *
  * Falls back to the explicit id, then to a placeholder: a field with neither a label nor an
  * id is still selectable, and an empty entry in the dropdown would be unusable.
@@ -55,9 +46,8 @@ const getFieldLabel = block => {
 		return label.trim();
 	}
 
-	// A direct `jetpack/option` child only ever belongs to a checkbox or consent field: the
-	// choice fields nest theirs one level down under a `jetpack/options` wrapper, so this
-	// cannot pick up the first choice of a multiple-choice field by mistake.
+	// A direct child only: the choice fields nest their options under a `jetpack/options`
+	// wrapper, so this cannot pick up one of their choices by mistake.
 	const optionBlock = innerBlocks.find( inner => inner.name === 'jetpack/option' );
 	const optionLabel = optionBlock?.attributes?.label;
 
@@ -67,20 +57,19 @@ const getFieldLabel = block => {
 
 	const id = block.attributes?.id;
 
-	// An id is worth showing when the author chose it, but not when it is the one this panel
-	// minted a moment ago from the placeholder: choosing an unnamed field would then rename it
-	// from "Untitled field" to "untitled-field" inside the very dropdown it was picked from,
-	// so the summary and the builder appeared to name two different fields. The numeric suffix
-	// is matched too, since the second unnamed field of a form is handed `untitled-field-2`.
-	const placeholderId = toFieldIdBase( untitledLabel() );
-	const isMintedFromPlaceholder =
+	// An author's id is worth showing; one this panel minted from the placeholder is not, or
+	// choosing an unnamed field renames it to "untitled-field" in the dropdown it was picked
+	// from. The suffix is matched too -- a second unnamed field is handed `untitled-field-2`.
+	const untitled = __( 'Untitled field', 'jetpack-forms' );
+	const placeholderId = toFieldIdBase( untitled );
+	const isMinted =
 		id === placeholderId || new RegExp( `^${ placeholderId }-\\d+$` ).test( id || '' );
 
-	if ( id && ! isMintedFromPlaceholder ) {
+	if ( id && ! isMinted ) {
 		return id;
 	}
 
-	return untitledLabel();
+	return untitled;
 };
 
 /**

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/hooks/use-subject-fields.js
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/hooks/use-subject-fields.js
@@ -39,37 +39,34 @@ const toFieldIdBase = label => {
  */
 const getFieldLabel = block => {
 	const innerBlocks = block.innerBlocks || [];
-	const labelBlock = innerBlocks.find( inner => inner.name === 'jetpack/label' );
-	const label = labelBlock?.attributes?.label;
+	// Direct children only: the choice fields nest their options under a `jetpack/options`
+	// wrapper, so a `jetpack/option` found here can only be a field's own inline label. The
+	// block also declares `isStandalone` for this, but position holds for older markup saved
+	// before that attribute existed.
+	const inlineLabel = name =>
+		innerBlocks.find( inner => inner.name === name )?.attributes?.label?.trim();
 
-	if ( label && label.trim() ) {
-		return label.trim();
-	}
+	const label = inlineLabel( 'jetpack/label' ) || inlineLabel( 'jetpack/option' );
 
-	// A direct child only: the choice fields nest their options under a `jetpack/options`
-	// wrapper, so this cannot pick up one of their choices by mistake.
-	const optionBlock = innerBlocks.find( inner => inner.name === 'jetpack/option' );
-	const optionLabel = optionBlock?.attributes?.label;
-
-	if ( optionLabel && optionLabel.trim() ) {
-		return optionLabel.trim();
+	if ( label ) {
+		return label;
 	}
 
 	const id = block.attributes?.id;
+	const untitled = __( 'Untitled field', 'jetpack-forms' );
+
+	if ( ! id ) {
+		return untitled;
+	}
 
 	// An author's id is worth showing; one this panel minted from the placeholder is not, or
 	// choosing an unnamed field renames it to "untitled-field" in the dropdown it was picked
-	// from. The suffix is matched too -- a second unnamed field is handed `untitled-field-2`.
-	const untitled = __( 'Untitled field', 'jetpack-forms' );
+	// from. `generateUniqueFormFieldId` only ever appends `-<n>`, so stripping that suffix is
+	// enough to recognize one.
 	const placeholderId = toFieldIdBase( untitled );
-	const isMinted =
-		id === placeholderId || new RegExp( `^${ placeholderId }-\\d+$` ).test( id || '' );
+	const isMinted = id === placeholderId || id.replace( /-\d+$/, '' ) === placeholderId;
 
-	if ( id && ! isMinted ) {
-		return id;
-	}
-
-	return untitled;
+	return isMinted ? untitled : id;
 };
 
 /**

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/hooks/use-subject-fields.js
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/hooks/use-subject-fields.js
@@ -26,7 +26,19 @@ const toFieldIdBase = label => {
 };
 
 /**
+ * The placeholder standing in for a field that has not been named.
+ *
+ * @return {string} The placeholder label.
+ */
+const untitledLabel = () => __( 'Untitled field', 'jetpack-forms' );
+
+/**
  * Read a field block's visible label.
+ *
+ * Two blocks keep their label somewhere other than a `jetpack/label` inner block: a checkbox
+ * and a consent field each write their inline label onto the standalone `jetpack/option`
+ * their template inserts. Reading only `jetpack/label` reported both as "Untitled field"
+ * however carefully they had been named, which is unusable in a form holding more than one.
  *
  * Falls back to the explicit id, then to a placeholder: a field with neither a label nor an
  * id is still selectable, and an empty entry in the dropdown would be unusable.
@@ -35,14 +47,40 @@ const toFieldIdBase = label => {
  * @return {string} A label suitable for the subject dropdown.
  */
 const getFieldLabel = block => {
-	const labelBlock = ( block.innerBlocks || [] ).find( inner => inner.name === 'jetpack/label' );
+	const innerBlocks = block.innerBlocks || [];
+	const labelBlock = innerBlocks.find( inner => inner.name === 'jetpack/label' );
 	const label = labelBlock?.attributes?.label;
 
 	if ( label && label.trim() ) {
 		return label.trim();
 	}
 
-	return block.attributes?.id || __( 'Untitled field', 'jetpack-forms' );
+	// A direct `jetpack/option` child only ever belongs to a checkbox or consent field: the
+	// choice fields nest theirs one level down under a `jetpack/options` wrapper, so this
+	// cannot pick up the first choice of a multiple-choice field by mistake.
+	const optionBlock = innerBlocks.find( inner => inner.name === 'jetpack/option' );
+	const optionLabel = optionBlock?.attributes?.label;
+
+	if ( optionLabel && optionLabel.trim() ) {
+		return optionLabel.trim();
+	}
+
+	const id = block.attributes?.id;
+
+	// An id is worth showing when the author chose it, but not when it is the one this panel
+	// minted a moment ago from the placeholder: choosing an unnamed field would then rename it
+	// from "Untitled field" to "untitled-field" inside the very dropdown it was picked from,
+	// so the summary and the builder appeared to name two different fields. The numeric suffix
+	// is matched too, since the second unnamed field of a form is handed `untitled-field-2`.
+	const placeholderId = toFieldIdBase( untitledLabel() );
+	const isMintedFromPlaceholder =
+		id === placeholderId || new RegExp( `^${ placeholderId }-\\d+$` ).test( id || '' );
+
+	if ( id && ! isMintedFromPlaceholder ) {
+		return id;
+	}
+
+	return untitledLabel();
 };
 
 /**

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
@@ -228,7 +228,9 @@ export const canValueCarryOver = (
 		case 'number':
 			return Number.isFinite( Number( raw ) );
 
-		// A date or time input renders nothing for a value outside its own format.
+		// A date or time input renders nothing for a value outside its own format. Stricter
+		// than `evaluate.ts`'s parser on purpose: that answers what the evaluator can read,
+		// this answers what the control can show, so `15/03/2026` has to go.
 		case 'date':
 			return /^\d{4}-\d{2}-\d{2}$/.test( raw );
 

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
@@ -196,6 +196,26 @@ export const operatorNeedsValue = ( operator: Operator | string ): boolean =>
 	! OPERATORS_WITHOUT_VALUE.has( operator );
 
 /**
+ * Whether `<input type="date">` will show this value.
+ *
+ * The format has to match and the day has to exist: a well-formed date that does not exist rolls
+ * over rather than failing to parse -- `2026-02-31` becomes 2 March -- so what came back has to be
+ * compared against what went in.
+ *
+ * @param value - A trimmed candidate value.
+ * @return True when the date input can display it.
+ */
+const isDisplayableDate = ( value: string ): boolean => {
+	if ( ! /^\d{4}-\d{2}-\d{2}$/.test( value ) ) {
+		return false;
+	}
+
+	const parsed = new Date( `${ value }T00:00:00Z` );
+
+	return ! Number.isNaN( parsed.getTime() ) && parsed.toISOString().startsWith( value );
+};
+
+/**
  * The value a subject change carries over, or null when it cannot be carried.
  *
  * Returns the value to store rather than a yes/no, because the decision is made on the
@@ -231,17 +251,20 @@ export const getCarriedOverValue = (
 		case 'options':
 			return options.some( option => option.value === raw ) ? raw : null;
 
+		// The grammar a number input accepts, rather than whatever `Number()` can coerce: it
+		// blanks `.5`, `5.`, `+5` and `0x10`, all of which `Number()` reads happily.
 		case 'number':
-			return Number.isFinite( Number( raw ) ) ? raw : null;
+			return /^-?\d+(\.\d+)?([eE][-+]?\d+)?$/.test( raw ) ? raw : null;
 
-		// A date or time input renders nothing for a value outside its own format. Stricter
-		// than `evaluate.ts`'s parser on purpose: that answers what the evaluator can read,
-		// this answers what the control can show, so `15/03/2026` has to go.
+		// A date or time input renders nothing for a value outside its own format, and nothing
+		// for one that is well-formed but not a real date or clock time. Stricter than
+		// `evaluate.ts`'s parser on purpose: that answers what the evaluator can read, this
+		// answers what the control can show, so `15/03/2026` and `2026-02-31` both have to go.
 		case 'date':
-			return /^\d{4}-\d{2}-\d{2}$/.test( raw ) ? raw : null;
+			return isDisplayableDate( raw ) ? raw : null;
 
 		case 'time':
-			return /^\d{2}:\d{2}(:\d{2})?$/.test( raw ) ? raw : null;
+			return /^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/.test( raw ) ? raw : null;
 
 		default:
 			return raw;

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
@@ -198,11 +198,8 @@ export const operatorNeedsValue = ( operator: Operator | string ): boolean =>
 /**
  * Whether a value the author has already typed still means something under a new subject.
  *
- * Choosing a subject used to clear the value unconditionally, which cost the author anything
- * they had typed first -- and the value box is offered before a subject is picked, so typing
- * the value first is a natural order to work in. Keeping it needs a check, though: a value the
- * new subject's control cannot represent would sit in the rule invisibly, showing an empty box
- * while the evaluators went on comparing against it.
+ * A value the new subject's control cannot represent would sit in the rule invisibly: an empty
+ * box, with the evaluators still comparing against what it holds.
  *
  * @param value   - The value currently on the rule.
  * @param typeKey - The new subject's comparison behavior.
@@ -225,15 +222,13 @@ export const canValueCarryOver = (
 		case 'none':
 			return false;
 
-		// A dropdown can only show a value that is one of its options.
 		case 'options':
 			return options.some( option => option.value === raw );
 
 		case 'number':
 			return Number.isFinite( Number( raw ) );
 
-		// `<input type="date">` and `<input type="time">` render nothing for a value outside
-		// their format, so anything else has to go rather than be kept out of sight.
+		// A date or time input renders nothing for a value outside its own format.
 		case 'date':
 			return /^\d{4}-\d{2}-\d{2}$/.test( raw );
 

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
@@ -194,3 +194,53 @@ export const getValueInputForTypeKey = ( typeKey: TypeKey | string ): ValueInput
  */
 export const operatorNeedsValue = ( operator: Operator | string ): boolean =>
 	! OPERATORS_WITHOUT_VALUE.has( operator );
+
+/**
+ * Whether a value the author has already typed still means something under a new subject.
+ *
+ * Choosing a subject used to clear the value unconditionally, which cost the author anything
+ * they had typed first -- and the value box is offered before a subject is picked, so typing
+ * the value first is a natural order to work in. Keeping it needs a check, though: a value the
+ * new subject's control cannot represent would sit in the rule invisibly, showing an empty box
+ * while the evaluators went on comparing against it.
+ *
+ * @param value   - The value currently on the rule.
+ * @param typeKey - The new subject's comparison behavior.
+ * @param options - The new subject's selectable options, where it has any.
+ * @return True when the value can be carried over as-is.
+ */
+export const canValueCarryOver = (
+	value: unknown,
+	typeKey: TypeKey | string,
+	options: ReadonlyArray< { value: string } > = []
+): boolean => {
+	const raw = String( value ?? '' ).trim();
+
+	if ( '' === raw ) {
+		return false;
+	}
+
+	switch ( getValueInputForTypeKey( typeKey ) ) {
+		// No value box at all: `is checked` and friends compare against nothing.
+		case 'none':
+			return false;
+
+		// A dropdown can only show a value that is one of its options.
+		case 'options':
+			return options.some( option => option.value === raw );
+
+		case 'number':
+			return Number.isFinite( Number( raw ) );
+
+		// `<input type="date">` and `<input type="time">` render nothing for a value outside
+		// their format, so anything else has to go rather than be kept out of sight.
+		case 'date':
+			return /^\d{4}-\d{2}-\d{2}$/.test( raw );
+
+		case 'time':
+			return /^\d{2}:\d{2}(:\d{2})?$/.test( raw );
+
+		default:
+			return true;
+	}
+};

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
@@ -196,48 +196,54 @@ export const operatorNeedsValue = ( operator: Operator | string ): boolean =>
 	! OPERATORS_WITHOUT_VALUE.has( operator );
 
 /**
- * Whether a value the author has already typed still means something under a new subject.
+ * The value a subject change carries over, or null when it cannot be carried.
  *
- * A value the new subject's control cannot represent would sit in the rule invisibly: an empty
- * box, with the evaluators still comparing against what it holds.
+ * Returns the value to store rather than a yes/no, because the decision is made on the
+ * trimmed form: handing back a verdict left the caller storing the padded original, which
+ * every control here then failed to display -- a dropdown has no option named `" Small "`,
+ * and a date input renders nothing for `" 2026-03-15 "`. One function owns both halves so
+ * they cannot disagree.
+ *
+ * A value the new subject's control cannot represent is dropped rather than kept out of
+ * sight, where the evaluators would go on comparing against it.
  *
  * @param value   - The value currently on the rule.
  * @param typeKey - The new subject's comparison behavior.
  * @param options - The new subject's selectable options, where it has any.
- * @return True when the value can be carried over as-is.
+ * @return The value to store, or null when the new subject cannot represent it.
  */
-export const canValueCarryOver = (
+export const getCarriedOverValue = (
 	value: unknown,
 	typeKey: TypeKey | string,
 	options: ReadonlyArray< { value: string } > = []
-): boolean => {
+): string | null => {
 	const raw = String( value ?? '' ).trim();
 
 	if ( '' === raw ) {
-		return false;
+		return null;
 	}
 
 	switch ( getValueInputForTypeKey( typeKey ) ) {
 		// No value box at all: `is checked` and friends compare against nothing.
 		case 'none':
-			return false;
+			return null;
 
 		case 'options':
-			return options.some( option => option.value === raw );
+			return options.some( option => option.value === raw ) ? raw : null;
 
 		case 'number':
-			return Number.isFinite( Number( raw ) );
+			return Number.isFinite( Number( raw ) ) ? raw : null;
 
 		// A date or time input renders nothing for a value outside its own format. Stricter
 		// than `evaluate.ts`'s parser on purpose: that answers what the evaluator can read,
 		// this answers what the control can show, so `15/03/2026` has to go.
 		case 'date':
-			return /^\d{4}-\d{2}-\d{2}$/.test( raw );
+			return /^\d{4}-\d{2}-\d{2}$/.test( raw ) ? raw : null;
 
 		case 'time':
-			return /^\d{2}:\d{2}(:\d{2})?$/.test( raw );
+			return /^\d{2}:\d{2}(:\d{2})?$/.test( raw ) ? raw : null;
 
 		default:
-			return true;
+			return raw;
 	}
 };

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1965,6 +1965,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 			$formatted_submission_data[] = array(
 				'label'          => Util::maybe_add_colon_to_label( $field_data['label'] ),
 				'value'          => self::get_submission_display_value( $field_data['value'], $type ),
+				// The submitted answer, kept beside the label the summary prints. The checkbox
+				// icon is chosen from it: `is_checked_value()` recognizes only the ASCII `no`
+				// sentinel, so a translated "No" would read as ticked in every locale whose
+				// word for it is not "no".
+				'rawValue'       => $field_data['value'],
 				'images'         => $images,
 				'url'            => $url,
 				'files'          => $files,
@@ -2271,7 +2276,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 					// field-type-icon: rendered based on field type and, for checkboxes, the answer.
 					// The data-rendered-type attribute enables hydration optimization by allowing
 					// the JS callback to skip re-rendering when the icon is already correct.
-					$field_value = $submission['value'] ?? '';
+					// The raw answer, not the printed label -- see `rawValue` above.
+					$field_value = $submission['rawValue'] ?? '';
 					$icon_key    = self::get_field_type_icon_key( $field_type, $field_value );
 					$html       .= '<div class="field-type-icon" data-wp-watch="callbacks.watchFieldTypeIcon" data-rendered-type="' . esc_attr( $icon_key ) . '">' . self::get_field_type_icon( $field_type, $field_value ) . '</div>';
 					// field-name: always present.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1527,13 +1527,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		$config = array(
-			'error_types'    => array(
+			'error_types'     => array(
 				'is_required'        => __( 'This field is required.', 'jetpack-forms' ),
 				'invalid_form_empty' => __( 'The form you are trying to submit is empty.', 'jetpack-forms' ),
 				'invalid_form'       => __( 'Please fill out the form correctly.', 'jetpack-forms' ),
 				'network_error'      => __( 'Connection issue while submitting the form. Check that you are connected to the Internet and try again.', 'jetpack-forms' ),
 			),
-			'admin_ajax_url' => admin_url( 'admin-ajax.php' ),
+			'admin_ajax_url'  => admin_url( 'admin-ajax.php' ),
+			// Translated here rather than in view.js: the interactivity module is a script
+			// module with no i18n dependency, and the string has to match what
+			// get_submission_display_value() rendered server-side or hydration rewrites it.
+			'unchecked_label' => __( 'No', 'jetpack-forms' ),
 		);
 		wp_interactivity_config( 'jetpack/form', $config );
 		\wp_enqueue_script_module(
@@ -1961,7 +1965,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 			$formatted_submission_data[] = array(
 				'label'          => Util::maybe_add_colon_to_label( $field_data['label'] ),
-				'value'          => self::maybe_transform_value( $field_data['value'] ),
+				'value'          => self::get_submission_display_value( $field_data['value'], $type ),
 				'images'         => $images,
 				'url'            => $url,
 				'files'          => $files,
@@ -1972,6 +1976,31 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 
 		return $formatted_submission_data;
+	}
+
+	/**
+	 * The value a submitted field shows in the confirmation summary.
+	 *
+	 * An unticked checkbox submits nothing, so its value arrives empty and the summary drew
+	 * the field's label over a blank line -- which reads as a field that failed to record
+	 * rather than as the answer "no". The email renderer has always said "No" here, so this
+	 * says it too and the two descriptions of one submission agree.
+	 *
+	 * Mirrored by `getSubmissionDisplayValue()` in src/modules/form/helpers.js, which formats
+	 * the same data for an AJAX submission. The two must produce the same string or the
+	 * summary changes as the Interactivity API hydrates it.
+	 *
+	 * @param mixed  $value The submitted value.
+	 * @param string $type  The field type.
+	 *
+	 * @return mixed The value to display.
+	 */
+	private static function get_submission_display_value( $value, $type ) {
+		if ( 'checkbox' === $type && ! Feedback_Field::is_checked_value( $value ) ) {
+			return __( 'No', 'jetpack-forms' );
+		}
+
+		return self::maybe_transform_value( $value );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1534,9 +1534,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 				'network_error'      => __( 'Connection issue while submitting the form. Check that you are connected to the Internet and try again.', 'jetpack-forms' ),
 			),
 			'admin_ajax_url'  => admin_url( 'admin-ajax.php' ),
-			// Translated here rather than in view.js: the interactivity module is a script
-			// module with no i18n dependency, and the string has to match what
-			// get_submission_display_value() rendered server-side or hydration rewrites it.
+			// Translated here because the interactivity module is a script module with no
+			// i18n dependency, and the string has to match what was rendered server-side.
 			'unchecked_label' => __( 'No', 'jetpack-forms' ),
 		);
 		wp_interactivity_config( 'jetpack/form', $config );
@@ -1981,13 +1980,11 @@ class Contact_Form extends Contact_Form_Shortcode {
 	/**
 	 * The value a submitted field shows in the confirmation summary.
 	 *
-	 * An unticked checkbox submits nothing, so its value arrives empty and the summary drew
-	 * the field's label over a blank line -- which reads as a field that failed to record
-	 * rather than as the answer "no". The email renderer has always said "No" here, so this
-	 * says it too and the two descriptions of one submission agree.
+	 * An unticked checkbox submits nothing, so it arrives empty and the summary drew the
+	 * label over a blank line. The email renderer has always said "No" here.
 	 *
 	 * Mirrored by `getSubmissionDisplayValue()` in src/modules/form/helpers.js, which formats
-	 * the same data for an AJAX submission. The two must produce the same string or the
+	 * the same data for an AJAX submission; the two must produce the same string or the
 	 * summary changes as the Interactivity API hydrates it.
 	 *
 	 * @param mixed  $value The submitted value.

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -135,8 +135,8 @@ class Feedback_Field {
 	 * explicit "No". The ticked value is a translated string ( "Yes" ), so this
 	 * tests for emptiness and the "no" sentinel rather than matching "yes".
 	 *
-	 * Mirrored by `isCheckedValue()` in src/modules/form/field-type-icons.js and
-	 * in the dashboard's field-icons.tsx, which must agree with this.
+	 * Mirrored by `isCheckedValue()` in src/modules/form/helpers.js and in the
+	 * dashboard's field-icons.tsx, which must agree with this.
 	 *
 	 * @param mixed $value The submitted value.
 	 *

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
@@ -47,10 +47,8 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 	const typeClassName = `is-field-type-${ fieldType }`;
 
 	const renderFieldValue = () => {
-		// An unticked checkbox submits nothing, so it fell through to the dash used for a
-		// field with no answer -- but the respondent did answer, and both the email and the
-		// confirmation summary say "No". A badge, because a ticked one is badged too and the
-		// pair should read as two answers to the same question.
+		// An unticked checkbox submits nothing, so it fell through to the dash meaning "no
+		// answer" -- but the respondent did answer. Badged, as a ticked one already is.
 		if ( fieldType === 'checkbox' && ! isCheckedValue( value ) ) {
 			return <Badge intent="draft">{ __( 'No', 'jetpack-forms' ) }</Badge>;
 		}

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
@@ -7,6 +7,7 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { Badge, Link } from '@wordpress/ui';
 /**
  * Internal dependencies
@@ -46,6 +47,14 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 	const typeClassName = `is-field-type-${ fieldType }`;
 
 	const renderFieldValue = () => {
+		// An unticked checkbox submits nothing, so it fell through to the dash used for a
+		// field with no answer -- but the respondent did answer, and both the email and the
+		// confirmation summary say "No". A badge, because a ticked one is badged too and the
+		// pair should read as two answers to the same question.
+		if ( fieldType === 'checkbox' && ! isCheckedValue( value ) ) {
+			return <Badge intent="draft">{ __( 'No', 'jetpack-forms' ) }</Badge>;
+		}
+
 		// Image select fields
 		if ( fieldType === 'image-select' ) {
 			const choices = ( value as { choices?: unknown[] } )?.choices;

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/index.tsx
@@ -22,10 +22,10 @@ import { EMAIL_REGEX, inferFieldTypeFromLabel } from './field-preview-utils.ts';
 import type { ResponseField, FieldType, FileItem } from '../../../../../types/index.ts';
 import './style.scss';
 
-const getFieldIcon = ( fieldType: FieldType, value: unknown ): React.ReactNode => {
+const getFieldIcon = ( fieldType: FieldType, isUnticked: boolean ): React.ReactNode => {
 	// A checkbox reflects the respondent's answer: an unchecked box gets the
 	// empty square rather than the ticked one.
-	if ( fieldType === 'checkbox' && ! isCheckedValue( value ) ) {
+	if ( isUnticked ) {
 		return <Icon icon={ checkboxUncheckedFieldIcon } />;
 	}
 	return <Icon icon={ fieldIcons[ fieldType ] ?? fieldIcons.text } />;
@@ -43,13 +43,15 @@ const FieldPreview = ( { field, onFilePreview }: FieldPreviewProps ) => {
 	// For legacy responses without a proper type (undefined or "basic"), try to infer from label
 	const fieldType: FieldType =
 		type && type !== 'basic' ? type : inferFieldTypeFromLabel( label ) ?? 'text';
-	const icon = getFieldIcon( fieldType, value );
+	// The icon and the value are two views of one answer, so they read it once.
+	const isUntickedCheckbox = fieldType === 'checkbox' && ! isCheckedValue( value );
+	const icon = getFieldIcon( fieldType, isUntickedCheckbox );
 	const typeClassName = `is-field-type-${ fieldType }`;
 
 	const renderFieldValue = () => {
 		// An unticked checkbox submits nothing, so it fell through to the dash meaning "no
 		// answer" -- but the respondent did answer. Badged, as a ticked one already is.
-		if ( fieldType === 'checkbox' && ! isCheckedValue( value ) ) {
+		if ( isUntickedCheckbox ) {
 			return <Badge intent="draft">{ __( 'No', 'jetpack-forms' ) }</Badge>;
 		}
 

--- a/projects/packages/forms/src/modules/form/field-type-icons-view.js
+++ b/projects/packages/forms/src/modules/form/field-type-icons-view.js
@@ -24,7 +24,9 @@ store( NAMESPACE, {
 
 			const context = getContext();
 			const fieldType = context.submission?.type || 'text';
-			const value = context.submission?.value;
+			// The raw answer rather than the printed label: a translated "No" is not the
+			// `no` sentinel `isCheckedValue()` tests for, and would render as ticked.
+			const value = context.submission?.rawValue;
 			// The rendered marker is the icon key, not the field type: a checkbox
 			// resolves to a different icon depending on the submitted value, so
 			// comparing types alone would leave a stale icon in place.

--- a/projects/packages/forms/src/modules/form/field-type-icons.js
+++ b/projects/packages/forms/src/modules/form/field-type-icons.js
@@ -24,6 +24,7 @@ import textIcon from '../../blocks/field-text/icon.svg?raw';
 import textareaIcon from '../../blocks/field-textarea/icon.svg?raw';
 import timeIcon from '../../blocks/field-time/icon.svg?raw';
 import urlIcon from '../../blocks/field-url/icon.svg?raw';
+import { isCheckedValue } from './helpers.js';
 
 /**
  * Map of icon keys to their raw SVG markup.
@@ -53,30 +54,6 @@ const FIELD_TYPE_ICONS = {
 	'image-select': imageSelectIcon,
 	slider: sliderIcon,
 };
-
-/**
- * Whether a submitted value means the respondent ticked the box.
- *
- * An unticked box submits an empty value, and some stored responses use an
- * explicit "No". The ticked value is a translated string ("Yes"), so this tests
- * for emptiness and the "no" sentinel rather than matching "yes".
- *
- * Must agree with `Feedback_Field::is_checked_value()` in PHP, which renders the
- * server-side icon for the same submission.
- *
- * @param {*} value - The submitted value.
- * @return {boolean} True when the box was ticked.
- */
-function isCheckedValue( value ) {
-	if ( Array.isArray( value ) ) {
-		return value.length > 0;
-	}
-	if ( value === null || value === undefined ) {
-		return false;
-	}
-	const normalized = String( value ).trim().toLowerCase();
-	return normalized !== '' && normalized !== '0' && normalized !== 'no';
-}
 
 /**
  * Returns the icon key for a submitted field.

--- a/projects/packages/forms/src/modules/form/helpers.js
+++ b/projects/packages/forms/src/modules/form/helpers.js
@@ -107,3 +107,52 @@ export const getUrl = value => {
 
 	return null;
 };
+
+/**
+ * Whether a submitted value means the respondent ticked the box.
+ *
+ * An unticked box submits an empty value, and some stored responses use an explicit "No". The
+ * ticked value is a translated string ("Yes"), so this tests for emptiness and the "no"
+ * sentinel rather than matching "yes".
+ *
+ * Must agree with `Feedback_Field::is_checked_value()` in PHP, which renders the server-side
+ * icon and summary for the same submission.
+ *
+ * @param {*} value - The submitted value.
+ * @return {boolean} True when the box was ticked.
+ */
+export const isCheckedValue = value => {
+	if ( Array.isArray( value ) ) {
+		return value.length > 0;
+	}
+	if ( value === null || value === undefined ) {
+		return false;
+	}
+	const normalized = String( value ).trim().toLowerCase();
+	return normalized !== '' && normalized !== '0' && normalized !== 'no';
+};
+
+/**
+ * The value a submitted field shows in the confirmation summary.
+ *
+ * An unticked checkbox submits nothing, so its value arrives empty and the summary drew the
+ * field's label over a blank line -- which reads as a field that failed to record rather than
+ * as the answer "no". The email renderer has always said "No" here, so this says it too.
+ *
+ * Mirrors `Contact_Form::get_submission_display_value()`, which renders the same summary
+ * server-side; the two must agree or the value changes as the Interactivity API hydrates it.
+ * The label is translated in PHP and passed through the module config, since a script module
+ * carries no i18n dependency.
+ *
+ * @param {*}      value          - The submitted value.
+ * @param {string} type           - The field type.
+ * @param {string} uncheckedLabel - The localized label for an unticked checkbox.
+ * @return {*} The value to display.
+ */
+export const getSubmissionDisplayValue = ( value, type, uncheckedLabel ) => {
+	if ( 'checkbox' === type && ! isCheckedValue( value ) ) {
+		return uncheckedLabel;
+	}
+
+	return maybeTransformValue( value );
+};

--- a/projects/packages/forms/src/modules/form/helpers.js
+++ b/projects/packages/forms/src/modules/form/helpers.js
@@ -135,14 +135,12 @@ export const isCheckedValue = value => {
 /**
  * The value a submitted field shows in the confirmation summary.
  *
- * An unticked checkbox submits nothing, so its value arrives empty and the summary drew the
- * field's label over a blank line -- which reads as a field that failed to record rather than
- * as the answer "no". The email renderer has always said "No" here, so this says it too.
+ * An unticked checkbox submits nothing, so it arrives empty and the summary drew the label
+ * over a blank line. The email renderer has always said "No" here.
  *
- * Mirrors `Contact_Form::get_submission_display_value()`, which renders the same summary
- * server-side; the two must agree or the value changes as the Interactivity API hydrates it.
- * The label is translated in PHP and passed through the module config, since a script module
- * carries no i18n dependency.
+ * Mirrors `Contact_Form::get_submission_display_value()`; the two must agree or the value
+ * changes as the Interactivity API hydrates it. The label is translated in PHP and passed
+ * through the module config, since a script module carries no i18n dependency.
  *
  * @param {*}      value          - The submitted value.
  * @param {string} type           - The field type.

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -93,6 +93,10 @@ const setSubmissionData = ( data = [] ) => {
 		return {
 			label: maybeAddColonToLabel( item.label ),
 			value: getSubmissionDisplayValue( item.value, item.type, config?.unchecked_label ?? '' ),
+			// The submitted answer, kept beside the label. The checkbox icon is chosen from
+			// it, and `isCheckedValue()` cannot read a translated "No". Mirrors `rawValue` in
+			// Contact_Form::format_submission_data(), which seeds this same context.
+			rawValue: item.value,
 			images,
 			url,
 			files,

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -14,7 +14,7 @@ import {
 import { validateField, isEmptyValue } from '../../contact-form/js/validate-helper.js';
 import { getRating } from '../field-rating/view.js';
 import { isFieldHiddenByLogic } from './conditional-visibility.js';
-import { maybeAddColonToLabel, maybeTransformValue, getImages, getUrl } from './helpers.js';
+import { maybeAddColonToLabel, getImages, getUrl, getSubmissionDisplayValue } from './helpers.js';
 import { focusNextInput, getForm, submitForm } from './shared.ts';
 // Import field type icons view to register its callbacks.
 import './field-type-icons-view.js';
@@ -92,7 +92,7 @@ const setSubmissionData = ( data = [] ) => {
 
 		return {
 			label: maybeAddColonToLabel( item.label ),
-			value: maybeTransformValue( item.value ),
+			value: getSubmissionDisplayValue( item.value, item.type, config?.unchecked_label ?? '' ),
 			images,
 			url,
 			files,

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/field-types.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/field-types.test.js
@@ -91,12 +91,9 @@ describe( 'field-types', () => {
 } );
 
 /**
- * Whether a value already typed survives choosing a subject.
- *
- * Choosing one used to clear the value outright, so anything typed first was lost -- and the
- * value box is offered before a subject is picked, so typing it first is a normal way to work.
- * The counter-risk is keeping a value the new subject's control cannot show: the box would
- * look empty while the evaluators went on comparing against it.
+ * Whether a value already typed survives choosing a subject. The risk on the other side is
+ * keeping one the new subject's control cannot show: an empty-looking box the evaluators are
+ * still comparing against.
  */
 describe( 'canValueCarryOver', () => {
 	it( 'keeps a value a text box can show', () => {
@@ -131,8 +128,7 @@ describe( 'canValueCarryOver', () => {
 		expect( canValueCarryOver( 'ten', 'number' ) ).toBe( false );
 	} );
 
-	// A date or time input renders nothing for a value outside its format, so a carried-over
-	// value that does not parse would be invisible rather than merely wrong.
+	// Outside its own format, the input renders nothing at all.
 	it( 'keeps it for date and time only in the format their inputs use', () => {
 		expect( canValueCarryOver( '2026-03-15', 'date' ) ).toBe( true );
 		expect( canValueCarryOver( '15/03/2026', 'date' ) ).toBe( false );

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/field-types.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/field-types.test.js
@@ -137,7 +137,17 @@ describe( 'getCarriedOverValue', () => {
 	it( 'keeps it for a number subject only when it is a number', () => {
 		expect( getCarriedOverValue( '10', 'number' ) ).toBe( '10' );
 		expect( getCarriedOverValue( '-2.5', 'number' ) ).toBe( '-2.5' );
+		expect( getCarriedOverValue( '1e3', 'number' ) ).toBe( '1e3' );
 		expect( getCarriedOverValue( 'ten', 'number' ) ).toBeNull();
+	} );
+
+	// `Number()` reads all of these; a number input displays none of them, which is the
+	// question being asked.
+	it( 'drops a number the input cannot show, however readable it is to Number()', () => {
+		expect( getCarriedOverValue( '0x10', 'number' ) ).toBeNull();
+		expect( getCarriedOverValue( '.5', 'number' ) ).toBeNull();
+		expect( getCarriedOverValue( '5.', 'number' ) ).toBeNull();
+		expect( getCarriedOverValue( '+5', 'number' ) ).toBeNull();
 	} );
 
 	// Outside its own format, the input renders nothing at all.
@@ -147,5 +157,18 @@ describe( 'getCarriedOverValue', () => {
 		expect( getCarriedOverValue( '09:30', 'time' ) ).toBe( '09:30' );
 		expect( getCarriedOverValue( '09:30:00', 'time' ) ).toBe( '09:30:00' );
 		expect( getCarriedOverValue( 'half nine', 'time' ) ).toBeNull();
+	} );
+
+	// The format is not the whole question: a day that does not exist rolls over into the
+	// next month rather than failing to parse, and the input shows nothing for it.
+	it( 'drops a well-formed date or time that does not exist', () => {
+		expect( getCarriedOverValue( '2024-02-29', 'date' ) ).toBe( '2024-02-29' );
+		expect( getCarriedOverValue( '2026-02-29', 'date' ) ).toBeNull();
+		expect( getCarriedOverValue( '2026-02-31', 'date' ) ).toBeNull();
+		expect( getCarriedOverValue( '2026-13-01', 'date' ) ).toBeNull();
+		expect( getCarriedOverValue( '23:59', 'time' ) ).toBe( '23:59' );
+		expect( getCarriedOverValue( '24:00', 'time' ) ).toBeNull();
+		expect( getCarriedOverValue( '09:99', 'time' ) ).toBeNull();
+		expect( getCarriedOverValue( '09:30:99', 'time' ) ).toBeNull();
 	} );
 } );

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/field-types.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/field-types.test.js
@@ -1,5 +1,6 @@
 import {
 	OPERATORS,
+	canValueCarryOver,
 	getOperatorsForTypeKey,
 	getValueInputForTypeKey,
 	operatorNeedsValue,
@@ -86,5 +87,57 @@ describe( 'field-types', () => {
 		expect( operatorNeedsValue( OPERATORS.IS_NOT_EMPTY ) ).toBe( false );
 		expect( operatorNeedsValue( OPERATORS.IS_CHECKED ) ).toBe( false );
 		expect( operatorNeedsValue( OPERATORS.IS_NOT_CHECKED ) ).toBe( false );
+	} );
+} );
+
+/**
+ * Whether a value already typed survives choosing a subject.
+ *
+ * Choosing one used to clear the value outright, so anything typed first was lost -- and the
+ * value box is offered before a subject is picked, so typing it first is a normal way to work.
+ * The counter-risk is keeping a value the new subject's control cannot show: the box would
+ * look empty while the evaluators went on comparing against it.
+ */
+describe( 'canValueCarryOver', () => {
+	it( 'keeps a value a text box can show', () => {
+		expect( canValueCarryOver( 'iPhone', 'string' ) ).toBe( true );
+		expect( canValueCarryOver( 'iPhone', 'hidden' ) ).toBe( true );
+	} );
+
+	it( 'has nothing to keep when the value is blank', () => {
+		expect( canValueCarryOver( '', 'string' ) ).toBe( false );
+		expect( canValueCarryOver( '   ', 'string' ) ).toBe( false );
+		expect( canValueCarryOver( null, 'string' ) ).toBe( false );
+		expect( canValueCarryOver( undefined, 'string' ) ).toBe( false );
+	} );
+
+	it( 'drops it for a subject that takes no value at all', () => {
+		expect( canValueCarryOver( 'iPhone', 'boolean' ) ).toBe( false );
+		expect( canValueCarryOver( 'iPhone', 'file' ) ).toBe( false );
+	} );
+
+	it( 'keeps it for a dropdown only when it is one of the options', () => {
+		const options = [ { value: 'Small' }, { value: 'Large' } ];
+
+		expect( canValueCarryOver( 'Small', 'choice', options ) ).toBe( true );
+		expect( canValueCarryOver( 'Medium', 'choice', options ) ).toBe( false );
+		// A subject whose options have not been filled in yet can show nothing.
+		expect( canValueCarryOver( 'Small', 'choice' ) ).toBe( false );
+	} );
+
+	it( 'keeps it for a number subject only when it is a number', () => {
+		expect( canValueCarryOver( '10', 'number' ) ).toBe( true );
+		expect( canValueCarryOver( '-2.5', 'number' ) ).toBe( true );
+		expect( canValueCarryOver( 'ten', 'number' ) ).toBe( false );
+	} );
+
+	// A date or time input renders nothing for a value outside its format, so a carried-over
+	// value that does not parse would be invisible rather than merely wrong.
+	it( 'keeps it for date and time only in the format their inputs use', () => {
+		expect( canValueCarryOver( '2026-03-15', 'date' ) ).toBe( true );
+		expect( canValueCarryOver( '15/03/2026', 'date' ) ).toBe( false );
+		expect( canValueCarryOver( '09:30', 'time' ) ).toBe( true );
+		expect( canValueCarryOver( '09:30:00', 'time' ) ).toBe( true );
+		expect( canValueCarryOver( 'half nine', 'time' ) ).toBe( false );
 	} );
 } );

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/field-types.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/field-types.test.js
@@ -1,6 +1,6 @@
 import {
 	OPERATORS,
-	canValueCarryOver,
+	getCarriedOverValue,
 	getOperatorsForTypeKey,
 	getValueInputForTypeKey,
 	operatorNeedsValue,
@@ -91,49 +91,61 @@ describe( 'field-types', () => {
 } );
 
 /**
- * Whether a value already typed survives choosing a subject. The risk on the other side is
- * keeping one the new subject's control cannot show: an empty-looking box the evaluators are
- * still comparing against.
+ * What a value already typed becomes when a subject is chosen. The risk on the other side of
+ * keeping it is a value the new subject's control cannot show: an empty-looking box the
+ * evaluators are still comparing against.
  */
-describe( 'canValueCarryOver', () => {
+describe( 'getCarriedOverValue', () => {
 	it( 'keeps a value a text box can show', () => {
-		expect( canValueCarryOver( 'iPhone', 'string' ) ).toBe( true );
-		expect( canValueCarryOver( 'iPhone', 'hidden' ) ).toBe( true );
+		expect( getCarriedOverValue( 'iPhone', 'string' ) ).toBe( 'iPhone' );
+		expect( getCarriedOverValue( 'iPhone', 'hidden' ) ).toBe( 'iPhone' );
+	} );
+
+	/**
+	 * The decision is made on the trimmed value, so the trimmed value is what comes back --
+	 * returning the padded original left every control here unable to display it.
+	 */
+	it( 'returns the value in the form the control can show', () => {
+		expect( getCarriedOverValue( '  iPhone  ', 'string' ) ).toBe( 'iPhone' );
+		expect( getCarriedOverValue( ' 10 ', 'number' ) ).toBe( '10' );
+		expect( getCarriedOverValue( ' 2026-03-15 ', 'date' ) ).toBe( '2026-03-15' );
+		expect( getCarriedOverValue( ' 09:30 ', 'time' ) ).toBe( '09:30' );
+		expect( getCarriedOverValue( '  Small  ', 'choice', [ { value: 'Small' } ] ) ).toBe( 'Small' );
 	} );
 
 	it( 'has nothing to keep when the value is blank', () => {
-		expect( canValueCarryOver( '', 'string' ) ).toBe( false );
-		expect( canValueCarryOver( '   ', 'string' ) ).toBe( false );
-		expect( canValueCarryOver( null, 'string' ) ).toBe( false );
-		expect( canValueCarryOver( undefined, 'string' ) ).toBe( false );
+		expect( getCarriedOverValue( '', 'string' ) ).toBeNull();
+		expect( getCarriedOverValue( '   ', 'string' ) ).toBeNull();
+		expect( getCarriedOverValue( null, 'string' ) ).toBeNull();
+		expect( getCarriedOverValue( undefined, 'string' ) ).toBeNull();
 	} );
 
 	it( 'drops it for a subject that takes no value at all', () => {
-		expect( canValueCarryOver( 'iPhone', 'boolean' ) ).toBe( false );
-		expect( canValueCarryOver( 'iPhone', 'file' ) ).toBe( false );
+		expect( getCarriedOverValue( 'iPhone', 'boolean' ) ).toBeNull();
+		expect( getCarriedOverValue( 'iPhone', 'file' ) ).toBeNull();
 	} );
 
 	it( 'keeps it for a dropdown only when it is one of the options', () => {
 		const options = [ { value: 'Small' }, { value: 'Large' } ];
 
-		expect( canValueCarryOver( 'Small', 'choice', options ) ).toBe( true );
-		expect( canValueCarryOver( 'Medium', 'choice', options ) ).toBe( false );
+		expect( getCarriedOverValue( 'Small', 'choice', options ) ).toBe( 'Small' );
+		expect( getCarriedOverValue( 'Medium', 'choice', options ) ).toBeNull();
 		// A subject whose options have not been filled in yet can show nothing.
-		expect( canValueCarryOver( 'Small', 'choice' ) ).toBe( false );
+		expect( getCarriedOverValue( 'Small', 'choice' ) ).toBeNull();
 	} );
 
 	it( 'keeps it for a number subject only when it is a number', () => {
-		expect( canValueCarryOver( '10', 'number' ) ).toBe( true );
-		expect( canValueCarryOver( '-2.5', 'number' ) ).toBe( true );
-		expect( canValueCarryOver( 'ten', 'number' ) ).toBe( false );
+		expect( getCarriedOverValue( '10', 'number' ) ).toBe( '10' );
+		expect( getCarriedOverValue( '-2.5', 'number' ) ).toBe( '-2.5' );
+		expect( getCarriedOverValue( 'ten', 'number' ) ).toBeNull();
 	} );
 
 	// Outside its own format, the input renders nothing at all.
 	it( 'keeps it for date and time only in the format their inputs use', () => {
-		expect( canValueCarryOver( '2026-03-15', 'date' ) ).toBe( true );
-		expect( canValueCarryOver( '15/03/2026', 'date' ) ).toBe( false );
-		expect( canValueCarryOver( '09:30', 'time' ) ).toBe( true );
-		expect( canValueCarryOver( '09:30:00', 'time' ) ).toBe( true );
-		expect( canValueCarryOver( 'half nine', 'time' ) ).toBe( false );
+		expect( getCarriedOverValue( '2026-03-15', 'date' ) ).toBe( '2026-03-15' );
+		expect( getCarriedOverValue( '15/03/2026', 'date' ) ).toBeNull();
+		expect( getCarriedOverValue( '09:30', 'time' ) ).toBe( '09:30' );
+		expect( getCarriedOverValue( '09:30:00', 'time' ) ).toBe( '09:30:00' );
+		expect( getCarriedOverValue( 'half nine', 'time' ) ).toBeNull();
 	} );
 } );

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/panel.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/panel.test.jsx
@@ -657,6 +657,16 @@ describe( 'ConditionalLogicPanel', () => {
 		// A checkbox compares against nothing, so the value has to go rather than sit unseen.
 		[ 'drops it for a subject that takes no value', 'iPhone', 'terms_1', 'is_checked', '' ],
 		[ 'keeps it for a dropdown that offers it', 'Large', 'size_1', 'is', 'Large' ],
+		// Padding is what the representability check ignores, so it must not survive into the
+		// stored value: a dropdown has no option named "  Large  " and would render blank.
+		[
+			'stores a padded value the way the control can show it',
+			'  Large  ',
+			'size_1',
+			'is',
+			'Large',
+		],
+		[ 'trims a padded number too', ' 10 ', 'budget_1', 'equals', '10' ],
 	] )( '%s', async ( _name, typed, selection, operator, expected ) => {
 		const { setAttributes } = await setup(
 			withRules( [ { field: '', operator: 'is', value: typed } ] )

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/panel.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/panel.test.jsx
@@ -647,60 +647,29 @@ describe( 'ConditionalLogicPanel', () => {
 		} );
 	} );
 
-	// The value box is offered before a subject is chosen, so filling it in first is a normal
-	// order to work in -- and choosing the subject used to wipe it.
-	it( 'keeps a value typed before the subject was chosen', async () => {
+	/**
+	 * The value box is offered before a subject is chosen, so filling it in first is a normal
+	 * order to work in -- and choosing the subject used to wipe it. It is kept only where the
+	 * new subject can still show it.
+	 */
+	it.each( [
+		[ 'keeps a value typed before the subject was chosen', 'iPhone', 'name_1', 'is', 'iPhone' ],
+		// A checkbox compares against nothing, so the value has to go rather than sit unseen.
+		[ 'drops it for a subject that takes no value', 'iPhone', 'terms_1', 'is_checked', '' ],
+		[ 'keeps it for a dropdown that offers it', 'Large', 'size_1', 'is', 'Large' ],
+	] )( '%s', async ( _name, typed, selection, operator, expected ) => {
 		const { setAttributes } = await setup(
-			withRules( [ { field: '', operator: 'is', value: 'iPhone' } ] )
+			withRules( [ { field: '', operator: 'is', value: typed } ] )
 		);
 
-		await userEvent.selectOptions( screen.getByLabelText( 'Field' ), 'name_1' );
+		await userEvent.selectOptions( screen.getByLabelText( 'Field' ), selection );
 
 		expect( setAttributes ).toHaveBeenCalledWith( {
 			conditionalLogic: expect.objectContaining( {
 				groups: [
 					{
 						logicalOperator: 'all',
-						rules: [ { field: 'name_1', operator: 'is', value: 'iPhone' } ],
-					},
-				],
-			} ),
-		} );
-	} );
-
-	// A checkbox compares against nothing, so the value has to go rather than sit out of sight.
-	it( 'drops the typed value for a subject that takes none', async () => {
-		const { setAttributes } = await setup(
-			withRules( [ { field: '', operator: 'is', value: 'iPhone' } ] )
-		);
-
-		await userEvent.selectOptions( screen.getByLabelText( 'Field' ), 'terms_1' );
-
-		expect( setAttributes ).toHaveBeenCalledWith( {
-			conditionalLogic: expect.objectContaining( {
-				groups: [
-					{
-						logicalOperator: 'all',
-						rules: [ { field: 'terms_1', operator: 'is_checked', value: '' } ],
-					},
-				],
-			} ),
-		} );
-	} );
-
-	it( 'keeps the typed value for a dropdown subject that offers it', async () => {
-		const { setAttributes } = await setup(
-			withRules( [ { field: '', operator: 'is', value: 'Large' } ] )
-		);
-
-		await userEvent.selectOptions( screen.getByLabelText( 'Field' ), 'size_1' );
-
-		expect( setAttributes ).toHaveBeenCalledWith( {
-			conditionalLogic: expect.objectContaining( {
-				groups: [
-					{
-						logicalOperator: 'all',
-						rules: [ { field: 'size_1', operator: 'is', value: 'Large' } ],
+						rules: [ { field: selection, operator, value: expected } ],
 					},
 				],
 			} ),

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/panel.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/panel.test.jsx
@@ -605,7 +605,9 @@ describe( 'ConditionalLogicPanel', () => {
 				groups: [
 					{
 						logicalOperator: 'all',
-						rules: [ { field: 'untitled-field', operator: 'is', value: '' } ],
+						// The value rides along: both subjects compare textually, so what was
+						// already typed still says something about the new one.
+						rules: [ { field: 'untitled-field', operator: 'is', value: 'x' } ],
 					},
 				],
 			} ),
@@ -646,6 +648,70 @@ describe( 'ConditionalLogicPanel', () => {
 					{
 						logicalOperator: 'all',
 						rules: [ { field: 'budget_1', operator: 'equals', value: '' } ],
+					},
+				],
+			} ),
+		} );
+	} );
+
+	/**
+	 * The value box is offered before a subject has been chosen, so filling it in first is a
+	 * natural order to work in -- and choosing the subject used to wipe it, sending the author
+	 * back to retype what they had just entered.
+	 */
+	it( 'keeps a value typed before the subject was chosen', async () => {
+		const { setAttributes } = await setup(
+			withRules( [ { field: '', operator: 'is', value: 'iPhone' } ] )
+		);
+
+		await userEvent.selectOptions( screen.getByLabelText( 'Field' ), 'name_1' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			conditionalLogic: expect.objectContaining( {
+				groups: [
+					{
+						logicalOperator: 'all',
+						rules: [ { field: 'name_1', operator: 'is', value: 'iPhone' } ],
+					},
+				],
+			} ),
+		} );
+	} );
+
+	// Kept only where the new subject can actually show it. A checkbox compares against
+	// nothing, so the value has to go rather than sit in the rule out of sight.
+	it( 'drops the typed value for a subject that takes none', async () => {
+		const { setAttributes } = await setup(
+			withRules( [ { field: '', operator: 'is', value: 'iPhone' } ] )
+		);
+
+		await userEvent.selectOptions( screen.getByLabelText( 'Field' ), 'terms_1' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			conditionalLogic: expect.objectContaining( {
+				groups: [
+					{
+						logicalOperator: 'all',
+						rules: [ { field: 'terms_1', operator: 'is_checked', value: '' } ],
+					},
+				],
+			} ),
+		} );
+	} );
+
+	it( 'keeps the typed value for a dropdown subject that offers it', async () => {
+		const { setAttributes } = await setup(
+			withRules( [ { field: '', operator: 'is', value: 'Large' } ] )
+		);
+
+		await userEvent.selectOptions( screen.getByLabelText( 'Field' ), 'size_1' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			conditionalLogic: expect.objectContaining( {
+				groups: [
+					{
+						logicalOperator: 'all',
+						rules: [ { field: 'size_1', operator: 'is', value: 'Large' } ],
 					},
 				],
 			} ),

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/panel.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/panel.test.jsx
@@ -686,6 +686,31 @@ describe( 'ConditionalLogicPanel', () => {
 		} );
 	} );
 
+	/**
+	 * Clearing the subject puts the row back where it started, which is a place the value box
+	 * is still offered -- so wiping the value would throw away something the author can still
+	 * see and is still allowed to type. It is representability that decides, and there is no
+	 * subject yet to decide it against.
+	 */
+	it( 'keeps the value when the subject is cleared again', async () => {
+		const { setAttributes } = await setup(
+			withRules( [ { field: 'name_1', operator: 'is', value: 'iPhone' } ] )
+		);
+
+		await userEvent.selectOptions( screen.getByLabelText( 'Field' ), '' );
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			conditionalLogic: expect.objectContaining( {
+				groups: [
+					{
+						logicalOperator: 'all',
+						rules: [ { field: '', operator: 'is', value: 'iPhone' } ],
+					},
+				],
+			} ),
+		} );
+	} );
+
 	it( 'removes a condition', async () => {
 		const { setAttributes } = await setup(
 			withRules( [

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/panel.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/panel.test.jsx
@@ -546,6 +546,32 @@ describe( 'ConditionalLogicPanel', () => {
 		expect( screen.getByRole( 'button', { name: 'Add condition' } ) ).toBeEnabled();
 	} );
 
+	/**
+	 * The builder opens with one empty condition waiting to be filled in, and that row used to
+	 * greet an author with the amber caution icon -- a warning about something they had not
+	 * done yet, which reads as an error before you have touched anything. Amber is kept for
+	 * the case it was meant for: a condition begun and left unfinished.
+	 */
+	it( 'stays neutral on a condition nobody has started', async () => {
+		await setup( withRules( [] ) );
+
+		const status = screen.getByLabelText( 'Choose a field to compare against.' );
+
+		// The class the muted colour hangs off, and the same condition that chooses
+		// between the draft icon and the caution icon.
+		expect( status ).toHaveClass( 'is-unstarted' );
+		expect( status ).not.toHaveClass( 'is-active' );
+	} );
+
+	it( 'warns once a condition has been started and left unfinished', async () => {
+		await setup( withRules( [ { field: 'name_1', operator: 'is', value: '' } ] ) );
+
+		const status = screen.getByLabelText( 'Give this condition a value.' );
+
+		expect( status ).not.toHaveClass( 'is-unstarted' );
+		expect( status ).not.toHaveClass( 'is-active' );
+	} );
+
 	it( 'marks a complete condition as active', async () => {
 		await setup( withRules( [ { field: 'name_1', operator: 'is', value: 'x' } ] ) );
 

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/panel.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/panel.test.jsx
@@ -546,19 +546,13 @@ describe( 'ConditionalLogicPanel', () => {
 		expect( screen.getByRole( 'button', { name: 'Add condition' } ) ).toBeEnabled();
 	} );
 
-	/**
-	 * The builder opens with one empty condition waiting to be filled in, and that row used to
-	 * greet an author with the amber caution icon -- a warning about something they had not
-	 * done yet, which reads as an error before you have touched anything. Amber is kept for
-	 * the case it was meant for: a condition begun and left unfinished.
-	 */
+	// The builder opens with one empty row, so amber there warned about something the author
+	// had not done yet. It is kept for a condition begun and left unfinished.
 	it( 'stays neutral on a condition nobody has started', async () => {
 		await setup( withRules( [] ) );
 
 		const status = screen.getByLabelText( 'Choose a field to compare against.' );
 
-		// The class the muted colour hangs off, and the same condition that chooses
-		// between the draft icon and the caution icon.
 		expect( status ).toHaveClass( 'is-unstarted' );
 		expect( status ).not.toHaveClass( 'is-active' );
 	} );
@@ -605,8 +599,7 @@ describe( 'ConditionalLogicPanel', () => {
 				groups: [
 					{
 						logicalOperator: 'all',
-						// The value rides along: both subjects compare textually, so what was
-						// already typed still says something about the new one.
+						// Carried over: both subjects compare textually.
 						rules: [ { field: 'untitled-field', operator: 'is', value: 'x' } ],
 					},
 				],
@@ -654,11 +647,8 @@ describe( 'ConditionalLogicPanel', () => {
 		} );
 	} );
 
-	/**
-	 * The value box is offered before a subject has been chosen, so filling it in first is a
-	 * natural order to work in -- and choosing the subject used to wipe it, sending the author
-	 * back to retype what they had just entered.
-	 */
+	// The value box is offered before a subject is chosen, so filling it in first is a normal
+	// order to work in -- and choosing the subject used to wipe it.
 	it( 'keeps a value typed before the subject was chosen', async () => {
 		const { setAttributes } = await setup(
 			withRules( [ { field: '', operator: 'is', value: 'iPhone' } ] )
@@ -678,8 +668,7 @@ describe( 'ConditionalLogicPanel', () => {
 		} );
 	} );
 
-	// Kept only where the new subject can actually show it. A checkbox compares against
-	// nothing, so the value has to go rather than sit in the rule out of sight.
+	// A checkbox compares against nothing, so the value has to go rather than sit out of sight.
 	it( 'drops the typed value for a subject that takes none', async () => {
 		const { setAttributes } = await setup(
 			withRules( [ { field: '', operator: 'is', value: 'iPhone' } ] )

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/use-subject-fields.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/use-subject-fields.test.jsx
@@ -47,6 +47,7 @@ await jest.unstable_mockModule( '../../../../../src/blocks/contact-form/child-bl
 	childBlocks: [
 		{ name: 'field-text', conditional_logic: { type: 'string' } },
 		{ name: 'field-select', conditional_logic: { type: 'choice' } },
+		{ name: 'field-checkbox', conditional_logic: { type: 'boolean' } },
 	],
 } ) );
 
@@ -57,19 +58,35 @@ const { default: useSubjectFields, useEnsureFieldId } = await import(
 /**
  * A field block, optionally carrying a label block and an explicit id.
  *
- * @param {string} clientId        - Block client id.
- * @param {object} [options]       - Field options.
- * @param {string} [options.label] - Text of the field's label block, if it has one.
- * @param {string} [options.id]    - Explicit field id, if the field carries one.
- * @param {string} [options.name]  - Block name; defaults to a text field.
+ * @param {string} clientId         - Block client id.
+ * @param {object} [options]        - Field options.
+ * @param {string} [options.label]  - Text of the field's label block, if it has one.
+ * @param {string} [options.id]     - Explicit field id, if the field carries one.
+ * @param {string} [options.name]   - Block name; defaults to a text field.
+ * @param {string} [options.option] - Text of a standalone `jetpack/option` inner block, which
+ *                                  is where a checkbox or consent field keeps its label.
  * @return {object} A block instance shaped the way the store returns them.
  */
-const field = ( clientId, { label, id, name = 'jetpack/field-text' } = {} ) => ( {
-	clientId,
-	name,
-	attributes: id ? { id } : {},
-	innerBlocks: label ? [ { name: 'jetpack/label', attributes: { label } } ] : [],
-} );
+const field = ( clientId, { label, id, option, name = 'jetpack/field-text' } = {} ) => {
+	const innerBlocks = [];
+
+	if ( label ) {
+		innerBlocks.push( { name: 'jetpack/label', attributes: { label } } );
+	}
+	if ( option ) {
+		innerBlocks.push( {
+			name: 'jetpack/option',
+			attributes: { label: option, isStandalone: true },
+		} );
+	}
+
+	return {
+		clientId,
+		name,
+		attributes: id ? { id } : {},
+		innerBlocks,
+	};
+};
 
 const ensureFieldId = () => renderHook( () => useEnsureFieldId() ).result.current;
 const subjectsFor = clientId => renderHook( () => useSubjectFields( clientId ) ).result.current;
@@ -212,6 +229,89 @@ describe( 'useSubjectFields', () => {
 			'c-labelled': 'Budget',
 			'c-id-only': 'total_1',
 			'c-bare': 'Untitled field',
+		} );
+	} );
+
+	/**
+	 * A checkbox and a consent field keep their inline label on the standalone
+	 * `jetpack/option` their template inserts, not on a `jetpack/label` block. Reading only
+	 * `jetpack/label` reported every one of them as "Untitled field" however carefully it had
+	 * been named, which is unusable in a form holding more than one.
+	 */
+	it( 'reads a checkbox label from its standalone option block', () => {
+		blocks = {
+			form: {
+				clientId: 'form',
+				name: 'jetpack/contact-form',
+				innerBlocks: [
+					field( 'c-consent', {
+						name: 'jetpack/field-checkbox',
+						option: 'Send me a copy',
+					} ),
+				],
+			},
+		};
+		rootOf = { 'c-owner': 'form' };
+
+		expect( subjectsFor( 'c-owner' )[ 0 ].label ).toBe( 'Send me a copy' );
+	} );
+
+	// The choice fields nest their options one level down under a `jetpack/options` wrapper,
+	// so only a direct child can be the field's own inline label.
+	it( 'ignores option blocks nested under an options wrapper', () => {
+		blocks = {
+			form: {
+				clientId: 'form',
+				name: 'jetpack/contact-form',
+				innerBlocks: [
+					{
+						clientId: 'c-choice',
+						name: 'jetpack/field-select',
+						attributes: {},
+						innerBlocks: [
+							{
+								name: 'jetpack/options',
+								innerBlocks: [ { name: 'jetpack/option', attributes: { label: 'Red' } } ],
+							},
+						],
+					},
+				],
+			},
+		};
+		rootOf = { 'c-owner': 'form' };
+
+		expect( subjectsFor( 'c-owner' )[ 0 ].label ).toBe( 'Untitled field' );
+	} );
+
+	/**
+	 * Choosing an unnamed field mints it an id from whatever this hook called it -- and that
+	 * used to be the placeholder, so the field was renamed from "Untitled field" to
+	 * "untitled-field" inside the dropdown it had just been picked from. The builder and the
+	 * inspector summary then appeared to name two different fields.
+	 */
+	it( 'does not show an id minted from the placeholder as the label', () => {
+		blocks = {
+			form: {
+				clientId: 'form',
+				name: 'jetpack/contact-form',
+				innerBlocks: [
+					field( 'c-first', { id: 'untitled-field' } ),
+					field( 'c-second', { id: 'untitled-field-2' } ),
+					field( 'c-author-named', { id: 'untitled-field-ish' } ),
+				],
+			},
+		};
+		rootOf = { 'c-owner': 'form' };
+
+		const labels = Object.fromEntries(
+			subjectsFor( 'c-owner' ).map( entry => [ entry.clientId, entry.label ] )
+		);
+
+		expect( labels ).toEqual( {
+			'c-first': 'Untitled field',
+			'c-second': 'Untitled field',
+			// Not one this panel could have minted, so it is the author's and still shown.
+			'c-author-named': 'untitled-field-ish',
 		} );
 	} );
 

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/use-subject-fields.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/use-subject-fields.test.jsx
@@ -63,8 +63,7 @@ const { default: useSubjectFields, useEnsureFieldId } = await import(
  * @param {string} [options.label]  - Text of the field's label block, if it has one.
  * @param {string} [options.id]     - Explicit field id, if the field carries one.
  * @param {string} [options.name]   - Block name; defaults to a text field.
- * @param {string} [options.option] - Text of a standalone `jetpack/option` inner block, which
- *                                  is where a checkbox or consent field keeps its label.
+ * @param {string} [options.option] - Text of a standalone `jetpack/option` inner block.
  * @return {object} A block instance shaped the way the store returns them.
  */
 const field = ( clientId, { label, id, option, name = 'jetpack/field-text' } = {} ) => {
@@ -232,12 +231,8 @@ describe( 'useSubjectFields', () => {
 		} );
 	} );
 
-	/**
-	 * A checkbox and a consent field keep their inline label on the standalone
-	 * `jetpack/option` their template inserts, not on a `jetpack/label` block. Reading only
-	 * `jetpack/label` reported every one of them as "Untitled field" however carefully it had
-	 * been named, which is unusable in a form holding more than one.
-	 */
+	// A checkbox and a consent field keep their inline label on the standalone `jetpack/option`
+	// their template inserts, not on a `jetpack/label` block.
 	it( 'reads a checkbox label from its standalone option block', () => {
 		blocks = {
 			form: {
@@ -256,8 +251,8 @@ describe( 'useSubjectFields', () => {
 		expect( subjectsFor( 'c-owner' )[ 0 ].label ).toBe( 'Send me a copy' );
 	} );
 
-	// The choice fields nest their options one level down under a `jetpack/options` wrapper,
-	// so only a direct child can be the field's own inline label.
+	// The choice fields nest theirs under a `jetpack/options` wrapper, so only a direct child
+	// can be the field's own inline label.
 	it( 'ignores option blocks nested under an options wrapper', () => {
 		blocks = {
 			form: {
@@ -283,12 +278,8 @@ describe( 'useSubjectFields', () => {
 		expect( subjectsFor( 'c-owner' )[ 0 ].label ).toBe( 'Untitled field' );
 	} );
 
-	/**
-	 * Choosing an unnamed field mints it an id from whatever this hook called it -- and that
-	 * used to be the placeholder, so the field was renamed from "Untitled field" to
-	 * "untitled-field" inside the dropdown it had just been picked from. The builder and the
-	 * inspector summary then appeared to name two different fields.
-	 */
+	// Choosing an unnamed field mints it an id from whatever this hook called it, so a
+	// placeholder-derived one would rename the field inside the dropdown it was picked from.
 	it( 'does not show an id minted from the placeholder as the label', () => {
 		blocks = {
 			form: {

--- a/projects/packages/forms/tests/js/dashboard/components/field-preview/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/field-preview/index.test.jsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import FieldPreview from '../../../../../src/dashboard/components/inspector/response-fields/field-preview/index.tsx';
+
+const noop = () => () => {};
+
+const preview = field => render( <FieldPreview field={ field } onFilePreview={ noop } /> );
+
+/**
+ * The path the checkmark is drawn with, so only the ticked icon carries it. Both icons are
+ * `aria-hidden`, which is right -- the value beside them says the same thing -- and leaves no
+ * accessible query to reach them. `Contact_Form_Test` pins the server-rendered pair against
+ * this same path.
+ */
+const CHECKMARK_PATH = 'M10.5171 16.4421';
+
+/**
+ * How a stored answer reads in the response detail pane.
+ *
+ * The gap this covers: an unticked checkbox submits nothing, so it fell through to the dash
+ * that means "nothing was answered" -- but the respondent did answer, and the email renderer
+ * has always said "No" here.
+ */
+describe( 'FieldPreview', () => {
+	it( 'names the answer an unticked checkbox gave', () => {
+		preview( { label: 'Send me a copy', value: '', type: 'checkbox' } );
+
+		expect( screen.getByText( 'No' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '-' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'leaves a ticked checkbox showing what was submitted', () => {
+		preview( { label: 'Send me a copy', value: 'Yes', type: 'checkbox' } );
+
+		expect( screen.getByText( 'Yes' ) ).toBeInTheDocument();
+	} );
+
+	// The icon and the value are two views of one answer, and the component now reads that
+	// answer once and hands the verdict to both -- so a mistake there moves them apart.
+	it( 'gives a ticked and an unticked checkbox different icons', () => {
+		const { container: unticked } = preview( {
+			label: 'Send me a copy',
+			value: '',
+			type: 'checkbox',
+		} );
+		const { container: ticked } = preview( {
+			label: 'Send me a copy',
+			value: 'Yes',
+			type: 'checkbox',
+		} );
+
+		expect( ticked.innerHTML ).toContain( CHECKMARK_PATH );
+		expect( unticked.innerHTML ).not.toContain( CHECKMARK_PATH );
+	} );
+
+	// Only the checkbox is treated this way: an empty text field really is unanswered.
+	it( 'still shows a dash for a field nobody answered', () => {
+		preview( { label: 'Name', value: '', type: 'text' } );
+
+		expect( screen.getByText( '-' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/forms/tests/js/modules/form/field-type-icons-view.test.js
+++ b/projects/packages/forms/tests/js/modules/form/field-type-icons-view.test.js
@@ -43,7 +43,7 @@ describe( 'watchFieldTypeIcon', () => {
 	} );
 
 	test( 'renders the icon for an AJAX submission', () => {
-		const ref = run( { innerHTML: '', dataset: {} }, { type: 'checkbox', value: 'Yes' } );
+		const ref = run( { innerHTML: '', dataset: {} }, { type: 'checkbox', rawValue: 'Yes' } );
 
 		expect( ref.dataset.renderedType ).toBe( 'checkbox' );
 		expect( ref.innerHTML ).toBe( getFieldTypeIconHtml( 'checkbox', 'Yes' ) );
@@ -52,7 +52,7 @@ describe( 'watchFieldTypeIcon', () => {
 	test( 'keeps a server-rendered icon whose key already matches', () => {
 		const ref = run(
 			{ innerHTML: '<svg data-server-rendered />', dataset: { renderedType: 'checkbox' } },
-			{ type: 'checkbox', value: 'Yes' }
+			{ type: 'checkbox', rawValue: 'Yes' }
 		);
 
 		expect( ref.innerHTML ).toBe( '<svg data-server-rendered />' );
@@ -63,12 +63,26 @@ describe( 'watchFieldTypeIcon', () => {
 		// checkbox must not inherit a ticked icon left over from a previous render.
 		const ref = run(
 			{ innerHTML: '<svg data-stale />', dataset: { renderedType: 'checkbox' } },
-			{ type: 'checkbox', value: '' }
+			{ type: 'checkbox', rawValue: '' }
 		);
 
 		expect( ref.dataset.renderedType ).toBe( 'checkbox:unchecked' );
 		expect( ref.innerHTML ).toBe( getFieldTypeIconHtml( 'checkbox', '' ) );
 		expect( getFieldTypeIconKey( 'checkbox', '' ) ).toBe( 'checkbox:unchecked' );
+	} );
+
+	/**
+	 * The printed label is localized; the answer is not. `isCheckedValue()` recognizes only
+	 * the ASCII `no` sentinel, so keying the icon off the label rendered the ticked box beside
+	 * the word for "no" in every locale whose word for it is not "no".
+	 */
+	test( 'keys off the submitted answer, not the localized label', () => {
+		const ref = run(
+			{ innerHTML: '', dataset: {} },
+			{ type: 'checkbox', value: 'Non', rawValue: '' }
+		);
+
+		expect( ref.dataset.renderedType ).toBe( 'checkbox:unchecked' );
 	} );
 
 	test( 'falls back to the text icon when the submission has no type', () => {

--- a/projects/packages/forms/tests/js/modules/form/helpers.test.js
+++ b/projects/packages/forms/tests/js/modules/form/helpers.test.js
@@ -1,5 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
-import { getSubmissionDisplayValue, isCheckedValue } from '../../../../src/modules/form/helpers.js';
+import {
+	getSubmissionDisplayValue,
+	isCheckedValue,
+	maybeAddColonToLabel,
+	maybeTransformValue,
+} from '../../../../src/modules/form/helpers.js';
 
 /**
  * The confirmation summary an AJAX submission builds in the browser. It has to produce the
@@ -43,5 +48,79 @@ describe( 'getSubmissionDisplayValue', () => {
 	it( 'leaves every other field type alone', () => {
 		expect( getSubmissionDisplayValue( '', 'text', 'No' ) ).toBe( '' );
 		expect( getSubmissionDisplayValue( '', 'consent', 'No' ) ).toBe( '' );
+	} );
+} );
+
+/**
+ * The shapes a stored field value arrives in, flattened to the one line a summary shows.
+ *
+ * Covered directly rather than through view.test.js's local copy of `setSubmissionData`,
+ * which reimplements the surrounding logic and cannot be trusted to track this.
+ */
+describe( 'maybeTransformValue', () => {
+	it( 'lists an image-select answer by its perceived values', () => {
+		expect(
+			maybeTransformValue( {
+				type: 'image-select',
+				choices: [ { perceived: 'A' }, { perceived: 'B' } ],
+			} )
+		).toBe( 'A, B' );
+	} );
+
+	// The choices can be shuffled per respondent, so the perceived letter is what identifies
+	// one; the label is appended only where the field is set to show labels.
+	it( 'appends an image label only when the field shows labels', () => {
+		expect(
+			maybeTransformValue( {
+				type: 'image-select',
+				choices: [
+					{ perceived: 'A', showLabels: true, label: 'Bold' },
+					{ perceived: 'B', showLabels: true, label: '' },
+					{ perceived: 'C', showLabels: false, label: 'Hidden' },
+				],
+			} )
+		).toBe( 'A - Bold, B, C' );
+	} );
+
+	it( 'unwraps a url field to its url', () => {
+		expect( maybeTransformValue( { type: 'url', url: 'https://example.com' } ) ).toBe(
+			'https://example.com'
+		);
+	} );
+
+	it( 'shows a rating by its display value', () => {
+		expect( maybeTransformValue( { type: 'rating', value: 3, displayValue: '3/5' } ) ).toBe(
+			'3/5'
+		);
+	} );
+
+	it( 'shows an uploaded file by name and size', () => {
+		expect( maybeTransformValue( { name: 'notes.pdf', size: '2 MB' } ) ).toBe( 'notes.pdf (2 MB)' );
+	} );
+
+	it( 'passes anything else through untouched', () => {
+		expect( maybeTransformValue( 'Ada' ) ).toBe( 'Ada' );
+		expect( maybeTransformValue( '' ) ).toBe( '' );
+		expect( maybeTransformValue( null ) ).toBeNull();
+	} );
+} );
+
+describe( 'maybeAddColonToLabel', () => {
+	it( 'ends a label with a colon', () => {
+		expect( maybeAddColonToLabel( 'Name' ) ).toBe( 'Name:' );
+	} );
+
+	// The Terms consent block's text ends in a period, and a question keeps its mark.
+	it( 'replaces a trailing period and leaves a question alone', () => {
+		expect( maybeAddColonToLabel( 'I agree to the terms.' ) ).toBe( 'I agree to the terms:' );
+		expect( maybeAddColonToLabel( 'Already a colon:' ) ).toBe( 'Already a colon:' );
+		expect( maybeAddColonToLabel( 'How did you hear about us?' ) ).toBe(
+			'How did you hear about us?'
+		);
+	} );
+
+	it( 'has nothing to punctuate for an empty label', () => {
+		expect( maybeAddColonToLabel( '' ) ).toBeNull();
+		expect( maybeAddColonToLabel( undefined ) ).toBeNull();
 	} );
 } );

--- a/projects/packages/forms/tests/js/modules/form/helpers.test.js
+++ b/projects/packages/forms/tests/js/modules/form/helpers.test.js
@@ -2,11 +2,9 @@ import { describe, expect, it } from '@jest/globals';
 import { getSubmissionDisplayValue, isCheckedValue } from '../../../../src/modules/form/helpers.js';
 
 /**
- * The confirmation summary an AJAX submission builds in the browser.
- *
- * It has to produce the same strings `Contact_Form::get_submission_display_value()` rendered
- * server-side: the Interactivity API hydrates over that markup, so a disagreement shows up as
- * the summary changing under the respondent a moment after it appears.
+ * The confirmation summary an AJAX submission builds in the browser. It has to produce the
+ * same strings `Contact_Form::get_submission_display_value()` rendered server-side, or the
+ * summary changes as the Interactivity API hydrates over it.
  */
 describe( 'isCheckedValue', () => {
 	it( 'treats a submitted answer as ticked', () => {

--- a/projects/packages/forms/tests/js/modules/form/helpers.test.js
+++ b/projects/packages/forms/tests/js/modules/form/helpers.test.js
@@ -1,0 +1,49 @@
+import { describe, expect, it } from '@jest/globals';
+import { getSubmissionDisplayValue, isCheckedValue } from '../../../../src/modules/form/helpers.js';
+
+/**
+ * The confirmation summary an AJAX submission builds in the browser.
+ *
+ * It has to produce the same strings `Contact_Form::get_submission_display_value()` rendered
+ * server-side: the Interactivity API hydrates over that markup, so a disagreement shows up as
+ * the summary changing under the respondent a moment after it appears.
+ */
+describe( 'isCheckedValue', () => {
+	it( 'treats a submitted answer as ticked', () => {
+		expect( isCheckedValue( 'Yes' ) ).toBe( true );
+		expect( isCheckedValue( [ 'a' ] ) ).toBe( true );
+	} );
+
+	// An unticked box submits nothing at all; older stored responses carry an explicit "No".
+	it( 'treats an empty value or an explicit no as unticked', () => {
+		expect( isCheckedValue( '' ) ).toBe( false );
+		expect( isCheckedValue( '   ' ) ).toBe( false );
+		expect( isCheckedValue( 'No' ) ).toBe( false );
+		expect( isCheckedValue( '0' ) ).toBe( false );
+		expect( isCheckedValue( null ) ).toBe( false );
+		expect( isCheckedValue( undefined ) ).toBe( false );
+		expect( isCheckedValue( [] ) ).toBe( false );
+	} );
+} );
+
+describe( 'getSubmissionDisplayValue', () => {
+	/**
+	 * The gap this closes: an unticked checkbox used to draw its label over a blank line,
+	 * which reads as a field that failed to record rather than as the answer "no".
+	 */
+	it( 'names the answer an unticked checkbox gave', () => {
+		expect( getSubmissionDisplayValue( '', 'checkbox', 'No' ) ).toBe( 'No' );
+		expect( getSubmissionDisplayValue( undefined, 'checkbox', 'No' ) ).toBe( 'No' );
+	} );
+
+	it( 'leaves a ticked checkbox showing what was submitted', () => {
+		expect( getSubmissionDisplayValue( 'Yes', 'checkbox', 'No' ) ).toBe( 'Yes' );
+	} );
+
+	// Only the checkbox is treated this way. An empty text field really is unanswered, and
+	// consent keeps its own wording.
+	it( 'leaves every other field type alone', () => {
+		expect( getSubmissionDisplayValue( '', 'text', 'No' ) ).toBe( '' );
+		expect( getSubmissionDisplayValue( '', 'consent', 'No' ) ).toBe( '' );
+	} );
+} );

--- a/projects/packages/forms/tests/js/modules/form/view.test.js
+++ b/projects/packages/forms/tests/js/modules/form/view.test.js
@@ -1,11 +1,6 @@
 import { describe, expect, test } from '@jest/globals';
 import { getRating } from '../../../../src/modules/field-rating/helpers.js';
-import {
-	maybeAddColonToLabel,
-	maybeTransformValue,
-	getImages,
-	getUrl,
-} from '../../../../src/modules/form/helpers.js';
+import { maybeAddColonToLabel, getImages, getUrl } from '../../../../src/modules/form/helpers.js';
 
 /**
  * Tests for the showPlainValue logic in form submission data formatting.
@@ -17,7 +12,11 @@ import {
 describe( 'Form View - showPlainValue computation', () => {
 	/**
 	 * Formats submission data for display, computing showPlainValue.
-	 * This matches the logic in setSubmissionData from view.js.
+	 * This matches the showPlainValue logic in setSubmissionData from view.js.
+	 *
+	 * The field value is deliberately absent: nothing here asserts it, and carrying a copy of
+	 * how view.js derives it only invites the reader to trust a mirror that is not kept. See
+	 * helpers.test.js for `getSubmissionDisplayValue`.
 	 *
 	 * @param {Array} data - Array of submission data items with label and value.
 	 * @return {Array} Formatted submission data with showPlainValue computed.
@@ -30,7 +29,6 @@ describe( 'Form View - showPlainValue computation', () => {
 
 			return {
 				label: maybeAddColonToLabel( item.label ),
-				value: maybeTransformValue( item.value ),
 				images,
 				url,
 				rating,

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -5110,6 +5110,50 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The confirmation summary picks its checkbox icon from the submitted answer, so the
+	 * answer has to survive alongside the label the summary prints.
+	 *
+	 * `is_checked_value()` recognizes only the ASCII sentinel `no`, so a translated "No" reads
+	 * as ticked -- English passes by coincidence of the sentinel, every other locale renders
+	 * the ticked icon next to the word for "no".
+	 */
+	public function test_format_submission_data_keeps_the_raw_answer_for_the_icon() {
+		$translate = function ( $translation, $text ) {
+			return 'No' === $text ? 'Non' : $translation;
+		};
+		add_filter( 'gettext_jetpack-forms', $translate, 10, 2 );
+
+		$formatted = $this->invoke_private_static(
+			'format_submission_data',
+			array(
+				array(
+					array(
+						'label' => 'Send me a copy',
+						'value' => '',
+						'type'  => 'checkbox',
+					),
+				),
+			)
+		);
+
+		remove_filter( 'gettext_jetpack-forms', $translate, 10 );
+
+		$this->assertSame( 'Non', $formatted[0]['value'], 'the summary prints the translated label' );
+		$this->assertSame( '', $formatted[0]['rawValue'], 'the answer itself is kept for the icon' );
+
+		// What the icon actually keys off, and what it would key off without the split.
+		$this->assertSame(
+			'checkbox:unchecked',
+			$this->invoke_private_static( 'get_field_type_icon_key', array( 'checkbox', $formatted[0]['rawValue'] ) )
+		);
+		$this->assertSame(
+			'checkbox',
+			$this->invoke_private_static( 'get_field_type_icon_key', array( 'checkbox', $formatted[0]['value'] ) ),
+			'the translated label reads as ticked, which is why the raw answer is carried'
+		);
+	}
+
+	/**
 	 * An unticked checkbox submits nothing, so the summary drew the label over a blank line.
 	 * The email renderer has always said "No" here.
 	 */

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -5099,27 +5099,6 @@ class Contact_Form_Test extends BaseTestCase {
 	 * hydration callback, so a checkbox has to key off its answer as well as its
 	 * type. Everything else keys off the type alone.
 	 */
-	/**
-	 * An unticked checkbox submits nothing, so the confirmation summary drew the field's
-	 * label over a blank line -- which reads as a field that failed to record rather than as
-	 * the answer "no". The email renderer has always said "No" here.
-	 */
-	public function test_get_submission_display_value_names_an_unticked_checkbox() {
-		$this->assertSame( 'No', $this->invoke_private_static( 'get_submission_display_value', array( '', 'checkbox' ) ) );
-		$this->assertSame( 'No', $this->invoke_private_static( 'get_submission_display_value', array( null, 'checkbox' ) ) );
-		$this->assertSame( 'No', $this->invoke_private_static( 'get_submission_display_value', array( 'No', 'checkbox' ) ) );
-	}
-
-	public function test_get_submission_display_value_leaves_other_values_alone() {
-		$this->assertSame( 'Yes', $this->invoke_private_static( 'get_submission_display_value', array( 'Yes', 'checkbox' ) ) );
-
-		// Only the checkbox is treated this way: an empty text field really is unanswered,
-		// and consent keeps its own wording.
-		$this->assertSame( '', $this->invoke_private_static( 'get_submission_display_value', array( '', 'text' ) ) );
-		$this->assertSame( '', $this->invoke_private_static( 'get_submission_display_value', array( '', 'consent' ) ) );
-		$this->assertSame( 'Ada', $this->invoke_private_static( 'get_submission_display_value', array( 'Ada', 'text' ) ) );
-	}
-
 	public function test_get_field_type_icon_key_reflects_the_checkbox_answer() {
 		$this->assertSame( 'checkbox', $this->invoke_private_static( 'get_field_type_icon_key', array( 'checkbox', 'Yes' ) ) );
 		$this->assertSame( 'checkbox:unchecked', $this->invoke_private_static( 'get_field_type_icon_key', array( 'checkbox', '' ) ) );
@@ -5128,6 +5107,27 @@ class Contact_Form_Test extends BaseTestCase {
 		// Other types never vary with the value.
 		$this->assertSame( 'text', $this->invoke_private_static( 'get_field_type_icon_key', array( 'text', '' ) ) );
 		$this->assertSame( 'consent', $this->invoke_private_static( 'get_field_type_icon_key', array( 'consent', '' ) ) );
+	}
+
+	/**
+	 * An unticked checkbox submits nothing, so the summary drew the label over a blank line.
+	 * The email renderer has always said "No" here.
+	 */
+	public function test_get_submission_display_value_names_an_unticked_checkbox() {
+		$this->assertSame( 'No', $this->invoke_private_static( 'get_submission_display_value', array( '', 'checkbox' ) ) );
+		$this->assertSame( 'No', $this->invoke_private_static( 'get_submission_display_value', array( null, 'checkbox' ) ) );
+		$this->assertSame( 'No', $this->invoke_private_static( 'get_submission_display_value', array( 'No', 'checkbox' ) ) );
+	}
+
+	/**
+	 * Only the checkbox is treated this way: an empty text field really is unanswered, and
+	 * consent keeps its own wording.
+	 */
+	public function test_get_submission_display_value_leaves_other_values_alone() {
+		$this->assertSame( 'Yes', $this->invoke_private_static( 'get_submission_display_value', array( 'Yes', 'checkbox' ) ) );
+		$this->assertSame( '', $this->invoke_private_static( 'get_submission_display_value', array( '', 'text' ) ) );
+		$this->assertSame( '', $this->invoke_private_static( 'get_submission_display_value', array( '', 'consent' ) ) );
+		$this->assertSame( 'Ada', $this->invoke_private_static( 'get_submission_display_value', array( 'Ada', 'text' ) ) );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -5099,6 +5099,27 @@ class Contact_Form_Test extends BaseTestCase {
 	 * hydration callback, so a checkbox has to key off its answer as well as its
 	 * type. Everything else keys off the type alone.
 	 */
+	/**
+	 * An unticked checkbox submits nothing, so the confirmation summary drew the field's
+	 * label over a blank line -- which reads as a field that failed to record rather than as
+	 * the answer "no". The email renderer has always said "No" here.
+	 */
+	public function test_get_submission_display_value_names_an_unticked_checkbox() {
+		$this->assertSame( 'No', $this->invoke_private_static( 'get_submission_display_value', array( '', 'checkbox' ) ) );
+		$this->assertSame( 'No', $this->invoke_private_static( 'get_submission_display_value', array( null, 'checkbox' ) ) );
+		$this->assertSame( 'No', $this->invoke_private_static( 'get_submission_display_value', array( 'No', 'checkbox' ) ) );
+	}
+
+	public function test_get_submission_display_value_leaves_other_values_alone() {
+		$this->assertSame( 'Yes', $this->invoke_private_static( 'get_submission_display_value', array( 'Yes', 'checkbox' ) ) );
+
+		// Only the checkbox is treated this way: an empty text field really is unanswered,
+		// and consent keeps its own wording.
+		$this->assertSame( '', $this->invoke_private_static( 'get_submission_display_value', array( '', 'text' ) ) );
+		$this->assertSame( '', $this->invoke_private_static( 'get_submission_display_value', array( '', 'consent' ) ) );
+		$this->assertSame( 'Ada', $this->invoke_private_static( 'get_submission_display_value', array( 'Ada', 'text' ) ) );
+	}
+
 	public function test_get_field_type_icon_key_reflects_the_checkbox_answer() {
 		$this->assertSame( 'checkbox', $this->invoke_private_static( 'get_field_type_icon_key', array( 'checkbox', 'Yes' ) ) );
 		$this->assertSame( 'checkbox:unchecked', $this->invoke_private_static( 'get_field_type_icon_key', array( 'checkbox', '' ) ) );

--- a/projects/plugins/jetpack/changelog/fix-forms-conditional-logic-feedback
+++ b/projects/plugins/jetpack/changelog/fix-forms-conditional-logic-feedback
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Forms: name a checkbox by its own label when building conditional logic, and show an unanswered checkbox as "No" rather than a blank.
+Forms: name a checkbox by its own label when building conditional logic, keep a value typed before the field was chosen, and show an unanswered checkbox as "No" rather than a blank.

--- a/projects/plugins/jetpack/changelog/fix-forms-conditional-logic-feedback
+++ b/projects/plugins/jetpack/changelog/fix-forms-conditional-logic-feedback
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Forms: name a checkbox by its own label when building conditional logic, keep a value typed before the field was chosen, and show an unanswered checkbox as "No" rather than a blank.
+Forms: Name a checkbox by its own label when building conditional logic, keep a value typed before the field was chosen, and show an unticked checkbox as "No" rather than a blank.

--- a/projects/plugins/jetpack/changelog/fix-forms-conditional-logic-feedback
+++ b/projects/plugins/jetpack/changelog/fix-forms-conditional-logic-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: name a checkbox by its own label when building conditional logic, and show an unanswered checkbox as "No" rather than a blank.


### PR DESCRIPTION
Fixes #

## Proposed changes

Follow-up to the conditional logic review. Four things the reviewer raised, all display-level — the evaluators themselves were behaving as designed.

* **A checkbox showed as "Untitled field" in the conditions dropdown, however carefully it was named.** `getFieldLabel()` only read a `jetpack/label` inner block, but a checkbox and a consent field keep their inline label on the standalone `jetpack/option` their template inserts. It now reads a *direct* `jetpack/option` child — the choice fields nest theirs under a `jetpack/options` wrapper, so this cannot pick up a dropdown's first choice by mistake.
* **Choosing an unnamed field renamed it inside the dropdown it had just been picked from.** The same function fell back to `block.attributes.id` *before* the placeholder, and picking a field mints it an id slugified from whatever the panel called it — so `Untitled field` became `untitled-field`, and the builder and the inspector summary appeared to name two different fields. An id matching `untitled-field` (or `untitled-field-N`) is now treated as one this panel minted, and the placeholder wins. An author-set id is still shown.
* **The amber icon greeted you before you had touched anything.** The builder opens with one empty condition waiting, and warning about it reads as an error. Three states now: the draft icon while a condition has no subject, amber once one has been started and left unfinished — the only case where a field silently will not react — and the published icon when it is complete.
* **Typing the value before choosing the field threw the value away.** The value box is offered before a subject has been picked, so filling it in first is a natural order to work in — but choosing the subject sent `value: ''` unconditionally, and the author had to retype what they had just entered. The value is now kept whenever the new subject can still represent it, and dropped when it cannot: a checkbox compares against nothing, a dropdown can only show one of its own options, a number box only a number, and a date or time input renders nothing at all for a value outside its format. Dropping those matters as much as keeping the rest — a value the control cannot show would sit in the rule invisibly while the evaluators went on comparing against it. This also applies when the subject is *changed*, so correcting a field choice no longer costs the value either.
* **An unticked checkbox came out as a dash in the inbox and a blank line in the confirmation.** It submits nothing, so it fell through to the placeholder used for a field with no answer — but the respondent did answer. The email renderer has always said "No" here; the confirmation summary and the response detail now say it too.

Only the checkbox is treated this way. An empty text field really is unanswered, and `consent` and `checkbox-multiple` keep their own wording — same scope as #51293, which this builds on.

Two things deliberately left alone, both noted rather than fixed:

* `formatFieldValue()` in `use-inbox-data.ts` still renders `-`. It builds a flat name→value map with no field type in scope, so it genuinely cannot tell an unticked checkbox from an unanswered text field.
* The reviewer's behavioural observations were all correct as designed: collapsing a whole chain when its root condition stops matching, a hidden required field not blocking submit, and a hidden field's value not reaching the confirmation or the inbox.

`isCheckedValue()` and the new `getSubmissionDisplayValue()` live in `modules/form/helpers.js` — the file that exists to be testable without the Interactivity API. The unticked label is translated in PHP and passed through `wp_interactivity_config()`, because a script module carries no i18n dependency and the string has to match the server-rendered markup or hydration rewrites it under the respondent.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Conditional logic is behind a feature flag that defaults off, so a plain site shows nothing. Enable it with a mu-plugin:

```php
<?php
add_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
```

Then, on a page with a form:

* Add a **Checkbox** field and give its inline label some text — say "Send me a copy". Add a **Text** field below it.
* Select the text field, open **Conditional logic** in the inspector, and press **Add conditions**. The row that greets you should carry the draft icon, not an amber warning.
* Type a value into the **Value** box *first*, then pick a field from the dropdown. The value should still be there. Picking the checkbox instead should clear it, since `is checked` compares against nothing.
* Open the field dropdown. The checkbox should be listed by its own label — `Send me a copy (Checkbox)` — not as `Untitled field (Checkbox)`. Pick it; the name must not change once selected, and the inspector summary behind the dialog should say the same thing.
* Leave a condition half-finished (subject chosen, no value) and confirm the icon turns amber; complete it and confirm it turns green.
* View the page, leave the checkbox unticked, and submit. The confirmation summary should read `Send me a copy: No` rather than showing the label over a blank line.
* Open that response in **Jetpack → Forms**. The checkbox should carry a `No` badge, not a dash.

### Real-screen before / after

Captured on a live Jurassic Ninja site at 1440×900. "Before" is `trunk` with the same form and the same stored response.

**Conditions dialog — a rule whose subject is a checkbox**

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-conditional-logic-feedback/before-rules-dialog.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-conditional-logic-feedback/after-rules-dialog.png) |

**A condition nobody has started yet**

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-conditional-logic-feedback/before-blank-rule.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-conditional-logic-feedback/after-blank-rule.png) |

**Response detail — an unticked checkbox**

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-conditional-logic-feedback/before-inbox.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-conditional-logic-feedback/after-inbox.png) |

**Confirmation summary — the same submission**

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-conditional-logic-feedback/before-confirmation.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-conditional-logic-feedback/after-confirmation.png) |

