### PR TITLE
Jetpack Mu Wpcom: Resolve Status Visitor at mu-plugin time so a plugi…

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-pin-status-visitor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-pin-status-visitor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the block editor working on sites where another plugin supplies an older copy of the Status package.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -43,6 +43,7 @@ class Jetpack_Mu_Wpcom {
 		// time, before WP loads active plugins.
 		if ( Constants::is_true( 'IS_ATOMIC' ) ) {
 			require_once __DIR__ . '/features/plugin-conflicts-guardian/probe-confirm-bootstrap.php';
+			require_once __DIR__ . '/common/pin-status-visitor.php';
 		}
 
 		/*

--- a/projects/packages/jetpack-mu-wpcom/src/common/pin-status-visitor.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/pin-status-visitor.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Resolve Status\Visitor before plugins can supply their own copy.
+ *
+ * Plugins outside the monorepo bundle jetpack-status too. One that registers its
+ * copy through a plain Composer autoloader never joins the version comparison,
+ * and Composer prepends, so it answers first and an older class wins site-wide.
+ *
+ * Resolving the class here — at mu-plugin time, before any plugin is loaded —
+ * lets the Jetpack autoloader pick the newest copy it knows about. PHP then has
+ * the class, so a copy loaded later cannot replace it.
+ *
+ * Remove once the call sites tolerate an older copy on their own.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+class_exists( \Automattic\Jetpack\Status\Visitor::class );


### PR DESCRIPTION
## Proposed changes

* Resolve `Automattic\Jetpack\Status\Visitor` at mu-plugin time on Atomic, before any plugin can supply its own copy.

Jetpack AI surfaces call `Visitor::is_tracking_automattician()`, added in jetpack-status 6.4.0. Jetpack ships that version, but a site can end up running an older copy of the class from another plugin, and then every editor load fatals:

```
Call to undefined method Automattic\Jetpack\Status\Visitor::is_tracking_automattician()
in extensions/plugins/image-studio/image-studio.php:423
```

These packages are published for anyone to use, so plugins outside the monorepo bundle their own copies. A plugin that loads its copy through `vendor/autoload.php` rather than `vendor/autoload_packages.php` never joins the version comparison — Composer registers with `prepend`, so it answers first and Jetpack's newer copy is never consulted.

wpcomsh runs before any regular plugin, so resolving the class there lets the Jetpack autoloader pick the newest copy it knows about. PHP then has the class, and a copy loaded later cannot replace it. The fatal stops and Jetpack AI keeps working.

The change is one line, placed beside the existing Atomic-only bootstrap that runs at mu-plugin time for the same load-order reason.

**Failure mode.** If the autoloader is not ready, `class_exists()` returns false and nothing is loaded — the pin is a no-op and behaviour is unchanged. It cannot introduce a fatal of its own.

**Cost today: none that I can find.** Our `Visitor` is a strict superset of the copies those plugins bundle — same `get_ip()` signature, same `is_automattician_feature_flags_only()` body, plus the new method. Anything they can call on their copy they can call on ours, with the same behaviour.

**Temporary by design.** That superset property is what makes this safe, and nothing guarantees it holds. Remove, rename or change a method on `Visitor` later and this hands those plugins a class that no longer matches what they built against — they take the fatal instead of us, on their users' sites, from our mu-plugin. The same applies if wpcomsh's bundled jetpack-status ever lags the plugin's: we would pin the older of our own copies. Neither case announces itself; the pin is silent when it is wrong.

So this is a bridge, not a pattern. It should come out once the call sites tolerate an older copy on their own, and it should not be copied for the next shared class that has this problem. The general protection is defensive call sites: we publish these packages, so older copies are guaranteed to exist, and plugin code should not call a newly added method on one without a check.

Related: #51495 reports the module inactive where the class is old, which fixes the fatal by turning Jetpack AI off on those sites. #51494 guards the call sites in the plugin and covers self-hosted too. All three stack — this one is a no-op wherever the class is already current.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On an Atomic site with Jetpack AI on, install **and activate** a plugin that bundles a pre-6.4.0 `jetpack-status` through plain Composer — `wp-whatsapp-chat` works:

* On trunk, opening the post editor or the site editor fatals with the error above, on every load.
* With this change, both editors load **and Jetpack AI features still work**, including Image Studio.
* Deactivating that plugin and reactivating it should make no difference either way.

On an Atomic site without such a plugin:

* Jetpack AI behaves exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
