### PR TITLE
STATS-343: document the WordPress.com connection API in the readme

### DIFF
--- a/projects/plugins/stats/changelog/stats-343-readme-connection-api
+++ b/projects/plugins/stats/changelog/stats-343-readme-connection-api
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Document the WordPress.com connection API in the readme.
+Document the WordPress.com connection, Sync and daily site report in the readme.

--- a/projects/plugins/stats/changelog/stats-343-readme-connection-api
+++ b/projects/plugins/stats/changelog/stats-343-readme-connection-api
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Document the WordPress.com connection API in the readme.

--- a/projects/plugins/stats/readme.txt
+++ b/projects/plugins/stats/readme.txt
@@ -96,6 +96,12 @@ This plugin relies on WordPress.com, a service operated by Automattic, to record
 
 It connects to the following external services:
 
+**WordPress.com connection API (`https://jetpack.wordpress.com`)**
+
+* What it does: registers your site with WordPress.com and links it to your WordPress.com account. Every other service on this list needs that connection.
+* Data sent: when the site is registered, its address, home address, name, language, time zone, the plugin version, the path of the WordPress installation on the server, the date the site was created, the Stats site ID if the site already has one, the versions of the bundled Jetpack packages, the plugins that use the Jetpack connection, the email address and user ID of the administrator who starts the connection, and one-time secrets that WordPress.com uses to check the request. To approve the connection, your browser goes to this host with your WordPress user name and email address, the name, address and icon of the site, and the role you connect with. Your site then exchanges an authorization code for the tokens that sign all later requests. Disconnecting the site, or removing a user from the connection, also sends a request to this host.
+* When: when you connect the site, when you approve the connection with your WordPress.com account, when you disconnect the site or remove a user from the connection, and once a day when the plugin makes sure that it can still reach WordPress.com over a secure connection.
+
 **WordPress.com view-tracking pixel (`https://pixel.wp.com/g.gif`)**
 
 * What it does: records a page view each time a visitor loads a page on your site.

--- a/projects/plugins/stats/readme.txt
+++ b/projects/plugins/stats/readme.txt
@@ -98,15 +98,15 @@ It connects to the following external services:
 
 **WordPress.com connection API (`https://jetpack.wordpress.com`)**
 
-* What it does: registers your site with WordPress.com and links it to your WordPress.com account. Every other service on this list needs that connection.
-* Data sent: when the site is registered, its address, home address, name, language, time zone, the plugin version, the path of the WordPress installation on the server, the date the site was created, the Stats site ID if the site already has one, the versions of the bundled Jetpack packages, the plugins that use the Jetpack connection, the email address and user ID of the administrator who starts the connection, and one-time secrets that WordPress.com uses to check the request. To approve the connection, your browser goes to this host with your WordPress user name and email address, the name, address and icon of the site, and the role you connect with. Your site then exchanges an authorization code for the tokens that sign all later requests. Disconnecting the site, or removing a user from the connection, also sends a request to this host.
+* What it does: registers your site with WordPress.com and links it to your WordPress.com account. The view tracking, the reporting API and the data sync do not work without it. The dashboard interface is the exception: it loads before the site is connected, so that the plugin can offer you the connection.
+* Data sent: when the site is registered, its address, home address, name, language, time zone, the path of the WordPress installation on the server, the date the site was created, the Stats site ID if the site already has one, the versions of the bundled Jetpack packages, the version of the Jetpack plugin if the site has that plugin, the plugins that use the Jetpack connection, the email address and user ID of the administrator who starts the connection, one-time secrets that WordPress.com uses to check the request, and either the WordPress.com user ID of that administrator or, if they have no connected WordPress.com account, a random identifier that is also kept in a `tk_ai` cookie in their browser. To approve the connection, your browser goes to this host with your WordPress user name and email address, the name, address and icon of the site, and the role you connect with. Your site then exchanges an authorization code for the tokens that sign all later requests. Disconnecting the site, or removing a user from the connection, also sends a request to this host.
 * When: when you connect the site, when you approve the connection with your WordPress.com account, when you disconnect the site or remove a user from the connection, and once a day when the plugin makes sure that it can still reach WordPress.com over a secure connection.
 
 **WordPress.com view-tracking pixel (`https://pixel.wp.com/g.gif`)**
 
-* What it does: records a page view each time a visitor loads a page on your site.
-* Data sent: the page viewed, the referring URL, the visitor's IP address, the user agent, and your site ID.
-* When: on every front-end page view.
+* What it does: records a page view each time a visitor loads a page on your site. Once a day, a scheduled task also uses this address to report the state of your site, so that WordPress.com can keep the service working with the software your site runs.
+* Data sent: for a page view, the page viewed, the referring URL, the visitor's IP address, the user agent, and your site ID. For the daily report, your WordPress and PHP versions, whether the site is public, whether it is served over HTTPS, whether it can reach WordPress.com over a secure connection, the site language and character set, whether the site is part of a network, the names of the active plugins and must-use plugins, the size of the uploads folder, the first two groups of digits of the server IP address, the versions of the bundled Jetpack packages, the plugins that use the Jetpack connection, and whether the plugin found a problem with the connection. Your visitors are not part of the daily report.
+* When: a page view is recorded on every front-end page view. The daily report is sent by a scheduled task, and not more than once every 23 hours.
 
 **WordPress.com measurement script (`https://stats.wp.com/e-{year}.js`)**
 
@@ -119,6 +119,12 @@ It connects to the following external services:
 * What it does: returns the aggregated statistics displayed in your Stats dashboard.
 * Data sent: your site ID and the report parameters (date ranges, metric requested). Requires an authenticated WordPress.com connection.
 * When: whenever you open the Stats dashboard or load a report.
+
+**WordPress.com Sync (`https://public-api.wordpress.com`)**
+
+* What it does: keeps a copy of your site's content and settings on WordPress.com. The reports need it to show post titles, authors and categories, and the service needs it to know how your site is set up. If your site cannot use this address, the same data goes to `https://jetpack.wordpress.com/xmlrpc.php` instead.
+* Data sent: your posts, pages, other post types and media, with their text, authors, categories, tags and publication state; your comments, with the name, email address and website that the commenter gave; your users, with their user names, email addresses, display names, roles and permissions, but never their passwords; your site settings, menus and theme; and the list of plugins and themes on the site with their versions and available updates.
+* When: continuously, as content and settings change, and in full when the site connects or when WordPress.com has to rebuild its copy.
 
 **WordPress.com dashboard assets (`https://widgets.wp.com/odyssey-stats/`)**
 


### PR DESCRIPTION
## Proposed changes

The WordPress.org plugin review asks for every external host to be named with what it does, what data it sends, and when. The `== External services ==` section of the Stats readme was missing one host outright and understating two others, so this fills the gaps. Documentation only — no code changes.

* **Adds `jetpack.wordpress.com`.** The bundled connection package uses it for site registration, the authorization redirect, the token exchange, disconnecting the site or unlinking a user, and a once-a-day check that the site can still reach WordPress.com over TLS. It was not named anywhere in the readme.
* **Adds the daily site report to the `pixel.wp.com` entry.** `Heartbeat::cron_exec()` sends the WordPress and PHP versions, the public/HTTPS/multisite flags, language and charset, the active plugins and mu-plugins, the uploads-folder size and the first two octets of the server IP through `A8c_Mc_Stats` to `pixel.wp.com/g.gif`. The entry described visitor view tracking only. The bullet says outright that visitors are not part of that ping.
* **Adds a Sync entry.** The plugin calls `Config::ensure( 'sync' )`, so posts, comments, users, settings, plugins and themes go to `public-api.wordpress.com` (`/sites/<id>/jetpack-sync-actions`), falling back to `jetpack.wordpress.com/xmlrpc.php`. None of that was documented. Post content is synced, not just metadata, and the entry says so; it also says that user passwords are not.
* **Narrows two claims** after review feedback: the dashboard assets do load before the site is connected (`Stats_Admin\Main::needs_own_dashboard()`), so the connection entry no longer says every other service needs the connection; and the standalone plugin defines only `JETPACK_STATS_PLUGIN__VERSION`, so `jetpack_version` in the registration body is the Jetpack plugin's version when that plugin is installed and empty otherwise.

Every claim is read off the code rather than off existing docs: `Manager::register()` and `Utils::filter_register_request_body()` for the registration body, `Manager::get_authorization_url()` and `Tokens::get()` for the authorization and token exchange, `Heartbeat::get_environment_stats()` and `Manager::add_stats_to_heartbeat()` for the daily report, and `Modules::DEFAULT_SYNC_MODULES` for the sync scope.

## Related product discussion/links

* [STATS-343](https://linear.app/a8c/issue/STATS-343/create-standalone-jetpack-stats-plugin)

## Does this pull request change what data or activity we track or use?

No. It describes data flows that already exist. Nothing is added, removed or changed.

## Testing instructions

* Read the `== External services ==` section of `projects/plugins/stats/readme.txt` and check each entry against the code it describes:
  * connection API — `Manager::register()`, `Utils::filter_register_request_body()`, `Manager::get_authorization_url()`, `Tokens::get()`, `jetpack.deregister` / `jetpack.unlink_user`, `Heartbeat::permit_ssl()` (all in `projects/packages/connection/src/`).
  * daily site report — `Heartbeat::cron_exec()` and `Heartbeat::get_environment_stats()` in `projects/packages/connection/src/class-heartbeat.php`, `Manager::add_stats_to_heartbeat()`, and `projects/packages/a8c-mc-stats/src/class-a8c-mc-stats.php`.
  * Sync — `Modules::DEFAULT_SYNC_MODULES` and `Actions::send_data()` in `projects/packages/sync/src/`.
* Please flag anything that reads as too vague or too technical for a site owner, and anything that claims more or less than the code does. Getting the level right matters more than the wording here.
* Optional: paste the readme into the [WordPress.org readme validator](https://wordpress.org/plugins/developers/readme-validator/) to confirm that the section still parses.
