### PR TITLE
Jetpack AI: Keep the AI module active on Atomic until its release ships

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-jetpack-ai-module-inactive-on-atomic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-jetpack-ai-module-inactive-on-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack AI: Keep AI features working on Atomic sites where the new AI module has not been activated.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -323,6 +323,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';
 		if ( Constants::is_true( 'IS_ATOMIC' ) ) {
+			require_once __DIR__ . '/features/jetpack-ai-module/jetpack-ai-module.php';
 			require_once __DIR__ . '/features/plugin-conflicts-guardian/plugin-conflicts-guardian.php';
 		}
 		require_once __DIR__ . '/features/post-categories/quick-actions.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Keep Jetpack AI usable on Atomic sites whose `ai` module never activated.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+/**
+ * Report the `ai` module as active so Jetpack AI keeps working.
+ *
+ * The module is the site-wide AI master switch off WordPress.com Simple, but the
+ * My Jetpack card that toggles it only renders in internal testing environments.
+ * A site whose module never activated therefore has AI switched off with no
+ * control anywhere to switch it back on, which is what happens on any release
+ * before the one the module was introduced in.
+ *
+ * Internal testing environments are left alone: the switch is reachable there,
+ * and forcing it on would make it impossible to test the off state.
+ *
+ * Remove this along with the gate on the module itself once the AI settings page
+ * ships and the switch is reachable everywhere.
+ *
+ * @param array $modules Active module slugs.
+ * @return array Active module slugs.
+ */
+function wpcom_keep_jetpack_ai_module_active( $modules ) {
+	if ( function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment() ) {
+		return $modules;
+	}
+
+	if ( ! is_array( $modules ) ) {
+		return $modules;
+	}
+
+	if ( ! in_array( 'ai', $modules, true ) ) {
+		$modules[] = 'ai';
+	}
+
+	return $modules;
+}
+add_filter( 'jetpack_active_modules', 'wpcom_keep_jetpack_ai_module_active' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
@@ -30,12 +30,12 @@ const OPTED_OUT_OPTION = 'wpcom_jetpack_ai_module_opted_out';
  * control anywhere to switch it back on, which is what happens on any release
  * before the one the module was introduced in.
  *
- * Two cases are left alone, so this defaults AI on rather than forcing it on:
- * an explicit opt-out, and internal testing environments, where the switch is
- * already reachable and the off state needs to stay testable.
+ * This only ever adds the module, so it defaults AI on rather than forcing it
+ * on. The option records that someone has made a choice; once they have, the
+ * stored module state is left to speak for itself.
  *
- * Remove this along with the gate on the module itself once the AI settings page
- * ships and the switch is reachable everywhere.
+ * Remove this once the AI settings page ships and the switch is reachable
+ * everywhere.
  *
  * @param array $modules Active module slugs.
  * @return array Active module slugs.
@@ -45,13 +45,7 @@ function keep_module_active( $modules ) {
 		return $modules;
 	}
 
-	// Keep an opt-out honoured even after auto-activation turns the module on,
-	// which it does once the release the module was introduced in ships.
 	if ( get_option( OPTED_OUT_OPTION ) ) {
-		return array_values( array_diff( $modules, array( 'ai' ) ) );
-	}
-
-	if ( function_exists( 'jetpack_is_internal_testing_environment' ) && \jetpack_is_internal_testing_environment() ) {
 		return $modules;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
@@ -6,6 +6,11 @@
  */
 
 /**
+ * Option recording that someone turned the `ai` module off on purpose.
+ */
+const WPCOM_JETPACK_AI_MODULE_OPTED_OUT = 'wpcom_jetpack_ai_module_opted_out';
+
+/**
  * Report the `ai` module as active so Jetpack AI keeps working.
  *
  * The module is the site-wide AI master switch off WordPress.com Simple, but the
@@ -14,8 +19,9 @@
  * control anywhere to switch it back on, which is what happens on any release
  * before the one the module was introduced in.
  *
- * Internal testing environments are left alone: the switch is reachable there,
- * and forcing it on would make it impossible to test the off state.
+ * Two cases are left alone, so this defaults AI on rather than forcing it on:
+ * an explicit opt-out, and internal testing environments, where the switch is
+ * already reachable and the off state needs to stay testable.
  *
  * Remove this along with the gate on the module itself once the AI settings page
  * ships and the switch is reachable everywhere.
@@ -24,11 +30,15 @@
  * @return array Active module slugs.
  */
 function wpcom_keep_jetpack_ai_module_active( $modules ) {
-	if ( function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment() ) {
+	if ( ! is_array( $modules ) ) {
 		return $modules;
 	}
 
-	if ( ! is_array( $modules ) ) {
+	if ( get_option( WPCOM_JETPACK_AI_MODULE_OPTED_OUT ) ) {
+		return $modules;
+	}
+
+	if ( function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment() ) {
 		return $modules;
 	}
 
@@ -39,3 +49,35 @@ function wpcom_keep_jetpack_ai_module_active( $modules ) {
 	return $modules;
 }
 add_filter( 'jetpack_active_modules', 'wpcom_keep_jetpack_ai_module_active' );
+
+/**
+ * Record an explicit opt-out so turning AI off sticks.
+ *
+ * Deactivating removes the module from `active_modules`, which the filter above
+ * would immediately undo. The option is what tells the two apart: a site that
+ * never activated the module, and a site that turned it off.
+ *
+ * @param string $module  Module slug.
+ * @param bool   $success Whether the module was deactivated.
+ * @return void
+ */
+function wpcom_record_jetpack_ai_module_opt_out( $module, $success ) {
+	if ( 'ai' === $module && $success ) {
+		update_option( WPCOM_JETPACK_AI_MODULE_OPTED_OUT, true );
+	}
+}
+add_action( 'jetpack_deactivate_module', 'wpcom_record_jetpack_ai_module_opt_out', 10, 2 );
+
+/**
+ * Clear the opt-out when AI is turned back on.
+ *
+ * @param string $module  Module slug.
+ * @param bool   $success Whether the module was activated.
+ * @return void
+ */
+function wpcom_clear_jetpack_ai_module_opt_out( $module, $success ) {
+	if ( 'ai' === $module && $success ) {
+		delete_option( WPCOM_JETPACK_AI_MODULE_OPTED_OUT );
+	}
+}
+add_action( 'jetpack_activate_module', 'wpcom_clear_jetpack_ai_module_opt_out', 10, 2 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
@@ -5,10 +5,12 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Module;
+
 /**
  * Option recording that someone turned the `ai` module off on purpose.
  */
-const WPCOM_JETPACK_AI_MODULE_OPTED_OUT = 'wpcom_jetpack_ai_module_opted_out';
+const OPTED_OUT_OPTION = 'wpcom_jetpack_ai_module_opted_out';
 
 /**
  * Report the `ai` module as active so Jetpack AI keeps working.
@@ -29,16 +31,16 @@ const WPCOM_JETPACK_AI_MODULE_OPTED_OUT = 'wpcom_jetpack_ai_module_opted_out';
  * @param array $modules Active module slugs.
  * @return array Active module slugs.
  */
-function wpcom_keep_jetpack_ai_module_active( $modules ) {
+function keep_module_active( $modules ) {
 	if ( ! is_array( $modules ) ) {
 		return $modules;
 	}
 
-	if ( get_option( WPCOM_JETPACK_AI_MODULE_OPTED_OUT ) ) {
+	if ( get_option( OPTED_OUT_OPTION ) ) {
 		return $modules;
 	}
 
-	if ( function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment() ) {
+	if ( function_exists( 'jetpack_is_internal_testing_environment' ) && \jetpack_is_internal_testing_environment() ) {
 		return $modules;
 	}
 
@@ -48,7 +50,7 @@ function wpcom_keep_jetpack_ai_module_active( $modules ) {
 
 	return $modules;
 }
-add_filter( 'jetpack_active_modules', 'wpcom_keep_jetpack_ai_module_active' );
+add_filter( 'jetpack_active_modules', __NAMESPACE__ . '\\keep_module_active' );
 
 /**
  * Record an explicit opt-out so turning AI off sticks.
@@ -61,12 +63,12 @@ add_filter( 'jetpack_active_modules', 'wpcom_keep_jetpack_ai_module_active' );
  * @param bool   $success Whether the module was deactivated.
  * @return void
  */
-function wpcom_record_jetpack_ai_module_opt_out( $module, $success ) {
+function record_opt_out( $module, $success ) {
 	if ( 'ai' === $module && $success ) {
-		update_option( WPCOM_JETPACK_AI_MODULE_OPTED_OUT, true );
+		update_option( OPTED_OUT_OPTION, true );
 	}
 }
-add_action( 'jetpack_deactivate_module', 'wpcom_record_jetpack_ai_module_opt_out', 10, 2 );
+add_action( 'jetpack_deactivate_module', __NAMESPACE__ . '\\record_opt_out', 10, 2 );
 
 /**
  * Clear the opt-out when AI is turned back on.
@@ -75,9 +77,9 @@ add_action( 'jetpack_deactivate_module', 'wpcom_record_jetpack_ai_module_opt_out
  * @param bool   $success Whether the module was activated.
  * @return void
  */
-function wpcom_clear_jetpack_ai_module_opt_out( $module, $success ) {
+function clear_opt_out( $module, $success ) {
 	if ( 'ai' === $module && $success ) {
-		delete_option( WPCOM_JETPACK_AI_MODULE_OPTED_OUT );
+		delete_option( OPTED_OUT_OPTION );
 	}
 }
-add_action( 'jetpack_activate_module', 'wpcom_clear_jetpack_ai_module_opt_out', 10, 2 );
+add_action( 'jetpack_activate_module', __NAMESPACE__ . '\\clear_opt_out', 10, 2 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
@@ -7,6 +7,15 @@
 
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Module;
 
+use Automattic\Jetpack\Constants;
+
+// Atomic only. Simple runs no Jetpack modules and keeps the `jetpack_ai_enabled`
+// option as the AI master, so none of this applies there. The loader already
+// gates on IS_ATOMIC; this keeps the file safe wherever it is required from.
+if ( ! Constants::is_true( 'IS_ATOMIC' ) ) {
+	return;
+}
+
 /**
  * Option recording that someone turned the `ai` module off on purpose.
  */
@@ -36,8 +45,10 @@ function keep_module_active( $modules ) {
 		return $modules;
 	}
 
+	// Keep an opt-out honoured even after auto-activation turns the module on,
+	// which it does once the release the module was introduced in ships.
 	if ( get_option( OPTED_OUT_OPTION ) ) {
-		return $modules;
+		return array_values( array_diff( $modules, array( 'ai' ) ) );
 	}
 
 	if ( function_exists( 'jetpack_is_internal_testing_environment' ) && \jetpack_is_internal_testing_environment() ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
@@ -8,34 +8,25 @@
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Module;
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Modules;
 
 // Atomic only. Simple runs no Jetpack modules and keeps the `jetpack_ai_enabled`
-// option as the AI master, so none of this applies there. The loader already
-// gates on IS_ATOMIC; this keeps the file safe wherever it is required from.
+// option as the AI master, so none of this applies there.
 if ( ! Constants::is_true( 'IS_ATOMIC' ) ) {
 	return;
 }
 
 /**
- * Option recording that someone turned the `ai` module off on purpose.
- */
-const OPTED_OUT_OPTION = 'wpcom_jetpack_ai_module_opted_out';
-
-/**
  * Report the `ai` module as active so Jetpack AI keeps working.
  *
- * The module is the site-wide AI master switch off WordPress.com Simple, but the
- * My Jetpack card that toggles it only renders in internal testing environments.
- * A site whose module never activated therefore has AI switched off with no
- * control anywhere to switch it back on, which is what happens on any release
- * before the one the module was introduced in.
+ * The module became the site-wide AI master switch off WordPress.com Simple, but
+ * it only auto-activates once the release that introduced it ships. Until then a
+ * site has AI switched off, which is not how Atomic behaved before the module
+ * existed, and the switch is not reachable to turn it back on.
  *
- * This only ever adds the module, so it defaults AI on rather than forcing it
- * on. The option records that someone has made a choice; once they have, the
- * stored module state is left to speak for itself.
- *
- * Remove this once the AI settings page ships and the switch is reachable
- * everywhere.
+ * AI is therefore on for everyone here, and cannot be turned off. That matches
+ * Atomic before the module, where there was no site-wide switch at all. Revert
+ * this once the release reaches Atomic and the module can be toggled for real.
  *
  * @param array $modules Active module slugs.
  * @return array Active module slugs.
@@ -45,7 +36,9 @@ function keep_module_active( $modules ) {
 		return $modules;
 	}
 
-	if ( get_option( OPTED_OUT_OPTION ) ) {
+	// Nothing to report active on a version that predates the module. Reads the
+	// available list, not the active one, so it does not re-enter this filter.
+	if ( ! ( new Modules() )->is_module( 'ai' ) ) {
 		return $modules;
 	}
 
@@ -56,35 +49,3 @@ function keep_module_active( $modules ) {
 	return $modules;
 }
 add_filter( 'jetpack_active_modules', __NAMESPACE__ . '\\keep_module_active' );
-
-/**
- * Record an explicit opt-out so turning AI off sticks.
- *
- * Deactivating removes the module from `active_modules`, which the filter above
- * would immediately undo. The option is what tells the two apart: a site that
- * never activated the module, and a site that turned it off.
- *
- * @param string $module  Module slug.
- * @param bool   $success Whether the module was deactivated.
- * @return void
- */
-function record_opt_out( $module, $success ) {
-	if ( 'ai' === $module && $success ) {
-		update_option( OPTED_OUT_OPTION, true );
-	}
-}
-add_action( 'jetpack_deactivate_module', __NAMESPACE__ . '\\record_opt_out', 10, 2 );
-
-/**
- * Clear the opt-out when AI is turned back on.
- *
- * @param string $module  Module slug.
- * @param bool   $success Whether the module was activated.
- * @return void
- */
-function clear_opt_out( $module, $success ) {
-	if ( 'ai' === $module && $success ) {
-		delete_option( OPTED_OUT_OPTION );
-	}
-}
-add_action( 'jetpack_activate_module', __NAMESPACE__ . '\\clear_opt_out', 10, 2 );

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-module-atomic-fallback-tests
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-module-atomic-fallback-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Tests: drop the temporary Atomic AI module fallback so the module-as-master tests keep exercising the plugin's own behaviour.

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -181,6 +181,25 @@ function _manually_load_muplugin() {
 	}
 }
 
+/**
+ * Drop the temporary Atomic fallback that reports the `ai` module active.
+ *
+ * These tests exercise the plugin's own module-as-master contract, where an
+ * inactive module means AI is off. Remove this alongside the fallback itself,
+ * once the release that introduced the module reaches Atomic.
+ *
+ * Runs on plugins_loaded because Jetpack_Mu_Wpcom::init() defers load_features()
+ * to that hook, so the filter does not exist any earlier.
+ *
+ * @return void
+ */
+function _remove_ai_module_atomic_fallback() {
+	remove_filter(
+		'jetpack_active_modules',
+		'Automattic\\Jetpack\\Jetpack_Mu_Wpcom\\Jetpack_AI_Module\\keep_module_active'
+	);
+}
+
 // If we are running the uninstall tests don't load jetpack.
 if ( ! ( in_running_uninstall_group() ) ) {
 	tests_add_filter( 'plugins_loaded', '_manually_load_plugin', 1 );
@@ -188,6 +207,7 @@ if ( ! ( in_running_uninstall_group() ) ) {
 	if ( '1' === getenv( 'JETPACK_TEST_WPCOMSH' ) ) {
 		define( 'IS_ATOMIC', true );
 		tests_add_filter( 'muplugins_loaded', '_manually_load_muplugin' );
+		tests_add_filter( 'plugins_loaded', '_remove_ai_module_atomic_fallback', 100 );
 	}
 
 	if ( '1' === getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {


### PR DESCRIPTION
## Proposed changes

Jetpack AI is switched off on Atomic sites running a 16.2 pre-release, and customers have no way to turn it back on.

16.2 adds an "AI" module that acts as the on/off switch for Jetpack AI. It is supposed to switch itself on automatically, but that only happens once 16.2 is properly released. A pre-release such as 16.2-a.1 counts as older than 16.2, so the module gets skipped and never switches on.

What people see: AI is missing from the editor, image generation is gone, and credits cannot be spent. Meanwhile the My Jetpack card still says AI is on, and the toggle that would fix it is only shown to Automatticians. Support has had a report from a customer with two affected sites.

This switches the module back on for Atomic sites, so AI works again.

## AI cannot be switched off while this is in place

Worth saying plainly. This forces AI on with no way out.

That is how Atomic worked before 16.2, when there was no site-wide AI switch at all, so nothing is being taken away. **Remove this once 16.2 reaches Atomic**, at which point the module switches on by itself and the toggle starts working properly.

## Notes

- Atomic only. Simple sites use a different switch and are unaffected.
- Self-hosted sites on a pre-release are not covered. `wp jetpack module activate ai` works there.
- Nothing is written to the site's database, so removing this leaves no trace.
- Tests that assume AI is off unless the module is on now run without this patch, so they keep checking the plugin's own behaviour.

Thanks to @enej for the approach and @kat3samsin for the check on older versions. @enej is fixing the version comparison itself separately, which removes the need for this.

## Testing instructions

Start on an Atomic site where the AI module is **not** active. Check the site's stored settings rather than a screen, because this change alters what the screens report:

```
wp option get jetpack_active_modules      # should not list 'ai'
```

If it is listed, switch AI off at `/wp-admin/admin.php?page=jetpack_modules` first.

- **Without this change:** open the post editor. AI is missing and image generation is unavailable.
- **With this change:** both work again.

Two things that are expected and not signs of a problem. The Jetpack modules screen will now show AI as active while `wp option get jetpack_active_modules` still does not list it, because nothing is written to the database. And the My Jetpack card reports AI as active either way, so it tells you nothing here.

## Does this pull request change what data or activity we track or use?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

