### PR TITLE
Connection: enqueue the users column CSS instead of printing a style element

### DIFF
--- a/projects/packages/connection/changelog/stats-343-connection-users-column-style
+++ b/projects/packages/connection/changelog/stats-343-connection-users-column-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enqueue the Users screen connection column CSS through wp_add_inline_style() instead of printing a style element.

--- a/projects/packages/connection/changelog/stats-343-connection-users-column-style-deprecation
+++ b/projects/packages/connection/changelog/stats-343-connection-users-column-style-deprecation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Deprecate Users_Connection_Admin::add_connection_column_styles(); the Users screen column CSS is enqueued as an inline style now.

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -194,9 +194,6 @@ class Users_Connection_Admin {
 				width: auto;
 			}
 		}
-		td.column-user_jetpack {
-			vertical-align: middle;
-		}
 		.jetpack-connection-status {
 			display: inline-flex;
 			align-items: center;

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -22,6 +22,13 @@ class Users_Connection_Admin {
 	const COLUMN_ID = 'user_jetpack';
 
 	/**
+	 * The handle used for the users list table column styles.
+	 *
+	 * @var string
+	 */
+	const STYLE_HANDLE = 'jetpack-connection-users-column';
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -40,7 +47,6 @@ class Users_Connection_Admin {
 		add_filter( 'manage_users_columns', array( $this, 'add_connection_column' ) );
 		add_filter( 'manage_users_custom_column', array( $this, 'render_connection_column' ), 9, 3 ); // Priority 9 to run before SSO
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_action( 'admin_print_styles-users.php', array( $this, 'add_connection_column_styles' ) );
 	}
 
 	/**
@@ -98,6 +104,13 @@ class Users_Connection_Admin {
 			return;
 		}
 
+		// A request can run several instances of this class, and wp_add_inline_style() appends, so the CSS is added once per handle.
+		if ( ! wp_style_is( self::STYLE_HANDLE, 'registered' ) ) {
+			wp_register_style( self::STYLE_HANDLE, false, array(), Package_Version::PACKAGE_VERSION );
+			wp_add_inline_style( self::STYLE_HANDLE, self::get_connection_column_styles() );
+		}
+		wp_enqueue_style( self::STYLE_HANDLE );
+
 		Assets::register_script(
 			'jetpack-users-connection',
 			'../dist/jetpack-users-connection.js',
@@ -122,66 +135,66 @@ class Users_Connection_Admin {
 	}
 
 	/**
-	 * Add styles for the connection column.
+	 * Get the styles for the connection column.
+	 *
+	 * @return string CSS rules.
 	 */
-	public function add_connection_column_styles() {
-		?>
-		<style>
-			.jetpack-connection-tooltip-icon {
-				position: relative;
-				cursor: pointer;
-			}
-			/* Add [?] icon using pseudo-element, only in column header */
-			th.manage-column .jetpack-connection-tooltip-icon::after {
-				content: '[?]';
-				color: #3c434a;
-				font-size: 1em;
-				margin-left: 4px;
-			}
-			.jetpack-connection-tooltip {
-				position: absolute;
-				background: #f6f7f7;
-				top: -85px;
-				width: 250px;
-				padding: 7px;
-				color: #3c434a;
-				font-size: .75rem;
-				line-height: 17px;
-				text-align: left;
-				margin: 0;
-				display: none;
-				border-radius: 4px;
-				font-family: sans-serif;
-				box-shadow: 5px 10px 10px rgba(0, 0, 0, 0.1);
-				left: -170px;
-			}
+	private static function get_connection_column_styles() {
+		return '
+		.jetpack-connection-tooltip-icon {
+			position: relative;
+			cursor: pointer;
+		}
+		/* Add [?] icon using pseudo-element, only in column header */
+		th.manage-column .jetpack-connection-tooltip-icon::after {
+			content: \'[?]\';
+			color: #3c434a;
+			font-size: 1em;
+			margin-left: 4px;
+		}
+		.jetpack-connection-tooltip {
+			position: absolute;
+			background: #f6f7f7;
+			top: -85px;
+			width: 250px;
+			padding: 7px;
+			color: #3c434a;
+			font-size: .75rem;
+			line-height: 17px;
+			text-align: left;
+			margin: 0;
+			display: none;
+			border-radius: 4px;
+			font-family: sans-serif;
+			box-shadow: 5px 10px 10px rgba(0, 0, 0, 0.1);
+			left: -170px;
+		}
+		.column-user_jetpack {
+			width: 190px;
+		}
+		@media screen and (max-width: 1100px) {
 			.column-user_jetpack {
-				width: 190px;
+				width: auto;
 			}
-			@media screen and (max-width: 1100px) {
-				.column-user_jetpack {
-					width: auto;
-				}
-			}
-			td.column-user_jetpack {
-				vertical-align: middle;
-			}
-			.jetpack-connection-status {
-				display: inline-flex;
-				align-items: center;
-				column-gap: 6px;
-			}
-			.jetpack-connection-status__logo {
-				display: block;
-				flex-shrink: 0;
-			}
-			/* Show tooltip on hover and focus */
-			.jetpack-connection-tooltip-icon:hover .jetpack-connection-tooltip,
-			.jetpack-connection-tooltip-icon:focus-within .jetpack-connection-tooltip {
-				display: block;
-			}
-		</style>
-		<?php
+		}
+		td.column-user_jetpack {
+			vertical-align: middle;
+		}
+		.jetpack-connection-status {
+			display: inline-flex;
+			align-items: center;
+			column-gap: 6px;
+		}
+		.jetpack-connection-status__logo {
+			display: block;
+			flex-shrink: 0;
+		}
+		/* Show tooltip on hover and focus */
+		.jetpack-connection-tooltip-icon:hover .jetpack-connection-tooltip,
+		.jetpack-connection-tooltip-icon:focus-within .jetpack-connection-tooltip {
+			display: block;
+		}
+		';
 	}
 
 	/**

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -104,12 +104,7 @@ class Users_Connection_Admin {
 			return;
 		}
 
-		// A request can run several instances of this class, and wp_add_inline_style() appends, so the CSS is added once per handle.
-		if ( ! wp_style_is( self::STYLE_HANDLE, 'registered' ) ) {
-			wp_register_style( self::STYLE_HANDLE, false, array(), Package_Version::PACKAGE_VERSION );
-			wp_add_inline_style( self::STYLE_HANDLE, self::get_connection_column_styles() );
-		}
-		wp_enqueue_style( self::STYLE_HANDLE );
+		self::enqueue_connection_column_styles();
 
 		Assets::register_script(
 			'jetpack-users-connection',
@@ -132,6 +127,28 @@ class Users_Connection_Admin {
 				'columnTooltip' => esc_html( self::get_column_tooltip_text() ),
 			)
 		);
+	}
+
+	/**
+	 * Enqueue the styles for the connection column as inline CSS on a source-less handle.
+	 */
+	private static function enqueue_connection_column_styles() {
+		// A request can run several instances of this class, and wp_add_inline_style() appends, so the CSS is added once per handle.
+		if ( ! wp_style_is( self::STYLE_HANDLE, 'registered' ) ) {
+			wp_register_style( self::STYLE_HANDLE, false, array(), Package_Version::PACKAGE_VERSION );
+			wp_add_inline_style( self::STYLE_HANDLE, self::get_connection_column_styles() );
+		}
+		wp_enqueue_style( self::STYLE_HANDLE );
+	}
+
+	/**
+	 * Add the styles for the connection column.
+	 *
+	 * @deprecated $$next-version$$ The CSS is enqueued on the `jetpack-connection-users-column` style handle by enqueue_scripts().
+	 */
+	public function add_connection_column_styles() {
+		_deprecated_function( __METHOD__, 'connection-$$next-version$$', __CLASS__ . '::enqueue_scripts' );
+		self::enqueue_connection_column_styles();
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Users_Connection_Admin_Test.php
+++ b/projects/packages/connection/tests/php/Users_Connection_Admin_Test.php
@@ -83,6 +83,48 @@ class Users_Connection_Admin_Test extends TestCase {
 	}
 
 	/**
+	 * Count every callback attached to a hook, across all priorities.
+	 *
+	 * @param string $hook Hook name.
+	 * @return int
+	 */
+	private function count_hook_callbacks( $hook ) {
+		if ( ! isset( $GLOBALS['wp_filter'][ $hook ] ) ) {
+			return 0;
+		}
+
+		$count = 0;
+		foreach ( $GLOBALS['wp_filter'][ $hook ]->callbacks as $callbacks ) {
+			$count += count( $callbacks );
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Check whether a hook holds a callback that belongs to the given object.
+	 *
+	 * @param string $hook     Hook name.
+	 * @param object $instance Object to look for.
+	 * @return bool
+	 */
+	private function hook_has_callback_from( $hook, $instance ) {
+		if ( ! isset( $GLOBALS['wp_filter'][ $hook ] ) ) {
+			return false;
+		}
+
+		foreach ( $GLOBALS['wp_filter'][ $hook ]->callbacks as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				if ( is_array( $callback['function'] ) && isset( $callback['function'][0] ) && $callback['function'][0] === $instance ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get the inline CSS attached to the column style handle.
 	 *
 	 * @return array
@@ -98,10 +140,16 @@ class Users_Connection_Admin_Test extends TestCase {
 	 */
 	public function test_init_does_not_print_styles_directly() {
 		$admin = $this->create_admin();
+
+		// SSO's User_Admin hooks this action as well, so the hook is occupied here to keep the assertions specific to this class.
+		add_action( 'admin_print_styles-users.php', '__return_false' );
+		$callbacks_before = $this->count_hook_callbacks( 'admin_print_styles-users.php' );
+
 		$admin->init();
 
 		$this->assertIsInt( has_action( 'admin_enqueue_scripts', array( $admin, 'enqueue_scripts' ) ) );
-		$this->assertFalse( has_action( 'admin_print_styles-users.php' ) );
+		$this->assertSame( $callbacks_before, $this->count_hook_callbacks( 'admin_print_styles-users.php' ) );
+		$this->assertFalse( $this->hook_has_callback_from( 'admin_print_styles-users.php', $admin ) );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Users_Connection_Admin_Test.php
+++ b/projects/packages/connection/tests/php/Users_Connection_Admin_Test.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Unit tests for the Users_Connection_Admin class.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Tests for the WordPress.com account column on the users list table.
+ *
+ * @covers \Automattic\Jetpack\Connection\Users_Connection_Admin
+ */
+#[CoversClass( Users_Connection_Admin::class )]
+class Users_Connection_Admin_Test extends TestCase {
+
+	/**
+	 * Admin user ID created for the test.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->admin_id = wp_insert_user(
+			array(
+				'user_login'   => 'users_column_admin',
+				'user_pass'    => 'password',
+				'user_email'   => 'admin@example.org',
+				'display_name' => 'Local Admin',
+				'role'         => 'administrator',
+			)
+		);
+
+		wp_set_current_user( $this->admin_id );
+		set_current_screen( 'users' );
+
+		$GLOBALS['wp_styles']  = null;
+		$GLOBALS['wp_scripts'] = null;
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_all_actions( 'admin_enqueue_scripts' );
+		remove_all_actions( 'admin_print_styles-users.php' );
+		remove_all_filters( 'manage_users_columns' );
+		remove_all_filters( 'manage_users_custom_column' );
+
+		$GLOBALS['wp_styles']  = null;
+		$GLOBALS['wp_scripts'] = null;
+		unset( $GLOBALS['current_screen'] );
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Build an instance without leaving its `init` callback on the global hook.
+	 *
+	 * @return Users_Connection_Admin
+	 */
+	private function create_admin() {
+		$admin = new Users_Connection_Admin();
+		remove_action( 'init', array( $admin, 'init' ) );
+
+		return $admin;
+	}
+
+	/**
+	 * Get the inline CSS attached to the column style handle.
+	 *
+	 * @return array
+	 */
+	private function get_inline_styles() {
+		$data = wp_styles()->get_data( Users_Connection_Admin::STYLE_HANDLE, 'after' );
+
+		return is_array( $data ) ? $data : array();
+	}
+
+	/**
+	 * The column CSS must reach the page through the style queue, not through a printed style element.
+	 */
+	public function test_init_does_not_print_styles_directly() {
+		$admin = $this->create_admin();
+		$admin->init();
+
+		$this->assertIsInt( has_action( 'admin_enqueue_scripts', array( $admin, 'enqueue_scripts' ) ) );
+		$this->assertFalse( has_action( 'admin_print_styles-users.php' ) );
+	}
+
+	/**
+	 * The column CSS is registered as an inline style on a source-less handle.
+	 */
+	public function test_enqueue_scripts_adds_the_column_css_as_an_inline_style() {
+		$this->create_admin()->enqueue_scripts( 'users.php' );
+
+		$this->assertTrue( wp_style_is( Users_Connection_Admin::STYLE_HANDLE, 'enqueued' ) );
+		$this->assertFalse( wp_styles()->registered[ Users_Connection_Admin::STYLE_HANDLE ]->src );
+
+		$css = implode( '', $this->get_inline_styles() );
+		$this->assertStringContainsString( '.column-user_jetpack', $css );
+		$this->assertStringContainsString( '.jetpack-connection-tooltip', $css );
+		$this->assertStringContainsString( '.jetpack-connection-status__logo', $css );
+		$this->assertStringNotContainsString( '<style', $css );
+	}
+
+	/**
+	 * The column CSS is limited to the users list table.
+	 */
+	public function test_enqueue_scripts_skips_other_admin_screens() {
+		$this->create_admin()->enqueue_scripts( 'index.php' );
+
+		$this->assertFalse( wp_style_is( Users_Connection_Admin::STYLE_HANDLE, 'registered' ) );
+		$this->assertFalse( wp_style_is( Users_Connection_Admin::STYLE_HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * One request can run several instances, but the CSS must be printed only once.
+	 */
+	public function test_column_css_is_printed_once_when_several_instances_run() {
+		$first_instance  = $this->create_admin();
+		$second_instance = $this->create_admin();
+
+		$first_instance->enqueue_scripts( 'users.php' );
+		$second_instance->enqueue_scripts( 'users.php' );
+
+		$this->assertCount( 1, $this->get_inline_styles() );
+
+		ob_start();
+		wp_styles()->do_items( array( Users_Connection_Admin::STYLE_HANDLE ) );
+		$output = ob_get_clean();
+
+		$this->assertSame( 1, substr_count( $output, '<style' ) );
+		$this->assertSame( 1, substr_count( $output, '.jetpack-connection-status__logo' ) );
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes
* The WordPress.org plugin review flagged the raw `<style>` element this package prints on the Users screen, under "Use wp_enqueue commands". The standalone Jetpack Stats plugin bundles the connection package, so the review applies to every plugin that ships it.
* `Users_Connection_Admin` no longer hooks `admin_print_styles-users.php` and no longer echoes a style element. The same CSS now goes through a registered, source-less handle (`jetpack-connection-users-column`) with `wp_add_inline_style()`, enqueued from the existing `enqueue_scripts()` callback and still only on `users.php`.
* The CSS rules are unchanged. The CSS now comes from a private static `get_connection_column_styles()` and is enqueued by a private `enqueue_connection_column_styles()`. The public `add_connection_column_styles()` stays as a deprecated shim (`@deprecated $$next-version$$`, `_deprecated_function()`) that enqueues the same CSS, for code outside the monorepo that may call it; nothing in the monorepo does. Changelog: `changed` (patch) + `deprecated` (minor).
* A request can construct several `Users_Connection_Admin` instances, and `wp_add_inline_style()` appends, so the inline style is added once per handle. Before this change the style element could be printed several times on one page.
* Adds unit tests for the users column styles and a `patch`/`changed` changelog entry.

## Related product discussion/links
* [STATS-343](https://linear.app/a8c/issue/STATS-343/create-standalone-jetpack-stats-plugin)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

You need a site with Jetpack connected and at least one user whose WordPress.com account is connected.

* Go to **Users** in wp-admin. The **WordPress.com account** column must look exactly as it did before: the same column width, the `[?]` marker next to the header, and a "Connected" row that shows the WordPress.com logo next to the label.
* Hover the `[?]` marker, then tab to it with the keyboard. The tooltip must appear on hover and on focus in both cases.
* Narrow the browser below 1100px. The column must go back to automatic width.
* View the page source. There must be no bare `<style>` block printed by this class. The rules must instead arrive in a `<style id='jetpack-connection-users-column-inline-css'>` element written by the style queue, and that element must appear only once.
* Activate the Jetpack SSO module and reload **Users**. The column must still render correctly, and the CSS must still appear only once.

