### PR TITLE
STATS-343: Admin UI: enqueue the core-notice CSS instead of printing a style element

### DIFF
--- a/projects/packages/admin-ui/changelog/stats-343-admin-ui-hide-notices-style
+++ b/projects/packages/admin-ui/changelog/stats-343-admin-ui-hide-notices-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enqueue the CSS that hides core admin notices on Jetpack pages through wp_add_inline_style() instead of printing a style element.

--- a/projects/packages/admin-ui/changelog/stats-343-admin-ui-hide-notices-style
+++ b/projects/packages/admin-ui/changelog/stats-343-admin-ui-hide-notices-style
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Enqueue the CSS that hides core admin notices on Jetpack pages through wp_add_inline_style() instead of printing a style element.
+Load the CSS that hides core admin notices on Jetpack pages through the style queue instead of printing a style element.

--- a/projects/packages/admin-ui/changelog/stats-343-admin-ui-hide-notices-style-deprecation
+++ b/projects/packages/admin-ui/changelog/stats-343-admin-ui-hide-notices-style-deprecation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Deprecate Admin_Menu::print_hide_core_admin_notices_style(); hide_core_admin_notices() enqueues the CSS now.

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -261,6 +261,18 @@ class Admin_Menu {
 	}
 
 	/**
+	 * Prints the inline style that hides WordPress core admin notices.
+	 *
+	 * @deprecated $$next-version$$ Use hide_core_admin_notices(), which enqueues the CSS.
+	 *
+	 * @return void
+	 */
+	public static function print_hide_core_admin_notices_style() {
+		_deprecated_function( __METHOD__, 'admin-ui-$$next-version$$', __CLASS__ . '::hide_core_admin_notices' );
+		self::hide_core_admin_notices();
+	}
+
+	/**
 	 * Gets the CSS that hides WordPress core admin notices.
 	 *
 	 * We only target direct children of #wpbody-content (where core renders notices via the

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -261,7 +261,12 @@ class Admin_Menu {
 	}
 
 	/**
-	 * Prints the inline style that hides WordPress core admin notices.
+	 * Enqueues the CSS that hides WordPress core admin notices.
+	 *
+	 * Callers must run this before WordPress flushes the style queue in
+	 * print_admin_styles() (admin_print_styles, priority 20). Later than that,
+	 * the handle is never printed. The previous admin_print_styles priority-10
+	 * hook still works.
 	 *
 	 * @deprecated $$next-version$$ Use hide_core_admin_notices(), which enqueues the CSS.
 	 *

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -47,6 +47,13 @@ class Admin_Menu {
 	const DESIGN_TOKENS_HANDLE = 'jetpack-admin-ui-design-tokens';
 
 	/**
+	 * Handle for the source-less stylesheet that hides WordPress core admin notices.
+	 *
+	 * @var string
+	 */
+	const HIDE_CORE_NOTICES_HANDLE = 'jetpack-admin-ui-hide-core-notices';
+
+	/**
 	 * Whether this class has been initialized
 	 *
 	 * @var boolean
@@ -236,36 +243,42 @@ class Admin_Menu {
 	}
 
 	/**
-	 * Queues an inline style that hides WordPress core admin notices on the current Jetpack page.
+	 * Enqueues the stylesheet that hides WordPress core admin notices on the current Jetpack page.
 	 *
-	 * Hooked from the page's load-<hook> action so it only runs on Jetpack screens.
+	 * Hooked from the page's load-<hook> action so it only runs on Jetpack screens. That action
+	 * runs before admin_enqueue_scripts, so the handle is queued in time to be printed.
 	 *
 	 * @return void
 	 */
 	public static function hide_core_admin_notices() {
-		add_action( 'admin_print_styles', array( __CLASS__, 'print_hide_core_admin_notices_style' ) );
+		// wp_add_inline_style() appends, so the CSS is attached only while the handle is new to the request.
+		if ( ! wp_style_is( self::HIDE_CORE_NOTICES_HANDLE, 'registered' ) ) {
+			wp_register_style( self::HIDE_CORE_NOTICES_HANDLE, false, array(), self::PACKAGE_VERSION );
+			wp_add_inline_style( self::HIDE_CORE_NOTICES_HANDLE, self::get_hide_core_admin_notices_styles() );
+		}
+
+		wp_enqueue_style( self::HIDE_CORE_NOTICES_HANDLE );
 	}
 
 	/**
-	 * Prints the inline style that hides WordPress core admin notices.
+	 * Gets the CSS that hides WordPress core admin notices.
 	 *
 	 * We only target direct children of #wpbody-content (where core renders notices via the
 	 * admin_notices / all_admin_notices hooks). This intentionally leaves JITMs untouched —
 	 * they output `.jetpack-jitm-message`, not `.notice` — and leaves in-app/React notices
-	 * untouched, since those render deeper inside `.wrap`. An inline style is used (rather than
-	 * an enqueued build asset) so it also works on older Jetpack pages that ship no stylesheet.
+	 * untouched, since those render deeper inside `.wrap`. The CSS rides on a source-less
+	 * handle rather than a build asset so it also reaches older Jetpack pages that ship no
+	 * stylesheet of their own.
 	 *
-	 * @return void
+	 * @return string CSS rules.
 	 */
-	public static function print_hide_core_admin_notices_style() {
-		?>
-		<style id="jetpack-admin-ui-hide-core-notices">
-			#wpbody-content > .notice,
-			#wpbody-content > .update-nag,
-			#wpbody-content > .updated,
-			#wpbody-content > .error { display: none !important; }
-		</style>
-		<?php
+	private static function get_hide_core_admin_notices_styles() {
+		return '
+		#wpbody-content > .notice,
+		#wpbody-content > .update-nag,
+		#wpbody-content > .updated,
+		#wpbody-content > .error { display: none !important; }
+		';
 	}
 
 	/**

--- a/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
@@ -240,7 +240,14 @@ class Admin_Menu_Test extends TestCase {
 	public function test_hide_core_admin_notices_css_is_scoped_to_jetpack_pages() {
 		$hook = Admin_Menu::add_menu( 'Test', 'Test', 'edit_posts', 'notices_scope_menu', '__return_null' );
 
-		do_action( 'load-toplevel_page_some_other_plugin' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+		wp_set_current_user( self::$admin_user_id );
+		set_current_screen( 'plugins' );
+
+		// Fire a hook that actually runs on every admin screen so this fails if
+		// the CSS is ever attached without a page check.
+		do_action( 'admin_enqueue_scripts', 'plugins.php' );
+
+		set_current_screen( 'front' );
 
 		$this->assertFalse(
 			wp_style_is( Admin_Menu::HIDE_CORE_NOTICES_HANDLE, 'registered' ),
@@ -271,6 +278,29 @@ class Admin_Menu_Test extends TestCase {
 		$this->assertSame( 1, substr_count( $output, '<style' ) );
 		$this->assertSame( 1, substr_count( $output, '#wpbody-content > .notice' ) );
 		$this->assertStringContainsString( 'jetpack-admin-ui-hide-core-notices-inline-css', $output );
+	}
+
+	/**
+	 * The deprecated print shim still enqueues the CSS and reports the deprecation.
+	 *
+	 * @return void
+	 */
+	public function test_print_hide_core_admin_notices_style_enqueues_and_is_deprecated() {
+		$deprecated = array();
+		$capture    = static function ( $function ) use ( &$deprecated ) {
+			$deprecated[] = $function;
+		};
+
+		add_filter( 'deprecated_function_trigger_error', '__return_false' );
+		add_action( 'deprecated_function_run', $capture );
+
+		Admin_Menu::print_hide_core_admin_notices_style();
+
+		remove_action( 'deprecated_function_run', $capture );
+		remove_filter( 'deprecated_function_trigger_error', '__return_false' );
+
+		$this->assertContains( Admin_Menu::class . '::print_hide_core_admin_notices_style', $deprecated );
+		$this->assertTrue( wp_style_is( Admin_Menu::HIDE_CORE_NOTICES_HANDLE, 'enqueued' ) );
 	}
 
 	/**

--- a/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
@@ -294,6 +294,7 @@ class Admin_Menu_Test extends TestCase {
 		add_filter( 'deprecated_function_trigger_error', '__return_false' );
 		add_action( 'deprecated_function_run', $capture );
 
+		// @phan-suppress-next-line PhanDeprecatedFunction -- This test is the contract for the deprecated shim.
 		Admin_Menu::print_hide_core_admin_notices_style();
 
 		remove_action( 'deprecated_function_run', $capture );

--- a/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
@@ -106,6 +106,8 @@ class Admin_Menu_Test extends TestCase {
 		wp_deregister_style( 'jetpack-admin-ui-upgrade-menu' );
 		wp_dequeue_script( 'jetpack-admin-ui-upgrade-menu' );
 		wp_deregister_script( 'jetpack-admin-ui-upgrade-menu' );
+		wp_dequeue_style( Admin_Menu::HIDE_CORE_NOTICES_HANDLE );
+		wp_deregister_style( Admin_Menu::HIDE_CORE_NOTICES_HANDLE );
 
 		$reflection = new \ReflectionClass( Admin_Menu::class );
 
@@ -209,35 +211,77 @@ class Admin_Menu_Test extends TestCase {
 	}
 
 	/**
-	 * Calling hide_core_admin_notices queues the inline style printer.
+	 * The core-notice CSS reaches the page through the style queue, not through a printed style element.
 	 *
 	 * @return void
 	 */
-	public function test_hide_core_admin_notices_queues_inline_style() {
+	public function test_hide_core_admin_notices_enqueues_the_css_as_an_inline_style() {
 		Admin_Menu::hide_core_admin_notices();
 
-		$this->assertNotFalse(
-			has_action( 'admin_print_styles', array( Admin_Menu::class, 'print_hide_core_admin_notices_style' ) ),
-			'Expected the inline style printer to be hooked to admin_print_styles.'
-		);
+		$this->assertTrue( wp_style_is( Admin_Menu::HIDE_CORE_NOTICES_HANDLE, 'enqueued' ) );
+		$this->assertFalse( wp_styles()->registered[ Admin_Menu::HIDE_CORE_NOTICES_HANDLE ]->src );
 
-		remove_action( 'admin_print_styles', array( Admin_Menu::class, 'print_hide_core_admin_notices_style' ) );
+		$css = implode( '', $this->get_hide_core_notices_css() );
+
+		$this->assertStringContainsString( '#wpbody-content > .notice', $css );
+		$this->assertStringContainsString( '#wpbody-content > .update-nag', $css );
+		$this->assertStringContainsString( '#wpbody-content > .updated', $css );
+		$this->assertStringContainsString( '#wpbody-content > .error', $css );
+		$this->assertStringNotContainsString( '<style', $css );
+		// JITMs render as `.jetpack-jitm-message`; the selector must not match them.
+		$this->assertStringNotContainsString( 'jetpack-jitm-message', $css );
 	}
 
 	/**
-	 * The printed style targets only direct-child core notices, leaving JITMs untouched.
+	 * The CSS loads on a Jetpack page's load hook and stays off every other admin screen.
 	 *
 	 * @return void
 	 */
-	public function test_print_hide_core_admin_notices_style_output() {
+	public function test_hide_core_admin_notices_css_is_scoped_to_jetpack_pages() {
+		$hook = Admin_Menu::add_menu( 'Test', 'Test', 'edit_posts', 'notices_scope_menu', '__return_null' );
+
+		do_action( 'load-toplevel_page_some_other_plugin' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+
+		$this->assertFalse(
+			wp_style_is( Admin_Menu::HIDE_CORE_NOTICES_HANDLE, 'registered' ),
+			'Expected no core-notice CSS on a screen that is not a Jetpack page.'
+		);
+
+		do_action( 'load-' . $hook ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+
+		$this->assertTrue( wp_style_is( Admin_Menu::HIDE_CORE_NOTICES_HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * The CSS is attached once even when the hide callback runs more than once in a request.
+	 *
+	 * @return void
+	 */
+	public function test_hide_core_admin_notices_adds_the_css_once() {
+		for ( $i = 0; $i < 2; $i++ ) {
+			Admin_Menu::hide_core_admin_notices();
+		}
+
+		$this->assertCount( 1, $this->get_hide_core_notices_css() );
+
 		ob_start();
-		Admin_Menu::print_hide_core_admin_notices_style();
+		wp_styles()->do_items( array( Admin_Menu::HIDE_CORE_NOTICES_HANDLE ) );
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'id="jetpack-admin-ui-hide-core-notices"', $output );
-		$this->assertStringContainsString( '#wpbody-content > .notice', $output );
-		// JITMs render as `.jetpack-jitm-message`; the selector must not match them.
-		$this->assertStringNotContainsString( 'jetpack-jitm-message', $output );
+		$this->assertSame( 1, substr_count( $output, '<style' ) );
+		$this->assertSame( 1, substr_count( $output, '#wpbody-content > .notice' ) );
+		$this->assertStringContainsString( 'jetpack-admin-ui-hide-core-notices-inline-css', $output );
+	}
+
+	/**
+	 * Gets the inline CSS attached to the core-notice style handle.
+	 *
+	 * @return array
+	 */
+	private function get_hide_core_notices_css() {
+		$data = wp_styles()->get_data( Admin_Menu::HIDE_CORE_NOTICES_HANDLE, 'after' );
+
+		return is_array( $data ) ? $data : array();
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

The `admin-ui` package builds the shared "Jetpack" admin menu that My Jetpack and every Jetpack standalone plugin hang their pages off. On each of those pages it printed a raw `<style id="jetpack-admin-ui-hide-core-notices">` element to hide WordPress core admin notices. The standalone Jetpack Stats plugin bundles the package, and the WordPress.org plugin review flagged that element under "Use wp_enqueue commands".

* The same CSS now rides on a source-less style handle (`jetpack-admin-ui-hide-core-notices`) registered from the page's `load-<hook>` action and attached with `wp_add_inline_style()`, so core prints it as part of the style queue.
* `Admin_Menu::print_hide_core_admin_notices_style()` stays as a deprecated shim (`@deprecated $$next-version$$`, `_deprecated_function()`) that delegates to `hide_core_admin_notices()`, for code outside the monorepo that may call it; the CSS lives in a private `get_hide_core_admin_notices_styles()`. `Admin_Menu::hide_core_admin_notices()` keeps its name and its `load-<hook>` / `load-<hook>-network` wiring, so page coverage is unchanged. Nothing in the monorepo calls the deprecated method outside this package's own tests.
* A `wp_style_is( $handle, 'registered' )` guard keeps the CSS to a single copy if the callback runs more than once in a request, since `wp_add_inline_style()` appends.

The selectors, the pages they apply to, and the "why" documentation (core notices only, JITMs and in-app notices left alone) are unchanged. This mirrors #51459 and #51460, which do the same move in the connection package.

## Related product discussion/links

* [STATS-343](https://linear.app/a8c/issue/STATS-343/create-standalone-jetpack-stats-plugin)
* #51459, #51460

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Activate a Jetpack plugin that uses the shared Jetpack menu (My Jetpack, Jetpack Stats, Jetpack Protect, etc.) so a core admin notice is showing — activating any plugin gives you the "Plugin activated." notice.
* Go to any page under the **Jetpack** menu.
* Core admin notices stay hidden, exactly as before. JITMs and in-app/React notices inside the page still show.
* View source. There is no `<style id="jetpack-admin-ui-hide-core-notices">` element any more. The same rules appear inside `<style id="jetpack-admin-ui-hide-core-notices-inline-css">`, printed with the rest of the enqueued styles in `<head>`.
* Go to a non-Jetpack screen (Dashboard, Plugins, Settings). Core notices still show there, and the handle is absent from the source.
* On multisite, repeat on a Jetpack page in Network Admin.

