### PR TITLE
WOOA7S-1968: Open a chart bucket by clicking it

### DIFF
--- a/projects/js-packages/charts/changelog/wooa7s-1968-chart-drill-down
+++ b/projects/js-packages/charts/changelog/wooa7s-1968-chart-drill-down
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Bar chart: Support pointer event handlers, so a bar can respond to a click.
+Bar and line charts: Report a click through the pointer event handlers and Enter or Space through an activation callback, so a chart can open the point under the pointer or the keyboard selection.

--- a/projects/js-packages/charts/changelog/wooa7s-1968-chart-drill-down
+++ b/projects/js-packages/charts/changelog/wooa7s-1968-chart-drill-down
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Bar chart: Support pointer event handlers, so a bar can respond to a click.

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -130,6 +130,7 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	gap = 'md',
 	onPointerDown,
 	onPointerUp,
+	onDatumActivate,
 } ) => {
 	const legendInteractive = legend.interactive ?? false;
 	const legendCollapseGroups = legend.collapseGroups ?? false;
@@ -198,16 +199,6 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		Math.max( 0, ...primarySeriesForNav.map( s => s.data?.length || 0 ) ) *
 		primarySeriesForNav.length;
 
-	// Use the keyboard navigation hook
-	const { tooltipRef, onChartFocus, onChartBlur, onChartKeyDown } = useKeyboardNavigation( {
-		selectedIndex,
-		setSelectedIndex,
-		isNavigating,
-		setIsNavigating,
-		chartRef,
-		totalPoints,
-	} );
-
 	// Add visibility information from the shared legend state.
 	const seriesWithVisibility = useMemo(
 		() =>
@@ -245,6 +236,37 @@ const BarChartInternal: FC< BarChartProps > = ( {
 		() => primaryEntries.map( ( { series } ) => series ),
 		[ primaryEntries ]
 	);
+
+	// Walks the selected index the way the highlight style does — series-major
+	// within each data point — so the bar handed on is the one outlined.
+	const activateSelectedBar = useCallback(
+		( index: number ) => {
+			const primaryCount = primaryEntries.length;
+
+			if ( ! primaryCount ) {
+				return;
+			}
+
+			const dataPointIndex = Math.floor( index / primaryCount );
+			const series = primaryEntries[ index % primaryCount ]?.series;
+			const datum = series?.data[ dataPointIndex ];
+
+			if ( series && datum ) {
+				onDatumActivate?.( { datum, index: dataPointIndex, key: series.label } );
+			}
+		},
+		[ primaryEntries, onDatumActivate ]
+	);
+
+	const { tooltipRef, onChartFocus, onChartBlur, onChartKeyDown } = useKeyboardNavigation( {
+		selectedIndex,
+		setSelectedIndex,
+		isNavigating,
+		setIsNavigating,
+		chartRef,
+		totalPoints,
+		onActivate: activateSelectedBar,
+	} );
 
 	const comparisonEntries = useMemo( () => {
 		const primaryByGroup = new Map< string | undefined, { label: string; index: number } >(

--- a/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/bar-chart.tsx
@@ -128,6 +128,8 @@ const BarChartInternal: FC< BarChartProps > = ( {
 	animation,
 	children,
 	gap = 'md',
+	onPointerDown,
+	onPointerUp,
 } ) => {
 	const legendInteractive = legend.interactive ?? false;
 	const legendCollapseGroups = legend.collapseGroups ?? false;
@@ -575,6 +577,8 @@ const BarChartInternal: FC< BarChartProps > = ( {
 										xScale={ xScale }
 										yScale={ yScale }
 										horizontal={ horizontal }
+										onPointerDown={ onPointerDown }
+										onPointerUp={ onPointerUp }
 										pointerEventsDataKey="nearest"
 									>
 										{ ! allSeriesHidden && (

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart-pointer-events.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart-pointer-events.test.tsx
@@ -1,0 +1,73 @@
+import { render } from '@testing-library/react';
+import { GlobalChartsProvider } from '../../../providers';
+import BarChart from '../bar-chart';
+import type { ReactNode } from 'react';
+
+// jsdom gives every element a zero-sized box, so visx can never resolve a
+// pointer to a datum here. Standing `XYChart` in for a prop recorder keeps this
+// test on the part jsdom can answer: that the handlers reach the chart at all.
+// Whether a bar then reports the datum under the pointer is a browser question.
+const mockXYChart = jest.fn();
+jest.mock( '@visx/xychart', () => {
+	const actual = jest.requireActual( '@visx/xychart' );
+
+	return {
+		__esModule: true,
+		...actual,
+		XYChart: ( props: { children?: ReactNode } ) => {
+			mockXYChart( props );
+			return <svg />;
+		},
+	};
+} );
+
+const mockRefCallback = jest.fn();
+jest.mock( '../../../hooks/use-element-size', () => ( {
+	useElementSize: () => [ mockRefCallback, 500, 300 ],
+} ) );
+
+const DATA = [
+	{
+		label: 'Series A',
+		data: [
+			{ date: new Date( '2024-01-01' ), value: 10 },
+			{ date: new Date( '2024-01-02' ), value: 20 },
+		],
+		options: {},
+	},
+];
+
+/**
+ * Render the chart with the recorder standing in for `XYChart`.
+ *
+ * @param props - Props layered onto the defaults.
+ * @return The render result.
+ */
+function renderBarChart( props = {} ) {
+	return render(
+		<GlobalChartsProvider>
+			<BarChart width={ 500 } height={ 300 } data={ DATA } { ...props } />
+		</GlobalChartsProvider>
+	);
+}
+
+describe( 'BarChart pointer events', () => {
+	beforeEach( () => mockXYChart.mockClear() );
+
+	test( 'hands the pointer handlers to the chart, so a bar can be clicked', () => {
+		const onPointerDown = jest.fn();
+		const onPointerUp = jest.fn();
+
+		renderBarChart( { onPointerDown, onPointerUp } );
+
+		const props = mockXYChart.mock.calls.at( -1 )[ 0 ];
+		expect( props.onPointerDown ).toBe( onPointerDown );
+		expect( props.onPointerUp ).toBe( onPointerUp );
+	} );
+
+	test( 'resolves pointer events to the nearest datum', () => {
+		renderBarChart();
+
+		expect( mockXYChart.mock.calls.at( -1 )[ 0 ].pointerEventsDataKey ).toBe( 'nearest' );
+	} );
+} );

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart-pointer-events.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart-pointer-events.test.tsx
@@ -64,10 +64,4 @@ describe( 'BarChart pointer events', () => {
 		expect( props.onPointerDown ).toBe( onPointerDown );
 		expect( props.onPointerUp ).toBe( onPointerUp );
 	} );
-
-	test( 'resolves pointer events to the nearest datum', () => {
-		renderBarChart();
-
-		expect( mockXYChart.mock.calls.at( -1 )[ 0 ].pointerEventsDataKey ).toBe( 'nearest' );
-	} );
 } );

--- a/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/bar-chart/test/bar-chart.test.tsx
@@ -996,6 +996,85 @@ describe( 'BarChart', () => {
 			} );
 		} );
 
+		describe( 'Activation', () => {
+			const SERIES_A = {
+				label: 'Series A',
+				data: [
+					{ date: new Date( '2024-01-01' ), value: 10 },
+					{ date: new Date( '2024-01-02' ), value: 20 },
+				],
+				options: {},
+			};
+			const SERIES_B = {
+				label: 'Series B',
+				data: [
+					{ date: new Date( '2024-01-01' ), value: 15 },
+					{ date: new Date( '2024-01-02' ), value: 25 },
+				],
+				options: {},
+			};
+
+			test( 'Enter hands the selected bar to onDatumActivate', async () => {
+				const user = userEvent.setup();
+				const onDatumActivate = jest.fn();
+				renderWithTheme( { withTooltips: true, data: [ SERIES_A ], onDatumActivate } );
+
+				screen.getByRole( 'grid', { name: /bar chart/i } ).focus();
+				await user.keyboard( '{ArrowRight}{ArrowRight}{Enter}' );
+
+				expect( onDatumActivate ).toHaveBeenCalledTimes( 1 );
+				expect( onDatumActivate ).toHaveBeenCalledWith( {
+					datum: SERIES_A.data[ 1 ],
+					index: 1,
+					key: 'Series A',
+				} );
+			} );
+
+			test( 'Space activates the selected bar too', async () => {
+				const user = userEvent.setup();
+				const onDatumActivate = jest.fn();
+				renderWithTheme( { withTooltips: true, data: [ SERIES_A ], onDatumActivate } );
+
+				screen.getByRole( 'grid', { name: /bar chart/i } ).focus();
+				await user.keyboard( '{ArrowRight}[Space]' );
+
+				expect( onDatumActivate ).toHaveBeenCalledWith( {
+					datum: SERIES_A.data[ 0 ],
+					index: 0,
+					key: 'Series A',
+				} );
+			} );
+
+			// The navigation index strides series-major within each data point, the
+			// order the highlight outlines bars in, so the second stop is the second
+			// series' first bar.
+			test( 'walks the series at each data point before the next point', async () => {
+				const user = userEvent.setup();
+				const onDatumActivate = jest.fn();
+				renderWithTheme( { withTooltips: true, data: [ SERIES_A, SERIES_B ], onDatumActivate } );
+
+				screen.getByRole( 'grid', { name: /bar chart/i } ).focus();
+				await user.keyboard( '{ArrowRight}{ArrowRight}{Enter}' );
+
+				expect( onDatumActivate ).toHaveBeenCalledWith( {
+					datum: SERIES_B.data[ 0 ],
+					index: 0,
+					key: 'Series B',
+				} );
+			} );
+
+			test( 'Enter with no bar selected activates nothing', async () => {
+				const user = userEvent.setup();
+				const onDatumActivate = jest.fn();
+				renderWithTheme( { withTooltips: true, data: [ SERIES_A ], onDatumActivate } );
+
+				screen.getByRole( 'grid', { name: /bar chart/i } ).focus();
+				await user.keyboard( '{Enter}' );
+
+				expect( onDatumActivate ).not.toHaveBeenCalled();
+			} );
+		} );
+
 		describe( 'Arrow Key Navigation', () => {
 			test( 'right arrow key navigates to next data point', async () => {
 				const user = userEvent.setup();

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -179,6 +179,7 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 			onPointerUp = undefined,
 			onPointerMove = undefined,
 			onPointerOut = undefined,
+			onDatumActivate = undefined,
 			zoomable = false,
 			rescaleYOnVisibilityChange = true,
 			defaultHiddenSeries,
@@ -280,7 +281,20 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 			return min < max ? [ min, max ] : undefined;
 		}, [ rescaleYOnVisibilityChange, dataSorted ] );
 
-		// Use the keyboard navigation hook
+		// Keyboard navigation steps through x positions, and the grouped tooltip
+		// reads every series at that position; the first series names the point.
+		const activateSelectedPoint = useCallback(
+			( index: number ) => {
+				const series = dataSorted[ 0 ];
+				const datum = series?.data[ index ];
+
+				if ( series && datum ) {
+					onDatumActivate?.( { datum, index, key: series.label } );
+				}
+			},
+			[ dataSorted, onDatumActivate ]
+		);
+
 		const { tooltipRef, onChartFocus, onChartBlur, onChartKeyDown } = useKeyboardNavigation( {
 			selectedIndex,
 			setSelectedIndex,
@@ -288,6 +302,7 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 			setIsNavigating,
 			chartRef,
 			totalPoints: dataSorted[ 0 ]?.data.length || 0,
+			onActivate: activateSelectedPoint,
 		} );
 
 		const chartOptions = useMemo( () => {

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -1188,21 +1188,6 @@ describe( 'LineChart', () => {
 				} );
 			} );
 
-			test( 'Space activates the selected point too', async () => {
-				const user = userEvent.setup();
-				const onDatumActivate = jest.fn();
-				renderWithTheme( { data: [ SERIES_A ], onDatumActivate } );
-
-				screen.getByRole( 'grid', { name: /line chart/i } ).focus();
-				await user.keyboard( '{ArrowRight}[Space]' );
-
-				expect( onDatumActivate ).toHaveBeenCalledWith( {
-					datum: SERIES_A.data[ 0 ],
-					index: 0,
-					key: 'Series A',
-				} );
-			} );
-
 			test( 'Enter with no point selected activates nothing', async () => {
 				const user = userEvent.setup();
 				const onDatumActivate = jest.fn();

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -1153,6 +1153,68 @@ describe( 'LineChart', () => {
 			} );
 		} );
 
+		describe( 'Activation', () => {
+			const SERIES_A = {
+				label: 'Series A',
+				data: [
+					{ date: new Date( '2024-01-01' ), value: 10 },
+					{ date: new Date( '2024-01-02' ), value: 20 },
+				],
+				options: {},
+			};
+			const SERIES_B = {
+				label: 'Series B',
+				data: [
+					{ date: new Date( '2024-01-01' ), value: 15 },
+					{ date: new Date( '2024-01-02' ), value: 25 },
+				],
+				options: {},
+			};
+
+			// Navigation steps through x positions; the first series names the point.
+			test( 'Enter hands the selected point to onDatumActivate', async () => {
+				const user = userEvent.setup();
+				const onDatumActivate = jest.fn();
+				renderWithTheme( { data: [ SERIES_A, SERIES_B ], onDatumActivate } );
+
+				screen.getByRole( 'grid', { name: /line chart/i } ).focus();
+				await user.keyboard( '{ArrowRight}{ArrowRight}{Enter}' );
+
+				expect( onDatumActivate ).toHaveBeenCalledTimes( 1 );
+				expect( onDatumActivate ).toHaveBeenCalledWith( {
+					datum: SERIES_A.data[ 1 ],
+					index: 1,
+					key: 'Series A',
+				} );
+			} );
+
+			test( 'Space activates the selected point too', async () => {
+				const user = userEvent.setup();
+				const onDatumActivate = jest.fn();
+				renderWithTheme( { data: [ SERIES_A ], onDatumActivate } );
+
+				screen.getByRole( 'grid', { name: /line chart/i } ).focus();
+				await user.keyboard( '{ArrowRight}[Space]' );
+
+				expect( onDatumActivate ).toHaveBeenCalledWith( {
+					datum: SERIES_A.data[ 0 ],
+					index: 0,
+					key: 'Series A',
+				} );
+			} );
+
+			test( 'Enter with no point selected activates nothing', async () => {
+				const user = userEvent.setup();
+				const onDatumActivate = jest.fn();
+				renderWithTheme( { data: [ SERIES_A ], onDatumActivate } );
+
+				screen.getByRole( 'grid', { name: /line chart/i } ).focus();
+				await user.keyboard( '{Enter}' );
+
+				expect( onDatumActivate ).not.toHaveBeenCalled();
+			} );
+		} );
+
 		describe( 'Arrow Key Navigation', () => {
 			test( 'right arrow key navigates to next data point', async () => {
 				const user = userEvent.setup();

--- a/projects/js-packages/charts/src/components/tooltip/accessible-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/accessible-tooltip.tsx
@@ -172,6 +172,11 @@ interface UseKeyboardNavigationProps {
 	 * Total number of navigation points (length of tooltip data array)
 	 */
 	totalPoints: number;
+	/**
+	 * Called with the selected index on Enter or Space, so a chart can treat the
+	 * keyboard selection the way it treats a click.
+	 */
+	onActivate?: ( index: number ) => void;
 }
 
 export const useKeyboardNavigation = ( {
@@ -181,6 +186,7 @@ export const useKeyboardNavigation = ( {
 	setIsNavigating,
 	chartRef,
 	totalPoints,
+	onActivate,
 }: UseKeyboardNavigationProps ) => {
 	// Focus the tooltip as soon as it is rendered
 	const tooltipRef = useCallback(
@@ -237,9 +243,11 @@ export const useKeyboardNavigation = ( {
 				setSelectedIndex( undefined );
 				setIsNavigating( false );
 				chartRef.current?.focus();
+			} else if ( ( event.key === 'Enter' || event.key === ' ' ) && selectedIndex !== undefined ) {
+				onActivate?.( selectedIndex );
 			}
 		},
-		[ totalPoints, selectedIndex, setSelectedIndex, setIsNavigating, chartRef ]
+		[ totalPoints, selectedIndex, setSelectedIndex, setIsNavigating, chartRef, onActivate ]
 	);
 
 	return {

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -707,6 +707,16 @@ export type BaseChartProps< T = DataPoint | DataPointDate | LeaderboardEntry > =
 	 */
 	onPointerOut?: ( event: PointerEvent< Element > ) => void;
 	/**
+	 * Callback for Enter or Space on the point keyboard navigation has selected:
+	 * the keyboard counterpart of a click. `index` is the point's position in its
+	 * series and `key` the series label.
+	 */
+	onDatumActivate?: ( params: {
+		datum: DataPoint | DataPointDate;
+		index: number;
+		key: string;
+	} ) => void;
+	/**
 	 * Whether to show tooltips on hover. False by default.
 	 */
 	withTooltips?: boolean;

--- a/projects/packages/premium-analytics/changelog/wooa7s-1968-chart-drill-down
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1968-chart-drill-down
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Traffic chart: Click a point on the chart to narrow the dashboard to that period.

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/drill-date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/drill-date-range.test.ts
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { TZDate } from '@date-fns/tz';
+/**
+ * Internal dependencies
+ */
+import { drillDateRange } from '../drill-date-range';
+
+/**
+ * A UTC instant, so bucket boundaries are the same on every machine.
+ *
+ * @param iso - ISO string in UTC.
+ * @return The date, in UTC.
+ */
+function utc( iso: string ): TZDate {
+	return new TZDate( Date.parse( iso ), 'UTC' );
+}
+
+// Far past every bucket under test, so the clamp only fires where a test asks.
+const NOW = utc( '2030-01-01T00:00:00.000Z' );
+
+describe( 'drillDateRange', () => {
+	it( 'opens the calendar day around the clicked instant', () => {
+		const range = drillDateRange( utc( '2026-07-21T13:45:00.000Z' ), 'day', NOW );
+
+		expect( range?.from?.getTime() ).toBe( Date.parse( '2026-07-21T00:00:00.000Z' ) );
+		expect( range?.to?.getTime() ).toBe( Date.parse( '2026-07-21T23:59:59.999Z' ) );
+	} );
+
+	it( 'opens the ISO week, so a Sunday click stays in the week it was drawn in', () => {
+		// 2026-07-26 is a Sunday: ISO weeks end there rather than starting there.
+		const range = drillDateRange( utc( '2026-07-26T09:00:00.000Z' ), 'week', NOW );
+
+		expect( range?.from?.getTime() ).toBe( Date.parse( '2026-07-20T00:00:00.000Z' ) );
+		expect( range?.to?.getTime() ).toBe( Date.parse( '2026-07-26T23:59:59.999Z' ) );
+	} );
+
+	it( 'opens the calendar month', () => {
+		const range = drillDateRange( utc( '2026-02-14T00:00:00.000Z' ), 'month', NOW );
+
+		expect( range?.from?.getTime() ).toBe( Date.parse( '2026-02-01T00:00:00.000Z' ) );
+		expect( range?.to?.getTime() ).toBe( Date.parse( '2026-02-28T23:59:59.999Z' ) );
+	} );
+
+	it( 'opens the calendar quarter', () => {
+		const range = drillDateRange( utc( '2026-05-09T00:00:00.000Z' ), 'quarter', NOW );
+
+		expect( range?.from?.getTime() ).toBe( Date.parse( '2026-04-01T00:00:00.000Z' ) );
+		expect( range?.to?.getTime() ).toBe( Date.parse( '2026-06-30T23:59:59.999Z' ) );
+	} );
+
+	it( 'opens the calendar year', () => {
+		const range = drillDateRange( utc( '2026-05-09T00:00:00.000Z' ), 'year', NOW );
+
+		expect( range?.from?.getTime() ).toBe( Date.parse( '2026-01-01T00:00:00.000Z' ) );
+		expect( range?.to?.getTime() ).toBe( Date.parse( '2026-12-31T23:59:59.999Z' ) );
+	} );
+
+	it( 'refuses to open an hour, the finest bucket the report draws', () => {
+		expect( drillDateRange( utc( '2026-07-21T13:00:00.000Z' ), 'hour', NOW ) ).toBeNull();
+	} );
+
+	it( 'stops the window at now when the bucket is still in progress', () => {
+		const now = utc( '2026-07-21T10:30:00.000Z' );
+		const range = drillDateRange( utc( '2026-07-21T09:00:00.000Z' ), 'day', now );
+
+		expect( range?.from?.getTime() ).toBe( Date.parse( '2026-07-21T00:00:00.000Z' ) );
+		expect( range?.to?.getTime() ).toBe( now.getTime() );
+	} );
+
+	it( 'refuses a bucket that has not started', () => {
+		const now = utc( '2026-07-21T10:30:00.000Z' );
+
+		expect( drillDateRange( utc( '2026-07-22T00:00:00.000Z' ), 'day', now ) ).toBeNull();
+	} );
+
+	it( 'cuts the day on the timezone the clicked date carries, not the machine', () => {
+		// 2026-07-21T02:00Z is still July 20 in New York, so the site's own day
+		// is the one that opens.
+		const range = drillDateRange(
+			new TZDate( Date.parse( '2026-07-21T02:00:00.000Z' ), 'America/New_York' ),
+			'day',
+			NOW
+		);
+
+		expect( range?.from?.getTime() ).toBe( Date.parse( '2026-07-20T04:00:00.000Z' ) );
+		expect( range?.to?.getTime() ).toBe( Date.parse( '2026-07-21T03:59:59.999Z' ) );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/datetime/src/drill-date-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/drill-date-range.ts
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import {
+	endOfDay,
+	endOfISOWeek,
+	endOfMonth,
+	endOfQuarter,
+	endOfYear,
+	startOfDay,
+	startOfISOWeek,
+	startOfMonth,
+	startOfQuarter,
+	startOfYear,
+} from 'date-fns';
+/**
+ * Internal dependencies
+ */
+import type { DateRange } from './get-comparison-range';
+import type { IntervalType } from './interval';
+
+/**
+ * Bucket boundaries per interval a chart can draw.
+ *
+ * `hour` is absent: an hour is the finest bucket the report offers, so a bar
+ * drawn in hours has nothing below it to open.
+ */
+const BUCKET_BOUNDS: Partial<
+	Record< IntervalType, { start: ( date: Date ) => Date; end: ( date: Date ) => Date } >
+> = {
+	day: { start: startOfDay, end: endOfDay },
+	// ISO weeks, matching how the report's own week buckets are cut.
+	week: { start: startOfISOWeek, end: endOfISOWeek },
+	month: { start: startOfMonth, end: endOfMonth },
+	quarter: { start: startOfQuarter, end: endOfQuarter },
+	year: { start: startOfYear, end: endOfYear },
+};
+
+/**
+ * The window behind one chart bucket: the range a click on it should open.
+ *
+ * The caller applies the result through the usual range machinery, which
+ * re-resolves the interval — a bucket's own length never allows the interval
+ * that drew it, so the reading always lands one level finer.
+ *
+ * The end is clamped at `now`, so opening the bucket in progress shows the part
+ * of it that exists rather than a window running into the future.
+ *
+ * Boundaries are cut in `date`'s own timezone, so a `TZDate` carrying the site
+ * zone closes its buckets on the site's clock rather than the browser's.
+ *
+ * @param date     - Any instant inside the bucket, typically the datum's date.
+ * @param interval - The interval the bucket was drawn in.
+ * @param now      - The current instant, for the clamp.
+ * @return The bucket's range, or null when the interval has nothing below it.
+ */
+export function drillDateRange( date: Date, interval: IntervalType, now: Date ): DateRange | null {
+	const bounds = BUCKET_BOUNDS[ interval ];
+
+	if ( ! bounds ) {
+		return null;
+	}
+
+	const from = bounds.start( date );
+
+	if ( from.getTime() > now.getTime() ) {
+		return null;
+	}
+
+	const to = bounds.end( date );
+
+	return { from, to: to.getTime() > now.getTime() ? now : to };
+}

--- a/projects/packages/premium-analytics/packages/datetime/src/index.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/index.ts
@@ -22,6 +22,8 @@ export { getDateRangeSpan, type DateRangeSpan, type DateRangeSpanUnit } from './
 
 export { stepDateRange, canStepForward, type StepDirection } from './step-date-range';
 
+export { drillDateRange } from './drill-date-range';
+
 export { parseSiteDateTime } from './site-datetime';
 
 export { siteTimeZone } from './site-time-zone';

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
@@ -19,11 +19,15 @@ jest.mock( '@jetpack-premium-analytics/data', () => {
  * way the real router makes them.
  */
 const mockNavigate = jest.fn();
+const mockUseSearch = jest.fn();
 let mockSearch: Record< string, unknown > = {};
 
 jest.mock( '@wordpress/route', () => ( {
 	useNavigate: () => mockNavigate,
-	useSearch: () => mockSearch,
+	useSearch: ( options: unknown ) => {
+		mockUseSearch( options );
+		return mockSearch;
+	},
 } ) );
 
 /**
@@ -311,6 +315,20 @@ describe( 'useReportDateFilters', () => {
 		expect( result.current.appliedPresetId ).toBe( 'last-7-days' );
 	} );
 
+	it( 'binds to the route it is given', () => {
+		renderDateFilters();
+
+		expect( mockUseSearch ).toHaveBeenLastCalledWith( { from: '/' } );
+	} );
+
+	// A widget renders on any page that hosts it, so without a route the hook
+	// reads whichever one is matched, as `WidgetRoot` resolves report params.
+	it( 'binds to whichever route is matched when given none', () => {
+		renderHook( () => useReportDateFilters() );
+
+		expect( mockUseSearch ).toHaveBeenLastCalledWith( { strict: false } );
+	} );
+
 	/*
 	 * Each case asserts the interval too, because that is the whole point of a
 	 * drill-down: a bucket's own length never allows the interval that drew it,
@@ -394,6 +412,29 @@ describe( 'useReportDateFilters', () => {
 				from: '2024-01-01T00:00:00.000Z',
 				to: '2024-12-31T23:59:59.999Z',
 				interval: 'month',
+			} );
+		} );
+
+		/*
+		 * A chart that cannot draw the applied interval clamps it — the traffic
+		 * chart draws a quarterly page in months — and names the size it drew, so
+		 * the click opens the bar it hit rather than the coarser bucket around it.
+		 */
+		it( 'opens the bucket in the interval the chart drew, not the applied one', () => {
+			const { result, rerender } = renderDateFilters( {
+				from: '2025-08-01T00:00:00.000Z',
+				to: '2026-07-31T23:59:59.999Z',
+				preset: 'custom',
+				interval: 'quarter',
+			} );
+
+			act( () => result.current.drillDown( new Date( '2026-02-14T00:00:00.000Z' ), 'month' ) );
+			rerender();
+
+			expect( mockSearch ).toMatchObject( {
+				from: '2026-02-01T00:00:00.000Z',
+				to: '2026-02-28T23:59:59.999Z',
+				interval: 'day',
 			} );
 		} );
 

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
@@ -310,4 +310,153 @@ describe( 'useReportDateFilters', () => {
 		expect( mockNavigate.mock.calls[ 0 ][ 0 ].replace ).toBe( true );
 		expect( result.current.appliedPresetId ).toBe( 'last-7-days' );
 	} );
+
+	/*
+	 * Each case asserts the interval too, because that is the whole point of a
+	 * drill-down: a bucket's own length never allows the interval that drew it,
+	 * so applying the bucket as the window drops the reading one level finer.
+	 */
+	describe( 'drillDown', () => {
+		beforeAll( () => {
+			// Every bucket under test is closed, so only the clamp cases care.
+			jest.useFakeTimers().setSystemTime( Date.parse( '2027-01-01T00:00:00.000Z' ) );
+		} );
+
+		afterAll( () => jest.useRealTimers() );
+
+		it( 'opens a day bucket into hours', () => {
+			const { result, rerender } = renderDateFilters( {
+				from: '2026-07-01T00:00:00.000Z',
+				to: '2026-07-30T23:59:59.999Z',
+				preset: 'last-30-days',
+				interval: 'day',
+			} );
+
+			act( () => result.current.drillDown( new Date( '2026-07-21T13:45:00.000Z' ) ) );
+			rerender();
+
+			expect( mockSearch ).toMatchObject( {
+				from: '2026-07-21T00:00:00.000Z',
+				to: '2026-07-21T23:59:59.999Z',
+				preset: 'custom',
+				interval: 'hour',
+			} );
+		} );
+
+		it( 'opens a week bucket into days', () => {
+			const { result, rerender } = renderDateFilters( {
+				from: '2026-05-01T00:00:00.000Z',
+				to: '2026-07-30T23:59:59.999Z',
+				preset: 'custom',
+				interval: 'week',
+			} );
+
+			act( () => result.current.drillDown( new Date( '2026-07-22T00:00:00.000Z' ) ) );
+			rerender();
+
+			expect( mockSearch ).toMatchObject( {
+				from: '2026-07-20T00:00:00.000Z',
+				to: '2026-07-26T23:59:59.999Z',
+				interval: 'day',
+			} );
+		} );
+
+		it( 'opens a month bucket into days', () => {
+			const { result, rerender } = renderDateFilters( {
+				from: '2025-08-01T00:00:00.000Z',
+				to: '2026-07-31T23:59:59.999Z',
+				preset: 'custom',
+				interval: 'month',
+			} );
+
+			act( () => result.current.drillDown( new Date( '2026-02-14T00:00:00.000Z' ) ) );
+			rerender();
+
+			expect( mockSearch ).toMatchObject( {
+				from: '2026-02-01T00:00:00.000Z',
+				to: '2026-02-28T23:59:59.999Z',
+				interval: 'day',
+			} );
+		} );
+
+		it( 'opens a year bucket into months', () => {
+			const { result, rerender } = renderDateFilters( {
+				from: '2022-01-01T00:00:00.000Z',
+				to: '2026-12-31T23:59:59.999Z',
+				preset: 'custom',
+				interval: 'year',
+			} );
+
+			act( () => result.current.drillDown( new Date( '2024-05-09T00:00:00.000Z' ) ) );
+			rerender();
+
+			expect( mockSearch ).toMatchObject( {
+				from: '2024-01-01T00:00:00.000Z',
+				to: '2024-12-31T23:59:59.999Z',
+				interval: 'month',
+			} );
+		} );
+
+		it( 'pushes a history entry, so Back is the way out of a drill-down', () => {
+			const { result } = renderDateFilters( {
+				from: '2026-07-01T00:00:00.000Z',
+				to: '2026-07-30T23:59:59.999Z',
+				preset: 'last-30-days',
+				interval: 'day',
+			} );
+
+			act( () => result.current.drillDown( new Date( '2026-07-21T13:45:00.000Z' ) ) );
+
+			expect( mockNavigate ).toHaveBeenCalledTimes( 1 );
+			expect( mockNavigate.mock.calls[ 0 ][ 0 ].replace ).toBeFalsy();
+		} );
+
+		it( 'ignores a click on an hourly bucket, the finest reading there is', () => {
+			const { result } = renderDateFilters( {
+				from: '2026-07-21T00:00:00.000Z',
+				to: '2026-07-21T23:59:59.999Z',
+				preset: 'custom',
+				interval: 'hour',
+			} );
+
+			act( () => result.current.drillDown( new Date( '2026-07-21T13:00:00.000Z' ) ) );
+
+			expect( mockNavigate ).not.toHaveBeenCalled();
+		} );
+
+		/*
+		 * Clamping a bucket that shares no ground with the applied window would
+		 * invert the range, so the click is refused rather than applied backwards.
+		 */
+		it( 'ignores a bucket lying outside the applied window', () => {
+			const { result } = renderDateFilters( {
+				from: '2026-07-01T00:00:00.000Z',
+				to: '2026-07-30T23:59:59.999Z',
+				preset: 'last-30-days',
+				interval: 'day',
+			} );
+
+			act( () => result.current.drillDown( new Date( '2026-09-05T00:00:00.000Z' ) ) );
+
+			expect( mockNavigate ).not.toHaveBeenCalled();
+		} );
+
+		it( 'keeps a partial edge bucket inside the applied window', () => {
+			// The window opens mid-week, so the first bar covers Jul 22-26 only.
+			const { result, rerender } = renderDateFilters( {
+				from: '2026-07-22T00:00:00.000Z',
+				to: '2026-10-20T23:59:59.999Z',
+				preset: 'custom',
+				interval: 'week',
+			} );
+
+			act( () => result.current.drillDown( new Date( '2026-07-23T00:00:00.000Z' ) ) );
+			rerender();
+
+			expect( mockSearch ).toMatchObject( {
+				from: '2026-07-22T00:00:00.000Z',
+				to: '2026-07-26T23:59:59.999Z',
+			} );
+		} );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
@@ -75,8 +75,11 @@ export type ReportDateFilters = {
 	/**
 	 * Open the chart bucket containing a date: narrow the applied window to that
 	 * bucket, which drops the reading to the next finer interval.
+	 *
+	 * `interval` is the bucket size the chart drew, for a chart that clamps the
+	 * applied interval into the sizes it offers. Defaults to the applied one.
 	 */
-	drillDown: ( date: Date ) => void;
+	drillDown: ( date: Date, interval?: IntervalType ) => void;
 
 	onApply: () => void;
 	onCancel: () => void;
@@ -125,10 +128,12 @@ function toPickerRange( from: string | undefined, to: string | undefined, timeZo
  * everything `DateFiltersPanel` needs. Shared by every analytics page that
  * mounts the panel so the staged-search behavior stays identical across them.
  *
- * @param from - The route path the search params are bound to (e.g. `/`).
+ * @param from - The route path the search params are bound to (e.g. `/`). Omit
+ *             to bind to whichever route is matched, as a widget must: it
+ *             renders on any page that hosts it.
  * @return Props for `DateFiltersPanel`.
  */
-export function useReportDateFilters< TFrom extends string >( from: TFrom ): ReportDateFilters {
+export function useReportDateFilters< TFrom extends string >( from?: TFrom ): ReportDateFilters {
 	const { committed, effective, stage, commit, revert, isDirty } = useStagedSearch<
 		ReportQuerySearchParams,
 		TFrom
@@ -306,19 +311,20 @@ export function useReportDateFilters< TFrom extends string >( from: TFrom ): Rep
 	 * Commits on click and pushes a history entry, like `onStep`, so Back is the
 	 * way out of a drill-down and the narrowed window survives a reload.
 	 *
-	 * Reads the applied interval and range rather than the staged ones: the
-	 * chart draws what is applied, so the bucket the user clicked belongs to
-	 * that window, not to a draft the picker is holding.
+	 * Reads the applied range rather than the staged one: the chart draws what
+	 * is applied, so the bucket the user clicked belongs to that window, not to
+	 * a draft the picker is holding. The same goes for the interval, unless the
+	 * chart names the size it actually drew.
 	 */
 	const drillDown = useCallback(
-		( date: Date ) => {
+		( date: Date, bucketInterval: IntervalType = appliedInterval ) => {
 			/*
 			 * `drillDateRange` closes a bucket on the clock of the date handed to it,
 			 * so the click is re-anchored in the site's zone first. A caller may pass
 			 * a plain instant, which would otherwise cut the bucket on the browser's
 			 * clock and open the wrong day west or east of the site.
 			 */
-			const drilled = drillDateRange( toLocalTZ( date, timeZone ), appliedInterval, new Date() );
+			const drilled = drillDateRange( toLocalTZ( date, timeZone ), bucketInterval, new Date() );
 
 			if ( ! drilled?.from || ! drilled.to ) {
 				return;

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
@@ -6,7 +6,12 @@ import {
 	hasComparisonEnabled,
 	resolveIntervalForRange,
 } from '@jetpack-premium-analytics/data';
-import { PRESET_CUSTOM, siteTimeZone, stepDateRange } from '@jetpack-premium-analytics/datetime';
+import {
+	drillDateRange,
+	PRESET_CUSTOM,
+	siteTimeZone,
+	stepDateRange,
+} from '@jetpack-premium-analytics/datetime';
 import { useCallback, useMemo } from 'react';
 /**
  * Internal dependencies
@@ -65,6 +70,12 @@ export type ReportDateFilters = {
 	 * Step the applied window backward or forward by its own length.
 	 */
 	onStep: ( direction: StepDirection ) => void;
+
+	/**
+	 * Open the chart bucket containing a date: narrow the applied window to that
+	 * bucket, which drops the reading to the next finer interval.
+	 */
+	drillDown: ( date: Date ) => void;
 
 	onApply: () => void;
 	onCancel: () => void;
@@ -290,6 +301,51 @@ export function useReportDateFilters< TFrom extends string >( from: TFrom ): Rep
 		[ appliedRange, commit, effective, stage ]
 	);
 
+	/*
+	 * Commits on click and pushes a history entry, like `onStep`, so Back is the
+	 * way out of a drill-down and the narrowed window survives a reload.
+	 *
+	 * Reads the applied interval and range rather than the staged ones: the
+	 * chart draws what is applied, so the bucket the user clicked belongs to
+	 * that window, not to a draft the picker is holding.
+	 */
+	const drillDown = useCallback(
+		( date: Date ) => {
+			const drilled = drillDateRange( date, appliedInterval, new Date() );
+
+			if ( ! drilled?.from || ! drilled.to ) {
+				return;
+			}
+
+			/*
+			 * Kept inside the applied window: a bucket at either edge of the chart
+			 * is usually a partial one, and opening it whole would widen the report
+			 * past the range the user asked for.
+			 */
+			const clampedFrom =
+				appliedRange.from && drilled.from < appliedRange.from ? appliedRange.from : drilled.from;
+			const clampedTo =
+				appliedRange.to && drilled.to > appliedRange.to ? appliedRange.to : drilled.to;
+
+			if ( clampedFrom.getTime() >= clampedTo.getTime() ) {
+				return;
+			}
+
+			const patch = buildRangePatch( {
+				nextRange: { from: clampedFrom, to: clampedTo },
+				nextPresetId: PRESET_CUSTOM,
+				exactRange: true,
+				effective,
+			} );
+
+			if ( patch ) {
+				stage( patch );
+				commit();
+			}
+		},
+		[ appliedInterval, appliedRange, commit, effective, stage ]
+	);
+
 	const onApply = useCallback( () => commit(), [ commit ] );
 	const onCancel = useCallback( () => revert(), [ revert ] );
 
@@ -324,6 +380,7 @@ export function useReportDateFilters< TFrom extends string >( from: TFrom ): Rep
 		onComparisonChange,
 		onIntervalChange,
 		onStep,
+		drillDown,
 		onApply,
 		onCancel,
 		canApply: isDirty,

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
@@ -11,6 +11,7 @@ import {
 	PRESET_CUSTOM,
 	siteTimeZone,
 	stepDateRange,
+	toLocalTZ,
 } from '@jetpack-premium-analytics/datetime';
 import { useCallback, useMemo } from 'react';
 /**
@@ -311,7 +312,13 @@ export function useReportDateFilters< TFrom extends string >( from: TFrom ): Rep
 	 */
 	const drillDown = useCallback(
 		( date: Date ) => {
-			const drilled = drillDateRange( date, appliedInterval, new Date() );
+			/*
+			 * `drillDateRange` closes a bucket on the clock of the date handed to it,
+			 * so the click is re-anchored in the site's zone first. A caller may pass
+			 * a plain instant, which would otherwise cut the bucket on the browser's
+			 * clock and open the wrong day west or east of the site.
+			 */
+			const drilled = drillDateRange( toLocalTZ( date, timeZone ), appliedInterval, new Date() );
 
 			if ( ! drilled?.from || ! drilled.to ) {
 				return;
@@ -343,7 +350,7 @@ export function useReportDateFilters< TFrom extends string >( from: TFrom ): Rep
 				commit();
 			}
 		},
-		[ appliedInterval, appliedRange, commit, effective, stage ]
+		[ appliedInterval, appliedRange, commit, effective, stage, timeZone ]
 	);
 
 	const onApply = useCallback( () => commit(), [ commit ] );

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-search/README.md
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-search/README.md
@@ -24,7 +24,7 @@ Atomic commit:
 
 ```ts
 type UseStagedSearchOptions< TFrom extends string > = {
-	from: TFrom; // TanStack route id/path
+	from?: TFrom; // TanStack route id/path; omit to bind to the matched route
 	autoCommitDebounceMs?: number; // optional debounce in ms
 };
 
@@ -43,7 +43,7 @@ type UseStagedSearchReturn< TSearch > = {
 
 Notes:
 
-- Internally uses `useSearch( { from } )` and `useNavigate( { from } )`.
+- Internally uses `useSearch( { from } )` and `useNavigate( { from } )`, or `useSearch( { strict: false } )` and `useNavigate()` when `from` is omitted.
 - No `to` is passed on commit, so the current route is preserved.
 
 ---

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-search/use-staged-search.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-search/use-staged-search.tsx
@@ -98,9 +98,16 @@ export function useStagedSearch< TSearch extends AnyObject, TFrom extends string
 	opts: UseStagedSearchOptions< TFrom >
 ): UseStagedSearchReturn< TSearch > {
 	const navigate = useNavigate( opts.from === undefined ? {} : { from: opts.from } );
-	const committed = useSearch(
+
+	/*
+	 * TanStack types the strict and loose forms as exclusive shapes keyed on a
+	 * generic, so a runtime choice between them cannot satisfy either on its own;
+	 * the widened parameter type admits both.
+	 */
+	const searchOptions = (
 		opts.from === undefined ? { strict: false } : { from: opts.from }
-	) as TSearch;
+	) as Parameters< typeof useSearch >[ 0 ];
+	const committed = useSearch( searchOptions ) as TSearch;
 
 	const [ staged, setStaged ] = useState< TSearch >( committed );
 

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-search/use-staged-search.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-search/use-staged-search.tsx
@@ -7,7 +7,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 type AnyObject = Record< string, unknown >;
 
 export type UseStagedSearchOptions< TFrom extends string > = {
-	from: TFrom; // e.g., '/',
+	/**
+	 * The route the search params are bound to, e.g. `/`. Omit to read whichever
+	 * route is matched — the way `WidgetRoot` resolves report params — so a
+	 * widget can commit on any page that hosts it.
+	 */
+	from?: TFrom;
 
 	/**
 	 * If provided, stage() will schedule an automatic debounced commit
@@ -92,8 +97,10 @@ function mergeDefined< T extends AnyObject >( base: T, patch: Partial< T > ): T 
 export function useStagedSearch< TSearch extends AnyObject, TFrom extends string >(
 	opts: UseStagedSearchOptions< TFrom >
 ): UseStagedSearchReturn< TSearch > {
-	const navigate = useNavigate( { from: opts.from } );
-	const committed = useSearch( { from: opts.from } ) as TSearch;
+	const navigate = useNavigate( opts.from === undefined ? {} : { from: opts.from } );
+	const committed = useSearch(
+		opts.from === undefined ? { strict: false } : { from: opts.from }
+	) as TSearch;
 
 	const [ staged, setStaged ] = useState< TSearch >( committed );
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/comparative-bar-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/comparative-bar-chart.tsx
@@ -127,6 +127,16 @@ export type ComparativeBarChartProps = {
 	 * into a single item, so clicking it would just empty the chart.
 	 */
 	legendInteractive?: boolean;
+
+	/**
+	 * Pointer-down on the plot, carrying the datum nearest the pointer.
+	 */
+	onPointerDown?: BarChartProps[ 'onPointerDown' ];
+
+	/**
+	 * Pointer-up on the plot, carrying the datum nearest the pointer.
+	 */
+	onPointerUp?: BarChartProps[ 'onPointerUp' ];
 };
 
 /**
@@ -155,6 +165,8 @@ export function ComparativeBarChart( {
 	maxWidth = Infinity,
 	defaultHiddenSeries,
 	legendInteractive = false,
+	onPointerDown,
+	onPointerUp,
 }: ComparativeBarChartProps ) {
 	const tooltipDateFormat = dateFormatForResolution( tickResolution );
 	const fallbackChartId = useId();
@@ -384,6 +396,8 @@ export function ComparativeBarChart( {
 				showLegend={ false }
 				withTooltips={ ! isEmptyData }
 				renderTooltip={ renderTooltip }
+				onPointerDown={ onPointerDown }
+				onPointerUp={ onPointerUp }
 			>
 				{ /* Circle swatches, not the bar's own shape: the legend only needs to name
 				     the metrics — the solid bar against its translucent shadow is what

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/comparative-bar-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/comparative-bar-chart.tsx
@@ -137,6 +137,11 @@ export type ComparativeBarChartProps = {
 	 * Pointer-up on the plot, carrying the datum nearest the pointer.
 	 */
 	onPointerUp?: BarChartProps[ 'onPointerUp' ];
+
+	/**
+	 * Enter or Space on the keyboard-selected bar, carrying its datum.
+	 */
+	onDatumActivate?: BarChartProps[ 'onDatumActivate' ];
 };
 
 /**
@@ -167,6 +172,7 @@ export function ComparativeBarChart( {
 	legendInteractive = false,
 	onPointerDown,
 	onPointerUp,
+	onDatumActivate,
 }: ComparativeBarChartProps ) {
 	const tooltipDateFormat = dateFormatForResolution( tickResolution );
 	const fallbackChartId = useId();
@@ -398,6 +404,7 @@ export function ComparativeBarChart( {
 				renderTooltip={ renderTooltip }
 				onPointerDown={ onPointerDown }
 				onPointerUp={ onPointerUp }
+				onDatumActivate={ onDatumActivate }
 			>
 				{ /* Circle swatches, not the bar's own shape: the legend only needs to name
 				     the metrics — the solid bar against its translucent shadow is what

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
@@ -178,6 +178,7 @@ export function ComparativeLineChart( {
 	legendInteractive = false,
 	onPointerDown,
 	onPointerUp,
+	onDatumActivate,
 }: ComparativeLineChartProps ) {
 	const tooltipDateFormat = dateFormatForResolution( tickResolution );
 	// The measured Stack fills its container (flex), so its height is independent
@@ -328,6 +329,7 @@ export function ComparativeLineChart( {
 				renderTooltip={ renderTooltip }
 				onPointerDown={ onPointerDown }
 				onPointerUp={ onPointerUp }
+				onDatumActivate={ onDatumActivate }
 			>
 				{ /* Names the metrics; the solid line against its dashed overlay is what
 				     tells the current period from the previous one. */ }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
@@ -176,6 +176,8 @@ export function ComparativeLineChart( {
 	compactWhenShort = false,
 	defaultHiddenSeries,
 	legendInteractive = false,
+	onPointerDown,
+	onPointerUp,
 }: ComparativeLineChartProps ) {
 	const tooltipDateFormat = dateFormatForResolution( tickResolution );
 	// The measured Stack fills its container (flex), so its height is independent
@@ -324,6 +326,8 @@ export function ComparativeLineChart( {
 				withGradientFill
 				withTooltips={ !! renderTooltip && ! isEmptyData }
 				renderTooltip={ renderTooltip }
+				onPointerDown={ onPointerDown }
+				onPointerUp={ onPointerUp }
 			>
 				{ /* Names the metrics; the solid line against its dashed overlay is what
 				     tells the current period from the previous one. */ }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
@@ -576,22 +576,6 @@ describe( 'MetricTabsChart', () => {
 			expect( onDatumClick ).not.toHaveBeenCalled();
 		} );
 
-		it( 'ignores a drag, so a zoom gesture never opens a date', () => {
-			const onDatumClick = jest.fn();
-
-			render(
-				<MetricTabsChart
-					metrics={ [ METRIC ] }
-					dataFormat={ DATA_FORMAT }
-					onDatumClick={ onDatumClick }
-				/>
-			);
-
-			pressAndRelease( mockLineSpy, { date: CLICKED, value: 200 }, 40 );
-
-			expect( onDatumClick ).not.toHaveBeenCalled();
-		} );
-
 		it( 'ignores a release over nothing datable', () => {
 			const onDatumClick = jest.fn();
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
@@ -42,6 +42,13 @@ type ChartProps = {
 	chartId?: string;
 	defaultHiddenSeries?: readonly string[];
 	legendInteractive?: boolean;
+	onPointerDown?: ( params: PointerParams ) => void;
+	onPointerUp?: ( params: PointerParams ) => void;
+};
+
+type PointerParams = {
+	datum?: unknown;
+	svgPoint?: { x: number; y: number };
 };
 
 const DATA_FORMAT = { type: 'number' as const, options: { decimals: 0 } };
@@ -111,6 +118,20 @@ const WALL_CLOCK_METRIC: MetricTab = {
  */
 function recordedSeries( spy: jest.Mock ): ComparativeLineChartSeries[] {
 	return recordedProps( spy ).series;
+}
+
+/**
+ * Play a press and release over a datum, optionally moving between them.
+ *
+ * @param spy      - The chart stand-in to drive.
+ * @param datum    - The datum the pointer resolves to.
+ * @param distance - How far (px) the pointer travels before release.
+ */
+function pressAndRelease( spy: jest.Mock, datum: unknown, distance = 0 ) {
+	const { onPointerDown, onPointerUp } = recordedProps( spy );
+
+	onPointerDown?.( { datum, svgPoint: { x: 10, y: 10 } } );
+	onPointerUp?.( { datum, svgPoint: { x: 10 + distance, y: 10 } } );
 }
 
 /**
@@ -457,5 +478,140 @@ describe( 'MetricTabsChart', () => {
 		);
 
 		expect( recordedPropsFor( mockBarSpy, 'Views' ).chartId ).toBe( lineChartId );
+	} );
+
+	describe( 'onDatumClick', () => {
+		const CLICKED = new Date( '2026-07-02T00:00:00Z' );
+
+		it.each( [
+			[ 'line', mockLineSpy, undefined ],
+			[ 'bar', mockBarSpy, 'bar' ],
+		] as const )( 'reports a click on the %s chart', ( _name, spy, chartType ) => {
+			const onDatumClick = jest.fn();
+
+			render(
+				<MetricTabsChart
+					metrics={ [ METRIC ] }
+					dataFormat={ DATA_FORMAT }
+					chartType={ chartType }
+					onDatumClick={ onDatumClick }
+				/>
+			);
+
+			pressAndRelease( spy, { date: CLICKED, value: 200 } );
+
+			expect( onDatumClick ).toHaveBeenCalledWith( CLICKED );
+		} );
+
+		/*
+		 * A wall-clock point names a bucket, not an instant, so the date handed on
+		 * must be re-anchored in the site's zone first — otherwise an hourly
+		 * bucket opens the browser's day rather than the site's.
+		 */
+		it.each( [
+			[ 'America/Los_Angeles', '2026-07-21T20:00:00.000Z' ],
+			[ 'Asia/Tokyo', '2026-07-21T04:00:00.000Z' ],
+		] )( 'reads a wall-clock point in the site zone, on a site in %s', ( zone, expected ) => {
+			setSettings( siteSettingsIn( zone ) );
+
+			const onDatumClick = jest.fn();
+
+			render(
+				<MetricTabsChart
+					metrics={ [ WALL_CLOCK_METRIC ] }
+					dataFormat={ DATA_FORMAT }
+					onDatumClick={ onDatumClick }
+					pointsAreWallClocks
+				/>
+			);
+
+			pressAndRelease( mockLineSpy, { date: new Date( '2026-07-21T13:00:00.000Z' ), value: 200 } );
+
+			expect( onDatumClick.mock.calls[ 0 ][ 0 ].getTime() ).toBe( Date.parse( expected ) );
+		} );
+
+		// Literal on purpose. Importing the component's tolerance would move both
+		// sides with it, leaving the threshold unpinned.
+		it.each( [
+			[ 6, true ],
+			[ 7, false ],
+		] )( 'travelling %ipx reports a click: %s', ( distance, reports ) => {
+			const onDatumClick = jest.fn();
+
+			render(
+				<MetricTabsChart
+					metrics={ [ METRIC ] }
+					dataFormat={ DATA_FORMAT }
+					onDatumClick={ onDatumClick }
+				/>
+			);
+
+			pressAndRelease( mockLineSpy, { date: CLICKED, value: 200 }, distance );
+
+			expect( onDatumClick ).toHaveBeenCalledTimes( reports ? 1 : 0 );
+		} );
+
+		/*
+		 * A release the chart never saw a press for belongs to a gesture that
+		 * started off the plot, so it must not open a date the pointer only
+		 * happened to end over.
+		 */
+		it( 'ignores a release with no press behind it', () => {
+			const onDatumClick = jest.fn();
+
+			render(
+				<MetricTabsChart
+					metrics={ [ METRIC ] }
+					dataFormat={ DATA_FORMAT }
+					onDatumClick={ onDatumClick }
+				/>
+			);
+
+			recordedProps( mockLineSpy ).onPointerUp?.( {
+				datum: { date: CLICKED, value: 200 },
+				svgPoint: { x: 10, y: 10 },
+			} );
+
+			expect( onDatumClick ).not.toHaveBeenCalled();
+		} );
+
+		it( 'ignores a drag, so a zoom gesture never opens a date', () => {
+			const onDatumClick = jest.fn();
+
+			render(
+				<MetricTabsChart
+					metrics={ [ METRIC ] }
+					dataFormat={ DATA_FORMAT }
+					onDatumClick={ onDatumClick }
+				/>
+			);
+
+			pressAndRelease( mockLineSpy, { date: CLICKED, value: 200 }, 40 );
+
+			expect( onDatumClick ).not.toHaveBeenCalled();
+		} );
+
+		it( 'ignores a release over nothing datable', () => {
+			const onDatumClick = jest.fn();
+
+			render(
+				<MetricTabsChart
+					metrics={ [ METRIC ] }
+					dataFormat={ DATA_FORMAT }
+					onDatumClick={ onDatumClick }
+				/>
+			);
+
+			pressAndRelease( mockLineSpy, { value: 200 } );
+
+			expect( onDatumClick ).not.toHaveBeenCalled();
+		} );
+
+		it( 'leaves the chart without pointer handlers when nothing listens', () => {
+			render( <MetricTabsChart metrics={ [ METRIC ] } dataFormat={ DATA_FORMAT } /> );
+
+			expect( recordedProps( mockLineSpy ).onPointerUp ).toBeUndefined();
+			expect( recordedProps( mockLineSpy ).onPointerDown ).toBeUndefined();
+		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
@@ -44,6 +44,7 @@ type ChartProps = {
 	legendInteractive?: boolean;
 	onPointerDown?: ( params: PointerParams ) => void;
 	onPointerUp?: ( params: PointerParams ) => void;
+	onDatumActivate?: ( params: { datum: unknown } ) => void;
 };
 
 type PointerParams = {
@@ -607,11 +608,34 @@ describe( 'MetricTabsChart', () => {
 			expect( onDatumClick ).not.toHaveBeenCalled();
 		} );
 
-		it( 'leaves the chart without pointer handlers when nothing listens', () => {
+		// The keyboard counterpart of the click: Enter on the point navigation
+		// selected reports the same date a pointer release over it would.
+		it.each( [
+			[ 'line', mockLineSpy, undefined ],
+			[ 'bar', mockBarSpy, 'bar' ],
+		] as const )( 'reports a keyboard activation on the %s chart', ( _name, spy, chartType ) => {
+			const onDatumClick = jest.fn();
+
+			render(
+				<MetricTabsChart
+					metrics={ [ METRIC ] }
+					dataFormat={ DATA_FORMAT }
+					chartType={ chartType }
+					onDatumClick={ onDatumClick }
+				/>
+			);
+
+			recordedProps( spy ).onDatumActivate?.( { datum: { date: CLICKED, value: 200 } } );
+
+			expect( onDatumClick ).toHaveBeenCalledWith( CLICKED );
+		} );
+
+		it( 'leaves the chart without pointer or keyboard handlers when nothing listens', () => {
 			render( <MetricTabsChart metrics={ [ METRIC ] } dataFormat={ DATA_FORMAT } /> );
 
 			expect( recordedProps( mockLineSpy ).onPointerUp ).toBeUndefined();
 			expect( recordedProps( mockLineSpy ).onPointerDown ).toBeUndefined();
+			expect( recordedProps( mockLineSpy ).onDatumActivate ).toBeUndefined();
 		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.module.scss
@@ -161,3 +161,9 @@
 	min-width: 0;
 	min-height: 0;
 }
+
+/* The plot answers a click, so the cursor says so; the legend beneath it does
+   not. */
+.drillable [role="grid"] {
+	cursor: pointer;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -49,6 +49,14 @@ type ChartPointerParams = Parameters<
 >[ 0 ];
 
 /**
+ * The keyboard activation payload both comparative charts report, carrying the
+ * datum keyboard navigation had selected.
+ */
+type ChartActivateParams = Parameters<
+	NonNullable< ComponentProps< typeof ComparativeLineChart >[ 'onDatumActivate' ] >
+>[ 0 ];
+
+/**
  * A single time-series point for a metric.
  */
 export interface MetricTabDatum {
@@ -126,8 +134,8 @@ export interface MetricTabsChartProps {
 	 */
 	pointsAreWallClocks?: boolean;
 	/**
-	 * A click on the plot, carrying the date of the bucket the pointer is over.
-	 * Omit to leave the chart non-interactive.
+	 * A click on the plot, or Enter on the keyboard-selected point, carrying the
+	 * date of that bucket. Omit to leave the chart non-interactive.
 	 */
 	onDatumClick?: ( date: Date ) => void;
 }
@@ -238,6 +246,22 @@ function MetricChart( {
 
 	const pointerDownRef = useRef< { x: number; y: number } | null >( null );
 
+	const reportDatum = useCallback(
+		( datum: unknown ) => {
+			/*
+			 * `alignSeriesDates` rewrites a comparison point's date to the primary
+			 * point it is drawn under, so whichever series the gesture resolves to,
+			 * its datum carries the current-period date.
+			 */
+			const date = ( datum as { date?: unknown } | undefined )?.date;
+
+			if ( date instanceof Date ) {
+				onDatumClick?.( readPointDate( date ) );
+			}
+		},
+		[ onDatumClick, readPointDate ]
+	);
+
 	const handlePointerDown = useCallback( ( { svgPoint }: ChartPointerParams ) => {
 		pointerDownRef.current = svgPoint ? { x: svgPoint.x, y: svgPoint.y } : null;
 	}, [] );
@@ -260,24 +284,24 @@ function MetricChart( {
 				return;
 			}
 
-			/*
-			 * `alignSeriesDates` rewrites a comparison point's date to the primary
-			 * point it is drawn under, so whichever series the pointer resolves to,
-			 * its datum carries the current-period date.
-			 */
-			const date = ( datum as { date?: unknown } | undefined )?.date;
-
-			if ( date instanceof Date ) {
-				onDatumClick?.( readPointDate( date ) );
-			}
+			reportDatum( datum );
 		},
-		[ onDatumClick, readPointDate ]
+		[ reportDatum ]
+	);
+
+	const handleActivate = useCallback(
+		( { datum }: ChartActivateParams ) => reportDatum( datum ),
+		[ reportDatum ]
 	);
 
 	// Left off entirely without a handler, so a chart that does not drill keeps
-	// no pointer listeners at all.
-	const pointerProps = onDatumClick
-		? { onPointerDown: handlePointerDown, onPointerUp: handlePointerUp }
+	// no pointer or keyboard listeners at all.
+	const drillHandlers = onDatumClick
+		? {
+				onPointerDown: handlePointerDown,
+				onPointerUp: handlePointerUp,
+				onDatumActivate: handleActivate,
+		  }
 		: {};
 
 	// Resolve each series' colour + line style from the chart theme so the chart
@@ -306,7 +330,7 @@ function MetricChart( {
 			tickResolution={ tickResolution }
 			formatTooltipDate={ formatTooltipDate }
 			compactWhenShort
-			{ ...pointerProps }
+			{ ...drillHandlers }
 		/>
 	) : (
 		<ComparativeLineChart
@@ -319,7 +343,7 @@ function MetricChart( {
 			tickResolution={ tickResolution }
 			formatTooltipDate={ formatTooltipDate }
 			compactWhenShort
-			{ ...pointerProps }
+			{ ...drillHandlers }
 		/>
 	);
 }
@@ -507,7 +531,7 @@ export function MetricTabsChart( {
 					</div>
 					{ controls }
 				</div>
-				<div className={ styles.chart }>
+				<div className={ clsx( styles.chart, onDatumClick && styles.drillable ) }>
 					<MetricChart
 						metric={ activeMetric }
 						counterpart={ counterpartFor( activeMetric ) }
@@ -578,7 +602,7 @@ export function MetricTabsChart( {
 					</div>
 					{ controls }
 				</div>
-				<div className={ styles.chart }>
+				<div className={ clsx( styles.chart, onDatumClick && styles.drillable ) }>
 					{ activeMetric && (
 						<MetricChart
 							metric={ activeMetric }
@@ -621,7 +645,11 @@ export function MetricTabsChart( {
 			{ /* One panel per tab (WAI-ARIA + @wordpress/ui parity). Only the active
 			     metric's panel renders its chart; the rest stay empty. */ }
 			{ metrics.map( metric => (
-				<Tabs.Panel key={ metric.key } value={ metric.key } className={ styles.chart }>
+				<Tabs.Panel
+					key={ metric.key }
+					value={ metric.key }
+					className={ clsx( styles.chart, onDatumClick && styles.drillable ) }
+				>
 					<MetricChart
 						metric={ metric }
 						counterpart={ counterpartFor( metric ) }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -33,6 +33,22 @@ import type { ComponentProps, CSSProperties, ReactNode } from 'react';
 const MIN_TAB_WIDTH = 120;
 
 /**
+ * How far (px) the pointer may travel between down and up and still count as a
+ * click. Above it the gesture is a drag — a zoom selection, or a slip on the
+ * way up — and must not drill the dashboard to a date the reader was only
+ * passing over.
+ */
+const CLICK_DRAG_TOLERANCE_PX = 6;
+
+/**
+ * The pointer-event payload both comparative charts report, carrying the datum
+ * nearest the pointer.
+ */
+type ChartPointerParams = Parameters<
+	NonNullable< ComponentProps< typeof ComparativeLineChart >[ 'onPointerUp' ] >
+>[ 0 ];
+
+/**
  * A single time-series point for a metric.
  */
 export interface MetricTabDatum {
@@ -109,6 +125,11 @@ export interface MetricTabsChartProps {
 	 * are, hence the opt-in. Full rationale in `chart-date.ts`.
 	 */
 	pointsAreWallClocks?: boolean;
+	/**
+	 * A click on the plot, carrying the date of the bucket the pointer is over.
+	 * Omit to leave the chart non-interactive.
+	 */
+	onDatumClick?: ( date: Date ) => void;
 }
 
 /**
@@ -186,6 +207,7 @@ function MetricChart( {
 	chartId,
 	tickResolution,
 	readPointDate,
+	onDatumClick,
 }: {
 	metric: MetricTab;
 	counterpart?: MetricTab;
@@ -194,6 +216,7 @@ function MetricChart( {
 	chartId: string;
 	tickResolution?: TickResolution;
 	readPointDate: ReadPointDate;
+	onDatumClick?: ( date: Date ) => void;
 } ) {
 	const { series, defaultHiddenSeries } = useMemo( () => {
 		const active = buildSeries( metric, chartType );
@@ -212,6 +235,50 @@ function MetricChart( {
 		( date: Date, format: DateFormatName ) => formatDate( readPointDate( date ), format ),
 		[ readPointDate ]
 	);
+
+	const pointerDownRef = useRef< { x: number; y: number } | null >( null );
+
+	const handlePointerDown = useCallback( ( { svgPoint }: ChartPointerParams ) => {
+		pointerDownRef.current = svgPoint ? { x: svgPoint.x, y: svgPoint.y } : null;
+	}, [] );
+
+	const handlePointerUp = useCallback(
+		( { datum, svgPoint }: ChartPointerParams ) => {
+			const start = pointerDownRef.current;
+			pointerDownRef.current = null;
+
+			// A release with no press behind it is the tail of a gesture that began
+			// off the plot, so there is no click here to report.
+			if ( ! start ) {
+				return;
+			}
+
+			if (
+				svgPoint &&
+				Math.hypot( svgPoint.x - start.x, svgPoint.y - start.y ) > CLICK_DRAG_TOLERANCE_PX
+			) {
+				return;
+			}
+
+			/*
+			 * `alignSeriesDates` rewrites a comparison point's date to the primary
+			 * point it is drawn under, so whichever series the pointer resolves to,
+			 * its datum carries the current-period date.
+			 */
+			const date = ( datum as { date?: unknown } | undefined )?.date;
+
+			if ( date instanceof Date ) {
+				onDatumClick?.( readPointDate( date ) );
+			}
+		},
+		[ onDatumClick, readPointDate ]
+	);
+
+	// Left off entirely without a handler, so a chart that does not drill keeps
+	// no pointer listeners at all.
+	const pointerProps = onDatumClick
+		? { onPointerDown: handlePointerDown, onPointerUp: handlePointerUp }
+		: {};
 
 	// Resolve each series' colour + line style from the chart theme so the chart
 	// lines and the tooltip glyphs share the same styling — including the dashed
@@ -239,6 +306,7 @@ function MetricChart( {
 			tickResolution={ tickResolution }
 			formatTooltipDate={ formatTooltipDate }
 			compactWhenShort
+			{ ...pointerProps }
 		/>
 	) : (
 		<ComparativeLineChart
@@ -251,6 +319,7 @@ function MetricChart( {
 			tickResolution={ tickResolution }
 			formatTooltipDate={ formatTooltipDate }
 			compactWhenShort
+			{ ...pointerProps }
 		/>
 	);
 }
@@ -346,6 +415,7 @@ export function MetricTabsChart( {
 	groupLabel = __( 'Select metric', 'jetpack-premium-analytics-pkg' ),
 	tickResolution,
 	pointsAreWallClocks = false,
+	onDatumClick,
 }: MetricTabsChartProps ) {
 	const readPointDate = pointsAreWallClocks ? fromChartDate : asInstant;
 	const [ selectedKey, setSelectedKey ] = useState( defaultMetricKey ?? metrics[ 0 ]?.key );
@@ -446,6 +516,7 @@ export function MetricTabsChart( {
 						chartId={ chartIdFor( activeMetric ) }
 						tickResolution={ tickResolution }
 						readPointDate={ readPointDate }
+						onDatumClick={ onDatumClick }
 					/>
 				</div>
 			</div>
@@ -517,6 +588,7 @@ export function MetricTabsChart( {
 							chartId={ chartIdFor( activeMetric ) }
 							tickResolution={ tickResolution }
 							readPointDate={ readPointDate }
+							onDatumClick={ onDatumClick }
 						/>
 					) }
 				</div>
@@ -558,6 +630,7 @@ export function MetricTabsChart( {
 						chartId={ chartIdFor( metric ) }
 						tickResolution={ tickResolution }
 						readPointDate={ readPointDate }
+						onDatumClick={ onDatumClick }
 					/>
 				</Tabs.Panel>
 			) ) }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/__tests__/report-page-layout.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/__tests__/report-page-layout.test.tsx
@@ -58,6 +58,7 @@ function buildDateFilters(): ReportDateFilters {
 		canApply: true,
 		timeZone: 'UTC',
 		replaceRange: jest.fn(),
+		drillDown: jest.fn(),
 	};
 }
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.tsx
@@ -180,6 +180,7 @@ const STORY_DATE_FILTERS: ReportDateFilters = {
 	canApply: false,
 	timeZone: STORY_TIMEZONE,
 	replaceRange: () => {},
+	drillDown: () => {},
 };
 
 /**

--- a/projects/packages/premium-analytics/tests/js/route-test-utils.tsx
+++ b/projects/packages/premium-analytics/tests/js/route-test-utils.tsx
@@ -59,6 +59,9 @@ function MockRouteLink( { to, params, search, children, ...props }: MockRouteLin
 export const mockWordPressRoute = {
 	Link: MockRouteLink,
 	useSearch: () => currentSearch,
+	// Swallows the write. A component under test may hold a hook that commits to
+	// the URL, and rendering it must not need a router.
+	useNavigate: () => () => {},
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/stories/with-story-router.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/with-story-router.tsx
@@ -6,12 +6,30 @@ import {
 	createRootRoute,
 	createRoute,
 	createRouter,
-	RouterContextProvider,
+	RouterProvider,
 } from '@tanstack/react-router';
+import { createContext, useContext } from 'react';
 import type { Decorator } from '@storybook/react';
 import type { ReactNode } from 'react';
 
+/*
+ * The story's own tree, handed to the dashboard route's component. A widget that
+ * reads the report window off the URL needs an active match to read it from, and
+ * a match exists only for a route the router actually renders — so the story is
+ * rendered *as* the dashboard route rather than beside it.
+ */
+const storyChildren = createContext< ReactNode >( null );
+
+function StoryRoute() {
+	return useContext( storyChildren );
+}
+
 const rootRoute = createRootRoute();
+const dashboardRoute = createRoute( {
+	getParentRoute: () => rootRoute,
+	path: '/',
+	component: StoryRoute,
+} );
 const reportRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: '/reports/$report',
@@ -21,7 +39,7 @@ const postDetailRoute = createRoute( {
 	path: '/post/$postId',
 } );
 const storyRouter = createRouter( {
-	routeTree: rootRoute.addChildren( [ reportRoute, postDetailRoute ] ),
+	routeTree: rootRoute.addChildren( [ dashboardRoute, reportRoute, postDetailRoute ] ),
 	history: createMemoryHistory( { initialEntries: [ '/' ] } ),
 	// TanStack's options type requires strictNullChecks, which this package does not enable.
 } as never );
@@ -32,7 +50,11 @@ const storyRouter = createRouter( {
  * real href shapes as the app.
  */
 export function StoryRouterProvider( { children }: { children: ReactNode } ) {
-	return <RouterContextProvider router={ storyRouter }>{ children }</RouterContextProvider>;
+	return (
+		<storyChildren.Provider value={ children }>
+			<RouterProvider router={ storyRouter } />
+		</storyChildren.Provider>
+	);
 }
 
 export const withStoryRouter: Decorator = Story => (

--- a/projects/packages/premium-analytics/widgets/stories/with-story-router.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/with-story-router.tsx
@@ -13,10 +13,13 @@ import type { Decorator } from '@storybook/react';
 import type { ReactNode } from 'react';
 
 /*
- * The story's own tree, handed to the dashboard route's component. A widget that
- * reads the report window off the URL needs an active match to read it from, and
- * a match exists only for a route the router actually renders — so the story is
- * rendered *as* the dashboard route rather than beside it.
+ * The story's own tree, rendered by the root route. A widget that reads the
+ * report window off the URL needs an active match to read it from, and a match
+ * exists only for a route the router actually renders — so the story is
+ * rendered *by* the router rather than beside it. The root, not the dashboard
+ * route, does the rendering: the dashboard and detail routes below carry no
+ * component, so a link click that moves the memory history onto one of them
+ * would otherwise unmount the story.
  */
 const storyChildren = createContext< ReactNode >( null );
 
@@ -24,11 +27,10 @@ function StoryRoute() {
 	return useContext( storyChildren );
 }
 
-const rootRoute = createRootRoute();
+const rootRoute = createRootRoute( { component: StoryRoute } );
 const dashboardRoute = createRoute( {
 	getParentRoute: () => rootRoute,
 	path: '/',
-	component: StoryRoute,
 } );
 const reportRoute = createRoute( {
 	getParentRoute: () => rootRoute,

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/render.test.tsx
@@ -13,11 +13,24 @@ jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mo
 
 jest.mock( '../use-traffic-chart' );
 
+// The click lands in the date-filter controller, so a recorder stands in for it.
+const mockDrillDown = jest.fn();
+jest.mock( '@jetpack-premium-analytics/routing', () => ( {
+	useReportDateFilters: () => ( {
+		drillDown: ( ...args: unknown[] ) => mockDrillDown( ...args ),
+	} ),
+} ) );
+
 // The chart itself is not this file's subject: the bucket the widget resolves is,
-// and `useTrafficChart` is where it lands.
+// and `useTrafficChart` is where it lands. The stand-in records its props so the
+// click handler the widget hands it can be driven.
+const mockMetricTabsChart = jest.fn();
 jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 	...jest.requireActual( '@jetpack-premium-analytics/widgets-toolkit' ),
-	MetricTabsChart: () => null,
+	MetricTabsChart: ( props: unknown ) => {
+		mockMetricTabsChart( props );
+		return null;
+	},
 } ) );
 
 const mockUseTrafficChart = jest.mocked( useTrafficChart );
@@ -44,7 +57,14 @@ function requestedBucket(): string {
 	return calls[ calls.length - 1 ][ 1 ];
 }
 
+/** The click handler the widget handed the chart on the latest render. */
+function chartClickHandler(): ( date: Date ) => void {
+	const calls = mockMetricTabsChart.mock.calls;
+	return calls[ calls.length - 1 ][ 0 ].onDatumClick;
+}
+
 beforeEach( () => {
+	mockDrillDown.mockClear();
 	mockUseTrafficChart.mockReset();
 	mockUseTrafficChart.mockReturnValue( {
 		metrics: [
@@ -108,5 +128,18 @@ describe( 'TrafficChart bucket size', () => {
 		);
 
 		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'TrafficChart drill-down', () => {
+	// A quarterly page draws in months here, so the click must name the month:
+	// left to the page interval, a click on March would open the whole quarter.
+	it( 'names the bucket size it drew, not the page interval', () => {
+		render( <TrafficChartRender attributes={ { reportParams: reportParams( 'quarter' ) } } /> );
+
+		const clicked = new Date( '2026-02-14T00:00:00.000Z' );
+		chartClickHandler()( clicked );
+
+		expect( mockDrillDown ).toHaveBeenCalledWith( clicked, 'month' );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/traffic-chart/package.json
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/package.json
@@ -7,6 +7,7 @@
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/fields": "link:../../packages/fields",
 		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
+		"@jetpack-premium-analytics/routing": "link:../../packages/routing",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/element": "8.3.0",
 		"@wordpress/i18n": "^6.9.0",

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -11,6 +11,7 @@ import {
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { reports } from '@jetpack-premium-analytics/icons';
+import { useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -29,6 +30,12 @@ type TrafficChartWidgetProps = WidgetRenderProps< TrafficChartRenderAttributes >
 	 */
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
+
+/**
+ * The route the dashboard's report window lives on, and the one this widget
+ * narrows when a bucket is clicked.
+ */
+const DASHBOARD_ROUTE = '/';
 
 const DATA_FORMAT = {
 	type: 'number' as const,
@@ -54,6 +61,8 @@ function TrafficChartInner( { chartType }: TrafficChartInnerProps ) {
 		reportParams.interval,
 		TRAFFIC_PERIODS
 	);
+
+	const { drillDown } = useReportDateFilters( DASHBOARD_ROUTE );
 
 	const {
 		metrics: metricTabs,
@@ -102,6 +111,7 @@ function TrafficChartInner( { chartType }: TrafficChartInnerProps ) {
 					groupLabel={ groupLabel }
 					tickResolution={ period }
 					pointsAreWallClocks
+					onDatumClick={ drillDown }
 				/>
 			</WidgetState>
 		</div>

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -13,6 +13,7 @@ import {
 import { reports } from '@jetpack-premium-analytics/icons';
 import { useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
 /**
  * Internal dependencies
  */
@@ -30,12 +31,6 @@ type TrafficChartWidgetProps = WidgetRenderProps< TrafficChartRenderAttributes >
 	 */
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
-
-/**
- * The route the dashboard's report window lives on, and the one this widget
- * narrows when a bucket is clicked.
- */
-const DASHBOARD_ROUTE = '/';
 
 const DATA_FORMAT = {
 	type: 'number' as const,
@@ -62,7 +57,15 @@ function TrafficChartInner( { chartType }: TrafficChartInnerProps ) {
 		TRAFFIC_PERIODS
 	);
 
-	const { drillDown } = useReportDateFilters( DASHBOARD_ROUTE );
+	// Bound to whichever route hosts the widget, the same way `reportParams` are.
+	const { drillDown } = useReportDateFilters();
+
+	// Names the bucket size drawn, not the page interval: a quarter or year page
+	// interval clamps to months here, and the click must open the bar it hit.
+	const openBucket = useCallback(
+		( date: Date ) => drillDown( date, period ),
+		[ drillDown, period ]
+	);
 
 	const {
 		metrics: metricTabs,
@@ -111,7 +114,7 @@ function TrafficChartInner( { chartType }: TrafficChartInnerProps ) {
 					groupLabel={ groupLabel }
 					tickResolution={ period }
 					pointsAreWallClocks
-					onDatumClick={ drillDown }
+					onDatumClick={ openBucket }
 				/>
 			</WidgetState>
 		</div>

--- a/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
@@ -9,6 +9,7 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { createStoryWidgetType } from '../../stories/create-story-widget-type';
+import { withStoryRouter } from '../../stories/with-story-router';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -65,6 +66,9 @@ const meta = {
 	title: 'Packages/Premium Analytics/Widgets/TrafficChart',
 	component: TrafficChartRender,
 	tags: [ 'autodocs' ],
+	// The widget reads the report window off the route to drill on a click, so it
+	// needs a router even in the close-up stories that mount it without a dashboard.
+	decorators: [ withStoryRouter ],
 	argTypes: {
 		withComparison: { control: 'boolean' },
 		...CHART_TYPE_ARG_TYPES,

--- a/projects/plugins/jetpack/changelog/wooa7s-1968-chart-drill-down
+++ b/projects/plugins/jetpack/changelog/wooa7s-1968-chart-drill-down
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: Click a point on the Traffic chart to narrow the dashboard to that period.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1968-chart-drill-down
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1968-chart-drill-down
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Traffic chart: Click a point on the chart to narrow the dashboard to that period.


### PR DESCRIPTION
Fixes WOOA7S-1968

## Proposed changes
* The current Stats experience lets you click a date in the Views chart and land on a view of the Traffic page for that day alone. The new one had no way to do that. This adds it: clicking a point in the Traffic chart narrows the dashboard to the bucket you clicked, so every widget on the page reports on that period. The reading drops one interval finer — a day opens into hours, a week into days, a month into days, a year into months.
* The opened window is clamped to the applied range, so a partial bucket at either edge of the chart cannot widen the report past what you asked for, and clamped to now, so a bucket still in progress does not run into the future. Hours refuse to drill, being the finest reading the report offers.
* The click commits through the usual range machinery and pushes a history entry, so Back is the way out of a drill-down and the narrowed window survives a reload.
* A press and release more than 6px apart counts as a drag rather than a click, so a zoom selection never opens a date.


https://github.com/user-attachments/assets/27cb4be9-9462-4140-9a7b-b0a8388b7f21



## Related product discussion/links
* WOOA7S-1968

## Does this pull request change what data or activity we track or use?
No. This changes which date range the existing widgets request; it adds no new data or tracking.

## Testing instructions

* Open the Premium Analytics dashboard on the Traffic page with a range of a month or so.
* Click a bar or point in the Traffic chart. The range should narrow to that day, the interval should drop to hours, and the other widgets on the page should re-report on that day alone.
* Press Back. The previous range should return.
* Reload while drilled in. The narrowed window should survive.
* Set the range to a year, switch **Group by** to Month, then click a month. It should open that month at a daily reading.
* Drag across the chart to zoom instead of clicking. The range should not change.
* Set a range that starts mid-week and click its first bar. The opened window should stay inside the range you applied rather than spilling outside it.
* On a site whose timezone differs from your browser's, click an hourly bucket and confirm the day it opens is the site's day.

**Recording:** _to add — clicking a bar, then Back._
