### PR TITLE
RTC: keep the collaboration setting when Gutenberg's migration runs twice

### DIFF
--- a/projects/packages/rtc/changelog/fix-rtc-restore-opt-in-repeated-migrations
+++ b/projects/packages/rtc/changelog/fix-rtc-restore-opt-in-repeated-migrations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+RTC: keep the collaboration setting when Gutenberg's migration runs more than once

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -58,6 +58,25 @@ class RTC {
 	private static $initialized = false;
 
 	/**
+	 * The stored collaboration setting as it was before Gutenberg's migration could run,
+	 * captured on `init` priority 0. Null when nothing was stored, false before we looked.
+	 *
+	 * Per-request, deliberately: it answers "did the migration take this away from us just
+	 * now", which a persisted value cannot, because an absent option means either "the
+	 * migration deleted it" or "the user switched collaboration off".
+	 *
+	 * @var mixed
+	 */
+	private static $pre_migration_value = false;
+
+	/**
+	 * Whether Gutenberg's migration ran during this request.
+	 *
+	 * @var bool
+	 */
+	private static $migration_ran = false;
+
+	/**
 	 * Initialize the RTC package by registering hooks.
 	 *
 	 * @return void
@@ -83,6 +102,14 @@ class RTC {
 		add_action( 'init', array( __CLASS__, 'register_experiment_filters' ), 1 );
 		// Priority 30 so it lands after Gutenberg's migration deletes the option at 20.
 		add_action( 'init', array( __CLASS__, 'restore_opt_in' ), 30 );
+
+		/*
+		 * `_gutenberg_migrate_database()` writes this option as its final statement, so the
+		 * hook firing is proof the migration just ran. That distinction matters: an absent
+		 * collaboration option means "the migration removed it" or "the user switched it
+		 * off", and only the first is ours to undo.
+		 */
+		add_action( 'update_option_gutenberg_version_migration', array( __CLASS__, 'note_migration_ran' ) );
 		add_action( 'admin_init', array( __CLASS__, 'register_rtc_setting' ) );
 
 		// Hook into both old and new option names for backwards compatibility.
@@ -362,6 +389,15 @@ class RTC {
 			return;
 		}
 
+		/*
+		 * Runs before Gutenberg's migration at priority 20, so this is the last chance to
+		 * see the stored value. Captured on every request, not just the first, because the
+		 * migration can run more than once: a sandbox on an older Gutenberg rewrites
+		 * `gutenberg_version_migration` to its own version, and production then re-runs its
+		 * migration and deletes the option again.
+		 */
+		self::$pre_migration_value = self::get_stored_option( self::OPTION_NEW );
+
 		// Already looked. Recorded as '1' or '0', so anything but false means done.
 		if ( false !== get_option( self::OPTION_PRE_EXPERIMENT_OPT_IN, false ) ) {
 			return;
@@ -378,15 +414,31 @@ class RTC {
 	}
 
 	/**
-	 * Re-apply a carried opt-in after Gutenberg's migration has removed the option.
+	 * Record that Gutenberg's migration ran during this request.
+	 *
+	 * @return void
+	 */
+	public static function note_migration_ran() {
+		self::$migration_ran = true;
+	}
+
+	/**
+	 * Re-apply the collaboration setting after Gutenberg's migration has removed it.
 	 *
 	 * Deliberately writes a real option value instead of leaning on
 	 * `default_rtc_option()`. Unchecking the box on Settings > Writing does not store a
 	 * '0' — it removes the row entirely — so anything expressed as a default would
 	 * re-apply itself on the next request and make the setting impossible to switch off.
 	 *
-	 * The carried flag is consumed here so this runs once. From then on the stored option
-	 * is the only thing that decides, exactly as it is for a site that never opted in.
+	 * Two things have to be true before anything is written. The migration must have run
+	 * in this request, and the value must have been there when we looked at priority 0.
+	 * Together they separate "the migration took this away" from "the user switched it
+	 * off", which an absent option cannot distinguish on its own.
+	 *
+	 * This is not once-only. The migration re-runs whenever `gutenberg_version_migration`
+	 * disagrees with the running Gutenberg, which happens every time a sandbox on an older
+	 * version rewrites it and production migrates again. Restoring only once left those
+	 * sites losing a deliberate opt-in on the second pass.
 	 *
 	 * @return void
 	 */
@@ -395,17 +447,33 @@ class RTC {
 			return;
 		}
 
+		if ( ! self::$migration_ran ) {
+			return;
+		}
+
+		// Only restore into the gap the migration left. Never overwrite a real choice.
+		if ( null !== self::get_stored_option( self::OPTION_NEW ) ) {
+			return;
+		}
+
+		if ( null !== self::$pre_migration_value && false !== self::$pre_migration_value ) {
+			// Restore exactly what was there, so a stored opt-out survives too.
+			update_option( self::OPTION_NEW, self::$pre_migration_value );
+			return;
+		}
+
+		/*
+		 * Nothing was stored when we looked, so fall back to the marker recorded the first
+		 * time this package ran. That covers a site whose option was already gone by then,
+		 * for instance because the old option names were removed by an earlier migration.
+		 * Consumed here, since it describes a moment that has passed and cannot recur.
+		 */
 		if ( '1' !== get_option( self::OPTION_PRE_EXPERIMENT_OPT_IN ) ) {
 			return;
 		}
 
-		// Consume first, so a failure below cannot leave this re-applying every request.
 		update_option( self::OPTION_PRE_EXPERIMENT_OPT_IN, '0' );
-
-		// Only restore into the gap the migration left. Never overwrite a real choice.
-		if ( null === self::get_stored_option( self::OPTION_NEW ) ) {
-			update_option( self::OPTION_NEW, '1' );
-		}
+		update_option( self::OPTION_NEW, '1' );
 	}
 
 	/**

--- a/projects/packages/rtc/tests/php/RTC_Test.php
+++ b/projects/packages/rtc/tests/php/RTC_Test.php
@@ -92,6 +92,21 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 			remove_all_filters( 'pre_option_' . $option );
 		}
 
+		/*
+		 * Reset the per-request statics too. They describe one request, so leaking
+		 * `migration_ran` into the next test would let a restore happen where the code
+		 * under test never saw a migration.
+		 */
+		$per_request = array(
+			'migration_ran'       => false,
+			'pre_migration_value' => false,
+		);
+		foreach ( $per_request as $property => $value ) {
+			$static = new \ReflectionProperty( RTC::class, $property );
+			$static->setAccessible( true );
+			$static->setValue( null, $value );
+		}
+
 		// Reset the static $initialized flag so hooks are re-registered in the next test.
 		$reflection = new \ReflectionProperty( RTC::class, 'initialized' );
 		if ( PHP_VERSION_ID < 80100 ) {
@@ -978,6 +993,7 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 
 		// Gutenberg's migration has removed the option by this point.
 		delete_option( RTC::OPTION_NEW );
+		RTC::note_migration_ran();
 		RTC::restore_opt_in();
 
 		$this->assertSame(
@@ -995,10 +1011,12 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '1' );
 		delete_option( RTC::OPTION_NEW );
 
+		RTC::note_migration_ran();
 		RTC::restore_opt_in();
 
 		$this->assertSame( '1', get_option( RTC::OPTION_NEW ) );
-		// The flag is consumed, so this only ever happens once.
+		// Nothing was stored before the migration, so this came from the marker, which is
+		// consumed because it describes a moment that cannot recur.
 		$this->assertSame( '0', get_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN ) );
 	}
 
@@ -1045,15 +1063,98 @@ class RTC_Test extends \WorDBless\BaseTestCase {
 		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '1' );
 		delete_option( RTC::OPTION_NEW );
 
+		RTC::note_migration_ran();
 		RTC::restore_opt_in();
 		$this->assertTrue( RTC::is_turned_on(), 'collaboration should be restored' );
 
-		// The user unchecks the box, which removes the row.
+		// The user unchecks the box, which removes the row. No migration ran, so nothing
+		// should put it back.
 		delete_option( RTC::OPTION_NEW );
 		RTC::restore_opt_in();
 
 		$this->assertFalse( RTC::is_turned_on(), 'collaboration should stay off' );
 		$this->assertSame( array(), RTC::filter_experiments( array() ) );
+	}
+
+	/**
+	 * Tests that a deliberate opt-in survives the migration running more than once.
+	 *
+	 * Regression test for the sandbox flip-flop: a sandbox on an older Gutenberg rewrites
+	 * `gutenberg_version_migration` to its own version, production disagrees and migrates
+	 * again, and the collaboration option is deleted on every pass. Restoring only once
+	 * meant the second deletion stuck and the site silently lost collaboration.
+	 */
+	public function test_opt_in_survives_repeated_migrations() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		add_option( RTC::OPTION_NEW, '1' );
+
+		for ( $pass = 1; $pass <= 3; $pass++ ) {
+			// Priority 0: we look before the migration can touch anything.
+			RTC::carry_over_opt_in();
+
+			// Priority 20: Gutenberg migrates and removes the option.
+			delete_option( RTC::OPTION_NEW );
+			RTC::note_migration_ran();
+
+			// Priority 30: we put it back.
+			RTC::restore_opt_in();
+
+			$this->assertSame( '1', get_option( RTC::OPTION_NEW ), "opt-in lost on pass {$pass}" );
+		}
+	}
+
+	/**
+	 * Tests that a stored opt-out survives the migration too.
+	 *
+	 * A stored '0' is a decision as much as a stored '1' is, and restoring the carried
+	 * marker rather than the actual previous value would quietly turn collaboration on.
+	 */
+	public function test_stored_opt_out_survives_the_migration() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		update_option( RTC::OPTION_PRE_EXPERIMENT_OPT_IN, '1' );
+		add_option( RTC::OPTION_NEW, '0' );
+
+		RTC::carry_over_opt_in();
+		delete_option( RTC::OPTION_NEW );
+		RTC::note_migration_ran();
+		RTC::restore_opt_in();
+
+		$this->assertSame( '0', get_option( RTC::OPTION_NEW ) );
+		$this->assertFalse( RTC::is_turned_on() );
+	}
+
+	/**
+	 * Tests that nothing is restored when no migration ran.
+	 *
+	 * This is what separates "the migration deleted it" from "the user switched it off".
+	 * Without the distinction, unchecking the box would be undone on the next request.
+	 */
+	public function test_no_restore_without_a_migration() {
+		$this->use_experiment_and_allow();
+		RTC::init();
+		add_option( RTC::OPTION_NEW, '1' );
+
+		RTC::carry_over_opt_in();
+
+		// The user unchecks the box. No migration involved.
+		delete_option( RTC::OPTION_NEW );
+		RTC::restore_opt_in();
+
+		$this->assertFalse( RTC::is_turned_on(), 'an unchecked box must stay unchecked' );
+	}
+
+	/**
+	 * Tests that init hooks the migration detector.
+	 */
+	public function test_init_watches_for_the_migration() {
+		RTC::init();
+
+		$this->assertSame(
+			10,
+			has_action( 'update_option_gutenberg_version_migration', array( RTC::class, 'note_migration_ran' ) )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes the collaboration setting being lost when Gutenberg's migration runs more than once.

## Proposed changes

* `restore_opt_in()` consumed its marker, so it ran exactly once. Gutenberg's migration is not once-only: a sandbox on an older Gutenberg rewrites `gutenberg_version_migration` to its own version, production then disagrees and migrates again, and `wp_collaboration_enabled` is deleted on every pass. From the second pass onward the deletion stuck, and a site that had deliberately switched collaboration on lost it silently.
* Restoring on every pass is not enough by itself. An absent option means either "the migration removed it" or "the user unchecked the box on Settings > Writing", which deletes the row rather than storing `0`. Undoing the second case would make the setting impossible to switch off, which is the regression `test_carried_site_can_turn_collaboration_off` already guards.
* Two per-request facts now separate the cases:
  * `carry_over_opt_in()` snapshots the stored value on every request at `init` priority 0, before the migration at priority 20 can touch it. Previously it only looked once.
  * `note_migration_ran()` hooks `update_option_gutenberg_version_migration`, which `_gutenberg_migrate_database()` writes as its final statement. The hook firing is proof the migration just ran.
* `restore_opt_in()` writes only when both hold, and restores the previous value rather than the carried marker, so a stored opt-out survives as well as an opt-in.

This hardens the package. It does not stop the churn itself, which needs a sandbox-side guard so sandboxes stop rewriting `gutenberg_version_migration`.

## Related product discussion/links

* Slack discussion about sandboxes reverting `gutenberg_version_migration` while production is on Gutenberg 23.8.

## Does this pull request change what data or activity we track or use?

No. Same options as before, written under narrower conditions.

## Testing instructions

Automated coverage is probably the quickest read, four new tests in `projects/packages/rtc/tests/php/RTC_Test.php`:

```
cd projects/packages/rtc && composer phpunit
```

* `test_opt_in_survives_repeated_migrations` fails on trunk and passes here. It runs three migration cycles and asserts the opt-in is still stored each time.
* `test_stored_opt_out_survives_the_migration` covers a stored `0` surviving, which restoring the marker would have turned on.
* `test_no_restore_without_a_migration` covers unchecking the box staying unchecked.
* `test_init_watches_for_the_migration` covers the hook registration.

To see it by hand on a site with collaboration switched on:

1. Confirm `wp_collaboration_enabled` is stored as `1`.
2. Simulate the migration re-running by setting `gutenberg_version_migration` to an older value, for example `22.8.0`, and loading any page. Gutenberg migrates, deletes `wp_collaboration_enabled`, and writes the version option back.
3. On trunk the option is gone after the second cycle. With this change it is restored on every cycle, and Settings > Writing still shows collaboration enabled.
4. Uncheck the box on Settings > Writing and reload. It stays off, because no migration ran.
