### PR TITLE
Jetpack: extract named seams from activate_new_modules()

### DIFF
--- a/projects/plugins/jetpack/changelog/refactor-activate-new-modules
+++ b/projects/plugins/jetpack/changelog/refactor-activate-new-modules
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Internal refactor of Jetpack::activate_new_modules() into named helpers; no functional change.
+
+

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2209,7 +2209,20 @@ class Jetpack {
 	}
 
 	/**
-	 * Activate new modules.
+	 * Bring the site's active modules in line with the version of Jetpack now running.
+	 *
+	 * Hooked on `init` for every request, but does real work only on the first request after
+	 * the plugin's version number goes up. On that request it:
+	 *
+	 *  1. deactivates each active module whose code changed since the recorded version, so that
+	 *     module's activation routine runs again below;
+	 *  2. records the version now running, keeping the previously recorded one alongside it;
+	 *  3. hands off to {@see self::activate_default_modules()} with the version window between
+	 *     the two. That is what actually turns modules on: every "Auto Activate: Yes" module
+	 *     introduced within the window, plus the modules deactivated in step 1.
+	 *
+	 * A site that has never recorded a version is seeded first, so a fresh install takes the
+	 * same path with the entire default module set inside its window.
 	 *
 	 * @param bool $redirect Should this function redirect after activation.
 	 *
@@ -2220,60 +2233,184 @@ class Jetpack {
 			return;
 		}
 
-		$jetpack_old_version = Jetpack_Options::get_option( 'version' );
-		if ( ! $jetpack_old_version ) {
-			$old_version         = '1.1:' . time();
-			$version             = $old_version;
-			$jetpack_old_version = $version;
-			/** This action is documented in class.jetpack.php */
-			do_action( 'updating_jetpack_version', $version, false );
-			Jetpack_Options::update_options( compact( 'version', 'old_version' ) );
-		}
+		$previous = self::seed_version_option();
 
-		list( $jetpack_version ) = explode( ':', $jetpack_old_version );
+		list( $previous_version ) = explode( ':', $previous );
 
-		if ( version_compare( JETPACK__VERSION, $jetpack_version, '<=' ) ) {
+		if ( ! self::is_version_upgrade( $previous_version ) ) {
 			return;
 		}
 
-		$active_modules     = self::get_active_modules();
-		$reactivate_modules = array();
-		foreach ( $active_modules as $active_module ) {
-			$module = self::get_module( $active_module );
+		// Order is load-bearing: the new version is recorded only after the changed modules have
+		// been deactivated, since recording it is what stops this from running again.
+		$reactivate_modules = self::deactivate_modules_changed_since( $previous_version );
+
+		self::record_version_upgrade( $previous );
+
+		self::state( 'message', 'modules_activated' );
+
+		self::activate_default_modules( $previous_version, self::current_version(), $reactivate_modules, $redirect );
+
+		if ( $redirect ) {
+			self::redirect_after_activation();
+		}
+	}
+
+	/**
+	 * The Jetpack version this code is running as.
+	 *
+	 * Read through Constants rather than the bare constant so a caller — a test, most of all —
+	 * can stand in a version instead of being pinned to whatever release the plugin is at.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string
+	 */
+	private static function current_version() {
+		return Constants::get_constant( 'JETPACK__VERSION' );
+	}
+
+	/**
+	 * The version recorded for this site, seeding it if the site has never recorded one.
+	 *
+	 * An unrecorded site is treated as having run 1.1 — far enough back that every module falls
+	 * inside the upgrade window — so a first run activates the default module set instead of
+	 * doing nothing.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string The recorded version, in `<version>:<timestamp>` form.
+	 */
+	private static function seed_version_option() {
+		$recorded = Jetpack_Options::get_option( 'version' );
+		if ( $recorded ) {
+			return $recorded;
+		}
+
+		$old_version = '1.1:' . time();
+		$version     = $old_version;
+
+		/** This action is documented in class.jetpack.php */
+		do_action( 'updating_jetpack_version', $version, false );
+		Jetpack_Options::update_options( compact( 'version', 'old_version' ) );
+
+		return $version;
+	}
+
+	/**
+	 * Whether the code now running is newer than the version last recorded for this site.
+	 *
+	 * Equal versions and downgrades are both "not an upgrade" — module activation only ever
+	 * runs forwards.
+	 *
+	 * @internal Public only so it can be exercised directly by tests. Not a plugin API.
+	 * @since $$next-version$$
+	 *
+	 * @param string $previous_version Version recorded for this site, without its timestamp.
+	 *
+	 * @return bool
+	 */
+	public static function is_version_upgrade( $previous_version ) {
+		return version_compare( self::current_version(), $previous_version, '>' );
+	}
+
+	/**
+	 * Which of the given modules declare that they changed after $previous_version.
+	 *
+	 * Decides nothing and touches no state, so the rule is readable on its own. A module opts in
+	 * by declaring a `Changed:` header; no module shipped today declares one, which makes this
+	 * an empty list in practice.
+	 *
+	 * @internal Public only so it can be exercised directly by tests. Not a plugin API.
+	 * @since $$next-version$$
+	 *
+	 * @param string $previous_version Version recorded for this site, without its timestamp.
+	 * @param array  $modules          Map of module slug to module data, as returned by self::get_module().
+	 *
+	 * @return string[] Module slugs.
+	 */
+	public static function get_modules_changed_since( $previous_version, array $modules ) {
+		$changed = array();
+
+		foreach ( $modules as $slug => $module ) {
 			if ( ! isset( $module['changed'] ) ) {
 				continue;
 			}
 
-			if ( version_compare( $module['changed'], $jetpack_version, '<=' ) ) {
+			if ( version_compare( $module['changed'], $previous_version, '<=' ) ) {
 				continue;
 			}
 
-			$reactivate_modules[] = $active_module;
-			self::deactivate_module( $active_module );
+			$changed[] = $slug;
 		}
 
-		$new_version = JETPACK__VERSION . ':' . time();
+		return $changed;
+	}
+
+	/**
+	 * Deactivate every active module that changed after $previous_version, so that the
+	 * activation which follows runs their activation routines afresh.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $previous_version Version recorded for this site, without its timestamp.
+	 *
+	 * @return string[] Slugs of the deactivated modules, for the caller to reactivate.
+	 */
+	private static function deactivate_modules_changed_since( $previous_version ) {
+		$modules = array();
+		foreach ( self::get_active_modules() as $slug ) {
+			$modules[ $slug ] = self::get_module( $slug );
+		}
+
+		$changed = self::get_modules_changed_since( $previous_version, $modules );
+
+		foreach ( $changed as $slug ) {
+			self::deactivate_module( $slug );
+		}
+
+		return $changed;
+	}
+
+	/**
+	 * Record that the site is now running the current version, keeping what it ran before.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $previous Version recorded for this site, in `<version>:<timestamp>` form.
+	 *
+	 * @return void
+	 */
+	private static function record_version_upgrade( $previous ) {
+		$new_version = self::current_version() . ':' . time();
+
 		/** This action is documented in class.jetpack.php */
-		do_action( 'updating_jetpack_version', $new_version, $jetpack_old_version );
+		do_action( 'updating_jetpack_version', $new_version, $previous );
 		Jetpack_Options::update_options(
 			array(
 				'version'     => $new_version,
-				'old_version' => $jetpack_old_version,
+				'old_version' => $previous,
 			)
 		);
+	}
 
-		self::state( 'message', 'modules_activated' );
-
-		self::activate_default_modules( $jetpack_version, JETPACK__VERSION, $reactivate_modules, $redirect );
-
-		if ( $redirect ) {
-			$page = 'jetpack'; // make sure we redirect to either settings or the jetpack page.
-			if ( isset( $_GET['page'] ) && in_array( $_GET['page'], array( 'jetpack', 'jetpack_modules' ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- we're not changing the site.
-				$page = sanitize_text_field( wp_unslash( $_GET['page'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- we're not changing the site.
-			}
-			wp_safe_redirect( self::admin_url( 'page=' . rawurlencode( $page ) ) );
-			exit( 0 );
+	/**
+	 * Send the admin back to the Jetpack screen now that activation is done.
+	 *
+	 * Kept apart because it ends the request: with `exit` out of activate_new_modules(), that
+	 * method stays reachable in tests.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return never
+	 */
+	private static function redirect_after_activation() {
+		$page = 'jetpack'; // make sure we redirect to either settings or the jetpack page.
+		if ( isset( $_GET['page'] ) && in_array( $_GET['page'], array( 'jetpack', 'jetpack_modules' ), true ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- we're not changing the site.
+			$page = sanitize_text_field( wp_unslash( $_GET['page'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- we're not changing the site.
 		}
+		wp_safe_redirect( self::admin_url( 'page=' . rawurlencode( $page ) ) );
+		exit( 0 );
 	}
 
 	/**


### PR DESCRIPTION
Fixes # N/A

## Proposed changes

`Jetpack::activate_new_modules()` is the method that turns modules on when the plugin's version number goes up. It was a single 60-line body that did four unrelated jobs, read `JETPACK__VERSION` directly, and ended in `exit`. That combination made it effectively untestable — there is not one test that calls it today — and hard to read.

This is a **pure refactor. No functional change.** The body is split into named helpers, each with one job:

* `current_version()` — reads `JETPACK__VERSION` through `Constants::get_constant()` instead of the bare constant. Same value at runtime; the point is that it can now be substituted.
* `seed_version_option()` — the "site has never recorded a version" bootstrap, which pretends the site ran `1.1` so a fresh install takes the upgrade path.
* `is_version_upgrade()` — the gate. Pure. Named, because the original was the double negative `version_compare( JETPACK__VERSION, $v, '<=' ) → return`.
* `get_modules_changed_since()` — pure list computation over a `slug => module data` map. No state, no decisions.
* `deactivate_modules_changed_since()` — the effectful wrapper around it.
* `record_version_upgrade()` — the version option writes and the `updating_jetpack_version` action.
* `redirect_after_activation()` — the `wp_safe_redirect()` + `exit`, moved out on its own.

Two helpers are `public` with an `@internal` docblock purely so tests can reach them; the rest are `private`.

Named `is_version_upgrade()` rather than `is_plugin_upgrade()` because `Jetpack::plugin_upgrade()` already exists in this class and the two would read as a pair.

### How the parts relate

`activate_new_modules()` is now just the sequence, with each step delegating:

```
activate_new_modules( $redirect )
│
├─ 1. GATE: is this site eligible at all?
│     is_connection_ready() || Status::is_offline_mode()          → bail
│
├─ 2. WHAT VERSION WAS THIS SITE ON?
│     seed_version_option()  ─────────────────► "14.0:1699999999"
│         └─ if never recorded: writes "1.1:<time>",
│            fires updating_jetpack_version( $v, false )
│     explode( ':' )         ─────────────────► "14.0"
│
├─ 3. GATE: is this actually an upgrade?
│     is_version_upgrade( "14.0" )                                → bail if not
│         └─ current_version() > "14.0" ?      (equal and downgrade both bail)
│
├─ 4. WHICH ACTIVE MODULES NEED RE-ACTIVATING?
│     deactivate_modules_changed_since( "14.0" )
│         ├─ get_active_modules()  →  get_module() per slug  →  map
│         ├─ get_modules_changed_since( "14.0", $map )   ← pure, the actual rule
│         └─ deactivate_module() for each hit    ─────────► ["sharedaddy", …]
│
├─ 5. RECORD THE NEW VERSION
│     record_version_upgrade( "14.0:1699999999" )
│         ├─ fires updating_jetpack_version( "14.1:<now>", "14.0:1699999999" )
│         └─ writes version + old_version
│
├─ 6. state( 'message', 'modules_activated' )
│
├─ 7. THE ACTUAL ACTIVATION
│     activate_default_modules( "14.0", current_version(), $reactivated, $redirect )
│         └─ turns on every "Auto Activate: Yes" module introduced inside the
│            version window, plus the modules deactivated in step 4
│
└─ 8. redirect_after_activation()   (only when $redirect, ends the request)
```

Two relationships are worth calling out to a reviewer:

1. **Step 4 must run before step 5.** The recorded version is what makes this a one-shot, so it is written only once the modules it accounts for have been dealt with. There is a comment in the code saying so, because it is the kind of ordering a later cleanup would happily "tidy".
2. **Step 7 is where modules actually turn on.** Steps 2–5 only compute the version window `(previously recorded, now running]` and hand it over. Nothing before step 7 activates anything — step 4 only ever *deactivates*.

### Notes for the reviewer

* The `changed`-header loop in step 4 is **inert in production**: no module shipped today declares a `Changed:` header, so `get_modules_changed_since()` always returns an empty list. That is not a change introduced here — it is pre-existing, and pulling it into a named pure function is what makes it visible. Left in place deliberately.
* `Modules::get_active()` ends in `array_unique()`, which is why step 4 can safely key modules by slug into a map rather than iterating a list.
* The `$redirect` branch is unchanged, just relocated.

## Related product discussion/links

* N/A — internal code health.

## Does this pull request change what data or activity we track or use?

No. No new data is collected, stored, or sent. The `updating_jetpack_version` action fires with the same arguments, in the same order, at the same point as before.

## Testing instructions

The goal is confirming **nothing changed**. Automated checks carry most of the weight; the manual pass exercises the real upgrade path.

### Automated

From the monorepo root:

```bash
jetpack docker phpunit jetpack        # full plugin suite
jetpack phan plugins/jetpack
composer phpcs:changed
```

Expected: suite green, Phan `FOUND 0 ISSUES TOTAL`, PHPCS clean. On this branch the full suite reports **3726 tests, 10722 assertions, 0 failures**.

> If you run this in a **git worktree** rather than your primary checkout, plugin PHPUnit will fail with *"the wordpress-develop checkout is incomplete"*. That is not this PR. `tools/docker/bin/run.sh` gates the whole wordpress-develop fixture setup behind `[ "$COMPOSE_PROJECT_NAME" == "jetpack_dev" ]`, and the fix the message suggests is behind the same gate. Copy `tools/docker/wordpress-develop/` from your primary checkout and symlink `/tmp/wordpress-develop/tests/phpunit/data/plugins/jetpack` inside the container.

### Manual — the upgrade path

On a Jetpack-connected site (or add `define( 'JETPACK_DEV_DEBUG', true );` to run in offline mode):

1. Record the starting state:
   ```bash
   wp eval 'echo Jetpack_Options::get_option( "version" ) . "\n";'
   wp jetpack module list
   ```
2. Fake an old install so the next request looks like an upgrade:
   ```bash
   wp eval 'Jetpack_Options::update_option( "version", "13.0:" . ( time() - 86400 ) );'
   ```
3. Load any front-end page in the browser to fire `init`.
4. Confirm the version advanced and `old_version` kept what was there:
   ```bash
   wp eval 'echo Jetpack_Options::get_option( "version" ) . "\n";'      # now <current>:<timestamp>
   wp eval 'echo Jetpack_Options::get_option( "old_version" ) . "\n";'  # 13.0:<timestamp from step 2>
   ```
   Note `old_version` keeps the **full** string including its timestamp, while the comparison uses only the number before the colon. That asymmetry is pre-existing and preserved.
5. Confirm modules introduced since 13.0 that are "Auto Activate: Yes" are now on:
   ```bash
   wp jetpack module list
   ```
6. **Idempotence.** Load another page and re-check the version — it must not change again, and no modules should flip. This is the `is_version_upgrade()` gate.
7. **Downgrade is a no-op.** Set the version *ahead* of the plugin and load a page; nothing should change:
   ```bash
   wp eval 'Jetpack_Options::update_option( "version", "999.0:" . time() );'
   ```
8. **Fresh site.** Clear the recorded version and load a page. It should seed and immediately run the upgrade, activating the default module set:
   ```bash
   wp eval 'Jetpack_Options::delete_option( "version" );'
   ```
9. **Disconnected does nothing.** Disconnect Jetpack (and leave offline mode off), repeat step 2, load a page — the version must stay at `13.0:…` and no modules should change.

### Manual — the redirect branch

The `$redirect = true` path is only reached from `admin_page_load()`. In `wp-admin`, complete a Jetpack connection or hit a Jetpack admin action that triggers module activation and confirm you land back on the Jetpack page (`?page=jetpack`), with `?page=jetpack_modules` preserved when you started there.

### Follow-up

Characterization tests for this method are the next PR. They were the original motivation here — the method has zero direct test coverage today, and this refactor is what makes writing them practical: the two gates become one-line calls, the `changed` rule can be tested with plain arrays and no WordPress, and `activate_new_modules()` no longer contains an `exit`.
