### PR TITLE
[DO NOT MERGE] Expiry notices: stop the rollout (prepared revert, do not merge)

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/revert-expiry-notices-rollout
+++ b/projects/packages/jetpack-mu-wpcom/changelog/revert-expiry-notices-rollout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Expiry notices: stop the rollout.

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
@@ -41,7 +41,7 @@ if ( ! function_exists( 'wpcom_expiry_get_purchases' ) ) {
  * two halves drift and a site ends up with both notices or neither.
  */
 function wpcom_expiry_notices_rollout_percentage(): int {
-	return 20;
+	return 0;
 }
 
 /**
@@ -122,17 +122,20 @@ function wpcom_expiry_notices_is_enabled_for_site(): bool {
 	$percentage = wpcom_expiry_notices_rollout_percentage();
 	$override   = wpcom_expiry_notices_rollout_override();
 
-	if ( null !== $override ) {
-		// Hand-picked, either way. Checked first so a site can be pulled in
-		// ahead of its bucket or held out of one it already falls in.
+	if ( $percentage <= 0 ) {
+		// Zero means zero, including for hand-picked sites. Checked before the
+		// override so that stopping the rollout is one number, and no site
+		// carrying the option stays on the new notices.
+		$enabled = false;
+	} elseif ( null !== $override ) {
+		// Hand-picked, either way. Pulls a site in ahead of its bucket, or
+		// holds one out of a bucket it already falls in.
 		$enabled = $override;
 	} elseif ( $percentage >= 100 ) {
 		// Fully rolled out. Answered before resolving an ID so that a site
 		// whose blog ID can't be read still gets the notices at the end of the
 		// ramp, rather than being stranded outside it forever.
 		$enabled = true;
-	} elseif ( $percentage <= 0 ) {
-		$enabled = false;
 	} else {
 		$blog_id = wpcom_expiry_notices_wpcom_blog_id();
 		$enabled = $blog_id > 0 && ( $blog_id % 100 ) < $percentage;

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Rollout_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Rollout_Test.php
@@ -46,9 +46,9 @@ class Rollout_Test extends \WorDBless\BaseTestCase {
 		);
 	}
 
-	public function test_ships_at_the_intended_share(): void {
-		// Pinned so widening the rollout is a deliberate edit, not a drift.
-		$this->assertSame( 20, wpcom_expiry_notices_rollout_percentage() );
+	public function test_ships_stopped(): void {
+		// The rollout is stopped. Pinned so restarting it is a deliberate edit.
+		$this->assertSame( 0, wpcom_expiry_notices_rollout_percentage() );
 	}
 
 	public function test_enables_exactly_the_configured_share(): void {
@@ -123,81 +123,62 @@ class Rollout_Test extends \WorDBless\BaseTestCase {
 		}
 	}
 
-	public function test_the_option_pulls_a_site_into_the_rollout_early(): void {
-		$this->set_blog_id( 55 ); // 55 % 100 = 55, outside the share.
-		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
-
+	public function test_the_option_cannot_pull_a_site_in_while_stopped(): void {
+		// The whole point of the stop: a site carrying the opt-in option from
+		// before the rollout was halted must not stay on the new notices.
+		$this->set_blog_id( 5 );
 		foreach ( array( '1', 1, 'true', 'yes', 'on', 'YES', ' 1 ' ) as $truthy ) {
 			update_option( 'wpcom_expiry_notices_enabled', $truthy );
-			$this->assertTrue(
-				wpcom_expiry_notices_is_enabled_for_site(),
-				sprintf( 'option value %s should read as opted in', var_export( $truthy, true ) )
-			);
-		}
-	}
-
-	public function test_the_option_holds_a_site_out_of_a_bucket_it_falls_in(): void {
-		$this->set_blog_id( 5 ); // 5 % 100 = 5, inside the share.
-		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
-
-		foreach ( array( '0', 0, 'false', 'no', 'off', 'NO', ' 0 ' ) as $falsy ) {
-			update_option( 'wpcom_expiry_notices_enabled', $falsy );
 			$this->assertFalse(
 				wpcom_expiry_notices_is_enabled_for_site(),
-				sprintf( 'option value %s should read as opted out', var_export( $falsy, true ) )
+				sprintf( 'option value %s must not re-enable the notices', var_export( $truthy, true ) )
 			);
 		}
 	}
 
-	public function test_clearing_the_option_returns_the_site_to_the_share(): void {
-		$this->set_blog_id( 5 ); // Inside the share.
-		update_option( 'wpcom_expiry_notices_enabled', '0' );
-		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
-
-		// Clearing must not read as "stay out" -- the site goes back under the
-		// normal rule, which for blog 5 means back in.
-		delete_option( 'wpcom_expiry_notices_enabled' );
-		$this->assertNull( wpcom_expiry_notices_rollout_override() );
-		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
-	}
-
-	public function test_an_unrecognised_option_value_changes_nothing(): void {
-		// A typo must not flip a site either way -- it leaves the normal rule in
-		// place, so a fat-fingered rollout command is inert rather than wrong.
-		$this->set_blog_id( 5 ); // Inside the share.
-		foreach ( array( 'ture', 'enabled', 'maybe', '' ) as $nonsense ) {
-			update_option( 'wpcom_expiry_notices_enabled', $nonsense );
-			$this->assertNull( wpcom_expiry_notices_rollout_override(), "'{$nonsense}' should not be read as an instruction" );
-			$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
-		}
-
-		$this->set_blog_id( 55 ); // Outside the share.
-		foreach ( array( 'ture', 'enabled', 'maybe', '' ) as $nonsense ) {
-			update_option( 'wpcom_expiry_notices_enabled', $nonsense );
+	public function test_the_option_still_holds_a_site_out(): void {
+		$this->set_blog_id( 5 );
+		foreach ( array( '0', 'false', 'no', 'off' ) as $falsy ) {
+			update_option( 'wpcom_expiry_notices_enabled', $falsy );
 			$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
 		}
 	}
 
-	public function test_the_option_beats_a_zero_percent_rollout(): void {
-		// Useful before the share is opened at all: pick a site, see the notices.
-		$this->at_percentage( 0 );
-		$this->set_blog_id( 55 );
-		remove_all_filters( 'wpcom_expiry_notices_enabled' );
+	public function test_clearing_the_option_leaves_the_site_out(): void {
+		// There is no share to return to while the rollout is stopped.
+		$this->set_blog_id( 5 );
 		update_option( 'wpcom_expiry_notices_enabled', '1' );
-		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
+		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
+
+		delete_option( 'wpcom_expiry_notices_enabled' );
+		$this->assertNull( wpcom_expiry_notices_rollout_override() );
+		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
 	}
 
-	public function test_the_filter_can_force_a_site_in_or_out(): void {
-		$this->set_blog_id( 55 ); // 55 % 100 = 55, outside the share.
+	public function test_an_unrecognised_option_value_changes_nothing(): void {
+		$this->set_blog_id( 5 );
+		foreach ( array( 'ture', 'enabled', 'maybe', '' ) as $nonsense ) {
+			update_option( 'wpcom_expiry_notices_enabled', $nonsense );
+			$this->assertNull( wpcom_expiry_notices_rollout_override(), "'{$nonsense}' should not be read as an instruction" );
+			$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
+		}
+	}
+
+	public function test_a_stopped_rollout_beats_the_option(): void {
+		// The inverse of what this asserted while the rollout was running.
+		$this->set_blog_id( 55 );
+		update_option( 'wpcom_expiry_notices_enabled', '1' );
+		$this->assertTrue( wpcom_expiry_notices_rollout_override() );
+		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
+	}
+
+	public function test_the_filter_can_still_force_a_site_in(): void {
+		// Runs after the stop, so it stays available as an escape hatch -- for
+		// putting a single site back on the new notices to confirm a fix.
+		$this->set_blog_id( 5 );
 		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
 
 		add_filter( 'wpcom_expiry_notices_enabled', '__return_true' );
 		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
-		remove_all_filters( 'wpcom_expiry_notices_enabled' );
-
-		$this->set_blog_id( 5 ); // 5 % 100 = 5, inside the share.
-		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
-		add_filter( 'wpcom_expiry_notices_enabled', '__return_false' );
-		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
 	}
 }


### PR DESCRIPTION
Related to DOTCOM-16615

⚠️ **Prepared in advance. Do not merge unless the new expiry notices are actually causing trouble.** Kept as a draft so it can't land by accident — mark it ready and merge when needed.

## Proposed changes

* Take the rollout share to **0%**.
* Move the zero check **ahead of the per-site override**, so zero means zero: a site still carrying `wpcom_expiry_notices_enabled = 1` from before the stop does not stay on the new notices. Without that ordering this would stop most of the rollout, not the rollout.

Both halves of the swap read the same predicate, so this single change also brings the previous notices back — wpcomsh's Atomic banner here, and the legacy plan-renew prompt on the WordPress.com side. No site ends up with no notice, and none gets two.

The `wpcom_expiry_notices_enabled` filter still runs last, so a single site can be forced back in to verify a fix without restarting the ramp.

## Related product discussion/links

* Linear: DOTCOM-16615
* WordPress.com companion stop, for a faster mitigation: see the Testing instructions below
* Feature PR this reverts: #49304

## Does this pull request change what data or activity we track or use?

No. It stops the new notices rendering, so their Tracks events stop firing too. Nothing is added.

## Testing instructions

**Sequencing matters.** The gate lives in jetpack-mu-wpcom, which reaches production on a package release — slower than a WordPress.com deploy. If you need to stop the notices *now*, the WordPress.com-side stop is the fast lever; it forces the same predicate false and takes effect in minutes. This PR is the durable stop, and the only one that reaches Atomic sites.

1. On a site inside the rollout, confirm the new banner renders before merging.
2. Apply this change; confirm the new banner is gone and the previous notice has returned — Atomic sites get wpcomsh's, WordPress.com Simple sites get the legacy plan-renew prompt.
3. On a site carrying `wp option update wpcom_expiry_notices_enabled 1`, confirm it is *also* out. That option no longer pulls a site in.
4. Confirm the escape hatch still works: `add_filter( 'wpcom_expiry_notices_enabled', '__return_true' );` puts that one site back on the new notices.

Unit tests describe the stopped contract rather than the running one, so they move with the change: 1038 pass in `packages/jetpack-mu-wpcom`.

**To restart the rollout**, put `wpcom_expiry_notices_rollout_percentage()` back to `10` (or higher) and restore the override-before-zero ordering if you want hand-picked sites to work while the share is 0 again.
