### PR TITLE
Backup: recover a restore session instead of arming a second one

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-restore-session-recovery
+++ b/projects/packages/backup/changelog/fix-backup-restore-session-recovery
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: adopt a restore that is already running when the modernized restore screen opens, instead of arming a Confirm button that would start a second concurrent one; match the recovered restore on recency rather than the first row, so a completed restore of the same backup is never reported as the one just started; hold a submission whose answer never arrived open until it is known whether it started; and stop polling the restores collection once the id is in hand. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/data/api/_helpers.ts
+++ b/projects/packages/backup/src/dashboard/data/api/_helpers.ts
@@ -75,6 +75,41 @@ export class ApiError extends Error {
 }
 
 /**
+ * Statuses that mean the request may have been carried out even though
+ * we never saw a usable answer.
+ *
+ * A gateway timeout is not a refusal. WordPress.com may have accepted
+ * and queued the work and only the reply went missing, which for a
+ * destructive operation is the difference between "try again" and
+ * "start a second one".
+ */
+const AMBIGUOUS_STATUSES = new Set( [ 408, 502, 503, 504 ] );
+
+/**
+ * Whether a failure leaves the outcome genuinely unknown.
+ *
+ * The bridges give every failure of one operation the same code — all
+ * three initiate failures are `restore_initiate_failed` — so the code
+ * cannot tell these apart. `data.transport` can: it is attached by
+ * `Rest_Controller::transport_error()` and by nothing else, so its
+ * presence means the request never reached WordPress.com's answer, not
+ * that WordPress.com said no.
+ *
+ * @param error - The rejection from `apiCall`.
+ * @return True when the caller must not assume nothing happened.
+ */
+export function isAmbiguousFailure( error: unknown ): boolean {
+	if ( ! ( error instanceof ApiError ) ) {
+		return false;
+	}
+	const data = error.data as { status?: unknown; transport?: unknown } | undefined;
+	if ( data?.transport ) {
+		return true;
+	}
+	return typeof data?.status === 'number' && AMBIGUOUS_STATUSES.has( data.status );
+}
+
+/**
  * Serialize a restore/download category checklist for WPCOM, refusing an
  * empty one.
  *

--- a/projects/packages/backup/src/dashboard/data/api/_helpers.ts
+++ b/projects/packages/backup/src/dashboard/data/api/_helpers.ts
@@ -88,12 +88,29 @@ const AMBIGUOUS_STATUSES = new Set( [ 408, 502, 503, 504 ] );
 /**
  * Whether a failure leaves the outcome genuinely unknown.
  *
- * The bridges give every failure of one operation the same code — all
- * three initiate failures are `restore_initiate_failed` — so the code
- * cannot tell these apart. `data.transport` can: it is attached by
- * `Rest_Controller::transport_error()` and by nothing else, so its
- * presence means the request never reached WordPress.com's answer, not
- * that WordPress.com said no.
+ * The question is not "did something go wrong" but "did our code get far
+ * enough to give a verdict". Only a failure the bridge itself shaped
+ * carries one, and every such failure carries a `data.status`; the
+ * bridges give every failure of one operation the same code — all three
+ * initiate failures are `restore_initiate_failed` — so the code cannot
+ * tell them apart, but the presence of a verdict can.
+ *
+ * So the default is *ambiguous*, and a failure has to earn its way out.
+ * That inversion matters: the hop the bridges describe is site →
+ * WordPress.com, but the request also crosses browser → site, and that
+ * hop fails in shapes carrying no `data` at all — `fetch_error` when the
+ * request never completes, `invalid_json` when a proxy answers with an
+ * HTML gateway page. The second is the dangerous one and is not exotic:
+ * initiate is a blocking `wp_remote_post`, so a site whose proxy times
+ * out before WordPress.com replies returns that page *after* the restore
+ * has been queued. Read as a plain error, it offered the retry that
+ * starts a second concurrent restore.
+ *
+ * The one exception is knowable rather than assumed. If the browser
+ * reports no network, the request did not leave it, so nothing can have
+ * started. `navigator.onLine` is unreliable when true and reliable when
+ * false — which is the only direction relied on here — and it spares the
+ * reader a five-minute wait for the most common failure there is.
  *
  * @param error - The rejection from `apiCall`.
  * @return True when the caller must not assume nothing happened.
@@ -102,11 +119,25 @@ export function isAmbiguousFailure( error: unknown ): boolean {
 	if ( ! ( error instanceof ApiError ) ) {
 		return false;
 	}
+
+	// Proof the request never left, rather than an assumption about it.
+	if ( typeof navigator !== 'undefined' && navigator.onLine === false ) {
+		return false;
+	}
+
 	const data = error.data as { status?: unknown; transport?: unknown } | undefined;
 	if ( data?.transport ) {
 		return true;
 	}
-	return typeof data?.status === 'number' && AMBIGUOUS_STATUSES.has( data.status );
+	if ( typeof data?.status === 'number' ) {
+		// A verdict from the bridge. Ambiguous only for the statuses that
+		// mean the answer itself went missing.
+		return AMBIGUOUS_STATUSES.has( data.status );
+	}
+
+	// No verdict at all — the failure happened before our code could give
+	// one, so the outcome is unknown.
+	return true;
 }
 
 /**

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -166,10 +166,10 @@ function sameRewindId( candidate: string, target: string ): boolean {
  * @return The best candidate, or null.
  */
 export function pickLiveRestore(
-	rows: RecentRestore[],
+	rows: RecentRestore[] | null,
 	rewindId: string | null
 ): RecentRestore | null {
-	const candidates = rows
+	const candidates = ( rows ?? [] )
 		.filter(
 			row => ! row.settled && ( rewindId === null || sameRewindId( row.rewind_id, rewindId ) )
 		)
@@ -239,15 +239,20 @@ export async function fetchRestoreStatus( restoreId: number ): Promise< RestoreS
  * this resolves rather than rejecting, and the empty list it returns in
  * that case means "could not read", not "no restores".
  *
- * @return The recent restores, or an empty list when the read failed.
+ * Returns `null` — not an empty list — when the read failed, because the
+ * two mean opposite things to a caller deciding whether it is safe to
+ * start a destructive operation, and an empty array quietly reads as
+ * "nothing is running".
+ *
+ * @return The recent restores, or null when the read failed.
  */
-export async function fetchRecentRestores(): Promise< RecentRestore[] > {
+export async function fetchRecentRestores(): Promise< RecentRestore[] | null > {
 	const data = await apiCall< unknown >( {
 		path: apiPath( '/restores' ),
 	} );
 
 	if ( ! Array.isArray( data ) ) {
-		return [];
+		return null;
 	}
 
 	return data
@@ -260,4 +265,29 @@ export async function fetchRecentRestores(): Promise< RecentRestore[] > {
 				typeof row.status === 'string' && SETTLED_ROW_STATUSES.has( row.status.toLowerCase() ),
 		} ) )
 		.filter( row => row.restore_id > 0 );
+}
+
+/**
+ * The restore this site has running right now, if any.
+ *
+ * Two reads, because the collection alone cannot answer it: its rows
+ * carry a status in a vocabulary that is not ours, so a row is only a
+ * candidate until the status route — which speaks the vocabulary the
+ * bridge maps — confirms it is `running`.
+ *
+ * Deliberately separate from `useAdoptedRestore`, which asks the same
+ * question at mount through two cached queries so its confirmation
+ * shares a key with the status poll and costs nothing extra. This one is
+ * for the moment of a destructive click, where a cached answer is the
+ * wrong answer.
+ *
+ * @return The running restore, or null when nothing is.
+ */
+export async function fetchRunningRestore(): Promise< RecentRestore | null > {
+	const candidate = pickLiveRestore( await fetchRecentRestores(), null );
+	if ( candidate === null ) {
+		return null;
+	}
+	const status = await fetchRestoreStatus( candidate.restore_id );
+	return 'running' === status.status ? candidate : null;
 }

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -46,19 +46,145 @@ export type RestoreStatusResponse = {
 };
 
 /**
+ * Status spellings from the restores collection that we are confident
+ * mean the restore is over.
+ *
+ * The collection's `status` is *not* the status route's vocabulary:
+ * WordPress.com's docblock for it claims `finished/started/fail` while
+ * its own consumer matches `running`, and the standalone plugin's legacy
+ * Admin screen reads `finished`. Rather than map a second,
+ * differently-spelled enum into ours — which would invite something to
+ * treat it as authoritative — this quarantines it as a single boolean,
+ * computed once, at the edge.
+ *
+ * An unrecognised spelling counts as *not* settled, so the row stays
+ * adoptable. That is the direction that fails least badly: the rows are
+ * ranked newest-first, so the restore we just started is the one we
+ * reach anyway, and a stale adoption self-corrects as soon as the real
+ * one appears. Guessing the other way would make an unknown spelling of
+ * "running" permanently unrecoverable.
+ */
+const SETTLED_ROW_STATUSES = new Set( [
+	'finished',
+	'success',
+	'success-with-errors',
+	'fail',
+	'failed',
+	'aborted',
+	'error',
+] );
+
+/**
  * One row of `GET /jetpack/v4/restores` — the last ten restores, any state.
  *
- * Deliberately only the two fields the recovery match needs. The rows
- * also carry a `status`, and it is not the status route's vocabulary:
- * WordPress.com's docblock for the collection claims `finished/started/
- * fail` while its own consumer matches `running`. Nothing here reads it,
- * and mapping a second, differently-spelled status enum would invite
- * something to.
+ * `when` is WordPress.com's own ISO-8601 timestamp and is compared only
+ * against other rows', never against the browser's clock: a browser
+ * minutes ahead of the server would otherwise reject the restore it had
+ * just started, and recovery would fail for the whole session.
+ *
+ * `settled` is the quarantined reading of the row's `status` — see
+ * `SETTLED_ROW_STATUSES`. The raw spelling is deliberately not carried
+ * any further than this file.
  */
 export type RecentRestore = {
 	restore_id: number;
 	rewind_id: string;
+	when: string;
+	settled: boolean;
 };
+
+/** Statuses that mean the restore is still going, or might be. */
+const LIVE_STATUSES: RestoreStatus[] = [ 'queued', 'running', 'unknown' ];
+
+/**
+ * Whether a status reading ends the poll.
+ *
+ * @param status - The status the bridge reported, if any.
+ * @return True when there is nothing left to wait for.
+ */
+export function isTerminal( status: RestoreStatus | undefined ): boolean {
+	return status !== undefined && ! LIVE_STATUSES.includes( status );
+}
+
+/**
+ * Whether two rewind ids name the same backup.
+ *
+ * Adopting the wrong id would report someone else's restore as this one,
+ * so this stays an equality test and never a prefix or integer-part
+ * match: two restores of the same backup share an integer part.
+ *
+ * What it does tolerate is formatting. A rewind id is a unix timestamp
+ * with a decimal suffix, and the value in `recent_restores[]` has been
+ * round-tripped through VaultPress rather than echoed back by
+ * WordPress.com — so a trailing zero gained or lost (`…613.9425` vs
+ * `…613.94250`) would defeat a strict string comparison for two
+ * representations of the same instant. Comparing them as numbers as well
+ * closes that without widening what counts as a match.
+ *
+ * @param candidate - A rewind id from the restores collection.
+ * @param target    - The rewind id this screen submitted.
+ * @return True when both name the same backup.
+ */
+function sameRewindId( candidate: string, target: string ): boolean {
+	if ( ! candidate || ! target ) {
+		return false;
+	}
+	if ( candidate === target ) {
+		return true;
+	}
+	const a = Number( candidate );
+	const b = Number( target );
+	return Number.isFinite( a ) && Number.isFinite( b ) && a === b;
+}
+
+/**
+ * The restore in this collection that best answers "the one for this
+ * backup that is still going", or null when there isn't one.
+ *
+ * Two rules, and the order matters.
+ *
+ * A settled row is never adopted. The same backup point can be restored
+ * more than once, and a plain first-match took an earlier, *completed*
+ * restore of it — whose status route then answered `finished`, so the
+ * screen announced "Restore complete." while the real restore was still
+ * overwriting the site.
+ *
+ * What remains is ranked newest-first by `when`. That comparison is
+ * between two WordPress.com timestamps and never against the browser's
+ * clock, so a machine whose time is minutes out still recovers its own
+ * restore. A row with no usable `when` sorts last rather than being
+ * dropped: it is still a candidate, just the weakest one.
+ *
+ * `rewindId` is null when the caller does not care which backup is being
+ * restored — the cold-mount case. A restore of any backup overwrites the
+ * same live site, so a second one is wrong whichever point it came from,
+ * and the screen has to adopt what is running rather than arm a button
+ * beside it.
+ *
+ * @param rows     - The restores collection, as the bridge returned it.
+ * @param rewindId - The rewind id to match, or null for any backup.
+ * @return The best candidate, or null.
+ */
+export function pickLiveRestore(
+	rows: RecentRestore[],
+	rewindId: string | null
+): RecentRestore | null {
+	const candidates = rows
+		.filter(
+			row => ! row.settled && ( rewindId === null || sameRewindId( row.rewind_id, rewindId ) )
+		)
+		.sort( ( a, b ) => {
+			const at = Date.parse( a.when );
+			const bt = Date.parse( b.when );
+			const av = Number.isNaN( at ) ? -Infinity : at;
+			const bv = Number.isNaN( bt ) ? -Infinity : bt;
+			// Restore ids are handed out in order, so they break a tie
+			// between two rows stamped in the same second.
+			return bv === av ? b.restore_id - a.restore_id : bv - av;
+		} );
+
+	return candidates[ 0 ] ?? null;
+}
 
 /**
  * Start a restore for the given backup point.
@@ -129,6 +255,9 @@ export async function fetchRecentRestores(): Promise< RecentRestore[] > {
 		.map( row => ( {
 			restore_id: Number( row.restore_id ) || 0,
 			rewind_id: typeof row.rewind_id === 'string' ? row.rewind_id : String( row.rewind_id ?? '' ),
+			when: typeof row.when === 'string' ? row.when : '',
+			settled:
+				typeof row.status === 'string' && SETTLED_ROW_STATUSES.has( row.status.toLowerCase() ),
 		} ) )
 		.filter( row => row.restore_id > 0 );
 }

--- a/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
@@ -1,4 +1,4 @@
-import { ApiError, requireTypes, toIntRewindId } from '../_helpers';
+import { ApiError, isAmbiguousFailure, requireTypes, toIntRewindId } from '../_helpers';
 
 describe( 'toIntRewindId', () => {
 	test( 'returns the input unchanged when there is no decimal suffix', () => {
@@ -58,5 +58,70 @@ describe( 'requireTypes', () => {
 
 		expect( thrown ).toBeInstanceOf( ApiError );
 		expect( ( thrown as ApiError ).code ).toBe( 'no_types_selected' );
+	} );
+} );
+
+describe( 'isAmbiguousFailure', () => {
+	/**
+	 * Force `navigator.onLine`, restoring it afterwards.
+	 *
+	 * @param value - What the browser should claim.
+	 * @return A function that puts it back.
+	 */
+	function forceOnLine( value: boolean ) {
+		const original = Object.getOwnPropertyDescriptor( window.navigator, 'onLine' );
+		Object.defineProperty( window.navigator, 'onLine', { value, configurable: true } );
+		return () => {
+			if ( original ) {
+				Object.defineProperty( window.navigator, 'onLine', original );
+			}
+		};
+	}
+
+	let restoreOnLine: () => void;
+
+	beforeEach( () => {
+		restoreOnLine = forceOnLine( true );
+	} );
+
+	afterEach( () => restoreOnLine() );
+
+	// The question is "did our code get far enough to give a verdict",
+	// and only a bridge-shaped failure carries one.
+	test.each( [
+		[ 'a transport failure the bridge wrapped', { status: 502, transport: { code: 'x' } }, true ],
+		[ 'a gateway status with no transport payload', { status: 504 }, true ],
+		[ 'a request timeout', { status: 408 }, true ],
+		[ 'an upstream refusal', { status: 412 }, false ],
+		[ 'an authorization failure', { status: 401 }, false ],
+		// The `ok`-falsy branch: WordPress.com answered and said no, so
+		// nothing was queued and a retry is safe at once.
+		[ 'a refusal reported as 500', { status: 500 }, false ],
+	] )( 'reads %s as ambiguous=%p', ( _label, data, expected ) => {
+		expect( isAmbiguousFailure( new ApiError( 'restore_initiate_failed', 'x', data ) ) ).toBe(
+			expected
+		);
+	} );
+
+	// These carry no `data` at all — the failure happened before the
+	// bridge could answer. They are the browser → site hop, which the
+	// bridges' own vocabulary never describes.
+	test.each( [
+		[ 'a request that never completed', 'fetch_error' ],
+		[ 'a non-JSON gateway page', 'invalid_json' ],
+	] )( 'reads %s as ambiguous', ( _label, code ) => {
+		expect( isAmbiguousFailure( new ApiError( code, 'x' ) ) ).toBe( true );
+	} );
+
+	test( 'reads any failure as unambiguous when the browser was offline', () => {
+		restoreOnLine();
+		restoreOnLine = forceOnLine( false );
+		// Proof rather than assumption: the request never left, so
+		// nothing can have started, and the reader keeps their retry.
+		expect( isAmbiguousFailure( new ApiError( 'fetch_error', 'x' ) ) ).toBe( false );
+	} );
+
+	test( 'ignores anything that is not an ApiError', () => {
+		expect( isAmbiguousFailure( new Error( 'boom' ) ) ).toBe( false );
 	} );
 } );

--- a/projects/packages/backup/src/dashboard/data/api/test/restore.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/restore.test.ts
@@ -1,0 +1,83 @@
+import apiFetch from '@wordpress/api-fetch';
+import { fetchRecentRestores } from '../restore';
+
+jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+beforeEach( () => {
+	mockedApiFetch.mockReset();
+} );
+
+// The single point where the restores collection's foreign vocabulary is
+// quarantined. Its consumer `pickLiveRestore` is well covered; this is
+// the mapper that produces what that consumer reads, and everything it
+// gets wrong is invisible downstream.
+describe( 'fetchRecentRestores', () => {
+	/**
+	 * Answer the collection route with a given body.
+	 *
+	 * @param body - What the route resolves with.
+	 */
+	function respondWith( body: unknown ) {
+		mockedApiFetch.mockResolvedValue( body );
+	}
+
+	test( 'distinguishes a failed read from an empty collection', async () => {
+		// The legacy route answers a non-200 from WordPress.com with a
+		// bare `null`, which WordPress then serves as HTTP 200 — so this
+		// resolves rather than rejecting. Returning `[]` for it would tell
+		// a caller deciding whether to start a destructive restore that
+		// nothing is running, which is the opposite of what it knows.
+		respondWith( null );
+		await expect( fetchRecentRestores() ).resolves.toBeNull();
+
+		respondWith( [] );
+		await expect( fetchRecentRestores() ).resolves.toEqual( [] );
+	} );
+
+	test.each( [
+		[ 'finished', true ],
+		[ 'FINISHED', true ],
+		[ 'success-with-errors', true ],
+		[ 'aborted', true ],
+		[ 'running', false ],
+		[ 'started', false ],
+		[ 'a-spelling-nobody-has-seen', false ],
+	] )( 'reads status %p as settled=%p', async ( status, settled ) => {
+		respondWith( [ { restore_id: 1, rewind_id: '1786512000.11', when: '', status } ] );
+		const rows = await fetchRecentRestores();
+		expect( rows?.[ 0 ].settled ).toBe( settled );
+	} );
+
+	test( 'treats a non-string status as not settled', async () => {
+		// Unknown means adoptable, and the confirmation decides. Guessing
+		// the other way would make an unrecognised spelling of "running"
+		// permanently unrecoverable.
+		respondWith( [ { restore_id: 1, rewind_id: '1786512000.11', status: 7 } ] );
+		const rows = await fetchRecentRestores();
+		expect( rows?.[ 0 ].settled ).toBe( false );
+	} );
+
+	test( 'carries a missing timestamp as an empty string rather than dropping the row', async () => {
+		respondWith( [ { restore_id: 1, rewind_id: '1786512000.11' } ] );
+		const rows = await fetchRecentRestores();
+		expect( rows ).toHaveLength( 1 );
+		expect( rows?.[ 0 ].when ).toBe( '' );
+	} );
+
+	test( 'drops rows with no usable restore id', async () => {
+		respondWith( [
+			{ restore_id: 0, rewind_id: '1786512000.11' },
+			{ restore_id: 'nope', rewind_id: '1786512000.11' },
+			{ restore_id: 912682, rewind_id: '1786512000.11' },
+		] );
+		const rows = await fetchRecentRestores();
+		expect( rows?.map( r => r.restore_id ) ).toEqual( [ 912682 ] );
+	} );
+
+	test( 'coerces a numeric rewind id to the string the match expects', async () => {
+		respondWith( [ { restore_id: 1, rewind_id: 1786512000.11 } ] );
+		const rows = await fetchRecentRestores();
+		expect( rows?.[ 0 ].rewind_id ).toBe( '1786512000.11' );
+	} );
+} );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
@@ -351,7 +351,16 @@ describe( 'useRestore — failing safe', () => {
 	} );
 
 	it( 'reports a refused submission and can be reset back to idle', async () => {
-		mockedApiFetch.mockRejectedValue( new Error( 'Could not start the backup restore.' ) );
+		// A refusal as the bridge actually shapes one. A bare `Error`
+		// stood in here before, which carries no `data` and so no verdict
+		// — and "no verdict" is precisely what now means *unknown*, since
+		// that is how a failure looks when it never reached our PHP at
+		// all. Modelling the real shape keeps this about refusals.
+		mockedApiFetch.mockRejectedValue( {
+			code: 'restore_initiate_failed',
+			message: 'Could not start the backup restore.',
+			data: { status: 500 },
+		} );
 		const { wrapper } = makeWrapper();
 
 		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
@@ -542,6 +551,34 @@ describe( 'useRestore — a restore already running when the screen opens', () =
 		expect( callsFor( '/rewind/restore/111/status' ) ).toBe( 0 );
 	} );
 
+	it( 'refuses to adopt on a status that only means "not visible"', async () => {
+		// `queued` is what the bridge mints for a **404** — "that restore
+		// is not visible to this route" — so reading it as a sign of life
+		// turns absence of evidence into evidence of life. Paired with a
+		// collection spelling we do not recognise as settled (`started` is
+		// the one WordPress.com's own docblock claims), a restore from
+		// January locks the screen out of restoring permanently: the form
+		// never returns, and the stale adoption is what withholds the
+		// button that would have replaced it.
+		respondWith( {
+			restores: [
+				{
+					restore_id: 111,
+					rewind_id: '1700000000.1',
+					when: '2026-01-01T00:00:00+00:00',
+					status: 'started',
+				},
+			],
+			status: statusPayload( { id: 111, status: 'queued', rewind_id: '1700000000.1' } ),
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'idle' ) );
+		expect( result.current.adopted ).toBeNull();
+	} );
+
 	it( 'withholds the form until it knows whether anything is running', async () => {
 		// Arming first and correcting later would put a live Confirm
 		// button on screen for exactly as long as the lookup takes.
@@ -561,6 +598,82 @@ describe( 'useRestore — a restore already running when the screen opens', () =
 
 		expect( result.current.state.phase ).toBe( 'checking' );
 	} );
+
+	it( 'reports an adopted restore finishing, instead of reverting to the form', async () => {
+		// The completion path of this whole feature. `adopted` was derived
+		// from the confirmation query, which shares its key with the
+		// caller's own poll — so the render that first read `finished` was
+		// the same render in which the adoption vanished, `restoreId`
+		// collapsed to null, and `deriveState` fell back to `idle`. The
+		// reader watched the bar climb and was then handed the armed
+		// Confirm button this screen exists to withhold, with no
+		// "Restore complete." and, on a failure, no error either.
+		let status: Record< string, unknown > = {
+			id: 912682,
+			status: 'running',
+			progress: 55,
+			rewind_id: OTHER_ID,
+			error_code: '',
+			message: '',
+		};
+		mockedApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			if ( ( options?.path ?? '' ).includes( '/restores' ) ) {
+				return Promise.resolve( [
+					{
+						restore_id: 912682,
+						rewind_id: OTHER_ID,
+						when: '2026-08-20T10:00:00+00:00',
+						status: 'running',
+					},
+				] );
+			}
+			return Promise.resolve( status );
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'progress' ) );
+
+		status = { ...status, status: 'finished', progress: 100 };
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'success' ), {
+			timeout: 8000,
+		} );
+		expect( result.current.state ).toEqual( { phase: 'success' } );
+	}, 15000 );
+
+	it( 'reports an adopted restore failing, rather than silently re-arming', async () => {
+		let status: Record< string, unknown > = {
+			id: 912682,
+			status: 'running',
+			progress: 55,
+			rewind_id: OTHER_ID,
+			error_code: 'checksum_mismatch',
+			message: '',
+		};
+		mockedApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			if ( ( options?.path ?? '' ).includes( '/restores' ) ) {
+				return Promise.resolve( [
+					{
+						restore_id: 912682,
+						rewind_id: OTHER_ID,
+						when: '2026-08-20T10:00:00+00:00',
+						status: 'running',
+					},
+				] );
+			}
+			return Promise.resolve( status );
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'progress' ) );
+
+		status = { ...status, status: 'failed', message: 'Restore aborted.' };
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'error' ), { timeout: 8000 } );
+		expect( result.current.state ).toMatchObject( { message: 'Restore aborted.' } );
+	}, 15000 );
 
 	it( 'drops the adoption when the candidate turns out to have finished', async () => {
 		// The collection's status vocabulary is not the status route's, so
@@ -822,6 +935,66 @@ describe( 'useRestore — a submission we never got an answer to', () => {
 		expect( result.current.state.phase ).toBe( 'error' );
 	} );
 
+	/**
+	 * Force `navigator.onLine`, restoring it afterwards.
+	 *
+	 * @param value - What the browser should claim.
+	 * @return A function that puts it back.
+	 */
+	function forceOnLine( value: boolean ) {
+		const original = Object.getOwnPropertyDescriptor( window.navigator, 'onLine' );
+		Object.defineProperty( window.navigator, 'onLine', { value, configurable: true } );
+		return () => {
+			if ( original ) {
+				Object.defineProperty( window.navigator, 'onLine', original );
+			}
+		};
+	}
+
+	// The hop this PR was written for is site → WordPress.com. These are
+	// the hop it left open: browser → site, which fails in shapes that
+	// carry no `data` at all, so nothing about them looked ambiguous.
+	it.each( [
+		[ 'a browser request that never completed', 'fetch_error' ],
+		[ "a gateway page from the site's own proxy", 'invalid_json' ],
+	] )( 'treats %s as unconfirmed', async ( _label, code ) => {
+		const restore = forceOnLine( true );
+		respondWith( {
+			initiateError: { code, message: 'Could not get a valid response from the server.' },
+			restores: [],
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'unconfirmed' );
+		// No control on screen: the whole point of the phase.
+		expect( result.current.state ).toMatchObject( { phase: 'unconfirmed' } );
+		restore();
+	} );
+
+	it( 'offers a retry at once when the browser says it was never online', async () => {
+		// The one case where "we do not know" is knowable: if the browser
+		// had no network, the request did not leave it. `navigator.onLine`
+		// is unreliable when true and reliable when false, which is the
+		// direction that matters here — and it saves the reader five
+		// minutes for the most common failure of all.
+		const restore = forceOnLine( false );
+		respondWith( {
+			initiateError: { code: 'fetch_error', message: 'You are probably offline.' },
+			restores: [],
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'error' );
+		expect( result.current.state ).toMatchObject( { phase: 'error' } );
+		restore();
+	} );
+
 	it( 'still reports a refusal immediately, because nothing started', async () => {
 		// WordPress.com answered. There is no ambiguity to resolve, so
 		// making the reader wait five minutes for a retry would be a
@@ -843,4 +1016,71 @@ describe( 'useRestore — a submission we never got an answer to', () => {
 			message: 'Could not start the backup restore.',
 		} );
 	} );
+} );
+
+describe( 'useRestore — a restore that starts after the screen loaded', () => {
+	// The mount lookup answers once. A reader who opens the screen, is
+	// interrupted, and comes back twenty minutes later after a colleague
+	// started a restore from Calypso is back in the original scenario,
+	// just displaced in time — and the click is the moment it matters.
+	it( 'adopts instead of starting a second restore', async () => {
+		let rows: unknown[] = [];
+		mockedApiFetch.mockImplementation( ( options: { path?: string; method?: string } ) => {
+			if ( options?.method === 'POST' ) {
+				return Promise.resolve( { id: 5, rewind_id: REWIND_ID } );
+			}
+			if ( ( options?.path ?? '' ).includes( '/restores' ) ) {
+				return Promise.resolve( rows );
+			}
+			return Promise.resolve(
+				statusPayload( { id: 912682, status: 'running', progress: 30, rewind_id: OTHER_ID } )
+			);
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'idle' ) );
+
+		// Someone else starts one while this screen sits armed.
+		rows = [
+			{
+				restore_id: 912682,
+				rewind_id: OTHER_ID,
+				when: '2026-08-20T10:00:00+00:00',
+				status: 'running',
+			},
+		];
+
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'progress' ) );
+		expect( result.current.adopted ).toEqual( { rewindId: OTHER_ID } );
+		// The whole point: no restore was started.
+		expect( initiateCall() ).toBeUndefined();
+	}, 15000 );
+
+	it( 'still starts the restore when the check cannot be read', async () => {
+		// Fail open on the read, closed on the evidence. Someone
+		// restoring is often mid-outage; refusing because a list could
+		// not be fetched would deny them the recovery they came for.
+		mockedApiFetch.mockImplementation( ( options: { path?: string; method?: string } ) => {
+			if ( options?.method === 'POST' ) {
+				return Promise.resolve( { id: 5, rewind_id: REWIND_ID } );
+			}
+			if ( ( options?.path ?? '' ).includes( '/restores' ) ) {
+				// The legacy route's non-200: a bare null, served as 200.
+				return Promise.resolve( null );
+			}
+			return Promise.resolve( statusPayload( { id: 5, status: 'running' } ) );
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'idle' ) );
+
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'progress' ) );
+		expect( initiateCall() ).toBeDefined();
+	}, 15000 );
 } );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
@@ -11,6 +11,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import { createElement, type ReactNode } from 'react';
+import { pickLiveRestore } from '../../data/api/restore';
 import { DEFAULT_RESTORE_ITEMS } from '../../types/restore';
 import { useRestore } from '../use-restore';
 
@@ -18,6 +19,9 @@ jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn(
 const mockedApiFetch = apiFetch as unknown as jest.Mock;
 
 const REWIND_ID = '1786663613.9425';
+// A different backup point, for the cases where the restore already
+// running is not the one this screen is pointed at.
+const OTHER_ID = '1786512000.11';
 
 /**
  * Fresh client per test, retries off so failures assert immediately.
@@ -54,19 +58,21 @@ function statusPayload( over: Record< string, unknown > = {} ) {
 /**
  * Answer the initiate call, then every status poll.
  *
- * @param options          - Overrides.
- * @param options.initiate - What the initiate call resolves with.
- * @param options.status   - What each status poll resolves with.
- * @param options.restores - What `/jetpack/v4/restores` resolves with.
+ * @param options               - Overrides.
+ * @param options.initiate      - What the initiate call resolves with.
+ * @param options.status        - What each status poll resolves with.
+ * @param options.restores      - What `/jetpack/v4/restores` resolves with.
+ * @param options.initiateError - What the initiate call rejects with, instead of resolving.
  */
 function respondWith( {
 	initiate = { id: 912682, rewind_id: REWIND_ID } as unknown,
 	status = statusPayload() as unknown,
 	restores = [] as unknown,
+	initiateError = null as unknown,
 } = {} ) {
 	mockedApiFetch.mockImplementation( ( options: { path?: string; method?: string } ) => {
 		if ( options?.method === 'POST' ) {
-			return Promise.resolve( initiate );
+			return initiateError ? Promise.reject( initiateError ) : Promise.resolve( initiate );
 		}
 		if ( ( options?.path ?? '' ).includes( '/restores' ) ) {
 			return Promise.resolve( restores );
@@ -87,6 +93,60 @@ function submitAll( result: RenderedRestore ) {
 	act( () => result.current.submit( DEFAULT_RESTORE_ITEMS ) );
 }
 
+/**
+ * Advance fake timers inside `act`, letting queued promises settle.
+ *
+ * Only usable inside a suite that installed fake timers — they are set
+ * up per-describe rather than file-wide, because every other suite here
+ * depends on React Query's real polling.
+ *
+ * @param ms - How far to advance.
+ */
+async function advance( ms: number ) {
+	await act( async () => {
+		await jest.advanceTimersByTimeAsync( ms );
+	} );
+}
+
+/**
+ * Wait for the hook to reach a phase before jumping the clock.
+ *
+ * Required rather than tidy: the deadline timer is scheduled when the
+ * restore is accepted, so a single large `advance()` from a standing
+ * start moves the clock past the point the timer is armed at, and it
+ * is then scheduled to fire five minutes after a `now` the test has
+ * already left behind. Real time does not jump.
+ *
+ * @param result - The rendered hook result.
+ * @param phase  - The phase to wait for.
+ */
+async function settleAt( result: PhaseResult, phase: string ) {
+	await waitFor( () => expect( result.current.state.phase ).toBe( phase ) );
+}
+
+/**
+ * The initiate request, whenever it was made.
+ *
+ * @return The apiFetch options for the POST.
+ */
+function initiateCall() {
+	// Not `calls[ 0 ]` any more: every cold mount asks what is already
+	// running before the reader can submit anything.
+	const call = mockedApiFetch.mock.calls.find( ( [ o ] ) => o?.method === 'POST' );
+	return call?.[ 0 ];
+}
+
+/**
+ * How many times a path fragment has been requested so far.
+ *
+ * @param fragment - Substring of the request path.
+ * @return The call count.
+ */
+function callsFor( fragment: string ): number {
+	return mockedApiFetch.mock.calls.filter( ( [ o ] ) => ( o?.path ?? '' ).includes( fragment ) )
+		.length;
+}
+
 beforeEach( () => {
 	mockedApiFetch.mockReset();
 } );
@@ -99,8 +159,8 @@ describe( 'useRestore — the request', () => {
 		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
 		submitAll( result );
 
-		await waitFor( () => expect( mockedApiFetch ).toHaveBeenCalled() );
-		const [ initiate ] = mockedApiFetch.mock.calls[ 0 ];
+		await waitFor( () => expect( initiateCall() ).toBeDefined() );
+		const initiate = initiateCall();
 		// Truncating it addresses a different backup than the reader picked.
 		expect( initiate.path ).toContain( REWIND_ID );
 		expect( initiate.path ).not.toContain( '1786663613/' );
@@ -113,8 +173,8 @@ describe( 'useRestore — the request', () => {
 		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
 		act( () => result.current.submit( { ...DEFAULT_RESTORE_ITEMS, plugins: false } ) );
 
-		await waitFor( () => expect( mockedApiFetch ).toHaveBeenCalled() );
-		const [ initiate ] = mockedApiFetch.mock.calls[ 0 ];
+		await waitFor( () => expect( initiateCall() ).toBeDefined() );
+		const initiate = initiateCall();
 		expect( Array.isArray( initiate.data.types ) ).toBe( false );
 		expect( initiate.data.types.plugins ).toBeUndefined();
 		expect( initiate.data.types.themes ).toBe( true );
@@ -215,10 +275,17 @@ describe( 'useRestore — a restore WordPress.com accepted without naming', () =
 		expect( result.current.state ).toMatchObject( { percent: 17 } );
 	} );
 
-	it( 'ignores a restore of a different backup', async () => {
+	it( 'ignores a settled restore of a different backup', async () => {
 		respondWith( {
 			initiate: { id: null, rewind_id: REWIND_ID },
-			restores: [ { restore_id: 111, rewind_id: '1700000000.1' } ],
+			restores: [
+				{
+					restore_id: 111,
+					rewind_id: '1700000000.1',
+					when: '2026-08-01T10:00:00+00:00',
+					status: 'finished',
+				},
+			],
 		} );
 		const { wrapper } = makeWrapper();
 
@@ -227,10 +294,7 @@ describe( 'useRestore — a restore WordPress.com accepted without naming', () =
 
 		await waitFor( () => expect( result.current.state.phase ).toBe( 'queued' ) );
 		// Adopting the wrong id would report someone else's restore as this one.
-		const polled = mockedApiFetch.mock.calls.some( ( [ o ] ) =>
-			( o?.path ?? '' ).includes( '/rewind/restore/111/status' )
-		);
-		expect( polled ).toBe( false );
+		expect( callsFor( '/rewind/restore/111/status' ) ).toBe( 0 );
 	} );
 } );
 
@@ -312,33 +376,6 @@ describe( 'useRestore — the silence deadline', () => {
 	afterEach( () => {
 		jest.useRealTimers();
 	} );
-
-	/**
-	 * Advance fake timers inside `act`, letting queued promises settle.
-	 *
-	 * @param ms - How far to advance.
-	 */
-	async function advance( ms: number ) {
-		await act( async () => {
-			await jest.advanceTimersByTimeAsync( ms );
-		} );
-	}
-
-	/**
-	 * Wait for the hook to reach a phase before jumping the clock.
-	 *
-	 * Required rather than tidy: the deadline timer is scheduled when the
-	 * restore is accepted, so a single large `advance()` from a standing
-	 * start moves the clock past the point the timer is armed at, and it
-	 * is then scheduled to fire five minutes after a `now` the test has
-	 * already left behind. Real time does not jump.
-	 *
-	 * @param result - The rendered hook result.
-	 * @param phase  - The phase to wait for.
-	 */
-	async function settleAt( result: PhaseResult, phase: string ) {
-		await waitFor( () => expect( result.current.state.phase ).toBe( phase ) );
-	}
 
 	// The case with no safety net before: the status query is disabled
 	// while the id is unknown, so the recovery poll is the only thing
@@ -434,6 +471,158 @@ describe( 'useRestore — the silence deadline', () => {
 	} );
 } );
 
+describe( 'useRestore — a restore already running when the screen opens', () => {
+	// Every piece of restore state lived in `useState`, so a reload, a
+	// second tab, or a restore started from Calypso left this screen at
+	// `idle` with an armed Confirm button — one click from a second
+	// concurrent whole-site restore, with nothing on screen saying the
+	// first was still running.
+
+	it( 'adopts a running restore instead of arming the form', async () => {
+		respondWith( {
+			restores: [
+				{
+					restore_id: 912682,
+					rewind_id: OTHER_ID,
+					when: '2026-08-20T10:00:00+00:00',
+					status: 'running',
+				},
+			],
+			status: statusPayload( { id: 912682, status: 'running', progress: 55, rewind_id: OTHER_ID } ),
+		} );
+		const { wrapper } = makeWrapper();
+
+		// No submit: this is a cold mount.
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'progress' ) );
+		expect( result.current.state ).toMatchObject( { percent: 55 } );
+	} );
+
+	it( 'reports which backup the running restore is for, not the one in the URL', async () => {
+		// The site is being overwritten either way, so a restore of a
+		// *different* backup is adopted too — and then has to say so, or
+		// the reader is left wondering why their checklist vanished.
+		respondWith( {
+			restores: [
+				{
+					restore_id: 912682,
+					rewind_id: OTHER_ID,
+					when: '2026-08-20T10:00:00+00:00',
+					status: 'running',
+				},
+			],
+			status: statusPayload( { id: 912682, status: 'running', rewind_id: OTHER_ID } ),
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+
+		await waitFor( () => expect( result.current.adopted ).not.toBeNull() );
+		expect( result.current.adopted ).toEqual( { rewindId: OTHER_ID } );
+	} );
+
+	it( 'arms the form when the most recent restore has finished', async () => {
+		respondWith( {
+			restores: [
+				{
+					restore_id: 111,
+					rewind_id: REWIND_ID,
+					when: '2026-08-10T10:00:00+00:00',
+					status: 'finished',
+				},
+			],
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'idle' ) );
+		expect( result.current.adopted ).toBeNull();
+		expect( callsFor( '/rewind/restore/111/status' ) ).toBe( 0 );
+	} );
+
+	it( 'withholds the form until it knows whether anything is running', async () => {
+		// Arming first and correcting later would put a live Confirm
+		// button on screen for exactly as long as the lookup takes.
+		respondWith( {
+			restores: [
+				{
+					restore_id: 912682,
+					rewind_id: OTHER_ID,
+					when: '2026-08-20T10:00:00+00:00',
+					status: 'running',
+				},
+			],
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+
+		expect( result.current.state.phase ).toBe( 'checking' );
+	} );
+
+	it( 'drops the adoption when the candidate turns out to have finished', async () => {
+		// The collection's status vocabulary is not the status route's, so
+		// a row we could not read as settled is confirmed against the
+		// route that speaks our own. Terminal there means it is not a
+		// restore in progress, and the reader gets their form.
+		respondWith( {
+			restores: [
+				{
+					restore_id: 912682,
+					rewind_id: OTHER_ID,
+					when: '2026-08-20T10:00:00+00:00',
+					status: 'some-spelling-we-do-not-know',
+				},
+			],
+			status: statusPayload( { id: 912682, status: 'finished', rewind_id: OTHER_ID } ),
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'idle' ) );
+		expect( result.current.adopted ).toBeNull();
+	} );
+} );
+
+describe( 'useRestore — the recovery poll', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'stops asking the collection once it has recovered the id', async () => {
+		// The recovery query is gated on "started, and no id yet". The id
+		// arrived, but it arrived in a `useMemo` derived from the query's
+		// own data — so the gate kept reading "no id yet" and the
+		// collection was fetched every five seconds for the life of the
+		// tab, including long after the restore had finished.
+		respondWith( {
+			initiate: { id: null, rewind_id: REWIND_ID },
+			restores: [ { restore_id: 912682, rewind_id: REWIND_ID } ],
+			status: statusPayload( { status: 'running', progress: 17 } ),
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'progress' );
+		const before = callsFor( '/restores' );
+
+		await advance( 30_000 );
+
+		expect( callsFor( '/restores' ) ).toBe( before );
+		// The status poll is the one that should still be running.
+		expect( callsFor( '/rewind/restore/912682/status' ) ).toBeGreaterThan( 1 );
+	} );
+} );
+
 describe( 'useRestore — matching the restore we started', () => {
 	it( 'matches a rewind id the collection formatted differently', async () => {
 		// The value in `recent_restores[]` has been round-tripped through
@@ -454,10 +643,23 @@ describe( 'useRestore — matching the restore we started', () => {
 		expect( result.current.state ).toMatchObject( { percent: 33 } );
 	} );
 
-	it( 'still refuses a different backup taken in the same second', async () => {
+	it( 'refuses a restore of this backup that has already finished', async () => {
+		// The same backup point can be restored more than once. The match
+		// was `find()` over the collection, so an earlier, completed
+		// restore of this backup was adopted as the one just started —
+		// and its status route answers `finished`, so the screen said
+		// "Restore complete." while the real restore was still
+		// overwriting the site.
 		respondWith( {
 			initiate: { id: null, rewind_id: REWIND_ID },
-			restores: [ { restore_id: 111, rewind_id: '1786663613.1111' } ],
+			restores: [
+				{
+					restore_id: 111,
+					rewind_id: REWIND_ID,
+					when: '2026-08-10T10:00:00+00:00',
+					status: 'finished',
+				},
+			],
 		} );
 		const { wrapper } = makeWrapper();
 
@@ -465,9 +667,180 @@ describe( 'useRestore — matching the restore we started', () => {
 		submitAll( result );
 
 		await waitFor( () => expect( result.current.state.phase ).toBe( 'queued' ) );
-		const polled = mockedApiFetch.mock.calls.some( ( [ o ] ) =>
-			( o?.path ?? '' ).includes( '/rewind/restore/111/status' )
-		);
-		expect( polled ).toBe( false );
+		expect( callsFor( '/rewind/restore/111/status' ) ).toBe( 0 );
+	} );
+
+	it( 'adopts the newest matching restore rather than the first row', async () => {
+		// Ordering is taken from `when`, and only ever by comparing two
+		// WordPress.com timestamps against each other — never against the
+		// browser's clock, which can be minutes out and would then reject
+		// the restore we just started.
+		respondWith( {
+			initiate: { id: null, rewind_id: REWIND_ID },
+			restores: [
+				{ restore_id: 111, rewind_id: REWIND_ID, when: '2026-08-10T10:00:00+00:00' },
+				{ restore_id: 912682, rewind_id: REWIND_ID, when: '2026-08-20T10:00:00+00:00' },
+			],
+			status: statusPayload( { status: 'running', progress: 42 } ),
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'progress' ) );
+		expect( callsFor( '/rewind/restore/912682/status' ) ).toBeGreaterThan( 0 );
+		expect( callsFor( '/rewind/restore/111/status' ) ).toBe( 0 );
+	} );
+} );
+
+describe( 'pickLiveRestore', () => {
+	// Rewind-id discrimination is proved here rather than through the
+	// hook. Since the screen now adopts whatever restore is already
+	// running, a *live* restore of another backup means the form is never
+	// armed — so "submit, then fail to match it" is a state the UI no
+	// longer reaches, and a hook test for it would assert against a
+	// scenario that cannot happen. The rule still has to hold.
+	const row = ( over: Record< string, unknown > = {} ) => ( {
+		restore_id: 1,
+		rewind_id: REWIND_ID,
+		when: '2026-08-20T10:00:00+00:00',
+		settled: false,
+		...over,
+	} );
+
+	it( 'refuses a different backup taken in the same second', () => {
+		// Two restores of the same second share an integer part, so this
+		// stays an equality test and never a prefix match.
+		expect(
+			pickLiveRestore( [ row( { restore_id: 111, rewind_id: '1786663613.1111' } ) ], REWIND_ID )
+		).toBeNull();
+	} );
+
+	it( 'refuses an unrelated backup', () => {
+		expect(
+			pickLiveRestore( [ row( { restore_id: 111, rewind_id: '1700000000.1' } ) ], REWIND_ID )
+		).toBeNull();
+	} );
+
+	it( 'matches a rewind id the collection formatted differently', () => {
+		expect(
+			pickLiveRestore( [ row( { restore_id: 912682, rewind_id: `${ REWIND_ID }0` } ) ], REWIND_ID )
+		).toMatchObject( { restore_id: 912682 } );
+	} );
+
+	it( 'takes any backup when asked for any, which is the cold-mount case', () => {
+		expect(
+			pickLiveRestore( [ row( { restore_id: 111, rewind_id: '1700000000.1' } ) ], null )
+		).toMatchObject( { restore_id: 111 } );
+	} );
+
+	it( 'never takes a settled row, whichever backup it names', () => {
+		expect( pickLiveRestore( [ row( { restore_id: 111, settled: true } ) ], null ) ).toBeNull();
+	} );
+
+	it( 'sorts a row with no usable timestamp last rather than dropping it', () => {
+		const rows = [ row( { restore_id: 5, when: '' } ), row( { restore_id: 6 } ) ];
+		expect( pickLiveRestore( rows, null ) ).toMatchObject( { restore_id: 6 } );
+		expect( pickLiveRestore( [ rows[ 0 ] ], null ) ).toMatchObject( { restore_id: 5 } );
+	} );
+} );
+
+describe( 'useRestore — a submission we never got an answer to', () => {
+	// The rule the state machine already stated: a retry is offered only
+	// when we know nothing is running. A transport failure is the one
+	// case where we know the least — WordPress.com may have queued the
+	// restore and the reply may simply have been lost — and it was
+	// landing in `error`, whose only control resets to an armed Confirm.
+	//
+	// `data.transport` is the marker. All three initiate failures share
+	// the code `restore_initiate_failed`; only `Rest_Controller::
+	// transport_error()` attaches a transport payload.
+	const TIMEOUT = {
+		code: 'restore_initiate_failed',
+		message: 'Could not reach WordPress.com. Check your connection and try again.',
+		data: {
+			status: 502,
+			transport: { code: 'http_request_failed', message: 'cURL error 28: Operation timed out' },
+		},
+	};
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'does not offer a retry while the restore may be running', async () => {
+		respondWith( { initiateError: TIMEOUT, restores: [] } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'unconfirmed' );
+		// The point of the phase: no control at all until we know.
+		expect( result.current.state ).not.toMatchObject( { phase: 'error' } );
+	} );
+
+	it( 'adopts the restore when it turns out to have started', async () => {
+		respondWith( {
+			initiateError: TIMEOUT,
+			restores: [
+				{
+					restore_id: 912682,
+					rewind_id: REWIND_ID,
+					when: '2026-08-20T10:00:00+00:00',
+					status: 'running',
+				},
+			],
+			status: statusPayload( { status: 'running', progress: 12 } ),
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'progress' );
+		expect( result.current.state ).toMatchObject( { percent: 12 } );
+	} );
+
+	it( 'offers a retry once the deadline proves nothing started', async () => {
+		respondWith( { initiateError: TIMEOUT, restores: [] } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'unconfirmed' );
+		await advance( 5 * 60_000 + 1000 );
+
+		// Now — and only now — a retry is safe, because five minutes of
+		// looking found no restore of this backup.
+		expect( result.current.state.phase ).toBe( 'error' );
+	} );
+
+	it( 'still reports a refusal immediately, because nothing started', async () => {
+		// WordPress.com answered. There is no ambiguity to resolve, so
+		// making the reader wait five minutes for a retry would be a
+		// regression.
+		respondWith( {
+			initiateError: {
+				code: 'restore_initiate_failed',
+				message: 'Could not start the backup restore.',
+				data: { status: 412 },
+			},
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'error' );
+		expect( result.current.state ).toMatchObject( {
+			message: 'Could not start the backup restore.',
+		} );
 	} );
 } );

--- a/projects/packages/backup/src/dashboard/hooks/use-adopted-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-adopted-restore.ts
@@ -1,0 +1,100 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from '@wordpress/element';
+import {
+	fetchRecentRestores,
+	fetchRestoreStatus,
+	isTerminal,
+	pickLiveRestore,
+} from '../data/api/restore';
+import { keys } from '../data/query-client';
+
+export type AdoptedRestore = {
+	id: number;
+	rewindId: string;
+};
+
+type Result = {
+	/** The restore already under way, once one has been confirmed. */
+	adopted: AdoptedRestore | null;
+	/** True while the answer is still unknown. */
+	isChecking: boolean;
+};
+
+/**
+ * Find the restore this site already has running, if any.
+ *
+ * Every piece of restore state used to live in `useState`, so nothing
+ * survived a page load: reloading mid-restore, opening the screen in a
+ * second tab, or arriving after a restore started from Calypso all left
+ * an armed **Confirm restore** button on screen. Following the only
+ * control there would have started a second concurrent whole-site
+ * restore, and nothing upstream is known to refuse that.
+ *
+ * Two reads, in order, because they answer different questions.
+ *
+ * `GET /jetpack/v4/restores` says what exists. It is signed with the blog
+ * token, so it answers for any admin rather than only the one who started
+ * the restore — which is what makes a second tab, or a second person,
+ * work at all.
+ *
+ * Its rows carry a status in a vocabulary that is not ours, so a row we
+ * cannot read as settled is only a *candidate*. The status route decides,
+ * because it speaks the vocabulary the bridge maps. That costs a second
+ * request only when there is something plausible to confirm: a site whose
+ * last restore finished — the overwhelmingly common case — is answered by
+ * the first read alone.
+ *
+ * Until both have answered, `isChecking` is true and the caller must show
+ * neither the form nor a progress bar. Arming first and correcting later
+ * would put a live Confirm button on screen for exactly as long as the
+ * lookup takes, which is the failure this exists to remove.
+ *
+ * @param enabled - False once this screen has a submission of its own, which makes the lookup moot.
+ * @return The adopted restore, and whether the answer is still pending.
+ */
+export function useAdoptedRestore( enabled: boolean ): Result {
+	const collection = useQuery( {
+		queryKey: keys.recentRestores(),
+		queryFn: fetchRecentRestores,
+		enabled,
+	} );
+
+	// Any backup, not just this screen's: a restore of a different point
+	// overwrites the same live site, so a second one is wrong whichever
+	// point it came from.
+	const candidate = useMemo(
+		() => ( enabled ? pickLiveRestore( collection.data ?? [], null ) : null ),
+		[ enabled, collection.data ]
+	);
+
+	// Always-defined key so @tanstack/query/exhaustive-deps stays happy;
+	// `enabled` keeps the placeholder from firing. The key is shared with
+	// the caller's own status poll, so confirming does not cost a request
+	// the poll would have made anyway.
+	const candidateId = candidate?.restore_id ?? -1;
+	const confirmation = useQuery( {
+		queryKey: keys.restoreStatus( candidateId ),
+		queryFn: () => fetchRestoreStatus( candidateId ),
+		// `enabled` as well as the candidate: the two derive from the same
+		// render, and gating on the candidate alone left a single-render
+		// window in which a caller that had just submitted still fired a
+		// confirmation for a restore it was no longer interested in.
+		enabled: enabled && candidate !== null,
+	} );
+
+	const isChecking =
+		enabled && ( collection.isPending || ( candidate !== null && confirmation.isPending ) );
+
+	// A confirmation that failed to arrive is not evidence of a restore.
+	// Adopting on a failed read would take the form away from someone who
+	// may have nothing running at all.
+	const isLive = confirmation.data !== undefined && ! isTerminal( confirmation.data.status );
+
+	return {
+		adopted:
+			candidate !== null && isLive
+				? { id: candidate.restore_id, rewindId: candidate.rewind_id }
+				: null,
+		isChecking,
+	};
+}

--- a/projects/packages/backup/src/dashboard/hooks/use-adopted-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-adopted-restore.ts
@@ -1,11 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from '@wordpress/element';
-import {
-	fetchRecentRestores,
-	fetchRestoreStatus,
-	isTerminal,
-	pickLiveRestore,
-} from '../data/api/restore';
+import { fetchRecentRestores, fetchRestoreStatus, pickLiveRestore } from '../data/api/restore';
 import { keys } from '../data/query-client';
 
 export type AdoptedRestore = {
@@ -63,7 +58,7 @@ export function useAdoptedRestore( enabled: boolean ): Result {
 	// overwrites the same live site, so a second one is wrong whichever
 	// point it came from.
 	const candidate = useMemo(
-		() => ( enabled ? pickLiveRestore( collection.data ?? [], null ) : null ),
+		() => ( enabled ? pickLiveRestore( collection.data ?? null, null ) : null ),
 		[ enabled, collection.data ]
 	);
 
@@ -85,10 +80,22 @@ export function useAdoptedRestore( enabled: boolean ): Result {
 	const isChecking =
 		enabled && ( collection.isPending || ( candidate !== null && confirmation.isPending ) );
 
-	// A confirmation that failed to arrive is not evidence of a restore.
-	// Adopting on a failed read would take the form away from someone who
-	// may have nothing running at all.
-	const isLive = confirmation.data !== undefined && ! isTerminal( confirmation.data.status );
+	// Positive evidence only, and deliberately stricter than the poll's
+	// own `! isTerminal(…)`.
+	//
+	// That test counts `queued` as live, and `queued` is exactly what the
+	// bridge mints for a **404** — "that restore is not visible to this
+	// route" — so it reads absence of evidence as evidence of life. For a
+	// restore we are *watching*, erring that way is right: keep polling.
+	// For one we are deciding whether to adopt, it is backwards. A
+	// collection row spelled in a way we do not recognise as settled,
+	// pointing at a restore upstream cannot find, would take the form
+	// away and never give it back — and the adoption is what withholds
+	// the button that would have replaced it, so it cannot self-correct.
+	//
+	// The cost of being strict is a missed adoption, which is what this
+	// hook already accepts for a confirmation that fails to arrive.
+	const isLive = confirmation.data?.status === 'running';
 
 	return {
 		adopted:

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -5,12 +5,14 @@ import { isAmbiguousFailure } from '../data/api/_helpers';
 import {
 	fetchRecentRestores,
 	fetchRestoreStatus,
+	fetchRunningRestore,
 	initiateRestore,
 	isTerminal,
 	pickLiveRestore,
 } from '../data/api/restore';
 import { keys } from '../data/query-client';
 import { useAdoptedRestore } from './use-adopted-restore';
+import type { AdoptedRestore } from './use-adopted-restore';
 import type { RestoreStatus, RestoreStatusResponse } from '../data/api/restore';
 import type { RestoreItems, RestoreState } from '../types/restore';
 
@@ -254,8 +256,32 @@ export function useRestore( rewindId: string ): Result {
 		reset: resetMutation,
 		isPending,
 	} = useMutation( {
-		mutationFn: ( items: RestoreItems ) => initiateRestore( rewindId, items ),
-		onSuccess: result => {
+		mutationFn: async ( items: RestoreItems ) => {
+			// The mount lookup answered once, possibly a long time ago. A
+			// screen left open while a colleague started a restore from
+			// Calypso is the very scenario this hook exists for, just
+			// displaced in time — and the click is the moment it matters.
+			//
+			// Fail open on the read, closed on the evidence: a restore is
+			// refused only on positive proof that one is running. Someone
+			// reaching for a restore is often mid-outage, and denying them
+			// their recovery because a list could not be fetched would be
+			// the worse failure by far.
+			const running = await fetchRunningRestore().catch( () => null );
+			if ( running !== null ) {
+				return { adopt: running } as const;
+			}
+			return { started: await initiateRestore( rewindId, items ) } as const;
+		},
+		onSuccess: outcome => {
+			if ( 'adopt' in outcome ) {
+				setErrorMessage( null );
+				setAdopted( { id: outcome.adopt.restore_id, rewindId: outcome.adopt.rewind_id } );
+				setAliveAt( Date.now() );
+				setLostTrack( false );
+				return;
+			}
+			const result = outcome.started;
 			setErrorMessage( null );
 			setStartedRewindId( result.rewind_id || rewindId );
 			// Acceptance starts the clock: it is the last thing we know
@@ -287,16 +313,32 @@ export function useRestore( rewindId: string ): Result {
 	// restore on screen is ours, and the lookup would only be a second
 	// opinion about a question we can already answer.
 	const hasOwnSubmission = startedRewindId !== null || isPending;
-	const { adopted, isChecking } = useAdoptedRestore( ! hasOwnSubmission );
+	const { adopted: found, isChecking } = useAdoptedRestore( ! hasOwnSubmission );
 
-	// An adopted restore was accepted before this screen existed, so the
-	// silence deadline has to start from the moment we found it rather
-	// than from a submission that never happened here.
+	// Latched, not read live, and that distinction is the whole
+	// lifecycle. `useAdoptedRestore` derives its answer from a
+	// confirmation query that shares a key with the status poll below —
+	// so the render that first reads `finished` is the same render in
+	// which the live value goes null. Reading it directly meant
+	// `restoreId` collapsed to null at exactly that moment,
+	// `deriveState` fell through to `idle`, and the reader who had been
+	// watching a progress bar was handed the armed Confirm button this
+	// screen exists to withhold. Every terminal branch below was
+	// unreachable for an adopted restore.
+	//
+	// The lookup decides only *whether* to adopt. Once it has, the
+	// ordinary poll owns the rest, exactly as it does for a restore
+	// started here.
+	const [ adopted, setAdopted ] = useState< AdoptedRestore | null >( null );
 	useEffect( () => {
-		if ( adopted !== null && ! hasOwnSubmission ) {
+		if ( found !== null && ! hasOwnSubmission ) {
+			setAdopted( previous => previous ?? found );
+			// An adopted restore was accepted before this screen existed,
+			// so the silence deadline starts from the moment we found it
+			// rather than from a submission that never happened here.
 			setAliveAt( previous => previous ?? Date.now() );
 		}
-	}, [ adopted, hasOwnSubmission ] );
+	}, [ found, hasOwnSubmission ] );
 
 	// Recovery for the no-id case. The query stays a plain read of the
 	// collection; the matching is derived below, so nothing here depends
@@ -316,7 +358,7 @@ export function useRestore( rewindId: string ): Result {
 		if ( ! needsId || startedRewindId === null ) {
 			return null;
 		}
-		const match = pickLiveRestore( restoresQuery.data ?? [], startedRewindId );
+		const match = pickLiveRestore( restoresQuery.data ?? null, startedRewindId );
 		return match ? match.restore_id : null;
 	}, [ needsId, restoresQuery.data, startedRewindId ] );
 
@@ -382,6 +424,7 @@ export function useRestore( rewindId: string ): Result {
 
 	const submit = useCallback( ( items: RestoreItems ) => kickOff( items ), [ kickOff ] );
 	const reset = useCallback( () => {
+		setAdopted( null );
 		setSubmittedId( null );
 		setErrorMessage( null );
 		setUnconfirmed( null );

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -1,8 +1,16 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { fetchRecentRestores, fetchRestoreStatus, initiateRestore } from '../data/api/restore';
+import { isAmbiguousFailure } from '../data/api/_helpers';
+import {
+	fetchRecentRestores,
+	fetchRestoreStatus,
+	initiateRestore,
+	isTerminal,
+	pickLiveRestore,
+} from '../data/api/restore';
 import { keys } from '../data/query-client';
+import { useAdoptedRestore } from './use-adopted-restore';
 import type { RestoreStatus, RestoreStatusResponse } from '../data/api/restore';
 import type { RestoreItems, RestoreState } from '../types/restore';
 
@@ -10,6 +18,13 @@ type Result = {
 	state: RestoreState;
 	submit: ( items: RestoreItems ) => void;
 	reset: () => void;
+	/**
+	 * Set when the restore on screen was already running before this
+	 * screen opened, rather than started here. Carries the backup it is
+	 * restoring, which need not be the one in the URL — see
+	 * `useAdoptedRestore`.
+	 */
+	adopted: { rewindId: string } | null;
 };
 
 /**
@@ -39,9 +54,6 @@ const POLL_INTERVAL_MS = 5000;
  */
 const QUIET_TIMEOUT_MS = 5 * 60 * 1000;
 
-/** Statuses that mean the restore is still going, or might be. */
-const LIVE_STATUSES: RestoreStatus[] = [ 'queued', 'running', 'unknown' ];
-
 /**
  * Whether a status reading counts as a sign of life, restarting the
  * silence deadline.
@@ -63,50 +75,11 @@ function isSignOfLife( status: RestoreStatus | undefined ): boolean {
 	return status === 'running';
 }
 
-/**
- * Whether a status reading ends the poll.
- *
- * @param status - The status the bridge reported, if any.
- * @return True when there is nothing left to wait for.
- */
-function isTerminal( status: RestoreStatus | undefined ): boolean {
-	return status !== undefined && ! LIVE_STATUSES.includes( status );
-}
-
-/**
- * Whether two rewind ids name the same backup.
- *
- * Adopting the wrong id would report someone else's restore as this one,
- * so this stays an equality test and never a prefix or integer-part
- * match: two restores of the same backup share an integer part.
- *
- * What it does tolerate is formatting. A rewind id is a unix timestamp
- * with a decimal suffix, and the value in `recent_restores[]` has been
- * round-tripped through VaultPress rather than echoed back by
- * WordPress.com — so a trailing zero gained or lost (`…613.9425` vs
- * `…613.94250`) would defeat a strict string comparison for two
- * representations of the same instant. Comparing them as numbers as well
- * closes that without widening what counts as a match.
- *
- * @param candidate - A rewind id from the restores collection.
- * @param target    - The rewind id this screen submitted.
- * @return True when both name the same backup.
- */
-function sameRewindId( candidate: string, target: string ): boolean {
-	if ( ! candidate || ! target ) {
-		return false;
-	}
-	if ( candidate === target ) {
-		return true;
-	}
-	const a = Number( candidate );
-	const b = Number( target );
-	return Number.isFinite( a ) && Number.isFinite( b ) && a === b;
-}
-
 type DeriveInput = {
 	errorMessage: string | null;
 	isPending: boolean;
+	isChecking: boolean;
+	unconfirmed: string | null;
 	startedRewindId: string | null;
 	restoreId: number | null;
 	statusError: Error | null;
@@ -127,8 +100,17 @@ type DeriveInput = {
  * @return The current phase.
  */
 function deriveState( input: DeriveInput ): RestoreState {
-	const { errorMessage, isPending, startedRewindId, restoreId, statusError, data, lostTrack } =
-		input;
+	const {
+		errorMessage,
+		isPending,
+		isChecking,
+		unconfirmed,
+		startedRewindId,
+		restoreId,
+		statusError,
+		data,
+		lostTrack,
+	} = input;
 
 	if ( errorMessage ) {
 		return { phase: 'error', message: errorMessage };
@@ -137,7 +119,27 @@ function deriveState( input: DeriveInput ): RestoreState {
 		return { phase: 'submitting' };
 	}
 	if ( startedRewindId === null ) {
-		return { phase: 'idle' };
+		// Nothing of our own, and we may not yet know whether the site has
+		// a restore running from somewhere else. Withholding the form is
+		// the whole point: see `useAdoptedRestore`.
+		return isChecking ? { phase: 'checking' } : { phase: 'idle' };
+	}
+	// A submission whose answer never arrived, and no restore found for it
+	// yet. The rule this serves is the one `RestoreState` states: a retry
+	// is offered only when we know nothing is running. Five minutes of
+	// looking and finding nothing is that knowledge — before it, offering
+	// one would risk a second concurrent restore.
+	if ( unconfirmed !== null && restoreId === null ) {
+		if ( lostTrack ) {
+			return {
+				phase: 'error',
+				message: __(
+					"Your restore didn't start, so nothing on your site has changed.",
+					'jetpack-backup-pkg'
+				),
+			};
+		}
+		return { phase: 'unconfirmed', detail: unconfirmed };
 	}
 	// A network failure mid-poll, surfaced rather than left sitting at
 	// the last known percent with no way out.
@@ -187,7 +189,17 @@ function deriveState( input: DeriveInput ): RestoreState {
  * Submit starts the restore, then a polled status query advances
  * idle → submitting → queued → progress → one of the terminal states.
  *
- * Two things make this more than a request and a poll.
+ * Four things make this more than a request and a poll.
+ *
+ * A restore may already be running before this screen ever mounts — from
+ * a reload, a second tab, or Calypso. None of this hook's state survives
+ * a page load, so the screen has to go and ask; until it has an answer it
+ * shows neither the form nor a progress bar. See `useAdoptedRestore`.
+ *
+ * A submission whose answer never arrived is not a failure. WordPress.com
+ * may have queued the restore and lost only the reply, so the outcome
+ * goes into the same recovery the no-id case uses rather than into
+ * `error` — whose only control resets to an armed Confirm button.
  *
  * WordPress.com may accept a restore without returning an id for it —
  * VaultPress does not reliably echo one, and the documented response for
@@ -208,6 +220,10 @@ function deriveState( input: DeriveInput ): RestoreState {
 export function useRestore( rewindId: string ): Result {
 	const [ submittedId, setSubmittedId ] = useState< number | null >( null );
 	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
+	// Non-null while a submission's outcome is unknown, holding the
+	// transport's own text. Distinct from `errorMessage`, which means
+	// WordPress.com answered and said no.
+	const [ unconfirmed, setUnconfirmed ] = useState< string | null >( null );
 	// Set once the restore is accepted, whether or not it came with an id.
 	// Distinguishes "queued, id unknown" from "not started".
 	const [ startedRewindId, setStartedRewindId ] = useState< string | null >( null );
@@ -251,9 +267,36 @@ export function useRestore( rewindId: string ): Result {
 			}
 		},
 		onError: ( err: Error ) => {
+			// We never saw an answer, so the restore may be running. Enter
+			// the same recovery the no-id case uses and let it decide:
+			// finding one adopts it, finding none for the whole silence
+			// deadline is what finally makes a retry safe to offer.
+			if ( isAmbiguousFailure( err ) ) {
+				setUnconfirmed( err.message || null );
+				setStartedRewindId( rewindId );
+				setAliveAt( Date.now() );
+				setLostTrack( false );
+				return;
+			}
 			setErrorMessage( err.message );
 		},
 	} );
+
+	// What this site already has running, if anything. Disabled the
+	// moment this screen has a submission of its own: from then on the
+	// restore on screen is ours, and the lookup would only be a second
+	// opinion about a question we can already answer.
+	const hasOwnSubmission = startedRewindId !== null || isPending;
+	const { adopted, isChecking } = useAdoptedRestore( ! hasOwnSubmission );
+
+	// An adopted restore was accepted before this screen existed, so the
+	// silence deadline has to start from the moment we found it rather
+	// than from a submission that never happened here.
+	useEffect( () => {
+		if ( adopted !== null && ! hasOwnSubmission ) {
+			setAliveAt( previous => previous ?? Date.now() );
+		}
+	}, [ adopted, hasOwnSubmission ] );
 
 	// Recovery for the no-id case. The query stays a plain read of the
 	// collection; the matching is derived below, so nothing here depends
@@ -273,11 +316,26 @@ export function useRestore( rewindId: string ): Result {
 		if ( ! needsId || startedRewindId === null ) {
 			return null;
 		}
-		const match = restoresQuery.data?.find( row => sameRewindId( row.rewind_id, startedRewindId ) );
+		const match = pickLiveRestore( restoresQuery.data ?? [], startedRewindId );
 		return match ? match.restore_id : null;
 	}, [ needsId, restoresQuery.data, startedRewindId ] );
 
-	const restoreId = submittedId ?? recoveredId;
+	// Promote a recovered id into state, which is what closes the gate
+	// above. Left purely derived, `submittedId` stayed null forever, so
+	// `needsId` never went false and the collection was fetched every
+	// five seconds for the life of the tab — long after the restore had
+	// finished, and behind a screen with nothing left to recover.
+	useEffect( () => {
+		if ( recoveredId !== null && submittedId === null ) {
+			setSubmittedId( recoveredId );
+		}
+	}, [ recoveredId, submittedId ] );
+
+	// An adoption stands in for a submission on both counts: it names the
+	// restore to poll, and it is what the screen renders instead of the
+	// form.
+	const restoreId = submittedId ?? recoveredId ?? adopted?.id ?? null;
+	const activeRewindId = startedRewindId ?? adopted?.rewindId ?? null;
 
 	// Always-defined query key so @tanstack/query/exhaustive-deps stays
 	// happy; the `enabled` flag keeps the placeholder query from firing.
@@ -326,6 +384,7 @@ export function useRestore( rewindId: string ): Result {
 	const reset = useCallback( () => {
 		setSubmittedId( null );
 		setErrorMessage( null );
+		setUnconfirmed( null );
 		setStartedRewindId( null );
 		setAliveAt( null );
 		setLostTrack( false );
@@ -336,12 +395,19 @@ export function useRestore( rewindId: string ): Result {
 	const state = deriveState( {
 		errorMessage,
 		isPending,
-		startedRewindId,
+		isChecking,
+		unconfirmed,
+		startedRewindId: activeRewindId,
 		restoreId,
 		statusError: statusQuery.error,
 		data: statusQuery.data,
 		lostTrack,
 	} );
 
-	return { state, submit, reset };
+	return {
+		state,
+		submit,
+		reset,
+		adopted: adopted && ! hasOwnSubmission ? { rewindId: adopted.rewindId } : null,
+	};
 }

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -1,7 +1,7 @@
 import { Notice, ProgressBar, Spinner } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { useCallback, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon, backup as backupIcon, arrowLeft } from '@wordpress/icons';
 import { Link, useParams } from '@wordpress/route';
 import { Button, Card, Stack, Text } from '@wordpress/ui';
@@ -88,17 +88,44 @@ export default function RestoreScreen() {
 					{ state.phase === 'checking' && (
 						<Stack direction="row" gap="sm" align="center">
 							<Spinner />
-							<Text className="jpb-text-muted">
+							{ /*
+							 * `role="status"` because this is the whole page for as
+							 * long as it lasts, and every other branch announces
+							 * itself through `Notice`'s own live region — leaving
+							 * this one silent means a screen-reader user gets
+							 * nothing on load and then a form that appeared without
+							 * comment.
+							 */ }
+							<Text className="jpb-text-muted" role="status">
 								{ __( 'Checking for a restore in progress…', 'jetpack-backup-pkg' ) }
 							</Text>
 						</Stack>
 					) }
-					{ adopted && (
+					{ /*
+					 * Suppressed once we have lost track, where it would sit
+					 * directly above a warning saying the restore may still be
+					 * running and we can no longer see it — promising an end state
+					 * the notice beneath has just disowned.
+					 *
+					 * "from here" because the constraint is this screen's, not the
+					 * product's: nothing upstream refuses a second restore, and the
+					 * reader can still start one from WordPress.com.
+					 */ }
+					{ adopted && state.phase !== 'lost-track' && (
 						<Notice status="info" isDismissible={ false }>
-							{ __(
-								"A restore is already running for this site. You can't start another until it finishes.",
-								'jetpack-backup-pkg'
-							) }
+							{ restorePoint
+								? sprintf(
+										/* translators: %s is a date, e.g. "Aug 12, 2026". */
+										__(
+											"A restore of your %s backup is already running. You can't start another from here until it finishes.",
+											'jetpack-backup-pkg'
+										),
+										dateI18n( 'M j, Y', restorePoint, undefined )
+								  )
+								: __(
+										"A restore is already running for this site. You can't start another from here until it finishes.",
+										'jetpack-backup-pkg'
+								  ) }
 						</Notice>
 					) }
 					{ ( state.phase === 'idle' || state.phase === 'submitting' ) && (

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -27,11 +27,20 @@ const SELECTION_HINT_ID = 'jpb-restore__selection-hint';
 export default function RestoreScreen() {
 	const { rewindId } = useParams( { from: '/restore/$rewindId' } );
 	const [ items, setItems ] = useState( DEFAULT_RESTORE_ITEMS );
-	const { state, submit, reset } = useRestore( rewindId );
+	const { state, submit, reset, adopted } = useRestore( rewindId );
 	const handleConfirm = useCallback( () => submit( items ), [ submit, items ] );
 	// An empty checklist would restore *everything* rather than nothing —
 	// see `hasSelectedItems`. On this screen that is unrecoverable.
 	const hasSelection = hasSelectedItems( items );
+
+	// When the restore on screen was already running before this screen
+	// opened, the heading has to name *its* backup. It need not be the one
+	// in the address: a restore of any point overwrites the same live
+	// site, so the screen adopts whatever is running rather than arming a
+	// button beside it, and then owes the reader an explanation of why
+	// their checklist is missing.
+	const shownRewindId =
+		adopted && isValidRewindId( adopted.rewindId ) ? adopted.rewindId : rewindId;
 
 	// A malformed id can only produce a failed restore, so the screen
 	// offers the way back and nothing else — see `InvalidRewindId`.
@@ -48,7 +57,7 @@ export default function RestoreScreen() {
 		);
 	}
 
-	const restorePoint = rewindIdToIso( rewindId );
+	const restorePoint = rewindIdToIso( shownRewindId );
 
 	return (
 		<DashboardLayout>
@@ -70,6 +79,28 @@ export default function RestoreScreen() {
 							</Text>
 						</Stack>
 					</Stack>
+					{ /*
+					 * The opening state of every cold load. Neither the form nor a
+					 * progress bar, because we do not yet know which is true — and
+					 * a Confirm button that appears and is withdrawn a moment later
+					 * is the same hazard as one that should never have appeared.
+					 */ }
+					{ state.phase === 'checking' && (
+						<Stack direction="row" gap="sm" align="center">
+							<Spinner />
+							<Text className="jpb-text-muted">
+								{ __( 'Checking for a restore in progress…', 'jetpack-backup-pkg' ) }
+							</Text>
+						</Stack>
+					) }
+					{ adopted && (
+						<Notice status="info" isDismissible={ false }>
+							{ __(
+								"A restore is already running for this site. You can't start another until it finishes.",
+								'jetpack-backup-pkg'
+							) }
+						</Notice>
+					) }
 					{ ( state.phase === 'idle' || state.phase === 'submitting' ) && (
 						<>
 							<Notice status="warning" isDismissible={ false }>
@@ -172,6 +203,31 @@ export default function RestoreScreen() {
 								</Text>
 							) }
 							<Link to="/">{ __( 'Back to overview', 'jetpack-backup-pkg' ) }</Link>
+						</Stack>
+					) }
+					{ /*
+					 * We asked and never got an answer, so nothing has been ruled
+					 * out: WordPress.com may have queued the restore and lost only
+					 * the reply. No control here on purpose — offering "Try again"
+					 * now is exactly how a second concurrent restore starts. The
+					 * recovery poll is looking, and either finds the restore or
+					 * runs out the deadline, at which point a retry is safe and
+					 * the error branch below offers one.
+					 */ }
+					{ state.phase === 'unconfirmed' && (
+						<Stack direction="column" gap="sm">
+							<Notice status="warning" isDismissible={ false }>
+								{ __(
+									"We didn't hear back from WordPress.com. Checking whether your restore started…",
+									'jetpack-backup-pkg'
+								) }
+							</Notice>
+							{ state.detail && (
+								<Text variant="body-sm" className="jpb-text-muted">
+									{ state.detail }
+								</Text>
+							) }
+							<ProgressBar />
 						</Stack>
 					) }
 					{ /*

--- a/projects/packages/backup/src/dashboard/types/restore.ts
+++ b/projects/packages/backup/src/dashboard/types/restore.ts
@@ -50,6 +50,18 @@ export function hasSelectedItems( items: RestoreItems ): boolean {
  * either neighbour. A restore that finished but not cleanly should not
  * be dismissed as done, and should not be retried as if nothing landed.
  *
+ * `checking` is the opening state of every cold load: the screen does not
+ * yet know whether this site already has a restore running, and must show
+ * neither the form nor a progress bar until it does. It is short — one
+ * request, usually — but it cannot be skipped, because the alternative is
+ * an armed Confirm button that is withdrawn a moment later.
+ *
+ * `unconfirmed` is the submission whose answer never arrived. It is not
+ * `error`, because nothing has been ruled out: WordPress.com may have
+ * queued the restore and lost only the reply. It is not `queued` either,
+ * because that copy promises a restore is under way. The screen says what
+ * is true — we are finding out — and offers no control until it knows.
+ *
  * `lost-track` is separate from `error` for the same reason, and it
  * matters more. The two say opposite things about the live site: `error`
  * means nothing is running, `lost-track` means something probably is and
@@ -70,9 +82,11 @@ export function hasSelectedItems( items: RestoreItems ): boolean {
  * headline.
  */
 export type RestoreState =
+	| { phase: 'checking' }
 	| { phase: 'idle' }
 	| { phase: 'submitting' }
 	| { phase: 'queued' }
+	| { phase: 'unconfirmed'; detail: string | null }
 	| { phase: 'progress'; percent: number }
 	| { phase: 'success' }
 	| { phase: 'success-with-errors'; message: string }

--- a/projects/packages/backup/tests/restore-session-recovery.test.tsx
+++ b/projects/packages/backup/tests/restore-session-recovery.test.tsx
@@ -1,0 +1,182 @@
+// JETPACK-2243 B3 — the Restore screen, opened while a restore is
+// already under way.
+//
+// Every piece of restore state lived in `useState`, so nothing survived a
+// page load. Reloading mid-restore, opening a second tab, or arriving
+// after a restore started from Calypso all rendered an armed **Confirm
+// restore** button with no hint that anything was running — and the only
+// control on screen would have started a second concurrent whole-site
+// restore.
+
+const mockApiFetch = jest.fn();
+const mockParams = jest.fn< { rewindId: string }, [] >();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+	useNavigate: () => () => {},
+	useParams: () => mockParams(),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, within } from '@testing-library/react';
+import { queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import RestoreScreen from '../src/dashboard/screens/restore';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const CAPABILITIES = { hasBackupPlan: true, hasScan: false };
+
+// The backup this screen is pointed at, and the different one that turns
+// out to be restoring.
+const URL_ID = '1786663613.9425';
+const RUNNING_ID = '1786512000.11';
+
+const CONFIRM = /Confirm restore/;
+const ALREADY_RUNNING = /A restore is already running/;
+
+/**
+ * Render the screen and return queries scoped to it.
+ *
+ * Scoped rather than `screen`, and that matters here. `Notice` announces
+ * itself through `@wordpress/a11y`, which appends a visually hidden
+ * speak region to `document.body` — once per process, and it keeps its
+ * text. A `screen` query therefore matches both the notice and its
+ * announcement, and worse, still matches an announcement left behind by
+ * the *previous* test, resolving before this render has adopted
+ * anything. The speak region lives outside the container, so scoping
+ * removes both problems.
+ *
+ * Callers wrap the result in `within()` themselves rather than having
+ * this do it, so that `testing-library/prefer-screen-queries` can see
+ * the scoping it is meant to allow.
+ *
+ * @return The rendered container.
+ */
+function renderScreen(): HTMLElement {
+	const { container } = render(
+		<QueryClientProvider>
+			<RestoreScreen />
+		</QueryClientProvider>
+	);
+	return container;
+}
+
+/**
+ * Route each request by path.
+ *
+ * @param options          - Overrides.
+ * @param options.restores - What `/jetpack/v4/restores` resolves with.
+ * @param options.status   - What a restore-status poll resolves with.
+ */
+function respondWith( { restores = [] as unknown, status = null as unknown } = {} ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/restores' ) ) {
+			return Promise.resolve( restores );
+		}
+		if ( path.includes( '/rewind/restore/' ) ) {
+			return Promise.resolve( status );
+		}
+		return Promise.resolve( CAPABILITIES );
+	} );
+}
+
+/**
+ * A row of the restores collection.
+ *
+ * @param over - Fields to override.
+ * @return The row.
+ */
+function restoreRow( over: Record< string, unknown > = {} ) {
+	return {
+		restore_id: 912682,
+		rewind_id: RUNNING_ID,
+		when: '2026-08-20T10:00:00+00:00',
+		status: 'running',
+		...over,
+	};
+}
+
+/**
+ * A status payload in the shape the bridge projects.
+ *
+ * @param over - Fields to override.
+ * @return The payload.
+ */
+function statusPayload( over: Record< string, unknown > = {} ) {
+	return {
+		id: 912682,
+		status: 'running',
+		progress: 47,
+		rewind_id: RUNNING_ID,
+		error_code: '',
+		message: '',
+		...over,
+	};
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockParams.mockReset();
+	mockParams.mockReturnValue( { rewindId: URL_ID } );
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'Restore screen — a restore already running', () => {
+	it( 'shows the restore in progress instead of the form', async () => {
+		respondWith( { restores: [ restoreRow() ], status: statusPayload() } );
+
+		const view = within( renderScreen() );
+
+		await expect( view.findByText( ALREADY_RUNNING ) ).resolves.toBeInTheDocument();
+		expect( view.queryByRole( 'button', { name: CONFIRM } ) ).not.toBeInTheDocument();
+		// The checklist goes with the button: choosing categories for a
+		// restore you cannot start is not a decision worth offering.
+		expect( view.queryByText( 'Choose the items you wish to restore:' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'names the backup being restored, not the one in the address', async () => {
+		respondWith( { restores: [ restoreRow() ], status: statusPayload() } );
+
+		const view = within( renderScreen() );
+
+		await expect( view.findByText( ALREADY_RUNNING ) ).resolves.toBeInTheDocument();
+		// The running restore is of 1786512000 (12 Aug); the address names
+		// 1786663613 (13 Aug). The heading has to follow the restore.
+		const point = await view.findByText( /Restore point:/ );
+		expect( point ).toHaveTextContent( /Aug 12, 2026/ );
+		expect( point ).not.toHaveTextContent( /Aug 13, 2026/ );
+	} );
+
+	it( 'never arms the form while it is still finding out', async () => {
+		// A Confirm button that appears and is then withdrawn is the same
+		// hazard, just briefer.
+		respondWith( { restores: [ restoreRow() ], status: statusPayload() } );
+
+		const view = within( renderScreen() );
+
+		expect( view.queryByRole( 'button', { name: CONFIRM } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'arms the form when nothing is running', async () => {
+		respondWith( { restores: [ restoreRow( { status: 'finished' } ) ] } );
+
+		const view = within( renderScreen() );
+
+		await expect( view.findByRole( 'button', { name: CONFIRM } ) ).resolves.toBeInTheDocument();
+		expect( view.queryByText( ALREADY_RUNNING ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/restore-session-recovery.test.tsx
+++ b/projects/packages/backup/tests/restore-session-recovery.test.tsx
@@ -38,7 +38,7 @@ const URL_ID = '1786663613.9425';
 const RUNNING_ID = '1786512000.11';
 
 const CONFIRM = /Confirm restore/;
-const ALREADY_RUNNING = /A restore is already running/;
+const ALREADY_RUNNING = /is already running/;
 
 /**
  * Render the screen and return queries scoped to it.
@@ -153,9 +153,14 @@ describe( 'Restore screen — a restore already running', () => {
 
 		const view = within( renderScreen() );
 
-		await expect( view.findByText( ALREADY_RUNNING ) ).resolves.toBeInTheDocument();
 		// The running restore is of 1786512000 (12 Aug); the address names
-		// 1786663613 (13 Aug). The heading has to follow the restore.
+		// 1786663613 (13 Aug). Both the notice and the heading have to
+		// follow the restore, and the notice has to say so outright — a
+		// heading that silently changes date leaves the reader to work out
+		// why their checklist vanished.
+		const notice = await view.findByText( ALREADY_RUNNING );
+		expect( notice ).toHaveTextContent( /Aug 12, 2026/ );
+
 		const point = await view.findByText( /Restore point:/ );
 		expect( point ).toHaveTextContent( /Aug 12, 2026/ );
 		expect( point ).not.toHaveTextContent( /Aug 13, 2026/ );
@@ -178,5 +183,36 @@ describe( 'Restore screen — a restore already running', () => {
 
 		await expect( view.findByRole( 'button', { name: CONFIRM } ) ).resolves.toBeInTheDocument();
 		expect( view.queryByText( ALREADY_RUNNING ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'stops promising an end state once it has lost track of the restore', async () => {
+		// "You can't start another until it finishes" sat directly above
+		// "We've lost track of this restore. It may still be running" —
+		// two notices, no action, and the first promising an end state the
+		// second had just disowned.
+		let calls = 0;
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( '/restores' ) ) {
+				return Promise.resolve( [ restoreRow() ] );
+			}
+			if ( path.includes( '/rewind/restore/' ) ) {
+				calls += 1;
+				// Adopt on the first read, then lose the connection.
+				return calls === 1
+					? Promise.resolve( statusPayload() )
+					: Promise.reject( { code: 'fetch_error', message: 'Connection lost.' } );
+			}
+			return Promise.resolve( CAPABILITIES );
+		} );
+
+		const view = within( renderScreen() );
+
+		await expect(
+			view.findByText( /We've lost track of this restore/ )
+		).resolves.toBeInTheDocument();
+		expect( view.queryByText( ALREADY_RUNNING ) ).not.toBeInTheDocument();
+		// And still no way to start a second one.
+		expect( view.queryByRole( 'button', { name: CONFIRM } ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Fixes #

Rebased onto trunk now that #51401, which this was stacked on, has merged.

**Second commit addresses the review in full** — two blockers and three suggestions, all one shape: the screen knew how to *enter* recovery and not how to leave it. An adopted restore now carries through to `success` / `error` instead of collapsing back to an armed form; a browser-side failure with no bridge verdict is treated as ambiguous rather than as a refusal; adoption requires positive evidence rather than a status that only means "not visible"; a failed collection read is distinguishable from "nothing is running"; and the collection is re-read at the click, so the guarantee is no longer mount-only. Copy, the `checking` live region, and the three coverage gaps are covered too.

## Proposed changes

Four defects in the modernized restore flow, all reachable today behind `rsm_jetpack_ui_modernization_backup` (default off). The legacy page is untouched and no PHP changes.

They are all versions of one rule the state machine already states, in `types/restore.ts`: *a retry is offered only when we know nothing is running.* `lost-track` exists to honour it mid-poll. The gaps were at the two edges that rule never reached — mount, and the initiate call itself.

* **Adopt a restore that is already running, instead of arming a second one (B3).** Every piece of restore state lived in `useState`, so nothing survived a page load. Reloading mid-restore, opening a second tab, or arriving after a restore started from Calypso all rendered a fully live **Confirm restore** button with no hint that anything was running — one click from a second concurrent whole-site restore, which nothing upstream is known to refuse.

  New `useAdoptedRestore` asks `GET /jetpack/v4/restores` what exists, confirms the candidate against the status route, and until both have answered the screen shows neither the form nor a progress bar. It adopts a restore of **any** backup, not only this screen's: a restore overwrites the same live site whichever point it came from. The heading then names the backup being restored rather than the one in the address, so the reader is told why their checklist is gone.

  Two reads, not one, and only when needed: a site whose last restore finished is answered by the collection alone. Measured live — the settled case issues **zero** status-route requests.

* **Match the recovered restore on recency, not row order (B10).** The match was `find()` over the collection, so an earlier *completed* restore of the same backup was adopted as the one just started — and its status route answers `finished`, so the screen said "Restore complete." while the real restore was still overwriting the site. Rows are now ranked newest-first by `when`, with settled rows excluded.

  `when` is only ever compared against another row's, never against the browser's clock. I had originally planned a `when >= submittedAt` filter and dropped it: a browser running minutes fast would then reject the restore it had just started, and recovery would fail for that whole session — a worse failure than the one being fixed.

* **A submission we never got an answer to no longer offers a retry (B11).** A transport failure landed in `error`, whose only control resets to an armed Confirm — and that is precisely the case where WordPress.com may have queued the restore and lost only the reply. It now enters the same recovery the no-id case uses: finding a restore adopts it; finding none for the whole five-minute silence deadline is what finally makes a retry safe, and it is offered only then.

  All three initiate failures share the code `restore_initiate_failed` (`class-restore-bridge.php:147-179`), so the code cannot tell them apart. The marker is `data.transport`, which `Rest_Controller::transport_error()` attaches and nothing else does. A genuine refusal — a 401, a 412, a falsy `ok` — still reports immediately, unchanged.

* **The recovery poll stops (B12).** The recovered id was derived in a `useMemo` and never promoted to state, so the gate kept reading "no id yet" and `/jetpack/v4/restores` was fetched every five seconds for the life of the tab — long after the restore had finished, behind a screen with nothing left to recover.

**One design note worth a reviewer's eye.** The collection's `status` is *not* the status route's vocabulary — WordPress.com's docblock for it claims `finished/started/fail` while its own consumer matches `running`, and `RecentRestore`'s docblock argues against mapping a second, differently-spelled enum. It is now collapsed to a single `settled` boolean at the fetch boundary, and the raw spelling never leaves `data/api/restore.ts`. An unrecognised spelling counts as *not* settled, so the row stays adoptable; guessing the other way would make an unknown spelling of "running" permanently unrecoverable.

**Two existing tests changed contract, deliberately.** With any live restore adopted at mount, "submit while a restore of another backup is running" is a state the UI no longer reaches, so a hook test for it would assert against an impossible scenario. Their rule — rewind-id discrimination — moved to direct unit tests of `pickLiveRestore`, which is where it now lives.

## Related product discussion/links

* [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243/backup-modernized-dashboard-work-needed-before-the-flag-can-flip) — task **B3**, plus three defects the task list did not have, filed there as **B10**, **B11** and **B12**
* Follows #51292, #51294, #51295, #51336, #51338 and #51401

## Does this pull request change what data or activity we track or use?

No. No new events, no new data collected. The only new outbound requests are to two routes the dashboard already calls.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, **default off** — confirm the legacy Backup page is unchanged first.

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

**The important case needs no real restore.** Serve a canned collection from a mu-plugin — note `rest_dispatch_request` and not `rest_request_before_callbacks`, whose return value the route callback overwrites, and note that its `$route` argument is the registered *pattern*, not the request path:

```php
add_filter(
	'rest_dispatch_request',
	function ( $result, $request, $route ) {
		if ( '/jetpack/v4/restores' === $route ) {
			return new WP_REST_Response( array( array(
				'restore_id' => 912682,
				'rewind_id'  => '1786512000.11',
				'when'       => '2026-08-20T10:00:00+00:00',
				'status'     => 'running',
			) ), 200 );
		}
		if ( false !== strpos( $route, '/rewind/restore/' ) && false !== strpos( $route, '/status' ) ) {
			return new WP_REST_Response( array(
				'id' => (int) $request['restore_id'], 'status' => 'running', 'progress' => 47,
				'rewind_id' => '1786512000.11', 'error_code' => '', 'message' => '',
			), 200 );
		}
		return $result;
	},
	PHP_INT_MAX,
	3
);
```

**A running restore is adopted**

* Open `…&p=/restore/<any valid rewind id>` on a **cold load**.
* Expect: **no** Confirm restore button, no checklist, an info notice reading "A restore is already running for this site. You can't start another until it finishes.", and a progress bar at 47%.
* The "Restore point:" line must name **12 Aug 2026** — the backup the running restore is for — and *not* the id you put in the address. That is the point: the site is being overwritten by a different restore, and the screen has to say which.

**Nothing running arms the form** (the control — please run this one, it is what proves the form is not simply always hidden)

* Change the collection row's `status` to `'finished'` and reload.
* Expect the checklist and a live Confirm restore button, the "Restore point:" line back to the id in the address, and no notice.
* In the network tab, `/rewind/restore/…/status` should be requested **zero** times: a settled row is filtered from the collection alone, without a second round trip.

**A submission whose answer never arrives**

* Drop the `/restores` override and make the bridge return a real `Rest_Controller::transport_error()`. Note that DevTools → Network → offline does *not* exercise this branch: `navigator.onLine` is then false, which is treated as proof the request never left, so that case deliberately keeps its immediate retry.
* Submit. Expect "We didn't hear back from WordPress.com. Checking whether your restore started…" with an indeterminate bar and **no** Try again button.
* Wait out the five-minute silence deadline with nothing in the collection. Only then should it become "Your restore didn't start, so nothing on your site has changed." with a working **Try again**.
* Now the refusal case, which must be unchanged: make the bridge return a 412 rather than a transport failure. Expect the error and its Try again **immediately**, with no waiting.

**Flag off**

* Turn the filter off and confirm the legacy Backup page renders exactly as before.

**Automated**

* `jp test js packages/backup` → **372 tests, 42 suites**. Was 320/40 on trunk before this branch.
* `pnpm run typecheck`, ESLint and Prettier clean. No PHP changed, so no PHPUnit or Phan delta.
* Verified live on a Jetpack-connected site with the modernized dashboard: both cases above, plus the footer still pinned at the correct 8px inset from #51401.


