### PR TITLE
Map Block: Remove the block's own alignment toolbar

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-map-block-duplicate-alignment-toolbar
+++ b/projects/plugins/jetpack/changelog/fix-map-block-duplicate-alignment-toolbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Map Block: Remove the duplicate alignment toolbar in the editor.

--- a/projects/plugins/jetpack/extensions/blocks/map/controls.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/map/controls.jsx
@@ -1,4 +1,4 @@
-import { BlockAlignmentToolbar, PanelColorSettings } from '@wordpress/block-editor';
+import { PanelColorSettings } from '@wordpress/block-editor';
 import {
 	PanelBody,
 	TextControl,
@@ -53,31 +53,15 @@ export default ( {
 	setPointVisibility,
 	mapProvider,
 } ) => {
-	const updateAlignment = value => {
-		setAttributes( { align: value } );
-
-		// Allow one cycle for alignment change to take effect
-		if ( mapRef.current?.sizeMap ) {
-			setTimeout( mapRef.current.sizeMap, 0 );
-		}
-	};
-
 	if ( context === 'toolbar' ) {
 		return (
-			<>
-				<BlockAlignmentToolbar
-					value={ attributes.align }
-					onChange={ updateAlignment }
-					controls={ [ 'center', 'wide', 'full' ] }
+			<ToolbarGroup>
+				<ToolbarButton
+					icon={ markerIcon }
+					label={ __( 'Add a marker', 'jetpack' ) }
+					onClick={ setPointVisibility }
 				/>
-				<ToolbarGroup>
-					<ToolbarButton
-						icon={ markerIcon }
-						label={ __( 'Add a marker', 'jetpack' ) }
-						onClick={ setPointVisibility }
-					/>
-				</ToolbarGroup>
-			</>
+			</ToolbarGroup>
 		);
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/map/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/map/edit.jsx
@@ -53,6 +53,7 @@ const MapEdit = ( {
 } ) => {
 	const {
 		address,
+		align,
 		mapDetails,
 		points,
 		zoom,
@@ -213,6 +214,17 @@ const MapEdit = ( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
+	// Changing the alignment changes the width of the block, so the map needs to be resized to match.
+	useEffect( () => {
+		if ( ! mapRef.current?.sizeMap ) {
+			return;
+		}
+
+		// Allow one cycle for the alignment change to take effect.
+		const timeout = setTimeout( mapRef.current.sizeMap, 0 );
+		return () => clearTimeout( timeout );
+	}, [ align ] );
+
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	useEffect( geoCodeAddress, [ address ] );
 
@@ -300,7 +312,6 @@ const MapEdit = ( {
 						onKeyChange={ onKeyChange }
 						setPointVisibility={ () => setAddPointVisibility( true ) }
 						context="toolbar"
-						mapRef={ mapRef }
 						mapProvider={ mapProvider }
 					/>
 				</BlockControls>


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* This is a follow-up to #50818.
* The Map block has rendered its own `BlockAlignmentToolbar` in `BlockControls` for a long time. #50818 added `supports.align` to `block.json`, which makes the editor render an alignment toolbar of its own, so the block toolbar now shows two alignment buttons writing to the same `align` attribute.
* This removes the hand-rolled toolbar and keeps `supports.align`.

`supports.align` is the half worth keeping; it's what puts `data-align` on the editor wrapper, so wide and full render as wide and full in the canvas. The custom toolbar only ever set the attribute, which is why alignment did nothing visible in the editor before #50818.

Of note, the custom toolbar's `onChange` was also calling `sizeMap()` after an alignment change, which Mapbox needs when its container width changes. The editor's own toolbar gives us no equivalent callback, so that call moves to an effect keyed on the `align` attribute.

Two things I left alone:

* `block.json` is untouched. The old toolbar offered `center` next to `wide` and `full`, but the block has no `aligncenter` styles and is always the full width of its container, so centering it did nothing. Scoping the support to `wide` and `full` in #50818 was right. I did briefly add `center` back for parity before checking whether it had ever done anything :)
* `sizeMap` only exists on the Mapbox component. Mapkit, on Simple sites, has never resized on an alignment change, before or after this PR. Its container is width-fluid via CSS, so as far as I can tell it doesn't need one.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* #50818
* #40715

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Add a Map block to a post, and give it an address so the map renders.
* Select the block and look at its toolbar. On trunk you'll see two alignment buttons; on this branch, one.
* Switch the alignment to Wide, then to Full. The block should widen in the canvas each time, and the map tiles should re-render to fill the new width instead of leaving a gap. This is the bit worth clicking through, since the resize call moved from a click handler to an effect.
* Save, and check the block still gets `alignwide` / `alignfull` on the front end.
* If you can, give it a pass on a Simple site too; those use Mapkit rather than Mapbox.
