### PR TITLE
Import: harden decoding of imported post meta

### DIFF
--- a/projects/packages/import/changelog/import-harden-post-meta
+++ b/projects/packages/import/changelog/import-harden-post-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Import: harden decoding of imported post meta so values are restored as plain data.

--- a/projects/packages/import/src/endpoints/class-post.php
+++ b/projects/packages/import/src/endpoints/class-post.php
@@ -167,7 +167,7 @@ class Post extends \WP_REST_Posts_Controller {
 		if ( is_array( $metas ) ) {
 			foreach ( $metas as $meta_key => $meta_value ) {
 
-				$meta_value = maybe_unserialize( $meta_value );
+				$meta_value = self::unserialize_no_objects( $meta_value );
 				if ( $meta_key === '_edit_last' ) {
 					update_post_meta( $post_id, $meta_key, $meta_value );
 				} else {
@@ -178,6 +178,50 @@ class Post extends \WP_REST_Posts_Controller {
 				do_action( 'import_post_meta', $post_id, $meta_key, $meta_value );
 			}
 		}
+	}
+
+	/**
+	 * Restore an imported meta value as plain data.
+	 *
+	 * Imported meta is plain data (scalars and arrays), so serialized values are decoded without
+	 * class instantiation and any residual objects are dropped. This matches maybe_unserialize()
+	 * for non-serialized and object-free serialized values.
+	 *
+	 * @param mixed $value The raw meta value.
+	 * @return mixed A plain (object-free) value.
+	 */
+	private static function unserialize_no_objects( $value ) {
+		if ( ! is_string( $value ) || ! is_serialized( $value ) ) {
+			return $value;
+		}
+
+		// maybe_unserialize() decodes with no `allowed_classes`; call unserialize() directly with classes
+		// disallowed so meta is only ever restored as plain data. The is_serialized() guard above and the
+		// @ (warnings on malformed input) mirror maybe_unserialize()'s own behavior.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- allowed_classes => false makes this decode safe.
+		$decoded = @unserialize( trim( $value ), array( 'allowed_classes' => false ) );
+
+		return self::strip_objects( $decoded );
+	}
+
+	/**
+	 * Recursively replace any objects in a decoded value with null.
+	 *
+	 * @param mixed $value Decoded value.
+	 * @return mixed The value with any objects removed.
+	 */
+	private static function strip_objects( $value ) {
+		if ( is_object( $value ) ) {
+			return null;
+		}
+
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $item ) {
+				$value[ $key ] = self::strip_objects( $item );
+			}
+		}
+
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

* The Unified Importer restores post meta from an export and runs `maybe_unserialize()` on each value so serialized values round-trip. `maybe_unserialize()` decodes with no `allowed_classes`, so it can build objects out of the incoming value. Imported meta is always plain data (scalars and arrays), so this decodes serialized meta without class instantiation and drops any residual objects before storing.
* Small refactor: `process_post_meta()` now calls a `unserialize_no_objects()` helper in place of `maybe_unserialize()`. Behavior is unchanged for non-serialized values and for legitimately-serialized (object-free) arrays/scalars.

## Related product discussion/links

* (internal)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Import a post via `POST /wp-json/jetpack/v4/import/posts` (importer enabled, i.e. a connected owner) with a `meta` object whose value is a serialized array of scalars, e.g. attachment metadata. Confirm the meta round-trips unchanged (`get_post_meta()` returns the same array).
* Confirm a `meta` value carrying a serialized object is stored as plain data (no object) rather than being reconstructed.
* Confirm plain (non-serialized) meta values are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)