### PR TITLE
Enable React 19 on 5% of Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-react-19-on-5pct-atomic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-react-19-on-5pct-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Gutenberg: Enable the React 19 experiment on 5% of Atomic sites.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -892,7 +892,7 @@ class Jetpack_Mu_Wpcom {
 			} elseif ( self::has_react_19_incompatible_extension() ) {
 				$is_enabled = false;
 			} else {
-				$current_segment = 2; // Segment of Atomic sites in the experiment, in %.
+				$current_segment = 5; // Segment of Atomic sites in the experiment, in %.
 				$site_segment    = $site_id % 100;
 
 				/*

--- a/projects/plugins/wpcomsh/changelog/update-react-19-on-5pct-atomic
+++ b/projects/plugins/wpcomsh/changelog/update-react-19-on-5pct-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enable wp-admin JS error reporting on 5% of sites, to keep up with the React 19 experiment rollout.

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -222,7 +222,7 @@ function wpcomsh_enable_error_reporting_for_react_19( $is_enabled ) {
 		return false;
 	}
 
-	$current_segment = 2; // Segment of sites that get error reporting, in %.
+	$current_segment = 5; // Segment of sites that get error reporting, in %.
 	$site_segment    = $site_id % 100;
 
 	// Sites whose id ends in digits < $current_segment are in the segment.


### PR DESCRIPTION
Let's enable React 19 on 5% of Atomic sites. The previous increase from 1% to 2% in #51351 didn't cause any new failures.

If the 5% rate also doesn't detect any new failures, it's probably time to enable React 19 again in the Gutenberg plugin 😉

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions
Deploy on your Atomic site and ensure things don't crash.