### PR TITLE
Jetpack AI: Stop the editor fataling when another plugin loads an older Status package

### DIFF
--- a/projects/plugins/jetpack/_inc/content-guidelines-ai.php
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai.php
@@ -18,6 +18,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Check whether the current visitor should be marked as Automattician traffic.
+ *
+ * @since $$next-version$$
+ *
+ * @return bool True when the visitor is Automattician traffic.
+ */
+function jetpack_content_guidelines_ai_is_tracking_automattician() {
+	$visitor = new Visitor();
+
+	// Another plugin can supply an older copy of jetpack-status through its own
+	// autoloader, where this method does not exist yet.
+	if ( ! method_exists( $visitor, 'is_tracking_automattician' ) ) {
+		return ( function_exists( 'is_automattician' ) && is_automattician() )
+			|| ( function_exists( 'wpcom_is_proxied_request' ) && wpcom_is_proxied_request() )
+			|| ( defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST );
+	}
+
+	return $visitor->is_tracking_automattician();
+}
+
+/**
  * Enqueue content-guidelines-ai script on the Content Guidelines admin page.
  *
  * @since 16.0
@@ -91,7 +112,7 @@ function jetpack_content_guidelines_ai_enqueue_scripts( $hook_suffix ) {
 		// Tags every Tracks event fired from this page as internal traffic. The
 		// feature is new and low-volume, so Automattician testing is otherwise a
 		// visible share of the numbers with no way to filter it out after the fact.
-		'isA11n'          => ( new Visitor() )->is_tracking_automattician(),
+		'isA11n'          => jetpack_content_guidelines_ai_is_tracking_automattician(),
 	);
 
 	// Resolve the AI feature state server-side so the bundle can hydrate the

--- a/projects/plugins/jetpack/changelog/fix-jetpack-status-visitor-guard
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-status-visitor-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI: Keep the editor working when another plugin loads an older copy of the Status package.

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -420,7 +420,17 @@ function get_tracking_site_type() {
  * @return bool True when the current visitor is an Automattician.
  */
 function is_tracking_automattician() {
-	return ( new Visitor() )->is_tracking_automattician();
+	$visitor = new Visitor();
+
+	// Another plugin can supply an older copy of jetpack-status through its own
+	// autoloader, where this method does not exist yet.
+	if ( ! method_exists( $visitor, 'is_tracking_automattician' ) ) {
+		return ( function_exists( 'is_automattician' ) && \is_automattician() )
+			|| ( function_exists( 'wpcom_is_proxied_request' ) && \wpcom_is_proxied_request() )
+			|| ( defined( 'AT_PROXIED_REQUEST' ) && AT_PROXIED_REQUEST );
+	}
+
+	return $visitor->is_tracking_automattician();
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

* Guard the two Jetpack AI call sites that reach into `Automattic\Jetpack\Status\Visitor::is_tracking_automattician()`, falling back to a local check when the loaded copy of the class does not define it.

`is_tracking_automattician()` was added in jetpack-status 6.4.0. Jetpack ships that version, but a site can end up running an older copy of the class supplied by an unrelated plugin, and then the call is fatal:

```
Uncaught Error: Call to undefined method Automattic\Jetpack\Status\Visitor::is_tracking_automattician()
in extensions/plugins/image-studio/image-studio.php:423
```

The packages are published for anyone to use, so plugins outside the monorepo carry their own copies. A plugin that registers those copies through a plain Composer autoloader rather than `jetpack-autoloader` never joins the version comparison — its classmap simply answers first, and Jetpack's newer copy is never consulted. Composer registers with `prepend`, so a plugin loading after Jetpack sits ahead of Jetpack's autoloader in the stack.

One observed example: Social Chat (`wp-whatsapp-chat`) pulls in `automattic/jetpack-assets`, which depends on `automattic/jetpack-status`. It ships `jetpack-status` v6.1.2, has no `jetpack_autoload_classmap.php`, and its copy predates the method. Its current release, 8.6.1, ships v6.1.9 and is affected the same way.

This only surfaced now because Image Studio does not enqueue while the site-wide AI switch is off. It is not specific to Image Studio: any newly added method on a shared package has the same exposure wherever plugin code calls it unguarded.

`isA11n` marks Automattician traffic in Tracks. On a site with an older copy the fallback answers from `is_automattician()` and `AT_PROXIED_REQUEST` instead, so no feature changes.

## Does this pull request change what data or activity we track or use?

No. `isA11n` is still reported; on affected sites it is derived locally rather than from the package.

## Testing instructions

Steps to reproduce and verify the fix

1. Configure the test site with:
   - A fresh Jurassic Ninja site — it ships Jetpack 16.2-a.1, which has the affected call sites
   - Jetpack connected
   - The [Jetpack Beta plugin](https://jetpack.com/download-jetpack-beta/), on `trunk`
2. Install and activate either conflicting plugin:
```
wp plugin install wp-whatsapp-chat --activate
```
OR
```
wp plugin install insta-gallery --activate
```
3. Activate the `ai` module:
```
wp jetpack module activate ai
```
- Image Studio does not enqueue while the site-wide AI switch is off, so with `ai` inactive the fatal never appears.
4. Open the Media Library. Confirm that it fails with this error in the UI or PHP logs:
```
Call to undefined method Automattic\Jetpack\Status\Visitor::is_tracking_automattician()
```
5. Confirm the same failure in the post editor, the page editor, and Settings → Content Guidelines.
6. Install this branch: Jetpack → Beta Tester → Jetpack → `fix/jetpack-status-visitor-guard`
7. Confirm that each of these screens loads without a fatal:
   - Media Library
   - Post editor
   - Page editor
   - Settings → Content Guidelines
8. Also confirm that Jetpack AI still works — Image Studio loads in the post editor and in the Media Library.
9. On a site with no conflicting plugin, confirm those same four screens load as before, and that a
   proxied request still reports `isA11n`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
