### PR TITLE
Jetpack: auto-activate new modules on prerelease versions

### DIFF
--- a/projects/plugins/jetpack/changelog/add-prerelease-module-auto-activation
+++ b/projects/plugins/jetpack/changelog/add-prerelease-module-auto-activation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Modules: activate new modules on prerelease versions instead of waiting for the final release.

--- a/projects/plugins/jetpack/changelog/fix-ai-optout-migration-timing
+++ b/projects/plugins/jetpack/changelog/fix-ai-optout-migration-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI: honor an explicit opt-out when the AI module activates on a prerelease build.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2250,7 +2250,12 @@ class Jetpack {
 
 		self::state( 'message', 'modules_activated' );
 
-		self::activate_default_modules_for_upgrade( $previous_version, $reactivate_modules, $redirect );
+		self::activate_default_modules_once(
+			$previous_version,
+			self::release_version( self::current_version() ),
+			$reactivate_modules,
+			$redirect
+		);
 
 		if ( $redirect ) {
 			self::redirect_after_activation();
@@ -2350,33 +2355,35 @@ class Jetpack {
 	}
 
 	/**
-	 * Hand off to activate_default_modules() with the prerelease adjustments applied.
+	 * Run activate_default_modules() without ever offering a module this site already handled.
 	 *
-	 * Two adjustments:
+	 * Modules this site has already auto-activated are subtracted through
+	 * `jetpack_get_default_modules`, so an upgrade never offers the same module twice and a user's
+	 * opt-out is not undone by the next prerelease or by the final release. A version window alone
+	 * cannot express "already offered", which is why the record exists.
 	 *
-	 *  - the window's ceiling is passed as a release version. `Modules::get_available()` keeps a
-	 *    module when `introduced <= $max_version`, and a prerelease sorts below its own release, so
-	 *    passing `16.2-a.1` excludes a module introduced in `16.2`. Passing `16.2` includes it. The
-	 *    floor stays raw on purpose: it is what keeps a module added mid-cycle visible on the next
-	 *    alpha, and what keeps modules from earlier release lines out.
-	 *  - modules this site has already auto-activated are subtracted, through
-	 *    `jetpack_get_default_modules` so the other callers of activate_default_modules() —
-	 *    reconnection, multisite, the resumed admin action — keep today's behavior. A window alone
-	 *    cannot express "already offered", so without this an upgrade would offer the same module
-	 *    twice and undo a user's opt-out on the next prerelease and again at the final release.
+	 * The subtraction lands before `$other_modules` is merged in by activate_default_modules(), so
+	 * modules being reactivated after a `Changed:` header bump are never suppressed.
 	 *
-	 * Both land before `$other_modules` is merged in, so modules being reactivated after a
-	 * `Changed:` header bump are never suppressed.
+	 * Two callers share this: the upgrade path, and the `activate_default_modules` admin action
+	 * that resumes an activation which redirected away after deactivating a conflicting plugin.
+	 * The resumed request matters — `exit` does not run `finally`, so the redirect abandons this
+	 * method mid-flight and the record write below never happens. Routing the resume through here
+	 * too is what repairs that: it subtracts the record on the way in and writes it on the way out.
+	 *
+	 * Callers that should keep the historical behavior — reconnection, multisite — still call
+	 * activate_default_modules() directly.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param string   $previous_version   Version recorded for this site, without its timestamp.
-	 * @param string[] $reactivate_modules Modules deactivated by this upgrade, to reactivate.
-	 * @param bool     $redirect           Should activation redirect when it finishes.
+	 * @param string|false $min_version   Lower bound, exclusive. The recorded version, raw.
+	 * @param string|false $max_version   Upper bound, inclusive. A release version.
+	 * @param string[]     $other_modules Modules to activate alongside the defaults.
+	 * @param bool|null    $redirect      Redirect when finished; null auto-detects.
 	 *
 	 * @return void
 	 */
-	private static function activate_default_modules_for_upgrade( $previous_version, array $reactivate_modules, $redirect ) {
+	private static function activate_default_modules_once( $min_version, $max_version, array $other_modules = array(), $redirect = null ) {
 		$is_prerelease = self::is_development_version();
 		$already       = self::get_prerelease_activated_modules();
 
@@ -2394,12 +2401,7 @@ class Jetpack {
 		add_filter( 'jetpack_get_default_modules', $adjust, 100 );
 
 		try {
-			self::activate_default_modules(
-				$previous_version,
-				self::release_version( self::current_version() ),
-				$reactivate_modules,
-				$redirect
-			);
+			self::activate_default_modules( $min_version, $max_version, $other_modules, $redirect );
 		} finally {
 			remove_filter( 'jetpack_get_default_modules', $adjust, 100 );
 		}
@@ -3349,6 +3351,17 @@ p {
 
 		// Simple keeps the `jetpack_ai_enabled` option as the master; modules don't run there.
 		if ( ( new Host() )->is_wpcom_simple() ) {
+			return;
+		}
+
+		// Nothing to reconcile until the module is genuinely active. Burning the one-shot before
+		// then consumes the migration: on a prerelease the module could not auto-activate at all
+		// (its `First Introduced` sorted above the running version), so this ran, found nothing,
+		// and marked the migration done — after which an opt-out would never be honored. Read the
+		// raw option rather than get_active_modules(), which `jetpack_active_modules` can report
+		// active for a module that was never really turned on.
+		$raw = Jetpack_Options::get_option( 'active_modules' );
+		if ( ! is_array( $raw ) || ! in_array( 'ai', $raw, true ) ) {
 			return;
 		}
 
@@ -4603,7 +4616,7 @@ p {
 					$min_version   = isset( $_GET['min_version'] ) ? sanitize_text_field( wp_unslash( $_GET['min_version'] ) ) : false;
 					$max_version   = isset( $_GET['max_version'] ) ? sanitize_text_field( wp_unslash( $_GET['max_version'] ) ) : false;
 					$other_modules = isset( $_GET['other_modules'] ) && is_array( $_GET['other_modules'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_GET['other_modules'] ) ) : array();
-					self::activate_default_modules( $min_version, $max_version, $other_modules );
+					self::activate_default_modules_once( $min_version, $max_version, $other_modules );
 					wp_safe_redirect( self::admin_url( 'page=jetpack' ) );
 					exit( 0 );
 				case 'disconnect':

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2211,8 +2211,9 @@ class Jetpack {
 	/**
 	 * Bring the site's active modules in line with the version of Jetpack now running.
 	 *
-	 * Hooked on `init` for every request, but does real work only on the first request after
-	 * the plugin's version number goes up. On that request it:
+	 * Hooked on `init` by {@see self::register_upgrade_init_hooks()}, which plugin_upgrade() calls
+	 * only when the recorded version differs from the running one — so this does not run at all on
+	 * a steady-state request. When it does run it:
 	 *
 	 *  1. deactivates each active module whose code changed since the recorded version, so that
 	 *     module's activation routine runs again below;
@@ -2286,8 +2287,8 @@ class Jetpack {
 	 * module introduced in 16.2 looks like the future to every alpha of 16.2. Comparing release
 	 * versions is what puts a prerelease back in the release line it belongs to.
 	 *
-	 * Covers the whole suffix grammar in the changelogger's WordpressVersioning plugin: `-dev`,
-	 * `-alpha`, `-beta`, `-rc` with or without a number, `-a.N`, `-beta.N`, plus `+buildinfo`.
+	 * Strips any suffix, so it covers the whole prerelease grammar the changelogger's
+	 * WordpressVersioning plugin defines, plus `+buildinfo`.
 	 *
 	 * @internal Public only so it can be exercised directly by tests. Not a plugin API.
 	 * @since $$next-version$$
@@ -2349,53 +2350,23 @@ class Jetpack {
 	}
 
 	/**
-	 * Auto-activating modules introduced in the release line now running.
-	 *
-	 * Deliberately narrow. Selecting every module introduced at or below the running version would
-	 * be catastrophic on an established site: the record starts empty, so every module the owner
-	 * had ever switched off would read as never-offered and be switched back on. Restricting
-	 * candidates to the current line puts older modules permanently out of reach, which is what
-	 * makes the empty starting record safe and removes any need for a migration.
-	 *
-	 * @internal Public only so it can be exercised directly by tests. Not a plugin API.
-	 * @since $$next-version$$
-	 *
-	 * @return string[] Module slugs.
-	 */
-	public static function get_current_line_modules() {
-		$line    = self::release_version( self::current_version() );
-		$modules = array();
-
-		foreach ( self::get_default_modules() as $slug ) {
-			$module = self::get_module( $slug );
-
-			if ( empty( $module['introduced'] ) ) {
-				continue;
-			}
-
-			if ( self::release_version( $module['introduced'] ) === $line ) {
-				$modules[] = $slug;
-			}
-		}
-
-		return $modules;
-	}
-
-	/**
 	 * Hand off to activate_default_modules() with the prerelease adjustments applied.
 	 *
-	 * Two changes to the default module list, both made through `jetpack_get_default_modules` so
-	 * the other callers of activate_default_modules() — reconnection, multisite, the resumed admin
-	 * action — keep today's behavior:
+	 * Two adjustments:
 	 *
-	 *  - on a prerelease, add modules introduced in the release line now running, which the version
-	 *    window cannot see because a prerelease sorts below its own release;
-	 *  - on every version, subtract modules this site has already auto-activated, so an upgrade
-	 *    never offers the same module twice and a user's opt-out is not undone by the next
-	 *    prerelease or by the final release.
+	 *  - the window's ceiling is passed as a release version. `Modules::get_available()` keeps a
+	 *    module when `introduced <= $max_version`, and a prerelease sorts below its own release, so
+	 *    passing `16.2-a.1` excludes a module introduced in `16.2`. Passing `16.2` includes it. The
+	 *    floor stays raw on purpose: it is what keeps a module added mid-cycle visible on the next
+	 *    alpha, and what keeps modules from earlier release lines out.
+	 *  - modules this site has already auto-activated are subtracted, through
+	 *    `jetpack_get_default_modules` so the other callers of activate_default_modules() —
+	 *    reconnection, multisite, the resumed admin action — keep today's behavior. A window alone
+	 *    cannot express "already offered", so without this an upgrade would offer the same module
+	 *    twice and undo a user's opt-out on the next prerelease and again at the final release.
 	 *
-	 * The adjustment lands before `$other_modules` is merged in, so modules being reactivated after
-	 * a `Changed:` header bump are never suppressed.
+	 * Both land before `$other_modules` is merged in, so modules being reactivated after a
+	 * `Changed:` header bump are never suppressed.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -2406,31 +2377,34 @@ class Jetpack {
 	 * @return void
 	 */
 	private static function activate_default_modules_for_upgrade( $previous_version, array $reactivate_modules, $redirect ) {
-		// Computed BEFORE the filter is added: get_current_line_modules() calls
-		// get_default_modules(), which applies the very filter added below.
-		$candidates = self::is_development_version() ? self::get_current_line_modules() : array();
-		$already    = self::get_prerelease_activated_modules();
+		$is_prerelease = self::is_development_version();
+		$already       = self::get_prerelease_activated_modules();
 
 		$offered = array();
 
-		$adjust = function ( $modules ) use ( $candidates, $already, &$offered ) {
-			$modules = array_values(
-				array_diff( array_unique( array_merge( $modules, $candidates ) ), $already )
-			);
-			$offered = $modules;
+		$adjust = function ( $modules ) use ( $already, &$offered ) {
+			$offered = array_values( array_diff( $modules, $already ) );
 
-			return $modules;
+			return $offered;
 		};
 
-		add_filter( 'jetpack_get_default_modules', $adjust );
+		// Priority 100 puts this last: after filter_default_modules() has dropped modules whose
+		// conflicting plugin is active, and after handle_deprecated_modules() at 99. Running
+		// earlier would record modules that a later filter went on to remove.
+		add_filter( 'jetpack_get_default_modules', $adjust, 100 );
 
 		try {
-			self::activate_default_modules( $previous_version, self::current_version(), $reactivate_modules, $redirect );
+			self::activate_default_modules(
+				$previous_version,
+				self::release_version( self::current_version() ),
+				$reactivate_modules,
+				$redirect
+			);
 		} finally {
-			remove_filter( 'jetpack_get_default_modules', $adjust );
+			remove_filter( 'jetpack_get_default_modules', $adjust, 100 );
 		}
 
-		if ( self::is_development_version() ) {
+		if ( $is_prerelease ) {
 			self::record_prerelease_activated_modules( $offered );
 		}
 	}

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2249,7 +2249,7 @@ class Jetpack {
 
 		self::state( 'message', 'modules_activated' );
 
-		self::activate_default_modules( $previous_version, self::current_version(), $reactivate_modules, $redirect );
+		self::activate_default_modules_for_upgrade( $previous_version, $reactivate_modules, $redirect );
 
 		if ( $redirect ) {
 			self::redirect_after_activation();
@@ -2268,6 +2268,171 @@ class Jetpack {
 	 */
 	private static function current_version() {
 		return Constants::get_constant( 'JETPACK__VERSION' );
+	}
+
+	/**
+	 * Option holding the module slugs this site has already auto-activated while running a
+	 * prerelease. Written only on prereleases; read on every version.
+	 *
+	 * @since $$next-version$$
+	 * @var string
+	 */
+	const PRERELEASE_ACTIVATED_MODULES_OPTION = 'jetpack_prerelease_activated_modules';
+
+	/**
+	 * The release version a version string belongs to, with any prerelease suffix removed.
+	 *
+	 * `16.2-a.1` is 16.2 under development, but version_compare() sorts it below `16.2`, so a
+	 * module introduced in 16.2 looks like the future to every alpha of 16.2. Comparing release
+	 * versions is what puts a prerelease back in the release line it belongs to.
+	 *
+	 * Covers the whole suffix grammar in the changelogger's WordpressVersioning plugin: `-dev`,
+	 * `-alpha`, `-beta`, `-rc` with or without a number, `-a.N`, `-beta.N`, plus `+buildinfo`.
+	 *
+	 * @internal Public only so it can be exercised directly by tests. Not a plugin API.
+	 * @since $$next-version$$
+	 *
+	 * @param string $version A Jetpack version string.
+	 *
+	 * @return string The version with any prerelease or build suffix removed.
+	 */
+	public static function release_version( $version ) {
+		return preg_replace( '/[-+].*$/', '', (string) $version );
+	}
+
+	/**
+	 * Module slugs this site has already auto-activated while running a prerelease.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string[] Module slugs.
+	 */
+	private static function get_prerelease_activated_modules() {
+		$record = get_option( self::PRERELEASE_ACTIVATED_MODULES_OPTION, array() );
+
+		return is_array( $record ) ? $record : array();
+	}
+
+	/**
+	 * Record which of the offered modules actually ended up active.
+	 *
+	 * Deliberately compares against the raw `active_modules` option rather than
+	 * {@see self::get_active_modules()}: the latter applies `jetpack_active_modules`, and a module
+	 * a filter merely reports as active was never really offered to anyone. Recording it would
+	 * suppress it permanently once that filter went away.
+	 *
+	 * Modules that were already active and therefore skipped are still in the raw option, so they
+	 * are still recorded — which is the point. Recording only newly activated modules would let a
+	 * user's opt-out be undone by the next prerelease.
+	 *
+	 * @internal Public only so it can be exercised directly by tests. Not a plugin API.
+	 * @since $$next-version$$
+	 *
+	 * @param string[] $offered Module slugs that were offered for auto-activation.
+	 *
+	 * @return void
+	 */
+	public static function record_prerelease_activated_modules( array $offered ) {
+		$raw = Jetpack_Options::get_option( 'active_modules' );
+		$raw = is_array( $raw ) ? $raw : array();
+
+		$activated = array_intersect( $offered, $raw );
+		if ( ! $activated ) {
+			return;
+		}
+
+		$record = array_values(
+			array_unique( array_merge( self::get_prerelease_activated_modules(), $activated ) )
+		);
+
+		update_option( self::PRERELEASE_ACTIVATED_MODULES_OPTION, $record, false );
+	}
+
+	/**
+	 * Auto-activating modules introduced in the release line now running.
+	 *
+	 * Deliberately narrow. Selecting every module introduced at or below the running version would
+	 * be catastrophic on an established site: the record starts empty, so every module the owner
+	 * had ever switched off would read as never-offered and be switched back on. Restricting
+	 * candidates to the current line puts older modules permanently out of reach, which is what
+	 * makes the empty starting record safe and removes any need for a migration.
+	 *
+	 * @internal Public only so it can be exercised directly by tests. Not a plugin API.
+	 * @since $$next-version$$
+	 *
+	 * @return string[] Module slugs.
+	 */
+	public static function get_current_line_modules() {
+		$line    = self::release_version( self::current_version() );
+		$modules = array();
+
+		foreach ( self::get_default_modules() as $slug ) {
+			$module = self::get_module( $slug );
+
+			if ( empty( $module['introduced'] ) ) {
+				continue;
+			}
+
+			if ( self::release_version( $module['introduced'] ) === $line ) {
+				$modules[] = $slug;
+			}
+		}
+
+		return $modules;
+	}
+
+	/**
+	 * Hand off to activate_default_modules() with the prerelease adjustments applied.
+	 *
+	 * Two changes to the default module list, both made through `jetpack_get_default_modules` so
+	 * the other callers of activate_default_modules() — reconnection, multisite, the resumed admin
+	 * action — keep today's behavior:
+	 *
+	 *  - on a prerelease, add modules introduced in the release line now running, which the version
+	 *    window cannot see because a prerelease sorts below its own release;
+	 *  - on every version, subtract modules this site has already auto-activated, so an upgrade
+	 *    never offers the same module twice and a user's opt-out is not undone by the next
+	 *    prerelease or by the final release.
+	 *
+	 * The adjustment lands before `$other_modules` is merged in, so modules being reactivated after
+	 * a `Changed:` header bump are never suppressed.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string   $previous_version   Version recorded for this site, without its timestamp.
+	 * @param string[] $reactivate_modules Modules deactivated by this upgrade, to reactivate.
+	 * @param bool     $redirect           Should activation redirect when it finishes.
+	 *
+	 * @return void
+	 */
+	private static function activate_default_modules_for_upgrade( $previous_version, array $reactivate_modules, $redirect ) {
+		// Computed BEFORE the filter is added: get_current_line_modules() calls
+		// get_default_modules(), which applies the very filter added below.
+		$candidates = self::is_development_version() ? self::get_current_line_modules() : array();
+		$already    = self::get_prerelease_activated_modules();
+
+		$offered = array();
+
+		$adjust = function ( $modules ) use ( $candidates, $already, &$offered ) {
+			$modules = array_values(
+				array_diff( array_unique( array_merge( $modules, $candidates ) ), $already )
+			);
+			$offered = $modules;
+
+			return $modules;
+		};
+
+		add_filter( 'jetpack_get_default_modules', $adjust );
+
+		try {
+			self::activate_default_modules( $previous_version, self::current_version(), $reactivate_modules, $redirect );
+		} finally {
+			remove_filter( 'jetpack_get_default_modules', $adjust );
+		}
+
+		if ( self::is_development_version() ) {
+			self::record_prerelease_activated_modules( $offered );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Master_Optout_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Master_Optout_Migration_Test.php
@@ -155,6 +155,74 @@ class Jetpack_AI_Master_Optout_Migration_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * The one-shot must not be consumed while the module is inactive.
+	 *
+	 * This ran on the alpha train before module auto-activation understood prerelease versions:
+	 * `ai` declares `First Introduced: 16.2` and version_compare() sorts `16.2-a.1` below `16.2`,
+	 * so the module could not auto-activate, yet this method still ran at init:20, found nothing to
+	 * do, and marked the migration complete. Once auto-activation was fixed the module would turn
+	 * on with the migration already spent, and an explicit opt-out would be silently overridden.
+	 */
+	public function test_migration_flag_is_not_consumed_while_the_module_is_inactive() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		\Jetpack_Options::update_option( 'active_modules', array() );
+		update_option( 'jetpack_ai_enabled', 0 );
+
+		Jetpack::reconcile_ai_master_optout();
+
+		$this->assertFalse(
+			get_option( Jetpack::AI_MASTER_OPTOUT_MIGRATED_OPTION, false ),
+			'The migration must stay pending until the module is genuinely active.'
+		);
+	}
+
+	/**
+	 * The companion: once the module really is active, the opt-out is honored and the one-shot is
+	 * spent. Together with the test above this pins the ordering the guard depends on.
+	 */
+	public function test_optout_is_honoured_on_the_upgrade_that_activates_the_module() {
+		$this->set_up_auto_activated_off_simple();
+		update_option( 'jetpack_ai_enabled', 0 );
+
+		Jetpack::reconcile_ai_master_optout();
+
+		$this->assertNotContains(
+			'ai',
+			(array) \Jetpack_Options::get_option( 'active_modules' ),
+			'The opt-out is honored on the upgrade that activates the module.'
+		);
+		$this->assertTrue(
+			(bool) get_option( Jetpack::AI_MASTER_OPTOUT_MIGRATED_OPTION ),
+			'And the one-shot is spent at that point, not before.'
+		);
+	}
+
+	/**
+	 * A module reported active only by a filter - the jetpack-mu-wpcom stopgap does exactly this on
+	 * Atomic - must not spend the one-shot either, since the module is not really on.
+	 */
+	public function test_migration_flag_is_not_consumed_by_a_filter_reported_module() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		\Jetpack_Options::update_option( 'active_modules', array() );
+		update_option( 'jetpack_ai_enabled', 0 );
+
+		$stopgap = function ( $modules ) {
+			$modules[] = 'ai';
+			return array_unique( $modules );
+		};
+		add_filter( 'jetpack_active_modules', $stopgap );
+
+		Jetpack::reconcile_ai_master_optout();
+
+		remove_filter( 'jetpack_active_modules', $stopgap );
+
+		$this->assertFalse(
+			get_option( Jetpack::AI_MASTER_OPTOUT_MIGRATED_OPTION, false ),
+			'A filter reporting the module active must not spend the migration.'
+		);
+	}
+
+	/**
 	 * The ordering contract, locked against the *production* registration (not a
 	 * priority hand-picked in the test): reconcile_ai_master_optout must be hooked
 	 * to run at a LATER init priority than activate_new_modules. Auto-activation

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Prerelease_Module_Activation_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Prerelease_Module_Activation_Test.php
@@ -201,18 +201,99 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The headline case: a module introduced in 16.2 turns on for a site running an alpha of 16.2,
-	 * instead of waiting for the final release.
+	 * The whole decision table in one place.
+	 *
+	 * Inputs: the version the site had recorded, the version now running, what the module's
+	 * `First Introduced` header says, and what the record already held. Outputs: whether the
+	 * module ends up in the raw `active_modules` option, and what the record holds afterwards
+	 * (`false` meaning the option was never created).
+	 *
+	 * Reading the table beats reading the code: the floor is the recorded version raw, the ceiling
+	 * is the running version reduced to its release, and the record is subtracted from whatever
+	 * survives both.
+	 *
+	 * @dataProvider provide_activation_matrix
+	 *
+	 * @param string         $previous      Version recorded for the site before the upgrade.
+	 * @param string         $current       Version now running.
+	 * @param string         $introduced    The module's `First Introduced` header.
+	 * @param string[]       $seed_record   Record contents before the upgrade.
+	 * @param bool           $expect_active Whether the module should end up active.
+	 * @param string[]|false $expect_record Record contents after, or false if no option.
 	 */
-	public function test_module_activates_on_the_first_alpha_of_its_release() {
-		$this->register_fake_modules( array( 'jptest-current' => '16.2' ) );
+	#[DataProvider( 'provide_activation_matrix' )]
+	public function test_activation_matrix( $previous, $current, $introduced, $seed_record, $expect_active, $expect_record ) {
+		if ( $seed_record ) {
+			update_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, $seed_record, false );
+		}
 
-		$this->run_upgrade( '16.1', '16.2-a.1' );
+		$this->register_fake_modules( array( 'jptest' => $introduced ) );
+		$this->run_upgrade( $previous, $current );
 
-		$this->assertContains( 'jptest-current', $this->raw_active_modules() );
-		$this->assertContains(
-			'jptest-current',
-			get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, array() )
+		$this->assertSame(
+			$expect_active,
+			in_array( 'jptest', $this->raw_active_modules(), true ),
+			sprintf(
+				'introduced %s, upgrading %s -> %s: expected the module %s',
+				$introduced,
+				$previous,
+				$current,
+				$expect_active ? 'active' : 'inactive'
+			)
+		);
+
+		$record = get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, false );
+
+		if ( false === $expect_record ) {
+			$this->assertFalse( $record, 'The record option should never have been created.' );
+			return;
+		}
+
+		$this->assertIsArray( $record );
+		sort( $record );
+		$this->assertSame( $expect_record, $record );
+	}
+
+	/**
+	 * Previous version, running version, module header, record before => active?, record after.
+	 *
+	 * @return array
+	 */
+	public static function provide_activation_matrix() {
+		$none = array();
+		$rec  = array( 'jptest' );
+
+		return array(
+			// A release-numbered module, which is what module authors should write.
+			'alpha activates a release-numbered module' => array( '16.1', '16.2-a.1', '16.2', $none, true, $rec ),
+			'a later alpha does the same'               => array( '16.1', '16.2-a.2', '16.2', $none, true, $rec ),
+			'module added mid-cycle'                    => array( '16.2-a.1', '16.2-a.2', '16.2', $none, true, $rec ),
+			'site skipped several alphas'               => array( '16.2-a.1', '16.2-a.5', '16.2', $none, true, $rec ),
+			'fresh install on an alpha'                 => array( '1.1', '16.2-a.5', '16.2', $none, true, $rec ),
+
+			// Out of range: the floor excludes older lines, the ceiling excludes future ones.
+			'earlier release line is left alone'        => array( '16.2-a.1', '16.2-a.2', '16.1', $none, false, false ),
+			'future release line is not offered yet'    => array( '16.1', '16.2-a.1', '16.3', $none, false, false ),
+			'previous line dropped on the next line'    => array( '16.2', '16.3-a.1', '16.2', $none, false, false ),
+
+			// Release versions behave exactly as before and write no record.
+			'release-only site records nothing'         => array( '16.1', '16.2', '16.2', $none, true, false ),
+			'point release behaves the same'            => array( '16.1', '16.2.1', '16.2', $none, true, false ),
+			'later release, module already past'        => array( '16.2', '16.3', '16.2', $none, false, false ),
+
+			// An existing record is what makes an opt-out stick.
+			'opt-out survives the next alpha'           => array( '16.2-a.1', '16.2-a.2', '16.2', $rec, false, $rec ),
+			'opt-out survives the final release'        => array( '16.2-a.9', '16.2', '16.2', $rec, false, $rec ),
+
+			// A header naming an exact alpha. Same availability, but the floor then dedupes
+			// instead of the record, which costs the retry - see the class docblock.
+			'precise header, alpha that ships it'       => array( '16.2-a.1', '16.2-a.2', '16.2-a.2', $none, true, $rec ),
+			'precise header, site already past it'      => array( '16.2-a.2', '16.2-a.3', '16.2-a.2', $none, false, false ),
+			'precise header, release-only site'         => array( '16.1', '16.2', '16.2-a.2', $none, true, false ),
+
+			// The upgrade gate itself.
+			'same version is not an upgrade'            => array( '16.2-a.1', '16.2-a.1', '16.2', $none, false, false ),
+			'downgrade is a no-op'                      => array( '16.3', '16.2-a.1', '16.2', $none, false, false ),
 		);
 	}
 
@@ -254,46 +335,6 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 			'next alpha'    => array( '16.2-a.1', '16.2-a.2' ),
 			'final release' => array( '16.2-a.9', '16.2' ),
 		);
-	}
-
-	/**
-	 * A module whose file first ships mid-cycle is still offered, even though the site has already
-	 * been through earlier alphas of the same release. This is what the per-slug record buys that a
-	 * version window cannot.
-	 */
-	public function test_module_added_mid_cycle_is_still_offered() {
-		$this->register_fake_modules( array( 'jptest-late' => '16.2' ) );
-
-		$this->run_upgrade( '16.2-a.1', '16.2-a.2' );
-
-		$this->assertContains( 'jptest-late', $this->raw_active_modules() );
-	}
-
-	/**
-	 * A site that never runs a prerelease gains no new state at all.
-	 */
-	public function test_release_only_site_never_writes_the_record() {
-		$this->register_fake_modules( array( 'jptest-current' => '16.2' ) );
-
-		$this->run_upgrade( '16.1', '16.2' );
-
-		$this->assertContains( 'jptest-current', $this->raw_active_modules() );
-		$this->assertFalse(
-			get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, false ),
-			'A site that never runs a prerelease gains no new state.'
-		);
-	}
-
-	/**
-	 * The empty starting record must not resurrect modules from earlier release lines that the
-	 * site owner switched off long ago.
-	 */
-	public function test_older_modules_are_never_resurrected() {
-		$this->register_fake_modules( array( 'jptest-old' => '16.1' ) );
-
-		$this->run_upgrade( '16.2-a.1', '16.2-a.2' );
-
-		$this->assertNotContains( 'jptest-old', $this->raw_active_modules() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Prerelease_Module_Activation_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Prerelease_Module_Activation_Test.php
@@ -115,8 +115,7 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 			)
 		);
 
-		$this->assertNotSame( 'yes', $autoload, 'The record must not be autoloaded.' );
-		$this->assertNotSame( 'on', $autoload, 'The record must not be autoloaded.' );
+		$this->assertNotContains( $autoload, array( 'yes', 'on' ), 'The record must not be autoloaded.' );
 	}
 
 	/**
@@ -160,8 +159,7 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 			'jetpack_get_module',
 			function ( $mod, $slug ) use ( $modules ) {
 				if ( isset( $modules[ $slug ] ) ) {
-					$mod['introduced']    = $modules[ $slug ];
-					$mod['auto_activate'] = 'Yes';
+					$mod['introduced'] = $modules[ $slug ];
 				}
 				return $mod;
 			},
@@ -171,45 +169,14 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Only modules introduced in the release line now running are candidates. Anything older is
-	 * out of reach, which is what makes an empty record safe on an established site.
+	 * The stored active_modules option, bypassing the `jetpack_active_modules` filter.
+	 *
+	 * The raw/filtered distinction is the whole point of this suite, so it gets a name.
+	 *
+	 * @return string[]
 	 */
-	public function test_current_line_modules_selects_only_the_running_release_line() {
-		Constants::set_constant( 'JETPACK__VERSION', '16.2-a.4' );
-		$this->register_fake_modules(
-			array(
-				'jptest-current' => '16.2',
-				'jptest-old'     => '16.1',
-				'jptest-future'  => '16.3',
-			)
-		);
-
-		$this->assertSame( array( 'jptest-current' ), array_values( Jetpack::get_current_line_modules() ) );
-	}
-
-	/**
-	 * A module whose header itself carries a prerelease suffix still belongs to its release line.
-	 */
-	public function test_current_line_modules_tolerates_a_prerelease_in_the_header() {
-		Constants::set_constant( 'JETPACK__VERSION', '16.2-a.4' );
-		$this->register_fake_modules( array( 'jptest-current' => '16.2-a.2' ) );
-
-		$this->assertSame( array( 'jptest-current' ), array_values( Jetpack::get_current_line_modules() ) );
-	}
-
-	/**
-	 * On a plain release the line is the release itself.
-	 */
-	public function test_current_line_modules_on_a_release_version() {
-		Constants::set_constant( 'JETPACK__VERSION', '16.2' );
-		$this->register_fake_modules(
-			array(
-				'jptest-current' => '16.2',
-				'jptest-old'     => '16.1',
-			)
-		);
-
-		$this->assertSame( array( 'jptest-current' ), array_values( Jetpack::get_current_line_modules() ) );
+	private function raw_active_modules() {
+		return (array) \Jetpack_Options::get_option( 'active_modules' );
 	}
 
 	/**
@@ -221,21 +188,16 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	private function run_upgrade( $from, $to ) {
+		// Setting the constant is enough: is_development_version() derives the answer from it.
 		Constants::set_constant( 'JETPACK__VERSION', $to );
 
-		$is_prerelease = function () use ( $to ) {
-			return (bool) preg_match( '/[-+]/', $to );
-		};
-
 		add_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
-		add_filter( 'jetpack_development_version', $is_prerelease );
 
 		\Jetpack_Options::update_option( 'version', $from . ':' . ( time() - 86400 ) );
 
 		Jetpack::activate_new_modules( false );
 
 		remove_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
-		remove_filter( 'jetpack_development_version', $is_prerelease );
 	}
 
 	/**
@@ -247,7 +209,7 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 
 		$this->run_upgrade( '16.1', '16.2-a.1' );
 
-		$this->assertContains( 'jptest-current', (array) \Jetpack_Options::get_option( 'active_modules' ) );
+		$this->assertContains( 'jptest-current', $this->raw_active_modules() );
 		$this->assertContains(
 			'jptest-current',
 			get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, array() )
@@ -255,44 +217,43 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Switching the module off must stick. The next alpha reopens a window that still contains it,
-	 * so only the record keeps it off.
+	 * Switching the module off must stick. Both the next alpha and the final release reopen a
+	 * window that still contains the module, so only the record keeps it off.
+	 *
+	 * @dataProvider provide_upgrades_after_opt_out
+	 *
+	 * @param string $from Version recorded before the second upgrade.
+	 * @param string $to   Version running for the second upgrade.
 	 */
-	public function test_opt_out_survives_the_next_alpha() {
+	#[DataProvider( 'provide_upgrades_after_opt_out' )]
+	public function test_opt_out_survives_later_upgrades( $from, $to ) {
 		$this->register_fake_modules( array( 'jptest-current' => '16.2' ) );
 		$this->run_upgrade( '16.1', '16.2-a.1' );
 
+		// Without this the test is vacuous: if the module never activated, "it is off" proves nothing.
 		$this->assertContains(
 			'jptest-current',
-			(array) \Jetpack_Options::get_option( 'active_modules' ),
+			$this->raw_active_modules(),
 			'Precondition: the first alpha activated the module.'
 		);
 
 		Jetpack::deactivate_module( 'jptest-current' );
 
-		$this->run_upgrade( '16.2-a.1', '16.2-a.2' );
+		$this->run_upgrade( $from, $to );
 
-		$this->assertNotContains( 'jptest-current', (array) \Jetpack_Options::get_option( 'active_modules' ) );
+		$this->assertNotContains( 'jptest-current', $this->raw_active_modules() );
 	}
 
 	/**
-	 * The same opt-out must survive the final release, whose window also contains the module.
+	 * The two upgrades whose window still contains a module introduced in 16.2.
+	 *
+	 * @return array
 	 */
-	public function test_opt_out_survives_the_final_release() {
-		$this->register_fake_modules( array( 'jptest-current' => '16.2' ) );
-		$this->run_upgrade( '16.1', '16.2-a.1' );
-
-		$this->assertContains(
-			'jptest-current',
-			(array) \Jetpack_Options::get_option( 'active_modules' ),
-			'Precondition: the first alpha activated the module.'
+	public static function provide_upgrades_after_opt_out() {
+		return array(
+			'next alpha'    => array( '16.2-a.1', '16.2-a.2' ),
+			'final release' => array( '16.2-a.9', '16.2' ),
 		);
-
-		Jetpack::deactivate_module( 'jptest-current' );
-
-		$this->run_upgrade( '16.2-a.9', '16.2' );
-
-		$this->assertNotContains( 'jptest-current', (array) \Jetpack_Options::get_option( 'active_modules' ) );
 	}
 
 	/**
@@ -305,7 +266,7 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 
 		$this->run_upgrade( '16.2-a.1', '16.2-a.2' );
 
-		$this->assertContains( 'jptest-late', (array) \Jetpack_Options::get_option( 'active_modules' ) );
+		$this->assertContains( 'jptest-late', $this->raw_active_modules() );
 	}
 
 	/**
@@ -316,7 +277,7 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 
 		$this->run_upgrade( '16.1', '16.2' );
 
-		$this->assertContains( 'jptest-current', (array) \Jetpack_Options::get_option( 'active_modules' ) );
+		$this->assertContains( 'jptest-current', $this->raw_active_modules() );
 		$this->assertFalse(
 			get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, false ),
 			'A site that never runs a prerelease gains no new state.'
@@ -332,7 +293,7 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 
 		$this->run_upgrade( '16.2-a.1', '16.2-a.2' );
 
-		$this->assertNotContains( 'jptest-old', (array) \Jetpack_Options::get_option( 'active_modules' ) );
+		$this->assertNotContains( 'jptest-old', $this->raw_active_modules() );
 	}
 
 	/**
@@ -354,11 +315,11 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 		remove_filter( 'jetpack_active_modules', $stopgap );
 
 		$record = get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, array() );
-		$raw    = (array) \Jetpack_Options::get_option( 'active_modules' );
+		$raw    = $this->raw_active_modules();
 
 		$this->assertSame(
 			array(),
-			array_values( array_diff( $record, $raw ) ),
+			array_diff( $record, $raw ),
 			'Nothing may be recorded that is not genuinely in the raw active_modules option.'
 		);
 	}
@@ -367,8 +328,12 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 	 * Pre-existing and surprising: activate_default_modules() seeds its working set from the
 	 * FILTERED module list, and Modules::update_active() diffs that against the RAW option, so a
 	 * module contributed only by `jetpack_active_modules` is written into the option as a side
-	 * effect of activating something else. Characterized so a change to either method cannot alter
-	 * it silently.
+	 * effect of activating something else.
+	 *
+	 * Kept in this file, despite testing neither new method, because it is the behavior
+	 * {@see Jetpack::record_prerelease_activated_modules()} exists to defend against: it is why
+	 * the record intersects the raw option rather than trusting get_active_modules(). If this test
+	 * ever fails, that design decision needs revisiting.
 	 */
 	public function test_filtered_active_modules_leak_into_the_stored_option() {
 		\Jetpack_Options::update_option( 'active_modules', array() );
@@ -385,7 +350,7 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 
 		$this->assertContains(
 			'stats',
-			(array) \Jetpack_Options::get_option( 'active_modules' ),
+			$this->raw_active_modules(),
 			'A module present only via jetpack_active_modules is persisted by update_active_modules().'
 		);
 	}

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Prerelease_Module_Activation_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Prerelease_Module_Activation_Test.php
@@ -6,6 +6,16 @@
  * version_compare() sorts a prerelease below its own release. These tests cover the rule that puts
  * it back in its release line, and the record that stops it being offered more than once.
  *
+ * On precise headers, and why a release number is the better thing to write. Because the ceiling is
+ * reduced to its release version, `First Introduced: 16.2-a.2` clears it on every alpha of 16.2 —
+ * exactly as `16.2` does — so precision never delays availability. It changes only the floor: once
+ * the site's recorded version reaches `16.2-a.2` the window itself excludes the module, so the
+ * record is no longer what dedupes it. That costs the retry. A module offered but not actually
+ * activated (`Auto Activate: public` on a non-public site, a conflicting plugin, a fatal) is never
+ * recorded, so a release-numbered header offers it again next upgrade; a precise header does not,
+ * and the module is stranded. This is not hypothetical: `modules/blocks.php` ships
+ * `First Introduced: 13.9-a.8`.
+ *
  * @package automattic/jetpack
  */
 
@@ -76,12 +86,23 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 	public function test_record_ignores_modules_that_are_not_really_active() {
 		\Jetpack_Options::update_option( 'active_modules', array( 'stats' ) );
 
-		Jetpack::record_prerelease_activated_modules( array( 'stats', 'ai' ) );
+		// Report a module active that is not in the option, the way the jetpack-mu-wpcom stopgap
+		// does for `ai` on Atomic. Without this filter the test cannot tell an implementation that
+		// reads the raw option from one that reads get_active_modules(), which is the entire point.
+		$stopgap = function ( $modules ) {
+			$modules[] = 'sso';
+			return array_unique( $modules );
+		};
+		add_filter( 'jetpack_active_modules', $stopgap );
+
+		Jetpack::record_prerelease_activated_modules( array( 'stats', 'sso' ) );
+
+		remove_filter( 'jetpack_active_modules', $stopgap );
 
 		$this->assertSame(
 			array( 'stats' ),
 			get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION ),
-			'Only the genuinely active module is recorded.'
+			'A module reported active only by a filter must not be recorded.'
 		);
 	}
 
@@ -140,7 +161,7 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	private function register_fake_modules( array $modules ) {
+	private function register_fake_modules( array $modules, array $changed = array() ) {
 		add_filter(
 			'jetpack_get_available_modules',
 			function () use ( $modules ) {
@@ -157,9 +178,12 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 
 		add_filter(
 			'jetpack_get_module',
-			function ( $mod, $slug ) use ( $modules ) {
+			function ( $mod, $slug ) use ( $modules, $changed ) {
 				if ( isset( $modules[ $slug ] ) ) {
 					$mod['introduced'] = $modules[ $slug ];
+				}
+				if ( isset( $changed[ $slug ] ) ) {
+					$mod['changed'] = $changed[ $slug ];
 				}
 				return $mod;
 			},
@@ -338,30 +362,60 @@ class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The jetpack-mu-wpcom stopgap reports `ai` active on Atomic without it being in the option.
-	 * Whatever branch activation takes, the record must never contain a module that is not really
-	 * in the raw option — otherwise removing the stopgap would suppress it permanently.
+	 * The record subtraction runs at priority 100, after handle_deprecated_modules() appends
+	 * replacement modules at 99. Running earlier would let a later filter put a recorded module
+	 * back into the list, undoing the user's opt-out.
 	 */
-	public function test_record_never_exceeds_the_raw_active_modules_option() {
-		$this->register_fake_modules( array( 'jptest-current' => '16.2' ) );
+	public function test_a_module_appended_by_a_later_filter_still_respects_the_record() {
+		update_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, array( 'jptest-late' ), false );
+		$this->register_fake_modules(
+			array(
+				'jptest'      => '16.2',
+				'jptest-late' => '16.2',
+			)
+		);
 
-		$stopgap = function ( $modules ) {
-			$modules[] = 'jptest-current';
-			return array_unique( $modules );
+		// Stands in for handle_deprecated_modules(), which appends at priority 99.
+		$appender = function ( $modules ) {
+			$modules[] = 'jptest-late';
+			return array_values( array_unique( $modules ) );
 		};
-		add_filter( 'jetpack_active_modules', $stopgap );
+		add_filter( 'jetpack_get_default_modules', $appender, 99 );
 
 		$this->run_upgrade( '16.1', '16.2-a.1' );
 
-		remove_filter( 'jetpack_active_modules', $stopgap );
+		remove_filter( 'jetpack_get_default_modules', $appender, 99 );
 
-		$record = get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, array() );
-		$raw    = $this->raw_active_modules();
+		$raw = $this->raw_active_modules();
+		$this->assertContains( 'jptest', $raw, 'The unrecorded module still activates.' );
+		$this->assertNotContains(
+			'jptest-late',
+			$raw,
+			'A recorded module appended by a later filter must still be suppressed.'
+		);
+	}
 
-		$this->assertSame(
-			array(),
-			array_diff( $record, $raw ),
-			'Nothing may be recorded that is not genuinely in the raw active_modules option.'
+	/**
+	 * A module deactivated by this upgrade because its `Changed:` header moved is handed to
+	 * activate_default_modules() as $other_modules, which is merged in AFTER the filter. Being in
+	 * the record must therefore not stop it coming back - otherwise the record would turn a
+	 * routine reactivation into a permanent deactivation.
+	 */
+	public function test_reactivated_module_is_not_suppressed_by_the_record() {
+		\Jetpack_Options::update_option( 'active_modules', array( 'jptest' ) );
+		update_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, array( 'jptest' ), false );
+
+		$this->register_fake_modules(
+			array( 'jptest' => '16.2' ),
+			array( 'jptest' => '99.0' )
+		);
+
+		$this->run_upgrade( '16.2-a.1', '16.2-a.2' );
+
+		$this->assertContains(
+			'jptest',
+			$this->raw_active_modules(),
+			'A module reactivated after a Changed: bump must survive being in the record.'
 		);
 	}
 

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Prerelease_Module_Activation_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Prerelease_Module_Activation_Test.php
@@ -1,0 +1,392 @@
+<?php
+/**
+ * Tests for auto-activating modules on prerelease versions of Jetpack.
+ *
+ * A module declaring `First Introduced: 16.2` is invisible to a site running `16.2-a.1`, because
+ * version_compare() sorts a prerelease below its own release. These tests cover the rule that puts
+ * it back in its release line, and the record that stops it being offered more than once.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Constants;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Class Jetpack_Prerelease_Module_Activation_Test
+ *
+ * @covers \Jetpack
+ */
+#[CoversClass( Jetpack::class )]
+class Jetpack_Prerelease_Module_Activation_Test extends \WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Reset everything this suite touches.
+	 */
+	public function tear_down() {
+		delete_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION );
+		\Jetpack_Options::update_option( 'active_modules', array() );
+		Constants::clear_single_constant( 'JETPACK__VERSION' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Every prerelease suffix in the changelogger grammar reduces to its release version.
+	 *
+	 * @dataProvider provide_versions
+	 *
+	 * @param string $version  Raw version string.
+	 * @param string $expected Expected release version.
+	 */
+	#[DataProvider( 'provide_versions' )]
+	public function test_release_version_strips_prerelease_suffixes( $version, $expected ) {
+		$this->assertSame( $expected, Jetpack::release_version( $version ) );
+	}
+
+	/**
+	 * Version strings drawn from WordpressVersioning's canonical grammar.
+	 *
+	 * @return array
+	 */
+	public static function provide_versions() {
+		return array(
+			'plain release'    => array( '16.2', '16.2' ),
+			'point release'    => array( '16.2.1', '16.2.1' ),
+			'dev'              => array( '16.2-dev', '16.2' ),
+			'alpha'            => array( '16.2-alpha', '16.2' ),
+			'numbered alpha'   => array( '16.2-alpha3', '16.2' ),
+			'dotted alpha'     => array( '16.2-a.1', '16.2' ),
+			'beta'             => array( '16.2-beta', '16.2' ),
+			'dotted beta'      => array( '16.2-beta.4', '16.2' ),
+			'rc'               => array( '16.2-rc1', '16.2' ),
+			'point prerelease' => array( '16.2.1-a.4', '16.2.1' ),
+			'buildinfo'        => array( '16.2+build.7', '16.2' ),
+			'both'             => array( '16.2-a.1+build.7', '16.2' ),
+		);
+	}
+
+	/**
+	 * Only modules genuinely in the raw active_modules option get recorded. A module a filter
+	 * merely reports as active must not be, or removing that filter would leave it permanently
+	 * suppressed.
+	 */
+	public function test_record_ignores_modules_that_are_not_really_active() {
+		\Jetpack_Options::update_option( 'active_modules', array( 'stats' ) );
+
+		Jetpack::record_prerelease_activated_modules( array( 'stats', 'ai' ) );
+
+		$this->assertSame(
+			array( 'stats' ),
+			get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION ),
+			'Only the genuinely active module is recorded.'
+		);
+	}
+
+	/**
+	 * Recording is additive across upgrades and never duplicates.
+	 */
+	public function test_record_accumulates_without_duplicates() {
+		\Jetpack_Options::update_option( 'active_modules', array( 'stats', 'sso' ) );
+
+		Jetpack::record_prerelease_activated_modules( array( 'stats' ) );
+		Jetpack::record_prerelease_activated_modules( array( 'stats', 'sso' ) );
+
+		$record = get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION );
+		sort( $record );
+		$this->assertSame( array( 'sso', 'stats' ), $record );
+	}
+
+	/**
+	 * The record is read only during an upgrade, so it must not be autoloaded on every request.
+	 */
+	public function test_record_is_not_autoloaded() {
+		global $wpdb;
+		\Jetpack_Options::update_option( 'active_modules', array( 'stats' ) );
+
+		Jetpack::record_prerelease_activated_modules( array( 'stats' ) );
+
+		$autoload = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT autoload FROM $wpdb->options WHERE option_name = %s",
+				Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION
+			)
+		);
+
+		$this->assertNotSame( 'yes', $autoload, 'The record must not be autoloaded.' );
+		$this->assertNotSame( 'on', $autoload, 'The record must not be autoloaded.' );
+	}
+
+	/**
+	 * Recording nothing must not create the option at all.
+	 */
+	public function test_record_with_nothing_active_writes_no_option() {
+		\Jetpack_Options::update_option( 'active_modules', array() );
+
+		Jetpack::record_prerelease_activated_modules( array( 'ai' ) );
+
+		$this->assertFalse( get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, false ) );
+	}
+
+	/**
+	 * Present a set of fake modules to the module system.
+	 *
+	 * Modules::get() bails before the `jetpack_get_module` filter for a slug whose file cannot be
+	 * read, so the path is pointed at a fixture carrying valid module headers; only then can
+	 * individual headers be overridden.
+	 *
+	 * @param array $modules Map of slug to `First Introduced` version.
+	 *
+	 * @return void
+	 */
+	private function register_fake_modules( array $modules ) {
+		add_filter(
+			'jetpack_get_available_modules',
+			function () use ( $modules ) {
+				return $modules;
+			}
+		);
+
+		add_filter(
+			'jetpack_get_module_path',
+			function () {
+				return __DIR__ . '/fixtures/prerelease-test-module.php';
+			}
+		);
+
+		add_filter(
+			'jetpack_get_module',
+			function ( $mod, $slug ) use ( $modules ) {
+				if ( isset( $modules[ $slug ] ) ) {
+					$mod['introduced']    = $modules[ $slug ];
+					$mod['auto_activate'] = 'Yes';
+				}
+				return $mod;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Only modules introduced in the release line now running are candidates. Anything older is
+	 * out of reach, which is what makes an empty record safe on an established site.
+	 */
+	public function test_current_line_modules_selects_only_the_running_release_line() {
+		Constants::set_constant( 'JETPACK__VERSION', '16.2-a.4' );
+		$this->register_fake_modules(
+			array(
+				'jptest-current' => '16.2',
+				'jptest-old'     => '16.1',
+				'jptest-future'  => '16.3',
+			)
+		);
+
+		$this->assertSame( array( 'jptest-current' ), array_values( Jetpack::get_current_line_modules() ) );
+	}
+
+	/**
+	 * A module whose header itself carries a prerelease suffix still belongs to its release line.
+	 */
+	public function test_current_line_modules_tolerates_a_prerelease_in_the_header() {
+		Constants::set_constant( 'JETPACK__VERSION', '16.2-a.4' );
+		$this->register_fake_modules( array( 'jptest-current' => '16.2-a.2' ) );
+
+		$this->assertSame( array( 'jptest-current' ), array_values( Jetpack::get_current_line_modules() ) );
+	}
+
+	/**
+	 * On a plain release the line is the release itself.
+	 */
+	public function test_current_line_modules_on_a_release_version() {
+		Constants::set_constant( 'JETPACK__VERSION', '16.2' );
+		$this->register_fake_modules(
+			array(
+				'jptest-current' => '16.2',
+				'jptest-old'     => '16.1',
+			)
+		);
+
+		$this->assertSame( array( 'jptest-current' ), array_values( Jetpack::get_current_line_modules() ) );
+	}
+
+	/**
+	 * Run one upgrade: pretend the site was on $from, is now running $to, and fire the upgrade.
+	 *
+	 * @param string $from Previously recorded version.
+	 * @param string $to   Version now running.
+	 *
+	 * @return void
+	 */
+	private function run_upgrade( $from, $to ) {
+		Constants::set_constant( 'JETPACK__VERSION', $to );
+
+		$is_prerelease = function () use ( $to ) {
+			return (bool) preg_match( '/[-+]/', $to );
+		};
+
+		add_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
+		add_filter( 'jetpack_development_version', $is_prerelease );
+
+		\Jetpack_Options::update_option( 'version', $from . ':' . ( time() - 86400 ) );
+
+		Jetpack::activate_new_modules( false );
+
+		remove_filter( 'jetpack_is_connection_ready', '__return_true', 1000 );
+		remove_filter( 'jetpack_development_version', $is_prerelease );
+	}
+
+	/**
+	 * The headline case: a module introduced in 16.2 turns on for a site running an alpha of 16.2,
+	 * instead of waiting for the final release.
+	 */
+	public function test_module_activates_on_the_first_alpha_of_its_release() {
+		$this->register_fake_modules( array( 'jptest-current' => '16.2' ) );
+
+		$this->run_upgrade( '16.1', '16.2-a.1' );
+
+		$this->assertContains( 'jptest-current', (array) \Jetpack_Options::get_option( 'active_modules' ) );
+		$this->assertContains(
+			'jptest-current',
+			get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, array() )
+		);
+	}
+
+	/**
+	 * Switching the module off must stick. The next alpha reopens a window that still contains it,
+	 * so only the record keeps it off.
+	 */
+	public function test_opt_out_survives_the_next_alpha() {
+		$this->register_fake_modules( array( 'jptest-current' => '16.2' ) );
+		$this->run_upgrade( '16.1', '16.2-a.1' );
+
+		$this->assertContains(
+			'jptest-current',
+			(array) \Jetpack_Options::get_option( 'active_modules' ),
+			'Precondition: the first alpha activated the module.'
+		);
+
+		Jetpack::deactivate_module( 'jptest-current' );
+
+		$this->run_upgrade( '16.2-a.1', '16.2-a.2' );
+
+		$this->assertNotContains( 'jptest-current', (array) \Jetpack_Options::get_option( 'active_modules' ) );
+	}
+
+	/**
+	 * The same opt-out must survive the final release, whose window also contains the module.
+	 */
+	public function test_opt_out_survives_the_final_release() {
+		$this->register_fake_modules( array( 'jptest-current' => '16.2' ) );
+		$this->run_upgrade( '16.1', '16.2-a.1' );
+
+		$this->assertContains(
+			'jptest-current',
+			(array) \Jetpack_Options::get_option( 'active_modules' ),
+			'Precondition: the first alpha activated the module.'
+		);
+
+		Jetpack::deactivate_module( 'jptest-current' );
+
+		$this->run_upgrade( '16.2-a.9', '16.2' );
+
+		$this->assertNotContains( 'jptest-current', (array) \Jetpack_Options::get_option( 'active_modules' ) );
+	}
+
+	/**
+	 * A module whose file first ships mid-cycle is still offered, even though the site has already
+	 * been through earlier alphas of the same release. This is what the per-slug record buys that a
+	 * version window cannot.
+	 */
+	public function test_module_added_mid_cycle_is_still_offered() {
+		$this->register_fake_modules( array( 'jptest-late' => '16.2' ) );
+
+		$this->run_upgrade( '16.2-a.1', '16.2-a.2' );
+
+		$this->assertContains( 'jptest-late', (array) \Jetpack_Options::get_option( 'active_modules' ) );
+	}
+
+	/**
+	 * A site that never runs a prerelease gains no new state at all.
+	 */
+	public function test_release_only_site_never_writes_the_record() {
+		$this->register_fake_modules( array( 'jptest-current' => '16.2' ) );
+
+		$this->run_upgrade( '16.1', '16.2' );
+
+		$this->assertContains( 'jptest-current', (array) \Jetpack_Options::get_option( 'active_modules' ) );
+		$this->assertFalse(
+			get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, false ),
+			'A site that never runs a prerelease gains no new state.'
+		);
+	}
+
+	/**
+	 * The empty starting record must not resurrect modules from earlier release lines that the
+	 * site owner switched off long ago.
+	 */
+	public function test_older_modules_are_never_resurrected() {
+		$this->register_fake_modules( array( 'jptest-old' => '16.1' ) );
+
+		$this->run_upgrade( '16.2-a.1', '16.2-a.2' );
+
+		$this->assertNotContains( 'jptest-old', (array) \Jetpack_Options::get_option( 'active_modules' ) );
+	}
+
+	/**
+	 * The jetpack-mu-wpcom stopgap reports `ai` active on Atomic without it being in the option.
+	 * Whatever branch activation takes, the record must never contain a module that is not really
+	 * in the raw option — otherwise removing the stopgap would suppress it permanently.
+	 */
+	public function test_record_never_exceeds_the_raw_active_modules_option() {
+		$this->register_fake_modules( array( 'jptest-current' => '16.2' ) );
+
+		$stopgap = function ( $modules ) {
+			$modules[] = 'jptest-current';
+			return array_unique( $modules );
+		};
+		add_filter( 'jetpack_active_modules', $stopgap );
+
+		$this->run_upgrade( '16.1', '16.2-a.1' );
+
+		remove_filter( 'jetpack_active_modules', $stopgap );
+
+		$record = get_option( Jetpack::PRERELEASE_ACTIVATED_MODULES_OPTION, array() );
+		$raw    = (array) \Jetpack_Options::get_option( 'active_modules' );
+
+		$this->assertSame(
+			array(),
+			array_values( array_diff( $record, $raw ) ),
+			'Nothing may be recorded that is not genuinely in the raw active_modules option.'
+		);
+	}
+
+	/**
+	 * Pre-existing and surprising: activate_default_modules() seeds its working set from the
+	 * FILTERED module list, and Modules::update_active() diffs that against the RAW option, so a
+	 * module contributed only by `jetpack_active_modules` is written into the option as a side
+	 * effect of activating something else. Characterized so a change to either method cannot alter
+	 * it silently.
+	 */
+	public function test_filtered_active_modules_leak_into_the_stored_option() {
+		\Jetpack_Options::update_option( 'active_modules', array() );
+
+		$leak = function ( $modules ) {
+			$modules[] = 'stats';
+			return array_unique( $modules );
+		};
+		add_filter( 'jetpack_active_modules', $leak );
+
+		Jetpack::update_active_modules( array_merge( Jetpack::get_active_modules(), array( 'sso' ) ) );
+
+		remove_filter( 'jetpack_active_modules', $leak );
+
+		$this->assertContains(
+			'stats',
+			(array) \Jetpack_Options::get_option( 'active_modules' ),
+			'A module present only via jetpack_active_modules is persisted by update_active_modules().'
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/general/fixtures/prerelease-test-module.php
+++ b/projects/plugins/jetpack/tests/php/general/fixtures/prerelease-test-module.php
@@ -1,0 +1,13 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Module Name: Prerelease Test Module
+ * Module Description: Fixture module for auto-activation tests. Does nothing.
+ * Sort Order: 99
+ * First Introduced: 16.2
+ * Auto Activate: Yes
+ * Feature: Other
+ *
+ * @package automattic/jetpack
+ */
+
+// Intentionally empty: activating this module must have no side effects.

--- a/projects/plugins/jetpack/uninstall.php
+++ b/projects/plugins/jetpack/uninstall.php
@@ -41,6 +41,7 @@ function jetpack_uninstall() {
 	Jetpack_Options::delete_all_known_options();
 
 	// Delete all legacy options.
+	delete_option( 'jetpack_prerelease_activated_modules' );
 	delete_option( 'jetpack_was_activated' );
 	delete_option( 'jetpack_auto_installed' );
 	delete_option( 'jetpack_register' );


### PR DESCRIPTION
Fixes # N/A

> **Stacked on #51490** (`refactor/activate-new-modules-seams`), which extracts the seams this builds on. Review that first; this PR's diff is only the change below. Retarget to `trunk` once #51490 merges.

## Proposed changes

A module declaring `First Introduced: 16.2` never auto-activates on a site running `16.2-a.N`. Atomic runs the alpha train, so on Atomic the module simply never turns on — and where its UI switch is not reachable, there is no way to turn it on by hand either. `modules/ai.php` is the live case.

The whole cause is one comparison: **`version_compare( '16.2-a.0', '16.2', '<' )` is true.** A prerelease sorts *below* its own release, so in `Modules::get_available()` the ceiling of the version window sits beneath a module introduced at `16.2`, and it is dropped until GA.

Confirmed on a live Atomic site running `16.2-a.0`:

```
JETPACK__VERSION:   16.2-a.0
version option:     16.2-a.0:1786989017
raw active_modules: blocks,carousel,…,account-protection        # no 'ai'
filtered active:    blocks,carousel,…,account-protection,ai    # 'ai' added by the mu-wpcom stopgap
prerelease record:  (option absent)
```

### The rule

Two changes, both at the single `activate_default_modules()` call site in `activate_new_modules()`:

1. **The window's ceiling is passed as a release version.** `Modules::get_available()` keeps a module when `introduced <= $max_version`; passing `16.2-a.1` excludes a module introduced in `16.2`, passing `16.2` includes it. The floor stays raw on purpose — that asymmetry is what keeps a module *added mid-cycle* visible on the next alpha while still excluding earlier release lines.
2. **A durable per-slug record is subtracted**, via `jetpack_get_default_modules` at priority 100 so the other callers of `activate_default_modules()` keep today's behavior. A version window cannot express "already offered", so without this the same module is offered on every alpha and the user's opt-out is undone again at GA.

| Case | Window | Record | Result |
|---|---|---|---|
| `16.1` → `16.2-a.1` | in | empty | **activated** |
| `16.2-a.1` → `16.2-a.2`, user opted out | in | present | stays off |
| `16.2-a.9` → `16.2` GA, user opted out | in | present | stays off |
| module added mid-cycle | in | empty | **activated** |
| older module, `introduced: 16.1` | out (floor) | — | untouched |
| release-only site | in | always empty | unchanged from today |

### Two decisions worth reviewing

**The record intersects the raw option**, read via `Jetpack_Options::get_option( 'active_modules' )`, never `Jetpack::get_active_modules()` — the latter applies `jetpack_active_modules`, which the Atomic stopgap hooks. Recording what is *actually* active rather than what was *offered* makes this immune to that filter and self-healing: a module that never reached the option is retried next upgrade rather than suppressed forever. It cannot be "record what we newly activated" either — the already-active skip path must still record, or an opt-out on `a.2` gets undone on `a.3`.

**The subtraction runs at priority 100**, after `filter_default_modules()` (priority 10, drops modules whose conflicting plugin is active) and `handle_deprecated_modules()` (99). Running earlier would record modules a later filter went on to remove.

### Also in this PR, and worth a second reviewer

**A guard on `reconcile_ai_master_optout()`.** That method's one-shot flag (`jetpack_ai_master_optout_migrated`) was being spent on prerelease builds where `ai` could not activate at all — it ran at init:20, found nothing to do, and marked the migration complete. `modules/ai.php` and the reconciler both landed 2026-08-10 (`9c8be75af5`); the `16.2-a.1` bump landed 2026-08-20 (`3f6d67ce26`), so sites taking that bump burned the flag with the module inactive.

Once auto-activation is fixed, those sites would activate `ai` at init:10 and find the migration already spent — silently overriding an explicit `jetpack_ai_enabled = false`. The guard is four lines: don't spend the one-shot until `ai` is genuinely in the **raw** `active_modules` option (raw, because `jetpack_active_modules` can report a module active that was never really turned on — which the Atomic stopgap does today).

Two notes for whoever owns the AI migration:
- This is a **pre-existing** bug, not one this PR introduces. The same sites would lose the opt-out at 16.2 GA regardless; this PR only makes it fire an alpha earlier, on a smaller population, where it is observable. It is fixed here because this PR is what changes the timing.
- Exposure is beta/JN/internal only. `branch-16.1.1` and `16.1.2` contain neither the module nor the reconciler, so stable-channel sites never spent the flag.

**The resumed admin action now shares the wrapper.** `activate_default_modules()` can `wp_safe_redirect()` + `exit` after deactivating a conflicting plugin, and PHP's `exit` does not run `finally` — so the record write was lost, and `admin_page_load()` resumed by calling the bare method with no record subtraction, re-offering modules a user had opted out of. Both callers now go through `activate_default_modules_once()`, which subtracts on the way in and records on the way out, so the resumed request repairs the abandoned one.

**`uninstall.php`** now deletes `jetpack_prerelease_activated_modules`.

### Deliberately not here

A header that is too *old* still strands its module: `First Introduced: 16.1` on a file first shipping in the 16.2 build is dropped on a `16.1 → 16.2` upgrade, since the window's floor is exclusive. Same class of bug, no prerelease involved. Fixing it means making the record authoritative over the version window plus a one-time backfill, and getting that backfill wrong turns modules on across every existing site. Weighed and declined; the narrow design cannot do that by construction.

### Rollout

**The wpcomsh stopgap removal is independent and can ship any time, in either order.** That is what the raw-option intersection buys. Until it lands, `ai` still cannot be switched off on Atomic, because `jetpack_active_modules` re-adds it to the filtered view whatever the option says.

No migration. Sites on an alpha have an empty record and `ai` inactive, so `ai` is a current-line candidate and activates on the next upgrade.

## Related product discussion/links

* N/A — internal code health.

## Does this pull request change what data or activity we track or use?

No new data is collected or sent. One new non-autoloaded option, `jetpack_prerelease_activated_modules`, holding module slugs. It is deliberately a plain WP option rather than a `Jetpack_Options` entry: that allowlist lives in the connection package, and adding to it would need changelog entries across every dependent plugin for state nothing else reads.

## Testing instructions

### Automated

```bash
jetpack docker phpunit jetpack -- --filter=Jetpack_Prerelease_Module_Activation_Test
jetpack docker phpunit jetpack
jetpack phan plugins/jetpack
composer phpcs:changed
```

Expected: 39 tests green in `Jetpack_Prerelease_Module_Activation_Test`, 10 in `Jetpack_AI_Master_Optout_Migration_Test`; full suite **3768 tests, 0 failures**; Phan `FOUND 0 ISSUES TOTAL`; PHPCS clean.

`test_activation_matrix` is the decision table: 18 rows of *(recorded version, running version, `First Introduced` header, record before)* → *(module active?, record after)*. Read it instead of the code — the floor is the recorded version raw, the ceiling is the running version reduced to its release, and the record is subtracted from whatever survives both.

The rows were verified to discriminate, not merely pass, with three single-line mutants:

| Mutant | Killed |
|---|---|
| Ceiling not normalized | 5 rows — every prerelease-activation row |
| Record not subtracted | 2 rows — both opt-out rows |
| Record written on releases too | 3 rows — all three release-only rows |
| Filter priority 100 → 10 | the later-filter-appends test |
| Record reads the filtered list, not raw | the raw-vs-filtered test |
| AI one-shot guard removed | 2 of the 3 new AI migration tests |

Ten of eighteen rows are load-bearing against a one-line change, partitioned exactly as the design predicts. The opt-out tests also assert the module *is* active before switching it off; without that guard they passed against a broken build.

Tests drive real filters, not mocks: `jetpack_development_version` for the prerelease gate, `Constants::set_constant( 'JETPACK__VERSION' )` for the running version, and `jetpack_get_available_modules` / `jetpack_get_module` / `jetpack_get_module_path` to inject synthetic modules. The path filter points at a fixture, because `Modules::get()` returns `false` for a slug whose file cannot be read *before* `jetpack_get_module` runs — filters alone cannot conjure a module.

### Manual

On a site running a prerelease build, with a module whose `First Introduced` matches the running release line:

1. Baseline:
   ```bash
   wp eval '
   echo "JETPACK__VERSION:   " . JETPACK__VERSION . "\n";
   echo "version option:     " . Jetpack_Options::get_option( "version" ) . "\n";
   echo "raw active_modules: " . implode( ",", (array) Jetpack_Options::get_option( "active_modules" ) ) . "\n";
   echo "filtered active:    " . implode( ",", Jetpack::get_active_modules() ) . "\n";
   echo "prerelease record:  " . implode( ",", (array) get_option( "jetpack_prerelease_activated_modules", array() ) ) . "\n";
   '
   ```
2. Force an upgrade: `wp eval 'Jetpack_Options::update_option( "version", "16.1:" . ( time() - 86400 ) );'` then load a front-end page.
3. Re-probe: the module is now in **raw** `active_modules` and in the record.
4. **The decisive step.** Turn the module off, force another upgrade, load a page, re-probe. It must stay off — in both raw and filtered. Repeat once more; still off.
5. Idempotence: load another page without forcing. Nothing changes.
6. Release behavior: on a plain release build, force an upgrade and confirm `jetpack_prerelease_activated_modules` is still absent.

Use a throwaway site — step 2 also re-runs activation for everything introduced between 16.1 and the running version.
