### PR TITLE
PCG: raise the Atomic rollout to 5%

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-pcg-rollout-5-percent
+++ b/projects/plugins/wpcomsh/changelog/update-pcg-rollout-5-percent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Plugin Conflicts Guardian: raise the Atomic rollout to 5% of sites.

--- a/projects/plugins/wpcomsh/plugin-conflicts-guardian-rollout.php
+++ b/projects/plugins/wpcomsh/plugin-conflicts-guardian-rollout.php
@@ -10,7 +10,7 @@
  * Percentage of Atomic sites the guardian runs on, 0-100. Raising it only
  * ever adds sites; 0 turns it off.
  */
-const WPCOMSH_PCG_ROLLOUT_PERCENTAGE = 2;
+const WPCOMSH_PCG_ROLLOUT_PERCENTAGE = 5;
 
 add_filter(
 	'pcg_rollout_percentage',


### PR DESCRIPTION
## Proposed changes

* Raise the Plugin Conflicts Guardian rollout from 2% to 5% of Atomic sites.

Follow-up to #51463, which took the cohort from 1% to 2%. The 1% cohort (from #51392, which fixed the bucketing to use the WP.com blog ID instead of the always-`1` local blog ID) and the 2% cohort have both been live without issue.

Bucketing is stable, so raising the percentage only ever adds sites — everyone already in the 2% cohort stays in it, and nothing gets re-shuffled.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No. The guardian's existing logging is unchanged; this only widens the set of sites it runs on.

## Testing instructions

The rollout constant lives in wpcomsh rather than the package so it can ship on the twice-daily Atomic platform deploy instead of waiting on a package release — so the practical check is on a WoW site.

* On a WoW dev blog, confirm the guardian's gate resolves as expected for a blog ID inside and outside the 5% cohort. `PCG_Rollout::blog_bucket()` is exposed for exactly this — a blog whose bucket is `0` through `4` is now enrolled, `5` and above is not.
* Sites that were in the 2% cohort (buckets `0` and `1`) must still be enrolled.
* Simple sites remain excluded regardless of percentage.
* Unit coverage for the gate is in `Plugin_Conflicts_Guardian_Test`.

After this lands, the change reaches Atomic on the next platform deploy (14:00 or 19:00 UTC on a weekday), not immediately.
