### PR TITLE
VideoPress: add a Home tab to the dashboard

### DIFF
--- a/projects/packages/videopress/changelog/add-dashboard-home-screen
+++ b/projects/packages/videopress/changelog/add-dashboard-home-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: Add the Home screen, a recent-videos rail with upload and add-to-a-post actions and no fabricated stats.

--- a/projects/packages/videopress/changelog/add-videopress-upload-onboarding
+++ b/projects/packages/videopress/changelog/add-videopress-upload-onboarding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Open a video by clicking its thumbnail on the home screen, and give the upload icon the design system's empty-state treatment.

--- a/projects/packages/videopress/routes/home/package.json
+++ b/projects/packages/videopress/routes/home/package.json
@@ -1,0 +1,28 @@
+{
+	"version": "1.0.0",
+	"private": true,
+	"dependencies": {
+		"@automattic/jetpack-components": "workspace:*",
+		"@tanstack/react-query": "5.101.2",
+		"@types/react": "18.3.28",
+		"@wordpress/api-fetch": "7.51.0",
+		"@wordpress/components": "37.0.0",
+		"@wordpress/compose": "8.4.0",
+		"@wordpress/dataviews": "17.1.0",
+		"@wordpress/date": "5.51.0",
+		"@wordpress/element": "8.3.0",
+		"@wordpress/i18n": "6.24.0",
+		"@wordpress/icons": "15.1.0",
+		"@wordpress/route": "0.17.0",
+		"@wordpress/ui": "0.17.0",
+		"@wordpress/url": "4.51.0"
+	},
+	"devDependencies": {
+		"@testing-library/react": "16.3.2",
+		"@testing-library/user-event": "^14.5.2"
+	},
+	"route": {
+		"path": "/home",
+		"page": "jetpack-videopress-dashboard"
+	}
+}

--- a/projects/packages/videopress/routes/home/recent-video-card.tsx
+++ b/projects/packages/videopress/routes/home/recent-video-card.tsx
@@ -1,0 +1,235 @@
+import { useGlobalNotices } from '@automattic/jetpack-components/global-notices';
+import { useCopyToClipboard } from '@wordpress/compose';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { __, sprintf, _n } from '@wordpress/i18n';
+import { Icon, video as videoIcon, copy as copyIcon } from '@wordpress/icons';
+import { Badge, Button, Card, Stack, Text } from '@wordpress/ui';
+import { useProcessingProgress } from '../../src/dashboard/hooks/use-processing-progress';
+import { formatDuration } from '../../src/dashboard/utils/format';
+import { resolveEmbedSnippet, resolveShareLink } from '../../src/dashboard/utils/video-links';
+import type { ViewsSlot } from './views-slot';
+import type { LibraryItem, LibraryItemPrivacy } from '../../src/dashboard/types/library';
+import type { ReactElement } from 'react';
+
+const dateSettings = getDateSettings();
+const NUMBER_FORMATTER = new Intl.NumberFormat();
+
+const PRIVACY_LABELS: Record< LibraryItemPrivacy, string > = {
+	public: __( 'Public', 'jetpack-videopress-pkg' ),
+	private: __( 'Private', 'jetpack-videopress-pkg' ),
+	'site-default': __( 'Site default', 'jetpack-videopress-pkg' ),
+};
+
+/**
+ * A small text button that copies a fixed string to the clipboard.
+ *
+ * Uses `@wordpress/compose`'s `useCopyToClipboard` (clipboard.js underneath)
+ * rather than `navigator.clipboard`, which is undefined on the plain-HTTP
+ * origins these dashboards are developed against. Mirrors the copy affordance
+ * on the video details screen, including its snackbar confirmation.
+ *
+ * @param props            - Component props.
+ * @param props.text       - The string written to the clipboard.
+ * @param props.label      - Visible button label.
+ * @param props.fieldLabel - Human-readable field name used in the snackbar.
+ * @param props.ariaLabel  - Accessible name; disambiguates the button between cards.
+ * @return The button element.
+ */
+function CopyButton( {
+	text,
+	label,
+	fieldLabel,
+	ariaLabel,
+}: {
+	text: string;
+	label: string;
+	fieldLabel: string;
+	ariaLabel: string;
+} ): ReactElement {
+	const { createSuccessNotice } = useGlobalNotices();
+	const ref = useCopyToClipboard( text, () =>
+		createSuccessNotice(
+			sprintf(
+				/* translators: %s: name of the copied field, e.g. "Video link". */
+				__( '%s copied to clipboard.', 'jetpack-videopress-pkg' ),
+				fieldLabel
+			)
+		)
+	);
+
+	return (
+		<Button
+			ref={ ref }
+			variant="minimal"
+			tone="neutral"
+			size="compact"
+			aria-label={ ariaLabel }
+			className="vp-home__card-action"
+		>
+			<Button.Icon icon={ copyIcon } />
+			{ label }
+		</Button>
+	);
+}
+
+type Props = {
+	item: LibraryItem;
+	/** What the "how is this doing?" slot is allowed to claim. See views-slot.ts. */
+	viewsSlot: ViewsSlot;
+	/** Views for this video; only ever read when `viewsSlot` is `views`. */
+	views?: number;
+	/** Opens the video details screen. */
+	onOpen: ( id: string ) => void;
+};
+
+/**
+ * One card in Home's recents rail.
+ *
+ * Everything above the fold is a fact the dashboard can always establish from
+ * `/wp/v2/media` alone — thumbnail, title, duration, upload date, privacy,
+ * processing state — so the card is fully truthful on a site with no
+ * WordPress.com connection and no stats. Only the single performance slot
+ * depends on the stats proxy, and it refuses to render a number it cannot
+ * stand behind (see `resolveViewsSlot`); when it can't, the row is an action
+ * instead.
+ *
+ * @param props           - Component props.
+ * @param props.item      - The video.
+ * @param props.viewsSlot - Which performance treatment is permitted.
+ * @param props.views     - Views for this video, when known.
+ * @param props.onOpen    - Opens the video details screen.
+ * @return The card element.
+ */
+export default function RecentVideoCard( { item, viewsSlot, views, onOpen }: Props ): ReactElement {
+	const processingProgress = useProcessingProgress(
+		item.guid,
+		item.isPrivate,
+		item.type === 'videopress' && item.isProcessing
+	);
+	// The zero guard stays at the call site rather than in `formatDuration`:
+	// a still-transcoding video reports 0, and the shared helper clamps that
+	// to "00:00" — a false claim about the video's length. The badge shows
+	// nothing instead. Library uses the same helper, so the same file no
+	// longer reads 0:34 here and 00:34 there.
+	const duration = item.durationSeconds > 0 ? formatDuration( item.durationSeconds ) : null;
+	const shareLink = resolveShareLink( item );
+	const embedSnippet = resolveEmbedSnippet( item );
+	const title = item.title || item.filename || __( 'Untitled video', 'jetpack-videopress-pkg' );
+
+	return (
+		<Card.Root className="vp-home__card">
+			{ /*
+			 * The picture opens the video, because that is what people aim at.
+			 * The title below is the keyboard and screen-reader path to the same
+			 * screen, so this is a redundant pointer affordance and is hidden
+			 * from assistive tech: a second button would put two tab stops on one
+			 * destination, and the thumbnail is decorative either way.
+			 */ }
+			<div
+				className="vp-home__card-media"
+				onClick={ () => onOpen( item.id ) }
+				aria-hidden="true"
+				data-testid="recent-video-media"
+			>
+				{ item.thumbnailUrl && ! item.isProcessing ? (
+					// Decorative: the title beneath is the accessible name of the
+					// card, so an alt repeating it would be announced twice.
+					<img src={ item.thumbnailUrl } alt="" className="vp-home__card-thumb" />
+				) : (
+					<span className="vp-home__card-thumb vp-home__card-thumb--placeholder">
+						<Icon icon={ videoIcon } size={ 28 } />
+					</span>
+				) }
+				{ item.isProcessing ? (
+					<span className="vp-home__card-pill vp-home__card-pill--processing">
+						{ processingProgress !== null
+							? sprintf(
+									/* translators: %d: transcoding progress percentage. */
+									__( 'Processing %d%%', 'jetpack-videopress-pkg' ),
+									processingProgress
+							  )
+							: __( 'Processing', 'jetpack-videopress-pkg' ) }
+					</span>
+				) : (
+					duration && <span className="vp-home__card-pill">{ duration }</span>
+				) }
+			</div>
+
+			<div className="vp-home__card-body">
+				<Button
+					variant="unstyled"
+					className="vp-home__card-title"
+					onClick={ () => onOpen( item.id ) }
+				>
+					{ title }
+				</Button>
+
+				<Stack direction="row" gap="sm" align="center" className="vp-home__card-meta">
+					{ item.uploadDate && (
+						<Text variant="body-sm" className="vp-home__card-date">
+							{ dateI18n( dateSettings.formats.date, item.uploadDate ) }
+						</Text>
+					) }
+					<Badge intent={ item.privacy === 'private' ? 'draft' : 'none' }>
+						{ PRIVACY_LABELS[ item.privacy ] }
+					</Badge>
+				</Stack>
+
+				{ /*
+				 * The performance slot. `views` renders a figure; every other
+				 * outcome renders an action instead of a number — and `unknown`
+				 * says nothing at all, because "No plays yet" is itself a claim
+				 * we can only make when the stats request actually came back.
+				 */ }
+				<div className="vp-home__card-performance">
+					{ viewsSlot === 'views' && views !== undefined && (
+						<Text variant="body-sm" className="vp-home__card-views">
+							{ sprintf(
+								/* translators: %s: formatted number of views. */
+								_n( '%s view', '%s views', views, 'jetpack-videopress-pkg' ),
+								NUMBER_FORMATTER.format( views )
+							) }
+						</Text>
+					) }
+					{ viewsSlot === 'no-plays' && (
+						<Text variant="body-sm" className="vp-home__card-no-plays">
+							{ __( 'No plays yet', 'jetpack-videopress-pkg' ) }
+						</Text>
+					) }
+				</div>
+
+				<Stack direction="row" gap="sm" align="center" className="vp-home__card-actions">
+					{ shareLink && (
+						<CopyButton
+							text={ shareLink }
+							label={ __( 'Copy link', 'jetpack-videopress-pkg' ) }
+							fieldLabel={ __( 'Video link', 'jetpack-videopress-pkg' ) }
+							ariaLabel={ sprintf(
+								/* translators: %s: video title. */
+								__( 'Copy link to “%s”', 'jetpack-videopress-pkg' ),
+								title
+							) }
+						/>
+					) }
+					{ /*
+					 * Only VideoPress-hosted videos have a shortcode; a local
+					 * attachment has nothing to embed, so the button is absent
+					 * rather than present-and-inert.
+					 */ }
+					{ embedSnippet && (
+						<CopyButton
+							text={ embedSnippet }
+							label={ __( 'Copy embed', 'jetpack-videopress-pkg' ) }
+							fieldLabel={ __( 'Embed code', 'jetpack-videopress-pkg' ) }
+							ariaLabel={ sprintf(
+								/* translators: %s: video title. */
+								__( 'Copy embed code for “%s”', 'jetpack-videopress-pkg' ),
+								title
+							) }
+						/>
+					) }
+				</Stack>
+			</div>
+		</Card.Root>
+	);
+}

--- a/projects/packages/videopress/routes/home/route.tsx
+++ b/projects/packages/videopress/routes/home/route.tsx
@@ -1,0 +1,1 @@
+export const route = {};

--- a/projects/packages/videopress/routes/home/stage.tsx
+++ b/projects/packages/videopress/routes/home/stage.tsx
@@ -1,0 +1,269 @@
+import { useGlobalNotices } from '@automattic/jetpack-components/global-notices';
+import { Tooltip } from '@wordpress/components';
+import { useCallback, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Link, useNavigate } from '@wordpress/route';
+import { Button, Card, Text, VisuallyHidden } from '@wordpress/ui';
+import DashboardLayout from '../../src/dashboard/components/dashboard-layout';
+import { TAB_PATHS } from '../../src/dashboard/components/dashboard-tabs';
+import FetchErrorNotice from '../../src/dashboard/components/fetch-error-notice';
+import FreeTierNotice, {
+	FREE_TIER_AT_LIMIT_MESSAGE,
+} from '../../src/dashboard/components/free-tier-notice';
+import QueryClientWrapper from '../../src/dashboard/components/query-client-wrapper';
+import UploadDropzone from '../../src/dashboard/components/upload-dropzone';
+import {
+	selectFilesForPlan,
+	UPLOAD_BATCH_CONTEXT,
+	UPLOAD_ONBOARDING_CONTEXT,
+} from '../../src/dashboard/components/upload-dropzone/select-files';
+import { useFreeTier } from '../../src/dashboard/hooks/use-free-tier';
+import { useLibrary } from '../../src/dashboard/hooks/use-library';
+import { TOP_VIDEOS_LIMIT, useStats } from '../../src/dashboard/hooks/use-stats';
+import { useUpload } from '../../src/dashboard/hooks/use-upload';
+import RecentVideoCard from './recent-video-card';
+import { resolveViewsSlot } from './views-slot';
+import './style.scss';
+import type { View } from '@wordpress/dataviews';
+
+// The rail shows the four most recent videos. Fixed, not user-controlled:
+// Home is a landing pad, and anyone who wants to page or sort has the Library
+// tab one click away.
+const RECENTS_PER_PAGE = 4;
+
+const RECENTS_VIEW: View = {
+	type: 'grid',
+	page: 1,
+	perPage: RECENTS_PER_PAGE,
+	fields: [],
+	filters: [],
+	search: '',
+	sort: { field: 'uploadDate', direction: 'desc' },
+};
+
+const SKELETON_KEYS = [ 'a', 'b', 'c', 'd' ];
+
+const StageInner = () => {
+	const navigate = useNavigate();
+	const { items, isLoading, isError, error: libraryError, refetch } = useLibrary( RECENTS_VIEW );
+	const { isFree, isUnlimited, isAtLimit } = useFreeTier();
+	const { stats, isError: statsIsError, hasData: statsHasData } = useStats();
+	const { startUpload } = useUpload();
+	const { createInfoNotice } = useGlobalNotices();
+
+	// Header upload action — "one click away" from Home rather than a tab of
+	// its own. It navigates to the Library rather than picking a file here:
+	// that surface owns the whole upload story (the onboarding flow on an
+	// empty library, in-flight rows and the pill otherwise). A picker on Home
+	// is only safe when it navigates the moment the files are queued, which is
+	// what the emptied-library dropzone below does; a header picker that left
+	// the user on Home would upload with nowhere to report progress, which is
+	// exactly how it read before.
+	const goToUpload = useCallback( () => {
+		if ( isAtLimit ) {
+			return;
+		}
+		navigate( { href: TAB_PATHS.library } );
+	}, [ isAtLimit, navigate ] );
+
+	const openVideoDetails = useCallback(
+		( id: string ) => {
+			navigate( { href: `/video/${ id }` } );
+		},
+		[ navigate ]
+	);
+
+	// The emptied-library hand-off. Files start in the shared queue under the
+	// onboarding flow's context tag, then land on the Library, where that flow
+	// expects them: a single file resumes the Library's onboarding empty state
+	// straight into its edit session (see the adoption-aware step in
+	// upload-onboarding); a batch stays on the listing, whose in-flight rows
+	// and the upload pill own multi-file progress — the same split the flow's
+	// own dropzone makes. No pill suppression here: navigation is immediate,
+	// so this screen never shows progress of its own.
+	const allowMultiple = ! isFree || isUnlimited;
+	const onEmptyStateFiles = useCallback(
+		( selected: File[] ) => {
+			// At-limit and non-video drops are refused — visibly, with a
+			// notice — by the dropzone itself; what reaches here is always
+			// files this plan can take.
+			const { files, discardedNotice } = selectFilesForPlan( selected, allowMultiple );
+			if ( ! files.length ) {
+				return;
+			}
+			if ( discardedNotice ) {
+				createInfoNotice( discardedNotice );
+			}
+			// A batch is tagged apart from the single flow: it has no surface of
+			// its own here or on /upload, so it must not be adopted as one — nor
+			// announced once per file when the user chains through "Add details".
+			const context = files.length === 1 ? UPLOAD_ONBOARDING_CONTEXT : UPLOAD_BATCH_CONTEXT;
+			files.forEach( file => startUpload( file, context ) );
+			navigate( { href: TAB_PATHS.library } );
+		},
+		[ allowMultiple, createInfoNotice, navigate, startUpload ]
+	);
+
+	// The same discipline the Analytics screen applies at
+	// `routes/overview/stage.tsx`: a failed stats request with nothing cached
+	// behind it must not be rendered as data. Here that means no card is
+	// allowed to claim a views figure — or to claim zero.
+	const statsAvailable = statsHasData && ! statsIsError;
+	const viewsById = useMemo( () => {
+		const map = new Map< string, number >();
+		stats.topVideos.forEach( video => map.set( video.id, video.views ) );
+		return map;
+	}, [ stats.topVideos ] );
+	// `stats.topVideos` is capped at TOP_VIDEOS_LIMIT, so a video's absence
+	// from a FULL list proves nothing about its views. See views-slot.ts.
+	const rankingTruncated = stats.topVideos.length >= TOP_VIDEOS_LIMIT;
+
+	const uploadButton = (
+		<Tooltip
+			text={
+				isAtLimit
+					? FREE_TIER_AT_LIMIT_MESSAGE
+					: __( 'Upload a new video', 'jetpack-videopress-pkg' )
+			}
+		>
+			<Button
+				className="vp-home__upload-button"
+				size="compact"
+				onClick={ goToUpload }
+				aria-disabled={ isAtLimit }
+			>
+				{ __( 'Upload video', 'jetpack-videopress-pkg' ) }
+			</Button>
+		</Tooltip>
+	);
+
+	const showEmptyState = ! isLoading && ! isError && items.length === 0;
+
+	return (
+		// The header carries the upload action alone. "Add to a post or page"
+		// was removed by design review: nobody adds a video to a post from the
+		// overview — that hand-off belongs to a specific video's screens. And
+		// while the emptied-library dropzone is on screen (or the library is
+		// still loading toward it), even that one action goes: the dropzone's
+		// button is the screen's single CTA, and a second "Upload video" in the
+		// header is the same invitation twice. The gate is "has videos", not
+		// "settled", so the button never flashes in during the skeleton pass —
+		// it first appears with the cards it belongs above.
+		<DashboardLayout activeTab="home" actions={ items.length > 0 ? uploadButton : undefined }>
+			<div className="vp-home">
+				{ /*
+				 * The notice only takes the dropzone's narrow measure when the
+				 * dropzone is actually under it. Alongside the recents rail it
+				 * stays full width — centered at 660 next to left-aligned
+				 * cards, it just reads as misaligned.
+				 */ }
+				{ isFree && (
+					<div className={ `vp-home__notice${ showEmptyState ? ' is-narrow' : '' }` }>
+						<FreeTierNotice />
+					</div>
+				) }
+
+				<section className="vp-home__section" aria-labelledby="vp-home-recents-heading">
+					{ showEmptyState ? (
+						// A "Recent videos" label over no recents is noise, so the
+						// empty state swaps the section head for a visually-hidden
+						// heading — hidden heading over aria-label so the page keeps
+						// a heading to navigate by (see the `render` note below) and
+						// the section's aria-labelledby keeps its target. Its text
+						// carries the "no videos yet" status the deleted EmptyState
+						// title used to announce.
+						<VisuallyHidden render={ <h2 id="vp-home-recents-heading" /> }>
+							{ __( 'No videos yet — upload a video', 'jetpack-videopress-pkg' ) }
+						</VisuallyHidden>
+					) : (
+						<div className="vp-home__section-head">
+							{ /* `render` is what makes this an actual <h2>. Without it the
+							     section's aria-labelledby points at a plain <span>, so the
+							     screen is a page with no headings to navigate by. */ }
+							<Text
+								variant="heading-md"
+								render={ <h2 /> }
+								id="vp-home-recents-heading"
+								className="vp-home__section-title"
+							>
+								{ __( 'Recent videos', 'jetpack-videopress-pkg' ) }
+							</Text>
+							{ items.length > 0 && (
+								<Link to="/">{ __( 'View all', 'jetpack-videopress-pkg' ) }</Link>
+							) }
+						</div>
+					) }
+
+					{ isError && items.length === 0 ? (
+						// A failed listing must not read as an empty library — the
+						// empty state below invites an upload, which is the wrong
+						// advice when the videos are simply unreachable. Same rule as
+						// the Library grid.
+						<FetchErrorNotice
+							className="vp-home__error"
+							message={ __( 'We couldn’t load your recent videos.', 'jetpack-videopress-pkg' ) }
+							error={ libraryError }
+							onRetry={ () => void refetch() }
+						/>
+					) : (
+						<div className="vp-home__rail">
+							{ isLoading &&
+								items.length === 0 &&
+								SKELETON_KEYS.map( key => (
+									<Card.Root key={ key } className="vp-home__card vp-home__card--skeleton">
+										<div className="vp-home__card-media" />
+										<div className="vp-home__card-body">
+											<span className="vp-home__skeleton-line" />
+											<span className="vp-home__skeleton-line vp-home__skeleton-line--narrow" />
+										</div>
+									</Card.Root>
+								) ) }
+							{ items.map( item => (
+								<RecentVideoCard
+									key={ item.id }
+									item={ item }
+									views={ viewsById.get( item.id ) }
+									viewsSlot={ resolveViewsSlot( {
+										statsAvailable,
+										views: viewsById.get( item.id ),
+										rankingTruncated,
+									} ) }
+									onOpen={ openVideoDetails }
+								/>
+							) ) }
+						</div>
+					) }
+
+					{ showEmptyState && (
+						// The dropzone stands alone — no EmptyState shell above it.
+						// Design review's rule: one screen, one job, one CTA. The
+						// shell's heading duplicated the dropzone's own hint, and its
+						// useful line — the "it will show up here" promise — moved
+						// into the sub copy below. Single-file copy: an empty library
+						// means the (new) first video, whatever the plan allows.
+						<div className="vp-home__empty-upload">
+							<UploadDropzone
+								onFiles={ onEmptyStateFiles }
+								disabled={ isAtLimit }
+								allowMultiple={ allowMultiple }
+								copyVariant="single"
+								subCopy={ __(
+									'Your video will show up here, ready to share or drop into a post.',
+									'jetpack-videopress-pkg'
+								) }
+							/>
+						</div>
+					) }
+				</section>
+			</div>
+		</DashboardLayout>
+	);
+};
+
+const Stage = () => (
+	<QueryClientWrapper>
+		<StageInner />
+	</QueryClientWrapper>
+);
+
+export { Stage as stage };

--- a/projects/packages/videopress/routes/home/style.scss
+++ b/projects/packages/videopress/routes/home/style.scss
@@ -1,0 +1,235 @@
+// Home — the returning-user landing screen.
+// Deliberately has no KPI row. The page leads with the videos themselves;
+// see routes/home/views-slot.ts for why no card is allowed to render a zero.
+.vp-home {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	box-sizing: border-box;
+	inline-size: 100%;
+	max-inline-size: 1344px;
+	margin-inline: auto;
+	padding-block: 24px;
+
+	// Matches the Analytics screen: the admin-page-layout mixin neutralizes
+	// `#wpcontent`'s padding, so without this the content touches the chrome.
+	padding-inline: 24px;
+
+	// `aria-disabled` rather than `disabled` so the button stays in the
+	// focus tree and the `@wordpress/components` Tooltip can fire on
+	// hover and focus. The onClick guard in stage.tsx short-circuits the
+	// file picker when at the free-tier limit.
+	&__upload-button[aria-disabled="true"] {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	&__section {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	&__section-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 16px;
+	}
+
+	&__section-title {
+		display: block;
+	}
+
+	&__rail {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 16px;
+
+		&:empty {
+			display: none;
+		}
+
+		// Step down one column at a time. Going straight 4 -> 2 at 1200px made
+		// each card *grow* as the window shrank (294px wide at 1440, 396px at
+		// 1024), turning a recents rail into a photo grid with two cards above
+		// the fold. The 820px step is below wp-admin's 782px sidebar collapse,
+		// so the content box widens before the columns drop again.
+		@media ( max-width: 1200px ) {
+			grid-template-columns: repeat(3, 1fr);
+		}
+
+		@media ( max-width: 820px ) {
+			grid-template-columns: repeat(2, 1fr);
+		}
+
+		@media ( max-width: 600px ) {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	&__card {
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+	}
+
+	&__card-media {
+		position: relative;
+		aspect-ratio: 16 / 9;
+		background: var(--wpds-color-background-surface-neutral);
+		overflow: hidden;
+		// The picture is the thing people aim at, so it opens the video. The
+		// title below does the same and is the keyboard/AT path — see the note
+		// at the call site for why this isn't a second button.
+		cursor: var(--wpds-cursor-control);
+	}
+
+	&__card-thumb {
+		display: block;
+		inline-size: 100%;
+		block-size: 100%;
+		object-fit: cover;
+
+		&--placeholder {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			color: var(--wpds-color-foreground-content-neutral-weak);
+
+			svg {
+				fill: currentColor;
+			}
+		}
+	}
+
+	// Duration / processing chip over the bottom-right of the poster. Dark
+	// scrim rather than a design-system Badge: it sits on top of arbitrary
+	// video frames and needs its own contrast guarantee.
+	&__card-pill {
+		position: absolute;
+		inset-block-end: 8px;
+		inset-inline-end: 8px;
+		padding: 2px 6px;
+		border-radius: 2px;
+		// Literal, not a token: this pill carries its own dark scrim over the
+		// thumbnail, so its foreground must stay white in either theme.
+		background: rgba(0, 0, 0, 0.75);
+		color: #fff;
+		font-size: 12px;
+		line-height: 16px;
+		font-variant-numeric: tabular-nums;
+
+		&--processing {
+			background: rgba(0, 0, 0, 0.85);
+		}
+	}
+
+	&__card-body {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		padding: 12px;
+	}
+
+	// The title is a Button (it navigates to the details screen) but must read
+	// as a heading, so the button chrome is stripped back to text.
+	&__card-title {
+		inline-size: 100%;
+		text-align: start;
+		font-size: var(--wpds-typography-font-size-md);
+		font-weight: var(--wpds-typography-font-weight-emphasis);
+		line-height: 20px;
+		color: inherit;
+		cursor: pointer;
+
+		// Two lines, then ellipsis, so a long title can't make one card in the
+		// rail taller than its neighbours. `min-block-size` reserves both lines
+		// even for a one-line title: clamping alone equalises the *maximum*, so
+		// without it the date and actions below sit 20px higher on short-titled
+		// cards and the rail stair-steps.
+		display: -webkit-box;
+		min-block-size: 40px;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	&__card-meta {
+		color: var(--wpds-color-foreground-content-neutral-weak);
+		flex-wrap: wrap;
+	}
+
+	&__card-date {
+		color: inherit;
+	}
+
+	// Reserved even when empty so cards in the rail stay aligned whether or not
+	// stats came back for a given video.
+	&__card-performance {
+		min-block-size: 20px;
+	}
+
+	&__card-views {
+		font-variant-numeric: tabular-nums;
+	}
+
+	&__card-no-plays {
+		color: var(--wpds-color-foreground-content-neutral-weak);
+	}
+
+	&__card-actions {
+		flex-wrap: wrap;
+		margin-block-start: 4px;
+	}
+
+	&__card--skeleton {
+
+		.vp-home__card-body {
+			gap: 10px;
+		}
+	}
+
+	&__skeleton-line {
+		display: block;
+		block-size: 1em;
+		inline-size: 80%;
+		border-radius: 2px;
+		background: var(--wpds-color-background-surface-neutral);
+
+		&--narrow {
+			inline-size: 45%;
+		}
+	}
+
+	// The emptied-library dropzone, alone on the screen now that the
+	// EmptyState shell above it is gone. Same 718px cap as the /upload card:
+	// at the full 1272px column a drop target reads as a void. Same card frame
+	// and 718px measure as /upload's dropzone — the two screens offer the same
+	// action and were reading as different components.
+	// On the empty screen the notice takes the same 660px measure as the
+	// dropzone beneath it, so the two read as one column. With the recents
+	// rail instead, it keeps the full width — a centered 660px bar over
+	// left-aligned cards looks like a mistake.
+	&__notice.is-narrow {
+		box-sizing: border-box;
+		inline-size: 100%;
+		max-inline-size: 660px;
+		margin-inline: auto;
+	}
+
+	&__empty-upload {
+		box-sizing: border-box;
+		inline-size: 100%;
+		max-inline-size: 660px;
+		margin-inline: auto;
+		margin-block-start: var(--wpds-dimension-gap-2xl);
+		border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
+		border-radius: var(--wpds-border-radius-lg);
+		background: var(--wpds-color-background-surface-neutral-strong);
+	}
+}

--- a/projects/packages/videopress/routes/home/test/recent-video-card.test.tsx
+++ b/projects/packages/videopress/routes/home/test/recent-video-card.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+/**
+ * Internal dependencies
+ */
+import RecentVideoCard from '../recent-video-card';
+import type { LibraryItem } from '../../../src/dashboard/types/library';
+
+jest.mock( '@automattic/jetpack-components/global-notices', () => ( {
+	useGlobalNotices: () => ( { createSuccessNotice: jest.fn(), createErrorNotice: jest.fn() } ),
+} ) );
+
+jest.mock( '../../../src/dashboard/hooks/use-processing-progress', () => ( {
+	useProcessingProgress: () => null,
+} ) );
+
+const item = {
+	id: 42,
+	guid: 'abc12345',
+	title: 'Harbour at dusk',
+	filename: 'harbour.mp4',
+	type: 'videopress',
+	privacy: 'public',
+	isPrivate: false,
+	isProcessing: false,
+	durationSeconds: 34,
+	thumbnailUrl: 'https://example.com/thumb.jpg',
+	uploadDate: '2026-08-14T00:00:00',
+} as unknown as LibraryItem;
+
+describe( 'RecentVideoCard', () => {
+	it( 'opens the video when the thumbnail is clicked', async () => {
+		// The picture is the biggest target on the card and the thing people aim
+		// at, so it has to be the thing that works — before this it was inert and
+		// only the title opened the video.
+		const onOpen = jest.fn();
+		render( <RecentVideoCard item={ item } viewsSlot="unknown" onOpen={ onOpen } /> );
+
+		await userEvent.click( screen.getByTestId( 'recent-video-media' ) );
+
+		expect( onOpen ).toHaveBeenCalledWith( 42 );
+	} );
+
+	it( 'leaves the title as the only tab stop to the video', async () => {
+		// The thumbnail is a redundant pointer affordance, so it must stay out of
+		// the accessibility tree: two tab stops onto one destination is worse for
+		// a keyboard user than one, and the thumbnail carries no name of its own.
+		const onOpen = jest.fn();
+		render( <RecentVideoCard item={ item } viewsSlot="unknown" onOpen={ onOpen } /> );
+
+		expect( screen.getByTestId( 'recent-video-media' ) ).toHaveAttribute( 'aria-hidden', 'true' );
+
+		// And the keyboard path still works.
+		await userEvent.click( screen.getByRole( 'button', { name: 'Harbour at dusk' } ) );
+		expect( onOpen ).toHaveBeenCalledWith( 42 );
+	} );
+} );

--- a/projects/packages/videopress/routes/home/test/stage.test.tsx
+++ b/projects/packages/videopress/routes/home/test/stage.test.tsx
@@ -1,0 +1,212 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { makeVideoFile, settleFileCheck } from '../../../src/dashboard/test-utils/video-file';
+import { stage as Stage } from '../stage';
+import type { LibraryItem } from '../../../src/dashboard/types/library';
+import type { ReactNode } from 'react';
+
+const mockNavigate = jest.fn();
+jest.mock( '@wordpress/route', () => ( {
+	__esModule: true,
+	useNavigate: () => mockNavigate,
+	Link: ( { children }: { children: ReactNode } ) => <a href="/">{ children }</a>,
+} ) );
+
+// The full dashboard chrome is not under test; reduce it to a passthrough
+// that surfaces the header actions so their contents stay assertable.
+jest.mock( '../../../src/dashboard/components/dashboard-layout', () => ( {
+	__esModule: true,
+	default: ( { children, actions }: { children: ReactNode; actions?: ReactNode } ) => (
+		<div>
+			<div data-testid="header-actions">{ actions }</div>
+			{ children }
+		</div>
+	),
+} ) );
+
+jest.mock( '../../../src/dashboard/components/query-client-wrapper', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+} ) );
+
+jest.mock( '../../../src/dashboard/components/free-tier-notice', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="free-tier-notice" />,
+} ) );
+
+jest.mock( '../recent-video-card', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="recent-video-card" />,
+} ) );
+
+let mockItems: LibraryItem[] = [];
+let mockLibraryIsLoading = false;
+jest.mock( '../../../src/dashboard/hooks/use-library', () => ( {
+	useLibrary: () => ( {
+		items: mockItems,
+		isLoading: mockLibraryIsLoading,
+		isError: false,
+		error: undefined,
+		refetch: jest.fn(),
+	} ),
+} ) );
+
+const defaultFreeTier = { isAtLimit: false, isFree: false, isUnlimited: true, videoCount: 0 };
+let mockFreeTier = defaultFreeTier;
+jest.mock( '../../../src/dashboard/hooks/use-free-tier', () => ( {
+	useFreeTier: () => mockFreeTier,
+} ) );
+
+jest.mock( '../../../src/dashboard/hooks/use-stats', () => ( {
+	TOP_VIDEOS_LIMIT: 10,
+	useStats: () => ( {
+		stats: { topVideos: [] },
+		isError: false,
+		hasData: false,
+	} ),
+} ) );
+
+const mockStartUpload = jest.fn( ( file: File ): string => `q-${ file.name }` );
+jest.mock( '../../../src/dashboard/hooks/use-upload', () => ( {
+	useUpload: () => ( {
+		uploadQueue: [],
+		startUpload: mockStartUpload,
+		retryUpload: jest.fn(),
+		cancelUpload: jest.fn(),
+		acknowledgeUpload: jest.fn(),
+	} ),
+} ) );
+
+const mockCreateInfoNotice = jest.fn();
+jest.mock( '@automattic/jetpack-components/global-notices', () => ( {
+	useGlobalNotices: () => ( {
+		createSuccessNotice: jest.fn(),
+		createErrorNotice: jest.fn(),
+		createInfoNotice: mockCreateInfoNotice,
+	} ),
+} ) );
+
+// Real container bytes: the dropzone's filter reads the header and checks it
+// against the extension, so `[ 'x' ]` is no longer a video.
+const makeFile = ( name: string ) => makeVideoFile( name );
+
+/**
+ * Drop files on the empty state's dropzone, then wait for the accepted-file
+ * check to settle — it reads each file's header, so the hand-off is a task
+ * later than the drop.
+ *
+ * @param container - The rendered stage's container.
+ * @param files     - Files to drop.
+ */
+async function dropOnDropzone( container: HTMLElement, files: File[] ) {
+	// eslint-disable-next-line testing-library/no-node-access -- the dropzone is a styled div with no accessible role; no query reaches it.
+	const dropzone = container.querySelector( '.vp-upload-dropzone' ) as HTMLElement;
+	fireEvent.drop( dropzone, { dataTransfer: { files } } );
+	await settleFileCheck();
+}
+
+describe( 'home stage empty state', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockItems = [];
+		mockLibraryIsLoading = false;
+		mockFreeTier = defaultFreeTier;
+	} );
+
+	it( 'renders the dropzone as the whole empty state — no shell, no section head', () => {
+		const { container } = render( <Stage /> );
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- asserting the surface exists, not interacting with it.
+		expect( container.querySelector( '.vp-upload-dropzone' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Drag and drop your video here' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Your video will show up here, ready to share or drop into a post.' )
+		).toBeInTheDocument();
+
+		// The old EmptyState heading/description are gone; the visible copy
+		// belongs to the dropzone alone.
+		expect( screen.queryByText( 'No videos yet' ) ).not.toBeInTheDocument();
+		// A "Recent videos" label over no recents is suppressed with it.
+		expect( screen.queryByText( 'Recent videos' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps a visually-hidden heading announcing the no-videos status', () => {
+		render( <Stage /> );
+
+		expect(
+			screen.getByRole( 'heading', { name: 'No videos yet — upload a video' } )
+		).toBeInTheDocument();
+	} );
+
+	it( 'hides the header upload action while the empty-state dropzone is on screen', () => {
+		render( <Stage /> );
+
+		expect( screen.getByTestId( 'header-actions' ) ).toBeEmptyDOMElement();
+	} );
+
+	it( 'shows no upload action while the library is still loading', () => {
+		mockLibraryIsLoading = true;
+		const { container } = render( <Stage /> );
+
+		// Neither surface may flash in before the listing settles: no header
+		// button, no dropzone — just the skeleton rail under its heading.
+		expect( screen.getByTestId( 'header-actions' ) ).toBeEmptyDOMElement();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- asserting the surface is absent, not interacting with it.
+		expect( container.querySelector( '.vp-upload-dropzone' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Recent videos' ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps the header to the upload action alone once the library has videos', () => {
+		mockItems = [ { id: '1' } as LibraryItem ];
+		render( <Stage /> );
+
+		const actions = screen.getByTestId( 'header-actions' );
+		expect( actions ).toHaveTextContent( 'Upload video' );
+		expect( actions ).not.toHaveTextContent( 'Add to a post or page' );
+	} );
+
+	it( 'starts a dropped file under the onboarding context and lands on the Library', async () => {
+		const { container } = render( <Stage /> );
+
+		const file = makeFile( 'one.mp4' );
+		await dropOnDropzone( container, [ file ] );
+
+		expect( mockStartUpload ).toHaveBeenCalledWith( file, 'upload-onboarding' );
+		expect( mockNavigate ).toHaveBeenCalledWith( { href: '/' } );
+	} );
+
+	it( 'hands a multi-file drop to the Library, every file in the queue', async () => {
+		const { container } = render( <Stage /> );
+
+		await dropOnDropzone( container, [ makeFile( 'a.mp4' ), makeFile( 'b.mp4' ) ] );
+
+		expect( mockStartUpload ).toHaveBeenCalledTimes( 2 );
+		expect( mockNavigate ).toHaveBeenCalledWith( { href: '/' } );
+		// The batch tag, not the single flow's: the Library's onboarding empty
+		// state must not adopt these as a session, and only one of them is a
+		// first-upload worth announcing.
+		expect( mockStartUpload ).toHaveBeenCalledWith( expect.anything(), 'upload-batch' );
+	} );
+
+	it( 'slices a free-plan drop to one file and surfaces the discarded count', async () => {
+		mockFreeTier = { isAtLimit: false, isFree: true, isUnlimited: false, videoCount: 0 };
+		const { container } = render( <Stage /> );
+
+		await dropOnDropzone( container, [ makeFile( 'a.mp4' ), makeFile( 'b.mp4' ) ] );
+
+		expect( mockStartUpload ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateInfoNotice ).toHaveBeenCalledWith(
+			'The free plan includes one video — uploading your first. Upgrade to add 1 more.'
+		);
+		expect( mockNavigate ).toHaveBeenCalledWith( { href: '/' } );
+	} );
+
+	it( 'shows no dropzone while the library has videos', () => {
+		mockItems = [ { id: '1' } as LibraryItem ];
+		const { container } = render( <Stage /> );
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- asserting the surface is absent, not interacting with it.
+		expect( container.querySelector( '.vp-upload-dropzone' ) ).not.toBeInTheDocument();
+		// The section head returns with the recents it labels.
+		expect( screen.getByText( 'Recent videos' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/videopress/routes/home/test/views-slot.test.ts
+++ b/projects/packages/videopress/routes/home/test/views-slot.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for the Home screen's "may this card show a views figure?" rule
+ * (see routes/home/views-slot.ts).
+ *
+ * This is the highest-risk logic on the screen and the least verifiable by
+ * hand: the stats proxy is unreachable in local development, so the browser
+ * only ever exercises the `unknown` branch.
+ */
+
+import { resolveViewsSlot } from '../views-slot';
+
+describe( 'resolveViewsSlot', () => {
+	it( 'shows the figure when stats are available and the video has views', () => {
+		expect( resolveViewsSlot( { statsAvailable: true, views: 12, rankingTruncated: false } ) ).toBe(
+			'views'
+		);
+	} );
+
+	it( 'never shows a figure when the stats request has no data behind it', () => {
+		// The local-dev / proxy-outage case. Even a cached-looking number must
+		// not be claimed here.
+		expect(
+			resolveViewsSlot( { statsAvailable: false, views: 12, rankingTruncated: false } )
+		).toBe( 'unknown' );
+	} );
+
+	it( 'claims nothing at all — not even "no plays" — when stats are unavailable', () => {
+		expect(
+			resolveViewsSlot( { statsAvailable: false, views: undefined, rankingTruncated: false } )
+		).toBe( 'unknown' );
+	} );
+
+	it( 'renders the action, not a zero, for a reported zero', () => {
+		expect( resolveViewsSlot( { statsAvailable: true, views: 0, rankingTruncated: false } ) ).toBe(
+			'no-plays'
+		);
+	} );
+
+	it( 'treats a negative count as no plays rather than rendering it', () => {
+		expect( resolveViewsSlot( { statsAvailable: true, views: -1, rankingTruncated: false } ) ).toBe(
+			'no-plays'
+		);
+	} );
+
+	it( 'reads absence from a short ranking as a genuine zero', () => {
+		expect(
+			resolveViewsSlot( { statsAvailable: true, views: undefined, rankingTruncated: false } )
+		).toBe( 'no-plays' );
+	} );
+
+	it( 'refuses to conclude anything from absence when the ranking was truncated', () => {
+		// The video could simply rank sixth. "No plays yet" would be a lie.
+		expect(
+			resolveViewsSlot( { statsAvailable: true, views: undefined, rankingTruncated: true } )
+		).toBe( 'unknown' );
+	} );
+
+	it( 'never returns "views" for a non-positive count, whatever else is true', () => {
+		for ( const rankingTruncated of [ true, false ] ) {
+			for ( const views of [ 0, -5 ] ) {
+				expect( resolveViewsSlot( { statsAvailable: true, views, rankingTruncated } ) ).not.toBe(
+					'views'
+				);
+			}
+		}
+	} );
+} );

--- a/projects/packages/videopress/routes/home/views-slot.ts
+++ b/projects/packages/videopress/routes/home/views-slot.ts
@@ -1,0 +1,61 @@
+/*
+ * The honesty rules for the Home screen's per-video "how is this doing?" slot.
+ *
+ * Home deliberately ships no KPI tiles: a brand-new site's stats are all zeros,
+ * and a first-run dashboard led by three zeroes is precisely the criticism this
+ * screen exists to answer. What each recent-video card gets instead is a single
+ * slot that either shows a real views figure or shows an action — never a
+ * fabricated `0 views`.
+ *
+ * Three outcomes, because there are genuinely three situations:
+ *
+ * - `views`    — stats loaded and this video has recorded plays. Show the number.
+ * - `no-plays` — stats loaded and this video provably has none. Say so, and
+ *                offer the action that might change it (copy the link).
+ * - `unknown`  — we do not know. Either the stats request failed / has no data
+ *                behind it (the local dev case, and any wpcom proxy outage), or
+ *                the video is missing from a list that was truncated before we
+ *                could rule it out. Claim nothing; render the action alone.
+ *
+ * Kept pure and separate from the stage so the rule is unit-testable without a
+ * React tree or a live wpcom proxy — the branch that matters most (`unknown`)
+ * is the one that cannot be exercised locally through the UI.
+ */
+
+export type ViewsSlot = 'views' | 'no-plays' | 'unknown';
+
+/**
+ * Decide what a recent-video card's views slot may claim.
+ *
+ * Mirrors the `isError && ! hasData` discipline on the Analytics screen
+ * (`routes/overview/stage.tsx`): a failed request must never be rendered as a
+ * zero, because a zero is a factual claim about the video.
+ *
+ * @param input                  - Inputs.
+ * @param input.statsAvailable   - Whether the stats query has real data behind it (`hasData && ! isError`-equivalent).
+ * @param input.views            - Views recorded for this video, or undefined when it is absent from the ranking.
+ * @param input.rankingTruncated - Whether the ranking hit its cap, so absence from it proves nothing.
+ * @return Which treatment the slot should render.
+ */
+export function resolveViewsSlot( {
+	statsAvailable,
+	views,
+	rankingTruncated,
+}: {
+	statsAvailable: boolean;
+	views?: number;
+	rankingTruncated: boolean;
+} ): ViewsSlot {
+	if ( ! statsAvailable ) {
+		return 'unknown';
+	}
+
+	if ( views !== undefined ) {
+		// A listed video with a non-positive count is a real, reported zero.
+		return views > 0 ? 'views' : 'no-plays';
+	}
+
+	// Absent from the ranking. That only means "no plays" when the ranking was
+	// short enough to have had room for it.
+	return rankingTruncated ? 'unknown' : 'no-plays';
+}

--- a/projects/packages/videopress/routes/video/stage.tsx
+++ b/projects/packages/videopress/routes/video/stage.tsx
@@ -8,6 +8,7 @@ import { Link, useNavigate, useParams } from '@wordpress/route';
 import { Stack, Text } from '@wordpress/ui';
 import CaptionManagerModal from '../../src/client/components/caption-manager-modal/lazy';
 import { getVideoInfoQueryKeyPrefix } from '../../src/client/components/caption-manager-modal/use-video-tracks';
+import { TAB_PATHS } from '../../src/dashboard/components/dashboard-tabs';
 import QueryClientWrapper from '../../src/dashboard/components/query-client-wrapper';
 import { UPLOAD_ONBOARDING_CONTEXT } from '../../src/dashboard/components/upload-dropzone/select-files';
 import UploadPill from '../../src/dashboard/components/upload-pill';
@@ -15,6 +16,7 @@ import Editor, {
 	getParentBreadcrumbItem,
 } from '../../src/dashboard/components/video-details/editor';
 import { useDeleteVideo } from '../../src/dashboard/hooks/use-delete-video';
+import { useLibrary } from '../../src/dashboard/hooks/use-library';
 import { useUpdateChapters } from '../../src/dashboard/hooks/use-update-chapters';
 import { useUpdateVideoMeta } from '../../src/dashboard/hooks/use-update-video-meta';
 import { useUpload } from '../../src/dashboard/hooks/use-upload';
@@ -26,6 +28,7 @@ import {
 import './style.scss';
 import type { UploadItem } from '../../src/dashboard/hooks/use-upload';
 import type { LibraryItem } from '../../src/dashboard/types/library';
+import type { View } from '@wordpress/dataviews';
 
 const isEditable = ( item: LibraryItem ): boolean =>
 	item.type === 'videopress' && item.upload.status !== 'failed';
@@ -77,6 +80,21 @@ type StageReadyProps = {
 	uploadRow?: UploadItem;
 };
 
+// "Was that the last video?" — the server total, deliberately NOT useFreeTier's
+// count: that one adds un-acknowledged queue rows, which on this page includes
+// the row for the very video being deleted. A perPage=1 read, and keyed
+// identically to the first-run count view so every other screen in the session
+// shares its cache entry.
+const LAST_VIDEO_COUNT_VIEW: View = {
+	type: 'table',
+	page: 1,
+	perPage: 1,
+	fields: [],
+	filters: [],
+	search: '',
+	sort: { field: 'date', direction: 'desc' },
+};
+
 // Per-video id so the settle notices replace the in-progress snackbar in
 // place (the notices store drops an existing notice with the same id on
 // create) instead of stacking a second notice next to it. Keyed by video id
@@ -95,6 +113,9 @@ const StageReady = ( { video, uploadRow }: StageReadyProps ) => {
 	const [ chaptersOpen, setChaptersOpen ] = useState( false );
 	const [ captionsOpen, setCaptionsOpen ] = useState( false );
 	const queryClient = useQueryClient();
+	const { paginationInfo } = useLibrary( LAST_VIDEO_COUNT_VIEW );
+	const libraryTotalRef = useRef( 0 );
+	libraryTotalRef.current = paginationInfo?.totalItems ?? 0;
 
 	// The upload's own screen. Arriving here from the /upload bridge (or from
 	// the pill's "Add details"), this page owns the tail of the upload: the
@@ -201,6 +222,8 @@ const StageReady = ( { video, uploadRow }: StageReadyProps ) => {
 					if ( ! confirmed ) {
 						return;
 					}
+					// Read before the delete: after it, the count has moved.
+					const wasLastVideo = libraryTotalRef.current <= 1;
 					// Deleting can take several seconds (the backend also removes the
 					// remote VideoPress copy); surface progress immediately so the
 					// action doesn't feel frozen. `explicitDismiss` keeps the snackbar
@@ -218,10 +241,9 @@ const StageReady = ( { video, uploadRow }: StageReadyProps ) => {
 								id: deletingNoticeId( video.id ),
 							} );
 							if ( isMountedRef.current ) {
-								// The Library: its empty state is the upload flow, so
-								// even deleting the last video lands somewhere with a
-								// next step.
-								navigate( { href: '/' } );
+								// An emptied Library is a dead end — no dropzone, no
+								// next step. Home has both.
+								navigate( { href: wasLastVideo ? TAB_PATHS.home : '/' } );
 							}
 						} )
 						.catch( () => {

--- a/projects/packages/videopress/routes/video/test/stage.test.tsx
+++ b/projects/packages/videopress/routes/video/test/stage.test.tsx
@@ -494,7 +494,7 @@ describe( 'video stage', () => {
 			confirmSpy.mockRestore();
 		} );
 
-		it( 'lands on the Library when the deleted video was the last one', async () => {
+		it( 'lands on Home when the deleted video was the last one', async () => {
 			mockLibraryTotal = 1;
 			const confirmSpy = jest.spyOn( window, 'confirm' ).mockReturnValue( true );
 			await renderReadyStage();
@@ -502,8 +502,8 @@ describe( 'video stage', () => {
 			await chooseDelete();
 			await waitFor( () => expect( navigate ).toHaveBeenCalled() );
 
-			// The emptied Library's empty state is the upload flow.
-			expect( navigate ).toHaveBeenCalledWith( { href: '/' } );
+			// An emptied Library has no dropzone and nothing to do next.
+			expect( navigate ).toHaveBeenCalledWith( { href: '/home' } );
 			confirmSpy.mockRestore();
 		} );
 

--- a/projects/packages/videopress/src/dashboard/components/dashboard-layout/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/dashboard-layout/index.tsx
@@ -5,11 +5,17 @@ import AdminPage from '@automattic/jetpack-components/admin-page';
 import useConnectionErrorNotice, {
 	ConnectionError,
 } from '@automattic/jetpack-connection/use-connection-error-notice';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
 import { Stack, Tabs } from '@wordpress/ui';
-import DashboardTabs, { TAB_PATHS, type DashboardTab } from '../dashboard-tabs';
+import { useSettledFirstRunState } from '../../hooks/use-first-run-state';
+import DashboardTabs, {
+	CANONICAL_TAB_ORDER,
+	TAB_PATHS,
+	useDashboardTabOrder,
+	type DashboardTab,
+} from '../dashboard-tabs';
 import OnboardingModal from '../onboarding-modal';
 import UploadPill from '../upload-pill';
 import './style.scss';
@@ -23,14 +29,17 @@ type Props = {
 	uploadPillSuppressContext?: string;
 };
 
-const TAB_VALUES: DashboardTab[] = [ 'library', 'stats', 'settings' ];
-
 /**
  * Shared chrome for every wp-build VideoPress dashboard tab. Renders
  * `AdminPage` (with header + JetpackFooter) and a `Tabs.Root` containing
  * the strip and one `Tabs.Panel` per tab so the `@wordpress/ui` Tabs
  * Tab/Panel pairing validator stays happy. Tab navigation between
  * sibling routes happens via `@wordpress/route`'s useNavigate.
+ *
+ * The Library owns `/`, so a bare `admin.php?page=jetpack-videopress` lands
+ * on the Library tab directly — there is no landing redirect. On a first run
+ * the Library's empty state is the upload flow, so the landing tab and the
+ * one job a new user has coincide.
  *
  * @param props                           - Component props.
  * @param props.activeTab                 - Currently active tab.
@@ -55,6 +64,38 @@ export default function DashboardLayout( {
 }: Props ) {
 	const navigate = useNavigate();
 	const { hasConnectionError } = useConnectionErrorNotice();
+	const settledFirstRunState = useSettledFirstRunState();
+	const liveTabs = useDashboardTabOrder();
+
+	// The tab order is frozen for this mount as soon as the count is known.
+	// It is derived from the first-run state, and the first successful upload
+	// flips that mid-session: the strip would then re-order under the user's
+	// cursor while they are still finishing the flow that caused it. The next
+	// navigation mounts fresh and picks up the new order.
+	//
+	// Only the SETTLED state freezes: before it, the optimistic order renders
+	// live (a loading count reads as first-run) so a brand-new user never sees
+	// the returning-user strip, and freezing the guess would make that
+	// permanent for the mount.
+	const frozenTabsRef = useRef< DashboardTab[] | null >( null );
+	if ( frozenTabsRef.current === null && settledFirstRunState !== 'loading' ) {
+		frozenTabsRef.current = liveTabs;
+	}
+	const tabs = frozenTabsRef.current ?? liveTabs;
+
+	// Panels are rendered by mapping over the tab order, so a route whose tab is
+	// not in that order would render its children nowhere — a blank page. This
+	// is reachable in normal use: a first-run order carries no Home tab, but a
+	// deep link to /home still mounts that route. Keep the active tab in the
+	// list (in its canonical position) so the body always has a panel to land
+	// in, and so every panel still has a paired tab.
+	const visibleTabs = useMemo(
+		() =>
+			tabs.includes( activeTab )
+				? tabs
+				: CANONICAL_TAB_ORDER.filter( tab => tab === activeTab || tabs.includes( tab ) ),
+		[ activeTab, tabs ]
+	);
 
 	const onValueChange = useCallback(
 		( next: string ) => {
@@ -82,17 +123,13 @@ export default function DashboardLayout( {
 				</Stack>
 			) }
 			<Tabs.Root className="vp-dashboard-tabs" value={ activeTab } onValueChange={ onValueChange }>
-				<DashboardTabs />
-				{ TAB_VALUES.map( tab => (
+				<DashboardTabs tabs={ visibleTabs } />
+				{ visibleTabs.map( tab => (
 					<Tabs.Panel key={ tab } value={ tab }>
 						{ activeTab === tab ? children : null }
 					</Tabs.Panel>
 				) ) }
 			</Tabs.Root>
-			{ /*
-			 * Rendered from the shared chrome rather than a route so the
-			 * first-run welcome greets the user on whichever tab they land on.
-			 */ }
 			<OnboardingModal />
 			<UploadPill suppressContext={ uploadPillSuppressContext } />
 		</AdminPage>

--- a/projects/packages/videopress/src/dashboard/components/dashboard-layout/test/index.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/dashboard-layout/test/index.test.tsx
@@ -2,14 +2,29 @@ import useConnectionErrorNotice, {
 	ConnectionError,
 } from '@automattic/jetpack-connection/use-connection-error-notice';
 import { render, screen } from '@testing-library/react';
-import { useNavigate } from '@wordpress/route';
+import userEvent from '@testing-library/user-event';
 import DashboardLayout from '../index';
+import type { FirstRunState } from '../../../hooks/use-first-run-state';
+import type { ReactNode } from 'react';
 
+const mockNavigate = jest.fn();
 jest.mock( '@wordpress/route', () => ( {
 	__esModule: true,
-	useNavigate: jest.fn(),
+	useNavigate: () => mockNavigate,
 } ) );
 
+// Renders the actions slot too, so the header behavior stays covered.
+jest.mock( '@automattic/jetpack-components/admin-page', () => ( {
+	__esModule: true,
+	default: ( { children, actions }: { children: ReactNode; actions?: ReactNode } ) => (
+		<div>
+			{ actions }
+			{ children }
+		</div>
+	),
+} ) );
+
+// Both carry their own queries and neither is under test here.
 // Stubbed so these tests assert only that the layout mounts the shared notice,
 // not the notice's own store wiring (which the connection package tests).
 jest.mock( '@automattic/jetpack-connection/use-connection-error-notice', () => ( {
@@ -18,65 +33,174 @@ jest.mock( '@automattic/jetpack-connection/use-connection-error-notice', () => (
 	default: jest.fn(),
 } ) );
 
-// The layout's other child reaches react-query (useOnboardingCounts → useLibrary),
-// which would need a QueryClientProvider these tests have no use for. Nothing here
-// asserts on the modal, so stub it rather than stand up the query machinery.
 jest.mock( '../../onboarding-modal', () => ( {
 	__esModule: true,
 	default: () => null,
 } ) );
-// The upload pill reads the shared queue through react-query; it has a suite
-// of its own and no QueryClientProvider here.
 jest.mock( '../../upload-pill', () => ( {
 	__esModule: true,
 	default: () => null,
 } ) );
 
-const mockUseNavigate = useNavigate as jest.Mock;
 const mockConnectionError = ConnectionError as jest.Mock;
 const mockUseConnectionErrorNotice = useConnectionErrorNotice as jest.MockedFunction<
 	typeof useConnectionErrorNotice
 >;
 
+let mockFirstRun: FirstRunState = 'home';
+let mockSettled: FirstRunState | 'loading' = 'home';
+jest.mock( '../../../hooks/use-first-run-state', () => ( {
+	useFirstRunState: () => mockFirstRun,
+	useSettledFirstRunState: () => mockSettled,
+} ) );
+
 describe( 'DashboardLayout', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockUseNavigate.mockReturnValue( jest.fn() );
 		mockConnectionError.mockReturnValue( null );
-		mockUseConnectionErrorNotice.mockReturnValue( {
-			hasConnectionError: true,
-		} as ReturnType< typeof useConnectionErrorNotice > );
-	} );
-
-	it( 'renders the connection error notice above the tabs', () => {
-		mockConnectionError.mockReturnValue( <div>Connection error notice</div> );
-
-		render( <DashboardLayout activeTab="library">Library body</DashboardLayout> );
-
-		const notice = screen.getByText( 'Connection error notice' );
-		expect( notice ).toBeInTheDocument();
-
-		// Above the strip, so it can't scroll away with a tab's body. The two are
-		// siblings, not nested, so the comparison is exactly "follows".
-		const tabList = screen.getByRole( 'tablist' );
-		expect( notice.compareDocumentPosition( tabList ) ).toBe( Node.DOCUMENT_POSITION_FOLLOWING );
-	} );
-
-	it( 'renders the notice with no props, so every tab describes the error the same way', () => {
-		render( <DashboardLayout activeTab="settings">Settings body</DashboardLayout> );
-
-		expect( mockConnectionError ).toHaveBeenCalled();
-		expect( mockConnectionError.mock.calls[ 0 ][ 0 ] ).toEqual( {} );
-	} );
-
-	it( 'leaves no notice behind when the connection is healthy', () => {
 		mockUseConnectionErrorNotice.mockReturnValue( {
 			hasConnectionError: false,
 		} as ReturnType< typeof useConnectionErrorNotice > );
+		mockFirstRun = 'home';
+		mockSettled = 'home';
+	} );
 
-		render( <DashboardLayout activeTab="library">Library body</DashboardLayout> );
+	describe( 'landing', () => {
+		// The Library owns `/` and is the landing tab; there is no redirect to
+		// burn and no hold to sit through. The Library route itself decides
+		// between the listing and the upload onboarding empty state.
+		it( 'renders the Library body immediately, with no redirect', () => {
+			render( <DashboardLayout activeTab="library">body</DashboardLayout> );
 
-		expect( mockConnectionError ).not.toHaveBeenCalled();
-		expect( screen.getByText( 'Library body' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'body' ) ).toBeInTheDocument();
+			expect( mockNavigate ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'tab order', () => {
+		it( 'holds the settled order for the life of the mount', () => {
+			mockFirstRun = 'first-run';
+			mockSettled = 'first-run';
+			const { rerender } = render( <DashboardLayout activeTab="library">body</DashboardLayout> );
+			expect( screen.queryByRole( 'tab', { name: 'Home' } ) ).not.toBeInTheDocument();
+
+			// The first successful upload flips this mid-session; the strip must
+			// not re-order under the cursor of someone still finishing the flow
+			// that caused it.
+			mockFirstRun = 'home';
+			mockSettled = 'home';
+			rerender( <DashboardLayout activeTab="library">body</DashboardLayout> );
+
+			expect( screen.queryByRole( 'tab', { name: 'Home' } ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( 'tab', { name: 'Library' } ) ).toBeInTheDocument();
+		} );
+
+		it( 'renders the live order until the count settles', () => {
+			// A loading count reads as first-run, so a brand-new user never sees
+			// the returning-user strip; freezing that guess would make it
+			// permanent for the mount.
+			mockFirstRun = 'first-run';
+			mockSettled = 'loading';
+			const { rerender } = render( <DashboardLayout activeTab="library">body</DashboardLayout> );
+			expect( screen.queryByRole( 'tab', { name: 'Home' } ) ).not.toBeInTheDocument();
+
+			mockFirstRun = 'home';
+			mockSettled = 'home';
+			rerender( <DashboardLayout activeTab="home">body</DashboardLayout> );
+
+			expect( screen.getByRole( 'tab', { name: 'Home' } ) ).toBeInTheDocument();
+		} );
+
+		// Panels are rendered by mapping over the tab order, so a route whose tab
+		// has dropped out of that order renders its children nowhere. Normal use
+		// reaches it: a first-run order carries no Home tab, but a deep link to
+		// /home still mounts that route.
+		it( 'keeps the active tab in the order when the order has dropped it', () => {
+			mockFirstRun = 'first-run';
+			mockSettled = 'first-run';
+
+			render( <DashboardLayout activeTab="home">body</DashboardLayout> );
+
+			expect( screen.getByText( 'body' ) ).toBeInTheDocument();
+			// Re-inserted in its canonical position rather than appended, so the
+			// strip does not re-order around the tab the user is standing on.
+			expect( screen.getAllByRole( 'tab' ).map( tab => tab.textContent ) ).toEqual( [
+				'Home',
+				'Library',
+				'Analytics',
+				'Settings',
+			] );
+		} );
+	} );
+
+	describe( 'tab navigation', () => {
+		// The tabs are sibling routes, so activating one is a navigation rather
+		// than local state: the strip's value comes back from the route.
+		it( 'navigates to the activated tab path', async () => {
+			const user = userEvent.setup();
+			render( <DashboardLayout activeTab="home">body</DashboardLayout> );
+
+			await user.click( screen.getByRole( 'tab', { name: 'Analytics' } ) );
+			expect( mockNavigate ).toHaveBeenCalledWith( { href: '/stats' } );
+
+			// Library owns `/`, which is the one path that is not its own name.
+			await user.click( screen.getByRole( 'tab', { name: 'Library' } ) );
+			expect( mockNavigate ).toHaveBeenLastCalledWith( { href: '/' } );
+		} );
+	} );
+
+	describe( 'header actions', () => {
+		it( 'renders the actions slot with the page', () => {
+			render(
+				<DashboardLayout
+					activeTab="library"
+					actions={ <button type="button">{ 'Upload video' }</button> }
+				>
+					body
+				</DashboardLayout>
+			);
+
+			expect( screen.getByRole( 'button', { name: 'Upload video' } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'connection error notice', () => {
+		beforeEach( () => {
+			mockUseConnectionErrorNotice.mockReturnValue( {
+				hasConnectionError: true,
+			} as ReturnType< typeof useConnectionErrorNotice > );
+		} );
+
+		it( 'renders the connection error notice above the tabs', () => {
+			mockConnectionError.mockReturnValue( <div>Connection error notice</div> );
+
+			render( <DashboardLayout activeTab="library">Library body</DashboardLayout> );
+
+			const notice = screen.getByText( 'Connection error notice' );
+			expect( notice ).toBeInTheDocument();
+
+			// Above the strip, so it can't scroll away with a tab's body. The two are
+			// siblings, not nested, so the comparison is exactly "follows".
+			const tabList = screen.getByRole( 'tablist' );
+			expect( notice.compareDocumentPosition( tabList ) ).toBe( Node.DOCUMENT_POSITION_FOLLOWING );
+		} );
+
+		it( 'renders the notice with no props, so every tab describes the error the same way', () => {
+			render( <DashboardLayout activeTab="settings">Settings body</DashboardLayout> );
+
+			expect( mockConnectionError ).toHaveBeenCalled();
+			expect( mockConnectionError.mock.calls[ 0 ][ 0 ] ).toEqual( {} );
+		} );
+
+		it( 'leaves no notice behind when the connection is healthy', () => {
+			mockUseConnectionErrorNotice.mockReturnValue( {
+				hasConnectionError: false,
+			} as ReturnType< typeof useConnectionErrorNotice > );
+
+			render( <DashboardLayout activeTab="library">Library body</DashboardLayout> );
+
+			expect( mockConnectionError ).not.toHaveBeenCalled();
+			expect( screen.getByText( 'Library body' ) ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/projects/packages/videopress/src/dashboard/components/dashboard-tabs/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/dashboard-tabs/index.tsx
@@ -1,32 +1,81 @@
 /**
  * External dependencies
  */
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Tabs } from '@wordpress/ui';
+import { useFirstRunState, type FirstRunState } from '../../hooks/use-first-run-state';
 
-export type DashboardTab = 'library' | 'stats' | 'settings';
+export type DashboardTab = 'home' | 'stats' | 'library' | 'settings';
 
 export const TAB_PATHS: Record< DashboardTab, string > = {
-	library: '/',
+	home: '/home',
 	stats: '/stats',
+	library: '/',
 	settings: '/settings',
 };
 
+const TAB_LABELS: Record< DashboardTab, string > = {
+	home: __( 'Home', 'jetpack-videopress-pkg' ),
+	// "Overview" route, surfaced to users as Analytics.
+	stats: __( 'Analytics', 'jetpack-videopress-pkg' ),
+	library: __( 'Library', 'jetpack-videopress-pkg' ),
+	settings: __( 'Settings', 'jetpack-videopress-pkg' ),
+};
+
+// Left-to-right order every tab keeps whenever it is shown. `getTabOrder`
+// picks a subset of this; DashboardLayout falls back to it when it has to
+// re-insert the active tab (see its `visibleTabs`).
+export const CANONICAL_TAB_ORDER: DashboardTab[] = [ 'home', 'library', 'stats', 'settings' ];
+
 /**
- * The Library / Stats / Settings tab strip. Must be rendered inside a
- * `<Tabs.Root>` whose `value` and `onValueChange` are managed by the parent
- * (DashboardLayout) so the strip and its sibling `<Tabs.Panel>`s share
- * Tabs context.
+ * The tab order for the current dashboard shape.
  *
+ * On first run the Library leads: with nothing uploaded yet, its empty state
+ * IS the upload flow, so the landing tab and the one job coincide. Home joins
+ * the strip once there is something to come back to — a brand-new user's Home
+ * would only echo the same empty state.
+ *
+ * @param firstRunState - The resolved first-run state.
+ * @return Ordered tab values.
+ */
+export function getTabOrder( firstRunState: FirstRunState ): DashboardTab[] {
+	// Product Compass spec — never lead with Stats (a new user's Stats read as zeros).
+	return firstRunState === 'first-run'
+		? [ 'library', 'stats', 'settings' ]
+		: [ 'home', 'library', 'stats', 'settings' ];
+}
+
+/**
+ * Resolve the visible dashboard tabs from the real first-run state.
+ *
+ * @return Ordered tab values.
+ */
+export function useDashboardTabOrder(): DashboardTab[] {
+	const firstRunState = useFirstRunState();
+
+	return useMemo( () => getTabOrder( firstRunState ), [ firstRunState ] );
+}
+
+/**
+ * The dashboard tab strip. Must be rendered inside a `<Tabs.Root>` whose
+ * `value` and `onValueChange` are managed by the parent (DashboardLayout) so
+ * the strip and its sibling `<Tabs.Panel>`s share Tabs context. Tab order
+ * adapts to the first-run state.
+ *
+ * @param props      - Component props.
+ * @param props.tabs - Tab values to render, in order.
  * @return The tab list element.
  */
-export default function DashboardTabs() {
+export default function DashboardTabs( { tabs }: { tabs: DashboardTab[] } ) {
 	return (
 		<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
 			<Tabs.List variant="minimal">
-				<Tabs.Tab value="library">{ __( 'Library', 'jetpack-videopress-pkg' ) }</Tabs.Tab>
-				<Tabs.Tab value="stats">{ __( 'Stats', 'jetpack-videopress-pkg' ) }</Tabs.Tab>
-				<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-videopress-pkg' ) }</Tabs.Tab>
+				{ tabs.map( tab => (
+					<Tabs.Tab key={ tab } value={ tab }>
+						{ TAB_LABELS[ tab ] }
+					</Tabs.Tab>
+				) ) }
 			</Tabs.List>
 		</div>
 	);

--- a/projects/packages/videopress/src/dashboard/components/dashboard-tabs/test/index.test.ts
+++ b/projects/packages/videopress/src/dashboard/components/dashboard-tabs/test/index.test.ts
@@ -1,0 +1,114 @@
+import { renderHook } from '@testing-library/react';
+import { markEstablishedLibrary } from '../../../hooks/use-first-run-state';
+import { useLibrary } from '../../../hooks/use-library';
+import { CANONICAL_TAB_ORDER, TAB_PATHS, getTabOrder, useDashboardTabOrder } from '../index';
+
+// Pulled in through the component module's `useDashboardTabOrder` import chain.
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getScriptData: () => ( {
+		site: { wpcom: { blog_id: 123 } },
+		user: { current_user: { id: 7 } },
+	} ),
+	isWoASite: jest.fn( () => false ),
+	isSimpleSite: jest.fn( () => false ),
+} ) );
+
+jest.mock( '../../../hooks/use-library', () => ( {
+	useLibrary: jest.fn(),
+	LIBRARY_QUERY_KEY: 'library',
+} ) );
+
+/**
+ * Answer the first-run count query, settled or still in flight.
+ *
+ * @param options            - Count state.
+ * @param options.totalItems - Videos the library reports.
+ * @param options.isLoading  - Whether the request is still in flight.
+ */
+const mockLibraryCount = ( {
+	totalItems,
+	isLoading,
+}: {
+	totalItems: number;
+	isLoading: boolean;
+} ) => {
+	( useLibrary as jest.Mock ).mockReturnValue( {
+		items: [],
+		isLoading,
+		isError: false,
+		paginationInfo: { totalItems, totalPages: 1 },
+	} );
+};
+
+describe( 'getTabOrder', () => {
+	it( 'leads with Library on first run', () => {
+		// With nothing in the library, its empty state — the upload flow —
+		// *is* the page, and Home would only echo it.
+		expect( getTabOrder( 'first-run' ) ).toEqual( [ 'library', 'stats', 'settings' ] );
+	} );
+
+	it( 'leads with Home once the user is past first run', () => {
+		expect( getTabOrder( 'home' ) ).toEqual( [ 'home', 'library', 'stats', 'settings' ] );
+	} );
+
+	// Upload is never a tab of its own: the Library's empty state carries the
+	// flow on first run, and the header's top-right slot carries the action
+	// everywhere else. Losing the tab must never mean losing the ability to
+	// upload.
+	it( 'never offers Upload as a tab', () => {
+		expect( getTabOrder( 'first-run' ) ).not.toContain( 'upload' );
+		expect( getTabOrder( 'home' ) ).not.toContain( 'upload' );
+	} );
+
+	// A new user's Stats read as zeros, so Stats never leads.
+	it( 'never leads with Stats', () => {
+		expect( getTabOrder( 'first-run' )[ 0 ] ).not.toBe( 'stats' );
+		expect( getTabOrder( 'home' )[ 0 ] ).not.toBe( 'stats' );
+	} );
+
+	it( 'is pure — repeated calls return equal, independent arrays', () => {
+		const first = getTabOrder( 'home' );
+		const second = getTabOrder( 'home' );
+
+		expect( first ).toEqual( second );
+		first.pop();
+		expect( getTabOrder( 'home' ) ).toEqual( second );
+	} );
+
+	it( 'only ever returns tabs that have a route path and a canonical position', () => {
+		for ( const state of [ 'first-run', 'home' ] as const ) {
+			for ( const tab of getTabOrder( state ) ) {
+				expect( TAB_PATHS[ tab ] ).toBeTruthy();
+				expect( CANONICAL_TAB_ORDER ).toContain( tab );
+			}
+		}
+	} );
+} );
+
+// The same fix as the one in use-first-run-state, stated as the thing the user
+// actually sees. Every in-app arrival is a fresh page load with a cold count,
+// so this is the FIRST paint of the strip on `?p=/settings`, `?p=/home` and
+// every other deep link.
+describe( 'useDashboardTabOrder', () => {
+	beforeEach( () => {
+		window.localStorage.clear();
+		jest.clearAllMocks();
+	} );
+
+	it( 'leads with Home from the first render for a remembered library', () => {
+		markEstablishedLibrary();
+		mockLibraryCount( { totalItems: 0, isLoading: true } );
+
+		const { result } = renderHook( () => useDashboardTabOrder() );
+
+		expect( result.current ).toEqual( [ 'home', 'library', 'stats', 'settings' ] );
+	} );
+
+	it( 'leads with Library from the first render when nothing is remembered', () => {
+		mockLibraryCount( { totalItems: 0, isLoading: true } );
+
+		const { result } = renderHook( () => useDashboardTabOrder() );
+
+		expect( result.current ).toEqual( [ 'library', 'stats', 'settings' ] );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/upload-onboarding/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/upload-onboarding/index.tsx
@@ -21,6 +21,7 @@ import { isAdoptableUpload, setUploadDraft, useUpload } from '../../hooks/use-up
 import { useVideo } from '../../hooks/use-video';
 import { isWpcomConnected } from '../../utils/connection';
 import AddToContentMenu from '../add-to-content-menu';
+import { TAB_PATHS } from '../dashboard-tabs';
 import FreeTierNotice from '../free-tier-notice';
 import UploadDropzone from '../upload-dropzone';
 import {
@@ -731,10 +732,10 @@ const SuccessCard = ( {
 					</Stack>
 				</Card.Content>
 				<div className="vp-success__actions">
-					{ /* Single video: the hand-off sits beside "Go to Library" in the footer. */ }
+					{ /* Single video: the hand-off sits beside "Go to Home" in the footer. */ }
 					<AddToContentMenu guid={ video?.videopressGuid } />
 					<Button variant="primary" __next40pxDefaultSize onClick={ onGoToHome }>
-						{ __( 'Go to Library', 'jetpack-videopress-pkg' ) }
+						{ __( 'Go to Home', 'jetpack-videopress-pkg' ) }
 					</Button>
 				</div>
 			</Card.Root>
@@ -794,7 +795,7 @@ const SuccessCard = ( {
 			</Card.Content>
 			<div className="vp-success__actions">
 				<Button variant="primary" __next40pxDefaultSize onClick={ onGoToHome }>
-					{ __( 'Go to Library', 'jetpack-videopress-pkg' ) }
+					{ __( 'Go to Home', 'jetpack-videopress-pkg' ) }
 				</Button>
 			</div>
 		</Card.Root>
@@ -1140,6 +1141,7 @@ const UploadOnboardingFlow = ( {
 	onExitToLibrary: () => void;
 } ) => {
 	const queryClient = useQueryClient();
+	const navigate = useNavigate();
 	const { createInfoNotice } = useGlobalNotices();
 	const batchRef = useRef( 0 );
 	const [ uploads, setUploads ] = useState< UploadItem[] >( [] );
@@ -1373,9 +1375,13 @@ const UploadOnboardingFlow = ( {
 		[ go, queryClient ]
 	);
 
-	// Publishing wraps the session up: hand the surface back to the Library
-	// listing, which now holds the published videos.
-	const goToHome = onExitToLibrary;
+	// Publishing the first video ends the first-run experience, so the hand-off
+	// goes to Home — the surface that answers "what happened since I was last
+	// here, and what do I want to do now" — rather than dropping the user into
+	// a bare file list.
+	const goToHome = useCallback( () => {
+		navigate( { href: TAB_PATHS.home } );
+	}, [ navigate ] );
 
 	const renderStep = ( s: Step ) => {
 		if ( s === 'upload' ) {

--- a/projects/packages/videopress/src/dashboard/components/upload-onboarding/test/index.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/upload-onboarding/test/index.test.tsx
@@ -675,10 +675,10 @@ describe( 'upload stage single-drop transition', () => {
 			expect( screen.getByLabelText( 'Share link' ) ).toHaveValue( 'https://example.com/one.mp4' );
 			expect( mockMarkFirstPublish ).toHaveBeenCalled();
 			// Nothing on this path navigates away on its own — the user leaves via
-			// "Go to Library".
+			// "Go to Home".
 			expect( mockNavigate ).not.toHaveBeenCalled();
-			await userEvent.click( screen.getByRole( 'button', { name: 'Go to Library' } ) );
-			expect( mockExitToLibrary ).toHaveBeenCalled();
+			await userEvent.click( screen.getByRole( 'button', { name: 'Go to Home' } ) );
+			expect( mockNavigate ).toHaveBeenCalledWith( { href: '/home' } );
 		} );
 
 		it( 'says the connection dropped when the request never lands', async () => {

--- a/projects/packages/videopress/src/dashboard/hooks/use-stats.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-stats.ts
@@ -55,7 +55,11 @@ const REST_PATH = '/jetpack/v4/videopress/stats/video-plays';
 // rest/v1.1 middleware site-prefixes this path and unwraps the envelope,
 // landing on the same WPCOM endpoint the proxy targets.
 const SIMPLE_REST_PATH = '/rest/v1.1/stats/video-plays';
-const TOP_VIDEOS_LIMIT = 5;
+// How many per-video rows `stats.topVideos` is capped at. Exported because a
+// consumer that looks a specific video up in that list has to know the list is
+// truncated: a video that is absent from a FULL list may simply rank 6th, which
+// is not the same as having no views. See routes/home/views-slot.ts.
+export const TOP_VIDEOS_LIMIT = 5;
 const ZERO_SUMMARY: KpiSummary = { current: 0, previousPeriod: 0 };
 
 const EMPTY_STATS: OverviewStats = {

--- a/projects/plugins/jetpack/changelog/add-videopress-home-tab
+++ b/projects/plugins/jetpack/changelog/add-videopress-home-tab
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+VideoPress: Add a Home tab to the dashboard with recent videos, view counts, and quick actions.

--- a/projects/plugins/videopress/changelog/add-videopress-home-tab
+++ b/projects/plugins/videopress/changelog/add-videopress-home-tab
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a Home tab to the dashboard with recent videos, view counts, and quick actions.


### PR DESCRIPTION
## Proposed changes

Part 3 of 4 splitting #51481 (welcome modal → Library upload empty state → **this PR** → follow-up fixes). Based on `add/videopress-library-upload-empty-state`.

* Add a **Home** tab: recent videos (thumbnail opens the video), per-video view counts fed by the stats top-videos list, an upload header action, and an emptied-library dropzone that hands files to the Library's onboarding flow.
* Home joins the tab strip only once the user has videos — on first run the Library's upload empty state is the page, so the strip stays Library-led. The strip's order freezes per mount so the first successful upload can't re-order it under the cursor.
* Publishing from the flow and deleting the last video now land on Home.

## Related product discussion/links

* Split out of #51481 (stack part 3).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build with `jetpack build plugins/jetpack --deps`, use a Jetpack-connected site with at least one VideoPress video.
* **Jetpack → VideoPress**: the tab strip shows Home / Library / Analytics / Settings. Home lists recent videos with view counts; clicking a thumbnail opens the video details.
* On a site with no videos, Home is absent from the strip and the Library leads.
* Delete every video from the Library, then visit Home: it leads with the upload dropzone; dropping a file lands in the Library's onboarding flow mid-upload.
* `jetpack test js packages/videopress` — all suites pass.
