### PR TITLE
Premium Analytics: group the jest suites that declare no module mocks

### DIFF
--- a/projects/packages/premium-analytics/changelog/group-no-mock-test-suites
+++ b/projects/packages/premium-analytics/changelog/group-no-mock-test-suites
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test-only change: group the suites that declare no module mocks, and guard against grouping a suite that pins a Jest environment.
+
+

--- a/projects/packages/premium-analytics/tests/groups/README.md
+++ b/projects/packages/premium-analytics/tests/groups/README.md
@@ -53,6 +53,15 @@ cannot see this difference.
 Do not list a suite in multiple groups. Leave suites with relative module mocks
 ungrouped because those mocks resolve from the suite's directory.
 
+Leave suites that pin their own environment ungrouped too. Jest reads the
+`@jest-environment` docblock of the file it collects, which for a member is the
+group file, so a member asking for `node` silently gets the group's jsdom and
+fails on whatever it wanted `node` for. The guard test reports this.
+
+A suite that declares no `jest.mock()` at all is compatible with every other
+such suite, whatever it covers — `mixed-no-mocks` collects the ones from areas
+too small for a group of their own.
+
 Keep groups at ten members or fewer and reset shared state in `beforeEach`.
 
 ## When a grouped run fails confusingly

--- a/projects/packages/premium-analytics/tests/groups/data-no-mocks-part1.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/data-no-mocks-part1.test.tsx
@@ -1,0 +1,11 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/data/src/hooks/__tests__/awaiting-data.test';
+import '../../packages/data/src/hooks/__tests__/stats-exports.test';
+import '../../packages/data/src/hooks/__tests__/use-report.test';
+import '../../packages/data/src/hooks/__tests__/use-stats-comment-followers.test';
+import '../../packages/data/src/hooks/__tests__/use-stats-hour-of-day.test';
+import '../../packages/data/src/hooks/__tests__/use-stats-query.test';
+import '../../packages/data/src/hooks/__tests__/use-stats-report.test';
+import '../../packages/data/src/processing/latest-post/__tests__/latest-post.test';
+import '../../packages/data/src/processing/stats/__tests__/archives-merge.test';

--- a/projects/packages/premium-analytics/tests/groups/data-no-mocks-part2.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/data-no-mocks-part2.test.tsx
@@ -1,0 +1,11 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/data/src/processing/stats/__tests__/archives.test';
+import '../../packages/data/src/processing/stats/__tests__/chart-buckets.test';
+import '../../packages/data/src/processing/stats/__tests__/clicks.test';
+import '../../packages/data/src/processing/stats/__tests__/comment-followers.test';
+import '../../packages/data/src/processing/stats/__tests__/comments.test';
+import '../../packages/data/src/processing/stats/__tests__/devices.test';
+import '../../packages/data/src/processing/stats/__tests__/drilldown-rows.test';
+import '../../packages/data/src/processing/stats/__tests__/email-breakdown.test';
+import '../../packages/data/src/processing/stats/__tests__/email-summary.test';

--- a/projects/packages/premium-analytics/tests/groups/data-no-mocks-part3.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/data-no-mocks-part3.test.tsx
@@ -1,0 +1,11 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/data/src/processing/stats/__tests__/file-downloads.test';
+import '../../packages/data/src/processing/stats/__tests__/followers.test';
+import '../../packages/data/src/processing/stats/__tests__/highlights.test';
+import '../../packages/data/src/processing/stats/__tests__/hour-of-day.test';
+import '../../packages/data/src/processing/stats/__tests__/insights.test';
+import '../../packages/data/src/processing/stats/__tests__/locations.test';
+import '../../packages/data/src/processing/stats/__tests__/post-comments.test';
+import '../../packages/data/src/processing/stats/__tests__/post-likes.test';
+import '../../packages/data/src/processing/stats/__tests__/post.test';

--- a/projects/packages/premium-analytics/tests/groups/data-no-mocks-part4.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/data-no-mocks-part4.test.tsx
@@ -1,0 +1,11 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/data/src/processing/stats/__tests__/referrers-merge.test';
+import '../../packages/data/src/processing/stats/__tests__/referrers.test';
+import '../../packages/data/src/processing/stats/__tests__/search-terms.test';
+import '../../packages/data/src/processing/stats/__tests__/single-video.test';
+import '../../packages/data/src/processing/stats/__tests__/streak.test';
+import '../../packages/data/src/processing/stats/__tests__/subscribers.test';
+import '../../packages/data/src/processing/stats/__tests__/tags.test';
+import '../../packages/data/src/processing/stats/__tests__/time-series.test';
+import '../../packages/data/src/processing/stats/__tests__/top-authors.test';

--- a/projects/packages/premium-analytics/tests/groups/data-no-mocks-part5.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/data-no-mocks-part5.test.tsx
@@ -1,0 +1,11 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/data/src/processing/stats/__tests__/top-posts.test';
+import '../../packages/data/src/processing/stats/__tests__/utils.test';
+import '../../packages/data/src/processing/stats/__tests__/utm.test';
+import '../../packages/data/src/processing/stats/__tests__/video-plays.test';
+import '../../packages/data/src/processing/stats/__tests__/visits.test';
+import '../../packages/data/src/processing/stats/__tests__/wordads.test';
+import '../../packages/data/src/providers/__tests__/query-client-provider.test';
+import '../../packages/data/src/providers/__tests__/report-scope.test';
+import '../../packages/data/src/queries/__tests__/stats-hour-of-day-query.test';

--- a/projects/packages/premium-analytics/tests/groups/data-no-mocks-part6.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/data-no-mocks-part6.test.tsx
@@ -1,0 +1,9 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/data/src/utils/__tests__/api-error.test';
+import '../../packages/data/src/utils/__tests__/date.test';
+import '../../packages/data/src/utils/__tests__/interval.test';
+import '../../packages/data/src/utils/__tests__/parsing.test';
+import '../../packages/data/src/utils/__tests__/stats-params.test';
+import '../../packages/data/src/utils/__tests__/to-post-id.test';
+import '../../packages/data/src/utils/__tests__/without-comparison.test';

--- a/projects/packages/premium-analytics/tests/groups/datetime-no-mocks-part1.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/datetime-no-mocks-part1.test.tsx
@@ -1,0 +1,8 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/datetime/src/__tests__/comparison-presets.test';
+import '../../packages/datetime/src/__tests__/date-range-span.test';
+import '../../packages/datetime/src/__tests__/date.test';
+import '../../packages/datetime/src/__tests__/get-comparison-range.test';
+import '../../packages/datetime/src/__tests__/relative-since.test';
+import '../../packages/datetime/src/__tests__/site-datetime.test';

--- a/projects/packages/premium-analytics/tests/groups/datetime-no-mocks-part2.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/datetime-no-mocks-part2.test.tsx
@@ -1,0 +1,8 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/datetime/src/__tests__/site-time-zone.test';
+import '../../packages/datetime/src/__tests__/site-timestamp.test';
+import '../../packages/datetime/src/__tests__/step-date-range.test';
+import '../../packages/datetime/src/__tests__/surface-preset-labels.test';
+import '../../packages/datetime/src/__tests__/tz.test';
+import '../../packages/datetime/src/__tests__/year-presets.test';

--- a/projects/packages/premium-analytics/tests/groups/formatters-no-mocks.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/formatters-no-mocks.test.tsx
@@ -1,0 +1,8 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/formatters/src/date/__tests__/elide-range.test';
+import '../../packages/formatters/src/date/__tests__/format-date-range-long.test';
+import '../../packages/formatters/src/date/__tests__/format-date-range.test';
+import '../../packages/formatters/src/date/__tests__/format-date.test';
+import '../../packages/formatters/src/date/__tests__/format-hour-of-day.test';
+import '../../packages/formatters/src/date/__tests__/php-format.test';

--- a/projects/packages/premium-analytics/tests/groups/mixed-no-mocks.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/mixed-no-mocks.test.tsx
@@ -1,0 +1,10 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/fields/src/field-select/__tests__/select-field.test';
+import '../../packages/fields/src/field-toggle-group/__tests__/toggle-group-field.test';
+import '../../packages/routing/src/search/date-range/date-range.test';
+import '../../packages/routing/src/search/report-origin/report-origin.test';
+import '../../packages/routing/src/search/report-params/report-params.test';
+import '../../packages/routing/src/tabs/define-report-tabs.test';
+import '../../packages/site-sync/src/status.test';
+import '../../tests/js/site-readiness.test';

--- a/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part3.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part3.test.tsx
@@ -5,4 +5,5 @@ import '../../routes/reports/search-terms/config/aggregate.test';
 import '../../routes/reports/search-terms/config/fields.test';
 import '../../routes/reports/utm/config/aggregate.test';
 import '../../routes/reports/utm/config/tabs.test';
+import '../../routes/use-detail-chart-intervals.test';
 import '../../routes/video-detail/config/layout.test';

--- a/projects/packages/premium-analytics/tests/groups/ui-no-mocks-part1.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/ui-no-mocks-part1.test.tsx
@@ -1,0 +1,11 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/ui/src/__tests__/date-range-layout.test';
+import '../../packages/ui/src/dataviews-drilldown-native/__tests__/collapsible-rows.test';
+import '../../packages/ui/src/dataviews-drilldown-native/__tests__/dataviews-drilldown-native.test';
+import '../../packages/ui/src/dataviews-drilldown-native/__tests__/process-hierarchy-levels.test';
+import '../../packages/ui/src/date-comparison-dropdown/__tests__/date-comparison-dropdown.test';
+import '../../packages/ui/src/date-filters-panel/__tests__/preset-row-probe.test';
+import '../../packages/ui/src/date-interval-dropdown/__tests__/date-interval-dropdown.test';
+import '../../packages/ui/src/date-period-navigation/__tests__/date-period-navigation.test';
+import '../../packages/ui/src/date-range-filter/__tests__/date-range-filter.test';

--- a/projects/packages/premium-analytics/tests/groups/ui-no-mocks-part2.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/ui-no-mocks-part2.test.tsx
@@ -1,0 +1,10 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/ui/src/date-range-input/__tests__/date-range-input.test';
+import '../../packages/ui/src/date-range-popover/__tests__/date-range-popover.test';
+import '../../packages/ui/src/date-range-popover/__tests__/get-custom-trigger-state.test';
+import '../../packages/ui/src/date-range-quick-presets/__tests__/date-range-quick-presets.test';
+import '../../packages/ui/src/date-year-filter/__tests__/date-year-filter.test';
+import '../../packages/ui/src/section-header/__tests__/get-section-subtitle.test';
+import '../../packages/ui/src/section-header/__tests__/section-header.test';
+import '../../packages/ui/src/utils/__tests__/safe-http-url.test';

--- a/projects/packages/premium-analytics/tests/groups/widgets-no-mocks.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/widgets-no-mocks.test.tsx
@@ -3,4 +3,5 @@
 import '../../widgets/authors/__tests__/build-top-authors-data.test';
 import '../../widgets/popular-days/__tests__/bucket-views-by-weekday.test';
 import '../../widgets/shares/__tests__/use-share-views.test';
+import '../../widgets/stories/preset-for-story-interval.test';
 import '../../widgets/videopress/__tests__/build-video-plays-data.test';

--- a/projects/packages/premium-analytics/tests/groups/widgets-toolkit-no-mocks-part4.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/widgets-toolkit-no-mocks-part4.test.tsx
@@ -1,5 +1,7 @@
 // See README.md before adding a suite to this group.
 
+import '../../packages/widgets-toolkit/src/components/metric-list/__tests__/metric-list.test';
+import '../../packages/widgets-toolkit/src/helpers/__tests__/chart-date.test';
 import '../../packages/widgets-toolkit/src/helpers/__tests__/default-period-for-interval.test';
 import '../../packages/widgets-toolkit/src/helpers/__tests__/describe-error.test';
 import '../../packages/widgets-toolkit/src/helpers/__tests__/format-legend-labels.test';

--- a/projects/packages/premium-analytics/tests/groups/widgets-toolkit-no-mocks-part5.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/widgets-toolkit-no-mocks-part5.test.tsx
@@ -1,0 +1,5 @@
+// See README.md before adding a suite to this group.
+
+import '../../packages/widgets-toolkit/src/helpers/__tests__/chart-display-attribute-fields.test';
+import '../../packages/widgets-toolkit/src/helpers/__tests__/followed-granularity.test';
+import '../../packages/widgets-toolkit/src/helpers/__tests__/granularities-for-range.test';

--- a/projects/packages/premium-analytics/tests/js/test-groups.test.ts
+++ b/projects/packages/premium-analytics/tests/js/test-groups.test.ts
@@ -132,6 +132,16 @@ function membersOf( groupFile: string ): string[] {
 	return readGroup( groupFile ).members;
 }
 
+/**
+ * Gets the leading docblock of a file, which is the only one Jest reads.
+ *
+ * @param {string} file - File to read.
+ * @return {string} The leading docblock, or an empty string when there is none.
+ */
+function leadingDocblock( file: string ): string {
+	return /^\s*\/\*\*[\s\S]*?\*\//.exec( fs.readFileSync( file, 'utf8' ) )?.[ 0 ] ?? '';
+}
+
 describe( 'mock signature parser', () => {
 	it( 'compares complete factories when comments and strings contain parentheses', () => {
 		const first = `jest.mock( 'example', () => {
@@ -214,6 +224,18 @@ describe( 'test groups', () => {
 				signature: first.signature,
 			} );
 		}
+	} );
+
+	// Jest reads the environment docblock of the file it collects, which for a
+	// grouped suite is the group file. A member pinning its own environment gets
+	// the group's instead, silently: `@jest-environment node` becomes jsdom, and
+	// the suite fails on whatever the node environment was there to provide.
+	it.each( groups )( '%s members do not pin a Jest environment', groupFile => {
+		const pinned = membersOf( groupFile )
+			.map( member => resolveSuite( member ) as string )
+			.filter( file => /@jest-environment\b/.test( leadingDocblock( file ) ) );
+
+		expect( pinned.map( file => path.relative( GROUPS_DIR, file ) ) ).toEqual( [] );
 	} );
 
 	it( 'never lists the same suite in two groups', () => {


### PR DESCRIPTION
Part of WOOA7S-1971

## Proposed changes

* Group the 102 suites that declare no `jest.mock()` at all, so they share one module registry.
* Top up three existing under-full `*-no-mocks` groups instead of adding near-duplicates.
* Guard against grouping a suite that pins its own `@jest-environment`, which a group file silently overrides.
* Document both rules in `tests/groups/README.md`.

These suites declare no mocks, so they are compatible with each other by definition and the README's mock-factory hazard cannot apply. No product code and no existing test file changes — only group files, which are lists of imports.

Measured on one machine with `--maxWorkers=4`, against the groups already on trunk: 217 → 128 suites, CPU 164s → 131s (−20%), wall 30.3s → 24.8s (−18%). The same 2,621 tests pass in grouped and ungrouped mode.

## Notes for whoever owns the CI workflow

Not in scope here, but they came out of profiling the `JS tests` job and are worth recording:

* `tests.yml` runs the project loop in lexicographic order, so the three longest projects start last — `premium-analytics` only begins 194s in. Longest-first would take the loop from 618s to ~541s.
* After that the makespan floor is `max(longest project 423s, total work 2162s / 4 lanes)`. Sharding the job or a larger runner reaches ~519s; more shards buy nothing beyond that, since premium-analytics alone then binds.
* The `JS tests` timeout is still 15 minutes with a comment saying "~5 minutes"; recent trunk runs are 11–13 minutes.

## Related product discussion/links

* p1787160829896779-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

No. This only changes test infrastructure.

## Testing instructions

* From `projects/packages/premium-analytics/`, run the suite both ways and confirm the same number of passing tests:

  ```bash
  pnpm run test
  PA_NO_GROUPS=1 pnpm run test
  ```

* Confirm a newly grouped suite still runs on its own:

  ```bash
  pnpm run test -- packages/data/src/hooks/__tests__/use-report
  ```

* Confirm the new guard fires. Append `import '../../packages/data/src/api/__tests__/is-response.test';` to `tests/groups/data-no-mocks-part1.test.tsx` (that suite pins `@jest-environment node`), then:

  ```bash
  pnpm exec jest --config=tests/jest.config.cjs tests/js/test-groups
  ```

  It should fail with "members do not pin a Jest environment". Revert the import afterward.
