### PR TITLE
Related Posts: add a Related Posts variation of the Query Loop block

### DIFF
--- a/projects/plugins/jetpack/changelog/add-related-posts-query-loop-variation
+++ b/projects/plugins/jetpack/changelog/add-related-posts-query-loop-variation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Related Posts: Add a Related Posts variation of the Query Loop block, allowing related posts to be laid out and styled with the full flexibility of the Query Loop block.

--- a/projects/plugins/jetpack/modules/related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts.php
@@ -63,6 +63,9 @@ class Jetpack_RelatedPosts_Module {
 		require_once __DIR__ . '/related-posts/jetpack-related-posts.php';
 		Jetpack_RelatedPosts::init();
 
+		require_once __DIR__ . '/related-posts/class-jetpack-relatedposts-query-loop.php';
+		Jetpack_RelatedPosts_Query_Loop::init();
+
 		if ( is_admin() ) {
 			Jetpack::enable_module_configurable( __FILE__ );
 		}

--- a/projects/plugins/jetpack/modules/related-posts/class-jetpack-relatedposts-query-loop.php
+++ b/projects/plugins/jetpack/modules/related-posts/class-jetpack-relatedposts-query-loop.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Related Posts Query Loop block variation.
+ *
+ * Registers a variation of the core Query Loop block that displays
+ * Jetpack Related Posts, so the results can be laid out and styled with
+ * the full flexibility of the Query Loop block instead of the fixed
+ * markup the Related Posts block renders.
+ *
+ * Originally developed by the Automattic Special Projects team as the
+ * standalone "Jetpack Related Posts Query Loop" plugin.
+ *
+ * @package automattic/jetpack
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Adds a "Related Posts" variation to the core Query Loop block, feeding it
+ * post IDs from the Related Posts module in place of the loop's normal query.
+ */
+class Jetpack_RelatedPosts_Query_Loop {
+
+	/**
+	 * The `namespace` attribute stamped on Query Loop blocks using this
+	 * variation. Rendering only diverges from a plain Query Loop when a
+	 * block carries this namespace.
+	 *
+	 * @var string
+	 */
+	const QUERY_NAMESPACE = 'jetpack/related-posts-query-loop';
+
+	/**
+	 * Hook the variation into block registration and rendering.
+	 */
+	public static function init() {
+		add_filter( 'get_block_type_variations', array( __CLASS__, 'register_block_variation' ), 10, 2 );
+		add_filter( 'pre_render_block', array( __CLASS__, 'pre_render_query_block' ), 10, 2 );
+	}
+
+	/**
+	 * Register the Related Posts variation of the Query Loop block.
+	 *
+	 * @param array         $variations Registered variations for the block type.
+	 * @param WP_Block_Type $block_type The full block type object.
+	 *
+	 * @return array
+	 */
+	public static function register_block_variation( $variations, $block_type ) {
+		if ( 'core/query' !== $block_type->name ) {
+			return $variations;
+		}
+
+		$variations[] = array(
+			'icon'            => 'star-filled',
+			'name'            => 'related-posts-query-loop',
+			'title'           => __( 'Related Posts (Query Loop)', 'jetpack' ),
+			'description'     => __( 'Display related posts in a customizable query loop. Note: the editor preview shows recent posts; related posts are calculated when the post is viewed.', 'jetpack' ),
+			'keywords'        => array(
+				/* translators: search keyword for the Related Posts Query Loop block variation */
+				__( 'query', 'jetpack' ),
+				/* translators: search keyword for the Related Posts Query Loop block variation */
+				__( 'related', 'jetpack' ),
+			),
+			'attributes'      => array(
+				'align'     => 'wide',
+				'query'     => array(
+					'perPage'  => 4,
+					'inherit'  => false,
+					'postType' => 'post',
+				),
+				'namespace' => self::QUERY_NAMESPACE,
+			),
+			'allowedControls' => array( 'postCount', 'postType' ),
+			'isActive'        => array( 'namespace' ),
+			'isDefault'       => false,
+		);
+
+		return $variations;
+	}
+
+	/**
+	 * When a Query Loop block using this variation is about to render, hook in
+	 * the query-vars filter that swaps the loop's query for related posts.
+	 *
+	 * The filter is added per matching block (and removes itself after running)
+	 * so it never affects sibling Query Loop blocks on the same page.
+	 *
+	 * @param string|null $pre_render The pre-rendered content. Default null.
+	 * @param array       $block      The block being rendered, as an associative array. See WP_Block_Parser_Block.
+	 *
+	 * @return string|null
+	 */
+	public static function pre_render_query_block( $pre_render, $block ) {
+		if ( 'core/query' !== $block['blockName'] ) {
+			return $pre_render;
+		}
+
+		if ( isset( $block['attrs']['namespace'] ) && self::QUERY_NAMESPACE === $block['attrs']['namespace'] ) {
+			add_filter( 'query_loop_block_query_vars', array( __CLASS__, 'filter_query_loop_block_query_vars' ) );
+		}
+
+		return $pre_render;
+	}
+
+	/**
+	 * Swap the Query Loop block's query vars for a related-posts query.
+	 *
+	 * Removes itself immediately so it only applies to the one block that
+	 * registered it in {@see pre_render_query_block()}.
+	 *
+	 * @param array $query_args `WP_Query` arguments as parsed from the block context.
+	 *
+	 * @return array
+	 */
+	public static function filter_query_loop_block_query_vars( $query_args ) {
+		remove_filter( 'query_loop_block_query_vars', array( __CLASS__, 'filter_query_loop_block_query_vars' ) );
+
+		return self::get_related_posts_query_args( $query_args );
+	}
+
+	/**
+	 * Build `WP_Query` arguments that pin the Query Loop to related posts.
+	 *
+	 * Asks the Related Posts module for posts related to the current post. If
+	 * none are available (for example, the site has not finished syncing), it
+	 * falls back to random recent posts so the block does not render empty.
+	 *
+	 * @param array $query_args `WP_Query` arguments as parsed from the block context.
+	 *
+	 * @return array
+	 */
+	public static function get_related_posts_query_args( $query_args ) {
+		$post_id = get_the_ID();
+
+		if ( false === $post_id ) {
+			return $query_args;
+		}
+
+		$posts_per_page = isset( $query_args['posts_per_page'] ) ? (int) $query_args['posts_per_page'] : 4;
+		$post_type      = $query_args['post_type'] ?? 'post';
+
+		$related  = Jetpack_RelatedPosts::init_raw()
+			->set_query_name( 'jetpack_related_posts_query_loop' )
+			->get_for_post_id(
+				$post_id,
+				array(
+					'size'      => $posts_per_page,
+					'post_type' => $post_type,
+				)
+			);
+		$post_ids = array_filter(
+			wp_list_pluck( $related, 'id' ),
+			function ( $related_post_id ) {
+				return (int) $related_post_id > 0;
+			}
+		);
+
+		if ( array() === $post_ids ) {
+			/**
+			 * Filter whether the Related Posts Query Loop variation falls back to
+			 * random recent posts when no related posts are available.
+			 *
+			 * @module related-posts
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param bool $fallback_enabled Whether to fall back to random recent posts. Default true.
+			 * @param int  $post_id          ID of the post the block is rendering on.
+			 */
+			if ( apply_filters( 'jetpack_relatedposts_query_loop_fallback', true, $post_id ) ) {
+				$fallback = new WP_Query(
+					array(
+						'posts_per_page'      => $posts_per_page * 3,
+						'fields'              => 'ids',
+						'post_type'           => $post_type,
+						'post__not_in'        => array( $post_id ),
+						'ignore_sticky_posts' => true,
+						'no_found_rows'       => true,
+					)
+				);
+
+				$post_ids = array_map( 'intval', (array) $fallback->posts );
+				shuffle( $post_ids );
+			}
+		}
+
+		// Only query for the posts we need.
+		$post_ids = array_slice( $post_ids, 0, $posts_per_page );
+
+		$query_args['offset']   = 0;
+		$query_args['post__in'] = $post_ids;
+		$query_args['orderby']  = 'post__in';
+
+		return $query_args;
+	}
+}

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -52,7 +52,7 @@ class Jetpack_RelatedPosts {
 	/**
 	 * Creates and returns a static instance of Jetpack_RelatedPosts_Raw.
 	 *
-	 * @return Jetpack_RelatedPosts
+	 * @return Jetpack_RelatedPosts_Raw
 	 */
 	public static function init_raw() {
 		if ( ! self::$instance_raw ) {

--- a/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Query_Loop_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Query_Loop_Test.php
@@ -1,0 +1,172 @@
+<?php
+
+require_once __DIR__ . '/../../../../modules/related-posts.php';
+
+/**
+ * Tests for the Related Posts Query Loop block variation.
+ */
+class Jetpack_RelatedPosts_Query_Loop_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		Jetpack_RelatedPosts_Module::instance()->action_on_load();
+
+		// Never hit the WordPress.com API during the tests.
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return new WP_Error( 'no_http_in_tests', 'HTTP disabled in tests' );
+			}
+		);
+	}
+
+	/**
+	 * The variation must be added to the core Query Loop block only.
+	 */
+	public function test_variation_is_registered_for_query_block_only() {
+		$query_variations = Jetpack_RelatedPosts_Query_Loop::register_block_variation(
+			array(),
+			new WP_Block_Type( 'core/query' )
+		);
+		$this->assertCount( 1, $query_variations );
+		$this->assertSame(
+			Jetpack_RelatedPosts_Query_Loop::QUERY_NAMESPACE,
+			$query_variations[0]['attributes']['namespace']
+		);
+
+		$this->assertSame(
+			array(),
+			Jetpack_RelatedPosts_Query_Loop::register_block_variation(
+				array(),
+				new WP_Block_Type( 'core/paragraph' )
+			),
+			'Other block types must not receive the variation.'
+		);
+	}
+
+	/**
+	 * The query-vars filter must only be hooked for Query Loop blocks that
+	 * carry the variation's namespace, so plain Query Loop blocks on the same
+	 * page render their normal query.
+	 */
+	public function test_query_vars_filter_only_hooked_for_variation_blocks() {
+		$callback = array( Jetpack_RelatedPosts_Query_Loop::class, 'filter_query_loop_block_query_vars' );
+
+		Jetpack_RelatedPosts_Query_Loop::pre_render_query_block(
+			null,
+			array(
+				'blockName' => 'core/query',
+				'attrs'     => array(),
+			)
+		);
+		$this->assertFalse(
+			has_filter( 'query_loop_block_query_vars', $callback ),
+			'A plain Query Loop block must not hook the filter.'
+		);
+
+		Jetpack_RelatedPosts_Query_Loop::pre_render_query_block(
+			null,
+			array(
+				'blockName' => 'core/query',
+				'attrs'     => array( 'namespace' => Jetpack_RelatedPosts_Query_Loop::QUERY_NAMESPACE ),
+			)
+		);
+		$this->assertNotFalse(
+			has_filter( 'query_loop_block_query_vars', $callback ),
+			'A variation block must hook the filter.'
+		);
+
+		// The filter removes itself after one run so it cannot leak into
+		// sibling Query Loop blocks rendered later on the same page.
+		Jetpack_RelatedPosts_Query_Loop::filter_query_loop_block_query_vars( array() );
+		$this->assertFalse( has_filter( 'query_loop_block_query_vars', $callback ) );
+	}
+
+	/**
+	 * When the module returns related posts, the query is pinned to exactly
+	 * those IDs in order.
+	 */
+	public function test_query_args_use_related_posts_when_available() {
+		$post_ids   = self::factory()->post->create_many( 3 );
+		$current_id = self::factory()->post->create();
+
+		$GLOBALS['post'] = get_post( $current_id );
+
+		add_filter(
+			'jetpack_relatedposts_returned_results',
+			static function () use ( $post_ids ) {
+				return array_map(
+					static function ( $id ) {
+						return array( 'id' => $id );
+					},
+					$post_ids
+				);
+			}
+		);
+
+		$query_args = Jetpack_RelatedPosts_Query_Loop::get_related_posts_query_args(
+			array( 'posts_per_page' => 2 )
+		);
+
+		$this->assertSame( array_slice( $post_ids, 0, 2 ), $query_args['post__in'] );
+		$this->assertSame( 'post__in', $query_args['orderby'] );
+		$this->assertSame( 0, $query_args['offset'] );
+	}
+
+	/**
+	 * When no related posts are available, the block falls back to random
+	 * recent posts, never including the post being viewed.
+	 */
+	public function test_query_args_fall_back_to_recent_posts() {
+		$post_ids   = self::factory()->post->create_many( 3 );
+		$current_id = self::factory()->post->create();
+
+		$GLOBALS['post'] = get_post( $current_id );
+
+		$query_args = Jetpack_RelatedPosts_Query_Loop::get_related_posts_query_args(
+			array( 'posts_per_page' => 2 )
+		);
+
+		$this->assertCount( 2, $query_args['post__in'] );
+		$this->assertNotContains( $current_id, $query_args['post__in'] );
+		$this->assertEmpty( array_diff( $query_args['post__in'], $post_ids ) );
+	}
+
+	/**
+	 * The jetpack_relatedposts_query_loop_fallback filter disables the
+	 * random-posts fallback, leaving the query pinned to no posts.
+	 */
+	public function test_fallback_can_be_disabled_via_filter() {
+		self::factory()->post->create_many( 3 );
+		$current_id = self::factory()->post->create();
+
+		$GLOBALS['post'] = get_post( $current_id );
+
+		add_filter( 'jetpack_relatedposts_query_loop_fallback', '__return_false' );
+
+		$query_args = Jetpack_RelatedPosts_Query_Loop::get_related_posts_query_args(
+			array( 'posts_per_page' => 2 )
+		);
+
+		$this->assertSame( array(), $query_args['post__in'] );
+	}
+
+	/**
+	 * Outside any post context the query args must pass through untouched.
+	 */
+	public function test_query_args_unchanged_without_a_post() {
+		unset( $GLOBALS['post'] );
+
+		$query_args = array( 'posts_per_page' => 2 );
+
+		$this->assertSame(
+			$query_args,
+			Jetpack_RelatedPosts_Query_Loop::get_related_posts_query_args( $query_args )
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Test.php
@@ -1,6 +1,6 @@
 <?php
 
-require __DIR__ . '/../../../../modules/related-posts.php';
+require_once __DIR__ . '/../../../../modules/related-posts.php';
 
 class Jetpack_RelatedPosts_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;


### PR DESCRIPTION
## Proposed changes

This ports the Special Projects team's standalone "Jetpack Related Posts Query Loop" plugin into the Jetpack plugin, so Related Posts placement and presentation are no longer limited to the fixed markup the Related Posts block renders or the auto-injected output.

* Adds a **Related Posts (Query Loop)** variation of the core Query Loop block, registered while the Related Posts module is active. The variation lets users lay out and style related posts with everything the Query Loop block supports (post template, columns, featured images, excerpts, etc.), and place them anywhere — including sidebars and templates.
* On the front end, a Query Loop block carrying the variation's `namespace` attribute has its query swapped for post IDs returned by `Jetpack_RelatedPosts` (via the existing `Jetpack_RelatedPosts_Raw` programmatic API). The query-vars filter is added per matching block and removes itself after running, so sibling Query Loop blocks are unaffected.
* When no related posts are available (e.g. the site hasn't finished syncing), the block falls back to random recent posts so it doesn't render an empty section. A new `jetpack_relatedposts_query_loop_fallback` filter allows disabling that fallback.
* Fixes the `@return` annotation on `Jetpack_RelatedPosts::init_raw()` (it returns the `Jetpack_RelatedPosts_Raw` subclass).
* Adds unit tests covering variation registration, per-block filter scoping, related-posts query args, the fallback, and the new filter.

Notes for reviewers:

* In the editor, the block preview shows recent posts — the related-posts query only applies at render time, matching the standalone plugin's behavior. The variation's description calls this out.
* The variation intentionally uses a new `jetpack/related-posts-query-loop` namespace, so sites still running the standalone plugin (`a8csp-jrpql/related-posts` namespace) keep working independently and nothing double-filters.

## Does this pull request change what data or activity we track or use?

No. The related-posts lookup uses the same existing WordPress.com REST endpoint the Related Posts feature already uses (tagged with a `jetpack_related_posts_query_loop` query name for tracking purposes, like other callers of `Jetpack_RelatedPosts_Raw`).

## Testing instructions

* Ensure the site is connected to WordPress.com and the **Related Posts** module is active (Jetpack → Settings → Traffic → "Show related content after posts", or `wp jetpack module activate related-posts`).
* Edit a post, open the block inserter, and search for "Related". Insert the **Related Posts (Query Loop)** block (it also appears via `/related`).
* Confirm it behaves like a Query Loop: you can change the post template layout, per-page count, and post type, and style the inner blocks.
* View a published post containing the block:
  * On a synced, connected site, it lists posts related to the one being viewed, excluding the post itself.
  * On a site with no related-posts data yet, it lists random recent posts instead.
  * Add `add_filter( 'jetpack_relatedposts_query_loop_fallback', '__return_false' );` and confirm the fallback list disappears while related results (when available) still render.
* Add a *plain* Query Loop block next to the variation and confirm it still renders its normal query.
* With the Related Posts module deactivated, confirm the variation no longer appears in the inserter and existing instances render as a normal (empty-namespace-behavior) Query Loop.
