### PR TITLE
Forms: fix scrolling on a single response, and align the mobile View action

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-single-form-scroll
+++ b/projects/packages/forms/changelog/fix-forms-single-form-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Responses: Allow a single response to scroll when it is taller than the screen.

--- a/projects/packages/forms/changelog/fix-forms-single-form-scroll-view-action
+++ b/projects/packages/forms/changelog/fix-forms-single-form-scroll-view-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Responses: On small screens, the View action now opens the response the same way tapping its title does.

--- a/projects/packages/forms/routes/responses/actions.tsx
+++ b/projects/packages/forms/routes/responses/actions.tsx
@@ -297,6 +297,11 @@ type NavigateFunction = UseNavigateResult< string >;
 
 type GetActionsParams = {
 	navigate: NavigateFunction;
+	// Below the `medium` breakpoint boot renders the inspector as a full-screen
+	// fixed overlay rather than a side panel, so selecting a response already
+	// fills the viewport. When supplied, View selects instead of navigating —
+	// matching what tapping the response's title does.
+	onSelectResponse?: ( id: string ) => void;
 };
 
 type GetActionsReturn = {
@@ -322,7 +327,7 @@ type GetRowActionsParams = GetActionsParams & {
  * @param {GetActionsParams} params - Parameters for generating actions.
  * @return {GetActionsReturn} Object containing the actions.
  */
-export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
+export function getActions( { navigate, onSelectResponse }: GetActionsParams ): GetActionsReturn {
 	const viewAction: Action = {
 		id: 'view-response',
 		isPrimary: true,
@@ -337,6 +342,11 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 			const [ item ] = items;
 
 			if ( ! item ) {
+				return;
+			}
+
+			if ( onSelectResponse ) {
+				onSelectResponse( String( item.id ) );
 				return;
 			}
 
@@ -1286,7 +1296,11 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
  * @param {GetRowActionsParams} params - Parameters for generating actions.
  * @return {Action[]} Array of action configurations.
  */
-export function getRowActions( { navigate, view }: GetRowActionsParams ): Action[] {
+export function getRowActions( {
+	navigate,
+	view,
+	onSelectResponse,
+}: GetRowActionsParams ): Action[] {
 	const {
 		viewAction,
 		printAction,
@@ -1298,7 +1312,7 @@ export function getRowActions( { navigate, view }: GetRowActionsParams ): Action
 		deleteAction,
 		markAsReadAction,
 		markAsUnreadAction,
-	} = getActions( { navigate } );
+	} = getActions( { navigate, onSelectResponse } );
 
 	switch ( view ) {
 		case 'trash':

--- a/projects/packages/forms/routes/responses/actions.tsx
+++ b/projects/packages/forms/routes/responses/actions.tsx
@@ -297,10 +297,8 @@ type NavigateFunction = UseNavigateResult< string >;
 
 type GetActionsParams = {
 	navigate: NavigateFunction;
-	// Below the `medium` breakpoint boot renders the inspector as a full-screen
-	// fixed overlay rather than a side panel, so selecting a response already
-	// fills the viewport. When supplied, View selects instead of navigating —
-	// matching what tapping the response's title does.
+	// When supplied, View selects the response instead of navigating to the
+	// standalone page. The caller decides when that applies.
 	onSelectResponse?: ( id: string ) => void;
 };
 

--- a/projects/packages/forms/routes/responses/package.json
+++ b/projects/packages/forms/routes/responses/package.json
@@ -13,6 +13,7 @@
 		"@wordpress/block-editor": "16.0.0",
 		"@wordpress/blocks": "15.24.0",
 		"@wordpress/components": "37.0.0",
+		"@wordpress/compose": "8.4.0",
 		"@wordpress/core-data": "7.51.0",
 		"@wordpress/data": "10.51.0",
 		"@wordpress/dataviews": "17.3.0",

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -7,6 +7,7 @@ import { formatNumber } from '@automattic/number-formatters';
  * WordPress dependencies
  */
 import { __experimentalText as Text } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { useViewportMatch } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
@@ -156,6 +157,9 @@ function StageInner() {
 	const statusView = params.view === 'spam' || params.view === 'trash' ? params.view : 'inbox';
 	const statusFilter = statusView === 'inbox' ? 'draft,publish' : statusView;
 	const dateSettings = getDateSettings();
+	// Matches the width at which boot flips the inspector from a side panel to a
+	// full-screen overlay.
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
 
 	const sourceIdValue = ( searchParams as { sourceId?: string | number } )?.sourceId;
 	const sourceIdNumber =
@@ -633,8 +637,9 @@ function StageInner() {
 			getRowActions( {
 				navigate,
 				view: statusView,
+				onSelectResponse: isMobileViewport ? id => onChangeSelection( [ id ] ) : undefined,
 			} ),
-		[ navigate, statusView ]
+		[ navigate, statusView, isMobileViewport, onChangeSelection ]
 	);
 
 	const paginationInfo = useMemo(

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -7,7 +7,7 @@ import { formatNumber } from '@automattic/number-formatters';
  * WordPress dependencies
  */
 import { __experimentalText as Text } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { useViewportMatch } from '@wordpress/compose';
+import { useEvent, useViewportMatch } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { DataViews } from '@wordpress/dataviews';
@@ -249,6 +249,11 @@ function StageInner() {
 		},
 		[ searchParams, navigate ]
 	);
+
+	// Selecting a single response is what both clicking a row and (on small
+	// screens) the View action do. `useEvent` keeps the reference stable so the
+	// memoized row actions don't rebuild every time `searchParams` changes.
+	const selectResponse = useEvent( ( id: string ) => onChangeSelection( [ id ] ) );
 
 	const onStatusChange = useCallback(
 		( nextStatus: 'inbox' | 'spam' | 'trash' ) => {
@@ -637,9 +642,9 @@ function StageInner() {
 			getRowActions( {
 				navigate,
 				view: statusView,
-				onSelectResponse: isMobileViewport ? id => onChangeSelection( [ id ] ) : undefined,
+				onSelectResponse: isMobileViewport ? selectResponse : undefined,
 			} ),
-		[ navigate, statusView, isMobileViewport, onChangeSelection ]
+		[ navigate, statusView, isMobileViewport, selectResponse ]
 	);
 
 	const paginationInfo = useMemo(
@@ -725,9 +730,9 @@ function StageInner() {
 
 	const onClickItem = useCallback(
 		( item: unknown ) => {
-			onChangeSelection( [ String( ( item as { id: number | string } ).id ) ] );
+			selectResponse( String( ( item as { id: number | string } ).id ) );
 		},
-		[ onChangeSelection ]
+		[ selectResponse ]
 	);
 
 	return (

--- a/projects/packages/forms/src/dashboard/wp-build/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/style.scss
@@ -105,10 +105,7 @@ body.jetpack-forms-responses {
 	// (`.jp-forms__single-response`) actually overflows and scrolls. The mixin's
 	// blanket `> *` rule would instead shrink the card to the viewport, and the
 	// card's own `overflow: hidden` then clips everything past the fold.
-	.jp-admin-page:has(.jp-forms__single-response) {
-
-		.jp-forms__single-response-card {
-			flex: 0 0 auto;
-		}
+	.jp-admin-page:has(.jp-forms__single-response) .jp-forms__single-response-card {
+		flex: 0 0 auto;
 	}
 }

--- a/projects/packages/forms/src/dashboard/wp-build/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/style.scss
@@ -99,4 +99,16 @@ body.jetpack-forms-responses {
 			}
 		}
 	}
+
+	// The standalone single response page is a document-flow page, not a bounded
+	// app surface: the card must take its content height so the scrollable middle
+	// (`.jp-forms__single-response`) actually overflows and scrolls. The mixin's
+	// blanket `> *` rule would instead shrink the card to the viewport, and the
+	// card's own `overflow: hidden` then clips everything past the fold.
+	.jp-admin-page:has(.jp-forms__single-response) {
+
+		.jp-forms__single-response-card {
+			flex: 0 0 auto;
+		}
+	}
 }

--- a/projects/plugins/jetpack/changelog/fix-forms-single-form-scroll
+++ b/projects/plugins/jetpack/changelog/fix-forms-single-form-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Allow a single response to scroll when it is taller than the screen.

--- a/projects/plugins/jetpack/changelog/fix-forms-single-form-scroll-view-action
+++ b/projects/plugins/jetpack/changelog/fix-forms-single-form-scroll-view-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: On small screens, the View action now opens a response the same way tapping its title does.


### PR DESCRIPTION
Fixes #

## Proposed changes

Two fixes to the single-response surfaces in the Forms responses dashboard.

**1. A response taller than the screen could not be scrolled.**

On the standalone single response page (`/response/<id>`), anything below the fold was unreachable — no scrollbar appeared anywhere on the page, and the content was simply clipped.

The cause is a specificity collision rather than a missing `overflow`. `jetpack-admin-page-layout-wp-build` blanket-sets `> * { flex: 1 1 auto; min-height: 0 }` on the scrollable middle's direct children so DataViews pages can fill their bounded slot. On this route the middle is `.jp-forms__single-response` and its only child is `.jp-forms__single-response-card`, so the card was forced to *shrink* to the viewport instead of growing to its content. The middle therefore never overflowed and its `overflow: auto` never produced a scrollbar, and the card's own `overflow: hidden` (which keeps the meta header's background inside the rounded corners) silently ate the remainder.

Measured before the fix on a response with a long textarea answer: card `clientHeight` 713 vs `scrollHeight` 902, and zero scrollable elements on the page. After: card 902/902, and the middle scrolls 189px.

The override lives in `src/dashboard/wp-build/style.scss` beside the existing DataViews override and uses the same `:has()` scoping — that scoping is what wins the specificity tie against the mixin.

**2. On small screens the View row action behaved differently from tapping a response.**

Tapping a response's title selects it, which below 782px opens the inspector as a full-screen overlay. The View row action instead navigated away to the standalone page. Below that breakpoint View now selects the response too, so both gestures land in the same place.

`getActions` takes an optional `onSelectResponse`; the stage passes it only when `useViewportMatch( 'medium', '<' )` is true. 782px is exactly where boot flips the inspector from a side panel to a fixed overlay (verified: 781px overlay, 782px side panel). Desktop behaviour is unchanged — View still opens the standalone page.

`@wordpress/compose` is added to `routes/responses/package.json`; the route already pulled it in transitively via `usePageHeaderDetails`, this just declares it.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Both changes are in the Forms responses dashboard (**Jetpack → Forms**). You need a form with at least one response whose answers are long enough to overflow the screen — a multi-line textarea answer of a few hundred words works.

**Scrolling a tall response**

* Open a response's standalone page: from the responses list, use the **View** row action (on desktop), or go directly to `admin.php?page=jetpack-forms-responses-wp-admin&p=/response/<id>`.
* On `trunk`, the response card is cut off at the bottom of the window and nothing scrolls — the long answer is unreachable.
* With this branch, the page scrolls and the whole response is reachable.
* Check a *short* response too: the card should now shrink-wrap its content rather than stretching to the full window height.
* Printing a response (the **Print** row action) should be unaffected.

**Mobile View action**

* Narrow the window below 782px (or use a phone).
* Tap a response's email address in the list — the response opens as a full-screen panel with a close (X) button.
* Go back, open the row's **⋮** menu and choose **View** — it should open that same full-screen panel, not navigate to a separate page.
* Widen back above 782px and use the inline **View** button on a row — it should still open the standalone response page as before.
