### PR TITLE
Premium Analytics: apply widget section flex workaround to detail routes

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-premium-analytics-detail-widget-section-flex
+++ b/projects/packages/premium-analytics/changelog/fix-premium-analytics-detail-widget-section-flex
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Apply the first widget section flex-column workaround to the post and video detail routes too.

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -30,6 +30,10 @@
 	// clips content-sized widgets like the traffic activity heatmap
 	// (WOOA7S-1905). TODO with #51101: consider fixing upstream in Card.
 	section:first-of-type {
+		// Temporary solution. Fixed upstream https://github.com/WordPress/gutenberg/pull/80570
+		display: flex;
+		flex-direction: column;
+
 		--wp-ui-card-padding: var(--wpds-dimension-padding-lg);
 		--wp-ui-card-header-content-margin: var(--wpds-dimension-padding-lg);
 

--- a/projects/packages/premium-analytics/routes/video-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.module.scss
@@ -32,6 +32,10 @@
 	// clips content-sized widgets like the traffic activity heatmap
 	// (WOOA7S-1905). TODO with #51101: consider fixing upstream in Card.
 	section:first-of-type {
+		// Temporary solution. Fixed upstream https://github.com/WordPress/gutenberg/pull/80570
+		display: flex;
+		flex-direction: column;
+
 		--wp-ui-card-padding: var(--wpds-dimension-padding-lg);
 		--wp-ui-card-header-content-margin: var(--wpds-dimension-padding-lg);
 


### PR DESCRIPTION
Fixes #

## Proposed changes
* Apply the `section:first-of-type { display: flex; flex-direction: column; }` workaround from #51070 to the post-detail and video-detail routes' `.widgets` block as well. #51070 only patched the dashboard route, but the detail routes render the same widget chrome, so their first widget tile still lays out without the flex column (header/content not stacked correctly).
* Same temporary-solution comment as the dashboard route, so all three sites can be removed together once `@wordpress/widget-dashboard` is bumped to a version containing [WordPress/gutenberg#80570](https://github.com/WordPress/gutenberg/pull/80570) (currently pinned to 0.4.0, which predates that fix).

## Related product discussion/links
* Follow-up to #51070
* https://github.com/WordPress/gutenberg/pull/80570

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Build Premium Analytics (`jp build packages/premium-analytics`) and open a post detail route (Stats → click a post) and a video detail route (Stats → click a video).
* Confirm the first widget tile on each page lays out its chrome as a column (header on top, content below, content filling the tile) — e.g. the "Video highlights" tile on the video detail page no longer has its stat tiles pushed down.
* Inspect the first `<section>` inside the widget grid and verify it has `display: flex; flex-direction: column` from `.widgets section:first-of-type`.
* Confirm the dashboard route is unchanged.
