### PR TITLE
Forms: zero the classic-theme editor margin on field labels and the file dropzone

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-spacing-editor
+++ b/projects/packages/forms/changelog/fix-forms-spacing-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: remove the classic-theme editor margin between a field's label and its input.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -361,6 +361,7 @@
 	flex-wrap: wrap;
 	justify-content: flex-start;
 	align-items: baseline;
+	margin-bottom: 0; /* Override default margin on classic theme wp-block */
 
 	.components-base-control {
 		margin-top: -1px;

--- a/projects/packages/forms/src/blocks/field-file/editor.scss
+++ b/projects/packages/forms/src/blocks/field-file/editor.scss
@@ -1,6 +1,8 @@
 /* Editor-specific styles for file upload field */
 .jetpack-form-file-field__dropzone {
 	position: relative;
+	margin-top: 0; /* Override default margin on classic theme wp-block */
+	margin-bottom: 0; /* Override default margin on classic theme wp-block */
 }
 
 .jetpack-form-file-field__dropzone-inner {

--- a/projects/plugins/jetpack/changelog/fix-forms-spacing-editor
+++ b/projects/plugins/jetpack/changelog/fix-forms-spacing-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Contact Form: remove the classic-theme editor margin between a field's label and its input.


### PR DESCRIPTION
Fixes #

## Proposed changes

* Zero the vertical margin on `.jetpack-field-label`, so a field's label sits against its own input in the editor.
* Zero the vertical margins on `.jetpack-form-file-field__dropzone`, the file upload field's drop area.

### Why

A theme with no `theme.json` makes WordPress load `wp-includes/css/dist/edit-post/classic.min.css` into the block editor. That stylesheet gives every `.wp-block` a 28px vertical margin — editor-only, and at a specificity of one class.

A field's inner blocks (`jetpack/label`, `jetpack/dropzone`) are real blocks in the editor, but the front end renders the field from PHP as plain `<label>`/`<input>` markup with no block margin. So on a classic theme the two surfaces disagree: in the editor the label is pushed a full line off the input it belongs to, while the front end looks correct.

Trunk only clears these margins for `jetpack/field-checkbox-multiple` and `jetpack/field-radio`, so every other field type — including the file field — still shows the gap.

### Note on overlap with #51302

This is a narrow, targeted fix for the two selectors above. #51302 addresses the same underlying classic-theme margin problem more broadly (a `.jetpack-field .wp-block { margin: 0; }` rule plus e2e coverage), and the two will conflict in `contact-form/editor.scss`. Whichever lands second should be rebased and the redundant rules dropped.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

These changes are editor-only and only visible on a theme without a `theme.json`.

1. Activate a classic theme — **Twenty Sixteen** is a good choice (Twenty Twenty-Four and other block themes will *not* reproduce this, as they ship a `theme.json` and core skips `classic.min.css`).
2. Create a new page or post and add a **Form** block. Pick any pattern.
3. **Before this change:** each field's label is separated from its input by a large gap (~28px), so the label reads as floating above an unrelated field. Compare against the front end — click **Preview**, where the label sits directly on its input.
4. **After this change:** the label sits directly against its input in the editor, matching the front end.
5. Repeat for the file field: add a **File Upload** field to the form. Before the change, the drop area has the same 28px gap above and below it; after, it sits flush.
6. Sanity-check that nothing else moved: add a Radio field and a Multiple Choice (checkbox) field — these were already handled on trunk and should look the same before and after.
7. Switch to a block theme (e.g. Twenty Twenty-Four) and confirm the form still looks correct — `classic.min.css` is never loaded there, so these rules should be inert.
