### PR TITLE
Backup: translate the dashboard's fallback API error message

### DIFF
--- a/projects/packages/backup/changelog/backup-translate-fallback-error
+++ b/projects/packages/backup/changelog/backup-translate-fallback-error
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Backup: translate the modernized dashboard's fallback API error message, which always rendered in English. No-op when the modernization filter is off.
 
-Fix an untranslated fallback error message on the Backup dashboard.

--- a/projects/packages/backup/changelog/backup-translate-fallback-error
+++ b/projects/packages/backup/changelog/backup-translate-fallback-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix an untranslated fallback error message on the Backup dashboard.

--- a/projects/packages/backup/src/dashboard/data/api/_helpers.ts
+++ b/projects/packages/backup/src/dashboard/data/api/_helpers.ts
@@ -211,7 +211,7 @@ export async function apiCall< T >( options: APIFetchOptions< true > ): Promise<
 		const err = raw as { code?: string; message?: string; data?: unknown };
 		throw new ApiError(
 			typeof err.code === 'string' ? err.code : 'unknown',
-			typeof err.message === 'string' ? err.message : 'Request failed',
+			typeof err.message === 'string' ? err.message : __( 'Request failed', 'jetpack-backup-pkg' ),
 			err.data
 		);
 	}

--- a/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
@@ -3,7 +3,10 @@ import { __ } from '@wordpress/i18n';
 import { ApiError, apiCall, isAmbiguousFailure, requireTypes, toIntRewindId } from '../_helpers';
 
 jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
-jest.mock( '@wordpress/i18n', () => ( { __: jest.fn( ( text: string ) => text ) } ) );
+jest.mock( '@wordpress/i18n', () => ( {
+	...jest.requireActual( '@wordpress/i18n' ),
+	__: jest.fn( ( text: string ) => text ),
+} ) );
 
 const mockedApiFetch = apiFetch as unknown as jest.Mock;
 const mockedTranslate = __ as jest.Mock;

--- a/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
@@ -1,4 +1,12 @@
-import { ApiError, isAmbiguousFailure, requireTypes, toIntRewindId } from '../_helpers';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+import { ApiError, apiCall, isAmbiguousFailure, requireTypes, toIntRewindId } from '../_helpers';
+
+jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
+jest.mock( '@wordpress/i18n', () => ( { __: jest.fn( ( text: string ) => text ) } ) );
+
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+const mockedTranslate = __ as jest.Mock;
 
 describe( 'toIntRewindId', () => {
 	test( 'returns the input unchanged when there is no decimal suffix', () => {
@@ -58,6 +66,25 @@ describe( 'requireTypes', () => {
 
 		expect( thrown ).toBeInstanceOf( ApiError );
 		expect( ( thrown as ApiError ).code ).toBe( 'no_types_selected' );
+	} );
+} );
+
+describe( 'apiCall', () => {
+	beforeEach( () => {
+		mockedApiFetch.mockReset();
+		mockedTranslate.mockClear();
+	} );
+
+	// A rejection with no `message` must still reach the reader in their
+	// own language. Asserting the rendered text would pass either way —
+	// the mocked `__` returns its input unchanged — so this pins the call
+	// instead, which only happens when the fallback is wrapped in `__()`.
+	test( 'translates the fallback message when the rejection carries none', async () => {
+		mockedApiFetch.mockRejectedValue( { code: 'some_code' } );
+
+		await expect( apiCall( { path: '/x' } ) ).rejects.toThrow( ApiError );
+
+		expect( mockedTranslate ).toHaveBeenCalledWith( 'Request failed', 'jetpack-backup-pkg' );
 	} );
 } );
 

--- a/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
@@ -1,15 +1,17 @@
 import apiFetch from '@wordpress/api-fetch';
-import { __ } from '@wordpress/i18n';
 import { ApiError, apiCall, isAmbiguousFailure, requireTypes, toIntRewindId } from '../_helpers';
 
 jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
+// `__` returns a sentinel rather than its input, so a message that reached
+// the reader untranslated is distinguishable from one that did not. The rest
+// of the module is preserved: replacing it wholesale would leave `sprintf`
+// and `_n` undefined for everything in this file's module graph.
 jest.mock( '@wordpress/i18n', () => ( {
 	...jest.requireActual( '@wordpress/i18n' ),
-	__: jest.fn( ( text: string ) => text ),
+	__: jest.fn( () => 'TRANSLATED' ),
 } ) );
 
 const mockedApiFetch = apiFetch as unknown as jest.Mock;
-const mockedTranslate = __ as jest.Mock;
 
 describe( 'toIntRewindId', () => {
 	test( 'returns the input unchanged when there is no decimal suffix', () => {
@@ -75,19 +77,17 @@ describe( 'requireTypes', () => {
 describe( 'apiCall', () => {
 	beforeEach( () => {
 		mockedApiFetch.mockReset();
-		mockedTranslate.mockClear();
 	} );
 
-	// A rejection with no `message` must still reach the reader in their
-	// own language. Asserting the rendered text would pass either way —
-	// the mocked `__` returns its input unchanged — so this pins the call
-	// instead, which only happens when the fallback is wrapped in `__()`.
+	// A rejection with no `message` must still reach the reader in their own
+	// language. Asserting on the thrown message pins the whole path: that
+	// `__()` runs, and that what it returns is what lands on `ApiError`.
 	test( 'translates the fallback message when the rejection carries none', async () => {
 		mockedApiFetch.mockRejectedValue( { code: 'some_code' } );
 
-		await expect( apiCall( { path: '/x' } ) ).rejects.toThrow( ApiError );
-
-		expect( mockedTranslate ).toHaveBeenCalledWith( 'Request failed', 'jetpack-backup-pkg' );
+		await expect( apiCall( { path: '/x' } ) ).rejects.toMatchObject( {
+			message: 'TRANSLATED',
+		} );
 	} );
 } );
 

--- a/projects/plugins/backup/changelog/backup-translate-fallback-error
+++ b/projects/plugins/backup/changelog/backup-translate-fallback-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix an untranslated error message shown when a backup dashboard request fails without a reason.

--- a/projects/plugins/backup/changelog/backup-translate-fallback-error
+++ b/projects/plugins/backup/changelog/backup-translate-fallback-error
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Backup: translate the modernized dashboard's fallback API error message, which always rendered in English. No-op when the modernization filter is off.
 
-Fix an untranslated error message shown when a backup dashboard request fails without a reason.


### PR DESCRIPTION
Fixes JETPACK-2323

## Proposed changes
* `apiCall()` in `projects/packages/backup/src/dashboard/data/api/_helpers.ts` wrapped every rejection from `@wordpress/api-fetch` in an `ApiError`. When the rejection carried no `message`, it fell back to the English literal `'Request failed'`, with no `__()`. Four render paths print `error.message` verbatim (the capabilities-error gate, the query-error notice, the error boundary, and the download/restore/enqueue hooks), so a non-English reader saw untranslated English text.
* Wrap the fallback in `__( 'Request failed', 'jetpack-backup-pkg' )`, the text domain the rest of the dashboard already uses.
* This `__()` call still gets a real translation catalog even though the modernized dashboard's esbuild route bundles declare no `wp-i18n` dependency: `Jetpack_Backup::enqueue_admin_scripts()` (`src/class-jetpack-backup.php:245-251`) explicitly enqueues `wp-jp-i18n-loader` before its early return, and the build's i18n manifest lists the route content bundles, so the init module downloads their JS translation catalogs by a different path than `wp_set_script_translations()`.
* Out of scope: mapping WordPress.com's own error codes to friendlier messages (tracked separately as JETPACK-2306).

No screenshots: the rendered string is identical before and after. A newly added string has no entry in any translation catalog until a translation cycle runs, so the notice reads "Request failed" in English either way. What changes is that the string is extracted and translatable at all, which is what the unit test pins.

## Related product discussion/links
JETPACK-2323

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

The modernized Backup dashboard is behind a feature switch that is OFF by default. On a site running the standalone Jetpack Backup plugin, add this to an mu-plugin to turn it on and to force one dashboard request to fail with a message-less body:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );

// Force the capabilities request to fail with a body that has no `message`
// key, so apiCall()'s fallback in _helpers.ts is the one that renders.
add_filter(
	'rest_request_after_callbacks',
	function ( $response, $handler, $request ) {
		if ( $request->get_route() === '/jetpack/v4/site/capabilities' ) {
			return new WP_REST_Response( array( 'code' => 'some_code' ), 500 );
		}
		return $response;
	},
	PHP_INT_MAX,
	3
);
```

The route string is exact: `Capabilities_Bridge::register_routes()` registers namespace `jetpack/v4` and route `/site/capabilities`, so `$request->get_route()` returns `/jetpack/v4/site/capabilities`.

`rest_request_after_callbacks` rather than `rest_pre_dispatch`, because its return value replaces the response wholesale — so a message-less body survives whatever else is on the hook. `rest_pre_dispatch` is contended: on the site I tested this on it already carried **6** other callbacks, against **0** on `rest_request_after_callbacks`, and a filter there that returns a fresh value instead of passing `$result` through would silently overwrite this one. It would then fail looking exactly like the mu-plugin never loaded.

Both hooks did in fact work on my test site, so this is removing a hazard rather than fixing a reproduction. `rest_request_before_callbacks` is not a substitute: it short-circuits only on a `WP_Error`, which always serializes a `message` key — the one body shape that never reaches this fallback.

Verified by injecting the filter and calling the route directly:

```
status: 500
body  : {"code":"some_code"}
has message key: NO
```

1. Load the Backup dashboard (**Jetpack > VaultPress Backup**). It calls `GET /jetpack/v4/site/capabilities` before anything else renders; `components/gates/index.tsx` shows `CapabilitiesErrorScreen` the moment that request fails, before the rest of the dashboard mounts.
2. With the filter active, that request returns HTTP 500 with body `{"code":"some_code"}` and no `message` key. The **shape of the body selects the fallback, not the status code** — any non-2xx response whose decoded JSON has no string `message` reaches `apiCall()`'s fallback.
3. The dashboard replaces itself with the **We couldn't load your backup details** screen. Its red error notice reads **Request failed**, above "This is usually temporary. Try again in a moment — your backups are unaffected." and a **Try again** button.
4. That string is now wrapped in `__()`, so it is extracted for translators like every other string in the file. Once this specific string has been translated, a site in that language shows the translated text instead. Until then it reads as English, before and after this change.

