### PR TITLE
Premium Analytics: group the routes jest suites

### DIFF
--- a/projects/packages/premium-analytics/changelog/group-routes-test-suites
+++ b/projects/packages/premium-analytics/changelog/group-routes-test-suites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test-only change: group the routes jest suites that share a mock signature.
+
+

--- a/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part1.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part1.test.tsx
@@ -1,0 +1,12 @@
+// See README.md before adding a suite to this group.
+
+import '../../routes/dashboard/components/section-sync-notice/section-sync-notice.test';
+import '../../routes/dashboard/config/date-filter.test';
+import '../../routes/dashboard/config/section-layouts.test';
+import '../../routes/dashboard/config/sections.test';
+import '../../routes/dashboard/hooks/use-dashboard-section-layout.test';
+import '../../routes/dashboard/hooks/use-section-date-filter.test';
+import '../../routes/post-detail/components/post-summary-card/post-summary-card.test';
+import '../../routes/post-detail/config/tab-layouts.test';
+import '../../routes/post-detail/config/widget-variants.test';
+import '../../routes/reports/authors/config/aggregate.test';

--- a/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part2.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part2.test.tsx
@@ -1,0 +1,12 @@
+// See README.md before adding a suite to this group.
+
+import '../../routes/reports/clicks/config/aggregate.test';
+import '../../routes/reports/clicks/config/fields.test';
+import '../../routes/reports/clicks/config/get-click-csv-group.test';
+import '../../routes/reports/count-fields.test';
+import '../../routes/reports/downloads/config/fields.test';
+import '../../routes/reports/locations/config/aggregate.test';
+import '../../routes/reports/locations/config/fields.test';
+import '../../routes/reports/locations/config/tabs.test';
+import '../../routes/reports/referrers/config/aggregate.test';
+import '../../routes/reports/referrers/config/fields.test';

--- a/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part3.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part3.test.tsx
@@ -1,0 +1,8 @@
+// See README.md before adding a suite to this group.
+
+import '../../routes/reports/report-names.test';
+import '../../routes/reports/search-terms/config/aggregate.test';
+import '../../routes/reports/search-terms/config/fields.test';
+import '../../routes/reports/utm/config/aggregate.test';
+import '../../routes/reports/utm/config/tabs.test';
+import '../../routes/video-detail/config/layout.test';

--- a/projects/packages/premium-analytics/tests/groups/routes-shared-route-mock.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/routes-shared-route-mock.test.tsx
@@ -1,0 +1,7 @@
+// See README.md before adding a suite to this group.
+
+import '../../routes/reports/authors/config/fields.test';
+import '../../routes/reports/comment-followers/config/fields.test';
+import '../../routes/reports/emails/config/fields.test';
+import '../../routes/reports/utm/config/fields.test';
+import '../../routes/reports/videos/config/fields.test';


### PR DESCRIPTION
## Proposed changes

- Group the 31 `routes/` suites that already declare an identical mock signature, into 4 group files (26 with no mocks, 5 sharing the `@wordpress/route` mock from `tests/js/route-test-utils`).
- Grouped suite count: **231 → 204**.

Stacked on #51464, which moved the groups out of `widgets/` so they can cover any area. Together the two take the package from 267 grouped suites to 204.

Local wall-clock is not quotable this round — the machine's available cores moved between runs, so the paired comparison broke down. The controlled measurement that motivated this: 8 representative `routes/` config and hook suites take **6.88s** run separately and **2.36s** as one group (`--runInBand`, same tree, interleaved).

## Related product discussion/links

- WOOA7S-1971

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Tests only — no product code changes.

- `pnpm run test` in `projects/packages/premium-analytics` (grouped): 204 suites, 2390 tests, all passing.
- `PA_NO_GROUPS=1 pnpm run test` (ungrouped fallback, which CI never exercises): 294 suites, **the same 2390 tests**. A mismatch here would mean a suite is running twice or not at all.

Unrelated, but worth flagging: a jest worker died with `SIGSEGV` on 3 of ~10 local full runs, in both the grouped and ungrouped modes and on trunk as well. Pre-existing, and likely the same memory pressure that CI hits running 12 jest workers on 4 vCPUs.
