### PR TITLE
Stats Admin: make the Blaze package a development-only dependency

### DIFF
--- a/projects/packages/stats-admin/AGENTS.md
+++ b/projects/packages/stats-admin/AGENTS.md
@@ -43,7 +43,7 @@ This package depends on several Jetpack packages:
 
 - `jetpack-connection` - WPCOM connection
 - `jetpack-stats` - Backend stats tracking (see sibling `stats` package)
-- `jetpack-blaze` - Blaze integration
+- `jetpack-blaze` - Blaze integration. Development-only dependency; the one runtime call is guarded by `class_exists()`.
 - `jetpack-constants` - Shared constants and environment/context helpers
 - `jetpack-plans` - Plan checking
 - `jetpack-status` - Site status

--- a/projects/packages/stats-admin/changelog/stats-343-stats-admin-blaze-dev-dependency
+++ b/projects/packages/stats-admin/changelog/stats-343-stats-admin-blaze-dev-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make the Blaze package a development-only dependency.

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -6,7 +6,6 @@
 	"require": {
 		"php": ">=7.2",
 		"automattic/jetpack-connection": "@dev",
-		"automattic/jetpack-blaze": "@dev",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-plans": "@dev",
 		"automattic/jetpack-stats": "@dev",
@@ -15,6 +14,7 @@
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",
+		"automattic/jetpack-blaze": "@dev",
 		"automattic/jetpack-test-environment": "@dev",
 		"automattic/phpunit-select-config": "@dev"
 	},

--- a/projects/plugins/jetpack/changelog/stats-343-stats-admin-blaze-dev-dependency
+++ b/projects/plugins/jetpack/changelog/stats-343-stats-admin-blaze-dev-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Stats Admin: update dependencies.

--- a/projects/plugins/jetpack/changelog/stats-343-stats-admin-blaze-dev-dependency
+++ b/projects/plugins/jetpack/changelog/stats-343-stats-admin-blaze-dev-dependency
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
+Comment: Refresh composer.lock after moving Blaze to a dev-only dependency in stats-admin.
 
-Stats Admin: update dependencies.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -3734,10 +3734,9 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "084dc9263d996f27e291c8febe3a4485d26a7b9d"
+                "reference": "b57ac9a5d2258772a37d4252bb6ae9c5983b6987"
             },
             "require": {
-                "automattic/jetpack-blaze": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-jitm": "@dev",
@@ -3747,6 +3746,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-blaze": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"

--- a/projects/plugins/mu-wpcom-plugin/changelog/stats-343-stats-admin-blaze-dev-dependency
+++ b/projects/plugins/mu-wpcom-plugin/changelog/stats-343-stats-admin-blaze-dev-dependency
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Refresh composer.lock after moving Blaze to a dev-only dependency in stats-admin.
 
-Stats Admin: update dependencies.

--- a/projects/plugins/mu-wpcom-plugin/changelog/stats-343-stats-admin-blaze-dev-dependency
+++ b/projects/plugins/mu-wpcom-plugin/changelog/stats-343-stats-admin-blaze-dev-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats Admin: update dependencies.

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -2177,10 +2177,9 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "084dc9263d996f27e291c8febe3a4485d26a7b9d"
+                "reference": "b57ac9a5d2258772a37d4252bb6ae9c5983b6987"
             },
             "require": {
-                "automattic/jetpack-blaze": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-jitm": "@dev",
@@ -2190,6 +2189,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-blaze": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"

--- a/projects/plugins/stats/changelog/stats-343-stats-admin-blaze-dev-dependency
+++ b/projects/plugins/stats/changelog/stats-343-stats-admin-blaze-dev-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stop bundling the Blaze package, which nothing in the plugin starts.

--- a/projects/plugins/stats/composer.lock
+++ b/projects/plugins/stats/composer.lock
@@ -353,82 +353,6 @@
             }
         },
         {
-            "name": "automattic/jetpack-blaze",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/blaze",
-                "reference": "7a7c6fc7ef68f3388c0c43dd402c7b31126fa587"
-            },
-            "require": {
-                "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-plans": "@dev",
-                "automattic/jetpack-redirect": "@dev",
-                "automattic/jetpack-status": "@dev",
-                "automattic/jetpack-sync": "@dev",
-                "php": ">=7.2"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-blaze",
-                "changelogger": {
-                    "link-template": "https://github.com/automattic/jetpack-blaze/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.28.x-dev"
-                },
-                "textdomain": "jetpack-blaze",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-dashboard.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "test-php-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "watch": [
-                    "Composer\\Config::disableProcessTimeout",
-                    "pnpm run watch"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Attract high-quality traffic to your site using Blaze.",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/jetpack-boost-core",
             "version": "dev-trunk",
             "dist": {
@@ -1841,10 +1765,9 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "084dc9263d996f27e291c8febe3a4485d26a7b9d"
+                "reference": "b57ac9a5d2258772a37d4252bb6ae9c5983b6987"
             },
             "require": {
-                "automattic/jetpack-blaze": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-jitm": "@dev",
@@ -1854,6 +1777,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-blaze": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"

--- a/projects/plugins/wpcomsh/changelog/stats-343-stats-admin-blaze-dev-dependency
+++ b/projects/plugins/wpcomsh/changelog/stats-343-stats-admin-blaze-dev-dependency
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Refresh composer.lock after moving Blaze to a dev-only dependency in stats-admin.
 
-Stats Admin: update dependencies.

--- a/projects/plugins/wpcomsh/changelog/stats-343-stats-admin-blaze-dev-dependency
+++ b/projects/plugins/wpcomsh/changelog/stats-343-stats-admin-blaze-dev-dependency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats Admin: update dependencies.

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -2358,10 +2358,9 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "d4fe2e9daa600ac417e3c400b63e533bfbc013a2"
+                "reference": "8c926a1a98e6899a9d82140b06f22924187aece7"
             },
             "require": {
-                "automattic/jetpack-blaze": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-constants": "@dev",
                 "automattic/jetpack-jitm": "@dev",
@@ -2371,6 +2370,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
+                "automattic/jetpack-blaze": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/phpunit-select-config": "@dev",
                 "yoast/phpunit-polyfills": "^4.0.0"


### PR DESCRIPTION
Fixes #

## Proposed changes

`stats-admin` reads Blaze in exactly one place, in `Odyssey_Config_Data::get_initial_state()`:

```php
$can_blaze = class_exists( 'Automattic\Jetpack\Blaze' ) && Blaze::should_initialize()['can_init'];
```

That call is already guarded by `class_exists()`, so the package behaves correctly whether or not some other plugin loads Blaze through the shared Jetpack autoloader. Nothing in `stats-admin`, and nothing in the standalone Stats plugin, ever calls `Blaze::init()`. This PR therefore moves `automattic/jetpack-blaze` from `require` to `require-dev` in `projects/packages/stats-admin/composer.json`, and refreshes the four plugin lock files that install `stats-admin`.

What each plugin sees:

* **Stats** — `projects/plugins/stats/composer.lock` drops the `automattic/jetpack-blaze` entry entirely, because nothing else in that plugin requires it. The WordPress.org ZIP stops shipping 360 KB / 12 files in the production build (measured on the review ZIP). This came out of the WordPress.org plugin review of the standalone Stats plugin, where several findings point at Blaze files that are unreachable there. It also removes a broken Promote button, described below.
* **Jetpack** — no practical change. The plugin requires `automattic/jetpack-blaze` directly and starts it from `modules/blaze.php`, so `can_blaze` keeps its value.
* **wpcomsh** and **mu-wpcom-plugin** — no practical change. Both receive Blaze through `masterbar`.

Those three lock files change only the `stats-admin` entry's `require`/`require-dev` metadata and its path reference. No other package's version or reference moves.

The `class_exists()` guard in `class-odyssey-config-data.php` is unchanged, and Phan needs no suppression: `require-dev` packages are still scanned, so the Blaze symbols stay declared during analysis.

### Behavior change on the standalone Stats plugin

On the standalone Stats plugin this is a fix, not a no-op. `Blaze::should_initialize()` does not check whether `Blaze::init()` ran. It only checks `manage_options`, the site ID, the site and user connection, Sync, and `site_supports_blaze()`. The standalone Stats plugin ships `jetpack-connection` and `jetpack-sync`, so on a connected and eligible site `can_blaze` is currently `true`, and Odyssey's `usePromoteWidget()` shows the Promote entry points. The Blaze module check does not apply there, because `jetpack_version` is empty without the Jetpack plugin.

Those entry points cannot work today. The BlazePress widget sends its requests to `jetpack/v4/blaze-app/*`, and only `Blaze::init()` registers those routes, through `rest_api_init`. Nothing in the standalone Stats plugin calls `init()`, so clicking Promote returns a 404.

After this PR the `Blaze` class is absent, `can_blaze` becomes `false`, and the Promote entry points stop appearing. The net effect is that a button which could never work is removed.

## Related product discussion/links

* Linear: [STATS-343](https://linear.app/a8c/issue/STATS-343/create-standalone-jetpack-stats-plugin)

## Does this pull request change what data or activity we track or use?

No. This change does not add or modify any tracking or data collection.

## Testing instructions

**Confirm the Stats plugin no longer ships Blaze**

* Go to the monorepo root and run:
  `jq '[.packages[], .["packages-dev"][]] | map(select(.name == "automattic/jetpack-blaze")) | length' projects/plugins/stats/composer.lock`
  It returns `0`. On trunk it returns `1`.
* Build the plugin: `jp build plugins/stats --production`
* Confirm `projects/plugins/stats/jetpack_vendor/automattic/jetpack-blaze` does not exist in the build output, and that no `jetpack-blaze` directory appears in a generated ZIP.

**Confirm `can_blaze` still reports correctly where Blaze does ship**

* On a site running the **Jetpack** plugin, connected, with Blaze eligible for the site, go to Jetpack → Stats.
* Confirm the Blaze entry points in the Odyssey dashboard appear exactly as they do on trunk. Alternatively, inspect the bootstrapped Redux state on that page and confirm `sites.items.<blog_id>.options.can_blaze` still holds the expected value.
* Repeat on an Atomic site (`wpcomsh`) and on a Simple site (`mu-wpcom`), where Blaze arrives through `masterbar`. `can_blaze` is unchanged in both.

**Confirm the standalone Stats plugin drops the broken Promote entry points**

* Use a site that runs only the **Jetpack Stats** plugin, with no Jetpack plugin. Connect the site and the user, and make sure the site is eligible for Blaze.
* On trunk, open the Stats dashboard. Confirm the Promote entry points appear, and that clicking Promote fails with a 404 on `jetpack/v4/blaze-app/*`.
* On this branch, open the Stats dashboard again. Confirm the dashboard loads normally, the Promote entry points no longer appear, and `sites.items.<blog_id>.options.can_blaze` is `false`.

**Automated checks run locally**

* `jp test php packages/stats-admin` — passes, 53 tests, 144 assertions.
* `jp phan packages/stats-admin` — output is byte-identical to trunk, with zero issues in `src/`.
