### PR TITLE
Search: report and validate the AI master switch state

### DIFF
--- a/projects/packages/search/changelog/update-ai-master-switch-audit
+++ b/projects/packages/search/changelog/update-ai-master-switch-audit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Answers: report the saved choice and the site-wide AI state in settings, disable the controls while AI is off, and honor the host AI opt-out in the AI Answer block.

--- a/projects/packages/search/changelog/update-ai-master-switch-audit
+++ b/projects/packages/search/changelog/update-ai-master-switch-audit
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-AI Answers: report the saved choice and the site-wide AI state in settings, disable the controls while AI is off, and honor the host AI opt-out in the AI Answer block. Require Instant Search to enable AI Answers.
+AI Answers: report the saved choice and the site-wide AI state in settings, disable the controls while AI is off, and honor the host AI opt-out in the AI Answer block. Require Instant Search to enable AI Answers. The master-state reporting follows the rollout: live on WordPress.com Simple, internal testing environments elsewhere.

--- a/projects/packages/search/changelog/update-ai-master-switch-audit
+++ b/projects/packages/search/changelog/update-ai-master-switch-audit
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-AI Answers: report the saved choice and the site-wide AI state in settings, disable the controls while AI is off, and honor the host AI opt-out in the AI Answer block.
+AI Answers: report the saved choice and the site-wide AI state in settings, disable the controls while AI is off, and honor the host AI opt-out in the AI Answer block. Require Instant Search to enable AI Answers.

--- a/projects/packages/search/jest.config.js
+++ b/projects/packages/search/jest.config.js
@@ -27,6 +27,13 @@ module.exports = {
 		'tiny-lru/lib/tiny-lru.esm$': '<rootDir>/src/instant-search/lib/test-helpers/tiny-lru.mock.js',
 		'instant-search/components/gridicon':
 			'<rootDir>/src/instant-search/components/gridicon/index.jsx',
+		// Mirror the customberg webpack resolution (tools/webpack.customberg.config.js):
+		// `instant-search` is an alias and `hooks/*` resolves against src/customberg.
+		// Exact-name hook entries so dashboard's own `hooks/*` resolution is untouched.
+		'^instant-search/(.*)$': '<rootDir>/src/instant-search/$1',
+		'^hooks/use-search-options$': '<rootDir>/src/customberg/hooks/use-search-options.js',
+		'^hooks/use-loading-state$': '<rootDir>/src/customberg/hooks/use-loading-state.js',
+		'^hooks/use-entity-record-state$': '<rootDir>/src/customberg/hooks/use-entity-record-state.js',
 	},
 	moduleDirectories: [ 'node_modules', '<rootDir>/src/dashboard' ],
 	setupFilesAfterEnv: [ ...baseConfig.setupFilesAfterEnv, '<rootDir>/tests/jest-globals.gui.js' ],

--- a/projects/packages/search/src/class-ai-answers.php
+++ b/projects/packages/search/src/class-ai-answers.php
@@ -14,6 +14,7 @@ namespace Automattic\Jetpack\Search;
 class AI_Answers {
 	const BEHAVIOR_META_KEY   = '_guideline_block_jetpack_search-ai-summary';
 	const BEHAVIOR_OPTION_KEY = 'jetpack_search_ai_behavior_instructions';
+	const ENABLED_OPTION      = 'jetpack_search_ai_answers_enabled';
 
 	/**
 	 * Hook up meta/setting registration.
@@ -88,9 +89,29 @@ class AI_Answers {
 	 * Whether AI Answers is enabled for the current site.
 	 */
 	public static function is_enabled() {
-		return (bool) apply_filters(
-			'jetpack_search_ai_answers_enabled',
-			(bool) get_option( 'jetpack_search_ai_answers_enabled', false )
-		);
+		return (bool) apply_filters( 'jetpack_search_ai_answers_enabled', self::is_saved_on() );
+	}
+
+	/**
+	 * The saved AI Answers choice — the raw option, ignoring any gates on the filter.
+	 *
+	 * @return bool
+	 */
+	public static function is_saved_on() {
+		return (bool) get_option( self::ENABLED_OPTION, false );
+	}
+
+	/**
+	 * Whether the site-wide AI gates currently allow AI Answers.
+	 *
+	 * The Jetpack plugin enforces the AI master switch and the host's AI opt-out
+	 * through the `jetpack_search_ai_answers_enabled` filter; probing the chain
+	 * with `true` reads that verdict without depending on the plugin. Sites with
+	 * no gate registered (e.g. standalone Search) report on.
+	 *
+	 * @return bool
+	 */
+	public static function is_master_enabled() {
+		return (bool) apply_filters( 'jetpack_search_ai_answers_enabled', true );
 	}
 }

--- a/projects/packages/search/src/class-ai-answers.php
+++ b/projects/packages/search/src/class-ai-answers.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Search;
 
+use Automattic\Jetpack\Constants;
+
 /**
  * Registers behavior meta on the Gutenberg Guidelines CPT and exposes the
  * jetpack_search_ai_answers_enabled option.
@@ -113,5 +115,21 @@ class AI_Answers {
 	 */
 	public static function is_master_enabled() {
 		return (bool) apply_filters( 'jetpack_search_ai_answers_enabled', true );
+	}
+
+	/**
+	 * Whether the host allows AI at all — core's wp_supports_ai(), falling back
+	 * to the WP_AI_SUPPORT constant on WordPress versions that predate it.
+	 * Mirrors the Jetpack plugin's Jetpack_AI_Settings::host_allows_ai().
+	 *
+	 * @return bool
+	 */
+	public static function host_allows_ai() {
+		if ( function_exists( 'wp_supports_ai' ) ) {
+			return wp_supports_ai();
+		}
+
+		// WordPress versions predating wp_supports_ai() only have the constant.
+		return ! Constants::is_defined( 'WP_AI_SUPPORT' ) || (bool) Constants::get_constant( 'WP_AI_SUPPORT' );
 	}
 }

--- a/projects/packages/search/src/class-ai-answers.php
+++ b/projects/packages/search/src/class-ai-answers.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Search;
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Status\Host;
 
 /**
  * Registers behavior meta on the Gutenberg Guidelines CPT and exposes the
@@ -97,6 +98,8 @@ class AI_Answers {
 	/**
 	 * The saved AI Answers choice — the raw option, ignoring any gates on the filter.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return bool
 	 */
 	public static function is_saved_on() {
@@ -111,16 +114,41 @@ class AI_Answers {
 	 * with `true` reads that verdict without depending on the plugin. Sites with
 	 * no gate registered (e.g. standalone Search) report on.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return bool
 	 */
 	public static function is_master_enabled() {
+		// Where enforcement hasn't rolled out, report ungated so no master-off
+		// UI shows before the switch itself does. Remove at public launch.
+		if ( ! self::is_master_rollout_active() ) {
+			return true;
+		}
+
 		return (bool) apply_filters( 'jetpack_search_ai_answers_enabled', true );
+	}
+
+	/**
+	 * Whether master enforcement has rolled out here — mirrors the Jetpack
+	 * plugin's rollout scoping: Simple keeps its option contract; elsewhere
+	 * the rollout is internal-only for now.
+	 *
+	 * @return bool
+	 */
+	private static function is_master_rollout_active() {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return true;
+		}
+
+		return function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment();
 	}
 
 	/**
 	 * Whether the host allows AI at all — core's wp_supports_ai(), falling back
 	 * to the WP_AI_SUPPORT constant on WordPress versions that predate it.
 	 * Mirrors the Jetpack plugin's Jetpack_AI_Settings::host_allows_ai().
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @return bool
 	 */

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -992,6 +992,7 @@ class Helper {
 			 */
 			'disableTracking'             => self::is_tracking_disabled() || apply_filters( 'jetpack_instant_search_disable_tracking', false ),
 			'aiAnswersEnabled'            => AI_Answers::is_enabled(),
+			'aiMasterEnabled'             => AI_Answers::is_master_enabled(),
 		);
 
 		/**

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -388,6 +388,16 @@ class REST_Controller {
 			);
 		}
 
+		// AI Answers cannot be turned on while the site-wide Jetpack AI switch is
+		// off. Turning it off stays allowed, so a saved choice can still be cleared.
+		if ( true === $ai_answers_enabled && ! AI_Answers::is_master_enabled() ) {
+			return new WP_Error(
+				'rest_invalid_arguments',
+				esc_html__( 'AI Answers cannot be enabled while Jetpack AI is turned off for this site.', 'jetpack-search-pkg' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		// `experience` is the canonical source of truth and writes the legacy booleans in lockstep.
 		// Reject requests that mix it with any other settings field so callers don't silently
 		// lose those fields — the `experience` branch in update_settings() early-returns and
@@ -442,6 +452,8 @@ class REST_Controller {
 			'swap_classic_to_inline_search'        => $this->search_module->is_swap_classic_to_inline_search(),
 			'experience'                           => $this->search_module->get_experience(),
 			'ai_answers_enabled'                   => AI_Answers::is_enabled(),
+			'ai_answers_saved'                     => AI_Answers::is_saved_on(),
+			'ai_master_enabled'                    => AI_Answers::is_master_enabled(),
 			'search_suggestions_enabled'           => (bool) get_option( 'jetpack_search_suggestions_enabled', false ),
 			'override_woocommerce_search_template' => Search_Blocks::woocommerce_search_template_override_enabled(),
 		);

--- a/projects/packages/search/src/class-rest-controller.php
+++ b/projects/packages/search/src/class-rest-controller.php
@@ -398,6 +398,16 @@ class REST_Controller {
 			);
 		}
 
+		// AI Answers runs inside Instant Search, so enabling it requires Instant
+		// Search on — either already, or turned on by this same request.
+		if ( true === $ai_answers_enabled && true !== $instant_search_enabled && ! $this->search_module->is_instant_search_enabled() ) {
+			return new WP_Error(
+				'rest_invalid_arguments',
+				esc_html__( 'AI Answers cannot be enabled while Instant Search is off.', 'jetpack-search-pkg' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		// `experience` is the canonical source of truth and writes the legacy booleans in lockstep.
 		// Reject requests that mix it with any other settings field so callers don't silently
 		// lose those fields — the `experience` branch in update_settings() early-returns and

--- a/projects/packages/search/src/customberg/components/app-wrapper/index.jsx
+++ b/projects/packages/search/src/customberg/components/app-wrapper/index.jsx
@@ -68,13 +68,14 @@ export default function AppWrapper() {
 	};
 
 	// aiAnswersEnabled + searchSuggestionsEnabled live at the top level of the
-	// instant-search options object (not under `overlayOptions`). Override them
-	// here so the preview reacts to the sidebar toggles without a save round-trip.
+	// options object; overridden here so the preview reacts to the sidebar. While
+	// the master is off a saved choice persists unenforced — preview gets false.
+	const { aiMasterEnabled = true } = window[ SERVER_OBJECT_NAME ];
 	const options = {
 		...window[ SERVER_OBJECT_NAME ],
 		...Object.fromEntries(
 			Object.entries( {
-				aiAnswersEnabled,
+				aiAnswersEnabled: aiMasterEnabled ? aiAnswersEnabled : false,
 				searchSuggestionsEnabled,
 			} ).filter( ( [ , v ] ) => typeof v !== 'undefined' )
 		),

--- a/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
@@ -15,7 +15,7 @@ import ColorControl from './color-control';
 import ExcludedPostTypesControl from './excluded-post-types-control';
 import ThemeControl from './theme-control';
 
-const { isFreePlan = false } = window[ SERVER_OBJECT_NAME ];
+const { isFreePlan = false, aiMasterEnabled = true } = window[ SERVER_OBJECT_NAME ];
 
 /**
  * Customization/configuration tab for the sidebar.
@@ -59,6 +59,17 @@ export default function SidebarOptions() {
 	const { isSaving } = useEntityRecordState();
 	const { isLoading } = useSiteLoadingState();
 	const isDisabled = isSaving || isLoading;
+
+	const aiAnswersHelp = aiMasterEnabled
+		? __(
+				'Generate AI-powered answers to visitor queries using your site’s content.',
+				'jetpack-search-pkg'
+		  )
+		: __(
+				'Jetpack AI is turned off for this site. Your setting will apply again when AI is turned back on.',
+				'jetpack-search-pkg',
+				/* dummy arg to avoid bad minification */ 0
+		  );
 
 	const sortOptions = [
 		{ label: __( 'Relevance (recommended)', 'jetpack-search-pkg' ), value: 'relevance' },
@@ -212,12 +223,9 @@ export default function SidebarOptions() {
 					<ToggleControl
 						className="jp-search-configure-ai-answers-toggle"
 						checked={ aiAnswersEnabled }
-						disabled={ isDisabled }
+						disabled={ isDisabled || ! aiMasterEnabled }
 						label={ __( 'Enable AI Answers', 'jetpack-search-pkg' ) }
-						help={ __(
-							'Generate AI-powered answers to visitor queries using your site’s content.',
-							'jetpack-search-pkg'
-						) }
+						help={ aiAnswersHelp }
 						onChange={ setAiAnswersEnabled }
 						__nextHasNoMarginBottom={ true }
 					/>

--- a/projects/packages/search/src/customberg/components/sidebar/test/sidebar-options-ai-off.test.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/test/sidebar-options-ai-off.test.jsx
@@ -1,0 +1,72 @@
+/**
+ * The sidebar reads the server object once at module scope, so the flag has to
+ * be in place before the component is required — hence require() over import,
+ * and one file per server-object state.
+ */
+jest.mock( 'hooks/use-search-options', () => ( {
+	__esModule: true,
+	default: () => ( {
+		color: '#000000',
+		excludedPostTypes: [],
+		infiniteScroll: true,
+		filteringOpensOverlay: true,
+		resultFormat: 'minimal',
+		setColor: jest.fn(),
+		setExcludedPostTypes: jest.fn(),
+		setInfiniteScroll: jest.fn(),
+		setFilteringOpensOverlay: jest.fn(),
+		setResultFormat: jest.fn(),
+		setShowLogo: jest.fn(),
+		setSort: jest.fn(),
+		setTheme: jest.fn(),
+		showLogo: true,
+		sort: 'relevance',
+		theme: 'light',
+		aiAnswersEnabled: true,
+		setAiAnswersEnabled: jest.fn(),
+	} ),
+} ) );
+jest.mock( 'hooks/use-entity-record-state', () => ( {
+	__esModule: true,
+	default: () => ( { isSaving: false } ),
+} ) );
+jest.mock( 'hooks/use-loading-state', () => ( {
+	__esModule: true,
+	default: () => ( { isLoading: false } ),
+} ) );
+jest.mock( '../color-control', () => () => null );
+jest.mock( '../excluded-post-types-control', () => () => null );
+jest.mock( '../theme-control', () => () => null );
+
+window.JetpackInstantSearchOptions = { isFreePlan: false, aiMasterEnabled: false };
+
+const { render, screen } = require( '@testing-library/react' );
+const React = require( 'react' );
+const SidebarOptions = require( '../sidebar-options' ).default;
+
+/**
+ * Render the sidebar for this file's server-object state.
+ */
+function renderSidebar() {
+	render( React.createElement( SidebarOptions ) );
+}
+
+describe( 'SidebarOptions with the site-wide AI switch off', () => {
+	it( 'locks the AI Answers toggle', () => {
+		renderSidebar();
+
+		expect( screen.getByLabelText( 'Enable AI Answers' ) ).toBeDisabled();
+	} );
+
+	it( 'explains why the toggle is locked', () => {
+		renderSidebar();
+
+		expect( screen.getByText( /Jetpack AI is turned off for this site/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps showing the saved choice', () => {
+		renderSidebar();
+
+		expect( screen.getByLabelText( 'Enable AI Answers' ) ).toBeChecked();
+	} );
+} );

--- a/projects/packages/search/src/customberg/components/sidebar/test/sidebar-options-ai-on.test.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/test/sidebar-options-ai-on.test.jsx
@@ -1,0 +1,75 @@
+/**
+ * The sidebar reads the server object once at module scope, so the flag has to
+ * be in place before the component is required — hence require() over import,
+ * and one file per server-object state.
+ */
+jest.mock( 'hooks/use-search-options', () => ( {
+	__esModule: true,
+	default: () => ( {
+		color: '#000000',
+		excludedPostTypes: [],
+		infiniteScroll: true,
+		filteringOpensOverlay: true,
+		resultFormat: 'minimal',
+		setColor: jest.fn(),
+		setExcludedPostTypes: jest.fn(),
+		setInfiniteScroll: jest.fn(),
+		setFilteringOpensOverlay: jest.fn(),
+		setResultFormat: jest.fn(),
+		setShowLogo: jest.fn(),
+		setSort: jest.fn(),
+		setTheme: jest.fn(),
+		showLogo: true,
+		sort: 'relevance',
+		theme: 'light',
+		aiAnswersEnabled: true,
+		setAiAnswersEnabled: jest.fn(),
+	} ),
+} ) );
+jest.mock( 'hooks/use-entity-record-state', () => ( {
+	__esModule: true,
+	default: () => ( { isSaving: false } ),
+} ) );
+jest.mock( 'hooks/use-loading-state', () => ( {
+	__esModule: true,
+	default: () => ( { isLoading: false } ),
+} ) );
+jest.mock( '../color-control', () => () => null );
+jest.mock( '../excluded-post-types-control', () => () => null );
+jest.mock( '../theme-control', () => () => null );
+
+// No aiMasterEnabled key: a back end that predates the field must not gate the toggle.
+window.JetpackInstantSearchOptions = { isFreePlan: false };
+
+const { render, screen } = require( '@testing-library/react' );
+const React = require( 'react' );
+const SidebarOptions = require( '../sidebar-options' ).default;
+
+/**
+ * Render the sidebar for this file's server-object state.
+ */
+function renderSidebar() {
+	render( React.createElement( SidebarOptions ) );
+}
+
+describe( 'SidebarOptions with the site-wide AI switch on', () => {
+	it( 'leaves the AI Answers toggle usable', () => {
+		renderSidebar();
+
+		expect( screen.getByLabelText( 'Enable AI Answers' ) ).toBeEnabled();
+	} );
+
+	it( 'shows the normal help text', () => {
+		renderSidebar();
+
+		expect(
+			screen.getByText( /Generate AI-powered answers to visitor queries/ )
+		).toBeInTheDocument();
+	} );
+
+	it( 'does not mention the AI switch', () => {
+		renderSidebar();
+
+		expect( screen.queryByText( /Jetpack AI is turned off/ ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/search/src/customberg/components/test/app-wrapper.test.jsx
+++ b/projects/packages/search/src/customberg/components/test/app-wrapper.test.jsx
@@ -1,0 +1,79 @@
+import { render } from '@testing-library/react';
+import useSearchOptions from 'hooks/use-search-options';
+import SearchApp from 'instant-search/components/search-app';
+
+jest.mock( 'instant-search/components/search-app', () => jest.fn( () => null ) );
+jest.mock( 'hooks/use-search-options', () => jest.fn( () => ( {} ) ) );
+jest.mock( 'hooks/use-loading-state', () => jest.fn( () => ( { isLoading: false } ) ) );
+jest.mock( 'instant-search/store', () => ( {
+	__esModule: true,
+	default: { subscribe: jest.fn(), dispatch: jest.fn(), getState: () => ( {} ) },
+} ) );
+jest.mock( 'instant-search/lib/api', () => ( { buildFilterAggregations: () => ( {} ) } ) );
+jest.mock( 'instant-search/lib/dom', () => ( { getThemeOptions: () => ( {} ) } ) );
+
+const makeServerObject = ( overrides = {} ) => ( {
+	webpackPublicPath: '/',
+	widgets: [],
+	widgetsOutsideOverlay: [],
+	overlayOptions: {},
+	aiAnswersEnabled: false,
+	...overrides,
+} );
+
+describe( 'AppWrapper AI Answers preview gating', () => {
+	let AppWrapper;
+
+	const searchAppOptions = () => SearchApp.mock.calls.at( -1 )[ 0 ].options;
+
+	beforeAll( () => {
+		// The module reads the server object at import time, so seed it first.
+		window.JetpackInstantSearchOptions = makeServerObject();
+		AppWrapper = require( '../app-wrapper' ).default;
+	} );
+
+	beforeEach( () => {
+		SearchApp.mockClear();
+	} );
+
+	it( 'feeds the preview the enforced value while the master is off', () => {
+		// A saved-on choice persists while the master is off, so the raw
+		// entity value can be true — the preview must not stream on it.
+		window.JetpackInstantSearchOptions = makeServerObject( { aiMasterEnabled: false } );
+		useSearchOptions.mockReturnValue( { aiAnswersEnabled: true } );
+
+		render( <AppWrapper /> );
+
+		expect( searchAppOptions().aiAnswersEnabled ).toBe( false );
+	} );
+
+	it( 'lets the sidebar toggle drive the preview while the master is on', () => {
+		window.JetpackInstantSearchOptions = makeServerObject( { aiMasterEnabled: true } );
+		useSearchOptions.mockReturnValue( { aiAnswersEnabled: true } );
+
+		render( <AppWrapper /> );
+
+		expect( searchAppOptions().aiAnswersEnabled ).toBe( true );
+	} );
+
+	it( 'defaults to ungated when the server object predates the master flag', () => {
+		window.JetpackInstantSearchOptions = makeServerObject();
+		useSearchOptions.mockReturnValue( { aiAnswersEnabled: true } );
+
+		render( <AppWrapper /> );
+
+		expect( searchAppOptions().aiAnswersEnabled ).toBe( true );
+	} );
+
+	it( 'falls back to the server value when the sidebar has no local edit', () => {
+		window.JetpackInstantSearchOptions = makeServerObject( {
+			aiMasterEnabled: true,
+			aiAnswersEnabled: true,
+		} );
+		useSearchOptions.mockReturnValue( {} );
+
+		render( <AppWrapper /> );
+
+		expect( searchAppOptions().aiAnswersEnabled ).toBe( true );
+	} );
+} );

--- a/projects/packages/search/src/dashboard/components/ai-answers-tab/index.jsx
+++ b/projects/packages/search/src/dashboard/components/ai-answers-tab/index.jsx
@@ -24,7 +24,24 @@ export default function AiAnswersTab() {
 	const blogID = useSelect( select => select( STORE_ID ).getBlogId(), [] );
 	const siteAdminUrl = useSelect( select => select( STORE_ID ).getSiteAdminUrl(), [] );
 
-	const { isAiAnswersEnabled, isInstantSearchEnabled, setAiAnswersEnabled } = useSearchSettings();
+	const {
+		isAiAnswersEnabled,
+		isInstantSearchEnabled,
+		isAiMasterEnabled,
+		isAiAnswersSaved,
+		setAiAnswersEnabled,
+	} = useSearchSettings();
+
+	// While the master switch is off the reported value is gated to false, so show
+	// the saved choice instead of misreporting it back as off.
+	const isToggleChecked = isAiMasterEnabled ? isAiAnswersEnabled : isAiAnswersSaved;
+
+	// Locked while the master is off, matching the AI Features view: the saved
+	// choice is shown but not editable. With the master on but Instant Search
+	// off, the toggle stays usable only to turn an already-enabled feature off.
+	const isToggleDisabled =
+		! isAiMasterEnabled || ( ! isInstantSearchEnabled && ! isAiAnswersEnabled );
+	const isAiAnswersActive = isAiMasterEnabled && isAiAnswersEnabled && isInstantSearchEnabled;
 
 	const { run: sendToCart } = useProductCheckoutWorkflow( {
 		productSlug: 'jetpack_search',
@@ -94,7 +111,20 @@ export default function AiAnswersTab() {
 							className="jp-search-ai-answers-tab__settings-inner lg-col-span-8 md-col-span-6 sm-col-span-4"
 						>
 							{ isLoading && <p>{ __( 'Loading…', 'jetpack-search-pkg' ) }</p> }
-							{ supportsInstantSearch && ! isInstantSearchEnabled && (
+							{ supportsInstantSearch && ! isAiMasterEnabled && (
+								<Notice.Root intent="warning">
+									<Notice.Title>
+										{ __( 'Jetpack AI is turned off for this site.', 'jetpack-search-pkg' ) }
+									</Notice.Title>
+									<Notice.Description>
+										{ __(
+											'Your AI Answers setting is saved and will apply again when AI is turned back on.',
+											'jetpack-search-pkg'
+										) }
+									</Notice.Description>
+								</Notice.Root>
+							) }
+							{ supportsInstantSearch && isAiMasterEnabled && ! isInstantSearchEnabled && (
 								<Notice.Root intent="warning">
 									<Notice.Title>
 										{ __(
@@ -109,10 +139,10 @@ export default function AiAnswersTab() {
 							) }
 							<ToggleControl
 								label={ __( 'Enable AI Answers', 'jetpack-search-pkg' ) }
-								checked={ isAiAnswersEnabled }
+								checked={ isToggleChecked }
 								onChange={ setAiAnswersEnabled }
 								className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
-								disabled={ ! isInstantSearchEnabled && ! isAiAnswersEnabled }
+								disabled={ isToggleDisabled }
 							/>
 
 							{ ! isLoading && ! isUnavailable && (
@@ -124,13 +154,13 @@ export default function AiAnswersTab() {
 										onChange={ setContent }
 										placeholder={ DEFAULT_PERSONALITY }
 										rows={ 10 }
-										disabled={ isSaving || ! isAiAnswersEnabled || ! isInstantSearchEnabled }
+										disabled={ isSaving || ! isAiAnswersActive }
 									/>
 									<div className="jp-search-ai-answers-tab__actions">
 										<Button
 											variant="solid"
 											onClick={ savePersonality }
-											disabled={ isSaving || ! isAiAnswersEnabled || ! isInstantSearchEnabled }
+											disabled={ isSaving || ! isAiAnswersActive }
 										>
 											{ isSaving ? savingLabel : saveLabel }
 										</Button>

--- a/projects/packages/search/src/dashboard/components/test/ai-answers-tab.test.jsx
+++ b/projects/packages/search/src/dashboard/components/test/ai-answers-tab.test.jsx
@@ -81,12 +81,16 @@ const mockUpdateJetpackSettings = jest.fn();
  * @param {boolean} root0.isInstantSearchEnabled - Whether instant search is enabled.
  * @param {boolean} root0.isFreePlan             - Whether the site is on a free plan.
  * @param {boolean} root0.isAiAnswersEnabled     - Whether AI Answers is enabled.
+ * @param {boolean} root0.isAiMasterEnabled      - Whether the site-wide Jetpack AI switch is on.
+ * @param {boolean} root0.isAiAnswersSaved       - The saved AI Answers choice, ignoring gates.
  */
 function setupStore( {
 	supportsInstantSearch = true,
 	isInstantSearchEnabled = true,
 	isFreePlan = false,
 	isAiAnswersEnabled = false,
+	isAiMasterEnabled = true,
+	isAiAnswersSaved = false,
 } = {} ) {
 	useDispatch.mockReturnValue( {
 		updateJetpackSettings: mockUpdateJetpackSettings,
@@ -97,6 +101,8 @@ function setupStore( {
 			isInstantSearchEnabled: () => isInstantSearchEnabled,
 			isFreePlan: () => isFreePlan,
 			isAiAnswersEnabled: () => isAiAnswersEnabled,
+			isAiMasterEnabled: () => isAiMasterEnabled,
+			isAiAnswersSaved: () => isAiAnswersSaved,
 			getBlogId: () => 1,
 			getSiteAdminUrl: () => 'http://example.com/wp-admin/',
 		} ) )
@@ -171,5 +177,40 @@ describe( 'AiAnswersTab', () => {
 		render( <AiAnswersTab /> );
 		const toggle = await screen.findByRole( 'checkbox' );
 		expect( toggle ).toBeDisabled();
+	} );
+
+	it( 'toggle is disabled when the site-wide AI switch is off', async () => {
+		// The back end reports ai_answers_enabled as the gated value, so it is
+		// false whenever the master is off — the saved choice comes separately.
+		setupStore( { isAiMasterEnabled: false, isAiAnswersEnabled: false, isAiAnswersSaved: true } );
+		render( <AiAnswersTab /> );
+		const toggle = await screen.findByRole( 'checkbox' );
+		expect( toggle ).toBeDisabled();
+	} );
+
+	it( 'toggle keeps showing a saved choice while the site-wide AI switch is off', async () => {
+		setupStore( { isAiMasterEnabled: false, isAiAnswersEnabled: false, isAiAnswersSaved: true } );
+		render( <AiAnswersTab /> );
+		const toggle = await screen.findByRole( 'checkbox' );
+		expect( toggle ).toBeChecked();
+	} );
+
+	it( 'explains why the toggle is unavailable when the site-wide AI switch is off', async () => {
+		setupStore( { isAiMasterEnabled: false } );
+		render( <AiAnswersTab /> );
+		await expect(
+			screen.findByText( 'Jetpack AI is turned off for this site.' )
+		).resolves.toBeInTheDocument();
+		expect( screen.getByText( /will apply again when AI is turned back on/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not explain the site-wide AI switch when it is on', async () => {
+		setupStore( { isAiMasterEnabled: true } );
+		render( <AiAnswersTab /> );
+		await waitFor( () => {
+			expect(
+				screen.queryByText( 'Jetpack AI is turned off for this site.' )
+			).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/projects/packages/search/src/dashboard/hooks/use-search-settings.js
+++ b/projects/packages/search/src/dashboard/hooks/use-search-settings.js
@@ -6,7 +6,7 @@ import { STORE_ID } from 'store';
  * Provides AI Answers and Instant Search settings from the store,
  * along with a dispatcher for updating them.
  *
- * @return {{ isAiAnswersEnabled: boolean, isInstantSearchEnabled: boolean, setAiAnswersEnabled: Function }} Settings state and updater.
+ * @return {{ isAiAnswersEnabled: boolean, isInstantSearchEnabled: boolean, isAiMasterEnabled: boolean, isAiAnswersSaved: boolean, setAiAnswersEnabled: Function }} Settings state and updater.
  */
 export default function useSearchSettings() {
 	const isAiAnswersEnabled = useSelect( select => select( STORE_ID ).isAiAnswersEnabled(), [] );
@@ -15,6 +15,9 @@ export default function useSearchSettings() {
 		[]
 	);
 
+	const isAiMasterEnabled = useSelect( select => select( STORE_ID ).isAiMasterEnabled(), [] );
+	const isAiAnswersSaved = useSelect( select => select( STORE_ID ).isAiAnswersSaved(), [] );
+
 	const { updateJetpackSettings } = useDispatch( STORE_ID );
 
 	const setAiAnswersEnabled = useCallback(
@@ -22,5 +25,11 @@ export default function useSearchSettings() {
 		[ updateJetpackSettings ]
 	);
 
-	return { isAiAnswersEnabled, isInstantSearchEnabled, setAiAnswersEnabled };
+	return {
+		isAiAnswersEnabled,
+		isInstantSearchEnabled,
+		isAiMasterEnabled,
+		isAiAnswersSaved,
+		setAiAnswersEnabled,
+	};
 }

--- a/projects/packages/search/src/dashboard/store/selectors/jetpack-settings.js
+++ b/projects/packages/search/src/dashboard/store/selectors/jetpack-settings.js
@@ -22,6 +22,12 @@ const jetpackSettingSelectors = {
 		Object.prototype.hasOwnProperty.call( state.jetpackSettings, 'reader_chat' ),
 	isReaderChatEnabled: state => state.jetpackSettings.reader_chat,
 	isAiAnswersEnabled: state => !! state.jetpackSettings.ai_answers_enabled,
+	// The stored choice, ungated — shown while the master switch is off so a
+	// saved setting isn't misreported back to the user as off.
+	isAiAnswersSaved: state => !! state.jetpackSettings.ai_answers_saved,
+	// Treat a missing value as on, so a back end that predates the field doesn't
+	// gate the toggle.
+	isAiMasterEnabled: state => state.jetpackSettings.ai_master_enabled !== false,
 	isSearchSuggestionsEnabled: state => !! state.jetpackSettings.search_suggestions_enabled,
 	isWooCommerceSearchTemplateOverrideEnabled: state =>
 		!! state.jetpackSettings.override_woocommerce_search_template,

--- a/projects/packages/search/src/dashboard/store/selectors/test/jetpack-settings.test.js
+++ b/projects/packages/search/src/dashboard/store/selectors/test/jetpack-settings.test.js
@@ -43,4 +43,38 @@ describe( 'jetpackSettingSelectors', () => {
 			expect( jetpackSettingSelectors.isAiAnswersEnabled( state ) ).toBe( false );
 		} );
 	} );
+
+	describe( 'isAiAnswersSaved', () => {
+		it( 'returns the stored choice even while the effective value is off', () => {
+			const state = {
+				jetpackSettings: { ai_answers_saved: true, ai_answers_enabled: false },
+			};
+			expect( jetpackSettingSelectors.isAiAnswersSaved( state ) ).toBe( true );
+		} );
+
+		it( 'returns false when the stored choice is off', () => {
+			const state = { jetpackSettings: { ai_answers_saved: false } };
+			expect( jetpackSettingSelectors.isAiAnswersSaved( state ) ).toBe( false );
+		} );
+
+		it( 'returns false when the field is missing', () => {
+			expect( jetpackSettingSelectors.isAiAnswersSaved( { jetpackSettings: {} } ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isAiMasterEnabled', () => {
+		it( 'returns false only when the field is explicitly false', () => {
+			const state = { jetpackSettings: { ai_master_enabled: false } };
+			expect( jetpackSettingSelectors.isAiMasterEnabled( state ) ).toBe( false );
+		} );
+
+		it( 'returns true when the switch is on', () => {
+			const state = { jetpackSettings: { ai_master_enabled: true } };
+			expect( jetpackSettingSelectors.isAiMasterEnabled( state ) ).toBe( true );
+		} );
+
+		it( 'treats a missing field as on, for back ends that predate it', () => {
+			expect( jetpackSettingSelectors.isAiMasterEnabled( { jetpackSettings: {} } ) ).toBe( true );
+		} );
+	} );
 } );

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
@@ -27,6 +27,12 @@ if ( ! Search_Blocks::supports_paid_search() ) {
 	return;
 }
 
+// Host-owner AI opt-out (core's wp_supports_ai() / WP_AI_SUPPORT). The overlay
+// already honors it through the plugin's filter gate; the block must agree.
+if ( ! AI_Answers::host_allows_ai() ) {
+	return;
+}
+
 // $attributes is injected by WordPress at block-render time via the
 // `render_callback` include scope; static analysis can't see the binding,
 // so both phpcs and Phan need a one-line suppression on the next statement.

--- a/projects/packages/search/tests/php/AI_Answers_Test.php
+++ b/projects/packages/search/tests/php/AI_Answers_Test.php
@@ -13,6 +13,8 @@ use Automattic\Jetpack\Search\TestCase as Search_TestCase;
  * Unit tests for the AI_Answers class.
  */
 class AI_Answers_Test extends Search_TestCase {
+	use Toggles_Ai_Master;
+
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		( new AI_Answers() )->init();
@@ -35,6 +37,8 @@ class AI_Answers_Test extends Search_TestCase {
 		$this->test_post_ids = array();
 
 		parent::tearDown();
+
+		$this->remove_ai_master_filters();
 
 		if ( $this->posts_query_filter !== null ) {
 			remove_filter( 'posts_pre_query', $this->posts_query_filter, 10 );
@@ -59,6 +63,62 @@ class AI_Answers_Test extends Search_TestCase {
 		add_filter( 'jetpack_search_ai_answers_enabled', '__return_true' );
 		$this->assertTrue( AI_Answers::is_enabled() );
 		remove_filter( 'jetpack_search_ai_answers_enabled', '__return_true' );
+	}
+
+	// -------------------------------------------------------------------------
+	// Tests for the site-wide Jetpack AI master switch
+	// -------------------------------------------------------------------------
+
+	/**
+	 * The saved choice is the raw option.
+	 */
+	public function test_is_saved_on_returns_the_raw_option() {
+		$this->assertFalse( AI_Answers::is_saved_on() );
+		update_option( 'jetpack_search_ai_answers_enabled', true );
+		$this->assertTrue( AI_Answers::is_saved_on() );
+		delete_option( 'jetpack_search_ai_answers_enabled' );
+	}
+
+	public function test_is_saved_on_ignores_the_filter() {
+		// The saved choice is the raw option; gates on the filter must not leak in.
+		add_filter( 'jetpack_search_ai_answers_enabled', '__return_true' );
+		$this->assertFalse( AI_Answers::is_saved_on() );
+		remove_filter( 'jetpack_search_ai_answers_enabled', '__return_true' );
+	}
+
+	public function test_is_enabled_is_false_when_the_master_is_off() {
+		// The saved choice persists while the master is off; only is_enabled() gates it.
+		update_option( 'jetpack_search_ai_answers_enabled', true );
+		$this->turn_ai_master_off();
+
+		$this->assertTrue( AI_Answers::is_saved_on() );
+		$this->assertFalse( AI_Answers::is_enabled() );
+
+		delete_option( 'jetpack_search_ai_answers_enabled' );
+	}
+
+	public function test_is_master_enabled_is_true_without_a_master_gate() {
+		// Standalone Jetpack Search plugin: nothing subscribes to the filter, so
+		// there is no master switch to obey and the site must not be gated.
+		$this->assertTrue( AI_Answers::is_master_enabled() );
+	}
+
+	public function test_is_master_enabled_is_false_when_the_master_is_off() {
+		$this->turn_ai_master_off();
+		$this->assertFalse( AI_Answers::is_master_enabled() );
+	}
+
+	public function test_is_master_enabled_is_true_when_the_master_is_on() {
+		$this->turn_ai_master_on();
+		$this->assertTrue( AI_Answers::is_master_enabled() );
+	}
+
+	public function test_is_master_enabled_ignores_the_option() {
+		// The master state is about the gates, not the feature's saved choice.
+		update_option( 'jetpack_search_ai_answers_enabled', false );
+		$this->turn_ai_master_on();
+		$this->assertTrue( AI_Answers::is_master_enabled() );
+		delete_option( 'jetpack_search_ai_answers_enabled' );
 	}
 
 	public function test_get_behavior_instructions_returns_empty_by_default() {

--- a/projects/packages/search/tests/php/AI_Answers_Test.php
+++ b/projects/packages/search/tests/php/AI_Answers_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Search\TestCase as Search_TestCase;
 
 /**
@@ -39,6 +40,8 @@ class AI_Answers_Test extends Search_TestCase {
 		parent::tearDown();
 
 		$this->remove_ai_master_filters();
+		unset( $GLOBALS['jetpack_search_test_internal_env'] );
+		Constants::clear_single_constant( 'IS_WPCOM' );
 
 		if ( $this->posts_query_filter !== null ) {
 			remove_filter( 'posts_pre_query', $this->posts_query_filter, 10 );
@@ -111,6 +114,38 @@ class AI_Answers_Test extends Search_TestCase {
 	public function test_is_master_enabled_is_true_when_the_master_is_on() {
 		$this->turn_ai_master_on();
 		$this->assertTrue( AI_Answers::is_master_enabled() );
+	}
+
+	public function test_is_master_enabled_reports_on_outside_internal_testing_environments() {
+		// The master rollout is a12s-scoped: public sites report ungated even
+		// when the gate is registered, so no master-off UI leaks before the sweep.
+		$this->turn_ai_master_off();
+		$GLOBALS['jetpack_search_test_internal_env'] = false;
+
+		$this->assertTrue( AI_Answers::is_master_enabled() );
+	}
+
+	public function test_is_master_enabled_reports_the_gate_on_wpcom_simple_regardless_of_environment() {
+		// On Simple the option keeps its contract and the master enforces
+		// publicly (see the plugin's is_master_rollout_active()), so the
+		// reporting must follow it there even outside internal environments.
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->turn_ai_master_off();
+		$GLOBALS['jetpack_search_test_internal_env'] = false;
+
+		$this->assertFalse( AI_Answers::is_master_enabled() );
+	}
+
+	public function test_is_enabled_still_gated_outside_internal_testing_environments() {
+		// Enforcement is the plugin's public filter — only the *reporting* is
+		// scoped. A public master-off site still reports the feature off.
+		update_option( 'jetpack_search_ai_answers_enabled', true );
+		$this->turn_ai_master_off();
+		$GLOBALS['jetpack_search_test_internal_env'] = false;
+
+		$this->assertFalse( AI_Answers::is_enabled() );
+
+		delete_option( 'jetpack_search_ai_answers_enabled' );
 	}
 
 	public function test_is_master_enabled_ignores_the_option() {

--- a/projects/packages/search/tests/php/AI_Answers_Test.php
+++ b/projects/packages/search/tests/php/AI_Answers_Test.php
@@ -121,6 +121,34 @@ class AI_Answers_Test extends Search_TestCase {
 		delete_option( 'jetpack_search_ai_answers_enabled' );
 	}
 
+	// -------------------------------------------------------------------------
+	// Tests for the host's AI opt-out
+	// -------------------------------------------------------------------------
+
+	/**
+	 * The host's opt-out is core's call, so the package follows wp_supports_ai().
+	 */
+	public function test_host_allows_ai_follows_core_when_the_host_opts_out() {
+		add_filter( 'wp_supports_ai', '__return_false' );
+
+		$this->assertFalse( AI_Answers::host_allows_ai() );
+
+		remove_filter( 'wp_supports_ai', '__return_false' );
+	}
+
+	public function test_host_allows_ai_follows_core_when_the_host_allows_it() {
+		add_filter( 'wp_supports_ai', '__return_true' );
+
+		$this->assertTrue( AI_Answers::host_allows_ai() );
+
+		remove_filter( 'wp_supports_ai', '__return_true' );
+	}
+
+	public function test_host_allows_ai_defaults_to_true() {
+		// No host opt-out configured: AI Answers must not be gated.
+		$this->assertTrue( AI_Answers::host_allows_ai() );
+	}
+
 	public function test_get_behavior_instructions_returns_empty_by_default() {
 		// wp_guideline is not registered; option is unset — expect empty string.
 		$this->assertSame( '', AI_Answers::get_behavior_instructions() );

--- a/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
+++ b/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Search;
 
+use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,6 +21,7 @@ use PHPUnit\Framework\TestCase;
  * front-end consumer expects.
  */
 class Ai_Answer_Render_Test extends TestCase {
+	use Toggles_Ai_Master;
 
 	/**
 	 * Register the ai-answer block inline so `do_blocks()` can resolve it
@@ -83,8 +85,30 @@ class Ai_Answer_Render_Test extends TestCase {
 
 	public function tearDown(): void {
 		delete_option( Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY );
+		// No per-test WorDBless reset in this plain-TestCase class, so clear the
+		// option here too — a failed assertion must not leak it into later tests.
+		delete_option( AI_Answers::ENABLED_OPTION );
 		Search_Blocks::reset_supports_paid_search_cache();
+		Constants::clear_single_constant( 'WP_AI_SUPPORT' );
+		remove_filter( 'wp_supports_ai', '__return_false' );
+		remove_filter( 'wp_supports_ai', '__return_true' );
+		$this->remove_ai_master_filters();
 		parent::tearDown();
+	}
+
+	/**
+	 * Set the host's AI support through whichever mechanism this WordPress has:
+	 * core's wp_supports_ai() filter where the function exists, the raw
+	 * WP_AI_SUPPORT constant on versions that predate it.
+	 *
+	 * @param bool $supported Whether the host supports AI.
+	 */
+	private function set_host_ai_support( bool $supported ): void {
+		if ( function_exists( 'wp_supports_ai' ) ) {
+			add_filter( 'wp_supports_ai', $supported ? '__return_true' : '__return_false' );
+			return;
+		}
+		Constants::set_constant( 'WP_AI_SUPPORT', $supported );
 	}
 
 	/**
@@ -199,6 +223,50 @@ class Ai_Answer_Render_Test extends TestCase {
 
 		$this->assertStringNotContainsString( 'jp-search-answers-panel', $markup );
 		$this->assertStringNotContainsString( 'data-wp-interactive', $markup );
+	}
+
+	public function test_renders_with_the_master_on_independent_of_site_option() {
+		// The contract's Search row: with the master on, the site option only
+		// governs the overlay — the embedded block renders either way.
+		$this->turn_ai_master_on();
+
+		update_option( 'jetpack_search_ai_answers_enabled', false );
+		$markup_with_option_off = $this->render();
+		update_option( 'jetpack_search_ai_answers_enabled', true );
+		$markup_with_option_on = $this->render();
+		delete_option( 'jetpack_search_ai_answers_enabled' );
+
+		foreach (
+			array(
+				'option off' => $markup_with_option_off,
+				'option on'  => $markup_with_option_on,
+			) as $label => $markup
+		) {
+			$this->assertStringContainsString(
+				'jp-search-answers-panel',
+				$markup,
+				"Block wrapper should render with the master on and the site option $label."
+			);
+		}
+	}
+
+	public function test_renders_nothing_when_the_host_disables_ai() {
+		// The host owner's AI opt-out (WP_AI_SUPPORT / wp_supports_ai()) already
+		// suppresses the overlay; the block must give the same answer.
+		$this->set_host_ai_support( false );
+
+		$markup = $this->render();
+
+		$this->assertStringNotContainsString( 'jp-search-answers-panel', $markup );
+		$this->assertStringNotContainsString( 'data-wp-interactive', $markup );
+	}
+
+	public function test_renders_when_the_host_allows_ai() {
+		$this->set_host_ai_support( true );
+
+		$markup = $this->render();
+
+		$this->assertStringContainsString( 'jp-search-answers-panel', $markup );
 	}
 
 	public function test_panel_is_hidden_until_status_changes() {

--- a/projects/packages/search/tests/php/Initial_Javascript_State_Test.php
+++ b/projects/packages/search/tests/php/Initial_Javascript_State_Test.php
@@ -17,7 +17,17 @@ class Initial_Javascript_State_Test extends Search_TestCase {
 
 	public function tearDown(): void {
 		$this->remove_ai_master_filters();
+		unset( $GLOBALS['jetpack_search_test_internal_env'] );
 		parent::tearDown();
+	}
+
+	public function test_it_reports_the_master_as_on_outside_internal_testing_environments() {
+		$this->turn_ai_master_off();
+		$GLOBALS['jetpack_search_test_internal_env'] = false;
+
+		$state = Helper::generate_initial_javascript_state();
+
+		$this->assertTrue( $state['aiMasterEnabled'] );
 	}
 
 	public function test_it_reports_the_ai_master_switch_as_off() {

--- a/projects/packages/search/tests/php/Initial_Javascript_State_Test.php
+++ b/projects/packages/search/tests/php/Initial_Javascript_State_Test.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Tests for the Instant Search / Customberg initial state payload.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use Automattic\Jetpack\Search\TestCase as Search_TestCase;
+
+/**
+ * Unit tests for Helper::generate_initial_javascript_state().
+ */
+class Initial_Javascript_State_Test extends Search_TestCase {
+	use Toggles_Ai_Master;
+
+	public function tearDown(): void {
+		$this->remove_ai_master_filters();
+		parent::tearDown();
+	}
+
+	public function test_it_reports_the_ai_master_switch_as_off() {
+		$this->turn_ai_master_off();
+
+		$state = Helper::generate_initial_javascript_state();
+
+		$this->assertFalse( $state['aiMasterEnabled'] );
+	}
+
+	public function test_it_reports_the_ai_master_switch_as_on() {
+		$this->turn_ai_master_on();
+
+		$state = Helper::generate_initial_javascript_state();
+
+		$this->assertTrue( $state['aiMasterEnabled'] );
+	}
+
+	public function test_the_enabled_flag_stays_gated_while_the_saved_choice_is_on() {
+		update_option( 'jetpack_search_ai_answers_enabled', true );
+		$this->turn_ai_master_off();
+
+		$state = Helper::generate_initial_javascript_state();
+
+		$this->assertFalse( $state['aiAnswersEnabled'] );
+
+		delete_option( 'jetpack_search_ai_answers_enabled' );
+	}
+}

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -14,6 +14,7 @@ use WP_REST_Server;
  * @package automattic/jetpack-search
  */
 class REST_Controller_Test extends Search_TestCase {
+	use Toggles_Ai_Master;
 
 	/**
 	 * REST Server object.
@@ -62,6 +63,7 @@ class REST_Controller_Test extends Search_TestCase {
 			unregister_setting( 'general', 'reader_chat' );
 		}
 		delete_option( 'reader_chat' );
+		$this->remove_ai_master_filters();
 		parent::tearDown();
 	}
 
@@ -145,6 +147,8 @@ class REST_Controller_Test extends Search_TestCase {
 				'experience'                           => 'overlay',
 				'search_suggestions_enabled'           => false,
 				'override_woocommerce_search_template' => false,
+				'ai_answers_saved'                     => false,
+				'ai_master_enabled'                    => true,
 			)
 		);
 
@@ -205,6 +209,8 @@ class REST_Controller_Test extends Search_TestCase {
 				'experience'                           => 'off',
 				'search_suggestions_enabled'           => false,
 				'override_woocommerce_search_template' => false,
+				'ai_answers_saved'                     => false,
+				'ai_master_enabled'                    => true,
 			)
 		);
 
@@ -232,6 +238,8 @@ class REST_Controller_Test extends Search_TestCase {
 			'ai_answers_enabled'                   => false,
 			'search_suggestions_enabled'           => false,
 			'override_woocommerce_search_template' => false,
+			'ai_answers_saved'                     => false,
+			'ai_master_enabled'                    => true,
 		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -258,6 +266,8 @@ class REST_Controller_Test extends Search_TestCase {
 			'ai_answers_enabled'                   => false,
 			'search_suggestions_enabled'           => false,
 			'override_woocommerce_search_template' => false,
+			'ai_answers_saved'                     => false,
+			'ai_master_enabled'                    => true,
 		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -284,6 +294,8 @@ class REST_Controller_Test extends Search_TestCase {
 			'ai_answers_enabled'                   => false,
 			'search_suggestions_enabled'           => false,
 			'override_woocommerce_search_template' => false,
+			'ai_answers_saved'                     => false,
+			'ai_master_enabled'                    => true,
 		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -310,6 +322,8 @@ class REST_Controller_Test extends Search_TestCase {
 			'ai_answers_enabled'                   => false,
 			'search_suggestions_enabled'           => false,
 			'override_woocommerce_search_template' => false,
+			'ai_answers_saved'                     => false,
+			'ai_master_enabled'                    => true,
 		);
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
@@ -643,6 +657,87 @@ class REST_Controller_Test extends Search_TestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertFalse( $data['ai_answers_enabled'] );
+	}
+
+	/**
+	 * Testing that ai_answers_enabled cannot be enabled while the site-wide
+	 * Jetpack AI master switch is off.
+	 */
+	public function test_update_settings_cannot_enable_ai_answers_when_ai_master_is_off() {
+		wp_set_current_user( $this->admin_id );
+		$this->turn_ai_master_off();
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'ai_answers_enabled' => true ), JSON_UNESCAPED_SLASHES ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertFalse( (bool) get_option( 'jetpack_search_ai_answers_enabled', false ) );
+	}
+
+	/**
+	 * Testing that ai_answers_enabled can still be turned off while the site-wide
+	 * Jetpack AI master switch is off.
+	 */
+	public function test_update_settings_can_disable_ai_answers_when_ai_master_is_off() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'jetpack_search_ai_answers_enabled', true );
+		$this->turn_ai_master_off();
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'ai_answers_enabled' => false ), JSON_UNESCAPED_SLASHES ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( (bool) get_option( 'jetpack_search_ai_answers_enabled', false ) );
+	}
+
+	/**
+	 * Testing that the settings payload reports the master switch state, so the
+	 * dashboard can explain why the toggle is unavailable.
+	 */
+	public function test_get_settings_reports_the_ai_master_state() {
+		wp_set_current_user( $this->admin_id );
+		$this->turn_ai_master_off();
+
+		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/search/settings' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( $response->get_data()['ai_master_enabled'] );
+	}
+
+	/**
+	 * Testing that the settings payload reports the saved choice separately from
+	 * the effective one, so the dashboard can show it while the master is off.
+	 */
+	public function test_get_settings_reports_the_saved_ai_answers_choice() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'jetpack_search_ai_answers_enabled', true );
+		$this->turn_ai_master_off();
+
+		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/search/settings' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertFalse( $data['ai_answers_enabled'] );
+		$this->assertTrue( $data['ai_answers_saved'] );
+	}
+
+	/**
+	 * The reported master state is true on a site that has no master switch.
+	 */
+	public function test_get_settings_reports_the_ai_master_on_without_a_master_switch() {
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/search/settings' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()['ai_master_enabled'] );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -631,6 +631,7 @@ class REST_Controller_Test extends Search_TestCase {
 	 */
 	public function test_update_settings_ai_answers_enabled_true() {
 		wp_set_current_user( $this->admin_id );
+		$this->enable_instant_search();
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
 		$request->set_header( 'content-type', 'application/json' );
@@ -657,6 +658,99 @@ class REST_Controller_Test extends Search_TestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertFalse( $data['ai_answers_enabled'] );
+	}
+
+	/**
+	 * Turn Instant Search on through the settings endpoint, the way the
+	 * dashboard does, so AI Answers' Instant Search precondition is met.
+	 */
+	private function enable_instant_search() {
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'module_active'          => true,
+					'instant_search_enabled' => true,
+				),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+		$this->assertEquals( 200, $this->server->dispatch( $request )->get_status() );
+	}
+
+	/**
+	 * Testing that ai_answers_enabled cannot be enabled while Instant Search is
+	 * off — AI Answers only runs inside Instant Search, so the precondition is
+	 * validated server-side, not just in the dashboard UI.
+	 */
+	public function test_update_settings_cannot_enable_ai_answers_without_instant_search() {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'ai_answers_enabled' => true ), JSON_UNESCAPED_SLASHES ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertFalse( (bool) get_option( 'jetpack_search_ai_answers_enabled', false ) );
+	}
+
+	/**
+	 * Testing that ai_answers_enabled can be enabled once Instant Search is on.
+	 */
+	public function test_update_settings_can_enable_ai_answers_with_instant_search_on() {
+		wp_set_current_user( $this->admin_id );
+		$this->enable_instant_search();
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'ai_answers_enabled' => true ), JSON_UNESCAPED_SLASHES ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( (bool) get_option( 'jetpack_search_ai_answers_enabled', false ) );
+	}
+
+	/**
+	 * Testing that one request may turn Instant Search and AI Answers on together.
+	 */
+	public function test_update_settings_can_enable_ai_answers_and_instant_search_together() {
+		wp_set_current_user( $this->admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'module_active'          => true,
+					'instant_search_enabled' => true,
+					'ai_answers_enabled'     => true,
+				),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( (bool) get_option( 'jetpack_search_ai_answers_enabled', false ) );
+	}
+
+	/**
+	 * Testing that ai_answers_enabled can still be turned off while Instant
+	 * Search is off — only enabling carries the precondition.
+	 */
+	public function test_update_settings_can_disable_ai_answers_without_instant_search() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'jetpack_search_ai_answers_enabled', true );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'ai_answers_enabled' => false ), JSON_UNESCAPED_SLASHES ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertFalse( (bool) get_option( 'jetpack_search_ai_answers_enabled', false ) );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -64,6 +64,7 @@ class REST_Controller_Test extends Search_TestCase {
 		}
 		delete_option( 'reader_chat' );
 		$this->remove_ai_master_filters();
+		unset( $GLOBALS['jetpack_search_test_internal_env'] );
 		parent::tearDown();
 	}
 
@@ -819,6 +820,30 @@ class REST_Controller_Test extends Search_TestCase {
 		$data = $response->get_data();
 		$this->assertFalse( $data['ai_answers_enabled'] );
 		$this->assertTrue( $data['ai_answers_saved'] );
+	}
+
+	/**
+	 * Outside internal testing environments the payload reports the master as
+	 * on and enabling stays allowed — the rollout must not leak publicly.
+	 */
+	public function test_master_reporting_is_scoped_to_internal_testing_environments() {
+		wp_set_current_user( $this->admin_id );
+		$this->enable_instant_search();
+		$this->turn_ai_master_off();
+		$GLOBALS['jetpack_search_test_internal_env'] = false;
+
+		$get = new WP_REST_Request( 'GET', '/jetpack/v4/search/settings' );
+		$this->assertTrue( $this->server->dispatch( $get )->get_data()['ai_master_enabled'] );
+
+		$post = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
+		$post->set_header( 'content-type', 'application/json' );
+		$post->set_body( wp_json_encode( array( 'ai_answers_enabled' => true ), JSON_UNESCAPED_SLASHES ) );
+		$response = $this->server->dispatch( $post );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( (bool) get_option( 'jetpack_search_ai_answers_enabled', false ) );
+
+		unset( $GLOBALS['jetpack_search_test_internal_env'] );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/bootstrap.php
+++ b/projects/packages/search/tests/php/bootstrap.php
@@ -10,6 +10,7 @@
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/class-testcase.php';
+require_once __DIR__ . '/trait-toggles-ai-master.php';
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Search\Helper;

--- a/projects/packages/search/tests/php/bootstrap.php
+++ b/projects/packages/search/tests/php/bootstrap.php
@@ -35,5 +35,14 @@ function dbless_default_options() {
 	);
 }
 
+// The plugin defines this; the package cannot. Stub it so tests can drive both
+// branches of the internal-environment guard in AI_Answers::is_master_enabled().
+// Defaults to true so the master-gate tests exercise the gate.
+if ( ! function_exists( 'jetpack_is_internal_testing_environment' ) ) {
+	function jetpack_is_internal_testing_environment() {
+		return (bool) ( $GLOBALS['jetpack_search_test_internal_env'] ?? true );
+	}
+}
+
 // Initialize WordPress test environment
 \Automattic\Jetpack\Test_Environment::init();

--- a/projects/packages/search/tests/php/trait-toggles-ai-master.php
+++ b/projects/packages/search/tests/php/trait-toggles-ai-master.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Helpers for flipping the site-wide Jetpack AI master switch in tests.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+/**
+ * The Jetpack plugin enforces the master switch (and the host's AI opt-out)
+ * through the `jetpack_search_ai_answers_enabled` filter; these helpers stand
+ * in for its gate callback. Call remove_ai_master_filters() in tearDown().
+ */
+trait Toggles_Ai_Master {
+
+	/**
+	 * The plugin's gate callback with the master off: restrictive for any input.
+	 *
+	 * @return bool
+	 */
+	public function apply_master_off_gate() {
+		return false;
+	}
+
+	/**
+	 * The plugin's gate callback with the master on: passes the value through.
+	 *
+	 * @param mixed $enabled Filtered value.
+	 * @return bool
+	 */
+	public function apply_master_on_gate( $enabled ) {
+		return (bool) $enabled;
+	}
+
+	/**
+	 * Site has a master switch and it is off.
+	 */
+	protected function turn_ai_master_off() {
+		$this->remove_ai_master_filters();
+		add_filter( 'jetpack_search_ai_answers_enabled', array( $this, 'apply_master_off_gate' ) );
+	}
+
+	/**
+	 * Site has a master switch and it is on.
+	 */
+	protected function turn_ai_master_on() {
+		$this->remove_ai_master_filters();
+		add_filter( 'jetpack_search_ai_answers_enabled', array( $this, 'apply_master_on_gate' ) );
+	}
+
+	/**
+	 * Drop everything the helpers added.
+	 */
+	protected function remove_ai_master_filters() {
+		remove_filter( 'jetpack_search_ai_answers_enabled', array( $this, 'apply_master_off_gate' ) );
+		remove_filter( 'jetpack_search_ai_answers_enabled', array( $this, 'apply_master_on_gate' ) );
+	}
+}

--- a/projects/plugins/jetpack/changelog/update-ai-master-switch-audit
+++ b/projects/plugins/jetpack/changelog/update-ai-master-switch-audit
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Search: report the saved AI Answers choice while the site-wide AI switch is off, disable the controls, and honor the host AI opt-out in the AI Answer block. Require Instant Search to enable AI Answers.
+Search: report the saved AI Answers choice while the site-wide AI switch is off, disable the controls, and honor the host AI opt-out in the AI Answer block. Require Instant Search to enable AI Answers. The master-state reporting follows the rollout: live on WordPress.com Simple, internal testing environments elsewhere.

--- a/projects/plugins/jetpack/changelog/update-ai-master-switch-audit
+++ b/projects/plugins/jetpack/changelog/update-ai-master-switch-audit
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Search: report the saved AI Answers choice while the site-wide AI switch is off, disable the controls, and honor the host AI opt-out in the AI Answer block.
+Search: report the saved AI Answers choice while the site-wide AI switch is off, disable the controls, and honor the host AI opt-out in the AI Answer block. Require Instant Search to enable AI Answers.

--- a/projects/plugins/jetpack/changelog/update-ai-master-switch-audit
+++ b/projects/plugins/jetpack/changelog/update-ai-master-switch-audit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Search: report the saved AI Answers choice while the site-wide AI switch is off, disable the controls, and honor the host AI opt-out in the AI Answer block.

--- a/projects/plugins/search/changelog/update-ai-master-switch-audit
+++ b/projects/plugins/search/changelog/update-ai-master-switch-audit
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Search: report the saved AI Answers choice while the site-wide AI switch is off, disable the controls, and honor the host AI opt-out in the AI Answer block. Require Instant Search to enable AI Answers.
+Search: report the saved AI Answers choice while the site-wide AI switch is off, disable the controls, and honor the host AI opt-out in the AI Answer block. Require Instant Search to enable AI Answers. The master-state reporting follows the rollout: live on WordPress.com Simple, internal testing environments elsewhere.

--- a/projects/plugins/search/changelog/update-ai-master-switch-audit
+++ b/projects/plugins/search/changelog/update-ai-master-switch-audit
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Search: report the saved AI Answers choice while the site-wide AI switch is off, disable the controls, and honor the host AI opt-out in the AI Answer block.

--- a/projects/plugins/search/changelog/update-ai-master-switch-audit
+++ b/projects/plugins/search/changelog/update-ai-master-switch-audit
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Search: report the saved AI Answers choice while the site-wide AI switch is off, disable the controls, and honor the host AI opt-out in the AI Answer block.
+Search: report the saved AI Answers choice while the site-wide AI switch is off, disable the controls, and honor the host AI opt-out in the AI Answer block. Require Instant Search to enable AI Answers.


### PR DESCRIPTION
Fixes #

## Proposed changes

When the site-wide Jetpack AI switch is off, the Search settings screen used to lie: a saved-on AI Answers choice showed as off, the toggle still accepted clicks, and saving showed "Updated settings." while doing nothing. This PR makes Search tell the truth and validate writes:

* The settings API now returns the saved choice and the AI switch state next to the effective value, so the dashboard can tell "off by choice" apart from "off because AI is off".
* With AI off: the toggle shows the saved choice, is locked, and a notice says why. Turning AI Answers **on** is rejected (400); turning it **off** still works, so the choice survives.
* Turning AI Answers on now also requires Instant Search to be on (or turned on in the same request) — it only runs inside Instant Search.
* The Customberg preview no longer streams an AI answer while AI is off, and its toggle is locked with help text.
* The AI Answer block now respects the host-level AI kill switch (`WP_AI_SUPPORT` / `wp_supports_ai()`), like the search overlay already does. This is the one behavior change that also applies to standalone Jetpack Search sites.
* All of the AI-switch behavior is limited to internal testing environments (and WordPress.com Simple, where the switch is the existing `jetpack_ai_enabled` option) until launch. Regular sites see no change.

## Related product discussion/links

* Internal: FORNO-427, and the Jetpack AI toggles contract P2.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Live run on an Atomic site, 26–27 Aug: 36/36 rows — onebin `3c588`.

Automated: from `projects/packages/search/` run `composer phpunit`, `pnpm test-scripts`, `pnpm test-url-tests` — the new tests cover every audience (internal, Simple, public, standalone).

Manual, on a Jurassic Ninja site with paid Search:
* `wp jetpack module deactivate ai`, reload Jetpack → Search → AI Answers: the toggle shows your saved choice, locked, with a notice; clicking it does nothing; saving on via the API returns 400.
* `wp jetpack module activate ai`: everything returns to the saved state.
* With Instant Search off, enabling AI Answers via the API returns 400; sending both in one request works.
* Add `define( 'WP_AI_SUPPORT', false );`: a page with the AI Answer block renders nothing.

---

🤖 Written by Claude, reviewed by me.


