### PR TITLE
Premium Analytics: keep the previous-month comparison the same length as the range

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1976-comparison-window-length
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1976-comparison-window-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Compare a date range against a previous month or year of the same length, unless the range is whole calendar months.

--- a/projects/packages/premium-analytics/packages/datetime/README.md
+++ b/projects/packages/premium-analytics/packages/datetime/README.md
@@ -127,7 +127,9 @@ if inputs are invalid
 - `previous-year` - Same duration, anchored one year before the reference end
 
 For whole-month references, `previous-month` and `previous-year` instead stay
-aligned to calendar month boundaries, so their duration can differ.
+aligned to calendar month boundaries, so their duration can differ. Whole months
+are read from the range itself, so a rolling window that happens to land on one
+(April 1-30 from "Last 30 days") compares against all 31 days of March.
 
 ### Range Measurement and Stepping
 

--- a/projects/packages/premium-analytics/packages/datetime/README.md
+++ b/projects/packages/premium-analytics/packages/datetime/README.md
@@ -123,14 +123,11 @@ if inputs are invalid
 **Supported presets:**
 
 - `previous-period` - Same duration, immediately before reference
-- `previous-month` - One month before reference dates
-- `previous-year` - One year before reference dates
+- `previous-month` - Same duration, anchored one month before the reference end
+- `previous-year` - Same duration, anchored one year before the reference end
 
-Every preset covers the same amount of time as the reference, so the deltas
-computed from it compare like with like. The one exception is a reference that
-covers whole calendar months: there `previous-month` and `previous-year` shift
-the calendar and re-snap to the month, because unequal lengths are the point —
-March against February is 31 days against 28.
+For whole-month references, `previous-month` and `previous-year` instead stay
+aligned to calendar month boundaries, so their duration can differ.
 
 ### Range Measurement and Stepping
 

--- a/projects/packages/premium-analytics/packages/datetime/README.md
+++ b/projects/packages/premium-analytics/packages/datetime/README.md
@@ -126,6 +126,12 @@ if inputs are invalid
 - `previous-month` - One month before reference dates
 - `previous-year` - One year before reference dates
 
+Every preset covers the same amount of time as the reference, so the deltas
+computed from it compare like with like. The one exception is a reference that
+covers whole calendar months: there `previous-month` and `previous-year` shift
+the calendar and re-snap to the month, because unequal lengths are the point —
+March against February is 31 days against 28.
+
 ### Range Measurement and Stepping
 
 #### `getDateRangeSpan( range? )`

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
@@ -156,6 +156,13 @@ describe( 'getComparisonRangeFromPreset', () => {
 				new Date( 2025, 11, 4, 23, 59, 59, 999 ),
 			],
 			[
+				'a window that starts on the 1st but stops short of the month end',
+				new Date( 2026, 2, 1, 0, 0, 0, 0 ),
+				new Date( 2026, 2, 15, 23, 59, 59, 999 ),
+				new Date( 2026, 1, 1, 0, 0, 0, 0 ),
+				new Date( 2026, 1, 15, 23, 59, 59, 999 ),
+			],
+			[
 				'a window whose start has no counterpart a month back',
 				new Date( 2026, 0, 31, 0, 0, 0, 0 ),
 				new Date( 2026, 2, 1, 23, 59, 59, 999 ),

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
@@ -1,7 +1,12 @@
 /**
+ * External dependencies
+ */
+import { differenceInCalendarDays } from 'date-fns';
+/**
  * Internal dependencies
  */
 import { COMPARISON_PRESETS, getComparisonRangeFromPreset } from '../get-comparison-range';
+import { createTZDateFromParts } from '../tz';
 
 describe( 'getComparisonRangeFromPreset', () => {
 	it( 'returns undefined when the reference range is incomplete', () => {
@@ -126,6 +131,146 @@ describe( 'getComparisonRangeFromPreset', () => {
 			expect( getComparisonRangeFromPreset( leapDay, 'previous-year' ) ).toEqual( {
 				from: new Date( 2027, 1, 27, 14, 0, 0, 0 ),
 				to: new Date( 2027, 1, 28, 14, 0, 0, 0 ),
+			} );
+		} );
+	} );
+
+	describe( 'day-aligned references that are not whole calendar months', () => {
+		it.each( [
+			// Shifting each endpoint on its own shortened this to 29 days.
+			[
+				'a rolling 30-day window',
+				new Date( 2026, 6, 21, 0, 0, 0, 0 ),
+				new Date( 2026, 7, 19, 23, 59, 59, 999 ),
+				new Date( 2026, 5, 20, 0, 0, 0, 0 ),
+				new Date( 2026, 6, 19, 23, 59, 59, 999 ),
+			],
+			// And this one to 6 days, across a year boundary.
+			[
+				'a week spanning a year boundary',
+				new Date( 2025, 11, 29, 0, 0, 0, 0 ),
+				new Date( 2026, 0, 4, 23, 59, 59, 999 ),
+				new Date( 2025, 10, 28, 0, 0, 0, 0 ),
+				new Date( 2025, 11, 4, 23, 59, 59, 999 ),
+			],
+			// The clamp grew this one instead: Mar 1 lands on Feb 1 while Jan 31
+			// lands on Dec 31, a 33-day baseline for a 30-day range.
+			[
+				'a window whose start has no counterpart a month back',
+				new Date( 2026, 0, 31, 0, 0, 0, 0 ),
+				new Date( 2026, 2, 1, 23, 59, 59, 999 ),
+				new Date( 2026, 0, 3, 0, 0, 0, 0 ),
+				new Date( 2026, 1, 1, 23, 59, 59, 999 ),
+			],
+		] )(
+			'keeps the reference length for previous-month with %s',
+			( _label, from, to, expectedFrom, expectedTo ) => {
+				expect( getComparisonRangeFromPreset( { from, to }, 'previous-month' ) ).toEqual( {
+					from: expectedFrom,
+					to: expectedTo,
+				} );
+			}
+		);
+
+		it( 'keeps the reference length for previous-year across a leap day', () => {
+			// February 2028 has 29 days and February 2027 has 28, so shifting both
+			// endpoints dropped a day from the baseline.
+			const reference = {
+				from: new Date( 2028, 1, 20, 0, 0, 0, 0 ),
+				to: new Date( 2028, 2, 5, 23, 59, 59, 999 ),
+			};
+
+			expect( getComparisonRangeFromPreset( reference, 'previous-year' ) ).toEqual( {
+				from: new Date( 2027, 1, 19, 0, 0, 0, 0 ),
+				to: new Date( 2027, 2, 5, 23, 59, 59, 999 ),
+			} );
+		} );
+
+		it.each( COMPARISON_PRESETS )(
+			'covers the same number of days as the reference for %s',
+			presetId => {
+				const reference = {
+					from: new Date( 2026, 0, 31, 0, 0, 0, 0 ),
+					to: new Date( 2026, 2, 1, 23, 59, 59, 999 ),
+				};
+				const comparison = getComparisonRangeFromPreset( reference, presetId );
+				const span = ( range?: { from?: Date; to?: Date } ) =>
+					range?.from && range?.to ? differenceInCalendarDays( range.to, range.from ) : null;
+
+				expect( span( comparison ) ).toBe( span( reference ) );
+			}
+		);
+	} );
+
+	describe( 'whole calendar months', () => {
+		it( 'sets a whole month against the whole month before it', () => {
+			// 31 days against 28 is the point of a month-over-month comparison,
+			// so this one keeps the calendar shift.
+			const march = {
+				from: new Date( 2026, 2, 1, 0, 0, 0, 0 ),
+				to: new Date( 2026, 2, 31, 23, 59, 59, 999 ),
+			};
+
+			expect( getComparisonRangeFromPreset( march, 'previous-month' ) ).toEqual( {
+				from: new Date( 2026, 1, 1, 0, 0, 0, 0 ),
+				to: new Date( 2026, 1, 28, 23, 59, 59, 999 ),
+			} );
+		} );
+
+		it( 'keeps a multi-month window on month bounds', () => {
+			// Shifting the end alone landed on Jan 28, ending the baseline
+			// mid-month.
+			const janToFeb = {
+				from: new Date( 2026, 0, 1, 0, 0, 0, 0 ),
+				to: new Date( 2026, 1, 28, 23, 59, 59, 999 ),
+			};
+
+			expect( getComparisonRangeFromPreset( janToFeb, 'previous-month' ) ).toEqual( {
+				from: new Date( 2025, 11, 1, 0, 0, 0, 0 ),
+				to: new Date( 2026, 0, 31, 23, 59, 59, 999 ),
+			} );
+		} );
+
+		it( 'sets a leap February against the shorter one a year back', () => {
+			const february2028 = {
+				from: new Date( 2028, 1, 1, 0, 0, 0, 0 ),
+				to: new Date( 2028, 1, 29, 23, 59, 59, 999 ),
+			};
+
+			expect( getComparisonRangeFromPreset( february2028, 'previous-year' ) ).toEqual( {
+				from: new Date( 2027, 1, 1, 0, 0, 0, 0 ),
+				to: new Date( 2027, 1, 28, 23, 59, 59, 999 ),
+			} );
+		} );
+
+		it( "reads the month boundary in the range's own zone", () => {
+			// The whole-month check runs on the incoming dates, so a site-zone
+			// TZDate must not be read against UTC — in Auckland these parts are
+			// March 1 and March 31, while their UTC instants are February 28 and
+			// March 30.
+			const timeZone = 'Pacific/Auckland';
+			const march = {
+				from: createTZDateFromParts( [ 2026, 2, 1, 0, 0, 0, 0 ], timeZone ),
+				to: createTZDateFromParts( [ 2026, 2, 31, 23, 59, 59, 999 ], timeZone ),
+			};
+
+			const comparison = getComparisonRangeFromPreset( march, 'previous-month' );
+
+			expect( comparison?.from?.getDate() ).toBe( 1 );
+			expect( comparison?.from?.getMonth() ).toBe( 1 );
+			expect( comparison?.to?.getDate() ).toBe( 28 );
+			expect( comparison?.to?.getMonth() ).toBe( 1 );
+		} );
+
+		it( 'still mirrors the reference length for previous-period', () => {
+			const march = {
+				from: new Date( 2026, 2, 1, 0, 0, 0, 0 ),
+				to: new Date( 2026, 2, 31, 23, 59, 59, 999 ),
+			};
+
+			expect( getComparisonRangeFromPreset( march, 'previous-period' ) ).toEqual( {
+				from: new Date( 2026, 0, 29, 0, 0, 0, 0 ),
+				to: new Date( 2026, 1, 28, 23, 59, 59, 999 ),
 			} );
 		} );
 	} );

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
@@ -1,10 +1,7 @@
 /**
- * External dependencies
- */
-import { differenceInCalendarDays } from 'date-fns';
-/**
  * Internal dependencies
  */
+import { getDateRangeSpan } from '../date-range-span';
 import { COMPARISON_PRESETS, getComparisonRangeFromPreset } from '../get-comparison-range';
 import { createTZDateFromParts } from '../tz';
 
@@ -137,7 +134,6 @@ describe( 'getComparisonRangeFromPreset', () => {
 
 	describe( 'day-aligned references that are not whole calendar months', () => {
 		it.each( [
-			// Shifting each endpoint on its own shortened this to 29 days.
 			[
 				'a rolling 30-day window',
 				new Date( 2026, 6, 21, 0, 0, 0, 0 ),
@@ -145,7 +141,13 @@ describe( 'getComparisonRangeFromPreset', () => {
 				new Date( 2026, 5, 20, 0, 0, 0, 0 ),
 				new Date( 2026, 6, 19, 23, 59, 59, 999 ),
 			],
-			// And this one to 6 days, across a year boundary.
+			[
+				'a window whose end clamps in a shorter month',
+				new Date( 2026, 2, 2, 0, 0, 0, 0 ),
+				new Date( 2026, 2, 31, 23, 59, 59, 999 ),
+				new Date( 2026, 0, 30, 0, 0, 0, 0 ),
+				new Date( 2026, 1, 28, 23, 59, 59, 999 ),
+			],
 			[
 				'a week spanning a year boundary',
 				new Date( 2025, 11, 29, 0, 0, 0, 0 ),
@@ -153,8 +155,6 @@ describe( 'getComparisonRangeFromPreset', () => {
 				new Date( 2025, 10, 28, 0, 0, 0, 0 ),
 				new Date( 2025, 11, 4, 23, 59, 59, 999 ),
 			],
-			// The clamp grew this one instead: Mar 1 lands on Feb 1 while Jan 31
-			// lands on Dec 31, a 33-day baseline for a 30-day range.
 			[
 				'a window whose start has no counterpart a month back',
 				new Date( 2026, 0, 31, 0, 0, 0, 0 ),
@@ -173,8 +173,6 @@ describe( 'getComparisonRangeFromPreset', () => {
 		);
 
 		it( 'keeps the reference length for previous-year across a leap day', () => {
-			// February 2028 has 29 days and February 2027 has 28, so shifting both
-			// endpoints dropped a day from the baseline.
 			const reference = {
 				from: new Date( 2028, 1, 20, 0, 0, 0, 0 ),
 				to: new Date( 2028, 2, 5, 23, 59, 59, 999 ),
@@ -194,18 +192,14 @@ describe( 'getComparisonRangeFromPreset', () => {
 					to: new Date( 2026, 2, 1, 23, 59, 59, 999 ),
 				};
 				const comparison = getComparisonRangeFromPreset( reference, presetId );
-				const span = ( range?: { from?: Date; to?: Date } ) =>
-					range?.from && range?.to ? differenceInCalendarDays( range.to, range.from ) : null;
 
-				expect( span( comparison ) ).toBe( span( reference ) );
+				expect( getDateRangeSpan( comparison ) ).toEqual( getDateRangeSpan( reference ) );
 			}
 		);
 	} );
 
 	describe( 'whole calendar months', () => {
 		it( 'sets a whole month against the whole month before it', () => {
-			// 31 days against 28 is the point of a month-over-month comparison,
-			// so this one keeps the calendar shift.
 			const march = {
 				from: new Date( 2026, 2, 1, 0, 0, 0, 0 ),
 				to: new Date( 2026, 2, 31, 23, 59, 59, 999 ),
@@ -218,8 +212,6 @@ describe( 'getComparisonRangeFromPreset', () => {
 		} );
 
 		it( 'keeps a multi-month window on month bounds', () => {
-			// Shifting the end alone landed on Jan 28, ending the baseline
-			// mid-month.
 			const janToFeb = {
 				from: new Date( 2026, 0, 1, 0, 0, 0, 0 ),
 				to: new Date( 2026, 1, 28, 23, 59, 59, 999 ),
@@ -244,10 +236,6 @@ describe( 'getComparisonRangeFromPreset', () => {
 		} );
 
 		it( "reads the month boundary in the range's own zone", () => {
-			// The whole-month check runs on the incoming dates, so a site-zone
-			// TZDate must not be read against UTC — in Auckland these parts are
-			// March 1 and March 31, while their UTC instants are February 28 and
-			// March 30.
 			const timeZone = 'Pacific/Auckland';
 			const march = {
 				from: createTZDateFromParts( [ 2026, 2, 1, 0, 0, 0, 0 ], timeZone ),

--- a/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
@@ -4,16 +4,16 @@
 import {
 	differenceInDays,
 	differenceInMilliseconds,
+	endOfDay,
+	endOfMonth,
 	isFirstDayOfMonth,
 	isLastDayOfMonth,
+	startOfDay,
+	startOfMonth,
 	subDays,
 	subMilliseconds,
 	subMonths,
 	subYears,
-	startOfDay,
-	startOfMonth,
-	endOfDay,
-	endOfMonth,
 } from 'date-fns';
 
 export type DateRange = { from?: Date; to?: Date };
@@ -44,6 +44,17 @@ export function isComparisonPresetId( value: unknown ): value is ComparisonPrese
 }
 
 /**
+ * Count the calendar days in an inclusive range.
+ *
+ * @param from - Range start.
+ * @param to   - Range end.
+ * @return The inclusive day count.
+ */
+function getInclusiveDayCount( from: Date, to: Date ): number {
+	return differenceInDays( to, from ) + 1;
+}
+
+/**
  * Returns a comparison DateRange (as Date objects) derived from a reference range
  * and a given preset.
  *
@@ -53,9 +64,8 @@ export function isComparisonPresetId( value: unknown ): value is ComparisonPrese
  * - Day-aligned references (midnight to end of day) produce day-aligned
  *   comparison ranges. Sub-day references (rolling windows like the last 24
  *   hours) mirror the exact window instead.
- * - The comparison covers the same amount of time as the reference, except
- *   where the reference covers whole calendar months: `previous-month` and
- *   `previous-year` then shift the calendar and keep both ends on the month.
+ * - Comparison ranges match the reference duration, except that whole-month
+ *   `previous-month` and `previous-year` ranges preserve calendar boundaries.
  *
  * @param reference - The reference range to compare against (must include both `from` and `to`).
  * @param presetId  - One of the supported preset identifiers.
@@ -106,7 +116,7 @@ export function getComparisonRangeFromPreset(
 		bound === 1 ? endOfDay( startOfDay( date ) ) : startOfDay( date );
 
 	if ( presetId === COMPARISON_PREVIOUS_PERIOD ) {
-		const daysInclusive = differenceInDays( refTo, refFrom ) + 1;
+		const daysInclusive = getInclusiveDayCount( refFrom, refTo );
 		return {
 			from: clampDayBound( subDays( refFrom, daysInclusive ), 0 ),
 			to: clampDayBound( subDays( refTo, daysInclusive ), 1 ),
@@ -116,11 +126,7 @@ export function getComparisonRangeFromPreset(
 	if ( presetId === COMPARISON_PREVIOUS_MONTH || presetId === COMPARISON_PREVIOUS_YEAR ) {
 		const shiftBack = presetId === COMPARISON_PREVIOUS_MONTH ? subMonths : subYears;
 
-		// A whole-month reference keeps the calendar shift, because unequal
-		// lengths are the point there: March against February is 31 days
-		// against 28. Both ends re-snap to the month, which also repairs the
-		// shift's day-of-month clamp — January 1 through February 28 shifted a
-		// month back ends on January 28, mid-month.
+		// Keep whole-month comparisons aligned to calendar boundaries.
 		if ( isFirstDayOfMonth( refFrom ) && isLastDayOfMonth( refTo ) ) {
 			return {
 				from: clampDayBound( startOfMonth( shiftBack( refFrom, 1 ) ), 0 ),
@@ -128,17 +134,10 @@ export function getComparisonRangeFromPreset(
 			};
 		}
 
-		/*
-		 * Every other window keeps its length. Shifting each end on its own
-		 * lets month lengths resize it — July 21 - August 19 (30 days) landed
-		 * on June 21 - July 19 (29) — and the widgets divide raw totals, with
-		 * no per-day normalization, so a missing day biases every delta.
-		 * The end is the anchor, as in the sub-day branch above: the comparison
-		 * then ends exactly the named interval before the reference does, which
-		 * is the endpoint the label promises.
-		 */
+		// Anchor the end, then rebuild the start to preserve the day count. If the
+		// calendar shift clamps the end (Mar 31 to Feb 28), the start may move into January.
 		const to = shiftBack( refTo, 1 );
-		const daysInclusive = differenceInDays( refTo, refFrom ) + 1;
+		const daysInclusive = getInclusiveDayCount( refFrom, refTo );
 
 		return {
 			from: clampDayBound( subDays( to, daysInclusive - 1 ), 0 ),

--- a/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
@@ -66,6 +66,9 @@ function getInclusiveDayCount( from: Date, to: Date ): number {
  *   hours) mirror the exact window instead.
  * - Comparison ranges match the reference duration, except that whole-month
  *   `previous-month` and `previous-year` ranges preserve calendar boundaries.
+ *   Whole months are detected from the range shape alone, so a rolling window
+ *   that happens to land on one (April 1-30 from a "last 30 days" preset) also
+ *   compares calendar-to-calendar, against all 31 days of March.
  *
  * @param reference - The reference range to compare against (must include both `from` and `to`).
  * @param presetId  - One of the supported preset identifiers.

--- a/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
@@ -4,12 +4,16 @@
 import {
 	differenceInDays,
 	differenceInMilliseconds,
+	isFirstDayOfMonth,
+	isLastDayOfMonth,
 	subDays,
 	subMilliseconds,
 	subMonths,
 	subYears,
 	startOfDay,
+	startOfMonth,
 	endOfDay,
+	endOfMonth,
 } from 'date-fns';
 
 export type DateRange = { from?: Date; to?: Date };
@@ -48,8 +52,10 @@ export function isComparisonPresetId( value: unknown ): value is ComparisonPrese
  *   the frame of the incoming dates (pass TZDate instances for site-local math).
  * - Day-aligned references (midnight to end of day) produce day-aligned
  *   comparison ranges. Sub-day references (rolling windows like the last 24
- *   hours) mirror the exact window instead, so the comparison always covers
- *   the same amount of time as the primary range.
+ *   hours) mirror the exact window instead.
+ * - The comparison covers the same amount of time as the reference, except
+ *   where the reference covers whole calendar months: `previous-month` and
+ *   `previous-year` then shift the calendar and keep both ends on the month.
  *
  * @param reference - The reference range to compare against (must include both `from` and `to`).
  * @param presetId  - One of the supported preset identifiers.
@@ -107,17 +113,36 @@ export function getComparisonRangeFromPreset(
 		};
 	}
 
-	if ( presetId === COMPARISON_PREVIOUS_MONTH ) {
-		return {
-			from: clampDayBound( subMonths( refFrom, 1 ), 0 ),
-			to: clampDayBound( subMonths( refTo, 1 ), 1 ),
-		};
-	}
+	if ( presetId === COMPARISON_PREVIOUS_MONTH || presetId === COMPARISON_PREVIOUS_YEAR ) {
+		const shiftBack = presetId === COMPARISON_PREVIOUS_MONTH ? subMonths : subYears;
 
-	if ( presetId === COMPARISON_PREVIOUS_YEAR ) {
+		// A whole-month reference keeps the calendar shift, because unequal
+		// lengths are the point there: March against February is 31 days
+		// against 28. Both ends re-snap to the month, which also repairs the
+		// shift's day-of-month clamp — January 1 through February 28 shifted a
+		// month back ends on January 28, mid-month.
+		if ( isFirstDayOfMonth( refFrom ) && isLastDayOfMonth( refTo ) ) {
+			return {
+				from: clampDayBound( startOfMonth( shiftBack( refFrom, 1 ) ), 0 ),
+				to: clampDayBound( endOfMonth( shiftBack( refTo, 1 ) ), 1 ),
+			};
+		}
+
+		/*
+		 * Every other window keeps its length. Shifting each end on its own
+		 * lets month lengths resize it — July 21 - August 19 (30 days) landed
+		 * on June 21 - July 19 (29) — and the widgets divide raw totals, with
+		 * no per-day normalization, so a missing day biases every delta.
+		 * The end is the anchor, as in the sub-day branch above: the comparison
+		 * then ends exactly the named interval before the reference does, which
+		 * is the endpoint the label promises.
+		 */
+		const to = shiftBack( refTo, 1 );
+		const daysInclusive = differenceInDays( refTo, refFrom ) + 1;
+
 		return {
-			from: clampDayBound( subYears( refFrom, 1 ), 0 ),
-			to: clampDayBound( subYears( refTo, 1 ), 1 ),
+			from: clampDayBound( subDays( to, daysInclusive - 1 ), 0 ),
+			to: clampDayBound( to, 1 ),
 		};
 	}
 

--- a/projects/plugins/jetpack/changelog/wooa7s-1976-comparison-window-length
+++ b/projects/plugins/jetpack/changelog/wooa7s-1976-comparison-window-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Compare a date range against a previous month or year of the same length, so the percentages no longer measure 30 days against 29. Whole calendar months still compare month to month.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-1976-comparison-window-length
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-1976-comparison-window-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Compare a date range against a previous month or year of the same length, so the percentages no longer measure 30 days against 29. Whole calendar months still compare month to month.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1976-comparison-window-length
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1976-comparison-window-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Compare a date range against a previous month or year of the same length, so the percentages no longer measure 30 days against 29. Whole calendar months still compare month to month.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-1976-comparison-window-length
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-1976-comparison-window-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Compare a date range against a previous month or year of the same length, so the percentages no longer measure 30 days against 29. Whole calendar months still compare month to month.


### PR DESCRIPTION
Fixes WOOA7S-1976

## Proposed changes

### Why

The **Previous month** and **Previous year** comparisons could cover a different number of days from the selected range.

For example, a 30-day range from July 21 to August 19 used to compare against June 21 to July 19, which is only 29 days. Because widget deltas compare raw totals rather than daily averages, the missing day made the percentage changes misleading.

### What changed

- For partial-month ranges, shift the comparison end back one month or year, then calculate its start so the comparison has the same duration as the selected range.
- Keep full calendar-month comparisons aligned to calendar boundaries. March 1–31 still compares with February 1–28 because comparing the complete months is more useful than forcing both ranges to have 31 days.
- Handle shorter-month clamping explicitly. For example, March 2–31 compares with January 30–February 28: shifting March 31 back one month ends on February 28, then the start moves back far enough to preserve all 30 days.
- Add tests and documentation for duration preservation, full-month ranges, shorter months, leap years, and site time zones.

This also matches the existing behavior for sub-day ranges, which already rebuild their start from the original duration (#51374).

## Related product discussion/links

- WOOA7S-1976 — decision and background.
- WOOA7S-1630 — follow-up about hiding **Previous month** for long ranges that substantially overlap their comparison.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open the Stats v2 dashboard.
2. Select **30 days**, then **Compare → Previous month**.
3. Confirm that the header shows the same number of days for both ranges and that the dashed comparison line spans the full chart.
4. Select a custom full month, such as March 1–31.
5. Confirm that **Previous month** shows the complete previous month, February 1–28, rather than a forced 31-day range.

Automated coverage:

```sh
jp test js packages/premium-analytics
```

The relevant suite is `packages/datetime/src/__tests__/get-comparison-range.test.ts`.

### Before / after

Captured on a local Premium Analytics dashboard with **30 days** and **Previous month** selected.

| Before                                                                                                                             | After                                                                                                                            |
| ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1976-comparison-window-length/before-comparison-window.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1976-comparison-window-length/after-comparison-window.png) |

- Before: 30 days compared with 29 days (`June 22–July 20`), so the dashed line stopped one bucket early.
- After: 30 days compared with 30 days (`June 21–July 20`), so the dashed line spans the full chart.
