### PR TITLE
Newsletters: backport changes from version 0.12.5 to trunk 

### DIFF
--- a/projects/packages/newsletter/CHANGELOG.md
+++ b/projects/packages/newsletter/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.5] - 2026-08-20
+### Changed
+- Update package dependencies. [#51190] [#51399]
+
+### Fixed
+- Make newsletter settings save feedback consistent and allow sender settings to save with Enter. [#51261]
+- Newsletter: Fix a fatal error on the settings page caused by Gutenberg removing a private API that DataViews toggle and radio fields relied on. [#51363]
+- Normalize spacing in Newsletter settings cards. [#51264]
+
 ## [0.12.4] - 2026-08-10
 ### Changed
 - Update package dependencies. [#50509] [#51008]
@@ -319,6 +328,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update package dependencies. [#46143]
 
+[0.12.5]: https://github.com/Automattic/jetpack-newsletter/compare/v0.12.4...v0.12.5
 [0.12.4]: https://github.com/Automattic/jetpack-newsletter/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/Automattic/jetpack-newsletter/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/Automattic/jetpack-newsletter/compare/v0.12.1...v0.12.2

--- a/projects/packages/newsletter/changelog/fix-newsletter-settings-save-consistency
+++ b/projects/packages/newsletter/changelog/fix-newsletter-settings-save-consistency
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Make newsletter settings save feedback consistent and allow sender settings to save with Enter.

--- a/projects/packages/newsletter/changelog/force-a-release
+++ b/projects/packages/newsletter/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/newsletter/changelog/nl-831-fix-inconsistent-spacing-in-newsletter-sections
+++ b/projects/packages/newsletter/changelog/nl-831-fix-inconsistent-spacing-in-newsletter-sections
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Normalize spacing in Newsletter settings cards.

--- a/projects/packages/newsletter/changelog/renovate-concurrently-10.x
+++ b/projects/packages/newsletter/changelog/renovate-concurrently-10.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/newsletter/changelog/update-jetpack-2277
+++ b/projects/packages/newsletter/changelog/update-jetpack-2277
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Newsletter: Fix a fatal error on the settings page caused by Gutenberg removing a private API that DataViews toggle and radio fields relied on.

--- a/projects/packages/newsletter/package.json
+++ b/projects/packages/newsletter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-newsletter",
-	"version": "0.12.4",
+	"version": "0.12.5",
 	"private": true,
 	"description": "Jetpack Newsletter functionality",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/newsletter/#readme",

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -21,7 +21,7 @@ use Jetpack_Tracks_Client;
  */
 class Settings {
 
-	const PACKAGE_VERSION = '0.12.4';
+	const PACKAGE_VERSION = '0.12.5';
 
 	const ADMIN_PAGE_SLUG = 'jetpack-newsletter';
 


### PR DESCRIPTION
## Proposed changes

Backport changes from the 0.12.5 bug fix release:

- Make newsletter settings save feedback consistent and allow sender settings to save with Enter. [#51261]
- Newsletter: Fix a fatal error on the settings page caused by Gutenberg removing a private API that DataViews toggle and radio fields relied on. [#51363]
- Normalize spacing in Newsletter settings cards. [#51264]

## Related product discussion/links

p1787065816520129-slack-C02NQ4HMJKV

## Does this pull request change what data or activity we track or use?

* No


## Testing instructions

* Is CI happy?