### PR TITLE
Premium Analytics: expect the Ads section in the sync-gate test

### DIFF
--- a/projects/packages/premium-analytics/changelog/echo-fix-sync-gate-test-ads-section
+++ b/projects/packages/premium-analytics/changelog/echo-fix-sync-gate-test-ads-section
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update a test expectation for the Ads dashboard section; no user-facing change.
+
+

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -404,6 +404,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 				'insights'    => false,
 				'subscribers' => false,
 				'store'       => true,
+				'ads'         => false,
 			),
 			array_column(
 				array_map(


### PR DESCRIPTION
Trunk's `packages/premium-analytics` PHP tests currently fail on every PR (nine matrix jobs), blocking merges — first observed on #51499's CI.

## Proposed changes

* #51422 added the Ads dashboard section and updated every section-list assertion in `Dashboard_Section_Test` except one: `test_only_the_store_section_requires_the_sync`, which #51279 added after #51422's branch was cut. Neither PR's CI ever saw the pair together, and trunk pushes don't re-run the matrix, so trunk landed with the test pinning a four-section list while `get_available_dashboard_sections()` now returns five. This adds the missing `'ads' => false` expectation, matching how #51422 updated the sibling assertions.

## Related product discussion/links

* Cross-merge between #51422 and #51279; surfaced on #51499's CI.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && vendor/bin/phpunit-select-config phpunit.#.xml.dist --filter Dashboard_Section_Test` — 58 tests pass (fails on trunk with `'ads' => false` unexpected in the actual array).
