### PR TITLE
Jetpack AI: Gate the AI module master switch to internal testing environments

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -252,11 +252,24 @@ class Jetpack_AI_Settings {
 	 * module machinery; there the option only carries the legacy pre-module
 	 * value the one-time opt-out migration reads, and is never written again.
 	 *
+	 * The module is only reachable from the My Jetpack AI card in internal
+	 * testing environments, which is why that card reports it active everywhere
+	 * else (see My_Jetpack\Products\Jetpack_Ai::is_module_active()). Enforcing
+	 * the module off-Simple without that same gate turns AI off on sites with no
+	 * way to turn it back on. Remove this gate when the AI settings page goes
+	 * public, alongside the My Jetpack override.
+	 *
 	 * @return bool
 	 */
 	public static function is_master_enabled() {
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			return (bool) get_option( self::MASTER_OPTION, true );
+		}
+
+		// Guarded because Simple loads this file without load-jetpack.php.
+		if ( ! function_exists( 'jetpack_is_internal_testing_environment' )
+			|| ! jetpack_is_internal_testing_environment() ) {
+			return true;
 		}
 
 		return ( new Modules() )->is_active( self::AI_MODULE );

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-master-switch-gate
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-master-switch-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI: Keep AI features available on sites where the new AI module has not been activated, so they are not turned off with no way to turn them back on.

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
@@ -49,9 +49,19 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Off-Simple the `ai` module only acts as the master inside an internal
+	 * testing environment, which is where these module-as-master tests live.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+	}
+
+	/**
 	 * Reset the options and filters this test touches.
 	 */
 	public function tear_down() {
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		delete_option( Jetpack_AI_Settings::MASTER_OPTION );
 		foreach ( Jetpack_AI_Settings::FEATURE_OPTIONS as $option ) {
 			delete_option( $option );
@@ -179,6 +189,21 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 		update_option( Jetpack_AI_Settings::MASTER_OPTION, 0 );
 		$this->force_ai_module_active();
 		$this->assertTrue( Jetpack_AI_Settings::is_master_enabled(), 'An active module means master on even with the option off.' );
+	}
+
+	/**
+	 * The `ai` module is only reachable from the My Jetpack card in internal
+	 * testing environments, so it must not gate AI anywhere else. Without this,
+	 * a site whose module never auto-activated loses AI with no way to restore
+	 * it.
+	 */
+	public function test_is_master_enabled_ignores_module_outside_internal_testing() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
+
+		// The module is inactive here, and the option is irrelevant off-Simple.
+		$this->assertTrue( Jetpack_AI_Settings::is_master_enabled(), 'An inactive module must not turn AI off outside internal testing.' );
+		$this->assertTrue( apply_filters( 'jetpack_ai_enabled', true ), 'AI filters must stay open outside internal testing.' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

The `ai` module recently became the site-wide AI master switch off WordPress.com Simple (self-hosted and Atomic). The My Jetpack card that toggles it is only rendered in internal testing environments, and outside those it reports the module as active so the card looks unchanged.

The enforcement did not get that same gate. `Jetpack_AI_Settings::is_master_enabled()` reads the real module state for everyone, so a site whose module has not been activated has AI switched off while the card still shows it as on, and there is no control anywhere in the UI to turn it back on.

This applies the internal-testing gate to the enforcement as well, so the two agree. Outside internal testing environments AI behaves as it did before the module existed, still subject to the host, plan and filter gates. Simple is untouched, since the option remains the master there.

Both gates are temporary and should come out together when the AI settings page goes public.

### Why sites end up without the module

Auto-activation runs through a version window, and a module whose `First Introduced` matches the current version is excluded on any prerelease of it, because a prerelease sorts below its release:

```
version_compare( '16.2-a.1', '16.2', '<' ) === true
```

So on 16.2 alphas the module is skipped and never activates. That is a general problem with new modules rather than an AI one, and is worth fixing separately in the modules package. This PR removes the user-visible consequence.

## Testing instructions

On a self-hosted or Atomic site that is **not** an internal testing environment:

- Confirm the `ai` module is inactive (`wp jetpack module list`, or `wp option get jetpack_active_modules`).
- Open the post editor. The AI features should work, and the AI settings should be available as they were before the module shipped.
- On trunk without this change, the same site has AI off with no way to turn it on.

On a local, Jurassic Ninja or proxied site (an internal testing environment):

- The module remains the master. Toggle the AI card in My Jetpack → Products and confirm AI turns on and off with it.

Also `Jetpack_AI_Settings_Test.php` covers both paths.

## Does this pull request change what data or activity we track or use?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)