### PR TITLE
Revert "Revert "Charts: finish the ChartInstanceContext rename and drop the aliases""

### DIFF
--- a/projects/js-packages/charts/changelog/charts-259-chart-instance-context-rename
+++ b/projects/js-packages/charts/changelog/charts-259-chart-instance-context-rename
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal rename of the private single-chart context module; no user-facing change.
+
+

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
@@ -30,8 +30,8 @@ import {
 import { attachSubComponents } from '../../utils';
 import { renderDefaultTooltip } from '../line-chart';
 import { useChartChildren } from '../private/chart-composition';
+import { ChartInstanceContext, type ChartInstanceRef } from '../private/chart-instance-context';
 import { ChartLayout } from '../private/chart-layout';
-import { SingleChartContext, type SingleChartRef } from '../private/single-chart-context';
 import { SvgEmptyState } from '../private/svg-empty-state';
 import { getCurveType, getFormatter, guessOptimalNumTicks } from '../private/time-axis';
 import { withResponsive } from '../private/with-responsive';
@@ -43,7 +43,7 @@ import type { DataPointDate, Optional } from '../../types';
 import type { ResponsiveConfig } from '../private/with-responsive';
 import type { TickFormatter } from '@visx/axis';
 
-const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
+const AreaChartInternal = forwardRef< ChartInstanceRef, AreaChartProps >(
 	(
 		{
 			data,
@@ -91,7 +91,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 		const chartRef = useRef< HTMLDivElement >( null );
 		const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 		const [ isNavigating, setIsNavigating ] = useState( false );
-		const internalChartRef = useRef< SingleChartRef >( null );
+		const internalChartRef = useRef< ChartInstanceRef >( null );
 
 		const zoom = useXZoom< Date >( {
 			enabled: zoomable,
@@ -365,7 +365,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 		};
 
 		return (
-			<SingleChartContext.Provider
+			<ChartInstanceContext.Provider
 				value={ {
 					chartId,
 					chartRef: internalChartRef,
@@ -503,7 +503,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 						);
 					} }
 				</ChartLayout>
-			</SingleChartContext.Provider>
+			</ChartInstanceContext.Provider>
 		);
 	}
 );
@@ -515,16 +515,16 @@ type AreaChartSubComponents = {
 type AreaChartBaseProps = Optional< AreaChartProps, 'width' | 'height' | 'size' >;
 
 type AreaChartComponent = React.ForwardRefExoticComponent<
-	AreaChartBaseProps & React.RefAttributes< SingleChartRef >
+	AreaChartBaseProps & React.RefAttributes< ChartInstanceRef >
 > &
 	AreaChartSubComponents;
 
 type AreaChartResponsiveComponent = React.ForwardRefExoticComponent<
-	AreaChartBaseProps & ResponsiveConfig & React.RefAttributes< SingleChartRef >
+	AreaChartBaseProps & ResponsiveConfig & React.RefAttributes< ChartInstanceRef >
 > &
 	AreaChartSubComponents;
 
-const AreaChartWithProvider = forwardRef< SingleChartRef, AreaChartProps >( ( props, ref ) => {
+const AreaChartWithProvider = forwardRef< ChartInstanceRef, AreaChartProps >( ( props, ref ) => {
 	const existingContext = useContext( GlobalChartsContext );
 
 	if ( existingContext ) {

--- a/projects/js-packages/charts/src/charts/area-chart/private/overlays.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/private/overlays.tsx
@@ -2,7 +2,7 @@ import { DataContext, TooltipContext } from '@visx/xychart';
 import { useContext, useImperativeHandle } from 'react';
 import type { ElementStyles, GetElementStylesParams } from '../../../providers';
 import type { DataPointDate, SeriesData } from '../../../types';
-import type { SingleChartRef } from '../../private/single-chart-context';
+import type { ChartInstanceRef } from '../../private/chart-instance-context';
 import type { FC, ReactNode, Ref } from 'react';
 
 export type VisibleSeriesEntry = { series: SeriesData; index: number; isVisible: boolean };
@@ -11,10 +11,10 @@ export type VisibleSeriesEntry = { series: SeriesData; index: number; isVisible:
 // instead of spreading `any`. `Number(...)` + `isFinite` guards every call.
 type ScaleFn = ( input: Date | number ) => number;
 
-// Bridges visx's `DataContext` to the chart's `SingleChartRef` so consumers
+// Bridges visx's `DataContext` to the chart's `ChartInstanceRef` so consumers
 // can read scales and dimensions imperatively. Must be inside `<XYChart>`.
 export const AreaChartScalesRef: FC< {
-	chartRef?: Ref< SingleChartRef >;
+	chartRef?: Ref< ChartInstanceRef >;
 	width: number;
 	height: number;
 	margin?: { top?: number; right?: number; bottom?: number; left?: number };

--- a/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { createRef } from 'react';
 import { GlobalChartsProvider } from '../../../providers';
 import AreaChart, { AreaChartUnresponsive } from '../area-chart';
-import type { SingleChartRef } from '../../private/single-chart-context';
+import type { ChartInstanceRef } from '../../private/chart-instance-context';
 
 const mockRefCallback = jest.fn();
 jest.mock( '../../../hooks/use-element-size', () => ( {
@@ -42,7 +42,7 @@ describe( 'AreaChart', () => {
 		);
 	};
 
-	const renderUnresponsive = ( props = {}, ref?: React.Ref< SingleChartRef > ) => {
+	const renderUnresponsive = ( props = {}, ref?: React.Ref< ChartInstanceRef > ) => {
 		return render(
 			<GlobalChartsProvider>
 				<AreaChartUnresponsive { ...defaultProps } { ...props } ref={ ref } />
@@ -242,7 +242,7 @@ describe( 'AreaChart', () => {
 
 		test( 'y-axis rescales across legend toggles by default', async () => {
 			const user = userEvent.setup();
-			const ref = createRef< SingleChartRef >();
+			const ref = createRef< ChartInstanceRef >();
 			render(
 				<GlobalChartsProvider>
 					<AreaChartUnresponsive
@@ -274,7 +274,7 @@ describe( 'AreaChart', () => {
 			// Exercises the non-stacked branch of fixedYDomain, which scans the
 			// raw min/max across all series rather than summing stack columns.
 			const user = userEvent.setup();
-			const ref = createRef< SingleChartRef >();
+			const ref = createRef< ChartInstanceRef >();
 			render(
 				<GlobalChartsProvider>
 					<AreaChartUnresponsive
@@ -306,7 +306,7 @@ describe( 'AreaChart', () => {
 
 		test( 'y-axis stays pinned when rescaleYOnLegendToggle is false', async () => {
 			const user = userEvent.setup();
-			const ref = createRef< SingleChartRef >();
+			const ref = createRef< ChartInstanceRef >();
 			render(
 				<GlobalChartsProvider>
 					<AreaChartUnresponsive
@@ -335,7 +335,7 @@ describe( 'AreaChart', () => {
 
 		test( 'y-axis stays pinned when rescaleYOnVisibilityChange is false', async () => {
 			const user = userEvent.setup();
-			const ref = createRef< SingleChartRef >();
+			const ref = createRef< ChartInstanceRef >();
 			render(
 				<GlobalChartsProvider>
 					<AreaChartUnresponsive
@@ -367,7 +367,7 @@ describe( 'AreaChart', () => {
 			// opts into pinned-Y behavior; visx's natural domain derivation for
 			// a `stackOffset: 'none'` stack does not extend below zero for
 			// purely-negative series, which is what this test guards against.
-			const ref = createRef< SingleChartRef >();
+			const ref = createRef< ChartInstanceRef >();
 			render(
 				<GlobalChartsProvider>
 					<AreaChartUnresponsive
@@ -406,7 +406,7 @@ describe( 'AreaChart', () => {
 		} );
 
 		test( 'does not pin domain for non-default stack offsets', () => {
-			const ref = createRef< SingleChartRef >();
+			const ref = createRef< ChartInstanceRef >();
 			render(
 				<GlobalChartsProvider>
 					<AreaChartUnresponsive
@@ -448,7 +448,7 @@ describe( 'AreaChart', () => {
 
 	describe( 'Chart Ref Interface', () => {
 		test( 'exposes getScales via ref', () => {
-			const ref = createRef< SingleChartRef >();
+			const ref = createRef< ChartInstanceRef >();
 			renderUnresponsive( {}, ref );
 
 			expect( ref.current?.getScales() ).toBeDefined();
@@ -457,7 +457,7 @@ describe( 'AreaChart', () => {
 		} );
 
 		test( 'exposes getChartDimensions via ref', () => {
-			const ref = createRef< SingleChartRef >();
+			const ref = createRef< ChartInstanceRef >();
 			renderUnresponsive( { width: 800, height: 400 }, ref );
 
 			const dimensions = ref.current?.getChartDimensions();

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -22,8 +22,8 @@ import {
 } from '../../providers';
 import { attachSubComponents } from '../../utils';
 import { useChartChildren } from '../private/chart-composition';
+import { ChartInstanceContext } from '../private/chart-instance-context';
 import { ChartLayout } from '../private/chart-layout';
-import { SingleChartContext } from '../private/single-chart-context';
 import { SvgEmptyState } from '../private/svg-empty-state';
 import { withResponsive } from '../private/with-responsive';
 import styles from './bar-chart.module.scss';
@@ -514,7 +514,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	);
 
 	return (
-		<SingleChartContext.Provider
+		<ChartInstanceContext.Provider
 			value={ {
 				chartId,
 				chartWidth: width,
@@ -673,7 +673,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 					);
 				} }
 			</ChartLayout>
-		</SingleChartContext.Provider>
+		</ChartInstanceContext.Provider>
 	);
 };
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -21,8 +21,8 @@ import {
 import { resolveCssVariable } from '../../utils/resolve-css-var';
 import { Center } from '../private/center';
 import { useChartChildren } from '../private/chart-composition';
+import { ChartInstanceContext } from '../private/chart-instance-context';
 import { ChartLayout } from '../private/chart-layout';
-import { SingleChartContext } from '../private/single-chart-context';
 import { withResponsive } from '../private/with-responsive';
 import styles from './heatmap-chart.module.scss';
 import {
@@ -313,7 +313,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 
 	return (
 		<HeatmapContext.Provider value={ heatmapContext }>
-			<SingleChartContext.Provider value={ { chartId } }>
+			<ChartInstanceContext.Provider value={ { chartId } }>
 				<ChartLayout
 					legendPosition="bottom"
 					// Legend renders via trailingContent, not the legend slot.
@@ -456,7 +456,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 						</TooltipInPortal>
 					) }
 				</ChartLayout>
-			</SingleChartContext.Provider>
+			</ChartInstanceContext.Provider>
 		</HeatmapContext.Provider>
 	);
 };

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -17,8 +17,8 @@ import {
 } from '../../providers';
 import { formatMetricValue, attachSubComponents } from '../../utils';
 import { useChartChildren } from '../private/chart-composition';
+import { ChartInstanceContext } from '../private/chart-instance-context';
 import { ChartLayout } from '../private/chart-layout';
-import { SingleChartContext } from '../private/single-chart-context';
 import { withResponsive } from '../private/with-responsive';
 import { useFittedRowCount, useLeaderboardLegendItems } from './hooks';
 import styles from './leaderboard-chart.module.scss';
@@ -291,7 +291,7 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 	// Handle empty or undefined data
 	if ( ! data || data.length === 0 ) {
 		return (
-			<SingleChartContext.Provider value={ { chartId } }>
+			<ChartInstanceContext.Provider value={ { chartId } }>
 				<ChartLayout
 					legendPosition={ legendPosition }
 					legendElement={ false }
@@ -315,7 +315,7 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 							: __( 'No data available', 'jetpack-charts' ) }
 					</div>
 				</ChartLayout>
-			</SingleChartContext.Provider>
+			</ChartInstanceContext.Provider>
 		);
 	}
 
@@ -335,7 +335,7 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 	);
 
 	return (
-		<SingleChartContext.Provider value={ { chartId } }>
+		<ChartInstanceContext.Provider value={ { chartId } }>
 			<ChartLayout
 				legendPosition={ legendPosition }
 				legendElement={ legendElement }
@@ -476,7 +476,7 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 					) }
 				</div>
 			</ChartLayout>
-		</SingleChartContext.Provider>
+		</ChartInstanceContext.Provider>
 	);
 };
 

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -31,9 +31,9 @@ import {
 } from '../../providers';
 import { attachSubComponents } from '../../utils';
 import { useChartChildren } from '../private/chart-composition';
+import { ChartInstanceContext, type ChartInstanceRef } from '../private/chart-instance-context';
 import { ChartLayout } from '../private/chart-layout';
 import { DefaultGlyph } from '../private/default-glyph';
-import { SingleChartContext, type SingleChartRef } from '../private/single-chart-context';
 import { SvgEmptyState } from '../private/svg-empty-state';
 import { getCurveType, getFormatter, guessOptimalNumTicks } from '../private/time-axis';
 import { withResponsive } from '../private/with-responsive';
@@ -119,7 +119,7 @@ const validateData = ( data: SeriesData[] ) => {
 
 // Inner component to access DataContext and provide scale data to ref
 const LineChartScalesRef: FC< {
-	chartRef?: Ref< SingleChartRef >;
+	chartRef?: Ref< ChartInstanceRef >;
 	width: number;
 	height: number;
 	margin?: { top?: number; right?: number; bottom?: number; left?: number };
@@ -150,7 +150,7 @@ const LineChartScalesRef: FC< {
 	return null; // This component only provides the ref interface
 };
 
-const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
+const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 	(
 		{
 			data,
@@ -199,7 +199,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 		const chartRef = useRef< HTMLDivElement >( null );
 		const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 		const [ isNavigating, setIsNavigating ] = useState( false );
-		const internalChartRef = useRef< SingleChartRef >( null );
+		const internalChartRef = useRef< ChartInstanceRef >( null );
 
 		const zoom = useXZoom< Date >( {
 			enabled: zoomable,
@@ -412,7 +412,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 		);
 
 		return (
-			<SingleChartContext.Provider
+			<ChartInstanceContext.Provider
 				value={ {
 					chartId,
 					chartRef: internalChartRef,
@@ -619,7 +619,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 						);
 					} }
 				</ChartLayout>
-			</SingleChartContext.Provider>
+			</ChartInstanceContext.Provider>
 		);
 	}
 );
@@ -634,16 +634,16 @@ type LineChartAnnotationComponents = {
 type LineChartBaseProps = Optional< LineChartProps, 'width' | 'height' | 'size' >;
 
 type LineChartComponent = React.ForwardRefExoticComponent<
-	LineChartBaseProps & React.RefAttributes< SingleChartRef >
+	LineChartBaseProps & React.RefAttributes< ChartInstanceRef >
 > &
 	LineChartAnnotationComponents;
 
 type LineChartResponsiveComponent = React.ForwardRefExoticComponent<
-	LineChartBaseProps & ResponsiveConfig & React.RefAttributes< SingleChartRef >
+	LineChartBaseProps & ResponsiveConfig & React.RefAttributes< ChartInstanceRef >
 > &
 	LineChartAnnotationComponents;
 
-const LineChartWithProvider = forwardRef< SingleChartRef, LineChartProps >( ( props, ref ) => {
+const LineChartWithProvider = forwardRef< ChartInstanceRef, LineChartProps >( ( props, ref ) => {
 	const existingContext = useContext( GlobalChartsContext );
 
 	// If we're already in a GlobalChartsProvider context, render the core component directly

--- a/projects/js-packages/charts/src/charts/line-chart/private/line-chart-annotations-overlay.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/private/line-chart-annotations-overlay.tsx
@@ -1,6 +1,6 @@
 import { DataContext } from '@visx/xychart';
 import { useEffect, useState, useCallback } from 'react';
-import { useSingleChartContext } from '../../private/single-chart-context';
+import { useChartInstanceContext } from '../../private/chart-instance-context';
 import styles from '../line-chart.module.scss';
 import type { AxisScale } from '@visx/axis';
 import type { FC, ReactNode } from 'react';
@@ -15,7 +15,7 @@ interface ScaleData {
 }
 
 const LineChartAnnotationsOverlay: FC< LineChartAnnotationsProps > = ( { children } ) => {
-	const { chartRef, chartWidth, chartHeight } = useSingleChartContext();
+	const { chartRef, chartWidth, chartHeight } = useChartInstanceContext();
 
 	const [ scales, setScales ] = useState< ScaleData | null >( null );
 	const [ scalesStable, setScalesStable ] = useState< boolean >( false );

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -6,7 +6,7 @@ import { GlyphDiamond } from '@visx/glyph';
 import { createElement, createRef } from 'react';
 import { GlobalChartsProvider, defaultTheme } from '../../../providers';
 import LineChart, { LineChartUnresponsive } from '../line-chart';
-import type { SingleChartRef } from '../../private/single-chart-context';
+import type { ChartInstanceRef } from '../../private/chart-instance-context';
 
 // Mock useElementSize to return non-zero dimensions in jsdom so charts render
 const mockRefCallback = jest.fn();
@@ -902,7 +902,7 @@ describe( 'LineChart', () => {
 
 	describe( 'Chart Ref Interface', () => {
 		test( 'exposes getScales method via ref', () => {
-			const ref = createRef< SingleChartRef >();
+			const ref = createRef< ChartInstanceRef >();
 			renderUnwrappedWithTheme( {}, 'default', ref );
 
 			expect( ref.current?.getScales() ).toBeDefined();
@@ -911,7 +911,7 @@ describe( 'LineChart', () => {
 		} );
 
 		test( 'exposes getChartDimensions method via ref', () => {
-			const ref = createRef< SingleChartRef >();
+			const ref = createRef< ChartInstanceRef >();
 			renderUnwrappedWithTheme( { width: 800, height: 400 }, 'default', ref );
 
 			const dimensions = ref.current?.getChartDimensions();

--- a/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-chart/pie-chart.tsx
@@ -24,9 +24,9 @@ import { attachSubComponents, resolveFontSize } from '../../utils';
 import { getStringWidth } from '../../visx/text';
 import { Center } from '../private/center';
 import { ChartSVG, ChartHTML, useChartChildren } from '../private/chart-composition';
+import { ChartInstanceContext } from '../private/chart-instance-context';
 import { ChartLayout } from '../private/chart-layout';
 import { RadialWipeAnimation } from '../private/radial-wipe-animation/';
-import { SingleChartContext } from '../private/single-chart-context';
 import { SvgEmptyState } from '../private/svg-empty-state';
 import { withResponsive, ResponsiveConfig } from '../private/with-responsive';
 import styles from './pie-chart.module.scss';
@@ -308,7 +308,7 @@ const PieChartInternal = ( {
 	);
 
 	return (
-		<SingleChartContext.Provider value={ { chartId } }>
+		<ChartInstanceContext.Provider value={ { chartId } }>
 			<ChartLayout
 				legendPosition={ legendPosition }
 				legendElement={ legendElement }
@@ -495,7 +495,7 @@ const PieChartInternal = ( {
 					);
 				} }
 			</ChartLayout>
-		</SingleChartContext.Provider>
+		</ChartInstanceContext.Provider>
 	);
 };
 

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/pie-semi-circle-chart.tsx
@@ -23,9 +23,9 @@ import { CHART_SCOPE_CLASS } from '../../styles/chart-scope-class';
 import { attachSubComponents } from '../../utils';
 import { Center } from '../private/center';
 import { ChartSVG, ChartHTML, useChartChildren } from '../private/chart-composition';
+import { ChartInstanceContext } from '../private/chart-instance-context';
 import { ChartLayout } from '../private/chart-layout';
 import { RadialWipeAnimation } from '../private/radial-wipe-animation';
-import { SingleChartContext } from '../private/single-chart-context';
 import { SvgEmptyState } from '../private/svg-empty-state';
 import { withResponsive } from '../private/with-responsive';
 import styles from './pie-semi-circle-chart.module.scss';
@@ -353,7 +353,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 	);
 
 	return (
-		<SingleChartContext.Provider value={ { chartId } }>
+		<ChartInstanceContext.Provider value={ { chartId } }>
 			<ChartLayout
 				legendPosition={ legendPosition }
 				legendElement={ legendElement }
@@ -493,7 +493,7 @@ const PieSemiCircleChartInternal: FC< PieSemiCircleChartProps > = ( {
 					);
 				} }
 			</ChartLayout>
-		</SingleChartContext.Provider>
+		</ChartInstanceContext.Provider>
 	);
 };
 

--- a/projects/js-packages/charts/src/charts/private/chart-instance-context/chart-instance-context.ts
+++ b/projects/js-packages/charts/src/charts/private/chart-instance-context/chart-instance-context.ts
@@ -18,8 +18,3 @@ export interface ChartInstanceContextValue {
 }
 
 export const ChartInstanceContext = createContext< ChartInstanceContextValue | null >( null );
-
-// Backward compatibility exports
-export const SingleChartContext = ChartInstanceContext;
-export type SingleChartContextValue = ChartInstanceContextValue;
-export type SingleChartRef = ChartInstanceRef;

--- a/projects/js-packages/charts/src/charts/private/chart-instance-context/index.ts
+++ b/projects/js-packages/charts/src/charts/private/chart-instance-context/index.ts
@@ -1,0 +1,3 @@
+export { ChartInstanceContext } from './chart-instance-context';
+export { useChartInstanceContext } from './use-chart-instance-context';
+export type { ChartInstanceContextValue, ChartInstanceRef } from './chart-instance-context';

--- a/projects/js-packages/charts/src/charts/private/chart-instance-context/use-chart-instance-context.ts
+++ b/projects/js-packages/charts/src/charts/private/chart-instance-context/use-chart-instance-context.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { ChartInstanceContext, type ChartInstanceContextValue } from './single-chart-context';
+import { ChartInstanceContext, type ChartInstanceContextValue } from './chart-instance-context';
 
 export const useChartInstanceContext = (): ChartInstanceContextValue => {
 	const context = useContext( ChartInstanceContext );
@@ -8,5 +8,3 @@ export const useChartInstanceContext = (): ChartInstanceContextValue => {
 	}
 	return context;
 };
-
-export const useSingleChartContext = useChartInstanceContext;

--- a/projects/js-packages/charts/src/charts/private/single-chart-context/index.ts
+++ b/projects/js-packages/charts/src/charts/private/single-chart-context/index.ts
@@ -1,8 +1,0 @@
-export { SingleChartContext, ChartInstanceContext } from './single-chart-context';
-export { useChartInstanceContext, useSingleChartContext } from './use-single-chart-context';
-export type {
-	ChartInstanceContextValue,
-	ChartInstanceRef,
-	SingleChartContextValue,
-	SingleChartRef,
-} from './single-chart-context';

--- a/projects/js-packages/charts/src/charts/private/x-zoom/test/x-zoom.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/x-zoom/test/x-zoom.test.tsx
@@ -2,7 +2,7 @@ import { act, render, renderHook, screen, waitFor } from '@testing-library/react
 import userEvent from '@testing-library/user-event';
 import { useCallback, useRef, useState } from 'react';
 import { useXZoom, ZoomResetButton } from '../index';
-import type { SingleChartRef } from '../../single-chart-context';
+import type { ChartInstanceRef } from '../../chart-instance-context';
 import type { EventHandlerParams } from '@visx/xychart';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
@@ -23,7 +23,7 @@ const makeChartRef = (
 			getScales: () => ( scale ? { xScale: scale, yScale: scale } : null ),
 			getChartDimensions: () => ( { width: 0, height: 0, margin: {} } ),
 		},
-	} ) as unknown as ReturnType< typeof useRef< SingleChartRef > >;
+	} ) as unknown as ReturnType< typeof useRef< ChartInstanceRef > >;
 
 const makeParams = ( x: number ): EventHandlerParams< object > =>
 	( {

--- a/projects/js-packages/charts/src/charts/private/x-zoom/x-zoom.tsx
+++ b/projects/js-packages/charts/src/charts/private/x-zoom/x-zoom.tsx
@@ -3,7 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/ui';
 import { useCallback, useContext, useMemo, useState } from 'react';
 import styles from './x-zoom.module.scss';
-import type { SingleChartRef } from '../single-chart-context';
+import type { ChartInstanceRef } from '../chart-instance-context';
 import type { AxisScale } from '@visx/axis';
 import type { EventHandlerParams } from '@visx/xychart';
 import type { KeyboardEvent, ReactNode, RefObject } from 'react';
@@ -38,7 +38,7 @@ export function useXZoom< T extends Date | number = Date >( {
 	userHandlers,
 }: {
 	enabled: boolean;
-	chartRef: RefObject< SingleChartRef | null >;
+	chartRef: RefObject< ChartInstanceRef | null >;
 	userHandlers?: {
 		onPointerDown?: PointerHandler;
 		onPointerMove?: PointerHandler;

--- a/projects/js-packages/charts/src/components/legend/legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/legend.tsx
@@ -1,5 +1,5 @@
 import { useContext, useMemo, forwardRef } from 'react';
-import { SingleChartContext } from '../../charts/private/single-chart-context';
+import { ChartInstanceContext } from '../../charts/private/chart-instance-context';
 import { GlobalChartsContext } from '../../providers';
 import { BaseLegend } from './private';
 import type { LegendProps } from './types';
@@ -20,11 +20,11 @@ export const Legend = forwardRef< HTMLDivElement, LegendProps >(
 	( { chartId, items, shape, ...props }, ref ) => {
 		// Get context but don't throw if it doesn't exist
 		const context = useContext( GlobalChartsContext );
-		const singleChartContext = useContext( SingleChartContext );
+		const chartInstanceContext = useContext( ChartInstanceContext );
 
 		// When chartId is used, it is standalone mode
-		// When chartId is not provided, we use the context's chartId, meaning it is in a single chart context
-		const contextChartId = chartId ?? singleChartContext?.chartId;
+		// When chartId is not provided, we use the context's chartId, meaning it is inside a chart instance
+		const contextChartId = chartId ?? chartInstanceContext?.chartId;
 
 		const chartData = useMemo(
 			() => ( contextChartId && context ? context.getChartData( contextChartId ) : undefined ),

--- a/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
+++ b/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
@@ -2,7 +2,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useMemo } from 'react';
-import { SingleChartContext } from '../../../charts/private/single-chart-context';
+import { ChartInstanceContext } from '../../../charts/private/chart-instance-context';
 import {
 	GlobalChartsProvider,
 	useChartId,
@@ -473,9 +473,9 @@ describe( 'BaseLegend', () => {
 			return render(
 				<GlobalChartsProvider>
 					<ChartRegistrar chartType={ chartType } chartId={ chartId } />
-					<SingleChartContext.Provider value={ { chartId } }>
+					<ChartInstanceContext.Provider value={ { chartId } }>
 						<Legend shape={ explicitShape } />
-					</SingleChartContext.Provider>
+					</ChartInstanceContext.Provider>
 				</GlobalChartsProvider>
 			);
 		};


### PR DESCRIPTION
Reverts Automattic/jetpack#51450 which was reverted to allow for the Charts 3.0 release to be published first.

## Testing instructions:

See https://github.com/Automattic/jetpack/pull/51373

## Does this pull request change what data or activity we track or use?

No