### PR TITLE
Backup: give the no-plan gate a way out, and stop guessing at plans

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-no-plan-gate-and-capabilities
+++ b/projects/packages/backup/changelog/fix-backup-no-plan-gate-and-capabilities
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: give the modernized dashboard's no-plan screen a site-scoped upgrade link and a license-key path, point the connection prompts at My Jetpack instead of a page the standalone plugin does not register, refuse an unreadable capabilities response rather than reporting it as "no plan", and keep the capabilities error on screen while it is retried. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/changelog/fix-backup-no-plan-gate-and-capabilities
+++ b/projects/packages/backup/changelog/fix-backup-no-plan-gate-and-capabilities
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Backup: give the modernized dashboard's no-plan screen a site-scoped upgrade link and a license-key path, point the connection prompts at My Jetpack instead of a page the standalone plugin does not register, refuse an unreadable capabilities response rather than reporting it as "no plan", and keep the capabilities error on screen while it is retried. No-op when the modernization filter is off.
+Comment: Backup: give the modernized dashboard's no-plan screen a site-scoped upgrade link and a license-key path, point the connection prompts at My Jetpack instead of a page that never reached a connection screen, refuse an unreadable capabilities response rather than reporting it as "no plan", and keep the capabilities error on screen while it is retried. No-op when the modernization filter is off.
 
 

--- a/projects/packages/backup/src/dashboard/components/gates/capabilities-error.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/capabilities-error.tsx
@@ -5,6 +5,8 @@ import { Stack, Text } from '@wordpress/ui';
 type Props = {
 	error: Error;
 	onRetry: () => void;
+	/** A retry is already in flight. */
+	isRetrying?: boolean;
 };
 
 /**
@@ -16,12 +18,13 @@ type Props = {
  * the plan is not the same as having no plan, so say so and offer a
  * retry.
  *
- * @param props         - Component props.
- * @param props.error   - The error the capabilities query failed with.
- * @param props.onRetry - Refetches the capabilities query.
+ * @param props            - Component props.
+ * @param props.error      - The error the capabilities query failed with.
+ * @param props.onRetry    - Refetches the capabilities query.
+ * @param props.isRetrying - Whether a retry is already in flight.
  * @return The rendered fallback.
  */
-export default function CapabilitiesErrorScreen( { error, onRetry }: Props ) {
+export default function CapabilitiesErrorScreen( { error, onRetry, isRetrying = false }: Props ) {
 	return (
 		<Card className="jpb-gates__card">
 			<Stack direction="column" gap="md" align="center">
@@ -37,7 +40,19 @@ export default function CapabilitiesErrorScreen( { error, onRetry }: Props ) {
 						'jetpack-backup-pkg'
 					) }
 				</Text>
-				<Button variant="primary" onClick={ onRetry }>
+				{ /*
+				 * Busy rather than merely clickable. The screen holds its
+				 * error across the retry now, so without this the DOM is
+				 * byte-identical before and after the click and a retry
+				 * that fails again reads as a dead button.
+				 */ }
+				<Button
+					variant="primary"
+					onClick={ onRetry }
+					isBusy={ isRetrying }
+					disabled={ isRetrying }
+					aria-disabled={ isRetrying }
+				>
 					{ __( 'Try again', 'jetpack-backup-pkg' ) }
 				</Button>
 			</Stack>

--- a/projects/packages/backup/src/dashboard/components/gates/capabilities-error.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/capabilities-error.tsx
@@ -45,13 +45,24 @@ export default function CapabilitiesErrorScreen( { error, onRetry, isRetrying = 
 				 * error across the retry now, so without this the DOM is
 				 * byte-identical before and after the click and a retry
 				 * that fails again reads as a dead button.
+				 *
+				 * `accessibleWhenDisabled` is what keeps this from undoing
+				 * the fix for keyboard users. `Button` sets the *native*
+				 * `disabled` attribute unless it is passed
+				 * (`trulyDisabled = disabled && ! accessibleWhenDisabled`),
+				 * and a browser blurs the element it has just disabled —
+				 * so focus would land on `<body>`. This card is the entire
+				 * dashboard body on all three routes, so there is nothing
+				 * adjacent to land on: the page would disappear for
+				 * exactly the readers the visual fix does not reach. The
+				 * prop also applies `aria-disabled` itself.
 				 */ }
 				<Button
 					variant="primary"
 					onClick={ onRetry }
 					isBusy={ isRetrying }
 					disabled={ isRetrying }
-					aria-disabled={ isRetrying }
+					accessibleWhenDisabled
 				>
 					{ __( 'Try again', 'jetpack-backup-pkg' ) }
 				</Button>

--- a/projects/packages/backup/src/dashboard/components/gates/capabilities-error.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/capabilities-error.tsx
@@ -34,28 +34,30 @@ export default function CapabilitiesErrorScreen( { error, onRetry, isRetrying = 
 				<Notice status="error" isDismissible={ false }>
 					{ error.message }
 				</Notice>
+				{ /*
+				 * Not "this is usually temporary". This screen also covers
+				 * `capabilities_unreadable`, which is upstream shape drift —
+				 * no amount of retrying clears it, so the copy has to leave
+				 * the reader somewhere to go when the button doesn't help.
+				 */ }
 				<Text>
 					{ __(
-						'This is usually temporary. Try again in a moment — your backups are unaffected.',
+						'Your backups are unaffected. Try again, and contact support if this keeps happening.',
 						'jetpack-backup-pkg'
 					) }
 				</Text>
 				{ /*
-				 * Busy rather than merely clickable. The screen holds its
-				 * error across the retry now, so without this the DOM is
+				 * Busy rather than merely clickable: the screen holds its
+				 * error across a retry, so without this the DOM is
 				 * byte-identical before and after the click and a retry
 				 * that fails again reads as a dead button.
 				 *
-				 * `accessibleWhenDisabled` is what keeps this from undoing
-				 * the fix for keyboard users. `Button` sets the *native*
-				 * `disabled` attribute unless it is passed
-				 * (`trulyDisabled = disabled && ! accessibleWhenDisabled`),
-				 * and a browser blurs the element it has just disabled —
-				 * so focus would land on `<body>`. This card is the entire
-				 * dashboard body on all three routes, so there is nothing
-				 * adjacent to land on: the page would disappear for
-				 * exactly the readers the visual fix does not reach. The
-				 * prop also applies `aria-disabled` itself.
+				 * `accessibleWhenDisabled` keeps that from costing keyboard
+				 * users the page. `Button` sets the *native* `disabled`
+				 * attribute unless it is passed, and a browser blurs the
+				 * element it has just disabled — focus would land on
+				 * `<body>`, and this card is the entire dashboard body, so
+				 * there is nothing adjacent to land on.
 				 */ }
 				<Button
 					variant="primary"

--- a/projects/packages/backup/src/dashboard/components/gates/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/index.tsx
@@ -18,6 +18,12 @@ type Props = {
  * Top-to-bottom decision tree, first match wins:
  * not-connected → secondary-admin → loading → capabilities-error → no-plan → children
  *
+ * The loading branch is deliberately first-load-only. It sits above the
+ * error branch, so a retry that made the query "loading" again would
+ * replace the error screen — reason, explanation and the only control
+ * that can ask again — with a bare spinner, for the whole round trip.
+ * See `useCapabilities`.
+ *
  * The connection checks come first because they're synchronous — they
  * read a global PHP emitted into the page. Gating them behind the
  * capabilities spinner would make a disconnected site sit through a
@@ -55,7 +61,11 @@ export default function Gates( { children }: Props ) {
 	// don't have a plan".
 	if ( capabilities.error ) {
 		return (
-			<CapabilitiesErrorScreen error={ capabilities.error } onRetry={ capabilities.refetch } />
+			<CapabilitiesErrorScreen
+				error={ capabilities.error }
+				onRetry={ capabilities.refetch }
+				isRetrying={ capabilities.isRetrying }
+			/>
 		);
 	}
 

--- a/projects/packages/backup/src/dashboard/components/gates/license-key-link.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/license-key-link.tsx
@@ -2,45 +2,32 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Where a license key is redeemed.
+ * Where a license key is redeemed. My Jetpack owns redemption for the
+ * standalone plugins; Backup has no redemption UI of its own.
  *
- * Relative on purpose. The legacy header built this from the connection
- * store's `adminUrl` (`src/js/components/Admin/index.jsx:66-69`), but
- * that store is populated from `JPBACKUP_INITIAL_STATE`, which the
- * modernized page deliberately does not emit — `enqueue_admin_scripts()`
- * returns before it. A relative path needs none of that: this only ever
- * renders from `admin.php`, so the browser resolves it against the same
- * directory the absolute form would have produced.
- *
- * My Jetpack owns license redemption for the standalone plugins; Backup
- * has no redemption UI of its own to link to.
+ * Relative on purpose: the legacy header built this from the connection
+ * store's `adminUrl`, which comes from `JPBACKUP_INITIAL_STATE` — and
+ * the modernized page deliberately does not emit that. This only ever
+ * renders from `admin.php`, so the browser resolves a relative path
+ * against the same directory the absolute form would have produced.
  */
 const ADD_LICENSE_URL = 'admin.php?page=my-jetpack#/add-license';
 
 /**
  * The way in for someone who has already bought Backup.
  *
- * The label is the one five other Jetpack products already ship, and
- * which this package itself still ships from the legacy header
- * (`src/js/components/Admin/index.jsx:82`) — so it arrives translated in
- * every locale rather than waiting a GlotPress cycle, and it matches the
- * phrase on the My Jetpack screen the reader is about to land on.
+ * The label is the one this package's legacy header already ships, so it
+ * arrives translated and matches the phrase on the My Jetpack screen the
+ * reader is about to land on.
  *
- * Where it appears is a small, deliberate widening rather than parity.
- * Legacy's `useShowActivateLicenseLink` returned true both when the site
- * was not fully connected and when it was connected without a plan — but
- * it only fed `headerActions`, and the secondary-admin path renders
- * `<AdminPage showHeader={ false }>` (`index.jsx:429`), so the link was
- * hidden there. It is shown on all three screens now: someone who bought
- * a license and hit a "link your account" wall is exactly who needs it.
+ * Legacy showed this only where `<AdminPage>` rendered a header, which
+ * excluded the secondary-admin path. Showing it on all three screens is
+ * a deliberate widening: someone who bought a license and hit a "link
+ * your account" wall is exactly who needs it.
  *
  * @return The rendered link.
  */
 export default function LicenseKeyLink() {
-	// `variant="link"` rather than a bare anchor: it brings the focus
-	// ring, hover treatment and type scale that the hand-rolled
-	// `jpb-gates__cta` next to it reimplements in SCSS. Rendered with an
-	// `href`, so it is still an `<a>` and still has the link role.
 	return (
 		<Button variant="link" href={ ADD_LICENSE_URL }>
 			{ __( 'Use license key', 'jetpack-backup-pkg' ) }

--- a/projects/packages/backup/src/dashboard/components/gates/license-key-link.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/license-key-link.tsx
@@ -1,0 +1,37 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Where a license key is redeemed.
+ *
+ * Relative on purpose. The legacy header built this from the connection
+ * store's `adminUrl` (`src/js/components/Admin/index.jsx:66-69`), but
+ * that store is populated from `JPBACKUP_INITIAL_STATE`, which the
+ * modernized page deliberately does not emit — `enqueue_admin_scripts()`
+ * returns before it. A relative path needs none of that: this only ever
+ * renders from `admin.php`, so the browser resolves it against the same
+ * directory the absolute form would have produced.
+ *
+ * My Jetpack owns license redemption for the standalone plugins; Backup
+ * has no redemption UI of its own to link to.
+ */
+const ADD_LICENSE_URL = 'admin.php?page=my-jetpack#/add-license';
+
+/**
+ * The way in for someone who has already bought Backup.
+ *
+ * Legacy showed this whenever the site was not fully connected *or* was
+ * connected without a plan (`useShowActivateLicenseLink`,
+ * `src/js/components/Admin/index.jsx:436-457`), which is every screen
+ * this gate layer can render — so all three of them carry it rather than
+ * only the upgrade screen. Someone who bought a license and arrived at a
+ * connection prompt is exactly the person who needs it.
+ *
+ * @return The rendered link.
+ */
+export default function LicenseKeyLink() {
+	return (
+		<a className="jpb-gates__license-link" href={ ADD_LICENSE_URL }>
+			{ __( 'Already have a license key?', 'jetpack-backup-pkg' ) }
+		</a>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/gates/license-key-link.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/license-key-link.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -19,19 +20,30 @@ const ADD_LICENSE_URL = 'admin.php?page=my-jetpack#/add-license';
 /**
  * The way in for someone who has already bought Backup.
  *
- * Legacy showed this whenever the site was not fully connected *or* was
- * connected without a plan (`useShowActivateLicenseLink`,
- * `src/js/components/Admin/index.jsx:436-457`), which is every screen
- * this gate layer can render — so all three of them carry it rather than
- * only the upgrade screen. Someone who bought a license and arrived at a
- * connection prompt is exactly the person who needs it.
+ * The label is the one five other Jetpack products already ship, and
+ * which this package itself still ships from the legacy header
+ * (`src/js/components/Admin/index.jsx:82`) — so it arrives translated in
+ * every locale rather than waiting a GlotPress cycle, and it matches the
+ * phrase on the My Jetpack screen the reader is about to land on.
+ *
+ * Where it appears is a small, deliberate widening rather than parity.
+ * Legacy's `useShowActivateLicenseLink` returned true both when the site
+ * was not fully connected and when it was connected without a plan — but
+ * it only fed `headerActions`, and the secondary-admin path renders
+ * `<AdminPage showHeader={ false }>` (`index.jsx:429`), so the link was
+ * hidden there. It is shown on all three screens now: someone who bought
+ * a license and hit a "link your account" wall is exactly who needs it.
  *
  * @return The rendered link.
  */
 export default function LicenseKeyLink() {
+	// `variant="link"` rather than a bare anchor: it brings the focus
+	// ring, hover treatment and type scale that the hand-rolled
+	// `jpb-gates__cta` next to it reimplements in SCSS. Rendered with an
+	// `href`, so it is still an `<a>` and still has the link role.
 	return (
-		<a className="jpb-gates__license-link" href={ ADD_LICENSE_URL }>
-			{ __( 'Already have a license key?', 'jetpack-backup-pkg' ) }
-		</a>
+		<Button variant="link" href={ ADD_LICENSE_URL }>
+			{ __( 'Use license key', 'jetpack-backup-pkg' ) }
+		</Button>
 	);
 }

--- a/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
@@ -28,9 +28,12 @@ import LicenseKeyLink from './license-key-link';
  */
 export default function NoBackupPlanScreen() {
 	const site = useSiteSuffix();
-	// `getRedirectUrl` omits the query arg entirely for an undefined
-	// site, so an unscoped link degrades rather than breaking.
-	const upgradeUrl = getRedirectUrl( 'backup-plugin-upgrade-10gb', { site } );
+	// The key is omitted rather than passed as undefined. `getRedirectUrl`
+	// walks its args with `for…in`, so a present-but-undefined `site` is
+	// encoded — the link would carry the literal string `undefined` — and
+	// its mere presence also suppresses the helper's own site fallback.
+	// Passing nothing is the only way this degrades cleanly.
+	const upgradeUrl = getRedirectUrl( 'backup-plugin-upgrade-10gb', site ? { site } : {} );
 
 	return (
 		<Card className="jpb-gates__card">

--- a/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
@@ -1,5 +1,5 @@
 import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
-import { Card, Notice } from '@wordpress/components';
+import { Button, Card, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
 import { useSiteSuffix } from '../../hooks/use-connection';
@@ -12,12 +12,10 @@ import LicenseKeyLink from './license-key-link';
  * This is the whole purchase path for a site without Backup, so it
  * carries both ways in: buy one, or redeem one already bought.
  *
- * The destination is the redirect service with the same slug the legacy
- * no-plan card used (`src/js/components/Admin/no-backup-capabilities.jsx:34`)
- * rather than a jetpack.com URL written here — the slug's target is
- * maintained outside this repo, and reusing it keeps this screen pointing
- * wherever that one already points. It is scoped to the site, without
- * which checkout has no idea which site the reader came from.
+ * The destination is the redirect service, with the same slug the legacy
+ * no-plan card used rather than a jetpack.com URL written here — that
+ * slug's target is maintained outside this repo, so reusing it keeps
+ * this screen pointing wherever that one already points.
  *
  * No Tracks event on the CTA yet: there is no Tracks client on the
  * modernized page at all — `enqueue_admin_scripts()` returns before
@@ -51,10 +49,14 @@ export default function NoBackupPlanScreen() {
 				 * Same tab, as legacy did. An upgrade flow that opens a new
 				 * one strands the page the reader started from, and returns
 				 * them to a dashboard that still says they have no plan.
+				 *
+				 * The label is legacy's, which this package still ships in
+				 * three other places — so it arrives translated rather than
+				 * waiting a GlotPress cycle.
 				 */ }
-				<a className="jpb-gates__cta" href={ upgradeUrl }>
-					{ __( 'Upgrade now', 'jetpack-backup-pkg' ) }
-				</a>
+				<Button variant="primary" href={ upgradeUrl }>
+					{ __( 'Get VaultPress Backup', 'jetpack-backup-pkg' ) }
+				</Button>
 				<LicenseKeyLink />
 			</Stack>
 		</Card>

--- a/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
@@ -1,16 +1,37 @@
+import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
 import { Card, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
-
-const UPGRADE_URL = 'https://jetpack.com/upgrade/backup/';
+import { useSiteSuffix } from '../../hooks/use-connection';
+import LicenseKeyLink from './license-key-link';
 
 /**
  * Fallback shown when the site is fully connected but has no active
  * Backup plan.
  *
+ * This is the whole purchase path for a site without Backup, so it
+ * carries both ways in: buy one, or redeem one already bought.
+ *
+ * The destination is the redirect service with the same slug the legacy
+ * no-plan card used (`src/js/components/Admin/no-backup-capabilities.jsx:34`)
+ * rather than a jetpack.com URL written here — the slug's target is
+ * maintained outside this repo, and reusing it keeps this screen pointing
+ * wherever that one already points. It is scoped to the site, without
+ * which checkout has no idea which site the reader came from.
+ *
+ * No Tracks event on the CTA yet: there is no Tracks client on the
+ * modernized page at all — `enqueue_admin_scripts()` returns before
+ * registering one — so legacy's `jetpack_backup_plugin_upgrade_click`
+ * has nowhere to go until that lands. Wiring it is H1b's job.
+ *
  * @return The rendered fallback.
  */
 export default function NoBackupPlanScreen() {
+	const site = useSiteSuffix();
+	// `getRedirectUrl` omits the query arg entirely for an undefined
+	// site, so an unscoped link degrades rather than breaking.
+	const upgradeUrl = getRedirectUrl( 'backup-plugin-upgrade-10gb', { site } );
+
 	return (
 		<Card className="jpb-gates__card">
 			<Stack direction="column" gap="md" align="center">
@@ -23,9 +44,15 @@ export default function NoBackupPlanScreen() {
 						'jetpack-backup-pkg'
 					) }
 				</Notice>
-				<a className="jpb-gates__cta" href={ UPGRADE_URL } target="_blank" rel="noreferrer">
-					{ __( 'See Backup plans', 'jetpack-backup-pkg' ) }
+				{ /*
+				 * Same tab, as legacy did. An upgrade flow that opens a new
+				 * one strands the page the reader started from, and returns
+				 * them to a dashboard that still says they have no plan.
+				 */ }
+				<a className="jpb-gates__cta" href={ upgradeUrl }>
+					{ __( 'Upgrade now', 'jetpack-backup-pkg' ) }
 				</a>
+				<LicenseKeyLink />
 			</Stack>
 		</Card>
 	);

--- a/projects/packages/backup/src/dashboard/components/gates/not-connected.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/not-connected.tsx
@@ -6,24 +6,26 @@ import LicenseKeyLink from './license-key-link';
 /**
  * My Jetpack, which owns connection for the standalone plugins.
  *
- * Not `admin.php?page=jetpack#/connection`: that screen belongs to the
- * Jetpack plugin, and the only thing that calls
- * `Jetpack_Backup::initialize()` is the standalone Backup plugin, where
- * `page=jetpack` is registered as a `__return_null` placeholder. The link
- * went nowhere for every site that could see it.
+ * Not `admin.php?page=jetpack#/connection`, which reached a connection
+ * screen on no site that could see it — by one of two mechanisms,
+ * depending on what else is installed. Without the Jetpack plugin,
+ * `page=jetpack` is a `__return_null` placeholder registered by
+ * `packages/admin-ui` behind a `! $jetpack_plugin_present` guard, so the
+ * page renders nothing at all. With it, that slug is the Jetpack React
+ * app — whose router has no `/connection` route, so the hash falls to
+ * the catch-all and is replaced with `#/dashboard`.
  *
- * My Jetpack cannot send the reader back here afterwards — its
- * return-to helper only accepts My Jetpack's own hash routes — so this
- * is a one-way trip. A dead link is the worse of the two.
+ * My Jetpack cannot send the reader back here afterwards — its return-to
+ * helper only accepts My Jetpack's own hash routes — so this is a
+ * one-way trip. Still the better of the two.
  */
 const JETPACK_CONNECT_URL = 'admin.php?page=my-jetpack';
 
 /**
  * Fallback shown when Jetpack isn't fully connected to WPCOM.
  *
- * Links out to the Jetpack settings connection screen instead of
- * embedding `<ConnectButton>` — the connection package pulls in SCSS
- * that wp-build can't resolve cleanly today.
+ * Links out rather than embedding `<ConnectButton>`: the connection
+ * package pulls in SCSS that wp-build can't resolve cleanly today.
  *
  * @return The rendered fallback.
  */

--- a/projects/packages/backup/src/dashboard/components/gates/not-connected.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/not-connected.tsx
@@ -1,8 +1,22 @@
 import { Button, Card } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
+import LicenseKeyLink from './license-key-link';
 
-const JETPACK_CONNECT_URL = 'admin.php?page=jetpack#/connection';
+/**
+ * My Jetpack, which owns connection for the standalone plugins.
+ *
+ * Not `admin.php?page=jetpack#/connection`: that screen belongs to the
+ * Jetpack plugin, and the only thing that calls
+ * `Jetpack_Backup::initialize()` is the standalone Backup plugin, where
+ * `page=jetpack` is registered as a `__return_null` placeholder. The link
+ * went nowhere for every site that could see it.
+ *
+ * My Jetpack cannot send the reader back here afterwards — its
+ * return-to helper only accepts My Jetpack's own hash routes — so this
+ * is a one-way trip. A dead link is the worse of the two.
+ */
+const JETPACK_CONNECT_URL = 'admin.php?page=my-jetpack';
 
 /**
  * Fallback shown when Jetpack isn't fully connected to WPCOM.
@@ -29,6 +43,7 @@ export default function NotConnectedScreen() {
 				<Button variant="primary" href={ JETPACK_CONNECT_URL }>
 					{ __( 'Connect Jetpack', 'jetpack-backup-pkg' ) }
 				</Button>
+				<LicenseKeyLink />
 			</Stack>
 		</Card>
 	);

--- a/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
@@ -1,8 +1,22 @@
 import { Button, Card } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
+import LicenseKeyLink from './license-key-link';
 
-const JETPACK_CONNECT_USER_URL = 'admin.php?page=jetpack#/connection';
+/**
+ * My Jetpack, which owns connection for the standalone plugins.
+ *
+ * Not `admin.php?page=jetpack#/connection`: that screen belongs to the
+ * Jetpack plugin, and the only thing that calls
+ * `Jetpack_Backup::initialize()` is the standalone Backup plugin, where
+ * `page=jetpack` is registered as a `__return_null` placeholder. The link
+ * went nowhere for every site that could see it.
+ *
+ * My Jetpack cannot send the reader back here afterwards — its
+ * return-to helper only accepts My Jetpack's own hash routes — so this
+ * is a one-way trip. A dead link is the worse of the two.
+ */
+const JETPACK_CONNECT_USER_URL = 'admin.php?page=my-jetpack';
 
 /**
  * Fallback shown when the current user is an admin but isn't personally
@@ -30,6 +44,7 @@ export default function SecondaryAdminScreen() {
 				<Button variant="primary" href={ JETPACK_CONNECT_USER_URL }>
 					{ __( 'Link my account', 'jetpack-backup-pkg' ) }
 				</Button>
+				<LicenseKeyLink />
 			</Stack>
 		</Card>
 	);

--- a/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
@@ -3,28 +3,12 @@ import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
 import LicenseKeyLink from './license-key-link';
 
-/**
- * My Jetpack, which owns connection for the standalone plugins.
- *
- * Not `admin.php?page=jetpack#/connection`: that screen belongs to the
- * Jetpack plugin, and the only thing that calls
- * `Jetpack_Backup::initialize()` is the standalone Backup plugin, where
- * `page=jetpack` is registered as a `__return_null` placeholder. The link
- * went nowhere for every site that could see it.
- *
- * My Jetpack cannot send the reader back here afterwards — its
- * return-to helper only accepts My Jetpack's own hash routes — so this
- * is a one-way trip. A dead link is the worse of the two.
- */
+/** My Jetpack, for the reasons spelled out in `not-connected.tsx`. */
 const JETPACK_CONNECT_USER_URL = 'admin.php?page=my-jetpack';
 
 /**
  * Fallback shown when the current user is an admin but isn't personally
  * linked to a WordPress.com account on this site.
- *
- * Links out to the Jetpack settings connection screen rather than
- * embedding `<ConnectButton>` (see `not-connected.tsx` for the
- * wp-build/SCSS rationale).
  *
  * @return The rendered fallback.
  */

--- a/projects/packages/backup/src/dashboard/components/gates/style.scss
+++ b/projects/packages/backup/src/dashboard/components/gates/style.scss
@@ -28,12 +28,4 @@
 			color: #fff;
 		}
 	}
-
-	// Secondary to the CTA above it: someone who already owns Backup is
-	// the smaller audience on these screens, and giving this the same
-	// weight as the purchase button would make the pair read as a choice
-	// between equals.
-	&__license-link {
-		font-size: 13px;
-	}
 }

--- a/projects/packages/backup/src/dashboard/components/gates/style.scss
+++ b/projects/packages/backup/src/dashboard/components/gates/style.scss
@@ -13,19 +13,4 @@
 		margin-block: 48px;
 		padding: 32px;
 	}
-
-	&__cta {
-		display: inline-block;
-		padding: 8px 16px;
-		background-color: var(--wp-admin-theme-color, #007cba);
-		border-radius: 2px;
-		text-decoration: none;
-
-		&,
-		&:hover,
-		&:focus,
-		&:visited {
-			color: #fff;
-		}
-	}
 }

--- a/projects/packages/backup/src/dashboard/components/gates/style.scss
+++ b/projects/packages/backup/src/dashboard/components/gates/style.scss
@@ -28,4 +28,12 @@
 			color: #fff;
 		}
 	}
+
+	// Secondary to the CTA above it: someone who already owns Backup is
+	// the smaller audience on these screens, and giving this the same
+	// weight as the purchase button would make the pair read as a choice
+	// between equals.
+	&__license-link {
+		font-size: 13px;
+	}
 }

--- a/projects/packages/backup/src/dashboard/hooks/use-capabilities.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-capabilities.ts
@@ -53,11 +53,12 @@ export function useCapabilities( { enabled = true }: Args = {} ): Result {
 
 	return {
 		data: query.data,
-		// `isPending && isFetching` rather than React Query's `isLoading`:
-		// the rewind makes a retry pending again, so `isLoading` is true
-		// for the whole round trip and the error screen would be replaced
-		// by a spinner. This has to mean "nothing has ever been shown".
-		isLoading: query.isPending && query.isFetching && error === null,
+		// React Query's own `isLoading` goes true again during a retry,
+		// because the rewind makes an errored data-less query pending —
+		// so on its own it would replace the error screen with a spinner
+		// for the whole round trip. The sticky error is what separates
+		// "nothing has ever been shown" from "we are asking again".
+		isLoading: query.isLoading && error === null,
 		error,
 		// Not `query.isRefetching`: that is `isFetching && ! isPending`,
 		// and the rewind makes a retry pending, so it stays false exactly

--- a/projects/packages/backup/src/dashboard/hooks/use-capabilities.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-capabilities.ts
@@ -2,13 +2,17 @@ import { useQuery } from '@tanstack/react-query';
 import { useCallback } from '@wordpress/element';
 import { fetchCapabilities, type Capabilities } from '../data/api/capabilities';
 import { keys } from '../data/query-client';
+import { useStickyError } from './use-sticky-error';
 
 const CAPABILITIES_STALE_MS = 5 * 60_000;
 
 type Result = {
 	data: Capabilities | undefined;
+	/** True only on the very first load, never during a retry. */
 	isLoading: boolean;
 	error: Error | null;
+	/** A retry is in flight and there is already something on screen. */
+	isRetrying: boolean;
 	refetch: () => void;
 };
 
@@ -41,10 +45,24 @@ export function useCapabilities( { enabled = true }: Args = {} ): Result {
 	const retry = useCallback( () => {
 		refetch();
 	}, [ refetch ] );
+	// Held across the refetch. React Query rewinds an errored query that
+	// holds no data back to `pending`, so without this the error vanishes
+	// in the same render as the click — and this is the query whose error
+	// screen wraps the entire dashboard body.
+	const error = useStickyError( query.error ?? null, query.isFetching );
+
 	return {
 		data: query.data,
-		isLoading: query.isLoading,
-		error: query.error ?? null,
+		// `isPending && isFetching` rather than React Query's `isLoading`:
+		// the rewind makes a retry pending again, so `isLoading` is true
+		// for the whole round trip and the error screen would be replaced
+		// by a spinner. This has to mean "nothing has ever been shown".
+		isLoading: query.isPending && query.isFetching && error === null,
+		error,
+		// Not `query.isRefetching`: that is `isFetching && ! isPending`,
+		// and the rewind makes a retry pending, so it stays false exactly
+		// when it is needed.
+		isRetrying: query.isFetching && ( error !== null || query.data !== undefined ),
 		refetch: retry,
 	};
 }

--- a/projects/packages/backup/src/dashboard/hooks/use-connection.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-connection.ts
@@ -63,9 +63,11 @@ export function useConnection(): Result {
  *
  * Read from the same connection global as `useConnection`, and used to
  * scope Jetpack redirect links to this site. Returns undefined when the
- * global is missing, in which case callers should emit an unscoped
- * redirect rather than a broken one — `getRedirectUrl` omits the query
- * arg for an undefined `site`.
+ * global is missing, in which case callers must omit the `site` key
+ * entirely rather than pass it as undefined: `getRedirectUrl` walks its
+ * args with `for…in`, so a present-but-undefined key is encoded as the
+ * literal string `undefined`, and its presence also suppresses the
+ * helper's own `jetpack_redirects` fallback. See `no-backup-plan.tsx`.
  *
  * @return The site slug, or undefined.
  */

--- a/projects/packages/backup/src/rest/class-capabilities-bridge.php
+++ b/projects/packages/backup/src/rest/class-capabilities-bridge.php
@@ -69,23 +69,52 @@ class Capabilities_Bridge {
 			return Rest_Controller::transport_error( $response, 'capabilities_fetch_failed' );
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
+		// Cast: `wp_remote_retrieve_response_code()` returns whatever the
+		// transport put there, and a numeric string fails a strict
+		// comparison against 200 — sending a perfectly good response down
+		// the failure branch, where the `is_int()` test below would then
+		// report it as a 500.
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
 			return new WP_Error(
 				'capabilities_fetch_failed',
 				__( 'Could not fetch site capabilities.', 'jetpack-backup-pkg' ),
-				array( 'status' => is_int( $status_code ) && $status_code > 0 ? $status_code : 500 )
+				array( 'status' => $status_code > 0 ? $status_code : 500 )
 			);
 		}
 
 		$body = json_decode( wp_remote_retrieve_body( $response ), true );
-		if ( ! is_array( $body ) ) {
-			$body = array();
+
+		// A 200 we cannot read is refused rather than projected.
+		//
+		// Coercing it to an empty list is the same as answering "this site
+		// has no Backup plan", and that answer is acted on: `<Gates>`
+		// renders the upgrade screen. So a truncated response, an HTML
+		// error page from something in front of WordPress.com, or a shape
+		// change upstream would each show a paying customer an advert for
+		// what they already own, with no error anywhere to explain it.
+		// The docblock above records this exact mechanism firing once
+		// already; that fix repointed the endpoint and left the tolerant
+		// projection in place.
+		//
+		// An *empty* list is not this case. It is a legitimate answer —
+		// the one every site without Backup gives — and refusing it would
+		// put a permanent error in front of precisely the people the
+		// upgrade screen is for.
+		if ( ! is_array( $body ) || ! isset( $body['capabilities'] ) || ! is_array( $body['capabilities'] ) ) {
+			return new WP_Error(
+				'capabilities_unreadable',
+				__( "Could not read this site's plan details.", 'jetpack-backup-pkg' ),
+				// Deliberately not the 502 `Rest_Controller::transport_error()`
+				// uses: the client reads 502 as "the answer went missing",
+				// a meaning it shares with the destructive restore
+				// mutation. Nothing was in flight here. WordPress.com
+				// answered; we could not read what it said.
+				array( 'status' => 500 )
+			);
 		}
 
-		$capabilities = isset( $body['capabilities'] ) && is_array( $body['capabilities'] )
-			? $body['capabilities']
-			: array();
+		$capabilities = $body['capabilities'];
 
 		return rest_ensure_response(
 			array(

--- a/projects/packages/backup/src/rest/class-capabilities-bridge.php
+++ b/projects/packages/backup/src/rest/class-capabilities-bridge.php
@@ -101,7 +101,18 @@ class Capabilities_Bridge {
 		// the one every site without Backup gives — and refusing it would
 		// put a permanent error in front of precisely the people the
 		// upgrade screen is for.
-		if ( ! is_array( $body ) || ! isset( $body['capabilities'] ) || ! is_array( $body['capabilities'] ) ) {
+		// `wp_is_numeric_array()` and not `is_array()`, because the two
+		// differ on the shape most likely to arrive if upstream drifts: a
+		// keyed map. `is_array()` accepts `{"capabilities":{"backup":true}}`,
+		// and `in_array()` then compares against that map's *values* — so
+		// the site reads as having no plan, which is the outcome this
+		// whole guard exists to prevent. It returns true for an empty
+		// array, so the carve-out below survives.
+		if (
+			! is_array( $body )
+			|| ! isset( $body['capabilities'] )
+			|| ! wp_is_numeric_array( $body['capabilities'] )
+		) {
 			return new WP_Error(
 				'capabilities_unreadable',
 				__( "Could not read this site's plan details.", 'jetpack-backup-pkg' ),

--- a/projects/packages/backup/tests/capabilities-error-retry.test.tsx
+++ b/projects/packages/backup/tests/capabilities-error-retry.test.tsx
@@ -152,9 +152,17 @@ describe( 'Gates — retrying a failed capabilities read', () => {
 		const button = view.getByRole( 'button', { name: /Try again/ } );
 		await user.click( button );
 
+		// `aria-disabled`, not `toBeDisabled()`: the button stays natively
+		// enabled on purpose so it keeps keyboard focus. Losing focus to
+		// `<body>` would reproduce "the page went away" for AT users, in
+		// the one place there is nothing adjacent to land on.
 		await waitFor( () =>
-			expect( view.getByRole( 'button', { name: /Try again/ } ) ).toBeDisabled()
+			expect( view.getByRole( 'button', { name: /Try again/ } ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			)
 		);
+		expect( view.getByRole( 'button', { name: /Try again/ } ) ).toBeEnabled();
 
 		pending.resolve( { hasBackupPlan: true, hasScan: false } );
 	} );

--- a/projects/packages/backup/tests/capabilities-error-retry.test.tsx
+++ b/projects/packages/backup/tests/capabilities-error-retry.test.tsx
@@ -1,0 +1,176 @@
+// JETPACK-2243 D6 — the fourth surface of the retry-rewind class, and
+// the widest.
+//
+// #51401 fixed the activity list, the file browser and the backup-status
+// card by holding the last error at the hook layer. `useCapabilities` was
+// not among them, and it is the one that matters most: `<Gates>` wraps
+// the entire dashboard body on all three routes, so clicking its "Try
+// again" replaced the whole page with an unlabelled spinner — the reason,
+// the explanation and the only control that can ask again, all gone —
+// then brought them back if the retry failed too.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+	useNavigate: () => () => {},
+	useParams: () => ( {} ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Gates from '../src/dashboard/components/gates';
+import { queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+const UPSTREAM_REASON = "Could not read this site's plan details.";
+// Matched as a pattern, not an exact string: `Notice` renders a
+// visually-hidden "Error notice" label inside the same content element,
+// so no single node's text equals the message on its own.
+const REASON_SHOWN = /Could not read this site's plan details/;
+
+/**
+ * A promise whose settlement the test controls, so a retry can be held
+ * in flight while assertions run against the rendered output.
+ *
+ * @return The promise and its resolver.
+ */
+function deferred< T >() {
+	let resolve!: ( value: T ) => void;
+	const promise = new Promise< T >( res => {
+		resolve = res;
+	} );
+	return { promise, resolve };
+}
+
+/**
+ * Answer the capabilities route from a queue of outcomes.
+ *
+ * A counter rather than `mockRejectedValueOnce`: React Query may invoke
+ * a query function more than once per logical fetch, and a `…Once` mock
+ * silently resolves `undefined` on the extra call — which reads as a
+ * successful capabilities read and renders the dashboard body.
+ *
+ * @param outcomes - One entry per logical fetch; later fetches reuse the last.
+ */
+function answerWith( outcomes: Array< () => Promise< unknown > > ) {
+	let call = 0;
+	mockApiFetch.mockImplementation( () => {
+		const outcome = outcomes[ Math.min( call, outcomes.length - 1 ) ];
+		call += 1;
+		return outcome();
+	} );
+}
+
+/**
+ * The bridge's own refusal of a 200 it could not read.
+ *
+ * @return A rejected promise in the shape `apiCall` re-throws.
+ */
+const unreadable = () =>
+	Promise.reject( {
+		code: 'capabilities_unreadable',
+		message: UPSTREAM_REASON,
+		data: { status: 500 },
+	} );
+
+/**
+ * Render the gate with a body that must never appear in these tests.
+ *
+ * Scoped queries rather than `screen`: the error card is a `Notice`,
+ * which announces itself through `@wordpress/a11y`'s speak region — a
+ * node appended to `document.body` once per process that keeps its text
+ * between tests.
+ *
+ * Callers wrap the result in `within()` themselves so that
+ * `testing-library/prefer-screen-queries` can see the scoping it allows.
+ *
+ * @return The rendered container.
+ */
+function renderGate(): HTMLElement {
+	const { container } = render(
+		<QueryClientProvider>
+			<Gates>
+				<div>dashboard body</div>
+			</Gates>
+		</QueryClientProvider>
+	);
+	return container;
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'Gates — retrying a failed capabilities read', () => {
+	it( 'keeps the reason on screen while the retry is in flight', async () => {
+		const user = userEvent.setup();
+		// Hold the retry in flight so the mid-retry render is observable.
+		const pending = deferred< unknown >();
+		answerWith( [ unreadable, () => pending.promise ] );
+
+		const view = within( renderGate() );
+		await expect( view.findByText( REASON_SHOWN ) ).resolves.toBeInTheDocument();
+
+		await user.click( view.getByRole( 'button', { name: /Try again/ } ) );
+
+		// The whole point: the page did not blank.
+		expect( view.getByText( REASON_SHOWN ) ).toBeInTheDocument();
+		expect( view.queryByText( 'dashboard body' ) ).not.toBeInTheDocument();
+
+		pending.resolve( { hasBackupPlan: true, hasScan: false } );
+		await expect( view.findByText( 'dashboard body' ) ).resolves.toBeInTheDocument();
+	} );
+
+	it( 'reports the retry as busy rather than leaving the button idle', async () => {
+		// Without this the DOM is byte-identical before and after the
+		// click, so a retry that fails again looks like a dead button.
+		const user = userEvent.setup();
+		const pending = deferred< unknown >();
+		answerWith( [ unreadable, () => pending.promise ] );
+
+		const view = within( renderGate() );
+		await expect( view.findByText( REASON_SHOWN ) ).resolves.toBeInTheDocument();
+
+		const button = view.getByRole( 'button', { name: /Try again/ } );
+		await user.click( button );
+
+		await waitFor( () =>
+			expect( view.getByRole( 'button', { name: /Try again/ } ) ).toBeDisabled()
+		);
+
+		pending.resolve( { hasBackupPlan: true, hasScan: false } );
+	} );
+
+	it( 'still shows a plain spinner on the very first load', async () => {
+		// The loading branch is first-load-only now, so it must still fire
+		// when there is genuinely nothing to show yet.
+		const pending = deferred< unknown >();
+		answerWith( [ () => pending.promise ] );
+
+		const view = within( renderGate() );
+
+		expect( view.queryByText( REASON_SHOWN ) ).not.toBeInTheDocument();
+		expect( view.queryByText( 'dashboard body' ) ).not.toBeInTheDocument();
+
+		pending.resolve( { hasBackupPlan: true, hasScan: false } );
+		await expect( view.findByText( 'dashboard body' ) ).resolves.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/no-plan-gate.test.tsx
+++ b/projects/packages/backup/tests/no-plan-gate.test.tsx
@@ -64,7 +64,7 @@ describe( 'No-plan gate', () => {
 	it( 'sends the site through to checkout rather than a generic marketing page', async () => {
 		renderScreen( NoBackupPlanScreen );
 
-		const cta = screen.getByRole( 'link', { name: /Upgrade|Backup plans|Get Backup/i } );
+		const cta = screen.getByRole( 'link', { name: /^Upgrade now$/ } );
 
 		// Site-scoped: without this the reader lands on a page that has no
 		// idea which site they came from. And on the redirect service, as
@@ -81,9 +81,27 @@ describe( 'No-plan gate', () => {
 		// on the modernized page, so the absolute `adminUrl` the legacy
 		// header used is not available — and does not need to be, since
 		// this renders inside wp-admin already.
-		expect( screen.getByRole( 'link', { name: /license key/i } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: /^Use license key$/ } ) ).toHaveAttribute(
 			'href',
 			'admin.php?page=my-jetpack#/add-license'
+		);
+	} );
+
+	it( 'omits the site rather than sending the word "undefined"', async () => {
+		// `getRedirectUrl` walks its args with `for…in`, so a key that is
+		// present-but-undefined is encoded rather than skipped — and its
+		// presence also suppresses the helper's own site fallback. Passing
+		// no key at all is the only way to degrade cleanly.
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			siteSuffix: undefined,
+		} as unknown as typeof window.JP_CONNECTION_INITIAL_STATE;
+
+		renderScreen( NoBackupPlanScreen );
+
+		expect( screen.getByRole( 'link', { name: /^Upgrade now$/ } ) ).not.toHaveAttribute(
+			'href',
+			expect.stringContaining( 'undefined' )
 		);
 	} );
 
@@ -124,6 +142,6 @@ describe.each( [
 		// Legacy showed it whenever the site was not fully connected, not
 		// only on the no-plan screen — see `useShowActivateLicenseLink`.
 		renderScreen( Screen );
-		expect( screen.getByRole( 'link', { name: /license key/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: /^Use license key$/ } ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/no-plan-gate.test.tsx
+++ b/projects/packages/backup/tests/no-plan-gate.test.tsx
@@ -1,0 +1,129 @@
+// JETPACK-2243 H2 — a site without Backup had no way to buy, connect or
+// redeem from this page.
+//
+// The gate was a static notice with a hardcoded `jetpack.com/upgrade/backup/`
+// link: not site-scoped, so nothing carried the site through to checkout,
+// and the "Use license key" entry point the legacy dashboard put in its
+// header was gone entirely.
+//
+// Also here: the connect link was dead. `admin.php?page=jetpack#/connection`
+// does not exist for the standalone Backup plugin, which is the only thing
+// that calls `Jetpack_Backup::initialize()` — `page=jetpack` is registered
+// there as a `__return_null` placeholder.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+	useNavigate: () => () => {},
+	useParams: () => ( {} ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import NoBackupPlanScreen from '../src/dashboard/components/gates/no-backup-plan';
+import NotConnectedScreen from '../src/dashboard/components/gates/not-connected';
+import SecondaryAdminScreen from '../src/dashboard/components/gates/secondary-admin';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+
+const SITE_SUFFIX = 'example.com';
+
+/**
+ * Render a gate screen.
+ *
+ * `screen` is safe for this file, unlike the retry suite next door:
+ * every query here is role-based, and `@wordpress/a11y`'s speak region
+ * contains no links or buttons to collide with.
+ *
+ * @param Screen - The screen component.
+ */
+function renderScreen( Screen: () => JSX.Element ) {
+	render(
+		<QueryClientProvider>
+			<Screen />
+		</QueryClientProvider>
+	);
+}
+
+beforeEach( () => {
+	mockApiFetch.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		siteSuffix: SITE_SUFFIX,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'No-plan gate', () => {
+	it( 'sends the site through to checkout rather than a generic marketing page', async () => {
+		renderScreen( NoBackupPlanScreen );
+
+		const cta = screen.getByRole( 'link', { name: /Upgrade|Backup plans|Get Backup/i } );
+
+		// Site-scoped: without this the reader lands on a page that has no
+		// idea which site they came from. And on the redirect service, as
+		// the legacy no-plan card used — not a hardcoded jetpack.com URL
+		// invented here.
+		expect( cta ).toHaveAttribute( 'href', expect.stringContaining( SITE_SUFFIX ) );
+		expect( cta ).toHaveAttribute( 'href', expect.stringContaining( 'jetpack.com/redirect' ) );
+	} );
+
+	it( 'offers a way in for someone who already bought a license', async () => {
+		renderScreen( NoBackupPlanScreen );
+
+		// Relative, deliberately: `JPBACKUP_INITIAL_STATE` is not emitted
+		// on the modernized page, so the absolute `adminUrl` the legacy
+		// header used is not available — and does not need to be, since
+		// this renders inside wp-admin already.
+		expect( screen.getByRole( 'link', { name: /license key/i } ) ).toHaveAttribute(
+			'href',
+			'admin.php?page=my-jetpack#/add-license'
+		);
+	} );
+
+	it( 'keeps the reader in the same tab', async () => {
+		// An upgrade flow that strands the tab it came from is worse, and
+		// legacy did not do it either.
+		renderScreen( NoBackupPlanScreen );
+
+		for ( const link of screen.getAllByRole( 'link' ) ) {
+			expect( link ).not.toHaveAttribute( 'target', '_blank' );
+		}
+	} );
+
+	it( 'issues no requests', async () => {
+		// This screen renders below the capabilities gate, but it must not
+		// add fetches of its own — the gates' zero-request property is a
+		// deliberate design commitment.
+		renderScreen( NoBackupPlanScreen );
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe.each( [
+	{ name: 'not-connected', Screen: NotConnectedScreen },
+	{ name: 'secondary-admin', Screen: SecondaryAdminScreen },
+] )( '$name gate', ( { Screen } ) => {
+	it( 'points somewhere that exists for the standalone Backup plugin', async () => {
+		renderScreen( Screen );
+
+		// `page=jetpack` is a `__return_null` placeholder in the standalone
+		// plugin — the link went nowhere. My Jetpack owns connection there.
+		const cta = screen.getByRole( 'link', { name: /Connect|Link my account/i } );
+		expect( cta ).not.toHaveAttribute( 'href', expect.stringContaining( 'page=jetpack#' ) );
+		expect( cta ).toHaveAttribute( 'href', expect.stringContaining( 'page=my-jetpack' ) );
+	} );
+
+	it( 'offers the license-key path too', async () => {
+		// Legacy showed it whenever the site was not fully connected, not
+		// only on the no-plan screen — see `useShowActivateLicenseLink`.
+		renderScreen( Screen );
+		expect( screen.getByRole( 'link', { name: /license key/i } ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/no-plan-gate.test.tsx
+++ b/projects/packages/backup/tests/no-plan-gate.test.tsx
@@ -6,10 +6,10 @@
 // and the "Use license key" entry point the legacy dashboard put in its
 // header was gone entirely.
 //
-// Also here: the connect link was dead. `admin.php?page=jetpack#/connection`
-// does not exist for the standalone Backup plugin, which is the only thing
-// that calls `Jetpack_Backup::initialize()` — `page=jetpack` is registered
-// there as a `__return_null` placeholder.
+// Also here: the connect link reached no connection screen.
+// `admin.php?page=jetpack` is a `__return_null` placeholder without the
+// Jetpack plugin, and the Jetpack React app with it — and that app has no
+// `/connection` route, so the hash bounced to `#/dashboard`.
 
 const mockApiFetch = jest.fn();
 
@@ -64,7 +64,7 @@ describe( 'No-plan gate', () => {
 	it( 'sends the site through to checkout rather than a generic marketing page', async () => {
 		renderScreen( NoBackupPlanScreen );
 
-		const cta = screen.getByRole( 'link', { name: /^Upgrade now$/ } );
+		const cta = screen.getByRole( 'link', { name: /^Get VaultPress Backup$/ } );
 
 		// Site-scoped: without this the reader lands on a page that has no
 		// idea which site they came from. And on the redirect service, as
@@ -99,7 +99,7 @@ describe( 'No-plan gate', () => {
 
 		renderScreen( NoBackupPlanScreen );
 
-		expect( screen.getByRole( 'link', { name: /^Upgrade now$/ } ) ).not.toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: /^Get VaultPress Backup$/ } ) ).not.toHaveAttribute(
 			'href',
 			expect.stringContaining( 'undefined' )
 		);
@@ -128,11 +128,11 @@ describe.each( [
 	{ name: 'not-connected', Screen: NotConnectedScreen },
 	{ name: 'secondary-admin', Screen: SecondaryAdminScreen },
 ] )( '$name gate', ( { Screen } ) => {
-	it( 'points somewhere that exists for the standalone Backup plugin', async () => {
+	it( 'points somewhere that actually reaches a connection screen', async () => {
 		renderScreen( Screen );
 
-		// `page=jetpack` is a `__return_null` placeholder in the standalone
-		// plugin — the link went nowhere. My Jetpack owns connection there.
+		// `page=jetpack#/connection` reached a connection screen on no site
+		// that could see it. My Jetpack owns connection for these plugins.
 		const cta = screen.getByRole( 'link', { name: /Connect|Link my account/i } );
 		expect( cta ).not.toHaveAttribute( 'href', expect.stringContaining( 'page=jetpack#' ) );
 		expect( cta ).toHaveAttribute( 'href', expect.stringContaining( 'page=my-jetpack' ) );

--- a/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
@@ -116,7 +116,7 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * The projection, in the three shapes a real site produces.
+	 * The projection, in the four shapes a real site produces.
 	 *
 	 * @param array $capabilities What WordPress.com lists for the site.
 	 * @param bool  $has_backup   Expected `hasBackupPlan`.
@@ -246,6 +246,11 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 			'an empty body'           => array( 'an empty body', '' ),
 			'no capabilities key'     => array( 'no capabilities key', '{"error":"unauthorized"}' ),
 			'a non-list capabilities' => array( 'a non-list capabilities', '{"capabilities":"backup"}' ),
+			// The likelier upstream drift of the two, and the one that
+			// slipped through: `is_array()` cannot tell a JSON list from a
+			// JSON object, and `in_array()` then compares against the
+			// map's *values*, so `{"backup":true}` reads as "no plan".
+			'a keyed capabilities map' => array( 'a keyed capabilities map', '{"capabilities":{"backup":true}}' ),
 		);
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
@@ -241,11 +241,11 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 	 */
 	public static function provide_unreadable_bodies() {
 		return array(
-			'not JSON at all'         => array( 'not JSON at all', '<html>502 Bad Gateway</html>' ),
-			'a bare scalar'           => array( 'a bare scalar', '"ok"' ),
-			'an empty body'           => array( 'an empty body', '' ),
-			'no capabilities key'     => array( 'no capabilities key', '{"error":"unauthorized"}' ),
-			'a non-list capabilities' => array( 'a non-list capabilities', '{"capabilities":"backup"}' ),
+			'not JSON at all'          => array( 'not JSON at all', '<html>502 Bad Gateway</html>' ),
+			'a bare scalar'            => array( 'a bare scalar', '"ok"' ),
+			'an empty body'            => array( 'an empty body', '' ),
+			'no capabilities key'      => array( 'no capabilities key', '{"error":"unauthorized"}' ),
+			'a non-list capabilities'  => array( 'a non-list capabilities', '{"capabilities":"backup"}' ),
 			// The likelier upstream drift of the two, and the one that
 			// slipped through: `is_array()` cannot tell a JSON list from a
 			// JSON object, and `in_array()` then compares against the

--- a/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Backup\V0005\REST;
 
 use Automattic\Jetpack\Backup\V0005\Jetpack_Backup;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
@@ -112,5 +113,139 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 		$this->assertSame( 'capabilities_fetch_failed', $response->get_error_code() );
 		$this->assertStringNotContainsString( 'cURL', $response->get_error_message() );
 		$this->assertSame( 502, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * The projection, in the three shapes a real site produces.
+	 *
+	 * @param array $capabilities What WordPress.com lists for the site.
+	 * @param bool  $has_backup   Expected `hasBackupPlan`.
+	 * @param bool  $has_scan     Expected `hasScan`.
+	 * @dataProvider provide_capability_lists
+	 */
+	#[DataProvider( 'provide_capability_lists' )]
+	public function test_projects_the_capability_list( array $capabilities, $has_backup, $has_scan ) {
+		$this->arrange_wpcom( array( 'capabilities' => $capabilities ) );
+
+		$response = Capabilities_Bridge::get_capabilities();
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame(
+			array(
+				'hasBackupPlan' => $has_backup,
+				'hasScan'       => $has_scan,
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Capability lists and the projection each should produce.
+	 *
+	 * @return array
+	 */
+	public static function provide_capability_lists() {
+		return array(
+			'backup and scan' => array( array( 'backup', 'scan' ), true, true ),
+			'backup only'     => array( array( 'backup' ), true, false ),
+			'scan only'       => array( array( 'scan' ), false, true ),
+			// A site that genuinely has nothing. This is the audience the
+			// upsell gate exists for, so it must stay a clean "no plan"
+			// answer and never an error.
+			'nothing'         => array( array(), false, false ),
+		);
+	}
+
+	/**
+	 * The route asks the capabilities endpoint, not site state.
+	 *
+	 * Pinned because the difference is invisible in the projection until
+	 * it is wrong: `/rewind?force=wpcom` returns site *state* and omits
+	 * `capabilities` entirely on some plan shapes, which produced a false
+	 * "no plan" gate for plans that do include Backup.
+	 */
+	public function test_asks_the_capabilities_endpoint() {
+		$this->arrange_wpcom( array( 'capabilities' => array( 'backup' ) ) );
+
+		Capabilities_Bridge::get_capabilities();
+
+		$this->assertStringContainsString( '/rewind/capabilities', $this->captured_url );
+		$this->assertStringNotContainsString( 'force=wpcom', $this->captured_url );
+	}
+
+	/**
+	 * A non-200 keeps WordPress.com's own status.
+	 */
+	public function test_forwards_the_upstream_status() {
+		$this->arrange_wpcom( array( 'error' => 'unauthorized' ), 401 );
+
+		$response = Capabilities_Bridge::get_capabilities();
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 401, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * A status that arrives as a numeric string is still a success.
+	 *
+	 * `wp_remote_retrieve_response_code()` returns the value uncast, so a
+	 * strict comparison against `200` sent a perfectly good response down
+	 * the failure branch — and then reported it as a 500, because the
+	 * `is_int()` ternary rejected the string too.
+	 */
+	public function test_treats_a_string_status_as_its_number() {
+		$this->arrange_wpcom_raw( '{"capabilities":["backup"]}', '200' );
+
+		$response = Capabilities_Bridge::get_capabilities();
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertTrue( $response->get_data()['hasBackupPlan'] );
+	}
+
+	/**
+	 * An unreadable 200 is refused, not read as "this site has no plan".
+	 *
+	 * The difference matters to the person on the other end: the second
+	 * reading shows a paying customer an upgrade screen. The class
+	 * docblock records this exact mechanism firing once already, on the
+	 * endpoint this route was moved off — that fix repointed the request
+	 * and left the tolerant projection in place.
+	 *
+	 * An *empty* list is deliberately not in here: it is a legitimate
+	 * answer, and refusing it would show a permanent error to the sites
+	 * the upsell is for. See `provide_capability_lists`.
+	 *
+	 * @param string $label Why this body is unreadable.
+	 * @param string $body  Raw body WordPress.com answers 200 with.
+	 * @dataProvider provide_unreadable_bodies
+	 */
+	#[DataProvider( 'provide_unreadable_bodies' )]
+	public function test_refuses_an_unreadable_success( $label, $body ) {
+		$this->arrange_wpcom_raw( $body );
+
+		$response = Capabilities_Bridge::get_capabilities();
+
+		$this->assertInstanceOf( WP_Error::class, $response, $label );
+		$this->assertSame( 'capabilities_unreadable', $response->get_error_code() );
+		// Deliberately not 502: the client classes 502 as "the answer went
+		// missing", a reading it shares with the destructive restore
+		// mutation. Nothing was in flight here — we simply could not read
+		// what came back.
+		$this->assertSame( 500, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * Bodies WordPress.com could answer 200 with that carry no usable list.
+	 *
+	 * @return array
+	 */
+	public static function provide_unreadable_bodies() {
+		return array(
+			'not JSON at all'         => array( 'not JSON at all', '<html>502 Bad Gateway</html>' ),
+			'a bare scalar'           => array( 'a bare scalar', '"ok"' ),
+			'an empty body'           => array( 'an empty body', '' ),
+			'no capabilities key'     => array( 'no capabilities key', '{"error":"unauthorized"}' ),
+			'a non-list capabilities' => array( 'a non-list capabilities', '{"capabilities":"backup"}' ),
+		);
 	}
 }

--- a/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
+++ b/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
@@ -131,6 +131,12 @@ trait Wpcom_Request_Mock {
 			function ( $preempt, $args, $url ) use ( $body, $status ) {
 				$this->captured_url    = $url;
 				$this->captured_urls[] = $url;
+				// Recorded here too, or `captured_body` would mean both
+				// "no request was made" and "a request was made and this
+				// helper did not look" — and the trait documents the
+				// former as how a test proves a guard refused before
+				// reaching the network.
+				$this->captured_body = isset( $args['body'] ) ? json_decode( $args['body'], true ) : null;
 				return array(
 					'response' => array( 'code' => $status ),
 					'body'     => $body,

--- a/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
+++ b/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
@@ -108,6 +108,40 @@ trait Wpcom_Request_Mock {
 	}
 
 	/**
+	 * Sign in and have WPCOM answer with a body exactly as given.
+	 *
+	 * `arrange_wpcom()` takes an array and always `wp_json_encode`s it, so
+	 * every body it can produce decodes back to an array. That makes the
+	 * "WordPress.com answered 200 with something we cannot read" case —
+	 * a truncated response, an HTML error page, a bare scalar —
+	 * unreachable through it, and that case is exactly the one a bridge's
+	 * projection has to refuse rather than quietly read as an empty list.
+	 *
+	 * @param string     $body   Raw body WPCOM should answer with.
+	 * @param int|string $status HTTP status WPCOM should answer with. A string is
+	 *                           legitimate here: the transport does not guarantee
+	 *                           an int, and a bridge that compares strictly
+	 *                           against 200 has to be tested against that.
+	 */
+	protected function arrange_wpcom_raw( $body, $status = 200 ) {
+		$this->sign_in_as_admin();
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( $body, $status ) {
+				$this->captured_url    = $url;
+				$this->captured_urls[] = $url;
+				return array(
+					'response' => array( 'code' => $status ),
+					'body'     => $body,
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	/**
 	 * Sign in and make the request fail in transport.
 	 *
 	 * `pre_http_request` returning a `WP_Error` is what the HTTP client


### PR DESCRIPTION
Fixes #

**Second commit addresses the review in full** — twelve findings, three substantive: a keyed capabilities map still projected as "no plan", `getRedirectUrl` encoded an undefined `site` rather than omitting it, and the disabled retry button dropped keyboard focus to `<body>` on the one screen with nothing adjacent to land on. Details in that commit; the notes below are updated to match.

Four items on the modernized Backup dashboard's gate layer, all behind `rsm_jetpack_ui_modernization_backup` (**default off**). The legacy dashboard is untouched.

They belong together because they are the same screen from two directions: **I6** decides whether the error screen should appear at all, **D6** decides whether it survives being clicked, and **H2** rebuilds the screen a *paying* customer could be wrongly shown when I6 misfires. Fixing the upsell without fixing the projection would have made the wrong-audience case more convincing, not less.

## Proposed changes

* **H2 — a site without Backup had no way to buy, connect or redeem.** The gate was static copy with a hardcoded `https://jetpack.com/upgrade/backup/` link, not scoped to the site, so nothing carried through to checkout.

  It now uses the redirect service with the **same slug the legacy no-plan card used** (`src/js/components/Admin/no-backup-capabilities.jsx:34`), scoped with `useSiteSuffix()`. Reusing the slug rather than writing a jetpack.com URL here matters: the target is maintained outside this repo, so this screen keeps pointing wherever that one already points. It stays in the same tab, as legacy did — an upgrade flow that opens a new one strands the page the reader came from and returns them to a dashboard still saying they have no plan. The CTA is **`Get VaultPress Backup`**, legacy's own label, which this package already ships in three places — so it arrives translated rather than waiting a GlotPress cycle, the same argument that keeps `Use license key`. It renders through `<Button variant="primary" href>` like the other two gates, rather than a hand-rolled anchor with its own SCSS.

  **"Use license key" comes back**, on all three gate screens — the label this package's own legacy header already ships, so it arrives translated rather than waiting a GlotPress cycle. Legacy's `useShowActivateLicenseLink` returned true both when the site was not fully connected and when it was connected without a plan, but it only fed `headerActions`, and the secondary-admin path renders `<AdminPage showHeader={ false }>` — so the link was hidden there. Showing it on all three is a small deliberate widening, not parity: someone who bought a license and hit a "link your account" wall is exactly who needs it. The URL is relative, so it needs none of the `adminUrl` from `JPBACKUP_INITIAL_STATE`, which the modernized page deliberately does not emit.

* **The connection prompts reached a connection screen on no site that could see them.** `admin.php?page=jetpack#/connection` failed by one of two mechanisms, depending on what else is installed. Without the Jetpack plugin, `page=jetpack` is a `__return_null` placeholder registered by `packages/admin-ui/src/class-admin-menu.php:130-139` behind a `! $jetpack_plugin_present` guard, and the page renders nothing. With it, that slug is the Jetpack React app — which claims it first, at `admin_menu` priority 998 against admin-ui's 1000 — and its router has no `/connection` route, so the hash falls to the catch-all and `main.jsx` replaces it with `#/dashboard`. Either way, never a connection screen. Now My Jetpack, which owns connection for these plugins.

  Worth knowing: My Jetpack cannot return the reader to Backup afterwards — its return-to helper only accepts My Jetpack's own hash routes — so this is a one-way trip. Still the better of the two, and an embedded flow would mean adding `@automattic/jetpack-connection` to `routes/dashboard`.

* **I6 — an unreadable 200 was reported as "this site has no plan".** `Capabilities_Bridge` coerced a non-array body, and a missing or non-array `capabilities` key, to an empty list. That answer is acted on: `<Gates>` renders the upgrade screen. So a truncated response, an HTML error page from something in front of WordPress.com, or a shape change upstream would advertise Backup to someone who already pays for it, with no error anywhere to explain it. The class docblock records this exact mechanism firing once before — that fix repointed the endpoint and left the projection alone.

  Those bodies are now refused with `capabilities_unreadable`, tested via `wp_is_numeric_array()` — `is_array()` cannot tell a JSON list from a JSON object, and a keyed `{"capabilities":{"backup":true}}` would otherwise clear every guard and then read as "no plan", since `in_array()` compares against the map's values. An **empty list is untouched**: it is the legitimate answer every site without Backup gives, and refusing it would put a permanent error in front of exactly the people the upgrade screen is for.

  The status is **500, deliberately not the 502** `Rest_Controller::transport_error()` uses — `data/api/_helpers.ts` classifies 502 as "the answer went missing", a reading it shares with the destructive restore mutation. Nothing was in flight here; WordPress.com answered and we could not read it. Also casts the response code, which let a string `'200'` take the non-200 branch and then be reported as a 500 by the `is_int()` ternary.

* **D6 — the capabilities retry blanked the whole dashboard.** `<Gates>` wraps the body on all three routes, and its loading branch sits above its error branch, so React Query's rewind replaced the reason, the explanation and the only control that can ask again with an unlabelled spinner for the entire round trip. This is the fourth surface of the class #51401 fixed, and the widest — `useCapabilities` was the one hook it missed.

  It now holds its error across the refetch like the other three, reports a first-load-only `isLoading`, and exposes `isRetrying` so the button shows busy instead of looking dead.

* **J1 (capabilities slice) — none of this had coverage.** The suite was three tests that never executed the callback. It now pins the request path (a revert to `/rewind?force=wpcom` used to pass), the projection in four shapes, upstream status forwarding, the string-status case, and five unreadable bodies. `Wpcom_Request_Mock` gains a raw-body helper, without which "answered 200 with something we cannot read" was unreachable — it always `wp_json_encode`d an array.

## Related product discussion/links

* [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243/backup-modernized-dashboard-work-needed-before-the-flag-can-flip) — **H2**, **I6**, **D6**, the **J1** capabilities slice, and a new item for the dead connect link
* Follows #51292, #51294, #51295, #51336, #51338, #51401, #51412, #51440

## Does this pull request change what data or activity we track or use?

No. No new events and nothing new collected.

Worth calling out what is **not** here: legacy fires `jetpack_backup_plugin_upgrade_click` from this CTA, and there is still no Tracks client on the modernized page at all — `enqueue_admin_scripts()` returns before registering one. #51403 puts the client on the page; porting the call sites is H1b. Half-wiring an event that cannot fire would be worse than leaving it.

## Open questions / caveats for review

1. **Failing closed on a malformed shape is a blast-radius judgement.** It matches the intent the gate's own comment states, but it means a WordPress.com shape change becomes a simultaneous hard failure rather than a silent wrong answer. The empty-list carve-out is what keeps a genuinely plan-less site out of it. Whether `/rewind/capabilities` can ever answer 200 without a `capabilities` key is only knowable WPCOM-side.
2. **No pricing on the screen.** `/jetpack/v4/backup-promoted-product-info` is registered and unused, so it would need no PHP — but it costs an uncached public-api round trip on a screen most users never see. Deliberately deferred. (Also: `PricingTable`'s primary-column gradient 404s under wp-build, so that component is not usable here as-is.)
3. **`BackupNowButton` re-derives the same three-way plan decision** (`:49-53`). I checked rather than changed it: during a retry it is now hidden via the sticky `error` instead of via `isLoading`, and released identically on success, so it is behaviour-preserving. Flagging it because the two must not drift.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, **default off** — confirm the legacy Backup page is unchanged first.

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

**Important:** after checking out this branch, run a **full** `jp build packages/backup`. A watch build only rebuilds the route whose own files changed, so a shared `src/dashboard/**` edit can leave you running new components against old hooks — which is exactly how this PR's own verification went wrong for a while. Confirm with:

```bash
grep -c "isRetrying: capabilities.isRetrying" projects/packages/backup/build/routes/dashboard/content.js   # want 1
```

**The no-plan screen** — stub the *upstream* call so the real bridge runs. Note `rest_dispatch_request` would bypass the bridge entirely; this has to be `pre_http_request`:

```php
add_filter( 'pre_http_request', function ( $preempt, $args, $url ) {
	if ( false === strpos( $url, '/rewind/capabilities' ) ) {
		return $preempt;
	}
	$mode = get_option( 'jp_tmp_caps_mode', 'no-plan' );  // no-plan | has-plan | unreadable
	if ( 'unreadable' === $mode ) {
		return array( 'response' => array( 'code' => 200 ), 'body' => '{"error":"unauthorized"}' );
	}
	if ( 'has-plan' === $mode ) {
		return array( 'response' => array( 'code' => 200 ), 'body' => '{"capabilities":["backup","scan"]}' );
	}
	return array( 'response' => array( 'code' => 200 ), 'body' => '{"capabilities":[]}' );
}, PHP_INT_MAX, 3 );
```

* With `jp_tmp_caps_mode` unset (**no-plan**): **Jetpack → VaultPress Backup** shows the upgrade card. The **"Get VaultPress Backup"** CTA should be a `jetpack.com/redirect` URL carrying your site, opening in the **same tab**, and **"Use license key"** should go to `admin.php?page=my-jetpack#/add-license`.
* Set it to **`has-plan`** and reload — the dashboard renders. This is the control: it proves the screen is following the stub rather than always hiding.

**I6 and D6** — set `jp_tmp_caps_mode` to **`unreadable`** and reload.

* Expect the **error screen**, not the upgrade card: "We couldn't load your backup details" with "Could not read this site's plan details." beneath it. Before this PR you would get the upsell, which is the bug.
* Click **Try again** while it still fails. The reason must **stay on screen** and the button must go busy — the page must not blank to a spinner. Before this PR the whole dashboard body was replaced for the round trip.
* Tab to the button and activate it with the keyboard. It must **keep focus** while busy (`aria-disabled="true"`, not natively disabled) — a natively disabled button is blurred by the browser, and focus would land on `<body>` with nothing to return to.
* Check the network tab: two capabilities requests per load, since `retry: 1`.

**The connection prompts**

* Disconnect the site (or force `isFullyConnected` false) and confirm the button goes to `admin.php?page=my-jetpack`, not `page=jetpack#/connection`, and that **"Use license key"** is present. Same for the secondary-admin screen.

**Flag off**

* Turn the filter off and confirm the legacy Backup page renders exactly as before.

**Automated**

* `jp test js packages/backup` → **384 tests, 44 suites**. Was 375/43 on trunk.
* `jp test php packages/backup` → **210 tests, 585 assertions**. Was 203/566.
* `jp phan packages/backup` → 0 issues. `pnpm run typecheck`, ESLint (zero warnings), Prettier, Stylelint and PHPCS all clean.
* Verified live on a Jetpack-connected site: all four states above, including the retry sequence sampled frame by frame.


