### PR TITLE
Publicize: gate connection script data on the Publicize capability

### DIFF
--- a/projects/packages/publicize/changelog/social-420-gate-publicize-connections-script-data
+++ b/projects/packages/publicize/changelog/social-420-gate-publicize-connections-script-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Only include social connection data in the script data for users who can access Publicize.

--- a/projects/packages/publicize/src/class-publicize-assets.php
+++ b/projects/packages/publicize/src/class-publicize-assets.php
@@ -37,10 +37,7 @@ class Publicize_Assets {
 			return false;
 		}
 
-		/** This filter is documented in projects/packages/publicize/src/class-publicize-base.php */
-		$capability = apply_filters( 'jetpack_publicize_capability', 'publish_posts' );
-
-		return current_user_can( $capability );
+		return Publicize_Utils::current_user_can_access_publicize_data();
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -216,10 +216,35 @@ class Publicize_Script_Data {
 
 		return array(
 			'connectionData' => array(
-				'connections' => Connections::get_all_for_user(),
+				'connections' => self::current_user_can_access_publicize_data() ? Connections::get_all_for_user() : array(),
 			),
 			'shareStatus'    => $share_status,
 		);
+	}
+
+	/**
+	 * Whether the current user may be handed Publicize data.
+	 *
+	 * `Publicize_Assets::should_enqueue_block_editor_scripts()` already requires this
+	 * capability before the editor UI loads. Without the same gate here, the script
+	 * data carried connection details to users who have nothing to render them with —
+	 * a Contributor, for instance.
+	 *
+	 * Falls back to evaluating the capability directly when the Publicize instance is
+	 * not available, so the check never depends on global initialization order.
+	 *
+	 * @return bool
+	 */
+	private static function current_user_can_access_publicize_data() {
+
+		$publicize = self::publicize();
+
+		if ( $publicize instanceof Publicize_Base ) {
+			return $publicize->current_user_can_access_publicize_data();
+		}
+
+		/** This filter is documented in projects/packages/publicize/src/class-publicize-base.php */
+		return current_user_can( apply_filters( 'jetpack_publicize_capability', 'publish_posts' ) );
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize-script-data.php
+++ b/projects/packages/publicize/src/class-publicize-script-data.php
@@ -216,35 +216,12 @@ class Publicize_Script_Data {
 
 		return array(
 			'connectionData' => array(
-				'connections' => self::current_user_can_access_publicize_data() ? Connections::get_all_for_user() : array(),
+				// Same gate the block editor assets are enqueued behind, so users who
+				// never get the Social UI are not handed connection details either.
+				'connections' => Utils::current_user_can_access_publicize_data() ? Connections::get_all_for_user() : array(),
 			),
 			'shareStatus'    => $share_status,
 		);
-	}
-
-	/**
-	 * Whether the current user may be handed Publicize data.
-	 *
-	 * `Publicize_Assets::should_enqueue_block_editor_scripts()` already requires this
-	 * capability before the editor UI loads. Without the same gate here, the script
-	 * data carried connection details to users who have nothing to render them with —
-	 * a Contributor, for instance.
-	 *
-	 * Falls back to evaluating the capability directly when the Publicize instance is
-	 * not available, so the check never depends on global initialization order.
-	 *
-	 * @return bool
-	 */
-	private static function current_user_can_access_publicize_data() {
-
-		$publicize = self::publicize();
-
-		if ( $publicize instanceof Publicize_Base ) {
-			return $publicize->current_user_can_access_publicize_data();
-		}
-
-		/** This filter is documented in projects/packages/publicize/src/class-publicize-base.php */
-		return current_user_can( apply_filters( 'jetpack_publicize_capability', 'publish_posts' ) );
 	}
 
 	/**

--- a/projects/packages/publicize/src/class-publicize-utils.php
+++ b/projects/packages/publicize/src/class-publicize-utils.php
@@ -86,6 +86,31 @@ class Publicize_Utils {
 	}
 
 	/**
+	 * Whether the current user may be shown Publicize data.
+	 *
+	 * The single definition of that gate. Both the block editor assets and the
+	 * script data ask this, and when they disagreed the script data handed
+	 * connection details to users the editor UI was never loaded for.
+	 *
+	 * Prefers the Publicize instance so any future override is honored, and falls
+	 * back to evaluating the capability directly when the global is not set, so the
+	 * answer never depends on initialization order.
+	 *
+	 * @return bool
+	 */
+	public static function current_user_can_access_publicize_data() {
+
+		global $publicize;
+
+		if ( $publicize instanceof Publicize_Base ) {
+			return $publicize->current_user_can_access_publicize_data();
+		}
+
+		/** This filter is documented in projects/packages/publicize/src/class-publicize-base.php */
+		return current_user_can( apply_filters( 'jetpack_publicize_capability', 'publish_posts' ) );
+	}
+
+	/**
 	 * Check if we are on WPCOM.
 	 *
 	 * @return bool

--- a/projects/packages/publicize/tests/php/Publicize_Assets_Test.php
+++ b/projects/packages/publicize/tests/php/Publicize_Assets_Test.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Tests for Publicize_Assets.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize;
+
+use PHPUnit\Framework\TestCase;
+use WorDBless\Posts as WorDBless_Posts;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Class Publicize_Assets_Test
+ *
+ * Covers the capability gate on the block editor assets. It shares a definition with
+ * the script data — Publicize_Utils::current_user_can_access_publicize_data() — so
+ * these assertions and Publicize_Script_Data_Test's exist to keep the two from
+ * drifting apart again.
+ */
+class Publicize_Assets_Test extends TestCase {
+
+	/**
+	 * User IDs keyed by role.
+	 *
+	 * @var array
+	 */
+	private $user_ids = array();
+
+	/**
+	 * The $publicize global as we found it.
+	 *
+	 * @var Publicize|null
+	 */
+	private $original_publicize;
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $publicize;
+		$this->original_publicize = $publicize;
+
+		foreach ( array( 'author', 'contributor' ) as $role ) {
+			$this->user_ids[ $role ] = wp_insert_user(
+				array(
+					'user_login' => 'dummy_' . $role,
+					'user_pass'  => 'dummy_pass',
+					'role'       => $role,
+				)
+			);
+		}
+
+		add_post_type_support( 'post', 'publicize' );
+
+		// should_enqueue_block_editor_scripts() reads the post type from the global post.
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'A post',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$GLOBALS['post'] = get_post( $post_id );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		global $publicize;
+		$publicize = $this->original_publicize;
+
+		unset( $GLOBALS['post'] );
+
+		remove_post_type_support( 'post', 'publicize' );
+
+		wp_set_current_user( 0 );
+
+		WorDBless_Posts::init()->clear_all_posts();
+		WorDBless_Users::init()->clear_all_users();
+	}
+
+	/**
+	 * A user who can publish gets the editor scripts.
+	 */
+	public function test_author_gets_the_editor_scripts() {
+		wp_set_current_user( $this->user_ids['author'] );
+
+		$this->assertTrue( Publicize_Assets::should_enqueue_block_editor_scripts() );
+	}
+
+	/**
+	 * A Contributor does not, which is why the script data must not carry
+	 * connection details for them either.
+	 */
+	public function test_contributor_does_not_get_the_editor_scripts() {
+		wp_set_current_user( $this->user_ids['contributor'] );
+
+		$this->assertFalse( Publicize_Assets::should_enqueue_block_editor_scripts() );
+	}
+
+	/**
+	 * The two gates agree. This is the invariant the shared helper exists to hold:
+	 * anyone refused the editor UI is also refused the connection data.
+	 */
+	public function test_the_assets_gate_and_the_script_data_gate_agree() {
+		foreach ( array( 'author', 'contributor' ) as $role ) {
+			wp_set_current_user( $this->user_ids[ $role ] );
+
+			$this->assertSame(
+				Publicize_Assets::should_enqueue_block_editor_scripts(),
+				Publicize_Utils::current_user_can_access_publicize_data(),
+				"The assets gate and the shared capability gate disagreed for the $role role."
+			);
+		}
+	}
+
+	/**
+	 * Anyone refused the editor UI gets no connection data. This is the bug that
+	 * started all of this, asserted across the two gates rather than one.
+	 */
+	public function test_a_user_refused_the_editor_ui_gets_no_connections() {
+		wp_set_current_user( $this->user_ids['contributor'] );
+
+		$this->assertFalse( Publicize_Assets::should_enqueue_block_editor_scripts() );
+
+		$state = Publicize_Script_Data::get_store_initial_state();
+
+		$this->assertSame( array(), $state['connectionData']['connections'] );
+	}
+
+	/**
+	 * A post type without publicize support is refused regardless of capability.
+	 */
+	public function test_unsupported_post_type_is_refused() {
+		remove_post_type_support( 'post', 'publicize' );
+
+		wp_set_current_user( $this->user_ids['author'] );
+
+		$this->assertFalse( Publicize_Assets::should_enqueue_block_editor_scripts() );
+	}
+
+	/**
+	 * Sites that move Publicize to another capability keep working.
+	 */
+	public function test_jetpack_publicize_capability_filter_is_respected() {
+		$to_read = function () {
+			return 'read';
+		};
+
+		add_filter( 'jetpack_publicize_capability', $to_read );
+
+		wp_set_current_user( $this->user_ids['contributor'] );
+
+		$can_enqueue = Publicize_Assets::should_enqueue_block_editor_scripts();
+
+		remove_filter( 'jetpack_publicize_capability', $to_read );
+
+		$this->assertTrue( $can_enqueue );
+	}
+}

--- a/projects/packages/publicize/tests/php/Publicize_Script_Data_Test.php
+++ b/projects/packages/publicize/tests/php/Publicize_Script_Data_Test.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\Publicize;
 
 use PHPUnit\Framework\TestCase;
-use WorDBless\Options as WorDBless_Options;
 use WorDBless\Posts as WorDBless_Posts;
 use WorDBless\Users as WorDBless_Users;
 
@@ -32,10 +31,20 @@ class Publicize_Script_Data_Test extends TestCase {
 	private $connections = array();
 
 	/**
+	 * The $publicize global as we found it.
+	 *
+	 * @var Publicize|null
+	 */
+	private $original_publicize;
+
+	/**
 	 * Setting up the test.
 	 */
 	public function setUp(): void {
 		parent::setUp();
+
+		global $publicize;
+		$this->original_publicize = $publicize;
 
 		foreach ( array( 'administrator', 'author', 'contributor' ) as $role ) {
 			$this->user_ids[ $role ] = wp_insert_user(
@@ -67,16 +76,42 @@ class Publicize_Script_Data_Test extends TestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 
+		/*
+		 * Restore rather than clear. Base_Controller::publicize_permissions_check()
+		 * 403s on a falsy $publicize, and the REST controller tests do not set the
+		 * global themselves — they inherit it from whichever test class ran before
+		 * them. Nulling it here would break the next class in the file order.
+		 */
 		global $publicize;
-		$publicize = null;
+		$publicize = $this->original_publicize;
 
 		wp_set_current_user( 0 );
 
-		WorDBless_Options::init()->clear_options();
+		/*
+		 * Clear only what this class created. WorDBless_Options::clear_options()
+		 * would wipe the whole option table, including the Jetpack options that
+		 * later test classes inherit from earlier ones.
+		 */
+		delete_transient( Connections::CONNECTIONS_TRANSIENT );
+
 		WorDBless_Posts::init()->clear_all_posts();
 		WorDBless_Users::init()->clear_all_users();
+	}
 
-		delete_transient( Connections::CONNECTIONS_TRANSIENT );
+	/**
+	 * Put a Publicize instance in the global.
+	 *
+	 * Built without its constructor on purpose: that registers hooks which would
+	 * outlive this class and leak into the test classes running after it. Every
+	 * method is the real one, so current_user_can_access_publicize_data() behaves
+	 * exactly as it does in production.
+	 *
+	 * @throws \ReflectionException If Publicize cannot be reflected.
+	 */
+	private function set_publicize_instance() {
+		global $publicize;
+
+		$publicize = ( new \ReflectionClass( Publicize::class ) )->newInstanceWithoutConstructor();
 	}
 
 	/**
@@ -94,8 +129,7 @@ class Publicize_Script_Data_Test extends TestCase {
 	 * A shared connection reaches a user who can publish.
 	 */
 	public function test_author_gets_connections() {
-		global $publicize;
-		$publicize = new Publicize();
+		$this->set_publicize_instance();
 
 		wp_set_current_user( $this->user_ids['author'] );
 
@@ -106,8 +140,7 @@ class Publicize_Script_Data_Test extends TestCase {
 	 * A Contributor gets no connection data, shared or otherwise.
 	 */
 	public function test_contributor_gets_no_connections() {
-		global $publicize;
-		$publicize = new Publicize();
+		$this->set_publicize_instance();
 
 		wp_set_current_user( $this->user_ids['contributor'] );
 
@@ -118,8 +151,7 @@ class Publicize_Script_Data_Test extends TestCase {
 	 * A logged-out request gets no connection data.
 	 */
 	public function test_logged_out_gets_no_connections() {
-		global $publicize;
-		$publicize = new Publicize();
+		$this->set_publicize_instance();
 
 		wp_set_current_user( 0 );
 
@@ -145,8 +177,7 @@ class Publicize_Script_Data_Test extends TestCase {
 	 * Sites that move Publicize to another capability keep working.
 	 */
 	public function test_jetpack_publicize_capability_filter_is_respected() {
-		global $publicize;
-		$publicize = new Publicize();
+		$this->set_publicize_instance();
 
 		$to_read = function () {
 			return 'read';

--- a/projects/packages/publicize/tests/php/Publicize_Script_Data_Test.php
+++ b/projects/packages/publicize/tests/php/Publicize_Script_Data_Test.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Tests for Publicize_Script_Data.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize;
+
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Posts as WorDBless_Posts;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Class Publicize_Script_Data_Test
+ */
+class Publicize_Script_Data_Test extends TestCase {
+
+	/**
+	 * User IDs keyed by role.
+	 *
+	 * @var array
+	 */
+	private $user_ids = array();
+
+	/**
+	 * The connections seeded into the transient.
+	 *
+	 * @var array
+	 */
+	private $connections = array();
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		foreach ( array( 'administrator', 'author', 'contributor' ) as $role ) {
+			$this->user_ids[ $role ] = wp_insert_user(
+				array(
+					'user_login' => 'dummy_' . $role,
+					'user_pass'  => 'dummy_pass',
+					'role'       => $role,
+				)
+			);
+		}
+
+		$this->connections = array(
+			array(
+				'connection_id' => '111',
+				'display_name'  => 'Tumblr Connection',
+				'service_name'  => 'tumblr',
+				'service_label' => 'Tumblr',
+				'shared'        => true,
+				'wpcom_user_id' => 0,
+			),
+		);
+
+		set_transient( Connections::CONNECTIONS_TRANSIENT, $this->connections, DAY_IN_SECONDS );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		global $publicize;
+		$publicize = null;
+
+		wp_set_current_user( 0 );
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Posts::init()->clear_all_posts();
+		WorDBless_Users::init()->clear_all_users();
+
+		delete_transient( Connections::CONNECTIONS_TRANSIENT );
+	}
+
+	/**
+	 * Read the connections out of the store initial state.
+	 *
+	 * @return array
+	 */
+	private function get_connections_from_store() {
+		$state = Publicize_Script_Data::get_store_initial_state();
+
+		return $state['connectionData']['connections'];
+	}
+
+	/**
+	 * A shared connection reaches a user who can publish.
+	 */
+	public function test_author_gets_connections() {
+		global $publicize;
+		$publicize = new Publicize();
+
+		wp_set_current_user( $this->user_ids['author'] );
+
+		$this->assertSame( $this->connections, $this->get_connections_from_store() );
+	}
+
+	/**
+	 * A Contributor gets no connection data, shared or otherwise.
+	 */
+	public function test_contributor_gets_no_connections() {
+		global $publicize;
+		$publicize = new Publicize();
+
+		wp_set_current_user( $this->user_ids['contributor'] );
+
+		$this->assertSame( array(), $this->get_connections_from_store() );
+	}
+
+	/**
+	 * A logged-out request gets no connection data.
+	 */
+	public function test_logged_out_gets_no_connections() {
+		global $publicize;
+		$publicize = new Publicize();
+
+		wp_set_current_user( 0 );
+
+		$this->assertSame( array(), $this->get_connections_from_store() );
+	}
+
+	/**
+	 * The capability is still enforced when no Publicize instance is available,
+	 * so the gate does not depend on global initialization order.
+	 */
+	public function test_capability_is_enforced_without_a_publicize_instance() {
+		global $publicize;
+		$publicize = null;
+
+		wp_set_current_user( $this->user_ids['contributor'] );
+		$this->assertSame( array(), $this->get_connections_from_store() );
+
+		wp_set_current_user( $this->user_ids['administrator'] );
+		$this->assertSame( $this->connections, $this->get_connections_from_store() );
+	}
+
+	/**
+	 * Sites that move Publicize to another capability keep working.
+	 */
+	public function test_jetpack_publicize_capability_filter_is_respected() {
+		global $publicize;
+		$publicize = new Publicize();
+
+		$to_read = function () {
+			return 'read';
+		};
+
+		add_filter( 'jetpack_publicize_capability', $to_read );
+
+		wp_set_current_user( $this->user_ids['contributor'] );
+
+		$connections = $this->get_connections_from_store();
+
+		remove_filter( 'jetpack_publicize_capability', $to_read );
+
+		$this->assertSame( $this->connections, $connections );
+	}
+}


### PR DESCRIPTION
Fixes SOCIAL-420

## Proposed changes

* Gate the social connection data in `JetpackScriptData` on the Publicize capability.

`Publicize_Script_Data::get_store_initial_state()` put `Connections::get_all_for_user()` into `window.JetpackScriptData` unconditionally, so a Contributor loading the block editor received the shared connections' display names, service labels and `wpcom_user_id`s.

`Publicize_Assets::should_enqueue_block_editor_scripts()` already requires `current_user_can( apply_filters( 'jetpack_publicize_capability', 'publish_posts' ) )` before the editor UI loads, so these users had nothing to render the data with in the first place. This applies the same gate to the script data.

The new helper prefers `Publicize_Base::current_user_can_access_publicize_data()`, and falls back to evaluating the capability directly when the `$publicize` global is not yet set, so the check never depends on initialization order.

### Scope

This is hardening, not a fix for an exploitable leak. `get_all_for_user()` already filtered to connections that are shared or owned by the caller, which is what @manzoorwanijk pointed out on the issue — a Contributor never saw anything private. But automated scanners keep re-reporting the missing capability check, and the gate costs one line. Filing it closes the loop.

Behavior for anyone who can actually use Publicize is unchanged, which is why there is a package changelog entry but no plugin entries.

### A note on the second commit

The first version of the test class cleared shared state it did not own and broke `Render_Messages_Controller_Test` two classes later — CI caught it. Worth knowing about if you write tests in this package, because the trap is not obvious:

* `Base_Controller::publicize_permissions_check()` returns 403 when the `$publicize` global is falsy, and the REST controller tests never set that global themselves. They inherit it from whichever test class happened to run before them. Nulling it in `tearDown()` breaks them.
* `WorDBless_Options::clear_options()` wipes the entire option table, not just what your class added.
* `new Publicize()` registers hooks that outlive the class that built it. The tests now use `newInstanceWithoutConstructor()`, so every method is still the real one but nothing gets hooked.

`Render_Messages_Controller_Test` also fails when run in isolation via `--filter`, for the same underlying reason: it has a latent dependency on a global another class sets. Not addressed here, but worth a follow-up.

### Other information

- [ ] Generate changelog entries for this PR (using AI).

## Related product discussion/links

* SOCIAL-420 — FIND-23 from the Jetpack Codex Security Review project.

## Does this pull request change what data or activity we track or use?

No. It removes data from a page payload; it does not add any.

## Testing instructions

Automated:

* `jetpack test php packages/publicize` — 122 tests, clean: no failures, deprecations or notices. Trunk is 117, so the five new cases are the only difference.
* The five new cases in `Publicize_Script_Data_Test` are verified by mutation: reverting the production hunk fails three of them (contributor, logged-out, and the no-instance fallback). The other two guard against over-blocking — an Author must still get connections, and the `jetpack_publicize_capability` filter must still be honored.

Manual, on a site with Jetpack Social active and at least one social connection marked as shared:

1. As an Administrator, open a new post in the block editor. Confirm the Jetpack Social panel still lists your connections and sharing works as before.
2. In the browser console, run `JetpackScriptData.social.store_initial_state.connectionData.connections`. It should return the connections, as it does today.
3. Log in as a Contributor and open a new post in the block editor. The Social panel is absent, as it was before this change.
4. Run the same console command. Before this change it returned the shared connections; it should now return `[]`.
5. Confirm the Jetpack and Jetpack Social settings pages still render their connection lists for an Administrator.
