### PR TITLE
AI Launchpad: add the AI standard properties to the Tracks events

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-583-ai-standard-tracks-props
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-583-ai-standard-tracks-props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Launchpad: add the AI standard properties to the Tracks events.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -25,7 +25,7 @@
 		"clean": "rm -rf src/build/ src/build-module/ build/",
 		"e2e-tests": "playwright test --config src/features/verbum-comments/playwright.config.ts",
 		"sync:newspack-blocks": "./bin/sync-newspack-blocks.sh",
-		"test": "node --test --test-reporter spec 'src/**/test/*.test.mjs'",
+		"test": "node --test --test-reporter spec 'src/**/test/*.test.mjs' 'src/**/*.test.mts'",
 		"test-coverage": "c8 --report-dir=\"$COVERAGE_DIR\" --temp-directory=\"$ARTIFACTS_DIR/v8\" pnpm run test",
 		"typecheck": "tsgo --build",
 		"watch": "pnpm run build-production-js && pnpm webpack watch"

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 
 // helpers.php defines the shared option reader the listeners depend on, so it loads first.
@@ -58,6 +59,7 @@ class AI_Launchpad {
 
 		self::load_wp_build();
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_jwt_initial_state' ), 20 );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_tracks' ), 20 );
 	}
 
 	/**
@@ -182,5 +184,38 @@ class AI_Launchpad {
 				'wpcomBlogId' => get_wpcom_blog_id(),
 			)
 		);
+	}
+
+	/**
+	 * Attach the page's Tracks preconditions: the transport itself on Atomic, and the standard
+	 * event properties as a global the client recorder reads.
+	 *
+	 * On Simple, wpcom's stats.php loads the Tracks transport on every admin page and pushes
+	 * identifyUser and the blog_id super prop with it. On Atomic nothing does — wpcomsh only
+	 * enqueues jp-tracks inside the editor — so `window._tkq` stays an ordinary array, every
+	 * push accumulates in it, and the whole client-side funnel is discarded on unload.
+	 */
+	public static function enqueue_tracks() {
+		$handle = self::MENU_SLUG . '-prerequisites';
+
+		if ( ! wp_script_is( $handle, 'registered' ) ) {
+			return;
+		}
+
+		if ( ! ( new Host() )->is_wpcom_simple() ) {
+			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+		}
+
+		// JSON rather than wp_localize_script(), which stringifies every value: `is_test`
+		// would reach Tracks as "" instead of false, and blog_id as a string.
+		$bootstrap = wp_json_encode(
+			array(
+				'props'    => wpcom_ai_launchpad_standard_props(),
+				'identity' => wpcom_ai_launchpad_tracks_identity(),
+			),
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
+		);
+
+		wp_add_inline_script( $handle, 'window.wpcomAiLaunchpadTracks = ' . $bootstrap . ';', 'before' );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -8,7 +8,11 @@
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Terms_Of_Service;
+use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 
 // helpers.php defines the shared option reader the listeners depend on, so it loads first.
@@ -194,6 +198,12 @@ class AI_Launchpad {
 	 * identifyUser and the blog_id super prop with it. On Atomic nothing does — wpcomsh only
 	 * enqueues jp-tracks inside the editor — so `window._tkq` stays an ordinary array, every
 	 * push accumulates in it, and the whole client-side funnel is discarded on unload.
+	 *
+	 * The transport is only enqueued where tracking is actually permitted: "not Simple" also
+	 * covers jurassic.ninja / jurassic.tube and self-hosted sites running this package, where
+	 * the server recorder already stays silent under a declined ToS or offline mode. Gating
+	 * here mirrors `wpcom_enqueue_tracking_scripts()` in `src/common/index.php`. The props/
+	 * identity global below stays ungated: it is inert without the transport.
 	 */
 	public static function enqueue_tracks() {
 		$handle = self::MENU_SLUG . '-prerequisites';
@@ -203,11 +213,14 @@ class AI_Launchpad {
 		}
 
 		if ( ! ( new Host() )->is_wpcom_simple() ) {
-			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+			$tracking = new Tracking( 'jetpack-mu-wpcom', new Connection_Manager() );
+			if ( $tracking->should_enable_tracking( new Terms_Of_Service(), new Status() ) ) {
+				wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+			}
 		}
 
-		// JSON rather than wp_localize_script(), which stringifies every value: `is_test`
-		// would reach Tracks as "" instead of false, and blog_id as a string.
+		// JSON rather than wp_localize_script(), which stringifies every value: blog_id would
+		// reach Tracks as a string instead of an int.
 		$bootstrap = wp_json_encode(
 			array(
 				'props'    => wpcom_ai_launchpad_standard_props(),
@@ -215,6 +228,15 @@ class AI_Launchpad {
 			),
 			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 		);
+
+		// WordPress concatenates every `before` inline script queued for this handle into one
+		// <script> tag, so a false here (encode failure) would emit a syntax error that also
+		// takes out the other scripts sharing the handle — including JP_CONNECTION_INITIAL_STATE
+		// and Jetpack_Editor_Initial_State.wpcomBlogId, the JWT and blog id the page needs to
+		// function at all. Fall back to an empty object so this global stays inert instead.
+		if ( false === $bootstrap ) {
+			$bootstrap = '{}';
+		}
 
 		wp_add_inline_script( $handle, 'window.wpcomAiLaunchpadTracks = ' . $bootstrap . ';', 'before' );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -359,7 +359,14 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 							'description'       => 'Client-minted id for this tailoring run, carried by every Tracks event fired afterwards.',
 							'type'              => 'string',
 							'default'           => '',
+							// A UUID is 36 characters; 64 leaves headroom without letting an
+							// oversized value reach the option, the inline script, and every
+							// Tracks event. sanitize_key() doesn't bound length on its own, so
+							// the validate_callback is what actually enforces maxLength here —
+							// WP only runs per-arg schema validation when one is wired in.
+							'maxLength'         => 64,
 							'sanitize_callback' => 'sanitize_key',
+							'validate_callback' => 'rest_validate_request_arg',
 						),
 					),
 				),

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -339,21 +339,27 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 					'callback'            => array( $this, 'update_tailored' ),
 					'permission_callback' => array( $this, 'can_write' ),
 					'args'                => array(
-						'source'      => array(
+						'source'        => array(
 							'description' => 'Whether the payload came from the AI or the deterministic fallback. Query parameter; the JSON body must match the agent output schema exactly.',
 							'type'        => 'string',
 							'enum'        => array( 'ai', 'fallback' ),
 							'default'     => 'ai',
 						),
-						'duration_ms' => array(
+						'duration_ms'   => array(
 							'description' => 'Client-measured tailoring duration in milliseconds, for the tailored Logstash record.',
 							'type'        => 'integer',
 							'minimum'     => 0,
 						),
-						'attempts'    => array(
+						'attempts'      => array(
 							'description' => 'How many jetpack-ai-query attempts the client made, for the tailored Logstash record.',
 							'type'        => 'integer',
 							'minimum'     => 0,
+						),
+						'ai_session_id' => array(
+							'description'       => 'Client-minted id for this tailoring run, carried by every Tracks event fired afterwards.',
+							'type'              => 'string',
+							'default'           => '',
+							'sanitize_callback' => 'sanitize_key',
 						),
 					),
 				),
@@ -796,6 +802,12 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'generated_at' => time(),
 			'payload'      => $payload,
 		);
+
+		// Omitted rather than stored empty, so the props builder reports "none" for a write
+		// that carried no session id (a client from before this shipped, or a direct call).
+		if ( '' !== $request['ai_session_id'] ) {
+			$ai_output['ai_session_id'] = $request['ai_session_id'];
+		}
 
 		update_option( self::OPTION_AI_OUTPUT, $ai_output, false );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
@@ -141,6 +141,143 @@ if ( ! function_exists( 'wpcom_ai_launchpad_tracks_context' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wpcom_ai_launchpad_is_test' ) ) {
+	/**
+	 * Whether this request comes from a development or test environment.
+	 *
+	 * Environment-based, never user-based. The AI property standard keeps `is_test` and
+	 * `is_a11n` independently filterable, so an Automattician working on a production site is
+	 * a11n but not test. The standard also lists a set of internal Atomic client IDs, which is
+	 * deliberately not implemented here: the reference implementation
+	 * (packages/agents-manager, is_dev_mode()) gates that clause behind AT_PROXIED_REQUEST,
+	 * which would make this user-based again, and ungated it would risk reporting real Atomic
+	 * sites as tests. Automattician sessions on real test sites are covered by is_a11n instead.
+	 *
+	 * @return bool
+	 */
+	function wpcom_ai_launchpad_is_test() {
+		$host = wp_parse_url( get_site_url(), PHP_URL_HOST );
+
+		if ( ! is_string( $host ) || '' === $host ) {
+			return false;
+		}
+
+		return 'localhost' === $host
+			|| '.jurassic.tube' === stristr( $host, '.jurassic.tube' )
+			|| '.jurassic.ninja' === stristr( $host, '.jurassic.ninja' );
+	}
+}
+
+if ( ! function_exists( 'wpcom_ai_launchpad_is_a11n' ) ) {
+	/**
+	 * Whether an Automattician is acting on this site.
+	 *
+	 * Mirrors the platform split used elsewhere in the package: on Simple the platform's own
+	 * is_automattician() is authoritative, and on Atomic the a8c proxy is what identifies us.
+	 * Both branches fail closed when their primitive is missing.
+	 *
+	 * Records who is acting, not who owns the site — an Automattician working on a customer's
+	 * site is a11n, a customer working on an a8c-owned site is not.
+	 *
+	 * @return bool
+	 */
+	function wpcom_ai_launchpad_is_a11n() {
+		if ( ( new \Automattic\Jetpack\Status\Host() )->is_wpcom_simple() ) {
+			return function_exists( 'is_automattician' ) && (bool) is_automattician();
+		}
+
+		return \Automattic\Jetpack\Constants::is_true( 'AT_PROXIED_REQUEST' );
+	}
+}
+
+if ( ! function_exists( 'wpcom_ai_launchpad_standard_props' ) ) {
+	/**
+	 * The AI standard Tracks properties, merged into every AI Launchpad event by both
+	 * recorders — the server one below and the client one in `js/lib/tracks.ts`, which reads
+	 * this same array from the page's `window.wpcomAiLaunchpadTracks` global.
+	 *
+	 * Every value is a string, an int or a bool, never null: the standard requires the string
+	 * "none" for a missing value, because null breaks group-by aggregations downstream.
+	 *
+	 * @return array The standard props.
+	 */
+	function wpcom_ai_launchpad_standard_props() {
+		$ai_output = get_option( 'wpcom_ai_launchpad_ai_output' );
+
+		$string_or_none = static function ( $value ) {
+			return is_string( $value ) && '' !== $value ? $value : 'none';
+		};
+
+		$source        = $string_or_none( is_array( $ai_output ) ? ( $ai_output['source'] ?? null ) : null );
+		$ai_session_id = $string_or_none( is_array( $ai_output ) ? ( $ai_output['ai_session_id'] ?? null ) : null );
+
+		// Redundant with $source by construction. The standard requires it and cross-product AI
+		// dashboards group by it, so it is derived here rather than stored a second time.
+		$outcome = 'none';
+		if ( 'ai' === $source ) {
+			$outcome = 'success';
+		} elseif ( 'fallback' === $source ) {
+			$outcome = 'error';
+		}
+
+		return array(
+			'channel'       => 'web',
+			'surface'       => 'dashboard',
+			// The Site Setup page's own $pagenow, hardcoded rather than read live: the two
+			// server-fired events fire inside REST requests, where $pagenow is index.php, and
+			// the two recorders have to report the same screen for the same user.
+			'screen'        => 'admin.php',
+			'ref'           => 'experiment_wpcom_launchpad_personalization_202607_v1',
+			'site_type'     => ( new \Automattic\Jetpack\Status\Host() )->is_wpcom_simple() ? 'simple' : 'atomic',
+			'agent_name'    => 'ai_launchpad',
+			'agent_version' => \Automattic\Jetpack\Jetpack_Mu_Wpcom::PACKAGE_VERSION,
+			'is_test'       => wpcom_ai_launchpad_is_test(),
+			'is_a11n'       => wpcom_ai_launchpad_is_a11n(),
+			// Explicit rather than left to the Tracks super prop: on the client the super prop
+			// is missing on about one page-view fire in twenty, which understates every
+			// per-site rate that uses `viewed` as its denominator.
+			'blog_id'       => (int) get_wpcom_blog_id(),
+			'source'        => $source,
+			'outcome'       => $outcome,
+			'ai_session_id' => $ai_session_id,
+		);
+	}
+}
+
+if ( ! function_exists( 'wpcom_ai_launchpad_tracks_identity' ) ) {
+	/**
+	 * The Tracks user identity the client recorder pushes as `identifyUser`, on Atomic only.
+	 *
+	 * On Simple, wpcom's stats.php already pushes identifyUser for every admin page load. On
+	 * Atomic nothing does, so without this the client events would land anonymous. The local
+	 * user id is not usable there — Tracks wants the connected WordPress.com identity.
+	 *
+	 * Returns only the id and the login: the Tracks client helper also hands back an email
+	 * address, which must not reach a JS global.
+	 *
+	 * @return array|null The identity, or null on Simple / when no connected user is available.
+	 */
+	function wpcom_ai_launchpad_tracks_identity() {
+		if ( ( new \Automattic\Jetpack\Status\Host() )->is_wpcom_simple() ) {
+			return null;
+		}
+
+		if ( ! class_exists( 'Jetpack_Tracks_Client' ) ) {
+			return null;
+		}
+
+		$identity = \Jetpack_Tracks_Client::get_connected_user_tracks_identity();
+		if ( ! is_array( $identity ) || empty( $identity['userid'] ) || empty( $identity['username'] ) ) {
+			return null;
+		}
+
+		return array(
+			'userid'   => (int) $identity['userid'],
+			'username' => (string) $identity['username'],
+		);
+	}
+}
+
 if ( ! function_exists( 'wpcom_ai_launchpad_record_tracks_event' ) ) {
 	/**
 	 * Records an AI Launchpad Tracks event server-side with the shared context merged in,

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
@@ -206,8 +206,8 @@ if ( ! function_exists( 'wpcom_ai_launchpad_standard_props' ) ) {
 	 * recorders — the server one below and the client one in `js/lib/tracks.ts`, which reads
 	 * this same array from the page's `window.wpcomAiLaunchpadTracks` global.
 	 *
-	 * Every value is a string, an int or a bool, never null: the standard requires the string
-	 * "none" for a missing value, because null breaks group-by aggregations downstream.
+	 * Every value is a string or an int, never null: the standard requires the string "none"
+	 * for a missing value, because null breaks group-by aggregations downstream.
 	 *
 	 * @return array The standard props.
 	 */
@@ -241,8 +241,14 @@ if ( ! function_exists( 'wpcom_ai_launchpad_standard_props' ) ) {
 			'site_type'     => ( new \Automattic\Jetpack\Status\Host() )->is_wpcom_simple() ? 'simple' : 'atomic',
 			'agent_name'    => 'ai_launchpad',
 			'agent_version' => \Automattic\Jetpack\Jetpack_Mu_Wpcom::PACKAGE_VERSION,
-			'is_test'       => wpcom_ai_launchpad_is_test(),
-			'is_a11n'       => wpcom_ai_launchpad_is_a11n(),
+			// Stringified rather than left as PHP bools: http_build_query() (both PHP Tracks
+			// clients end in one) renders a bool as "1"/"0", while the client recorder's
+			// encodeURIComponent() renders it as "true"/"false" — the same logical value would
+			// reach Tracks differently depending on which recorder fired it. The literal strings
+			// 'true'/'false' are what the Fieldguide standard documents and the only
+			// representation both encoders pass through unchanged.
+			'is_test'       => wpcom_ai_launchpad_is_test() ? 'true' : 'false',
+			'is_a11n'       => wpcom_ai_launchpad_is_a11n() ? 'true' : 'false',
 			// Explicit rather than left to the Tracks super prop: on the client the super prop
 			// is missing on about one page-view fire in twenty, which understates every
 			// per-site rate that uses `viewed` as its denominator.
@@ -305,8 +311,15 @@ if ( ! function_exists( 'wpcom_ai_launchpad_tracks_identity' ) ) {
 
 if ( ! function_exists( 'wpcom_ai_launchpad_record_tracks_event' ) ) {
 	/**
-	 * Records an AI Launchpad Tracks event server-side with the shared context merged in,
-	 * so call sites can't forget it. Explicit props win over the context.
+	 * Records an AI Launchpad Tracks event server-side, merging three layers before it is sent:
+	 *
+	 * 1. `wpcom_ai_launchpad_standard_props()` — the AI standard props shared with the client
+	 *    recorder. Applied first and never dropped: "none" and "false" are values, not gaps.
+	 * 2. `wpcom_ai_launchpad_tracks_context( $rendered_task_ids )` — the feature-specific
+	 *    context (goal, niche, rendered list, …). Its null-valued keys are filtered out here
+	 *    (mirroring the client recorder) rather than reaching Tracks as literal "null" strings,
+	 *    so an unset context value is simply absent, unlike an unset standard prop.
+	 * 3. `$props`, the call site's own properties, which win over both of the above.
 	 *
 	 * @param string        $event_name        The Tracks event name, already feature-prefixed.
 	 * @param array         $props             Event properties. No PII: task IDs are fine, free text is not.
@@ -326,7 +339,7 @@ if ( ! function_exists( 'wpcom_ai_launchpad_record_tracks_event' ) ) {
 		);
 
 		// Merged outside that filter, and first, so the standard props are never dropped
-		// (`is_test: false` is a value, not a gap) and a call site still wins over both.
+		// (`is_test: 'false'` is a value, not a gap) and a call site still wins over both.
 		$props = array_merge( wpcom_ai_launchpad_standard_props(), $context );
 
 		/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
@@ -314,14 +314,20 @@ if ( ! function_exists( 'wpcom_ai_launchpad_record_tracks_event' ) ) {
 	 * @return void
 	 */
 	function wpcom_ai_launchpad_record_tracks_event( $event_name, $props = array(), $rendered_task_ids = null ) {
-		$props = array_merge( wpcom_ai_launchpad_tracks_context( $rendered_task_ids ), $props );
-		// Null-valued props are omitted, mirroring the client recorder.
-		$props = array_filter(
-			$props,
+		$context = array_merge( wpcom_ai_launchpad_tracks_context( $rendered_task_ids ), $props );
+
+		// Null-valued context props are omitted, mirroring the client recorder: the Tracks
+		// pipeline would otherwise record them as literal "null" strings.
+		$context = array_filter(
+			$context,
 			static function ( $value ) {
 				return null !== $value;
 			}
 		);
+
+		// Merged outside that filter, and first, so the standard props are never dropped
+		// (`is_test: false` is a value, not a gap) and a call site still wins over both.
+		$props = array_merge( wpcom_ai_launchpad_standard_props(), $context );
 
 		/**
 		 * Fires for every server-side AI Launchpad analytics event, before it is sent to

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
@@ -162,9 +162,19 @@ if ( ! function_exists( 'wpcom_ai_launchpad_is_test' ) ) {
 			return false;
 		}
 
-		return 'localhost' === $host
-			|| '.jurassic.tube' === stristr( $host, '.jurassic.tube' )
-			|| '.jurassic.ninja' === stristr( $host, '.jurassic.ninja' );
+		$host = strtolower( $host );
+
+		if ( 'localhost' === $host ) {
+			return true;
+		}
+
+		foreach ( array( '.jurassic.tube', '.jurassic.ninja' ) as $suffix ) {
+			if ( substr( $host, - strlen( $suffix ) ) === $suffix ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }
 
@@ -244,6 +254,29 @@ if ( ! function_exists( 'wpcom_ai_launchpad_standard_props' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wpcom_ai_launchpad_shape_tracks_identity' ) ) {
+	/**
+	 * Reduces a Tracks client identity to the two fields the browser is allowed to see.
+	 *
+	 * The client helper also returns an email address, a blog id and a locale. Only the id and
+	 * the login may reach a JS global, so this rebuilds the array rather than unsetting keys —
+	 * a field added to the helper later cannot leak through by default.
+	 *
+	 * @param mixed $identity The raw identity from Jetpack_Tracks_Client, or false.
+	 * @return array|null The id and login, or null when the identity is unusable.
+	 */
+	function wpcom_ai_launchpad_shape_tracks_identity( $identity ) {
+		if ( ! is_array( $identity ) || empty( $identity['userid'] ) || empty( $identity['username'] ) ) {
+			return null;
+		}
+
+		return array(
+			'userid'   => (int) $identity['userid'],
+			'username' => (string) $identity['username'],
+		);
+	}
+}
+
 if ( ! function_exists( 'wpcom_ai_launchpad_tracks_identity' ) ) {
 	/**
 	 * The Tracks user identity the client recorder pushes as `identifyUser`, on Atomic only.
@@ -266,15 +299,7 @@ if ( ! function_exists( 'wpcom_ai_launchpad_tracks_identity' ) ) {
 			return null;
 		}
 
-		$identity = \Jetpack_Tracks_Client::get_connected_user_tracks_identity();
-		if ( ! is_array( $identity ) || empty( $identity['userid'] ) || empty( $identity['username'] ) ) {
-			return null;
-		}
-
-		return array(
-			'userid'   => (int) $identity['userid'],
-			'username' => (string) $identity['username'],
-		);
+		return wpcom_ai_launchpad_shape_tracks_identity( \Jetpack_Tracks_Client::get_connected_user_tracks_identity() );
 	}
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tailor.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tailor.ts
@@ -21,6 +21,25 @@ interface AiQueryResponse {
 type FetchOutcome = { ok: true; output: TailoredOutput } | { ok: false; retryable: boolean };
 
 /**
+ * Mints a session id for a tailoring run, or '' when `crypto.randomUUID` isn't available.
+ *
+ * `crypto.randomUUID` is undefined outside a secure context and on older Safari/Firefox, and
+ * throws rather than returning undefined — unguarded, that would reject `tailor()` before any
+ * tailoring happens, and every caller catches, so the user would see an empty launchpad instead
+ * of a list. This purely analytical id must not be able to break list rendering; the server
+ * already treats an empty `ai_session_id` as absent.
+ *
+ * @return A UUID, or '' when unavailable.
+ */
+function mintAiSessionId(): string {
+	try {
+		return crypto.randomUUID();
+	} catch {
+		return '';
+	}
+}
+
+/**
  * Call jetpack-ai-query once with the combined prompt and return the validated
  * output, or a failure outcome tagging whether the failure is worth retrying.
  *
@@ -168,7 +187,7 @@ export async function tailor( input: WizardInput ): Promise< TailorResult > {
 	// One id per tailoring run, not per attempt: a retry re-rolls the same checklist. Minted
 	// here rather than server-side so it survives a failed PUT, where the client still renders
 	// a list and still fires events against it.
-	const aiSessionId = crypto.randomUUID();
+	const aiSessionId = mintAiSessionId();
 	const availableTaskIds = await fetchAvailableTaskIds( input.goal );
 	const { output: aiOutput, attempts } = await fetchAiOutputWithRetry( input, availableTaskIds );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tailor.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tailor.ts
@@ -4,6 +4,7 @@ import { selectFallback } from './fallback.ts';
 import { requestJwt } from './jwt.ts';
 import { buildTailorPrompt, chooseTailoringMenu } from './prompts.ts';
 import { parseAgentResponse } from './schema-validator.ts';
+import { contextFromTailorResult, setTracksContext } from './tracks.ts';
 import type { TailoredOutput, TailorResult, TailorSource, WizardInput } from './types.ts';
 
 const AI_QUERY_ENDPOINT = 'https://public-api.wordpress.com/wpcom/v2/jetpack-ai-query';
@@ -131,22 +132,24 @@ async function fetchAvailableTaskIds( goal: string ): Promise< readonly string[]
  * telemetry rides along as query params so the server's `tailored` Logstash
  * record carries it; there is no separate client-side event.
  *
- * @param output               - The tailored output to persist.
- * @param source               - Whether the output came from AI or the fallback.
- * @param telemetry            - Tailoring telemetry for the server's Logstash record.
- * @param telemetry.durationMs - How long tailoring took so far, in milliseconds.
- * @param telemetry.attempts   - How many jetpack-ai-query attempts were made.
+ * @param output                - The tailored output to persist.
+ * @param source                - Whether the output came from AI or the fallback.
+ * @param telemetry             - Tailoring telemetry for the server's Logstash record.
+ * @param telemetry.durationMs  - How long tailoring took so far, in milliseconds.
+ * @param telemetry.attempts    - How many jetpack-ai-query attempts were made.
+ * @param telemetry.aiSessionId - The id minted for this tailoring run.
  */
 async function persist(
 	output: TailoredOutput,
 	source: TailorSource,
-	telemetry: { durationMs: number; attempts: number }
+	telemetry: { durationMs: number; attempts: number; aiSessionId: string }
 ): Promise< void > {
 	await apiFetch( {
 		path: addQueryArgs( '/wpcom/v2/ai-launchpad/tailored', {
 			source,
 			duration_ms: telemetry.durationMs,
 			attempts: telemetry.attempts,
+			ai_session_id: telemetry.aiSessionId,
 		} ),
 		method: 'PUT',
 		data: output,
@@ -162,6 +165,10 @@ async function persist(
  */
 export async function tailor( input: WizardInput ): Promise< TailorResult > {
 	const start = performance.now();
+	// One id per tailoring run, not per attempt: a retry re-rolls the same checklist. Minted
+	// here rather than server-side so it survives a failed PUT, where the client still renders
+	// a list and still fires events against it.
+	const aiSessionId = crypto.randomUUID();
 	const availableTaskIds = await fetchAvailableTaskIds( input.goal );
 	const { output: aiOutput, attempts } = await fetchAiOutputWithRetry( input, availableTaskIds );
 
@@ -170,7 +177,9 @@ export async function tailor( input: WizardInput ): Promise< TailorResult > {
 			await persist( aiOutput, 'ai', {
 				durationMs: Math.round( performance.now() - start ),
 				attempts,
+				aiSessionId,
 			} );
+			setTracksContext( contextFromTailorResult( 'ai', aiSessionId ) );
 			return { source: 'ai', output: aiOutput };
 		} catch {
 			// PUT rejected the AI output; fall through to the deterministic fallback below.
@@ -183,9 +192,11 @@ export async function tailor( input: WizardInput ): Promise< TailorResult > {
 		await persist( fallbackOutput, 'fallback', {
 			durationMs: Math.round( performance.now() - start ),
 			attempts,
+			aiSessionId,
 		} );
 	} catch {
 		// Even if the write fails, still return the fallback so the consumer renders a list, not an empty launchpad.
 	}
+	setTracksContext( contextFromTailorResult( 'fallback', aiSessionId ) );
 	return { source: 'fallback', output: fallbackOutput };
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.test.mts
@@ -130,6 +130,23 @@ describe( 'ai-launchpad tracks', () => {
 		} );
 	} );
 
+	// An unmintable id must not be recorded as an empty string: the server never persisted it
+	// either, so leaving it null keeps both recorders reporting the bootstrap's 'none'.
+	it( 'contextFromTailorResult nulls an unminted session id', () => {
+		assert.deepEqual( contextFromTailorResult( 'fallback', '' ), {
+			source: 'fallback',
+			outcome: 'error',
+			ai_session_id: null,
+		} );
+	} );
+
+	it( 'records none, not an empty id, when the session id could not be minted', () => {
+		setTracksContext( contextFromTailorResult( 'fallback', '' ) );
+		trackTaskCtaClicked( { task_id: 'site_theme_selected' } );
+		assert.equal( lastProps().ai_session_id, 'none' );
+		assert.equal( lastProps().source, 'fallback' );
+	} );
+
 	it( 'merges the shared context into every event', () => {
 		setTracksContext( { goal: 'write', niche: 'hiking' } );
 		trackTaskCtaClicked( { task_id: 'site_theme_selected' } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.test.mts
@@ -34,8 +34,12 @@ const BOOTSTRAP = {
 		site_type: 'simple',
 		agent_name: 'ai_launchpad',
 		agent_version: '6.10.1',
-		is_test: false,
-		is_a11n: false,
+		// Strings, not booleans: the two recorders' encoders disagree on how a bool
+		// serializes (http_build_query() → "1"/"0", encodeURIComponent() → "true"/"false"), so
+		// the server sends the literal strings both pass through unchanged. See
+		// wpcom_ai_launchpad_standard_props().
+		is_test: 'false',
+		is_a11n: 'false',
 		blog_id: 12345,
 		source: 'none',
 		outcome: 'none',
@@ -95,9 +99,9 @@ describe( 'ai-launchpad tracks', () => {
 		} );
 	}
 
-	it( 'keeps is_test false rather than dropping it', () => {
+	it( "keeps is_test 'false' rather than dropping it", () => {
 		trackWizardCompleted();
-		assert.equal( lastProps().is_test, false );
+		assert.equal( lastProps().is_test, 'false' );
 		assert.equal( lastProps().blog_id, 12345 );
 	} );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { beforeEach, describe, it } from 'node:test';
 import {
 	contextFromInferred,
+	contextFromTailorResult,
 	contextFromTaskIds,
 	resetTracksContext,
 	setTracksContext,
@@ -19,12 +20,33 @@ import {
 import type { TailoredInferred, TrackEventProps } from './types.ts';
 
 // tracks.ts touches window only inside record(), so a bare object is enough.
-const win = globalThis as unknown as { window: { _tkq?: unknown[] } };
-
-const lastEvent = () => {
-	const queue = win.window._tkq as unknown[];
-	return queue[ queue.length - 1 ];
+const win = globalThis as unknown as {
+	window: { _tkq?: unknown[]; wpcomAiLaunchpadTracks?: unknown };
 };
+
+// What the page's inline script sets, minus the values that vary by site.
+const BOOTSTRAP = {
+	props: {
+		channel: 'web',
+		surface: 'dashboard',
+		screen: 'admin.php',
+		ref: 'experiment_wpcom_launchpad_personalization_202607_v1',
+		site_type: 'simple',
+		agent_name: 'ai_launchpad',
+		agent_version: '6.10.1',
+		is_test: false,
+		is_a11n: false,
+		blog_id: 12345,
+		source: 'none',
+		outcome: 'none',
+		ai_session_id: 'none',
+	},
+	identity: null,
+};
+
+const events = () => win.window._tkq as unknown[];
+const lastEvent = () => events()[ events().length - 1 ];
+const lastProps = () => ( lastEvent() as [ string, string, TrackEventProps ] )[ 2 ];
 
 /**
  * Bind a recorder to the props it should record, for the table below.
@@ -42,14 +64,13 @@ function fire< P extends TrackEventProps >( record: ( props: P ) => void, props:
 
 describe( 'ai-launchpad tracks', () => {
 	beforeEach( () => {
-		win.window = { _tkq: [] };
+		win.window = { _tkq: [], wpcomAiLaunchpadTracks: structuredClone( BOOTSTRAP ) };
 		resetTracksContext();
 	} );
 
-	// Each recorder must land on the queue as [ 'recordEvent', name, props ] carrying exactly
-	// the props it was given. No shared context is set for these cases, so they also pin the
-	// null-key omission: a leaked context key would show up as a literal "null" string, and
-	// launchpad_variant (dropped from the schema) would show up at all.
+	// Each recorder must land on the queue as [ 'recordEvent', name, props ] carrying its own
+	// props plus the standard ones. No shared context is set for these cases, so they also pin
+	// the null-key omission: a leaked context key would show up as a literal "null" string.
 	const RECORDERS: Array< [ event: string, fired: () => TrackEventProps ] > = [
 		[ 'viewed', fire( trackViewed, { step: 'goal' } ) ],
 		[ 'wizard_goal_clicked', fire( trackWizardGoalClicked, { goal_clicked: 'sell' } ) ],
@@ -64,11 +85,46 @@ describe( 'ai-launchpad tracks', () => {
 	];
 
 	for ( const [ event, fired ] of RECORDERS ) {
-		it( `records jetpack_ai_launchpad_${ event } with exactly its own props`, () => {
+		it( `records jetpack_ai_launchpad_${ event } with its own props and the standard ones`, () => {
 			const props = fired();
-			assert.deepEqual( lastEvent(), [ 'recordEvent', `jetpack_ai_launchpad_${ event }`, props ] );
+			assert.deepEqual( lastEvent(), [
+				'recordEvent',
+				`jetpack_ai_launchpad_${ event }`,
+				{ ...BOOTSTRAP.props, ...props },
+			] );
 		} );
 	}
+
+	it( 'keeps is_test false rather than dropping it', () => {
+		trackWizardCompleted();
+		assert.equal( lastProps().is_test, false );
+		assert.equal( lastProps().blog_id, 12345 );
+	} );
+
+	it( 'reports the tailoring-scoped props as none before a tailor runs', () => {
+		trackViewed( { step: 'goal' } );
+		assert.equal( lastProps().source, 'none' );
+		assert.equal( lastProps().outcome, 'none' );
+		assert.equal( lastProps().ai_session_id, 'none' );
+	} );
+
+	it( 'lets a fresh tailor override the tailoring-scoped props', () => {
+		setTracksContext(
+			contextFromTailorResult( 'fallback', 'a755f9e8-8e0a-45be-81bc-524aaf8e2703' )
+		);
+		trackTaskCtaClicked( { task_id: 'site_theme_selected' } );
+		assert.equal( lastProps().source, 'fallback' );
+		assert.equal( lastProps().outcome, 'error' );
+		assert.equal( lastProps().ai_session_id, 'a755f9e8-8e0a-45be-81bc-524aaf8e2703' );
+	} );
+
+	it( 'contextFromTailorResult maps an AI result to a success outcome', () => {
+		assert.deepEqual( contextFromTailorResult( 'ai', 'abc' ), {
+			source: 'ai',
+			outcome: 'success',
+			ai_session_id: 'abc',
+		} );
+	} );
 
 	it( 'merges the shared context into every event', () => {
 		setTracksContext( { goal: 'write', niche: 'hiking' } );
@@ -76,17 +132,44 @@ describe( 'ai-launchpad tracks', () => {
 		assert.deepEqual( lastEvent(), [
 			'recordEvent',
 			'jetpack_ai_launchpad_task_cta_clicked',
-			{ goal: 'write', niche: 'hiking', task_id: 'site_theme_selected' },
+			{ ...BOOTSTRAP.props, goal: 'write', niche: 'hiking', task_id: 'site_theme_selected' },
 		] );
+	} );
+
+	it( 'records nothing but the event when the bootstrap global is missing', () => {
+		win.window = { _tkq: [] };
+		trackViewed( { step: 'goal' } );
+		assert.deepEqual( lastEvent(), [
+			'recordEvent',
+			'jetpack_ai_launchpad_viewed',
+			{ step: 'goal' },
+		] );
+	} );
+
+	it( 'pushes identifyUser once, before the first event, when an identity is present', () => {
+		win.window = {
+			_tkq: [],
+			wpcomAiLaunchpadTracks: { ...BOOTSTRAP, identity: { userid: 7, username: 'copons' } },
+		};
+		trackViewed( { step: 'goal' } );
+		trackWizardGoalClicked( { goal_clicked: 'sell' } );
+
+		assert.deepEqual( events()[ 0 ], [ 'identifyUser', 7, 'copons' ] );
+		assert.equal( events().filter( e => ( e as unknown[] )[ 0 ] === 'identifyUser' ).length, 1 );
+		assert.equal( events().length, 3 );
+	} );
+
+	it( 'pushes no identifyUser when the identity is null', () => {
+		trackViewed( { step: 'goal' } );
+		assert.equal( events().length, 1 );
 	} );
 
 	it( 'later setTracksContext calls override earlier values and keep the rest', () => {
 		setTracksContext( { goal: 'write', vibe: 'warm' } );
 		setTracksContext( { goal: 'sell' } );
 		trackWizardCompleted();
-		const [ , , props ] = lastEvent() as [ string, string, Record< string, unknown > ];
-		assert.equal( props.goal, 'sell' );
-		assert.equal( props.vibe, 'warm' );
+		assert.equal( lastProps().goal, 'sell' );
+		assert.equal( lastProps().vibe, 'warm' );
 	} );
 
 	it( 'contextFromInferred maps fields and coalesces missing ones to null', () => {
@@ -124,13 +207,13 @@ describe( 'ai-launchpad tracks', () => {
 	it( 'latches wizard_completed to once per page load', () => {
 		trackWizardCompleted();
 		trackWizardCompleted();
-		assert.equal( ( win.window._tkq as unknown[] ).length, 1 );
+		assert.equal( events().length, 1 );
 	} );
 
 	it( 'initializes window._tkq when it is undefined', () => {
-		win.window = {};
+		win.window = { wpcomAiLaunchpadTracks: structuredClone( BOOTSTRAP ) };
 		trackViewed( { step: 'launchpad' } );
 		assert.ok( Array.isArray( win.window._tkq ) );
-		assert.equal( ( win.window._tkq as unknown[] ).length, 1 );
+		assert.equal( events().length, 1 );
 	} );
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.ts
@@ -144,7 +144,7 @@ export function contextFromTailorResult(
  * Records a Tracks event with the standard props and the shared context merged in, so call
  * sites can't forget either. Null-valued context props are omitted: the Tracks pipeline would
  * otherwise record them as literal "null" strings. The standard props merge outside that
- * filter, and first, so `is_test: false` survives and a call site still wins over both.
+ * filter, and first, so `is_test: 'false'` survives and a call site still wins over both.
  *
  * @param eventName - The Tracks event name, already feature-prefixed.
  * @param props     - Event properties. No PII: task IDs are fine, free text is not.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.ts
@@ -1,8 +1,19 @@
-import type { GoalSlug, TailoredInferred, TrackEventProps } from './types.ts';
+import type { GoalSlug, TailoredInferred, TailorSource, TrackEventProps } from './types.ts';
+
+/** The Tracks bootstrap the Site Setup page sets before this module runs. */
+interface TracksBootstrap {
+	// The AI standard props, resolved server-side. See wpcom_ai_launchpad_standard_props().
+	props: TrackEventProps;
+	// The Tracks identity to push as identifyUser, on Atomic only — null on Simple, where
+	// wpcom's stats.php has already pushed it.
+	identity: { userid: number; username: string } | null;
+}
 
 declare global {
 	interface Window {
-		_tkq: Array< [ 'recordEvent', string, TrackEventProps ] >;
+		// Widened past [ 'recordEvent', … ]: the queue also carries identifyUser pushes.
+		_tkq: unknown[][];
+		wpcomAiLaunchpadTracks?: TracksBootstrap;
 	}
 }
 
@@ -28,6 +39,13 @@ export interface TracksContext {
 	rendered_list: string | null;
 	// The goal the AI infers from the site name and description alone.
 	inferred_goal: string | null;
+	// Whether the rendered list came from the AI or the deterministic fallback, the same value
+	// under the standard's name, and the id of the tailoring run that produced it. Null until a
+	// tailor completes in this page load, so the server-resolved values in the bootstrap global
+	// show through for a returning user.
+	source: string | null;
+	outcome: string | null;
+	ai_session_id: string | null;
 }
 
 const EMPTY_CONTEXT: TracksContext = {
@@ -38,6 +56,9 @@ const EMPTY_CONTEXT: TracksContext = {
 	audience: null,
 	rendered_list: null,
 	inferred_goal: null,
+	source: null,
+	outcome: null,
+	ai_session_id: null,
 };
 
 let context: TracksContext = { ...EMPTY_CONTEXT };
@@ -46,6 +67,9 @@ let context: TracksContext = { ...EMPTY_CONTEXT };
 // only ever fire once per page load — latched here so a re-render/remount of the
 // firing component can never double-count the funnel's terminal step.
 let wizardCompletedRecorded = false;
+
+// identifyUser only has to be pushed once per page load, and only where nothing else does it.
+let userIdentified = false;
 
 /**
  * Merges values into the shared event context. Call as data becomes available
@@ -61,6 +85,7 @@ export function setTracksContext( partial: Partial< TracksContext > ): void {
 export function resetTracksContext(): void {
 	context = { ...EMPTY_CONTEXT };
 	wizardCompletedRecorded = false;
+	userIdentified = false;
 }
 
 /**
@@ -94,9 +119,32 @@ export function contextFromTaskIds( ids: string[] ): Partial< TracksContext > {
 }
 
 /**
- * Records a Tracks event with the shared context merged in, so call sites can't
- * forget it. Null-valued props are omitted: the Tracks pipeline would otherwise
- * record them as literal "null" strings.
+ * Derives the tailoring-scoped context from a completed tailor call, so every event fired
+ * afterwards is attributable to that run and to whether the AI or the fallback produced it.
+ *
+ * `outcome` is redundant with `source` by construction. The AI property standard requires it
+ * and cross-product dashboards group by it, so it is derived rather than carried separately.
+ *
+ * @param source      - Whether the output came from the AI or the deterministic fallback.
+ * @param aiSessionId - The id minted for this tailoring run.
+ * @return The context slice to merge.
+ */
+export function contextFromTailorResult(
+	source: TailorSource,
+	aiSessionId: string
+): Partial< TracksContext > {
+	return {
+		source,
+		outcome: 'ai' === source ? 'success' : 'error',
+		ai_session_id: aiSessionId,
+	};
+}
+
+/**
+ * Records a Tracks event with the standard props and the shared context merged in, so call
+ * sites can't forget either. Null-valued context props are omitted: the Tracks pipeline would
+ * otherwise record them as literal "null" strings. The standard props merge outside that
+ * filter, and first, so `is_test: false` survives and a call site still wins over both.
  *
  * @param eventName - The Tracks event name, already feature-prefixed.
  * @param props     - Event properties. No PII: task IDs are fine, free text is not.
@@ -106,7 +154,30 @@ function record( eventName: string, props: TrackEventProps = {} ): void {
 		Object.entries( { ...context, ...props } ).filter( ( [ , value ] ) => value !== null )
 	);
 	window._tkq = window._tkq || [];
-	window._tkq.push( [ 'recordEvent', eventName, merged ] );
+	identifyUser();
+	window._tkq.push( [
+		'recordEvent',
+		eventName,
+		{ ...( window.wpcomAiLaunchpadTracks?.props ?? {} ), ...merged },
+	] );
+}
+
+/**
+ * Pushes the Tracks identity once per page load, before the first event.
+ *
+ * Only Atomic supplies one: on Simple wpcom's stats.php has already identified the user for
+ * every admin page load, and pushing a second time would be redundant.
+ */
+function identifyUser(): void {
+	if ( userIdentified ) {
+		return;
+	}
+	userIdentified = true;
+
+	const identity = window.wpcomAiLaunchpadTracks?.identity;
+	if ( identity ) {
+		window._tkq.push( [ 'identifyUser', identity.userid, identity.username ] );
+	}
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tracks.ts
@@ -136,7 +136,11 @@ export function contextFromTailorResult(
 	return {
 		source,
 		outcome: 'ai' === source ? 'success' : 'error',
-		ai_session_id: aiSessionId,
+		// '' means crypto.randomUUID was unavailable, so no id was minted. Null rather than the
+		// empty string: null is what record()'s filter drops, letting the bootstrap's
+		// server-resolved value show through. The server never persisted the empty id either, so
+		// both recorders then report 'none' rather than disagreeing.
+		ai_session_id: '' !== aiSessionId ? aiSessionId : null,
 	};
 }
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -1038,7 +1038,7 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( 'ai_launchpad', $props['agent_name'] );
 		$this->assertSame( \Automattic\Jetpack\Jetpack_Mu_Wpcom::PACKAGE_VERSION, $props['agent_version'] );
 		$this->assertArrayHasKey( 'is_a11n', $props );
-		$this->assertFalse( $props['is_test'] );
+		$this->assertSame( 'false', $props['is_test'] );
 		$this->assertSame( 'ai', $props['source'] );
 		$this->assertSame( 'success', $props['outcome'] );
 		// Null context values are omitted from the recorded event, never "null" strings.
@@ -1376,6 +1376,26 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$envelope = get_option( 'wpcom_ai_launchpad_ai_output' );
 		$this->assertArrayNotHasKey( 'ai_session_id', $envelope );
 		$this->assertSame( 'none', wpcom_ai_launchpad_standard_props()['ai_session_id'] );
+	}
+
+	/**
+	 * Test that the schema rejects an oversized ai_session_id (rather than silently truncating
+	 * it), so an id can't land 100 KB deep in an option, the inline script, and every Tracks
+	 * event fired afterwards.
+	 */
+	public function test_tailored_rejects_an_oversized_ai_session_id() {
+		$result = $this->call_api(
+			'PUT',
+			'/tailored',
+			self::valid_payload(),
+			array(
+				'source'        => 'ai',
+				'ai_session_id' => str_repeat( 'a', 65 ),
+			)
+		);
+
+		$this->assertSame( 400, $result->get_status() );
+		$this->assertFalse( get_option( 'wpcom_ai_launchpad_ai_output' ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -1343,6 +1343,42 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that the tailoring run's session id is persisted on the envelope, so every event
+	 * fired afterwards — on this page load and on later ones — is attributable to that run.
+	 */
+	public function test_tailored_persists_the_ai_session_id() {
+		$result = $this->call_api(
+			'PUT',
+			'/tailored',
+			self::valid_payload(),
+			array(
+				'source'        => 'ai',
+				'ai_session_id' => 'a755f9e8-8e0a-45be-81bc-524aaf8e2703',
+			)
+		);
+
+		$this->assertSame( 200, $result->get_status() );
+
+		$envelope = get_option( 'wpcom_ai_launchpad_ai_output' );
+		$this->assertSame( 'a755f9e8-8e0a-45be-81bc-524aaf8e2703', $envelope['ai_session_id'] );
+		$this->assertSame( 'a755f9e8-8e0a-45be-81bc-524aaf8e2703', wpcom_ai_launchpad_standard_props()['ai_session_id'] );
+	}
+
+	/**
+	 * Test that a write without a session id leaves the key off the envelope rather than
+	 * persisting an empty string, so the props builder reports "none" for it.
+	 */
+	public function test_tailored_omits_a_missing_ai_session_id() {
+		$result = $this->call_api( 'PUT', '/tailored', self::valid_payload(), array( 'source' => 'ai' ) );
+
+		$this->assertSame( 200, $result->get_status() );
+
+		$envelope = get_option( 'wpcom_ai_launchpad_ai_output' );
+		$this->assertArrayNotHasKey( 'ai_session_id', $envelope );
+		$this->assertSame( 'none', wpcom_ai_launchpad_standard_props()['ai_session_id'] );
+	}
+
+	/**
 	 * Test that the schema accepts the analytics-only inferred_goal (persisting it into the envelope, where
 	 * the Tracks context readers find it) and rejects an out-of-enum value.
 	 */

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -1030,6 +1030,17 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		// The shared context rides along, populated from the persisted options.
 		$this->assertSame( 'write', $props['goal'] );
 		$this->assertSame( 'hiking', $props['niche'] );
+		// The AI standard props ride along too, and unlike the shared context they are never
+		// dropped — "none" and false are meaningful values, not missing ones.
+		$this->assertSame( 'web', $props['channel'] );
+		$this->assertSame( 'dashboard', $props['surface'] );
+		$this->assertSame( 'admin.php', $props['screen'] );
+		$this->assertSame( 'ai_launchpad', $props['agent_name'] );
+		$this->assertSame( \Automattic\Jetpack\Jetpack_Mu_Wpcom::PACKAGE_VERSION, $props['agent_version'] );
+		$this->assertArrayHasKey( 'is_a11n', $props );
+		$this->assertFalse( $props['is_test'] );
+		$this->assertSame( 'ai', $props['source'] );
+		$this->assertSame( 'success', $props['outcome'] );
 		// Null context values are omitted from the recorded event, never "null" strings.
 		$this->assertArrayNotHasKey( 'inferred_goal', $props );
 		$this->assertJson( $props['rendered_list'] );
@@ -1123,6 +1134,29 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		// The latch prevents a re-fire on later reads.
 		$this->call_api( Requests::GET );
 		$this->assertCount( 2, $events );
+	}
+
+	/**
+	 * Test that a call-site property beats a standard property of the same name, so the
+	 * wrapper can never silently overwrite what a call site deliberately sent.
+	 */
+	public function test_call_site_props_win_over_the_standard_props() {
+		$this->seed_tailored_site();
+
+		$events = array();
+		$this->capture_tracks_events( $events );
+
+		wpcom_ai_launchpad_record_tracks_event(
+			'jetpack_ai_launchpad_task_completed',
+			array(
+				'task_id' => 'site_title',
+				'surface' => 'somewhere_else',
+			)
+		);
+
+		list( , $props ) = self::captured_event( $events );
+		$this->assertSame( 'somewhere_else', $props['surface'] );
+		$this->assertSame( 'web', $props['channel'] );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Tracks_Props_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Tracks_Props_Test.php
@@ -125,6 +125,21 @@ class AI_Launchpad_Tracks_Props_Test extends \WorDBless\BaseTestCase {
 		update_option( 'siteurl', 'https://copons.jurassic.tube' );
 		update_option( 'home', 'https://copons.jurassic.tube' );
 		$this->assertTrue( wpcom_ai_launchpad_is_test() );
+
+		// The host match is case-insensitive.
+		update_option( 'siteurl', 'https://DEMO.Jurassic.Ninja' );
+		update_option( 'home', 'https://DEMO.Jurassic.Ninja' );
+		$this->assertTrue( wpcom_ai_launchpad_is_test() );
+
+		// A suffix match, not a substring match: a host that merely contains the marker, before
+		// or after the real suffix, is not a test host.
+		update_option( 'siteurl', 'https://jurassic.ninja.evil.com' );
+		update_option( 'home', 'https://jurassic.ninja.evil.com' );
+		$this->assertFalse( wpcom_ai_launchpad_is_test() );
+
+		update_option( 'siteurl', 'https://notjurassic.ninja' );
+		update_option( 'home', 'https://notjurassic.ninja' );
+		$this->assertFalse( wpcom_ai_launchpad_is_test() );
 	}
 
 	/**
@@ -145,17 +160,45 @@ class AI_Launchpad_Tracks_Props_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * The identity bundle exists only on Atomic, where nothing else pushes identifyUser, and
-	 * never carries the email address the Tracks client helper also returns.
+	 * The identity bundle exists only on Atomic; on Simple it is always null.
 	 */
-	public function test_tracks_identity_is_atomic_only_and_carries_no_email() {
+	public function test_tracks_identity_is_null_on_simple() {
 		Constants::set_constant( 'IS_WPCOM', true );
 		$this->assertNull( wpcom_ai_launchpad_tracks_identity() );
+	}
 
-		Constants::set_constant( 'IS_WPCOM', false );
-		$identity = wpcom_ai_launchpad_tracks_identity();
-		if ( null !== $identity ) {
-			$this->assertSame( array( 'userid', 'username' ), array_keys( $identity ) );
-		}
+	/**
+	 * The shaping step is what actually enforces "no email, no blog id, no locale" — it rebuilds
+	 * the array from scratch rather than unsetting keys, so a field the client helper adds later
+	 * cannot leak through by default.
+	 */
+	public function test_shape_tracks_identity_strips_everything_but_id_and_login() {
+		$raw = array(
+			'blogid'      => 1,
+			'email'       => 'someone@example.com',
+			'userid'      => 7,
+			'username'    => 'copons',
+			'user_locale' => 'en',
+		);
+
+		$shaped = wpcom_ai_launchpad_shape_tracks_identity( $raw );
+
+		$this->assertSame(
+			array(
+				'userid'   => 7,
+				'username' => 'copons',
+			),
+			$shaped
+		);
+		$this->assertArrayNotHasKey( 'email', $shaped );
+	}
+
+	/**
+	 * An identity that isn't usable — no connected user, or a partial record — shapes to null.
+	 */
+	public function test_shape_tracks_identity_is_null_for_unusable_input() {
+		$this->assertNull( wpcom_ai_launchpad_shape_tracks_identity( false ) );
+		$this->assertNull( wpcom_ai_launchpad_shape_tracks_identity( array( 'username' => 'copons' ) ) );
+		$this->assertNull( wpcom_ai_launchpad_shape_tracks_identity( array( 'userid' => 7 ) ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Tracks_Props_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Tracks_Props_Test.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Tests for the AI Launchpad Tracks standard properties.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Constants;
+
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/helpers.php';
+
+/**
+ * Test class for the AI Launchpad Tracks standard properties.
+ */
+class AI_Launchpad_Tracks_Props_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		Constants::clear_constants();
+		delete_option( 'wpcom_ai_launchpad_ai_output' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Persists a tailored envelope with the given source and session id.
+	 *
+	 * @param string      $source     'ai' or 'fallback'.
+	 * @param string|null $session_id The session id to persist, or null to omit the key.
+	 */
+	private function seed_envelope( $source, $session_id = null ) {
+		$envelope = array(
+			'version'      => 1,
+			'source'       => $source,
+			'generated_at' => 1750000000,
+			'payload'      => array( 'tasks' => array() ),
+		);
+		if ( null !== $session_id ) {
+			$envelope['ai_session_id'] = $session_id;
+		}
+		update_option( 'wpcom_ai_launchpad_ai_output', $envelope, false );
+	}
+
+	/**
+	 * The constant properties never vary.
+	 */
+	public function test_constant_props() {
+		$props = wpcom_ai_launchpad_standard_props();
+
+		$this->assertSame( 'web', $props['channel'] );
+		$this->assertSame( 'dashboard', $props['surface'] );
+		$this->assertSame( 'admin.php', $props['screen'] );
+		$this->assertSame( 'experiment_wpcom_launchpad_personalization_202607_v1', $props['ref'] );
+		$this->assertSame( 'ai_launchpad', $props['agent_name'] );
+		$this->assertSame( \Automattic\Jetpack\Jetpack_Mu_Wpcom::PACKAGE_VERSION, $props['agent_version'] );
+	}
+
+	/**
+	 * Before tailoring has run, the three tailoring-scoped props report the string "none",
+	 * never null: null breaks group-by aggregations downstream.
+	 */
+	public function test_tailoring_props_default_to_none() {
+		$props = wpcom_ai_launchpad_standard_props();
+
+		$this->assertSame( 'none', $props['source'] );
+		$this->assertSame( 'none', $props['outcome'] );
+		$this->assertSame( 'none', $props['ai_session_id'] );
+	}
+
+	/**
+	 * An AI-sourced list reports outcome success; the fallback reports error.
+	 */
+	public function test_outcome_is_derived_from_source() {
+		$this->seed_envelope( 'ai' );
+		$props = wpcom_ai_launchpad_standard_props();
+		$this->assertSame( 'ai', $props['source'] );
+		$this->assertSame( 'success', $props['outcome'] );
+
+		$this->seed_envelope( 'fallback' );
+		$props = wpcom_ai_launchpad_standard_props();
+		$this->assertSame( 'fallback', $props['source'] );
+		$this->assertSame( 'error', $props['outcome'] );
+	}
+
+	/**
+	 * The session id is read from the persisted envelope, and an envelope written before the
+	 * key existed still reports "none" rather than an empty string.
+	 */
+	public function test_ai_session_id_is_read_from_the_envelope() {
+		$this->seed_envelope( 'ai', 'a755f9e8-8e0a-45be-81bc-524aaf8e2703' );
+		$props = wpcom_ai_launchpad_standard_props();
+		$this->assertSame( 'a755f9e8-8e0a-45be-81bc-524aaf8e2703', $props['ai_session_id'] );
+
+		$this->seed_envelope( 'ai', '' );
+		$props = wpcom_ai_launchpad_standard_props();
+		$this->assertSame( 'none', $props['ai_session_id'] );
+	}
+
+	/**
+	 * The site_type prop reports the hosting platform, not the kind of site the user is building.
+	 */
+	public function test_site_type_follows_the_platform() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->assertSame( 'simple', wpcom_ai_launchpad_standard_props()['site_type'] );
+
+		Constants::set_constant( 'IS_WPCOM', false );
+		$this->assertSame( 'atomic', wpcom_ai_launchpad_standard_props()['site_type'] );
+	}
+
+	/**
+	 * The is_test check is environment-based. A production Atomic site is never a test site,
+	 * however the request reached it — that distinction is what is_a11n is for.
+	 */
+	public function test_is_test_is_environment_based() {
+		update_option( 'siteurl', 'https://example.wordpress.com' );
+		update_option( 'home', 'https://example.wordpress.com' );
+		$this->assertFalse( wpcom_ai_launchpad_is_test() );
+
+		update_option( 'siteurl', 'https://demo.jurassic.ninja' );
+		update_option( 'home', 'https://demo.jurassic.ninja' );
+		$this->assertTrue( wpcom_ai_launchpad_is_test() );
+
+		update_option( 'siteurl', 'https://copons.jurassic.tube' );
+		update_option( 'home', 'https://copons.jurassic.tube' );
+		$this->assertTrue( wpcom_ai_launchpad_is_test() );
+	}
+
+	/**
+	 * A proxied request marks the user, not the environment: is_a11n true, is_test untouched.
+	 */
+	public function test_is_a11n_on_atomic_follows_the_proxy() {
+		update_option( 'siteurl', 'https://example.wordpress.com' );
+		update_option( 'home', 'https://example.wordpress.com' );
+		Constants::set_constant( 'IS_WPCOM', false );
+
+		$this->assertFalse( wpcom_ai_launchpad_is_a11n() );
+		$this->assertFalse( wpcom_ai_launchpad_is_test() );
+
+		Constants::set_constant( 'AT_PROXIED_REQUEST', true );
+
+		$this->assertTrue( wpcom_ai_launchpad_is_a11n() );
+		$this->assertFalse( wpcom_ai_launchpad_is_test() );
+	}
+
+	/**
+	 * The identity bundle exists only on Atomic, where nothing else pushes identifyUser, and
+	 * never carries the email address the Tracks client helper also returns.
+	 */
+	public function test_tracks_identity_is_atomic_only_and_carries_no_email() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->assertNull( wpcom_ai_launchpad_tracks_identity() );
+
+		Constants::set_constant( 'IS_WPCOM', false );
+		$identity = wpcom_ai_launchpad_tracks_identity();
+		if ( null !== $identity ) {
+			$this->assertSame( array( 'userid', 'username' ), array_keys( $identity ) );
+		}
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Tracks_Props_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Tracks_Props_Test.php
@@ -160,6 +160,35 @@ class AI_Launchpad_Tracks_Props_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * `is_test` and `is_a11n` are the underlying booleans stringified to 'true'/'false' in the
+	 * props array — never PHP bools — because the two Tracks recorders' encoders disagree on
+	 * how a bool serializes (http_build_query() gives "1"/"0", encodeURIComponent() gives
+	 * "true"/"false"). The raw functions themselves stay real booleans; only this array
+	 * stringifies them.
+	 */
+	public function test_is_test_and_is_a11n_are_stringified_in_props() {
+		update_option( 'siteurl', 'https://example.wordpress.com' );
+		update_option( 'home', 'https://example.wordpress.com' );
+		Constants::set_constant( 'IS_WPCOM', false );
+
+		$props = wpcom_ai_launchpad_standard_props();
+		$this->assertSame( 'false', $props['is_test'] );
+		$this->assertSame( 'false', $props['is_a11n'] );
+		$this->assertFalse( wpcom_ai_launchpad_is_test() );
+		$this->assertFalse( wpcom_ai_launchpad_is_a11n() );
+
+		update_option( 'siteurl', 'https://demo.jurassic.ninja' );
+		update_option( 'home', 'https://demo.jurassic.ninja' );
+		Constants::set_constant( 'AT_PROXIED_REQUEST', true );
+
+		$props = wpcom_ai_launchpad_standard_props();
+		$this->assertSame( 'true', $props['is_test'] );
+		$this->assertSame( 'true', $props['is_a11n'] );
+		$this->assertTrue( wpcom_ai_launchpad_is_test() );
+		$this->assertTrue( wpcom_ai_launchpad_is_a11n() );
+	}
+
+	/**
 	 * The identity bundle exists only on Atomic; on Simple it is always null.
 	 */
 	public function test_tracks_identity_is_null_on_simple() {


### PR DESCRIPTION
Part of DOTOBRD-583

## Proposed changes

The Data team audited the 15 `jetpack_ai_launchpad_*` events (158,871 fires in the 30 days to 2026-08-10) and found that none of them carries an AI standard property. `is_a11n` and `is_test` are the ones that matter now: the feature went through moderated user testing in July and internal use continues, so the wizard completion rate and the task completion rate both currently mix Automattician activity into the number with no way to take it back out. `source` — whether a user got an AI checklist or the static fallback — reaches Logstash but not Tracks, so every rate the project cares about pools the two into one number, which makes the AI's contribution unmeasurable. And `jetpack_ai_launchpad_viewed` carries `blog_id` on only 95.3% of fires, understating every per-site rate that uses it as a denominator.

The instrumentation already routed every event through a wrapper, so this is one function rather than 14 call sites — except there are two wrappers, a PHP one and a TypeScript one, and they have to agree.

* Add `wpcom_ai_launchpad_standard_props()` as the single source of truth for the 13 standard properties. The server recorder merges its return value; the Site Setup page JSON-encodes the same array into a `window.wpcomAiLaunchpadTracks` global that the client recorder reads. Neither side re-derives a value the other computes.
* Send `blog_id` explicitly rather than relying on the Tracks super prop.
* Mint an `ai_session_id` per tailoring run, so a re-tailored checklist can be told apart from the first one. The client mints it, sends it on `PUT /tailored`, and the server persists it on the AI-output envelope, so it survives a reload.
* **Load the Tracks transport on Atomic.** This one is not in the audit. `window._tkq` is an ordinary array until `stats.wp.com/w.js` replaces its `push`; on Simple, wpcom's `stats.php` loads that on every admin page, and on Atomic nothing does. Every other Jetpack surface that needs it enqueues it itself. The Site Setup page never did, so on Atomic all 12 client-fired events accumulated in a dead array and were discarded on unload — which is why `task_completed` and `all_tasks_completed`, the two PHP-fired events, are the only two at 100% `blog_id` in the audit's table. The enqueue is gated on `should_enable_tracking()`, matching `wpcom_enqueue_tracking_scripts()`.
* Widen the package's JS test glob. It matched `src/**/test/*.test.mjs`, so all 14 `.test.mts` suites in this package — 13 of which predate this PR — had never run in CI. They pass; the added wall-clock is ~140ms.

`is_test` and `is_a11n` are sent as the strings `'true'`/`'false'`, not booleans, because the two recorders' encoders disagree: PHP's Tracks clients end in `http_build_query()` (`false` → `0`) and the JS transport uses `encodeURIComponent()` (`false` → `false`). Left as booleans, `task_completed` would carry `is_a11n=1` while the client events carried `is_a11n=true`, and any single filter would silently drop or keep half the funnel.

`is_test` is environment-based only (localhost, `*.jurassic.tube`, `*.jurassic.ninja`) and `is_a11n` is user-based, kept independently filterable as the standard requires. The standard's internal-Atomic-client-ID clause for `is_test` is deliberately not implemented: the reference implementation gates it behind `AT_PROXIED_REQUEST`, which would make `is_test` user-based again, and ungated it would risk reporting real Atomic sites as tests.

**Expect a step change in the data**, not an anomaly: 12 events that have never fired on Atomic will start firing.

Out of scope, tracked separately: registering the 14 live events, and correcting the two event names in the project's success metrics that do not exist (`ai_response_received` was retired in #50606, `jetpack_ai_launchpad_launched` never shipped).

## Related product discussion/links

* DOTOBRD-583
* #50606, which built this instrumentation and retired the event that used to carry `source`
* Experiment `wpcom_launchpad_personalization_202607_v1`, the running experiment these events measure
* Standard: the "Tracks Standards for AI Product Events" Field Guide page

## Does this pull request change what data or activity we track or use?

Yes — it is the entire point of the PR. No new personal data is collected.

Every `jetpack_ai_launchpad_*` event gains: `channel`, `surface`, `screen`, `ref`, `site_type`, `agent_name`, `agent_version`, `is_test`, `is_a11n`, `blog_id`, `source`, `outcome`, `ai_session_id`. All are constants, enums, booleans-as-strings, the site's blog id, or a generated UUID.

Two points worth a reviewer's attention:

* `is_a11n` records whether an Automattician is acting on the site. It is a flag, not an identity, and it exists so Automattician activity can be subtracted from the rates rather than silently inflating them.
* `identifyUser` is now pushed on Atomic, where nothing else does it, using the connected user's Tracks identity. The helper that supplies it returns an email address alongside the id and login; this rebuilds the array from scratch with only `userid` and `username`, so the email cannot reach the page. `wpcom_ai_launchpad_shape_tracks_identity()` is unit-tested for exactly that.

No support documentation is affected — there is no user-facing change.

## Testing instructions

The client-side half only fires where the Tracks transport is loaded, so **test on an Atomic site** — before this PR, none of the client events reached Tracks there at all.

1. On an Atomic test site, enable the feature: visit any admin page with `?enable-ai-launchpad=1`, then go to **Site Setup**.
2. In the console, confirm the bootstrap and the transport:
   * `window.wpcomAiLaunchpadTracks.props` — `is_test` and `is_a11n` are the **strings** `'false'`/`'true'`, not `""`. (A string `""` would mean the value went through `wp_localize_script()`, which stringifies everything.)
   * `props.site_type` is `atomic`, `props.blog_id` is the site's WordPress.com blog id as a number.
   * `window.wpcomAiLaunchpadTracks.identity` has exactly `userid` and `username`, and no `email`.
   * `document.querySelector('script[src*="stats.wp.com/w.js"]')` is non-null, and `window._tkq.push !== Array.prototype.push` — the real Tracks client has replaced the array. On trunk this is `false`.
3. Run the wizard end to end. In the network panel, filter for `pixel.wp.com` and confirm `jetpack_ai_launchpad_*` requests are actually sent. Check that `jetpack_ai_launchpad_viewed` carries `blog_id`, `is_a11n`, `agent_name`, and `source=none`.
4. Once the tasklist renders, click a collapsed task. `jetpack_ai_launchpad_task_clicked` should now carry a real `source` (`ai` or `fallback`), the matching `outcome` (`success` or `error`), and a UUID `ai_session_id`.
5. Reset with `?reset-ai-launchpad=1` and run the wizard again — the second run's `ai_session_id` must differ from the first.
6. On a Simple site, confirm `props.site_type` is `simple`, `identity` is `null`, and no second `w.js` tag was added (wpcom's `stats.php` already loads it there).
