### PR TITLE
[Do not merge] Premium Analytics: measure the ungrouped jest run on CI

### DIFF
--- a/projects/packages/premium-analytics/changelog/group-routes-test-suites
+++ b/projects/packages/premium-analytics/changelog/group-routes-test-suites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test-only change: group the routes jest suites that share a mock signature.
+
+

--- a/projects/packages/premium-analytics/changelog/measure-ungrouped
+++ b/projects/packages/premium-analytics/changelog/measure-ungrouped
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Throwaway branch: measure the ungrouped jest run on CI.
+
+

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -12,7 +12,7 @@
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build && pnpm run build:strip-unminified-prod && pnpm run validate",
 		"clean": "rm -rf build/",
 		"storybook": "cd ../../js-packages/storybook && pnpm run storybook:dev",
-		"test": "PA_TEST_GROUPS=1 TZ=UTC jest --config=tests/jest.config.cjs",
+		"test": "PA_TEST_GROUPS=1 PA_NO_GROUPS=1 TZ=UTC jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
 		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",

--- a/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part1.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part1.test.tsx
@@ -1,0 +1,12 @@
+// See README.md before adding a suite to this group.
+
+import '../../routes/dashboard/components/section-sync-notice/section-sync-notice.test';
+import '../../routes/dashboard/config/date-filter.test';
+import '../../routes/dashboard/config/section-layouts.test';
+import '../../routes/dashboard/config/sections.test';
+import '../../routes/dashboard/hooks/use-dashboard-section-layout.test';
+import '../../routes/dashboard/hooks/use-section-date-filter.test';
+import '../../routes/post-detail/components/post-summary-card/post-summary-card.test';
+import '../../routes/post-detail/config/tab-layouts.test';
+import '../../routes/post-detail/config/widget-variants.test';
+import '../../routes/reports/authors/config/aggregate.test';

--- a/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part2.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part2.test.tsx
@@ -1,0 +1,12 @@
+// See README.md before adding a suite to this group.
+
+import '../../routes/reports/clicks/config/aggregate.test';
+import '../../routes/reports/clicks/config/fields.test';
+import '../../routes/reports/clicks/config/get-click-csv-group.test';
+import '../../routes/reports/count-fields.test';
+import '../../routes/reports/downloads/config/fields.test';
+import '../../routes/reports/locations/config/aggregate.test';
+import '../../routes/reports/locations/config/fields.test';
+import '../../routes/reports/locations/config/tabs.test';
+import '../../routes/reports/referrers/config/aggregate.test';
+import '../../routes/reports/referrers/config/fields.test';

--- a/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part3.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part3.test.tsx
@@ -1,0 +1,8 @@
+// See README.md before adding a suite to this group.
+
+import '../../routes/reports/report-names.test';
+import '../../routes/reports/search-terms/config/aggregate.test';
+import '../../routes/reports/search-terms/config/fields.test';
+import '../../routes/reports/utm/config/aggregate.test';
+import '../../routes/reports/utm/config/tabs.test';
+import '../../routes/video-detail/config/layout.test';

--- a/projects/packages/premium-analytics/tests/groups/routes-shared-route-mock.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/routes-shared-route-mock.test.tsx
@@ -1,0 +1,7 @@
+// See README.md before adding a suite to this group.
+
+import '../../routes/reports/authors/config/fields.test';
+import '../../routes/reports/comment-followers/config/fields.test';
+import '../../routes/reports/emails/config/fields.test';
+import '../../routes/reports/utm/config/fields.test';
+import '../../routes/reports/videos/config/fields.test';


### PR DESCRIPTION
## Proposed changes

**Throwaway — do not review, do not merge. This PR exists to take one CI measurement and will be closed.**

It is #51467 with a single line changed: `PA_NO_GROUPS=1` added to the package's `test` script, which turns jest suite grouping off. Same base, same commits, same set of projects in the CI job — so the `JS tests` timing for `packages/premium-analytics` here is the ungrouped counterpart of the 194.8s that #51467 measured, with nothing else varying.

Comparing across earlier PRs did not work: the pre-grouping run was on an older base with 160 fewer tests and a lighter competing load in the same job.

## Related product discussion/links

- WOOA7S-1971

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

None — read the `[packages/premium-analytics] Time:` line from the `JS tests` job and close.
