### PR TITLE
VideoPress: extend poster update request timeout beyond WP default

### DIFF
--- a/projects/packages/videopress/changelog/vidp-374-poster-timeout
+++ b/projects/packages/videopress/changelog/vidp-374-poster-timeout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a timeout error when updating a video poster from the media library.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -772,6 +772,8 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 					'content-type'  => 'application/json',
 					'Authorization' => 'X_UPLOAD_TOKEN token="' . $token . '" blog_id="' . $blog_id . '"',
 				),
+				// The WordPress.com poster update fetches and processes the image, which routinely exceeds WordPress's 5-second default timeout.
+				'timeout' => 30,
 			);
 
 			return $this->wpcom_poster_request(

--- a/projects/plugins/jetpack/changelog/vidp-374-poster-timeout
+++ b/projects/plugins/jetpack/changelog/vidp-374-poster-timeout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Fix a timeout error when updating a video poster from the media library.

--- a/projects/plugins/videopress/changelog/vidp-374-poster-timeout
+++ b/projects/plugins/videopress/changelog/vidp-374-poster-timeout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a timeout error when updating a video poster from the media library.


### PR DESCRIPTION
Fixes VIDP-374

## Proposed changes
* Add an explicit `'timeout' => 30` to the outbound WordPress.com request in `videopress_block_update_poster()` (VideoPress package REST proxy).
* Previously the request used WordPress's 5-second default timeout. The WordPress.com-side poster write for the media-library path (`poster_attachment_id`) fetches and processes the image and routinely takes ~7s, so the proxy returned a 500 `http_request_failed` (cURL error 28) even though WordPress.com still completed the poster change.
* This is a pre-existing bug surfaced by the rebuilt VideoPress dashboard in #51268. The GET poster path is untouched — it is not affected.

## Related product discussion/links
* Linear: VIDP-374

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Use a Jetpack-connected site with VideoPress and at least one uploaded video, plus an image in the media library.
* Go to the VideoPress dashboard, open a video's details page, and update the video thumbnail by selecting an image from the media library.
* Before this fix: the request to `.../wpcom/v2/videopress/{guid}/poster` fails with a 500 (`http_request_failed`, cURL error 28) after ~5 seconds — although the poster is eventually updated on WordPress.com, the UI shows an error.
* After this fix: the request completes successfully (typically ~7s) and the new poster is reflected without an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
