### PR TITLE
Charts: keep derived short date ticks when tickFormat is passed as undefined

### DIFF
--- a/projects/js-packages/charts/changelog/fix-undefined-tickformat-clobber
+++ b/projects/js-packages/charts/changelog/fix-undefined-tickformat-clobber
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-LineChart, AreaChart: Keep the derived abbreviated date tick labels when a consumer passes an undefined tickFormat.
+LineChart, AreaChart, BarChart: Keep the derived date tick labels when a consumer passes an undefined tickFormat.

--- a/projects/js-packages/charts/changelog/fix-undefined-tickformat-clobber
+++ b/projects/js-packages/charts/changelog/fix-undefined-tickformat-clobber
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: keep the abbreviated date tick labels on line and area chart x-axes when a consumer passes an undefined tickFormat.

--- a/projects/js-packages/charts/changelog/fix-undefined-tickformat-clobber
+++ b/projects/js-packages/charts/changelog/fix-undefined-tickformat-clobber
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Charts: keep the abbreviated date tick labels on line and area chart x-axes when a consumer passes an undefined tickFormat.
+LineChart, AreaChart: Keep the derived abbreviated date tick labels when a consumer passes an undefined tickFormat.

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
@@ -205,8 +205,8 @@ const AreaChartInternal = forwardRef< ChartInstanceRef, AreaChartProps >(
 		}, [ dataSorted, stacked, stackOffset, rescaleYOnVisibility ] );
 
 		const chartOptions = useMemo( () => {
-			const { tickResolution, ...xAxisOptions } = options?.axis?.x ?? {};
-			const formatter = xAxisOptions.tickFormat || getFormatter( dataSorted, tickResolution );
+			const { tickResolution, tickFormat, ...xAxisOptions } = options?.axis?.x ?? {};
+			const formatter = tickFormat || getFormatter( dataSorted, tickResolution );
 
 			return {
 				axis: {

--- a/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
@@ -128,21 +128,20 @@ describe( 'AreaChart', () => {
 
 		test( 'keeps the derived month formatter when tickFormat is passed as undefined', () => {
 			renderWithProvider( {
-				width: 800,
 				options: { axis: { x: { tickFormat: undefined } } },
 				data: monthlySeries,
 			} );
 
+			// January is absent: formatMonthOrYearTick renders it as the year instead.
 			const ticks = screen.getAllByText( /^(Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$/ );
 			expect( ticks.length ).toBeGreaterThan( 1 );
 			expect(
-				screen.queryByText( /^(February|March|April|May|June|July|August|September|October)$/ )
+				screen.queryByText( /^(February|March|April|June|July|August|September|October)$/ )
 			).not.toBeInTheDocument();
 		} );
 
 		test( 'honors an explicit tickFormat over the derived formatter', () => {
 			renderWithProvider( {
-				width: 800,
 				options: {
 					axis: {
 						x: {

--- a/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/test/area-chart.test.tsx
@@ -112,6 +112,52 @@ describe( 'AreaChart', () => {
 		} );
 	} );
 
+	describe( 'X-Axis Ticks', () => {
+		const monthlySeries = [
+			{
+				label: 'Series A',
+				data: [
+					{ date: new Date( '2024-01-01' ), value: 10 },
+					{ date: new Date( '2024-04-01' ), value: 20 },
+					{ date: new Date( '2024-07-01' ), value: 30 },
+					{ date: new Date( '2024-10-01' ), value: 40 },
+					{ date: new Date( '2025-03-01' ), value: 50 },
+				],
+			},
+		];
+
+		test( 'keeps the derived month formatter when tickFormat is passed as undefined', () => {
+			renderWithProvider( {
+				width: 800,
+				options: { axis: { x: { tickFormat: undefined } } },
+				data: monthlySeries,
+			} );
+
+			const ticks = screen.getAllByText( /^(Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$/ );
+			expect( ticks.length ).toBeGreaterThan( 1 );
+			expect(
+				screen.queryByText( /^(February|March|April|May|June|July|August|September|October)$/ )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'honors an explicit tickFormat over the derived formatter', () => {
+			renderWithProvider( {
+				width: 800,
+				options: {
+					axis: {
+						x: {
+							tickFormat: ( date: Date | number ) =>
+								`tick-${ new Date( Number( date ) ).getUTCMonth() }`,
+						},
+					},
+				},
+				data: monthlySeries,
+			} );
+
+			expect( screen.getAllByText( /^tick-\d+$/ ).length ).toBeGreaterThan( 0 );
+		} );
+	} );
+
 	describe( 'Stacking', () => {
 		test( 'is stacked by default', () => {
 			renderWithProvider();

--- a/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
+++ b/projects/js-packages/charts/src/charts/bar-chart/private/use-bar-chart-options.ts
@@ -154,23 +154,29 @@ export function useBarChartOptions(
 	const stableOptions = useDeepMemo( options );
 
 	// `labelOverflow` and `tickResolution` are consumed by this hook rather than
-	// forwarded — visx has an axis prop for neither — so they are split off the
-	// caller's axis options once, here, and only the rest reaches visx below.
+	// forwarded — visx has an axis prop for neither — and `tickFormat` is merged
+	// with the derived default explicitly, so an `undefined` passed by a caller
+	// cannot clobber it through the spread. They are split off the caller's axis
+	// options once, here, and only the rest reaches visx below.
 	const axisConfig = useMemo( () => {
 		const {
 			labelOverflow: xLabelOverflow,
 			tickResolution: xTickResolution,
+			tickFormat: xTickFormat,
 			...xAxisOptions
 		} = stableOptions.axis?.x || {};
 		const {
 			labelOverflow: yLabelOverflow,
 			tickResolution: yTickResolution,
+			tickFormat: yTickFormat,
 			...yAxisOptions
 		} = stableOptions.axis?.y || {};
 
 		return {
 			xLabelOverflow,
 			yLabelOverflow,
+			xTickFormat,
+			yTickFormat,
 			xAxisOptions,
 			yAxisOptions,
 			// The dates sit on the x axis normally, and on the y axis when the
@@ -243,8 +249,8 @@ export function useBarChartOptions(
 	return useMemo( () => {
 		const orientationKey = horizontal ? 'horizontal' : 'vertical';
 		const {
-			xTickFormat,
-			yTickFormat,
+			xTickFormat: defaultXTickFormat,
+			yTickFormat: defaultYTickFormat,
 			tooltipLabelFormatter: defaultTooltipLabelFormatter,
 			xAccessor,
 			yAccessor,
@@ -294,10 +300,11 @@ export function useBarChartOptions(
 			...( stableOptions.yScale || {} ),
 			...( ! horizontal ? valueScaleDomainOverride : {} ),
 		};
-		const { xLabelOverflow, yLabelOverflow, xAxisOptions, yAxisOptions } = axisConfig;
-		const providedToolTipLabelFormatter = horizontal
-			? yAxisOptions.tickFormat
-			: xAxisOptions.tickFormat;
+		const { xLabelOverflow, yLabelOverflow, xTickFormat, yTickFormat, xAxisOptions, yAxisOptions } =
+			axisConfig;
+		// The dates sit on the y axis of a horizontal chart, so the caller's format
+		// for them moves with the orientation. It also labels the tooltip.
+		const dateAxisTickFormat = horizontal ? yTickFormat : xTickFormat;
 
 		// A band scale has no ticks of its own for visx to ask for, so it samples
 		// the domain by index and can miss the tick that dates the day or names the
@@ -306,7 +313,7 @@ export function useBarChartOptions(
 		const { timeAxis } = defaultOptions;
 		const dateAxisOptions = horizontal ? yAxisOptions : xAxisOptions;
 		const bandTickValues =
-			timeAxis && ! dateAxisOptions.tickFormat
+			timeAxis && ! dateAxisTickFormat
 				? getBandTickValues(
 						timeAxis.domain,
 						timeAxis.tickFormatter,
@@ -327,7 +334,7 @@ export function useBarChartOptions(
 				x: {
 					orientation: 'bottom' as const,
 					numTicks: DEFAULT_NUM_TICKS,
-					tickFormat: xTickFormat,
+					tickFormat: xTickFormat || defaultXTickFormat,
 					...( horizontal ? {} : dateAxisTickValues ),
 					...( xLabelOverflow === 'ellipsis' ? { tickComponent: TruncatedXTickComponent } : {} ),
 					...xAxisOptions,
@@ -335,7 +342,7 @@ export function useBarChartOptions(
 				y: {
 					orientation: 'left' as const,
 					numTicks: DEFAULT_NUM_TICKS,
-					tickFormat: yTickFormat,
+					tickFormat: yTickFormat || defaultYTickFormat,
 					...( horizontal ? dateAxisTickValues : {} ),
 					...( yLabelOverflow === 'ellipsis' ? { tickComponent: TruncatedYTickComponent } : {} ),
 					...yAxisOptions,
@@ -345,7 +352,7 @@ export function useBarChartOptions(
 				padding: getGroupPadding( horizontal ? yScale : xScale ),
 			},
 			tooltip: {
-				labelFormatter: providedToolTipLabelFormatter || defaultTooltipLabelFormatter,
+				labelFormatter: dateAxisTickFormat || defaultTooltipLabelFormatter,
 			},
 		};
 	}, [ defaultOptions, axisConfig, stableOptions, horizontal, data ] );

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -505,6 +505,28 @@ describe( 'BarChart', () => {
 			expect( distinctTexts( ticks ).size ).toBeGreaterThan( 1 );
 		} );
 
+		test( 'keeps the derived date formatter when tickFormat is passed as undefined', () => {
+			renderWithTheme( {
+				width: 800,
+				options: { axis: { x: { tickFormat: undefined } } },
+				data: [
+					{
+						label: 'Series A',
+						data: Array.from( { length: 14 }, ( _, i ) => ( {
+							date: new Date( 2024, 0, 1 + i ),
+							value: 10 + i,
+						} ) ),
+						options: {},
+					},
+				],
+			} );
+
+			const ticks = screen.getAllByText( /^Jan \d+$/ );
+			expect( distinctTexts( ticks ).size ).toBeGreaterThan( 1 );
+			// A clobbered formatter falls back to raw `Date.toString()` ticks.
+			expect( screen.queryByText( /GMT/ ) ).not.toBeInTheDocument();
+		} );
+
 		test( 'renders distinct hour ticks for sub-daily buckets in a single day', () => {
 			renderWithTheme( {
 				width: 800,

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -291,8 +291,8 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 		} );
 
 		const chartOptions = useMemo( () => {
-			const { tickResolution, ...xAxisOptions } = options?.axis?.x ?? {};
-			const formatter = xAxisOptions.tickFormat || getFormatter( dataSorted, tickResolution );
+			const { tickResolution, tickFormat, ...xAxisOptions } = options?.axis?.x ?? {};
+			const formatter = tickFormat || getFormatter( dataSorted, tickResolution );
 
 			return {
 				axis: {

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -518,10 +518,11 @@ describe( 'LineChart', () => {
 				],
 			} );
 
+			// January is absent: formatMonthOrYearTick renders it as the year instead.
 			const ticks = screen.getAllByText( /^(Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$/ );
 			expect( ticks.length ).toBeGreaterThan( 1 );
 			expect(
-				screen.queryByText( /^(February|March|April|May|June|July|August|September|October)$/ )
+				screen.queryByText( /^(February|March|April|June|July|August|September|October)$/ )
 			).not.toBeInTheDocument();
 		} );
 

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -500,6 +500,56 @@ describe( 'LineChart', () => {
 			expect( ticks.length ).toBeGreaterThan( 1 );
 		} );
 
+		test( 'keeps the derived month formatter when tickFormat is passed as undefined.', () => {
+			renderWithTheme( {
+				width: 800,
+				options: { axis: { x: { tickFormat: undefined } } },
+				data: [
+					{
+						label: 'Series A',
+						data: [
+							{ date: new Date( '2024-01-01' ), value: 10 },
+							{ date: new Date( '2024-04-01' ), value: 20 },
+							{ date: new Date( '2024-07-01' ), value: 30 },
+							{ date: new Date( '2024-10-01' ), value: 40 },
+							{ date: new Date( '2025-03-01' ), value: 50 },
+						],
+					},
+				],
+			} );
+
+			const ticks = screen.getAllByText( /^(Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$/ );
+			expect( ticks.length ).toBeGreaterThan( 1 );
+			expect(
+				screen.queryByText( /^(February|March|April|May|June|July|August|September|October)$/ )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'honors an explicit tickFormat over the derived formatter.', () => {
+			renderWithTheme( {
+				width: 800,
+				options: {
+					axis: {
+						x: {
+							tickFormat: ( date: Date | number ) =>
+								`tick-${ new Date( Number( date ) ).getUTCMonth() }`,
+						},
+					},
+				},
+				data: [
+					{
+						label: 'Series A',
+						data: [
+							{ date: new Date( '2024-01-01' ), value: 10 },
+							{ date: new Date( '2024-07-01' ), value: 30 },
+						],
+					},
+				],
+			} );
+
+			expect( screen.getAllByText( /^tick-\d+$/ ).length ).toBeGreaterThan( 0 );
+		} );
+
 		test( 'renders ticks in year format.', () => {
 			renderWithTheme( {
 				width: 800,

--- a/projects/packages/premium-analytics/changelog/fix-undefined-tickformat-clobber
+++ b/projects/packages/premium-analytics/changelog/fix-undefined-tickformat-clobber
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Rely on the bar chart's new tickFormat contract instead of a conditional spread workaround; no behavior change.
+
+

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/__tests__/comparative-bar-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/__tests__/comparative-bar-chart.test.tsx
@@ -243,13 +243,12 @@ describe( 'ComparativeBarChart', () => {
 		mockChartHeight = Infinity;
 	} );
 
-	it( 'omits the x tickFormat key when no tick format is requested', () => {
+	it( 'passes no x tickFormat when no tick format is requested', () => {
 		render( <ComparativeBarChart series={ SERIES } dataFormat={ DATA_FORMAT } /> );
 
-		// The bar chart spreads these options over its own defaults, so an explicit
-		// `tickFormat: undefined` would erase its date formatter and leave the axis
-		// rendering raw `Date.toString()` values.
-		expect( recordedOptions().axis.x ).not.toHaveProperty( 'tickFormat' );
+		// `undefined` hands the axis to the chart's derived date formatter;
+		// `formatDate`'s `medium` default would override it.
+		expect( recordedOptions().axis.x.tickFormat ).toBeUndefined();
 	} );
 
 	it( 'passes an x tickFormat when one is requested', () => {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/comparative-bar-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/comparative-bar-chart.tsx
@@ -208,8 +208,11 @@ export function ComparativeBarChart( {
 		[ dataFormat ]
 	);
 
-	const xTickFormat = useCallback(
-		( date: number ) => formatDate( date, xTickFormatType ),
+	// With no declared format, `undefined` hands the axis to the chart's derived
+	// date formatter; `formatDate`'s `medium` default would otherwise put full
+	// site-format dates on every tick.
+	const xTickFormat = useMemo(
+		() => ( xTickFormatType ? ( date: number ) => formatDate( date, xTickFormatType ) : undefined ),
 		[ xTickFormatType ]
 	);
 
@@ -333,13 +336,7 @@ export function ComparativeBarChart( {
 		const baseOptions = {
 			axis: {
 				x: {
-					// Omit the key entirely rather than passing `undefined`: the bar chart
-					// spreads these options over its own defaults, so an explicit
-					// `tickFormat: undefined` overwrites its `formatDateTick` and the axis
-					// falls back to raw `Date.toString()`. Staying conditional also keeps
-					// `formatDate`'s `medium` default from putting full site-format dates
-					// on every tick when no format was asked for.
-					...( xTickFormatType ? { tickFormat: xTickFormat } : {} ),
+					tickFormat: xTickFormat,
 					tickResolution,
 				},
 				y: {
@@ -355,7 +352,7 @@ export function ComparativeBarChart( {
 		}
 
 		return { ...baseOptions, yScale: { domain: fixedYAxis.domain } };
-	}, [ xTickFormat, xTickFormatType, tickResolution, yTickFormat, isCompact, fixedYAxis ] );
+	}, [ xTickFormat, tickResolution, yTickFormat, isCompact, fixedYAxis ] );
 
 	const margin = useMemo( () => {
 		// With the y-axis hidden, reclaim its reserved left margin for the bars.

--- a/projects/plugins/jetpack/changelog/fix-undefined-tickformat-clobber
+++ b/projects/plugins/jetpack/changelog/fix-undefined-tickformat-clobber
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Show abbreviated month names on chart x-axes in line and area views.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-undefined-tickformat-clobber
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-undefined-tickformat-clobber
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Show abbreviated month names on chart x-axes in line and area views.

--- a/projects/plugins/premium-analytics/changelog/fix-undefined-tickformat-clobber
+++ b/projects/plugins/premium-analytics/changelog/fix-undefined-tickformat-clobber
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show abbreviated month names on chart x-axes in line and area views.

--- a/projects/plugins/wpcomsh/changelog/fix-undefined-tickformat-clobber
+++ b/projects/plugins/wpcomsh/changelog/fix-undefined-tickformat-clobber
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Show abbreviated month names on chart x-axes in line and area views.


### PR DESCRIPTION
Fixes WOOA7S-1988

## Why

In Premium Analytics' Traffic summary widget, the line chart's monthly x-axis rendered full month names ("August", "September"), wasting horizontal space, while bar mode already showed the intended "Aug" / "Sep". Month and date tick labels now use the charts library's abbreviated formats everywhere.

## Proposed changes

* `LineChart` and `AreaChart` no longer let a caller-supplied `tickFormat: undefined` clobber the derived tick formatter. The x-axis options spread the caller's config after the computed defaults, so an own-but-`undefined` `tickFormat` key (which `ComparativeLineChart` in Premium Analytics always emits when no format is requested) erased the derived formatter and left visx to fall back to d3's default `scaleTime` format — full month names at month boundaries. `tickFormat` is now destructured out of the spread the way `tickResolution` already is: an explicit formatter still wins, an `undefined` one no longer erases the default.
* Regression tests for both charts: monthly data with `axis.x.tickFormat: undefined` renders abbreviated month labels, and an explicit `tickFormat` function still overrides the derived formatter.

## Screenshots

Traffic summary, **12 months** preset, line mode, captured on a local docker site at 1400×900:

![before/after: full month names on trunk vs abbreviated months with the fix](https://github.com/user-attachments/assets/87ea080e-8f5a-4dba-99f2-8462a2b1050d)

Also verified in line mode on the live dashboard: hourly ranges keep hour ticks (`9 PM`, `12 AM`, …), daily ranges keep short dates (`Jul 25`, `Jul 27`, …), and bar mode is unchanged.

## Related product discussion/links

* WOOA7S-1988
* Related: WOOA7S-1903 (`tickResolution` on `BarChart`), WOOA7S-1827 (axis tick localization) — both live in the same formatter-selection code and are intentionally out of scope here.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Premium Analytics dashboard (Stats v2) on a site with traffic data.
* In the Traffic summary widget, pick the **12 months** preset and the **line** chart type.
* Verify the acceptance criteria:
  - [ ] Line mode, "By months": the x-axis shows short months with the year at January boundaries (`Aug Sep … 2026 Feb …`) — matching bar mode.
  - [ ] Other resolutions in line mode keep their derived formats: hourly ranges show hour ticks (`9 PM`, `12 AM`, …), daily ranges show short dates (`Jul 25`, `Jul 27`, …).
  - [ ] Bar mode is unchanged (already abbreviated).
  - [ ] A consumer passing an explicit `tickFormat` still overrides the derived formatter (covered by unit tests).
* Unit tests: `pnpm --dir projects/js-packages/charts run test -- --testPathPattern '(line-chart|area-chart)\.test'` — the two new "keeps the derived month formatter" tests fail without the source change and pass with it.
