### PR TITLE
Premium Analytics: align chart legend with the design reference

### DIFF
--- a/projects/packages/premium-analytics/changelog/legend-align-with-design-reference
+++ b/projects/packages/premium-analytics/changelog/legend-align-with-design-reference
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Widgets: Align chart legend bullets, row spacing, and value weight with the design reference.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/legend/legend.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/legend/legend.module.scss
@@ -8,8 +8,8 @@
 }
 
 .bullet {
-	width: 8px;
-	height: 8px;
+	width: 16px;
+	height: 16px;
 	border-radius: 50%;
 	flex-shrink: 0;
 }
@@ -23,6 +23,7 @@
 
 .value {
 	text-align: right;
-	font-weight: 600;
+	// Use --wpds-typography-font-weight-medium once the theme ships it.
+	font-weight: 500;
 	white-space: nowrap;
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/legend/legend.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/legend/legend.tsx
@@ -52,7 +52,7 @@ export function Legend( { items, withComparison = false, hideValue = false }: Le
 			className={ styles.legend }
 			templateColumns={ getTemplateColumns( hideValue, withComparison ) }
 			templateRows={ `repeat( ${ items.length }, var(--wpds-dimension-padding-2xl) )` }
-			rowGap={ 4 }
+			rowGap={ 12 }
 			columnGap={ 10 }
 			align="center"
 		>


### PR DESCRIPTION
Fixes #

## Proposed changes

The Devices widget legend had drifted from the design reference — the bullets read as undersized, the rows sat too tight, and the value weight was heavier than the rest of the dashboard. I measured the legend on the prototype dashboard and matched the three values.

- Enlarge legend bullets from 8px to 16px.
- Loosen legend row gap from 4px to 12px, giving a 36px row pitch.
- Drop the legend value weight from 600 to 500, matching `MetricValue`.
- `--wpds-typography-font-weight-medium` is not in the installed `@wordpress/theme` token map yet, and `plugin-wpds/no-token-fallback-values` forbids a hand-written fallback, so this stays a plain `500` with a note to swap it later.
- Shared by the Devices widget, `DonutChart` and `SemiCircleChart`. `LeaderboardChart` uses the `@automattic/charts` legend and is unaffected.
- Frame every `SemiCircleChart` story in a sized tile. The chart derives its width from the height left after the legend, so a canvas with no definite height collapsed it to `MIN_CHART_WIDTH` and squeezed the legend with it, truncating labels to a single letter. `DonutChart` does not apply the chart's max-width to its legend, so its stories are unaffected.

## Related product discussion/links

- WOOA7S-1829

## Before / after

Devices widget, `WithComparison` story, captured from Storybook.

| Before                                                                                                                        | After                                                                                                                       |
| ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/legend-align-with-design-reference/before-devices-legend.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/legend-align-with-design-reference/after-devices-legend.png) |

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Start Storybook: `pnpm run storybook` from `projects/packages/premium-analytics`.
- Open **Packages/Premium Analytics/Widgets/Devices → WithComparison**. The legend bullets should be 16px, rows 36px apart, and the percentages at medium weight rather than semibold.
- Open **Components/SemiCircleChart → LargeContainer** and confirm the legend labels render in full rather than truncating to a single letter. **SmallContainer** (200px) still truncates "Desktop", which is the narrow-tile behaviour that story exists to show.
- Open **Components/DonutChart → SmallContainer** and confirm the taller legend still fits without clipping the chart.
