### PR TITLE
Backup: key the detail pane by rewindId so switching backups resets it

### DIFF
--- a/projects/packages/backup/changelog/change-backup-key-detail-pane
+++ b/projects/packages/backup/changelog/change-backup-key-detail-pane
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix the file selection and open file carrying over when you switch to a different backup.
+Reset the file browser when you switch to a different backup.

--- a/projects/packages/backup/changelog/change-backup-key-detail-pane
+++ b/projects/packages/backup/changelog/change-backup-key-detail-pane
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Backup: reset the modernized dashboard's file browser — the file selection, the header's selected-item counts and any open file preview — when you switch to a different backup. No-op when the modernization filter is off.
 
-Reset the file browser when you switch to a different backup.

--- a/projects/packages/backup/changelog/change-backup-key-detail-pane
+++ b/projects/packages/backup/changelog/change-backup-key-detail-pane
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the file selection and open file carrying over when you switch to a different backup.

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -224,7 +224,10 @@ function RightPane( {
 		);
 	}
 	if ( isBackupItem( item ) ) {
-		return <BackupDetail item={ item } />;
+		// Keyed by rewindId so switching backups remounts the detail pane —
+		// `BackupDetail` and `FileBrowser` hold selection/open-file state that
+		// otherwise survives a prop change and leaks into the next backup.
+		return <BackupDetail key={ item.rewindId } item={ item } />;
 	}
 	return <ActivityDetail item={ item } />;
 }

--- a/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
+++ b/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
@@ -21,7 +21,7 @@ jest.mock( '@wordpress/route', () => ( {
 } ) );
 
 // Imports must come after the jest.mock factories above.
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
 import { queryClient } from '../src/dashboard/data/query-client';
@@ -109,15 +109,29 @@ beforeEach( () => {
 } );
 
 /**
- * The single root file's own checkbox. `getAllByRole` returns document
- * order: the tree has exactly one root file, so its row checkbox is
- * always the second one — the first is the tree's own "N selected"
- * summary checkbox, rendered above the tree.
+ * The single root file's own checkbox.
+ *
+ * The row checkboxes carry `label=""` and no `aria-label`, so there is
+ * nothing to address them by name — position is the only handle. Scoped
+ * to the file browser so it stays the right handle: DataViews' list
+ * layout renders no row checkboxes today, but a layout change that
+ * added them would otherwise silently move this index onto an activity
+ * row. Within the browser the order is fixed — the tree's own "N items
+ * selected" summary checkbox first, then the one root file's row.
  *
  * @return The file row's checkbox.
  */
 function fileRowCheckbox(): HTMLElement {
-	return screen.getAllByRole( 'checkbox' )[ 1 ];
+	return within( fileBrowser() ).getAllByRole( 'checkbox' )[ 1 ];
+}
+
+/**
+ * The file browser pane.
+ *
+ * @return The file browser container.
+ */
+function fileBrowser(): HTMLElement {
+	return document.querySelector( '.jpb-file-browser' ) as HTMLElement;
 }
 
 describe( 'Switching between backups', () => {
@@ -133,12 +147,16 @@ describe( 'Switching between backups', () => {
 		).resolves.toBeInTheDocument();
 		await userEvent.click( fileRowCheckbox() );
 
-		// Selecting the file swaps the header action's label off its default.
+		// Selecting the file swaps both header actions off their defaults.
 		// The mocked `<Link>` renders a plain `<a>` with no `href` (the real
 		// component takes `to`), so it carries no implicit `link` role here.
+		// Both are asserted because `BackupDetail` labels them from one
+		// `count`, and a reset that missed either would leave the reader a
+		// header that describes a selection they cannot see.
 		await expect(
 			screen.findByText( 'Download 1 selected item', undefined, SETTLE )
 		).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Restore 1 selected item' ) ).toBeInTheDocument();
 
 		// Open the file's preview as well. A regression that cleared the
 		// selection but left `openFile` set would otherwise pass.
@@ -163,5 +181,7 @@ describe( 'Switching between backups', () => {
 		expect( fileRowCheckbox() ).not.toBeChecked();
 		expect( screen.getByText( 'Download backup' ) ).toBeInTheDocument();
 		expect( screen.queryByText( /Download \d+ selected item/ ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Restore to this point' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Restore \d+ selected item/ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
+++ b/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
@@ -1,0 +1,159 @@
+// Switching the selected backup must not carry the previous backup's
+// file selection into the next one. Both backups here list a file at
+// the same path — realistic, since most files survive between backups
+// — which is exactly the case where a leftover `selected` set still
+// matches a node in the new tree and renders as checked.
+
+const mockApiFetch = jest.fn();
+const mockSearch = jest.fn< Record< string, unknown >, [] >();
+const mockNavigate = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => mockSearch(),
+	useNavigate: () => mockNavigate,
+	useParams: () => ( {} ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { stage as OverviewStage } from '../routes/dashboard/stage';
+import { queryClient } from '../src/dashboard/data/query-client';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+// Testing Library's default `findBy` window is one second. These stages
+// render behind several sequential requests, and a loaded CI runner under
+// coverage has taken well over that for the same work locally-green here.
+const SETTLE = { timeout: 10000 };
+
+const REWIND_A = '1786644531.100';
+const REWIND_B = '1786644532.200';
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );
+
+/**
+ * One rewindable-activity entry, in WPCOM's shape.
+ *
+ * @param rewindId - The backup's rewind id.
+ * @param title    - The row's summary/title.
+ * @return A raw activity entry.
+ */
+function backupEntry( rewindId: string, title: string ) {
+	return {
+		activity_id: `act-${ rewindId }`,
+		gridicon: 'cloud',
+		summary: title,
+		published: '2026-08-13T18:08:56+00:00',
+		rewind_id: rewindId,
+		actor: { type: 'Application', name: 'Jetpack' },
+		content: { text: '10 plugins, 4 themes' },
+		name: 'rewind__backup_complete_full',
+	};
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockApiFetch.mockImplementation( ( o: { path?: string; data?: { rewind_id?: string } } ) => {
+		const path = o?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		if ( path.includes( '/site/rewindable-activity' ) ) {
+			return Promise.resolve( {
+				current: {
+					orderedItems: [
+						backupEntry( REWIND_A, 'Backup A complete' ),
+						backupEntry( REWIND_B, 'Backup B complete' ),
+					],
+				},
+				totalItems: 2,
+				totalPages: 1,
+			} );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: false } );
+		}
+		if ( path === '/jetpack/v4/backups' ) {
+			return Promise.resolve( [] );
+		}
+		if ( path.includes( '/rewind/backup/ls' ) ) {
+			// Both backups carry the same root file — the same file
+			// surviving between backups is the ordinary case, not an edge
+			// one.
+			return Promise.resolve( { contents: { 'wp-config.php': { type: 'file', period: '123' } } } );
+		}
+		return Promise.resolve( {} );
+	} );
+	mockSearch.mockReset();
+	mockNavigate.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+/**
+ * The single root file's own checkbox. `getAllByRole` returns document
+ * order: the tree has exactly one root file, so its row checkbox is
+ * always the second one — the first is the tree's own "N selected"
+ * summary checkbox, rendered above the tree.
+ *
+ * @return The file row's checkbox.
+ */
+function fileRowCheckbox(): HTMLElement {
+	return screen.getAllByRole( 'checkbox' )[ 1 ];
+}
+
+describe( 'Switching between backups', () => {
+	it( "clears the previous backup's file selection", async () => {
+		mockSearch.mockReturnValue( { selected: REWIND_A } );
+		const { rerender } = render( <OverviewStage /> );
+
+		await expect(
+			screen.findByRole( 'heading', { name: 'Backup A complete' }, SETTLE )
+		).resolves.toBeInTheDocument();
+		await expect(
+			screen.findByRole( 'button', { name: 'File: wp-config.php' }, SETTLE )
+		).resolves.toBeInTheDocument();
+		await userEvent.click( fileRowCheckbox() );
+
+		// Selecting the file swaps the header action's label off its default.
+		// The mocked `<Link>` renders a plain `<a>` with no `href` (the real
+		// component takes `to`), so it carries no implicit `link` role here.
+		await expect(
+			screen.findByText( 'Download 1 selected item', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		mockSearch.mockReturnValue( { selected: REWIND_B } );
+		rerender( <OverviewStage /> );
+
+		await expect(
+			screen.findByRole( 'heading', { name: 'Backup B complete' }, SETTLE )
+		).resolves.toBeInTheDocument();
+		await expect(
+			screen.findByRole( 'button', { name: 'File: wp-config.php' }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		// The new backup's own file — same path, never checked here — must
+		// come up unselected, and the header must report zero selected.
+		expect( fileRowCheckbox() ).not.toBeChecked();
+		expect( screen.getByText( 'Download backup' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Download \d+ selected item/ ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
+++ b/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
@@ -140,6 +140,13 @@ describe( 'Switching between backups', () => {
 			screen.findByText( 'Download 1 selected item', undefined, SETTLE )
 		).resolves.toBeInTheDocument();
 
+		// Open the file's preview as well. A regression that cleared the
+		// selection but left `openFile` set would otherwise pass.
+		await userEvent.click( screen.getByRole( 'button', { name: 'File: wp-config.php' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: 'Close preview' }, SETTLE )
+		).resolves.toBeInTheDocument();
+
 		mockSearch.mockReturnValue( { selected: REWIND_B } );
 		rerender( <OverviewStage /> );
 
@@ -152,6 +159,7 @@ describe( 'Switching between backups', () => {
 
 		// The new backup's own file — same path, never checked here — must
 		// come up unselected, and the header must report zero selected.
+		expect( screen.queryByRole( 'button', { name: 'Close preview' } ) ).not.toBeInTheDocument();
 		expect( fileRowCheckbox() ).not.toBeChecked();
 		expect( screen.getByText( 'Download backup' ) ).toBeInTheDocument();
 		expect( screen.queryByText( /Download \d+ selected item/ ) ).not.toBeInTheDocument();

--- a/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
+++ b/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
@@ -111,18 +111,30 @@ beforeEach( () => {
 /**
  * The single root file's own checkbox.
  *
- * The row checkboxes carry `label=""` and no `aria-label`, so there is
- * nothing to address them by name — position is the only handle. Scoped
- * to the file browser so it stays the right handle: DataViews' list
- * layout renders no row checkboxes today, but a layout change that
- * added them would otherwise silently move this index onto an activity
- * row. Within the browser the order is fixed — the tree's own "N items
- * selected" summary checkbox first, then the one root file's row.
+ * The row checkboxes carry `label=""` and no `aria-label`, so they cannot
+ * be addressed by name. Rather than take one by index, exclude the only
+ * checkbox that *does* have a name — the tree's own "N items selected"
+ * summary — and require exactly one to remain.
+ *
+ * An index would keep passing for the wrong reason. The summary sits
+ * inside `.jpb-file-browser` too, so anything that later rendered a
+ * checkbox above the tree would slide the index onto it, and the summary
+ * is unchecked in the buggy case as well: the reset assertion would stop
+ * failing and nothing would say so. Excluding by identity and counting
+ * what is left turns that into a loud failure instead.
  *
  * @return The file row's checkbox.
  */
 function fileRowCheckbox(): HTMLElement {
-	return within( fileBrowser() ).getAllByRole( 'checkbox' )[ 1 ];
+	const browser = fileBrowser();
+	const summary = within( browser ).getByRole( 'checkbox', { name: /items? selected/ } );
+	const rows = within( browser )
+		.getAllByRole( 'checkbox' )
+		.filter( box => box !== summary );
+	if ( rows.length !== 1 ) {
+		throw new Error( `Expected one file row checkbox, found ${ rows.length }` );
+	}
+	return rows[ 0 ];
 }
 
 /**
@@ -183,5 +195,42 @@ describe( 'Switching between backups', () => {
 		expect( screen.queryByText( /Download \d+ selected item/ ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'Restore to this point' ) ).toBeInTheDocument();
 		expect( screen.queryByText( /Restore \d+ selected item/ ) ).not.toBeInTheDocument();
+	} );
+
+	// The other half of the invariant. Keying by `rewindId` makes the
+	// lifetime of the reader's selection depend on that id staying stable
+	// across refetches. It does today — the normalizer derives it per
+	// entry — but were it ever to vary (a synthesized id, a shape change
+	// upstream), the selection would be wiped mid-task on every
+	// activity-log refetch and the test above would stay green.
+	it( 'keeps the selection when the same backup is re-rendered', async () => {
+		mockSearch.mockReturnValue( { selected: REWIND_A } );
+		const { rerender } = render( <OverviewStage /> );
+
+		await expect(
+			screen.findByRole( 'heading', { name: 'Backup A complete' }, SETTLE )
+		).resolves.toBeInTheDocument();
+		await expect(
+			screen.findByRole( 'button', { name: 'File: wp-config.php' }, SETTLE )
+		).resolves.toBeInTheDocument();
+		await userEvent.click( fileRowCheckbox() );
+		await expect(
+			screen.findByText( 'Download 1 selected item', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'File: wp-config.php' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: 'Close preview' }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		// Same backup, so the key is unchanged and nothing should remount.
+		rerender( <OverviewStage /> );
+
+		await expect(
+			screen.findByRole( 'button', { name: 'File: wp-config.php' }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( fileRowCheckbox() ).toBeChecked();
+		expect( screen.getByText( 'Download 1 selected item' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Close preview' } ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/backup/changelog/change-backup-key-detail-pane
+++ b/projects/plugins/backup/changelog/change-backup-key-detail-pane
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix the file selection and open file carrying over when you switch to a different backup.
+Reset the file browser when you switch to a different backup.

--- a/projects/plugins/backup/changelog/change-backup-key-detail-pane
+++ b/projects/plugins/backup/changelog/change-backup-key-detail-pane
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
+Comment: Backup: reset the modernized dashboard's file browser — the file selection, the header's selected-item counts and any open file preview — when you switch to a different backup. No-op when the modernization filter is off.
 
-Reset the file browser when you switch to a different backup.

--- a/projects/plugins/backup/changelog/change-backup-key-detail-pane
+++ b/projects/plugins/backup/changelog/change-backup-key-detail-pane
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Backup: reset the modernized dashboard's file browser — the file selection, the header's selected-item counts and any open file preview — when you switch to a different backup. No-op when the modernization filter is off.
-

--- a/projects/plugins/backup/changelog/change-backup-key-detail-pane
+++ b/projects/plugins/backup/changelog/change-backup-key-detail-pane
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the file selection and open file carrying over when you switch to a different backup.


### PR DESCRIPTION
Fixes JETPACK-2320

## Proposed changes
* Key `<BackupDetail>` by `item.rewindId` in `projects/packages/backup/src/dashboard/screens/overview.tsx` so React remounts the whole detail pane when the selected backup changes, instead of re-rendering the same instance with new props.
* `BackupDetail` holds `selection` and `count` in local state, and the `FileBrowser` it renders holds `openFile` and `loadedChildren` in local state. Only the `useFileTree` query inside `FileBrowser` was keyed by `rewindId` — the four pieces of component state were not. Switching to a different backup left the previous backup's file selection checked (when the same path exists in both backups, which is the common case), left the button labels reporting "Download N selected items" / "Restore N selected items" for a backup nobody selected anything in, and left any open file preview showing the old file.
* Add `projects/packages/backup/tests/switching-backups-resets-detail.test.tsx`, which renders the Overview stage with two backups that both list a file at the same root path, selects that file under the first backup, switches to the second, and asserts the checkbox and button labels reset.

## Before / after

Both frames are the same moment: `wp-config.php` was ticked under the 13 August backup, then the 12 August backup was selected in the left-hand list.

| Before | After |
|---|---|
| <img width="1440" height="900" alt="before-c4b-selection-leak" src="https://github.com/user-attachments/assets/dd879e4b-4616-4eba-a3d8-90ee057a41d7" /> | <img width="1440" height="900" alt="after-c4b-selection-reset" src="https://github.com/user-attachments/assets/c379bed9-6107-4e94-97a3-7385d741927e" /> |
| "1 item selected", `wp-config.php` still ticked, and the buttons read **Download 1 selected item** / **Restore 1 selected item** — for a backup nothing was selected in. | "0 items selected", nothing ticked, and the buttons read **Download backup** / **Restore to this point**. |

Captured on a Jurassic Ninja site at 1440x900. The backup history behind these frames comes from a local fixture — a fresh JN site has no real backup history — so the data is canned while the dashboard, the build and the behaviour are real.

## Related product discussion/links
JETPACK-2320

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

The modernized Backup dashboard is behind a feature filter that is off by default. You need a site running the standalone Jetpack Backup plugin, connected to WordPress.com, with a Backup plan and at least two backups that contain files. Force the filter on with `wp-content/mu-plugins/force-backup-modernization.php`:

```php
<?php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

1. In wp-admin, open **Jetpack > VaultPress Backup** (`wp-admin/admin.php?page=jetpack-backup`). The Overview screen loads with the activity list on the left and a detail card on the right for the newest backup, headed by **Download backup** and **Restore to this point**.
2. In the right pane, under "Files", tick the checkbox on a file row — not the "N items selected" checkbox above the tree.
   - **Expected:** the header buttons relabel to **Download 1 selected item** and **Restore 1 selected item**.

   <img width="1440" height="900" alt="c4b-context-selected" src="https://github.com/user-attachments/assets/f97dfb8f-3198-4be2-819e-a76ff67b89eb" />

3. Click the file's own name to open its preview panel.
4. In the left-hand list, click a different backup's title to select it.
   - **Before this fix:** the checkbox stays ticked whenever the new backup has a file at the same path (common — most files survive between backups), the header still reads "Download 1 selected item" / "Restore 1 selected item", and the preview panel stays open on the previous backup's file.
   - **After this fix:** the checkbox is clear, the header reads **Download backup** / **Restore to this point**, and the preview panel is closed — the pane looks as it would on a fresh visit to that backup.
