### PR TITLE
Include Pinterest crawler user agents in device detection

### DIFF
--- a/projects/packages/device-detection/changelog/add-pinterestbot-to-bot-device-detection-package
+++ b/projects/packages/device-detection/changelog/add-pinterestbot-to-bot-device-detection-package
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Recognize Pinterest's documented crawler user agents as bots.

--- a/projects/packages/device-detection/src/class-user-agent-info.php
+++ b/projects/packages/device-detection/src/class-user-agent-info.php
@@ -2027,6 +2027,10 @@ class User_Agent_Info {
 			'perplexitybot', // index builder https://docs.perplexity.ai/guides/bots
 			'perplexity-user', // human-triggered visit https://docs.perplexity.ai/guides/bots
 
+			// Pinterest https://help.pinterest.com/en/business/article/pinterestbot
+			'pinterest/0.2',
+			'pinterestbot',
+
 			// Meta https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/
 			'facebookbot', // AI data scraper https://darkvisitors.com/agents/facebookbot
 			'facebookexternalhit', // shares https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/#identify

--- a/projects/packages/device-detection/tests/php/Bot_User_Agent_Test.php
+++ b/projects/packages/device-detection/tests/php/Bot_User_Agent_Test.php
@@ -47,6 +47,11 @@ class Bot_User_Agent_Test extends TestCase {
 			// Perplexity.
 			array( 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)' ),
 
+			// Pinterest.
+			array( 'Pinterest/0.2 (+https://www.pinterest.com/bot.html)' ),
+			array( 'Mozilla/5.0 (compatible; Pinterestbot/1.0; +http://www.pinterest.com/bot.html)' ),
+			array( 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Pinterestbot/1.0; +https://www.pinterest.com/bot.html)' ),
+
 			// Googlebot.
 			array( 'Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' ),
 		);


### PR DESCRIPTION
## Proposed changes

This PR ensures that Pinterest’s documented `Pinterestbot` and `Pinterest/0.2` user agents are recognized as bots. The goal is to allow consumers such as Pinterest for WooCommerce to exclude Pinterest crawler requests from human-traffic handling.

[Pinterestbot documentation](https://help.pinterest.com/en/business/article/pinterestbot)

## Related product discussion/links

Related to PIN4WOO-95

## Does this pull request change what data or activity we track or use?
No. This only expands the existing local user-agent classification list.

## Testing instructions
Unit tests
