### PR TITLE
Stats: escape the AMP tracking pixel markup at output

### DIFF
--- a/projects/packages/stats/changelog/stats-343-stats-amp-pixel-escape
+++ b/projects/packages/stats/changelog/stats-343-stats-amp-pixel-escape
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Escape the AMP tracking pixel markup at output with wp_kses().

--- a/projects/packages/stats/changelog/stats-343-stats-amp-pixel-escape
+++ b/projects/packages/stats/changelog/stats-343-stats-amp-pixel-escape
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Escape the AMP tracking pixel markup at output with wp_kses().
+Escape the AMP tracking pixel URL at output.

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -38,6 +38,12 @@ class Tracking_Pixel {
 		'utm_marketing_tactic',
 	);
 
+	private const AMP_PIXEL_ALLOWED_HTML = array(
+		'amp-pixel' => array(
+			'src' => true,
+		),
+	);
+
 	/**
 	 * Stats Build View Data.
 	 *
@@ -408,7 +414,7 @@ if ( document.readyState === "loading" ) {
 		}
 
 		$pixel = self::get_amp_footer( $data );
-		echo $pixel; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo wp_kses( $pixel, self::AMP_PIXEL_ALLOWED_HTML );
 	}
 
 	/**
@@ -455,7 +461,7 @@ if ( document.readyState === "loading" ) {
 	 * @param array $data Array of data for the AMP pixel tracker.
 	 */
 	public static function render_amp_footer( $data ) {
-		print self::get_amp_footer( $data ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo wp_kses( self::get_amp_footer( $data ), self::AMP_PIXEL_ALLOWED_HTML );
 	}
 
 	/**

--- a/projects/packages/stats/src/class-tracking-pixel.php
+++ b/projects/packages/stats/src/class-tracking-pixel.php
@@ -38,12 +38,6 @@ class Tracking_Pixel {
 		'utm_marketing_tactic',
 	);
 
-	private const AMP_PIXEL_ALLOWED_HTML = array(
-		'amp-pixel' => array(
-			'src' => true,
-		),
-	);
-
 	/**
 	 * Stats Build View Data.
 	 *
@@ -374,13 +368,13 @@ if ( document.readyState === "loading" ) {
 	}
 
 	/**
-	 * Gets the stats footer for AMP output.
+	 * Gets the tracking pixel URL for AMP output.
 	 *
 	 * @access private
 	 * @param array $data Array of data for the AMP pixel tracker.
-	 * @return string Returns the footer to add for the Stats tracker in an AMP scenario.
+	 * @return string Returns the URL for the Stats tracker in an AMP scenario.
 	 */
-	private static function get_amp_footer( $data ) {
+	private static function get_amp_pixel_url( $data ) {
 		/**
 		 * Filter the parameters added to the AMP pixel tracking code.
 		 *
@@ -396,8 +390,7 @@ if ( document.readyState === "loading" ) {
 		$data['rand'] = 'RANDOM'; // AMP placeholder.
 		$data['ref']  = 'DOCUMENT_REFERRER'; // AMP placeholder.
 		$data         = array_map( 'rawurlencode', $data );
-		$pixel_url    = add_query_arg( $data, 'https://pixel.wp.com/g.gif' );
-		return '<amp-pixel src="' . esc_url( $pixel_url ) . '"></amp-pixel>';
+		return add_query_arg( $data, 'https://pixel.wp.com/g.gif' );
 	}
 
 	/**
@@ -413,8 +406,7 @@ if ( document.readyState === "loading" ) {
 			return;
 		}
 
-		$pixel = self::get_amp_footer( $data );
-		echo wp_kses( $pixel, self::AMP_PIXEL_ALLOWED_HTML );
+		printf( '<amp-pixel src="%s"></amp-pixel>', esc_url( self::get_amp_pixel_url( $data ) ) );
 	}
 
 	/**
@@ -461,7 +453,7 @@ if ( document.readyState === "loading" ) {
 	 * @param array $data Array of data for the AMP pixel tracker.
 	 */
 	public static function render_amp_footer( $data ) {
-		echo wp_kses( self::get_amp_footer( $data ), self::AMP_PIXEL_ALLOWED_HTML );
+		printf( '<amp-pixel src="%s"></amp-pixel>', esc_url( self::get_amp_pixel_url( $data ) ) );
 	}
 
 	/**

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -448,6 +448,83 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 	}
 
 	/**
+	 * Asserts that the markup is a lone <amp-pixel> element and returns its src with the HTML
+	 * character references decoded. Escaping is free to pick either spelling of an encoded
+	 * ampersand, so the URL the browser ends up requesting is what the tests pin down.
+	 *
+	 * @param string $markup The emitted AMP pixel markup.
+	 * @return string The decoded src URL.
+	 */
+	private function amp_pixel_src( $markup ) {
+		$matched = (bool) preg_match( '~^<amp-pixel src="([^"]*)"></amp-pixel>$~', $markup, $matches );
+		$this->assertTrue( $matched, "Expected a single <amp-pixel> element, got: $markup" );
+		return html_entity_decode( $matches[1], ENT_QUOTES | ENT_HTML5 );
+	}
+
+	/**
+	 * Test for Tracking_Pixel::render_amp_footer.
+	 */
+	public function test_render_amp_footer_prints_the_pixel_url_intact() {
+		$_SERVER['HTTP_HOST'] = '127.0.0.1';
+		$data                 = array(
+			'v'    => 'ext',
+			'blog' => 1234,
+			'post' => 0,
+			'tz'   => false,
+			'srv'  => 'example.org',
+		);
+
+		ob_start();
+		Tracking_Pixel::render_amp_footer( $data );
+		$output = (string) ob_get_clean();
+
+		$expected_url = 'https://pixel.wp.com/g.gif?v=ext&blog=1234&post=0&tz&srv=example.org&host=127.0.0.1&rand=RANDOM&ref=DOCUMENT_REFERRER';
+		$this->assertSame( $expected_url, $this->amp_pixel_src( $output ) );
+	}
+
+	/**
+	 * Test for Tracking_Pixel::add_amp_pixel on an AMP request.
+	 */
+	public function test_add_amp_pixel_prints_the_pixel_on_an_amp_request() {
+		global $wp_the_query;
+		$wp_the_query->is_home = true;
+		$_SERVER['HTTP_HOST']  = '127.0.0.1';
+
+		$output = '';
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		try {
+			ob_start();
+			Tracking_Pixel::add_amp_pixel();
+			$output = (string) ob_get_clean();
+		} finally {
+			remove_filter( 'jetpack_is_amp_request', '__return_true' );
+		}
+
+		$expected_url = 'https://pixel.wp.com/g.gif?v=ext&blog=1234&post=0&tz&srv=example.org&utm_id=some_id&utm_source=a_source&arch_home=1&host=127.0.0.1&rand=RANDOM&ref=DOCUMENT_REFERRER';
+		$this->assertSame( $expected_url, $this->amp_pixel_src( $output ) );
+	}
+
+	/**
+	 * Test for Tracking_Pixel::add_amp_pixel on a request that is not AMP.
+	 */
+	public function test_add_amp_pixel_prints_nothing_on_a_non_amp_request() {
+		global $wp_the_query;
+		$wp_the_query->is_home = true;
+
+		$output = '';
+		add_filter( 'jetpack_is_amp_request', '__return_false' );
+		try {
+			ob_start();
+			Tracking_Pixel::add_amp_pixel();
+			$output = (string) ob_get_clean();
+		} finally {
+			remove_filter( 'jetpack_is_amp_request', '__return_false' );
+		}
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
 	 * Mock filter function to test the use of stats_array filter.
 	 *
 	 * @param array $kvs The stats array in key values.

--- a/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
+++ b/projects/packages/stats/tests/php/Tracking_Pixel_Test.php
@@ -420,66 +420,51 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 	}
 
 	/**
-	 * Test for Tracking_Pixel::test_get_footer_to_add for an amp request
+	 * Sample view data for the AMP pixel tests.
+	 *
+	 * @return array
 	 */
-	public function test_get_amp_footer() {
-		$_SERVER['HTTP_HOST'] = '127.0.0.1';
-		$data                 = array(
+	private function amp_pixel_data() {
+		return array(
 			'v'    => 'ext',
 			'blog' => 1234,
 			'post' => 0,
 			'tz'   => false,
 			'srv'  => 'example.org',
 		);
-		add_filter( 'jetpack_is_amp_request', '__return_true' );
+	}
 
-		$method = new \ReflectionMethod( Tracking_Pixel::class, 'get_amp_footer' );
+	/**
+	 * Test for Tracking_Pixel::get_amp_pixel_url.
+	 */
+	public function test_get_amp_pixel_url() {
+		$_SERVER['HTTP_HOST'] = '127.0.0.1';
+
+		$method = new \ReflectionMethod( Tracking_Pixel::class, 'get_amp_pixel_url' );
 		// @todo Remove this call once we no longer need to support PHP <8.1.
 		if ( PHP_VERSION_ID < 80100 ) {
 			$method->setAccessible( true );
 		}
-
-		$amp_footer_data = $method->invoke( new Tracking_Pixel(), $data );
-
-		remove_filter( 'jetpack_is_amp_request', '__return_true' );
-
-		$footer_to_add_should_be = '<amp-pixel src="https://pixel.wp.com/g.gif?v=ext&#038;blog=1234&#038;post=0&#038;tz&#038;srv=example.org&#038;host=127.0.0.1&#038;rand=RANDOM&#038;ref=DOCUMENT_REFERRER"></amp-pixel>';
-		$this->assertSame( $footer_to_add_should_be, $amp_footer_data );
-	}
-
-	/**
-	 * Asserts that the markup is a lone <amp-pixel> element and returns its src with the HTML
-	 * character references decoded. Escaping is free to pick either spelling of an encoded
-	 * ampersand, so the URL the browser ends up requesting is what the tests pin down.
-	 *
-	 * @param string $markup The emitted AMP pixel markup.
-	 * @return string The decoded src URL.
-	 */
-	private function amp_pixel_src( $markup ) {
-		$matched = (bool) preg_match( '~^<amp-pixel src="([^"]*)"></amp-pixel>$~', $markup, $matches );
-		$this->assertTrue( $matched, "Expected a single <amp-pixel> element, got: $markup" );
-		return html_entity_decode( $matches[1], ENT_QUOTES | ENT_HTML5 );
-	}
-
-	/**
-	 * Test for Tracking_Pixel::render_amp_footer.
-	 */
-	public function test_render_amp_footer_prints_the_pixel_url_intact() {
-		$_SERVER['HTTP_HOST'] = '127.0.0.1';
-		$data                 = array(
-			'v'    => 'ext',
-			'blog' => 1234,
-			'post' => 0,
-			'tz'   => false,
-			'srv'  => 'example.org',
-		);
-
-		ob_start();
-		Tracking_Pixel::render_amp_footer( $data );
-		$output = (string) ob_get_clean();
+		$pixel_url = $method->invoke( new Tracking_Pixel(), $this->amp_pixel_data() );
 
 		$expected_url = 'https://pixel.wp.com/g.gif?v=ext&blog=1234&post=0&tz&srv=example.org&host=127.0.0.1&rand=RANDOM&ref=DOCUMENT_REFERRER';
-		$this->assertSame( $expected_url, $this->amp_pixel_src( $output ) );
+		$this->assertSame( $expected_url, $pixel_url );
+	}
+
+	/**
+	 * Test for Tracking_Pixel::render_amp_footer. The Jetpack plugin calls this from its AMP
+	 * support layer, so the emitted markup is a contract: the ampersands stay encoded as &#038;
+	 * and the AMP placeholders RANDOM and DOCUMENT_REFERRER survive as query values.
+	 */
+	public function test_render_amp_footer_prints_the_pixel() {
+		$_SERVER['HTTP_HOST'] = '127.0.0.1';
+
+		ob_start();
+		Tracking_Pixel::render_amp_footer( $this->amp_pixel_data() );
+		$output = (string) ob_get_clean();
+
+		$expected = '<amp-pixel src="https://pixel.wp.com/g.gif?v=ext&#038;blog=1234&#038;post=0&#038;tz&#038;srv=example.org&#038;host=127.0.0.1&#038;rand=RANDOM&#038;ref=DOCUMENT_REFERRER"></amp-pixel>';
+		$this->assertSame( $expected, $output );
 	}
 
 	/**
@@ -500,8 +485,8 @@ class Tracking_Pixel_Test extends StatsBaseTestCase {
 			remove_filter( 'jetpack_is_amp_request', '__return_true' );
 		}
 
-		$expected_url = 'https://pixel.wp.com/g.gif?v=ext&blog=1234&post=0&tz&srv=example.org&utm_id=some_id&utm_source=a_source&arch_home=1&host=127.0.0.1&rand=RANDOM&ref=DOCUMENT_REFERRER';
-		$this->assertSame( $expected_url, $this->amp_pixel_src( $output ) );
+		$expected = '<amp-pixel src="https://pixel.wp.com/g.gif?v=ext&#038;blog=1234&#038;post=0&#038;tz&#038;srv=example.org&#038;utm_id=some_id&#038;utm_source=a_source&#038;arch_home=1&#038;host=127.0.0.1&#038;rand=RANDOM&#038;ref=DOCUMENT_REFERRER"></amp-pixel>';
+		$this->assertSame( $expected, $output );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
* The standalone Jetpack Stats plugin bundles this package. The WordPress.org plugin review flagged the two lines that echo the AMP tracking pixel, under "Variables and options must be escaped when echo'd". Both lines echoed a pre-built string behind a `phpcs:ignore`.
* The private builder now returns only the URL: `get_amp_footer()` becomes `get_amp_pixel_url()`. The `jetpack_stats_footer_amp_data` filter, the `host` / `rand` / `ref` values and the `add_query_arg()` call are unchanged. `add_amp_pixel()` and the public `render_amp_footer()` compose the element themselves with `printf( '<amp-pixel src="%s"></amp-pixel>', esc_url( $url ) )`, so the escaping happens at the output call. Both suppressions are removed.
* The markup is byte for byte what trunk emits, including the `&#038;` separators that `esc_url()` produces. I captured the trunk output first, and the tests assert the full string against it. This matters outside the package too: `projects/plugins/jetpack/3rd-party/class.jetpack-amp-support.php` calls `render_amp_footer()` directly.
* Note on `wp_kses()`: it cannot do this job without changing the output. On WordPress 7.0 and later, `wp_kses_hair()` reads attribute values through the HTML API, which decodes them and encodes the ampersands again, so `&#038;` becomes `&amp;`. The URL stays the same, but the bytes do not. `esc_url()` at the output call avoids that.

## Related product discussion/links
* [STATS-343](https://linear.app/a8c/issue/STATS-343/create-standalone-jetpack-stats-plugin)

## Does this pull request change what data or activity we track or use?
No. The AMP pixel requests the same URL with the same query parameters, and the markup does not change.

## Testing instructions
* Enable AMP on a site that runs Jetpack Stats, or the standalone Stats plugin, and make sure Stats is active.
* Open an AMP page and look at the page source. The `<amp-pixel src="https://pixel.wp.com/g.gif?...">` element is present, and it is identical to the element on trunk. The query string contains `v`, `blog`, `post`, `srv`, `host`, `rand=RANDOM` and `ref=DOCUMENT_REFERRER`, with `&#038;` between the parameters.
* Open the browser network tab and reload the AMP page. The request to `pixel.wp.com/g.gif` still occurs, and the view appears in Stats.
* Run `jp test php packages/stats`. The AMP tests assert the full markup string for both output paths.
