### PR TITLE
Forms: fix fatal error when a file field has a malformed stored value

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-file-field-empty-value-fatal
+++ b/projects/packages/forms/changelog/fix-forms-file-field-empty-value-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Responses: Prevent an error that could stop responses from loading when a file upload field was stored without any file data.

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -906,6 +906,25 @@ class Feedback_Field {
 	}
 
 	/**
+	 * Get the uploaded files of a file field.
+	 *
+	 * The stored value of a file field is normally an array with a `files` key,
+	 * but a feedback can carry a malformed value — an empty string, for
+	 * instance — so callers must never assume that shape.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array The list of files, empty when the value holds none.
+	 */
+	private function get_file_list() {
+		if ( ! is_array( $this->value ) || ! isset( $this->value['files'] ) || ! is_array( $this->value['files'] ) ) {
+			return array();
+		}
+
+		return $this->value['files'];
+	}
+
+	/**
 	 * Get the default value of the field for rendering.
 	 *
 	 * @return string
@@ -913,7 +932,7 @@ class Feedback_Field {
 	private function get_render_default_value() {
 		if ( $this->is_of_type( 'file' ) ) {
 			$files = array();
-			foreach ( $this->value['files'] as &$file ) {
+			foreach ( $this->get_file_list() as $file ) {
 				if ( ! isset( $file['size'] ) || ! isset( $file['file_id'] ) ) {
 					// this shouldn't happen, todo: log this
 					continue;
@@ -945,8 +964,8 @@ class Feedback_Field {
 	private function get_render_api_value() {
 		if ( $this->is_of_type( 'file' ) ) {
 			$files = array();
-			$value = $this->value;
-			foreach ( $value['files'] as $file ) {
+			$value = is_array( $this->value ) ? $this->value : array();
+			foreach ( $this->get_file_list() as $file ) {
 				if ( ! isset( $file['size'] ) || ! isset( $file['file_id'] ) ) {
 					// this shouldn't happen, todo: log this
 					continue;
@@ -989,7 +1008,7 @@ class Feedback_Field {
 	private function get_render_submit_value() {
 		if ( $this->is_of_type( 'file' ) ) {
 			$files = array();
-			foreach ( $this->value['files'] as $file ) {
+			foreach ( $this->get_file_list() as $file ) {
 				if ( ! isset( $file['size'] ) || ! isset( $file['file_id'] ) ) {
 					// this shouldn't happen, todo: log this
 					continue;

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -959,7 +959,10 @@ class Feedback_Field {
 	/**
 	 * Get the value of the field for the API.
 	 *
-	 * @return string
+	 * File, image-select and checkbox-multiple fields answer with the structured
+	 * value the dashboard expects; everything else answers with a string.
+	 *
+	 * @return array|string The value for the API context.
 	 */
 	private function get_render_api_value() {
 		if ( $this->is_of_type( 'file' ) ) {

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -335,6 +335,76 @@ class Feedback_Field_Test extends BaseTestCase {
 		remove_filter( 'jetpack_unauth_file_download_url', array( $this, 'return_url' ) );
 	}
 
+	/**
+	 * A file field can be stored with a malformed value — an empty string, say,
+	 * rather than the expected array with a `files` key. Rendering it must not
+	 * fatal, in any context.
+	 */
+	public function test_get_render_value_with_malformed_file_value() {
+		$malformed = array(
+			'empty string'      => '',
+			'null'              => null,
+			'empty array'       => array(),
+			'non-empty string'  => 'not-an-array',
+			'string files key'  => array( 'files' => '' ),
+			'files key missing' => array( 'field_id' => 'g1-1' ),
+		);
+
+		foreach ( $malformed as $case => $value ) {
+			$field = new Feedback_Field( 'test_key', 'test_label', $value, 'file' );
+
+			$api = $field->get_render_value( 'api' );
+			$this->assertIsArray( $api, "api value for {$case} should be an array" );
+			$this->assertSame( array(), $api['files'], "api files for {$case} should be empty" );
+
+			$this->assertSame(
+				array(
+					'field_id' => '',
+					'files'    => array(),
+				),
+				$field->get_render_value( 'submit' ),
+				"submit value for {$case} should carry no files"
+			);
+
+			$this->assertSame(
+				array(
+					'type'  => 'file',
+					'files' => array(),
+				),
+				$field->get_render_value( 'web' ),
+				"web value for {$case} should carry no files"
+			);
+
+			$this->assertSame( '', $field->get_render_value( 'default' ), "default value for {$case} should be empty" );
+			$this->assertSame( '', $field->get_render_value( 'csv' ), "csv value for {$case} should be empty" );
+			$this->assertIsString( $field->get_render_value( 'email_html' ), "email_html value for {$case} should be a string" );
+			$this->assertFalse( $field->has_file(), "{$case} should not report a file" );
+		}
+	}
+
+	/**
+	 * A well-formed file value keeps the keys it arrived with.
+	 */
+	public function test_get_render_api_value_preserves_sibling_keys_when_files_are_dropped() {
+		$field = new Feedback_Field(
+			'test_key',
+			'test_label',
+			array(
+				'field_id' => 'g1-1',
+				'files'    => '',
+			),
+			'file'
+		);
+
+		$this->assertSame(
+			array(
+				'field_id' => 'g1-1',
+				'files'    => array(),
+			),
+			$field->get_render_value( 'api' )
+		);
+	}
+
 	public function test_render_label_in_different_contexts() {
 		$field = new Feedback_Field( 'test_key', 'test_label', 'test_value' );
 		$this->assertEquals( 'test_label', $field->get_label() );

--- a/projects/plugins/jetpack/changelog/fix-forms-file-field-empty-value-fatal
+++ b/projects/plugins/jetpack/changelog/fix-forms-file-field-empty-value-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Prevent an error that could stop responses from loading when a file upload field was stored without any file data.


### PR DESCRIPTION
Fixes #

## Proposed changes

A file field's stored value is normally an array shaped like `array( 'field_id' => …, 'files' => array( … ) )`, but a feedback can carry a malformed value instead — most commonly an empty string, from a submission that went through a file field without an upload. Three render paths in `Feedback_Field` walked `$this->value['files']` with no guard:

* `get_render_api_value()` — used by `GET /wp/v2/feedback`
* `get_render_default_value()` — the default and CSV contexts
* `get_render_submit_value()`

On PHP 8 `''['files']` throws `TypeError: Cannot access offset of type string on string`, so a **single** malformed row is enough to fatal the whole `/wp/v2/feedback` request. The symptom is a Forms responses dashboard that renders an empty table while `wp post list --post_type=feedback` shows the rows are there. `get_render_api_value()` fataled twice over — once reading `$value['files']`, once writing `$value['files'] = $files` back onto a string.

Other file-value readers in the same class (`get_render_web_value()`, `render_email_file()`, `has_file()`) already guarded, so this makes the remaining three consistent with them:

* Add a `get_file_list()` helper that returns the `files` array, or an empty array when the value doesn't have that shape.
* Use it in the three unguarded loops.
* In `get_render_api_value()`, also fall back to an empty array before writing `files` back, so the API returns a well-formed `array( 'files' => array() )` rather than a string. Sibling keys such as `field_id` are preserved.

Values that are already well-formed are unaffected — the helper returns the same array the loops read before.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Unit tests cover this — `test_get_render_value_with_malformed_file_value()` fails on trunk with the exact `TypeError` and passes here:

```
jp test php packages/forms
```

To reproduce by hand on a test site:

1. Have a form with a file upload field, and submit it so there's at least one response.
2. Corrupt one response's stored file value — the shape that arrives in the wild:
   ```
   wp eval '
     $ids = get_posts( array( "post_type" => "feedback", "posts_per_page" => 1, "fields" => "ids" ) );
     $extra = get_post_meta( $ids[0], "_feedback_extra_fields", true );
     foreach ( $extra as $k => $v ) { if ( is_array( $v ) && isset( $v["files"] ) ) { $extra[$k] = ""; } }
     update_post_meta( $ids[0], "_feedback_extra_fields", $extra );
   '
   ```
3. Open **Jetpack → Forms → Responses**. Before this change the table is empty and `GET /wp/v2/feedback` returns a 500 with `Cannot access offset of type string on string` in the error log. After it, the responses list loads and the corrupted row shows with no attachments.
