### PR TITLE
Premium Analytics: stamp Stats bucket dates without a fabricated offset

### DIFF
--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-naive-bucket-stamps
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-naive-bucket-stamps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: stamp bucket dates as timezone-naive site-local wall times, fixing report dates that could read a day off for sites away from UTC.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1977-subscribers-wall-clock
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1977-subscribers-wall-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers chart, email timeline: label chart points by the bucket they name rather than by the viewer's time zone.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/archives.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/archives.test.ts
@@ -84,13 +84,13 @@ describe( 'Stats archives normalizer', () => {
 		).toEqual( [
 			{
 				time_interval: '2026-06-01',
-				date_start: '2026-06-01T00:00:00+00:00',
-				date_end: '2026-06-07T23:59:59+00:00',
+				date_start: '2026-06-01T00:00:00',
+				date_end: '2026-06-07T23:59:59',
 			},
 			{
 				time_interval: '2026-06-08',
-				date_start: '2026-06-08T00:00:00+00:00',
-				date_end: '2026-06-14T23:59:59+00:00',
+				date_start: '2026-06-08T00:00:00',
+				date_end: '2026-06-14T23:59:59',
 			},
 		] );
 	} );
@@ -141,8 +141,8 @@ describe( 'Stats archives normalizer', () => {
 		expect( result.data ).toEqual( [
 			expect.objectContaining( {
 				time_interval: '2025-06-02',
-				date_start: '2025-06-01T00:00:00+00:00',
-				date_end: '2025-06-02T23:59:59+00:00',
+				date_start: '2025-06-01T00:00:00',
+				date_end: '2025-06-02T23:59:59',
 				items: [
 					{
 						label: 'home',

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts
@@ -15,8 +15,8 @@ describe( 'Stats clicks normalizer', () => {
 		expect( result.summary ).toEqual( {
 			total_clicks: 1323,
 			other_clicks: 0,
-			date_start: '2026-06-16T00:00:00+00:00',
-			date_end: '2026-06-22T23:59:59+00:00',
+			date_start: '2026-06-16T00:00:00',
+			date_end: '2026-06-22T23:59:59',
 		} );
 		expect( result.data[ 0 ] ).toEqual(
 			expect.objectContaining( {
@@ -54,8 +54,8 @@ describe( 'Stats clicks normalizer', () => {
 		expect( result.data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-16',
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-16T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-16T23:59:59',
 				items: [
 					expect.objectContaining( {
 						label: 'wordpress.org',
@@ -403,8 +403,8 @@ describe( 'Stats clicks normalizer', () => {
 			data: [
 				{
 					time_interval: '2026-06-29',
-					date_start: '2026-06-29T00:00:00+00:00',
-					date_end: '2026-06-29T23:59:59+00:00',
+					date_start: '2026-06-29T00:00:00',
+					date_end: '2026-06-29T23:59:59',
 					items: [
 						{
 							label: 'wordpress.org',
@@ -464,8 +464,8 @@ describe( 'Stats clicks normalizer', () => {
 			data: [
 				{
 					time_interval: '2026-06-29',
-					date_start: '2026-06-29T00:00:00+00:00',
-					date_end: '2026-06-29T23:59:59+00:00',
+					date_start: '2026-06-29T00:00:00',
+					date_end: '2026-06-29T23:59:59',
 					items: [
 						{
 							label: 'wordpress.org',
@@ -524,8 +524,8 @@ describe( 'Stats clicks normalizer', () => {
 			data: [
 				{
 					time_interval: '2026-06-29',
-					date_start: '2026-06-29T00:00:00+00:00',
-					date_end: '2026-06-29T23:59:59+00:00',
+					date_start: '2026-06-29T00:00:00',
+					date_end: '2026-06-29T23:59:59',
 					items: [
 						{
 							label: 'wordpress.org',
@@ -610,8 +610,8 @@ describe( 'Stats clicks normalizer', () => {
 			data: [
 				{
 					time_interval: '2026-06-29',
-					date_start: '2026-06-29T00:00:00+00:00',
-					date_end: '2026-06-29T23:59:59+00:00',
+					date_start: '2026-06-29T00:00:00',
+					date_end: '2026-06-29T23:59:59',
 					items,
 				},
 			],

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/comments.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/comments.test.ts
@@ -16,8 +16,8 @@ describe( 'Stats comments normalizer', () => {
 		expect( result.data ).toEqual( [
 			expect.objectContaining( {
 				time_interval: '2026-06-16',
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-16T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-16T23:59:59',
 				items: [
 					{
 						label: 'authors',

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/locations.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/locations.test.ts
@@ -33,14 +33,14 @@ describe( 'Stats locations normalizer', () => {
 		expect( result.summary ).toEqual( {
 			total_views: 0,
 			other_views: 0,
-			date_start: '2026-06-16T00:00:00+00:00',
-			date_end: '2026-06-22T23:59:59+00:00',
+			date_start: '2026-06-16T00:00:00',
+			date_end: '2026-06-22T23:59:59',
 		} );
 		expect( result.data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-22',
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-22T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-22T23:59:59',
 			} )
 		);
 		expect( result.data[ 0 ].items ).toEqual( [
@@ -86,14 +86,14 @@ describe( 'Stats locations normalizer', () => {
 		expect( result.summary ).toEqual( {
 			total_views: 0,
 			other_views: 0,
-			date_start: '2026-06-16T00:00:00+00:00',
-			date_end: '2026-06-22T23:59:59+00:00',
+			date_start: '2026-06-16T00:00:00',
+			date_end: '2026-06-22T23:59:59',
 		} );
 		expect( result.data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-22',
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-22T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-22T23:59:59',
 			} )
 		);
 		expect( result.data[ 0 ].items ).toEqual( [

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers.test.ts
@@ -11,8 +11,8 @@ describe( 'Stats referrers normalizer', () => {
 		expect( result.data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-16',
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-16T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-16T23:59:59',
 				items: [
 					expect.objectContaining( {
 						label: 'example.com/path',
@@ -37,14 +37,14 @@ describe( 'Stats referrers normalizer', () => {
 			summary: {
 				total_views: 8474,
 				other_views: 0,
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-22T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-22T23:59:59',
 			},
 			data: [
 				{
 					time_interval: '2026-06-22',
-					date_start: '2026-06-16T00:00:00+00:00',
-					date_end: '2026-06-22T23:59:59+00:00',
+					date_start: '2026-06-16T00:00:00',
+					date_end: '2026-06-22T23:59:59',
 					items: [
 						expect.objectContaining( {
 							label: 'Search Engines',

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/search-terms.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/search-terms.test.ts
@@ -34,8 +34,8 @@ describe( 'Stats search terms normalizer', () => {
 		expect( result.data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-16',
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-16T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-16T23:59:59',
 				encrypted_search_terms: 4,
 				items: [
 					expect.objectContaining( {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/subscribers.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/subscribers.test.ts
@@ -13,8 +13,8 @@ describe( 'Stats subscribers normalizers', () => {
 			expect.objectContaining( {
 				subscribers: 22,
 				subscribers_paid: 5,
-				date_start: '2026-06-24T00:00:00+00:00',
-				date_end: '2026-06-25T23:59:59+00:00',
+				date_start: '2026-06-24T00:00:00',
+				date_end: '2026-06-25T23:59:59',
 			} )
 		);
 		expect( result.data ).toEqual( [

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/tags.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/tags.test.ts
@@ -9,8 +9,8 @@ describe( 'Stats tags normalizer', () => {
 		expect( result.data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-22',
-				date_start: '2026-06-22T00:00:00+00:00',
-				date_end: '2026-06-22T23:59:59+00:00',
+				date_start: '2026-06-22T00:00:00',
+				date_end: '2026-06-22T23:59:59',
 				items: [
 					expect.objectContaining( {
 						label: [
@@ -78,8 +78,8 @@ describe( 'Stats tags normalizer', () => {
 		expect( result.data ).toEqual( [
 			{
 				time_interval: '2026-06-16',
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-16T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-16T23:59:59',
 				items: [
 					expect.objectContaining( {
 						label: [
@@ -109,14 +109,14 @@ describe( 'Stats tags normalizer', () => {
 		expect( result ).toEqual( {
 			summary: {
 				total_views: 34,
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-22T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-22T23:59:59',
 			},
 			data: [
 				{
 					time_interval: '2026-06-22',
-					date_start: '2026-06-16T00:00:00+00:00',
-					date_end: '2026-06-22T23:59:59+00:00',
+					date_start: '2026-06-16T00:00:00',
+					date_end: '2026-06-22T23:59:59',
 					items: [
 						expect.objectContaining( {
 							label: [

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -27,15 +27,15 @@ describe( 'Stats time-series normalizer', () => {
 			expect.objectContaining( {
 				views: 21,
 				visitors: 8,
-				date_start: '2026-06-15T00:00:00+00:00',
-				date_end: '2026-06-16T23:59:59+00:00',
+				date_start: '2026-06-15T00:00:00',
+				date_end: '2026-06-16T23:59:59',
 			} )
 		);
 		expect( result.data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-15',
-				date_start: '2026-06-15T00:00:00+00:00',
-				date_end: '2026-06-15T23:59:59+00:00',
+				date_start: '2026-06-15T00:00:00',
+				date_end: '2026-06-15T23:59:59',
 				label: '2026-06-15',
 				value: 8,
 				views: 8,
@@ -68,8 +68,8 @@ describe( 'Stats time-series normalizer', () => {
 		expect( sanitizeStatsTimeSeriesResponse( weeklySubscribersFixture ).data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-15',
-				date_start: '2026-06-15T00:00:00+00:00',
-				date_end: '2026-06-21T23:59:59+00:00',
+				date_start: '2026-06-15T00:00:00',
+				date_end: '2026-06-21T23:59:59',
 				value: 9,
 				subscribers: 9,
 			} )
@@ -80,8 +80,8 @@ describe( 'Stats time-series normalizer', () => {
 		expect( sanitizeStatsTimeSeriesResponse( wpcomWeeklySubscribersFixture ).data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-29',
-				date_start: '2026-06-29T00:00:00+00:00',
-				date_end: '2026-07-05T23:59:59+00:00',
+				date_start: '2026-06-29T00:00:00',
+				date_end: '2026-07-05T23:59:59',
 				value: 9,
 				subscribers: 9,
 			} )
@@ -92,8 +92,8 @@ describe( 'Stats time-series normalizer', () => {
 		expect( sanitizeStatsTimeSeriesResponse( invalidWeekSubscribersFixture ).data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-W54',
-				date_start: '2026-W54T00:00:00+00:00',
-				date_end: '2026-W54T23:59:59+00:00',
+				date_start: '2026-W54T00:00:00',
+				date_end: '2026-W54T23:59:59',
 				value: 9,
 				subscribers: 9,
 			} )
@@ -103,8 +103,8 @@ describe( 'Stats time-series normalizer', () => {
 		).toEqual(
 			expect.objectContaining( {
 				time_interval: '2025-W53',
-				date_start: '2025-W53T00:00:00+00:00',
-				date_end: '2025-W53T23:59:59+00:00',
+				date_start: '2025-W53T00:00:00',
+				date_end: '2025-W53T23:59:59',
 				value: 9,
 				subscribers: 9,
 			} )
@@ -115,8 +115,8 @@ describe( 'Stats time-series normalizer', () => {
 		expect( sanitizeStatsTimeSeriesResponse( monthlySubscribersFixture ).data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2024-02-01',
-				date_start: '2024-02-01T00:00:00+00:00',
-				date_end: '2024-02-29T23:59:59+00:00',
+				date_start: '2024-02-01T00:00:00',
+				date_end: '2024-02-29T23:59:59',
 				value: 29,
 				subscribers: 29,
 			} )
@@ -124,8 +124,8 @@ describe( 'Stats time-series normalizer', () => {
 		expect( sanitizeStatsTimeSeriesResponse( yearlySubscribersFixture ).data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2024-01-01',
-				date_start: '2024-01-01T00:00:00+00:00',
-				date_end: '2024-12-31T23:59:59+00:00',
+				date_start: '2024-01-01T00:00:00',
+				date_end: '2024-12-31T23:59:59',
 				value: 366,
 				subscribers: 366,
 			} )
@@ -160,8 +160,8 @@ describe( 'Stats time-series normalizer', () => {
 		expect( result.summary ).toEqual(
 			expect.objectContaining( {
 				opens_count: 21,
-				date_start: '2026-06-15T00:00:00+00:00',
-				date_end: '2026-06-16T23:59:59+00:00',
+				date_start: '2026-06-15T00:00:00',
+				date_end: '2026-06-16T23:59:59',
 			} )
 		);
 		expect( result.data[ 0 ] ).toEqual(
@@ -192,8 +192,8 @@ describe( 'Stats time-series normalizer', () => {
 		expect( result.data ).toEqual( [
 			expect.objectContaining( {
 				time_interval: '2026-06-15 09:00',
-				date_start: '2026-06-15T09:00:00+00:00',
-				date_end: '2026-06-15T09:59:59+00:00',
+				date_start: '2026-06-15T09:00:00',
+				date_end: '2026-06-15T09:59:59',
 				label: '2026-06-15 09:00',
 				value: 3,
 				opens_count: 3,
@@ -201,7 +201,7 @@ describe( 'Stats time-series normalizer', () => {
 			} ),
 			expect.objectContaining( {
 				time_interval: '2026-06-15 10:00',
-				date_start: '2026-06-15T10:00:00+00:00',
+				date_start: '2026-06-15T10:00:00',
 				value: 5,
 				opens_count: 5,
 				hour: 10,
@@ -220,8 +220,8 @@ describe( 'Stats time-series normalizer', () => {
 		expect( result.data ).toEqual( [
 			expect.objectContaining( {
 				time_interval: '2026-06-15 09:00',
-				date_start: '2026-06-15T09:00:00+00:00',
-				date_end: '2026-06-15T09:59:59+00:00',
+				date_start: '2026-06-15T09:00:00',
+				date_end: '2026-06-15T09:59:59',
 				value: 4,
 				clicks_count: 4,
 				hour: 9,
@@ -257,7 +257,7 @@ describe( 'Stats time-series normalizer', () => {
 		expect( result.data[ 1 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-15 23:00',
-				date_end: '2026-06-15T23:59:59+00:00',
+				date_end: '2026-06-15T23:59:59',
 				hour: '23',
 				value: 4,
 			} )
@@ -282,8 +282,8 @@ describe( 'Stats time-series normalizer', () => {
 
 		expect( result.data ).toEqual( [] );
 		expect( result.summary ).toEqual( {
-			date_start: '2026-06-15T00:00:00+00:00',
-			date_end: '2026-06-16T23:59:59+00:00',
+			date_start: '2026-06-15T00:00:00',
+			date_end: '2026-06-16T23:59:59',
 		} );
 	} );
 
@@ -294,8 +294,8 @@ describe( 'Stats time-series normalizer', () => {
 		);
 
 		expect( result.summary ).toEqual( {
-			date_start: '2026-06-15T00:00:00+00:00',
-			date_end: '2026-06-16T23:59:59+00:00',
+			date_start: '2026-06-15T00:00:00',
+			date_end: '2026-06-16T23:59:59',
 		} );
 	} );
 
@@ -316,18 +316,18 @@ describe( 'Stats time-series normalizer', () => {
 		expect( result.data ).toEqual( [
 			expect.objectContaining( {
 				time_interval: '2026-06-15 09:00',
-				date_start: '2026-06-15T09:00:00+00:00',
-				date_end: '2026-06-15T09:59:59+00:00',
+				date_start: '2026-06-15T09:00:00',
+				date_end: '2026-06-15T09:59:59',
 				value: 3,
 			} ),
 			expect.objectContaining( {
 				time_interval: '2026-06-15 10:00',
-				date_start: '2026-06-15T10:00:00+00:00',
+				date_start: '2026-06-15T10:00:00',
 				value: 5,
 			} ),
 			expect.objectContaining( {
 				time_interval: '2026-06-16 00:00',
-				date_start: '2026-06-16T00:00:00+00:00',
+				date_start: '2026-06-16T00:00:00',
 				value: 1,
 			} ),
 		] );
@@ -342,8 +342,8 @@ describe( 'Stats time-series normalizer', () => {
 		expect( result.data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-15',
-				date_start: '2026-06-15T00:00:00+00:00',
-				date_end: '2026-06-15T23:59:59+00:00',
+				date_start: '2026-06-15T00:00:00',
+				date_end: '2026-06-15T23:59:59',
 			} )
 		);
 	} );
@@ -386,8 +386,8 @@ describe( 'Stats time-series normalizer', () => {
 		] );
 		expect( result.summary ).toEqual(
 			expect.objectContaining( {
-				date_start: '2026-06-15T00:00:00+00:00',
-				date_end: '2026-06-17T23:59:59+00:00',
+				date_start: '2026-06-15T00:00:00',
+				date_end: '2026-06-17T23:59:59',
 			} )
 		);
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-authors.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-authors.test.ts
@@ -11,8 +11,8 @@ describe( 'Stats top authors normalizer', () => {
 		} );
 
 		expect( result.summary ).toEqual( {
-			date_start: '2026-06-16T00:00:00+00:00',
-			date_end: '2026-06-22T23:59:59+00:00',
+			date_start: '2026-06-16T00:00:00',
+			date_end: '2026-06-22T23:59:59',
 		} );
 		expect( result.data[ 0 ].items[ 0 ] ).toEqual(
 			expect.objectContaining( {
@@ -48,8 +48,8 @@ describe( 'Stats top authors normalizer', () => {
 		expect( result.data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-16',
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-16T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-16T23:59:59',
 				items: [
 					expect.objectContaining( {
 						id: 196411292,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-posts.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-posts.test.ts
@@ -8,8 +8,8 @@ function makeReport( items: StatsTopPostsItem[] ): StatsNormalizedReport< StatsT
 		data: [
 			{
 				time_interval: '2026-06-25',
-				date_start: '2026-06-25T00:00:00+00:00',
-				date_end: '2026-06-25T23:59:59+00:00',
+				date_start: '2026-06-25T00:00:00',
+				date_end: '2026-06-25T23:59:59',
 				items,
 			},
 		],
@@ -29,14 +29,14 @@ describe( 'Stats top posts normalizer', () => {
 			summary: {
 				total_views: 0,
 				dropped_ids: [],
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-22T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-22T23:59:59',
 			},
 			data: [
 				{
 					time_interval: '2026-06-22',
-					date_start: '2026-06-16T00:00:00+00:00',
-					date_end: '2026-06-22T23:59:59+00:00',
+					date_start: '2026-06-16T00:00:00',
+					date_end: '2026-06-22T23:59:59',
 					items: [
 						expect.objectContaining( {
 							id: 265143,
@@ -75,8 +75,8 @@ describe( 'Stats top posts normalizer', () => {
 		expect( result.data ).toEqual( [
 			{
 				time_interval: '2026-06-16',
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-16T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-16T23:59:59',
 				items: [
 					expect.objectContaining( {
 						id: 41,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
@@ -35,14 +35,14 @@ describe( 'Stats report utilities', () => {
 				status: 'complete',
 				empty_label: '',
 				enabled: true,
-				date_start: '2026-06-16T00:00:00+00:00',
+				date_start: '2026-06-16T00:00:00',
 			} )
 		).toEqual( {
 			total_views: 123,
 			status: 'complete',
 			empty_label: '',
 			enabled: true,
-			date_start: '2026-06-16T00:00:00+00:00',
+			date_start: '2026-06-16T00:00:00',
 		} );
 	} );
 
@@ -63,8 +63,8 @@ describe( 'Stats report utilities', () => {
 				}
 			)
 		).toEqual( {
-			date_start: '2026-06-16T00:00:00+00:00',
-			date_end: '2026-06-22T23:59:59+00:00',
+			date_start: '2026-06-16T00:00:00',
+			date_end: '2026-06-22T23:59:59',
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts
@@ -8,8 +8,8 @@ function makeReport( items: StatsUtmItem[] ): StatsNormalizedReport< StatsUtmIte
 		data: [
 			{
 				time_interval: '2026-06-16',
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-16T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-16T23:59:59',
 				items,
 			},
 		],
@@ -44,8 +44,8 @@ describe( 'Stats UTM normalizer', () => {
 		expect( result.data[ 0 ] ).toEqual(
 			expect.objectContaining( {
 				time_interval: '2026-06-16',
-				date_start: '2026-06-16T00:00:00+00:00',
-				date_end: '2026-06-16T23:59:59+00:00',
+				date_start: '2026-06-16T00:00:00',
+				date_end: '2026-06-16T23:59:59',
 				items: [
 					{
 						label: 'newsletter / email',

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/wordads.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/wordads.test.ts
@@ -22,15 +22,15 @@ describe( 'Stats WordAds normalizers', () => {
 				impressions: 2000,
 				revenue: 9.75,
 				cpm: 4.875,
-				date_start: '2026-05-01T00:00:00+00:00',
-				date_end: '2026-06-30T23:59:59+00:00',
+				date_start: '2026-05-01T00:00:00',
+				date_end: '2026-06-30T23:59:59',
 			} )
 		);
 		expect( result.data ).toEqual( [
 			expect.objectContaining( {
 				time_interval: '2026-05-01',
-				date_start: '2026-05-01T00:00:00+00:00',
-				date_end: '2026-05-31T23:59:59+00:00',
+				date_start: '2026-05-01T00:00:00',
+				date_end: '2026-05-31T23:59:59',
 				label: '2026-05-01',
 				value: 1200,
 				impressions: 1200,
@@ -40,8 +40,8 @@ describe( 'Stats WordAds normalizers', () => {
 			} ),
 			expect.objectContaining( {
 				time_interval: '2026-06-01',
-				date_start: '2026-06-01T00:00:00+00:00',
-				date_end: '2026-06-30T23:59:59+00:00',
+				date_start: '2026-06-01T00:00:00',
+				date_end: '2026-06-30T23:59:59',
 				value: 800,
 				impressions: 800,
 				revenue: 3.25,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/chart-buckets.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/chart-buckets.ts
@@ -51,7 +51,7 @@ export function getStatsChartBucketKey( date: string, period: StatsChartBucketPe
  *
  * The caller maps each data point to its chart metrics, including the required
  * headline `value`. Metrics are summed when daily points share a chart bucket.
- * Each bucket preserves the first daily point's time and offset.
+ * Each bucket preserves the first daily point's time suffix.
  *
  * @param report          - The normalized daily Stats report.
  * @param period          - The chart bucket period.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -114,12 +114,10 @@ function getPrimaryMetricValue( row: StatsRecord ) {
 }
 
 function getDateFnsIntervalFields( startDate: Date, endDate: Date ) {
-	// Stats interval fields are normalized calendar bucket labels, matching getStatsIntervalFields.
-	// They are not intended to be reinterpreted as site-timezone instants downstream.
 	return {
 		time_interval: format( startDate, dateFormat ),
-		date_start: `${ format( startDate, dateFormat ) }T00:00:00+00:00`,
-		date_end: `${ format( endDate, dateFormat ) }T23:59:59+00:00`,
+		date_start: formatDatePartWithTime( format( startDate, dateFormat ), '00:00:00' ),
+		date_end: formatDatePartWithTime( format( endDate, dateFormat ), '23:59:59' ),
 	};
 }
 
@@ -208,10 +206,8 @@ function getHourIntervalFields( date: string, hour: unknown ) {
 	const datePart = getDatePart( date ) ?? date;
 	const hourPart = String( Math.trunc( Number( hour ) ) || 0 ).padStart( 2, '0' );
 
-	// Like getStatsIntervalFields, these are calendar bucket labels stamped with a nominal +00:00
-	// (formatDatePartWithTime's default), not real UTC instants — the API's hour is already
-	// site-local, so a consumer must render the bucket as wall-clock rather than convert it across
-	// the site offset.
+	// Like getStatsIntervalFields, these are timezone-naive calendar bucket labels — the API's
+	// hour is already site-local, so no offset is stamped for a consumer to convert across.
 	return {
 		time_interval: `${ datePart } ${ hourPart }:00`,
 		date_start: formatDatePartWithTime( datePart, `${ hourPart }:00:00` ),
@@ -248,10 +244,10 @@ function getRowIntervalFields( row: StatsRecord, rawPeriod: unknown, unit: strin
 }
 
 // Rebuild a summary bound from a query date when no rows came back. Rows stamp
-// `date_start`/`date_end` as full ISO 8601 with a nominal +00:00 (see
+// `date_start`/`date_end` as timezone-naive wall times (see
 // getStatsIntervalFields), so the query's own site-local offset can't be passed
-// through verbatim: consumers read these as wall-clock bucket labels, and a real
-// offset would be converted a second time. Mirrors getStatsSummaryIntervalFields.
+// through verbatim — a real offset would get converted rather than read as the
+// bucket's label. Mirrors getStatsSummaryIntervalFields.
 function toSummaryBound( value: string | undefined, time: string ) {
 	const datePart = getDatePart( value );
 

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/date.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/date.test.ts
@@ -10,13 +10,8 @@ describe( 'date helpers', () => {
 		expect( getDatePart( undefined ) ).toBeUndefined();
 	} );
 
-	it( 'formats date parts with a time and offset', () => {
-		expect( formatDatePartWithTime( '2026-06-22', '23:59:59' ) ).toBe(
-			'2026-06-22T23:59:59+00:00'
-		);
-		expect( formatDatePartWithTime( '2026-06-22', '00:00:00', '-05:00' ) ).toBe(
-			'2026-06-22T00:00:00-05:00'
-		);
+	it( 'formats date parts with a time and no offset', () => {
+		expect( formatDatePartWithTime( '2026-06-22', '23:59:59' ) ).toBe( '2026-06-22T23:59:59' );
 	} );
 
 	it( 'returns same-day intervals for day and hour periods', () => {

--- a/projects/packages/premium-analytics/packages/datetime/src/date.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/date.ts
@@ -23,19 +23,20 @@ export function getDatePart( value: unknown ): string | undefined {
 }
 
 /**
- * Format a date part and time into the Premium Analytics ISO-ish response shape.
+ * Format a date part and time into the Premium Analytics response shape: a
+ * timezone-naive stamp naming a site-local wall time.
+ *
+ * Deliberately offset-less. Stats bucket labels are site-local calendar dates,
+ * and a fabricated offset would assert an instant the bucket never named —
+ * `toLocalTZ` would then anchor it in the wrong zone, and every chart consumer
+ * would have to strip it back off.
  *
  * @param datePart - Date part, normally `YYYY-MM-DD`.
  * @param time     - Time part, normally `HH:mm:ss`.
- * @param offset   - Timezone offset suffix.
- * @return Date-time string with offset.
+ * @return Timezone-naive date-time string.
  */
-export function formatDatePartWithTime(
-	datePart: string,
-	time: string,
-	offset = '+00:00'
-): string {
-	return `${ datePart }T${ time }${ offset }`;
+export function formatDatePartWithTime( datePart: string, time: string ): string {
+	return `${ datePart }T${ time }`;
 }
 
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-date.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-date.ts
@@ -9,12 +9,11 @@ const nominalOffset = /(?:Z|[+-]\d{2}:?\d{2})$/;
 /**
  * Read a bucket's `date_start` as the wall clock it names.
  *
- * Bucket stamps carry a nominal `+00:00` rather than a real offset (see
- * `getStatsIntervalFields`), and the chart library lays a point out and labels
- * the axis through the browser's timezone — so keeping the offset shifts every
- * label by the viewer's own offset, turning a midnight bucket into the previous
- * day west of UTC. Dropping it and parsing the remaining wall clock locally
- * keeps a label on the bucket it names.
+ * Bucket stamps name site-local wall times (see `getStatsIntervalFields`), and
+ * the chart library lays a point out and labels the axis through the browser's
+ * timezone — so honouring an offset would shift every label by the viewer's own
+ * offset, turning a midnight bucket into the previous day west of UTC. Parsing
+ * the wall clock locally keeps a label on the bucket it names.
  *
  * The instant this produces is therefore only meaningful as a wall clock. Read
  * it back with `fromChartDate` before handing it to a date formatter, which
@@ -24,12 +23,11 @@ const nominalOffset = /(?:Z|[+-]\d{2}:?\d{2})$/;
  * @return The bucket's wall clock as a local instant.
  */
 export function toChartDate( dateStart: string ): Date {
-	// Only the offset-stripping lives here: knowing the stamp's offset is nominal
-	// is Stats API knowledge the generic parser must not have — `parseAsLocalDate`
-	// rightly honours a real offset. The naive remainder is the charts library's
-	// own wall-clock reading, covering every shape `date_start` arrives in
-	// (`formatDatePartWithTime` stamps, and the bare or space-separated dates the
-	// `getRowIntervalFields` passthrough forwards from the API).
+	// The normalizers emit naive stamps, but the `getRowIntervalFields`
+	// passthrough forwards whatever `date_start` the API sent, which can still
+	// carry a nominal offset — knowing that offset is a label is Stats API
+	// knowledge the generic parser must not have, so it is stripped here before
+	// the charts library's own wall-clock reading handles the naive remainder.
 	return parseAsLocalDate( dateStart.replace( nominalOffset, '' ).trim() );
 }
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -63,7 +63,7 @@ export { toDay } from './to-day';
 export { defaultPeriodForInterval } from './default-period-for-interval';
 export { granularitiesForRange } from './granularities-for-range';
 export { buildMetricTab, type MetricReport, type BuildMetricTabOptions } from './build-metric-tab';
-export { fromChartDate } from './chart-date';
+export { fromChartDate, toChartDate } from './chart-date';
 export { dateFormatForResolution } from './tick-resolution-date-format';
 export {
 	followedGranularity,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -194,6 +194,7 @@ export {
 	GRANULARITY_ATTRIBUTE,
 	GRANULARITY_PICKED_FOR_ATTRIBUTE,
 	buildMetricTab,
+	toChartDate,
 	CHART_DISPLAY_CHART_TYPES,
 	chartTypeAttributeField,
 	granularityAttributeField,

--- a/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
@@ -18,6 +18,7 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 	MetricTabsChart: ( {
 		metrics,
 		chartType,
+		pointsAreWallClocks,
 	}: {
 		metrics: {
 			key: string;
@@ -26,6 +27,7 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 			current: { date: Date; value: number }[];
 		}[];
 		chartType?: string;
+		pointsAreWallClocks?: boolean;
 	} ) => (
 		<div
 			data-testid="metric-tabs-chart"
@@ -33,7 +35,9 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 			data-metric-label={ metrics[ 0 ]?.label }
 			data-metric-total={ String( metrics[ 0 ]?.value ) }
 			data-values={ metrics[ 0 ]?.current.map( point => point.value ).join( ',' ) }
+			data-days={ metrics[ 0 ]?.current.map( point => point.date.getDate() ).join( ',' ) }
 			data-chart-type={ String( chartType ) }
+			data-wall-clocks={ String( pointsAreWallClocks ) }
 		/>
 	),
 } ) );
@@ -91,6 +95,40 @@ describe( 'EmailTimeSeriesWidget', () => {
 		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
 		expect( requestedPath ).toContain( 'stats/opens/emails/1234' );
 		expect( requestedPath ).toContain( 'stats_fields=timeline' );
+	} );
+
+	// Pinned west of UTC on purpose: under a UTC runner the wall-clock reading
+	// and the old instant reading coincide, so this would pass either way. `TZ`
+	// is not on the typed env shape, hence the cast.
+	it( 'builds chart points as the wall clocks the buckets name, declared to the chart', async () => {
+		const env = process.env as Record< string, string | undefined >;
+		const runnerTimeZone = env.TZ;
+		env.TZ = 'America/Los_Angeles';
+
+		try {
+			mockApiFetch.mockResolvedValue( OPENS_TIMELINE_RESPONSE );
+
+			render(
+				<EmailTimeSeriesWidget
+					attributes={ {
+						reportParams: { ...getDefaultQueryParams( false ), post_id: 1234 },
+						metric: 'opens',
+					} }
+				/>
+			);
+
+			const chart = await screen.findByTestId( 'metric-tabs-chart' );
+			// The old `localTZDate` reading anchors the buckets away from the
+			// local frame, so these read as the previous day (3,4,5) under it.
+			expect( chart ).toHaveAttribute( 'data-days', '4,5,6' );
+			expect( chart ).toHaveAttribute( 'data-wall-clocks', 'true' );
+		} finally {
+			if ( runnerTimeZone === undefined ) {
+				delete env.TZ;
+			} else {
+				env.TZ = runnerTimeZone;
+			}
+		}
 	} );
 
 	it( 'reads the clicks endpoint when metric is clicks', async () => {

--- a/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
@@ -15,8 +15,8 @@ import {
 	MetricTabsChartSkeleton,
 	WidgetRoot,
 	WidgetState,
-	buildReportMetricSeries,
 	defaultPeriodForInterval,
+	toChartDate,
 	useWidgetRootContext,
 	type MetricTab,
 	type ReportParamsFieldAttributes,
@@ -111,14 +111,14 @@ function EmailTimeSeriesReport( { metric, chartType }: EmailTimeSeriesReportProp
 	}, [ report, period, field ] );
 
 	// One metric: the headline is the window total (the timeline is summed per
-	// bucket, so the sum of buckets is the range's opens/clicks).
+	// bucket, so the sum of buckets is the range's opens/clicks). Point dates are
+	// wall clocks, read back via `pointsAreWallClocks` (rationale in
+	// `chart-date.ts`).
 	const metricTabs = useMemo< MetricTab[] >( () => {
-		const points = chartReport
-			? buildReportMetricSeries( {
-					primary: chartReport,
-					metrics: [ { key: field, label: metricLabel( metric ) } ],
-			  } )[ 0 ]?.data ?? []
-			: [];
+		const points = ( chartReport?.data ?? [] ).map( point => ( {
+			date: toChartDate( point.date_start ),
+			value: Number( point[ field ] ?? 0 ),
+		} ) );
 
 		return [
 			{
@@ -162,6 +162,7 @@ function EmailTimeSeriesReport( { metric, chartType }: EmailTimeSeriesReportProp
 					metrics={ metricTabs }
 					dataFormat={ DATA_FORMAT }
 					chartType={ chartType }
+					pointsAreWallClocks
 				/>
 			</WidgetState>
 		</div>

--- a/projects/packages/premium-analytics/widgets/popular-days/bucket-views-by-weekday.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/bucket-views-by-weekday.ts
@@ -25,9 +25,9 @@ function weekdayLabel( weekday: number ) {
 	return formatWeekday( ( weekday + 1 ) % 7 );
 }
 
-// The `+00:00` on `date_start` labels a calendar bucket rather than marking a
-// real UTC time, so `new Date()` would resolve it against the viewer's timezone
-// and slide the row onto the previous weekday west of Greenwich.
+// `date_start` labels a calendar bucket rather than marking a real instant, so
+// `new Date()` would resolve it against the viewer's timezone and slide the row
+// onto the previous weekday west of Greenwich.
 function readRowDate( row: Record< string, unknown > ) {
 	const datePart = getDatePart( row.date_start ?? row.time_interval ?? row.period );
 

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/__tests__/subscribers-chart.test.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/__tests__/subscribers-chart.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import SubscribersChartWidget from '../render';
+
+const mockUseStatsSubscribersReport = jest.fn();
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	useStatsSubscribersReport: ( params: unknown ) => mockUseStatsSubscribersReport( params ),
+} ) );
+
+// The chart itself is visx SVG rendering, outside this widget's concern. Keep
+// the tabs observable so the tests can assert what the widget charts.
+jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/widgets-toolkit' ),
+	MetricTabsChart: ( {
+		metrics,
+		pointsAreWallClocks,
+	}: {
+		metrics: { key: string; value: number; current: { date: Date; value: number }[] }[];
+		pointsAreWallClocks?: boolean;
+	} ) => (
+		<div
+			data-testid="metric-tabs-chart"
+			data-metric-keys={ metrics.map( metric => metric.key ).join( ',' ) }
+			data-values={ metrics[ 0 ]?.current.map( point => point.value ).join( ',' ) }
+			data-days={ metrics[ 0 ]?.current.map( point => point.date.getDate() ).join( ',' ) }
+			data-wall-clocks={ String( pointsAreWallClocks ) }
+		/>
+	),
+} ) );
+
+// WidgetRoot reads URL search params as a fallback for report params; outside
+// a matched route the real hook warns and throws.
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
+
+function reportWith( data: Record< string, unknown >[] ) {
+	return {
+		primary: { data: { data } },
+		comparison: { data: undefined },
+		isLoading: false,
+		isFetching: false,
+		isError: false,
+		refetch: jest.fn(),
+	};
+}
+
+describe( 'SubscribersChartWidget', () => {
+	beforeEach( () => {
+		mockUseStatsSubscribersReport.mockReset();
+	} );
+
+	// Pinned west of UTC on purpose: under a UTC runner the wall-clock reading
+	// and the old instant reading coincide, so this would pass either way. `TZ`
+	// is not on the typed env shape, hence the cast.
+	it( 'builds chart points as the wall clocks the buckets name, declared to the chart', async () => {
+		const env = process.env as Record< string, string | undefined >;
+		const runnerTimeZone = env.TZ;
+		env.TZ = 'America/Los_Angeles';
+
+		try {
+			mockUseStatsSubscribersReport.mockReturnValue(
+				reportWith( [
+					{ date_start: '2026-07-04T00:00:00', subscribers: 5, subscribers_paid: 0 },
+					{ date_start: '2026-07-05T00:00:00', subscribers: 6, subscribers_paid: 0 },
+				] )
+			);
+
+			render(
+				<SubscribersChartWidget attributes={ { reportParams: getDefaultQueryParams( false ) } } />
+			);
+
+			const chart = await screen.findByTestId( 'metric-tabs-chart' );
+			// The old `localTZDate` reading anchors the buckets away from the
+			// local frame, so these read as the previous day (3,4) under it.
+			expect( chart ).toHaveAttribute( 'data-days', '4,5' );
+			expect( chart ).toHaveAttribute( 'data-values', '5,6' );
+			expect( chart ).toHaveAttribute( 'data-wall-clocks', 'true' );
+		} finally {
+			if ( runnerTimeZone === undefined ) {
+				delete env.TZ;
+			} else {
+				env.TZ = runnerTimeZone;
+			}
+		}
+	} );
+
+	it( 'offers the Paid subscribers tab only when the site has paid subscribers', async () => {
+		mockUseStatsSubscribersReport.mockReturnValue(
+			reportWith( [ { date_start: '2026-07-04T00:00:00', subscribers: 5, subscribers_paid: 2 } ] )
+		);
+
+		render(
+			<SubscribersChartWidget attributes={ { reportParams: getDefaultQueryParams( false ) } } />
+		);
+
+		const chart = await screen.findByTestId( 'metric-tabs-chart' );
+		expect( chart ).toHaveAttribute( 'data-metric-keys', 'subscribers,paid' );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
@@ -156,6 +156,7 @@ function SubscribersChartInner( { chartType }: SubscribersChartInnerProps ) {
 					dataFormat={ DATA_FORMAT }
 					chartType={ chartType }
 					groupLabel={ groupLabel }
+					pointsAreWallClocks
 				/>
 			</WidgetState>
 		</div>

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/use-subscribers-chart.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/use-subscribers-chart.ts
@@ -3,11 +3,11 @@
  */
 import {
 	useStatsSubscribersReport,
-	localTZDate,
 	type ReportParams,
 	type StatsSubscribersResponse,
 	type StatsSubscribersUnit,
 } from '@jetpack-premium-analytics/data';
+import { toChartDate } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 
 /**
@@ -40,9 +40,11 @@ export interface SubscribersChartState {
 	refetch: () => void;
 }
 
+// Wall clocks, not instants — the chart reads them back via
+// `pointsAreWallClocks` (rationale in `chart-date.ts`).
 function toPoints( report: StatsSubscribersResponse | undefined ): SubscribersChartPoint[] {
 	return ( report?.data ?? [] ).map( point => ( {
-		date: localTZDate( point.date_start ),
+		date: toChartDate( point.date_start ),
 		subscribers: Number( point.subscribers ?? point.value ?? 0 ),
 		paid: Number( point.subscribers_paid ?? 0 ),
 	} ) );

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-1902-naive-bucket-stamps
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-1902-naive-bucket-stamps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: fix report and chart dates that could read a day off for sites away from UTC.

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-1977-subscribers-wall-clock
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-1977-subscribers-wall-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: label Subscribers chart and email timeline points by the bucket they name rather than by the viewer's time zone.

--- a/projects/plugins/mu-wpcom-plugin/changelog/echo-wooa7s-1902-naive-bucket-stamps
+++ b/projects/plugins/mu-wpcom-plugin/changelog/echo-wooa7s-1902-naive-bucket-stamps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: fix report and chart dates that could read a day off for sites away from UTC.

--- a/projects/plugins/mu-wpcom-plugin/changelog/echo-wooa7s-1977-subscribers-wall-clock
+++ b/projects/plugins/mu-wpcom-plugin/changelog/echo-wooa7s-1977-subscribers-wall-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: label Subscribers chart and email timeline points by the bucket they name rather than by the viewer's time zone.

--- a/projects/plugins/premium-analytics/changelog/echo-wooa7s-1902-naive-bucket-stamps
+++ b/projects/plugins/premium-analytics/changelog/echo-wooa7s-1902-naive-bucket-stamps
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: fix report and chart dates that could read a day off for sites away from UTC.

--- a/projects/plugins/premium-analytics/changelog/echo-wooa7s-1977-subscribers-wall-clock
+++ b/projects/plugins/premium-analytics/changelog/echo-wooa7s-1977-subscribers-wall-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers chart, email timeline: label chart points by the bucket they name rather than by the viewer's time zone.


### PR DESCRIPTION
Follow-up to #51445, addressing the root cause the review discussion circled: why bucket stamps carried a nominal `+00:00` at all.

Premium Analytics users on sites away from UTC could see report dates read a day off, because the data layer claimed its Stats buckets happened at UTC when they are actually site-local calendar labels. This PR makes the data layer say what it means, so dates stop needing per-consumer correction.

## Proposed changes

* The Stats API returns bare site-local calendar labels (`days` keyed by `2026-06-15`, hour buckets that are already site-local). Our normalizers (`getStatsIntervalFields`, `getHourIntervalFields`, `getDateFnsIntervalFields`) then stamped `date_start`/`date_end` with a fabricated `+00:00` — asserting a UTC instant no bucket ever named. Every consumer had to compensate: `toChartDate` strips the offset before charting, and `localTZDate` consumers honoured it, anchoring buckets at UTC midnight so site-timezone formatters read them a day off for sites west of UTC.
* `formatDatePartWithTime` now emits timezone-naive wall times (`2026-06-15T00:00:00`), and `getDateFnsIntervalFields` goes through it instead of appending `+00:00` inline. `localTZDate` reads a naive stamp as wall time in the site's timezone — the instant the bucket actually names — so those consumers become correct with no change on their side.
* This also matches the WooCommerce analytics convention the normalized report shape mimics: naive site-local `date_start`, offsets only on `*_gmt` fields.
* `toChartDate` keeps its offset strip as a guard for the row passthrough in `getRowIntervalFields`, which forwards whatever `date_start` the API sends; comments that documented the nominal `+00:00` are updated.
* Normalizer test expectations updated to the naive shape. Tests feeding offset-carrying stamps as *inputs* are kept, preserving coverage that consumers still tolerate that shape.

## Related product discussion/links

* WOOA7S-1902
* WOOA7S-1977 (the Subscribers chart / email time series follow-up — this PR fixes their underlying data; their chart-label reading is the remaining half)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && pnpm run test` — full suite passes (2445 tests).
* In wp-admin on a site whose timezone is west of UTC (e.g. `America/Los_Angeles`), open Premium Analytics report pages that render a time-series legend/date range (e.g. a report page metric chart). On trunk the legend's range can read a day earlier than the selected range; with this PR it matches.
* Traffic and WordAds charts (from #51445/#51446) are unaffected: `toChartDate` handles both stamp shapes.
