### PR TITLE
Premium Analytics: read chart points as the wall clocks they name

### DIFF
--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-chart-wall-clock
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-chart-wall-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size.

--- a/projects/packages/premium-analytics/packages/externals/src/index.ts
+++ b/projects/packages/premium-analytics/packages/externals/src/index.ts
@@ -44,6 +44,7 @@ export {
 	type HeatmapTooltipData,
 	type LineStyles,
 	type SeriesData,
+	type TickResolution,
 } from '@automattic/charts';
 
 export { LineShape, RectShape } from '@automattic/charts/visx/legend';

--- a/projects/packages/premium-analytics/packages/externals/src/index.ts
+++ b/projects/packages/premium-analytics/packages/externals/src/index.ts
@@ -31,6 +31,7 @@ export {
 	buildCalendarHeatmapData,
 	lightenHexColor,
 	normalizeColorToHex,
+	parseAsLocalDate,
 	useGlobalChartsContext,
 	type BaseLegendItem,
 	type ChartTheme,

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
@@ -79,4 +79,10 @@ describe( 'formatDate', () => {
 
 		expect( formatDate( JUNE_21, 'full' ) ).toBe( 'Saturday, June 21, 2025' );
 	} );
+
+	it( 'appends the site time format for "dateTime"', () => {
+		setSettings( EN_US_SETTINGS );
+
+		expect( formatDate( JUNE_21, 'dateTime' ) ).toBe( 'June 21, 2025 12:00 am' );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
@@ -22,7 +22,8 @@ export type DateFormatName =
 	| 'year'
 	| 'iso'
 	| 'full'
-	| 'fullNoYear';
+	| 'fullNoYear'
+	| 'dateTime';
 
 /**
  * An instant to render, such as a `TZDate` or a timestamp.
@@ -51,6 +52,10 @@ function formatFor( name: DateFormatName ): string {
 
 	const siteFormat = getSettings().formats.date;
 	const withoutYearFormat = withoutYear( siteFormat ) || siteFormat;
+
+	if ( name === 'dateTime' ) {
+		return `${ siteFormat } ${ getSettings().formats.time }`;
+	}
 
 	if ( name === 'compact' ) {
 		return withShortMonth( siteFormat );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/__fixtures__/wp-date-settings.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/__fixtures__/wp-date-settings.ts
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { getSettings, type DateSettings } from '@wordpress/date';
+
+const DEFAULTS = getSettings();
+
+/**
+ * Settings for a site in a given timezone, on the US English defaults.
+ *
+ * @param timeZone - IANA zone name.
+ * @return Settings ready for `setSettings`.
+ */
+export const siteSettingsIn = ( timeZone: string ): DateSettings => ( {
+	...DEFAULTS,
+	timezone: { ...DEFAULTS.timezone, string: timeZone },
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/__tests__/comparative-bar-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/__tests__/comparative-bar-chart.test.tsx
@@ -2,9 +2,11 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import { setSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
+import { siteSettingsIn } from '../../../__fixtures__/wp-date-settings';
 import { ComparativeBarChart } from '../comparative-bar-chart';
 import type { ComparativeBarChartSeries } from '../types';
 
@@ -67,6 +69,11 @@ const DATA_FORMAT = { type: 'number' as const, options: { decimals: 0 } };
 const JULY_1 = new Date( '2026-07-01T00:00:00Z' );
 const JULY_2 = new Date( '2026-07-02T00:00:00Z' );
 
+// A tooltip label reads its point as the instant it is, in the site's timezone,
+// so this one is an instant and every label assertion fixes the site's zone.
+// Callers whose points are wall clocks pass their own `formatTooltipDate`.
+const JULY_2_2PM_TOKYO = new Date( '2026-07-02T05:00:00Z' );
+
 const SERIES: ComparativeBarChartSeries[] = [
 	{
 		label: 'July',
@@ -97,6 +104,7 @@ const SERIES_WITH_COMPARISON: ComparativeBarChartSeries[] = [
 type TooltipProps = {
 	tooltipData: { datumByKey: Record< string, { datum: { value: number } } > };
 	seriesStyles: { stroke: string; opacity?: number }[];
+	getLabel: ( datum: { date?: Date; realDate?: Date }, index: number, key: string ) => string;
 };
 
 /**
@@ -158,6 +166,30 @@ function tooltipRowsFor( hoveredDate: Date ): Record< string, number > {
 	);
 }
 
+/**
+ * The label the tooltip puts on a hovered point.
+ *
+ * @param hoveredDate - The point's date.
+ * @return The rendered row label.
+ */
+function tooltipLabelFor( hoveredDate: Date ): string {
+	/* eslint-disable testing-library/render-result-naming-convention --
+	   As above: this is the chart's `renderTooltip` prop, not testing-library's
+	   `render()`. */
+	const tooltipRenderer = recordedProps().renderTooltip;
+	const hovered = { date: hoveredDate, value: 100 };
+
+	const tooltipNode = tooltipRenderer( {
+		tooltipData: {
+			nearestDatum: { datum: hovered, key: 'July' },
+			datumByKey: { July: { datum: hovered, index: 0, key: 'July' } },
+		},
+	} );
+
+	return tooltipNode.props.getLabel( hovered, 0, 'July' );
+	/* eslint-enable testing-library/render-result-naming-convention */
+}
+
 const ZERO_SERIES: ComparativeBarChartSeries[] = [
 	{
 		label: 'July',
@@ -190,6 +222,51 @@ describe( 'ComparativeBarChart', () => {
 		);
 
 		expect( typeof recordedOptions().axis.x.tickFormat ).toBe( 'function' );
+	} );
+
+	it( 'declares the bucket size to the x-axis', () => {
+		render(
+			<ComparativeBarChart series={ SERIES } dataFormat={ DATA_FORMAT } tickResolution="hour" />
+		);
+
+		// Two hourly points an hour apart are also two daily points 24 hours apart
+		// as far as gap-measuring goes, so the axis needs telling which it is.
+		expect( recordedOptions().axis.x.tickResolution ).toBe( 'hour' );
+	} );
+
+	it( "labels a tooltip with the point's date, read in the site's timezone", () => {
+		setSettings( siteSettingsIn( 'Asia/Tokyo' ) );
+		render( <ComparativeBarChart series={ SERIES } dataFormat={ DATA_FORMAT } /> );
+
+		expect( tooltipLabelFor( JULY_2_2PM_TOKYO ) ).toBe( 'July 2, 2026' );
+	} );
+
+	// A date alone names 24 hourly buckets, so it cannot identify the one hovered
+	// — and the hour it gains has to be the one the axis tick under it shows.
+	it( 'adds the hour the point names at the hourly resolution', () => {
+		setSettings( siteSettingsIn( 'Asia/Tokyo' ) );
+		render(
+			<ComparativeBarChart series={ SERIES } dataFormat={ DATA_FORMAT } tickResolution="hour" />
+		);
+
+		expect( tooltipLabelFor( JULY_2_2PM_TOKYO ) ).toBe( 'July 2, 2026 2:00 pm' );
+	} );
+
+	// How a point's date is read is the caller's to decide — Stats buckets are
+	// wall clocks rather than instants — while which format names it stays here.
+	it( 'hands the point and the format it picked to a caller-supplied formatter', () => {
+		const formatTooltipDate = jest.fn( () => 'the bucket' );
+		render(
+			<ComparativeBarChart
+				series={ SERIES }
+				dataFormat={ DATA_FORMAT }
+				tickResolution="hour"
+				formatTooltipDate={ formatTooltipDate }
+			/>
+		);
+
+		expect( tooltipLabelFor( JULY_2_2PM_TOKYO ) ).toBe( 'the bucket' );
+		expect( formatTooltipDate ).toHaveBeenCalledWith( JULY_2_2PM_TOKYO, 'dateTime' );
 	} );
 
 	it( 'adds the previous-period value to the tooltip when comparing', () => {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/comparative-bar-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/comparative-bar-chart.tsx
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { BarChart, Stack, useGlobalChartsContext } from '@jetpack-premium-analytics/externals';
+import {
+	BarChart,
+	Stack,
+	useGlobalChartsContext,
+	type TickResolution,
+} from '@jetpack-premium-analytics/externals';
 import {
 	formatDate,
 	formatMetricValue,
@@ -14,7 +19,7 @@ import { useCallback, useId, useMemo, useState } from 'react';
  * Internal dependencies
  */
 import { RESIZE_DEBOUNCE_MS } from '../../constants';
-import { isEmptyChartData, getFixedYAxis } from '../../helpers';
+import { isEmptyChartData, getFixedYAxis, dateFormatForResolution } from '../../helpers';
 import { alignSeriesDates } from '../chart-comparative-line/utils';
 import { ChartTooltip } from '../chart-tooltip';
 import styles from './comparative-bar-chart.module.scss';
@@ -71,6 +76,23 @@ export type ComparativeBarChartProps = {
 	tickFormat?: DateFormatName;
 
 	/**
+	 * The series' bucket size. Declaring it lets the automatic tick formatter pick
+	 * its regime from a known granularity instead of measuring the gaps between
+	 * points, which a single-bucket or DST-shortened series gives it no way to
+	 * read. An explicit `tickFormat` still wins over both. The tooltip reads it
+	 * too, to decide whether a date alone identifies a bucket.
+	 */
+	tickResolution?: TickResolution;
+
+	/**
+	 * Renders a point's date for a tooltip row, in the named format this chart
+	 * picked for it. Defaults to reading the date as the instant it is. Callers
+	 * whose points are wall clocks rather than instants — Stats buckets, built by
+	 * `toChartDate` — pass a variant that re-anchors them first.
+	 */
+	formatTooltipDate?: ( date: Date, format: DateFormatName ) => string;
+
+	/**
 	 * Degrade to a sparkline (no y-axis, grid, or legend) when the chart area
 	 * is too short for readable axis labels. Defaults to false.
 	 */
@@ -101,9 +123,12 @@ export function ComparativeBarChart( {
 	className,
 	dataFormat,
 	tickFormat: xTickFormatType,
+	tickResolution,
+	formatTooltipDate = formatDate,
 	compactWhenShort = false,
 	maxWidth = Infinity,
 }: ComparativeBarChartProps ) {
+	const tooltipDateFormat = dateFormatForResolution( tickResolution );
 	const chartId = useId();
 	const { getElementStyles } = useGlobalChartsContext();
 
@@ -170,9 +195,10 @@ export function ComparativeBarChart( {
 			if ( ! displayDate ) {
 				return key;
 			}
-			return formatDate( displayDate );
+
+			return formatTooltipDate( displayDate, tooltipDateFormat );
 		},
-		[]
+		[ tooltipDateFormat, formatTooltipDate ]
 	);
 
 	/**
@@ -254,6 +280,7 @@ export function ComparativeBarChart( {
 					// `formatDate`'s `medium` default from putting full site-format dates
 					// on every tick when no format was asked for.
 					...( xTickFormatType ? { tickFormat: xTickFormat } : {} ),
+					tickResolution,
 				},
 				y: {
 					tickFormat: yTickFormat,
@@ -268,7 +295,7 @@ export function ComparativeBarChart( {
 		}
 
 		return { ...baseOptions, yScale: { domain: fixedYAxis.domain } };
-	}, [ xTickFormat, xTickFormatType, yTickFormat, isCompact, fixedYAxis ] );
+	}, [ xTickFormat, xTickFormatType, tickResolution, yTickFormat, isCompact, fixedYAxis ] );
 
 	const margin = useMemo( () => {
 		// With the y-axis hidden, reclaim its reserved left margin for the bars.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/comparative-bar-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/comparative-bar-chart.tsx
@@ -86,9 +86,8 @@ export type ComparativeBarChartProps = {
 
 	/**
 	 * Renders a point's date for a tooltip row, in the named format this chart
-	 * picked for it. Defaults to reading the date as the instant it is. Callers
-	 * whose points are wall clocks rather than instants — Stats buckets, built by
-	 * `toChartDate` — pass a variant that re-anchors them first.
+	 * picked for it. Callers whose points are wall clocks (see `chart-date.ts`)
+	 * pass a variant that re-anchors them first; defaults to `formatDate`.
 	 */
 	formatTooltipDate?: ( date: Date, format: DateFormatName ) => string;
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/__tests__/comparative-line-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/__tests__/comparative-line-chart.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { setSettings } from '@wordpress/date';
+/**
+ * Internal dependencies
+ */
+import { siteSettingsIn } from '../../../__fixtures__/wp-date-settings';
+import { ComparativeLineChart } from '../comparative-line-chart';
+import type { ComparativeLineChartSeries } from '../types';
+
+// Record the props handed to the underlying chart. The real one renders SVG
+// through a provider jsdom cannot lay out, and what matters here is the tooltip
+// renderer this wrapper composes.
+const mockLineSpy = jest.fn();
+
+jest.mock( '@jetpack-premium-analytics/externals', () => {
+	const { forwardRef } = jest.requireActual( 'react' );
+
+	const LineChart = ( props: { children?: React.ReactNode } ) => {
+		mockLineSpy( props );
+		return <div data-testid="line-chart">{ props.children }</div>;
+	};
+	LineChart.Legend = () => <div data-testid="line-chart-legend" />;
+
+	return {
+		LineChart,
+		// The wrapper measures this element, so the stand-in must take the ref.
+		Stack: forwardRef(
+			(
+				{ children }: { children?: React.ReactNode },
+				ref: React.ForwardedRef< HTMLDivElement >
+			) => <div ref={ ref }>{ children }</div>
+		),
+	};
+} );
+
+jest.mock( '../../../hooks', () => ( {
+	useSeriesStyles: () => [],
+} ) );
+
+const DATA_FORMAT = { type: 'number' as const, options: { decimals: 0 } };
+
+// A tooltip label reads its point as the instant it is, in the site's timezone,
+// so these are instants and every assertion below fixes the site's zone. Callers
+// whose points are wall clocks instead pass their own `formatTooltipDate`.
+const JULY_1 = new Date( '2026-07-01T00:00:00Z' );
+// 2pm on July 2 in Tokyo.
+const JULY_2 = new Date( '2026-07-02T05:00:00Z' );
+
+const SERIES: ComparativeLineChartSeries[] = [
+	{
+		label: 'July',
+		group: 'views',
+		data: [
+			{ date: JULY_1, value: 100 },
+			{ date: JULY_2, value: 200 },
+		],
+	},
+];
+
+// A comparison point carries the primary axis date, with the real
+// previous-period date in `realDate`; that is what `alignSeriesDates` does.
+const COMPARISON_POINT = {
+	date: JULY_1,
+	// 9am on June 1 in Tokyo.
+	realDate: new Date( '2026-06-01T00:00:00Z' ),
+	value: 80,
+};
+
+type TooltipProps = {
+	getLabel: ( datum: { date: Date; realDate?: Date }, index: number ) => string;
+};
+
+/**
+ * The label the tooltip puts on a point, at a given series index. Index 0 is the
+ * current period; anything higher is a comparison series.
+ *
+ * @param datum          - The hovered point.
+ * @param datum.date     - The axis date it is plotted on.
+ * @param datum.realDate - Its own date, when it belongs to a comparison series.
+ * @param index          - Its series index.
+ * @return The rendered row label.
+ */
+function tooltipLabelFor( datum: { date: Date; realDate?: Date }, index = 0 ): string {
+	/* eslint-disable testing-library/render-result-naming-convention --
+	   This is the chart's `renderTooltip` prop and its return value, not
+	   testing-library's `render()`; the rule matches on the name alone. */
+	expect( mockLineSpy ).toHaveBeenCalled();
+	const tooltipRenderer = mockLineSpy.mock.calls.at( -1 )[ 0 ].renderTooltip;
+
+	const tooltipNode = tooltipRenderer( {
+		tooltipData: { datumByKey: { July: { datum, index, key: 'July' } } },
+	} ) as { props: TooltipProps };
+
+	return tooltipNode.props.getLabel( datum, index );
+	/* eslint-enable testing-library/render-result-naming-convention */
+}
+
+describe( 'ComparativeLineChart', () => {
+	beforeEach( () => {
+		mockLineSpy.mockClear();
+	} );
+
+	it( "labels a tooltip with the point's date, read in the site's timezone", () => {
+		setSettings( siteSettingsIn( 'Asia/Tokyo' ) );
+		render( <ComparativeLineChart series={ SERIES } dataFormat={ DATA_FORMAT } /> );
+
+		expect( tooltipLabelFor( { date: JULY_2 } ) ).toBe( 'July 2, 2026' );
+	} );
+
+	// A date alone names 24 hourly buckets, so it cannot identify the one hovered
+	// — and the hour it gains has to be the one the axis tick under it shows.
+	it( 'adds the hour the point names at the hourly resolution', () => {
+		setSettings( siteSettingsIn( 'Asia/Tokyo' ) );
+		render(
+			<ComparativeLineChart series={ SERIES } dataFormat={ DATA_FORMAT } tickResolution="hour" />
+		);
+
+		expect( tooltipLabelFor( { date: JULY_2 } ) ).toBe( 'July 2, 2026 2:00 pm' );
+	} );
+
+	// How a point's date is read is the caller's to decide — Stats buckets are
+	// wall clocks rather than instants — while which format names it stays here.
+	it( 'hands the point and the format it picked to a caller-supplied formatter', () => {
+		const formatTooltipDate = jest.fn( () => 'the bucket' );
+		render(
+			<ComparativeLineChart
+				series={ SERIES }
+				dataFormat={ DATA_FORMAT }
+				tickResolution="hour"
+				formatTooltipDate={ formatTooltipDate }
+			/>
+		);
+
+		expect( tooltipLabelFor( { date: JULY_2 } ) ).toBe( 'the bucket' );
+		expect( formatTooltipDate ).toHaveBeenCalledWith( JULY_2, 'dateTime' );
+	} );
+
+	it( 'labels a comparison row from its own date, not the axis date it shares', () => {
+		setSettings( siteSettingsIn( 'Asia/Tokyo' ) );
+		render(
+			<ComparativeLineChart series={ SERIES } dataFormat={ DATA_FORMAT } tickResolution="hour" />
+		);
+
+		// Reading `datum.date` here would repeat the current period's date on both
+		// rows; the point of `realDate` is that the previous period keeps its own.
+		expect( tooltipLabelFor( COMPARISON_POINT, 1 ) ).toBe( 'June 1, 2026 9:00 am' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { LineChart, Stack } from '@jetpack-premium-analytics/externals';
+import { LineChart, Stack, type TickResolution } from '@jetpack-premium-analytics/externals';
 import {
 	formatDate,
 	formatMetricValue,
@@ -15,7 +15,7 @@ import { type ComponentProps } from 'react';
  * Internal dependencies
  */
 import { RESIZE_DEBOUNCE_MS } from '../../constants';
-import { isEmptyChartData, getFixedYAxis } from '../../helpers';
+import { isEmptyChartData, getFixedYAxis, dateFormatForResolution } from '../../helpers';
 import { ChartTooltip } from '../chart-tooltip';
 import styles from './comparative-line-chart.module.scss';
 import { alignSeriesDates } from './utils';
@@ -117,6 +117,22 @@ export type ComparativeLineChartProps = {
 	tickFormat?: DateFormatName;
 
 	/**
+	 * The series' bucket size. Declaring it lets the automatic tick formatter pick
+	 * its regime from a known granularity instead of measuring the gaps between
+	 * points, which a single-bucket or DST-shortened series gives it no way to
+	 * read. An explicit `tickFormat` still wins over both.
+	 */
+	tickResolution?: TickResolution;
+
+	/**
+	 * Renders a point's date for a tooltip row, in the named format this chart
+	 * picked for it. Defaults to reading the date as the instant it is. Callers
+	 * whose points are wall clocks rather than instants — Stats buckets, built by
+	 * `toChartDate` — pass a variant that re-anchors them first.
+	 */
+	formatTooltipDate?: ( date: Date, format: DateFormatName ) => string;
+
+	/**
 	 * Degrade to a sparkline (no y-axis, grid, or legend) when the chart area
 	 * is too short for readable axis labels. Defaults to false.
 	 */
@@ -140,9 +156,12 @@ export function ComparativeLineChart( {
 	className,
 	dataFormat,
 	tickFormat: xTickFormatType,
+	tickResolution,
+	formatTooltipDate = formatDate,
 	maxWidth = Infinity,
 	compactWhenShort = false,
 }: ComparativeLineChartProps ) {
+	const tooltipDateFormat = dateFormatForResolution( tickResolution );
 	// The measured Stack fills its container (flex), so its height is independent
 	// of whether the axis/legend are shown — no measure/hide feedback loop.
 	const [ chartAreaHeight, setChartAreaHeight ] = useState( Infinity );
@@ -165,9 +184,10 @@ export function ComparativeLineChart( {
 		( datum: { date: Date; realDate?: Date }, index: number ): string => {
 			const isComparison = index > 0;
 			const displayDate = isComparison ? datum.realDate ?? datum.date : datum.date;
-			return formatDate( displayDate );
+
+			return formatTooltipDate( displayDate, tooltipDateFormat );
 		},
-		[]
+		[ tooltipDateFormat, formatTooltipDate ]
 	);
 
 	const renderTooltip = useCallback(
@@ -229,6 +249,7 @@ export function ComparativeLineChart( {
 					// unconditional `xTickFormat` would put full site-format dates on every
 					// tick. Without the prop, the chart library's own tick labels stay in use.
 					tickFormat: xTickFormatType ? xTickFormat : undefined,
+					tickResolution,
 				},
 				y: {
 					tickFormat: yTickFormat,
@@ -243,7 +264,7 @@ export function ComparativeLineChart( {
 		}
 
 		return { ...baseOptions, yScale: { domain: fixedYAxis.domain } };
-	}, [ xTickFormat, xTickFormatType, yTickFormat, fixedYAxis, isCompact ] );
+	}, [ xTickFormat, xTickFormatType, tickResolution, yTickFormat, fixedYAxis, isCompact ] );
 
 	const margin = fixedYAxis ? { ...DEFAULT_MARGIN, left: fixedYAxis.marginLeft } : DEFAULT_MARGIN;
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
@@ -126,9 +126,8 @@ export type ComparativeLineChartProps = {
 
 	/**
 	 * Renders a point's date for a tooltip row, in the named format this chart
-	 * picked for it. Defaults to reading the date as the instant it is. Callers
-	 * whose points are wall clocks rather than instants — Stats buckets, built by
-	 * `toChartDate` — pass a variant that re-anchors them first.
+	 * picked for it. Callers whose points are wall clocks (see `chart-date.ts`)
+	 * pass a variant that re-anchors them first; defaults to `formatDate`.
 	 */
 	formatTooltipDate?: ( date: Date, format: DateFormatName ) => string;
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
@@ -174,12 +174,12 @@ describe( 'MetricTabsChart', () => {
 		expect( screen.queryByText( '300' ) ).not.toBeInTheDocument();
 	} );
 
-	// Only the Stats widgets build wall clocks; the post and video charts hand over
-	// real instants (`parseSiteDateTime`). Re-anchoring one of those would shift its
-	// label by the offset between the viewer's timezone and the site's, so the
-	// reading has to stay opt-in. Asserted against the formatter rather than a
-	// literal, and over two site zones, so the check cannot come out vacuous on
-	// whichever timezone the machine running it happens to be in.
+	// Only the Stats widgets build wall clocks; the post and video charts hand
+	// over real instants (`parseSiteDateTime`), which re-anchoring would shift
+	// (see `chart-date.ts`) — so the reading has to stay opt-in. Asserted against
+	// the formatter rather than a literal, and over two site zones, so the check
+	// cannot come out vacuous on whichever timezone the machine running it
+	// happens to be in.
 	it.each( [ 'Asia/Tokyo', 'America/Los_Angeles' ] )(
 		'reads a point as the instant it is unless the producer says otherwise, on a site in %s',
 		siteZone => {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
@@ -1,10 +1,13 @@
 /**
  * External dependencies
  */
+import { formatDate, type DateFormatName } from '@jetpack-premium-analytics/formatters';
 import { render, screen } from '@testing-library/react';
+import { setSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
+import { siteSettingsIn } from '../../../__fixtures__/wp-date-settings';
 import { MetricTabsChart } from '../metric-tabs-chart';
 import type { ComparativeLineChartSeries } from '../../chart-comparative-line/types';
 import type { MetricTab } from '../metric-tabs-chart';
@@ -51,6 +54,17 @@ const METRIC: MetricTab = {
 	],
 };
 
+// Chart points are wall clocks, so this one is built from local parts, the same
+// way `toChartDate` builds them.
+const WALL_CLOCK_METRIC: MetricTab = {
+	...METRIC,
+	current: [
+		{ date: new Date( 2026, 6, 1, 0, 0 ), value: 100 },
+		{ date: new Date( 2026, 6, 2, 0, 0 ), value: 200 },
+	],
+	previous: undefined,
+};
+
 /**
  * The series the most recent chart render received.
  *
@@ -62,6 +76,19 @@ function recordedSeries( spy: jest.Mock ): ComparativeLineChartSeries[] {
 	// assertions below fail as a TypeError that names the wrong cause.
 	expect( spy ).toHaveBeenCalled();
 	return spy.mock.calls.at( -1 )[ 0 ].series;
+}
+
+/**
+ * The tooltip date formatter the most recent chart render received.
+ *
+ * @param spy - The chart stand-in to read.
+ * @return The recorded formatter.
+ */
+function recordedTooltipDateFormatter(
+	spy: jest.Mock
+): ( date: Date, format: DateFormatName ) => string {
+	expect( spy ).toHaveBeenCalled();
+	return spy.mock.calls.at( -1 )[ 0 ].formatTooltipDate;
 }
 
 describe( 'MetricTabsChart', () => {
@@ -132,6 +159,108 @@ describe( 'MetricTabsChart', () => {
 			toOpacity: 0,
 		} );
 		expect( recordedSeries( mockBarSpy )[ 1 ].options?.gradient ).toBeUndefined();
+	} );
+
+	it( 'replaces an unavailable metric with its reason instead of drawing a zero line', () => {
+		const reason = "Hourly data isn't available for this metric.";
+		const unavailable = { ...METRIC, unavailable: reason };
+
+		render( <MetricTabsChart metrics={ [ unavailable ] } dataFormat={ DATA_FORMAT } /> );
+
+		expect( screen.queryByTestId( 'line-chart' ) ).not.toBeInTheDocument();
+		expect( screen.getAllByText( reason ) ).not.toHaveLength( 0 );
+		// The headline stands down to a placeholder rather than reporting a total
+		// the endpoint never returned.
+		expect( screen.queryByText( '300' ) ).not.toBeInTheDocument();
+	} );
+
+	// Only the Stats widgets build wall clocks; the post and video charts hand over
+	// real instants (`parseSiteDateTime`). Re-anchoring one of those would shift its
+	// label by the offset between the viewer's timezone and the site's, so the
+	// reading has to stay opt-in. Asserted against the formatter rather than a
+	// literal, and over two site zones, so the check cannot come out vacuous on
+	// whichever timezone the machine running it happens to be in.
+	it.each( [ 'Asia/Tokyo', 'America/Los_Angeles' ] )(
+		'reads a point as the instant it is unless the producer says otherwise, on a site in %s',
+		siteZone => {
+			setSettings( siteSettingsIn( siteZone ) );
+
+			const instant = new Date( Date.UTC( 2026, 6, 1, 15, 0 ) );
+
+			render(
+				<MetricTabsChart
+					metrics={ [ { ...WALL_CLOCK_METRIC, current: [ { date: instant, value: 100 } ] } ] }
+					dataFormat={ DATA_FORMAT }
+				/>
+			);
+
+			const { formatTooltipDate } = mockLineSpy.mock.calls.at( -1 )[ 0 ];
+
+			expect( formatTooltipDate( instant, 'dateTime' ) ).toBe( formatDate( instant, 'dateTime' ) );
+		}
+	);
+
+	// The legend names each series by its date range, read off the points — which
+	// are wall clocks, so the range must not move with the site's timezone.
+	it.each( [ 'Asia/Tokyo', 'America/Los_Angeles' ] )(
+		'labels a series with the range its points name, on a site in %s',
+		siteZone => {
+			setSettings( siteSettingsIn( siteZone ) );
+
+			render(
+				<MetricTabsChart
+					metrics={ [ WALL_CLOCK_METRIC ] }
+					dataFormat={ DATA_FORMAT }
+					pointsAreWallClocks
+				/>
+			);
+
+			// `elideRange` borrows CLDR's range pattern, whose separator spaces are
+			// typographic rather than plain ones.
+			const label = recordedSeries( mockLineSpy )[ 0 ].label.replace( /\s/gu, ' ' );
+
+			expect( label ).toBe( 'July 1 – 2, 2026' );
+		}
+	);
+
+	// The charts read a point's date as an instant unless told otherwise, and
+	// these points are wall clocks, so the reading is this component's to supply.
+	it.each( [ 'Asia/Tokyo', 'America/Los_Angeles' ] )(
+		'labels a chart point with the bucket it names, on a site in %s',
+		siteZone => {
+			setSettings( siteSettingsIn( siteZone ) );
+
+			render(
+				<MetricTabsChart
+					metrics={ [ WALL_CLOCK_METRIC ] }
+					dataFormat={ DATA_FORMAT }
+					pointsAreWallClocks
+				/>
+			);
+
+			const formatTooltipDate = recordedTooltipDateFormatter( mockLineSpy );
+
+			expect( formatTooltipDate( new Date( 2026, 6, 2, 14, 0 ), 'dateTime' ) ).toBe(
+				'July 2, 2026 2:00 pm'
+			);
+		}
+	);
+
+	it( 'keeps an unavailable metric selectable, so its reason stays reachable', () => {
+		const unavailable = {
+			...METRIC,
+			key: 'likes',
+			label: 'Likes',
+			unavailable: "Hourly data isn't available for this metric.",
+		};
+
+		render( <MetricTabsChart metrics={ [ METRIC, unavailable ] } dataFormat={ DATA_FORMAT } /> );
+
+		const tabs = screen.getAllByRole( 'tab' );
+		expect( tabs ).toHaveLength( 2 );
+		for ( const tab of tabs ) {
+			expect( tab ).toBeEnabled();
+		}
 	} );
 
 	it( 'emits a single series when the metric has no previous period', () => {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.module.scss
@@ -132,6 +132,29 @@
 	min-width: 0;
 }
 
+/* Stands in for the headline of a metric with nothing to report at the current
+ * bucket size. The size comes from the caller, matching the value it replaces
+ * so cards keep a common height. */
+.unavailableValue {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	font-size: var(--jpa-unavailable-value-font-size, var(--wpds-typography-font-size-xl));
+	line-height: var(--wpds-typography-line-height-sm);
+}
+
+/* The same metric's chart area: the reason it has no data, centred where the
+ * series would be. */
+.unavailableChart {
+	display: flex;
+	height: 100%;
+	align-items: center;
+	justify-content: center;
+	padding: var(--wpds-dimension-padding-md);
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	font-size: var(--wpds-typography-font-size-md);
+	line-height: var(--wpds-typography-line-height-sm);
+	text-align: center;
+}
+
 .chart {
 	position: relative;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -1,8 +1,18 @@
 /**
  * External dependencies
  */
-import { SelectControl, Tabs, Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
-import { formatDateRange } from '@jetpack-premium-analytics/formatters';
+import {
+	SelectControl,
+	Tabs,
+	Text,
+	VisuallyHidden,
+	type TickResolution,
+} from '@jetpack-premium-analytics/externals';
+import {
+	formatDate,
+	formatDateRange,
+	type DateFormatName,
+} from '@jetpack-premium-analytics/formatters';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -10,6 +20,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 /**
  * Internal dependencies
  */
+import { fromChartDate } from '../../helpers';
 import { useSeriesStyles } from '../../hooks';
 import { ComparativeBarChart } from '../chart-comparative-bar';
 import { ComparativeLineChart } from '../chart-comparative-line';
@@ -17,7 +28,7 @@ import { MetricWithComparison } from '../metric-with-comparison';
 import styles from './metric-tabs-chart.module.scss';
 import type { DataFormat } from '../../types';
 import type { ComparativeLineChartSeries } from '../chart-comparative-line/types';
-import type { ReactNode } from 'react';
+import type { ComponentProps, CSSProperties, ReactNode } from 'react';
 
 /**
  * Width (px) budgeted per metric tab; below `metrics.length` times this the
@@ -53,6 +64,12 @@ export interface MetricTab {
 	dataFormat?: DataFormat;
 	/** Optional explanatory text, surfaced as the card's tooltip. */
 	description?: string;
+	/**
+	 * Why this metric has no data at the current bucket size. Set it and the card
+	 * shows a placeholder instead of a value, and the chart the reason instead of
+	 * a flat zero line. The tab stays selectable, so the reason is reachable.
+	 */
+	unavailable?: string;
 }
 
 /**
@@ -76,20 +93,45 @@ export interface MetricTabsChartProps {
 	controls?: ReactNode;
 	/** Accessible label for the metric tab list. */
 	groupLabel?: string;
+	/**
+	 * The series' bucket size, declared to the x-axis so tick formats follow the
+	 * known granularity rather than being inferred from point spacing.
+	 */
+	tickResolution?: TickResolution;
+	/**
+	 * Whether each point's date is a Stats bucket's wall clock (as `toChartDate`
+	 * builds them) rather than a real instant. Wall clocks are re-anchored in the
+	 * site's timezone before a label reads them; instants are read as they are.
+	 * Defaults to instants — re-anchoring one would shift its label by the offset
+	 * between the viewer's timezone and the site's.
+	 */
+	pointsAreWallClocks?: boolean;
 }
+
+/**
+ * Resolves a chart point's date to the instant its label should name. Which one
+ * applies is the producer's to declare, through `pointsAreWallClocks`.
+ */
+type ReadPointDate = ( date: Date ) => Date;
+
+const asInstant: ReadPointDate = date => date;
 
 /**
  * Format a series' legend label as its date range (first to last point), so the
  * legend reads as date ranges — consistent with the other comparative charts
  * (see `buildTimeSeriesChartData`). The selected card names the metric.
  *
- * @param points - The series points, oldest first.
+ * @param points        - The series points, oldest first.
+ * @param readPointDate - Resolves each end to the instant it names.
  * @return The formatted date range, or '' when empty.
  */
-function rangeLabel( points: MetricTabDatum[] ): string {
+function rangeLabel( points: MetricTabDatum[], readPointDate: ReadPointDate ): string {
 	const first = points[ 0 ];
 	const last = points[ points.length - 1 ];
-	return first && last ? formatDateRange( { from: first.date, to: last.date } ) : '';
+
+	return first && last
+		? formatDateRange( { from: readPointDate( first.date ), to: readPointDate( last.date ) } )
+		: '';
 }
 
 /**
@@ -103,21 +145,27 @@ function rangeLabel( points: MetricTabDatum[] ): string {
  * rather than a stroke. Bars therefore carry `type` alone and let the charts
  * theme resolve the shadow's colour and width factor.
  *
- * @param metric    - The metric to draw.
- * @param chartType - How the metric is drawn.
+ * @param metric        - The metric to draw.
+ * @param chartType     - How the metric is drawn.
+ * @param readPointDate - Resolves a point's date to the instant its label names.
  * @return The chart series.
  */
 function buildSeries(
 	metric: MetricTab,
-	chartType: MetricTabsChartType
+	chartType: MetricTabsChartType,
+	readPointDate: ReadPointDate
 ): ComparativeLineChartSeries[] {
 	const series: ComparativeLineChartSeries[] = [
-		{ label: rangeLabel( metric.current ), group: metric.key, data: metric.current },
+		{
+			label: rangeLabel( metric.current, readPointDate ),
+			group: metric.key,
+			data: metric.current,
+		},
 	];
 
 	if ( metric.previous?.length ) {
 		series.push( {
-			label: rangeLabel( metric.previous ),
+			label: rangeLabel( metric.previous, readPointDate ),
 			group: metric.key,
 			data: metric.previous,
 			options:
@@ -150,12 +198,23 @@ function MetricChart( {
 	metric,
 	dataFormat,
 	chartType,
+	tickResolution,
+	readPointDate,
 }: {
 	metric: MetricTab;
 	dataFormat: DataFormat;
 	chartType: MetricTabsChartType;
+	tickResolution?: TickResolution;
+	readPointDate: ReadPointDate;
 } ) {
-	const series = useMemo( () => buildSeries( metric, chartType ), [ metric, chartType ] );
+	const series = useMemo(
+		() => buildSeries( metric, chartType, readPointDate ),
+		[ metric, chartType, readPointDate ]
+	);
+	const formatTooltipDate = useCallback(
+		( date: Date, format: DateFormatName ) => formatDate( readPointDate( date ), format ),
+		[ readPointDate ]
+	);
 
 	// Resolve each series' colour + line style from the chart theme so the chart
 	// lines and the tooltip glyphs share the same styling — including the dashed
@@ -165,15 +224,88 @@ function MetricChart( {
 	const seriesStyles = useSeriesStyles( series );
 	const resolvedDataFormat = metric.dataFormat ?? dataFormat;
 
+	if ( metric.unavailable ) {
+		return <div className={ styles.unavailableChart }>{ metric.unavailable }</div>;
+	}
+
 	return chartType === 'bar' ? (
-		<ComparativeBarChart series={ series } dataFormat={ resolvedDataFormat } compactWhenShort />
+		<ComparativeBarChart
+			series={ series }
+			dataFormat={ resolvedDataFormat }
+			tickResolution={ tickResolution }
+			formatTooltipDate={ formatTooltipDate }
+			compactWhenShort
+		/>
 	) : (
 		<ComparativeLineChart
 			series={ series }
 			styles={ seriesStyles }
 			dataFormat={ resolvedDataFormat }
+			tickResolution={ tickResolution }
+			formatTooltipDate={ formatTooltipDate }
 			compactWhenShort
 		/>
+	);
+}
+
+/**
+ * A metric's card face: its label over the headline value and delta, or over a
+ * placeholder when the metric has nothing to report at this bucket size. Shared
+ * by the tab, single-metric, and dropdown-trigger layouts so the three cannot
+ * drift apart.
+ *
+ * @return The card's content.
+ */
+function MetricTabContent( {
+	metric,
+	dataFormat,
+	fontSize,
+	withDescription = false,
+}: {
+	metric: MetricTab;
+	dataFormat: DataFormat;
+	fontSize?: ComponentProps< typeof MetricWithComparison >[ 'fontSize' ];
+	withDescription?: boolean;
+} ) {
+	// The unavailable reason has no other channel here, so it is always exposed.
+	// The description is not: as a tab it already rides on `title`, and inside the
+	// dropdown trigger a hidden node would join the button's accessible name and
+	// be announced on every focus.
+	const note = metric.unavailable ?? ( withDescription ? metric.description : undefined );
+
+	return (
+		<span className={ styles.tabContent }>
+			<Text className={ styles.tabLabel }>{ metric.label }</Text>
+			{ metric.unavailable ? (
+				// Sized off the same token as the value it stands in for — the tab and
+				// trigger layouts ask for different ones, so a fixed size reads a step
+				// too large in one of them. `MetricWithComparison`'s own default.
+				<span
+					className={ styles.unavailableValue }
+					style={
+						{
+							'--jpa-unavailable-value-font-size': `var( --wpds-typography-font-size-${
+								fontSize ?? 'xl'
+							} )`,
+						} as CSSProperties
+					}
+					aria-hidden="true"
+				>
+					&mdash;
+				</span>
+			) : (
+				<MetricWithComparison
+					className={ styles.metricComparison }
+					value={ metric.value }
+					previousValue={ metric.previousValue }
+					dataFormat={ metric.dataFormat ?? dataFormat }
+					fontSize={ fontSize }
+					direction="row"
+					align="flex-end"
+				/>
+			) }
+			{ note && <VisuallyHidden>{ note }</VisuallyHidden> }
+		</span>
 	);
 }
 
@@ -200,7 +332,10 @@ export function MetricTabsChart( {
 	onMetricChange,
 	controls,
 	groupLabel = __( 'Select metric', 'jetpack-premium-analytics-pkg' ),
+	tickResolution,
+	pointsAreWallClocks = false,
 }: MetricTabsChartProps ) {
+	const readPointDate = pointsAreWallClocks ? fromChartDate : asInstant;
 	const [ selectedKey, setSelectedKey ] = useState( defaultMetricKey ?? metrics[ 0 ]?.key );
 
 	// Controlled open state: the dashboard's focusable drag-sortable wrapper
@@ -256,27 +391,24 @@ export function MetricTabsChart( {
 				<div className={ styles.header }>
 					<div className={ clsx( styles.tabs, styles.singleMetric ) }>
 						<div className={ styles.tab }>
-							<span className={ styles.tabContent }>
-								<Text className={ styles.tabLabel }>{ activeMetric.label }</Text>
-								<MetricWithComparison
-									className={ styles.metricComparison }
-									value={ activeMetric.value }
-									previousValue={ activeMetric.previousValue }
-									dataFormat={ activeMetric.dataFormat ?? dataFormat }
-									fontSize="2xl"
-									direction="row"
-									align="flex-end"
-								/>
-								{ activeMetric.description && (
-									<VisuallyHidden>{ activeMetric.description }</VisuallyHidden>
-								) }
-							</span>
+							<MetricTabContent
+								metric={ activeMetric }
+								dataFormat={ dataFormat }
+								fontSize="2xl"
+								withDescription
+							/>
 						</div>
 					</div>
 					{ controls }
 				</div>
 				<div className={ styles.chart }>
-					<MetricChart metric={ activeMetric } dataFormat={ dataFormat } chartType={ chartType } />
+					<MetricChart
+						metric={ activeMetric }
+						dataFormat={ dataFormat }
+						chartType={ chartType }
+						tickResolution={ tickResolution }
+						readPointDate={ readPointDate }
+					/>
 				</div>
 			</div>
 		);
@@ -330,17 +462,7 @@ export function MetricTabsChart( {
 							} }
 							triggerContent={
 								activeMetric && (
-									<span className={ styles.tabContent }>
-										<Text className={ styles.tabLabel }>{ activeMetric.label }</Text>
-										<MetricWithComparison
-											className={ styles.metricComparison }
-											value={ activeMetric.value }
-											previousValue={ activeMetric.previousValue }
-											dataFormat={ activeMetric.dataFormat ?? dataFormat }
-											direction="row"
-											align="flex-end"
-										/>
-									</span>
+									<MetricTabContent metric={ activeMetric } dataFormat={ dataFormat } />
 								)
 							}
 						/>
@@ -353,6 +475,8 @@ export function MetricTabsChart( {
 							metric={ activeMetric }
 							dataFormat={ dataFormat }
 							chartType={ chartType }
+							tickResolution={ tickResolution }
+							readPointDate={ readPointDate }
 						/>
 					) }
 				</div>
@@ -374,20 +498,9 @@ export function MetricTabsChart( {
 							key={ metric.key }
 							value={ metric.key }
 							className={ styles.tab }
-							title={ metric.description }
+							title={ metric.unavailable ?? metric.description }
 						>
-							<span className={ styles.tabContent }>
-								<Text className={ styles.tabLabel }>{ metric.label }</Text>
-								<MetricWithComparison
-									className={ styles.metricComparison }
-									value={ metric.value }
-									previousValue={ metric.previousValue }
-									dataFormat={ metric.dataFormat ?? dataFormat }
-									fontSize="2xl"
-									direction="row"
-									align="flex-end"
-								/>
-							</span>
+							<MetricTabContent metric={ metric } dataFormat={ dataFormat } fontSize="2xl" />
 						</Tabs.Tab>
 					) ) }
 				</Tabs.List>
@@ -397,7 +510,13 @@ export function MetricTabsChart( {
 			     metric's panel renders its chart; the rest stay empty. */ }
 			{ metrics.map( metric => (
 				<Tabs.Panel key={ metric.key } value={ metric.key } className={ styles.chart }>
-					<MetricChart metric={ metric } dataFormat={ dataFormat } chartType={ chartType } />
+					<MetricChart
+						metric={ metric }
+						dataFormat={ dataFormat }
+						chartType={ chartType }
+						tickResolution={ tickResolution }
+						readPointDate={ readPointDate }
+					/>
 				</Tabs.Panel>
 			) ) }
 		</Tabs.Root>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -100,10 +100,9 @@ export interface MetricTabsChartProps {
 	tickResolution?: TickResolution;
 	/**
 	 * Whether each point's date is a Stats bucket's wall clock (as `toChartDate`
-	 * builds them) rather than a real instant. Wall clocks are re-anchored in the
-	 * site's timezone before a label reads them; instants are read as they are.
-	 * Defaults to instants — re-anchoring one would shift its label by the offset
-	 * between the viewer's timezone and the site's.
+	 * builds them) rather than a real instant. Wall clocks are re-anchored via
+	 * `fromChartDate` before a label reads them; instants must be read as they
+	 * are, hence the opt-in. Full rationale in `chart-date.ts`.
 	 */
 	pointsAreWallClocks?: boolean;
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/build-metric-tab.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/build-metric-tab.test.ts
@@ -98,4 +98,47 @@ describe( 'buildMetricTab', () => {
 		expect( tab.previousValue ).toBeUndefined();
 		expect( tab.previous ).toBeUndefined();
 	} );
+	// The chart library renders a point through the *browser's* timezone, while a
+	// Stats bucket's `date_start` carries a nominal `+00:00` that is a label, not
+	// a real offset. Honouring it would move a midnight bucket to the previous
+	// day for every viewer west of UTC. These cases fail under the old
+	// `localTZDate` reading and are the only guard on that.
+	describe( 'bucket stamps are read as the wall clock they name', () => {
+		// Pinned west of UTC on purpose: under a UTC runner the correct reading and
+		// the buggy one coincide, so these cases would pass either way. `TZ` is not
+		// on the typed env shape, hence the cast.
+		const env = process.env as Record< string, string | undefined >;
+		const runnerTimeZone = env.TZ;
+		beforeAll( () => {
+			env.TZ = 'America/Los_Angeles';
+		} );
+		afterAll( () => {
+			env.TZ = runnerTimeZone;
+		} );
+
+		const dateOf = ( dateStart: string ) =>
+			buildMetricTab( {
+				primary: { summary: { views: 1 }, data: [ { date_start: dateStart, views: 1 } ] },
+				comparison: undefined,
+				hasComparison: false,
+				field: 'views',
+				label: 'Views',
+			} ).current[ 0 ].date;
+
+		it.each( [
+			// The shape every `formatDatePartWithTime` branch emits.
+			[ '2026-06-15T00:00:00+00:00', 15, 0 ],
+			[ '2026-06-15T09:00:00+00:00', 15, 9 ],
+			[ '2026-06-15T00:00:00Z', 15, 0 ],
+			// The `row.date_start` passthrough in `getRowIntervalFields` forwards
+			// whatever the API sent, which need not carry a time at all. A bare date
+			// parses as UTC unless it is anchored, so this is the same bug's back door.
+			[ '2026-06-15', 15, 0 ],
+		] )( 'reads %s as day %i hour %i in the local frame', ( stamp, day, hour ) => {
+			const date = dateOf( stamp );
+
+			expect( date.getDate() ).toBe( day );
+			expect( date.getHours() ).toBe( hour );
+		} );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/build-metric-tab.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/build-metric-tab.test.ts
@@ -98,11 +98,9 @@ describe( 'buildMetricTab', () => {
 		expect( tab.previousValue ).toBeUndefined();
 		expect( tab.previous ).toBeUndefined();
 	} );
-	// The chart library renders a point through the *browser's* timezone, while a
-	// Stats bucket's `date_start` carries a nominal `+00:00` that is a label, not
-	// a real offset. Honouring it would move a midnight bucket to the previous
-	// day for every viewer west of UTC. These cases fail under the old
-	// `localTZDate` reading and are the only guard on that.
+	// Bucket stamps carry a nominal offset that must be dropped, not honoured
+	// (the full rationale lives on `toChartDate`). These cases fail under the
+	// old `localTZDate` reading and are the only guard on that.
 	describe( 'bucket stamps are read as the wall clock they name', () => {
 		// Pinned west of UTC on purpose: under a UTC runner the correct reading and
 		// the buggy one coincide, so these cases would pass either way. `TZ` is not
@@ -113,7 +111,13 @@ describe( 'buildMetricTab', () => {
 			env.TZ = 'America/Los_Angeles';
 		} );
 		afterAll( () => {
-			env.TZ = runnerTimeZone;
+			// Assigning `undefined` to an env var sets the literal string "undefined";
+			// an unset variable has to be deleted back off.
+			if ( runnerTimeZone === undefined ) {
+				delete env.TZ;
+			} else {
+				env.TZ = runnerTimeZone;
+			}
 		} );
 
 		const dateOf = ( dateStart: string ) =>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/chart-date.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/chart-date.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import { toChartDate } from '../chart-date';
+
+describe( 'toChartDate', () => {
+	// The stamps carry a nominal `+00:00` rather than a real offset, so keeping it
+	// would shift every label by the viewer's own offset.
+	it( 'reads a stamp as the wall clock it names, not as an instant', () => {
+		const date = toChartDate( '2026-06-29T09:00:00+00:00' );
+
+		expect( date.getFullYear() ).toBe( 2026 );
+		expect( date.getMonth() ).toBe( 5 );
+		expect( date.getDate() ).toBe( 29 );
+		expect( date.getHours() ).toBe( 9 );
+	} );
+
+	// `getRowIntervalFields` forwards `row.date_start` verbatim when the API
+	// supplies it, so the shapes that arrive here are not only the ones this
+	// package stamps itself. A bare date parsed as-is would land in UTC, and a
+	// space-separated stamp would not parse at all.
+	it.each( [
+		[ 'a bare date', '2026-06-29', 0 ],
+		[ 'a space-separated stamp', '2026-06-29 09:00:00', 9 ],
+		[ 'a T-separated stamp', '2026-06-29T09:00:00', 9 ],
+	] )( 'reads %s in local wall-clock terms', ( _label, stamp, expectedHour ) => {
+		const date = toChartDate( stamp as string );
+
+		expect( Number.isNaN( date.getTime() ) ).toBe( false );
+		expect( date.getDate() ).toBe( 29 );
+		expect( date.getHours() ).toBe( expectedHour );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-metric-tab.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-metric-tab.ts
@@ -1,10 +1,7 @@
 /**
- * External dependencies
- */
-import { localTZDate } from '@jetpack-premium-analytics/data';
-/**
  * Internal dependencies
  */
+import { toChartDate } from './chart-date';
 import type { MetricTab } from '../components';
 import type { DataFormat } from '../types';
 
@@ -54,7 +51,7 @@ function total( report: MetricReport | undefined, field: string ): number {
  */
 function toPoints( report: MetricReport | undefined, field: string ) {
 	return ( report?.data ?? [] ).map( point => ( {
-		date: localTZDate( point.date_start ),
+		date: toChartDate( point.date_start ),
 		value: Number( ( point as Record< string, unknown > )[ field ] ?? 0 ),
 	} ) );
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-date.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-date.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { createTZDateFromParts, siteTimeZone } from '@jetpack-premium-analytics/datetime';
+import { parseAsLocalDate } from '@jetpack-premium-analytics/externals';
 
 const nominalOffset = /(?:Z|[+-]\d{2}:?\d{2})$/;
 
@@ -23,17 +24,13 @@ const nominalOffset = /(?:Z|[+-]\d{2}:?\d{2})$/;
  * @return The bucket's wall clock as a local instant.
  */
 export function toChartDate( dateStart: string ): Date {
-	const wallClock = dateStart.replace( nominalOffset, '' ).trim();
-
-	// Rebuilt from its parts rather than parsed as-is: a bare `yyyy-MM-dd` parses
-	// as UTC rather than as the local wall clock, which would reintroduce the same
-	// day shift, and a space-separated stamp does not parse at all in every engine.
-	// Most branches stamp a time via `formatDatePartWithTime`, but the
-	// `row.date_start` passthrough in `getRowIntervalFields` forwards whatever the
-	// API sent, so both shapes reach here.
-	const [ datePart, timePart = '00:00:00' ] = wallClock.split( /[T ]/ );
-
-	return new Date( `${ datePart }T${ timePart }` );
+	// Only the offset-stripping lives here: knowing the stamp's offset is nominal
+	// is Stats API knowledge the generic parser must not have — `parseAsLocalDate`
+	// rightly honours a real offset. The naive remainder is the charts library's
+	// own wall-clock reading, covering every shape `date_start` arrives in
+	// (`formatDatePartWithTime` stamps, and the bare or space-separated dates the
+	// `getRowIntervalFields` passthrough forwards from the API).
+	return parseAsLocalDate( dateStart.replace( nominalOffset, '' ).trim() );
 }
 
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-date.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-date.ts
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { createTZDateFromParts, siteTimeZone } from '@jetpack-premium-analytics/datetime';
+
+const nominalOffset = /(?:Z|[+-]\d{2}:?\d{2})$/;
+
+/**
+ * Read a bucket's `date_start` as the wall clock it names.
+ *
+ * Bucket stamps carry a nominal `+00:00` rather than a real offset (see
+ * `getStatsIntervalFields`), and the chart library lays a point out and labels
+ * the axis through the browser's timezone — so keeping the offset shifts every
+ * label by the viewer's own offset, turning a midnight bucket into the previous
+ * day west of UTC. Dropping it and parsing the remaining wall clock locally
+ * keeps a label on the bucket it names.
+ *
+ * The instant this produces is therefore only meaningful as a wall clock. Read
+ * it back with `fromChartDate` before handing it to a date formatter, which
+ * resolves the site's timezone rather than the browser's.
+ *
+ * @param dateStart - The bucket's `date_start`.
+ * @return The bucket's wall clock as a local instant.
+ */
+export function toChartDate( dateStart: string ): Date {
+	const wallClock = dateStart.replace( nominalOffset, '' ).trim();
+
+	// Rebuilt from its parts rather than parsed as-is: a bare `yyyy-MM-dd` parses
+	// as UTC rather than as the local wall clock, which would reintroduce the same
+	// day shift, and a space-separated stamp does not parse at all in every engine.
+	// Most branches stamp a time via `formatDatePartWithTime`, but the
+	// `row.date_start` passthrough in `getRowIntervalFields` forwards whatever the
+	// API sent, so both shapes reach here.
+	const [ datePart, timePart = '00:00:00' ] = wallClock.split( /[T ]/ );
+
+	return new Date( `${ datePart }T${ timePart }` );
+}
+
+/**
+ * Re-anchor a chart point's wall clock in the site's timezone.
+ *
+ * The inverse of `toChartDate`: it hands back the instant the bucket named, so
+ * the site's date formatters read out the clock the axis drew rather than one
+ * shifted by the offset between the viewer's timezone and the site's. Every
+ * label derived from a chart point — a tooltip's date, a legend's range — goes
+ * through here first.
+ *
+ * @param date - A chart point's date.
+ * @return The same wall clock, anchored in the site's timezone.
+ */
+export function fromChartDate( date: Date ): Date {
+	return createTZDateFromParts(
+		[
+			date.getFullYear(),
+			date.getMonth(),
+			date.getDate(),
+			date.getHours(),
+			date.getMinutes(),
+			date.getSeconds(),
+		],
+		siteTimeZone()
+	);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -62,6 +62,8 @@ export { summaryCount } from './summary-count';
 export { toDay } from './to-day';
 export { defaultPeriodForInterval } from './default-period-for-interval';
 export { buildMetricTab, type MetricReport, type BuildMetricTabOptions } from './build-metric-tab';
+export { fromChartDate } from './chart-date';
+export { dateFormatForResolution } from './tick-resolution-date-format';
 export {
 	CHART_DISPLAY_CHART_TYPES,
 	chartTypeAttributeField,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/tick-resolution-date-format.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/tick-resolution-date-format.ts
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import type { TickResolution } from '@jetpack-premium-analytics/externals';
+import type { DateFormatName } from '@jetpack-premium-analytics/formatters';
+
+/**
+ * How precisely a label has to name a point for the bucket size it was drawn at.
+ *
+ * A bucket is identified by the finest field its size varies in: a date alone
+ * names 24 hourly buckets and so identifies none of them, while it names a daily
+ * one exactly. Anything coarser than a day is still named by its date, since the
+ * range covered is what the axis and legend already spell out.
+ */
+const DATE_FORMAT_FOR_RESOLUTION: Partial< Record< TickResolution, DateFormatName > > = {
+	hour: 'dateTime',
+};
+
+const DEFAULT_DATE_FORMAT: DateFormatName = 'medium';
+
+/**
+ * The named date format a point's label should use at a bucket size.
+ *
+ * @param tickResolution - The bucket size the series was drawn at.
+ * @return The named format.
+ */
+export function dateFormatForResolution( tickResolution?: TickResolution ): DateFormatName {
+	return (
+		( tickResolution ? DATE_FORMAT_FOR_RESOLUTION[ tickResolution ] : undefined ) ??
+		DEFAULT_DATE_FORMAT
+	);
+}

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -100,6 +100,7 @@ function TrafficChartInner( { granularity, chartType }: TrafficChartInnerProps )
 					dataFormat={ DATA_FORMAT }
 					chartType={ chartType }
 					groupLabel={ groupLabel }
+					pointsAreWallClocks
 				/>
 			</WidgetState>
 		</div>

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/render.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/render.tsx
@@ -90,6 +90,7 @@ function WordAdsChartTabsInner( { granularity }: WordAdsChartTabsInnerProps ) {
 					metrics={ metrics }
 					dataFormat={ DATA_FORMAT }
 					groupLabel={ __( 'WordAds metric', 'jetpack-premium-analytics-pkg' ) }
+					pointsAreWallClocks
 				/>
 			</WidgetState>
 		</div>

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-1902-chart-wall-clock
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-1902-chart-wall-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Charts: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size.

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-1902-chart-wall-clock
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-1902-chart-wall-clock
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Charts: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size.
+Premium Analytics: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size.

--- a/projects/plugins/mu-wpcom-plugin/changelog/echo-wooa7s-1902-chart-wall-clock
+++ b/projects/plugins/mu-wpcom-plugin/changelog/echo-wooa7s-1902-chart-wall-clock
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Charts: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size.
+Premium Analytics: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size.

--- a/projects/plugins/mu-wpcom-plugin/changelog/echo-wooa7s-1902-chart-wall-clock
+++ b/projects/plugins/mu-wpcom-plugin/changelog/echo-wooa7s-1902-chart-wall-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size.

--- a/projects/plugins/premium-analytics/changelog/echo-wooa7s-1902-chart-wall-clock
+++ b/projects/plugins/premium-analytics/changelog/echo-wooa7s-1902-chart-wall-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size.


### PR DESCRIPTION
Part 3 of 5, split out of the Traffic-chart interval work (WOOA7S-1902). Targets `trunk`; part 4 stacks on this one.

## Proposed changes
* Read a chart point as the wall clock its bucket names, instead of as an instant that the browser's timezone then shifts.
* Give the comparative line and bar charts the series' bucket size, so tick formats and tooltips follow the declared granularity rather than one inferred from point spacing.
* Add an optional `unavailable` reason to `MetricTab`, for a metric that has nothing to show at the current bucket size.

A bucket's `date_start` carries a nominal `+00:00` rather than a real offset, and the chart library lays each point out and labels the axis through the browser's timezone. Kept as an instant, every label shifted by the viewer's own offset — a midnight bucket read as the previous day anywhere west of UTC.

`toChartDate` parses a bucket into the wall clock it names; `fromChartDate` re-anchors it in the site's timezone before any formatter sees it. Reading points back that way is **opt-in** via `pointsAreWallClocks`, so a caller whose points really are instants is unaffected. Only two widgets build points through `buildMetricTab` — the WordAds chart tabs, which opt in here, and the Traffic chart, which arrives in part 4.

Inferring tick format from point spacing has nothing to go on at a single point and guesses wrong on an irregular month, hence `tickResolution`.

The `unavailable` field rides along because it is entangled with the same `MetricTabContent` extraction the label changes required; splitting it by hand would have risked more than it bought. Nothing sets it yet — the Traffic chart does, in part 4.

## Related product discussion/links
* WOOA7S-1902

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

The visible change is on the **WordAds chart tabs**, the only widget currently reading points this way.

* Set your WordPress user's timezone (or the browser's) to something well west of the site's — `America/Los_Angeles` against a UTC site is enough.
* Open Stats → WordAds on a site with ad data and hover the chart.
  * **Before:** tooltip and axis labels sit a day earlier than the bucket they belong to.
  * **After:** each label names its own bucket.
* Switch the chart between line and bar — both now format ticks at the series' bucket size.
* Check a single-point range (one day): the axis should still label at the right granularity rather than falling back to a guess.
* `jetpack test js packages/premium-analytics` — new coverage in `chart-date.test.ts`, `comparative-line-chart.test.tsx`, `comparative-bar-chart.test.tsx`, `format-date.test.ts`.
