### PR TITLE
Premium Analytics: align title link styling across widgets

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-pa-video-title-link-alignment
+++ b/projects/packages/premium-analytics/changelog/fix-pa-video-title-link-alignment
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Align video title links with post title links, adding the outbound marker to external rows.
+Align title link styling across widgets: external video rows gain the standard outbound marker, long titles no longer clip it, and hover underlines cover only the title text.

--- a/projects/packages/premium-analytics/changelog/fix-pa-video-title-link-alignment
+++ b/projects/packages/premium-analytics/changelog/fix-pa-video-title-link-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Align video title links with post title links, adding the outbound marker to external rows.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/video-title-link/__tests__/video-title-link.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/video-title-link/__tests__/video-title-link.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { VideoTitleLink } from '../video-title-link';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+
+type MockRouteLinkProps = {
+	to: string;
+	params?: Record< string, unknown >;
+	search?: Record< string, unknown >;
+	children: ReactNode;
+} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
+
+// `forwardRef`, because the design system link that renders this forwards a ref.
+jest.mock( '@wordpress/route', () => {
+	const { forwardRef } = jest.requireActual( 'react' ) as typeof import('react');
+
+	return {
+		Link: forwardRef< HTMLAnchorElement, MockRouteLinkProps >(
+			( { to, params, search, children, ...props }, ref ) => {
+				const path = Object.entries( params ?? {} ).reduce(
+					( result, [ key, value ] ) => result.replace( `$${ key }`, String( value ) ),
+					to
+				);
+				const query = new URLSearchParams();
+				Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
+					if ( value !== undefined && value !== null ) {
+						query.set( key, String( value ) );
+					}
+				} );
+				const queryString = query.toString();
+
+				return (
+					<a ref={ ref } href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
+						{ children }
+					</a>
+				);
+			}
+		),
+	};
+} );
+
+describe( 'VideoTitleLink', () => {
+	it( 'routes a row with a video ID to the detail page, carrying the report window', () => {
+		render(
+			<VideoTitleLink
+				id={ 105 }
+				label="Launch teaser"
+				link="https://example.com/launch-teaser/"
+				search={ { from: '2026-03-01', to: '2026-03-10' } }
+			/>
+		);
+
+		const link = screen.getByRole( 'link', { name: 'Launch teaser' } );
+		const href = link.getAttribute( 'href' ) ?? '';
+		const search = new URL( href, 'https://example.com' ).searchParams;
+
+		expect( link ).toHaveAttribute( 'href', expect.stringContaining( '/video/105' ) );
+		expect( search.get( 'from' ) ).toBe( '2026-03-01' );
+		expect( search.get( 'to' ) ).toBe( '2026-03-10' );
+	} );
+
+	it( 'gives an internal link no outbound target and no external marker', () => {
+		render( <VideoTitleLink id={ 105 } label="Launch teaser" /> );
+
+		const link = screen.getByRole( 'link', { name: 'Launch teaser' } );
+		expect( link ).not.toHaveAttribute( 'target' );
+		expect( link ).not.toHaveAttribute( 'rel' );
+		expect( screen.queryByRole( 'img', { name: '(opens in a new tab)' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'falls back to the public URL with an external marker when there is no video ID', () => {
+		render( <VideoTitleLink label="Old upload" link="https://example.com/old-upload/" /> );
+
+		const link = screen.getByRole( 'link', { name: 'Old upload(opens in a new tab)' } );
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/old-upload/' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+		expect( screen.getByRole( 'img', { name: '(opens in a new tab)' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders plain text when there is no ID and the fallback URL has an unsupported scheme', () => {
+		render( <VideoTitleLink label="Sketchy" link="javascript:alert(1)" /> );
+
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Sketchy' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/video-title-link/video-title-link.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/video-title-link/video-title-link.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Link as UiLink } from '@jetpack-premium-analytics/externals';
 import { safeHttpUrl } from '@jetpack-premium-analytics/ui';
 import { Link } from '@wordpress/route';
 
@@ -15,6 +16,7 @@ export type VideoTitleLinkProps = {
 		internal?: string;
 		external?: string;
 		plain?: string;
+		text?: string;
 	};
 	title?: string;
 };
@@ -22,7 +24,8 @@ export type VideoTitleLinkProps = {
 /**
  * Render a video title as an internal detail link, an external fallback link,
  * or plain text. `search` takes either an object or an updater that receives
- * the current search.
+ * the current search. Mirrors `PostTitleLink`'s structure so post and video
+ * rows read identically across the dashboard.
  *
  * @return The linked or plain video title.
  */
@@ -35,18 +38,26 @@ export function VideoTitleLink( {
 	title,
 }: VideoTitleLinkProps ): JSX.Element {
 	const videoId = Number( id );
+	const text = <span className={ classNames?.text }>{ label }</span>;
 
 	if ( Number.isInteger( videoId ) && videoId > 0 ) {
+		// `UiLink` renders the router link so the anchor keeps the design
+		// system's unlayered guard, without which wp-admin repaints it blue.
 		return (
-			<Link
+			<UiLink
 				className={ classNames?.internal }
-				to="/video/$videoId"
-				params={ { videoId: String( videoId ) } as unknown as never }
-				search={ search as unknown as never }
+				variant="unstyled"
 				title={ title }
+				render={
+					<Link
+						to="/video/$videoId"
+						params={ { videoId: String( videoId ) } as unknown as never }
+						search={ search as unknown as never }
+					/>
+				}
 			>
-				{ label }
-			</Link>
+				{ text }
+			</UiLink>
 		);
 	}
 
@@ -55,22 +66,25 @@ export function VideoTitleLink( {
 	const href = safeHttpUrl( link );
 
 	if ( href ) {
+		// `openInNewTab` appends the design system's outbound marker, so the row
+		// carries the same arrow as every other external link in the dashboard.
 		return (
-			<a
+			<UiLink
 				className={ classNames?.external }
 				href={ href }
-				target="_blank"
+				variant="unstyled"
+				openInNewTab
 				rel="noopener noreferrer"
 				title={ title }
 			>
-				{ label }
-			</a>
+				{ text }
+			</UiLink>
 		);
 	}
 
 	return (
 		<span className={ classNames?.plain } title={ title }>
-			{ label }
+			{ text }
 		</span>
 	);
 }

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
@@ -93,7 +93,8 @@ describe( 'videos fields', () => {
 	it( 'keeps the external page link as the fallback for a row without an ID', () => {
 		renderTitleField( { ...video, id: undefined } );
 
-		const link = screen.getByRole( 'link', { name: 'Launch video' } );
+		// The design system's outbound marker joins the accessible name.
+		const link = screen.getByRole( 'link', { name: 'Launch video(opens in a new tab)' } );
 		expect( link ).toHaveAttribute( 'href', 'https://example.com/video/' );
 		expect( link ).toHaveAttribute( 'target', '_blank' );
 		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
@@ -102,10 +103,9 @@ describe( 'videos fields', () => {
 	it( 'does not create a detail link for a non-positive ID', () => {
 		renderTitleField( { ...video, id: 0 } );
 
-		expect( screen.getByRole( 'link', { name: 'Launch video' } ) ).toHaveAttribute(
-			'href',
-			'https://example.com/video/'
-		);
+		expect(
+			screen.getByRole( 'link', { name: 'Launch video(opens in a new tab)' } )
+		).toHaveAttribute( 'href', 'https://example.com/video/' );
 	} );
 
 	it( 'renders plain text when a row has neither an ID nor a URL', () => {

--- a/projects/packages/premium-analytics/widgets/top-posts/style.module.css
+++ b/projects/packages/premium-analytics/widgets/top-posts/style.module.css
@@ -31,13 +31,15 @@
 
 /* `min-width: 0` lets the flex item shrink below its content width so the
    ellipsis applies; without it a long title pushes the trailing icon out. The
-   outbound marker brings its own inline spacing, so the box needs no gap. */
+   gap matches the leaderboard rows' `.rowLink`, so the outbound marker sits
+   at the same distance from the title in every widget. */
 .labelTitle,
 .labelTitleLink,
 .labelExternalLink {
 	min-width: 0;
 	display: inline-flex;
 	align-items: center;
+	gap: var(--wpds-dimension-gap-xs);
 }
 
 /* The label text carries the ellipsis in every branch: `text-overflow` needs

--- a/projects/packages/premium-analytics/widgets/top-posts/style.module.css
+++ b/projects/packages/premium-analytics/widgets/top-posts/style.module.css
@@ -56,9 +56,11 @@
 	text-decoration: none;
 }
 
-.labelTitleLink:hover,
-.labelTitleLink:focus,
-.labelExternalLink:hover,
-.labelExternalLink:focus {
+/* Underline only the title text, matching the leaderboard rows' hover rule —
+   the outbound marker stays clean instead of taking the underline with it. */
+.labelTitleLink:hover .labelText,
+.labelTitleLink:focus .labelText,
+.labelExternalLink:hover .labelText,
+.labelExternalLink:focus .labelText {
 	text-decoration: underline;
 }

--- a/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
@@ -122,7 +122,9 @@ describe( 'VideoPressWidget', () => {
 
 		const title = await screen.findByText( 'Unlinked video' );
 		expect( title ).not.toHaveRole( 'link' );
-		expect( title ).toHaveAttribute( 'title', 'Unlinked video' );
+		// The tooltip lives on the plain-branch wrapper; the label itself sits in
+		// the inner text span shared by every branch.
+		expect( screen.getByTitle( 'Unlinked video' ) ).toBeInTheDocument();
 	} );
 
 	it( 'requests the dashboard date range from report params', async () => {

--- a/projects/packages/premium-analytics/widgets/videopress/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/render.tsx
@@ -57,6 +57,7 @@ function buildVideoTitle( row: VideoPlaysRow, search: Record< string, unknown > 
 				internal: styles.internalLink,
 				external: styles.labelLink,
 				plain: styles.labelText,
+				text: styles.titleText,
 			} }
 			title={ row.label }
 		/>

--- a/projects/packages/premium-analytics/widgets/videopress/style.module.css
+++ b/projects/packages/premium-analytics/widgets/videopress/style.module.css
@@ -1,7 +1,15 @@
 .labelLink,
 .labelText,
 .internalLink {
-	display: block;
+
+	/* `inline-flex` keeps the outbound marker outside the clipped text: the
+	   inner text span carries the ellipsis, so a long title truncates while
+	   the marker stays visible. `min-width: 0` lets the box shrink below its
+	   content width; `max-width: 100%` keeps it inside the label slot. */
+	display: inline-flex;
+	align-items: center;
+	min-width: 0;
+	max-width: 100%;
 
 	/* Vertical padding sets the overlay bar height — the bar fills the row,
 	   whose height is driven by this label (there is no image to size it). */
@@ -11,9 +19,16 @@
 	   its default `.label` in overlay mode (`.is-overlay .label`), but a custom
 	   label element bypasses that rule, so we mirror it here. */
 	padding-inline-start: var(--wpds-dimension-padding-sm);
-	overflow: hidden;
 	color: inherit;
 	text-decoration: none;
+}
+
+/* The label text carries the ellipsis in every branch: `text-overflow` needs
+   an inline formatting context, which the flex containers above do not give
+   it. */
+.titleText {
+	min-width: 0;
+	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }

--- a/projects/packages/premium-analytics/widgets/videopress/style.module.css
+++ b/projects/packages/premium-analytics/widgets/videopress/style.module.css
@@ -5,11 +5,14 @@
 	/* `inline-flex` keeps the outbound marker outside the clipped text: the
 	   inner text span carries the ellipsis, so a long title truncates while
 	   the marker stays visible. `min-width: 0` lets the box shrink below its
-	   content width; `max-width: 100%` keeps it inside the label slot. */
+	   content width; `max-width: 100%` keeps it inside the label slot. The gap
+	   matches the leaderboard rows' `.rowLink`, so the marker sits at the same
+	   distance from the title in every widget. */
 	display: inline-flex;
 	align-items: center;
 	min-width: 0;
 	max-width: 100%;
+	gap: var(--wpds-dimension-gap-xs);
 
 	/* Vertical padding sets the overlay bar height — the bar fills the row,
 	   whose height is driven by this label (there is no image to size it). */

--- a/projects/packages/premium-analytics/widgets/videopress/style.module.css
+++ b/projects/packages/premium-analytics/widgets/videopress/style.module.css
@@ -33,10 +33,12 @@
 	white-space: nowrap;
 }
 
-.labelLink:hover,
-.labelLink:focus,
-.internalLink:hover,
-.internalLink:focus {
+/* Underline only the title text, matching the leaderboard rows' hover rule —
+   the outbound marker stays clean instead of taking the underline with it. */
+.labelLink:hover .titleText,
+.labelLink:focus .titleText,
+.internalLink:hover .titleText,
+.internalLink:focus .titleText {
 	text-decoration: underline;
 }
 

--- a/projects/plugins/jetpack/changelog/fix-pa-video-title-link-alignment
+++ b/projects/plugins/jetpack/changelog/fix-pa-video-title-link-alignment
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Premium Analytics: Align video title links with post title links, adding the outbound marker to external rows.
+Premium Analytics: Align title link styling across widgets: external video rows gain the standard outbound marker, long titles no longer clip it, and hover underlines cover only the title text.

--- a/projects/plugins/jetpack/changelog/fix-pa-video-title-link-alignment
+++ b/projects/plugins/jetpack/changelog/fix-pa-video-title-link-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Align video title links with post title links, adding the outbound marker to external rows.

--- a/projects/plugins/premium-analytics/changelog/fix-pa-video-title-link-alignment
+++ b/projects/plugins/premium-analytics/changelog/fix-pa-video-title-link-alignment
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Align video title links with post title links, adding the outbound marker to external rows.
+Align title link styling across widgets: external video rows gain the standard outbound marker, long titles no longer clip it, and hover underlines cover only the title text.

--- a/projects/plugins/premium-analytics/changelog/fix-pa-video-title-link-alignment
+++ b/projects/plugins/premium-analytics/changelog/fix-pa-video-title-link-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Align video title links with post title links, adding the outbound marker to external rows.


### PR DESCRIPTION
## Proposed changes

Four alignment fixes so title links read identically across the dashboard's widgets:

* **`VideoTitleLink` mirrors `PostTitleLink`'s structure** (covers the VideoPress widget and the Videos report at once):
  * The internal detail link renders through `UiLink variant="unstyled"` around the router `Link`, keeping the design system's unlayered guard — without it, wp-admin repaints the anchor blue.
  * The external fallback renders through `UiLink openInNewTab`, so the row carries the same outbound marker as every other external link in the dashboard (previously a bare `<a target="_blank">` with no marker).
  * The label sits in a shared inner text span (`classNames.text`).
* **Long titles no longer clip the outbound marker** (VideoPress widget): the ellipsis used to live on the outer link, so an overflowing title clipped the marker with it. The outer branches are now `inline-flex` boxes and the inner text span carries the ellipsis, mirroring Top posts.
* **The title-to-marker gap matches the leaderboard rows** (Top posts + VideoPress): both widgets relied on the marker's own inline spacing, so the arrow sat closer to the title than on the leaderboard rows (Top referrers, Top commented authors, …), whose `.rowLink` adds a `gap-xs`. The custom labels now carry the same gap.
* **Hover underline covers only the title text** (Top posts + VideoPress): both widgets underlined the whole link on hover, running the underline beneath the outbound marker, while the shared leaderboard rows (Top referrers, Top commented authors, …) underline only the label text. All four now follow the text-only rule, so the marker stays clean everywhere.

Also adds a `VideoTitleLink` unit-test suite mirroring `PostTitleLink`'s (detail routing with the report window, no marker on internal links, marker + `rel` on the external fallback, plain-text fallback for unsafe schemes), and updates the two consumers' assertions for the new accessible names.

Audited the rest of the dashboard while here: all other widgets already route external links through `openInNewTab` or the shared title-link components. The remaining bare anchors are in two report-page field configs (`comment-followers`, `downloads`), left for a follow-up since one of them hand-rolls its own external icon and needs a closer look.

## Related product discussion/links

* Follow-up to the video detail work in #51501, where the divergence was noticed.

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

Top videos widget, a row with a video ID (internal detail link). Before: the bare router link falls through to wp-admin's default blue underlined anchor. After: the design system's link styling, matching the Top posts widget's rows.

| Before | After |
| --- | --- |
| <img width="294" height="438" alt="截圖 2026-08-25 下午3 09 45" src="https://github.com/user-attachments/assets/6f05ed1b-8195-400c-86a3-0ee0e938cf41" /> | <img width="300" height="438" alt="截圖 2026-08-25 下午3 07 46" src="https://github.com/user-attachments/assets/7796e497-749f-467b-a2ad-637b61ac06a4" /> |

Top pages widget, hover on an external row. Before: the underline runs beneath the outbound marker, and the marker sits tight against the title. After: the underline covers only the title text and the marker sits at the leaderboard rows' gap, matching Top referrers.

| Before | After |
| --- | --- |
| <img width="582" height="433" alt="截圖 2026-08-25 下午3 09 36" src="https://github.com/user-attachments/assets/930c4428-3283-48ee-b98d-2fa9ff846615" /> | <img width="587" height="437" alt="截圖 2026-08-25 下午3 07 34" src="https://github.com/user-attachments/assets/8e4ead3c-bff6-49f0-a497-11596d6db47c" /> |

## Testing instructions

* Build Premium Analytics and open the dashboard in wp-admin.
* On the VideoPress widget and the Videos report (`/reports/videos`):
  * A row with a video ID navigates to the video detail page in-app, styled by the design system (not wp-admin's blue link color), with no outbound arrow.
  * A row without an ID (e.g. a row whose attachment no longer resolves) links out to the public URL in a new tab and now carries the standard outbound arrow, matching the Top posts widget's external rows.
  * A row with neither an ID nor a URL renders as plain text with the full title on hover.
* Hover a Top pages external row (e.g. "Home page / Archives") and a Top videos row: the underline stops at the title text; the arrow is not underlined, and its distance from the title matches Top referrers / Top commented authors. Those two widgets are unchanged.
* Narrow the window (or find a long title) until a Top videos title ellipsizes: the outbound arrow stays visible after the `…` instead of being clipped.
* `TZ=UTC pnpm jest --config=tests/jest.config.cjs video-title-link widgets/videopress widgets/top-posts routes/reports/videos` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

