### PR TITLE
Connection: enqueue the SSO login and users-table styles

### DIFF
--- a/projects/packages/connection/changelog/stats-343-connection-sso-inline-styles
+++ b/projects/packages/connection/changelog/stats-343-connection-sso-inline-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+SSO: enqueue the login and user-admin styles through wp_add_inline_style() instead of printing style elements.

--- a/projects/packages/connection/changelog/stats-343-connection-sso-inline-styles-deprecation
+++ b/projects/packages/connection/changelog/stats-343-connection-sso-inline-styles-deprecation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+SSO: deprecate print_inline_admin_css() in favour of enqueue_login_styles().

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -328,12 +328,19 @@ class SSO {
 		// login stylesheet, which sets `.message` margins at the same specificity.
 		wp_register_style( $handle, false, array( 'login' ), Package_Version::PACKAGE_VERSION );
 		wp_enqueue_style( $handle );
-		wp_add_inline_style(
-			$handle,
-			'.jetpack-sso .message { margin-top: 20px; }'
-			. '.jetpack-sso #login .message:first-child,'
-			. '.jetpack-sso #login h1 + .message { margin-top: 0; }'
-		);
+
+		$css = <<<'CSS'
+.jetpack-sso .message {
+	margin-top: 20px;
+}
+
+.jetpack-sso #login .message:first-child,
+.jetpack-sso #login h1 + .message {
+	margin-top: 0;
+}
+CSS;
+
+		wp_add_inline_style( $handle, $css );
 	}
 
 	/**

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -319,6 +319,16 @@ class SSO {
 	}
 
 	/**
+	 * Print the SSO styles for the login screen.
+	 *
+	 * @deprecated $$next-version$$ Use enqueue_login_styles().
+	 */
+	public function print_inline_admin_css() {
+		_deprecated_function( __METHOD__, 'connection-$$next-version$$', __CLASS__ . '::enqueue_login_styles' );
+		$this->enqueue_login_styles();
+	}
+
+	/**
 	 * Enqueue the SSO styles for the login screen.
 	 */
 	public function enqueue_login_styles() {

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -319,21 +319,21 @@ class SSO {
 	}
 
 	/**
-	 * Inlined admin styles for SSO.
+	 * Enqueue the SSO styles for the login screen.
 	 */
-	public function print_inline_admin_css() {
-		?>
-			<style>
-				.jetpack-sso .message {
-					margin-top: 20px;
-				}
+	public function enqueue_login_styles() {
+		$handle = 'jetpack-sso-login-styles';
 
-				.jetpack-sso #login .message:first-child,
-				.jetpack-sso #login h1 + .message {
-					margin-top: 0;
-				}
-			</style>
-		<?php
+		// No src: the handle only carries the inline CSS below. It depends on `login` so these rules stay after the core
+		// login stylesheet, which sets `.message` margins at the same specificity.
+		wp_register_style( $handle, false, array( 'login' ), Package_Version::PACKAGE_VERSION );
+		wp_enqueue_style( $handle );
+		wp_add_inline_style(
+			$handle,
+			'.jetpack-sso .message { margin-top: 20px; }'
+			. '.jetpack-sso #login .message:first-child,'
+			. '.jetpack-sso #login h1 + .message { margin-top: 0; }'
+		);
 	}
 
 	/**
@@ -559,7 +559,7 @@ class SSO {
 	 */
 	public function display_sso_login_form() {
 		add_filter( 'login_body_class', array( $this, 'login_body_class' ) );
-		add_action( 'login_head', array( $this, 'print_inline_admin_css' ) );
+		add_action( 'login_enqueue_scripts', array( $this, 'enqueue_login_styles' ) );
 
 		if ( ( new Status() )->in_safe_mode() ) {
 			add_filter( 'login_message', array( Notices::class, 'sso_not_allowed_in_safe_mode' ) );

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -334,9 +334,11 @@ class SSO {
 	public function enqueue_login_styles() {
 		$handle = 'jetpack-sso-login-styles';
 
-		// No src: the handle only carries the inline CSS below. It depends on `login` so these rules stay after the core
-		// login stylesheet, which sets `.message` margins at the same specificity.
-		wp_register_style( $handle, false, array( 'login' ), Package_Version::PACKAGE_VERSION );
+		// No src: the handle only carries the inline CSS below. Core enqueues `login` before `login_enqueue_scripts` fires,
+		// so these rules already print after the core login stylesheet, which sets `.message` margins at the same
+		// specificity. No dependency on `login`: plugins that replace the login screen deregister that handle, and a
+		// missing dependency would drop this one from the queue.
+		wp_register_style( $handle, false, array(), Package_Version::PACKAGE_VERSION );
 		wp_enqueue_style( $handle );
 
 		$css = <<<'CSS'

--- a/projects/packages/connection/src/sso/class-user-admin.php
+++ b/projects/packages/connection/src/sso/class-user-admin.php
@@ -73,7 +73,6 @@ class User_Admin extends Base_Admin {
 		add_action( 'admin_post_jetpack_invite_user_to_wpcom', array( $this, 'invite_user_to_wpcom' ) );
 		add_action( 'admin_post_jetpack_revoke_invite_user_to_wpcom', array( $this, 'handle_request_revoke_invite' ) );
 		add_action( 'admin_post_jetpack_resend_invite_user_to_wpcom', array( $this, 'handle_request_resend_invite' ) );
-		add_action( 'admin_print_styles-users.php', array( $this, 'jetpack_user_table_styles' ) );
 		add_filter( 'users_list_table_query_args', array( $this, 'set_user_query' ), 100, 1 );
 		add_action( 'admin_print_styles-user-new.php', array( $this, 'jetpack_new_users_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
@@ -1222,77 +1221,29 @@ class User_Admin extends Base_Admin {
 	}
 
 	/**
-	 * Style the Jetpack user rows and columns.
+	 * Enqueue the styles for the Jetpack user rows and columns.
 	 */
 	public function jetpack_user_table_styles() {
-		?>
-	<style>
-		#the-list tr:has(.sso-disconnected-user) {
-			background: #F5F1E1;
-		}
-		#the-list tr:has(.sso-pending-invite) {
-			background: #E9F0F5;
-		}
-		.jetpack-sso-invitation {
-			background: none;
-			border: none;
-			color: #50575e;
-			padding: 0;
-			text-align: unset;
-		}
-		.jetpack-sso-invitation.sso-disconnected-user {
-			color: #0073aa;
-			cursor: pointer;
-			text-decoration: underline;
-		}
-		.jetpack-sso-invitation.sso-disconnected-user:hover,
-		.jetpack-sso-invitation.sso-disconnected-user:focus,
-		.jetpack-sso-invitation.sso-disconnected-user:active {
-			color: #0096dd;
-		}
+		$handle = 'jetpack-sso-users-styles';
 
-		.sso-disconnected-user-icon {
-			cursor: pointer;
-			background: gray;
-			border-radius: 10px;
-		}
-
-		.sso-disconnected-user-icon.dashicons {
-			font-size: 1rem;
-			height: 1rem;
-			width: 1rem;
-			background-color: #9D6E00;
-			color: #F5F1E1;
-		}
-		.jetpack-sso-invitation-tooltip-icon{
-			position: relative;
-			cursor: pointer;
-			display: inline-flex;
-			align-items: center;
-			column-gap: 6px;
-		}
-		.jetpack-sso-td-tooltip {
-			left: -256px;
-		}
-		.jetpack-sso-invitation-tooltip {
-			position: absolute;
-			background: #f6f7f7;
-			top: -85px;
-			width: 250px;
-			padding: 7px;
-			color: #3c434a;
-			font-size: .75rem;
-			line-height: 17px;
-			text-align: left;
-			margin: 0;
-			display: none;
-			border-radius: 4px;
-			font-family: sans-serif;
-			box-shadow: 5px 10px 10px rgba(0, 0, 0, 0.1);
-		}
-
-	</style>
-		<?php
+		// No src: the handle only carries the inline CSS below.
+		wp_register_style( $handle, false, array(), Package_Version::PACKAGE_VERSION );
+		wp_enqueue_style( $handle );
+		wp_add_inline_style(
+			$handle,
+			'#the-list tr:has(.sso-disconnected-user) { background: #F5F1E1; }'
+			. '#the-list tr:has(.sso-pending-invite) { background: #E9F0F5; }'
+			. '.jetpack-sso-invitation { background: none; border: none; color: #50575e; padding: 0; text-align: unset; }'
+			. '.jetpack-sso-invitation.sso-disconnected-user { color: #0073aa; cursor: pointer; text-decoration: underline; }'
+			. '.jetpack-sso-invitation.sso-disconnected-user:hover,'
+			. '.jetpack-sso-invitation.sso-disconnected-user:focus,'
+			. '.jetpack-sso-invitation.sso-disconnected-user:active { color: #0096dd; }'
+			. '.sso-disconnected-user-icon { cursor: pointer; background: gray; border-radius: 10px; }'
+			. '.sso-disconnected-user-icon.dashicons { font-size: 1rem; height: 1rem; width: 1rem; background-color: #9D6E00; color: #F5F1E1; }'
+			. '.jetpack-sso-invitation-tooltip-icon { position: relative; cursor: pointer; display: inline-flex; align-items: center; column-gap: 6px; }'
+			. '.jetpack-sso-td-tooltip { left: -256px; }'
+			. '.jetpack-sso-invitation-tooltip { position: absolute; background: #f6f7f7; top: -85px; width: 250px; padding: 7px; color: #3c434a; font-size: .75rem; line-height: 17px; text-align: left; margin: 0; display: none; border-radius: 4px; font-family: sans-serif; box-shadow: 5px 10px 10px rgba(0, 0, 0, 0.1); }'
+		);
 	}
 
 	/**
@@ -1306,6 +1257,9 @@ class User_Admin extends Base_Admin {
 		}
 
 		parent::enqueue_scripts( $hook );
+
+		$this->jetpack_user_table_styles();
+
 		// Enqueue the SSO users script.
 		Assets::register_script(
 			'jetpack-sso-users',

--- a/projects/packages/connection/src/sso/class-user-admin.php
+++ b/projects/packages/connection/src/sso/class-user-admin.php
@@ -1229,21 +1229,81 @@ class User_Admin extends Base_Admin {
 		// No src: the handle only carries the inline CSS below.
 		wp_register_style( $handle, false, array(), Package_Version::PACKAGE_VERSION );
 		wp_enqueue_style( $handle );
-		wp_add_inline_style(
-			$handle,
-			'#the-list tr:has(.sso-disconnected-user) { background: #F5F1E1; }'
-			. '#the-list tr:has(.sso-pending-invite) { background: #E9F0F5; }'
-			. '.jetpack-sso-invitation { background: none; border: none; color: #50575e; padding: 0; text-align: unset; }'
-			. '.jetpack-sso-invitation.sso-disconnected-user { color: #0073aa; cursor: pointer; text-decoration: underline; }'
-			. '.jetpack-sso-invitation.sso-disconnected-user:hover,'
-			. '.jetpack-sso-invitation.sso-disconnected-user:focus,'
-			. '.jetpack-sso-invitation.sso-disconnected-user:active { color: #0096dd; }'
-			. '.sso-disconnected-user-icon { cursor: pointer; background: gray; border-radius: 10px; }'
-			. '.sso-disconnected-user-icon.dashicons { font-size: 1rem; height: 1rem; width: 1rem; background-color: #9D6E00; color: #F5F1E1; }'
-			. '.jetpack-sso-invitation-tooltip-icon { position: relative; cursor: pointer; display: inline-flex; align-items: center; column-gap: 6px; }'
-			. '.jetpack-sso-td-tooltip { left: -256px; }'
-			. '.jetpack-sso-invitation-tooltip { position: absolute; background: #f6f7f7; top: -85px; width: 250px; padding: 7px; color: #3c434a; font-size: .75rem; line-height: 17px; text-align: left; margin: 0; display: none; border-radius: 4px; font-family: sans-serif; box-shadow: 5px 10px 10px rgba(0, 0, 0, 0.1); }'
-		);
+
+		$css = <<<'CSS'
+#the-list tr:has(.sso-disconnected-user) {
+	background: #F5F1E1;
+}
+
+#the-list tr:has(.sso-pending-invite) {
+	background: #E9F0F5;
+}
+
+.jetpack-sso-invitation {
+	background: none;
+	border: none;
+	color: #50575e;
+	padding: 0;
+	text-align: unset;
+}
+
+.jetpack-sso-invitation.sso-disconnected-user {
+	color: #0073aa;
+	cursor: pointer;
+	text-decoration: underline;
+}
+
+.jetpack-sso-invitation.sso-disconnected-user:hover,
+.jetpack-sso-invitation.sso-disconnected-user:focus,
+.jetpack-sso-invitation.sso-disconnected-user:active {
+	color: #0096dd;
+}
+
+.sso-disconnected-user-icon {
+	cursor: pointer;
+	background: gray;
+	border-radius: 10px;
+}
+
+.sso-disconnected-user-icon.dashicons {
+	font-size: 1rem;
+	height: 1rem;
+	width: 1rem;
+	background-color: #9D6E00;
+	color: #F5F1E1;
+}
+
+.jetpack-sso-invitation-tooltip-icon {
+	position: relative;
+	cursor: pointer;
+	display: inline-flex;
+	align-items: center;
+	column-gap: 6px;
+}
+
+.jetpack-sso-td-tooltip {
+	left: -256px;
+}
+
+.jetpack-sso-invitation-tooltip {
+	position: absolute;
+	background: #f6f7f7;
+	top: -85px;
+	width: 250px;
+	padding: 7px;
+	color: #3c434a;
+	font-size: .75rem;
+	line-height: 17px;
+	text-align: left;
+	margin: 0;
+	display: none;
+	border-radius: 4px;
+	font-family: sans-serif;
+	box-shadow: 5px 10px 10px rgba(0, 0, 0, 0.1);
+}
+CSS;
+
+		wp_add_inline_style( $handle, $css );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -304,7 +304,7 @@ class SSO_Test extends BaseTestCase {
 		$this->assertTrue( wp_style_is( 'jetpack-sso-login-styles', 'enqueued' ) );
 
 		$styles = wp_styles();
-		$this->assertSame( array( 'login' ), $styles->registered['jetpack-sso-login-styles']->deps );
+		$this->assertSame( array(), $styles->registered['jetpack-sso-login-styles']->deps );
 
 		$css = preg_replace( '/\s+/', ' ', implode( '', (array) $styles->get_data( 'jetpack-sso-login-styles', 'after' ) ) );
 		$this->assertStringContainsString( '.jetpack-sso .message { margin-top: 20px; }', $css );

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -292,6 +292,29 @@ class SSO_Test extends BaseTestCase {
 	}
 
 	// ──────────────────────────────────────────────
+	// enqueue_login_styles
+	// ──────────────────────────────────────────────
+
+	/**
+	 * Test that the login styles reach the page through the style queue.
+	 */
+	public function test_enqueue_login_styles_queues_the_css_as_inline_style() {
+		$this->sso->enqueue_login_styles();
+
+		$this->assertTrue( wp_style_is( 'jetpack-sso-login-styles', 'enqueued' ) );
+
+		$styles = wp_styles();
+		$this->assertSame( array( 'login' ), $styles->registered['jetpack-sso-login-styles']->deps );
+
+		$css = implode( '', (array) $styles->get_data( 'jetpack-sso-login-styles', 'after' ) );
+		$this->assertStringContainsString( '.jetpack-sso .message { margin-top: 20px; }', $css );
+		$this->assertStringContainsString( '.jetpack-sso #login h1 + .message { margin-top: 0; }', $css );
+
+		wp_dequeue_style( 'jetpack-sso-login-styles' );
+		wp_deregister_style( 'jetpack-sso-login-styles' );
+	}
+
+	// ──────────────────────────────────────────────
 	// profile_page_url
 	// ──────────────────────────────────────────────
 

--- a/projects/packages/connection/tests/php/sso/SSO_Test.php
+++ b/projects/packages/connection/tests/php/sso/SSO_Test.php
@@ -306,7 +306,7 @@ class SSO_Test extends BaseTestCase {
 		$styles = wp_styles();
 		$this->assertSame( array( 'login' ), $styles->registered['jetpack-sso-login-styles']->deps );
 
-		$css = implode( '', (array) $styles->get_data( 'jetpack-sso-login-styles', 'after' ) );
+		$css = preg_replace( '/\s+/', ' ', implode( '', (array) $styles->get_data( 'jetpack-sso-login-styles', 'after' ) ) );
 		$this->assertStringContainsString( '.jetpack-sso .message { margin-top: 20px; }', $css );
 		$this->assertStringContainsString( '.jetpack-sso #login h1 + .message { margin-top: 0; }', $css );
 


### PR DESCRIPTION
## Proposed changes

The SSO code in `projects/packages/connection` printed two blocks of CSS as raw `<style>` elements. Both blocks now go through the style queue.

* `SSO::print_inline_admin_css()` is now `SSO::enqueue_login_styles()`; the old name stays as a deprecated shim (`@deprecated $$next-version$$`, `_deprecated_function()`) that delegates to it, for code outside the monorepo that may call it. `SSO::enqueue_login_styles()` It runs on `login_enqueue_scripts`, registers a `jetpack-sso-login-styles` handle with no `src`, and attaches the same CSS with `wp_add_inline_style()`. The handle depends on the core `login` handle. This keeps the `.jetpack-sso .message` rules after the core login stylesheet, which is where they were before: the old `<style>` printed on `login_head` at priority 10, and `print_admin_styles` runs on that hook at priority 9.
* `User_Admin::jetpack_user_table_styles()` keeps its name. It now registers a `jetpack-sso-users-styles` handle with no `src` and attaches the same CSS. `User_Admin::enqueue_scripts()` calls it. That method already runs on `admin_enqueue_scripts` and already limits itself to `users.php`, so the audience does not change. The `admin_print_styles-users.php` hook is removed.

Every CSS rule is identical, in the same order. Both handles use `Package_Version::PACKAGE_VERSION`, like the SSO scripts.

One ordering note for the reviewer. On the users screen the old `<style>` printed on `admin_print_styles-users.php`. That hook fires before `admin_print_styles`, where core prints the admin stylesheets at priority 20. The old block therefore came before the core admin CSS, and the inline CSS now comes after it. This does not change what renders. Every rule in the block already wins on specificity against the core rule it competes with (`#the-list tr:has(...)` against `.striped > tbody > :nth-child(odd)`, `.sso-disconnected-user-icon.dashicons` against `.dashicons`, and so on), and every selector is limited to an SSO class.

Context: the standalone Jetpack Stats plugin bundles the connection package, so it ships this SSO code even though it never starts SSO. The WordPress.org plugin review flagged both `<style>` elements under "Use wp_enqueue commands". The Jetpack plugin ships the same code to many sites, so the visual result must stay the same.

Added one test, `SSO_Test::test_enqueue_login_styles_queues_the_css_as_inline_style`. It checks that the handle is enqueued, that it depends on `login`, and that the CSS is attached as inline data. There is no `User_Admin` test file, and building one to cover the users screen would need `Assets::register_script()` to resolve a built asset, so that side is covered by the manual steps below.

## Related product discussion/links

* [STATS-343](https://linear.app/a8c/issue/STATS-343/create-standalone-jetpack-stats-plugin)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Use a site with the Jetpack plugin connected to WordPress.com and the Secure Sign On (SSO) module active.

**Login screen**

* Log out, then go to `wp-login.php`.
* The "Log in with WordPress.com" button and the login form look the same as on trunk.
* Check the space above a notice. Load `wp-login.php?loggedout=true`, and also submit a bad password to get an error notice. The spacing must match trunk.
* View the page source. There is no raw `<style>` block from the SSO class. There is a `<style id="jetpack-sso-login-styles-inline-css">` block with the `.jetpack-sso .message` rules, and it comes after the core `login-css` stylesheet.

**Users screen**

* Go to Users > All Users. Use a site that has at least one user with no WordPress.com connection, and if possible one user with a pending invite.
* The row colours (cream for a disconnected user, blue for a pending invite), the "Send invite" link, the warning icon, and the tooltip on hover and on keyboard focus all look the same as on trunk.
* View the page source. There is no raw `<style>` block from `User_Admin`. There is a `<style id="jetpack-sso-users-styles-inline-css">` block instead.
* Open Users > Add New. This screen is not touched by this PR and must be unchanged.

**Automated**

* `jp test php packages/connection`
* `jp phan packages/connection`

