### PR TITLE
Newsletter: add the email design editor's data layer endpoint

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-editor-bootstrap.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-editor-bootstrap.php
@@ -146,7 +146,11 @@ class WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap extends WP_REST_Controll
 			 * personalization tags and the blog's saved design. Unfiltered on a site with nothing
 			 * implementing it, which the endpoint reports as unavailable rather than as an empty design.
 			 *
+			 * Internal, and not settled: the editor this serves is still being built, so the shape of
+			 * what comes back is expected to change. Do not depend on it from outside the plugin.
+			 *
 			 * @since $$next-version$$
+			 * @access private
 			 *
 			 * @param array|WP_Error|null $data    The editor's bootstrap data. Null until something provides one.
 			 * @param WP_REST_Request     $request The REST request.
@@ -177,7 +181,11 @@ class WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap extends WP_REST_Controll
 			 * theme.json schema, so a save can succeed into invisibility, and the screen has to be
 			 * able to tell a person their edit did not survive.
 			 *
+			 * Internal, and not settled, for the same reason as the read above: expect the shape of the
+			 * design document and of what is returned to change while the editor is being built.
+			 *
 			 * @since $$next-version$$
+			 * @access private
 			 *
 			 * @param array|WP_Error|null $result  The stored design. Null until something provides one.
 			 * @param WP_REST_Request     $request The REST request.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-editor-bootstrap.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-editor-bootstrap.php
@@ -108,8 +108,10 @@ class WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap extends WP_REST_Controll
 	 */
 	public function permissions_check() {
 		if ( ! ( new Host() )->is_wpcom_simple() && ! ( new Manager() )->is_user_connected() ) {
-			// The proxy sends the request as the user with no blog-token fallback, so an unconnected
-			// user cannot reach WordPress.com at all. Saying so here beats a round trip that cannot succeed.
+			// The proxy refuses an unconnected user too, and returns this same error when it does, so
+			// this changes nothing observable today. It is here because the proxy refuses only while it
+			// is called with no blog-token fallback: without this, a change to that default inside the
+			// connection package would quietly start serving unconnected users on the site's token.
 			return new WP_Error(
 				'rest_unauthorized',
 				__( 'Please connect your user account to WordPress.com', 'jetpack' ),
@@ -191,26 +193,28 @@ class WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap extends WP_REST_Controll
 	/**
 	 * Turns a filtered value into a response.
 	 *
-	 * An unfiltered `null` means nothing implements the filter on this site — the plugin is running
-	 * somewhere its WordPress.com half has not shipped. Reported as unavailable, because returning it
-	 * bare would be indistinguishable from a site whose email design is genuinely empty, and this
-	 * data layer exists to stop a design silently reading or saving as nothing.
+	 * Anything that is not an array or a `WP_Error` is treated as no answer at all, because this data
+	 * layer exists to stop a design silently reading or saving as nothing. An unfiltered `null` means
+	 * nothing implements the filter on this site — the plugin is running somewhere its WordPress.com
+	 * half has not shipped. `false` means an implementation failed and said so the way PHP usually
+	 * does. Returning either bare would be indistinguishable from a site whose email design is
+	 * genuinely empty, so both report as unavailable instead.
 	 *
 	 * @param array|WP_Error|null $value The filtered value.
 	 *
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	private function respond( $value ) {
-		if ( null === $value ) {
+		if ( is_wp_error( $value ) ) {
+			return $value;
+		}
+
+		if ( ! is_array( $value ) ) {
 			return new WP_Error(
 				'email_editor_unavailable',
 				__( 'The email editor is not available on this site.', 'jetpack' ),
 				array( 'status' => 501 )
 			);
-		}
-
-		if ( is_wp_error( $value ) ) {
-			return $value;
 		}
 
 		return rest_ensure_response( $value );
@@ -228,6 +232,18 @@ class WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap extends WP_REST_Controll
 	 * @return WP_Error
 	 */
 	private function unexpected_error( $e ) {
+		/**
+		 * Fires when a filter serving the email editor raises.
+		 *
+		 * This plugin does not record the exception itself — the message can carry internals, so where
+		 * it is safe to write it is the host's call rather than ours. Hook this to log it.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param Throwable $e The exception raised while filtering.
+		 */
+		do_action( 'jetpack_email_editor_error', $e );
+
 		$data = array( 'status' => 500 );
 
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-editor-bootstrap.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-email-editor-bootstrap.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Email editor bootstrap endpoint for the WordPress.com REST API.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
+use Automattic\Jetpack\Status\Host;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap
+ *
+ * Serves the newsletter email design screen its data, and saves the design back.
+ *
+ * The screen ships in this plugin, but the design it edits lives on the WordPress.com shadow blog,
+ * so the record is not in the site's own database on Atomic or self-hosted. Declaring the route here
+ * means the browser calls one local `/wpcom/v2/` URL on all three platforms, and this class decides
+ * whether that is answered in-process (Simple) or proxied (everywhere else).
+ *
+ * Nothing about the email engine lives in this plugin: both callbacks apply a filter and return what
+ * comes back. WordPress.com implements those filters, exactly as it implements
+ * `jetpack_generate_email_preview_html` for the email preview endpoint next door.
+ */
+class WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap extends WP_REST_Controller {
+
+	use WPCOM_REST_API_Proxy_Request;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->base_api_path                   = 'wpcom';
+		$this->version                         = 'v2';
+		$this->namespace                       = $this->base_api_path . '/' . $this->version;
+		$this->rest_base                       = '/email-editor-bootstrap';
+		$this->wpcom_is_wpcom_only_endpoint    = true;
+		$this->wpcom_is_site_specific_endpoint = true;
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Registers the routes for the email editor's data layer.
+	 *
+	 * @see register_rest_route()
+	 */
+	public function register_routes() {
+		// Off Simple the record lives on a database this site cannot reach, so every method proxies.
+		// The trait forwards the request's own method, query args and body, so one callback serves
+		// both the read and the write.
+		$is_simple = ( new Host() )->is_wpcom_simple();
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'show_in_index'       => true,
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => $is_simple
+						? array( $this, 'get_bootstrap_data' )
+						: array( $this, 'proxy_request_to_wpcom_as_user' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'template_slug' => array(
+							'description' => __( 'Slug of the email template to open in the editor.', 'jetpack' ),
+							'type'        => 'string',
+						),
+					),
+				),
+				array(
+					// The editor sends POST and the server has been observed receiving PUT, so this
+					// takes the constant covering both rather than betting on either.
+					'show_in_index'       => true,
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => $is_simple
+						? array( $this, 'save_design' )
+						: array( $this, 'proxy_request_to_wpcom_as_user' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'design' => array(
+							'description' => __( 'The email design document to store.', 'jetpack' ),
+							'type'        => 'object',
+							'required'    => true,
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Checks that the user may read and write the site's email design.
+	 *
+	 * `edit_theme_options` rather than `edit_posts`: this is the same shape of data core's
+	 * `WP_REST_Global_Styles_Controller` guards with that capability, and it is what the design
+	 * screen itself requires. It also matters more than a read-only route would — building the
+	 * bundle creates a global styles scaffold row on WordPress.com the first time it is called for a
+	 * blog, so a low bar here would let anyone make WordPress.com write rows on any blog they can name.
+	 *
+	 * @return true|WP_Error True if the request may proceed, WP_Error otherwise.
+	 */
+	public function permissions_check() {
+		if ( ! ( new Host() )->is_wpcom_simple() && ! ( new Manager() )->is_user_connected() ) {
+			// The proxy sends the request as the user with no blog-token fallback, so an unconnected
+			// user cannot reach WordPress.com at all. Saying so here beats a round trip that cannot succeed.
+			return new WP_Error(
+				'rest_unauthorized',
+				__( 'Please connect your user account to WordPress.com', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to edit this site&#8217;s email design.', 'jetpack' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the data the email editor needs to start.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_bootstrap_data( $request ) {
+		try {
+			/**
+			 * Filters the data the newsletter email editor needs to start.
+			 *
+			 * Returns the editor's settings, its theme, the resolved canvas template, the available
+			 * personalization tags and the blog's saved design. Unfiltered on a site with nothing
+			 * implementing it, which the endpoint reports as unavailable rather than as an empty design.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param array|WP_Error|null $data    The editor's bootstrap data. Null until something provides one.
+			 * @param WP_REST_Request     $request The REST request.
+			 */
+			$data = apply_filters( 'jetpack_email_editor_bootstrap', null, $request );
+		} catch ( Throwable $e ) {
+			return $this->unexpected_error( $e );
+		}
+
+		return $this->respond( $data );
+	}
+
+	/**
+	 * Saves the site's email design.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function save_design( $request ) {
+		try {
+			/**
+			 * Filters the result of saving the newsletter email design.
+			 *
+			 * The editor sends the whole styles document rather than a patch, so implementations
+			 * replace rather than merge. Implementations should report on a read-back of the stored
+			 * design rather than echoing the submitted one: sanitizing drops properties outside the
+			 * theme.json schema, so a save can succeed into invisibility, and the screen has to be
+			 * able to tell a person their edit did not survive.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param array|WP_Error|null $result  The stored design. Null until something provides one.
+			 * @param WP_REST_Request     $request The REST request.
+			 */
+			$result = apply_filters( 'jetpack_email_editor_save_design', null, $request );
+		} catch ( Throwable $e ) {
+			return $this->unexpected_error( $e );
+		}
+
+		return $this->respond( $result );
+	}
+
+	/**
+	 * Turns a filtered value into a response.
+	 *
+	 * An unfiltered `null` means nothing implements the filter on this site — the plugin is running
+	 * somewhere its WordPress.com half has not shipped. Reported as unavailable, because returning it
+	 * bare would be indistinguishable from a site whose email design is genuinely empty, and this
+	 * data layer exists to stop a design silently reading or saving as nothing.
+	 *
+	 * @param array|WP_Error|null $value The filtered value.
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	private function respond( $value ) {
+		if ( null === $value ) {
+			return new WP_Error(
+				'email_editor_unavailable',
+				__( 'The email editor is not available on this site.', 'jetpack' ),
+				array( 'status' => 501 )
+			);
+		}
+
+		if ( is_wp_error( $value ) ) {
+			return $value;
+		}
+
+		return rest_ensure_response( $value );
+	}
+
+	/**
+	 * Turns a throwing filter into an error response.
+	 *
+	 * On Simple the filter runs in this process, so an implementation that raises would otherwise
+	 * surface as a bare fatal with nothing for the screen to show. Off Simple the request is proxied
+	 * and WordPress.com catches its own.
+	 *
+	 * @param Throwable $e The exception raised while filtering.
+	 *
+	 * @return WP_Error
+	 */
+	private function unexpected_error( $e ) {
+		$data = array( 'status' => 500 );
+
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			// Without this the raise is invisible: the message is the only thing separating a bug in
+			// the implementation from an outage. Debug builds only, since it can carry internals.
+			$data['exception'] = $e->getMessage();
+		}
+
+		return new WP_Error(
+			'email_editor_failed',
+			__( 'The email editor could not be reached. Please try again.', 'jetpack' ),
+			$data
+		);
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap' );

--- a/projects/plugins/jetpack/changelog/add-email-editor-bootstrap-endpoint
+++ b/projects/plugins/jetpack/changelog/add-email-editor-bootstrap-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: other
+
+Newsletter: Add an endpoint serving the email design editor's data.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap_Test.php
@@ -110,6 +110,21 @@ class WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap_Test extends Jetpack_RES
 	}
 
 	/**
+	 * Re-register the routes as a site that is not WordPress.com Simple.
+	 *
+	 * The callbacks are chosen in `register_routes()` from the host, so switching platform means
+	 * firing `rest_api_init` again against a fresh server rather than only flipping the constant.
+	 */
+	private function register_routes_as_non_simple() {
+		Constants::set_constant( 'IS_WPCOM', false );
+
+		global $wp_rest_server;
+		$wp_rest_server = new JPTest_Spy_REST_Server();
+		$this->server   = $wp_rest_server;
+		do_action( 'rest_api_init' );
+	}
+
+	/**
 	 * A design document, in the shape the editor saves.
 	 *
 	 * @return array
@@ -406,5 +421,91 @@ class WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap_Test extends Jetpack_RES
 		$response = $this->server->dispatch( $this->request( Requests::GET ) );
 
 		$this->assertErrorResponse( 'email_editor_failed', $response, 500 );
+	}
+
+	/**
+	 * Test that an unconnected user cannot reach the endpoint, on the path every Atomic and
+	 * self-hosted site takes.
+	 *
+	 * This pins the guarantee, not the line that enforces it, and is worth being precise about: the
+	 * endpoint's permission callback and the connection package's proxy both refuse an unconnected
+	 * user with this same `rest_unauthorized`, so nothing asserted here can tell them apart and
+	 * removing either one alone leaves this green. What it does hold is the contract a caller depends
+	 * on — a site with no connection is refused, rather than served or left waiting on a request that
+	 * cannot be made.
+	 */
+	public function test_an_unconnected_user_cannot_reach_the_endpoint_off_simple() {
+		$this->register_routes_as_non_simple();
+
+		$this->assertErrorResponse(
+			'rest_unauthorized',
+			$this->server->dispatch( $this->request( Requests::GET ) ),
+			403
+		);
+		$this->assertErrorResponse(
+			'rest_unauthorized',
+			$this->server->dispatch( $this->request( Requests::POST, array( 'design' => $this->design() ) ) ),
+			403
+		);
+	}
+
+	/**
+	 * Test that a read implementation returning something other than a bundle is not served as one.
+	 *
+	 * `false` is how PHP conventionally reports failure, so an implementation that fails this way must
+	 * not reach the screen as a successful, empty design.
+	 */
+	public function test_read_rejects_a_non_array_filter_return() {
+		$this->add_temporary_filter( 'jetpack_email_editor_bootstrap', '__return_false' );
+
+		$response = $this->server->dispatch( $this->request( Requests::GET ) );
+
+		$this->assertErrorResponse( 'email_editor_unavailable', $response, 501 );
+	}
+
+	/**
+	 * Test that a write implementation returning something other than a stored design is not reported
+	 * as a successful save.
+	 */
+	public function test_write_rejects_a_non_array_filter_return() {
+		$this->add_temporary_filter(
+			'jetpack_email_editor_save_design',
+			static function () {
+				return 'saved';
+			}
+		);
+
+		$response = $this->server->dispatch( $this->request( Requests::POST, array( 'design' => $this->design() ) ) );
+
+		$this->assertErrorResponse( 'email_editor_unavailable', $response, 501 );
+	}
+
+	/**
+	 * Test that a raising filter is announced, so a host can log what this plugin deliberately does not.
+	 */
+	public function test_a_throwing_filter_fires_the_error_action() {
+		$seen = null;
+
+		$this->add_temporary_filter(
+			'jetpack_email_editor_bootstrap',
+			/**
+			 * @return never
+			 */
+			static function () {
+				throw new RuntimeException( 'the bootstrap raised' );
+			}
+		);
+
+		$this->add_temporary_filter(
+			'jetpack_email_editor_error',
+			static function ( $e ) use ( &$seen ) {
+				$seen = $e;
+			}
+		);
+
+		$this->server->dispatch( $this->request( Requests::GET ) );
+
+		$this->assertInstanceOf( RuntimeException::class, $seen );
+		$this->assertSame( 'the bootstrap raised', $seen->getMessage() );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap_Test.php
@@ -1,0 +1,410 @@
+<?php
+/**
+ * Tests for WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap.
+ * To run this test by itself use the following command:
+ * jetpack docker phpunit jetpack -- --filter=WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap_Test
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Constants;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WpOrg\Requests\Requests;
+
+require_once dirname( __DIR__, 2 ) . '/lib/Jetpack_REST_TestCase.php';
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap_Test
+ *
+ * Runs as WordPress.com Simple, so the local callbacks are registered rather than the proxy. That is
+ * where the endpoint's own behaviour lives; off Simple it hands the whole request to the connection
+ * package's proxy trait, which has its own tests.
+ *
+ * @covers \WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap
+ */
+#[CoversClass( WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap::class )]
+class WPCOM_REST_API_V2_Endpoint_Email_Editor_Bootstrap_Test extends Jetpack_REST_TestCase {
+
+	/**
+	 * Route to the endpoint.
+	 *
+	 * @var string
+	 */
+	private static $path = '/wpcom/v2/email-editor-bootstrap';
+
+	/**
+	 * A user who may edit theme options.
+	 *
+	 * @var int
+	 */
+	private static $user_id_admin = 0;
+
+	/**
+	 * A user who may edit posts but not theme options.
+	 *
+	 * @var int
+	 */
+	private static $user_id_editor = 0;
+
+	/**
+	 * Filters added by a test, removed again on tear down.
+	 *
+	 * @var array
+	 */
+	private $added_filters = array();
+
+	/**
+	 * Set up. IS_WPCOM must be set before parent::set_up() so `rest_api_init` registers the local
+	 * callbacks rather than the proxy.
+	 */
+	public function set_up() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		parent::set_up();
+
+		static::$user_id_admin  = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		static::$user_id_editor = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_current_user( static::$user_id_admin );
+	}
+
+	/**
+	 * Reset the environment to its original state after the test.
+	 */
+	public function tear_down() {
+		foreach ( $this->added_filters as $filter ) {
+			remove_filter( $filter[0], $filter[1] );
+		}
+		$this->added_filters = array();
+
+		Constants::clear_constants();
+		parent::tear_down();
+	}
+
+	/**
+	 * Hook a filter for the duration of one test.
+	 *
+	 * @param string   $hook     Filter name.
+	 * @param callable $callback Callback.
+	 */
+	private function add_temporary_filter( $hook, $callback ) {
+		add_filter( $hook, $callback, 10, 2 );
+		$this->added_filters[] = array( $hook, $callback );
+	}
+
+	/**
+	 * A request to the endpoint.
+	 *
+	 * @param string $method HTTP method.
+	 * @param array  $params Request params.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function request( $method, array $params = array() ) {
+		$request = new WP_REST_Request( $method, static::$path );
+
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		return $request;
+	}
+
+	/**
+	 * A design document, in the shape the editor saves.
+	 *
+	 * @return array
+	 */
+	private function design() {
+		return array( 'styles' => array( 'typography' => array( 'fontSize' => '42px' ) ) );
+	}
+
+	/**
+	 * Test that the endpoint route is registered.
+	 */
+	public function test_route_is_registered() {
+		$this->assertArrayHasKey( static::$path, $this->server->get_routes() );
+	}
+
+	/**
+	 * Test that the route accepts a read and a write.
+	 */
+	public function test_route_accepts_read_and_write_methods() {
+		$routes  = $this->server->get_routes();
+		$methods = array();
+
+		foreach ( $routes[ static::$path ] as $handler ) {
+			$methods = array_merge( $methods, array_keys( $handler['methods'] ) );
+		}
+
+		// The editor sends POST and the server has been observed receiving PUT. Both must be accepted.
+		$this->assertContains( Requests::GET, $methods );
+		$this->assertContains( Requests::POST, $methods );
+		$this->assertContains( Requests::PUT, $methods );
+	}
+
+	/**
+	 * Test that an unauthenticated user cannot read the bundle.
+	 */
+	public function test_read_rejects_unauthenticated_user() {
+		wp_set_current_user( 0 );
+
+		$response = $this->server->dispatch( $this->request( Requests::GET ) );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
+	}
+
+	/**
+	 * Test that a user who may edit posts but not theme options cannot read the bundle.
+	 *
+	 * The capability bar is the point: an editor can write posts, and must still not be able to
+	 * change the site's email design.
+	 */
+	public function test_read_rejects_user_without_edit_theme_options() {
+		wp_set_current_user( static::$user_id_editor );
+
+		$response = $this->server->dispatch( $this->request( Requests::GET ) );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
+	}
+
+	/**
+	 * Test that the same capability guards the write.
+	 */
+	public function test_write_rejects_user_without_edit_theme_options() {
+		wp_set_current_user( static::$user_id_editor );
+
+		$response = $this->server->dispatch( $this->request( Requests::POST, array( 'design' => $this->design() ) ) );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
+	}
+
+	/**
+	 * Test that the read returns whatever the filter provides.
+	 */
+	public function test_read_returns_the_filtered_bundle() {
+		$bundle = array(
+			'editor_settings'      => array( 'color' => array() ),
+			'editor_theme'         => array( 'version' => 3 ),
+			'template'             => array( 'id' => 'pub/theme//wpcom-new-post' ),
+			'personalization_tags' => array(),
+			'blog_id'              => 1234,
+			'design'               => $this->design(),
+		);
+
+		$this->add_temporary_filter(
+			'jetpack_email_editor_bootstrap',
+			static function () use ( $bundle ) {
+				return $bundle;
+			}
+		);
+
+		$response = $this->server->dispatch( $this->request( Requests::GET ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $bundle, $response->get_data() );
+	}
+
+	/**
+	 * Test that the read hands the request to the filter, so an implementation can resolve a
+	 * caller-supplied template.
+	 */
+	public function test_read_passes_the_request_to_the_filter() {
+		$seen = null;
+
+		$this->add_temporary_filter(
+			'jetpack_email_editor_bootstrap',
+			static function ( $data, $request ) use ( &$seen ) {
+				$seen = $request;
+				return array( 'ok' => true );
+			}
+		);
+
+		$this->server->dispatch( $this->request( Requests::GET, array( 'template_slug' => 'wpcom-new-post' ) ) );
+
+		$this->assertInstanceOf( WP_REST_Request::class, $seen );
+		$this->assertSame( 'wpcom-new-post', $seen->get_param( 'template_slug' ) );
+	}
+
+	/**
+	 * Test that a filter which has already produced a value is passed it, rather than the endpoint
+	 * overriding whatever ran before.
+	 */
+	public function test_read_filter_receives_a_null_default() {
+		$seen = 'untouched';
+
+		$this->add_temporary_filter(
+			'jetpack_email_editor_bootstrap',
+			static function ( $data ) use ( &$seen ) {
+				$seen = $data;
+				return array( 'ok' => true );
+			}
+		);
+
+		$this->server->dispatch( $this->request( Requests::GET ) );
+
+		// WordPress.com's implementations short-circuit on a non-null value, so the default the
+		// endpoint passes has to be null or they never run.
+		$this->assertNull( $seen );
+	}
+
+	/**
+	 * Test that the write returns whatever the filter provides.
+	 */
+	public function test_write_returns_the_filtered_result() {
+		$stored = array(
+			'blog_id' => 1234,
+			'design'  => $this->design(),
+		);
+
+		$this->add_temporary_filter(
+			'jetpack_email_editor_save_design',
+			static function () use ( $stored ) {
+				return $stored;
+			}
+		);
+
+		$response = $this->server->dispatch( $this->request( Requests::POST, array( 'design' => $this->design() ) ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $stored, $response->get_data() );
+	}
+
+	/**
+	 * Test that the design reaches the filter.
+	 */
+	public function test_write_passes_the_design_to_the_filter() {
+		$seen = null;
+
+		$this->add_temporary_filter(
+			'jetpack_email_editor_save_design',
+			static function ( $result, $request ) use ( &$seen ) {
+				$seen = $request->get_param( 'design' );
+				return array( 'design' => $seen );
+			}
+		);
+
+		$this->server->dispatch( $this->request( Requests::POST, array( 'design' => $this->design() ) ) );
+
+		$this->assertSame( $this->design(), $seen );
+	}
+
+	/**
+	 * Test that a PUT saves, not only a POST.
+	 */
+	public function test_write_accepts_put() {
+		$this->add_temporary_filter(
+			'jetpack_email_editor_save_design',
+			static function ( $result, $request ) {
+				return array( 'design' => $request->get_param( 'design' ) );
+			}
+		);
+
+		$response = $this->server->dispatch( $this->request( Requests::PUT, array( 'design' => $this->design() ) ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $this->design(), $response->get_data()['design'] );
+	}
+
+	/**
+	 * Test that a write with no design is refused before anything is called.
+	 */
+	public function test_write_requires_a_design() {
+		$called = false;
+
+		$this->add_temporary_filter(
+			'jetpack_email_editor_save_design',
+			static function () use ( &$called ) {
+				$called = true;
+				return array();
+			}
+		);
+
+		$response = $this->server->dispatch( $this->request( Requests::POST ) );
+
+		$this->assertErrorResponse( 'rest_missing_callback_param', $response, 400 );
+		$this->assertFalse( $called, 'The filter should not run for a request with no design.' );
+	}
+
+	/**
+	 * Test that an unimplemented read reports as unavailable rather than as an empty design.
+	 *
+	 * This is the failure mode the data layer exists to avoid: a site whose WordPress.com half has
+	 * not shipped must not look like a site whose email design is genuinely empty.
+	 */
+	public function test_read_without_an_implementation_is_not_an_empty_bundle() {
+		$response = $this->server->dispatch( $this->request( Requests::GET ) );
+
+		$this->assertErrorResponse( 'email_editor_unavailable', $response, 501 );
+	}
+
+	/**
+	 * Test that an unimplemented write reports as unavailable rather than as a successful save.
+	 */
+	public function test_write_without_an_implementation_is_not_a_silent_success() {
+		$response = $this->server->dispatch( $this->request( Requests::POST, array( 'design' => $this->design() ) ) );
+
+		$this->assertErrorResponse( 'email_editor_unavailable', $response, 501 );
+	}
+
+	/**
+	 * Test that an error from the filter reaches the client unchanged, so the screen can show what
+	 * went wrong rather than a generic failure.
+	 */
+	public function test_an_error_from_the_filter_is_returned_as_is() {
+		$this->add_temporary_filter(
+			'jetpack_email_editor_save_design',
+			static function () {
+				return new WP_Error(
+					'email_editor_design_not_saved',
+					'The email design could not be saved.',
+					array( 'status' => 500 )
+				);
+			}
+		);
+
+		$response = $this->server->dispatch( $this->request( Requests::POST, array( 'design' => $this->design() ) ) );
+
+		$this->assertErrorResponse( 'email_editor_design_not_saved', $response, 500 );
+	}
+
+	/**
+	 * Test that a filter which raises becomes an error response rather than a fatal.
+	 *
+	 * On Simple the filter runs in this process, so an implementation that throws would otherwise
+	 * take the request down with nothing for the screen to display.
+	 */
+	public function test_a_throwing_filter_becomes_an_error_response() {
+		$this->add_temporary_filter(
+			'jetpack_email_editor_save_design',
+			/**
+			 * @return never
+			 */
+			static function () {
+				throw new RuntimeException( 'the store raised' );
+			}
+		);
+
+		$response = $this->server->dispatch( $this->request( Requests::POST, array( 'design' => $this->design() ) ) );
+
+		$this->assertErrorResponse( 'email_editor_failed', $response, 500 );
+	}
+
+	/**
+	 * Test that a raising read is caught too.
+	 */
+	public function test_a_throwing_read_filter_becomes_an_error_response() {
+		$this->add_temporary_filter(
+			'jetpack_email_editor_bootstrap',
+			/**
+			 * @return never
+			 */
+			static function () {
+				throw new RuntimeException( 'the bootstrap raised' );
+			}
+		);
+
+		$response = $this->server->dispatch( $this->request( Requests::GET ) );
+
+		$this->assertErrorResponse( 'email_editor_failed', $response, 500 );
+	}
+}


### PR DESCRIPTION
## Proposed changes

Adds the `wpcom/v2` route that serves the newsletter email design screen its data and saves the design back.

The screen ships in the Jetpack plugin, but the design it edits lives on the WordPress.com shadow blog, so on Atomic and self-hosted the record is not in the site's own database. Declaring the route here means the browser calls one local `/wpcom/v2/email-editor-bootstrap` URL on Simple, Atomic and self-hosted alike, and the endpoint decides whether that is answered in-process or proxied. This is the same division of labour as `WPCOM_REST_API_V2_Endpoint_Email_Preview` next door, and follows its shape closely.

Nothing about the email engine lives in this plugin. Both callbacks apply a filter and return what comes back — `jetpack_email_editor_bootstrap` for the read, `jetpack_email_editor_save_design` for the write — which the WordPress.com side implements, exactly as it implements `jetpack_generate_email_preview_html` today.

Decisions worth a reviewer's attention:

* **`edit_theme_options`, not `edit_posts`.** It is what core's `WP_REST_Global_Styles_Controller` requires for the same shape of data, and what the design screen itself requires. It also matters more than a read-only route would: building the bundle creates a global styles scaffold row on the first call for a blog, so a low bar here would let anyone cause a row to be written on any blog they can name.
* **`WP_REST_Server::EDITABLE` rather than a hand-written method list.** The editor sends `POST` and the server has been observed receiving `PUT`; the constant covers both rather than betting on either.
* **An unfiltered `null` is reported as a 501, not returned bare.** On a site where nothing implements the filters, returning the empty value would be indistinguishable from a site whose email design is genuinely empty. A design silently reading or saving as nothing is the failure this data layer exists to prevent.
* **A raising filter is caught and returned as an error.** On Simple the filter runs in this process, so an implementation that throws would otherwise be a bare fatal with nothing for the screen to display.

## Related product discussion/links

* NL-848

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

There is no UI yet, but this was tested with Dotcom in 236433-ghe-Automattic/wpcom