### PR TITLE
Backup: forward the reader's locale to the activity log

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-activity-log-locale
+++ b/projects/packages/backup/changelog/fix-backup-activity-log-locale
@@ -1,4 +1,3 @@
 Significance: patch
 Type: fixed
-
-Show the activity log in the reader's language.
+Comment: Backup: forward the reader's locale to the modernized dashboard's activity list so WordPress.com renders the summaries in their language. No-op when the modernization filter is off.

--- a/projects/packages/backup/changelog/fix-backup-activity-log-locale
+++ b/projects/packages/backup/changelog/fix-backup-activity-log-locale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show the activity log in the reader's language.

--- a/projects/packages/backup/src/rest/class-activity-log-bridge.php
+++ b/projects/packages/backup/src/rest/class-activity-log-bridge.php
@@ -85,8 +85,11 @@ class Activity_Log_Bridge {
 
 		$query = array_filter(
 			array(
-				'number' => $request->get_param( 'number' ),
-				'page'   => $request->get_param( 'page' ),
+				'number'  => $request->get_param( 'number' ),
+				'page'    => $request->get_param( 'page' ),
+				// Activity summaries are rendered by WPCOM. Without this they
+				// come back in English whatever the reader's language is.
+				'_locale' => get_user_locale(),
 			),
 			static function ( $value ) {
 				return null !== $value && '' !== $value;

--- a/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
@@ -18,6 +18,7 @@ use WP_REST_Server;
 use function add_action;
 use function add_filter;
 use function do_action;
+use function get_user_locale;
 use function remove_filter;
 use function wp_insert_user;
 use function wp_set_current_user;
@@ -112,5 +113,21 @@ class Rest_Activity_Log_Bridge_Test extends TestCase {
 		$this->assertSame( 'activity_log_fetch_failed', $response->get_error_code() );
 		$this->assertStringNotContainsString( 'cURL', $response->get_error_message() );
 		$this->assertSame( 502, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * WPCOM renders the activity summaries, so the reader's locale has to
+	 * travel with the request or every string comes back in English.
+	 */
+	public function test_forwards_the_reader_locale() {
+		$this->sign_in_as_admin();
+		$this->arrange_wpcom( array( 'current' => array( 'orderedItems' => array() ) ) );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/site/rewindable-activity' );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'number', 10 );
+		Activity_Log_Bridge::get_activity_log( $request );
+
+		$this->assertStringContainsString( '_locale=' . get_user_locale(), $this->captured_url );
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
@@ -18,8 +18,9 @@ use WP_REST_Server;
 use function add_action;
 use function add_filter;
 use function do_action;
-use function get_user_locale;
+use function get_current_user_id;
 use function remove_filter;
+use function update_user_meta;
 use function wp_insert_user;
 use function wp_set_current_user;
 
@@ -118,16 +119,20 @@ class Rest_Activity_Log_Bridge_Test extends TestCase {
 	/**
 	 * WPCOM renders the activity summaries, so the reader's locale has to
 	 * travel with the request or every string comes back in English.
+	 *
+	 * The user locale is set away from the site locale on purpose: reading it
+	 * back with `get_user_locale()` would compare the code against itself and
+	 * pass just as well against `get_locale()`.
 	 */
 	public function test_forwards_the_reader_locale() {
-		$this->sign_in_as_admin();
 		$this->arrange_wpcom( array( 'current' => array( 'orderedItems' => array() ) ) );
+		update_user_meta( get_current_user_id(), 'locale', 'es_ES' );
 
 		$request = new WP_REST_Request( 'GET', '/jetpack/v4/site/rewindable-activity' );
 		$request->set_param( 'page', 1 );
 		$request->set_param( 'number', 10 );
 		Activity_Log_Bridge::get_activity_log( $request );
 
-		$this->assertStringContainsString( '_locale=' . get_user_locale(), $this->captured_url );
+		$this->assertStringContainsString( '_locale=es_ES', $this->captured_url );
 	}
 }


### PR DESCRIPTION
## Proposed changes

Activity summaries are rendered by WordPress.com, and the Backup bridge forwarded only `number` and `page` — no locale. So the modernized dashboard's activity list comes back in English whatever language the reader's wp-admin is in.

Appends `_locale` (the `wpcom/v2` spelling) from `get_user_locale()`.

`get_user_locale()` rather than `get_locale()`: it matches the language wp-admin is already rendering in for that reader, which is the language the list sits next to. On a site whose admins use different languages, the site locale would be wrong for all but one of them.

Prior art for the same call shape — a v2 `/sites/{blog_id}/…` path through `wpcom_json_api_request_as_user`:
* `projects/plugins/jetpack/_inc/blogging-prompts.php:188`
* `projects/packages/jitm/src/class-post-connection-jitm.php:279`

## Scope — this is behind the modernization flag

`Rest_Controller::register_routes()` returns early unless `Jetpack_Backup::is_modernized()`, and that filter is default-off, so the route this changes does not exist on a default site.

The legacy dashboard is unaffected and has no activity list of its own — `src/js/components/Backups.jsx:221` links out to WordPress.com's activity log. The only consumer is the modernized data layer, `src/dashboard/data/api/activity-log.ts:46`.

## Related product discussion/links

* [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243/backup-modernized-dashboard-work-needed-before-the-flag-can-flip) — item **F11**
* Found while reviewing #51404, which is where the heading that shows this string comes from

## Does this pull request change what data or activity we track or use?

No. `get_user_locale()` is a WordPress core value already sent on other WordPress.com requests from this plugin, and it is URL-encoded through `http_build_query()`.

## Testing instructions

### Automated — this is the real proof, and it needs no site

```bash
jp test php packages/backup      # OK (190 tests, 544 assertions)
```

`test_forwards_the_reader_locale` sets the current user's locale to `es_ES` — away from the site locale on purpose — and asserts `_locale=es_ES` reaches the outgoing WordPress.com URL.

Both mutations fail it, which is the property that matters:

| Mutation | Result |
|---|---|
| `get_user_locale()` → `get_locale()` | **fails** — got `_locale=en_US` |
| `_locale` removed entirely | **fails** — no `_locale` in the URL |

The first is the one worth having. An earlier version of this test read the expected value back with `get_user_locale()`, which compared the code against itself and stayed green under that mutation — caught in review by @dhasilva.

### Manual — needs a connected site with a paid Backup plan

A plain local install shows none of this. `<Gates>` (`src/dashboard/components/gates/index.tsx:36-64`) stops an unconnected site at "Connect Jetpack to get started" and a connected site without a plan at "This site doesn't have an active Backup plan"; neither renders the activity list. Use a Jurassic Ninja or WoA site with Backup and at least one completed backup.

1. **Activate the standalone Backup plugin.** `Jetpack_Backup::initialize()` only runs from it — without it there is no `page=jetpack-backup` at all.
2. **Build:** `jp build packages/backup`. `build/` is gitignored, so with the flag on and no build you get a blank page (that is #51436, not this PR).
3. **Turn the dashboard on**, as an mu-plugin so it reverts by deleting the file:
   ```php
   <?php // wp-content/mu-plugins/backup-modernize.php
   add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
   ```
4. **Set your own user language**, not the site's: **Users → Profile → Language → Español**. The point of the change is that it follows the user, so leave Settings → General alone.

### What to expect

Open **Jetpack → VaultPress Backup** and read the activity list.

| | Expect |
|---|---|
| **This branch** | Summaries in Spanish — "Copia de seguridad completada", etc. |
| **trunk** | The same summaries in English, with your profile set to Español |

To see the mechanism rather than the output, log the outgoing request from the same mu-plugin:

```php
add_filter( 'pre_http_request', function ( $pre, $args, $url ) {
	if ( false !== strpos( $url, '/activity/rewindable' ) ) {
		error_log( $url );   // expect &_locale=es_ES
	}
	return $pre;
}, 10, 3 );
```

Note `jetpack_dev` Docker sets `WP_DEBUG_DISPLAY=false`, so read `error_log` output from the log file rather than the screen.

### What this does not fix

Only the activity list. If WordPress.com has no translation for a given summary it still returns English — this makes the request ask correctly, it does not add translations upstream.
