### PR TITLE
WOOA7S-1937: Match current Stats date range presets

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Date controls: Include the current day in the last-N-day ranges, and count the 12-month range in whole calendar months, to match Jetpack Stats.
+Date controls: Include the current day in the last-N-day ranges, and count the 12-month range in whole calendar months for its dates, its length, the step arrows and the previous period, to match Jetpack Stats.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Date controls: Include the current day in the 7-day and 30-day ranges, and count the 12-month range in whole calendar months, to match Jetpack Stats.
+Date controls: Include the current day in the last-N-day ranges, and count the 12-month range in whole calendar months, to match Jetpack Stats.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Date controls: Include the current day in the last-N-day ranges, and count the 12-month range in whole calendar months for its dates, its length, the step arrows and the previous period, to match Jetpack Stats.
+Date controls: Include the current day in the last-N-day ranges, and count the 12-month range in whole calendar months for its dates, its length and the step arrows, to match Jetpack Stats. The previous period covers the same number of days as the range it compares.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Date controls: Include the current day in the 7-day and 30-day ranges, and count the 12-month range in whole calendar months, to match Jetpack Stats.

--- a/projects/packages/premium-analytics/packages/data/src/defaults/__tests__/get-default-preset.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/defaults/__tests__/get-default-preset.test.ts
@@ -86,3 +86,24 @@ describe( 'getDefaultPreset', () => {
 		expect( getDefaultPreset( '2025-04-01T00:00:00Z' ) ).toBe( 'today' );
 	} );
 } );
+
+describe( 'getDefaultQueryParams - comparison', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.setSystemTime( new Date( '2026-08-20T12:00:00.000Z' ) );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'compares the 12-month preset with the twelve whole months before it', () => {
+		expect( getDefaultQueryParams( true, 'last-12-months' ) ).toMatchObject( {
+			from: '2025-09-01T00:00:00.000+00:00',
+			to: '2026-08-20T23:59:59.999+00:00',
+			compare_from: '2024-09-01T00:00:00.000+00:00',
+			compare_to: '2025-08-31T23:59:59.999+00:00',
+			compare_preset: 'previous-period',
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/defaults/__tests__/get-default-preset.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/defaults/__tests__/get-default-preset.test.ts
@@ -97,12 +97,14 @@ describe( 'getDefaultQueryParams - comparison', () => {
 		jest.useRealTimers();
 	} );
 
-	it( 'compares the 12-month preset with the twelve whole months before it', () => {
+	it( 'compares the 12-month preset with the same window twelve months back', () => {
+		// Twelve months back from the first, ending on the same day of the
+		// month the reference has reached, so the two cover the same 354 days.
 		expect( getDefaultQueryParams( true, 'last-12-months' ) ).toMatchObject( {
 			from: '2025-09-01T00:00:00.000+00:00',
 			to: '2026-08-20T23:59:59.999+00:00',
 			compare_from: '2024-09-01T00:00:00.000+00:00',
-			compare_to: '2025-08-31T23:59:59.999+00:00',
+			compare_to: '2025-08-20T23:59:59.999+00:00',
 			compare_preset: 'previous-period',
 		} );
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/defaults/reports.ts
+++ b/projects/packages/premium-analytics/packages/data/src/defaults/reports.ts
@@ -81,13 +81,9 @@ export const getDefaultQueryParams = (
 	const from = localTZDate( new Date( fromString ) );
 	const to = localTZDate( new Date( toString ) );
 
-	const comparisonParams = getComparisonRangeFromPreset(
-		{
-			from,
-			to,
-		},
-		'previous-period'
-	);
+	const comparisonParams = getComparisonRangeFromPreset( { from, to }, 'previous-period', {
+		primaryPresetId: preset,
+	} );
 
 	return {
 		from: fromString,

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/compute-date-range-from-preset.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/compute-date-range-from-preset.test.ts
@@ -88,20 +88,20 @@ describe( 'computeDateRangeFromPreset', () => {
 		expect( range!.to ).toBe( toZ( endOfHour( NOW, { in: UTC } ) ) );
 	} );
 
-	it( 'returns 7-day range ending yesterday for "last-7-days"', () => {
+	it( 'returns 7-day range ending today for "last-7-days"', () => {
 		const range = computeDateRangeFromPreset( 'last-7-days' );
 
 		expect( range ).toBeDefined();
-		expect( range!.from ).toBe( toZ( subDays( TODAY_START, 7 ) ) );
-		expect( range!.to ).toBe( toZ( YESTERDAY_END ) );
+		expect( range!.from ).toBe( toZ( subDays( TODAY_START, 6 ) ) );
+		expect( range!.to ).toBe( toZ( TODAY_END ) );
 	} );
 
-	it( 'returns 30-day range ending yesterday for "last-30-days"', () => {
+	it( 'returns 30-day range ending today for "last-30-days"', () => {
 		const range = computeDateRangeFromPreset( 'last-30-days' );
 
 		expect( range ).toBeDefined();
-		expect( range!.from ).toBe( toZ( subDays( TODAY_START, 30 ) ) );
-		expect( range!.to ).toBe( toZ( YESTERDAY_END ) );
+		expect( range!.from ).toBe( toZ( subDays( TODAY_START, 29 ) ) );
+		expect( range!.to ).toBe( toZ( TODAY_END ) );
 	} );
 
 	it( 'returns 90-day range ending yesterday for "last-90-days"', () => {
@@ -128,12 +128,12 @@ describe( 'computeDateRangeFromPreset', () => {
 		expect( range!.to ).toBe( toZ( endOfMonth( LAST_MONTH, { in: UTC } ) ) );
 	} );
 
-	it( 'returns rolling 12-month range ending yesterday for "last-12-months"', () => {
+	it( 'returns twelve whole calendar months ending today for "last-12-months"', () => {
 		const range = computeDateRangeFromPreset( 'last-12-months' );
 
 		expect( range ).toBeDefined();
-		expect( range!.from ).toBe( toZ( subMonths( TODAY_START, 12 ) ) );
-		expect( range!.to ).toBe( toZ( YESTERDAY_END ) );
+		expect( range!.from ).toBe( toZ( startOfMonth( subMonths( TODAY_START, 11 ), { in: UTC } ) ) );
+		expect( range!.to ).toBe( toZ( TODAY_END ) );
 	} );
 
 	it( 'returns last calendar year for "last-year"', () => {

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/compute-date-range-from-preset.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/compute-date-range-from-preset.test.ts
@@ -104,20 +104,20 @@ describe( 'computeDateRangeFromPreset', () => {
 		expect( range!.to ).toBe( toZ( TODAY_END ) );
 	} );
 
-	it( 'returns 90-day range ending yesterday for "last-90-days"', () => {
+	it( 'returns 90-day range ending today for "last-90-days"', () => {
 		const range = computeDateRangeFromPreset( 'last-90-days' );
 
 		expect( range ).toBeDefined();
-		expect( range!.from ).toBe( toZ( subDays( TODAY_START, 90 ) ) );
-		expect( range!.to ).toBe( toZ( YESTERDAY_END ) );
+		expect( range!.from ).toBe( toZ( subDays( TODAY_START, 89 ) ) );
+		expect( range!.to ).toBe( toZ( TODAY_END ) );
 	} );
 
-	it( 'returns 365-day range ending yesterday for "last-365-days"', () => {
+	it( 'returns 365-day range ending today for "last-365-days"', () => {
 		const range = computeDateRangeFromPreset( 'last-365-days' );
 
 		expect( range ).toBeDefined();
-		expect( range!.from ).toBe( toZ( subDays( TODAY_START, 365 ) ) );
-		expect( range!.to ).toBe( toZ( YESTERDAY_END ) );
+		expect( range!.from ).toBe( toZ( subDays( TODAY_START, 364 ) ) );
+		expect( range!.to ).toBe( toZ( TODAY_END ) );
 	} );
 
 	it( 'returns last calendar month for "last-month"', () => {

--- a/projects/packages/premium-analytics/packages/datetime/README.md
+++ b/projects/packages/premium-analytics/packages/datetime/README.md
@@ -104,7 +104,7 @@ const withTZ = dateToISOStringWithTZ( new Date(), 'America/New_York' );
 
 ### Comparison Range Calculations
 
-#### `getComparisonRangeFromPreset( reference, presetId )`
+#### `getComparisonRangeFromPreset( reference, presetId, options? )`
 
 Calculates comparison date ranges based on predefined presets.
 
@@ -121,6 +121,8 @@ const comparison = getComparisonRangeFromPreset( reference, 'previous-period' );
 
 - `reference`: `DateRange` - Reference date range with `from` and `to`
 - `presetId`: `ComparisonPresetId` - One of the supported preset identifiers
+- `options`: `ComparisonRangeOptions` - Optional. `primaryPresetId` names the
+  preset the reference came from
 
 **Returns:** `DateRange | undefined` - Comparison date range or undefined
 if inputs are invalid
@@ -139,7 +141,13 @@ so their duration can differ. Whole months are read from the range itself, so a
 rolling window that happens to land on one (April 1-30 from "Last 30 days")
 compares against all 31 days of March.
 
-#### `getComparisonOptions( reference )`
+A to-date preset (`last-12-months` runs to the end of today) is measured on
+the window it covers once its running month closes, so `previous-period` steps
+back twelve months and stops as many days short as the reference does; both
+windows are the same length. `previous-month` / `previous-year` shift the dates
+as read.
+
+#### `getComparisonOptions( reference, options? )`
 
 The comparison options the given range offers, in display order: the previous
 period always; the week, month, and year shifts only while they cannot overlap
@@ -151,6 +159,9 @@ same window as an earlier one is dropped. Each option carries the resolved
 **Parameters:**
 
 - `reference`: `DateRange` - The applied range with `from` and `to`
+- `options`: `ComparisonRangeOptions` - Optional. `primaryPresetId` names the
+  preset the range came from, so a to-date window is measured on its
+  completed month
 
 **Returns:** `ComparisonOption[]` - Empty when the range is incomplete or
 inverted

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/date-range-span.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/date-range-span.test.ts
@@ -81,7 +81,7 @@ describe( 'getDateRangeSpan', () => {
 			value: 12,
 		} );
 
-		// Rolling, as `last-12-months` actually produces it.
+		// Rolling, twelve months to the day rather than month-aligned.
 		expect( getDateRangeSpan( { from: at( 2025, 7, 29 ), to: endOf( 2026, 7, 28 ) } ) ).toEqual( {
 			unit: 'month',
 			value: 12,

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
@@ -347,4 +347,105 @@ describe( 'getComparisonRangeFromPreset', () => {
 			);
 		} );
 	} );
+
+	describe( 'whole-month and whole-year references', () => {
+		it( 'moves a calendar year back by a year, not by its day count', () => {
+			// 2024 has 366 days, so 365 days back from 1 January 2025 is
+			// 2 January 2024, and the previous period drops New Year's Day.
+			expect(
+				getComparisonRangeFromPreset(
+					{
+						from: new Date( 2025, 0, 1, 0, 0, 0, 0 ),
+						to: new Date( 2025, 11, 31, 23, 59, 59, 999 ),
+					},
+					'previous-period'
+				)
+			).toEqual( {
+				from: new Date( 2024, 0, 1, 0, 0, 0, 0 ),
+				to: new Date( 2024, 11, 31, 23, 59, 59, 999 ),
+			} );
+		} );
+
+		it( 'moves twelve rolling months back by calendar months', () => {
+			expect(
+				getComparisonRangeFromPreset(
+					{
+						from: new Date( 2025, 7, 20, 0, 0, 0, 0 ),
+						to: new Date( 2026, 7, 19, 23, 59, 59, 999 ),
+					},
+					'previous-period'
+				)
+			).toEqual( {
+				from: new Date( 2024, 7, 20, 0, 0, 0, 0 ),
+				to: new Date( 2025, 7, 19, 23, 59, 59, 999 ),
+			} );
+		} );
+
+		it( 'ends the previous whole months on a month end, whatever day the reference ends on', () => {
+			// January through February: moving the end back two months would
+			// land it on 28 December, not on the end of December.
+			expect(
+				getComparisonRangeFromPreset(
+					{
+						from: new Date( 2026, 0, 1, 0, 0, 0, 0 ),
+						to: new Date( 2026, 1, 28, 23, 59, 59, 999 ),
+					},
+					'previous-period'
+				)
+			).toEqual( {
+				from: new Date( 2025, 10, 1, 0, 0, 0, 0 ),
+				to: new Date( 2025, 11, 31, 23, 59, 59, 999 ),
+			} );
+		} );
+	} );
+
+	describe( 'to-date presets', () => {
+		// `last-12-months` as read on 20 August 2026.
+		const reference = {
+			from: new Date( 2025, 8, 1, 0, 0, 0, 0 ),
+			to: new Date( 2026, 7, 20, 23, 59, 59, 999 ),
+		};
+
+		it( 'takes the previous period from the completed window', () => {
+			expect(
+				getComparisonRangeFromPreset( reference, 'previous-period', {
+					primaryPresetId: 'last-12-months',
+				} )
+			).toEqual( {
+				from: new Date( 2024, 8, 1, 0, 0, 0, 0 ),
+				to: new Date( 2025, 7, 31, 23, 59, 59, 999 ),
+			} );
+		} );
+
+		it( 'compares the previous month and year with the days read so far', () => {
+			// Year over year and month over month stay to-date, so the totals
+			// line up with the same days a year or a month earlier.
+			expect(
+				getComparisonRangeFromPreset( reference, 'previous-year', {
+					primaryPresetId: 'last-12-months',
+				} )
+			).toEqual( {
+				from: new Date( 2024, 8, 1, 0, 0, 0, 0 ),
+				to: new Date( 2025, 7, 20, 23, 59, 59, 999 ),
+			} );
+			expect(
+				getComparisonRangeFromPreset( reference, 'previous-month', {
+					primaryPresetId: 'last-12-months',
+				} )
+			).toEqual( {
+				from: new Date( 2025, 7, 1, 0, 0, 0, 0 ),
+				to: new Date( 2026, 6, 20, 23, 59, 59, 999 ),
+			} );
+		} );
+
+		it( 'measures the same dates by the day under any other preset', () => {
+			// Picked by hand, the window has no running month: 354 days back.
+			expect(
+				getComparisonRangeFromPreset( reference, 'previous-period', { primaryPresetId: 'custom' } )
+			).toEqual( {
+				from: new Date( 2024, 8, 12, 0, 0, 0, 0 ),
+				to: new Date( 2025, 7, 31, 23, 59, 59, 999 ),
+			} );
+		} );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
@@ -1,8 +1,13 @@
 /**
+ * External dependencies
+ */
+import { differenceInDays } from 'date-fns';
+/**
  * Internal dependencies
  */
 import { getDateRangeSpan } from '../date-range-span';
 import { COMPARISON_PRESETS, getComparisonRangeFromPreset } from '../get-comparison-range';
+import { stepDateRange } from '../step-date-range';
 import { createTZDateFromParts } from '../tz';
 
 describe( 'getComparisonRangeFromPreset', () => {
@@ -381,6 +386,24 @@ describe( 'getComparisonRangeFromPreset', () => {
 			} );
 		} );
 
+		it( 'falls back to the day count where a month step will not reverse', () => {
+			// 31 January through 30 March measures as two months, but two months
+			// back from 31 January clamps to 30 November: 62 days against the
+			// reference's 59. The step arrows count days there, and a comparison
+			// naming a different window than the arrow would is a defect.
+			const clamping = {
+				from: new Date( 2026, 0, 31, 0, 0, 0, 0 ),
+				to: new Date( 2026, 2, 30, 23, 59, 59, 999 ),
+			};
+			const expected = {
+				from: new Date( 2025, 11, 3, 0, 0, 0, 0 ),
+				to: new Date( 2026, 0, 30, 23, 59, 59, 999 ),
+			};
+
+			expect( getComparisonRangeFromPreset( clamping, 'previous-period' ) ).toEqual( expected );
+			expect( stepDateRange( clamping, 'previous' ) ).toEqual( expected );
+		} );
+
 		it( 'ends the previous whole months on a month end, whatever day the reference ends on', () => {
 			// January through February: moving the end back two months would
 			// land it on 28 December, not on the end of December.
@@ -406,15 +429,28 @@ describe( 'getComparisonRangeFromPreset', () => {
 			to: new Date( 2026, 7, 20, 23, 59, 59, 999 ),
 		};
 
-		it( 'takes the previous period from the completed window', () => {
+		it( 'steps the previous period back by the completed window', () => {
+			// Twelve whole months back from 1 September 2025, not the 354 days
+			// read so far.
 			expect(
 				getComparisonRangeFromPreset( reference, 'previous-period', {
 					primaryPresetId: 'last-12-months',
-				} )
-			).toEqual( {
-				from: new Date( 2024, 8, 1, 0, 0, 0, 0 ),
-				to: new Date( 2025, 7, 31, 23, 59, 59, 999 ),
+				} )?.from
+			).toEqual( new Date( 2024, 8, 1, 0, 0, 0, 0 ) );
+		} );
+
+		it( 'stops the previous period as many days short as the reference does', () => {
+			// The completed window runs to 31 August, the reference only to the
+			// 20th. Comparing the whole twelve months would read 354 days of
+			// data against 365.
+			const comparison = getComparisonRangeFromPreset( reference, 'previous-period', {
+				primaryPresetId: 'last-12-months',
 			} );
+
+			expect( comparison?.to ).toEqual( new Date( 2025, 7, 20, 23, 59, 59, 999 ) );
+			expect( differenceInDays( comparison!.to!, comparison!.from! ) ).toBe(
+				differenceInDays( reference.to, reference.from )
+			);
 		} );
 
 		it( 'compares the previous month and year with the days read so far', () => {

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/to-date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/to-date-range.test.ts
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { TZDate } from '@date-fns/tz';
+/**
+ * Internal dependencies
+ */
+import { getDateRangeSpan } from '../date-range-span';
+import { completeToDateRange } from '../to-date-range';
+
+/**
+ * A zone away from UTC, so a boundary computed on the wrong clock lands on a
+ * different day.
+ */
+const TIMEZONE = 'America/New_York';
+
+/**
+ * The first instant of a day in the site's zone.
+ *
+ * @param year  - Full year.
+ * @param month - 1-indexed month.
+ * @param day   - Day of month.
+ * @return The date.
+ */
+function at( year: number, month: number, day: number ): TZDate {
+	return new TZDate( year, month - 1, day, 0, 0, 0, 0, TIMEZONE );
+}
+
+/**
+ * The last instant of a day in the site's zone, the shape presets use for `to`.
+ *
+ * @param year  - Full year.
+ * @param month - 1-indexed month.
+ * @param day   - Day of month.
+ * @return The end of that day.
+ */
+function endOf( year: number, month: number, day: number ): TZDate {
+	return new TZDate( year, month - 1, day, 23, 59, 59, 999, TIMEZONE );
+}
+
+describe( 'completeToDateRange', () => {
+	// `last-12-months` as read on 20 August 2026: eleven whole months and the
+	// running one.
+	const toDate = { from: at( 2025, 9, 1 ), to: endOf( 2026, 8, 20 ) };
+
+	it( 'runs the 12-month window to the end of its running month', () => {
+		const completed = completeToDateRange( toDate, 'last-12-months' );
+
+		expect( completed.from ).toEqual( toDate.from );
+		expect( completed.to ).toEqual( endOf( 2026, 8, 31 ) );
+	} );
+
+	it( 'closes the month on the window’s own clock', () => {
+		const completed = completeToDateRange( toDate, 'last-12-months' );
+
+		expect( completed.to ).toBeInstanceOf( TZDate );
+		expect( ( completed.to as TZDate ).timeZone ).toBe( TIMEZONE );
+	} );
+
+	/*
+	 * The property everything downstream relies on: the same selection, read
+	 * mid-month, on the last day of a month, and on the first of the next,
+	 * always measures as twelve months.
+	 */
+	it.each( [
+		[ 'mid-month', { from: at( 2025, 9, 1 ), to: endOf( 2026, 8, 20 ) } ],
+		[ 'on the last day of a month', { from: at( 2025, 9, 1 ), to: endOf( 2026, 8, 31 ) } ],
+		[ 'on the first of a month', { from: at( 2025, 10, 1 ), to: endOf( 2026, 9, 1 ) } ],
+	] )( 'measures as twelve months when read %s', ( _label, range ) => {
+		expect( getDateRangeSpan( completeToDateRange( range, 'last-12-months' ) ) ).toEqual( {
+			unit: 'month',
+			value: 12,
+		} );
+	} );
+
+	it( 'leaves a window that already ends on a month end where it is', () => {
+		const complete = { from: at( 2025, 9, 1 ), to: endOf( 2026, 8, 31 ) };
+
+		expect( completeToDateRange( complete, 'last-12-months' ) ).toEqual( complete );
+	} );
+
+	it( 'returns any other preset’s range as is, even one starting on the first', () => {
+		// A hand-picked range has no running month to complete.
+		expect( completeToDateRange( toDate, 'custom' ) ).toBe( toDate );
+		expect( completeToDateRange( toDate, 'last-30-days' ) ).toBe( toDate );
+		expect( completeToDateRange( toDate, undefined ) ).toBe( toDate );
+	} );
+
+	it( 'returns a range without an end untouched', () => {
+		const open = { from: at( 2025, 9, 1 ) };
+
+		expect( completeToDateRange( open, 'last-12-months' ) ).toBe( open );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/to-date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/to-date-range.test.ts
@@ -6,7 +6,7 @@ import { TZDate } from '@date-fns/tz';
  * Internal dependencies
  */
 import { getDateRangeSpan } from '../date-range-span';
-import { completeToDateRange } from '../to-date-range';
+import { clampRangeEndToToday, completeToDateRange } from '../to-date-range';
 
 /**
  * A zone away from UTC, so a boundary computed on the wrong clock lands on a
@@ -90,5 +90,49 @@ describe( 'completeToDateRange', () => {
 		const open = { from: at( 2025, 9, 1 ) };
 
 		expect( completeToDateRange( open, 'last-12-months' ) ).toBe( open );
+	} );
+} );
+
+describe( 'clampRangeEndToToday', () => {
+	// Where a forward step out of "12 months" lands: the running month closed,
+	// which reaches eleven days past the day it was taken on.
+	const steppedForward = { from: at( 2025, 9, 1 ), to: endOf( 2026, 8, 31 ) };
+	const noon = new TZDate( 2026, 7, 20, 12, 0, 0, 0, TIMEZONE );
+
+	it( 'pulls a window ending after today back to the end of today', () => {
+		expect( clampRangeEndToToday( steppedForward, noon ) ).toEqual( {
+			from: at( 2025, 9, 1 ),
+			to: endOf( 2026, 8, 20 ),
+		} );
+	} );
+
+	it( 'closes the day on the window’s own clock', () => {
+		// 02:00 UTC is still the 26th in New York, so a clamp read on the
+		// browser's clock would leave the window a day long.
+		const clamped = clampRangeEndToToday(
+			steppedForward,
+			new Date( Date.UTC( 2026, 7, 27, 2, 0 ) )
+		);
+
+		expect( clamped.to ).toEqual( endOf( 2026, 8, 26 ) );
+		expect( clamped.to ).toBeInstanceOf( TZDate );
+	} );
+
+	it( 'leaves a window that already ends today where it is', () => {
+		const toDate = { from: at( 2025, 9, 1 ), to: endOf( 2026, 8, 20 ) };
+
+		expect( clampRangeEndToToday( toDate, noon ) ).toBe( toDate );
+	} );
+
+	it( 'leaves a window ending in the past where it is', () => {
+		const past = { from: at( 2024, 9, 1 ), to: endOf( 2025, 8, 31 ) };
+
+		expect( clampRangeEndToToday( past, noon ) ).toBe( past );
+	} );
+
+	it( 'returns a range without an end untouched', () => {
+		const open = { from: at( 2025, 9, 1 ) };
+
+		expect( clampRangeEndToToday( open, noon ) ).toBe( open );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
@@ -20,6 +20,11 @@ import {
 	subWeeks,
 	subYears,
 } from 'date-fns';
+/**
+ * Internal dependencies
+ */
+import { completeToDateRange } from './to-date-range';
+import type { PrimaryPresetId } from './presets/types';
 
 export type DateRange = { from?: Date; to?: Date };
 
@@ -91,6 +96,18 @@ export function getWholeMonthCount( from: Date, to: Date ): number | null {
 }
 
 /**
+ * Context the comparison is derived in.
+ */
+export type ComparisonRangeOptions = {
+	/**
+	 * The preset the reference range came from. A to-date preset is measured
+	 * by the day it is read on, so its previous period is taken from the
+	 * completed window: the twelve whole months before "12 months".
+	 */
+	primaryPresetId?: PrimaryPresetId;
+};
+
+/**
  * Returns a comparison DateRange derived from a reference range and a preset.
  *
  * - Day boundaries are resolved in the frame of the incoming dates; pass TZDate
@@ -100,11 +117,13 @@ export function getWholeMonthCount( from: Date, to: Date ): number | null {
  *
  * @param reference - The reference range to compare against (must include both `from` and `to`).
  * @param presetId  - One of the supported preset identifiers.
+ * @param options   - The context the reference range was produced in.
  * @return A new DateRange for the comparison period, or `undefined` if inputs are invalid.
  */
 export function getComparisonRangeFromPreset(
 	reference: DateRange,
-	presetId: ComparisonPresetId
+	presetId: ComparisonPresetId,
+	options: ComparisonRangeOptions = {}
 ): DateRange | undefined {
 	if ( ! reference?.from || ! reference?.to ) {
 		return undefined;
@@ -147,23 +166,29 @@ export function getComparisonRangeFromPreset(
 		bound === 1 ? endOfDay( startOfDay( date ) ) : startOfDay( date );
 
 	if ( presetId === COMPARISON_PREVIOUS_PERIOD ) {
+		// Only the previous period reads a to-date preset's completed window. The
+		// previous month and year shift the dates as read, so a to-date window
+		// compares with the same days a month or a year earlier.
+		const completed = completeToDateRange( { from: refFrom, to: refTo }, options.primaryPresetId );
+		const completedTo = completed.to ?? refTo;
+
 		// A whole-months window steps back by its month count — Last month lands
 		// on the previous calendar month, Last year on the previous calendar
 		// year — where a day-count shift would skew across unequal month and
 		// year lengths (365-day 2025 against 366-day 2024).
-		const wholeMonths = getWholeMonthCount( refFrom, refTo );
+		const wholeMonths = getWholeMonthCount( refFrom, completedTo );
 		if ( wholeMonths ) {
-			const dayAfterTo = startOfDay( addDays( refTo, 1 ) );
+			const dayAfterTo = startOfDay( addDays( completedTo, 1 ) );
 			return {
 				from: clampDayBound( subMonths( refFrom, wholeMonths ), 0 ),
 				to: clampDayBound( subDays( subMonths( dayAfterTo, wholeMonths ), 1 ), 1 ),
 			};
 		}
 
-		const daysInclusive = getInclusiveDayCount( refFrom, refTo );
+		const daysInclusive = getInclusiveDayCount( refFrom, completedTo );
 		return {
 			from: clampDayBound( subDays( refFrom, daysInclusive ), 0 ),
-			to: clampDayBound( subDays( refTo, daysInclusive ), 1 ),
+			to: clampDayBound( subDays( completedTo, daysInclusive ), 1 ),
 		};
 	}
 

--- a/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
@@ -69,9 +69,11 @@ function getInclusiveDayCount( from: Date, to: Date ): number {
 /**
  * Whole calendar months a day-aligned range covers, or null when it is not a
  * whole number of months. Detected by round trip against the day after the
- * range ends, so a clamped month end (Oct 31 plus a month is Nov 30) still
- * counts. Shared by the previous-period shift and its label, so both take the
- * same branch; unlike `getDateRangeSpan`, a single month counts.
+ * range ends, and again from the start stepped back by that count: a start a
+ * month step cannot undo (31 January two months back clamps to 30 November)
+ * measures in days, the way the step arrows measure it. Shared by the
+ * previous-period shift and its label, so both take the same branch; unlike
+ * `getDateRangeSpan`, a single month counts.
  *
  * @param from - Range start.
  * @param to   - Range end.
@@ -88,11 +90,11 @@ export function getWholeMonthCount( from: Date, to: Date ): number | null {
 	const dayAfterTo = startOfDay( addDays( to, 1 ) );
 	const months = differenceInCalendarMonths( dayAfterTo, from );
 
-	if ( months < 1 ) {
+	if ( months < 1 || ! isSameDay( addMonths( from, months ), dayAfterTo ) ) {
 		return null;
 	}
 
-	return isSameDay( addMonths( from, months ), dayAfterTo ) ? months : null;
+	return isSameDay( addMonths( subMonths( from, months ), months ), from ) ? months : null;
 }
 
 /**
@@ -101,8 +103,8 @@ export function getWholeMonthCount( from: Date, to: Date ): number | null {
 export type ComparisonRangeOptions = {
 	/**
 	 * The preset the reference range came from. A to-date preset is measured
-	 * by the day it is read on, so its previous period is taken from the
-	 * completed window: the twelve whole months before "12 months".
+	 * by the day it is read on, so its previous period steps by the length of
+	 * the completed window: "12 months" moves back twelve months, not 354 days.
 	 */
 	primaryPresetId?: PrimaryPresetId;
 };
@@ -114,6 +116,9 @@ export type ComparisonRangeOptions = {
  *   instances for site-local math.
  * - Whole months are detected from the range shape alone, so a rolling window
  *   that happens to land on one also compares calendar-to-calendar.
+ * - `previous-period` ends the day before the reference starts; a reference
+ *   still running its final month stops as many days short, so the two windows
+ *   are the same length.
  *
  * @param reference - The reference range to compare against (must include both `from` and `to`).
  * @param presetId  - One of the supported preset identifiers.
@@ -166,11 +171,17 @@ export function getComparisonRangeFromPreset(
 		bound === 1 ? endOfDay( startOfDay( date ) ) : startOfDay( date );
 
 	if ( presetId === COMPARISON_PREVIOUS_PERIOD ) {
-		// Only the previous period reads a to-date preset's completed window. The
-		// previous month and year shift the dates as read, so a to-date window
-		// compares with the same days a month or a year earlier.
+		// Measured on the window a to-date preset covers once its running month
+		// closes, so "12 months" steps back twelve months rather than 354 days.
+		// The previous month and year shift the dates as read, so a to-date
+		// window compares with the same days a month or a year earlier.
 		const completed = completeToDateRange( { from: refFrom, to: refTo }, options.primaryPresetId );
 		const completedTo = completed.to ?? refTo;
+
+		// The previous period stops as many days short as the reference itself
+		// does: a window still running compares with one of its own length, not
+		// with the whole period it sits in.
+		const daysStillToRun = differenceInDays( completedTo, refTo );
 
 		// A whole-months window steps back by its month count — Last month lands
 		// on the previous calendar month, Last year on the previous calendar
@@ -181,14 +192,14 @@ export function getComparisonRangeFromPreset(
 			const dayAfterTo = startOfDay( addDays( completedTo, 1 ) );
 			return {
 				from: clampDayBound( subMonths( refFrom, wholeMonths ), 0 ),
-				to: clampDayBound( subDays( subMonths( dayAfterTo, wholeMonths ), 1 ), 1 ),
+				to: clampDayBound( subDays( subMonths( dayAfterTo, wholeMonths ), 1 + daysStillToRun ), 1 ),
 			};
 		}
 
 		const daysInclusive = getInclusiveDayCount( refFrom, completedTo );
 		return {
 			from: clampDayBound( subDays( refFrom, daysInclusive ), 0 ),
-			to: clampDayBound( subDays( completedTo, daysInclusive ), 1 ),
+			to: clampDayBound( subDays( refTo, daysInclusive ), 1 ),
 		};
 	}
 

--- a/projects/packages/premium-analytics/packages/datetime/src/index.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/index.ts
@@ -22,7 +22,7 @@ export { INTERVAL_TYPES, isIntervalType, type IntervalType } from './interval';
 export { getDateRangeSpan, type DateRangeSpan, type DateRangeSpanUnit } from './date-range-span';
 
 export { stepDateRange, canStepForward, type StepDirection } from './step-date-range';
-export { completeToDateRange } from './to-date-range';
+export { completeToDateRange, clampRangeEndToToday } from './to-date-range';
 
 export { drillDateRange } from './drill-date-range';
 

--- a/projects/packages/premium-analytics/packages/datetime/src/index.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/index.ts
@@ -4,6 +4,7 @@ export {
 	type DateRange,
 	type ComparisonPresetId,
 } from './get-comparison-range';
+export type { ComparisonRangeOptions } from './get-comparison-range';
 
 export {
 	createTZDateFromParts,
@@ -21,6 +22,7 @@ export { INTERVAL_TYPES, isIntervalType, type IntervalType } from './interval';
 export { getDateRangeSpan, type DateRangeSpan, type DateRangeSpanUnit } from './date-range-span';
 
 export { stepDateRange, canStepForward, type StepDirection } from './step-date-range';
+export { completeToDateRange } from './to-date-range';
 
 export { drillDateRange } from './drill-date-range';
 

--- a/projects/packages/premium-analytics/packages/datetime/src/presets/comparison.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/presets/comparison.ts
@@ -16,6 +16,7 @@ import {
 	getComparisonRangeFromPreset,
 	getWholeMonthCount,
 	type ComparisonPresetId,
+	type ComparisonRangeOptions,
 	type DateRange,
 } from '../get-comparison-range';
 
@@ -181,9 +182,14 @@ function getOptionLabel(
  * a 7-day range lists no last-week entry.
  *
  * @param reference - The applied range (both ends required).
+ * @param options   - The context the range was produced in; the preset it came
+ *                  from decides how a to-date window is measured.
  * @return The options, empty when the range is incomplete or inverted.
  */
-export function getComparisonOptions( reference: DateRange ): ComparisonOption[] {
+export function getComparisonOptions(
+	reference: DateRange,
+	options: ComparisonRangeOptions = {}
+): ComparisonOption[] {
 	const refFrom = reference?.from;
 	const refTo = reference?.to;
 
@@ -204,17 +210,17 @@ export function getComparisonOptions( reference: DateRange ): ComparisonOption[]
 		candidates.push( COMPARISON_PREVIOUS_YEAR );
 	}
 
-	const options: ComparisonOption[] = [];
+	const offered: ComparisonOption[] = [];
 
 	for ( const id of candidates ) {
-		const range = getComparisonRangeFromPreset( reference, id );
+		const range = getComparisonRangeFromPreset( reference, id, options );
 
 		if ( ! range?.from || ! range.to ) {
 			continue;
 		}
 
 		const resolved = range as Required< DateRange >;
-		const duplicate = options.some(
+		const duplicate = offered.some(
 			option =>
 				option.range.from.getTime() === resolved.from.getTime() &&
 				option.range.to.getTime() === resolved.to.getTime()
@@ -224,7 +230,7 @@ export function getComparisonOptions( reference: DateRange ): ComparisonOption[]
 			continue;
 		}
 
-		options.push( {
+		offered.push( {
 			id,
 			label: getOptionLabel( id, { from: refFrom, to: refTo }, resolved ),
 			shortLabel: SHORT_LABELS[ id ](),
@@ -232,5 +238,5 @@ export function getComparisonOptions( reference: DateRange ): ComparisonOption[]
 		} );
 	}
 
-	return options;
+	return offered;
 }

--- a/projects/packages/premium-analytics/packages/datetime/src/presets/primary.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/presets/primary.ts
@@ -126,17 +126,17 @@ export const PRESET_DEFINITIONS: ReadonlyArray< PresetDefinition > = [
 	{
 		id: PRESET_LAST_90_DAYS,
 		getLabel: () => __( 'Last 90 days', 'jetpack-premium-analytics-pkg' ),
-		getRange: ( { initOfToday, endOfYesterday } ) => ( {
-			from: subDays( initOfToday, 90 ),
-			to: endOfYesterday,
+		getRange: ( { initOfToday, endOfToday } ) => ( {
+			from: subDays( initOfToday, 89 ),
+			to: endOfToday,
 		} ),
 	},
 	{
 		id: PRESET_LAST_365_DAYS,
 		getLabel: () => __( 'Last 365 days', 'jetpack-premium-analytics-pkg' ),
-		getRange: ( { initOfToday, endOfYesterday } ) => ( {
-			from: subDays( initOfToday, 365 ),
-			to: endOfYesterday,
+		getRange: ( { initOfToday, endOfToday } ) => ( {
+			from: subDays( initOfToday, 364 ),
+			to: endOfToday,
 		} ),
 	},
 	{

--- a/projects/packages/premium-analytics/packages/datetime/src/presets/primary.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/presets/primary.ts
@@ -110,17 +110,17 @@ export const PRESET_DEFINITIONS: ReadonlyArray< PresetDefinition > = [
 	{
 		id: PRESET_LAST_7_DAYS,
 		getLabel: () => __( 'Last 7 days', 'jetpack-premium-analytics-pkg' ),
-		getRange: ( { initOfToday, endOfYesterday } ) => ( {
-			from: subDays( initOfToday, 7 ),
-			to: endOfYesterday,
+		getRange: ( { initOfToday, endOfToday } ) => ( {
+			from: subDays( initOfToday, 6 ),
+			to: endOfToday,
 		} ),
 	},
 	{
 		id: PRESET_LAST_30_DAYS,
 		getLabel: () => __( 'Last 30 days', 'jetpack-premium-analytics-pkg' ),
-		getRange: ( { initOfToday, endOfYesterday } ) => ( {
-			from: subDays( initOfToday, 30 ),
-			to: endOfYesterday,
+		getRange: ( { initOfToday, endOfToday } ) => ( {
+			from: subDays( initOfToday, 29 ),
+			to: endOfToday,
 		} ),
 	},
 	{
@@ -150,9 +150,11 @@ export const PRESET_DEFINITIONS: ReadonlyArray< PresetDefinition > = [
 	{
 		id: PRESET_LAST_12_MONTHS,
 		getLabel: () => __( 'Last 12 months', 'jetpack-premium-analytics-pkg' ),
-		getRange: ( { initOfToday, endOfYesterday } ) => ( {
-			from: subMonths( initOfToday, 12 ),
-			to: endOfYesterday,
+		// The chart buckets this preset by month, so a mid-month start would split
+		// the current month across a partial bucket at each end.
+		getRange: ( { initOfToday, endOfToday } ) => ( {
+			from: startOfMonth( subMonths( initOfToday, 11 ) ),
+			to: endOfToday,
 		} ),
 	},
 	{

--- a/projects/packages/premium-analytics/packages/datetime/src/to-date-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/to-date-range.ts
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { endOfMonth } from 'date-fns';
+/**
+ * Internal dependencies
+ */
+import { PRESET_LAST_12_MONTHS, type PrimaryPresetId } from './presets/types';
+import type { DateRange } from './get-comparison-range';
+
+/**
+ * The window a to-date preset covers once its running month completes.
+ *
+ * `last-12-months` runs from the first of a month to the end of today, so
+ * measuring it reports the shape of today's date rather than of the
+ * selection: 354 days mid-month, 12 months on the last day of one. Anything
+ * that describes or moves the window in whole units — its length, the step
+ * arrows, the previous period — measures this window instead. What the reader
+ * sees stays the range as selected.
+ *
+ * Every other preset comes back untouched. A hand-picked range that happens
+ * to start on the first has no running month to complete, so it is measured
+ * as read.
+ *
+ * `endOfMonth` keeps a `TZDate` in its zone, so the completed end closes the
+ * month on the site's clock.
+ *
+ * @param range    - The range the preset produced.
+ * @param presetId - The preset that produced it.
+ * @return The completed window, or `range` itself for any other preset.
+ */
+export function completeToDateRange< T extends DateRange >(
+	range: T,
+	presetId?: PrimaryPresetId
+): T {
+	if ( presetId !== PRESET_LAST_12_MONTHS || ! range.to ) {
+		return range;
+	}
+
+	return { ...range, to: endOfMonth( range.to ) };
+}

--- a/projects/packages/premium-analytics/packages/datetime/src/to-date-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/to-date-range.ts
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { endOfMonth } from 'date-fns';
+import { TZDate } from '@date-fns/tz';
+import { endOfDay, endOfMonth } from 'date-fns';
 /**
  * Internal dependencies
  */
@@ -38,4 +39,31 @@ export function completeToDateRange< T extends DateRange >(
 	}
 
 	return { ...range, to: endOfMonth( range.to ) };
+}
+
+/**
+ * Pull a window's end back to the end of today when it runs past it.
+ *
+ * A window measured in whole months or years may step forward into the month
+ * or year in progress, which `canStepForward` counts as reachable so the
+ * window a reader stepped back from stays reachable. The step itself lands on
+ * the end of that unit, days the report has no data for and the chart would
+ * draw as empty buckets. Stepping forward out of "12 months" therefore returns
+ * the to-date window the reader started from.
+ *
+ * @param range - The window to clamp.
+ * @param now   - The current instant.
+ * @return The clamped window, or `range` itself when it already ends today or earlier.
+ */
+export function clampRangeEndToToday< T extends DateRange >( range: T, now: Date ): T {
+	if ( ! range.to ) {
+		return range;
+	}
+
+	// Anchored to the window's own timezone, so a site offset from the browser
+	// closes the day on its own clock.
+	const timeZone = 'timeZone' in range.to ? ( range.to as TZDate ).timeZone : undefined;
+	const endOfToday = endOfDay( timeZone ? new TZDate( now.getTime(), timeZone ) : now );
+
+	return range.to.getTime() > endOfToday.getTime() ? { ...range, to: endOfToday } : range;
 }

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/build-range-patch.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/build-range-patch.test.ts
@@ -229,4 +229,24 @@ describe( 'buildRangePatch', () => {
 			preset: 'last-7-days',
 		} );
 	} );
+
+	it( 'derives the comparison from the preset being staged, not the one it replaces', () => {
+		// `last-12-months` as read on 20 August 2026, staged over a 7-day window.
+		// Measured as the 7-day preset would be, the previous period starts on
+		// 12 September; as the to-date preset, on the first.
+		const patch = buildRangePatch( {
+			nextRange: {
+				from: new Date( '2025-09-01T00:00:00.000Z' ),
+				to: new Date( '2026-08-20T23:59:59.999Z' ),
+			},
+			nextPresetId: 'last-12-months',
+			effective: { preset: 'last-7-days', comp: '1', compare_preset: 'previous-period' },
+		} );
+
+		expect( patch ).toMatchObject( {
+			preset: 'last-12-months',
+			compare_from: '2024-09-01T00:00:00.000+00:00',
+			compare_to: '2025-08-31T23:59:59.999+00:00',
+		} );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/build-range-patch.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/build-range-patch.test.ts
@@ -233,7 +233,7 @@ describe( 'buildRangePatch', () => {
 	it( 'derives the comparison from the preset being staged, not the one it replaces', () => {
 		// `last-12-months` as read on 20 August 2026, staged over a 7-day window.
 		// Measured as the 7-day preset would be, the previous period starts on
-		// 12 September; as the to-date preset, on the first.
+		// 12 September; as the to-date preset, twelve months back on the first.
 		const patch = buildRangePatch( {
 			nextRange: {
 				from: new Date( '2025-09-01T00:00:00.000Z' ),
@@ -246,7 +246,7 @@ describe( 'buildRangePatch', () => {
 		expect( patch ).toMatchObject( {
 			preset: 'last-12-months',
 			compare_from: '2024-09-01T00:00:00.000+00:00',
-			compare_to: '2025-08-31T23:59:59.999+00:00',
+			compare_to: '2025-08-20T23:59:59.999+00:00',
 		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
@@ -627,4 +627,29 @@ describe( 'useReportDateFilters', () => {
 			} );
 		} );
 	} );
+
+	it( 'steps a to-date preset by whole months and compares it with the months before', () => {
+		// `last-12-months` as read on 20 August 2026. Stepped by its day count
+		// the window would start on 12 September and its comparison on the 24th.
+		const { result, rerender } = renderDateFilters( {
+			from: '2025-09-01T00:00:00.000Z',
+			to: '2026-08-20T23:59:59.999Z',
+			preset: 'last-12-months',
+			interval: 'month',
+			comp: '1',
+			compare_preset: 'previous-period',
+		} );
+
+		act( () => result.current.onStep( 'previous' ) );
+		rerender();
+
+		expect( mockSearch ).toMatchObject( {
+			from: '2024-09-01T00:00:00.000Z',
+			to: '2025-08-31T23:59:59.999Z',
+			preset: 'custom',
+			interval: 'month',
+			compare_from: '2023-09-01T00:00:00.000Z',
+			compare_to: '2024-08-31T23:59:59.999Z',
+		} );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
@@ -72,6 +72,10 @@ describe( 'useReportDateFilters', () => {
 		);
 	} );
 
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
 	it( 'derives the applied state from the URL search params', () => {
 		const { result } = renderDateFilters( {
 			from: '2026-07-01T00:00:00.000Z',
@@ -650,6 +654,30 @@ describe( 'useReportDateFilters', () => {
 			interval: 'month',
 			compare_from: '2023-09-01T00:00:00.000Z',
 			compare_to: '2024-08-31T23:59:59.999Z',
+		} );
+	} );
+
+	it( 'lands back on the to-date window when a step forward closes the running month', () => {
+		// The window a step back out of `last-12-months` leaves. Stepping
+		// forward again closes August, eleven days past the day it is read on:
+		// days the report has no data for, and the forward arrow would then
+		// disappear on a window nobody can leave.
+		jest.useFakeTimers().setSystemTime( Date.parse( '2026-08-20T12:00:00.000Z' ) );
+
+		const { result, rerender } = renderDateFilters( {
+			from: '2024-09-01T00:00:00.000Z',
+			to: '2025-08-31T23:59:59.999Z',
+			preset: 'custom',
+			interval: 'month',
+		} );
+
+		act( () => result.current.onStep( 'next' ) );
+		rerender();
+
+		expect( mockSearch ).toMatchObject( {
+			from: '2025-09-01T00:00:00.000Z',
+			to: '2026-08-20T23:59:59.999Z',
+			preset: 'custom',
 		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/build-range-patch.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/build-range-patch.ts
@@ -90,9 +90,15 @@ export function buildRangePatch( {
 			effective.interval
 		);
 
-		// Loose `comp` check: an unquoted URL delivers number 1, not '1'.
+		// Loose `comp` check: an unquoted URL delivers number 1, not '1'. The
+		// preset being staged measures the new range, not the one it replaces.
 		if ( String( effective.comp ) === '1' ) {
-			const derived = deriveComparisonRange( { ...effective, from: rangeFrom, to: rangeTo } );
+			const derived = deriveComparisonRange( {
+				...effective,
+				from: rangeFrom,
+				to: rangeTo,
+				preset: nextPresetId ?? effective.preset,
+			} );
 			if ( derived ) {
 				patch.compare_from = derived.compare_from;
 				patch.compare_to = derived.compare_to;

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
@@ -7,6 +7,7 @@ import {
 	resolveIntervalForRange,
 } from '@jetpack-premium-analytics/data';
 import {
+	clampRangeEndToToday,
 	completeToDateRange,
 	drillDateRange,
 	PRESET_CUSTOM,
@@ -276,7 +277,11 @@ export function useReportDateFilters< TFrom extends string >( from?: TFrom ): Re
 			}
 
 			const patch = buildRangePatch( {
-				nextRange: stepped,
+				// A forward step closes the running unit the window was measured
+				// against, which reaches past today. Stepping forward out of
+				// "12 months" returns the to-date window, not a month of empty
+				// buckets.
+				nextRange: clampRangeEndToToday( stepped, toLocalTZ( undefined, timeZone ) ),
 				nextPresetId: PRESET_CUSTOM,
 				exactRange: true,
 				effective,
@@ -287,7 +292,7 @@ export function useReportDateFilters< TFrom extends string >( from?: TFrom ): Re
 				commit();
 			}
 		},
-		[ appliedPresetId, appliedRange, commit, effective, stage ]
+		[ appliedPresetId, appliedRange, commit, effective, stage, timeZone ]
 	);
 
 	/*

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
@@ -7,6 +7,7 @@ import {
 	resolveIntervalForRange,
 } from '@jetpack-premium-analytics/data';
 import {
+	completeToDateRange,
 	drillDateRange,
 	PRESET_CUSTOM,
 	reportingTimeZone,
@@ -263,7 +264,12 @@ export function useReportDateFilters< TFrom extends string >( from?: TFrom ): Re
 	 */
 	const onStep = useCallback(
 		( direction: StepDirection ) => {
-			const stepped = stepDateRange( appliedRange, direction );
+			// A to-date window steps as its completed window, so the arrows move
+			// "12 months" by whole months rather than by the days read so far.
+			const stepped = stepDateRange(
+				completeToDateRange( appliedRange, appliedPresetId ),
+				direction
+			);
 
 			if ( ! stepped ) {
 				return;
@@ -281,7 +287,7 @@ export function useReportDateFilters< TFrom extends string >( from?: TFrom ): Re
 				commit();
 			}
 		},
-		[ appliedRange, commit, effective, stage ]
+		[ appliedPresetId, appliedRange, commit, effective, stage ]
 	);
 
 	/*

--- a/projects/packages/premium-analytics/packages/routing/src/search/comparison/__tests__/derive-comparison-range.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/comparison/__tests__/derive-comparison-range.test.ts
@@ -141,4 +141,25 @@ describe( 'deriveComparisonRange', () => {
 			compare_preset: 'previous-period',
 		} );
 	} );
+
+	it( 'derives the previous period of a to-date preset from its completed window', () => {
+		// `last-12-months` as read on 20 August 2026.
+		const range = {
+			from: '2025-09-01T00:00:00.000Z',
+			to: '2026-08-20T23:59:59.999Z',
+			comp: '1' as const,
+			compare_preset: 'previous-period' as const,
+		};
+
+		expect( deriveComparisonRange( { ...range, preset: 'last-12-months' } ) ).toEqual( {
+			compare_from: '2024-09-01T00:00:00.000+00:00',
+			compare_to: '2025-08-31T23:59:59.999+00:00',
+		} );
+
+		// The same dates picked by hand are a day count.
+		expect( deriveComparisonRange( { ...range, preset: 'custom' } ) ).toEqual( {
+			compare_from: '2024-09-12T00:00:00.000+00:00',
+			compare_to: '2025-08-31T23:59:59.999+00:00',
+		} );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/routing/src/search/comparison/__tests__/derive-comparison-range.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/comparison/__tests__/derive-comparison-range.test.ts
@@ -142,7 +142,7 @@ describe( 'deriveComparisonRange', () => {
 		} );
 	} );
 
-	it( 'derives the previous period of a to-date preset from its completed window', () => {
+	it( 'steps a to-date preset back by its completed window and stops where it does', () => {
 		// `last-12-months` as read on 20 August 2026.
 		const range = {
 			from: '2025-09-01T00:00:00.000Z',
@@ -151,15 +151,19 @@ describe( 'deriveComparisonRange', () => {
 			compare_preset: 'previous-period' as const,
 		};
 
+		// Twelve months back from the first, running as many days short as the
+		// reference does: 354 days against 354, not against 365.
 		expect( deriveComparisonRange( { ...range, preset: 'last-12-months' } ) ).toEqual( {
 			compare_from: '2024-09-01T00:00:00.000+00:00',
-			compare_to: '2025-08-31T23:59:59.999+00:00',
+			compare_to: '2025-08-20T23:59:59.999+00:00',
+			compare_preset: 'previous-period',
 		} );
 
 		// The same dates picked by hand are a day count.
 		expect( deriveComparisonRange( { ...range, preset: 'custom' } ) ).toEqual( {
 			compare_from: '2024-09-12T00:00:00.000+00:00',
 			compare_to: '2025-08-31T23:59:59.999+00:00',
+			compare_preset: 'previous-period',
 		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/routing/src/search/comparison/derive-comparison-range.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/comparison/derive-comparison-range.ts
@@ -9,6 +9,7 @@ import {
 import {
 	getComparisonOptions,
 	isComparisonPresetId,
+	isPrimaryPreset,
 	reportingTimeZone,
 	type ComparisonPresetId,
 } from '@jetpack-premium-analytics/datetime';
@@ -30,8 +31,10 @@ const toComparisonPresetId = ( value?: string ): ComparisonPresetId | undefined 
 /**
  * Resolve the comparison params for the main range, in the site timezone: the
  * active preset where the range still offers it, else the previous period, so
- * a range change never strands a comparison the picker cannot name. Returns
- * ISO strings with the site offset, plus the preset they came from.
+ * a range change never strands a comparison the picker cannot name. The primary
+ * preset travels along, so a to-date preset's previous period is its previous
+ * whole period rather than a day count. Returns ISO strings with the site
+ * offset, plus the preset they came from.
  *
  * @param opts - Report params carrying the main range and comparison state.
  * @return The comparison params, or undefined when comparison is off or the range unreadable.
@@ -64,7 +67,9 @@ export function deriveComparisonRange( opts: ReportParams ):
 		return undefined;
 	}
 
-	const options = getComparisonOptions( reference );
+	const options = getComparisonOptions( reference, {
+		primaryPresetId: isPrimaryPreset( opts.preset ) ? opts.preset : undefined,
+	} );
 	const presetId = toComparisonPresetId( opts.compare_preset );
 
 	// A preset the range doesn't offer — or an id from an old link — falls back

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
@@ -135,29 +135,30 @@ describe( 'DateFiltersPanel', () => {
 		expect( screen.getByRole( 'menuitemradio', { name: 'All time' } ) ).toBeChecked();
 	} );
 
-	it( 'derives the comparison of a to-date preset from its completed window', async () => {
-		mockContainerResize();
+	it( 'steps the comparison of a to-date preset back by its completed window', async () => {
 		const onComparisonChange = jest.fn();
 		const user = userEvent.setup();
 
 		// `last-12-months` as read on 20 August 2026. Measured by the day, the
 		// previous period would start on 12 September 2024.
+		const toDateRange = {
+			from: new Date( '2025-09-01T00:00:00.000Z' ),
+			to: new Date( '2026-08-20T23:59:59.999Z' ),
+		};
 		renderPanel( {
-			presetId: 'last-12-months',
-			range: {
-				from: new Date( '2025-09-01T00:00:00.000Z' ),
-				to: new Date( '2026-08-20T23:59:59.999Z' ),
-			},
+			appliedPresetId: 'last-12-months',
+			range: toDateRange,
+			appliedRange: toDateRange,
 			onComparisonChange,
 		} );
 
 		await user.click( screen.getByRole( 'button', { name: 'Compare' } ) );
-		await user.click( screen.getByRole( 'menuitemradio', { name: 'Previous period' } ) );
+		await user.click( screen.getByRole( 'menuitemradio', { name: 'Previous 354 days' } ) );
 
 		expect( onComparisonChange ).toHaveBeenCalledWith(
 			{
 				from: new Date( '2024-09-01T00:00:00.000Z' ),
-				to: new Date( '2025-08-31T23:59:59.999Z' ),
+				to: new Date( '2025-08-20T23:59:59.999Z' ),
 			},
 			'previous-period'
 		);

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
@@ -134,4 +134,32 @@ describe( 'DateFiltersPanel', () => {
 		).toEqual( [ 'Last 24 hours', 'Last 7 days', 'Last 30 days', 'Last 12 months', 'All time' ] );
 		expect( screen.getByRole( 'menuitemradio', { name: 'All time' } ) ).toBeChecked();
 	} );
+
+	it( 'derives the comparison of a to-date preset from its completed window', async () => {
+		mockContainerResize();
+		const onComparisonChange = jest.fn();
+		const user = userEvent.setup();
+
+		// `last-12-months` as read on 20 August 2026. Measured by the day, the
+		// previous period would start on 12 September 2024.
+		renderPanel( {
+			presetId: 'last-12-months',
+			range: {
+				from: new Date( '2025-09-01T00:00:00.000Z' ),
+				to: new Date( '2026-08-20T23:59:59.999Z' ),
+			},
+			onComparisonChange,
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Compare' } ) );
+		await user.click( screen.getByRole( 'menuitemradio', { name: 'Previous period' } ) );
+
+		expect( onComparisonChange ).toHaveBeenCalledWith(
+			{
+				from: new Date( '2024-09-01T00:00:00.000Z' ),
+				to: new Date( '2025-08-31T23:59:59.999Z' ),
+			},
+			'previous-period'
+		);
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
@@ -186,10 +186,14 @@ export function DateFiltersPanel( {
 	 */
 	const [ isPrimaryPickerOpen, setIsPrimaryPickerOpen ] = useState( false );
 	const comparisonSourceRange = isPrimaryPickerOpen ? range : appliedRange ?? range;
+	// The draft's preset never reaches the panel, so an open draft is measured
+	// as read; the applied preset decides how a to-date window is measured.
+	const comparisonSourcePresetId = isPrimaryPickerOpen ? undefined : validatedAppliedPresetId;
 
 	// Available comparison presets, derived from whichever primary range the
-	// picker is currently reflecting (draft while open, applied while closed).
-	const presets = useComparisonDatePresets( comparisonSourceRange );
+	// picker is currently reflecting (draft while open, applied while closed)
+	// and from its preset, which decides how a to-date window is measured.
+	const presets = useComparisonDatePresets( comparisonSourceRange, comparisonSourcePresetId );
 
 	const presetChange = useCallback(
 		( id: ComparisonPresetId ) => {

--- a/projects/packages/premium-analytics/packages/ui/src/use-comparison-date-presets/use-comparison-date-presets.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/use-comparison-date-presets/use-comparison-date-presets.ts
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { getComparisonOptions, type ComparisonOption } from '@jetpack-premium-analytics/datetime';
+import {
+	getComparisonOptions,
+	type ComparisonOption,
+	type PrimaryPresetId,
+} from '@jetpack-premium-analytics/datetime';
 import { useMemo } from 'react';
 /**
  * Internal dependencies
@@ -18,7 +22,18 @@ export type ComparisonDateRangePreset = ComparisonOption;
  * Comparison options derived from the primary range: which shifts are offered,
  * the window each resolves to, and the label naming it all follow the range —
  * see `getComparisonOptions`.
+ *
+ * @param referenceRange - The primary range.
+ * @param presetId       - The preset that produced it, so a to-date window
+ *                       compares with its previous whole period.
+ * @return The comparison options, each with its range.
  */
-export function useComparisonDatePresets( referenceRange: DateRange ): ComparisonDateRangePreset[] {
-	return useMemo( () => getComparisonOptions( referenceRange ), [ referenceRange ] );
+export function useComparisonDatePresets(
+	referenceRange: DateRange,
+	presetId?: PrimaryPresetId
+): ComparisonDateRangePreset[] {
+	return useMemo(
+		() => getComparisonOptions( referenceRange, { primaryPresetId: presetId } ),
+		[ referenceRange, presetId ]
+	);
 }

--- a/projects/packages/premium-analytics/widgets/popular-post/__tests__/popular-post.test.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-post/__tests__/popular-post.test.tsx
@@ -133,7 +133,7 @@ describe( 'PopularPostWidget', () => {
 		// The window's own bounds are asserted in the hook's suite; what only shows
 		// here is that the injected year never displaces them.
 		const [ ranking ] = topPostsRequests().map( decodeURIComponent );
-		expect( ranking ).toContain( 'start_date=2025-08-27T00:00:00' );
+		expect( ranking ).toContain( 'start_date=2025-09-01T00:00:00' );
 		expect( ranking ).not.toContain( '2022' );
 
 		// A different section year is the change this card must ignore: it reads
@@ -159,8 +159,8 @@ describe( 'PopularPostWidget', () => {
 		const { searchParams: search } = getMockRouteLinkUrl( link );
 
 		expect( search.get( 'preset' ) ).toBe( 'last-12-months' );
-		expect( search.get( 'from' ) ).toContain( '2025-08-27T00:00:00' );
-		expect( search.get( 'to' ) ).toContain( '2026-08-26T23:59:59' );
+		expect( search.get( 'from' ) ).toContain( '2025-09-01T00:00:00' );
+		expect( search.get( 'to' ) ).toContain( '2026-08-27T23:59:59' );
 
 		// A complete window, so the detail route reseeds the URL from these params
 		// rather than from its own defaults. (It does reseed either way — its
@@ -185,6 +185,6 @@ describe( 'PopularPostWidget', () => {
 		await expect( screen.findByText( 'Winning post' ) ).resolves.toBeInTheDocument();
 
 		const [ ranking ] = topPostsRequests().map( decodeURIComponent );
-		expect( ranking ).toContain( 'start_date=2025-08-27T00:00:00' );
+		expect( ranking ).toContain( 'start_date=2025-09-01T00:00:00' );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/popular-post/__tests__/use-popular-post.test.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-post/__tests__/use-popular-post.test.tsx
@@ -310,10 +310,10 @@ describe( 'usePopularPost', () => {
 			const [ rankingPath ] = topPostsRequestPaths();
 			const ranking = decodeURIComponent( rankingPath );
 
-			// Whole days: from the start of the day 12 months back, through the end
-			// of yesterday.
-			expect( ranking ).toContain( 'start_date=2025-08-27T00:00:00' );
-			expect( ranking ).toContain( 'date=2026-08-26T23:59:59' );
+			// Whole calendar months: from the first of the month eleven months back,
+			// through the end of today.
+			expect( ranking ).toContain( 'start_date=2025-09-01T00:00:00' );
+			expect( ranking ).toContain( 'date=2026-08-27T23:59:59' );
 			expect( ranking ).not.toContain( 'days=' );
 		} );
 
@@ -336,10 +336,10 @@ describe( 'usePopularPost', () => {
 
 			await waitFor( () => expect( result.current.post?.id ).toBe( 7 ) );
 
-			expect( result.current.range.from ).toBe( '2025-08-27T00:00:00.000-07:00' );
-			expect( result.current.range.to ).toBe( '2026-08-26T23:59:59.999-07:00' );
+			expect( result.current.range.from ).toBe( '2025-09-01T00:00:00.000-07:00' );
+			expect( result.current.range.to ).toBe( '2026-08-27T23:59:59.999-07:00' );
 			expect( decodeURIComponent( topPostsRequestPaths()[ 0 ] ) ).toContain(
-				'start_date=2025-08-27T00:00:00.000-07:00'
+				'start_date=2025-09-01T00:00:00.000-07:00'
 			);
 		} );
 
@@ -354,8 +354,8 @@ describe( 'usePopularPost', () => {
 			// range from it, and both its date control and the dashboard's render
 			// it as a pill.
 			expect( result.current.range.preset ).toBe( 'last-12-months' );
-			expect( result.current.range.from ).toContain( '2025-08-27T00:00:00' );
-			expect( result.current.range.to ).toContain( '2026-08-26T23:59:59' );
+			expect( result.current.range.from ).toContain( '2025-09-01T00:00:00' );
+			expect( result.current.range.to ).toContain( '2026-08-27T23:59:59' );
 			// Whatever the detail page would have resolved for this window, so its
 			// route has no incomplete window to seed.
 			expect( result.current.range.interval ).toBe( 'month' );

--- a/projects/plugins/jetpack/changelog/wooa7s-1937-include-today-in-date-ranges
+++ b/projects/plugins/jetpack/changelog/wooa7s-1937-include-today-in-date-ranges
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: Include the current day in the last-N-day ranges, and count the 12-month range in whole calendar months, to match Jetpack Stats.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Date controls: Include the current day in the last-N-day ranges, and count the 12-month range in whole calendar months, to match Jetpack Stats.
+Date controls: Include the current day in the last-N-day ranges, and count the 12-month range in whole calendar months for its dates, its length, the step arrows and the previous period, to match Jetpack Stats.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Date controls: Include the current day in the 7-day and 30-day ranges, and count the 12-month range in whole calendar months, to match Jetpack Stats.
+Date controls: Include the current day in the last-N-day ranges, and count the 12-month range in whole calendar months, to match Jetpack Stats.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Date controls: Include the current day in the last-N-day ranges, and count the 12-month range in whole calendar months for its dates, its length, the step arrows and the previous period, to match Jetpack Stats.
+Date controls: Include the current day in the last-N-day ranges, and count the 12-month range in whole calendar months for its dates, its length and the step arrows, to match Jetpack Stats. The previous period covers the same number of days as the range it compares.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1937-include-today-in-date-ranges
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Date controls: Include the current day in the 7-day and 30-day ranges, and count the 12-month range in whole calendar months, to match Jetpack Stats.


### PR DESCRIPTION
Fixes WOOA7S-1937

## Proposed changes
* v2's rolling date presets stop at yesterday, while current Stats runs to today. Testers running the two side by side read this as a 24-hour lag in v2's numbers. `7 days` and `30 days` now end with today, so each still spans N days and the window matches current Stats.
* `12 months` differed in kind, not only by a day. v2 counted back twelve months from today's date, so the range started mid-month. It now covers twelve whole calendar months ending with the current one in progress, as current Stats does. This also stops the month-bucketed chart from drawing thirteen bars with the same month split across the first and the last.
* `90 days` and `365 days` follow the same rule, so they end today as well. Neither has a pill in the picker today, but both resolve from a URL, and matching the rule now keeps them from falling out of step if either is surfaced later.
* The 12-month window is now measured on its completed month wherever it is moved in whole units. The step arrows move it by whole months, and the previous-period comparison starts twelve months back and stops as many days short as the range itself, so a picker opened on 20 August 2026 compares 354 days against 354, not against 365. Stepping forward out of `12 months` lands back on the to-date window instead of a month of empty buckets. Where a month step would clamp (31 January – 30 March), the comparison falls back to the day count the way the arrows already do, so both name the same window.

### Before / after

The `7 days` preset, on a picker opened on **20 August 2026**.

| Before | After |
| --- | --- |
|<img alt="Google Chrome -2026-08-20 at 17 05 42@2x" src="https://github.com/user-attachments/assets/41f1af84-2a2b-4778-859d-3758ae7381cc" /><br>`7 days` selected: **Thursday, August 13 – Wednesday, August 19**. The range stops at yesterday. | <img alt="Google Chrome -2026-08-20 at 17 06 08@2x" src="https://github.com/user-attachments/assets/061c989a-28f5-4f0f-ab05-f420ecfede8e" /><br>`7 days` selected: **Friday, August 14 – Thursday, August 20**. The range now ends today. |

## Related product discussion/links
* WOOA7S-1937

## Does this pull request change what data or activity we track or use?
No. This changes only the date range the dashboard requests.

## Testing instructions

* Open the Premium Analytics dashboard and note the site's timezone.
* In the date range picker, choose **7 days**. The range must end on today's date and start six days earlier.
* Repeat for **30 days**. It must end today and start 29 days earlier.
* Repeat for **12 months**. It must end today and start on the first day of the month eleven months back. For a range picked on 20 August 2026, that is 1 September 2025.
* Open Jetpack Stats for the same site and pick the matching shortcuts. The three ranges must now agree.
* Look at the 12-month chart. It must draw twelve month bars, not thirteen with the current month split across the first and the last.
* With **12 months** selected, open **Compare** and pick the previous-period entry. It is named by its length, **Previous 354 days** on 20 August 2026. Hover the Compare toggle: the compared window must be **1 September 2024 – 20 August 2025**, the same number of days as the range, not the whole twelve months to 31 August. The `compare_from` and `compare_to` URL parameters carry the same dates.
* Press the **Previous period** arrow. The range must move to the twelve whole months before it, **1 September 2024 – 31 August 2025**, and the chart must still draw twelve month bars.
* Press the **Next period** arrow from there. The range must return to the to-date window ending today, not run on to 31 August 2026.





