### PR TITLE
Jetpack AI: Pin the module First Introduced to an alpha version so it activates on prerelease builds

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-module-first-introduced-alpha
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-module-first-introduced-alpha
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI: Auto-activate the AI module on sites running a 16.2 prerelease build.

--- a/projects/plugins/jetpack/modules/ai.php
+++ b/projects/plugins/jetpack/modules/ai.php
@@ -4,7 +4,7 @@
  * Module Description: Turn your ideas into ready-to-publish content and generate images with the power of AI.
  * Sort Order: 40
  * Recommendation Order: 15
- * First Introduced: 16.2
+ * First Introduced: 16.2-a.3
  * Requires Connection: Yes
  * Requires User Connection: Yes
  * Auto Activate: Yes


### PR DESCRIPTION
Fixes #

## Proposed changes
* Change the AI module's `First Introduced` header from `16.2` to `16.2-a.3`, so the module auto-activates for sites running a 16.2 prerelease build.

Jetpack's module auto-activation only keeps a module when `old_version < First Introduced <= new_version` (`projects/packages/status/src/class-modules.php`, plain PHP `version_compare`). PHP sorts every prerelease suffix *below* the release: `16.2-a.1 < 16.2-beta < 16.2-rc < 16.2`.

That makes `First Introduced: 16.2` inert for the entire prerelease cycle — it only fires on the rc → final hop. Alpha testers, Jurassic Ninja bleeding-edge sites, and Atomic sites tracking trunk's `-a.N` builds get the AI module added by #50718 but never have it auto-activated, so the site-wide master switch is off for exactly the audience that should be exercising it.

Pinning to a concrete `-a.N` fixes both audiences at once: prerelease sites cross `16.2-a.3` on their next build, and regular `16.1 → 16.2` upgraders still satisfy `16.1 < 16.2-a.3 <= 16.2`. `modules/blocks.php` uses the same workaround (`First Introduced: 13.9-a.8`).

**Why `a.3` and not `a.1`:** the range check's lower bound is strict (`old_version <`), so a site that has *already* run the pinned version is stranded permanently. Trunk currently ships `16.2-a.1` and the module itself shipped in `16.2-a.1`, so pinning at or below `a.1` would exclude every existing alpha site forever. `a.3` is the first value comfortably ahead of trunk. **If this PR sits while trunk bumps past `16.2-a.3`, the header needs re-pinning before merge.**

## Related product discussion/links
* Follow-up to #50718, which added the module.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

This is a header-only change to module metadata; there is no runtime code to exercise directly. Verify the version math and the upgrade path.

**Verify the version comparison (no site needed):**

```bash
php -r 'var_dump(
  version_compare( "16.2-a.1", "16.2", "<" ),      // true  - alpha is BELOW the release
  version_compare( "16.2", "16.2-a.1", "<=" ),     // false - old behaviour: never activates on alpha
  version_compare( "16.2-a.1", "16.2-a.3", "<" ),  // true  - new behaviour: alpha site is below the pin
  version_compare( "16.2-a.3", "16.2-a.3", "<=" ), // true  - and reaches it on the next build
  version_compare( "16.1", "16.2-a.3", "<" ),      // true  - stable upgraders still qualify
  version_compare( "16.2-a.3", "16.2", "<=" )      // true
);'
```

All six should be `true` except the second, which demonstrates the bug this fixes.

**Verify auto-activation on a site:**

1. Set up a Jetpack-connected site (Jurassic Ninja works) running this branch.
2. Confirm the AI module is *not* currently active: `wp jetpack module list | grep ai`.
3. Simulate a site coming from an older build, then run the upgrade routine:
   ```bash
   wp option update jetpack_active_modules '[]' --format=json
   wp eval 'Jetpack_Options::update_option( "version", "16.2-a.1:" . time() );'
   wp eval 'Jetpack_Options::delete_option( "available_modules" );'
   wp eval 'Jetpack::activate_new_modules( true );'
   ```
4. `wp jetpack module list | grep ai` — the AI module should now be **active**.
5. Repeat step 3 with `Jetpack_Options::update_option( "version", "16.1:" . time() )` to confirm the stable `16.1 → 16.2` upgrade path also activates it.
6. Check out `trunk` (with `First Introduced: 16.2`) and repeat step 3 with the `16.2-a.1` starting version — the module should stay **inactive**, reproducing the bug.

Note: `activate_new_modules()` writes the new `version` option *before* activating, so each run consumes the upgrade window. Re-run the `update_option( "version", ... )` line between attempts.

**Also confirm no regression for explicit opt-outs:** a site that has deliberately deactivated the AI module should stay deactivated across the upgrade (the module is only auto-activated for sites that have never seen it).
