### PR TITLE
Jetpack AI: Keep the AI module off where an older Status copy would fatal the editor

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-gate-ai-module-on-old-visitor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-gate-ai-module-on-old-visitor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep Jetpack AI off where another plugin supplies an older copy of the Status package, so the block editor keeps working.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -323,6 +323,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/marketplace-products-updater/class-marketplace-products-updater.php';
 		require_once __DIR__ . '/features/media/heif-support.php';
 		if ( Constants::is_true( 'IS_ATOMIC' ) ) {
+			require_once __DIR__ . '/features/jetpack-ai-module/jetpack-ai-module.php';
 			require_once __DIR__ . '/features/plugin-conflicts-guardian/plugin-conflicts-guardian.php';
 		}
 		require_once __DIR__ . '/features/post-categories/quick-actions.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-module/jetpack-ai-module.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * Retained, unloaded, so the file deletion deploys separately from the require removal.
- *
- * Nothing requires this file. It is deleted in a follow-up once this has deployed.
+ * Keep the `ai` module off where the loaded Status package cannot serve it.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -10,7 +8,7 @@
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Module;
 
 use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Status\Visitor;
 
 // Atomic only. Simple runs no Jetpack modules and keeps the `jetpack_ai_enabled`
 // option as the AI master, so none of this applies there.
@@ -19,34 +17,28 @@ if ( ! Constants::is_true( 'IS_ATOMIC' ) ) {
 }
 
 /**
- * Report the `ai` module as active so Jetpack AI keeps working.
+ * Report the `ai` module inactive when an older copy of Visitor is in play.
  *
- * The module became the site-wide AI master switch off WordPress.com Simple, but
- * it only auto-activates once the release that introduced it ships. Until then a
- * site has AI switched off, which is not how Atomic behaved before the module
- * existed, and the switch is not reachable to turn it back on.
+ * Jetpack AI surfaces call `Visitor::is_tracking_automattician()`, added in
+ * jetpack-status 6.4.0. A plugin can supply an older copy of that class through
+ * its own autoloader, leaving the method undefined and the editor fataling on
+ * every load. Reporting the module inactive keeps those surfaces from loading.
  *
- * AI is therefore on for everyone here, and cannot be turned off. That matches
- * Atomic before the module, where there was no site-wide switch at all. Revert
- * this once the release reaches Atomic and the module can be toggled for real.
+ * AI is unavailable on such a site until the call sites tolerate an older copy.
+ * Remove this once that ships.
  *
  * @param array $modules Active module slugs.
  * @return array Active module slugs.
  */
-function keep_module_active( $modules ) {
-	if ( ! is_array( $modules ) ) {
+function gate_module_on_status_version( $modules ) {
+	if ( ! is_array( $modules ) || ! in_array( 'ai', $modules, true ) ) {
 		return $modules;
 	}
 
-	// Nothing to report active on a version that predates the module. Reads the
-	// available list, not the active one, so it does not re-enter this filter.
-	if ( ! ( new Modules() )->is_module( 'ai' ) ) {
-		return $modules;
-	}
-
-	if ( ! in_array( 'ai', $modules, true ) ) {
-		$modules[] = 'ai';
+	if ( class_exists( Visitor::class ) && ! method_exists( Visitor::class, 'is_tracking_automattician' ) ) {
+		return array_values( array_diff( $modules, array( 'ai' ) ) );
 	}
 
 	return $modules;
 }
+add_filter( 'jetpack_active_modules', __NAMESPACE__ . '\\gate_module_on_status_version' );


### PR DESCRIPTION
## Proposed changes

* Report the `ai` module inactive on Atomic when the loaded `Automattic\Jetpack\Status\Visitor` does not define `is_tracking_automattician()`.

Jetpack AI surfaces call that method, added in jetpack-status 6.4.0. Jetpack ships that version, but a site can be running an older copy of the class supplied by another plugin, and then every editor load fatals:

```
Call to undefined method Automattic\Jetpack\Status\Visitor::is_tracking_automattician()
in extensions/plugins/image-studio/image-studio.php:423
```

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On an Atomic site with Jetpack AI on, install **and activate** a plugin that bundles a pre-6.4.0 `jetpack-status` through plain Composer — Social Chat (`wp-whatsapp-chat`) or Social Feed Gallery (`insta-gallery`) both work:

* On trunk, opening the post editor or the site editor fatals with the error above, on every load.
* With this change, both editors load, and Jetpack AI features are absent from the editor.
* `wp option get jetpack_active_modules` still lists `ai` — the filter changes what is reported, not what is stored.

On an Atomic site without such a plugin:

* Jetpack AI behaves exactly as before. The filter finds the current class and returns the module list untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
