### PR TITLE
AGENTS.md: name the product in dependent plugins' changelog entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,8 @@ An entry only lands in the CHANGELOG of the project it was added to. A PR confin
 
 **When a change to a package or js-package is user-facing — a new block, new or changed UI, a behavior change, a bug fix someone would notice — add a changelog entry to every plugin that ships it, on top of the project's own entry.** Write each one from that plugin's user's perspective; the wording rarely needs to be identical.
 
+Prefix each plugin's entry with the product the shared project backs — `Premium Analytics:` for `packages/premium-analytics`, `Search:` for `packages/search` — so readers of a plugin changelog that bundles many products can place the change. The exception is a plugin named for that same product (`plugins/premium-analytics`, `plugins/search`): there the prefix would only repeat the plugin's own name, so leave it off (or use a narrower component prefix), as in the example below.
+
 List the plugins that ship a project (works the same for `packages/…` and `js-packages/…`):
 
 ```bash


### PR DESCRIPTION
## Proposed changes
* Document in AGENTS.md that changelog entries added to dependent plugins for a shared package's user-facing change must be prefixed with the product that package backs (e.g. `Premium Analytics:` for `packages/premium-analytics`), except in a plugin named for that same product (`plugins/premium-analytics`, `plugins/search`), where the prefix would only repeat the plugin's own name.

## Related product discussion/links
* WOOA7S-1902 (where the convention came up in review)

## Does this pull request change what data or activity we track or use?
No — documentation only.

## Testing instructions

* Read the added paragraph under "User-Facing Changes Outside a Plugin Also Need Plugin Entries" in AGENTS.md and check it matches the existing example block below it (unprefixed `plugins/search`, prefixed `plugins/jetpack`).
