### PR TITLE
Expiry notices: widen the rollout to 30%

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rollout-expiry-notices-30
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rollout-expiry-notices-30
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Expiry notices: widen the rollout to 30% of sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
@@ -41,7 +41,7 @@ if ( ! function_exists( 'wpcom_expiry_get_purchases' ) ) {
  * two halves drift and a site ends up with both notices or neither.
  */
 function wpcom_expiry_notices_rollout_percentage(): int {
-	return 20;
+	return 30;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Rollout_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Rollout_Test.php
@@ -48,7 +48,7 @@ class Rollout_Test extends \WorDBless\BaseTestCase {
 
 	public function test_ships_at_the_intended_share(): void {
 		// Pinned so widening the rollout is a deliberate edit, not a drift.
-		$this->assertSame( 20, wpcom_expiry_notices_rollout_percentage() );
+		$this->assertSame( 30, wpcom_expiry_notices_rollout_percentage() );
 	}
 
 	public function test_enables_exactly_the_configured_share(): void {


### PR DESCRIPTION
Part of DOTCOM-16615

The step after #51476: **20% → 30%** of sites.

⚠️ **Merge #51476 first.** This is stacked on it, so the diff shown here is just the `20` → `30` change. GitHub will retarget this to `trunk` when #51476 merges.

**If #51476 lands as a squash** (the default here — #49304 did), this branch will need *rebuilding* rather than rebasing: its base commits won't be ancestors of trunk, so git will report the whole 20% change as a conflict. Recreate it as a single commit on trunk:

```
git checkout -B rollout/expiry-notices-30 origin/trunk
git cherry-pick <this branch's commit>
```

## Proposed changes

* `wpcom_expiry_notices_rollout_percentage()` returns `30`.
* The pinned assertion moves to `30`. Nothing else — #51476 made the rest of the tests derive from the shipped share.

Same `blog_id % 100` bucketing, so it only ever adds sites.

## Related product discussion/links

* Linear: DOTCOM-16615
* Previous step: #51476
* Feature: #49304
* Prepared stop: #51475

## Does this pull request change what data or activity we track or use?

No new data; existing events and MC stats cover more sites.

## Testing instructions

1. On a site whose blog ID lands in the new band (`blog_id % 100` between 20 and 29), confirm the new banner replaces the legacy one.
2. On a site below 20, confirm nothing changed.
3. On a site at 30 or above, confirm the legacy notice still shows.

## ⚠️ Before merging

**Expect the MC alert to fire again**, for the same reason as the previous step — a 50% jump in `billing-lookup` volume against a standard-deviation alert.

Test fixtures use blog 5 (in) and blog 55 (out), which hold for any share from 6% to 55%. A widening past 55% needs those revisited; there's a note on `set_blog_id()` saying so.
