### PR TITLE
Premium Analytics: bound a visits request with its range alone

### DIFF
--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-visits-range-only
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-visits-range-only
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Stats: Bound the visits request with its date range alone; the endpoint recounts its buckets from the range and ignores a bucket count sent alongside it.
+Comment: Drop a parameter the visits endpoint discards. The request changes; the response, and so everything a reader sees, does not.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-visits-range-only
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-visits-range-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats: Bound the visits request with its date range alone; the endpoint recounts its buckets from the range and ignores a bucket count sent alongside it.

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -1315,7 +1315,7 @@ describe( 'Stats query factories', () => {
 			to: '2026-06-07',
 			interval: 'day',
 			days: 3,
-		} as Parameters< typeof statsVisitsQuery >[ 0 ] );
+		} );
 		const apiParams = query.queryKey[ 5 ] as Record< string, unknown >;
 
 		expect( apiParams ).toEqual( {
@@ -1335,16 +1335,16 @@ describe( 'Stats query factories', () => {
 			to: '2026-06-15T23:59:59-07:00',
 			interval: 'hour',
 		} );
+		const apiParams = query.queryKey[ 5 ] as Record< string, unknown >;
 
-		expect( query.queryKey ).toEqual(
-			expect.arrayContaining( [
-				expect.objectContaining( {
-					unit: 'hour',
-					date: '2026-06-15T23:59:59-07:00',
-					start_date: '2026-06-15T00:00:00-07:00',
-				} ),
-			] )
-		);
+		// Exact rather than a superset: hour is the unit a re-added `quantity`
+		// would land on first, and a partial match would not notice it.
+		expect( apiParams ).toEqual( {
+			unit: 'hour',
+			date: '2026-06-15T23:59:59-07:00',
+			start_date: '2026-06-15T00:00:00-07:00',
+			stat_fields: 'views,visitors',
+		} );
 	} );
 
 	it( 'builds UTM query keys from the selected UTM parameter', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -1306,20 +1306,42 @@ describe( 'Stats query factories', () => {
 		] );
 	} );
 
-	it( 'sets visits quantity for day ranges', () => {
+	// The range is the only thing that bounds a visits request: the endpoint
+	// recounts the buckets from start_date/date and ignores a bucket count sent
+	// alongside them, so neither `quantity` nor `days` belongs in the request.
+	it( 'bounds visits with the range alone', () => {
 		const query = statsVisitsQuery( {
 			from: '2026-06-01',
 			to: '2026-06-07',
 			interval: 'day',
+			days: 3,
+		} as Parameters< typeof statsVisitsQuery >[ 0 ] );
+		const apiParams = query.queryKey[ 5 ] as Record< string, unknown >;
+
+		expect( apiParams ).toEqual( {
+			unit: 'day',
+			date: '2026-06-07',
+			start_date: '2026-06-01',
+			stat_fields: 'views,visitors',
+		} );
+	} );
+
+	// Hourly is the one unit whose window needs finer precision than a calendar
+	// day, and the endpoint reads these two straight off the request — so they
+	// have to reach it with their time of day intact.
+	it( 'carries the hourly range at full precision', () => {
+		const query = statsVisitsQuery( {
+			from: '2026-06-15T00:00:00-07:00',
+			to: '2026-06-15T23:59:59-07:00',
+			interval: 'hour',
 		} );
 
 		expect( query.queryKey ).toEqual(
 			expect.arrayContaining( [
 				expect.objectContaining( {
-					unit: 'day',
-					date: '2026-06-07',
-					start_date: '2026-06-01',
-					quantity: 7,
+					unit: 'hour',
+					date: '2026-06-15T23:59:59-07:00',
+					start_date: '2026-06-15T00:00:00-07:00',
 				} ),
 			] )
 		);
@@ -1408,7 +1430,7 @@ describe( 'Stats query factories', () => {
 		);
 	} );
 
-	it( 'omits visits quantity for non-day ranges', () => {
+	it( 'bounds a coarser visits unit the same way', () => {
 		const query = statsVisitsQuery( {
 			from: '2026-06-01',
 			to: '2026-06-30',
@@ -1416,14 +1438,12 @@ describe( 'Stats query factories', () => {
 		} );
 		const apiParams = query.queryKey[ 5 ] as Record< string, unknown >;
 
-		expect( apiParams ).toEqual(
-			expect.objectContaining( {
-				unit: 'month',
-				date: '2026-06-30',
-				start_date: '2026-06-01',
-			} )
-		);
-		expect( apiParams ).not.toHaveProperty( 'quantity' );
+		expect( apiParams ).toEqual( {
+			unit: 'month',
+			date: '2026-06-30',
+			start_date: '2026-06-01',
+			stat_fields: 'views,visitors',
+		} );
 	} );
 
 	it( 'builds insights query keys without report params', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
@@ -30,11 +30,13 @@ export const statsVisitsQuery = (
 ): StatsReportQueryOptions< 'visits' > => {
 	const statsParams = reportParamsToStatsQueryParams( params );
 	const apiParams = statsQueryParamsToApiParams( statsParams );
+	// `start_date` + `date` bound the window at every unit, hourly included, and
+	// the endpoint recounts the buckets from them — a `quantity` alongside is
+	// ignored. So the range alone describes the request.
 	const visitsParams: StatsProxyParams = {
 		unit: apiParams.period,
 		date: apiParams.date,
 		start_date: apiParams.start_date,
-		...( apiParams.period === 'day' ? { quantity: apiParams.days } : {} ),
 		stat_fields: params.stat_fields ?? 'views,visitors',
 	};
 


### PR DESCRIPTION
Part 2 of 5, split out of the Traffic-chart interval work (WOOA7S-1902). Independent of the rest — targets `trunk` and can land on its own.

## Proposed changes
* Drop the `quantity` param from the `stats/visits` request and let the date range alone bound it.

`stats/visits` recounts its buckets from `start_date` and `date` at every unit, and **ignores a `quantity` sent alongside them** — so the count this query derived for day ranges never reached the chart. It was dead weight that read as if it were load-bearing.

Verified against the endpoint's own code (`class.wpcom-json-api-stats-visits-v1-1-endpoint.php`): once `start_date` parses, `$chart_num` is overwritten with `days_diff + 1` and the hourly path recomputes `$num_hours` from the timestamp delta. The comment there says it outright — *"Ignore passed parameter $num and $unit when the start_date is given."*

`wordads/stats` keeps its `quantity`: it does not declare `start_date`, so the endpoint framework strips it before the callback runs and only `quantity` bounds it. Verified again just now — it still returns its default 30 when given a range.

`stats/subscribers` **has since gained `start_date`** (it ignored it earlier today). It is not migrated here, because the support isn't clean yet: at `day` it honours the range exactly, but at coarser units it returns **one bucket more than asked for** — `unit=week&start_date=2026-07-20&date=2026-08-16` yields 5 weeks starting `2026W07W13`, and `unit=month&start_date=2026-03-01&date=2026-08-31` yields 7 months starting `2026-02-01`. Switching the subscribers query over would silently widen every weekly and monthly subscribers chart by a period outside the selected range, so that migration wants its own PR (and probably a fix on the WPCOM side first).

## Related product discussion/links
* WOOA7S-1902

## Does this pull request change what data or activity we track or use?
No. The request loses a parameter the endpoint was discarding; the response is byte-identical.

## Testing instructions

This is a no-op on the wire, so the useful test is confirming the response doesn't change.

* Open any Stats-enabled site's dashboard and load a Traffic view. Charts should look exactly as they do on `trunk` for every range.
* To confirm directly against the API, request the same window twice — with and without `quantity` — and compare the bucket counts:
  * `unit=day&start_date=2026-08-13&date=2026-08-19` → 7 buckets
  * `unit=day&start_date=2026-08-13&date=2026-08-19&quantity=3` → still 7 buckets
  * Same holds at `week`, `month`, `year`, and `hour`.
  * Dropping `start_date` is the one case where `quantity` bites: `unit=day&date=2026-08-19` alone returns the endpoint's default 30.
* `jetpack test js packages/premium-analytics` — `stats-queries.test.ts` now pins the exact request params for day, hour and month ranges.
