### PR TITLE
Connection: deliver the owner notice script via wp_add_inline_script()

### DIFF
--- a/projects/packages/connection/changelog/stats-343-connection-owner-notice-script
+++ b/projects/packages/connection/changelog/stats-343-connection-owner-notice-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enqueue the connection owner notice script through wp_add_inline_script() instead of printing a script element.

--- a/projects/packages/connection/src/class-connection-notice.php
+++ b/projects/packages/connection/src/class-connection-notice.php
@@ -212,7 +212,7 @@ class Connection_Notice {
 		$rest_url        = wp_json_encode( esc_url_raw( get_rest_url() . 'jetpack/v4/connection/owner' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 		$rest_nonce      = wp_json_encode( wp_create_nonce( 'wp_rest' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 		$success_message = wp_json_encode( esc_html__( 'Success!', 'jetpack-connection' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
-		$error_message   = esc_html__( 'Something went wrong. Please try again.', 'jetpack-connection' );
+		$error_message   = wp_json_encode( esc_html__( 'Something went wrong. Please try again.', 'jetpack-connection' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 
 		return <<<JS
 ( function() {
@@ -235,7 +235,7 @@ class Connection_Notice {
 			submitBtn.disabled = false;
 
 			results.classList.add( 'error-message' );
-			results.innerHTML = message || "{$error_message}";
+			results.innerHTML = message || {$error_message};
 		}
 
 		fetch(

--- a/projects/packages/connection/src/class-connection-notice.php
+++ b/projects/packages/connection/src/class-connection-notice.php
@@ -143,60 +143,8 @@ class Connection_Notice {
 
 			echo "<div id='jp-switch-user-results'></div>";
 			echo '</form>';
-			?>
-			<script type="text/javascript">
-				( function() {
-					const switchOwnerButton = document.getElementById('jp-switch-connection-owner');
-					if ( ! switchOwnerButton ) {
-						return;
-					}
 
-					switchOwnerButton.addEventListener( 'submit', function ( e ) {
-						e.preventDefault();
-
-						const submitBtn = document.getElementById('jp-switch-connection-owner-submit');
-						submitBtn.disabled = true;
-
-						const results = document.getElementById('jp-switch-user-results');
-						results.innerHTML = '';
-						results.classList.remove( 'error-message' );
-
-						const handleAPIError = ( message ) => {
-							submitBtn.disabled = false;
-
-							results.classList.add( 'error-message' );
-							results.innerHTML = message || "<?php esc_html_e( 'Something went wrong. Please try again.', 'jetpack-connection' ); ?>";
-						}
-
-						fetch(
-							<?php echo wp_json_encode( esc_url_raw( get_rest_url() . 'jetpack/v4/connection/owner' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>,
-							{
-								method: 'POST',
-								headers: {
-									'X-WP-Nonce': <?php echo wp_json_encode( wp_create_nonce( 'wp_rest' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>,
-								},
-								body: new URLSearchParams( new FormData( this ) ),
-							}
-						)
-							.then( response => response.json() )
-							.then( data => {
-								if ( data.hasOwnProperty( 'code' ) && data.code === 'success' ) {
-									// Owner successfully changed.
-									results.innerHTML = <?php echo wp_json_encode( esc_html__( 'Success!', 'jetpack-connection' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
-									setTimeout(function () {
-										document.getElementById( 'jetpack-notice-switch-connection-owner' ).style.display = 'none';
-									}, 1000);
-
-									return;
-								}
-
-								handleAPIError( data?.message );
-							} )
-							.catch( () => handleAPIError() );
-					});
-				} )();
-			</script>
-			<?php
+			$this->enqueue_connection_owner_script();
 		} else {
 			echo '<p>' . esc_html__( 'Every Jetpack site needs at least one connected admin for the features to work properly. Please connect to your WordPress.com account via the button below. Once you connect, you may refresh this page to see an option to change the connection owner.', 'jetpack-connection' ) . '</p>';
 			$connect_url = $connection_manager->get_authorization_url();
@@ -237,5 +185,86 @@ class Connection_Notice {
 		);
 		echo '</p>';
 		echo '</div>';
+	}
+
+	/**
+	 * Enqueue the script that hands the chosen owner to the connection owner REST endpoint.
+	 *
+	 * The notice prints on `admin_notices`, after `admin_enqueue_scripts` has run, so the handle
+	 * has no source of its own and goes in the footer, where the form it binds to already exists.
+	 *
+	 * @return void
+	 */
+	private function enqueue_connection_owner_script() {
+		$handle = 'jetpack-connection-owner-notice';
+
+		wp_register_script( $handle, false, array(), Package_Version::PACKAGE_VERSION, true );
+		wp_enqueue_script( $handle );
+		wp_add_inline_script( $handle, $this->get_connection_owner_script() );
+	}
+
+	/**
+	 * Build the script that hands the chosen owner to the connection owner REST endpoint.
+	 *
+	 * @return string
+	 */
+	private function get_connection_owner_script() {
+		$rest_url        = wp_json_encode( esc_url_raw( get_rest_url() . 'jetpack/v4/connection/owner' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
+		$rest_nonce      = wp_json_encode( wp_create_nonce( 'wp_rest' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
+		$success_message = wp_json_encode( esc_html__( 'Success!', 'jetpack-connection' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
+		$error_message   = esc_html__( 'Something went wrong. Please try again.', 'jetpack-connection' );
+
+		return <<<JS
+( function() {
+	const switchOwnerButton = document.getElementById('jp-switch-connection-owner');
+	if ( ! switchOwnerButton ) {
+		return;
+	}
+
+	switchOwnerButton.addEventListener( 'submit', function ( e ) {
+		e.preventDefault();
+
+		const submitBtn = document.getElementById('jp-switch-connection-owner-submit');
+		submitBtn.disabled = true;
+
+		const results = document.getElementById('jp-switch-user-results');
+		results.innerHTML = '';
+		results.classList.remove( 'error-message' );
+
+		const handleAPIError = ( message ) => {
+			submitBtn.disabled = false;
+
+			results.classList.add( 'error-message' );
+			results.innerHTML = message || "{$error_message}";
+		}
+
+		fetch(
+			{$rest_url},
+			{
+				method: 'POST',
+				headers: {
+					'X-WP-Nonce': {$rest_nonce},
+				},
+				body: new URLSearchParams( new FormData( this ) ),
+			}
+		)
+			.then( response => response.json() )
+			.then( data => {
+				if ( data.hasOwnProperty( 'code' ) && data.code === 'success' ) {
+					// Owner successfully changed.
+					results.innerHTML = {$success_message};
+					setTimeout(function () {
+						document.getElementById( 'jetpack-notice-switch-connection-owner' ).style.display = 'none';
+					}, 1000);
+
+					return;
+				}
+
+				handleAPIError( data?.message );
+			} )
+			.catch( () => handleAPIError() );
+	});
+} )();
+JS;
 	}
 }

--- a/projects/packages/connection/tests/php/Connection_Notice_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Notice_Test.php
@@ -91,6 +91,32 @@ class Connection_Notice_Test extends TestCase {
 	}
 
 	/**
+	 * A translation is attacker-adjacent input: it must reach the script as a JSON literal, so that
+	 * quotes, backslashes or newlines in it cannot terminate the string and break the script.
+	 */
+	public function test_delete_user_change_owner_notice_encodes_the_fallback_message() {
+		$translation = 'Backslash \\ and "quotes" and a' . "\n" . 'newline.';
+
+		$filter = function ( $translated, $text ) use ( $translation ) {
+			return 'Something went wrong. Please try again.' === $text ? $translation : $translated;
+		};
+		add_filter( 'gettext', $filter, 10, 2 );
+
+		$notice = new Connection_Notice();
+
+		ob_start();
+		$notice->delete_user_update_connection_owner_notice();
+		ob_end_clean();
+
+		remove_filter( 'gettext', $filter, 10 );
+
+		$inline_script = implode( '', (array) wp_scripts()->get_data( self::OWNER_SCRIPT_HANDLE, 'after' ) );
+
+		$this->assertSame( 1, preg_match( '/message \|\| ([^\n]+);/', $inline_script, $matches ) );
+		$this->assertSame( esc_html( $translation ), json_decode( $matches[1] ) );
+	}
+
+	/**
 	 * Set up the environment.
 	 */
 	protected function setUp(): void {

--- a/projects/packages/connection/tests/php/Connection_Notice_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Notice_Test.php
@@ -17,6 +17,11 @@ class Connection_Notice_Test extends TestCase {
 	use \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 	/**
+	 * Handle of the script that drives the "choose new owner" form.
+	 */
+	const OWNER_SCRIPT_HANDLE = 'jetpack-connection-owner-notice';
+
+	/**
 	 * Database query filter.
 	 *
 	 * @var callable
@@ -60,6 +65,7 @@ class Connection_Notice_Test extends TestCase {
 
 		$this->assertMatchesRegularExpression( '#Connect to WordPress.com#i', $output );
 		$this->assertMatchesRegularExpression( '#https:\/\/jetpack\.wordpress\.com\/jetpack\.authorize\/1\/\?response_type=code#i', $output ); // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
+		$this->assertFalse( wp_script_is( self::OWNER_SCRIPT_HANDLE, 'enqueued' ) );
 
 		\Jetpack_Options::update_option( 'user_tokens', $tokens );
 	}
@@ -75,7 +81,13 @@ class Connection_Notice_Test extends TestCase {
 		$output = ob_get_clean();
 
 		$this->assertMatchesRegularExpression( '#Set new connection owner#i', $output );
-		$this->assertMatchesRegularExpression( '#' . preg_quote( 'http://example.org/index.php?rest_route=/jetpack/v4/connection/owner', '#' ) . '#i', $output );
+		$this->assertStringNotContainsString( '<script', $output );
+
+		$this->assertTrue( wp_script_is( self::OWNER_SCRIPT_HANDLE, 'enqueued' ) );
+
+		$inline_script = implode( '', (array) wp_scripts()->get_data( self::OWNER_SCRIPT_HANDLE, 'after' ) );
+		$this->assertStringContainsString( 'http://example.org/index.php?rest_route=/jetpack/v4/connection/owner', $inline_script );
+		$this->assertStringContainsString( 'jp-switch-connection-owner', $inline_script );
 	}
 
 	/**
@@ -156,6 +168,9 @@ class Connection_Notice_Test extends TestCase {
 		parent::tearDown();
 
 		global $current_screen;
+
+		wp_dequeue_script( self::OWNER_SCRIPT_HANDLE );
+		wp_deregister_script( self::OWNER_SCRIPT_HANDLE );
 
 		delete_transient( 'jetpack_connected_user_data_' . get_current_user_id() );
 


### PR DESCRIPTION
Fixes #

## Proposed changes
* The connection owner deletion notice printed its own `<script>` element straight into `admin_notices`. The standalone Jetpack Stats plugin bundles the connection package, and the WordPress.org plugin review flagged that markup under "Use `wp_enqueue` commands".
* The same JavaScript now goes out through the WordPress script API instead: a sourceless handle registered for the footer, enqueued, and filled in with `wp_add_inline_script()`. Because the notice renders after `admin_enqueue_scripts`, the handle prints in the admin footer — still below the form it binds to, which is where the old `<script>` sat.
* Behaviour is meant to be identical. The REST URL, the `wp_rest` nonce and the message strings keep the `wp_json_encode()` escaping they already had, and the JavaScript that reaches the browser is unchanged. Every plugin that ships the connection package gets this code, so the notice should look and act exactly as before.

## Related product discussion/links
* [STATS-343](https://linear.app/a8c/issue/STATS-343/create-standalone-jetpack-stats-plugin)

## Does this pull request change what data or activity we track or use?
No. The notice still fires the same `delete_connection_owner_notice_view` event and calls the same REST endpoint.

## Testing instructions

You need a site connected to WordPress.com with **at least two connected admins**, so the owner-transfer form shows up.

* Log in as a connected admin who is *not* the connection owner.
* Go to **Users**, hover the connection owner and click **Delete** (a bulk-select delete works too).
* The warning notice appears with the "You can choose to transfer connection ownership..." text, the admin dropdown and the **Set new connection owner** button, same as before.
* Pick another connected admin and submit. The button should disable, the request should go to `/jetpack/v4/connection/owner`, "Success!" should appear, and the notice should hide about a second later. Reload and confirm the connection owner really changed.
* Make the request fail (block `/jetpack/v4/connection/owner` in the browser devtools network panel) and confirm the error message shows in the results area and the submit button re-enables.
* View source on the Users page: the notice markup should contain no `<script>` element of its own. The JavaScript should instead be in the admin footer, in the block that `wp_add_inline_script()` prints for the `jetpack-connection-owner-notice` handle.
* Repeat on a site with only one connected admin: the notice should fall back to the "Connect to WordPress.com" branch, and no owner-notice script should be enqueued at all.
