### PR TITLE
Premium Analytics: offer the chart only the buckets its range can fill

### DIFF
--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-group-by-range
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-group-by-range
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Traffic: Offer only the groupings the selected date range supports in the chart's Group by control.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/package.json
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/package.json
@@ -36,6 +36,7 @@
 	"devDependencies": {
 		"@storybook/react": "10.4.6",
 		"@testing-library/react": "16.3.2",
+		"@testing-library/user-event": "14.6.1",
 		"@wordpress/dataviews": "17.3.0",
 		"@wordpress/date": "5.51.0"
 	}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/page-granularity-field/__tests__/page-granularity-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/page-granularity-field/__tests__/page-granularity-field.test.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 /**
  * Internal dependencies
  */
@@ -49,15 +50,66 @@ function groupByControl( data: Attributes ) {
 	return screen.getByRole( 'combobox', { name: 'Group by' } );
 }
 
+/**
+ * The buckets the control lists, in order.
+ *
+ * The select mounts its options only once opened, and `hidden: true` because in
+ * jsdom, with no layout to position the popup against, it stays `hidden` even
+ * then.
+ *
+ * @param control - The combobox to open.
+ * @return The option labels.
+ */
+async function offeredBuckets( control: HTMLElement ): Promise< string[] > {
+	await userEvent.click( control );
+
+	return screen
+		.getAllByRole( 'option', { hidden: true } )
+		.map( option => option.textContent ?? '' );
+}
+
 describe( 'PageGranularityField', () => {
 	it( "names a reader's pick while the page still resolves to what it was picked against", () => {
+		// A 30-day range, which allows both the page's bucket and the picked one.
 		const control = groupByControl( {
 			granularity: 'week',
+			granularityPickedFor: 'day',
+			reportParams: { from: '2026-06-01', to: '2026-06-30', interval: 'day' },
+		} );
+
+		expect( control ).toHaveTextContent( 'By weeks' );
+	} );
+
+	// The range bounds the control, not just the chart: offering a bucket the
+	// range cannot fill would let a reader pick one and get another.
+	it( 'offers only the buckets the range can fill', async () => {
+		const control = groupByControl( {
+			reportParams: { from: '2026-06-01', to: '2026-06-30', interval: 'day' },
+		} );
+
+		await expect( offeredBuckets( control ) ).resolves.toEqual( [ 'By days', 'By weeks' ] );
+	} );
+
+	// Nothing this chart draws is coarse enough for a multi-year window, so the
+	// control names the bucket the chart clamps to rather than emptying out.
+	it( 'names the clamped bucket when the range outruns every option', async () => {
+		const control = groupByControl( {
+			reportParams: { from: '2020-01-01', to: '2026-06-30', interval: 'year' },
+		} );
+
+		await expect( offeredBuckets( control ) ).resolves.toEqual( [ 'By months' ] );
+	} );
+
+	// A pick the range no longer allows lapses, even though the page's own bucket
+	// has not moved — otherwise it would outlive the range it was made for.
+	it( 'lets a pick lapse once the range stops allowing it', () => {
+		const control = groupByControl( {
+			granularity: 'day',
 			granularityPickedFor: 'month',
 			reportParams: { from: '2025-01-01', to: '2026-06-30', interval: 'month' },
 		} );
 
-		expect( control ).toHaveTextContent( 'By weeks' );
+		expect( control ).toHaveTextContent( 'By months' );
 	} );
 
 	// The bug this guards: the control resolved the page's bucket from the URL

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/page-granularity-field/page-granularity-field.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/page-granularity-field/page-granularity-field.tsx
@@ -4,6 +4,7 @@
 import {
 	getDefaultPreset,
 	normalizeReportParams,
+	type ReportParams,
 	type StatsPeriod,
 } from '@jetpack-premium-analytics/data';
 import { SelectField } from '@jetpack-premium-analytics/fields';
@@ -17,25 +18,30 @@ import {
 	GRANULARITY_ATTRIBUTE,
 	GRANULARITY_PICKED_FOR_ATTRIBUTE,
 } from '../../helpers/followed-granularity';
+import { granularitiesForRange } from '../../helpers/granularities-for-range';
 import { getStoreInfo } from '../../helpers/store-info';
 import { useAttributesWithSearchFallback } from '../../hooks/use-attributes-with-search-fallback';
 import type { ReportParamsFieldAttributes } from '../date-report-params-field';
 import type { DataFormControlProps } from '@jetpack-premium-analytics/externals';
 
 /**
- * The page's interval, resolved exactly as the widget body resolves it: a host
- * that injects report params through attributes (Storybook, the dashboard
- * previews) must not leave this control reading one interval while the chart
- * reads another.
+ * The page's report params, resolved exactly as the widget body resolves them: a
+ * host that injects them through attributes (Storybook, the dashboard previews)
+ * must not leave this control reading one range while the chart reads another.
  *
  * @param attributes - The widget's attributes, which may carry report params.
- * @return The page's interval.
+ * @return The page's normalized report params.
  */
-function usePageInterval( attributes: Partial< ReportParamsFieldAttributes > ): string | undefined {
+function usePageReportParams( attributes: Partial< ReportParamsFieldAttributes > ): ReportParams {
 	const { reportParams } = useAttributesWithSearchFallback( attributes );
 	const { launchedDate } = getStoreInfo();
 
-	return normalizeReportParams( reportParams, getDefaultPreset( launchedDate ) ).interval;
+	// Memoized because the resolved params key the field memo below, and
+	// `normalizeReportParams` returns a fresh object every call.
+	return useMemo(
+		() => normalizeReportParams( reportParams, getDefaultPreset( launchedDate ) ),
+		[ reportParams, launchedDate ]
+	);
 }
 
 /**
@@ -53,15 +59,23 @@ function usePageInterval( attributes: Partial< ReportParamsFieldAttributes > ): 
  */
 export default function PageGranularityField< Item >( props: DataFormControlProps< Item > ) {
 	const { field, data } = props;
-	const interval = usePageInterval( data as Partial< ReportParamsFieldAttributes > );
+	const params = usePageReportParams( data as Partial< ReportParamsFieldAttributes > );
+	const interval = params.interval;
 
 	const followingField = useMemo( () => {
-		const allowed = ( field.elements ?? [] ).map( element =>
+		const declared = ( field.elements ?? [] ).map( element =>
 			String( element.value )
 		) as unknown as [ StatsPeriod, ...StatsPeriod[] ];
+		// Offer only what the range can fill. The chart narrows its own set the
+		// same way, so the two never name different buckets.
+		const allowed = granularitiesForRange( declared, params );
+		const elements = ( field.elements ?? [] ).filter( element =>
+			( allowed as readonly string[] ).includes( String( element.value ) )
+		);
 
 		return {
 			...field,
+			elements,
 			getValue: ( { item }: { item: Item } ) =>
 				followedGranularity( {
 					picked: field.getValue( { item } ) as string | undefined,
@@ -80,7 +94,7 @@ export default function PageGranularityField< Item >( props: DataFormControlProp
 					[ GRANULARITY_PICKED_FOR_ATTRIBUTE ]: defaultPeriodForInterval( interval, allowed ),
 				} ) as unknown as Partial< Item >,
 		};
-	}, [ field, interval ] );
+	}, [ field, interval, params ] );
 
 	return <SelectField { ...props } field={ followingField } data={ data } />;
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/granularities-for-range.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/granularities-for-range.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Internal dependencies
+ */
+import { granularitiesForRange } from '../granularities-for-range';
+import type { ReportParams } from '@jetpack-premium-analytics/data';
+
+const CHART_PERIODS = [ 'hour', 'day', 'week', 'month' ] as const;
+
+function params( from: string, to: string, interval: string, preset?: string ): ReportParams {
+	return { from, to, interval, preset } as ReportParams;
+}
+
+describe( 'granularitiesForRange', () => {
+	it( 'keeps only the buckets the range can fill, in the chart order', () => {
+		// A 30-day range allows days and weeks; the chart also draws hours and
+		// months, which this range has no use for.
+		expect(
+			granularitiesForRange( CHART_PERIODS, params( '2026-06-01', '2026-06-30', 'day' ) )
+		).toEqual( [ 'day', 'week' ] );
+	} );
+
+	it( 'orders by the chart, not by the range default', () => {
+		// A short range names `day` first as its default, but the chart lists
+		// finest first — the control must not reorder itself per range.
+		expect(
+			granularitiesForRange( CHART_PERIODS, params( '2026-06-01', '2026-06-03', 'day' ) )
+		).toEqual( [ 'hour', 'day' ] );
+	} );
+
+	it( 'narrows to one bucket where the range allows one', () => {
+		expect(
+			granularitiesForRange(
+				CHART_PERIODS,
+				params( '2026-06-15T00:00:00+00:00', '2026-06-15T23:59:59+00:00', 'hour' )
+			)
+		).toEqual( [ 'hour' ] );
+	} );
+
+	it( 'drops a range bucket the chart cannot draw', () => {
+		// Past a year the range allows months and quarters; the chart has no
+		// quarter, so only the month survives.
+		expect(
+			granularitiesForRange( CHART_PERIODS, params( '2025-01-01', '2026-06-30', 'month' ) )
+		).toEqual( [ 'month' ] );
+	} );
+
+	it( 'names the clamped bucket when the range and the chart share nothing', () => {
+		// Quarters and years only, none of which this chart draws — so it reports
+		// what the chart clamps to rather than an empty set.
+		expect(
+			granularitiesForRange( CHART_PERIODS, params( '2020-01-01', '2026-06-30', 'year' ) )
+		).toEqual( [ 'month' ] );
+	} );
+
+	it( 'never returns an empty set for a missing range', () => {
+		expect(
+			granularitiesForRange( CHART_PERIODS, params( '', '', 'day' ) ).length
+		).toBeGreaterThan( 0 );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/granularities-for-range.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/granularities-for-range.ts
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import {
+	getAllowedIntervalsForPreset,
+	type ReportParams,
+	type StatsPeriod,
+} from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import { defaultPeriodForInterval } from './default-period-for-interval';
+
+/**
+ * The buckets a chart offers for the page's range: the ones it can draw,
+ * narrowed to the ones the range can fill.
+ *
+ * The two constraints are independent — what a chart is able to draw is fixed,
+ * what a range has to draw with is not — so a chart that offered its whole set
+ * would list buckets the range would only coerce away, and a reader picking one
+ * would get a different bucket than the one they clicked.
+ *
+ * Also the set a pick is judged against, so a pick that a range change leaves
+ * unfillable lapses back to the page's bucket instead of quietly outliving the
+ * range it was made for.
+ *
+ * @param declared - The buckets the chart can draw, ordered finest to coarsest.
+ * @param params   - The page's normalized report params.
+ * @return The buckets to offer, in the chart's own order, never empty.
+ */
+export function granularitiesForRange< P extends StatsPeriod >(
+	declared: readonly [ P, ...P[] ],
+	params: Pick< ReportParams, 'preset' | 'from' | 'to' | 'interval' >
+): readonly [ P, ...P[] ] {
+	const forRange = getAllowedIntervalsForPreset(
+		params.preset,
+		params.from ?? '',
+		params.to ?? ''
+	) as readonly string[];
+	const offered = declared.filter( period => forRange.includes( period ) );
+
+	// A range whose buckets are all coarser than anything the chart draws — a
+	// multi-year window against a chart that stops at months — leaves nothing in
+	// common. The chart still draws its clamped bucket, so name that one rather
+	// than offer an empty control.
+	return offered.length > 0
+		? ( offered as [ P, ...P[] ] )
+		: [ defaultPeriodForInterval( params.interval, declared ) ];
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -61,6 +61,7 @@ export { describeError } from './describe-error';
 export { summaryCount } from './summary-count';
 export { toDay } from './to-day';
 export { defaultPeriodForInterval } from './default-period-for-interval';
+export { granularitiesForRange } from './granularities-for-range';
 export { buildMetricTab, type MetricReport, type BuildMetricTabOptions } from './build-metric-tab';
 export { fromChartDate } from './chart-date';
 export { dateFormatForResolution } from './tick-resolution-date-format';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -184,6 +184,7 @@ export {
 	toDay,
 	defaultPeriodForInterval,
 	followedGranularity,
+	granularitiesForRange,
 	GRANULARITY_ATTRIBUTE,
 	GRANULARITY_PICKED_FOR_ATTRIBUTE,
 	buildMetricTab,

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/render.test.tsx
@@ -24,8 +24,11 @@ const mockUseTrafficChart = jest.mocked( useTrafficChart );
 
 // The dashboard only lets a range carry the intervals it can draw, and
 // `normalizeReportParams` coerces anything else away — so each interval needs a
-// range long enough to keep it.
+// range long enough to keep it. The range also bounds the buckets the widget
+// offers, so a case about a pick needs one that allows the picked bucket too:
+// `day` here is a 30-day window, which allows both days and weeks.
 const RANGE_FOR_INTERVAL: Record< string, { from: string; to: string } > = {
+	day: { from: '2026-06-01', to: '2026-06-30' },
 	month: { from: '2025-01-01', to: '2026-06-30' },
 	week: { from: '2026-01-01', to: '2026-06-30' },
 };
@@ -69,6 +72,22 @@ describe( 'TrafficChart bucket size', () => {
 		render(
 			<TrafficChartRender
 				attributes={ {
+					reportParams: reportParams( 'day' ),
+					granularity: 'week',
+					granularityPickedFor: 'day',
+				} }
+			/>
+		);
+
+		expect( requestedBucket() ).toBe( 'week' );
+	} );
+
+	// The pick above survives a page whose bucket has not moved; this one must
+	// not, because the range it now sits in cannot draw it at all.
+	it( 'lets the pick lapse once the range stops allowing it', () => {
+		render(
+			<TrafficChartRender
+				attributes={ {
 					reportParams: reportParams( 'month' ),
 					granularity: 'day',
 					granularityPickedFor: 'month',
@@ -76,7 +95,7 @@ describe( 'TrafficChart bucket size', () => {
 			/>
 		);
 
-		expect( requestedBucket() ).toBe( 'day' );
+		expect( requestedBucket() ).toBe( 'month' );
 	} );
 
 	// Otherwise a reader who looked at one widget by days would keep seeing days

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -8,6 +8,7 @@ import {
 	WidgetState,
 	useWidgetRootContext,
 	followedGranularity,
+	granularitiesForRange,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { reports } from '@jetpack-premium-analytics/icons';
@@ -69,11 +70,14 @@ function TrafficChartInner( {
 	chartType,
 }: TrafficChartInnerProps ) {
 	const { reportParams } = useWidgetRootContext();
+	// The range narrows what this chart draws, not just what the control offers:
+	// judging the pick against the same set is what makes one that the range no
+	// longer supports lapse instead of outliving the range it was made for.
 	const period = followedGranularity( {
 		picked: granularity,
 		pickedFor: granularityPickedFor,
 		interval: reportParams.interval,
-		allowed: TRAFFIC_PERIODS,
+		allowed: granularitiesForRange( TRAFFIC_PERIODS, reportParams ),
 	} );
 
 	const {

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-1902-group-by-range
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-1902-group-by-range
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Traffic: Offer only the groupings the selected date range supports in the chart's Group by control.

--- a/projects/plugins/mu-wpcom-plugin/changelog/echo-wooa7s-1902-group-by-range
+++ b/projects/plugins/mu-wpcom-plugin/changelog/echo-wooa7s-1902-group-by-range
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Traffic: Offer only the groupings the selected date range supports in the chart's Group by control.

--- a/projects/plugins/premium-analytics/changelog/echo-wooa7s-1902-group-by-range
+++ b/projects/plugins/premium-analytics/changelog/echo-wooa7s-1902-group-by-range
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Traffic: Offer only the groupings the selected date range supports in the chart's Group by control.


### PR DESCRIPTION
Part 5 of 5, split out of the Traffic-chart interval work (WOOA7S-1902). **Stacked on #51446** — review that one first; this diff is against it, and it retargets as the stack lands.

## Proposed changes
* Offer the Traffic chart's Group by only the buckets the selected date range can actually fill.
* Judge a reader's bucket pick against that same set, so one the range stops allowing lapses instead of outliving it.

The Group by listed every bucket the chart can draw, whatever the page was showing: "By hours" on a year, "By months" on a week. Picking one didn't get it — the chart clamps the page interval into what it draws — so the control was offering choices it could not honour.

The offer is now the range's allowed intervals intersected with the buckets the chart draws. A range that outruns the chart entirely (a multi-year window against a chart that stops at months) shares nothing with it, so the set falls back to the single bucket the chart clamps to rather than emptying the control.

The chart body narrows against the same set, which is what makes this more than cosmetic. **It fixes a live bug:** a "By weeks" pick made on Last 30 days survived a move to Last 7 days, because the *page's* bucket hadn't moved — so the chart drew weekly buckets over a 7-day window.

## Related product discussion/links
* WOOA7S-1902

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Open Stats → Traffic and select **Last 30 days**. Open the widget's Group by.
  * **Before:** By hours, By days, By weeks, By months.
  * **After:** By days, By weeks.
* Select **Last 7 days** → only By days. **Last 24 hours** → only By hours. **Last 12 months** → only By months.
* Pick a custom 2–3 day range → By hours and By days, in that order (the chart's own order, not the range's preference order).
* Select a multi-year range: the control should name the one bucket the chart clamps to (By months) rather than going empty.
* The lapse fix: on **Last 30 days** set Group by to **By weeks**, then switch the page to **Last 7 days**.
  * **Before:** chart kept drawing weekly buckets over 7 days.
  * **After:** it falls back to By days.
* `jetpack test js packages/premium-analytics` — see `granularities-for-range.test.ts` and the new cases in `page-granularity-field.test.tsx`.
