### PR TITLE
Jetpack AI: Retain the unloaded AI module file so its deletion deploys separately

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-restore-ai-module-file
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-mu-wpcom-restore-ai-module-file
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Retain an unloaded file so its deletion deploys separately from the require removal.
+

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Retained, unloaded, so the file deletion deploys separately from the require removal.
+ *
+ * Nothing requires this file. It is deleted in a follow-up once this has deployed.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Module;
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Modules;
+
+// Atomic only. Simple runs no Jetpack modules and keeps the `jetpack_ai_enabled`
+// option as the AI master, so none of this applies there.
+if ( ! Constants::is_true( 'IS_ATOMIC' ) ) {
+	return;
+}
+
+/**
+ * Report the `ai` module as active so Jetpack AI keeps working.
+ *
+ * The module became the site-wide AI master switch off WordPress.com Simple, but
+ * it only auto-activates once the release that introduced it ships. Until then a
+ * site has AI switched off, which is not how Atomic behaved before the module
+ * existed, and the switch is not reachable to turn it back on.
+ *
+ * AI is therefore on for everyone here, and cannot be turned off. That matches
+ * Atomic before the module, where there was no site-wide switch at all. Revert
+ * this once the release reaches Atomic and the module can be toggled for real.
+ *
+ * @param array $modules Active module slugs.
+ * @return array Active module slugs.
+ */
+function keep_module_active( $modules ) {
+	if ( ! is_array( $modules ) ) {
+		return $modules;
+	}
+
+	// Nothing to report active on a version that predates the module. Reads the
+	// available list, not the active one, so it does not re-enter this filter.
+	if ( ! ( new Modules() )->is_module( 'ai' ) ) {
+		return $modules;
+	}
+
+	if ( ! in_array( 'ai', $modules, true ) ) {
+		$modules[] = 'ai';
+	}
+
+	return $modules;
+}


### PR DESCRIPTION
## Proposed changes

* Restore `features/jetpack-ai-module/jetpack-ai-module.php` to the tree, unloaded, and drop its `add_filter` call.
* The `require_once` removed by #51491 stays removed. Behaviour is unchanged — the `ai` module stays inactive on Atomic.

#51491 deleted that file and removed its `require_once` in the same commit. wpcom's "unsupported commits" check blocks that pairing, because if the deletion deploys before the require removal the require fatals, so the deploy aborted.

This splits it in two. Restoring the file leaves the next deploy carrying only the require removal, and a follow-up deletes the file once this has shipped. A deletion on its own passes the check.

Nothing loads the file: the require is gone, and the only glob in this package scans `features/wpcom-endpoints/`. The `add_filter` line is dropped as well, so it cannot act even if something did load it.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On an Atomic site, confirm nothing changed from #51491: `wp option get jetpack_active_modules` does not list `ai`, and AI features are unavailable in the editor.
* Confirm `src/features/jetpack-ai-module/jetpack-ai-module.php` is present, and that `src/class-jetpack-mu-wpcom.php` has no `require_once` for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
