### PR TITLE
Charts: add defaultHiddenSeries to seed a series hidden on load

### DIFF
--- a/projects/js-packages/charts/changelog/charts-246-default-hidden-series
+++ b/projects/js-packages/charts/changelog/charts-246-default-hidden-series
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add defaultHiddenSeries to seed a series hidden on load, plus absolute visibility setters.
+Add defaultHiddenSeries to seed a series hidden on load, plus absolute visibility setters. Keep the keyboard tooltip open when the chart re-renders under it.

--- a/projects/js-packages/charts/changelog/charts-246-default-hidden-series
+++ b/projects/js-packages/charts/changelog/charts-246-default-hidden-series
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add defaultHiddenSeries to seed a series hidden on load, plus absolute visibility setters.

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
@@ -27,6 +27,7 @@ import {
 	useGlobalChartsContext,
 	useGlobalChartsTheme,
 } from '../../providers';
+import { useDefaultHiddenSeries } from '../../providers/chart-context/hooks/use-default-hidden-series';
 import { attachSubComponents } from '../../utils';
 import { renderDefaultTooltip } from '../line-chart';
 import { useChartChildren } from '../private/chart-composition';
@@ -72,6 +73,7 @@ const AreaChartInternal = forwardRef< ChartInstanceRef, AreaChartProps >(
 			zoomable = false,
 			rescaleYOnVisibilityChange,
 			rescaleYOnLegendToggle,
+			defaultHiddenSeries,
 			children,
 			gridVisibility,
 			gap = 'md',
@@ -88,6 +90,7 @@ const AreaChartInternal = forwardRef< ChartInstanceRef, AreaChartProps >(
 		const providerTheme = useGlobalChartsTheme();
 		const theme = useXYChartTheme( data );
 		const chartId = useChartId( providedChartId );
+		useDefaultHiddenSeries( chartId, defaultHiddenSeries );
 		const chartRef = useRef< HTMLDivElement >( null );
 		const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 		const [ isNavigating, setIsNavigating ] = useState( false );

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
@@ -90,7 +90,11 @@ const AreaChartInternal = forwardRef< ChartInstanceRef, AreaChartProps >(
 		const providerTheme = useGlobalChartsTheme();
 		const theme = useXYChartTheme( data );
 		const chartId = useChartId( providedChartId );
-		useDefaultHiddenSeries( chartId, defaultHiddenSeries );
+		const hiddenSeries = useDefaultHiddenSeries( chartId, defaultHiddenSeries );
+		const isSeriesVisible = useCallback(
+			( seriesLabel: string ) => ! hiddenSeries.has( seriesLabel ),
+			[ hiddenSeries ]
+		);
 		const chartRef = useRef< HTMLDivElement >( null );
 		const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 		const [ isNavigating, setIsNavigating ] = useState( false );
@@ -124,15 +128,15 @@ const AreaChartInternal = forwardRef< ChartInstanceRef, AreaChartProps >(
 		);
 
 		const dataSorted = useChartDataTransform( data );
-		const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
+		const { getElementStyles } = useGlobalChartsContext();
 
 		const seriesWithVisibility = useMemo( () => {
 			return dataSorted.map( ( series, index ) => ( {
 				series,
 				index,
-				isVisible: isSeriesVisible( chartId, series.label ),
+				isVisible: ! hiddenSeries.has( series.label ),
 			} ) );
-		}, [ dataSorted, chartId, isSeriesVisible ] );
+		}, [ dataSorted, hiddenSeries ] );
 
 		const allSeriesHidden = useMemo(
 			() => seriesWithVisibility.every( ( { isVisible } ) => ! isVisible ),
@@ -367,6 +371,7 @@ const AreaChartInternal = forwardRef< ChartInstanceRef, AreaChartProps >(
 				value={ {
 					chartId,
 					chartRef: internalChartRef,
+					isSeriesVisible,
 					chartWidth: width,
 					chartHeight: measuredChartHeight || 0,
 				} }

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.api.mdx
@@ -29,6 +29,7 @@ Stacked-by-default area chart component with responsive behaviour.
 | `animation` | `boolean` | `false` | Enable entry animation. Respects `prefers-reduced-motion` |
 | `showLegend` | `boolean` | `false` | Display chart legend |
 | `legend` | `SeriesChartLegendConfig` | - | Legend configuration object. See [SeriesChartLegendConfig](#serieschartlegendconfig-type) |
+| `defaultHiddenSeries` | `string[]` | — | Series labels to hide at mount. Revealable through an interactive legend; re-applied only on remount. |
 | `rescaleYOnVisibilityChange` | `boolean?` | `true` | Whether the value axis rescales to the visible series when the visible set changes. Set `false` to pin it to the full data range so the baseline doesn't move as series are hidden |
 | `gridVisibility` | `'x' \| 'y' \| 'xy' \| 'none'?` | grid shown | Control grid visibility |
 | `margin` | `{ top?: number; right?: number; bottom?: number; left?: number }?` | calculated | Chart margins |

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.api.mdx
@@ -29,7 +29,7 @@ Stacked-by-default area chart component with responsive behaviour.
 | `animation` | `boolean` | `false` | Enable entry animation. Respects `prefers-reduced-motion` |
 | `showLegend` | `boolean` | `false` | Display chart legend |
 | `legend` | `SeriesChartLegendConfig` | - | Legend configuration object. See [SeriesChartLegendConfig](#serieschartlegendconfig-type) |
-| `defaultHiddenSeries` | `string[]` | — | Series labels to hide at mount. Revealable through an interactive legend; re-applied only on remount. |
+| `defaultHiddenSeries` | `string[]` | — | Series labels to hide at mount. Revealable through an interactive legend; re-applied on remount or when `chartId` changes. |
 | `rescaleYOnVisibilityChange` | `boolean?` | `true` | Whether the value axis rescales to the visible series when the visible set changes. Set `false` to pin it to the full data range so the baseline doesn't move as series are hidden |
 | `gridVisibility` | `'x' \| 'y' \| 'xy' \| 'none'?` | grid shown | Control grid visibility |
 | `margin` | `{ top?: number; right?: number; bottom?: number; left?: number }?` | calculated | Chart margins |

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.api.mdx
@@ -29,7 +29,7 @@ Stacked-by-default area chart component with responsive behaviour.
 | `animation` | `boolean` | `false` | Enable entry animation. Respects `prefers-reduced-motion` |
 | `showLegend` | `boolean` | `false` | Display chart legend |
 | `legend` | `SeriesChartLegendConfig` | - | Legend configuration object. See [SeriesChartLegendConfig](#serieschartlegendconfig-type) |
-| `defaultHiddenSeries` | `string[]` | — | Series labels to hide at mount. Revealable through an interactive legend; re-applied on remount or when `chartId` changes. |
+| `defaultHiddenSeries` | `readonly string[]` | — | Series labels to hide from the first defined value. User changes persist until remount or `chartId` change; later values for the same ID are ignored. |
 | `rescaleYOnVisibilityChange` | `boolean?` | `true` | Whether the value axis rescales to the visible series when the visible set changes. Set `false` to pin it to the full data range so the baseline doesn't move as series are hidden |
 | `gridVisibility` | `'x' \| 'y' \| 'xy' \| 'none'?` | grid shown | Control grid visibility |
 | `margin` | `{ top?: number; right?: number; bottom?: number; left?: number }?` | calculated | Chart margins |

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.docs.mdx
@@ -122,6 +122,10 @@ Use the composition API to place a legend explicitly:
 
 For full legend configuration options, see the [Legend component docs](./?path=/docs/js-packages-charts-library-components-legend--docs).
 
+Use `defaultHiddenSeries` to hide selected series initially while keeping them available through an interactive legend. The first defined list is used; later values for the same `chartId` are ignored. User changes persist until the chart remounts or its ID changes.
+
+<Canvas of={ AreaChartStories.WithDefaultHiddenSeries } />
+
 ## Responsive Behavior
 
 By default, charts **fill their parent container's dimensions**. The parent must have an explicit height, or the chart must receive an `aspectRatio`:

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
@@ -256,6 +256,22 @@ export const RescaleYOnVisibilityChange: StoryObj< StoryArgs > = {
 	},
 };
 
+export const WithDefaultHiddenSeries: StoryObj< StoryArgs > = Template.bind( {} );
+WithDefaultHiddenSeries.args = {
+	...Default.args,
+	legend: { interactive: true },
+	chartId: 'default-hidden-series-demo',
+	defaultHiddenSeries: [ 'London' ],
+};
+WithDefaultHiddenSeries.parameters = {
+	docs: {
+		description: {
+			story:
+				'London is seeded hidden and struck through in the legend. Reload the story and watch the load: it must never appear, not even for one frame. Click it to reveal.',
+		},
+	},
+};
+
 export const WithCompositionLegend: StoryObj< StoryArgs > = {
 	render: args => {
 		const legend = extractLegendConfig< ChartLegendConfig< SeriesData[] > >( args );

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
@@ -267,7 +267,7 @@ WithDefaultHiddenSeries.parameters = {
 	docs: {
 		description: {
 			story:
-				'London is seeded hidden and struck through in the legend. Reload the story and watch the load: it must never appear, not even for one frame. Click it to reveal.',
+				'London is hidden from the initial render and marked inactive in the legend. Select its legend item to reveal it.',
 		},
 	},
 };

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
@@ -259,7 +259,7 @@ export const RescaleYOnVisibilityChange: StoryObj< StoryArgs > = {
 export const WithDefaultHiddenSeries: StoryObj< StoryArgs > = Template.bind( {} );
 WithDefaultHiddenSeries.args = {
 	...Default.args,
-	legend: { interactive: true },
+	legendInteractive: true,
 	chartId: 'default-hidden-series-demo',
 	defaultHiddenSeries: [ 'London' ],
 };

--- a/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
@@ -870,4 +870,70 @@ describe( 'AreaChart', () => {
 			).toBeInTheDocument();
 		} );
 	} );
+
+	describe( 'defaultHiddenSeries', () => {
+		it( 'renders a series hidden when named in defaultHiddenSeries', () => {
+			render(
+				<GlobalChartsProvider>
+					<AreaChartUnresponsive
+						width={ 500 }
+						height={ 300 }
+						showLegend={ true }
+						legend={ { interactive: true } }
+						chartId="test-default-hidden-area"
+						defaultHiddenSeries={ [ 'Series B' ] }
+						data={ [
+							{
+								label: 'Series A',
+								data: [ { date: new Date( '2024-01-01' ), value: 10, label: 'Jan 1' } ],
+								options: {},
+							},
+							{
+								label: 'Series B',
+								data: [ { date: new Date( '2024-01-01' ), value: 20, label: 'Jan 1' } ],
+								options: {},
+							},
+						] }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			const items = screen.getAllByRole( 'button' );
+			expect( items[ 0 ] ).toHaveAttribute( 'aria-pressed', 'true' );
+			expect( items[ 1 ] ).toHaveAttribute( 'aria-pressed', 'false' );
+		} );
+
+		it( 'lets the user reveal a series seeded hidden', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<GlobalChartsProvider>
+					<AreaChartUnresponsive
+						width={ 500 }
+						height={ 300 }
+						showLegend={ true }
+						legend={ { interactive: true } }
+						chartId="test-default-hidden-reveal-area"
+						defaultHiddenSeries={ [ 'Series B' ] }
+						data={ [
+							{
+								label: 'Series A',
+								data: [ { date: new Date( '2024-01-01' ), value: 10, label: 'Jan 1' } ],
+								options: {},
+							},
+							{
+								label: 'Series B',
+								data: [ { date: new Date( '2024-01-01' ), value: 20, label: 'Jan 1' } ],
+								options: {},
+							},
+						] }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			await user.click( screen.getAllByRole( 'button' )[ 1 ] );
+
+			expect( screen.getAllByRole( 'button' )[ 1 ] ).toHaveAttribute( 'aria-pressed', 'true' );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/charts/area-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/area-chart/types.ts
@@ -77,10 +77,8 @@ export interface AreaChartProps extends BaseChartProps< SeriesData[] > {
 	 */
 	rescaleYOnLegendToggle?: boolean;
 	/**
-	 * Series labels to hide when the chart first mounts, as if they had been
-	 * toggled off in the legend. The user can reveal them through an interactive
-	 * legend, and revealing sticks — the defaults are not re-applied on re-render.
-	 * A remount re-applies exactly this list and nothing else.
+	 * Series labels to hide when the chart mounts. User changes persist until the
+	 * chart remounts or its ID changes.
 	 */
 	defaultHiddenSeries?: string[];
 	children?: ReactNode;

--- a/projects/js-packages/charts/src/charts/area-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/area-chart/types.ts
@@ -76,5 +76,12 @@ export interface AreaChartProps extends BaseChartProps< SeriesData[] > {
 	 * `rescaleYOnVisibilityChange` is not set.
 	 */
 	rescaleYOnLegendToggle?: boolean;
+	/**
+	 * Series labels to hide when the chart first mounts, as if they had been
+	 * toggled off in the legend. The user can reveal them through an interactive
+	 * legend, and revealing sticks — the defaults are not re-applied on re-render.
+	 * A remount re-applies exactly this list and nothing else.
+	 */
+	defaultHiddenSeries?: string[];
 	children?: ReactNode;
 }

--- a/projects/js-packages/charts/src/charts/area-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/area-chart/types.ts
@@ -3,12 +3,13 @@ import type {
 	DataPointDate,
 	SeriesData,
 	SeriesChartLegendConfig,
+	SeriesVisibilityProps,
 } from '../../types';
 import type { RenderTooltipParams } from '../../visx/types';
 import type { CurveType } from '../line-chart/types';
 import type { ReactNode } from 'react';
 
-export interface AreaChartProps extends BaseChartProps< SeriesData[] > {
+export interface AreaChartProps extends BaseChartProps< SeriesData[] >, SeriesVisibilityProps {
 	/**
 	 * Legend configuration. Supports `collapseGroups` on top of the shared options.
 	 */
@@ -76,10 +77,5 @@ export interface AreaChartProps extends BaseChartProps< SeriesData[] > {
 	 * `rescaleYOnVisibilityChange` is not set.
 	 */
 	rescaleYOnLegendToggle?: boolean;
-	/**
-	 * Series labels to hide when the chart mounts. User changes persist until the
-	 * chart remounts or its ID changes.
-	 */
-	defaultHiddenSeries?: string[];
 	children?: ReactNode;
 }

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -43,13 +43,14 @@ import type {
 	DataPointDate,
 	SeriesData,
 	SeriesChartLegendConfig,
+	SeriesVisibilityProps,
 	Optional,
 } from '../../types';
 import type { RenderTooltipParams } from '../../visx/types';
 import type { ResponsiveConfig } from '../private/with-responsive';
 import type { FC, ReactNode, ComponentType } from 'react';
 
-export interface BarChartProps extends BaseChartProps< SeriesData[] > {
+export interface BarChartProps extends BaseChartProps< SeriesData[] >, SeriesVisibilityProps {
 	/**
 	 * Legend configuration. Supports `collapseGroups` on top of the shared options.
 	 */
@@ -58,11 +59,6 @@ export interface BarChartProps extends BaseChartProps< SeriesData[] > {
 	orientation?: 'horizontal' | 'vertical';
 	withPatterns?: boolean;
 	showZeroValues?: boolean;
-	/**
-	 * Series labels to hide when the chart mounts. User changes persist until the
-	 * chart remounts or its ID changes.
-	 */
-	defaultHiddenSeries?: string[];
 	children?: ReactNode;
 }
 

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -20,6 +20,7 @@ import {
 	useGlobalChartsContext,
 	GlobalChartsContext,
 } from '../../providers';
+import { useDefaultHiddenSeries } from '../../providers/chart-context/hooks/use-default-hidden-series';
 import { attachSubComponents } from '../../utils';
 import { useChartChildren } from '../private/chart-composition';
 import { ChartInstanceContext } from '../private/chart-instance-context';
@@ -57,6 +58,13 @@ export interface BarChartProps extends BaseChartProps< SeriesData[] > {
 	orientation?: 'horizontal' | 'vertical';
 	withPatterns?: boolean;
 	showZeroValues?: boolean;
+	/**
+	 * Series labels to hide when the chart first mounts, as if they had been
+	 * toggled off in the legend. The user can reveal them through an interactive
+	 * legend, and revealing sticks — the defaults are not re-applied on re-render.
+	 * A remount re-applies exactly this list and nothing else.
+	 */
+	defaultHiddenSeries?: string[];
 	children?: ReactNode;
 }
 
@@ -122,6 +130,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	orientation = 'vertical',
 	withPatterns = false,
 	showZeroValues = false,
+	defaultHiddenSeries,
 	animation,
 	children,
 	gap = 'md',
@@ -130,6 +139,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	const legendCollapseGroups = legend.collapseGroups ?? false;
 	const horizontal = orientation === 'horizontal';
 	const chartId = useChartId( providedChartId );
+	useDefaultHiddenSeries( chartId, defaultHiddenSeries );
 	const theme = useXYChartTheme( data );
 
 	const dataSorted = useChartDataTransform( data );

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -137,7 +137,11 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	const legendCollapseGroups = legend.collapseGroups ?? false;
 	const horizontal = orientation === 'horizontal';
 	const chartId = useChartId( providedChartId );
-	useDefaultHiddenSeries( chartId, defaultHiddenSeries );
+	const hiddenSeries = useDefaultHiddenSeries( chartId, defaultHiddenSeries );
+	const isSeriesVisible = useCallback(
+		( seriesLabel: string ) => ! hiddenSeries.has( seriesLabel ),
+		[ hiddenSeries ]
+	);
 	const theme = useXYChartTheme( data );
 
 	const dataSorted = useChartDataTransform( data );
@@ -156,14 +160,14 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	);
 	const legendItems = useChartLegendItems( dataSorted, legendOptions );
 
-	const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
+	const { getElementStyles } = useGlobalChartsContext();
 
 	// A hidden series is unmounted, so it is not on the band scale either — the
 	// axis has to choose its tick values from what is left. Visibility is owned by
 	// the provider, whether it changed through the legend or programmatically.
 	const isSeriesRendered = useCallback(
-		( series: SeriesData ) => isSeriesVisible( chartId, series.label ),
-		[ chartId, isSeriesVisible ]
+		( series: SeriesData ) => isSeriesVisible( series.label ),
+		[ isSeriesVisible ]
 	);
 
 	const chartOptions = useBarChartOptions(
@@ -525,6 +529,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		<ChartInstanceContext.Provider
 			value={ {
 				chartId,
+				isSeriesVisible,
 				chartWidth: width,
 				chartHeight: measuredChartHeight || 0,
 			} }

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -59,10 +59,8 @@ export interface BarChartProps extends BaseChartProps< SeriesData[] > {
 	withPatterns?: boolean;
 	showZeroValues?: boolean;
 	/**
-	 * Series labels to hide when the chart first mounts, as if they had been
-	 * toggled off in the legend. The user can reveal them through an interactive
-	 * legend, and revealing sticks — the defaults are not re-applied on re-render.
-	 * A remount re-applies exactly this list and nothing else.
+	 * Series labels to hide when the chart mounts. User changes persist until the
+	 * chart remounts or its ID changes.
 	 */
 	defaultHiddenSeries?: string[];
 	children?: ReactNode;

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
@@ -24,7 +24,7 @@ Main chart component with responsive behavior by default.
 | `showZeroValues` | `boolean` | `false` | Display zero values with minimum visual height |
 | `showLegend` | `boolean` | `false` | Display chart legend |
 | `legend` | `SeriesChartLegendConfig` | `undefined` | Legend configuration object. See [SeriesChartLegendConfig](#serieschartlegendconfig-type) |
-| `defaultHiddenSeries` | `string[]` | — | Series labels to hide at mount. Revealable through an interactive legend; re-applied on remount or when `chartId` changes. |
+| `defaultHiddenSeries` | `readonly string[]` | — | Series labels to hide from the first defined value. User changes persist until remount or `chartId` change; later values for the same ID are ignored. |
 | `gridVisibility` | `'x' \| 'y' \| 'xy' \| 'none'` | orientation-based | Grid line visibility |
 | `renderTooltip` | `(params: RenderTooltipParams) => ReactNode` | - | Custom tooltip render function |
 | `margin` | `{ top?: number; right?: number; bottom?: number; left?: number }` | calculated | Chart margins |

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
@@ -24,6 +24,7 @@ Main chart component with responsive behavior by default.
 | `showZeroValues` | `boolean` | `false` | Display zero values with minimum visual height |
 | `showLegend` | `boolean` | `false` | Display chart legend |
 | `legend` | `SeriesChartLegendConfig` | `undefined` | Legend configuration object. See [SeriesChartLegendConfig](#serieschartlegendconfig-type) |
+| `defaultHiddenSeries` | `string[]` | — | Series labels to hide at mount. Revealable through an interactive legend; re-applied only on remount. |
 | `gridVisibility` | `'x' \| 'y' \| 'xy' \| 'none'` | orientation-based | Grid line visibility |
 | `renderTooltip` | `(params: RenderTooltipParams) => ReactNode` | - | Custom tooltip render function |
 | `margin` | `{ top?: number; right?: number; bottom?: number; left?: number }` | calculated | Chart margins |

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
@@ -24,7 +24,7 @@ Main chart component with responsive behavior by default.
 | `showZeroValues` | `boolean` | `false` | Display zero values with minimum visual height |
 | `showLegend` | `boolean` | `false` | Display chart legend |
 | `legend` | `SeriesChartLegendConfig` | `undefined` | Legend configuration object. See [SeriesChartLegendConfig](#serieschartlegendconfig-type) |
-| `defaultHiddenSeries` | `string[]` | — | Series labels to hide at mount. Revealable through an interactive legend; re-applied only on remount. |
+| `defaultHiddenSeries` | `string[]` | — | Series labels to hide at mount. Revealable through an interactive legend; re-applied on remount or when `chartId` changes. |
 | `gridVisibility` | `'x' \| 'y' \| 'xy' \| 'none'` | orientation-based | Grid line visibility |
 | `renderTooltip` | `(params: RenderTooltipParams) => ReactNode` | - | Custom tooltip render function |
 | `margin` | `{ top?: number; right?: number; bottom?: number; left?: number }` | calculated | Chart margins |

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -80,6 +80,7 @@ The simplest bar chart requires only a `data` prop with categorical data:
 **Legend:**
 - **`showLegend`**: Display chart legend (`false` by default)
 - **`legend`**: Legend configuration object (`ChartLegendConfig`) for controlling orientation, position, alignment, shape, interactivity, and styling
+- **`defaultHiddenSeries`**: Series labels hidden from the first defined value; later values for the same `chartId` are ignored
 
 **Advanced:**
 - **`options`**: Advanced axis and scale configuration
@@ -385,6 +386,10 @@ Use the composition API to add a legend by placing `<BarChart.Legend />` as a ch
 />
 
 For full legend configuration options — positioning, orientation, shapes, interactivity, and the composition API — see the [Legend component docs](./?path=/docs/js-packages-charts-library-components-legend--docs).
+
+Use `defaultHiddenSeries` to hide selected series initially while keeping them available through an interactive legend. The first defined list is used; later values for the same `chartId` are ignored. User changes persist until the chart remounts or its ID changes.
+
+<Canvas of={ BarChartStories.WithDefaultHiddenSeries } />
 
 ## Theming Integration
 

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -419,6 +419,24 @@ export const WithLegend: Story = {
 	},
 };
 
+export const WithDefaultHiddenSeries: Story = {
+	args: {
+		...Default.args,
+		showLegend: true,
+		legend: { interactive: true },
+		chartId: 'default-hidden-series-demo',
+		defaultHiddenSeries: [ 'Great Britain' ],
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Great Britain is seeded hidden and struck through in the legend. Reload the story and watch the load: it must never appear, not even for one frame. Click it to reveal.',
+			},
+		},
+	},
+};
+
 // Story demonstrating composition API
 export const WithCompositionLegend: Story = {
 	render: args => {

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -423,7 +423,7 @@ export const WithDefaultHiddenSeries: Story = {
 	args: {
 		...Default.args,
 		showLegend: true,
-		legend: { interactive: true },
+		legendInteractive: true,
 		chartId: 'default-hidden-series-demo',
 		defaultHiddenSeries: [ 'Great Britain' ],
 	},

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.stories.tsx
@@ -431,7 +431,7 @@ export const WithDefaultHiddenSeries: Story = {
 		docs: {
 			description: {
 				story:
-					'Great Britain is seeded hidden and struck through in the legend. Reload the story and watch the load: it must never appear, not even for one frame. Click it to reveal.',
+					'Great Britain is hidden from the initial render and marked inactive in the legend. Select its legend item to reveal it.',
 			},
 		},
 	},

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -1019,6 +1019,64 @@ describe( 'BarChart', () => {
 				expect( screen.queryByTestId( 'chart-tooltip-0' ) ).not.toBeInTheDocument();
 			} );
 
+			test( 'keeps the tooltip open once the chart re-renders under it', async () => {
+				// visx hides its tooltip on a debounce and cancels only the most recently
+				// scheduled hide, so anything that re-runs the tooltip effect while nothing
+				// is shown leaves a hide pending that lands on the next tooltip. Seeding a
+				// hidden series re-renders the chart right after mount, which is exactly
+				// that shape.
+				jest.useFakeTimers();
+
+				try {
+					const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
+					renderWithTheme( {
+						withTooltips: true,
+						defaultHiddenSeries: [ 'Series B' ],
+						data: [
+							{
+								label: 'Series A',
+								data: [
+									{ date: new Date( '2024-01-01' ), value: 10, label: 'Jan 1' },
+									{ date: new Date( '2024-01-02' ), value: 20, label: 'Jan 2' },
+								],
+								options: {},
+							},
+							{
+								label: 'Series B',
+								data: [
+									{ date: new Date( '2024-01-01' ), value: 15, label: 'Jan 1' },
+									{ date: new Date( '2024-01-02' ), value: 25, label: 'Jan 2' },
+								],
+								options: {},
+							},
+						],
+					} );
+
+					const chart = screen.getByRole( 'grid', { name: /bar chart/i } );
+					chart.focus();
+
+					await user.keyboard( '{ArrowRight}' );
+					expect( screen.getByTestId( 'chart-tooltip-0' ) ).toHaveTextContent( 'Series A' );
+
+					// Well past any pending hide.
+					await act( async () => {
+						jest.advanceTimersByTime( 5000 );
+					} );
+
+					expect( screen.getByTestId( 'chart-tooltip-0' ) ).toBeInTheDocument();
+
+					// Leaving navigation still closes it.
+					await user.keyboard( '{Escape}' );
+					await act( async () => {
+						jest.advanceTimersByTime( 5000 );
+					} );
+
+					expect( screen.queryByTestId( 'chart-tooltip-0' ) ).not.toBeInTheDocument();
+				} finally {
+					jest.useRealTimers();
+				}
+			} );
+
 			test( 'left arrow key navigates to previous data point', async () => {
 				const user = userEvent.setup();
 				renderWithTheme( {

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -2125,4 +2125,70 @@ describe( 'BarChart', () => {
 			).toBeInTheDocument();
 		} );
 	} );
+
+	describe( 'defaultHiddenSeries', () => {
+		it( 'renders a series hidden when named in defaultHiddenSeries', () => {
+			render(
+				<GlobalChartsProvider>
+					<BarChartUnresponsive
+						width={ 500 }
+						height={ 300 }
+						showLegend={ true }
+						legend={ { interactive: true } }
+						chartId="test-default-hidden-bar"
+						defaultHiddenSeries={ [ 'Series B' ] }
+						data={ [
+							{
+								label: 'Series A',
+								data: [ { date: new Date( '2024-01-01' ), value: 10, label: 'Jan 1' } ],
+								options: {},
+							},
+							{
+								label: 'Series B',
+								data: [ { date: new Date( '2024-01-01' ), value: 20, label: 'Jan 1' } ],
+								options: {},
+							},
+						] }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			const items = screen.getAllByRole( 'button' );
+			expect( items[ 0 ] ).toHaveAttribute( 'aria-pressed', 'true' );
+			expect( items[ 1 ] ).toHaveAttribute( 'aria-pressed', 'false' );
+		} );
+
+		it( 'lets the user reveal a series seeded hidden', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<GlobalChartsProvider>
+					<BarChartUnresponsive
+						width={ 500 }
+						height={ 300 }
+						showLegend={ true }
+						legend={ { interactive: true } }
+						chartId="test-default-hidden-reveal-bar"
+						defaultHiddenSeries={ [ 'Series B' ] }
+						data={ [
+							{
+								label: 'Series A',
+								data: [ { date: new Date( '2024-01-01' ), value: 10, label: 'Jan 1' } ],
+								options: {},
+							},
+							{
+								label: 'Series B',
+								data: [ { date: new Date( '2024-01-01' ), value: 20, label: 'Jan 1' } ],
+								options: {},
+							},
+						] }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			await user.click( screen.getAllByRole( 'button' )[ 1 ] );
+
+			expect( screen.getAllByRole( 'button' )[ 1 ] ).toHaveAttribute( 'aria-pressed', 'true' );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -29,6 +29,7 @@ import {
 	useGlobalChartsContext,
 	useGlobalChartsTheme,
 } from '../../providers';
+import { useDefaultHiddenSeries } from '../../providers/chart-context/hooks/use-default-hidden-series';
 import { attachSubComponents } from '../../utils';
 import { useChartChildren } from '../private/chart-composition';
 import { ChartInstanceContext, type ChartInstanceRef } from '../private/chart-instance-context';
@@ -180,6 +181,7 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 			onPointerOut = undefined,
 			zoomable = false,
 			rescaleYOnVisibilityChange = true,
+			defaultHiddenSeries,
 			children,
 			gridVisibility,
 			gap = 'md',
@@ -196,6 +198,7 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 		// Gradient stops apply this as an SVG attribute, where CSS var() cannot resolve. useXYChartTheme has already resolved the same role inside its memo, against the chart's scope element, so read it back rather than paying another getComputedStyle on every render.
 		const resolvedBackgroundColor = theme.backgroundColor ?? providerTheme.backgroundColor;
 		const chartId = useChartId( providedChartId );
+		useDefaultHiddenSeries( chartId, defaultHiddenSeries );
 		const chartRef = useRef< HTMLDivElement >( null );
 		const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 		const [ isNavigating, setIsNavigating ] = useState( false );

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -198,7 +198,11 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 		// Gradient stops apply this as an SVG attribute, where CSS var() cannot resolve. useXYChartTheme has already resolved the same role inside its memo, against the chart's scope element, so read it back rather than paying another getComputedStyle on every render.
 		const resolvedBackgroundColor = theme.backgroundColor ?? providerTheme.backgroundColor;
 		const chartId = useChartId( providedChartId );
-		useDefaultHiddenSeries( chartId, defaultHiddenSeries );
+		const hiddenSeries = useDefaultHiddenSeries( chartId, defaultHiddenSeries );
+		const isSeriesVisible = useCallback(
+			( seriesLabel: string ) => ! hiddenSeries.has( seriesLabel ),
+			[ hiddenSeries ]
+		);
 		const chartRef = useRef< HTMLDivElement >( null );
 		const [ selectedIndex, setSelectedIndex ] = useState< number | undefined >( undefined );
 		const [ isNavigating, setIsNavigating ] = useState( false );
@@ -236,7 +240,7 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 		);
 
 		const dataSorted = useChartDataTransform( data );
-		const { getElementStyles, isSeriesVisible } = useGlobalChartsContext();
+		const { getElementStyles } = useGlobalChartsContext();
 
 		// Series visibility is owned by the provider, so it applies whether it changed
 		// through the interactive legend or programmatically.
@@ -244,9 +248,9 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 			return dataSorted.map( ( series, index ) => ( {
 				series,
 				index,
-				isVisible: isSeriesVisible( chartId, series.label ),
+				isVisible: ! hiddenSeries.has( series.label ),
 			} ) );
-		}, [ dataSorted, chartId, isSeriesVisible ] );
+		}, [ dataSorted, hiddenSeries ] );
 
 		// Check if all series are hidden
 		const allSeriesHidden = useMemo( () => {
@@ -418,6 +422,7 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 				value={ {
 					chartId,
 					chartRef: internalChartRef,
+					isSeriesVisible,
 					chartWidth: width,
 					chartHeight: measuredChartHeight || 0,
 				} }

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
@@ -24,7 +24,7 @@ Main chart component with responsive behavior by default.
 | `animation` | `boolean` | `false` | Enable entry animation on initial render. Creates a rising effect where lines scale up from the bottom. Automatically respects user's `prefers-reduced-motion` system setting |
 | `showLegend` | `boolean` | `false` | Display chart legend |
 | `legend` | `SeriesChartLegendConfig` | `undefined` | Legend configuration object. See [SeriesChartLegendConfig](#serieschartlegendconfig-type) |
-| `defaultHiddenSeries` | `string[]` | — | Series labels to hide at mount. Revealable through an interactive legend; re-applied only on remount. |
+| `defaultHiddenSeries` | `string[]` | — | Series labels to hide at mount. Revealable through an interactive legend; re-applied on remount or when `chartId` changes. |
 | `rescaleYOnVisibilityChange` | `boolean?` | `true` | Whether the value axis rescales to the visible series when the visible set changes. Set `false` to pin it to the full data range so the baseline doesn't move as series are hidden |
 | `withStartGlyphs` | `boolean?` | `false` | Show markers at the first data point of each series |
 | `withLegendGlyph` | `boolean?` | `false` | Use custom glyphs in legend |

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
@@ -24,7 +24,7 @@ Main chart component with responsive behavior by default.
 | `animation` | `boolean` | `false` | Enable entry animation on initial render. Creates a rising effect where lines scale up from the bottom. Automatically respects user's `prefers-reduced-motion` system setting |
 | `showLegend` | `boolean` | `false` | Display chart legend |
 | `legend` | `SeriesChartLegendConfig` | `undefined` | Legend configuration object. See [SeriesChartLegendConfig](#serieschartlegendconfig-type) |
-| `defaultHiddenSeries` | `string[]` | — | Series labels to hide at mount. Revealable through an interactive legend; re-applied on remount or when `chartId` changes. |
+| `defaultHiddenSeries` | `readonly string[]` | — | Series labels to hide from the first defined value. User changes persist until remount or `chartId` change; later values for the same ID are ignored. |
 | `rescaleYOnVisibilityChange` | `boolean?` | `true` | Whether the value axis rescales to the visible series when the visible set changes. Set `false` to pin it to the full data range so the baseline doesn't move as series are hidden |
 | `withStartGlyphs` | `boolean?` | `false` | Show markers at the first data point of each series |
 | `withLegendGlyph` | `boolean?` | `false` | Use custom glyphs in legend |

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
@@ -24,6 +24,7 @@ Main chart component with responsive behavior by default.
 | `animation` | `boolean` | `false` | Enable entry animation on initial render. Creates a rising effect where lines scale up from the bottom. Automatically respects user's `prefers-reduced-motion` system setting |
 | `showLegend` | `boolean` | `false` | Display chart legend |
 | `legend` | `SeriesChartLegendConfig` | `undefined` | Legend configuration object. See [SeriesChartLegendConfig](#serieschartlegendconfig-type) |
+| `defaultHiddenSeries` | `string[]` | — | Series labels to hide at mount. Revealable through an interactive legend; re-applied only on remount. |
 | `rescaleYOnVisibilityChange` | `boolean?` | `true` | Whether the value axis rescales to the visible series when the visible set changes. Set `false` to pin it to the full data range so the baseline doesn't move as series are hidden |
 | `withStartGlyphs` | `boolean?` | `false` | Show markers at the first data point of each series |
 | `withLegendGlyph` | `boolean?` | `false` | Use custom glyphs in legend |

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -96,6 +96,7 @@ The simplest line chart requires only a `data` prop with time-series data:
 **Legend:**
 - **`showLegend`**: Display chart legend (`false` by default)
 - **`legend`**: Legend configuration object (`ChartLegendConfig`) for controlling orientation, position, alignment, shape, interactivity, and styling
+- **`defaultHiddenSeries`**: Series labels hidden from the first defined value; later values for the same `chartId` are ignored
 - **`withLegendGlyph`**: Use custom glyphs in legend (`false` by default)
 
 **Advanced:**
@@ -551,6 +552,10 @@ Use the composition API to add a legend by placing `<LineChart.Legend />` as a c
 />
 
 For full legend configuration options — positioning, orientation, shapes, interactivity, and the composition API — see the [Legend component docs](./?path=/docs/js-packages-charts-library-components-legend--docs).
+
+Use `defaultHiddenSeries` to hide selected series initially while keeping them available through an interactive legend. The first defined list is used; later values for the same `chartId` are ignored. User changes persist until the chart remounts or its ID changes.
+
+<Canvas of={ LineChartStories.WithDefaultHiddenSeries } />
 
 ## Theming Integration
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -198,6 +198,23 @@ export const WithCompositionLegend: StoryObj< StoryArgs > = {
 	},
 };
 
+export const WithDefaultHiddenSeries: StoryObj< StoryArgs > = Template.bind( {} );
+WithDefaultHiddenSeries.args = {
+	...Default.args,
+	showLegend: true,
+	legend: { interactive: true },
+	chartId: 'default-hidden-series-demo',
+	defaultHiddenSeries: [ 'London' ],
+};
+WithDefaultHiddenSeries.parameters = {
+	docs: {
+		description: {
+			story:
+				'London is seeded hidden and struck through in the legend. Reload the story and watch the load: it must never appear, not even for one frame. Click it to reveal.',
+		},
+	},
+};
+
 // Story with gradient filled line chart
 export const GradientFilled: StoryObj< StoryArgs > = Template.bind( {} );
 GradientFilled.args = {

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -202,7 +202,7 @@ export const WithDefaultHiddenSeries: StoryObj< StoryArgs > = Template.bind( {} 
 WithDefaultHiddenSeries.args = {
 	...Default.args,
 	showLegend: true,
-	legend: { interactive: true },
+	legendInteractive: true,
 	chartId: 'default-hidden-series-demo',
 	defaultHiddenSeries: [ 'London' ],
 };

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -210,7 +210,7 @@ WithDefaultHiddenSeries.parameters = {
 	docs: {
 		description: {
 			story:
-				'London is seeded hidden and struck through in the legend. Reload the story and watch the load: it must never appear, not even for one frame. Click it to reveal.',
+				'London is hidden from the initial render and marked inactive in the legend. Select its legend item to reveal it.',
 		},
 	},
 };

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -1722,5 +1722,62 @@ describe( 'LineChart', () => {
 
 			expect( screen.getAllByRole( 'button' )[ 1 ] ).toHaveAttribute( 'aria-pressed', 'true' );
 		} );
+
+		it( 'keeps a revealed series visible after a data change', async () => {
+			// Matters specifically at chart level: useChartRegistration unregisters and
+			// re-registers whenever legendItems change, which a data prop change triggers.
+			// A hook-level harness has no registration at all, so it can't catch a
+			// regression where re-registration re-triggers the seeding effect.
+			const user = userEvent.setup();
+			const chartId = 'test-default-hidden-data-change-line';
+
+			const makeData = ( seriesAValue: number ) => [
+				{
+					label: 'Series A',
+					data: [ { date: new Date( '2024-01-01' ), value: seriesAValue, label: 'Jan 1' } ],
+					options: {},
+				},
+				{
+					label: 'Series B',
+					data: [ { date: new Date( '2024-01-01' ), value: 20, label: 'Jan 1' } ],
+					options: {},
+				},
+			];
+
+			const { rerender } = render(
+				<GlobalChartsProvider>
+					<LineChartUnresponsive
+						width={ 500 }
+						height={ 300 }
+						withGradientFill={ false }
+						showLegend={ true }
+						legend={ { interactive: true } }
+						chartId={ chartId }
+						defaultHiddenSeries={ [ 'Series B' ] }
+						data={ makeData( 10 ) }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			await user.click( screen.getAllByRole( 'button' )[ 1 ] );
+			expect( screen.getAllByRole( 'button' )[ 1 ] ).toHaveAttribute( 'aria-pressed', 'true' );
+
+			rerender(
+				<GlobalChartsProvider>
+					<LineChartUnresponsive
+						width={ 500 }
+						height={ 300 }
+						withGradientFill={ false }
+						showLegend={ true }
+						legend={ { interactive: true } }
+						chartId={ chartId }
+						defaultHiddenSeries={ [ 'Series B' ] }
+						data={ makeData( 30 ) }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			expect( screen.getAllByRole( 'button' )[ 1 ] ).toHaveAttribute( 'aria-pressed', 'true' );
+		} );
 	} );
 } );

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -1655,4 +1655,72 @@ describe( 'LineChart', () => {
 			).toBeInTheDocument();
 		} );
 	} );
+
+	describe( 'defaultHiddenSeries', () => {
+		it( 'renders a series hidden when named in defaultHiddenSeries', () => {
+			render(
+				<GlobalChartsProvider>
+					<LineChartUnresponsive
+						width={ 500 }
+						height={ 300 }
+						withGradientFill={ false }
+						showLegend={ true }
+						legend={ { interactive: true } }
+						chartId="test-default-hidden-line"
+						defaultHiddenSeries={ [ 'Series B' ] }
+						data={ [
+							{
+								label: 'Series A',
+								data: [ { date: new Date( '2024-01-01' ), value: 10, label: 'Jan 1' } ],
+								options: {},
+							},
+							{
+								label: 'Series B',
+								data: [ { date: new Date( '2024-01-01' ), value: 20, label: 'Jan 1' } ],
+								options: {},
+							},
+						] }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			const items = screen.getAllByRole( 'button' );
+			expect( items[ 0 ] ).toHaveAttribute( 'aria-pressed', 'true' );
+			expect( items[ 1 ] ).toHaveAttribute( 'aria-pressed', 'false' );
+		} );
+
+		it( 'lets the user reveal a series seeded hidden', async () => {
+			const user = userEvent.setup();
+
+			render(
+				<GlobalChartsProvider>
+					<LineChartUnresponsive
+						width={ 500 }
+						height={ 300 }
+						withGradientFill={ false }
+						showLegend={ true }
+						legend={ { interactive: true } }
+						chartId="test-default-hidden-reveal-line"
+						defaultHiddenSeries={ [ 'Series B' ] }
+						data={ [
+							{
+								label: 'Series A',
+								data: [ { date: new Date( '2024-01-01' ), value: 10, label: 'Jan 1' } ],
+								options: {},
+							},
+							{
+								label: 'Series B',
+								data: [ { date: new Date( '2024-01-01' ), value: 20, label: 'Jan 1' } ],
+								options: {},
+							},
+						] }
+					/>
+				</GlobalChartsProvider>
+			);
+
+			await user.click( screen.getAllByRole( 'button' )[ 1 ] );
+
+			expect( screen.getAllByRole( 'button' )[ 1 ] ).toHaveAttribute( 'aria-pressed', 'true' );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/charts/line-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/line-chart/types.ts
@@ -62,10 +62,8 @@ export interface LineChartProps extends BaseChartProps< SeriesData[] > {
 	 */
 	rescaleYOnVisibilityChange?: boolean;
 	/**
-	 * Series labels to hide when the chart first mounts, as if they had been
-	 * toggled off in the legend. The user can reveal them through an interactive
-	 * legend, and revealing sticks — the defaults are not re-applied on re-render.
-	 * A remount re-applies exactly this list and nothing else.
+	 * Series labels to hide when the chart mounts. User changes persist until the
+	 * chart remounts or its ID changes.
 	 */
 	defaultHiddenSeries?: string[];
 	children?: ReactNode;

--- a/projects/js-packages/charts/src/charts/line-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/line-chart/types.ts
@@ -61,6 +61,13 @@ export interface LineChartProps extends BaseChartProps< SeriesData[] > {
 	 * @default true
 	 */
 	rescaleYOnVisibilityChange?: boolean;
+	/**
+	 * Series labels to hide when the chart first mounts, as if they had been
+	 * toggled off in the legend. The user can reveal them through an interactive
+	 * legend, and revealing sticks — the defaults are not re-applied on re-render.
+	 * A remount re-applies exactly this list and nothing else.
+	 */
+	defaultHiddenSeries?: string[];
 	children?: ReactNode;
 }
 

--- a/projects/js-packages/charts/src/charts/line-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/line-chart/types.ts
@@ -3,6 +3,7 @@ import type {
 	DataPointDate,
 	SeriesData,
 	SeriesChartLegendConfig,
+	SeriesVisibilityProps,
 	AnnotationStyles,
 	DataPoint,
 } from '../../types';
@@ -28,7 +29,7 @@ export type RenderLineGlyphProps< Datum extends object > = GlyphProps< Datum > &
 	position?: 'start' | 'end';
 };
 
-export interface LineChartProps extends BaseChartProps< SeriesData[] > {
+export interface LineChartProps extends BaseChartProps< SeriesData[] >, SeriesVisibilityProps {
 	/**
 	 * Legend configuration. Supports `collapseGroups` on top of the shared options.
 	 */
@@ -61,11 +62,6 @@ export interface LineChartProps extends BaseChartProps< SeriesData[] > {
 	 * @default true
 	 */
 	rescaleYOnVisibilityChange?: boolean;
-	/**
-	 * Series labels to hide when the chart mounts. User changes persist until the
-	 * chart remounts or its ID changes.
-	 */
-	defaultHiddenSeries?: string[];
 	children?: ReactNode;
 }
 

--- a/projects/js-packages/charts/src/charts/private/chart-instance-context/chart-instance-context.ts
+++ b/projects/js-packages/charts/src/charts/private/chart-instance-context/chart-instance-context.ts
@@ -15,6 +15,7 @@ export interface ChartInstanceContextValue {
 	chartRef?: React.RefObject< ChartInstanceRef >;
 	chartWidth?: number;
 	chartHeight?: number;
+	isSeriesVisible?: ( seriesLabel: string ) => boolean;
 }
 
 export const ChartInstanceContext = createContext< ChartInstanceContextValue | null >( null );

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
@@ -169,15 +169,10 @@ export const BaseLegend: ForwardRefExoticComponent<
 		const handleLegendClick = useCallback(
 			( seriesLabels: string[] ) => {
 				if ( interactive && chartId && context ) {
-					// Converge the whole group on the representative's next state: only toggle series that
-					// currently match it, so a desynced group (e.g. one member hidden programmatically)
-					// ends up uniformly hidden/shown after one click.
 					const representativeVisible = context.isSeriesVisible( chartId, seriesLabels[ 0 ] );
-					seriesLabels.forEach( label => {
-						if ( context.isSeriesVisible( chartId, label ) === representativeVisible ) {
-							context.toggleSeriesVisibility( chartId, label );
-						}
-					} );
+					seriesLabels.forEach( label =>
+						context.setSeriesVisibility( chartId, label, ! representativeVisible )
+					);
 				}
 			},
 			[ interactive, chartId, context ]

--- a/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
+++ b/projects/js-packages/charts/src/components/legend/private/base-legend.tsx
@@ -12,6 +12,7 @@ import {
 	useCallback,
 	useContext,
 } from 'react';
+import { ChartInstanceContext } from '../../../charts/private/chart-instance-context';
 import { useTextTruncation } from '../../../hooks';
 import { GlobalChartsContext, useGlobalChartsTheme } from '../../../providers';
 import { useStandaloneScopeClass } from '../../../providers/chart-scope';
@@ -150,6 +151,7 @@ export const BaseLegend: ForwardRefExoticComponent<
 
 		const theme = useGlobalChartsTheme();
 		const context = useContext( GlobalChartsContext );
+		const chartInstanceContext = useContext( ChartInstanceContext );
 		const standaloneScopeClass = useStandaloneScopeClass();
 
 		const legendScale = scaleOrdinal( {
@@ -185,12 +187,15 @@ export const BaseLegend: ForwardRefExoticComponent<
 		// programmatically must read as hidden even when the legend cannot be clicked.
 		const isSeriesVisible = useCallback(
 			( seriesLabel: string ) => {
+				if ( chartInstanceContext?.isSeriesVisible ) {
+					return chartInstanceContext.isSeriesVisible( seriesLabel );
+				}
 				if ( ! chartId || ! context ) {
 					return true;
 				}
 				return context.isSeriesVisible( chartId, seriesLabel );
 			},
-			[ chartId, context ]
+			[ chartId, chartInstanceContext, context ]
 		);
 
 		// Create event handlers to avoid inline arrow functions

--- a/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
+++ b/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
@@ -622,6 +622,24 @@ describe( 'BaseLegend', () => {
 			expect( buttons ).toHaveLength( 0 );
 		} );
 
+		it( 'uses chart-instance visibility before provider state', () => {
+			render(
+				<GlobalChartsProvider>
+					<ChartInstanceContext.Provider
+						value={ {
+							chartId: 'test-chart',
+							isSeriesVisible: label => label !== 'Item 1',
+						} }
+					>
+						<BaseLegend items={ defaultItems } chartId="test-chart" />
+					</ChartInstanceContext.Provider>
+				</GlobalChartsProvider>
+			);
+
+			expect( screen.getByRole( 'listitem', { name: 'Item 1: hidden' } ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Item 2' ) ).toBeInTheDocument();
+		} );
+
 		it( 'works without chartId but does not toggle', async () => {
 			const user = userEvent.setup();
 

--- a/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
+++ b/projects/js-packages/charts/src/components/legend/test/legend.test.tsx
@@ -636,7 +636,7 @@ describe( 'BaseLegend', () => {
 				</GlobalChartsProvider>
 			);
 
-			expect( screen.getByRole( 'listitem', { name: 'Item 1: hidden' } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'listitem', { name: /Item 1.*hidden/ } ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Item 2' ) ).toBeInTheDocument();
 		} );
 

--- a/projects/js-packages/charts/src/components/tooltip/accessible-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/accessible-tooltip.tsx
@@ -1,6 +1,6 @@
 import { Tooltip, TooltipContext } from '@visx/xychart';
 import clsx from 'clsx';
-import { useContext, useEffect, useCallback, useMemo } from 'react';
+import { useContext, useEffect, useCallback, useMemo, useRef } from 'react';
 import { CHART_SCOPE_CLASS } from '../../styles/chart-scope-class';
 import type { SeriesData, DataPointDate } from '../../types';
 import type { RenderTooltipParams, XyChartTooltipProps } from '../../visx/types';
@@ -79,12 +79,23 @@ export const AccessibleTooltip: React.FC< AccessibleTooltipProps > = ( {
 		return flattened;
 	}, [ series, mode ] );
 
+	// Tracks whether this effect opened a tooltip, so it only closes its own.
+	const hasKeyboardSelection = useRef( false );
+
 	// Handle tooltip highlighting for keyboard navigation
 	useEffect( () => {
 		if ( selectedIndex === undefined ) {
-			tooltipContext?.hideTooltip();
+			// visx debounces the hide and cancels only the most recently scheduled one,
+			// so hiding on every run leaves earlier hides pending. One of those lands
+			// mid-navigation and closes the tooltip the user is reading.
+			if ( hasKeyboardSelection.current ) {
+				hasKeyboardSelection.current = false;
+				tooltipContext?.hideTooltip();
+			}
 			return;
 		}
+
+		hasKeyboardSelection.current = true;
 
 		if ( mode === 'group' ) {
 			// Show all series at the selected data point index in single tooltip.

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -63,6 +63,7 @@ export type {
 	LegendPosition,
 	ChartLegendConfig,
 	SeriesChartLegendConfig,
+	SeriesVisibilityProps,
 	BaseChartProps,
 	GoogleDataTableColumn,
 	GoogleDataTableRow,

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -242,25 +242,18 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 		[ providerTheme, resolveColor ]
 	);
 
-	// Series visibility management methods.
-	// One writer for the hidden-set shape: an empty set drops the chart's entry,
-	// which `isSeriesVisible` and `getHiddenSeries` both read as "nothing hidden".
+	// Keep hidden-series updates and no-op detection consistent across setters.
 	const updateHiddenSeries = useCallback(
 		( chartId: string, update: ( current: Set< string > ) => Set< string > ) => {
 			setHiddenSeries( prev => {
 				const current = prev.get( chartId );
 				const next = update( new Set( current ?? [] ) );
 
-				// No stored entry and nothing to add: writing an empty set would
-				// only be deleted again below, so bail out before touching the Map.
 				if ( ! current && next.size === 0 ) {
 					return prev;
 				}
 
-				// Same members as what's already stored: return `prev` unchanged so
-				// its identity is preserved. Consumers derived from `hiddenSeries`
-				// (e.g. `isSeriesVisible`) must not appear to change on a no-op write,
-				// or an effect keyed on them would re-fire forever.
+				// Preserve identity for no-op updates.
 				if (
 					current &&
 					current.size === next.size &&
@@ -310,8 +303,6 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 		[ updateHiddenSeries ]
 	);
 
-	// Replaces the chart's whole hidden set. `defaultHiddenSeries` has to mean
-	// "these and nothing else", which per-series writes cannot express.
 	const setChartHiddenSeries = useCallback(
 		( chartId: string, seriesLabels: string[] ) => {
 			updateHiddenSeries( chartId, () => new Set( seriesLabels ) );

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -248,9 +248,28 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 	const updateHiddenSeries = useCallback(
 		( chartId: string, update: ( current: Set< string > ) => Set< string > ) => {
 			setHiddenSeries( prev => {
-				const newMap = new Map( prev );
-				const next = update( new Set( newMap.get( chartId ) ?? [] ) );
+				const current = prev.get( chartId );
+				const next = update( new Set( current ?? [] ) );
 
+				// No stored entry and nothing to add: writing an empty set would
+				// only be deleted again below, so bail out before touching the Map.
+				if ( ! current && next.size === 0 ) {
+					return prev;
+				}
+
+				// Same members as what's already stored: return `prev` unchanged so
+				// its identity is preserved. Consumers derived from `hiddenSeries`
+				// (e.g. `isSeriesVisible`) must not appear to change on a no-op write,
+				// or an effect keyed on them would re-fire forever.
+				if (
+					current &&
+					current.size === next.size &&
+					[ ...next ].every( label => current.has( label ) )
+				) {
+					return prev;
+				}
+
+				const newMap = new Map( prev );
 				if ( next.size === 0 ) {
 					newMap.delete( chartId );
 				} else {

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -304,7 +304,7 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 	);
 
 	const setChartHiddenSeries = useCallback(
-		( chartId: string, seriesLabels: string[] ) => {
+		( chartId: string, seriesLabels: readonly string[] ) => {
 			updateHiddenSeries( chartId, () => new Set( seriesLabels ) );
 		},
 		[ updateHiddenSeries ]

--- a/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/global-charts-provider.tsx
@@ -242,28 +242,63 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 		[ providerTheme, resolveColor ]
 	);
 
-	// Series visibility management methods
-	const toggleSeriesVisibility = useCallback( ( chartId: string, seriesLabel: string ) => {
-		setHiddenSeries( prev => {
-			const newMap = new Map( prev );
-			const chartHidden = newMap.get( chartId ) || new Set();
-			const newSet = new Set( chartHidden );
+	// Series visibility management methods.
+	// One writer for the hidden-set shape: an empty set drops the chart's entry,
+	// which `isSeriesVisible` and `getHiddenSeries` both read as "nothing hidden".
+	const updateHiddenSeries = useCallback(
+		( chartId: string, update: ( current: Set< string > ) => Set< string > ) => {
+			setHiddenSeries( prev => {
+				const newMap = new Map( prev );
+				const next = update( new Set( newMap.get( chartId ) ?? [] ) );
 
-			if ( newSet.has( seriesLabel ) ) {
-				newSet.delete( seriesLabel );
-			} else {
-				newSet.add( seriesLabel );
-			}
+				if ( next.size === 0 ) {
+					newMap.delete( chartId );
+				} else {
+					newMap.set( chartId, next );
+				}
 
-			if ( newSet.size === 0 ) {
-				newMap.delete( chartId );
-			} else {
-				newMap.set( chartId, newSet );
-			}
+				return newMap;
+			} );
+		},
+		[]
+	);
 
-			return newMap;
-		} );
-	}, [] );
+	const toggleSeriesVisibility = useCallback(
+		( chartId: string, seriesLabel: string ) => {
+			updateHiddenSeries( chartId, current => {
+				if ( current.has( seriesLabel ) ) {
+					current.delete( seriesLabel );
+				} else {
+					current.add( seriesLabel );
+				}
+				return current;
+			} );
+		},
+		[ updateHiddenSeries ]
+	);
+
+	const setSeriesVisibility = useCallback(
+		( chartId: string, seriesLabel: string, visible: boolean ) => {
+			updateHiddenSeries( chartId, current => {
+				if ( visible ) {
+					current.delete( seriesLabel );
+				} else {
+					current.add( seriesLabel );
+				}
+				return current;
+			} );
+		},
+		[ updateHiddenSeries ]
+	);
+
+	// Replaces the chart's whole hidden set. `defaultHiddenSeries` has to mean
+	// "these and nothing else", which per-series writes cannot express.
+	const setChartHiddenSeries = useCallback(
+		( chartId: string, seriesLabels: string[] ) => {
+			updateHiddenSeries( chartId, () => new Set( seriesLabels ) );
+		},
+		[ updateHiddenSeries ]
+	);
 
 	const isSeriesVisible = useCallback(
 		( chartId: string, seriesLabel: string ) => {
@@ -290,6 +325,8 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 			theme: providerTheme,
 			getElementStyles,
 			toggleSeriesVisibility,
+			setSeriesVisibility,
+			setChartHiddenSeries,
 			isSeriesVisible,
 			getHiddenSeries,
 			isColorPaletteResolved,
@@ -302,6 +339,8 @@ export const GlobalChartsProvider: FC< GlobalChartsProviderProps > = ( { childre
 			providerTheme,
 			getElementStyles,
 			toggleSeriesVisibility,
+			setSeriesVisibility,
+			setChartHiddenSeries,
 			isSeriesVisible,
 			getHiddenSeries,
 			isColorPaletteResolved,

--- a/projects/js-packages/charts/src/providers/chart-context/hooks/use-default-hidden-series.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/hooks/use-default-hidden-series.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { useGlobalChartsContext } from './use-global-charts-context';
 
 // Hide seeded series before paint without triggering React's SSR warning.
@@ -31,5 +31,12 @@ export const useDefaultHiddenSeries = (
 		setChartHiddenSeries( chartId, labelsRef.current );
 	}, [ chartId, hasSeriesLabels, setChartHiddenSeries ] );
 
-	return shouldUseDefaults ? new Set( seriesLabels ) : getHiddenSeries( chartId );
+	// getHiddenSeries hands out a fresh copy per call, so hold the set still between
+	// visibility changes. Charts derive their rendered series from it, and a new
+	// identity every render invalidates every memo downstream — including the one
+	// the accessible tooltip watches, which closes a tooltip mid-navigation.
+	return useMemo(
+		() => ( shouldUseDefaults ? new Set( labelsRef.current ) : getHiddenSeries( chartId ) ),
+		[ shouldUseDefaults, getHiddenSeries, chartId ]
+	);
 };

--- a/projects/js-packages/charts/src/providers/chart-context/hooks/use-default-hidden-series.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/hooks/use-default-hidden-series.ts
@@ -8,27 +8,28 @@ const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffec
  * Seeds a chart's hidden series once per mount or chart ID change.
  *
  * @param chartId      - The chart ID passed to the provider's visibility methods.
- * @param seriesLabels - Labels to hide at mount. Omit to leave visibility untouched.
+ * @param seriesLabels - Labels to hide from the first defined value. Later values are ignored.
  * @return The resolved hidden-series set.
  */
 export const useDefaultHiddenSeries = (
 	chartId: string,
-	seriesLabels?: string[]
+	seriesLabels?: readonly string[]
 ): Set< string > => {
 	const { getHiddenSeries, setChartHiddenSeries } = useGlobalChartsContext();
 	const seededChartId = useRef< string | undefined >( undefined );
 	// Read through a ref so the effect never depends on a new array identity.
 	const labelsRef = useRef( seriesLabels );
 	labelsRef.current = seriesLabels;
-	const shouldUseDefaults = seededChartId.current !== chartId && seriesLabels !== undefined;
+	const hasSeriesLabels = seriesLabels !== undefined;
+	const shouldUseDefaults = seededChartId.current !== chartId && hasSeriesLabels;
 
 	useIsomorphicLayoutEffect( () => {
-		if ( seededChartId.current === chartId || ! labelsRef.current ) {
+		if ( seededChartId.current === chartId || labelsRef.current === undefined ) {
 			return;
 		}
 		seededChartId.current = chartId;
 		setChartHiddenSeries( chartId, labelsRef.current );
-	}, [ chartId, setChartHiddenSeries ] );
+	}, [ chartId, hasSeriesLabels, setChartHiddenSeries ] );
 
 	return shouldUseDefaults ? new Set( seriesLabels ) : getHiddenSeries( chartId );
 };

--- a/projects/js-packages/charts/src/providers/chart-context/hooks/use-default-hidden-series.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/hooks/use-default-hidden-series.ts
@@ -1,27 +1,13 @@
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import { useGlobalChartsContext } from './use-global-charts-context';
 
-// useLayoutEffect on the client so the seeded series is hidden in the first
-// painted frame, useEffect on the server to avoid React's SSR warning. Same
-// pattern as charts/private/with-responsive.
+// Hide seeded series before paint without triggering React's SSR warning.
 const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
- * Seeds a chart's hidden series once per mount.
+ * Seeds a chart's hidden series once per mount or chart ID change.
  *
- * Applies the labels as the chart's entire hidden set, so a remount honours
- * exactly the declared defaults rather than inheriting the previous mount's
- * hides — `hiddenSeries` outlives an unmount. Runs once per mount: re-applying
- * would undo the user's own legend toggles, and "this chart has no hidden entry
- * yet" cannot distinguish a fresh mount from a user who just revealed
- * everything, because an emptied hidden set deletes the entry.
- *
- * A `chartId` change is treated as a logical remount too: the guard tracks
- * which* id it last seeded rather than a bare boolean, so switching to a new
- * id (e.g. the same `<LineChart>` re-keyed by a changing `chartId` prop
- * instead of `key`) seeds that id's defaults instead of silently no-op'ing.
- *
- * @param chartId      - The chart's id, as passed to the provider's visibility methods.
+ * @param chartId      - The chart ID passed to the provider's visibility methods.
  * @param seriesLabels - Labels to hide at mount. Omit to leave visibility untouched.
  */
 export const useDefaultHiddenSeries = ( chartId: string, seriesLabels?: string[] ): void => {

--- a/projects/js-packages/charts/src/providers/chart-context/hooks/use-default-hidden-series.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/hooks/use-default-hidden-series.ts
@@ -1,0 +1,36 @@
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useGlobalChartsContext } from './use-global-charts-context';
+
+// useLayoutEffect on the client so the seeded series is hidden in the first
+// painted frame, useEffect on the server to avoid React's SSR warning. Same
+// pattern as charts/private/with-responsive.
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+/**
+ * Seeds a chart's hidden series once per mount.
+ *
+ * Applies the labels as the chart's entire hidden set, so a remount honours
+ * exactly the declared defaults rather than inheriting the previous mount's
+ * hides — `hiddenSeries` outlives an unmount. Runs once per mount: re-applying
+ * would undo the user's own legend toggles, and "this chart has no hidden entry
+ * yet" cannot distinguish a fresh mount from a user who just revealed
+ * everything, because an emptied hidden set deletes the entry.
+ *
+ * @param chartId      - The chart's id, as passed to the provider's visibility methods.
+ * @param seriesLabels - Labels to hide at mount. Omit to leave visibility untouched.
+ */
+export const useDefaultHiddenSeries = ( chartId: string, seriesLabels?: string[] ): void => {
+	const { setChartHiddenSeries } = useGlobalChartsContext();
+	const seeded = useRef( false );
+	// Read through a ref so the effect never depends on a new array identity.
+	const labelsRef = useRef( seriesLabels );
+	labelsRef.current = seriesLabels;
+
+	useIsomorphicLayoutEffect( () => {
+		if ( seeded.current || ! labelsRef.current ) {
+			return;
+		}
+		seeded.current = true;
+		setChartHiddenSeries( chartId, labelsRef.current );
+	}, [ chartId, setChartHiddenSeries ] );
+};

--- a/projects/js-packages/charts/src/providers/chart-context/hooks/use-default-hidden-series.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/hooks/use-default-hidden-series.ts
@@ -9,13 +9,18 @@ const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffec
  *
  * @param chartId      - The chart ID passed to the provider's visibility methods.
  * @param seriesLabels - Labels to hide at mount. Omit to leave visibility untouched.
+ * @return The resolved hidden-series set.
  */
-export const useDefaultHiddenSeries = ( chartId: string, seriesLabels?: string[] ): void => {
-	const { setChartHiddenSeries } = useGlobalChartsContext();
+export const useDefaultHiddenSeries = (
+	chartId: string,
+	seriesLabels?: string[]
+): Set< string > => {
+	const { getHiddenSeries, setChartHiddenSeries } = useGlobalChartsContext();
 	const seededChartId = useRef< string | undefined >( undefined );
 	// Read through a ref so the effect never depends on a new array identity.
 	const labelsRef = useRef( seriesLabels );
 	labelsRef.current = seriesLabels;
+	const shouldUseDefaults = seededChartId.current !== chartId && seriesLabels !== undefined;
 
 	useIsomorphicLayoutEffect( () => {
 		if ( seededChartId.current === chartId || ! labelsRef.current ) {
@@ -24,4 +29,6 @@ export const useDefaultHiddenSeries = ( chartId: string, seriesLabels?: string[]
 		seededChartId.current = chartId;
 		setChartHiddenSeries( chartId, labelsRef.current );
 	}, [ chartId, setChartHiddenSeries ] );
+
+	return shouldUseDefaults ? new Set( seriesLabels ) : getHiddenSeries( chartId );
 };

--- a/projects/js-packages/charts/src/providers/chart-context/hooks/use-default-hidden-series.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/hooks/use-default-hidden-series.ts
@@ -16,21 +16,26 @@ const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffec
  * yet" cannot distinguish a fresh mount from a user who just revealed
  * everything, because an emptied hidden set deletes the entry.
  *
+ * A `chartId` change is treated as a logical remount too: the guard tracks
+ * which* id it last seeded rather than a bare boolean, so switching to a new
+ * id (e.g. the same `<LineChart>` re-keyed by a changing `chartId` prop
+ * instead of `key`) seeds that id's defaults instead of silently no-op'ing.
+ *
  * @param chartId      - The chart's id, as passed to the provider's visibility methods.
  * @param seriesLabels - Labels to hide at mount. Omit to leave visibility untouched.
  */
 export const useDefaultHiddenSeries = ( chartId: string, seriesLabels?: string[] ): void => {
 	const { setChartHiddenSeries } = useGlobalChartsContext();
-	const seeded = useRef( false );
+	const seededChartId = useRef< string | undefined >( undefined );
 	// Read through a ref so the effect never depends on a new array identity.
 	const labelsRef = useRef( seriesLabels );
 	labelsRef.current = seriesLabels;
 
 	useIsomorphicLayoutEffect( () => {
-		if ( seeded.current || ! labelsRef.current ) {
+		if ( seededChartId.current === chartId || ! labelsRef.current ) {
 			return;
 		}
-		seeded.current = true;
+		seededChartId.current = chartId;
 		setChartHiddenSeries( chartId, labelsRef.current );
 	}, [ chartId, setChartHiddenSeries ] );
 };

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
@@ -37,7 +37,7 @@ interface GlobalChartsContextValue {
 	toggleSeriesVisibility: (chartId: string, seriesLabel: string) => void;
 	// Absolute counterpart to the toggle, for callers that know the target state.
 	setSeriesVisibility: (chartId: string, seriesLabel: string, visible: boolean) => void;
-	// Replaces a chart's entire hidden set. Used to apply `defaultHiddenSeries` at mount.
+	// Replaces a chart's entire hidden set. Used to apply `defaultHiddenSeries` at mount or when the chart ID changes.
 	setChartHiddenSeries: (chartId: string, seriesLabels: string[]) => void;
 	isSeriesVisible: (chartId: string, seriesLabel: string) => boolean;
 	getHiddenSeries: (chartId: string) => Set<string>;

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
@@ -35,6 +35,10 @@ interface GlobalChartsContextValue {
 
 	// Series visibility management shared by charts and legends
 	toggleSeriesVisibility: (chartId: string, seriesLabel: string) => void;
+	// Absolute counterpart to the toggle, for callers that know the target state.
+	setSeriesVisibility: (chartId: string, seriesLabel: string, visible: boolean) => void;
+	// Replaces a chart's entire hidden set. Used to apply `defaultHiddenSeries` at mount.
+	setChartHiddenSeries: (chartId: string, seriesLabels: string[]) => void;
 	isSeriesVisible: (chartId: string, seriesLabel: string) => boolean;
 	getHiddenSeries: (chartId: string) => Set<string>;
 

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.api.mdx
@@ -37,8 +37,8 @@ interface GlobalChartsContextValue {
 	toggleSeriesVisibility: (chartId: string, seriesLabel: string) => void;
 	// Absolute counterpart to the toggle, for callers that know the target state.
 	setSeriesVisibility: (chartId: string, seriesLabel: string, visible: boolean) => void;
-	// Replaces a chart's entire hidden set. Used to apply `defaultHiddenSeries` at mount or when the chart ID changes.
-	setChartHiddenSeries: (chartId: string, seriesLabels: string[]) => void;
+	// Replaces a chart's entire hidden set. Used for the first defined `defaultHiddenSeries` value and chart ID changes.
+	setChartHiddenSeries: (chartId: string, seriesLabels: readonly string[]) => void;
 	isSeriesVisible: (chartId: string, seriesLabel: string) => boolean;
 	getHiddenSeries: (chartId: string) => Set<string>;
 

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
@@ -250,6 +250,30 @@ Charts automatically register themselves with the Global Charts Context when mou
 	// - Any additional metadata` }
 />
 
+## Series Visibility
+
+The context tracks which series are hidden per chart (by `chartId`) and exposes three ways to change that state, each suited to a different caller:
+
+- **`toggleSeriesVisibility( chartId, seriesLabel )`** — flips a series' current state. This is what an interactive legend (`legend.interactive`) calls on click; use it when you don't know or don't care about the series' current visibility.
+- **`setSeriesVisibility( chartId, seriesLabel, visible )`** — the absolute counterpart to the toggle. Use it when the caller already knows the target state, e.g. driving visibility from an external control instead of a click.
+- **`setChartHiddenSeries( chartId, seriesLabels )`** — replaces a chart's entire hidden set in one call, rather than toggling series one at a time. This is what the `defaultHiddenSeries` prop (available on `LineChart`, `AreaChart`, and `BarChart`) uses internally to seed a series hidden once on mount; revealing a series through the legend afterwards sticks, and only a remount re-applies the declared list.
+
+<Source
+	language="tsx"
+	code={ `import { useGlobalChartsContext } from '@automattic/charts';
+
+	function VisibilityControls( { chartId } ) {
+		const { toggleSeriesVisibility, setSeriesVisibility, setChartHiddenSeries } =
+			useGlobalChartsContext();
+
+		return (
+			<button onClick={ () => toggleSeriesVisibility( chartId, 'Revenue' ) }>
+				Toggle Revenue
+			</button>
+		);
+	}` }
+/>
+
 ## Context Hooks
 
 ### useGlobalChartsContext

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
@@ -256,7 +256,7 @@ The context tracks which series are hidden per chart (by `chartId`) and exposes 
 
 - **`toggleSeriesVisibility( chartId, seriesLabel )`** — flips a series' current state. This is what an interactive legend (`legend.interactive`) calls on click; use it when you don't know or don't care about the series' current visibility.
 - **`setSeriesVisibility( chartId, seriesLabel, visible )`** — the absolute counterpart to the toggle. Use it when the caller already knows the target state, e.g. driving visibility from an external control instead of a click.
-- **`setChartHiddenSeries( chartId, seriesLabels )`** — replaces a chart's entire hidden set in one call, rather than toggling series one at a time. This is what the `defaultHiddenSeries` prop (available on `LineChart`, `AreaChart`, and `BarChart`) uses internally to seed a series hidden once on mount; revealing a series through the legend afterwards sticks, and only a remount re-applies the declared list.
+- **`setChartHiddenSeries( chartId, seriesLabels )`** — replaces a chart's entire hidden set in one call, rather than toggling series one at a time. This is what the `defaultHiddenSeries` prop (available on `LineChart`, `AreaChart`, and `BarChart`) uses internally to seed a series hidden on mount; revealing a series through the legend afterwards sticks until the chart remounts or its `chartId` changes.
 
 <Source
 	language="tsx"

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
@@ -256,7 +256,7 @@ The context tracks which series are hidden per chart (by `chartId`) and exposes 
 
 - **`toggleSeriesVisibility( chartId, seriesLabel )`** — flips a series' current state. This is what an interactive legend (`legend.interactive`) calls on click; use it when you don't know or don't care about the series' current visibility.
 - **`setSeriesVisibility( chartId, seriesLabel, visible )`** — the absolute counterpart to the toggle. Use it when the caller already knows the target state, e.g. driving visibility from an external control instead of a click.
-- **`setChartHiddenSeries( chartId, seriesLabels )`** — replaces a chart's entire hidden set in one call, rather than toggling series one at a time. This is what the `defaultHiddenSeries` prop (available on `LineChart`, `AreaChart`, and `BarChart`) uses internally to seed a series hidden on mount; revealing a series through the legend afterwards sticks until the chart remounts or its `chartId` changes.
+- **`setChartHiddenSeries( chartId, seriesLabels )`** — replaces a chart's entire hidden set in one call, rather than toggling series one at a time. This is what the `defaultHiddenSeries` prop (available on `LineChart`, `AreaChart`, and `BarChart`) uses internally for its first defined value; later values for the same `chartId` are ignored, and user changes persist until the chart remounts or its ID changes.
 
 <Source
 	language="tsx"

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
@@ -267,9 +267,25 @@ The context tracks which series are hidden per chart (by `chartId`) and exposes 
 			useGlobalChartsContext();
 
 		return (
-			<button onClick={ () => toggleSeriesVisibility( chartId, 'Revenue' ) }>
-				Toggle Revenue
-			</button>
+			<>
+				{ /* Don't know or care about the current state: just flip it, like a legend click would. */ }
+				<button onClick={ () => toggleSeriesVisibility( chartId, 'Revenue' ) }>
+					Toggle Revenue
+				</button>
+
+				{ /* Know the target state: drive visibility from an external control. */ }
+				<button onClick={ () => setSeriesVisibility( chartId, 'Revenue', true ) }>
+					Show Revenue
+				</button>
+				<button onClick={ () => setSeriesVisibility( chartId, 'Revenue', false ) }>
+					Hide Revenue
+				</button>
+
+				{ /* Replace the whole hidden set in one call, e.g. to reset to a preset view. */ }
+				<button onClick={ () => setChartHiddenSeries( chartId, [ 'Costs', 'Refunds' ] ) }>
+					Reset to defaults
+				</button>
+			</>
 		);
 	}` }
 />

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -1728,6 +1728,91 @@ describe( 'ChartContext', () => {
 			// Should have empty set after all series are visible
 			expect( hidden.size ).toBe( 0 );
 		} );
+
+		it( 'setSeriesVisibility sets state absolutely rather than toggling', () => {
+			let contextValue: GlobalChartsContextValue;
+			const TestComponent = () => {
+				contextValue = useGlobalChartsContext();
+				return <div>Test</div>;
+			};
+
+			render(
+				<GlobalChartsProvider>
+					<TestComponent />
+				</GlobalChartsProvider>
+			);
+
+			act( () => {
+				contextValue.setSeriesVisibility( 'test-chart', 'Series 1', false );
+			} );
+			expect( contextValue.isSeriesVisible( 'test-chart', 'Series 1' ) ).toBe( false );
+
+			// Calling it again with the same value must not flip it back.
+			act( () => {
+				contextValue.setSeriesVisibility( 'test-chart', 'Series 1', false );
+			} );
+			expect( contextValue.isSeriesVisible( 'test-chart', 'Series 1' ) ).toBe( false );
+
+			act( () => {
+				contextValue.setSeriesVisibility( 'test-chart', 'Series 1', true );
+			} );
+			expect( contextValue.isSeriesVisible( 'test-chart', 'Series 1' ) ).toBe( true );
+		} );
+
+		it( 'setChartHiddenSeries replaces the hidden set rather than merging into it', () => {
+			let contextValue: GlobalChartsContextValue;
+			const TestComponent = () => {
+				contextValue = useGlobalChartsContext();
+				return <div>Test</div>;
+			};
+
+			render(
+				<GlobalChartsProvider>
+					<TestComponent />
+				</GlobalChartsProvider>
+			);
+
+			act( () => {
+				contextValue.setChartHiddenSeries( 'test-chart', [ 'Series 1', 'Series 2' ] );
+			} );
+			expect( contextValue.getHiddenSeries( 'test-chart' ) ).toEqual(
+				new Set( [ 'Series 1', 'Series 2' ] )
+			);
+
+			act( () => {
+				contextValue.setChartHiddenSeries( 'test-chart', [ 'Series 2' ] );
+			} );
+			expect( contextValue.isSeriesVisible( 'test-chart', 'Series 1' ) ).toBe( true );
+			expect( contextValue.isSeriesVisible( 'test-chart', 'Series 2' ) ).toBe( false );
+
+			act( () => {
+				contextValue.setChartHiddenSeries( 'test-chart', [] );
+			} );
+			expect( contextValue.getHiddenSeries( 'test-chart' ) ).toEqual( new Set() );
+		} );
+
+		it( 'setChartHiddenSeries leaves other charts alone', () => {
+			let contextValue: GlobalChartsContextValue;
+			const TestComponent = () => {
+				contextValue = useGlobalChartsContext();
+				return <div>Test</div>;
+			};
+
+			render(
+				<GlobalChartsProvider>
+					<TestComponent />
+				</GlobalChartsProvider>
+			);
+
+			act( () => {
+				contextValue.setChartHiddenSeries( 'chart-a', [ 'Series 1' ] );
+				contextValue.setChartHiddenSeries( 'chart-b', [ 'Series 2' ] );
+			} );
+
+			expect( contextValue.isSeriesVisible( 'chart-a', 'Series 1' ) ).toBe( false );
+			expect( contextValue.isSeriesVisible( 'chart-a', 'Series 2' ) ).toBe( true );
+			expect( contextValue.isSeriesVisible( 'chart-b', 'Series 2' ) ).toBe( false );
+		} );
 	} );
 
 	describe( 'GlobalChartsProvider - CSS Variable Support', () => {

--- a/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/chart-context.test.tsx
@@ -1813,6 +1813,63 @@ describe( 'ChartContext', () => {
 			expect( contextValue.isSeriesVisible( 'chart-a', 'Series 2' ) ).toBe( true );
 			expect( contextValue.isSeriesVisible( 'chart-b', 'Series 2' ) ).toBe( false );
 		} );
+
+		it( 'a redundant setSeriesVisibility write does not change context identity or re-render', () => {
+			let contextValue: GlobalChartsContextValue;
+			let childUpdateTally = 0;
+			const TestComponent = () => {
+				contextValue = useGlobalChartsContext();
+				childUpdateTally++;
+				return <div>Test</div>;
+			};
+
+			render(
+				<GlobalChartsProvider>
+					<TestComponent />
+				</GlobalChartsProvider>
+			);
+
+			act( () => {
+				contextValue.setSeriesVisibility( 'test-chart', 'Series 1', false );
+			} );
+			const isSeriesVisibleAfterFirstWrite = contextValue.isSeriesVisible;
+			const tallyAfterFirstWrite = childUpdateTally;
+
+			// Redundant write: the series is already hidden, so this must be a no-op.
+			act( () => {
+				contextValue.setSeriesVisibility( 'test-chart', 'Series 1', false );
+			} );
+
+			expect( contextValue.isSeriesVisible ).toBe( isSeriesVisibleAfterFirstWrite );
+			expect( childUpdateTally ).toBe( tallyAfterFirstWrite );
+		} );
+
+		it( 'setting an already-empty hidden set does not create then delete a Map entry', () => {
+			let contextValue: GlobalChartsContextValue;
+			let childUpdateTally = 0;
+			const TestComponent = () => {
+				contextValue = useGlobalChartsContext();
+				childUpdateTally++;
+				return <div>Test</div>;
+			};
+
+			render(
+				<GlobalChartsProvider>
+					<TestComponent />
+				</GlobalChartsProvider>
+			);
+
+			const tallyBeforeWrite = childUpdateTally;
+			const isSeriesVisibleBefore = contextValue.isSeriesVisible;
+
+			// This chart has no hidden-series entry at all yet.
+			act( () => {
+				contextValue.setChartHiddenSeries( 'test-chart', [] );
+			} );
+
+			expect( childUpdateTally ).toBe( tallyBeforeWrite );
+			expect( contextValue.isSeriesVisible ).toBe( isSeriesVisibleBefore );
+		} );
 	} );
 
 	describe( 'GlobalChartsProvider - CSS Variable Support', () => {

--- a/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series-paint.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series-paint.test.tsx
@@ -49,6 +49,16 @@ describe( 'useDefaultHiddenSeries paint timing', () => {
 		// deps `[ chartId, setChartHiddenSeries ]`, which is unique to it (the
 		// provider's own effects use different deps shapes). Find that exact call
 		// among both mocks to see which one it landed on.
+		//
+		// Known blind spot: this matches by deps *shape*, not by origin. It fails
+		// closed if useDefaultHiddenSeries's own deps ever change (no call would then
+		// match, and the assertions below go red). It can fail open only in a narrow,
+		// compound case: an unrelated future layout effect that happens to carry a
+		// 2-element deps array starting with the string 'chart', landing at the same
+		// time as this hook regressing from useLayoutEffect to useEffect — that
+		// impostor call would satisfy `isSeedingCall` and mask the regression.
+		// Accepted here because both conditions must hold at once, and neither is
+		// likely on its own.
 		const isSeedingCall = ( call: unknown[] ) =>
 			Array.isArray( call[ 1 ] ) && call[ 1 ][ 0 ] === 'chart' && call[ 1 ].length === 2;
 

--- a/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series-paint.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series-paint.test.tsx
@@ -1,74 +1,56 @@
-import { act, render } from '@testing-library/react';
-import * as React from 'react';
+import { screen } from '@testing-library/react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { GlobalChartsProvider } from '../global-charts-provider';
 import { useDefaultHiddenSeries } from '../hooks/use-default-hidden-series';
-
-// A jest.mock( 'react', ... ) factory affects every test in the file it lives in,
-// so this test gets its own file rather than joining use-default-hidden-series.test.tsx.
-jest.mock( 'react', () => {
-	const actual = jest.requireActual( 'react' );
-	return {
-		...actual,
-		useLayoutEffect: jest.fn( actual.useLayoutEffect ),
-		useEffect: jest.fn( actual.useEffect ),
-	};
-} );
+import { useGlobalChartsContext } from '../hooks/use-global-charts-context';
+import type { Root } from 'react-dom/client';
 
 describe( 'useDefaultHiddenSeries paint timing', () => {
-	it( 'seeds in a layout effect, not a passive one, so the series is hidden in the first painted frame', () => {
+	let host: HTMLDivElement;
+	let root: Root;
+	let previousActEnvironment: boolean | undefined;
+
+	beforeEach( () => {
+		previousActEnvironment = globalThis.IS_REACT_ACT_ENVIRONMENT;
+		globalThis.IS_REACT_ACT_ENVIRONMENT = false;
+		host = document.createElement( 'div' );
+		document.body.appendChild( host );
+		root = createRoot( host );
+	} );
+
+	afterEach( () => {
+		flushSync( () => root.unmount() );
+		host.remove();
+		globalThis.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+	} );
+
+	it( 'updates provider visibility before the first paint', () => {
 		const Chart = () => {
 			useDefaultHiddenSeries( 'chart', [ 'Visitors' ] );
 			return null;
 		};
 
-		// `mounted` lives on a component *inside* GlobalChartsProvider, not above it,
-		// so toggling it only re-renders this subtree.
-		let setMounted: ( mounted: boolean ) => void = () => {};
-		const Toggle = () => {
-			const [ mounted, mountedSetter ] = React.useState( false );
-			setMounted = mountedSetter;
-			return mounted ? <Chart /> : null;
+		const Visibility = () => {
+			const { isSeriesVisible } = useGlobalChartsContext();
+			return (
+				<span data-testid="series-visibility">
+					{ isSeriesVisible( 'chart', 'Visitors' ) ? 'visible' : 'hidden' }
+				</span>
+			);
 		};
 
-		render(
-			<GlobalChartsProvider>
-				<Toggle />
-			</GlobalChartsProvider>
-		);
-
-		act( () => {
-			setMounted( true );
+		// flushSync lets us inspect the layout-effect result before a later passive
+		// effect could seed the provider.
+		flushSync( () => {
+			root.render(
+				<GlobalChartsProvider>
+					<Chart />
+					<Visibility />
+				</GlobalChartsProvider>
+			);
 		} );
 
-		// GlobalChartsProvider has its own internal useLayoutEffect (for its color
-		// cache, deps `[ providerTheme ]`) and, because seeding calls
-		// `setChartHiddenSeries`, mounting the chart also causes the provider to
-		// re-render and call that same hook again as a side effect — so counting
-		// total useLayoutEffect calls can't isolate Chart's own effect. Instead,
-		// identify the call by its actual signature: `useDefaultHiddenSeries` passes
-		// deps `[ chartId, setChartHiddenSeries ]`, which is unique to it (the
-		// provider's own effects use different deps shapes). Find that exact call
-		// among both mocks to see which one it landed on.
-		//
-		// Known blind spot: this matches by deps *shape*, not by origin. It fails
-		// closed if useDefaultHiddenSeries's own deps ever change (no call would then
-		// match, and the assertions below go red). It can fail open only in a narrow,
-		// compound case: an unrelated future layout effect that happens to carry a
-		// 2-element deps array starting with the string 'chart', landing at the same
-		// time as this hook regressing from useLayoutEffect to useEffect — that
-		// impostor call would satisfy `isSeedingCall` and mask the regression.
-		// Accepted here because both conditions must hold at once, and neither is
-		// likely on its own.
-		const isSeedingCall = ( call: unknown[] ) =>
-			Array.isArray( call[ 1 ] ) && call[ 1 ][ 0 ] === 'chart' && call[ 1 ].length === 2;
-
-		const layoutEffectMock = React.useLayoutEffect as jest.Mock;
-		const effectMock = React.useEffect as jest.Mock;
-
-		const seededViaLayoutEffect = layoutEffectMock.mock.calls.some( isSeedingCall );
-		const seededViaPassiveEffect = effectMock.mock.calls.some( isSeedingCall );
-
-		expect( seededViaLayoutEffect ).toBe( true );
-		expect( seededViaPassiveEffect ).toBe( false );
+		expect( screen.getByTestId( 'series-visibility' ) ).toHaveTextContent( 'hidden' );
 	} );
 } );

--- a/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series-paint.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series-paint.test.tsx
@@ -1,0 +1,64 @@
+import { act, render } from '@testing-library/react';
+import * as React from 'react';
+import { GlobalChartsProvider } from '../global-charts-provider';
+import { useDefaultHiddenSeries } from '../hooks/use-default-hidden-series';
+
+// A jest.mock( 'react', ... ) factory affects every test in the file it lives in,
+// so this test gets its own file rather than joining use-default-hidden-series.test.tsx.
+jest.mock( 'react', () => {
+	const actual = jest.requireActual( 'react' );
+	return {
+		...actual,
+		useLayoutEffect: jest.fn( actual.useLayoutEffect ),
+		useEffect: jest.fn( actual.useEffect ),
+	};
+} );
+
+describe( 'useDefaultHiddenSeries paint timing', () => {
+	it( 'seeds in a layout effect, not a passive one, so the series is hidden in the first painted frame', () => {
+		const Chart = () => {
+			useDefaultHiddenSeries( 'chart', [ 'Visitors' ] );
+			return null;
+		};
+
+		// `mounted` lives on a component *inside* GlobalChartsProvider, not above it,
+		// so toggling it only re-renders this subtree.
+		let setMounted: ( mounted: boolean ) => void = () => {};
+		const Toggle = () => {
+			const [ mounted, mountedSetter ] = React.useState( false );
+			setMounted = mountedSetter;
+			return mounted ? <Chart /> : null;
+		};
+
+		render(
+			<GlobalChartsProvider>
+				<Toggle />
+			</GlobalChartsProvider>
+		);
+
+		act( () => {
+			setMounted( true );
+		} );
+
+		// GlobalChartsProvider has its own internal useLayoutEffect (for its color
+		// cache, deps `[ providerTheme ]`) and, because seeding calls
+		// `setChartHiddenSeries`, mounting the chart also causes the provider to
+		// re-render and call that same hook again as a side effect — so counting
+		// total useLayoutEffect calls can't isolate Chart's own effect. Instead,
+		// identify the call by its actual signature: `useDefaultHiddenSeries` passes
+		// deps `[ chartId, setChartHiddenSeries ]`, which is unique to it (the
+		// provider's own effects use different deps shapes). Find that exact call
+		// among both mocks to see which one it landed on.
+		const isSeedingCall = ( call: unknown[] ) =>
+			Array.isArray( call[ 1 ] ) && call[ 1 ][ 0 ] === 'chart' && call[ 1 ].length === 2;
+
+		const layoutEffectMock = React.useLayoutEffect as jest.Mock;
+		const effectMock = React.useEffect as jest.Mock;
+
+		const seededViaLayoutEffect = layoutEffectMock.mock.calls.some( isSeedingCall );
+		const seededViaPassiveEffect = effectMock.mock.calls.some( isSeedingCall );
+
+		expect( seededViaLayoutEffect ).toBe( true );
+		expect( seededViaPassiveEffect ).toBe( false );
+	} );
+} );

--- a/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series.ssr.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series.ssr.test.tsx
@@ -1,0 +1,37 @@
+/** @jest-environment node */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { useDefaultHiddenSeries } from '../hooks/use-default-hidden-series';
+
+const mockGetHiddenSeries = jest.fn( () => new Set( [ 'Provider hidden' ] ) );
+const mockSetChartHiddenSeries = jest.fn();
+
+jest.mock( '../hooks/use-global-charts-context', () => ( {
+	useGlobalChartsContext: () => ( {
+		getHiddenSeries: mockGetHiddenSeries,
+		setChartHiddenSeries: mockSetChartHiddenSeries,
+	} ),
+} ) );
+
+describe( 'useDefaultHiddenSeries SSR', () => {
+	it( 'applies defaults to the server-rendered output before effects run', () => {
+		const Chart = () => {
+			const hiddenSeries = useDefaultHiddenSeries( 'chart', [ 'Visitors' ] );
+
+			return (
+				<>
+					{ [ 'Visitors', 'Views' ].map( label =>
+						! hiddenSeries.has( label ) ? <span key={ label }>{ label }</span> : null
+					) }
+				</>
+			);
+		};
+
+		const view = renderToStaticMarkup( <Chart /> );
+
+		expect( view ).not.toContain( 'Visitors' );
+		expect( view ).toContain( 'Views' );
+		expect( mockGetHiddenSeries ).not.toHaveBeenCalled();
+		expect( mockSetChartHiddenSeries ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series.test.tsx
@@ -1,0 +1,85 @@
+import { render, act } from '@testing-library/react';
+import { GlobalChartsProvider } from '../global-charts-provider';
+import { useDefaultHiddenSeries } from '../hooks/use-default-hidden-series';
+import { useGlobalChartsContext } from '../hooks/use-global-charts-context';
+import type { GlobalChartsContextValue } from '../types';
+
+describe( 'useDefaultHiddenSeries', () => {
+	let contextValue: GlobalChartsContextValue;
+
+	const Grab = () => {
+		contextValue = useGlobalChartsContext();
+		return null;
+	};
+
+	const Chart = ( { defaults }: { defaults?: string[] } ) => {
+		useDefaultHiddenSeries( 'chart', defaults );
+		return null;
+	};
+
+	it( 'hides the named series at mount', () => {
+		render(
+			<GlobalChartsProvider>
+				<Grab />
+				<Chart defaults={ [ 'Visitors' ] } />
+			</GlobalChartsProvider>
+		);
+
+		expect( contextValue.isSeriesVisible( 'chart', 'Visitors' ) ).toBe( false );
+		expect( contextValue.isSeriesVisible( 'chart', 'Views' ) ).toBe( true );
+	} );
+
+	it( 'writes nothing when no defaults are given', () => {
+		render(
+			<GlobalChartsProvider>
+				<Grab />
+				<Chart />
+			</GlobalChartsProvider>
+		);
+
+		expect( contextValue.getHiddenSeries( 'chart' ) ).toEqual( new Set() );
+	} );
+
+	it( 'does not re-hide a series the user revealed', () => {
+		const Harness = () => (
+			<GlobalChartsProvider>
+				<Grab />
+				<Chart defaults={ [ 'Visitors' ] } />
+			</GlobalChartsProvider>
+		);
+
+		const { rerender } = render( <Harness /> );
+
+		act( () => {
+			contextValue.setSeriesVisibility( 'chart', 'Visitors', true );
+		} );
+
+		rerender( <Harness /> );
+
+		expect( contextValue.isSeriesVisible( 'chart', 'Visitors' ) ).toBe( true );
+	} );
+
+	it( 'applies only the declared defaults after a remount', () => {
+		// The provider stays mounted; only the chart unmounts and comes back, which
+		// is the case where a stale hidden set would leak into the new mount.
+		const Harness = ( { mounted }: { mounted: boolean } ) => (
+			<GlobalChartsProvider>
+				<Grab />
+				{ mounted && <Chart defaults={ [ 'Visitors' ] } /> }
+			</GlobalChartsProvider>
+		);
+
+		const { rerender } = render( <Harness mounted /> );
+
+		act( () => {
+			contextValue.setSeriesVisibility( 'chart', 'Views', false );
+		} );
+		expect( contextValue.isSeriesVisible( 'chart', 'Views' ) ).toBe( false );
+
+		rerender( <Harness mounted={ false } /> );
+		rerender( <Harness mounted /> );
+
+		expect( contextValue.isSeriesVisible( 'chart', 'Visitors' ) ).toBe( false );
+		expect( contextValue.isSeriesVisible( 'chart', 'Views' ) ).toBe( true );
+	} );
+} );

--- a/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series.test.tsx
@@ -6,6 +6,7 @@ import type { GlobalChartsContextValue } from '../types';
 
 describe( 'useDefaultHiddenSeries', () => {
 	let contextValue: GlobalChartsContextValue;
+	let resolvedHiddenSeries: Set< string >;
 
 	const Grab = () => {
 		contextValue = useGlobalChartsContext();
@@ -13,7 +14,7 @@ describe( 'useDefaultHiddenSeries', () => {
 	};
 
 	const Chart = ( { defaults, chartId = 'chart' }: { defaults?: string[]; chartId?: string } ) => {
-		useDefaultHiddenSeries( chartId, defaults );
+		resolvedHiddenSeries = useDefaultHiddenSeries( chartId, defaults );
 		return null;
 	};
 
@@ -38,6 +39,23 @@ describe( 'useDefaultHiddenSeries', () => {
 		);
 
 		expect( contextValue.getHiddenSeries( 'chart' ) ).toEqual( new Set() );
+	} );
+
+	it( 'reflects provider visibility changes after mount', () => {
+		render(
+			<GlobalChartsProvider>
+				<Grab />
+				<Chart />
+			</GlobalChartsProvider>
+		);
+
+		expect( resolvedHiddenSeries.has( 'Visitors' ) ).toBe( false );
+
+		act( () => {
+			contextValue.setSeriesVisibility( 'chart', 'Visitors', false );
+		} );
+
+		expect( resolvedHiddenSeries.has( 'Visitors' ) ).toBe( true );
 	} );
 
 	it( 'does not re-hide a series the user revealed', () => {

--- a/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series.test.tsx
@@ -150,6 +150,29 @@ describe( 'useDefaultHiddenSeries', () => {
 		expect( contextValue.isSeriesVisible( 'chart', 'Visitors' ) ).toBe( false );
 	} );
 
+	it( 'keeps the same set across renders until visibility changes', () => {
+		// Charts memoize their rendered series off this set. A fresh identity per
+		// render invalidates those memos, which re-runs the accessible tooltip's
+		// effect and closes a tooltip the user is still navigating with.
+		const Harness = () => (
+			<GlobalChartsProvider>
+				<Grab />
+				<Chart defaults={ [ 'Visitors' ] } />
+			</GlobalChartsProvider>
+		);
+
+		const { rerender } = render( <Harness /> );
+		const seeded = resolvedHiddenSeries;
+
+		rerender( <Harness /> );
+		expect( resolvedHiddenSeries ).toBe( seeded );
+
+		act( () => {
+			contextValue.setSeriesVisibility( 'chart', 'Views', false );
+		} );
+		expect( resolvedHiddenSeries ).not.toBe( seeded );
+	} );
+
 	it( 're-seeds the defaults when chartId changes mid-mount', () => {
 		// Same mount, only the chartId prop changes (e.g. <LineChart chartId={ metric } ... />
 		// with `metric` going 'views' -> 'clicks'), so the component never unmounts.

--- a/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series.test.tsx
@@ -58,6 +58,38 @@ describe( 'useDefaultHiddenSeries', () => {
 		expect( resolvedHiddenSeries.has( 'Visitors' ) ).toBe( true );
 	} );
 
+	it( 'seeds the first defined value and ignores later values for the same chart ID', () => {
+		const Harness = ( { defaults }: { defaults?: string[] } ) => (
+			<GlobalChartsProvider>
+				<Grab />
+				<Chart defaults={ defaults } />
+			</GlobalChartsProvider>
+		);
+
+		const { rerender } = render( <Harness /> );
+
+		rerender( <Harness defaults={ [ 'Visitors' ] } /> );
+		expect( contextValue.getHiddenSeries( 'chart' ) ).toEqual( new Set( [ 'Visitors' ] ) );
+
+		rerender( <Harness defaults={ [ 'Views' ] } /> );
+		expect( contextValue.getHiddenSeries( 'chart' ) ).toEqual( new Set( [ 'Visitors' ] ) );
+	} );
+
+	it( 'treats an empty array as a defined default', () => {
+		const Harness = ( { defaults }: { defaults: string[] } ) => (
+			<GlobalChartsProvider>
+				<Grab />
+				<Chart defaults={ defaults } />
+			</GlobalChartsProvider>
+		);
+
+		const { rerender } = render( <Harness defaults={ [] } /> );
+
+		rerender( <Harness defaults={ [ 'Visitors' ] } /> );
+
+		expect( contextValue.getHiddenSeries( 'chart' ) ).toEqual( new Set() );
+	} );
+
 	it( 'does not re-hide a series the user revealed', () => {
 		const Harness = () => (
 			<GlobalChartsProvider>
@@ -99,6 +131,23 @@ describe( 'useDefaultHiddenSeries', () => {
 
 		expect( contextValue.isSeriesVisible( 'chart', 'Visitors' ) ).toBe( false );
 		expect( contextValue.isSeriesVisible( 'chart', 'Views' ) ).toBe( true );
+	} );
+
+	it( 'retains provider visibility when remounted without defaults', () => {
+		const Harness = ( { defaults, mounted }: { defaults?: string[]; mounted: boolean } ) => (
+			<GlobalChartsProvider>
+				<Grab />
+				{ mounted && <Chart defaults={ defaults } /> }
+			</GlobalChartsProvider>
+		);
+
+		const { rerender } = render( <Harness defaults={ [ 'Visitors' ] } mounted /> );
+		expect( contextValue.isSeriesVisible( 'chart', 'Visitors' ) ).toBe( false );
+
+		rerender( <Harness mounted={ false } /> );
+		rerender( <Harness mounted /> );
+
+		expect( contextValue.isSeriesVisible( 'chart', 'Visitors' ) ).toBe( false );
 	} );
 
 	it( 're-seeds the defaults when chartId changes mid-mount', () => {

--- a/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series.test.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/test/use-default-hidden-series.test.tsx
@@ -12,8 +12,8 @@ describe( 'useDefaultHiddenSeries', () => {
 		return null;
 	};
 
-	const Chart = ( { defaults }: { defaults?: string[] } ) => {
-		useDefaultHiddenSeries( 'chart', defaults );
+	const Chart = ( { defaults, chartId = 'chart' }: { defaults?: string[]; chartId?: string } ) => {
+		useDefaultHiddenSeries( chartId, defaults );
 		return null;
 	};
 
@@ -81,5 +81,27 @@ describe( 'useDefaultHiddenSeries', () => {
 
 		expect( contextValue.isSeriesVisible( 'chart', 'Visitors' ) ).toBe( false );
 		expect( contextValue.isSeriesVisible( 'chart', 'Views' ) ).toBe( true );
+	} );
+
+	it( 're-seeds the defaults when chartId changes mid-mount', () => {
+		// Same mount, only the chartId prop changes (e.g. <LineChart chartId={ metric } ... />
+		// with `metric` going 'views' -> 'clicks'), so the component never unmounts.
+		const Harness = ( { chartId }: { chartId: string } ) => (
+			<GlobalChartsProvider>
+				<Grab />
+				<Chart chartId={ chartId } defaults={ [ 'Visitors' ] } />
+			</GlobalChartsProvider>
+		);
+
+		const { rerender } = render( <Harness chartId="views" /> );
+
+		expect( contextValue.isSeriesVisible( 'views', 'Visitors' ) ).toBe( false );
+
+		rerender( <Harness chartId="clicks" /> );
+
+		// The new chart id gets the same declared defaults seeded...
+		expect( contextValue.isSeriesVisible( 'clicks', 'Visitors' ) ).toBe( false );
+		// ...and the old id's hidden set is left as it was, not silently cleared.
+		expect( contextValue.isSeriesVisible( 'views', 'Visitors' ) ).toBe( false );
 	} );
 } );

--- a/projects/js-packages/charts/src/providers/chart-context/types.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/types.ts
@@ -41,6 +41,10 @@ export interface GlobalChartsContextValue {
 	// Series visibility management shared by charts, legends, and programmatic controls.
 	toggleSeriesVisibility: ( chartId: string, seriesLabel: string ) => void;
 	// Absolute counterpart to the toggle, for callers that know the target state.
+	// Note: with `legend.collapseGroups`, a grouped legend item reads its visibility from
+	// only the first series in its group (see base-legend.tsx). Setting visibility on a
+	// different member of the group changes that series without updating what the legend
+	// item displays, until the group is next clicked (which converges the whole group).
 	setSeriesVisibility: ( chartId: string, seriesLabel: string, visible: boolean ) => void;
 	// Replaces a chart's entire hidden set. Used to apply `defaultHiddenSeries` at mount.
 	setChartHiddenSeries: ( chartId: string, seriesLabels: string[] ) => void;

--- a/projects/js-packages/charts/src/providers/chart-context/types.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/types.ts
@@ -40,13 +40,7 @@ export interface GlobalChartsContextValue {
 	getElementStyles: ( params: GetElementStylesParams ) => ElementStyles;
 	// Series visibility management shared by charts, legends, and programmatic controls.
 	toggleSeriesVisibility: ( chartId: string, seriesLabel: string ) => void;
-	// Absolute counterpart to the toggle, for callers that know the target state.
-	// Note: with `legend.collapseGroups`, a grouped legend item reads its visibility from
-	// only the first series in its group (see base-legend.tsx). Setting visibility on a
-	// different member of the group changes that series without updating what the legend
-	// item displays, until the group is next clicked (which converges the whole group).
 	setSeriesVisibility: ( chartId: string, seriesLabel: string, visible: boolean ) => void;
-	// Replaces a chart's entire hidden set. Used to apply `defaultHiddenSeries` at mount.
 	setChartHiddenSeries: ( chartId: string, seriesLabels: string[] ) => void;
 	isSeriesVisible: ( chartId: string, seriesLabel: string ) => boolean;
 	getHiddenSeries: ( chartId: string ) => Set< string >;

--- a/projects/js-packages/charts/src/providers/chart-context/types.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/types.ts
@@ -41,7 +41,7 @@ export interface GlobalChartsContextValue {
 	// Series visibility management shared by charts, legends, and programmatic controls.
 	toggleSeriesVisibility: ( chartId: string, seriesLabel: string ) => void;
 	setSeriesVisibility: ( chartId: string, seriesLabel: string, visible: boolean ) => void;
-	setChartHiddenSeries: ( chartId: string, seriesLabels: string[] ) => void;
+	setChartHiddenSeries: ( chartId: string, seriesLabels: readonly string[] ) => void;
 	isSeriesVisible: ( chartId: string, seriesLabel: string ) => boolean;
 	getHiddenSeries: ( chartId: string ) => Set< string >;
 	isColorPaletteResolved: boolean;

--- a/projects/js-packages/charts/src/providers/chart-context/types.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/types.ts
@@ -38,8 +38,12 @@ export interface GlobalChartsContextValue {
 	getChartData: ( id: string ) => ChartRegistration | undefined;
 	theme: CompleteChartTheme;
 	getElementStyles: ( params: GetElementStylesParams ) => ElementStyles;
-	// Series visibility management shared by charts and legends.
+	// Series visibility management shared by charts, legends, and programmatic controls.
 	toggleSeriesVisibility: ( chartId: string, seriesLabel: string ) => void;
+	// Absolute counterpart to the toggle, for callers that know the target state.
+	setSeriesVisibility: ( chartId: string, seriesLabel: string, visible: boolean ) => void;
+	// Replaces a chart's entire hidden set. Used to apply `defaultHiddenSeries` at mount.
+	setChartHiddenSeries: ( chartId: string, seriesLabels: string[] ) => void;
 	isSeriesVisible: ( chartId: string, seriesLabel: string ) => boolean;
 	getHiddenSeries: ( chartId: string ) => Set< string >;
 	isColorPaletteResolved: boolean;

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -640,6 +640,18 @@ export type SeriesChartLegendConfig = ChartLegendConfig< SeriesData[] > & {
 };
 
 /**
+ * Initial visibility options for charts built from labelled series.
+ */
+export interface SeriesVisibilityProps {
+	/**
+	 * Series labels to hide from the first defined value. User changes persist until
+	 * the chart remounts or its ID changes; later values for the same ID are ignored.
+	 * Omit to retain the provider's existing visibility for the chart ID.
+	 */
+	defaultHiddenSeries?: readonly string[];
+}
+
+/**
  * Base properties shared across all chart components
  */
 export type BaseChartProps< T = DataPoint | DataPointDate | LeaderboardEntry > = {


### PR DESCRIPTION

## Proposed changes

- Add `defaultHiddenSeries` to LineChart, AreaChart, and BarChart so selected series are hidden before the first paint.
- Preserve user visibility changes across re-renders and data updates. Remounting the chart or changing `chartId` reapplies the defaults.
- Add explicit chart-context setters for changing one series or replacing the hidden-series set, with supporting stories, docs, and tests.

### Screenshots

Seeded hidden on load, revealed by the user, and still revealed after the data refreshes:

<img width="2900" height="920" alt="Three area charts: London seeded hidden, London revealed, and London still visible after new data arrives" src="https://github.com/user-attachments/assets/f8dc9cc3-85c6-4559-a7c4-ddaad14510be" />

The committed story, Area Chart → With Default Hidden Series:

<img width="1800" height="1040" alt="Stacked area chart with London hidden and struck through in the legend" src="https://github.com/user-attachments/assets/80c64c15-824d-408e-9c12-699531ddbe2e" />



Stacked on #51457 and targeting its branch — please review that one first.

## Related product discussion/links

- CHARTS-246
- Unblocks WOOA7S-1844

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- In Storybook, open Area Chart → With Default Hidden Series and hard-reload. London must already be hidden and struck through when the chart appears — it should never flash in and collapse. Clicking it reveals the band; reloading hides it again.
- Same story exists for Line Chart and Bar Chart.
- Re-render the chart with changed `data` after revealing a seeded-hidden series and confirm it stays visible.
- Call `setSeriesVisibility` twice with the same value and confirm the second call does not re-render the charts under the provider.


https://github.com/user-attachments/assets/055b5786-ee54-4f69-8d6d-3698fe7d9837


