### PR TITLE
VideoPress: Show connection errors on dashboard and on upload

### DIFF
--- a/projects/packages/videopress/changelog/connection-error-block-editor-upload
+++ b/projects/packages/videopress/changelog/connection-error-block-editor-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Video block: Say when an upload failed because of a Jetpack connection problem, instead of only "Failed to upload your video".

--- a/projects/packages/videopress/changelog/connection-error-notice-videopress-dashboard
+++ b/projects/packages/videopress/changelog/connection-error-notice-videopress-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Show the Jetpack connection error notice on the modernized dashboard.

--- a/projects/packages/videopress/changelog/connection-error-upload-attribution
+++ b/projects/packages/videopress/changelog/connection-error-upload-attribution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Say when an upload failed because of a Jetpack connection problem, instead of only "Upload failed".

--- a/projects/packages/videopress/routes/library/package.json
+++ b/projects/packages/videopress/routes/library/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:*",
+		"@automattic/jetpack-connection": "workspace:*",
 		"@tanstack/react-query": "5.101.2",
 		"@types/react": "18.3.28",
 		"@wordpress/api-fetch": "7.51.0",

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -1,4 +1,5 @@
 import { useGlobalNotices } from '@automattic/jetpack-components/global-notices';
+import useConnectionErrorNotice from '@automattic/jetpack-connection/use-connection-error-notice';
 import { DropZone, Spinner, Tooltip } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
@@ -26,6 +27,7 @@ import { useUploadFromLibrary } from '../../src/dashboard/hooks/use-upload-from-
 import { useVideoPressUpgrade } from '../../src/dashboard/hooks/use-videopress-upgrade';
 import { createPromoteLocal } from './promote-local';
 import { planVideoDrop } from './upload-drop';
+import { classifyUploadFailure } from './upload-failure';
 import './style.scss';
 import type { LibraryItem, LibraryItemPrivacy } from '../../src/dashboard/types/library';
 import type { SupportedLayouts, View } from '@wordpress/dataviews';
@@ -107,6 +109,10 @@ const StageInner = () => {
 		refetch,
 	} = useLibrary( view );
 	const { uploadQueue, startUpload, retryUpload } = useUpload();
+	// Read the store's existing errors so a failed row can name the cause; the
+	// notice this dashboard already renders carries the diagnosis and the
+	// reconnect button, so the row only has to point at it.
+	const { hasConnectionError } = useConnectionErrorNotice();
 	const { paginationInfo: totalPagination } = useLibrary( TOTAL_COUNT_VIEW );
 	const { mutateAsync: deleteVideo } = useDeleteVideo();
 	const { mutateAsync: setPrivacyAsync } = useSetPrivacy();
@@ -391,6 +397,8 @@ const StageInner = () => {
 				upload: {
 					status: u.status === 'failed' ? ( 'failed' as const ) : ( 'uploading' as const ),
 					progress: Math.round( u.progress * 100 ),
+					failureReason:
+						u.status === 'failed' ? classifyUploadFailure( u, hasConnectionError ) : undefined,
 				},
 				description: '',
 				rating: 'G' as LibraryItem[ 'rating' ],
@@ -416,7 +424,7 @@ const StageInner = () => {
 			return item;
 		} );
 		return [ ...inFlight, ...overlaid ];
-	}, [ uploadQueue, items, promotingProgress, deletingIds ] );
+	}, [ uploadQueue, items, promotingProgress, deletingIds, hasConnectionError ] );
 
 	const getItemId = useCallback( ( item: LibraryItem ) => item.id, [] );
 

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -221,6 +221,8 @@
 		inset: 0;
 		background: rgba(204, 24, 24, 0.85);
 		color: #fff;
+		padding-inline: 8px;
+		text-align: center;
 	}
 
 	&__filename {

--- a/projects/packages/videopress/routes/library/test/upload-failure.test.ts
+++ b/projects/packages/videopress/routes/library/test/upload-failure.test.ts
@@ -26,7 +26,7 @@ describe( 'classifyUploadFailure', () => {
 		expect( classifyUploadFailure( failed( 'some_other_code' ), true ) ).toBe( 'other' );
 	} );
 
-	it( 'reports nothing for an upload that has not failed', () => {
+	it( 'returns "other" for an upload that has not failed', () => {
 		expect( classifyUploadFailure( { status: 'uploading', errorCode: undefined }, true ) ).toBe(
 			'other'
 		);

--- a/projects/packages/videopress/routes/library/test/upload-failure.test.ts
+++ b/projects/packages/videopress/routes/library/test/upload-failure.test.ts
@@ -1,0 +1,34 @@
+import { classifyUploadFailure } from '../upload-failure';
+import type { UploadItem } from '../../../src/dashboard/hooks/use-upload';
+
+const failed = ( errorCode?: string ): Pick< UploadItem, 'status' | 'errorCode' > => ( {
+	status: 'failed',
+	errorCode,
+} );
+
+describe( 'classifyUploadFailure', () => {
+	it( 'attributes a token failure on a broken connection to the connection', () => {
+		expect( classifyUploadFailure( failed( 'videopress_no_upload_token' ), true ) ).toBe(
+			'connection'
+		);
+	} );
+
+	it( 'does not blame the connection for a token failure when none is reported', () => {
+		// WordPress.com can decline to mint a token for its own reasons.
+		expect( classifyUploadFailure( failed( 'videopress_no_upload_token' ), false ) ).toBe(
+			'other'
+		);
+	} );
+
+	it( 'does not blame the connection for an unrelated failure on a broken site', () => {
+		// The file that was simply too large must not be reported as a connection problem.
+		expect( classifyUploadFailure( failed(), true ) ).toBe( 'other' );
+		expect( classifyUploadFailure( failed( 'some_other_code' ), true ) ).toBe( 'other' );
+	} );
+
+	it( 'reports nothing for an upload that has not failed', () => {
+		expect( classifyUploadFailure( { status: 'uploading', errorCode: undefined }, true ) ).toBe(
+			'other'
+		);
+	} );
+} );

--- a/projects/packages/videopress/routes/library/upload-failure.ts
+++ b/projects/packages/videopress/routes/library/upload-failure.ts
@@ -1,0 +1,26 @@
+import { UPLOAD_TOKEN_ERROR_CODE } from '../../src/client/hooks/use-resumable-uploader';
+import type { UploadItem } from '../../src/dashboard/hooks/use-upload';
+import type { UploadFailureReason } from '../../src/dashboard/types/library';
+
+/**
+ * Decide what a failed upload should tell the user about its cause.
+ *
+ * The upload token is created by a blog-token-signed request to WordPress.com
+ * (Ajax::wp_ajax_videopress_get_upload_jwt()). The dashboard only checks whether the
+ * user is connected, so a broken blog token or blocked outbound requests can pass
+ * that check and still fail here. Historically, the user would only see “Upload failed.”
+ *
+ * Both checks are needed, because each rules out a different mistake.
+ *
+ * @param {UploadItem} item               - The failed queue item.
+ * @param {boolean}    hasConnectionError - Whether the connection store is reporting an error.
+ * @return {UploadFailureReason} What to attribute the failure to.
+ */
+export function classifyUploadFailure(
+	item: Pick< UploadItem, 'status' | 'errorCode' >,
+	hasConnectionError: boolean
+): UploadFailureReason {
+	const failedOnToken = item.status === 'failed' && item.errorCode === UPLOAD_TOKEN_ERROR_CODE;
+
+	return failedOnToken && hasConnectionError ? 'connection' : 'other';
+}

--- a/projects/packages/videopress/routes/library/upload-failure.ts
+++ b/projects/packages/videopress/routes/library/upload-failure.ts
@@ -12,7 +12,7 @@ import type { UploadFailureReason } from '../../src/dashboard/types/library';
  *
  * Both checks are needed, because each rules out a different mistake.
  *
- * @param {UploadItem} item               - The failed queue item.
+ * @param {UploadItem} item               - The queue item to classify. One that has not failed is always 'other'.
  * @param {boolean}    hasConnectionError - Whether the connection store is reporting an error.
  * @return {UploadFailureReason} What to attribute the failure to.
  */

--- a/projects/packages/videopress/routes/library/upload-failure.ts
+++ b/projects/packages/videopress/routes/library/upload-failure.ts
@@ -1,4 +1,4 @@
-import { UPLOAD_TOKEN_ERROR_CODE } from '../../src/client/hooks/use-resumable-uploader';
+import { isConnectionAttributedFailure } from '../../src/client/hooks/use-resumable-uploader';
 import type { UploadItem } from '../../src/dashboard/hooks/use-upload';
 import type { UploadFailureReason } from '../../src/dashboard/types/library';
 
@@ -10,7 +10,7 @@ import type { UploadFailureReason } from '../../src/dashboard/types/library';
  * user is connected, so a broken blog token or blocked outbound requests can pass
  * that check and still fail here. Historically, the user would only see “Upload failed.”
  *
- * Both checks are needed, because each rules out a different mistake.
+ * The rule itself lives with the error code, in `isConnectionAttributedFailure()`.
  *
  * @param {UploadItem} item               - The queue item to classify. One that has not failed is always 'other'.
  * @param {boolean}    hasConnectionError - Whether the connection store is reporting an error.
@@ -20,7 +20,10 @@ export function classifyUploadFailure(
 	item: Pick< UploadItem, 'status' | 'errorCode' >,
 	hasConnectionError: boolean
 ): UploadFailureReason {
-	const failedOnToken = item.status === 'failed' && item.errorCode === UPLOAD_TOKEN_ERROR_CODE;
+	// The status guard is this caller's own: a queue item can be read at any status,
+	// while the block editor's equivalent only ever renders after a failure.
+	const attributable =
+		item.status === 'failed' && isConnectionAttributedFailure( item.errorCode, hasConnectionError );
 
-	return failedOnToken && hasConnectionError ? 'connection' : 'other';
+	return attributable ? 'connection' : 'other';
 }

--- a/projects/packages/videopress/routes/video/package.json
+++ b/projects/packages/videopress/routes/video/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"dependencies": {
 		"@automattic/jetpack-components": "workspace:*",
+		"@automattic/jetpack-connection": "workspace:*",
 		"@tanstack/react-query": "5.101.2",
 		"@types/react": "18.3.28",
 		"@wordpress/admin-ui": "2.8.0",

--- a/projects/packages/videopress/routes/video/stage.tsx
+++ b/projects/packages/videopress/routes/video/stage.tsx
@@ -1,5 +1,8 @@
 import AdminPage from '@automattic/jetpack-components/admin-page';
 import { useGlobalNotices } from '@automattic/jetpack-components/global-notices';
+import useConnectionErrorNotice, {
+	ConnectionError,
+} from '@automattic/jetpack-connection/use-connection-error-notice';
 import { useQueryClient } from '@tanstack/react-query';
 import { Breadcrumbs } from '@wordpress/admin-ui';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
@@ -111,6 +114,7 @@ const Editor = ( {
 	setChaptersOpen,
 }: EditorProps ) => {
 	const { values, update, isDirty, reset } = useVideoDetailsForm( video );
+	const { hasConnectionError } = useConnectionErrorNotice();
 
 	// The sub-nav's only sibling tab is the Editor, whose route is stripped
 	// from the registry when the chapters editor is off — a one-tab strip
@@ -190,6 +194,11 @@ const Editor = ( {
 				/>
 			}
 		>
+			{ hasConnectionError && (
+				<Stack direction="column">
+					<ConnectionError />
+				</Stack>
+			) }
 			{ showVideoNav && (
 				<VideoNav
 					videoId={ video.id }

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-error.test.jsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/uploader-error.test.jsx
@@ -1,0 +1,64 @@
+import { render } from '@testing-library/react';
+import UploadError from '../uploader-error.jsx';
+
+const mockUseConnectionErrorNotice = jest.fn();
+// The wrapper is where the message lands, so capturing its props is the only
+// way to read what getErrorMessage() decided.
+const mockPlaceholderWrapper = jest.fn( () => null );
+
+jest.mock( '@automattic/jetpack-connection/use-connection-error-notice', () => ( {
+	__esModule: true,
+	default: ( ...args ) => mockUseConnectionErrorNotice( ...args ),
+} ) );
+jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
+	getRequiredPlan: () => null,
+	getSiteFragment: () => 'example.com',
+} ) );
+jest.mock( '@wordpress/components', () => ( {
+	Button: () => null,
+} ) );
+jest.mock( '@wordpress/i18n', () => ( {
+	__: s => s,
+} ) );
+jest.mock( '@wordpress/ui', () => ( {
+	Link: () => null,
+} ) );
+jest.mock( '../../../edit', () => ( {
+	PlaceholderWrapper: ( ...args ) => mockPlaceholderWrapper( ...args ),
+} ) );
+
+const TOKEN_ERROR = { code: 'videopress_no_upload_token', message: 'No token provided' };
+
+const renderError = ( errorData, hasConnectionError ) => {
+	mockUseConnectionErrorNotice.mockReturnValue( { hasConnectionError } );
+	render( <UploadError errorData={ errorData } onRetry={ () => {} } onCancel={ () => {} } /> );
+	return mockPlaceholderWrapper.mock.calls[ 0 ][ 0 ].errorMessage;
+};
+
+describe( 'UploadError', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'names the connection when a token failure lands on a site reporting one', () => {
+		expect( renderError( TOKEN_ERROR, true ) ).toBe(
+			'Failed to upload your video. Check your Jetpack connection and try again.'
+		);
+	} );
+
+	it( 'stays generic for a token failure on a site reporting no connection error', () => {
+		// VideoPress switched off, a lapsed plan and a failed capability check all
+		// reach here with this code, and none of them are connection problems.
+		expect( renderError( TOKEN_ERROR, false ) ).toBe(
+			'Failed to upload your video. Please try again.'
+		);
+	} );
+
+	it( 'does not blame the connection for an unrelated failure on a broken site', () => {
+		expect( renderError( { data: { message: 'File too large' } }, true ) ).toBe( 'File too large' );
+	} );
+
+	it( 'renders nothing to say when there is no error data', () => {
+		expect( renderError( null, false ) ).toBe( '' );
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-error.jsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-error.jsx
@@ -7,7 +7,7 @@ import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
-import { UPLOAD_TOKEN_ERROR_CODE } from '../../../../../hooks/use-resumable-uploader';
+import { isConnectionAttributedFailure } from '../../../../../hooks/use-resumable-uploader';
 import { PlaceholderWrapper } from '../../edit';
 
 const getErrorMessage = ( uploadErrorData, hasConnectionError ) => {
@@ -15,9 +15,7 @@ const getErrorMessage = ( uploadErrorData, hasConnectionError ) => {
 		return '';
 	}
 
-	// Same rule as classifyUploadFailure(): a missing token means the upload never reached
-	// WordPress.com, but not why; only a connection error alongside it justifies naming the connection.
-	if ( uploadErrorData?.code === UPLOAD_TOKEN_ERROR_CODE && hasConnectionError ) {
+	if ( isConnectionAttributedFailure( uploadErrorData?.code, hasConnectionError ) ) {
 		return __(
 			'Failed to upload your video. Check your Jetpack connection and try again.',
 			'jetpack-videopress-pkg'

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-error.jsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/uploader-error.jsx
@@ -1,16 +1,27 @@
 /**
  * External dependencies
  */
+import useConnectionErrorNotice from '@automattic/jetpack-connection/use-connection-error-notice';
 import { getRequiredPlan, getSiteFragment } from '@automattic/jetpack-shared-extension-utils';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
+import { UPLOAD_TOKEN_ERROR_CODE } from '../../../../../hooks/use-resumable-uploader';
 import { PlaceholderWrapper } from '../../edit';
 
-const getErrorMessage = uploadErrorData => {
+const getErrorMessage = ( uploadErrorData, hasConnectionError ) => {
 	if ( ! uploadErrorData ) {
 		return '';
+	}
+
+	// Same rule as classifyUploadFailure(): a missing token means the upload never reached
+	// WordPress.com, but not why; only a connection error alongside it justifies naming the connection.
+	if ( uploadErrorData?.code === UPLOAD_TOKEN_ERROR_CODE && hasConnectionError ) {
+		return __(
+			'Failed to upload your video. Check your Jetpack connection and try again.',
+			'jetpack-videopress-pkg'
+		);
 	}
 
 	const errorMessage =
@@ -56,7 +67,10 @@ const getErrorMessage = uploadErrorData => {
 	return errorMessage;
 };
 const UploadError = ( { errorData, onRetry, onCancel } ) => {
-	const message = getErrorMessage( errorData );
+	// The editor has no ConnectionError notice of its own, so this is read only
+	// as corroboration for the message below, not to render anything.
+	const { hasConnectionError } = useConnectionErrorNotice();
+	const message = getErrorMessage( errorData, hasConnectionError );
 
 	return (
 		<PlaceholderWrapper errorMessage={ message } onNoticeRemove={ onCancel }>

--- a/projects/packages/videopress/src/client/hooks/use-resumable-uploader/index.ts
+++ b/projects/packages/videopress/src/client/hooks/use-resumable-uploader/index.ts
@@ -19,6 +19,19 @@ const debug = debugFactory( 'videopress:use-resumable-uploader' );
 export const UPLOAD_TOKEN_ERROR_CODE = 'videopress_no_upload_token';
 
 /**
+ * A failure as it reaches `onError` and the returned `error`.
+ *
+ * Always an `Error`, but the extras depend on where it came from: `code` on
+ * failures raised here (see `UploadTokenError`), `originalResponse` on tus
+ * transport failures. Consumers branch on both, so they are declared optional
+ * rather than left off the type.
+ */
+export type ResumableUploadError = Error & {
+	code?: string;
+	originalResponse?: { getBody?: () => string };
+};
+
+/**
  * The error raised when the upload JWT can't be obtained.
  */
 export class UploadTokenError extends Error {
@@ -56,10 +69,20 @@ type UseResumableUploader = {
 	resumeHandler: ResumaHandlerProps;
 	uploadingData: UploadingDataProps;
 	media: VideoMediaProps;
-	error: string;
+	error: ResumableUploadError | null;
 };
 
-const useResumableUploader = ( { onProgress, onSuccess, onError } ): UseResumableUploader => {
+type UseResumableUploaderProps = {
+	onProgress: ( bytesSent: number, bytesTotal: number ) => void;
+	onSuccess: ( data: VideoMediaProps ) => void;
+	onError: ( error: ResumableUploadError ) => void;
+};
+
+const useResumableUploader = ( {
+	onProgress,
+	onSuccess,
+	onError,
+}: UseResumableUploaderProps ): UseResumableUploader => {
 	const [ uploadingData, setUploadingData ] = useState< UploadingDataProps >( {
 		bytesSent: 0,
 		bytesTotal: 0,
@@ -68,7 +91,7 @@ const useResumableUploader = ( { onProgress, onSuccess, onError } ): UseResumabl
 	} );
 
 	const [ media, setMedia ] = useState< VideoMediaProps >();
-	const [ error, setError ] = useState( null );
+	const [ error, setError ] = useState< ResumableUploadError | null >( null );
 	const [ resumeHandler, setResumeHandler ] = useState< ResumaHandlerProps >();
 
 	/**
@@ -115,7 +138,7 @@ const useResumableUploader = ( { onProgress, onSuccess, onError } ): UseResumabl
 				setMedia( data );
 				onSuccess( data );
 			},
-			onError: ( err: Error ) => {
+			onError: ( err: ResumableUploadError ) => {
 				setUploadingData( prev => ( { ...prev, status: 'error' } ) );
 				setError( err );
 				onError( err );

--- a/projects/packages/videopress/src/client/hooks/use-resumable-uploader/index.ts
+++ b/projects/packages/videopress/src/client/hooks/use-resumable-uploader/index.ts
@@ -13,6 +13,29 @@ import type { ChangeEvent } from 'react';
 
 const debug = debugFactory( 'videopress:use-resumable-uploader' );
 
+/**
+ * `code` carried by the error raised when the upload JWT can't be obtained.
+ */
+export const UPLOAD_TOKEN_ERROR_CODE = 'videopress_no_upload_token';
+
+/**
+ * The error raised when the upload JWT can't be obtained.
+ */
+export class UploadTokenError extends Error {
+	public readonly code = UPLOAD_TOKEN_ERROR_CODE;
+
+	/**
+	 * Build the error.
+	 *
+	 * The message is unchanged from the string this replaced: it is developer
+	 * text, and the dashboard describes the failure in its own words.
+	 */
+	constructor() {
+		super( 'No token provided' );
+		this.name = 'UploadTokenError';
+	}
+}
+
 type UploadingStatusProp = 'idle' | 'resumed' | 'aborted' | 'uploading' | 'done' | 'error';
 
 type UploadingDataProps = {
@@ -57,7 +80,7 @@ const useResumableUploader = ( { onProgress, onSuccess, onError } ): UseResumabl
 	async function uploadHandler( file: File ) {
 		const tokenData = await getMediaToken( 'upload-jwt' );
 		if ( ! tokenData.token ) {
-			return onError( 'No token provided' );
+			return onError( new UploadTokenError() );
 		}
 
 		// The file starts to upload automatically, so we need to set the status to uploading

--- a/projects/packages/videopress/src/client/hooks/use-resumable-uploader/index.ts
+++ b/projects/packages/videopress/src/client/hooks/use-resumable-uploader/index.ts
@@ -49,6 +49,25 @@ export class UploadTokenError extends Error {
 	}
 }
 
+/**
+ * Whether a failed upload may be blamed on the Jetpack connection.
+ *
+ * A missing token means the upload never reached WordPress.com, but not why; only
+ * a connection error alongside it justifies naming the connection. Both checks are
+ * needed, because each rules out a different mistake. Shared so the dashboard's
+ * `classifyUploadFailure()` and the block editor's `getErrorMessage()` cannot drift.
+ *
+ * @param {string}  errorCode          - The `code` carried by the failure, if it carried one.
+ * @param {boolean} hasConnectionError - Whether the connection store is reporting an error.
+ * @return {boolean} Whether the failure should be attributed to the connection.
+ */
+export function isConnectionAttributedFailure(
+	errorCode: string | undefined,
+	hasConnectionError: boolean
+): boolean {
+	return errorCode === UPLOAD_TOKEN_ERROR_CODE && hasConnectionError;
+}
+
 type UploadingStatusProp = 'idle' | 'resumed' | 'aborted' | 'uploading' | 'done' | 'error';
 
 type UploadingDataProps = {

--- a/projects/packages/videopress/src/client/hooks/use-resumable-uploader/test/index.test.ts
+++ b/projects/packages/videopress/src/client/hooks/use-resumable-uploader/test/index.test.ts
@@ -1,4 +1,4 @@
-import { UPLOAD_TOKEN_ERROR_CODE, UploadTokenError } from '../index';
+import { UPLOAD_TOKEN_ERROR_CODE, UploadTokenError, isConnectionAttributedFailure } from '../index';
 
 describe( 'UploadTokenError', () => {
 	it( 'carries the code consumers branch on', () => {
@@ -11,5 +11,19 @@ describe( 'UploadTokenError', () => {
 
 		expect( error ).toBeInstanceOf( Error );
 		expect( error.message ).toBe( 'No token provided' );
+	} );
+} );
+
+describe( 'isConnectionAttributedFailure', () => {
+	it( 'attributes a token failure on a site reporting a connection error', () => {
+		expect( isConnectionAttributedFailure( UPLOAD_TOKEN_ERROR_CODE, true ) ).toBe( true );
+	} );
+
+	it( 'needs both halves: a missing token says the upload never left, not why', () => {
+		expect( isConnectionAttributedFailure( UPLOAD_TOKEN_ERROR_CODE, false ) ).toBe( false );
+	} );
+
+	it( 'needs both halves: a connection error alone does not explain any failure', () => {
+		expect( isConnectionAttributedFailure( undefined, true ) ).toBe( false );
 	} );
 } );

--- a/projects/packages/videopress/src/client/hooks/use-resumable-uploader/test/index.test.ts
+++ b/projects/packages/videopress/src/client/hooks/use-resumable-uploader/test/index.test.ts
@@ -1,0 +1,15 @@
+import { UPLOAD_TOKEN_ERROR_CODE, UploadTokenError } from '../index';
+
+describe( 'UploadTokenError', () => {
+	it( 'carries the code consumers branch on', () => {
+		expect( new UploadTokenError().code ).toBe( UPLOAD_TOKEN_ERROR_CODE );
+		expect( UPLOAD_TOKEN_ERROR_CODE ).toBe( 'videopress_no_upload_token' );
+	} );
+
+	it( 'is a real Error, so a caller that only reads `message` still works', () => {
+		const error = new UploadTokenError();
+
+		expect( error ).toBeInstanceOf( Error );
+		expect( error.message ).toBe( 'No token provided' );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/dashboard-layout/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/dashboard-layout/index.tsx
@@ -2,10 +2,13 @@
  * External dependencies
  */
 import AdminPage from '@automattic/jetpack-components/admin-page';
+import useConnectionErrorNotice, {
+	ConnectionError,
+} from '@automattic/jetpack-connection/use-connection-error-notice';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
-import { Tabs } from '@wordpress/ui';
+import { Stack, Tabs } from '@wordpress/ui';
 import DashboardTabs, { TAB_PATHS, type DashboardTab } from '../dashboard-tabs';
 import OnboardingModal from '../onboarding-modal';
 import './style.scss';
@@ -38,6 +41,7 @@ const TAB_VALUES: DashboardTab[] = [ 'library', 'stats', 'settings' ];
  */
 export default function DashboardLayout( { activeTab, children, actions, hideFooter }: Props ) {
 	const navigate = useNavigate();
+	const { hasConnectionError } = useConnectionErrorNotice();
 
 	const onValueChange = useCallback(
 		( next: string ) => {
@@ -59,6 +63,11 @@ export default function DashboardLayout( { activeTab, children, actions, hideFoo
 			actions={ actions }
 			showFooter={ ! hideFooter }
 		>
+			{ hasConnectionError && (
+				<Stack direction="column">
+					<ConnectionError />
+				</Stack>
+			) }
 			<Tabs.Root className="vp-dashboard-tabs" value={ activeTab } onValueChange={ onValueChange }>
 				<DashboardTabs />
 				{ TAB_VALUES.map( tab => (

--- a/projects/packages/videopress/src/dashboard/components/dashboard-layout/test/index.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/dashboard-layout/test/index.test.tsx
@@ -18,6 +18,14 @@ jest.mock( '@automattic/jetpack-connection/use-connection-error-notice', () => (
 	default: jest.fn(),
 } ) );
 
+// The layout's other child reaches react-query (useOnboardingCounts → useLibrary),
+// which would need a QueryClientProvider these tests have no use for. Nothing here
+// asserts on the modal, so stub it rather than stand up the query machinery.
+jest.mock( '../../onboarding-modal', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
 const mockUseNavigate = useNavigate as jest.Mock;
 const mockConnectionError = ConnectionError as jest.Mock;
 const mockUseConnectionErrorNotice = useConnectionErrorNotice as jest.MockedFunction<

--- a/projects/packages/videopress/src/dashboard/components/dashboard-layout/test/index.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/dashboard-layout/test/index.test.tsx
@@ -1,0 +1,68 @@
+import useConnectionErrorNotice, {
+	ConnectionError,
+} from '@automattic/jetpack-connection/use-connection-error-notice';
+import { render, screen } from '@testing-library/react';
+import { useNavigate } from '@wordpress/route';
+import DashboardLayout from '../index';
+
+jest.mock( '@wordpress/route', () => ( {
+	__esModule: true,
+	useNavigate: jest.fn(),
+} ) );
+
+// Stubbed so these tests assert only that the layout mounts the shared notice,
+// not the notice's own store wiring (which the connection package tests).
+jest.mock( '@automattic/jetpack-connection/use-connection-error-notice', () => ( {
+	__esModule: true,
+	ConnectionError: jest.fn(),
+	default: jest.fn(),
+} ) );
+
+const mockUseNavigate = useNavigate as jest.Mock;
+const mockConnectionError = ConnectionError as jest.Mock;
+const mockUseConnectionErrorNotice = useConnectionErrorNotice as jest.MockedFunction<
+	typeof useConnectionErrorNotice
+>;
+
+describe( 'DashboardLayout', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseNavigate.mockReturnValue( jest.fn() );
+		mockConnectionError.mockReturnValue( null );
+		mockUseConnectionErrorNotice.mockReturnValue( {
+			hasConnectionError: true,
+		} as ReturnType< typeof useConnectionErrorNotice > );
+	} );
+
+	it( 'renders the connection error notice above the tabs', () => {
+		mockConnectionError.mockReturnValue( <div>Connection error notice</div> );
+
+		render( <DashboardLayout activeTab="library">Library body</DashboardLayout> );
+
+		const notice = screen.getByText( 'Connection error notice' );
+		expect( notice ).toBeInTheDocument();
+
+		// Above the strip, so it can't scroll away with a tab's body. The two are
+		// siblings, not nested, so the comparison is exactly "follows".
+		const tabList = screen.getByRole( 'tablist' );
+		expect( notice.compareDocumentPosition( tabList ) ).toBe( Node.DOCUMENT_POSITION_FOLLOWING );
+	} );
+
+	it( 'renders the notice with no props, so every tab describes the error the same way', () => {
+		render( <DashboardLayout activeTab="settings">Settings body</DashboardLayout> );
+
+		expect( mockConnectionError ).toHaveBeenCalled();
+		expect( mockConnectionError.mock.calls[ 0 ][ 0 ] ).toEqual( {} );
+	} );
+
+	it( 'leaves no notice behind when the connection is healthy', () => {
+		mockUseConnectionErrorNotice.mockReturnValue( {
+			hasConnectionError: false,
+		} as ReturnType< typeof useConnectionErrorNotice > );
+
+		render( <DashboardLayout activeTab="library">Library body</DashboardLayout> );
+
+		expect( mockConnectionError ).not.toHaveBeenCalled();
+		expect( screen.getByText( 'Library body' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/fields.tsx
@@ -118,7 +118,13 @@ const TitleCell = ( { item }: { item: LibraryItem } ) => {
 	} else if ( upload.status === 'failed' ) {
 		pill = {
 			intent: 'high',
-			label: __( 'Upload failed', 'jetpack-videopress-pkg' ),
+			label:
+				upload.failureReason === 'connection'
+					? // The connection notice above the library carries the diagnosis and
+					  // the reconnect button, so the row only has to say which problem it
+					  // belongs to.
+					  __( 'Upload failed: Jetpack connection issue', 'jetpack-videopress-pkg' )
+					: __( 'Upload failed', 'jetpack-videopress-pkg' ),
 		};
 	} else if ( isProcessing ) {
 		pill = {

--- a/projects/packages/videopress/src/dashboard/components/library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/fields.tsx
@@ -6,6 +6,7 @@ import { useProcessingProgress } from '../../hooks/use-processing-progress';
 import { formatBytes, formatDuration } from '../../utils/format';
 import ThumbnailField from './thumbnail-field';
 import { useUploadActions } from './upload-actions-context';
+import { getUploadFailureLabel } from './upload-failure-label';
 import type { LibraryItem } from '../../types/library';
 import type { Field, Operator } from '@wordpress/dataviews';
 
@@ -116,15 +117,19 @@ const TitleCell = ( { item }: { item: LibraryItem } ) => {
 			label: __( 'Deleting…', 'jetpack-videopress-pkg' ),
 		};
 	} else if ( upload.status === 'failed' ) {
+		// The pill is one line, so the cause is joined onto the summary here. The
+		// grid's thumbnail overlay stacks the same two parts instead.
+		const { summary, cause } = getUploadFailureLabel( upload.failureReason );
 		pill = {
 			intent: 'high',
-			label:
-				upload.failureReason === 'connection'
-					? // The connection notice above the library carries the diagnosis and
-					  // the reconnect button, so the row only has to say which problem it
-					  // belongs to.
-					  __( 'Upload failed: Jetpack connection issue', 'jetpack-videopress-pkg' )
-					: __( 'Upload failed', 'jetpack-videopress-pkg' ),
+			label: cause
+				? sprintf(
+						/* translators: 1: what went wrong, e.g. "Upload failed". 2: what it was attributed to, e.g. "Jetpack connection issue". */
+						__( '%1$s: %2$s', 'jetpack-videopress-pkg' ),
+						summary,
+						cause
+				  )
+				: summary,
 		};
 	} else if ( isProcessing ) {
 		pill = {

--- a/projects/packages/videopress/src/dashboard/components/library/test/fields.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/test/fields.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { makeLibraryItem } from '../../../test-utils/library-item';
 import { libraryFields } from '../fields';
+import { UploadActionsProvider } from '../upload-actions-context';
 import type { LibraryItem } from '../../../types/library';
 import type { Field } from '@wordpress/dataviews';
 
@@ -11,6 +12,50 @@ const getField = ( id: string ): Field< LibraryItem > => {
 	}
 	return field;
 };
+
+describe( 'title field upload pill', () => {
+	const uploadActions = {
+		promoteLocal: jest.fn(),
+		retryUpload: jest.fn(),
+		openVideoDetails: jest.fn(),
+	};
+
+	const renderTitle = ( item: LibraryItem ) => {
+		const TitleRender = getField( 'title' ).render as React.ComponentType< {
+			item: LibraryItem;
+		} >;
+		return render(
+			<UploadActionsProvider value={ uploadActions }>
+				<TitleRender item={ item } />
+			</UploadActionsProvider>
+		);
+	};
+
+	it( 'points a connection-caused failure at the connection notice', () => {
+		renderTitle(
+			makeLibraryItem( {
+				type: 'local',
+				upload: { status: 'failed', progress: 0, failureReason: 'connection' },
+			} )
+		);
+
+		expect( screen.getByText( 'Upload failed: Jetpack connection issue' ) ).toBeInTheDocument();
+	} );
+
+	it.each( [ [ 'other' as const ], [ undefined ] ] )(
+		'leaves the plain label on a failure attributed to %s',
+		failureReason => {
+			renderTitle(
+				makeLibraryItem( {
+					type: 'local',
+					upload: { status: 'failed', progress: 0, failureReason },
+				} )
+			);
+
+			expect( screen.getByText( 'Upload failed' ) ).toBeInTheDocument();
+		}
+	);
+} );
 
 describe( 'orientation field', () => {
 	const renderOrientation = ( item: LibraryItem ) => {

--- a/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
@@ -90,6 +90,36 @@ describe( 'ThumbnailField — grid Details access', () => {
 		expect( actions.retryUpload ).toHaveBeenCalledWith( '5' );
 	} );
 
+	it( 'shows the Jetpack connection cause alongside the failure summary', () => {
+		renderField(
+			<ThumbnailField
+				item={ item( {
+					type: 'local',
+					upload: { status: 'failed', progress: 0, failureReason: 'connection' },
+				} ) }
+			/>,
+			makeActions()
+		);
+
+		expect( screen.getByText( 'Upload failed' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Jetpack connection issue' ) ).toBeInTheDocument();
+	} );
+
+	it( 'leaves the summary alone for a failure attributed to nothing in particular', () => {
+		renderField(
+			<ThumbnailField
+				item={ item( {
+					type: 'local',
+					upload: { status: 'failed', progress: 0, failureReason: 'other' },
+				} ) }
+			/>,
+			makeActions()
+		);
+
+		expect( screen.getByText( 'Upload failed' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Jetpack connection issue' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'does not render the open-details button while uploading', () => {
 		renderField(
 			<ThumbnailField item={ item( { upload: { status: 'uploading', progress: 40 } } ) } />,

--- a/projects/packages/videopress/src/dashboard/components/library/thumbnail-field.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/thumbnail-field.tsx
@@ -5,6 +5,7 @@ import { usePosterUrl } from '../../hooks/use-poster-url';
 import { useProcessingProgress } from '../../hooks/use-processing-progress';
 import { formatDuration } from '../../utils/format';
 import { useUploadActions } from './upload-actions-context';
+import { getUploadFailureLabel } from './upload-failure-label';
 import type { LibraryItem } from '../../types/library';
 
 type Props = { item: LibraryItem };
@@ -30,6 +31,7 @@ export default function ThumbnailField( { item }: Props ) {
 	const { type, upload, durationSeconds, id, guid, title, isPrivate, isProcessing } = item;
 	const posterUrl = usePosterUrl( item );
 
+	const failureLabel = getUploadFailureLabel( upload.failureReason );
 	const isVideoPressIdle = type === 'videopress' && upload.status === 'idle';
 	const processingProgress = useProcessingProgress(
 		guid,
@@ -153,7 +155,10 @@ export default function ThumbnailField( { item }: Props ) {
 					justify="center"
 					className="vp-library__failed"
 				>
-					<Text>{ __( 'Upload failed', 'jetpack-videopress-pkg' ) }</Text>
+					<Text>{ failureLabel.summary }</Text>
+					{ /* Own line rather than joined onto the summary: the tile is too
+					     narrow for one string, and the Retry button sits below. */ }
+					{ failureLabel.cause ? <Text variant="body-sm">{ failureLabel.cause }</Text> : null }
 					<Button size="compact" onClick={ () => retryUpload( id ) }>
 						{ __( 'Retry', 'jetpack-videopress-pkg' ) }
 					</Button>

--- a/projects/packages/videopress/src/dashboard/components/library/upload-failure-label.ts
+++ b/projects/packages/videopress/src/dashboard/components/library/upload-failure-label.ts
@@ -1,0 +1,33 @@
+import { __ } from '@wordpress/i18n';
+import type { UploadFailureReason } from '../../types/library';
+
+export type UploadFailureLabel = {
+	/** What went wrong, in the terms every failed upload shares. */
+	summary: string;
+	/** What to blame it on, when the failure was attributed to something specific. */
+	cause?: string;
+};
+
+/**
+ * Describe a failed upload for the library.
+ *
+ * Returned in two parts rather than one string because the two views that render
+ * a failure have different room for it: the table's title pill can carry a single
+ * joined line, while the grid's thumbnail overlay is a narrow column above a Retry
+ * button and needs the cause on its own second line. Both call this so the wording
+ * can't drift apart again.
+ *
+ * @param {UploadFailureReason} failureReason - What the failure was attributed to, if anything.
+ * @return {UploadFailureLabel} The summary, plus a cause when one was established.
+ */
+export function getUploadFailureLabel( failureReason?: UploadFailureReason ): UploadFailureLabel {
+	const summary = __( 'Upload failed', 'jetpack-videopress-pkg' );
+
+	// The connection notice above the library carries the diagnosis and the
+	// reconnect button, so a row only has to say which problem it belongs to.
+	if ( failureReason === 'connection' ) {
+		return { summary, cause: __( 'Jetpack connection issue', 'jetpack-videopress-pkg' ) };
+	}
+
+	return { summary };
+}

--- a/projects/packages/videopress/src/dashboard/components/video-layout/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-layout/index.tsx
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import AdminPage from '@automattic/jetpack-components/admin-page';
+import useConnectionErrorNotice, {
+	ConnectionError,
+} from '@automattic/jetpack-connection/use-connection-error-notice';
 import { Breadcrumbs } from '@wordpress/admin-ui';
+import { Stack } from '@wordpress/ui';
 import VideoNav, { type VideoNavTab } from '../video-nav';
 import './style.scss';
 import type { ReactNode } from 'react';
@@ -54,6 +58,8 @@ export default function VideoLayout( {
 	confirmNavigation,
 	children,
 }: Props ) {
+	const { hasConnectionError } = useConnectionErrorNotice();
+
 	return (
 		<AdminPage
 			breadcrumbs={
@@ -63,6 +69,11 @@ export default function VideoLayout( {
 			}
 			actions={ actions }
 		>
+			{ hasConnectionError && (
+				<Stack direction="column">
+					<ConnectionError />
+				</Stack>
+			) }
 			<VideoNav
 				videoId={ videoId }
 				activeTab={ activeTab }

--- a/projects/packages/videopress/src/dashboard/components/video-layout/test/index.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-layout/test/index.test.tsx
@@ -1,0 +1,75 @@
+import useConnectionErrorNotice, {
+	ConnectionError,
+} from '@automattic/jetpack-connection/use-connection-error-notice';
+import { render, screen } from '@testing-library/react';
+import VideoLayout from '../index';
+import type { ReactNode } from 'react';
+
+// `Link` as well as `useNavigate`: the breadcrumbs this layout renders resolve
+// their crumbs through it.
+jest.mock( '@wordpress/route', () => ( {
+	__esModule: true,
+	useNavigate: jest.fn( () => jest.fn() ),
+	Link: ( { to, children }: { to: string; children: ReactNode } ) => (
+		<a href={ to }>{ children }</a>
+	),
+} ) );
+
+// Stubbed so these tests assert only that the layout mounts the shared notice,
+// not the notice's own store wiring (which the connection package tests).
+jest.mock( '@automattic/jetpack-connection/use-connection-error-notice', () => ( {
+	__esModule: true,
+	ConnectionError: jest.fn(),
+	default: jest.fn(),
+} ) );
+
+const mockConnectionError = ConnectionError as jest.Mock;
+const mockUseConnectionErrorNotice = useConnectionErrorNotice as jest.MockedFunction<
+	typeof useConnectionErrorNotice
+>;
+
+const renderLayout = () =>
+	render(
+		<VideoLayout videoId="42" activeTab="details" breadcrumbLabel="A video">
+			Video body
+		</VideoLayout>
+	);
+
+describe( 'VideoLayout', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockConnectionError.mockReturnValue( null );
+		mockUseConnectionErrorNotice.mockReturnValue( {
+			hasConnectionError: true,
+		} as ReturnType< typeof useConnectionErrorNotice > );
+	} );
+
+	it( 'renders the connection error notice above the per-video sub-nav', () => {
+		mockConnectionError.mockReturnValue( <div>Connection error notice</div> );
+
+		renderLayout();
+
+		// Siblings, not nested, so the comparison is exactly "follows".
+		const notice = screen.getByText( 'Connection error notice' );
+		const tabList = screen.getByRole( 'tablist' );
+		expect( notice.compareDocumentPosition( tabList ) ).toBe( Node.DOCUMENT_POSITION_FOLLOWING );
+	} );
+
+	it( 'renders the notice with no props, so it matches the dashboard tabs', () => {
+		renderLayout();
+
+		expect( mockConnectionError ).toHaveBeenCalled();
+		expect( mockConnectionError.mock.calls[ 0 ][ 0 ] ).toEqual( {} );
+	} );
+
+	it( 'leaves no notice behind when the connection is healthy', () => {
+		mockUseConnectionErrorNotice.mockReturnValue( {
+			hasConnectionError: false,
+		} as ReturnType< typeof useConnectionErrorNotice > );
+
+		renderLayout();
+
+		expect( mockConnectionError ).not.toHaveBeenCalled();
+		expect( screen.getByText( 'Video body' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-upload.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-upload.test.ts
@@ -32,6 +32,11 @@ jest.mock( '../../../client/hooks/use-resumable-uploader', () => ( {
 	} ),
 } ) );
 
+const tokenError = () =>
+	Object.assign( new Error( 'No token provided' ), {
+		code: 'videopress_no_upload_token',
+	} );
+
 describe( 'useUpload', () => {
 	beforeEach( () => {
 		mockUploadHandler.mockClear();
@@ -89,6 +94,50 @@ describe( 'useUpload', () => {
 		expect( mockUploadHandler ).toHaveBeenCalledWith( file );
 		expect( result.current.uploadQueue[ 0 ].status ).toBe( 'pending' );
 		expect( result.current.uploadQueue[ 0 ].progress ).toBe( 0 );
+	} );
+
+	it( 'keeps the failed error message and its code on the queue item', () => {
+		const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
+		act( () => {
+			result.current.startUpload( new File( [ 'x' ], 't.mp4', { type: 'video/mp4' } ) );
+		} );
+		act( () => {
+			lastCallbacks.onError?.( tokenError() );
+		} );
+
+		expect( result.current.uploadQueue[ 0 ].status ).toBe( 'failed' );
+		expect( result.current.uploadQueue[ 0 ].error ).toBe( 'No token provided' );
+		expect( result.current.uploadQueue[ 0 ].errorCode ).toBe( 'videopress_no_upload_token' );
+	} );
+
+	it( 'leaves errorCode unset for a failure that carried no code', () => {
+		const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
+		act( () => {
+			result.current.startUpload( new File( [ 'x' ], 't.mp4', { type: 'video/mp4' } ) );
+		} );
+		act( () => {
+			lastCallbacks.onError?.( new Error( 'boom' ) );
+		} );
+
+		expect( result.current.uploadQueue[ 0 ].error ).toBe( 'boom' );
+		expect( result.current.uploadQueue[ 0 ].errorCode ).toBeUndefined();
+	} );
+
+	it( 'clears the previous failure when an item is retried', () => {
+		const { result } = renderHook( () => useUpload(), { wrapper: createTestWrapper() } );
+		let id: string | undefined;
+		act( () => {
+			id = result.current.startUpload( new File( [ 'x' ], 't.mp4', { type: 'video/mp4' } ) );
+		} );
+		act( () => {
+			lastCallbacks.onError?.( tokenError() );
+		} );
+		act( () => {
+			result.current.retryUpload( id! );
+		} );
+
+		expect( result.current.uploadQueue[ 0 ].error ).toBeUndefined();
+		expect( result.current.uploadQueue[ 0 ].errorCode ).toBeUndefined();
 	} );
 
 	it( 'retryUpload is a no-op for an unknown id', () => {

--- a/projects/packages/videopress/src/dashboard/hooks/use-upload.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-upload.ts
@@ -40,6 +40,7 @@ export type UploadItem = {
 	progress: number; // 0..1
 	status: UploadStatus;
 	error?: string;
+	errorCode?: string;
 };
 
 const STORE_KEY = '__jetpackVideopressUploadStore' as const;
@@ -205,9 +206,16 @@ export function useUpload() {
 			} else if ( typeof err === 'string' ) {
 				message = err;
 			}
+			// Errors reach here from two places — the token step and tus — and only
+			// some carry a code. Read it off whatever arrived rather than narrowing
+			// to a type, since an uncoded error is a normal outcome here, not a bug.
+			const errorCode =
+				typeof ( err as { code?: unknown } )?.code === 'string'
+					? ( err as { code: string } ).code
+					: undefined;
 			mutateQueue( prev =>
 				prev.map( item =>
-					item.id === id ? { ...item, status: 'failed', error: message } : item
+					item.id === id ? { ...item, status: 'failed', error: message, errorCode } : item
 				)
 			);
 			// Failed items stay in the queue so the user can retry. Move
@@ -243,7 +251,9 @@ export function useUpload() {
 			}
 			mutateQueue( prev =>
 				prev.map( q =>
-					q.id === id ? { ...q, status: 'pending', progress: 0, error: undefined } : q
+					q.id === id
+						? { ...q, status: 'pending', progress: 0, error: undefined, errorCode: undefined }
+						: q
 				)
 			);
 			// Dispatch immediately if idle; otherwise wait for the

--- a/projects/packages/videopress/src/dashboard/types/library.ts
+++ b/projects/packages/videopress/src/dashboard/types/library.ts
@@ -11,9 +11,14 @@ export type VideoRating = 'G' | 'PG-13' | 'R';
 // null when the orientation is unknown (missing dimensions) or square.
 export type VideoOrientation = 'landscape' | 'portrait' | null;
 
+// Why an upload failed, in the only terms the row has space to say it.
+export type UploadFailureReason = 'connection' | 'other';
+
 export interface UploadState {
 	status: UploadStatus;
 	progress: number;
+	// Only set on a failed upload.
+	failureReason?: UploadFailureReason;
 }
 
 export interface LibraryItem {

--- a/projects/plugins/jetpack/changelog/connection-error-block-editor-upload
+++ b/projects/plugins/jetpack/changelog/connection-error-block-editor-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Say when a video upload from the Video block failed because of a Jetpack connection problem, instead of only "Failed to upload your video".

--- a/projects/plugins/jetpack/changelog/connection-error-notice-videopress-dashboard
+++ b/projects/plugins/jetpack/changelog/connection-error-notice-videopress-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Show the Jetpack connection error notice on the VideoPress dashboard again.

--- a/projects/plugins/jetpack/changelog/connection-error-upload-attribution
+++ b/projects/plugins/jetpack/changelog/connection-error-upload-attribution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Say when a video upload failed because of a Jetpack connection problem, instead of only "Upload failed".

--- a/projects/plugins/videopress/changelog/connection-error-block-editor-upload
+++ b/projects/plugins/videopress/changelog/connection-error-block-editor-upload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Say when a video upload from the Video block failed because of a Jetpack connection problem, instead of only "Failed to upload your video".

--- a/projects/plugins/videopress/changelog/connection-error-notice-videopress-dashboard
+++ b/projects/plugins/videopress/changelog/connection-error-notice-videopress-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show the Jetpack connection error notice on the VideoPress dashboard again.

--- a/projects/plugins/videopress/changelog/connection-error-upload-attribution
+++ b/projects/plugins/videopress/changelog/connection-error-upload-attribution
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Say when a video upload failed because of a Jetpack connection problem, instead of only "Upload failed".


### PR DESCRIPTION
Fixes CONNECT-310

## Proposed changes

* This PR ensures that the new VideoPress dashboard shows a `<ConnectionError \>` notice as it did before.
* It also enhances the experience for users by adding a small message to the end of the 'Upload failed' wording in the dashboard if a video upload fails due to a connection issue (now seeing 'Upload failed: Jetpack connection issue'. With the `<ConnectionError \>` notice showing above, the relevant connection issue details should then be more obvious so the simpler wording is sufficient.
* Additionally, the error message in the block editor when there is a connection related failure is now clearer. There is no notice visible in the editor if there is a connection issue so the wording is slightly more verbose: 'Failed to upload your video. Check your Jetpack connection and try again.'. Since `<ConnectionError \>` notices will be visible in wp-admin, it's assumed that the connection between the editor notice and wp-admin notice will also then become self-evident -- just not whilst in the editor. 

## Related product discussion/links

* See Linear issue.
* p1787575712052059-slack-C02LT75D3 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

To test, on a Jetpack-connected site with this branch applied locally or using the Jetpack Beta tester plugin. Make sure to apply the branch for the VideoPress plugin.

* On the VideoPress wp-admin dashboard page, to mimic a connection error showing the notice at the top of the page, you can add this snippet using a code snippets plugin: 3c500-pb
* Alternatively, apply this snippet directly in the browser console: 3c549-pb -- it will mimic both a notice, as well as an upload failure from the dashboard
* To mimic an upload failure from the dashboard, use the above snippet, and attempt an upload. You should see something like this in table view:

<img width="800" height="67" alt="Screenshot 2026-08-25 at 11 55 10" src="https://github.com/user-attachments/assets/2ac3dfff-6c8d-4d0a-ba45-73f7c53e2903" />

-- and this in grid view:

<img width="243" height="239" alt="Screenshot 2026-08-25 at 12 52 40" src="https://github.com/user-attachments/assets/18039a3c-e7f9-46b3-bbb0-ad8cbd93df76" />


* Alternatively, you  can test by actually breaking the blog token. Via ssh for a Jurassic Ninja site:

```
wp eval 'echo Jetpack_Options::get_option( "blog_token" );'   # save it first
wp eval 'Jetpack_Options::update_option( "blog_token", "broken.broken.1" );'
```

* Then attempt an upload. It should display the upload failure and updated notice. You can then re-update the blog token with the saved value (or reconnect).


* To mimic an upload failure from the block editor using the VideoPress block, before attempting an upload paste the following snippet into the console: 3c54a-pb

* Attempt an upload, and you should see the following:

<img width="630" height="241" alt="Screenshot 2026-08-25 at 11 54 45" src="https://github.com/user-attachments/assets/5a2a827f-9f1a-497d-b736-cb73bc1d7189" />

