### PR TITLE
build: Try to better order mirror pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -540,7 +540,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       AWAIT_JOB_NAME: 'Push to mirror repos'
-      BUILD_JOB_NAMES: '[ "Build wpcom projects", "Build non-wpcom projects" ]'
+      BUILD_JOB_NAMES: '[ "Build all projects", "Build wpcom projects", "Build non-wpcom projects" ]'
     steps: *await_mirrors_steps
 
   update_all_mirrors:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -456,6 +456,9 @@ jobs:
             exit 0
           fi
 
+          # To avoid spending too much rate limit, we only re-check the run status after 15 minutes and then every 5 thereafter.
+          NEXTRUNCHECK=$( jq '[ now + 5 * 60, ( .created_at | 15 * 60 + fromdateiso8601 | round ) ] | max' <<<"$JSON" || true )
+
           # Now poll the run until the target job name shows up
           BADCT=0
           while true; do
@@ -476,7 +479,20 @@ jobs:
               exit 0
             fi
 
-            # No job yet. Figure out how long to sleep.
+            # No job yet. Figure out how long to sleep, and maybe check that the watched job is still running at all.
+            if [[ $NEXTRUNCHECK -le $EPOCHSECONDS ]]; then
+              JSON2=$( gh api -X GET "/repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID" || true )
+              if ! jq -e '.id // empty' <<<"$JSON2" &>/dev/null; then
+                echo "Bad JSON when re-checking run conclusion. Will try again later."
+              else
+                CONCLUSION=$( jq '.conclusion // null' <<<"$JSON2" || true )
+                if [[ "$CONCLUSION" != "null" ]]; then
+                  echo "🤷 Workflow $RUN_ID for $SHA has concluded ($CONCLUSION), despite no \"$AWAIT_JOB_NAME\" being found. May as well go ahead."
+                  exit 0
+                fi
+                NEXTRUNCHECK=$(( EPOCHSECONDS + 5 * 60 ))
+              fi
+            fi
             DELAY=$( jq --argjson BUILDS "$BUILD_JOB_NAMES" '.jobs | map( select( .name as $N | $BUILDS | index( $N ) ) | .started_at | fromdateiso8601 ) | max // now | 10 * 60 - ( now - . ) | round' <<<"$JSON" || true )
             [[ "$DELAY" =~ ^[0-9]+$ ]] || DELAY=30
             [[ "$DELAY" -ge 30 ]] || DELAY=30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -457,7 +457,7 @@ jobs:
           fi
 
           # To avoid spending too much rate limit, we only re-check the run status after 15 minutes and then every 5 thereafter.
-          NEXTRUNCHECK=$( jq '[ now + 5 * 60, ( .created_at | 15 * 60 + fromdateiso8601 | round ) ] | max' <<<"$JSON" || true )
+          NEXTRUNCHECK=$( jq '[ now + 5 * 60, ( .created_at | 15 * 60 + fromdateiso8601 ) ] | max | round' <<<"$JSON" || true )
 
           # Now poll the run until the target job name shows up
           BADCT=0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -412,10 +412,83 @@ jobs:
             const { checkTestReminderComment } = require('./monorepo/.github/files/build-reminder-comment/check-test-reminder-comment.js')
             await checkTestReminderComment( github, context, core );
 
+  # GitHub provides no way to make sure the `update_wpcom_mirrors` jobs run in merge order.
+  # So we poll for the previous commit's Build run, and only let our `update_wpcom_mirrors` get queued when that run's `update_wpcom_mirrors` is already queued.
+  await_update_wpcom_mirrors:
+    name: Wait for previous commit wpcom-mirrors push
+    runs-on: ubuntu-latest
+    needs: [ build_wpcom ]
+    if: github.event_name == 'push' && github.repository == 'Automattic/jetpack'
+    # No timeout, might take arbitrary amounts of time.
+    permissions:
+      # Polling
+      actions: read
+      # actions/checkout
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      AWAIT_JOB_NAME: 'Push wpcom plugins to mirror repos'
+      BUILD_JOB_NAMES: '[ "Build wpcom projects" ]'
+
+    steps: &await_mirrors_steps
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 2
+          # We don't need any files for this check, just the tree. A non-cone sparse checkout with a custom filter does the trick.
+          sparse-checkout-cone-mode: false
+          sparse-checkout: .
+          filter: 'tree:0'
+
+      - name: Wait for previous commit to queue
+        run: |
+          # First, get the previous commit sha
+          SHA=$( git log -1 --format='%H' HEAD^ || true )
+          [[ -z "$SHA" ]] && { echo "🤷 Failed to fetch previous commit sha. May as well go for it."; exit 0; }
+
+          # Look up the run for that sha
+          JSON=$( gh api -X GET "/repos/$GITHUB_REPOSITORY/actions/workflows/build.yml/runs" -F event=push -F head_sha="$SHA" --jq '.workflow_runs[0]' || true )
+          RUN_ID=$( jq '.id // empty' <<<"$JSON" || true )
+          [[ -z "$RUN_ID" ]] && { echo "🤷 Failed to find build run for $SHA. May as well go for it."; exit 0; }
+          echo "Watching run https://github.com/$GITHUB_REPOSITORY/actions/runs/$RUN_ID"
+          CONCLUSION=$( jq '.conclusion // null' <<<"$JSON" || true )
+          if [[ "$CONCLUSION" != "null" ]]; then
+            echo "🎉 Workflow for $SHA already concluded ($CONCLUSION). No need to wait on it."
+            exit 0
+          fi
+
+          # Now poll the run until the target job name shows up
+          BADCT=0
+          while true; do
+            JSON=$( gh api -X GET "/repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs" -F filter=latest -F per_page=100 || true )
+            if ! jq -e '.jobs' <<<"$JSON" &>/dev/null; then
+              BADCT=$(( BADCT + 1 ))
+              if [[ $BADCT -ge 3 ]]; then
+                echo "🤷 Repeated bad JSON. Giving up."
+                exit 0
+              fi
+              echo "⏱️ Bad JSON. Will retry."
+              sleep 30
+              continue
+            fi
+            BADCT=0
+            if jq -e --arg NAME "$AWAIT_JOB_NAME" '.jobs[] | select( .name == $NAME )' <<<"$JSON" &>/dev/null; then
+              echo "🎉 Found the \"$AWAIT_JOB_NAME\" job!"
+              exit 0
+            fi
+
+            # No job yet. Figure out how long to sleep.
+            DELAY=$( jq --argjson BUILDS "$BUILD_JOB_NAMES" '.jobs | map( select( .name as $N | $BUILDS | index( $N ) ) | .started_at | fromdateiso8601 ) | max // now | 10 * 60 - ( now - . ) | round' <<<"$JSON" || true )
+            [[ "$DELAY" =~ ^[0-9]+$ ]] || DELAY=30
+            [[ "$DELAY" -ge 30 ]] || DELAY=30
+            [[ "$DELAY" -le 120 ]] || DELAY=120
+            echo "⏱️ No \"$AWAIT_JOB_NAME\" job yet, waiting $DELAY seconds"
+            sleep "$DELAY"
+          done
+
   update_wpcom_mirrors:
     name: Push wpcom plugins to mirror repos
     runs-on: ubuntu-latest
-    needs: [ build_wpcom ]
+    needs: [ await_update_wpcom_mirrors ]
     if: github.event_name == 'push' && github.repository == 'Automattic/jetpack'
     concurrency:
       group: build-push_wpcom
@@ -448,10 +521,32 @@ jobs:
           username: matticbot
           working-directory: ${{ github.workspace }}/build
 
+  # Ditto for `update_all_mirrors`.
+  await_update_all_mirrors:
+    name: Wait for previous commit all-mirrors push
+    runs-on: ubuntu-latest
+    needs: [ merge_artifacts ]
+    # Have to check success manually, GitHub's default sees that merge_artifacts depends on a build job that skipped and skips otherwise. 🙄
+    if: >
+      ! cancelled() &&
+      github.event_name == 'push' && github.repository == 'Automattic/jetpack' &&
+      needs.merge_artifacts.result == 'success'
+    # No timeout, might take arbitrary amounts of time.
+    permissions:
+      # Polling
+      actions: read
+      # actions/checkout
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      AWAIT_JOB_NAME: 'Push to mirror repos'
+      BUILD_JOB_NAMES: '[ "Build wpcom projects", "Build non-wpcom projects" ]'
+    steps: *await_mirrors_steps
+
   update_all_mirrors:
     name: Push to mirror repos
     runs-on: ubuntu-latest
-    needs: [ prepare, merge_artifacts ]
+    needs: [ prepare, merge_artifacts, await_update_all_mirrors ]
     concurrency:
       group: build-push_all
       queue: max


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
GitHub provides no way to ensure that the mirror-push jobs run in merge order (I asked their support, they confirmed it). So what happens occasionally is that two PRs will get merged in quick succession, the second happens to build quicker and gets to the mirror-push before the first, resulting in a squashed push to the mirror and confused devs because the first is never pinged for deploy.

We can do some API polling to try to enforce the order: the run for a commit can look for the previous commit's run, and not allow the workflow to proceed to the mirror-push job until that previous commit's run queued its own job. Then GitHub's concurrency queue stuff keeps things good from there.

The new check intentionally fails open: if there's any sort of unexpected API response, it allows the workflow to go ahead and push.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1787320122797109-slack-C01U2KGS2PQ
p1787004654339019-slack-C01U2KGS2PQ
p1786961865406599/1786961617.136239-slack-C01U2KGS2PQ
p1786117926025119-slack-C01U2KGS2PQ
etc

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷 Best bet would be to merge into a fork, and then hack the `if` so things run that normally don't and the pushes to not actually push.