### PR TITLE
Jetpack AI: jetpack_is_internal_testing_environment with a8c proxy in AI Hub settings

### DIFF
--- a/projects/packages/my-jetpack/.phan/config.php
+++ b/projects/packages/my-jetpack/.phan/config.php
@@ -22,7 +22,7 @@ return make_phan_config(
 			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
 			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
 			__DIR__ . '/../../../plugins/jetpack/jetpack.php',                             // JETPACK__VERSION
-			__DIR__ . '/../../../plugins/jetpack/functions.global.php',                    // function jetpack_is_internal_testing_environment
+			__DIR__ . '/../../../plugins/jetpack/functions.global.php',                    // function jetpack_is_a8c_proxied_request
 			__DIR__ . '/../../../plugins/jetpack/class.jetpack.php',                       // class Jetpack
 			__DIR__ . '/../../../plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php',    // class Jetpack_AI_Helper
 			__DIR__ . '/../../../plugins/jetpack/3rd-party/class.jetpack-amp-support.php', // class Jetpack_AMP_Support

--- a/projects/packages/my-jetpack/changelog/update-jetpack-ai-gate-a8c-proxy
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-ai-gate-a8c-proxy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Gate the pre-release AI card module toggle on Automattic-proxied requests rather than on the testing environment, so an unproxied request sees what an end user sees.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -531,11 +531,10 @@ class Initializer {
 			// Only says which destination `manage_url` is: the legacy Stats page
 			// caches its report and wants a `force_refresh` hint the dashboard does not.
 			'premiumAnalyticsEnabled'  => Products\Stats::is_premium_analytics_enabled(),
-			// Pre-release gate: only internal testing environments get the AI
-			// card's module toggle. The helper lives in the Jetpack plugin, so
-			// standalone installs resolve to false. Remove when the AI settings
-			// page goes public.
-			'showAiModuleToggle'       => function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment(),
+			// Pre-release gate: only a8c-proxied requests get the AI card's module
+			// toggle. The helper lives in the Jetpack plugin, so standalone installs
+			// resolve to false. Remove when the AI settings page goes public.
+			'showAiModuleToggle'       => function_exists( 'jetpack_is_a8c_proxied_request' ) && jetpack_is_a8c_proxied_request(),
 		);
 
 		return $flags;

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -569,10 +569,10 @@ class Jetpack_Ai extends Module_Product {
 	/**
 	 * Whether the 'ai' module backs this product.
 	 *
-	 * Pre-release gate: the module-backed card is limited to internal testing
-	 * environments. Everywhere else this reports the module as active so the
-	 * product's status and every card built from it match the pre-module
-	 * behavior — the module state never surfaces in My Jetpack.
+	 * Pre-release gate: the module-backed card is limited to a8c-proxied requests.
+	 * Everywhere else this reports the module as active so the product's status and
+	 * every card built from it match the pre-module behavior — the module state
+	 * never surfaces in My Jetpack.
 	 *
 	 * Remove this override when the AI settings page goes public.
 	 *
@@ -580,8 +580,8 @@ class Jetpack_Ai extends Module_Product {
 	 */
 	public static function is_module_active() {
 		if (
-			! function_exists( 'jetpack_is_internal_testing_environment' ) ||
-			! jetpack_is_internal_testing_environment()
+			! function_exists( 'jetpack_is_a8c_proxied_request' ) ||
+			! jetpack_is_a8c_proxied_request()
 		) {
 			return true;
 		}

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -240,15 +240,30 @@ class Initializer_Test extends BaseTestCase {
 
 	/**
 	 * The AI card's pre-release toggle flag follows the Jetpack plugin's
-	 * internal-testing helper.
+	 * proxied-request helper.
 	 */
 	public function test_my_jetpack_flags_gate_the_ai_module_toggle() {
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
+		$GLOBALS['jetpack_mock_a8c_proxied_request'] = true;
 		$this->assertTrue( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
 
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
+		$GLOBALS['jetpack_mock_a8c_proxied_request'] = false;
 		$this->assertFalse( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
 
-		unset( $GLOBALS['jetpack_mock_internal_testing_environment'] );
+		unset( $GLOBALS['jetpack_mock_a8c_proxied_request'] );
+	}
+
+	/**
+	 * A testing environment with the proxy off does not open the toggle.
+	 *
+	 * Testing hostnames make the environment check true for anyone reviewing a
+	 * Jetpack change, which is why the gate reads the proxy instead.
+	 */
+	public function test_my_jetpack_flags_gate_the_ai_module_toggle_on_the_proxy_alone() {
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
+		$GLOBALS['jetpack_mock_a8c_proxied_request']          = false;
+
+		$this->assertFalse( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
+
+		unset( $GLOBALS['jetpack_mock_internal_testing_environment'], $GLOBALS['jetpack_mock_a8c_proxied_request'] );
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
@@ -62,7 +62,7 @@ class Jetpack_Ai_Product_Test extends TestCase {
 		WorDBless_Users::init()->clear_all_users();
 		// Remove all filters to avoid interference between tests.
 		remove_all_filters( 'jetpack_ai_enabled' );
-		unset( $GLOBALS['jetpack_mock_internal_testing_environment'] );
+		unset( $GLOBALS['jetpack_mock_internal_testing_environment'], $GLOBALS['jetpack_mock_a8c_proxied_request'] );
 		// Reset the mock Jetpack module state so it doesn't leak between tests.
 		if ( class_exists( 'Jetpack' ) && property_exists( 'Jetpack', 'active_modules' ) ) {
 			// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Declared on the mock in ./assets/jetpack-mock-plugin.txt
@@ -155,12 +155,12 @@ class Jetpack_Ai_Product_Test extends TestCase {
 	}
 
 	/**
-	 * Pre-release gate: outside internal testing environments the product is not
-	 * module-backed at all, so an inactive module never surfaces — the status is
-	 * what it was before the module existed.
+	 * Pre-release gate: on an unproxied request the product is not module-backed at
+	 * all, so an inactive module never surfaces — the status is what it was before
+	 * the module existed.
 	 */
-	public function test_jetpack_ai_ignores_the_module_outside_internal_testing() {
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
+	public function test_jetpack_ai_ignores_the_module_on_unproxied_requests() {
+		$GLOBALS['jetpack_mock_a8c_proxied_request'] = false;
 
 		Jetpack_Options::update_option( 'id', 123 );
 		activate_plugins( 'jetpack/jetpack.php' );
@@ -168,5 +168,22 @@ class Jetpack_Ai_Product_Test extends TestCase {
 
 		$this->assertTrue( Jetpack_Ai::is_module_active() );
 		$this->assertNotSame( Products::STATUS_MODULE_DISABLED, Jetpack_Ai::get_status() );
+	}
+
+	/**
+	 * A testing environment with the proxy off leaves the product un-module-backed.
+	 *
+	 * Anyone reviewing a Jetpack change on a testing hostname satisfies the
+	 * environment check, so the gate reads the proxy instead.
+	 */
+	public function test_jetpack_ai_ignores_the_module_in_a_testing_environment_without_the_proxy() {
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
+		$GLOBALS['jetpack_mock_a8c_proxied_request']          = false;
+
+		Jetpack_Options::update_option( 'id', 123 );
+		activate_plugins( 'jetpack/jetpack.php' );
+		\Jetpack::deactivate_module( 'ai' );
+
+		$this->assertTrue( Jetpack_Ai::is_module_active() );
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/assets/jetpack-mock-plugin.txt
+++ b/projects/packages/my-jetpack/tests/php/assets/jetpack-mock-plugin.txt
@@ -16,12 +16,16 @@ define( 'JETPACK__API_VERSION', 1 );
 define( 'JETPACK__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK__PLUGIN_FILE', __FILE__ );
 
-// Mirrors the real plugin's helper (functions.global.php). Defaults to true so
-// module-backed behavior is what tests see unless they opt out; flip
-// $GLOBALS['jetpack_mock_internal_testing_environment'] to exercise the
-// pre-release AI gate.
+// Mirror the real plugin's helpers (functions.global.php). Both default to true so
+// module-backed behavior is what tests see unless they opt out. The proxy helper is
+// the pre-release AI gate; the environment helper only tags test traffic, so tests
+// can flip them apart to prove the gate no longer follows the broader check.
 function jetpack_is_internal_testing_environment() {
 	return $GLOBALS['jetpack_mock_internal_testing_environment'] ?? true;
+}
+
+function jetpack_is_a8c_proxied_request() {
+	return $GLOBALS['jetpack_mock_a8c_proxied_request'] ?? true;
 }
 
 class Jetpack {

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -138,9 +138,10 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 					// destination for the MCP upsell can be retargeted without
 					// shipping a code change.
 					'upgradeUrl'       => Redirect::get_url( 'jetpack-ai-upgrade-url-for-jetpack-sites' ),
-					// Pre-release gate: only internal testing environments see
-					// the Features view. Remove when the view goes public.
-					'showFeaturesView' => jetpack_is_internal_testing_environment(),
+					// Pre-release gate: only a8c-proxied requests see the Features
+					// view, so an unproxied request renders what an end user sees.
+					// Remove when the view goes public.
+					'showFeaturesView' => jetpack_is_a8c_proxied_request(),
 					// Tracks audience properties for the jetpack_mcp_* events, per the
 					// Tracks standards for AI product events (AIINT-586). The client
 					// sends them as the strings 'true'/'false' (AIINT-576).

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-gate-a8c-proxy
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-gate-a8c-proxy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Gate the pre-release AI settings views on Automattic-proxied requests rather than on the testing environment, so an unproxied request sees what an end user sees.

--- a/projects/plugins/jetpack/functions.global.php
+++ b/projects/plugins/jetpack/functions.global.php
@@ -506,6 +506,10 @@ if ( ! function_exists( 'jetpack_is_internal_testing_environment' ) ) {
 	 * for tagging analytics events as test traffic so they can be filtered out
 	 * of production reporting.
 	 *
+	 * Reporting signal only. To gate a pre-release feature on internal access, use
+	 * jetpack_is_a8c_proxied_request() instead: a testing hostname is true for
+	 * anyone reviewing a Jetpack change, and cannot be switched off per request.
+	 *
 	 * Not to be confused with Jetpack's legacy "Development Mode", which is now
 	 * Status::is_offline_mode() and controls whether Jetpack connects to
 	 * WordPress.com.
@@ -530,16 +534,7 @@ if ( ! function_exists( 'jetpack_is_internal_testing_environment' ) ) {
 			return true;
 		}
 
-		// Proxied A8C request via function.
-		if ( function_exists( 'wpcom_is_proxied_request' ) && wpcom_is_proxied_request() ) {
-			return true;
-		}
-
-		// Proxied A8C request via server variable or constant.
-		if (
-			( isset( $_SERVER['A8C_PROXIED_REQUEST'] ) && (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) ) ||
-			( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST )
-		) {
+		if ( jetpack_is_a8c_proxied_request() ) {
 			return true;
 		}
 
@@ -555,5 +550,36 @@ if ( ! function_exists( 'jetpack_is_internal_testing_environment' ) ) {
 		}
 
 		return false;
+	}
+}
+
+if ( ! function_exists( 'jetpack_is_a8c_proxied_request' ) ) {
+	/**
+	 * Check whether the current request comes through the Automattic proxy.
+	 *
+	 * The gate to reach for when limiting a pre-release feature to internal access.
+	 * It is a per-request switch: with the proxy off the page renders exactly what
+	 * an end user sees, so pre-release UI cannot hide end-user bugs.
+	 *
+	 * Access signal only, never authorization.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	function jetpack_is_a8c_proxied_request() {
+		// Proxied A8C request via function.
+		if ( function_exists( 'wpcom_is_proxied_request' ) && wpcom_is_proxied_request() ) {
+			return true;
+		}
+
+		// Proxied A8C request via server variable. The marker rides every request,
+		// carrying '0' when the proxy is off, so read its value and not its presence.
+		if ( isset( $_SERVER['A8C_PROXIED_REQUEST'] ) && (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) ) ) {
+			return true;
+		}
+
+		// Proxied A8C request via constant.
+		return defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
 	}
 }

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -723,6 +723,23 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the isDevMode reporting flag follows the broad environment check.
+	 *
+	 * It tags test traffic for analytics rather than gating anything, so a testing
+	 * hostname alone is enough — unlike the pre-release gates, which need the proxy.
+	 */
+	public function test_inline_script_dev_mode_follows_the_environment_check() {
+		update_option( 'siteurl', 'https://mysite.jurassic.ninja' );
+
+		$this->enable_and_enqueue_block_editor();
+
+		$data = $this->get_image_studio_inline_data();
+
+		$this->assertIsArray( $data );
+		$this->assertTrue( $data['isDevMode'] );
+	}
+
+	/**
 	 * Test that exact employee identity is sufficient for the tracking signal.
 	 *
 	 * @runInSeparateProcess

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -729,6 +729,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 * hostname alone is enough — unlike the pre-release gates, which need the proxy.
 	 */
 	public function test_inline_script_dev_mode_follows_the_environment_check() {
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		update_option( 'siteurl', 'https://mysite.jurassic.ninja' );
 
 		$this->enable_and_enqueue_block_editor();

--- a/projects/plugins/jetpack/tests/php/general/Functions_Global_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Functions_Global_Test.php
@@ -9,10 +9,12 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * @covers ::jetpack_get_future_removed_version
  * @covers ::jetpack_get_vary_headers
  * @covers ::jetpack_is_internal_testing_environment
+ * @covers ::jetpack_is_a8c_proxied_request
  */
 #[CoversFunction( 'jetpack_get_future_removed_version' )]
 #[CoversFunction( 'jetpack_get_vary_headers' )]
 #[CoversFunction( 'jetpack_is_internal_testing_environment' )]
+#[CoversFunction( 'jetpack_is_a8c_proxied_request' )]
 class Functions_Global_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
@@ -126,5 +128,52 @@ class Functions_Global_Test extends WP_UnitTestCase {
 	public function test_jetpack_is_internal_testing_environment_true_for_jurassic_tube() {
 		update_option( 'siteurl', 'https://mysite.jurassic.tube' );
 		$this->assertTrue( jetpack_is_internal_testing_environment() );
+	}
+
+	/**
+	 * Test jetpack_is_internal_testing_environment returns true for a proxied request.
+	 */
+	public function test_jetpack_is_internal_testing_environment_true_for_proxied_request() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->assertTrue( jetpack_is_internal_testing_environment() );
+	}
+
+	/**
+	 * Test jetpack_is_a8c_proxied_request returns false with no proxy marker.
+	 */
+	public function test_jetpack_is_a8c_proxied_request_false_without_a_marker() {
+		$this->assertFalse( jetpack_is_a8c_proxied_request() );
+	}
+
+	/**
+	 * Test jetpack_is_a8c_proxied_request reads the marker's value, not its presence.
+	 *
+	 * The marker is sent on every request, carrying '0' when the proxy is off, so a
+	 * check written with isset() alone would be permanently true.
+	 */
+	public function test_jetpack_is_a8c_proxied_request_false_when_marker_is_zero() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '0';
+		$this->assertFalse( jetpack_is_a8c_proxied_request() );
+	}
+
+	/**
+	 * Test jetpack_is_a8c_proxied_request returns true when the marker is set.
+	 */
+	public function test_jetpack_is_a8c_proxied_request_true_when_marker_is_one() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->assertTrue( jetpack_is_a8c_proxied_request() );
+	}
+
+	/**
+	 * Test a testing hostname alone does not make a request proxied.
+	 *
+	 * This split is the point of the two functions: with the proxy off, a Jurassic
+	 * Ninja visitor sees exactly what an end user sees.
+	 */
+	public function test_jetpack_is_a8c_proxied_request_ignores_testing_hostnames() {
+		update_option( 'siteurl', 'https://mysite.jurassic.ninja' );
+
+		$this->assertTrue( jetpack_is_internal_testing_environment() );
+		$this->assertFalse( jetpack_is_a8c_proxied_request() );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -2,10 +2,11 @@
 /**
  * Tests for the Jetpack AI admin page script data.
  *
- * The contract worth locking down: the pre-release a11n gate flag rides the
- * jetpackAiSettings inline script and follows
- * jetpack_is_internal_testing_environment(), so the Features view stays hidden
- * outside internal testing environments while the MCP-only page keeps working.
+ * The contract worth locking down: the pre-release gate flag rides the
+ * jetpackAiSettings inline script and follows the a8c proxy, so the Features view
+ * stays hidden on unproxied requests while the MCP-only page keeps working. The
+ * Tracks properties in the same payload keep following the broader environment
+ * check, which is what they are for.
  *
  * @package automattic/jetpack
  */
@@ -24,9 +25,29 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
 	/**
-	 * Reset the proxied-request marker and the scripts registry.
+	 * Saved siteurl option for restoration in tear_down.
+	 *
+	 * @var string|null
+	 */
+	private $saved_siteurl;
+
+	/**
+	 * Record the siteurl option and clear the proxied-request marker.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->saved_siteurl = get_option( 'siteurl' );
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
+	}
+
+	/**
+	 * Reset the siteurl option, the proxied-request marker and the scripts registry.
 	 */
 	public function tear_down() {
+		if ( null !== $this->saved_siteurl ) {
+			update_option( 'siteurl', $this->saved_siteurl );
+		}
 		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		unset( $GLOBALS['wp_scripts'] );
 
@@ -54,7 +75,7 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Outside internal testing environments the Features view flag is off.
+	 * An unproxied request does not get the Features view flag.
 	 */
 	public function test_features_view_flag_is_off_by_default() {
 		$settings = $this->get_injected_settings();
@@ -64,15 +85,51 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * A proxied a8c request marks an internal testing environment and turns
-	 * the Features view flag on.
+	 * A proxied a8c request turns the Features view flag on.
 	 */
-	public function test_features_view_flag_follows_internal_testing_environment() {
+	public function test_features_view_flag_follows_the_a8c_proxy() {
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$settings = $this->get_injected_settings();
 
 		$this->assertTrue( $settings['showFeaturesView'] );
+	}
+
+	/**
+	 * The proxy marker rides every request, carrying '0' when the proxy is off, so
+	 * the gate has to read its value rather than the key's presence.
+	 */
+	public function test_features_view_flag_is_off_when_the_proxy_marker_is_zero() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '0';
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertFalse( $settings['showFeaturesView'] );
+	}
+
+	/**
+	 * A testing hostname on its own no longer opens the gate, which is the whole
+	 * point: an unproxied Jurassic Ninja visitor sees what an end user sees.
+	 */
+	public function test_features_view_flag_ignores_testing_hostnames() {
+		update_option( 'siteurl', 'https://mysite.jurassic.ninja' );
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertTrue( jetpack_is_internal_testing_environment() );
+		$this->assertFalse( $settings['showFeaturesView'] );
+	}
+
+	/**
+	 * The Tracks environment flag keeps following the broader check, so traffic from
+	 * a testing hostname stays tagged as test traffic even with the proxy off.
+	 */
+	public function test_tracks_is_test_still_follows_testing_hostnames() {
+		update_option( 'siteurl', 'https://mysite.jurassic.ninja' );
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertTrue( $settings['isTest'] );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

* Gate the AI WordPress Agent (features) view and the My Jetpack AI card's module toggle on whether the request is proxied through a8c (`jetpack_is_a8c_proxied_request()`), instead of the broader "internal testing environment" check.

The proxy is a per-request switch: with it off, the pages now render exactly what a real user gets.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a Jurassic Ninja site running this branch, with the a8c proxy off (default), confirm both are hidden: the AI Features view (Jetpack → AI) and the My Jetpack AI card's module toggle.
2. Turn the a8c proxy on for the request and reload. Confirm both reappear.
3. With the proxy off, confirm Tracks still reports `isTest`/`isDevMode` as true for the JN hostname — telemetry didn't move.