### PR TITLE
Forms: zero the classic-theme editor margin on every block inside a form

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-classic-theme-nested-block-margin
+++ b/projects/packages/forms/changelog/fix-forms-classic-theme-nested-block-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: remove the classic-theme editor margin from blocks nested inside a form.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -101,6 +101,7 @@
 
 		.wp-block {
 			max-width: 100%;
+			margin: 0;
 
 			&.wp-block-button,
 			&.wp-block-jetpack-button {

--- a/projects/plugins/jetpack/changelog/fix-forms-classic-theme-nested-block-margin
+++ b/projects/plugins/jetpack/changelog/fix-forms-classic-theme-nested-block-margin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Contact Form: remove the classic-theme editor margin from blocks nested inside a form.


### PR DESCRIPTION
Fixes #

## Proposed changes

* Follow-up to #51527. A theme with no `theme.json` makes WordPress load `wp-includes/css/dist/edit-post/classic.min.css` into the block editor, which gives every `.wp-block` a 28px vertical margin. That margin is editor-only: a field's inner blocks are real blocks in the editor but plain markup on the front end, so it pushes elements apart in the editor that sit together when the form is rendered.
* #51527 zeroed that margin one spot at a time — on the field label and on the file field's dropzone. The same margin lands on every other block a form nests, so this zeroes it once on the shared `.wp-block` rule inside `.jetpack-contact-form` / `[class*="wp-block-jetpack-field-option"]` instead of chasing each block individually.
* One line of SCSS, editor styles only. No front-end CSS, markup, or block output changes.

## Related product discussion/links

* Follow-up to #51527 and #51266.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Reviewer note: the existing `> .wp-block` rule just above this change is deliberately scoped to *direct* children, with a comment explaining that zeroing margins on descendants can collapse the block gap of a Group or Columns block that lays out its own children. This change zeroes margins on descendants, so please pay particular attention to step 4 below — that is the case most likely to regress.

**Setup**

1. Activate a theme with **no `theme.json`** — e.g. Twenty Twenty (not Twenty Twenty-Four). This is required; the 28px margin comes from the classic-theme editor stylesheet and does not exist on block themes.
2. Create a new page and insert a **Form** block.

**Field spacing (the fix)**

3. Add a variety of fields to the form — a single-line text field, a checkbox, a radio/multiple-choice field, a dropdown, a file upload field, and the submit button.
   * **Before:** nested blocks inside the form carry an extra ~28px of vertical space in the editor that isn't there on the front end.
   * **After:** the editor spacing matches what the front end renders.
4. Save and view the page on the front end, and confirm nothing moved — this change is editor-only, so the published form should look exactly the same before and after.

**Nested layout blocks (the regression risk)**

5. Inside the form, add a **Group** block and a **Columns** block, and put a couple of fields inside each.
   * Confirm the blocks inside the Group/Columns are still spaced by the theme's block gap in the editor, and that the editor spacing still matches the front end.
   * If this collapses, the fix needs to be scoped more narrowly than the shared `.wp-block` rule.

**Block themes (no change expected)**

6. Switch to a block theme (e.g. Twenty Twenty-Four) and confirm the form and its fields are unchanged in both the editor and on the front end.
