### PR TITLE
Premium Analytics: read Subscribers chart and email timeline points as wall clocks

### DIFF
--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1977-subscribers-wall-clock
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1977-subscribers-wall-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers chart, email timeline: label chart points by the bucket they name rather than by the viewer's time zone.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -63,7 +63,7 @@ export { toDay } from './to-day';
 export { defaultPeriodForInterval } from './default-period-for-interval';
 export { granularitiesForRange } from './granularities-for-range';
 export { buildMetricTab, type MetricReport, type BuildMetricTabOptions } from './build-metric-tab';
-export { fromChartDate } from './chart-date';
+export { fromChartDate, toChartDate } from './chart-date';
 export { dateFormatForResolution } from './tick-resolution-date-format';
 export {
 	followedGranularity,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -194,6 +194,7 @@ export {
 	GRANULARITY_ATTRIBUTE,
 	GRANULARITY_PICKED_FOR_ATTRIBUTE,
 	buildMetricTab,
+	toChartDate,
 	CHART_DISPLAY_CHART_TYPES,
 	chartTypeAttributeField,
 	granularityAttributeField,

--- a/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
@@ -18,6 +18,7 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 	MetricTabsChart: ( {
 		metrics,
 		chartType,
+		pointsAreWallClocks,
 	}: {
 		metrics: {
 			key: string;
@@ -26,6 +27,7 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 			current: { date: Date; value: number }[];
 		}[];
 		chartType?: string;
+		pointsAreWallClocks?: boolean;
 	} ) => (
 		<div
 			data-testid="metric-tabs-chart"
@@ -33,7 +35,9 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 			data-metric-label={ metrics[ 0 ]?.label }
 			data-metric-total={ String( metrics[ 0 ]?.value ) }
 			data-values={ metrics[ 0 ]?.current.map( point => point.value ).join( ',' ) }
+			data-days={ metrics[ 0 ]?.current.map( point => point.date.getDate() ).join( ',' ) }
 			data-chart-type={ String( chartType ) }
+			data-wall-clocks={ String( pointsAreWallClocks ) }
 		/>
 	),
 } ) );
@@ -91,6 +95,40 @@ describe( 'EmailTimeSeriesWidget', () => {
 		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
 		expect( requestedPath ).toContain( 'stats/opens/emails/1234' );
 		expect( requestedPath ).toContain( 'stats_fields=timeline' );
+	} );
+
+	// Pinned west of UTC on purpose: under a UTC runner the wall-clock reading
+	// and the old instant reading coincide, so this would pass either way. `TZ`
+	// is not on the typed env shape, hence the cast.
+	it( 'builds chart points as the wall clocks the buckets name, declared to the chart', async () => {
+		const env = process.env as Record< string, string | undefined >;
+		const runnerTimeZone = env.TZ;
+		env.TZ = 'America/Los_Angeles';
+
+		try {
+			mockApiFetch.mockResolvedValue( OPENS_TIMELINE_RESPONSE );
+
+			render(
+				<EmailTimeSeriesWidget
+					attributes={ {
+						reportParams: { ...getDefaultQueryParams( false ), post_id: 1234 },
+						metric: 'opens',
+					} }
+				/>
+			);
+
+			const chart = await screen.findByTestId( 'metric-tabs-chart' );
+			// The old `localTZDate` reading anchors the buckets away from the
+			// local frame, so these read as the previous day (3,4,5) under it.
+			expect( chart ).toHaveAttribute( 'data-days', '4,5,6' );
+			expect( chart ).toHaveAttribute( 'data-wall-clocks', 'true' );
+		} finally {
+			if ( runnerTimeZone === undefined ) {
+				delete env.TZ;
+			} else {
+				env.TZ = runnerTimeZone;
+			}
+		}
 	} );
 
 	it( 'reads the clicks endpoint when metric is clicks', async () => {

--- a/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
@@ -15,8 +15,8 @@ import {
 	MetricTabsChartSkeleton,
 	WidgetRoot,
 	WidgetState,
-	buildReportMetricSeries,
 	defaultPeriodForInterval,
+	toChartDate,
 	useWidgetRootContext,
 	type MetricTab,
 	type ReportParamsFieldAttributes,
@@ -111,14 +111,14 @@ function EmailTimeSeriesReport( { metric, chartType }: EmailTimeSeriesReportProp
 	}, [ report, period, field ] );
 
 	// One metric: the headline is the window total (the timeline is summed per
-	// bucket, so the sum of buckets is the range's opens/clicks).
+	// bucket, so the sum of buckets is the range's opens/clicks). Point dates are
+	// wall clocks, read back via `pointsAreWallClocks` (rationale in
+	// `chart-date.ts`).
 	const metricTabs = useMemo< MetricTab[] >( () => {
-		const points = chartReport
-			? buildReportMetricSeries( {
-					primary: chartReport,
-					metrics: [ { key: field, label: metricLabel( metric ) } ],
-			  } )[ 0 ]?.data ?? []
-			: [];
+		const points = ( chartReport?.data ?? [] ).map( point => ( {
+			date: toChartDate( point.date_start ),
+			value: Number( point[ field ] ?? 0 ),
+		} ) );
 
 		return [
 			{
@@ -162,6 +162,7 @@ function EmailTimeSeriesReport( { metric, chartType }: EmailTimeSeriesReportProp
 					metrics={ metricTabs }
 					dataFormat={ DATA_FORMAT }
 					chartType={ chartType }
+					pointsAreWallClocks
 				/>
 			</WidgetState>
 		</div>

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/__tests__/subscribers-chart.test.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/__tests__/subscribers-chart.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import SubscribersChartWidget from '../render';
+
+const mockUseStatsSubscribersReport = jest.fn();
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	useStatsSubscribersReport: ( params: unknown ) => mockUseStatsSubscribersReport( params ),
+} ) );
+
+// The chart itself is visx SVG rendering, outside this widget's concern. Keep
+// the tabs observable so the tests can assert what the widget charts.
+jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/widgets-toolkit' ),
+	MetricTabsChart: ( {
+		metrics,
+		pointsAreWallClocks,
+	}: {
+		metrics: { key: string; value: number; current: { date: Date; value: number }[] }[];
+		pointsAreWallClocks?: boolean;
+	} ) => (
+		<div
+			data-testid="metric-tabs-chart"
+			data-metric-keys={ metrics.map( metric => metric.key ).join( ',' ) }
+			data-values={ metrics[ 0 ]?.current.map( point => point.value ).join( ',' ) }
+			data-days={ metrics[ 0 ]?.current.map( point => point.date.getDate() ).join( ',' ) }
+			data-wall-clocks={ String( pointsAreWallClocks ) }
+		/>
+	),
+} ) );
+
+// WidgetRoot reads URL search params as a fallback for report params; outside
+// a matched route the real hook warns and throws.
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
+
+function reportWith( data: Record< string, unknown >[] ) {
+	return {
+		primary: { data: { data } },
+		comparison: { data: undefined },
+		isLoading: false,
+		isFetching: false,
+		isError: false,
+		refetch: jest.fn(),
+	};
+}
+
+describe( 'SubscribersChartWidget', () => {
+	beforeEach( () => {
+		mockUseStatsSubscribersReport.mockReset();
+	} );
+
+	// Pinned west of UTC on purpose: under a UTC runner the wall-clock reading
+	// and the old instant reading coincide, so this would pass either way. `TZ`
+	// is not on the typed env shape, hence the cast.
+	it( 'builds chart points as the wall clocks the buckets name, declared to the chart', async () => {
+		const env = process.env as Record< string, string | undefined >;
+		const runnerTimeZone = env.TZ;
+		env.TZ = 'America/Los_Angeles';
+
+		try {
+			mockUseStatsSubscribersReport.mockReturnValue(
+				reportWith( [
+					{ date_start: '2026-07-04T00:00:00', subscribers: 5, subscribers_paid: 0 },
+					{ date_start: '2026-07-05T00:00:00', subscribers: 6, subscribers_paid: 0 },
+				] )
+			);
+
+			render(
+				<SubscribersChartWidget attributes={ { reportParams: getDefaultQueryParams( false ) } } />
+			);
+
+			const chart = await screen.findByTestId( 'metric-tabs-chart' );
+			// The old `localTZDate` reading anchors the buckets away from the
+			// local frame, so these read as the previous day (3,4) under it.
+			expect( chart ).toHaveAttribute( 'data-days', '4,5' );
+			expect( chart ).toHaveAttribute( 'data-values', '5,6' );
+			expect( chart ).toHaveAttribute( 'data-wall-clocks', 'true' );
+		} finally {
+			if ( runnerTimeZone === undefined ) {
+				delete env.TZ;
+			} else {
+				env.TZ = runnerTimeZone;
+			}
+		}
+	} );
+
+	it( 'offers the Paid subscribers tab only when the site has paid subscribers', async () => {
+		mockUseStatsSubscribersReport.mockReturnValue(
+			reportWith( [ { date_start: '2026-07-04T00:00:00', subscribers: 5, subscribers_paid: 2 } ] )
+		);
+
+		render(
+			<SubscribersChartWidget attributes={ { reportParams: getDefaultQueryParams( false ) } } />
+		);
+
+		const chart = await screen.findByTestId( 'metric-tabs-chart' );
+		expect( chart ).toHaveAttribute( 'data-metric-keys', 'subscribers,paid' );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
@@ -156,6 +156,7 @@ function SubscribersChartInner( { chartType }: SubscribersChartInnerProps ) {
 					dataFormat={ DATA_FORMAT }
 					chartType={ chartType }
 					groupLabel={ groupLabel }
+					pointsAreWallClocks
 				/>
 			</WidgetState>
 		</div>

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/use-subscribers-chart.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/use-subscribers-chart.ts
@@ -3,11 +3,11 @@
  */
 import {
 	useStatsSubscribersReport,
-	localTZDate,
 	type ReportParams,
 	type StatsSubscribersResponse,
 	type StatsSubscribersUnit,
 } from '@jetpack-premium-analytics/data';
+import { toChartDate } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 
 /**
@@ -40,9 +40,11 @@ export interface SubscribersChartState {
 	refetch: () => void;
 }
 
+// Wall clocks, not instants — the chart reads them back via
+// `pointsAreWallClocks` (rationale in `chart-date.ts`).
 function toPoints( report: StatsSubscribersResponse | undefined ): SubscribersChartPoint[] {
 	return ( report?.data ?? [] ).map( point => ( {
-		date: localTZDate( point.date_start ),
+		date: toChartDate( point.date_start ),
 		subscribers: Number( point.subscribers ?? point.value ?? 0 ),
 		paid: Number( point.subscribers_paid ?? 0 ),
 	} ) );

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-1977-subscribers-wall-clock
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-1977-subscribers-wall-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: label Subscribers chart and email timeline points by the bucket they name rather than by the viewer's time zone.

--- a/projects/plugins/mu-wpcom-plugin/changelog/echo-wooa7s-1977-subscribers-wall-clock
+++ b/projects/plugins/mu-wpcom-plugin/changelog/echo-wooa7s-1977-subscribers-wall-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: label Subscribers chart and email timeline points by the bucket they name rather than by the viewer's time zone.

--- a/projects/plugins/premium-analytics/changelog/echo-wooa7s-1977-subscribers-wall-clock
+++ b/projects/plugins/premium-analytics/changelog/echo-wooa7s-1977-subscribers-wall-clock
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers chart, email timeline: label chart points by the bucket they name rather than by the viewer's time zone.


### PR DESCRIPTION
Completes WOOA7S-1977, stacked on #51499 (which fixed the underlying data). Third PR in the wall-clock series after #51445.

Subscribers chart and email timeline dates could read a day off for viewers in a different timezone than their site — the same drift #51445 fixed for the Traffic and WordAds charts. With this PR, every `MetricTabsChart` consumer labels points by the bucket they name, for every viewer.

## Proposed changes

* The Subscribers chart and email timeline widgets were the last two `MetricTabsChart` consumers building points with `localTZDate` — a site-timezone instant the chart library then renders through the *viewer's* timezone, sliding axis labels a day behind for viewers west of the site (while tooltips, read in the site frame, stayed correct — a mismatched pair). They now build points with `toChartDate` and declare `pointsAreWallClocks`, so axis, tooltip, and legend all read the same wall clock regardless of the viewer's timezone.
* The email timeline stops going through `buildReportMetricSeries`: it only ever kept `series[0].data` and overwrote the legend label the builder computes, so it now maps its points directly. The shared builders (`buildReportMetricSeries`, `buildTimeSeriesChartData` — used by report pages and the Woo store-performance widget) are deliberately untouched; converting their consumers is part of the broader date-flow audit.
* `toChartDate` joins the widgets-toolkit public exports (it was internal until now; `fromChartDate` was already exported).
* Cross-timezone widget tests pin a non-UTC zone so the wall-clock reading and the old instant reading cannot coincide — both new tests fail against the previous code (verified by reverting the fix locally).

## Related product discussion/links

* WOOA7S-1977
* WOOA7S-1902 (the Traffic/WordAds fix this follows: #51445)
* #51499 (the bucket-stamp fix this stacks on)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && pnpm run test` — full suite passes (2448 tests).
* In wp-admin with the site timezone far from your own (e.g. site `America/Los_Angeles`, viewer east of UTC), open the dashboard's Subscribers chart and an email report's timeline. On the base branch the axis dates can sit a day behind the tooltip dates; with this PR they agree, and both match the Traffic chart's dates for the same range.
