### PR TITLE
Backup: refresh the activity list when a backup finishes

### DIFF
--- a/projects/packages/backup/changelog/change-backup-refresh-activity-list
+++ b/projects/packages/backup/changelog/change-backup-refresh-activity-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Backup: Refresh the activity list automatically when a backup finishes.

--- a/projects/packages/backup/changelog/change-backup-refresh-activity-list
+++ b/projects/packages/backup/changelog/change-backup-refresh-activity-list
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Backup: refresh the modernized dashboard's activity list when a backup finishes, so the new restore point appears without a page reload. No-op when the modernization filter is off.
 
-Refresh the activity list automatically when a backup finishes.

--- a/projects/packages/backup/changelog/change-backup-refresh-activity-list
+++ b/projects/packages/backup/changelog/change-backup-refresh-activity-list
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Backup: Refresh the activity list automatically when a backup finishes.
+Refresh the activity list automatically when a backup finishes.

--- a/projects/packages/backup/src/dashboard/hooks/test/use-backups.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-backups.test.ts
@@ -242,10 +242,11 @@ describe( 'useBackups', () => {
 
 		// Still running on the next poll: no invalidation yet.
 		act( () => result.current.refetch() );
-		await waitFor( () => expect( mockedApiFetch ).toHaveBeenCalledTimes( 2 ) );
+		// At least two: the 5s in-progress poll can land its own tick on a slow runner.
+		await waitFor( () => expect( mockedApiFetch.mock.calls.length ).toBeGreaterThanOrEqual( 2 ) );
 		expect( invalidate ).not.toHaveBeenCalled();
 
-		// Finishes: invalidate the activity log exactly once.
+		// Finishes: one invalidation for this consumer, however many polls ran.
 		act( () => result.current.refetch() );
 		await waitFor( () => expect( result.current.state ).toBe( 'complete' ) );
 

--- a/projects/packages/backup/src/dashboard/hooks/test/use-backups.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-backups.test.ts
@@ -207,9 +207,6 @@ describe( 'useBackups', () => {
 		expect( mockedApiFetch ).not.toHaveBeenCalled();
 	} );
 
-	// The regression this guards: finishing a backup never refreshed the
-	// activity list, so the reader had to reload the page to see their
-	// new restore point.
 	it( 'invalidates the activity log once when an in-progress backup finishes, not on every poll', async () => {
 		const inProgress: RawBackupEntry[] = [
 			{

--- a/projects/packages/backup/src/dashboard/hooks/test/use-backups.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-backups.test.ts
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import { createElement, type ReactNode } from 'react';
 import { isUsableBackup, isWillRetryStatus, summarizeBackups, useBackups } from '../use-backups';
@@ -205,5 +205,77 @@ describe( 'useBackups', () => {
 
 		expect( result.current.state ).toBe( 'loading' );
 		expect( mockedApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	// The regression this guards: finishing a backup never refreshed the
+	// activity list, so the reader had to reload the page to see their
+	// new restore point.
+	it( 'invalidates the activity log once when an in-progress backup finishes, not on every poll', async () => {
+		const inProgress: RawBackupEntry[] = [
+			{
+				id: '1',
+				started: '2026-08-14 17:25:46',
+				last_updated: '2026-08-14 17:36:04',
+				status: 'started',
+				period: '1786728342',
+				percent: '50',
+				is_backup: '1',
+				is_scan: '0',
+			},
+		];
+		const finished: RawBackupEntry[] = [
+			{
+				...inProgress[ 0 ],
+				status: 'finished',
+				percent: '100',
+				last_updated: '2026-08-14 17:36:10',
+				stats: { plugins: {} },
+			},
+		];
+		mockedApiFetch
+			.mockResolvedValueOnce( inProgress )
+			.mockResolvedValueOnce( inProgress )
+			.mockResolvedValue( finished );
+		const { client, wrapper } = makeWrapper();
+		const invalidate = jest.spyOn( client, 'invalidateQueries' );
+
+		const { result } = renderHook( () => useBackups(), { wrapper } );
+		await waitFor( () => expect( result.current.state ).toBe( 'in-progress' ) );
+		expect( invalidate ).not.toHaveBeenCalled();
+
+		// Still running on the next poll: no invalidation yet.
+		act( () => result.current.refetch() );
+		await waitFor( () => expect( mockedApiFetch ).toHaveBeenCalledTimes( 2 ) );
+		expect( invalidate ).not.toHaveBeenCalled();
+
+		// Finishes: invalidate the activity log exactly once.
+		act( () => result.current.refetch() );
+		await waitFor( () => expect( result.current.state ).toBe( 'complete' ) );
+
+		expect( invalidate ).toHaveBeenCalledTimes( 1 );
+		expect( invalidate ).toHaveBeenCalledWith( { queryKey: [ 'backup', 'activity-log' ] } );
+	} );
+
+	it( 'does not invalidate the activity log on mount when no backup is in progress', async () => {
+		mockedApiFetch.mockResolvedValue( [
+			{
+				id: '1',
+				started: '2026-08-14 17:25:46',
+				last_updated: '2026-08-14 17:36:04',
+				status: 'finished',
+				period: '1786728342',
+				percent: '100',
+				is_backup: '1',
+				is_scan: '0',
+				stats: { plugins: {} },
+			},
+		] as RawBackupEntry[] );
+		const { client, wrapper } = makeWrapper();
+		const invalidate = jest.spyOn( client, 'invalidateQueries' );
+
+		const { result } = renderHook( () => useBackups(), { wrapper } );
+		await waitFor( () => expect( result.current.state ).toBe( 'complete' ) );
+
+		expect( invalidate ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-backups.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-backups.test.ts
@@ -207,7 +207,13 @@ describe( 'useBackups', () => {
 		expect( mockedApiFetch ).not.toHaveBeenCalled();
 	} );
 
-	it( 'invalidates the activity log once when an in-progress backup finishes, not on every poll', async () => {
+	// The invalidation this hook used to own lives in
+	// `useRefreshActivityOnBackupComplete`, mounted once by the Overview
+	// screen. It has to stay out of here: `BackupNowButton` mounts a
+	// second `useBackups` on that same screen, and a per-observer
+	// invalidation costs a second WPCOM round trip that the first one's
+	// in-flight refetch is silently cancelled for.
+	it( 'invalidates nothing itself when an in-progress backup finishes', async () => {
 		const inProgress: RawBackupEntry[] = [
 			{
 				id: '1',
@@ -229,49 +235,14 @@ describe( 'useBackups', () => {
 				stats: { plugins: {} },
 			},
 		];
-		mockedApiFetch
-			.mockResolvedValueOnce( inProgress )
-			.mockResolvedValueOnce( inProgress )
-			.mockResolvedValue( finished );
+		mockedApiFetch.mockResolvedValueOnce( inProgress ).mockResolvedValue( finished );
 		const { client, wrapper } = makeWrapper();
 		const invalidate = jest.spyOn( client, 'invalidateQueries' );
 
 		const { result } = renderHook( () => useBackups(), { wrapper } );
 		await waitFor( () => expect( result.current.state ).toBe( 'in-progress' ) );
-		expect( invalidate ).not.toHaveBeenCalled();
 
-		// Still running on the next poll: no invalidation yet.
 		act( () => result.current.refetch() );
-		// At least two: the 5s in-progress poll can land its own tick on a slow runner.
-		await waitFor( () => expect( mockedApiFetch.mock.calls.length ).toBeGreaterThanOrEqual( 2 ) );
-		expect( invalidate ).not.toHaveBeenCalled();
-
-		// Finishes: one invalidation for this consumer, however many polls ran.
-		act( () => result.current.refetch() );
-		await waitFor( () => expect( result.current.state ).toBe( 'complete' ) );
-
-		expect( invalidate ).toHaveBeenCalledTimes( 1 );
-		expect( invalidate ).toHaveBeenCalledWith( { queryKey: [ 'backup', 'activity-log' ] } );
-	} );
-
-	it( 'does not invalidate the activity log on mount when no backup is in progress', async () => {
-		mockedApiFetch.mockResolvedValue( [
-			{
-				id: '1',
-				started: '2026-08-14 17:25:46',
-				last_updated: '2026-08-14 17:36:04',
-				status: 'finished',
-				period: '1786728342',
-				percent: '100',
-				is_backup: '1',
-				is_scan: '0',
-				stats: { plugins: {} },
-			},
-		] as RawBackupEntry[] );
-		const { client, wrapper } = makeWrapper();
-		const invalidate = jest.spyOn( client, 'invalidateQueries' );
-
-		const { result } = renderHook( () => useBackups(), { wrapper } );
 		await waitFor( () => expect( result.current.state ).toBe( 'complete' ) );
 
 		expect( invalidate ).not.toHaveBeenCalled();

--- a/projects/packages/backup/src/dashboard/hooks/test/use-refresh-activity-on-backup-complete.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-refresh-activity-on-backup-complete.test.ts
@@ -1,0 +1,102 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { useRefreshActivityOnBackupComplete } from '../use-refresh-activity-on-backup-complete';
+import type { BackupsState } from '../../types/backup';
+
+/**
+ * Fresh client per test so the module singleton's cache can't leak.
+ *
+ * @return The client and a wrapper providing it.
+ */
+function makeWrapper() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	const wrapper = ( { children }: { children: ReactNode } ) =>
+		createElement( QueryClientProvider, { client }, children );
+	return { client, wrapper };
+}
+
+/**
+ * Drive the hook through a sequence of states and report every
+ * invalidation it asked for.
+ *
+ * @param states - States to render, in order.
+ * @return The spy on `invalidateQueries`.
+ */
+function walk( states: BackupsState[] ): jest.SpyInstance {
+	const { client, wrapper } = makeWrapper();
+	const invalidate = jest.spyOn( client, 'invalidateQueries' );
+	const [ first, ...rest ] = states;
+	const { rerender } = renderHook(
+		( state: BackupsState ) => useRefreshActivityOnBackupComplete( state ),
+		{ wrapper, initialProps: first }
+	);
+	rest.forEach( state => rerender( state ) );
+	return invalidate;
+}
+
+const ACTIVITY_LOG_ROOT = { queryKey: [ 'backup', 'activity-log' ] };
+
+describe( 'useRefreshActivityOnBackupComplete', () => {
+	it( 'refreshes the activity log when a running backup completes', () => {
+		const invalidate = walk( [ 'loading', 'in-progress', 'complete' ] );
+
+		expect( invalidate ).toHaveBeenCalledTimes( 1 );
+		expect( invalidate ).toHaveBeenCalledWith( ACTIVITY_LOG_ROOT );
+	} );
+
+	it( 'stays quiet on a screen where no backup was ever running', () => {
+		const invalidate = walk( [ 'loading', 'complete', 'complete' ] );
+
+		expect( invalidate ).not.toHaveBeenCalled();
+	} );
+
+	// `useBackups`' most common failure mode — a non-200 from WPCOM
+	// served as HTTP 200 with a `null` body — lands here. There is no new
+	// restore point to fetch, and `pollInterval()` deliberately stops
+	// polling rather than hammering an upstream that just failed.
+	it( 'does not refresh when a running backup drops to an error', () => {
+		const invalidate = walk( [ 'in-progress', 'error' ] );
+
+		expect( invalidate ).not.toHaveBeenCalled();
+	} );
+
+	// The positive control for the case above: the run is remembered
+	// across the failed poll, so the reader's retry still refreshes the
+	// list. A previous-state comparison would have forgotten it.
+	it( 'still refreshes when the run is only seen to end after a failed poll', () => {
+		const invalidate = walk( [ 'in-progress', 'error', 'complete' ] );
+
+		expect( invalidate ).toHaveBeenCalledTimes( 1 );
+		expect( invalidate ).toHaveBeenCalledWith( ACTIVITY_LOG_ROOT );
+	} );
+
+	// WPCOM logs a failed attempt as its own activity row, so both
+	// no-restore-point outcomes are worth a refresh.
+	it.each( [ 'will-retry', 'no-good-backups' ] as BackupsState[] )(
+		'refreshes when a running backup ends in %s',
+		state => {
+			const invalidate = walk( [ 'in-progress', state ] );
+
+			expect( invalidate ).toHaveBeenCalledTimes( 1 );
+		}
+	);
+
+	// Nothing new has run, so the retry that recovers from a failed poll
+	// on an idle screen must not refresh the list a second time.
+	it( 'does not refresh again when a later poll fails and recovers', () => {
+		const invalidate = walk( [ 'in-progress', 'complete', 'error', 'complete' ] );
+
+		expect( invalidate ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	// Two finished backups in one session — a reader who clicks "Back up
+	// now" twice — must each get their own refresh.
+	it( 'arms again for the next run', () => {
+		const invalidate = walk( [ 'in-progress', 'complete', 'in-progress', 'complete' ] );
+
+		expect( invalidate ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/projects/packages/backup/src/dashboard/hooks/use-backups.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backups.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useRef } from '@wordpress/element';
 import { fetchBackups, type RawBackupEntry } from '../data/api/backups';
 import { normalizeBackups } from '../data/normalize/backups';
 import { keys } from '../data/query-client';
@@ -203,6 +203,7 @@ type Result = BackupsSummary & {
  */
 export function useBackups( { forcePoll = false }: Args = {} ): Result {
 	const enabled = useCanQueryWpcom();
+	const queryClient = useQueryClient();
 	const query = useQuery( {
 		queryKey: keys.backups(),
 		queryFn: fetchBackups,
@@ -241,6 +242,20 @@ export function useBackups( { forcePoll = false }: Args = {} ): Result {
 		}
 		return summarizeBackups( backups );
 	}, [ data, error, backups ] );
+
+	// The activity log has no poll of its own (see query-client.ts's key
+	// split), so a backup that finishes while the page is open never
+	// shows up there on its own. Fire the invalidation on the
+	// `in-progress` -> anything-else edge, not on every poll tick or on
+	// mount, or a long-open tab would re-fetch the activity log every
+	// 5 seconds for nothing.
+	const wasInProgress = useRef( false );
+	useEffect( () => {
+		if ( wasInProgress.current && summary.state !== 'in-progress' ) {
+			queryClient.invalidateQueries( { queryKey: keys.activityLogRoot() } );
+		}
+		wasInProgress.current = summary.state === 'in-progress';
+	}, [ summary.state, queryClient ] );
 
 	// Wrapped so callers can hand it straight to `onClick` without
 	// returning a floating promise from the event handler.

--- a/projects/packages/backup/src/dashboard/hooks/use-backups.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backups.ts
@@ -244,7 +244,7 @@ export function useBackups( { forcePoll = false }: Args = {} ): Result {
 	}, [ data, error, backups ] );
 
 	// The activity log has no poll of its own (see the key split in query-client.ts).
-	// Fire on the in-progress -> finished edge only; per-tick would refetch every 5s.
+	// Fire once when a run leaves in-progress; per-tick would refetch every 5s.
 	const wasInProgress = useRef( false );
 	useEffect( () => {
 		if ( wasInProgress.current && summary.state !== 'in-progress' ) {

--- a/projects/packages/backup/src/dashboard/hooks/use-backups.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backups.ts
@@ -1,5 +1,5 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useMemo, useRef } from '@wordpress/element';
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useMemo } from '@wordpress/element';
 import { fetchBackups, type RawBackupEntry } from '../data/api/backups';
 import { normalizeBackups } from '../data/normalize/backups';
 import { keys } from '../data/query-client';
@@ -203,7 +203,6 @@ type Result = BackupsSummary & {
  */
 export function useBackups( { forcePoll = false }: Args = {} ): Result {
 	const enabled = useCanQueryWpcom();
-	const queryClient = useQueryClient();
 	const query = useQuery( {
 		queryKey: keys.backups(),
 		queryFn: fetchBackups,
@@ -242,16 +241,6 @@ export function useBackups( { forcePoll = false }: Args = {} ): Result {
 		}
 		return summarizeBackups( backups );
 	}, [ data, error, backups ] );
-
-	// The activity log has no poll of its own (see the key split in query-client.ts).
-	// Fire once when a run leaves in-progress; per-tick would refetch every 5s.
-	const wasInProgress = useRef( false );
-	useEffect( () => {
-		if ( wasInProgress.current && summary.state !== 'in-progress' ) {
-			queryClient.invalidateQueries( { queryKey: keys.activityLogRoot() } );
-		}
-		wasInProgress.current = summary.state === 'in-progress';
-	}, [ summary.state, queryClient ] );
 
 	// Wrapped so callers can hand it straight to `onClick` without
 	// returning a floating promise from the event handler.

--- a/projects/packages/backup/src/dashboard/hooks/use-backups.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backups.ts
@@ -243,12 +243,8 @@ export function useBackups( { forcePoll = false }: Args = {} ): Result {
 		return summarizeBackups( backups );
 	}, [ data, error, backups ] );
 
-	// The activity log has no poll of its own (see query-client.ts's key
-	// split), so a backup that finishes while the page is open never
-	// shows up there on its own. Fire the invalidation on the
-	// `in-progress` -> anything-else edge, not on every poll tick or on
-	// mount, or a long-open tab would re-fetch the activity log every
-	// 5 seconds for nothing.
+	// The activity log has no poll of its own (see the key split in query-client.ts).
+	// Fire on the in-progress -> finished edge only; per-tick would refetch every 5s.
 	const wasInProgress = useRef( false );
 	useEffect( () => {
 		if ( wasInProgress.current && summary.state !== 'in-progress' ) {

--- a/projects/packages/backup/src/dashboard/hooks/use-refresh-activity-on-backup-complete.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-refresh-activity-on-backup-complete.ts
@@ -1,0 +1,61 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from '@wordpress/element';
+import { keys } from '../data/query-client';
+import type { BackupsState } from '../types/backup';
+
+/**
+ * States that mean "the run that was going is over".
+ *
+ * `error` is deliberately absent. It is not an outcome of the backup but
+ * of the *request* — and per `useBackups`, the most common failure of
+ * `/jetpack/v4/backups` is a non-200 served as HTTP 200 with a `null`
+ * body, which lands exactly here. Refetching the activity log on it
+ * would aim a round trip at an upstream that just failed, for an answer
+ * that cannot contain the finished backup. `loading` is absent for the
+ * same reason: nothing has been learned yet.
+ */
+const RUN_ENDED_STATES: readonly BackupsState[] = [
+	'complete',
+	'will-retry',
+	'no-good-backups',
+] as const;
+
+/**
+ * Refresh the activity list once a running backup has ended.
+ *
+ * The activity-log family has no poll of its own — see the key split in
+ * `data/query-client.ts` — so nothing else notices that a new restore
+ * point exists, and the row only appears on a reload.
+ *
+ * Mount this **once per screen**. Every mounted observer would otherwise
+ * invalidate on the same edge, and concurrent invalidations do not
+ * coalesce: `invalidateQueries` forwards to `refetchQueries`, which
+ * defaults `cancelRefetch: true`, so `Query.fetch()` cancels the
+ * in-flight refetch and starts another. `apiCall` passes no `signal`, so
+ * the cancelled request is not aborted on the wire — it completes and
+ * its response is discarded. Two observers therefore cost two WPCOM
+ * round trips per finished backup per open tab, not one.
+ *
+ * @param state - The derived backups state, from `useBackups`.
+ */
+export function useRefreshActivityOnBackupComplete( state: BackupsState ): void {
+	const queryClient = useQueryClient();
+	// Latched rather than compared against the previous render's state:
+	// a single failed poll mid-backup moves the state to `error` and
+	// stops the poll, so the run's end is only ever observed on the
+	// reader's retry — one transition later. A plain previous-state
+	// comparison would have forgotten the run by then and left the list
+	// stale, which is the bug this hook exists to fix.
+	const sawInProgress = useRef( false );
+
+	useEffect( () => {
+		if ( state === 'in-progress' ) {
+			sawInProgress.current = true;
+			return;
+		}
+		if ( sawInProgress.current && RUN_ENDED_STATES.includes( state ) ) {
+			sawInProgress.current = false;
+			queryClient.invalidateQueries( { queryKey: keys.activityLogRoot() } );
+		}
+	}, [ state, queryClient ] );
+}

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -17,6 +17,7 @@ import {
 	useHasRestorePoints,
 } from '../hooks/use-activity-log';
 import { useBackups } from '../hooks/use-backups';
+import { useRefreshActivityOnBackupComplete } from '../hooks/use-refresh-activity-on-backup-complete';
 import { isBackupItem } from '../types/activity';
 import type { View } from '@wordpress/dataviews';
 
@@ -78,6 +79,11 @@ export default function OverviewScreen() {
 		isRefetching: backupsRefetching,
 		refetch: refetchBackups,
 	} = useBackups();
+	// Owned here, and only here. `BackupNowButton` reads the same query
+	// through its own `useBackups`, so this screen has two observers of
+	// the state below — but the refresh must fire once per finished
+	// backup, not once per observer. See the hook's docblock.
+	useRefreshActivityOnBackupComplete( backupsState );
 	// A second opinion on whether anything is restorable, from the
 	// paginated activity log rather than the short `/backups` window.
 	// While it is still unknown, assume there *are* restore points:

--- a/projects/packages/backup/tests/activity-refresh-on-backup-complete.test.tsx
+++ b/projects/packages/backup/tests/activity-refresh-on-backup-complete.test.tsx
@@ -1,0 +1,204 @@
+// A finished backup must put its row in the activity list without a
+// reload, and must cost exactly one request to do it.
+//
+// The Overview screen mounts `useBackups` twice — once in its own body
+// and once inside `BackupNowButton` — so every observer of the derived
+// state is a candidate place to fire the refresh from. Firing per
+// observer does not coalesce: `invalidateQueries` forwards to
+// `refetchQueries`, which defaults `cancelRefetch: true`, so the second
+// call cancels the first's in-flight refetch and issues its own. The
+// cancelled request carries no `signal`, so it is not aborted on the
+// wire either — it completes and its response is thrown away. That is
+// two WPCOM round trips through the Jetpack proxy per finished backup
+// per open tab, for one list.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+	useNavigate: () => () => {},
+	useParams: () => ( {} ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import { stage as OverviewStage } from '../routes/dashboard/stage';
+import { queryClient } from '../src/dashboard/data/query-client';
+import { BACKUPS_POLL_INTERVAL_MS } from '../src/dashboard/hooks/use-backups';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+const SETTLE = { timeout: 10000 };
+
+const OLD_REWIND = '1786644531.100';
+const NEW_REWIND = '1786644532.200';
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );
+
+/**
+ * One rewindable-activity entry, in WPCOM's shape.
+ *
+ * @param rewindId - The backup's rewind id.
+ * @param title    - The row's summary/title.
+ * @return A raw activity entry.
+ */
+function backupEntry( rewindId: string, title: string ) {
+	return {
+		activity_id: `act-${ rewindId }`,
+		gridicon: 'cloud',
+		summary: title,
+		published: '2026-08-13T18:08:56+00:00',
+		rewind_id: rewindId,
+		actor: { type: 'Application', name: 'Jetpack' },
+		content: { text: '10 plugins, 4 themes' },
+		name: 'rewind__backup_complete_full',
+	};
+}
+
+/** One `/jetpack/v4/backups` row, in WPCOM's string-typed wire shape. */
+const RUNNING_BACKUP = {
+	id: '1',
+	started: '2026-08-14 17:25:46',
+	last_updated: '2026-08-14 17:36:04',
+	status: 'started',
+	period: '1786644532',
+	percent: '50',
+	is_backup: '1',
+	is_scan: '0',
+};
+
+const FINISHED_BACKUP = {
+	...RUNNING_BACKUP,
+	status: 'finished',
+	percent: '100',
+	last_updated: '2026-08-14 17:36:10',
+	stats: { plugins: {} },
+};
+
+/** Rows the next `/jetpack/v4/backups` call answers with. */
+let backupRows: unknown[] = [];
+/** Activity rows the next `/site/rewindable-activity` call answers with. */
+let activityRows: ReturnType< typeof backupEntry >[] = [];
+/** How many times each upstream has been asked. */
+let calls = { activity: 0, backups: 0 };
+
+beforeEach( () => {
+	jest.useFakeTimers();
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	calls = { activity: 0, backups: 0 };
+	backupRows = [ RUNNING_BACKUP ];
+	activityRows = [ backupEntry( OLD_REWIND, 'Older backup complete' ) ];
+
+	mockApiFetch.mockReset();
+	mockApiFetch.mockImplementation( ( o: { path?: string } ) => {
+		const path = o?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		if ( path.includes( '/site/rewindable-activity' ) ) {
+			calls.activity++;
+			return Promise.resolve( {
+				current: { orderedItems: [ ...activityRows ] },
+				totalItems: activityRows.length,
+				totalPages: 1,
+			} );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: false } );
+		}
+		if ( path === '/jetpack/v4/backups' ) {
+			calls.backups++;
+			return Promise.resolve( [ ...backupRows ] );
+		}
+		if ( path.includes( '/rewind/backup/ls' ) ) {
+			return Promise.resolve( { contents: {} } );
+		}
+		return Promise.resolve( {} );
+	} );
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+afterEach( () => {
+	jest.useRealTimers();
+} );
+
+/**
+ * Run one poll tick and let everything it triggers settle, so a count
+ * read afterwards is a final value rather than a value mid-flight.
+ */
+async function pollAndSettle(): Promise< void > {
+	await act( async () => {
+		await jest.advanceTimersByTimeAsync( BACKUPS_POLL_INTERVAL_MS );
+	} );
+	await act( async () => {
+		await jest.advanceTimersByTimeAsync( 0 );
+	} );
+}
+
+/**
+ * The activity list pane. Scoped queries matter here: the newest
+ * backup's title is also the detail pane's heading, so an unscoped
+ * text match finds two nodes.
+ *
+ * @return The list container.
+ */
+function activityList(): HTMLElement {
+	return document.querySelector( '.jpb-activity-list' ) as HTMLElement;
+}
+
+describe( 'A backup finishing while the Overview is open', () => {
+	it( 'adds its row to the activity list, in exactly one request', async () => {
+		render( <OverviewStage /> );
+
+		// The running backup is reported alongside the list, not in place
+		// of it, because the site already has a restore point.
+		await expect(
+			screen.findByRole( 'heading', { name: 'Older backup complete' }, SETTLE )
+		).resolves.toBeInTheDocument();
+		// Settle the opening burst of requests before counting, so the
+		// baseline is a resting value rather than one mid-flight.
+		await pollAndSettle();
+		const activityCallsWhileRunning = calls.activity;
+		expect(
+			within( activityList() ).queryByText( 'Newest backup complete' )
+		).not.toBeInTheDocument();
+
+		// WPCOM finishes the backup and indexes its activity row.
+		backupRows = [ FINISHED_BACKUP ];
+		activityRows = [
+			backupEntry( NEW_REWIND, 'Newest backup complete' ),
+			backupEntry( OLD_REWIND, 'Older backup complete' ),
+		];
+		await pollAndSettle();
+
+		await waitFor(
+			() =>
+				expect(
+					within( activityList() ).getByText( 'Newest backup complete' )
+				).toBeInTheDocument(),
+			SETTLE
+		);
+
+		// Let a second refetch happen if one was going to, so the count
+		// below is settled rather than merely early.
+		await pollAndSettle();
+		expect( calls.activity ).toBe( activityCallsWhileRunning + 1 );
+	} );
+} );

--- a/projects/plugins/backup/changelog/change-backup-refresh-activity-list
+++ b/projects/plugins/backup/changelog/change-backup-refresh-activity-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Refresh the activity list automatically when a backup finishes.

--- a/projects/plugins/backup/changelog/change-backup-refresh-activity-list
+++ b/projects/plugins/backup/changelog/change-backup-refresh-activity-list
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Backup: refresh the modernized dashboard's activity list when a backup finishes, so the new restore point appears without a page reload. No-op when the modernization filter is off.
 
-Refresh the activity list automatically when a backup finishes.


### PR DESCRIPTION
Fixes JETPACK-2307

## Proposed changes
* Finishing a backup while the modernized Backup dashboard is open never refreshed the activity list, so the new restore point only appeared after a page reload.
* A new hook, `useRefreshActivityOnBackupComplete`, invalidates the activity-log query cache when a running backup ends. `screens/overview.tsx` mounts it **once**. `use-backups.ts` is unchanged from trunk.
* Mounted once, not per `useBackups` consumer. The Overview screen has two (`screens/overview.tsx` and `components/backup-now-button/index.tsx`), and concurrent invalidations do **not** coalesce. In the pinned `@tanstack/query-core@5.101.2`, `invalidateQueries` forwards to `refetchQueries`, which defaults `cancelRefetch: options.cancelRefetch ?? true`; `Query.fetch()` then cancels the in-flight refetch (`state.data !== undefined && fetchStatus !== 'idle'`) and starts another. `apiCall` passes no `signal`, so the cancelled request is not aborted on the wire either — it completes and its response is discarded. Two observers therefore cost two WPCOM round trips per finished backup per open tab, for one list.
* The trigger is the run **ending** — `complete`, `will-retry` or `no-good-backups` — not the state leaving `in-progress`. `error` is excluded deliberately: this route's most common failure is a non-200 from WordPress.com served as HTTP 200 with a `null` body, which lands exactly there, and `pollInterval()` already stops polling in that case rather than hammering a failing upstream.
* The run is latched rather than compared against the previous render's state. A failed poll mid-backup moves the state to `error` and stops the poll, so the run's end is only ever observed on the reader's retry — one transition later. A previous-state comparison would have forgotten the run by then and left the list stale, which is the bug this PR exists to fix.
* The `backups` query and the `activity-log` query intentionally keep separate cache keys (see the comment in `query-client.ts`) because the backups query polls while a backup runs and the activity log does not. This change does not touch that split — it adds the one missing observer.

## Before / after

Both frames are the same moment: the backup has finished and the header button has returned to **Back up now**. Neither page was reloaded.

| Before | After |
|---|---|
| <img width="1440" height="900" alt="before-e5-no-refresh" src="https://github.com/user-attachments/assets/277ff0bd-709f-4e48-b151-892da27389ae" /> | <img width="1440" height="900" alt="after-e5-auto-refresh" src="https://github.com/user-attachments/assets/8b2afb74-b8c9-4900-816e-bb811e2a568e" /> |
| The list still shows two rows. The finished backup is missing, and stays missing until a reload. | The new row appears on its own, at the top of the list. |

Captured on a Jurassic Ninja site at 1440x900. The backup history behind these frames comes from a local fixture — a fresh JN site has no real backup history — so the data is canned while the dashboard, the build and the behaviour are real.

## Tests

* `src/dashboard/hooks/test/use-refresh-activity-on-backup-complete.test.ts` — every transition, including the two negatives: no refresh on a screen where nothing ever ran, and none when a run drops to `error`. Each test was checked against a mutation of the line it guards.
* `tests/activity-refresh-on-backup-complete.test.tsx` — renders the real Overview stage with both `useBackups` consumers mounted, drives one poll tick, and counts `/site/rewindable-activity` requests. One with this change; **two** on the first revision of this PR; on trunk the row never appears at all.
* `src/dashboard/hooks/test/use-backups.test.ts` — asserts the hook itself invalidates nothing, so mounting N of them stays inert.

## Open question

Whether WordPress.com's activity log can lag VaultPress's `finished` — if it does, the single refetch returns the same list and the row stays missing until a reload. Raised in review; not settled here. `/jetpack/v4/backups` and `/site/rewindable-activity` are different upstreams, and this repo documents no ordering between them. Measuring it needs a site where backups actually run.

## Related product discussion/links
JETPACK-2307

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

The modernized Backup dashboard is behind a feature switch that is OFF by default. As step 1, add this to an mu-plugin on a site that runs the standalone Jetpack Backup plugin (`plugins/backup`), is connected to WordPress.com, and has a Backup plan:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

1. Go to **Jetpack > VaultPress Backup** in wp-admin (`wp-admin/admin.php?page=jetpack-backup`). The Overview screen opens with the activity list in the left pane.
2. Click **Back up now** in the page header.
3. Watch the button change to **Backup in progress**, and leave the tab open.
4. When the backup finishes, the button returns to **Back up now**.

**Before the fix:** the finished backup does not appear in the list until you reload the page.
**After the fix:** its row appears on its own, within a few seconds of the button leaving **Backup in progress**.

⚠️ **Start the backup from this tab, or you will see no difference.** The backups query only polls while the enqueue state is `enqueued`, which is set by clicking **Back up now** on this screen. A backup started anywhere else — WordPress.com, another tab, a schedule — never makes this screen poll, so the transition is never observed and the list does not refresh either way.

