### PR TITLE
wpcomsh: bump wc-calypso-bridge to 2.11.7

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-bump_wc-calypso-bridge
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-bump_wc-calypso-bridge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update wc-calypso-bridge to 2.11.7.

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -8,7 +8,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "^2.11.6",
+		"automattic/wc-calypso-bridge": "^2.11.7",
 		"wordpress/classic-editor-plugin": "1.6.7",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9d4bc712b476604df193f64608b93ab",
+    "content-hash": "0b7920d3395815adac1fafc57b65fe94",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -2765,16 +2765,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.11.6",
+            "version": "v2.11.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "90f66ebabaf540e078eb4f2b70e83c336795bfa7"
+                "reference": "ff8f1980da53ce4ad724edb3ca3e7188a7f1778e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/90f66ebabaf540e078eb4f2b70e83c336795bfa7",
-                "reference": "90f66ebabaf540e078eb4f2b70e83c336795bfa7",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/ff8f1980da53ce4ad724edb3ca3e7188a7f1778e",
+                "reference": "ff8f1980da53ce4ad724edb3ca3e7188a7f1778e",
                 "shasum": ""
             },
             "require-dev": {
@@ -2816,7 +2816,7 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "time": "2026-03-27T12:47:04+00:00"
+            "time": "2026-08-21T15:43:09+00:00"
         },
         {
             "name": "automattic/woocommerce-analytics",


### PR DESCRIPTION
## Proposed changes

* Updates the `wc-calypso-bridge` dependency in wpcomsh from 2.11.6 to 2.11.7.
* Raises the constraint to `^2.11.7` in addition to moving the lockfile, so a fresh resolve settles on 2.11.7 as the minimum rather than merely the current pick.

The lockfile change is scoped to this one package. No unrelated dependencies were updated, so the lock diff is 12 lines.

Upstream release: https://github.com/Automattic/wc-calypso-bridge/releases/tag/2.11.7

## Related product discussion/links

* WCCOM-2880

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a Simple site running wpcomsh, confirm `vendor/automattic/wc-calypso-bridge` reports version 2.11.7.
* Load a store and request `wp-json/wc/v3/data/counts`. Confirm the response returns `orders`, `products` and `reviews` counts as expected.
* Go to **WooCommerce → Settings → Products → Inventory** and set **Out of stock threshold** and **Low stock threshold** to different integer values, saving between each.
* Repeat the `data/counts` request after each change and confirm `products.out-of-stock` and `products.low-inventory` follow the thresholds you set.
* Confirm no database errors or PHP notices appear in the logs.
