### PR TITLE
Forms: show each form field as a column on a single form's responses

### DIFF
--- a/projects/packages/forms/changelog/add-forms-per-form-field-columns
+++ b/projects/packages/forms/changelog/add-forms-per-form-field-columns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Responses: Show each form field as a column when viewing a single form's responses.

--- a/projects/packages/forms/changelog/add-forms-responses-mobile-columns
+++ b/projects/packages/forms/changelog/add-forms-responses-mobile-columns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Responses: On small screens, show only the response and its actions instead of a table that scrolls sideways.

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -56,6 +56,9 @@ type FeedbackFilters = {
 
 const EMPTY_ARRAY = [];
 
+/** Mobile shows the title column and the actions column, and nothing besides. */
+const EMPTY_FIELDS: string[] = [];
+
 // Sentinel value used in the Source filter to represent form-preview (test) responses.
 // Source IDs are numeric post IDs, so this non-numeric value is safe from collision.
 const FORM_PREVIEW_SOURCE_VALUE = 'form_preview';
@@ -160,7 +163,8 @@ function StageInner() {
 	const statusFilter = statusView === 'inbox' ? 'draft,publish' : statusView;
 	const dateSettings = getDateSettings();
 	// Matches the width at which boot flips the inspector from a side panel to a
-	// full-screen overlay.
+	// full-screen overlay. Also the width below which the responses table drops every
+	// column but the response and its actions, since it cannot usefully scroll sideways.
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 
 	const sourceIdValue = ( searchParams as { sourceId?: string | number } )?.sourceId;
@@ -206,7 +210,11 @@ function StageInner() {
 	}, [ searchParams?.search ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	const onChangeView = useCallback(
-		( newView: View ) => {
+		( incomingView: View ) => {
+			// DataViews is handed a collapsed column set on mobile; keep the real one so
+			// widening the window restores the columns the user had chosen.
+			const newView = isMobileViewport ? { ...incomingView, fields: view.fields } : incomingView;
+
 			if ( ! isSingleFormView ) {
 				// If the Folder filter changes (CFM-on behavior), treat it as a route param change.
 				const folderValue =
@@ -237,7 +245,15 @@ function StageInner() {
 				} );
 			}
 		},
-		[ isSingleFormView, navigate, searchParams, statusView, view.search ]
+		[
+			isMobileViewport,
+			isSingleFormView,
+			navigate,
+			searchParams,
+			statusView,
+			view.fields,
+			view.search,
+		]
 	);
 
 	const onChangeSelection = useCallback(
@@ -655,9 +671,17 @@ function StageInner() {
 	// the selection checkbox and the title. DataViews drops the title column when the
 	// user turns it off, which would freeze an answer column in its place.
 	const answerColumnsClassName =
-		responseFieldColumns.length > 0 && view.titleField && view.showTitle !== false
+		! isMobileViewport &&
+		responseFieldColumns.length > 0 &&
+		view.titleField &&
+		view.showTitle !== false
 			? 'has-field-columns'
 			: undefined;
+
+	const viewForDataViews = useMemo(
+		() => ( isMobileViewport ? { ...view, fields: EMPTY_FIELDS } : view ),
+		[ isMobileViewport, view ]
+	);
 
 	const actions = useMemo(
 		() =>
@@ -815,7 +839,7 @@ function StageInner() {
 					}
 					data={ isQueryStale ? EMPTY_ARRAY : records || EMPTY_ARRAY }
 					fields={ fields as Field< unknown >[] }
-					view={ view }
+					view={ viewForDataViews }
 					onChangeView={ onChangeView }
 					paginationInfo={ paginationInfo }
 					isLoading={ isLoadingData || isQueryStale }

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -27,7 +27,12 @@ import EmptyResponses from '../../src/dashboard/components/empty-responses';
 import TextWithFlag from '../../src/dashboard/components/text-with-flag/index.tsx';
 import useInboxData from '../../src/dashboard/hooks/use-inbox-data.ts';
 import useResponseFieldColumns from '../../src/dashboard/hooks/use-response-field-columns.ts';
-import { buildResponseFieldColumns } from '../../src/dashboard/response-field-columns.tsx';
+import {
+	buildResponseFieldColumns,
+	getFrozenColumnsClassName,
+	getResponseTableView,
+	keepColumnChoice,
+} from '../../src/dashboard/response-field-columns.tsx';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import { getFormEditUrl } from '../../src/dashboard/utils.ts';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
@@ -55,9 +60,6 @@ type FeedbackFilters = {
 };
 
 const EMPTY_ARRAY = [];
-
-/** Mobile shows the title column and the actions column, and nothing besides. */
-const EMPTY_FIELDS: string[] = [];
 
 // Sentinel value used in the Source filter to represent form-preview (test) responses.
 // Source IDs are numeric post IDs, so this non-numeric value is safe from collision.
@@ -211,9 +213,7 @@ function StageInner() {
 
 	const onChangeView = useCallback(
 		( incomingView: View ) => {
-			// DataViews is handed a collapsed column set on mobile; keep the real one so
-			// widening the window restores the columns the user had chosen.
-			const newView = isMobileViewport ? { ...incomingView, fields: view.fields } : incomingView;
+			const newView = keepColumnChoice( incomingView, view, isMobileViewport );
 
 			if ( ! isSingleFormView ) {
 				// If the Folder filter changes (CFM-on behavior), treat it as a route param change.
@@ -245,15 +245,7 @@ function StageInner() {
 				} );
 			}
 		},
-		[
-			isMobileViewport,
-			isSingleFormView,
-			navigate,
-			searchParams,
-			statusView,
-			view.fields,
-			view.search,
-		]
+		[ isMobileViewport, isSingleFormView, navigate, searchParams, statusView, view ]
 	);
 
 	const onChangeSelection = useCallback(
@@ -666,20 +658,14 @@ function StageInner() {
 		]
 	);
 
-	// Freezing the leading columns only makes sense once the table is wide enough to
-	// scroll, and only holds if the columns being frozen are the ones it assumes:
-	// the selection checkbox and the title. DataViews drops the title column when the
-	// user turns it off, which would freeze an answer column in its place.
-	const answerColumnsClassName =
-		! isMobileViewport &&
-		responseFieldColumns.length > 0 &&
-		view.titleField &&
-		view.showTitle !== false
-			? 'has-field-columns'
-			: undefined;
+	const answerColumnsClassName = getFrozenColumnsClassName(
+		responseFieldColumns,
+		view,
+		isMobileViewport
+	);
 
 	const viewForDataViews = useMemo(
-		() => ( isMobileViewport ? { ...view, fields: EMPTY_FIELDS } : view ),
+		() => getResponseTableView( view, isMobileViewport ),
 		[ isMobileViewport, view ]
 	);
 

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -12,7 +12,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
+import { useMemo, useState, useCallback, useEffect, useRef } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { caution } from '@wordpress/icons';
@@ -26,6 +26,13 @@ import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-
 import EmptyResponses from '../../src/dashboard/components/empty-responses';
 import TextWithFlag from '../../src/dashboard/components/text-with-flag/index.tsx';
 import useInboxData from '../../src/dashboard/hooks/use-inbox-data.ts';
+import {
+	buildResponseFieldColumns,
+	getResponseFieldColumns,
+	isResponseFieldColumnId,
+	mergeResponseFieldColumns,
+	type ResponseFieldColumn,
+} from '../../src/dashboard/response-field-columns.tsx';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import { getFormEditUrl } from '../../src/dashboard/utils.ts';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
@@ -78,6 +85,8 @@ type QueryParams = {
 	search?: string;
 	fields_format?: string;
 };
+
+const EMPTY_FIELD_COLUMNS: ResponseFieldColumn[] = [];
 
 const DEFAULT_VIEW: View = {
 	type: 'table',
@@ -289,6 +298,72 @@ function StageInner() {
 			};
 		} );
 	}, [ isSingleFormView, setView, statusView ] );
+
+	// A form's own fields become columns, so a single form's responses can be read
+	// across at a glance. The "All responses" view spans every form and has no
+	// shared field set, so it keeps the built-in columns only.
+	const [ responseFieldColumns, setResponseFieldColumns ] =
+		useState< ResponseFieldColumn[] >( EMPTY_FIELD_COLUMNS );
+
+	useEffect( () => {
+		if ( ! isSingleFormView ) {
+			setResponseFieldColumns( EMPTY_FIELD_COLUMNS );
+			return;
+		}
+
+		const discovered = getResponseFieldColumns( records );
+
+		setResponseFieldColumns( previous => mergeResponseFieldColumns( previous, discovered ) );
+	}, [ isSingleFormView, records ] );
+
+	// Answer columns are discovered from the responses, so they cannot be part of
+	// DEFAULT_VIEW. Show each one as soon as it turns up — but only the first time,
+	// so a column the user has since hidden stays hidden.
+	const shownFieldColumnIds = useRef( new Set< string >() );
+
+	useEffect( () => {
+		const newIds = responseFieldColumns
+			.map( column => column.id )
+			.filter( id => ! shownFieldColumnIds.current.has( id ) );
+
+		if ( newIds.length === 0 ) {
+			return;
+		}
+
+		newIds.forEach( id => shownFieldColumnIds.current.add( id ) );
+
+		setView( previousView => {
+			const previousFields = previousView.fields || [];
+			const additions = newIds.filter( id => ! previousFields.includes( id ) );
+
+			if ( additions.length === 0 ) {
+				return previousView;
+			}
+
+			// Answers sit together, after Date and ahead of the remaining metadata.
+			const lastAnswerIndex = previousFields.reduce(
+				( last, id, index ) => ( isResponseFieldColumnId( id ) ? index : last ),
+				-1
+			);
+			const dateIndex = previousFields.indexOf( 'date' );
+			let insertAt;
+
+			if ( lastAnswerIndex !== -1 ) {
+				insertAt = lastAnswerIndex + 1;
+			} else {
+				insertAt = dateIndex === -1 ? 0 : dateIndex + 1;
+			}
+
+			return {
+				...previousView,
+				fields: [
+					...previousFields.slice( 0, insertAt ),
+					...additions,
+					...previousFields.slice( insertAt ),
+				],
+			};
+		} );
+	}, [ responseFieldColumns, setView ] );
 
 	const queryParams = useMemo( () => {
 		const queryArgs: QueryParams = {
@@ -528,6 +603,7 @@ function StageInner() {
 				enableSorting: false,
 				enableHiding: false,
 			},
+			...buildResponseFieldColumns( responseFieldColumns ),
 			{
 				id: 'date',
 				type: 'date',
@@ -631,6 +707,7 @@ function StageInner() {
 			dateSettings.formats.datetime,
 			filterOptions,
 			isSingleFormView,
+			responseFieldColumns,
 			totalItemsInbox,
 			totalItemsSpam,
 			totalItemsTrash,
@@ -780,44 +857,50 @@ function StageInner() {
 					/>
 				</Stack>
 			) : (
-				<DataViews
-					empty={
-						<EmptyResponses
-							isSearch={ !! view.search }
-							isSingleFormView={ isSingleFormView }
-							readStatusFilter={ readStatusFilter }
-							status={ statusView }
-							isNotCollecting={ isFormNotCollecting }
-							notCollectingEditUrl={ formEditUrl }
-						/>
-					}
-					data={ isQueryStale ? EMPTY_ARRAY : records || EMPTY_ARRAY }
-					fields={ fields as Field< unknown >[] }
-					view={ view }
-					onChangeView={ onChangeView }
-					paginationInfo={ paginationInfo }
-					isLoading={ isLoadingData || isQueryStale }
-					getItemId={ getItemId }
-					defaultLayouts={ defaultLayouts }
-					selection={ selection }
-					onChangeSelection={ onChangeSelection }
-					onClickItem={ onClickItem }
-					actions={ actions as Action< unknown >[] }
+				<div
+					className={ `jp-forms-responses-dataviews${
+						responseFieldColumns.length > 0 ? ' has-field-columns' : ''
+					}` }
 				>
-					<DataViewsHeaderRow
-						activeTab="responses"
-						isSingleFormView={ isSingleFormView }
-						activeStatus={ statusView }
-						statusCounts={ {
-							inbox: totalItemsInbox ?? 0,
-							spam: totalItemsSpam ?? 0,
-							trash: totalItemsTrash ?? 0,
-						} }
-						onStatusChange={ onStatusChange }
-					/>
-					<DataViews.Layout />
-					<DataViews.Footer />
-				</DataViews>
+					<DataViews
+						empty={
+							<EmptyResponses
+								isSearch={ !! view.search }
+								isSingleFormView={ isSingleFormView }
+								readStatusFilter={ readStatusFilter }
+								status={ statusView }
+								isNotCollecting={ isFormNotCollecting }
+								notCollectingEditUrl={ formEditUrl }
+							/>
+						}
+						data={ isQueryStale ? EMPTY_ARRAY : records || EMPTY_ARRAY }
+						fields={ fields as Field< unknown >[] }
+						view={ view }
+						onChangeView={ onChangeView }
+						paginationInfo={ paginationInfo }
+						isLoading={ isLoadingData || isQueryStale }
+						getItemId={ getItemId }
+						defaultLayouts={ defaultLayouts }
+						selection={ selection }
+						onChangeSelection={ onChangeSelection }
+						onClickItem={ onClickItem }
+						actions={ actions as Action< unknown >[] }
+					>
+						<DataViewsHeaderRow
+							activeTab="responses"
+							isSingleFormView={ isSingleFormView }
+							activeStatus={ statusView }
+							statusCounts={ {
+								inbox: totalItemsInbox ?? 0,
+								spam: totalItemsSpam ?? 0,
+								trash: totalItemsTrash ?? 0,
+							} }
+							onStatusChange={ onStatusChange }
+						/>
+						<DataViews.Layout />
+						<DataViews.Footer />
+					</DataViews>
+				</div>
 			) }
 			<IntegrationsModal
 				isOpen={ isIntegrationsModalOpen }

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -12,7 +12,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useMemo, useState, useCallback, useEffect, useRef } from '@wordpress/element';
+import { useMemo, useState, useCallback, useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { caution } from '@wordpress/icons';
@@ -26,13 +26,8 @@ import IntegrationsModal from '../../src/blocks/contact-form/components/jetpack-
 import EmptyResponses from '../../src/dashboard/components/empty-responses';
 import TextWithFlag from '../../src/dashboard/components/text-with-flag/index.tsx';
 import useInboxData from '../../src/dashboard/hooks/use-inbox-data.ts';
-import {
-	buildResponseFieldColumns,
-	getResponseFieldColumns,
-	isResponseFieldColumnId,
-	mergeResponseFieldColumns,
-	type ResponseFieldColumn,
-} from '../../src/dashboard/response-field-columns.tsx';
+import useResponseFieldColumns from '../../src/dashboard/hooks/use-response-field-columns.ts';
+import { buildResponseFieldColumns } from '../../src/dashboard/response-field-columns.tsx';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import { getFormEditUrl } from '../../src/dashboard/utils.ts';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
@@ -85,8 +80,6 @@ type QueryParams = {
 	search?: string;
 	fields_format?: string;
 };
-
-const EMPTY_FIELD_COLUMNS: ResponseFieldColumn[] = [];
 
 const DEFAULT_VIEW: View = {
 	type: 'table',
@@ -302,68 +295,11 @@ function StageInner() {
 	// A form's own fields become columns, so a single form's responses can be read
 	// across at a glance. The "All responses" view spans every form and has no
 	// shared field set, so it keeps the built-in columns only.
-	const [ responseFieldColumns, setResponseFieldColumns ] =
-		useState< ResponseFieldColumn[] >( EMPTY_FIELD_COLUMNS );
-
-	useEffect( () => {
-		if ( ! isSingleFormView ) {
-			setResponseFieldColumns( EMPTY_FIELD_COLUMNS );
-			return;
-		}
-
-		const discovered = getResponseFieldColumns( records );
-
-		setResponseFieldColumns( previous => mergeResponseFieldColumns( previous, discovered ) );
-	}, [ isSingleFormView, records ] );
-
-	// Answer columns are discovered from the responses, so they cannot be part of
-	// DEFAULT_VIEW. Show each one as soon as it turns up — but only the first time,
-	// so a column the user has since hidden stays hidden.
-	const shownFieldColumnIds = useRef( new Set< string >() );
-
-	useEffect( () => {
-		const newIds = responseFieldColumns
-			.map( column => column.id )
-			.filter( id => ! shownFieldColumnIds.current.has( id ) );
-
-		if ( newIds.length === 0 ) {
-			return;
-		}
-
-		newIds.forEach( id => shownFieldColumnIds.current.add( id ) );
-
-		setView( previousView => {
-			const previousFields = previousView.fields || [];
-			const additions = newIds.filter( id => ! previousFields.includes( id ) );
-
-			if ( additions.length === 0 ) {
-				return previousView;
-			}
-
-			// Answers sit together, after Date and ahead of the remaining metadata.
-			const lastAnswerIndex = previousFields.reduce(
-				( last, id, index ) => ( isResponseFieldColumnId( id ) ? index : last ),
-				-1
-			);
-			const dateIndex = previousFields.indexOf( 'date' );
-			let insertAt;
-
-			if ( lastAnswerIndex !== -1 ) {
-				insertAt = lastAnswerIndex + 1;
-			} else {
-				insertAt = dateIndex === -1 ? 0 : dateIndex + 1;
-			}
-
-			return {
-				...previousView,
-				fields: [
-					...previousFields.slice( 0, insertAt ),
-					...additions,
-					...previousFields.slice( insertAt ),
-				],
-			};
-		} );
-	}, [ responseFieldColumns, setView ] );
+	const responseFieldColumns = useResponseFieldColumns( {
+		formId: isSingleFormView ? sourceIdNumber : null,
+		records,
+		setView,
+	} );
 
 	const queryParams = useMemo( () => {
 		const queryArgs: QueryParams = {
@@ -714,6 +650,15 @@ function StageInner() {
 		]
 	);
 
+	// Freezing the leading columns only makes sense once the table is wide enough to
+	// scroll, and only holds if the columns being frozen are the ones it assumes:
+	// the selection checkbox and the title. DataViews drops the title column when the
+	// user turns it off, which would freeze an answer column in its place.
+	const answerColumnsClassName =
+		responseFieldColumns.length > 0 && view.titleField && view.showTitle !== false
+			? 'has-field-columns'
+			: undefined;
+
 	const actions = useMemo(
 		() =>
 			getRowActions( {
@@ -857,50 +802,44 @@ function StageInner() {
 					/>
 				</Stack>
 			) : (
-				<div
-					className={ `jp-forms-responses-dataviews${
-						responseFieldColumns.length > 0 ? ' has-field-columns' : ''
-					}` }
-				>
-					<DataViews
-						empty={
-							<EmptyResponses
-								isSearch={ !! view.search }
-								isSingleFormView={ isSingleFormView }
-								readStatusFilter={ readStatusFilter }
-								status={ statusView }
-								isNotCollecting={ isFormNotCollecting }
-								notCollectingEditUrl={ formEditUrl }
-							/>
-						}
-						data={ isQueryStale ? EMPTY_ARRAY : records || EMPTY_ARRAY }
-						fields={ fields as Field< unknown >[] }
-						view={ view }
-						onChangeView={ onChangeView }
-						paginationInfo={ paginationInfo }
-						isLoading={ isLoadingData || isQueryStale }
-						getItemId={ getItemId }
-						defaultLayouts={ defaultLayouts }
-						selection={ selection }
-						onChangeSelection={ onChangeSelection }
-						onClickItem={ onClickItem }
-						actions={ actions as Action< unknown >[] }
-					>
-						<DataViewsHeaderRow
-							activeTab="responses"
+				<DataViews
+					empty={
+						<EmptyResponses
+							isSearch={ !! view.search }
 							isSingleFormView={ isSingleFormView }
-							activeStatus={ statusView }
-							statusCounts={ {
-								inbox: totalItemsInbox ?? 0,
-								spam: totalItemsSpam ?? 0,
-								trash: totalItemsTrash ?? 0,
-							} }
-							onStatusChange={ onStatusChange }
+							readStatusFilter={ readStatusFilter }
+							status={ statusView }
+							isNotCollecting={ isFormNotCollecting }
+							notCollectingEditUrl={ formEditUrl }
 						/>
-						<DataViews.Layout />
-						<DataViews.Footer />
-					</DataViews>
-				</div>
+					}
+					data={ isQueryStale ? EMPTY_ARRAY : records || EMPTY_ARRAY }
+					fields={ fields as Field< unknown >[] }
+					view={ view }
+					onChangeView={ onChangeView }
+					paginationInfo={ paginationInfo }
+					isLoading={ isLoadingData || isQueryStale }
+					getItemId={ getItemId }
+					defaultLayouts={ defaultLayouts }
+					selection={ selection }
+					onChangeSelection={ onChangeSelection }
+					onClickItem={ onClickItem }
+					actions={ actions as Action< unknown >[] }
+				>
+					<DataViewsHeaderRow
+						activeTab="responses"
+						isSingleFormView={ isSingleFormView }
+						activeStatus={ statusView }
+						statusCounts={ {
+							inbox: totalItemsInbox ?? 0,
+							spam: totalItemsSpam ?? 0,
+							trash: totalItemsTrash ?? 0,
+						} }
+						onStatusChange={ onStatusChange }
+					/>
+					<DataViews.Layout className={ answerColumnsClassName } />
+					<DataViews.Footer />
+				</DataViews>
 			) }
 			<IntegrationsModal
 				isOpen={ isIntegrationsModalOpen }

--- a/projects/packages/forms/routes/responses/style.scss
+++ b/projects/packages/forms/routes/responses/style.scss
@@ -1,5 +1,6 @@
 @use "@wordpress/base-styles/variables";
 @use "../shared";
+@use "../../src/dashboard/response-field-columns";
 
 // Filters "pills" row: collapse when empty (match Inbox behavior).
 .jp-forms-dataviews-filters__container,

--- a/projects/packages/forms/src/dashboard/_response-field-columns.scss
+++ b/projects/packages/forms/src/dashboard/_response-field-columns.scss
@@ -1,0 +1,52 @@
+// Form field answer columns on a single form's responses view. Answers are free
+// text, so each cell is capped to one line and reveals the rest through its tooltip.
+.jp-forms__inbox__field-column {
+	display: block;
+	max-inline-size: 22em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+
+	&.is-empty {
+		opacity: 0.5;
+	}
+}
+
+// Answer columns push the table wider than the viewport, so it scrolls sideways.
+// Freeze the two columns that say *who* a row belongs to — the selection checkbox
+// and From — so a row stays attributable while its answers scroll underneath.
+// DataViews already pins the actions column to the trailing edge the same way.
+.jp-forms-responses-dataviews {
+	// No box of its own: the class exists only to scope these rules to a view that
+	// has answer columns, leaving "All responses" untouched.
+	display: contents;
+}
+
+.jp-forms-responses-dataviews.has-field-columns .dataviews-view-table {
+	// Matches the background DataViews gives its own sticky actions column, so
+	// scrolled cells pass behind these rather than showing through them.
+	--jp-forms-frozen-column-background: var(--wp-dataviews-color-background, var(--wpds-color-background-surface-neutral-strong, #fff));
+	// The checkbox column is the table's leading padding plus the 24px control.
+	--jp-forms-from-column-offset: calc(var(--wpds-dimension-padding-2xl, 24px) + 24px);
+
+	th.dataviews-view-table__checkbox-column,
+	td.dataviews-view-table__checkbox-column {
+		position: sticky;
+		inset-inline-start: 0;
+		z-index: 2;
+		background-color: var(--jp-forms-frozen-column-background);
+	}
+
+	// The From column: the checkbox column's next sibling. DataViews gives the
+	// title column no class of its own, and the checkbox column is always present.
+	th.dataviews-view-table__checkbox-column + th,
+	td.dataviews-view-table__checkbox-column + td {
+		position: sticky;
+		inset-inline-start: var(--jp-forms-from-column-offset);
+		z-index: 2;
+		background-color: var(--jp-forms-frozen-column-background);
+		// Breathing room so answers scrolling past never crowd the name.
+		padding-inline-end: var(--wpds-dimension-padding-2xl, 24px);
+		border-inline-end: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #f0f0f0);
+	}
+}

--- a/projects/packages/forms/src/dashboard/_response-field-columns.scss
+++ b/projects/packages/forms/src/dashboard/_response-field-columns.scss
@@ -78,6 +78,16 @@
 		min-inline-size: 280px;
 	}
 
+	/*
+	 * A selected row is tinted on the `tr`, which a frozen cell's own background
+	 * would otherwise paint over — so the two frozen columns have to repeat the
+	 * tint. DataViews does exactly this for its own sticky actions column.
+	 */
+	tr.is-selected td.dataviews-view-table__checkbox-column,
+	tr.is-selected td.dataviews-view-table__checkbox-column + td {
+		background-color: var(--wpds-color-background-interactive-brand-weak-active);
+	}
+
 	// No z-index on the frozen body cells: being positioned already paints
 	// them over the ordinary cells scrolling past, while leaving them below
 	// the sticky `thead` (z-index 1). The frozen header cells need to win

--- a/projects/packages/forms/src/dashboard/_response-field-columns.scss
+++ b/projects/packages/forms/src/dashboard/_response-field-columns.scss
@@ -14,39 +14,46 @@
 
 // Answer columns push the table wider than the viewport, so it scrolls sideways.
 // Freeze the two columns that say *who* a row belongs to — the selection checkbox
-// and From — so a row stays attributable while its answers scroll underneath.
+// and the title — so a row stays attributable while its answers scroll underneath.
 // DataViews already pins the actions column to the trailing edge the same way.
-.jp-forms-responses-dataviews {
-	// No box of its own: the class exists only to scope these rules to a view that
-	// has answer columns, leaving "All responses" untouched.
-	display: contents;
-}
-
-.jp-forms-responses-dataviews.has-field-columns .dataviews-view-table {
+//
+// `has-field-columns` comes from `DataViews.Layout`'s className, and the stage only
+// sets it when both frozen columns are actually present. `has-bulk-actions` is
+// DataViews' own flag for the checkbox column, which it drops when no row on the
+// page has a possible bulk action — without it the offset below would be wrong.
+.dataviews-view-table.has-bulk-actions.has-field-columns {
 	// Matches the background DataViews gives its own sticky actions column, so
 	// scrolled cells pass behind these rather than showing through them.
 	--jp-forms-frozen-column-background: var(--wp-dataviews-color-background, var(--wpds-color-background-surface-neutral-strong, #fff));
-	// The checkbox column is the table's leading padding plus the 24px control.
-	--jp-forms-from-column-offset: calc(var(--wpds-dimension-padding-2xl, 24px) + 24px);
+	// The checkbox column is the table's leading padding plus the control's own box.
+	// DataViews gives us no way to read that width, so it is reconstructed here;
+	// `--jp-forms-frozen-column-background` hides the seam if it is ever a pixel out.
+	--jp-forms-title-column-offset: calc(var(--wpds-dimension-padding-2xl, 24px) + 24px);
 
 	th.dataviews-view-table__checkbox-column,
 	td.dataviews-view-table__checkbox-column {
 		position: sticky;
 		inset-inline-start: 0;
-		z-index: 2;
 		background-color: var(--jp-forms-frozen-column-background);
 	}
 
-	// The From column: the checkbox column's next sibling. DataViews gives the
-	// title column no class of its own, and the checkbox column is always present.
+	// The title column: the checkbox column's next sibling. DataViews gives the title
+	// column no class of its own on the header cell.
 	th.dataviews-view-table__checkbox-column + th,
 	td.dataviews-view-table__checkbox-column + td {
 		position: sticky;
-		inset-inline-start: var(--jp-forms-from-column-offset);
-		z-index: 2;
+		inset-inline-start: var(--jp-forms-title-column-offset);
 		background-color: var(--jp-forms-frozen-column-background);
 		// Breathing room so answers scrolling past never crowd the name.
 		padding-inline-end: var(--wpds-dimension-padding-2xl, 24px);
 		border-inline-end: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #f0f0f0);
+	}
+
+	// No z-index on the frozen body cells: being positioned already paints them over
+	// the ordinary cells scrolling past, while leaving them below the sticky `thead`
+	// (z-index 1). The frozen header cells need to win against their own row.
+	thead th.dataviews-view-table__checkbox-column,
+	thead th.dataviews-view-table__checkbox-column + th {
+		z-index: 2;
 	}
 }

--- a/projects/packages/forms/src/dashboard/_response-field-columns.scss
+++ b/projects/packages/forms/src/dashboard/_response-field-columns.scss
@@ -10,6 +10,12 @@
 	&.is-empty {
 		opacity: 0.5;
 	}
+
+	// Rating cells hold icons, not text, so the one-line text clamp does not apply.
+	&.is-rating {
+		max-inline-size: none;
+		overflow: visible;
+	}
 }
 
 // Answer columns push the table wider than the viewport, so it scrolls sideways.
@@ -47,6 +53,10 @@
 		// Breathing room so answers scrolling past never crowd the name.
 		padding-inline-end: var(--wpds-dimension-padding-2xl, 24px);
 		border-inline-end: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #f0f0f0);
+		// Answer columns compete for width, and the browser will happily shrink this
+		// one until the address under the name is cut mid-word. Hold enough room for
+		// an avatar plus a typical email before any of them get their share.
+		min-inline-size: 280px;
 	}
 
 	// No z-index on the frozen body cells: being positioned already paints them over

--- a/projects/packages/forms/src/dashboard/_response-field-columns.scss
+++ b/projects/packages/forms/src/dashboard/_response-field-columns.scss
@@ -16,6 +16,16 @@
 		max-inline-size: none;
 		overflow: visible;
 	}
+
+	// Choice answers are badges. They sit on one line and scroll rather than wrap,
+	// so a response that ticked six boxes cannot stretch every row in the table.
+	&.is-badges {
+		display: flex;
+		align-items: center;
+		gap: var(--wpds-dimension-padding-xs, 4px);
+		overflow: hidden;
+		white-space: nowrap;
+	}
 }
 
 // Answer columns push the table wider than the viewport, so it scrolls sideways.

--- a/projects/packages/forms/src/dashboard/_response-field-columns.scss
+++ b/projects/packages/forms/src/dashboard/_response-field-columns.scss
@@ -1,5 +1,6 @@
-// Form field answer columns on a single form's responses view. Answers are free
-// text, so each cell is capped to one line and reveals the rest through its tooltip.
+// Form field answer columns on a single form's responses view. Answers
+// are free text, so each cell is capped to one line and reveals the rest
+// through its tooltip.
 .jp-forms__inbox__field-column {
 	display: block;
 	max-inline-size: 22em;
@@ -7,74 +8,80 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 
-	// Muted via colour, never `opacity`: an opacity below 1 creates a stacking context,
-	// which lifts the cell into the same paint layer as the frozen columns and lets it
-	// show through them while the table is scrolled sideways.
+	// Muted via colour, never `opacity`: an opacity below 1 creates a
+	// stacking context, which lifts the cell into the same paint layer as
+	// the frozen columns and lets it show through them while the table is
+	// scrolled sideways.
 	&.is-empty {
-		color: var(--wpds-color-foreground-content-neutral-weak, #707070);
+		color: var(--wpds-color-foreground-content-neutral-weak);
 	}
 
-	// Rating cells hold icons, not text, so the one-line text clamp does not apply.
+	// Rating cells hold icons, not text, so the one-line clamp cannot apply.
 	&.is-rating {
 		max-inline-size: none;
 		overflow: visible;
 	}
 
-	// Choice answers are badges. They sit on one line and scroll rather than wrap,
-	// so a response that ticked six boxes cannot stretch every row in the table.
+	// Choice answers are badges. They sit on one line and clip rather than
+	// wrap, so a response that ticked six boxes cannot stretch every row.
 	&.is-badges {
 		display: flex;
 		align-items: center;
-		gap: var(--wpds-dimension-padding-xs, 4px);
+		gap: var(--wpds-dimension-padding-xs);
 		overflow: hidden;
 		white-space: nowrap;
 	}
 }
 
-// Answer columns push the table wider than the viewport, so it scrolls sideways.
-// Freeze the two columns that say *who* a row belongs to — the selection checkbox
-// and the title — so a row stays attributable while its answers scroll underneath.
-// DataViews already pins the actions column to the trailing edge the same way.
-//
-// `has-field-columns` comes from `DataViews.Layout`'s className, and the stage only
-// sets it when both frozen columns are actually present. `has-bulk-actions` is
-// DataViews' own flag for the checkbox column, which it drops when no row on the
-// page has a possible bulk action — without it the offset below would be wrong.
+// Answer columns push the table wider than the viewport, so it scrolls
+// sideways. Freeze the two columns that say *who* a row belongs to — the
+// selection checkbox and the title — so a row stays attributable while its
+// answers scroll underneath. DataViews already pins the actions column to
+// the trailing edge the same way.
+// -
+// `has-field-columns` comes from `DataViews.Layout`'s className, and the
+// stage only sets it when both frozen columns are actually present.
+// `has-bulk-actions` is DataViews' own flag for the checkbox column, which
+// it drops when no row on the page has a possible bulk action — without it
+// the offset below would be wrong.
 .dataviews-view-table.has-bulk-actions.has-field-columns {
-	// Matches the background DataViews gives its own sticky actions column, so
-	// scrolled cells pass behind these rather than showing through them.
-	--jp-forms-frozen-column-background: var(--wp-dataviews-color-background, var(--wpds-color-background-surface-neutral-strong, #fff));
-	// The checkbox column is the table's leading padding plus the control's own box.
-	// DataViews gives us no way to read that width, so it is reconstructed here;
-	// `--jp-forms-frozen-column-background` hides the seam if it is ever a pixel out.
-	--jp-forms-title-column-offset: calc(var(--wpds-dimension-padding-2xl, 24px) + 24px);
+	// Matches the background DataViews gives its own sticky actions column,
+	// so scrolled cells pass behind these rather than showing through them.
+	--jp-frozen-base: var(--wpds-color-background-surface-neutral-strong);
+	--jp-frozen-bg: var(--wp-dataviews-color-background, var(--jp-frozen-base));
+	// The checkbox column is the table's leading padding plus the control's
+	// own box. DataViews gives us no way to read that width, so it is
+	// reconstructed here; the background above hides the seam if it is ever
+	// a pixel out.
+	--jp-frozen-offset: calc(var(--wpds-dimension-padding-2xl) + 24px);
 
 	th.dataviews-view-table__checkbox-column,
 	td.dataviews-view-table__checkbox-column {
 		position: sticky;
 		inset-inline-start: 0;
-		background-color: var(--jp-forms-frozen-column-background);
+		background-color: var(--jp-frozen-bg);
 	}
 
-	// The title column: the checkbox column's next sibling. DataViews gives the title
-	// column no class of its own on the header cell.
+	// The title column: the checkbox column's next sibling. DataViews gives
+	// the title column no class of its own on the header cell.
 	th.dataviews-view-table__checkbox-column + th,
 	td.dataviews-view-table__checkbox-column + td {
 		position: sticky;
-		inset-inline-start: var(--jp-forms-title-column-offset);
-		background-color: var(--jp-forms-frozen-column-background);
+		inset-inline-start: var(--jp-frozen-offset);
+		background-color: var(--jp-frozen-bg);
 		// Breathing room so answers scrolling past never crowd the name.
-		padding-inline-end: var(--wpds-dimension-padding-2xl, 24px);
-		border-inline-end: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #f0f0f0);
-		// Answer columns compete for width, and the browser will happily shrink this
-		// one until the address under the name is cut mid-word. Hold enough room for
-		// an avatar plus a typical email before any of them get their share.
+		padding-inline-end: var(--wpds-dimension-padding-2xl);
+		border-inline-end: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
+		// Answer columns compete for width, and the browser will happily
+		// shrink this one until the address under the name is cut mid-word.
+		// Hold room for an avatar plus a typical email before they share out.
 		min-inline-size: 280px;
 	}
 
-	// No z-index on the frozen body cells: being positioned already paints them over
-	// the ordinary cells scrolling past, while leaving them below the sticky `thead`
-	// (z-index 1). The frozen header cells need to win against their own row.
+	// No z-index on the frozen body cells: being positioned already paints
+	// them over the ordinary cells scrolling past, while leaving them below
+	// the sticky `thead` (z-index 1). The frozen header cells need to win
+	// against their own row.
 	thead th.dataviews-view-table__checkbox-column,
 	thead th.dataviews-view-table__checkbox-column + th {
 		z-index: 2;

--- a/projects/packages/forms/src/dashboard/_response-field-columns.scss
+++ b/projects/packages/forms/src/dashboard/_response-field-columns.scss
@@ -7,8 +7,11 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 
+	// Muted via colour, never `opacity`: an opacity below 1 creates a stacking context,
+	// which lifts the cell into the same paint layer as the frozen columns and lets it
+	// show through them while the table is scrolled sideways.
 	&.is-empty {
-		opacity: 0.5;
+		color: var(--wpds-color-foreground-content-neutral-weak, #707070);
 	}
 
 	// Rating cells hold icons, not text, so the one-line text clamp does not apply.

--- a/projects/packages/forms/src/dashboard/hooks/test/use-response-field-columns.test.js
+++ b/projects/packages/forms/src/dashboard/hooks/test/use-response-field-columns.test.js
@@ -1,0 +1,155 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+import useResponseFieldColumns from '../use-response-field-columns.ts';
+
+const DEFAULT_FIELDS = [ 'date', 'source', 'ip' ];
+
+/**
+ * Builds a response carrying the given fields, tied to a form.
+ *
+ * @param {number}   formId - The jetpack_form post the response belongs to.
+ * @param {string[]} labels - One field per label, keyed `<n>_<label>`.
+ * @return {object} A form response.
+ */
+const response = ( formId, labels ) => ( {
+	id: `${ formId }-${ labels.join( '-' ) }`,
+	form_id: formId,
+	fields: labels.map( ( label, index ) => ( {
+		key: `${ index + 1 }_${ label }`,
+		label,
+		value: 'x',
+		type: 'text',
+	} ) ),
+} );
+
+/**
+ * Renders the hook with a view whose state persists across rerenders, the way a
+ * real `useState` view does.
+ *
+ * @param {object} initial - Initial props (`formId`, `records`).
+ * @return {object} The hook result plus `view()` and `rerender()` helpers.
+ */
+const setup = initial => {
+	let view = { titleField: 'from', fields: [ ...DEFAULT_FIELDS ] };
+	const setView = jest.fn( updater => {
+		view = typeof updater === 'function' ? updater( view ) : updater;
+	} );
+
+	const utils = renderHook( props => useResponseFieldColumns( { ...props, setView } ), {
+		initialProps: initial,
+	} );
+
+	return { ...utils, setView, view: () => view };
+};
+
+describe( 'useResponseFieldColumns', () => {
+	it( 'returns no columns and leaves the view alone when no form is in scope', () => {
+		const { result, setView, view } = setup( {
+			formId: null,
+			records: [ response( 5, [ 'Name', 'Email' ] ) ],
+		} );
+
+		expect( result.current ).toEqual( [] );
+		expect( setView ).not.toHaveBeenCalled();
+		expect( view().fields ).toEqual( DEFAULT_FIELDS );
+	} );
+
+	it( 'discovers a column per field and shows it right after Date', () => {
+		const { result, view } = setup( {
+			formId: 5,
+			records: [ response( 5, [ 'Name', 'Email' ] ) ],
+		} );
+
+		expect( result.current.map( column => column.label ) ).toEqual( [ 'Name', 'Email' ] );
+		expect( view().fields ).toEqual( [ 'date', 'field:1_Name', 'field:2_Email', 'source', 'ip' ] );
+	} );
+
+	it( 'keeps later batches together with the columns already shown', () => {
+		const { rerender, view } = setup( {
+			formId: 5,
+			records: [ response( 5, [ 'Name' ] ) ],
+		} );
+
+		rerender( { formId: 5, records: [ response( 5, [ 'Name', 'Email' ] ) ] } );
+
+		// 'Email' lands after 'Name', not back at the front.
+		expect( view().fields ).toEqual( [ 'date', 'field:1_Name', 'field:2_Email', 'source', 'ip' ] );
+	} );
+
+	it( 'does not bring back a column the user has hidden', () => {
+		const { rerender, view, setView } = setup( {
+			formId: 5,
+			records: [ response( 5, [ 'Name', 'Email' ] ) ],
+		} );
+
+		// The user hides Email through the DataViews properties panel.
+		setView( previous => ( {
+			...previous,
+			fields: previous.fields.filter( id => id !== 'field:2_Email' ),
+		} ) );
+
+		rerender( { formId: 5, records: [ response( 5, [ 'Name', 'Email' ] ) ] } );
+
+		expect( view().fields ).not.toContain( 'field:2_Email' );
+	} );
+
+	it( 'drops the previous form’s columns when the form changes', () => {
+		const { rerender, result, view } = setup( {
+			formId: 5,
+			records: [ response( 5, [ 'Name', 'Email' ] ) ],
+		} );
+
+		rerender( { formId: 30, records: [ response( 30, [ 'Reporter' ] ) ] } );
+
+		expect( result.current.map( column => column.label ) ).toEqual( [ 'Reporter' ] );
+		expect( view().fields ).toEqual( [ 'date', 'field:1_Reporter', 'source', 'ip' ] );
+	} );
+
+	it( 'ignores responses belonging to a form that is no longer in scope', () => {
+		const { rerender, result, view } = setup( {
+			formId: 5,
+			records: [ response( 5, [ 'Name', 'Email' ] ) ],
+		} );
+
+		// Switching forms re-runs the effect one render before the new responses land,
+		// so `records` still holds the outgoing form's. Its fields must not come back.
+		rerender( { formId: 30, records: [ response( 5, [ 'Name', 'Email' ] ) ] } );
+
+		expect( result.current ).toEqual( [] );
+		expect( view().fields ).toEqual( DEFAULT_FIELDS );
+
+		// ...and the new form's own responses still populate once they arrive.
+		rerender( { formId: 30, records: [ response( 30, [ 'Reporter' ] ) ] } );
+
+		expect( view().fields ).toEqual( [ 'date', 'field:1_Reporter', 'source', 'ip' ] );
+	} );
+
+	it( 'keeps a column whose field is missing from the responses now loaded', () => {
+		const { rerender, result } = setup( {
+			formId: 5,
+			records: [ response( 5, [ 'Name', 'Email' ] ) ],
+		} );
+
+		// Page two happens to carry only one of the two fields.
+		rerender( { formId: 5, records: [ response( 5, [ 'Name' ] ) ] } );
+
+		expect( result.current.map( column => column.label ) ).toEqual( [ 'Name', 'Email' ] );
+	} );
+
+	it( 'shows answers first when Date is not among the visible columns', () => {
+		let view = { titleField: 'from', fields: [ 'ip' ] };
+		const setView = jest.fn( updater => {
+			view = typeof updater === 'function' ? updater( view ) : updater;
+		} );
+
+		renderHook( () =>
+			useResponseFieldColumns( {
+				formId: 5,
+				records: [ response( 5, [ 'Name' ] ) ],
+				setView,
+			} )
+		);
+
+		expect( view.fields ).toEqual( [ 'field:1_Name', 'ip' ] );
+	} );
+} );

--- a/projects/packages/forms/src/dashboard/hooks/use-response-field-columns.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-response-field-columns.ts
@@ -1,0 +1,140 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef, useState } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import {
+	getResponseFieldColumns,
+	mergeResponseFieldColumns,
+	type ResponseFieldColumn,
+} from '../response-field-columns.tsx';
+/**
+ * Types
+ */
+import type { FormResponse } from '../../types/index.ts';
+import type { View } from '@wordpress/dataviews';
+
+const EMPTY_COLUMNS: ResponseFieldColumn[] = [];
+
+type SetView = ( updater: ( previousView: View ) => View ) => void;
+
+type UseResponseFieldColumnsArgs = {
+	/** The form whose responses are on screen, or null on a view that spans every form. */
+	formId: number | null;
+	/** The responses currently loaded. */
+	records: FormResponse[];
+	/** The DataViews view setter. Must accept a functional updater. */
+	setView: SetView;
+};
+
+/**
+ * Returns the view's `fields` with `newIds` slotted in after the answer columns.
+ *
+ * Answers are always inserted directly after Date, so Date can never end up behind
+ * one: "one past the last Date-or-answer column" places them correctly whether this
+ * is the first batch or a later one.
+ *
+ * @param previousView - The view to update.
+ * @param newIds       - The column ids to add.
+ * @param answerIds    - Every answer column id known so far.
+ * @return               The updated view.
+ */
+const showColumns = ( previousView: View, newIds: string[], answerIds: Set< string > ): View => {
+	const previousFields = previousView.fields || [];
+	const insertAt =
+		previousFields.reduce(
+			( last, id, index ) => ( id === 'date' || answerIds.has( id ) ? index : last ),
+			-1
+		) + 1;
+
+	return {
+		...previousView,
+		fields: [
+			...previousFields.slice( 0, insertAt ),
+			...newIds,
+			...previousFields.slice( insertAt ),
+		],
+	};
+};
+
+/**
+ * Turns a form's own fields into DataViews columns on its responses view.
+ *
+ * Columns are discovered from the responses rather than declared up front, so they
+ * cannot live in the default view. Three behaviors follow from that, and this hook
+ * owns all three:
+ *
+ * A column appears as soon as a response carrying that field loads, but only the
+ * first time. Columns accumulate for as long as the form is open, so one never
+ * disappears mid-session — and because a known field is never re-offered, a column
+ * the user has hidden stays hidden.
+ *
+ * Switching forms starts over: the previous form's columns are dropped from the view
+ * instead of lingering there empty. The stage does not remount between forms, so
+ * nothing else would clear them. A view that spans every form gets no answer columns
+ * at all; those forms share no field set.
+ *
+ * @param args         - Hook arguments.
+ * @param args.formId  - The form on screen, or null on a view spanning every form.
+ * @param args.records - The responses currently loaded.
+ * @param args.setView - The DataViews view setter.
+ * @return               The answer columns to render, in first-seen order.
+ */
+export default function useResponseFieldColumns( {
+	formId,
+	records,
+	setView,
+}: UseResponseFieldColumnsArgs ): ResponseFieldColumn[] {
+	const [ columns, setColumns ] = useState< ResponseFieldColumn[] >( EMPTY_COLUMNS );
+	// The accumulated columns, read and written without re-running this effect.
+	const seen = useRef< { formId: number | null; columns: ResponseFieldColumn[] } >( {
+		formId: null,
+		columns: EMPTY_COLUMNS,
+	} );
+
+	useEffect( () => {
+		const previous = seen.current;
+
+		if ( previous.formId !== formId ) {
+			const staleIds = new Set( previous.columns.map( column => column.id ) );
+
+			seen.current = { formId, columns: EMPTY_COLUMNS };
+			setColumns( EMPTY_COLUMNS );
+
+			if ( staleIds.size > 0 ) {
+				setView( previousView => ( {
+					...previousView,
+					fields: ( previousView.fields || [] ).filter( id => ! staleIds.has( id ) ),
+				} ) );
+			}
+		}
+
+		if ( formId === null ) {
+			return;
+		}
+
+		const known = seen.current.columns;
+		// Only this form's responses may contribute columns. Switching forms re-runs
+		// this effect one render before the new responses land, and without the filter
+		// the outgoing form's fields would be rediscovered from the stale records and
+		// immediately re-added to the view the reset above just cleared.
+		const ownRecords = ( records || [] ).filter( record => record.form_id === formId );
+		const merged = mergeResponseFieldColumns( known, getResponseFieldColumns( ownRecords ) );
+
+		if ( merged === known ) {
+			return;
+		}
+
+		// mergeResponseFieldColumns only ever appends, so the tail is what is new.
+		const newIds = merged.slice( known.length ).map( column => column.id );
+		const answerIds = new Set( merged.map( column => column.id ) );
+
+		seen.current = { formId, columns: merged };
+		setColumns( merged );
+		setView( previousView => showColumns( previousView, newIds, answerIds ) );
+	}, [ formId, records, setView ] );
+
+	return columns;
+}

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.jsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.jsx
@@ -10,7 +10,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { Badge, Link } from '@wordpress/ui';
@@ -34,12 +34,8 @@ import IntegrationsButton from '../../components/integrations-button/index.tsx';
 import Page from '../../components/page/index.tsx';
 import TextWithFlag from '../../components/text-with-flag/index.tsx';
 import useInboxData from '../../hooks/use-inbox-data.ts';
-import {
-	buildResponseFieldColumns,
-	getResponseFieldColumns,
-	isResponseFieldColumnId,
-	mergeResponseFieldColumns,
-} from '../../response-field-columns.tsx';
+import useResponseFieldColumns from '../../hooks/use-response-field-columns.ts';
+import { buildResponseFieldColumns } from '../../response-field-columns.tsx';
 import { useDashboardSearchParams } from '../../router/dashboard-search-params-context.tsx';
 import { getPath, getItemId } from '../utils.js';
 import {
@@ -180,67 +176,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 	// A form's own fields become columns, so a single form's responses can be read
 	// across at a glance. The "All responses" view spans every form and has no
 	// shared field set, so it keeps the built-in columns only.
-	const [ responseFieldColumns, setResponseFieldColumns ] = useState( EMPTY_ARRAY );
-
-	useEffect( () => {
-		if ( ! isSingleFormView ) {
-			setResponseFieldColumns( EMPTY_ARRAY );
-			return;
-		}
-
-		const discovered = getResponseFieldColumns( records );
-
-		setResponseFieldColumns( previous => mergeResponseFieldColumns( previous, discovered ) );
-	}, [ isSingleFormView, records ] );
-
-	// Answer columns are discovered from the responses, so they cannot be part of
-	// `defaultView`. Show each one as soon as it turns up — but only the first time,
-	// so a column the user has since hidden stays hidden.
-	const shownFieldColumnIds = useRef( new Set() );
-
-	useEffect( () => {
-		const newIds = responseFieldColumns
-			.map( column => column.id )
-			.filter( id => ! shownFieldColumnIds.current.has( id ) );
-
-		if ( newIds.length === 0 ) {
-			return;
-		}
-
-		newIds.forEach( id => shownFieldColumnIds.current.add( id ) );
-
-		setView( previousView => {
-			const previousFields = previousView.fields || [];
-			const additions = newIds.filter( id => ! previousFields.includes( id ) );
-
-			if ( additions.length === 0 ) {
-				return previousView;
-			}
-
-			// Answers sit together, after Date and ahead of the remaining metadata.
-			const lastAnswerIndex = previousFields.reduce(
-				( last, id, index ) => ( isResponseFieldColumnId( id ) ? index : last ),
-				-1
-			);
-			const dateIndex = previousFields.indexOf( 'date' );
-			let insertAt;
-
-			if ( lastAnswerIndex !== -1 ) {
-				insertAt = lastAnswerIndex + 1;
-			} else {
-				insertAt = dateIndex === -1 ? 0 : dateIndex + 1;
-			}
-
-			return {
-				...previousView,
-				fields: [
-					...previousFields.slice( 0, insertAt ),
-					...additions,
-					...previousFields.slice( insertAt ),
-				],
-			};
-		} );
-	}, [ responseFieldColumns, setView ] );
+	const responseFieldColumns = useResponseFieldColumns( { formId: parent, records, setView } );
 
 	useEffect( () => {
 		const _filters = view.filters?.reduce( ( accumulator, { field, value } ) => {
@@ -626,6 +562,15 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 		} );
 	}, [ isInboxStatusToggleView, setView, urlFolder ] );
 
+	// Freezing the leading columns only makes sense once the table is wide enough to
+	// scroll, and only holds if the columns being frozen are the ones it assumes:
+	// the selection checkbox and the title. DataViews drops the title column when the
+	// user turns it off, which would freeze an answer column in its place.
+	const answerColumnsClassName =
+		responseFieldColumns.length > 0 && view.titleField && view.showTitle !== false
+			? 'has-field-columns'
+			: undefined;
+
 	const actions = useMemo( () => {
 		const mobileViewAction = {
 			...viewAction,
@@ -739,43 +684,37 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 			actions={ headerActions }
 			hasPadding={ false }
 		>
-			<div
-				className={ `jp-forms-responses-dataviews${
-					responseFieldColumns.length > 0 ? ' has-field-columns' : ''
-				}` }
-			>
-				<DataViews
-					paginationInfo={ paginationInfo }
-					fields={ fields }
-					actions={ actions }
-					data={ records || EMPTY_ARRAY }
-					isLoading={ isInboxLoading }
-					view={ view }
-					onChangeView={ onChangeView }
-					selection={ selection }
-					onChangeSelection={ onChangeSelection }
-					onClickItem={ onClickItem }
-					getItemId={ getItemId }
-					defaultLayouts={ defaultLayouts }
-					empty={
-						<EmptyResponses
-							status={ statusFilter }
-							isSearch={ !! view.search }
-							isSingleFormView={ isSingleFormView }
-							readStatusFilter={ readStatusFilter }
-						/>
-					}
-				>
-					<DataViewsHeaderRow
-						onLegacyStatusChange={ resetPage }
-						isInboxStatusToggleView={ isInboxStatusToggleView }
+			<DataViews
+				paginationInfo={ paginationInfo }
+				fields={ fields }
+				actions={ actions }
+				data={ records || EMPTY_ARRAY }
+				isLoading={ isInboxLoading }
+				view={ view }
+				onChangeView={ onChangeView }
+				selection={ selection }
+				onChangeSelection={ onChangeSelection }
+				onClickItem={ onClickItem }
+				getItemId={ getItemId }
+				defaultLayouts={ defaultLayouts }
+				empty={
+					<EmptyResponses
+						status={ statusFilter }
+						isSearch={ !! view.search }
+						isSingleFormView={ isSingleFormView }
+						readStatusFilter={ readStatusFilter }
 					/>
-					<div className="jp-forms-dataviews-layout-container">
-						<DataViews.Layout />
-						<DataViews.Footer />
-					</div>
-				</DataViews>
-			</div>
+				}
+			>
+				<DataViewsHeaderRow
+					onLegacyStatusChange={ resetPage }
+					isInboxStatusToggleView={ isInboxStatusToggleView }
+				/>
+				<div className="jp-forms-dataviews-layout-container">
+					<DataViews.Layout className={ answerColumnsClassName } />
+					<DataViews.Footer />
+				</div>
+			</DataViews>
 		</Page>
 	);
 

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.jsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.jsx
@@ -53,6 +53,9 @@ import { useView, defaultLayouts } from './views.js';
 
 const EMPTY_ARRAY = [];
 
+/** Mobile shows the title column and the actions column, and nothing besides. */
+const EMPTY_FIELDS = [];
+
 // Sentinel value used in the Source filter to represent form-preview (test) responses.
 // Source IDs are numeric post IDs, so this non-numeric value is safe from collision.
 const FORM_PREVIEW_SOURCE_VALUE = 'form_preview';
@@ -292,7 +295,11 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 	);
 
 	const onChangeView = useCallback(
-		newView => {
+		incomingView => {
+			// DataViews is handed a collapsed column set on mobile; keep the real one so
+			// widening the window restores the columns the user had chosen.
+			let newView = isMobileViewport ? { ...incomingView, fields: view.fields } : incomingView;
+
 			if ( ! isInboxStatusToggleView ) {
 				const folderValue = newView.filters?.find( filter => filter.field === 'folder' )?.value;
 				const nextFolder = [ 'inbox', 'spam', 'trash' ].includes( folderValue )
@@ -326,7 +333,15 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 			}
 			setView( newView );
 		},
-		[ isInboxStatusToggleView, setSearchParams, setSelectedResponses, setView, urlFolder ]
+		[
+			isInboxStatusToggleView,
+			isMobileViewport,
+			setSearchParams,
+			setSelectedResponses,
+			setView,
+			urlFolder,
+			view.fields,
+		]
 	);
 
 	const wrapperUnread = ( isUnread, itemValue ) => {
@@ -567,9 +582,19 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 	// the selection checkbox and the title. DataViews drops the title column when the
 	// user turns it off, which would freeze an answer column in its place.
 	const answerColumnsClassName =
-		responseFieldColumns.length > 0 && view.titleField && view.showTitle !== false
+		! isMobileViewport &&
+		responseFieldColumns.length > 0 &&
+		view.titleField &&
+		view.showTitle !== false
 			? 'has-field-columns'
 			: undefined;
+
+	// Narrow screens cannot make use of a table that scrolls sideways, so they get the
+	// response and its actions and nothing else.
+	const viewForDataViews = useMemo(
+		() => ( isMobileViewport ? { ...view, fields: EMPTY_FIELDS } : view ),
+		[ isMobileViewport, view ]
+	);
 
 	const actions = useMemo( () => {
 		const mobileViewAction = {
@@ -690,7 +715,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 				actions={ actions }
 				data={ records || EMPTY_ARRAY }
 				isLoading={ isInboxLoading }
-				view={ view }
+				view={ viewForDataViews }
 				onChangeView={ onChangeView }
 				selection={ selection }
 				onChangeSelection={ onChangeSelection }

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.jsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.jsx
@@ -10,7 +10,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { Badge, Link } from '@wordpress/ui';
@@ -34,6 +34,12 @@ import IntegrationsButton from '../../components/integrations-button/index.tsx';
 import Page from '../../components/page/index.tsx';
 import TextWithFlag from '../../components/text-with-flag/index.tsx';
 import useInboxData from '../../hooks/use-inbox-data.ts';
+import {
+	buildResponseFieldColumns,
+	getResponseFieldColumns,
+	isResponseFieldColumnId,
+	mergeResponseFieldColumns,
+} from '../../response-field-columns.tsx';
 import { useDashboardSearchParams } from '../../router/dashboard-search-params-context.tsx';
 import { getPath, getItemId } from '../utils.js';
 import {
@@ -170,6 +176,71 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 	);
 
 	const isInboxLoading = isLoadingData || isAkismetStatusPending;
+
+	// A form's own fields become columns, so a single form's responses can be read
+	// across at a glance. The "All responses" view spans every form and has no
+	// shared field set, so it keeps the built-in columns only.
+	const [ responseFieldColumns, setResponseFieldColumns ] = useState( EMPTY_ARRAY );
+
+	useEffect( () => {
+		if ( ! isSingleFormView ) {
+			setResponseFieldColumns( EMPTY_ARRAY );
+			return;
+		}
+
+		const discovered = getResponseFieldColumns( records );
+
+		setResponseFieldColumns( previous => mergeResponseFieldColumns( previous, discovered ) );
+	}, [ isSingleFormView, records ] );
+
+	// Answer columns are discovered from the responses, so they cannot be part of
+	// `defaultView`. Show each one as soon as it turns up — but only the first time,
+	// so a column the user has since hidden stays hidden.
+	const shownFieldColumnIds = useRef( new Set() );
+
+	useEffect( () => {
+		const newIds = responseFieldColumns
+			.map( column => column.id )
+			.filter( id => ! shownFieldColumnIds.current.has( id ) );
+
+		if ( newIds.length === 0 ) {
+			return;
+		}
+
+		newIds.forEach( id => shownFieldColumnIds.current.add( id ) );
+
+		setView( previousView => {
+			const previousFields = previousView.fields || [];
+			const additions = newIds.filter( id => ! previousFields.includes( id ) );
+
+			if ( additions.length === 0 ) {
+				return previousView;
+			}
+
+			// Answers sit together, after Date and ahead of the remaining metadata.
+			const lastAnswerIndex = previousFields.reduce(
+				( last, id, index ) => ( isResponseFieldColumnId( id ) ? index : last ),
+				-1
+			);
+			const dateIndex = previousFields.indexOf( 'date' );
+			let insertAt;
+
+			if ( lastAnswerIndex !== -1 ) {
+				insertAt = lastAnswerIndex + 1;
+			} else {
+				insertAt = dateIndex === -1 ? 0 : dateIndex + 1;
+			}
+
+			return {
+				...previousView,
+				fields: [
+					...previousFields.slice( 0, insertAt ),
+					...additions,
+					...previousFields.slice( insertAt ),
+				],
+			};
+		} );
+	}, [ responseFieldColumns, setView ] );
 
 	useEffect( () => {
 		const _filters = view.filters?.reduce( ( accumulator, { field, value } ) => {
@@ -463,6 +534,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 				enableSorting: false,
 				enableHiding: false,
 			},
+			...buildResponseFieldColumns( responseFieldColumns ),
 			{
 				id: 'date',
 				label: __( 'Date', 'jetpack-forms' ),
@@ -527,6 +599,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 			dateSettings.formats.datetime,
 			isInboxStatusToggleView,
 			isSingleFormView,
+			responseFieldColumns,
 		]
 	);
 
@@ -666,37 +739,43 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 			actions={ headerActions }
 			hasPadding={ false }
 		>
-			<DataViews
-				paginationInfo={ paginationInfo }
-				fields={ fields }
-				actions={ actions }
-				data={ records || EMPTY_ARRAY }
-				isLoading={ isInboxLoading }
-				view={ view }
-				onChangeView={ onChangeView }
-				selection={ selection }
-				onChangeSelection={ onChangeSelection }
-				onClickItem={ onClickItem }
-				getItemId={ getItemId }
-				defaultLayouts={ defaultLayouts }
-				empty={
-					<EmptyResponses
-						status={ statusFilter }
-						isSearch={ !! view.search }
-						isSingleFormView={ isSingleFormView }
-						readStatusFilter={ readStatusFilter }
-					/>
-				}
+			<div
+				className={ `jp-forms-responses-dataviews${
+					responseFieldColumns.length > 0 ? ' has-field-columns' : ''
+				}` }
 			>
-				<DataViewsHeaderRow
-					onLegacyStatusChange={ resetPage }
-					isInboxStatusToggleView={ isInboxStatusToggleView }
-				/>
-				<div className="jp-forms-dataviews-layout-container">
-					<DataViews.Layout />
-					<DataViews.Footer />
-				</div>
-			</DataViews>
+				<DataViews
+					paginationInfo={ paginationInfo }
+					fields={ fields }
+					actions={ actions }
+					data={ records || EMPTY_ARRAY }
+					isLoading={ isInboxLoading }
+					view={ view }
+					onChangeView={ onChangeView }
+					selection={ selection }
+					onChangeSelection={ onChangeSelection }
+					onClickItem={ onClickItem }
+					getItemId={ getItemId }
+					defaultLayouts={ defaultLayouts }
+					empty={
+						<EmptyResponses
+							status={ statusFilter }
+							isSearch={ !! view.search }
+							isSingleFormView={ isSingleFormView }
+							readStatusFilter={ readStatusFilter }
+						/>
+					}
+				>
+					<DataViewsHeaderRow
+						onLegacyStatusChange={ resetPage }
+						isInboxStatusToggleView={ isInboxStatusToggleView }
+					/>
+					<div className="jp-forms-dataviews-layout-container">
+						<DataViews.Layout />
+						<DataViews.Footer />
+					</div>
+				</DataViews>
+			</div>
 		</Page>
 	);
 

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.jsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.jsx
@@ -35,7 +35,12 @@ import Page from '../../components/page/index.tsx';
 import TextWithFlag from '../../components/text-with-flag/index.tsx';
 import useInboxData from '../../hooks/use-inbox-data.ts';
 import useResponseFieldColumns from '../../hooks/use-response-field-columns.ts';
-import { buildResponseFieldColumns } from '../../response-field-columns.tsx';
+import {
+	buildResponseFieldColumns,
+	getFrozenColumnsClassName,
+	getResponseTableView,
+	keepColumnChoice,
+} from '../../response-field-columns.tsx';
 import { useDashboardSearchParams } from '../../router/dashboard-search-params-context.tsx';
 import { getPath, getItemId } from '../utils.js';
 import {
@@ -52,9 +57,6 @@ import {
 import { useView, defaultLayouts } from './views.js';
 
 const EMPTY_ARRAY = [];
-
-/** Mobile shows the title column and the actions column, and nothing besides. */
-const EMPTY_FIELDS = [];
 
 // Sentinel value used in the Source filter to represent form-preview (test) responses.
 // Source IDs are numeric post IDs, so this non-numeric value is safe from collision.
@@ -296,9 +298,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 
 	const onChangeView = useCallback(
 		incomingView => {
-			// DataViews is handed a collapsed column set on mobile; keep the real one so
-			// widening the window restores the columns the user had chosen.
-			let newView = isMobileViewport ? { ...incomingView, fields: view.fields } : incomingView;
+			let newView = keepColumnChoice( incomingView, view, isMobileViewport );
 
 			if ( ! isInboxStatusToggleView ) {
 				const folderValue = newView.filters?.find( filter => filter.field === 'folder' )?.value;
@@ -340,7 +340,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 			setSelectedResponses,
 			setView,
 			urlFolder,
-			view.fields,
+			view,
 		]
 	);
 
@@ -577,22 +577,16 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 		} );
 	}, [ isInboxStatusToggleView, setView, urlFolder ] );
 
-	// Freezing the leading columns only makes sense once the table is wide enough to
-	// scroll, and only holds if the columns being frozen are the ones it assumes:
-	// the selection checkbox and the title. DataViews drops the title column when the
-	// user turns it off, which would freeze an answer column in its place.
-	const answerColumnsClassName =
-		! isMobileViewport &&
-		responseFieldColumns.length > 0 &&
-		view.titleField &&
-		view.showTitle !== false
-			? 'has-field-columns'
-			: undefined;
+	const answerColumnsClassName = getFrozenColumnsClassName(
+		responseFieldColumns,
+		view,
+		isMobileViewport
+	);
 
 	// Narrow screens cannot make use of a table that scrolls sideways, so they get the
 	// response and its actions and nothing else.
 	const viewForDataViews = useMemo(
-		() => ( isMobileViewport ? { ...view, fields: EMPTY_FIELDS } : view ),
+		() => getResponseTableView( view, isMobileViewport ),
 		[ isMobileViewport, view ]
 	);
 

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -2,6 +2,7 @@
 @use "../mixins";
 @use "../../blocks/shared/styles/empty_image_option" as *;
 @use "../design-tokens";
+@use "../response-field-columns";
 @import "@wordpress/dataviews/build-style/style.css";
 
 .jp-forms-dataviews-layout-container {

--- a/projects/packages/forms/src/dashboard/response-field-columns.tsx
+++ b/projects/packages/forms/src/dashboard/response-field-columns.tsx
@@ -2,10 +2,12 @@
  * External dependencies
  */
 import { decodeEntities } from '@wordpress/html-entities';
-import { _n, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { inferFieldTypeFromLabel } from './components/inspector/response-fields/field-preview/field-preview-utils.ts';
+import FieldRating from './components/inspector/response-fields/field-rating/index.tsx';
 import {
 	isFieldsCollection,
 	isFileUploadField,
@@ -14,13 +16,16 @@ import {
 /**
  * Types
  */
-import type { FileItem, FormResponse, ResponseField } from '../types/index.ts';
+import type { FieldType, FileItem, FormResponse, ResponseField } from '../types/index.ts';
 import type { Field } from '@wordpress/dataviews';
 
 /**
  * Prefix keeping generated column ids clear of the built-in ones ( 'from', 'date', 'ip', … ).
  */
 const COLUMN_ID_PREFIX = 'field:';
+
+/** Announced in place of the em dash that marks a field this response left blank. */
+const NO_ANSWER_LABEL = __( 'No answer', 'jetpack-forms' );
 
 export type ResponseFieldColumn = {
 	/** The DataViews field id. */
@@ -29,6 +34,8 @@ export type ResponseFieldColumn = {
 	key: string;
 	/** The column header. */
 	label: string;
+	/** The form field type, so the cell can render the way the inspector does. */
+	type: FieldType;
 };
 
 /**
@@ -97,10 +104,18 @@ export const getResponseFieldColumns = ( responses: FormResponse[] ): ResponseFi
 				continue;
 			}
 
+			const label = decodeEntities( String( field.label || key ) );
+
 			columns.set( key, {
 				id: `${ COLUMN_ID_PREFIX }${ key }`,
 				key,
-				label: decodeEntities( String( field.label || key ) ),
+				label,
+				// Legacy responses carry no type (or a useless 'basic'); the inspector
+				// infers one from the label in that case, so match it.
+				type:
+					field.type && field.type !== 'basic'
+						? ( field.type as FieldType )
+						: inferFieldTypeFromLabel( label ) ?? 'text',
 			} );
 		}
 	}
@@ -214,7 +229,21 @@ export const buildResponseFieldColumns = (
 			const value = getResponseFieldValue( item, column.key );
 
 			if ( ! value ) {
-				return <span className="jp-forms__inbox__field-column is-empty">&mdash;</span>;
+				return (
+					<span className="jp-forms__inbox__field-column is-empty" aria-label={ NO_ANSWER_LABEL }>
+						&mdash;
+					</span>
+				);
+			}
+
+			// Ratings read as icons here just as they do in the response inspector;
+			// "4/5" in a table cell is meaningless at a glance.
+			if ( column.type === 'rating' ) {
+				return (
+					<span className="jp-forms__inbox__field-column is-rating">
+						<FieldRating value={ value } />
+					</span>
+				);
 			}
 
 			return (

--- a/projects/packages/forms/src/dashboard/response-field-columns.tsx
+++ b/projects/packages/forms/src/dashboard/response-field-columns.tsx
@@ -3,6 +3,7 @@
  */
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -26,6 +27,12 @@ const COLUMN_ID_PREFIX = 'field:';
 
 /** Announced in place of the em dash that marks a field this response left blank. */
 const NO_ANSWER_LABEL = __( 'No answer', 'jetpack-forms' );
+
+/**
+ * Field types whose answer is one of a fixed set of choices, so it reads as a badge
+ * rather than as free text. Mirrors the response inspector's own list.
+ */
+const BADGED_VALUE_FIELDS: FieldType[] = [ 'consent', 'checkbox', 'radio', 'select' ];
 
 export type ResponseFieldColumn = {
 	/** The DataViews field id. */
@@ -199,6 +206,18 @@ const getFieldText = ( field?: ResponseField ): string => {
 };
 
 /**
+ * Reads one field off a response, whatever shape the response arrived in.
+ *
+ * @param response - The form response.
+ * @param key      - The form field key.
+ * @return           The field, or undefined when this response has no such field.
+ */
+export const getResponseField = (
+	response: FormResponse,
+	key: string
+): ResponseField | undefined => getFieldMap( response ).get( key );
+
+/**
  * Reads one field's value off a response, as display text.
  *
  * @param response - The form response.
@@ -242,6 +261,30 @@ export const buildResponseFieldColumns = (
 				return (
 					<span className="jp-forms__inbox__field-column is-rating">
 						<FieldRating value={ value } />
+					</span>
+				);
+			}
+
+			// Answers picked from a fixed set of choices are badges, as in the inspector.
+			// Multi-select keeps one badge per choice rather than a comma-joined string.
+			const rawValue = getResponseField( item, column.key )?.value;
+
+			if ( column.type === 'checkbox-multiple' && Array.isArray( rawValue ) ) {
+				return (
+					<span className="jp-forms__inbox__field-column is-badges">
+						{ rawValue.map( ( choice, index ) => (
+							<Badge intent="draft" key={ index }>
+								{ decodeEntities( String( choice ) ) }
+							</Badge>
+						) ) }
+					</span>
+				);
+			}
+
+			if ( BADGED_VALUE_FIELDS.includes( column.type ) ) {
+				return (
+					<span className="jp-forms__inbox__field-column is-badges" title={ value }>
+						<Badge intent="draft">{ value }</Badge>
 					</span>
 				);
 			}

--- a/projects/packages/forms/src/dashboard/response-field-columns.tsx
+++ b/projects/packages/forms/src/dashboard/response-field-columns.tsx
@@ -21,7 +21,7 @@ import {
  * Types
  */
 import type { FieldType, FileItem, FormResponse, ResponseField } from '../types/index.ts';
-import type { Field } from '@wordpress/dataviews';
+import type { Field, View } from '@wordpress/dataviews';
 
 /**
  * Prefix keeping generated column ids clear of the built-in ones ( 'from', 'date', 'ip', … ).
@@ -260,6 +260,64 @@ export const getFieldLink = (
 
 	return null;
 };
+
+/** A narrow screen shows the title column and the actions column, nothing else. */
+const NO_COLUMNS: string[] = [];
+
+/**
+ * The view to hand DataViews.
+ *
+ * A table that scrolls sideways is no use on a phone, so a narrow screen drops
+ * every column but the response and its actions. The caller's own view is left
+ * untouched, so widening the window restores the columns the user had chosen.
+ *
+ * @param view     - The stage's view state.
+ * @param isMobile - Whether the viewport is below the table's usable width.
+ * @return           The view to render with.
+ */
+export const getResponseTableView = ( view: View, isMobile: boolean ): View =>
+	isMobile ? { ...view, fields: NO_COLUMNS } : view;
+
+/**
+ * The view to persist when DataViews reports a change.
+ *
+ * On a narrow screen DataViews is working from a collapsed column set, so a sort
+ * or search there would otherwise write that empty set back over the user's real
+ * choice of columns.
+ *
+ * @param incomingView - The view DataViews handed back.
+ * @param currentView  - The stage's own view state.
+ * @param isMobile     - Whether the viewport is below the table's usable width.
+ * @return               The view to store.
+ */
+export const keepColumnChoice = (
+	incomingView: View,
+	currentView: View,
+	isMobile: boolean
+): View => ( isMobile ? { ...incomingView, fields: currentView.fields } : incomingView );
+
+/**
+ * The modifier that turns on the frozen leading columns, when they apply.
+ *
+ * Freezing only makes sense once answers have widened the table past the
+ * viewport, and only holds if the columns being frozen are the ones the
+ * stylesheet assumes: the selection checkbox and the title. DataViews drops the
+ * title column when the user turns it off, which would freeze an answer column
+ * in its place.
+ *
+ * @param columns  - The answer columns on screen.
+ * @param view     - The stage's view state.
+ * @param isMobile - Whether the viewport is below the table's usable width.
+ * @return           The class name, or undefined when the columns must not freeze.
+ */
+export const getFrozenColumnsClassName = (
+	columns: ResponseFieldColumn[],
+	view: View,
+	isMobile: boolean
+): string | undefined =>
+	! isMobile && columns.length > 0 && view.titleField && view.showTitle !== false
+		? 'has-field-columns'
+		: undefined;
 
 /**
  * Turns column descriptors into DataViews field definitions.

--- a/projects/packages/forms/src/dashboard/response-field-columns.tsx
+++ b/projects/packages/forms/src/dashboard/response-field-columns.tsx
@@ -3,11 +3,14 @@
  */
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Badge } from '@wordpress/ui';
+import { Badge, Link } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
-import { inferFieldTypeFromLabel } from './components/inspector/response-fields/field-preview/field-preview-utils.ts';
+import {
+	EMAIL_REGEX,
+	inferFieldTypeFromLabel,
+} from './components/inspector/response-fields/field-preview/field-preview-utils.ts';
 import FieldRating from './components/inspector/response-fields/field-rating/index.tsx';
 import {
 	isFieldsCollection,
@@ -229,6 +232,25 @@ export const getResponseFieldValue = ( response: FormResponse, key: string ): st
 };
 
 /**
+ * The link a field's value should open, when it is the kind of value worth acting on.
+ *
+ * @param type  - The form field type.
+ * @param value - The value as display text.
+ * @return        An href, or null when the value should render as plain text.
+ */
+const getFieldHref = ( type: FieldType, value: string ): string | null => {
+	if ( type === 'email' && EMAIL_REGEX.test( value ) ) {
+		return `mailto:${ value }`;
+	}
+
+	if ( type === 'telephone' || type === 'phone' ) {
+		return `tel:${ value.replace( /\s+/g, '' ) }`;
+	}
+
+	return null;
+};
+
+/**
  * Turns column descriptors into DataViews field definitions.
  *
  * @param columns - The column descriptors.
@@ -285,6 +307,20 @@ export const buildResponseFieldColumns = (
 				return (
 					<span className="jp-forms__inbox__field-column is-badges" title={ value }>
 						<Badge intent="draft">{ value }</Badge>
+					</span>
+				);
+			}
+
+			// An address or number in a table is worth acting on, so make it actionable.
+			// The inspector's own FieldEmail/FieldPhone are deliberately not reused here:
+			// they add a copy button and an async country-code lookup per value, which is
+			// the right weight for one open response and the wrong weight for every row.
+			const href = getFieldHref( column.type, value );
+
+			if ( href ) {
+				return (
+					<span className="jp-forms__inbox__field-column" title={ value }>
+						<Link href={ href }>{ value }</Link>
 					</span>
 				);
 			}

--- a/projects/packages/forms/src/dashboard/response-field-columns.tsx
+++ b/projects/packages/forms/src/dashboard/response-field-columns.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { VisuallyHidden } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Badge, Link } from '@wordpress/ui';
@@ -77,8 +78,10 @@ const getFieldList = ( response: FormResponse ): ResponseField[] => {
 /**
  * Per-response key lookup, so a row's fields are walked once rather than once per cell.
  *
- * Keyed on the record object, which `useInboxData` keeps stable between fetches; entries
- * fall away with the records themselves, so there is nothing to invalidate.
+ * Keyed on the record object, so the map holds for as long as a render pass reuses the
+ * same records. `useInboxData` rebuilds every record whenever it recomputes, so a refetch
+ * simply misses and rebuilds; entries fall away with the records themselves, and there is
+ * nothing to invalidate.
  */
 const fieldsByKey = new WeakMap< FormResponse, Map< string, ResponseField > >();
 
@@ -339,9 +342,15 @@ export const buildResponseFieldColumns = (
 			const value = getResponseFieldValue( item, column.key );
 
 			if ( ! value ) {
+				/*
+				 * Visually hidden text rather than an `aria-label`: the span carries no
+				 * role, and ARIA forbids naming a generic element, so the label would go
+				 * unannounced. `FieldRating` names its icons the same way.
+				 */
 				return (
-					<span className="jp-forms__inbox__field-column is-empty" aria-label={ NO_ANSWER_LABEL }>
-						&mdash;
+					<span className="jp-forms__inbox__field-column is-empty">
+						<VisuallyHidden as="span">{ NO_ANSWER_LABEL }</VisuallyHidden>
+						<span aria-hidden="true">&mdash;</span>
 					</span>
 				);
 			}
@@ -390,7 +399,13 @@ export const buildResponseFieldColumns = (
 			if ( link ) {
 				return (
 					<span className="jp-forms__inbox__field-column" title={ value }>
-						<Link href={ link.href } openInNewTab={ link.openInNewTab }>
+						<Link
+							href={ link.href }
+							openInNewTab={ link.openInNewTab }
+							// The value came from a form submission, and `Link` sets
+							// `target` without a `rel` of its own.
+							rel={ link.openInNewTab ? 'noopener noreferrer' : undefined }
+						>
 							{ value }
 						</Link>
 					</span>

--- a/projects/packages/forms/src/dashboard/response-field-columns.tsx
+++ b/projects/packages/forms/src/dashboard/response-field-columns.tsx
@@ -234,17 +234,28 @@ export const getResponseFieldValue = ( response: FormResponse, key: string ): st
 /**
  * The link a field's value should open, when it is the kind of value worth acting on.
  *
+ * Mirrors the response inspector: an address opens a mail client, a number dials, and a
+ * web address opens in a new tab. A value that does not look like its type — an "email"
+ * that is not one, a "website" with no scheme — stays plain text there and here.
+ *
  * @param type  - The form field type.
  * @param value - The value as display text.
- * @return        An href, or null when the value should render as plain text.
+ * @return        The href and how to open it, or null when the value is plain text.
  */
-const getFieldHref = ( type: FieldType, value: string ): string | null => {
+export const getFieldLink = (
+	type: FieldType,
+	value: string
+): { href: string; openInNewTab: boolean } | null => {
 	if ( type === 'email' && EMAIL_REGEX.test( value ) ) {
-		return `mailto:${ value }`;
+		return { href: `mailto:${ value }`, openInNewTab: false };
 	}
 
 	if ( type === 'telephone' || type === 'phone' ) {
-		return `tel:${ value.replace( /\s+/g, '' ) }`;
+		return { href: `tel:${ value.replace( /\s+/g, '' ) }`, openInNewTab: false };
+	}
+
+	if ( type === 'url' && /^https?:\/\//.test( value ) ) {
+		return { href: value, openInNewTab: true };
 	}
 
 	return null;
@@ -311,16 +322,19 @@ export const buildResponseFieldColumns = (
 				);
 			}
 
-			// An address or number in a table is worth acting on, so make it actionable.
+			// An address, number or web address in a table is worth acting on, so make it
+			// actionable.
 			// The inspector's own FieldEmail/FieldPhone are deliberately not reused here:
 			// they add a copy button and an async country-code lookup per value, which is
 			// the right weight for one open response and the wrong weight for every row.
-			const href = getFieldHref( column.type, value );
+			const link = getFieldLink( column.type, value );
 
-			if ( href ) {
+			if ( link ) {
 				return (
 					<span className="jp-forms__inbox__field-column" title={ value }>
-						<Link href={ href }>{ value }</Link>
+						<Link href={ link.href } openInNewTab={ link.openInNewTab }>
+							{ value }
+						</Link>
 					</span>
 				);
 			}

--- a/projects/packages/forms/src/dashboard/response-field-columns.tsx
+++ b/projects/packages/forms/src/dashboard/response-field-columns.tsx
@@ -1,0 +1,222 @@
+/**
+ * External dependencies
+ */
+import { decodeEntities } from '@wordpress/html-entities';
+import { _n, sprintf } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import {
+	isCollectionFormatField,
+	isFileUploadField,
+	isImageSelectField,
+} from './components/inspector/utils.ts';
+/**
+ * Types
+ */
+import type { FileItem, FormResponse, ResponseField } from '../types/index.ts';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * Prefix keeping generated column ids clear of the built-in ones ( 'from', 'date', 'ip', … ).
+ */
+const COLUMN_ID_PREFIX = 'field:';
+
+export type ResponseFieldColumn = {
+	/** The DataViews field id. */
+	id: string;
+	/** The form field key the column reads from. */
+	key: string;
+	/** The column header. */
+	label: string;
+};
+
+/**
+ * Tells a generated answer column apart from a built-in one.
+ *
+ * @param id - A DataViews field id.
+ * @return     True when the id belongs to a form field column.
+ */
+export const isResponseFieldColumnId = ( id: string ): boolean =>
+	typeof id === 'string' && id.startsWith( COLUMN_ID_PREFIX );
+
+/**
+ * Reads a response's fields as a list, whatever shape they arrived in.
+ *
+ * `useInboxData` passes collection-format fields through untouched and flattens
+ * legacy `label-value` fields into a label-keyed object, so both shapes land here.
+ *
+ * @param response - The form response.
+ * @return           The response's fields, normalized to a list.
+ */
+const getFieldList = ( response: FormResponse ): ResponseField[] => {
+	const fields = response?.fields;
+
+	if ( ! fields || typeof fields !== 'object' ) {
+		return [];
+	}
+
+	const values = Array.isArray( fields ) ? fields : Object.values( fields );
+
+	if ( values.length === 0 ) {
+		return [];
+	}
+
+	if ( isCollectionFormatField( values[ 0 ] ) ) {
+		return values as ResponseField[];
+	}
+
+	// Legacy shape: the label is the only stable identifier available.
+	return Object.entries( fields ).map( ( [ label, value ] ) => ( { key: label, label, value } ) );
+};
+
+/**
+ * Collects one column per distinct form field across the given responses.
+ *
+ * Responses on a single form share a form, but not necessarily a form *version* —
+ * a field added or removed since an older submission only shows up on the
+ * responses that carry it, so the column set is the union across all of them.
+ *
+ * @param responses - The responses currently loaded.
+ * @return            One column descriptor per distinct field, in first-seen order.
+ */
+export const getResponseFieldColumns = ( responses: FormResponse[] ): ResponseFieldColumn[] => {
+	const columns = new Map< string, ResponseFieldColumn >();
+
+	for ( const response of responses ?? [] ) {
+		for ( const field of getFieldList( response ) ) {
+			const key = String( field.key ?? '' );
+
+			if ( ! key || columns.has( key ) ) {
+				continue;
+			}
+
+			columns.set( key, {
+				id: `${ COLUMN_ID_PREFIX }${ key }`,
+				key,
+				label: decodeEntities( String( field.label || key ) ),
+			} );
+		}
+	}
+
+	return Array.from( columns.values() );
+};
+
+/**
+ * Merges newly discovered columns into the ones already on screen.
+ *
+ * Columns are kept for as long as the form is open rather than recomputed from
+ * whatever page happens to be loaded: dropping one mid-session would take the
+ * user's column choice with it.
+ *
+ * @param previous   - The columns discovered so far.
+ * @param discovered - The columns in the current result set.
+ * @return             The merged list — `previous` itself when nothing is new.
+ */
+export const mergeResponseFieldColumns = (
+	previous: ResponseFieldColumn[],
+	discovered: ResponseFieldColumn[]
+): ResponseFieldColumn[] => {
+	const known = new Set( previous.map( column => column.key ) );
+	const additions = discovered.filter( column => ! known.has( column.key ) );
+
+	return additions.length === 0 ? previous : [ ...previous, ...additions ];
+};
+
+/**
+ * Renders a field's value as a single line of text.
+ *
+ * @param field - The response field, if the response has one for this column.
+ * @return        The value as text, or an empty string when there is nothing to show.
+ */
+const getFieldText = ( field?: ResponseField ): string => {
+	const value = field?.value;
+
+	if ( value === null || value === undefined ) {
+		return '';
+	}
+
+	if ( isImageSelectField( value ) ) {
+		const { choices = [] } = value as { choices?: Array< { selected?: string; label?: string } > };
+		return choices
+			.map( choice => choice?.label || choice?.selected || '' )
+			.filter( Boolean )
+			.join( ', ' );
+	}
+
+	if ( isFileUploadField( value ) ) {
+		const { files = [] } = value as { files?: FileItem[] };
+
+		if ( files.length === 0 ) {
+			return '';
+		}
+
+		if ( files.length === 1 ) {
+			return files[ 0 ]?.name ?? '';
+		}
+
+		return sprintf(
+			/* translators: %d: number of files uploaded in a single form field. */
+			_n( '%d file', '%d files', files.length, 'jetpack-forms' ),
+			files.length
+		);
+	}
+
+	if ( Array.isArray( value ) ) {
+		return value
+			.map( entry => ( entry === null || entry === undefined ? '' : String( entry ) ) )
+			.filter( Boolean )
+			.join( ', ' );
+	}
+
+	// Files and image selects are the only object values with a text form.
+	if ( typeof value === 'object' ) {
+		return '';
+	}
+
+	return String( value );
+};
+
+/**
+ * Reads one field's value off a response, as display text.
+ *
+ * @param response - The form response.
+ * @param key      - The form field key.
+ * @return           The value as text, or an empty string.
+ */
+export const getResponseFieldValue = ( response: FormResponse, key: string ): string => {
+	const field = getFieldList( response ).find( item => String( item.key ) === key );
+
+	return decodeEntities( getFieldText( field ) ).trim();
+};
+
+/**
+ * Turns column descriptors into DataViews field definitions.
+ *
+ * @param columns - The column descriptors.
+ * @return          DataViews fields, one per form field.
+ */
+export const buildResponseFieldColumns = (
+	columns: ResponseFieldColumn[]
+): Field< FormResponse >[] =>
+	columns.map( column => ( {
+		id: column.id,
+		label: column.label,
+		// The responses query only understands the built-in fields, so sorting on an
+		// answer would silently do nothing.
+		enableSorting: false,
+		getValue: ( { item }: { item: FormResponse } ) => getResponseFieldValue( item, column.key ),
+		render: ( { item }: { item: FormResponse } ) => {
+			const value = getResponseFieldValue( item, column.key );
+
+			if ( ! value ) {
+				return <span className="jp-forms__inbox__field-column is-empty">&mdash;</span>;
+			}
+
+			return (
+				<span className="jp-forms__inbox__field-column" title={ value }>
+					{ value }
+				</span>
+			);
+		},
+	} ) );

--- a/projects/packages/forms/src/dashboard/response-field-columns.tsx
+++ b/projects/packages/forms/src/dashboard/response-field-columns.tsx
@@ -7,7 +7,7 @@ import { _n, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import {
-	isCollectionFormatField,
+	isFieldsCollection,
 	isFileUploadField,
 	isImageSelectField,
 } from './components/inspector/utils.ts';
@@ -32,15 +32,6 @@ export type ResponseFieldColumn = {
 };
 
 /**
- * Tells a generated answer column apart from a built-in one.
- *
- * @param id - A DataViews field id.
- * @return     True when the id belongs to a form field column.
- */
-export const isResponseFieldColumnId = ( id: string ): boolean =>
-	typeof id === 'string' && id.startsWith( COLUMN_ID_PREFIX );
-
-/**
  * Reads a response's fields as a list, whatever shape they arrived in.
  *
  * `useInboxData` passes collection-format fields through untouched and flattens
@@ -56,18 +47,33 @@ const getFieldList = ( response: FormResponse ): ResponseField[] => {
 		return [];
 	}
 
-	const values = Array.isArray( fields ) ? fields : Object.values( fields );
-
-	if ( values.length === 0 ) {
-		return [];
-	}
-
-	if ( isCollectionFormatField( values[ 0 ] ) ) {
-		return values as ResponseField[];
+	// `isFieldsCollection` handles both true arrays and the numeric-keyed objects
+	// PHP's JSON encoding can produce.
+	if ( isFieldsCollection( fields ) ) {
+		return Object.values( fields ) as ResponseField[];
 	}
 
 	// Legacy shape: the label is the only stable identifier available.
 	return Object.entries( fields ).map( ( [ label, value ] ) => ( { key: label, label, value } ) );
+};
+
+/**
+ * Per-response key lookup, so a row's fields are walked once rather than once per cell.
+ *
+ * Keyed on the record object, which `useInboxData` keeps stable between fetches; entries
+ * fall away with the records themselves, so there is nothing to invalidate.
+ */
+const fieldsByKey = new WeakMap< FormResponse, Map< string, ResponseField > >();
+
+const getFieldMap = ( response: FormResponse ): Map< string, ResponseField > => {
+	let map = fieldsByKey.get( response );
+
+	if ( ! map ) {
+		map = new Map( getFieldList( response ).map( field => [ String( field.key ), field ] ) );
+		fieldsByKey.set( response, map );
+	}
+
+	return map;
 };
 
 /**
@@ -185,9 +191,7 @@ const getFieldText = ( field?: ResponseField ): string => {
  * @return           The value as text, or an empty string.
  */
 export const getResponseFieldValue = ( response: FormResponse, key: string ): string => {
-	const field = getFieldList( response ).find( item => String( item.key ) === key );
-
-	return decodeEntities( getFieldText( field ) ).trim();
+	return decodeEntities( getFieldText( getFieldMap( response ).get( key ) ) ).trim();
 };
 
 /**

--- a/projects/packages/forms/src/dashboard/test/response-field-columns.test.js
+++ b/projects/packages/forms/src/dashboard/test/response-field-columns.test.js
@@ -1,6 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 import {
 	getFieldLink,
+	getFrozenColumnsClassName,
+	getResponseTableView,
+	keepColumnChoice,
 	getResponseField,
 	getResponseFieldColumns,
 	getResponseFieldValue,
@@ -131,6 +134,68 @@ describe( 'getResponseFieldValue', () => {
 
 	it( 'renders a rating as submitted', () => {
 		expect( valueOf( '4/5' ) ).toBe( '4/5' );
+	} );
+} );
+
+const DESKTOP_VIEW = { titleField: 'from', fields: [ 'date', 'field:1_Name', 'ip' ] };
+const COLUMNS = [ { id: 'field:1_Name', key: '1_Name', label: 'Name', type: 'text' } ];
+
+describe( 'getResponseTableView', () => {
+	it( 'hands DataViews the view untouched on a wide screen', () => {
+		expect( getResponseTableView( DESKTOP_VIEW, false ) ).toBe( DESKTOP_VIEW );
+	} );
+
+	it( 'drops every column but the title and actions on a narrow screen', () => {
+		const view = getResponseTableView( DESKTOP_VIEW, true );
+
+		expect( view.fields ).toEqual( [] );
+		// The title column is DataViews' own, so it survives; the caller's view is
+		// left alone so widening the window restores the columns.
+		expect( view.titleField ).toBe( 'from' );
+		expect( DESKTOP_VIEW.fields ).toEqual( [ 'date', 'field:1_Name', 'ip' ] );
+	} );
+} );
+
+describe( 'keepColumnChoice', () => {
+	it( 'persists what DataViews reports on a wide screen', () => {
+		const incoming = { ...DESKTOP_VIEW, sort: { field: 'date', direction: 'asc' } };
+
+		expect( keepColumnChoice( incoming, DESKTOP_VIEW, false ) ).toBe( incoming );
+	} );
+
+	it( 'keeps the real columns when a narrow screen reports a change', () => {
+		// Sorting on a phone must not write the collapsed column set back over the
+		// columns the user chose on a wide screen.
+		const incoming = { ...DESKTOP_VIEW, fields: [], sort: { field: 'date' } };
+		const kept = keepColumnChoice( incoming, DESKTOP_VIEW, true );
+
+		expect( kept.fields ).toEqual( [ 'date', 'field:1_Name', 'ip' ] );
+		expect( kept.sort ).toEqual( { field: 'date' } );
+	} );
+} );
+
+describe( 'getFrozenColumnsClassName', () => {
+	it( 'freezes the leading columns once there are answers to scroll past', () => {
+		expect( getFrozenColumnsClassName( COLUMNS, DESKTOP_VIEW, false ) ).toBe( 'has-field-columns' );
+	} );
+
+	it( 'does not freeze when there are no answer columns', () => {
+		expect( getFrozenColumnsClassName( [], DESKTOP_VIEW, false ) ).toBeUndefined();
+	} );
+
+	it( 'does not freeze on a narrow screen, where nothing scrolls sideways', () => {
+		expect( getFrozenColumnsClassName( COLUMNS, DESKTOP_VIEW, true ) ).toBeUndefined();
+	} );
+
+	it( 'does not freeze when the title column is hidden', () => {
+		// The stylesheet freezes the checkbox column's next sibling. Without a title
+		// column that is an answer column, which must not be frozen in its place.
+		expect(
+			getFrozenColumnsClassName( COLUMNS, { ...DESKTOP_VIEW, showTitle: false }, false )
+		).toBeUndefined();
+		expect(
+			getFrozenColumnsClassName( COLUMNS, { ...DESKTOP_VIEW, titleField: undefined }, false )
+		).toBeUndefined();
 	} );
 } );
 

--- a/projects/packages/forms/src/dashboard/test/response-field-columns.test.js
+++ b/projects/packages/forms/src/dashboard/test/response-field-columns.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import {
+	getFieldLink,
 	getResponseField,
 	getResponseFieldColumns,
 	getResponseFieldValue,
@@ -130,6 +131,44 @@ describe( 'getResponseFieldValue', () => {
 
 	it( 'renders a rating as submitted', () => {
 		expect( valueOf( '4/5' ) ).toBe( '4/5' );
+	} );
+} );
+
+describe( 'getFieldLink', () => {
+	it( 'opens an address in a mail client', () => {
+		expect( getFieldLink( 'email', 'ada@example.com' ) ).toEqual( {
+			href: 'mailto:ada@example.com',
+			openInNewTab: false,
+		} );
+	} );
+
+	it( 'dials a phone number, without the spaces it is displayed with', () => {
+		expect( getFieldLink( 'telephone', '+1 415 555 0101' ) ).toEqual( {
+			href: 'tel:+14155550101',
+			openInNewTab: false,
+		} );
+		expect( getFieldLink( 'phone', '555 0101' ).href ).toBe( 'tel:5550101' );
+	} );
+
+	it( 'opens a web address in a new tab', () => {
+		expect( getFieldLink( 'url', 'https://example.com/a-page' ) ).toEqual( {
+			href: 'https://example.com/a-page',
+			openInNewTab: true,
+		} );
+		expect( getFieldLink( 'url', 'http://example.com' ).openInNewTab ).toBe( true );
+	} );
+
+	it( 'leaves a value that does not look like its type as plain text', () => {
+		// The response inspector applies the same two guards, so the table matches it.
+		expect( getFieldLink( 'email', 'not an address' ) ).toBeNull();
+		expect( getFieldLink( 'url', 'example.com' ) ).toBeNull();
+		expect( getFieldLink( 'url', 'javascript:alert(1)' ) ).toBeNull();
+	} );
+
+	it( 'leaves every other field type as plain text', () => {
+		expect( getFieldLink( 'text', 'https://example.com' ) ).toBeNull();
+		expect( getFieldLink( 'textarea', 'ada@example.com' ) ).toBeNull();
+		expect( getFieldLink( 'select', 'Newsletter' ) ).toBeNull();
 	} );
 } );
 

--- a/projects/packages/forms/src/dashboard/test/response-field-columns.test.js
+++ b/projects/packages/forms/src/dashboard/test/response-field-columns.test.js
@@ -1,0 +1,131 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+	getResponseFieldColumns,
+	getResponseFieldValue,
+	isResponseFieldColumnId,
+	mergeResponseFieldColumns,
+} from '../response-field-columns.tsx';
+
+const collectionResponse = ( fields ) => ( { id: 1, fields } );
+
+describe( 'getResponseFieldColumns', () => {
+	it( 'derives one column per field, keyed by the field key', () => {
+		const columns = getResponseFieldColumns( [
+			collectionResponse( [
+				{ key: '1_Name', label: 'Name', value: 'Ada', type: 'name' },
+				{ key: '2_Email', label: 'Email', value: 'ada@example.com', type: 'email' },
+			] ),
+		] );
+
+		expect( columns ).toEqual( [
+			{ id: 'field:1_Name', key: '1_Name', label: 'Name' },
+			{ id: 'field:2_Email', key: '2_Email', label: 'Email' },
+		] );
+	} );
+
+	it( 'unions fields across responses, so a field only some responses carry still gets a column', () => {
+		const columns = getResponseFieldColumns( [
+			collectionResponse( [ { key: '1_Name', label: 'Name', value: 'Ada' } ] ),
+			collectionResponse( [
+				{ key: '1_Name', label: 'Name', value: 'Grace' },
+				{ key: '2_Phone', label: 'Phone', value: '555' },
+			] ),
+		] );
+
+		expect( columns.map( column => column.key ) ).toEqual( [ '1_Name', '2_Phone' ] );
+	} );
+
+	it( 'decodes entities in the column label', () => {
+		const [ column ] = getResponseFieldColumns( [
+			collectionResponse( [ { key: 'k', label: 'Tom &amp; Jerry', value: 'x' } ] ),
+		] );
+
+		expect( column.label ).toBe( 'Tom & Jerry' );
+	} );
+
+	it( 'reads the legacy label-value shape, keying columns by label', () => {
+		const columns = getResponseFieldColumns( [
+			{ id: 1, fields: { Name: 'Ada', Message: 'Hello' } },
+		] );
+
+		expect( columns ).toEqual( [
+			{ id: 'field:Name', key: 'Name', label: 'Name' },
+			{ id: 'field:Message', key: 'Message', label: 'Message' },
+		] );
+	} );
+
+	it( 'returns nothing for responses without fields', () => {
+		expect( getResponseFieldColumns( [ { id: 1 }, { id: 2, fields: [] } ] ) ).toEqual( [] );
+		expect( getResponseFieldColumns( undefined ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'getResponseFieldValue', () => {
+	const valueOf = ( value, key = 'k' ) =>
+		getResponseFieldValue( collectionResponse( [ { key, label: 'L', value } ] ), key );
+
+	it( 'renders a plain string', () => {
+		expect( valueOf( 'Social Media' ) ).toBe( 'Social Media' );
+	} );
+
+	it( 'joins a multiple-choice array', () => {
+		expect( valueOf( [ 'Keynote', 'Workshop', 'Panel' ] ) ).toBe( 'Keynote, Workshop, Panel' );
+	} );
+
+	it( 'names a single uploaded file and counts several', () => {
+		expect( valueOf( { files: [ { name: 'proposal.pdf' } ] } ) ).toBe( 'proposal.pdf' );
+		expect( valueOf( { files: [ { name: 'a.pdf' }, { name: 'b.pdf' } ] } ) ).toBe( '2 files' );
+		expect( valueOf( { files: [] } ) ).toBe( '' );
+	} );
+
+	it( 'lists the chosen image-select options', () => {
+		expect(
+			valueOf( {
+				type: 'image-select',
+				choices: [ { selected: 'Riverside Hall' }, { selected: 'b', label: 'Garden Room' } ],
+			} )
+		).toBe( 'Riverside Hall, Garden Room' );
+	} );
+
+	it( 'decodes entities in the value', () => {
+		expect( valueOf( 'Tom &amp; Jerry' ) ).toBe( 'Tom & Jerry' );
+	} );
+
+	it( 'renders an empty string for missing, empty and unrecognized values', () => {
+		expect( valueOf( null ) ).toBe( '' );
+		expect( valueOf( undefined ) ).toBe( '' );
+		expect( valueOf( '   ' ) ).toBe( '' );
+		expect( valueOf( { unexpected: true } ) ).toBe( '' );
+		expect( getResponseFieldValue( collectionResponse( [] ), 'missing' ) ).toBe( '' );
+	} );
+
+	it( 'renders a rating as submitted', () => {
+		expect( valueOf( '4/5' ) ).toBe( '4/5' );
+	} );
+} );
+
+describe( 'mergeResponseFieldColumns', () => {
+	const a = { id: 'field:a', key: 'a', label: 'A' };
+	const b = { id: 'field:b', key: 'b', label: 'B' };
+
+	it( 'appends columns that are new', () => {
+		expect( mergeResponseFieldColumns( [ a ], [ a, b ] ) ).toEqual( [ a, b ] );
+	} );
+
+	it( 'keeps the same reference when nothing is new, so the view does not churn', () => {
+		const previous = [ a, b ];
+		expect( mergeResponseFieldColumns( previous, [ a ] ) ).toBe( previous );
+	} );
+
+	it( 'keeps columns that the current page no longer carries', () => {
+		expect( mergeResponseFieldColumns( [ a, b ], [] ) ).toEqual( [ a, b ] );
+	} );
+} );
+
+describe( 'isResponseFieldColumnId', () => {
+	it( 'tells answer columns apart from the built-in ones', () => {
+		expect( isResponseFieldColumnId( 'field:1_Name' ) ).toBe( true );
+		expect( isResponseFieldColumnId( 'from' ) ).toBe( false );
+		expect( isResponseFieldColumnId( 'date' ) ).toBe( false );
+	} );
+} );

--- a/projects/packages/forms/src/dashboard/test/response-field-columns.test.js
+++ b/projects/packages/forms/src/dashboard/test/response-field-columns.test.js
@@ -2,11 +2,10 @@ import { describe, expect, it } from '@jest/globals';
 import {
 	getResponseFieldColumns,
 	getResponseFieldValue,
-	isResponseFieldColumnId,
 	mergeResponseFieldColumns,
 } from '../response-field-columns.tsx';
 
-const collectionResponse = ( fields ) => ( { id: 1, fields } );
+const collectionResponse = fields => ( { id: 1, fields } );
 
 describe( 'getResponseFieldColumns', () => {
 	it( 'derives one column per field, keyed by the field key', () => {
@@ -119,13 +118,5 @@ describe( 'mergeResponseFieldColumns', () => {
 
 	it( 'keeps columns that the current page no longer carries', () => {
 		expect( mergeResponseFieldColumns( [ a, b ], [] ) ).toEqual( [ a, b ] );
-	} );
-} );
-
-describe( 'isResponseFieldColumnId', () => {
-	it( 'tells answer columns apart from the built-in ones', () => {
-		expect( isResponseFieldColumnId( 'field:1_Name' ) ).toBe( true );
-		expect( isResponseFieldColumnId( 'from' ) ).toBe( false );
-		expect( isResponseFieldColumnId( 'date' ) ).toBe( false );
 	} );
 } );

--- a/projects/packages/forms/src/dashboard/test/response-field-columns.test.js
+++ b/projects/packages/forms/src/dashboard/test/response-field-columns.test.js
@@ -17,8 +17,8 @@ describe( 'getResponseFieldColumns', () => {
 		] );
 
 		expect( columns ).toEqual( [
-			{ id: 'field:1_Name', key: '1_Name', label: 'Name' },
-			{ id: 'field:2_Email', key: '2_Email', label: 'Email' },
+			{ id: 'field:1_Name', key: '1_Name', label: 'Name', type: 'name' },
+			{ id: 'field:2_Email', key: '2_Email', label: 'Email', type: 'email' },
 		] );
 	} );
 
@@ -34,6 +34,33 @@ describe( 'getResponseFieldColumns', () => {
 		expect( columns.map( column => column.key ) ).toEqual( [ '1_Name', '2_Phone' ] );
 	} );
 
+	it( 'infers a type from the label for legacy responses that carry none', () => {
+		const [ column ] = getResponseFieldColumns( [
+			collectionResponse( [ { key: 'k', label: 'Rating', value: '4/5' } ] ),
+		] );
+
+		expect( column.type ).toBe( 'rating' );
+	} );
+
+	it( 'falls back to text when the label matches no known field type', () => {
+		// `inferFieldTypeFromLabel` matches on a label *prefix*, so a renamed field
+		// ("Please rate our website") is not recognized and its column renders as
+		// text. The response inspector behaves the same way, which is the point.
+		const [ column ] = getResponseFieldColumns( [
+			collectionResponse( [ { key: 'k', label: 'Please rate our website', value: '4/5' } ] ),
+		] );
+
+		expect( column.type ).toBe( 'text' );
+	} );
+
+	it( 'keeps an explicit field type over the label guess', () => {
+		const [ column ] = getResponseFieldColumns( [
+			collectionResponse( [ { key: 'k', label: 'Name', value: 'x', type: 'rating' } ] ),
+		] );
+
+		expect( column.type ).toBe( 'rating' );
+	} );
+
 	it( 'decodes entities in the column label', () => {
 		const [ column ] = getResponseFieldColumns( [
 			collectionResponse( [ { key: 'k', label: 'Tom &amp; Jerry', value: 'x' } ] ),
@@ -47,9 +74,11 @@ describe( 'getResponseFieldColumns', () => {
 			{ id: 1, fields: { Name: 'Ada', Message: 'Hello' } },
 		] );
 
+		// The legacy shape carries no type, so it is inferred from the label the way
+		// the response inspector does.
 		expect( columns ).toEqual( [
-			{ id: 'field:Name', key: 'Name', label: 'Name' },
-			{ id: 'field:Message', key: 'Message', label: 'Message' },
+			{ id: 'field:Name', key: 'Name', label: 'Name', type: 'name' },
+			{ id: 'field:Message', key: 'Message', label: 'Message', type: 'textarea' },
 		] );
 	} );
 
@@ -104,8 +133,8 @@ describe( 'getResponseFieldValue', () => {
 } );
 
 describe( 'mergeResponseFieldColumns', () => {
-	const a = { id: 'field:a', key: 'a', label: 'A' };
-	const b = { id: 'field:b', key: 'b', label: 'B' };
+	const a = { id: 'field:a', key: 'a', label: 'A', type: 'text' };
+	const b = { id: 'field:b', key: 'b', label: 'B', type: 'text' };
 
 	it( 'appends columns that are new', () => {
 		expect( mergeResponseFieldColumns( [ a ], [ a, b ] ) ).toEqual( [ a, b ] );

--- a/projects/packages/forms/src/dashboard/test/response-field-columns.test.js
+++ b/projects/packages/forms/src/dashboard/test/response-field-columns.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 import {
+	getResponseField,
 	getResponseFieldColumns,
 	getResponseFieldValue,
 	mergeResponseFieldColumns,
@@ -129,6 +130,17 @@ describe( 'getResponseFieldValue', () => {
 
 	it( 'renders a rating as submitted', () => {
 		expect( valueOf( '4/5' ) ).toBe( '4/5' );
+	} );
+} );
+
+describe( 'getResponseField', () => {
+	it( 'returns the field so a caller can read its raw value, not just the text', () => {
+		const response = collectionResponse( [
+			{ key: 'k', label: 'Sessions', value: [ 'Keynote', 'Panel' ], type: 'checkbox-multiple' },
+		] );
+
+		expect( getResponseField( response, 'k' ).value ).toEqual( [ 'Keynote', 'Panel' ] );
+		expect( getResponseField( response, 'missing' ) ).toBeUndefined();
 	} );
 } );
 

--- a/projects/plugins/jetpack/changelog/add-forms-per-form-field-columns
+++ b/projects/plugins/jetpack/changelog/add-forms-per-form-field-columns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Show each form field as a column when viewing a single form's responses.

--- a/projects/plugins/jetpack/changelog/add-forms-responses-mobile-columns
+++ b/projects/plugins/jetpack/changelog/add-forms-responses-mobile-columns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: On small screens, show only the response and its actions instead of a table that scrolls sideways.


### PR DESCRIPTION
## Proposed changes

On a single form's responses page, every field on that form now gets its own column, so you can read who answered what without opening each response one at a time.

* **Columns come from the responses themselves** — the union of fields across the loaded set — so a field added or removed since an older submission still gets a column instead of vanishing.
* **Values render per type, matching the response inspector.** A rating shows its star icons rather than `4/5`. Answers picked from a fixed set of choices — dropdown, radio, checkbox, consent — render as badges, and a multi-select renders one badge per choice. An email answer is a `mailto:` link, a phone answer a `tel:` link, and a website answer opens in a new tab — so they can be acted on straight from the table. As in the inspector, a value that does not look like its type (a website with no `http(s)://` scheme) stays plain text. An uploaded file shows its name (or "N files"), an image-select shows the chosen option's label, and an unanswered field shows an em dash. Long answers truncate to one line with the full text on hover.
* **The identity columns are frozen.** Answer columns make the table wider than the viewport, so the selection checkbox and **From** stay pinned to the leading edge while the answers scroll underneath — the same treatment DataViews already gives the trailing actions column. From also holds a minimum width so the address under the name is never cut off.
* **Every field column can be hidden** from the DataViews properties panel, and one the user hides stays hidden.
* **Small screens collapse to the response and its actions.** A table that scrolls sideways is no use on a phone, so below 782px every other column is dropped — on both response views. The user's chosen columns are preserved, not discarded, so widening the window brings them straight back.
* **"All responses" is unchanged on desktop.** It spans every form and has no shared field set, so it keeps the built-in columns only — and the frozen-column treatment is scoped to views that actually have answer columns. On mobile it collapses like the per-form view (see above).

Both dashboard implementations are updated — the wp-build route (`routes/responses/stage.tsx`, what users see today) and the legacy SPA (`src/dashboard/inbox/stage/index.jsx`) — sharing `src/dashboard/response-field-columns.tsx` and `src/dashboard/hooks/use-response-field-columns.ts` so the two can't drift.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No. The columns render field values already returned by the existing `fields_format=collection` payload and already shown in the response inspector. No new data is requested, stored, or tracked.

## Testing instructions

1. On a site with Jetpack Forms active and connected, enable central form management — the responses dashboard needs it to expose a per-form view:
   ```php
   add_filter( 'jetpack_block_editor_feature_flags', function ( $flags ) {
       $flags['central-form-management'] = true;
       return $flags;
   } );
   ```
2. Create a form with a wide spread of field types — name, email, phone, a dropdown, **a rating**, a multiple-choice, **an image-select**, **a file upload**, and a long textarea — and publish it on a page.
3. Submit it several times. Leave some fields blank on at least one submission, and upload more than one file on another.
4. Go to **Jetpack → Forms**, open the form, and view its responses.
5. **Expect:** one column per form field, between Date and Source. The rating column shows star icons, not `4/5`. The dropdown answer is a badge, and the multiple-choice answer is one badge per ticked option — the same treatment as the response sidebar. Email, phone and website answers are links (`mailto:` / `tel:` / new tab); a website typed without a scheme stays plain text. A multi-file upload reads "2 files", and blank answers show an em dash. Long answers truncate to one line and show in full on hover.
6. Scroll the table sideways. **Expect:** the checkbox and **From** columns stay pinned to the left while the answers scroll underneath, and the email under each name is never clipped.
7. Open the properties panel (the gear icon). **Expect:** every form field is listed and can be toggled off. Hide one — it should not come back when the list refreshes or you page through.
8. Open a different form's responses. **Expect:** only that form's fields as columns; the previous form's columns are gone.
9. Go back to **All responses**. **Expect:** unchanged — From, Date, Source, IP Address, Actions only, and no frozen columns.
10. Narrow the window below 782px (or open on a phone), on either view. **Expect:** only the response and its actions, and no sideways scrolling. Widen it again — the columns come back exactly as they were.

### Screenshots

Captured on a live Jurassic Ninja site at 1600×900.

**A single form's responses**

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-per-form-field-columns/before-single-form.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-per-form-field-columns/after-single-form.png) |

**Linked email, phone and website answers**

![links](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-per-form-field-columns/after-single-form-links.png)

**Rating icons, and badges for dropdown / multiple-choice answers**

![rating](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-per-form-field-columns/after-single-form-rating.png)

**Scrolled sideways — From stays frozen, file and long-text answers truncate**

| Before | After |
|---|---|
| ![before scrolled](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-per-form-field-columns/before-single-form-scrolled.png) | ![after scrolled](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-per-form-field-columns/after-single-form-scrolled.png) |

**Every field is a toggleable column**

![column picker](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-per-form-field-columns/after-column-picker.png)

**Small screens — response and actions only, no sideways scrolling**

| Per-form | All responses |
|---|---|
| ![mobile single](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-per-form-field-columns/after-mobile-single-form.png) | ![mobile all](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-per-form-field-columns/after-mobile-all-responses.png) |

**All responses on desktop — unchanged**

| Before | After |
|---|---|
| ![before all](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-per-form-field-columns/before-all-responses.png) | ![after all](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-per-form-field-columns/after-all-responses.png) |

### Known gaps

* Email and phone answers are plain links rather than the inspector's `FieldEmail`/`FieldPhone`, which add a copy-to-clipboard button and an async `libphonenumber-js` country lookup per value — the right weight for one open response, the wrong weight for every row of a table.
* A multi-select's badges sit on one line and clip, where the inspector stacks them vertically; stacking would let one response set the row height for the whole table.
* A legacy response whose rating field was renamed away from the default label falls back to text, because field-type inference matches on a label prefix. The response inspector behaves the same way.
* Two fields sharing a label produce two columns with identical headers.
* The mobile collapse is verified live (at an iPhone viewport the table reports `FROM`, `ACTIONS` and no horizontal overflow) but has no automated test — it lives in the two stage components rather than in the shared hook.
* An image-select answer shows its chosen label as text rather than the image card the inspector renders — a card would set the row height for the whole table.
