### PR TITLE
VideoPress: fix Add to content on empty posts, and polish follow-ups

### DIFF
--- a/projects/packages/videopress/changelog/fix-add-to-content-empty-post
+++ b/projects/packages/videopress/changelog/fix-add-to-content-empty-post
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Video details: insert the video when "Add to a post or page" opens a new post or page on sites running VideoPress through the Jetpack plugin, instead of creating an empty draft.

--- a/projects/packages/videopress/routes/video-editor/stage.tsx
+++ b/projects/packages/videopress/routes/video-editor/stage.tsx
@@ -266,7 +266,7 @@ function EditorNotFound( { videoId }: { videoId: string } ): ReactElement {
 		<EditorChrome videoId={ videoId }>
 			<div className="vp-video-editor vp-video-editor__not-found">
 				<Stack direction="column" gap="md" align="center">
-					<Text>{ __( "We couldn't find that video.", 'jetpack-videopress-pkg' ) }</Text>
+					<Text>{ __( 'We couldn’t find that video.', 'jetpack-videopress-pkg' ) }</Text>
 					<Link to="/">{ __( 'Back to Library', 'jetpack-videopress-pkg' ) }</Link>
 				</Stack>
 			</div>

--- a/projects/packages/videopress/routes/video-editor/test/stage.test.tsx
+++ b/projects/packages/videopress/routes/video-editor/test/stage.test.tsx
@@ -302,7 +302,7 @@ describe( 'video-editor stage', () => {
 
 		render( <Stage />, { wrapper: createTestWrapper( mockTestClient ) } );
 
-		expect( screen.getByText( "We couldn't find that video." ) ).toBeInTheDocument();
+		expect( screen.getByText( 'We couldn’t find that video.' ) ).toBeInTheDocument();
 		expect( screen.queryByTestId( 'chapters-preview-video' ) ).not.toBeInTheDocument();
 		// Guarded ahead of the media fetch, so no request escapes either.
 		expect( getApiFetchMock() ).not.toHaveBeenCalled();
@@ -322,7 +322,7 @@ describe( 'video-editor stage', () => {
 		render( <Stage />, { wrapper: createTestWrapper( mockTestClient ) } );
 
 		await expect(
-			screen.findByText( "We couldn't find that video." )
+			screen.findByText( 'We couldn’t find that video.' )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByTestId( 'chapters' ) ).not.toBeInTheDocument();
 	} );

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -19,6 +19,18 @@ class Block_Editor_Content {
 	 * This method should be called only once by the Initializer class. Do not call this method again.
 	 */
 	public static function init() {
+		/*
+		 * The dashboard's "Add to a post or page" hand-off. Registered BEFORE the
+		 * standalone guard below, and deliberately outside it: that guard exists
+		 * to stop this class's shortcodes colliding with the ones the Jetpack
+		 * plugin registers in modules/videopress/shortcode.php. The Jetpack
+		 * plugin hooks nothing on `default_content`, so there is nothing here to
+		 * collide with — and while this filter sat behind the guard, every
+		 * Jetpack-plugin site got the menu, the nonce and a brand-new post that
+		 * stayed empty, because the only thing missing was this line.
+		 */
+		add_filter( 'default_content', array( static::class, 'videopress_video_block_by_guid' ), 10, 2 );
+
 		if ( ! Status::is_standalone_plugin_active() ) {
 			return;
 		}
@@ -35,8 +47,6 @@ class Block_Editor_Content {
 		add_shortcode( 'wpvideo', array( static::class, 'videopress_embed_shortcode' ) );
 
 		add_filter( 'wp_video_shortcode_override', array( static::class, 'video_shortcode_override' ), 10, 4 );
-
-		add_filter( 'default_content', array( static::class, 'videopress_video_block_by_guid' ), 10, 2 );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/Block_Editor_Content_Test.php
+++ b/projects/packages/videopress/tests/php/Block_Editor_Content_Test.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Tests for the `videopress_guid` hand-off into a brand-new post or page.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Covers `Block_Editor_Content::videopress_video_block_by_guid()` — the server
+ * half of the dashboard's "Add to a post or page" menu — and the hook
+ * registration that decides whether it ever runs.
+ */
+class Block_Editor_Content_Test extends BaseTestCase {
+
+	const GUID = 'aBcD1234';
+
+	/**
+	 * Reset everything the filter reads.
+	 */
+	protected function tear_down() {
+		remove_all_filters( 'default_content' );
+		unset( $_GET['videopress_guid'], $_GET['_wpnonce'] );
+		wp_set_current_user( 0 );
+		\WorDBless\Posts::init()->clear_all_posts();
+	}
+
+	/**
+	 * Sign in as a new user with the given role.
+	 *
+	 * @param string $role Role slug.
+	 * @return int The user id.
+	 */
+	private function login_as( $role ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => $role . '_user',
+				'user_pass'  => 'pass',
+				'user_email' => $role . '@test.com',
+				'role'       => $role,
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		return (int) $user_id;
+	}
+
+	/**
+	 * Stand in for the auto-draft `get_default_post_to_edit()` creates before it
+	 * applies `default_content`.
+	 *
+	 * @param int $author_id Author of the draft.
+	 * @return \WP_Post The draft post.
+	 */
+	private function create_auto_draft( $author_id ) {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Auto Draft',
+				'post_status' => 'auto-draft',
+				'post_author' => $author_id,
+			)
+		);
+
+		return get_post( $post_id );
+	}
+
+	/**
+	 * Put a valid request on `$_GET`, exactly as the dashboard menu builds it.
+	 */
+	private function seed_request() {
+		$_GET['videopress_guid'] = self::GUID;
+		$_GET['_wpnonce']        = wp_create_nonce( 'videopress-content-nonce' );
+	}
+
+	/**
+	 * The hand-off has nothing to do with the shortcodes the rest of `init()`
+	 * registers, and must not inherit their standalone-plugin guard: on a site
+	 * running the Jetpack plugin the dashboard, the menu and the nonce all ship,
+	 * so a missing filter means every "New post" opens an empty editor.
+	 */
+	public function test_init_registers_the_default_content_filter_without_the_standalone_plugin() {
+		// The premise: the standalone plugin's entry class is absent here, as it
+		// is on any site running VideoPress through the Jetpack plugin.
+		$this->assertFalse( Status::is_standalone_plugin_active() );
+
+		Block_Editor_Content::init();
+
+		$this->assertSame(
+			10,
+			has_filter( 'default_content', array( Block_Editor_Content::class, 'videopress_video_block_by_guid' ) )
+		);
+	}
+
+	/**
+	 * The happy path: a valid request turns the empty default content into a
+	 * VideoPress block carrying the guid.
+	 */
+	public function test_fills_empty_content_with_the_video_block() {
+		$author = $this->login_as( 'administrator' );
+		$post   = $this->create_auto_draft( $author );
+		$this->seed_request();
+
+		$content = Block_Editor_Content::videopress_video_block_by_guid( '', $post );
+
+		$this->assertStringContainsString( '<!-- wp:videopress/video {"guid":"' . self::GUID . '"} -->', $content );
+		$this->assertStringContainsString( 'https://videopress.com/v/' . self::GUID, $content );
+		$this->assertStringContainsString( '<!-- /wp:videopress/video -->', $content );
+	}
+
+	/**
+	 * Condition 1: no guid, nothing to insert.
+	 */
+	public function test_leaves_content_alone_without_a_guid() {
+		$author = $this->login_as( 'administrator' );
+		$post   = $this->create_auto_draft( $author );
+		$this->seed_request();
+		unset( $_GET['videopress_guid'] );
+
+		$this->assertSame( '', Block_Editor_Content::videopress_video_block_by_guid( '', $post ) );
+	}
+
+	/**
+	 * Condition 2: the nonce is verified against `videopress-content-nonce`, the
+	 * same action `Initial_State`/`Admin_UI` mint it for.
+	 */
+	public function test_leaves_content_alone_with_a_nonce_for_another_action() {
+		$author = $this->login_as( 'administrator' );
+		$post   = $this->create_auto_draft( $author );
+		$this->seed_request();
+		$_GET['_wpnonce'] = wp_create_nonce( 'some-other-action' );
+
+		$this->assertSame( '', Block_Editor_Content::videopress_video_block_by_guid( '', $post ) );
+	}
+
+	/**
+	 * Condition 3: a user who cannot edit the draft gets nothing.
+	 */
+	public function test_leaves_content_alone_for_a_user_who_cannot_edit_the_post() {
+		$author = $this->login_as( 'administrator' );
+		$post   = $this->create_auto_draft( $author );
+		$this->login_as( 'subscriber' );
+		$this->seed_request();
+
+		$this->assertSame( '', Block_Editor_Content::videopress_video_block_by_guid( '', $post ) );
+	}
+
+	/**
+	 * Condition 4: content another filter (or `?content=`) already supplied is
+	 * never overwritten.
+	 */
+	public function test_leaves_prefilled_content_alone() {
+		$author = $this->login_as( 'administrator' );
+		$post   = $this->create_auto_draft( $author );
+		$this->seed_request();
+
+		$this->assertSame(
+			'Already written.',
+			Block_Editor_Content::videopress_video_block_by_guid( 'Already written.', $post )
+		);
+	}
+}

--- a/projects/plugins/jetpack/changelog/fix-videopress-add-to-content
+++ b/projects/plugins/jetpack/changelog/fix-videopress-add-to-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: adding a video to a post or page now inserts the video instead of creating an empty draft.

--- a/projects/plugins/videopress/changelog/fix-videopress-add-to-content
+++ b/projects/plugins/videopress/changelog/fix-videopress-add-to-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Adding a video to a post or page now inserts the video instead of creating an empty draft.


### PR DESCRIPTION
## Proposed changes

Part 4 of 4 splitting #51481 (welcome modal → Library upload empty state → Home tab → **this PR**). Based on `add/videopress-home-tab`.

* Fix the `videopress_guid` content filter producing a broken block when the target post has no content ("Add to a post or page" on an empty post), with a PHP regression test.
* Typography fix in the video editor's not-found copy.

With this PR the stack's combined tree is byte-identical to #51481's code.

## Related product discussion/links

* Split out of #51481 (stack part 4).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a video's details page, use "Add to a post or page" → New post: the created post contains a valid VideoPress block even though the post started empty.
* `jetpack test php packages/videopress` — passes, including the new `Block_Editor_Content_Test`.
