### PR TITLE
Backport jetpack 16.2-a.3 changes

### DIFF
--- a/projects/js-packages/charts/CHANGELOG.md
+++ b/projects/js-packages/charts/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-08-25
+### Added
+- Add `defaultHiddenSeries` to seed a series hidden on load, plus absolute visibility setters. Keep the keyboard tooltip open when the chart re-renders under it. [#51458]
+- Let a calendar heatmap draw a grid wider than its data, filling the extra weeks with cells that report nothing rather than claiming there was no activity on them. [#51385]
+- Export `GoogleDataTableColumnRoleType` as a value, so a consumer can build a GeoChart tooltip column. [#51312]
+
+### Fixed
+- Draw labels at the design system's font weight and size, and follow the WordPress admin color scheme for the zoom selection. [#51452]
+- GeoChart: Stop an HTML tooltip breaking its lines when it opens near a map edge. [#51312]
+- Honor series visibility set programmatically, not only through the interactive legend. [#51457]
+- Keep a series revealed from the legend revealed when the chart remounts, instead of re-applying `defaultHiddenSeries`. [#51468]
+
 ## [3.0.0] - 2026-08-21
 ### Changed
 - Emit the `--a8c-charts-*` token catalog on the charts provider, so any token can be overridden in CSS anywhere inside it or through the `theme` prop, and resolve tokens against the chart element so CSS-painted and SVG-painted colors honour the same override. A `theme`-prop override keeps the reach of the field it was set from: `svgLabelSmall.fill` moves the SVG axis labels without touching legend labels or heatmap cell values, and `backgroundColor` repaints the chart background without touching tooltips, the annotation label or the zoom-reset control.
@@ -991,6 +1003,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed lints following ESLint rule changes for TS [#40584]
 - Fixing a bug in Chart storybook data. [#40640]
 
+[3.1.0]: https://github.com/Automattic/charts/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/Automattic/charts/compare/v2.0.1...v3.0.0
 [2.0.1]: https://github.com/Automattic/charts/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Automattic/charts/compare/v1.12.0...v2.0.0

--- a/projects/js-packages/charts/CHANGELOG.md
+++ b/projects/js-packages/charts/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.1.0] - 2026-08-25
 ### Added
 - Add `defaultHiddenSeries` to seed a series hidden on load, plus absolute visibility setters. Keep the keyboard tooltip open when the chart re-renders under it. [#51458]
-- Let a calendar heatmap draw a grid wider than its data, filling the extra weeks with cells that report nothing rather than claiming there was no activity on them. [#51385]
 - Export `GoogleDataTableColumnRoleType` as a value, so a consumer can build a GeoChart tooltip column. [#51312]
+- Let a calendar heatmap draw a grid wider than its data, filling the extra weeks with cells that report nothing rather than claiming there was no activity on them. [#51385]
 
 ### Fixed
 - Draw labels at the design system's font weight and size, and follow the WordPress admin color scheme for the zoom selection. [#51452]

--- a/projects/js-packages/charts/changelog/charts-246-default-hidden-series
+++ b/projects/js-packages/charts/changelog/charts-246-default-hidden-series
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add defaultHiddenSeries to seed a series hidden on load, plus absolute visibility setters. Keep the keyboard tooltip open when the chart re-renders under it.

--- a/projects/js-packages/charts/changelog/charts-246-hidden-series-api
+++ b/projects/js-packages/charts/changelog/charts-246-hidden-series-api
@@ -1,4 +1,0 @@
-Significance: minor
-Type: fixed
-
-Honor series visibility set programmatically, not only through the interactive legend.

--- a/projects/js-packages/charts/changelog/charts-254-align-wpds-fallback-values
+++ b/projects/js-packages/charts/changelog/charts-254-align-wpds-fallback-values
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Charts: Draw labels at the design system's font weight and size, and follow the WordPress admin color scheme for the zoom selection.

--- a/projects/js-packages/charts/changelog/charts-259-chart-instance-context-rename
+++ b/projects/js-packages/charts/changelog/charts-259-chart-instance-context-rename
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Internal rename of the private single-chart context module; no user-facing change.
-
-

--- a/projects/js-packages/charts/changelog/fix-wooa7s-1963-heatmap-window
+++ b/projects/js-packages/charts/changelog/fix-wooa7s-1963-heatmap-window
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Charts: let a calendar heatmap draw a grid wider than its data, filling the extra weeks with cells that report nothing rather than claiming there was no activity on them.

--- a/projects/js-packages/charts/changelog/wooa7s-1844-views-visitors-pair
+++ b/projects/js-packages/charts/changelog/wooa7s-1844-views-visitors-pair
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Keep a series revealed from the legend revealed when the chart remounts, instead of re-applying defaultHiddenSeries.

--- a/projects/js-packages/charts/changelog/wooa7s-1922-geo-tooltip-width
+++ b/projects/js-packages/charts/changelog/wooa7s-1922-geo-tooltip-width
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-GeoChart: Stop an HTML tooltip breaking its lines when it opens near a map edge.

--- a/projects/js-packages/charts/changelog/wooa7s-1922-locations-regions
+++ b/projects/js-packages/charts/changelog/wooa7s-1922-locations-regions
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Export GoogleDataTableColumnRoleType as a value, so a consumer can build a GeoChart tooltip column.

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/charts",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"description": "Display charts within Automattic products.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/charts/#readme",
 	"bugs": {

--- a/projects/packages/activity-log/CHANGELOG.md
+++ b/projects/packages/activity-log/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2026-08-25
+### Changed
+- Update dependencies. [#50841]
+
 ## [0.2.5] - 2026-08-20
 ### Changed
 - Update dependencies. [#50841]
@@ -119,6 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release.
 
+[0.2.6]: https://github.com/Automattic/jetpack-activity-log/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/Automattic/jetpack-activity-log/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/Automattic/jetpack-activity-log/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/Automattic/jetpack-activity-log/compare/v0.2.2...v0.2.3

--- a/projects/packages/activity-log/src/class-package-version.php
+++ b/projects/packages/activity-log/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Activity_Log;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '0.2.5';
+	const PACKAGE_VERSION = '0.2.6';
 
 	const PACKAGE_SLUG = 'activity-log';
 

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-08-25
+### Changed
+- Load the CSS that hides core admin notices on Jetpack pages through the style queue instead of printing a style element. [#51474]
+
+### Deprecated
+- Deprecate `Admin_Menu::print_hide_core_admin_notices_style()`; `hide_core_admin_notices()` enqueues the CSS now. [#51474]
+
 ## [0.9.15] - 2026-08-06
 ### Changed
 - Update package dependencies. [#50509]
@@ -339,6 +346,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing menu visibility issues.
 
+[0.10.0]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.15...0.10.0
 [0.9.15]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.14...0.9.15
 [0.9.14]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.13...0.9.14
 [0.9.13]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.12...0.9.13

--- a/projects/packages/admin-ui/changelog/stats-343-admin-ui-hide-notices-style
+++ b/projects/packages/admin-ui/changelog/stats-343-admin-ui-hide-notices-style
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Load the CSS that hides core admin notices on Jetpack pages through the style queue instead of printing a style element.

--- a/projects/packages/admin-ui/changelog/stats-343-admin-ui-hide-notices-style-deprecation
+++ b/projects/packages/admin-ui/changelog/stats-343-admin-ui-hide-notices-style-deprecation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-Deprecate Admin_Menu::print_hide_core_admin_notices_style(); hide_core_admin_notices() enqueues the CSS now.

--- a/projects/packages/admin-ui/composer.json
+++ b/projects/packages/admin-ui/composer.json
@@ -59,7 +59,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.9.x-dev"
+			"dev-trunk": "0.10.x-dev"
 		},
 		"dependencies": {
 			"test-only": [

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.9.15",
+	"version": "0.10.0",
 	"private": true,
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -17,7 +17,7 @@ use Jetpack_Tracks_Client;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.9.15';
+	const PACKAGE_VERSION = '0.10.0';
 
 	/**
 	 * Slug used for the upgrade menu item and redirect URL.
@@ -268,12 +268,12 @@ class Admin_Menu {
 	 * the handle is never printed. The previous admin_print_styles priority-10
 	 * hook still works.
 	 *
-	 * @deprecated $$next-version$$ Use hide_core_admin_notices(), which enqueues the CSS.
+	 * @deprecated 0.10.0 Use hide_core_admin_notices(), which enqueues the CSS.
 	 *
 	 * @return void
 	 */
 	public static function print_hide_core_admin_notices_style() {
-		_deprecated_function( __METHOD__, 'admin-ui-$$next-version$$', __CLASS__ . '::hide_core_admin_notices' );
+		_deprecated_function( __METHOD__, 'admin-ui-0.10.0', __CLASS__ . '::hide_core_admin_notices' );
 		self::hide_core_admin_notices();
 	}
 

--- a/projects/packages/backup/CHANGELOG.md
+++ b/projects/packages/backup/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.15] - 2026-08-25
+### Changed
+- Internal updates.
+
 ## [4.3.14] - 2026-08-20
 ### Changed
 - Update package dependencies. [#51399]
@@ -1193,6 +1197,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add API endpoints and Jetpack Backup package for managing Help…
 
+[4.3.15]: https://github.com/Automattic/jetpack-backup/compare/v4.3.14...v4.3.15
 [4.3.14]: https://github.com/Automattic/jetpack-backup/compare/v4.3.13...v4.3.14
 [4.3.13]: https://github.com/Automattic/jetpack-backup/compare/v4.3.12...v4.3.13
 [4.3.12]: https://github.com/Automattic/jetpack-backup/compare/v4.3.11...v4.3.12

--- a/projects/packages/backup/changelog/fix-backup-activity-log-locale
+++ b/projects/packages/backup/changelog/fix-backup-activity-log-locale
@@ -1,3 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Backup: forward the reader's locale to the modernized dashboard's activity list so WordPress.com renders the summaries in their language. No-op when the modernization filter is off.

--- a/projects/packages/backup/changelog/fix-backup-dashboard-ui-correctness
+++ b/projects/packages/backup/changelog/fix-backup-dashboard-ui-correctness
@@ -1,3 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Backup: draw the correct file and folder icons in the modernized dashboard's file browser, head the detail pane with the selected row's own title, and indent the restore checklist helper text logically for RTL. No-op when the modernization filter is off.

--- a/projects/packages/backup/changelog/fix-backup-invalid-rewind-id-and-list-loading
+++ b/projects/packages/backup/changelog/fix-backup-invalid-rewind-id-and-list-loading
@@ -1,3 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Backup: refuse a malformed rewind id in the modernized restore and download screens instead of arming a form that cannot succeed, keep a failed request's reason on screen while it is being retried, report the activity list as busy while a page change is in flight, and pin the page footer to the bottom of the viewport on the restore and download routes. No-op when the modernization filter is off.

--- a/projects/packages/backup/changelog/fix-backup-preview-manifest-path-encoding
+++ b/projects/packages/backup/changelog/fix-backup-preview-manifest-path-encoding
@@ -1,3 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Backup: fix the modernized file browser's preview, which corrupted the manifest path by percent-encoding an already-base64 value, and restore the per-file details pane so it shows each file's real size, hash and modification time. The manifest path and period are now schema-validated, since the path is interpolated into the upstream URL unescaped. No-op when the modernization filter is off.

--- a/projects/packages/backup/changelog/fix-backup-restore-session-recovery
+++ b/projects/packages/backup/changelog/fix-backup-restore-session-recovery
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Backup: adopt a restore that is already running when the modernized restore screen opens, instead of arming a Confirm button that would start a second concurrent one; match the recovered restore on recency rather than the first row, so a completed restore of the same backup is never reported as the one just started; hold a submission whose answer never arrived open until it is known whether it started; and stop polling the restores collection once the id is in hand. No-op when the modernization filter is off.
-
-

--- a/projects/packages/backup/src/class-package-version.php
+++ b/projects/packages/backup/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Backup;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '4.3.14';
+	const PACKAGE_VERSION = '4.3.15';
 
 	const PACKAGE_SLUG = 'backup';
 

--- a/projects/packages/blaze/CHANGELOG.md
+++ b/projects/packages/blaze/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.5] - 2026-08-25
+### Changed
+- Update dependencies. [#51438]
+
 ## [0.28.4] - 2026-08-20
 ### Changed
 - Update dependencies. [#51190]
@@ -898,6 +902,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated package dependencies. [#27906]
 
+[0.28.5]: https://github.com/automattic/jetpack-blaze/compare/v0.28.4...v0.28.5
 [0.28.4]: https://github.com/automattic/jetpack-blaze/compare/v0.28.3...v0.28.4
 [0.28.3]: https://github.com/automattic/jetpack-blaze/compare/v0.28.2...v0.28.3
 [0.28.2]: https://github.com/automattic/jetpack-blaze/compare/v0.28.1...v0.28.2

--- a/projects/packages/blaze/package.json
+++ b/projects/packages/blaze/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-blaze",
-	"version": "0.28.4",
+	"version": "0.28.5",
 	"private": true,
 	"description": "Attract high-quality traffic to your site using Blaze. Using this service, you can advertise a post or page on some of the millions of pages across WordPress.com and Tumblr from just $5 per day.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/blaze/#readme",

--- a/projects/packages/blaze/src/class-dashboard.php
+++ b/projects/packages/blaze/src/class-dashboard.php
@@ -21,7 +21,7 @@ class Dashboard {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.28.4';
+	const PACKAGE_VERSION = '0.28.5';
 
 	/**
 	 * List of dependencies needed to render the dashboard in wp-admin.

--- a/projects/packages/comments/CHANGELOG.md
+++ b/projects/packages/comments/CHANGELOG.md
@@ -4,3 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 - 2026-08-25
+### Added
+- Add an on-site comment form with a textarea, guest name and email fields, and reply threading when the `jetpack_comments_new_hotness` filter returns true. [#51466]
+- Initial version. [#51210]

--- a/projects/packages/comments/changelog/add-comments-phase-1
+++ b/projects/packages/comments/changelog/add-comments-phase-1
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add the comment form: a textarea, guest name and email fields, and reply threading, rendered on the site itself. Off unless the jetpack_comments_new_hotness filter returns true.

--- a/projects/packages/comments/changelog/initial-version
+++ b/projects/packages/comments/changelog/initial-version
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Initial version.

--- a/projects/packages/comments/package.json
+++ b/projects/packages/comments/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-comments",
-	"version": "0.1.0-alpha",
+	"version": "0.1.0",
 	"private": true,
 	"description": "Replaces the default WordPress comment form.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/comments/#readme",

--- a/projects/packages/comments/src/class-comments.php
+++ b/projects/packages/comments/src/class-comments.php
@@ -15,12 +15,12 @@ class Comments {
 	/**
 	 * Package version.
 	 */
-	const PACKAGE_VERSION = '0.1.0-alpha';
+	const PACKAGE_VERSION = '0.1.0';
 
 	/**
 	 * Whether Jetpack Comments should load.
 	 *
-	 * @since $$next-version$$
+	 * @since 0.1.0
 	 *
 	 * @return bool
 	 */
@@ -28,7 +28,7 @@ class Comments {
 		/**
 		 * Load Jetpack Comments in place of the site's existing comment experience.
 		 *
-		 * @since $$next-version$$
+		 * @since 0.1.0
 		 *
 		 * @param bool $enabled Whether to load Jetpack Comments. Default false.
 		 */
@@ -38,7 +38,7 @@ class Comments {
 	/**
 	 * Register the package's features. Safe to call more than once.
 	 *
-	 * @since $$next-version$$
+	 * @since 0.1.0
 	 *
 	 * @return void
 	 */

--- a/projects/packages/comments/src/form/class-comment-form.php
+++ b/projects/packages/comments/src/form/class-comment-form.php
@@ -420,7 +420,7 @@ class Comment_Form {
 		/**
 		 * Filter the copy the comment form renders.
 		 *
-		 * @since $$next-version$$
+		 * @since 0.1.0
 		 *
 		 * @param array $strings Keyed by the name the app reads.
 		 * @param array $args    Comment form arguments.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.12.0] - 2026-08-25
+### Changed
+- Enqueue the connection owner notice script through `wp_add_inline_script()` instead of printing a script element. [#51461]
+- Enqueue the Users screen connection column CSS through `wp_add_inline_style()` instead of printing a style element. [#51459]
+- SSO: Enqueue the login and user-admin styles through `wp_add_inline_style()` instead of printing style elements. [#51460]
+
+### Deprecated
+- Deprecate `Users_Connection_Admin::add_connection_column_styles()`; the Users screen column CSS is enqueued as an inline style now. [#51459]
+- SSO: Deprecate `print_inline_admin_css()` in favour of `enqueue_login_styles()`. [#51460]
+
 ## [8.11.0] - 2026-08-20
 ### Added
 - Error UI: Document displayable connection errors and identify cases where consumers should offer a support link. [#51360]
@@ -2018,6 +2028,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[8.12.0]: https://github.com/Automattic/jetpack-connection/compare/v8.11.0...v8.12.0
 [8.11.0]: https://github.com/Automattic/jetpack-connection/compare/v8.10.4...v8.11.0
 [8.10.4]: https://github.com/Automattic/jetpack-connection/compare/v8.10.3...v8.10.4
 [8.10.3]: https://github.com/Automattic/jetpack-connection/compare/v8.10.2...v8.10.3

--- a/projects/packages/connection/changelog/stats-343-connection-owner-notice-script
+++ b/projects/packages/connection/changelog/stats-343-connection-owner-notice-script
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Enqueue the connection owner notice script through wp_add_inline_script() instead of printing a script element.

--- a/projects/packages/connection/changelog/stats-343-connection-sso-inline-styles
+++ b/projects/packages/connection/changelog/stats-343-connection-sso-inline-styles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-SSO: enqueue the login and user-admin styles through wp_add_inline_style() instead of printing style elements.

--- a/projects/packages/connection/changelog/stats-343-connection-sso-inline-styles-deprecation
+++ b/projects/packages/connection/changelog/stats-343-connection-sso-inline-styles-deprecation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-SSO: deprecate print_inline_admin_css() in favour of enqueue_login_styles().

--- a/projects/packages/connection/changelog/stats-343-connection-users-column-style
+++ b/projects/packages/connection/changelog/stats-343-connection-users-column-style
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Enqueue the Users screen connection column CSS through wp_add_inline_style() instead of printing a style element.

--- a/projects/packages/connection/changelog/stats-343-connection-users-column-style-deprecation
+++ b/projects/packages/connection/changelog/stats-343-connection-users-column-style-deprecation
@@ -1,4 +1,0 @@
-Significance: minor
-Type: deprecated
-
-Deprecate Users_Connection_Admin::add_connection_column_styles(); the Users screen column CSS is enqueued as an inline style now.

--- a/projects/packages/connection/changelog/update-connection-error-handling-docs
+++ b/projects/packages/connection/changelog/update-connection-error-handling-docs
@@ -1,5 +1,0 @@
-Significance: patch
-Type: added
-Comment: Connection Error Handling: Readme update.
-
-

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -72,7 +72,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "8.11.x-dev"
+			"dev-trunk": "8.12.x-dev"
 		},
 		"dependencies": {
 			"test-only": [

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '8.11.0';
+	const PACKAGE_VERSION = '8.12.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/src/class-users-connection-admin.php
+++ b/projects/packages/connection/src/class-users-connection-admin.php
@@ -144,10 +144,10 @@ class Users_Connection_Admin {
 	/**
 	 * Add the styles for the connection column.
 	 *
-	 * @deprecated $$next-version$$ The CSS is enqueued on the `jetpack-connection-users-column` style handle by enqueue_scripts().
+	 * @deprecated 8.12.0 The CSS is enqueued on the `jetpack-connection-users-column` style handle by enqueue_scripts().
 	 */
 	public function add_connection_column_styles() {
-		_deprecated_function( __METHOD__, 'connection-$$next-version$$', __CLASS__ . '::enqueue_scripts' );
+		_deprecated_function( __METHOD__, 'connection-8.12.0', __CLASS__ . '::enqueue_scripts' );
 		self::enqueue_connection_column_styles();
 	}
 

--- a/projects/packages/connection/src/sso/class-sso.php
+++ b/projects/packages/connection/src/sso/class-sso.php
@@ -321,10 +321,10 @@ class SSO {
 	/**
 	 * Print the SSO styles for the login screen.
 	 *
-	 * @deprecated $$next-version$$ Use enqueue_login_styles().
+	 * @deprecated 8.12.0 Use enqueue_login_styles().
 	 */
 	public function print_inline_admin_css() {
-		_deprecated_function( __METHOD__, 'connection-$$next-version$$', __CLASS__ . '::enqueue_login_styles' );
+		_deprecated_function( __METHOD__, 'connection-8.12.0', __CLASS__ . '::enqueue_login_styles' );
 		$this->enqueue_login_styles();
 	}
 

--- a/projects/packages/device-detection/CHANGELOG.md
+++ b/projects/packages/device-detection/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.6] - 2026-08-25
+### Fixed
+- Recognize Pinterest's documented crawler user agents as bots. [#51508]
+- Stop treating a user agent that starts with the iPad or Galaxy Tab name as a phone. [#51350]
+
 ## [3.4.5] - 2026-06-15
 ### Changed
 - Internal updates.
@@ -291,6 +296,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moving jetpack_is_mobile into a package
 
+[3.4.6]: https://github.com/Automattic/jetpack-device-detection/compare/v3.4.5...v3.4.6
 [3.4.5]: https://github.com/Automattic/jetpack-device-detection/compare/v3.4.4...v3.4.5
 [3.4.4]: https://github.com/Automattic/jetpack-device-detection/compare/v3.4.3...v3.4.4
 [3.4.3]: https://github.com/Automattic/jetpack-device-detection/compare/v3.4.2...v3.4.3

--- a/projects/packages/device-detection/changelog/add-pinterestbot-to-bot-device-detection-package
+++ b/projects/packages/device-detection/changelog/add-pinterestbot-to-bot-device-detection-package
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Recognize Pinterest's documented crawler user agents as bots.

--- a/projects/packages/device-detection/changelog/stats-343-device-detection-sanitize-agent
+++ b/projects/packages/device-detection/changelog/stats-343-device-detection-sanitize-agent
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Stop treating a user agent that starts with the iPad or Galaxy Tab name as a phone.

--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.26.0] - 2026-08-25
+### Added
+- Responses: Show each form field as a column when viewing a single form's responses. [#51448]
+
+### Changed
+- Responses: On small screens, show only the response and its actions instead of a table that scrolls sideways. [#51448]
+- Responses: On small screens, the View action now opens the response the same way tapping its title does. [#51486]
+- Show progress while a new form's editor opens, and report it when creating a form fails. [#51371]
+
+### Fixed
+- Apply the name typed when creating a form, and stop a dismissed save from reporting into a reopened dialog. [#51371]
+- Contact Form: Remove the classic-theme editor margin between a field's label and its input. [#51527]
+- Responses: Allow a single response to scroll when it is taller than the screen. [#51486]
+- Responses: Prevent an error that could stop responses from loading when a file upload field was stored without any file data. [#51485]
+
 ## [7.25.0] - 2026-08-20
 ### Added
 - Add a Print action to form responses, which opens the response on its own page and prints just the response. [#51368]
@@ -2650,6 +2665,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a new jetpack/forms package [#28409]
 - Added a public load_contact_form method for initializing the contact form module. [#28416]
 
+[7.26.0]: https://github.com/automattic/jetpack-forms/compare/v7.25.0...v7.26.0
 [7.25.0]: https://github.com/automattic/jetpack-forms/compare/v7.24.0...v7.25.0
 [7.24.0]: https://github.com/automattic/jetpack-forms/compare/v7.23.4...v7.24.0
 [7.23.4]: https://github.com/automattic/jetpack-forms/compare/v7.23.3...v7.23.4

--- a/projects/packages/forms/changelog/add-forms-per-form-field-columns
+++ b/projects/packages/forms/changelog/add-forms-per-form-field-columns
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Responses: Show each form field as a column when viewing a single form's responses.

--- a/projects/packages/forms/changelog/add-forms-responses-mobile-columns
+++ b/projects/packages/forms/changelog/add-forms-responses-mobile-columns
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Responses: On small screens, show only the response and its actions instead of a table that scrolls sideways.

--- a/projects/packages/forms/changelog/fix-forms-create-title-and-superseded-save
+++ b/projects/packages/forms/changelog/fix-forms-create-title-and-superseded-save
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Apply the name typed when creating a form, and stop a dismissed save from reporting into a reopened dialog.

--- a/projects/packages/forms/changelog/fix-forms-file-field-empty-value-fatal
+++ b/projects/packages/forms/changelog/fix-forms-file-field-empty-value-fatal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Responses: Prevent an error that could stop responses from loading when a file upload field was stored without any file data.

--- a/projects/packages/forms/changelog/fix-forms-single-form-scroll
+++ b/projects/packages/forms/changelog/fix-forms-single-form-scroll
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Responses: Allow a single response to scroll when it is taller than the screen.

--- a/projects/packages/forms/changelog/fix-forms-single-form-scroll-view-action
+++ b/projects/packages/forms/changelog/fix-forms-single-form-scroll-view-action
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Responses: On small screens, the View action now opens the response the same way tapping its title does.

--- a/projects/packages/forms/changelog/fix-forms-spacing-editor
+++ b/projects/packages/forms/changelog/fix-forms-spacing-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Contact Form: remove the classic-theme editor margin between a field's label and its input.

--- a/projects/packages/forms/changelog/update-forms-new-form-editor-preload
+++ b/projects/packages/forms/changelog/update-forms-new-form-editor-preload
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Show progress while a new form's editor opens, and report it when creating a form fails.

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -73,7 +73,7 @@
 			"link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "7.25.x-dev"
+			"dev-trunk": "7.26.x-dev"
 		},
 		"textdomain": "jetpack-forms",
 		"version-constants": {

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-forms",
-	"version": "7.25.0",
+	"version": "7.26.0",
 	"private": true,
 	"description": "Jetpack Forms",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/forms/#readme",

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -16,7 +16,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard;
  */
 class Jetpack_Forms {
 
-	const PACKAGE_VERSION = '7.25.0';
+	const PACKAGE_VERSION = '7.26.0';
 
 	/**
 	 * Name of the feature flag gating field conditional logic.

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -912,7 +912,7 @@ class Feedback_Field {
 	 * but a feedback can carry a malformed value — an empty string, for
 	 * instance — so callers must never assume that shape.
 	 *
-	 * @since $$next-version$$
+	 * @since 7.26.0
 	 *
 	 * @return array The list of files, empty when the value holds none.
 	 */

--- a/projects/packages/masterbar/CHANGELOG.md
+++ b/projects/packages/masterbar/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.38] - 2026-08-25
+### Fixed
+- Admin color schemes: Stop labelling the Fresh scheme "Default", which duplicated the Default (Modern) entry on WordPress 7.0. [#51376]
+
 ## [0.27.37] - 2026-08-20
 ### Changed
 - Update package dependencies. [#51008]
@@ -634,6 +638,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Notifications: Change Icon [#37676]
 - Updated package dependencies. [#37669] [#37706]
 
+[0.27.38]: https://github.com/Automattic/jetpack-masterbar/compare/v0.27.37...v0.27.38
 [0.27.37]: https://github.com/Automattic/jetpack-masterbar/compare/v0.27.36...v0.27.37
 [0.27.36]: https://github.com/Automattic/jetpack-masterbar/compare/v0.27.35...v0.27.36
 [0.27.35]: https://github.com/Automattic/jetpack-masterbar/compare/v0.27.34...v0.27.35

--- a/projects/packages/masterbar/changelog/admin-color-fresh-default
+++ b/projects/packages/masterbar/changelog/admin-color-fresh-default
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Admin color schemes: Stop labelling the Fresh scheme "Default", which duplicated the Default (Modern) entry on WordPress 7.0.

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-masterbar",
-	"version": "0.27.37",
+	"version": "0.27.38",
 	"private": true,
 	"description": "The WordPress.com Toolbar feature replaces the default admin bar and offers quick links to the Reader, all your sites, your WordPress.com profile, and notifications.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/masterbar/#readme",

--- a/projects/packages/masterbar/src/class-main.php
+++ b/projects/packages/masterbar/src/class-main.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Main {
 
-	const PACKAGE_VERSION = '0.27.37';
+	const PACKAGE_VERSION = '0.27.38';
 
 	/**
 	 * Initializer.

--- a/projects/packages/my-jetpack/CHANGELOG.md
+++ b/projects/packages/my-jetpack/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.44.1] - 2026-08-25
+### Changed
+- Stats: Replace the commercial-use row on the Add Stats screen with UTM tracking, device stats, and location detail. [#51410]
+
+### Fixed
+- Fix a PHP 8.5 deprecation notice raised for products that do not ship a standalone plugin. [#51162]
+- Plans section: Always label the license activation link "Activate a license", including on sites with a plan but no activated licenses. [#51283]
+- Stats: Tell the Stats dashboard when Start for Free was chosen, so it does not ask which plan you want a second time. [#51413]
+
 ## [5.44.0] - 2026-08-20
 ### Added
 - Error UI: Add a support link to broken-connection notices when reconnecting may not resolve the problem. [#51360]
@@ -2853,6 +2862,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created package
 
+[5.44.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.44.0...5.44.1
 [5.44.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.43.1...5.44.0
 [5.43.1]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.43.0...5.43.1
 [5.43.0]: https://github.com/Automattic/jetpack-my-jetpack/compare/5.42.3...5.43.0

--- a/projects/packages/my-jetpack/changelog/fix-activate-license-link-text
+++ b/projects/packages/my-jetpack/changelog/fix-activate-license-link-text
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Plans section: always label the license activation link 'Activate a license'. It previously read 'Activate a new license' on any site with a plan, including sites with no licenses activated.

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-array-key-exists-null-php85
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-array-key-exists-null-php85
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix a PHP 8.5 deprecation notice raised for products that do not ship a standalone plugin.

--- a/projects/packages/my-jetpack/changelog/stats-447-add-stats-differentiators
+++ b/projects/packages/my-jetpack/changelog/stats-447-add-stats-differentiators
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Stats: Replace the commercial-use row on the Add Stats screen with UTM tracking, device stats, and location detail.

--- a/projects/packages/my-jetpack/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/packages/my-jetpack/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Stats: Tell the Stats dashboard when Start for Free was chosen, so it does not ask which plan you want a second time.

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-my-jetpack",
-	"version": "5.44.0",
+	"version": "5.44.1",
 	"private": true,
 	"description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/my-jetpack/#readme",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -43,7 +43,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '5.44.0';
+	const PACKAGE_VERSION = '5.44.1';
 
 	/**
 	 * HTML container ID for the IDC screen on My Jetpack page.

--- a/projects/packages/newsletter/CHANGELOG.md
+++ b/projects/packages/newsletter/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.7] - 2026-08-25
+### Changed
+- Update dependencies. [#51423]
+
 ## [0.12.6] - 2026-08-20
 ### Changed
 - Update dependencies. [#51423]
@@ -332,6 +336,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update package dependencies. [#46143]
 
+[0.12.7]: https://github.com/Automattic/jetpack-newsletter/compare/v0.12.6...v0.12.7
 [0.12.6]: https://github.com/Automattic/jetpack-newsletter/compare/v0.12.5...v0.12.6
 [0.12.5]: https://github.com/Automattic/jetpack-newsletter/compare/v0.12.4...v0.12.5
 [0.12.4]: https://github.com/Automattic/jetpack-newsletter/compare/v0.12.3...v0.12.4

--- a/projects/packages/newsletter/package.json
+++ b/projects/packages/newsletter/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-newsletter",
-	"version": "0.12.6",
+	"version": "0.12.7",
 	"private": true,
 	"description": "Jetpack Newsletter functionality",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/newsletter/#readme",

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -21,7 +21,7 @@ use Jetpack_Tracks_Client;
  */
 class Settings {
 
-	const PACKAGE_VERSION = '0.12.6';
+	const PACKAGE_VERSION = '0.12.7';
 
 	const ADMIN_PAGE_SLUG = 'jetpack-newsletter';
 

--- a/projects/packages/podcast/CHANGELOG.md
+++ b/projects/packages/podcast/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2026-08-25
+### Changed
+- Update dependencies. [#51456]
+
 ## [1.5.0] - 2026-08-20
 ### Added
 - Settings: Add an episode limit for the podcast feed. [#51247]
@@ -226,6 +230,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dashboard: Replace the wp-build placeholder with page chrome and tab navigation. [#48559]
 - Dashboard: Slim down wp-build wiring to the Backup pattern. [#48600]
 
+[1.5.1]: https://github.com/Automattic/jetpack-podcast/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/Automattic/jetpack-podcast/compare/v1.4.4...v1.5.0
 [1.4.4]: https://github.com/Automattic/jetpack-podcast/compare/v1.4.3...v1.4.4
 [1.4.3]: https://github.com/Automattic/jetpack-podcast/compare/v1.4.2...v1.4.3

--- a/projects/packages/podcast/changelog/force-a-release
+++ b/projects/packages/podcast/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/podcast/package.json
+++ b/projects/packages/podcast/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-podcast",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"private": true,
 	"description": "Jetpack Podcast functionality (Simple and Atomic only).",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/podcast/#readme",

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -16,7 +16,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Podcast {
 
-	const PACKAGE_VERSION = '1.5.0';
+	const PACKAGE_VERSION = '1.5.1';
 
 	/**
 	 * Whether the class has been initialized.

--- a/projects/packages/premium-analytics/CHANGELOG.md
+++ b/projects/packages/premium-analytics/CHANGELOG.md
@@ -29,11 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Date filters: Compute day boundaries and daylight-saving wall times in the site's timezone instead of the visitor's browser timezone. [#51419]
 - Fix charts getting stuck on their loading skeleton after switching a control that turns one of the underlying requests off. [#51443]
 - Insights: Scope the calendar heatmaps to the selected period, so the card no longer draws and reports on years outside it. [#51385]
+- Label Subscribers chart and email timeline points by the bucket they name rather than by the viewer's time zone. [#51499]
 - Show only the rows that fit the tile for Latest subscribers, Latest likes, and Latest comments, while keeping the "N more" footer visible. [#51379]
 - Show the dashboard right away instead of a sync screen, and flag the Store section's numbers as incomplete while store data is still syncing. [#51279]
 - Stats: Compare a date range against a previous month or year of the same length, unless the range is whole calendar months. [#51469]
 - Stats: Stamp bucket dates as timezone-naive site-local wall times, fixing report dates that could read a day off for sites away from UTC. [#51499]
-- Label Subscribers chart and email timeline points by the bucket they name rather than by the viewer's time zone. [#51499]
 - Traffic: Start the chart's Group by control from the dashboard's interval, and replace Auto with hourly grouping. [#51446]
 
 ## [0.3.0] - 2026-08-20

--- a/projects/packages/premium-analytics/CHANGELOG.md
+++ b/projects/packages/premium-analytics/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-08-25
+### Added
+- Add an Ads dashboard section showing WordAds earnings and performance. [#51422]
+- Charts: Name each legend item by metric, folding a metric's two periods into one item. Traffic summary: add the paired metric to the chart, hidden until revealed from the legend. [#51468]
+- Insights: Add a Popular hours widget and show it instead of Most popular day by default. [#51239]
+- Link the post list table's views column to the post detail page. [#51357]
+- Locations: Name the regions behind each country total in the Regions map tooltip. [#51312]
+- Page the calendar heatmaps through weeks that do not fit the tile with floating hover arrows, replacing the post detail header pager and the Insights heatmaps' silent clipping. [#51437]
+- Referrers report: Add referrer groups that open folded and expand on demand. [#51465]
+
+### Changed
+- Chart widgets: Follow the page chart interval control instead of a per-widget Group by. [#51278]
+- Latest emails sent: Drop the bar behind each row and show the subject and rate as a plain list. [#51425]
+- Leaderboard: Replace the deprecated `--a8c--charts--leaderboard--bar--border-radius` variable with `--a8c-charts-border-radius-leaderboard-bar`. [#51308]
+- Name comparison dates in the dashboard header, omit weekdays from ranges longer than a week, and omit the year when it matches the current range. [#51420]
+- Traffic: Offer only the groupings the selected date range supports in the chart's Group by control. [#51446]
+
+### Fixed
+- Apply the first widget section flex-column workaround to the post and video detail routes too. [#51434]
+- Charts: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size. [#51445]
+- Date comparison: End a sub-day previous period immediately before the reference window instead of one instant inside it. [#51374]
+- Date filters: Compute day boundaries and daylight-saving wall times in the site's timezone instead of the visitor's browser timezone. [#51419]
+- Fix charts getting stuck on their loading skeleton after switching a control that turns one of the underlying requests off. [#51443]
+- Insights: Scope the calendar heatmaps to the selected period, so the card no longer draws and reports on years outside it. [#51385]
+- Show only the rows that fit the tile for Latest subscribers, Latest likes, and Latest comments, while keeping the "N more" footer visible. [#51379]
+- Show the dashboard right away instead of a sync screen, and flag the Store section's numbers as incomplete while store data is still syncing. [#51279]
+- Stats: Compare a date range against a previous month or year of the same length, unless the range is whole calendar months. [#51469]
+- Stats: Stamp bucket dates as timezone-naive site-local wall times, fixing report dates that could read a day off for sites away from UTC. [#51499]
+- Label Subscribers chart and email timeline points by the bucket they name rather than by the viewer's time zone. [#51499]
+- Traffic: Start the chart's Group by control from the dashboard's interval, and replace Auto with hourly grouping. [#51446]
+
 ## [0.3.0] - 2026-08-20
 ### Added
 - Date controls: Let each dashboard section declare whether its header offers the period-over-period comparison control. [#51230]
@@ -136,5 +167,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - VideoPress: Add a video detail page with plays leaderboard, video highlights, and embed locations. [#50311] [#50536]
 - WordAds: Add widgets for ads served, average CPM and revenue over time, all-time earnings highlights, and earnings, sponsored content and adjustments history. [#50314] [#50490]
 
+[0.4.0]: https://github.com/Automattic/jetpack-premium-analytics/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/Automattic/jetpack-premium-analytics/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/Automattic/jetpack-premium-analytics/compare/0.1.0...0.2.0

--- a/projects/packages/premium-analytics/changelog/add-pa-calendar-heatmap-hover-pager
+++ b/projects/packages/premium-analytics/changelog/add-pa-calendar-heatmap-hover-pager
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Premium Analytics: page the calendar heatmaps through weeks that do not fit the tile with floating hover arrows, replacing the post detail header pager and the Insights heatmaps' silent clipping.

--- a/projects/packages/premium-analytics/changelog/change-emails-widget-plain-list
+++ b/projects/packages/premium-analytics/changelog/change-emails-widget-plain-list
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Latest emails sent: drop the bar behind each row and show the subject and rate as a plain list.

--- a/projects/packages/premium-analytics/changelog/change-wooa7s-1897-popular-hours
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-1897-popular-hours
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Insights: Add a Popular hours widget and show it instead of Most popular day by default.

--- a/projects/packages/premium-analytics/changelog/charts-203-charts-theming-architecture
+++ b/projects/packages/premium-analytics/changelog/charts-203-charts-theming-architecture
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Leaderboard: Set the bar corner radius through `--a8c-charts-border-radius-leaderboard-bar`, replacing the deprecated `--a8c--charts--leaderboard--bar--border-radius` name that `@automattic/charts` no longer reads.

--- a/projects/packages/premium-analytics/changelog/echo-fix-sync-gate-test-ads-section
+++ b/projects/packages/premium-analytics/changelog/echo-fix-sync-gate-test-ads-section
@@ -1,5 +1,0 @@
-Significance: patch
-Type: fixed
-Comment: Update a test expectation for the Ads dashboard section; no user-facing change.
-
-

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-chart-wall-clock
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-chart-wall-clock
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Charts: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-group-by-range
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-group-by-range
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Traffic: Offer only the groupings the selected date range supports in the chart's Group by control.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-naive-bucket-stamps
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-naive-bucket-stamps
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Stats: stamp bucket dates as timezone-naive site-local wall times, fixing report dates that could read a day off for sites away from UTC.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-stuck-skeleton
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-stuck-skeleton
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix charts getting stuck on their loading skeleton after switching a control that turns one of the underlying requests off.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-traffic-global-interval
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-traffic-global-interval
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Traffic: Start the chart's Group by control from the dashboard's interval, and replace Auto with hourly grouping.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-visits-range-only
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1902-visits-range-only
@@ -1,3 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Drop a parameter the visits endpoint discards. The request changes; the response, and so everything a reader sees, does not.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1977-subscribers-wall-clock
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1977-subscribers-wall-clock
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Subscribers chart, email timeline: label chart points by the bucket they name rather than by the viewer's time zone.

--- a/projects/packages/premium-analytics/changelog/fix-premium-analytics-detail-widget-section-flex
+++ b/projects/packages/premium-analytics/changelog/fix-premium-analytics-detail-widget-section-flex
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Apply the first widget section flex-column workaround to the post and video detail routes too.

--- a/projects/packages/premium-analytics/changelog/fix-sub-day-comparison-range
+++ b/projects/packages/premium-analytics/changelog/fix-sub-day-comparison-range
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Date comparison: end a sub-day previous period immediately before the reference window instead of one instant inside it.

--- a/projects/packages/premium-analytics/changelog/fix-wooa7s-1963-heatmap-window
+++ b/projects/packages/premium-analytics/changelog/fix-wooa7s-1963-heatmap-window
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Insights: scope the calendar heatmaps to the selected period, so the card no longer draws and reports on years outside it.

--- a/projects/packages/premium-analytics/changelog/group-no-mock-test-suites
+++ b/projects/packages/premium-analytics/changelog/group-no-mock-test-suites
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Test-only change: group the suites that declare no module mocks, and guard against grouping a suite that pins a Jest environment.
-
-

--- a/projects/packages/premium-analytics/changelog/group-routes-test-suites
+++ b/projects/packages/premium-analytics/changelog/group-routes-test-suites
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Test-only change: group the routes jest suites that share a mock signature.
-
-

--- a/projects/packages/premium-analytics/changelog/group-widget-test-suites
+++ b/projects/packages/premium-analytics/changelog/group-widget-test-suites
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Test-only change: group widget jest suites so they share one module registry.
-
-

--- a/projects/packages/premium-analytics/changelog/group-widgets-toolkit-test-suites
+++ b/projects/packages/premium-analytics/changelog/group-widgets-toolkit-test-suites
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Test-only change: move the jest test groups to tests/groups and group the widgets-toolkit suites.
-
-

--- a/projects/packages/premium-analytics/changelog/roster-fit-to-tile
+++ b/projects/packages/premium-analytics/changelog/roster-fit-to-tile
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Latest subscribers, Latest likes and Latest comments: show only the rows that fit the tile and keep the "N more" footer visible.

--- a/projects/packages/premium-analytics/changelog/stats-410-scope-sync-gate-to-store
+++ b/projects/packages/premium-analytics/changelog/stats-410-scope-sync-gate-to-store
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Show the dashboard right away instead of a sync screen, and flag the Store section's numbers as incomplete while store data is still syncing.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1619-ads-section
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1619-ads-section
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add an Ads dashboard section showing WordAds earnings and performance.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1681-post-list-stats-link
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1681-post-list-stats-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Link the post list table's views column to the post detail page.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1744-collapsible-drilldown
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1744-collapsible-drilldown
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Referrers report: Add referrer groups that open folded and expand on demand.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1844-views-visitors-pair
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1844-views-visitors-pair
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Charts: Name each legend item by metric, folding a metric's two periods into one item. Traffic summary: add the paired metric to the chart, hidden until revealed from the legend.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1913-drop-group-by
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1913-drop-group-by
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Chart widgets: follow the page chart interval control instead of a per-widget Group by.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1918-comparison-actual-dates
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1918-comparison-actual-dates
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Name the dates a comparison covers in the dashboard header, instead of "Previous period", drop the weekdays from ranges longer than a week, and leave the year off ranges that sit inside the current one.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1922-locations-regions
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1922-locations-regions
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Locations: Name the regions behind each country total in the Regions map tooltip.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1970-date-math-site-timezone
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1970-date-math-site-timezone
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Date filters: Compute day boundaries and daylight-saving wall times in the site's timezone instead of the visitor's browser timezone.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1976-comparison-window-length
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1976-comparison-window-length
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Stats: Compare a date range against a previous month or year of the same length, unless the range is whole calendar months.

--- a/projects/packages/premium-analytics/composer.json
+++ b/projects/packages/premium-analytics/composer.json
@@ -72,7 +72,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-premium-analytics/compare/${old}...${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "0.3.x-dev"
+			"dev-trunk": "0.4.x-dev"
 		}
 	}
 }

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-premium-analytics",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -21,7 +21,7 @@ use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
  */
 class Analytics {
 
-	const PACKAGE_VERSION = '0.3.0';
+	const PACKAGE_VERSION = '0.4.0';
 
 	/**
 	 * Whether the class has been initialized.
@@ -202,7 +202,7 @@ class Analytics {
 	 * rest of the query. Encoded here because add_query_arg() leaves values
 	 * alone, and a `?` inside the path would read as an outer query param.
 	 *
-	 * @since $$next-version$$
+	 * @since 0.4.0
 	 *
 	 * @param string $path Route path, e.g. `/post/123`.
 	 * @return string

--- a/projects/packages/premium-analytics/src/class-capabilities.php
+++ b/projects/packages/premium-analytics/src/class-capabilities.php
@@ -109,7 +109,7 @@ class Capabilities {
 	/**
 	 * Whether the current user may view ad reports.
 	 *
-	 * @since $$next-version$$
+	 * @since 0.4.0
 	 *
 	 * @return bool
 	 */

--- a/projects/packages/premium-analytics/src/class-dashboard-section.php
+++ b/projects/packages/premium-analytics/src/class-dashboard-section.php
@@ -117,7 +117,7 @@ final class Dashboard_Section {
 	 * Whether the section's data only reaches WordPress.com through the analytics
 	 * full sync, so its numbers are incomplete until that sync has finished once.
 	 *
-	 * @since $$next-version$$
+	 * @since 0.4.0
 	 * @var bool
 	 */
 	public $requires_sync = false;

--- a/projects/packages/premium-analytics/src/class-post-list-link.php
+++ b/projects/packages/premium-analytics/src/class-post-list-link.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\PremiumAnalytics;
  * Sends the views column in the posts and pages list tables to the dashboard's
  * post detail page instead of the Stats one.
  *
- * @since $$next-version$$
+ * @since 0.4.0
  */
 class Post_List_Link {
 

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -122,7 +122,7 @@ function is_subscribers_dashboard_section_available() {
  * WPCOM reads the plan feature rather than the module, which is a false negative
  * on Atomic and meaningless on Simple. Mirrors is_videopress_available().
  *
- * @since $$next-version$$
+ * @since 0.4.0
  *
  * @return bool True when the site can produce WordAds earnings.
  */
@@ -136,7 +136,7 @@ function is_ads_dashboard_section_available() {
 	/**
 	 * Filters whether the Ads dashboard section is available.
 	 *
-	 * @since $$next-version$$
+	 * @since 0.4.0
 	 *
 	 * @param bool $is_available Whether WordAds was detected in the current request.
 	 */
@@ -146,7 +146,7 @@ function is_ads_dashboard_section_available() {
 /**
  * Whether the current user can access the Ads dashboard section.
  *
- * @since $$next-version$$
+ * @since 0.4.0
  *
  * @return bool
  */

--- a/projects/packages/publicize/CHANGELOG.md
+++ b/projects/packages/publicize/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.85.1] - 2026-08-25
+### Changed
+- Only include social connection data in the script data for users who can access Publicize. [#51483]
+- Update dependencies. [#51456]
+
 ## [0.85.0] - 2026-08-20
 ### Added
 - Connections: Explain why an Instagram Business connection found no accounts to choose from. [#51282]
@@ -1617,6 +1622,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated package dependencies.
 - Update package.json metadata.
 
+[0.85.1]: https://github.com/Automattic/jetpack-publicize/compare/v0.85.0...v0.85.1
 [0.85.0]: https://github.com/Automattic/jetpack-publicize/compare/v0.84.4...v0.85.0
 [0.84.4]: https://github.com/Automattic/jetpack-publicize/compare/v0.84.3...v0.84.4
 [0.84.3]: https://github.com/Automattic/jetpack-publicize/compare/v0.84.2...v0.84.3

--- a/projects/packages/publicize/changelog/force-a-release
+++ b/projects/packages/publicize/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/publicize/changelog/social-420-gate-publicize-connections-script-data
+++ b/projects/packages/publicize/changelog/social-420-gate-publicize-connections-script-data
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Only include social connection data in the script data for users who can access Publicize.

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-publicize",
-	"version": "0.85.0",
+	"version": "0.85.1",
 	"private": true,
 	"description": "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/publicize/#readme",

--- a/projects/packages/scan/CHANGELOG.md
+++ b/projects/packages/scan/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.16] - 2026-08-25
+### Changed
+- Update dependencies. [#51438]
+
 ## [0.1.15] - 2026-08-20
 ### Changed
 - Update dependencies. [#51259]
@@ -102,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release.
 
+[0.1.16]: https://github.com/Automattic/jetpack-scan-page/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/Automattic/jetpack-scan-page/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/Automattic/jetpack-scan-page/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/Automattic/jetpack-scan-page/compare/v0.1.12...v0.1.13

--- a/projects/packages/scan/src/class-package-version.php
+++ b/projects/packages/scan/src/class-package-version.php
@@ -16,7 +16,7 @@ namespace Automattic\Jetpack\Scan_Page;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '0.1.15';
+	const PACKAGE_VERSION = '0.1.16';
 
 	const PACKAGE_SLUG = 'scan-page';
 

--- a/projects/packages/seo/CHANGELOG.md
+++ b/projects/packages/seo/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-08-25
+### Changed
+- Update dependencies. [#51438]
+
 ## [0.8.2] - 2026-08-20
 ### Added
 - Add a shared gate for the AI SEO Enhancer's availability, so the surfaces that offer it can stop each deriving their own answer. [#51169]
@@ -146,6 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create a Settings screen with site visibility, post title structure, front-page description, and site verification. [#49256]
 - Scaffold the new `jetpack-seo` package and mount its admin page. [#49203]
 
+[0.8.3]: https://github.com/Automattic/jetpack-seo/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/Automattic/jetpack-seo/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/Automattic/jetpack-seo/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/Automattic/jetpack-seo/compare/0.7.0...0.8.0

--- a/projects/packages/seo/package.json
+++ b/projects/packages/seo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-seo",
-	"version": "0.8.2",
+	"version": "0.8.3",
 	"private": true,
 	"description": "Jetpack SEO — the visibility command center for WordPress sites in the agentic web.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/seo/#readme",

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -28,7 +28,7 @@ class Initializer {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.8.2';
+	const PACKAGE_VERSION = '0.8.3';
 
 	/**
 	 * WordPress.com site feature that enables the Jetpack SEO surface.

--- a/projects/packages/stats-admin/CHANGELOG.md
+++ b/projects/packages/stats-admin/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.34.0 - 2026-08-25
+### Added
+- Add a filter for the post list table's views column link. [#51357]
+
+### Changed
+- Make the Blaze package a development-only dependency. [#51462]
+
 ## 0.33.0 - 2026-08-20
 ### Added
 - Show the Stats dashboard before the site is connected to WordPress.com, so a plan can be picked and the site connected from there. [#51200]

--- a/projects/packages/stats-admin/changelog/stats-343-stats-admin-blaze-dev-dependency
+++ b/projects/packages/stats-admin/changelog/stats-343-stats-admin-blaze-dev-dependency
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Make the Blaze package a development-only dependency.

--- a/projects/packages/stats-admin/changelog/wooa7s-1681-post-list-stats-link
+++ b/projects/packages/stats-admin/changelog/wooa7s-1681-post-list-stats-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a filter for the post list table's views column link.

--- a/projects/packages/stats-admin/composer.json
+++ b/projects/packages/stats-admin/composer.json
@@ -50,7 +50,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-stats-admin",
 		"branch-alias": {
-			"dev-trunk": "0.33.x-dev"
+			"dev-trunk": "0.34.x-dev"
 		},
 		"textdomain": "jetpack-stats-admin",
 		"version-constants": {

--- a/projects/packages/stats-admin/package.json
+++ b/projects/packages/stats-admin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-stats-admin",
-	"version": "0.33.0",
+	"version": "0.34.0",
 	"private": true,
 	"description": "Stats Dashboard",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/stats-admin/#readme",

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -132,7 +132,7 @@ class Admin_Post_List_Column {
 				 * Lets a newer analytics dashboard claim the entry point without this
 				 * package knowing about it.
 				 *
-				 * @since $$next-version$$
+				 * @since 0.34.0
 				 *
 				 * @param string $stats_post_url Stats URL for the post.
 				 * @param int    $post_id        The post the row belongs to.

--- a/projects/packages/stats-admin/src/class-main.php
+++ b/projects/packages/stats-admin/src/class-main.php
@@ -23,7 +23,7 @@ class Main {
 	/**
 	 * Stats version.
 	 */
-	const VERSION = '0.33.0';
+	const VERSION = '0.34.0';
 
 	/**
 	 * Singleton Main instance.

--- a/projects/packages/stats/CHANGELOG.md
+++ b/projects/packages/stats/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.4] - 2026-08-25
+### Changed
+- Escape the AMP tracking pixel URL at output. [#51472]
+
+### Fixed
+- Normalize the excluded IP list so addresses written in another form still match. [#51349]
+
 ## [0.20.3] - 2026-08-20
 ### Changed
 - Load the rule that hides the tracking pixel through the stylesheet queue. [#51358]
@@ -370,6 +377,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing static method which was called without self reference. [#26640]
 
+[0.20.4]: https://github.com/Automattic/jetpack-stats/compare/v0.20.3...v0.20.4
 [0.20.3]: https://github.com/Automattic/jetpack-stats/compare/v0.20.2...v0.20.3
 [0.20.2]: https://github.com/Automattic/jetpack-stats/compare/v0.20.1...v0.20.2
 [0.20.1]: https://github.com/Automattic/jetpack-stats/compare/v0.20.0...v0.20.1

--- a/projects/packages/stats/changelog/stats-343-stats-amp-pixel-escape
+++ b/projects/packages/stats/changelog/stats-343-stats-amp-pixel-escape
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Escape the AMP tracking pixel URL at output.

--- a/projects/packages/stats/changelog/stats-343-status-sanitize-visitor-ip
+++ b/projects/packages/stats/changelog/stats-343-status-sanitize-visitor-ip
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Normalize the excluded IP list so addresses written in another form still match.

--- a/projects/packages/stats/src/class-package-version.php
+++ b/projects/packages/stats/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Stats;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '0.20.3';
+	const PACKAGE_VERSION = '0.20.4';
 
 	const PACKAGE_SLUG = 'stats';
 

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.5.0] - 2026-08-25
+### Changed
+- Visitor: Resolve the visitor address through the site's trusted header alone where one is configured, instead of also reading the forwarded headers. [#51349]
+- Visitor: Return only a valid IP address, and take the client address from a comma-separated forwarded header. [#51349]
+
 ## [6.4.0] - 2026-08-19
 ### Added
 - Visitor: Add is_tracking_automattician() to identify Automattician traffic for analytics reporting. [#51280]
@@ -575,6 +580,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[6.5.0]: https://github.com/Automattic/jetpack-status/compare/v6.4.0...v6.5.0
 [6.4.0]: https://github.com/Automattic/jetpack-status/compare/v6.3.1...v6.4.0
 [6.3.1]: https://github.com/Automattic/jetpack-status/compare/v6.3.0...v6.3.1
 [6.3.0]: https://github.com/Automattic/jetpack-status/compare/v6.2.1...v6.3.0

--- a/projects/packages/status/changelog/stats-343-status-sanitize-visitor-ip
+++ b/projects/packages/status/changelog/stats-343-status-sanitize-visitor-ip
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Visitor: Return only a valid IP address, and take the client address from a comma-separated forwarded header.

--- a/projects/packages/status/changelog/stats-343-status-trusted-ip-header
+++ b/projects/packages/status/changelog/stats-343-status-trusted-ip-header
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Visitor: Resolve the visitor address through the site's trusted header alone where one is configured, instead of also reading the forwarded headers.

--- a/projects/packages/status/composer.json
+++ b/projects/packages/status/composer.json
@@ -48,7 +48,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "6.4.x-dev"
+			"dev-trunk": "6.5.x-dev"
 		},
 		"dependencies": {
 			"test-only": [

--- a/projects/packages/videopress/CHANGELOG.md
+++ b/projects/packages/videopress/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.47.2] - 2026-08-25
+### Added
+- Video details: Move the add-to-content action into the page header, where it can now create a new page as well as a new post. [#51480]
+
+### Changed
+- Update dependencies. [#51456]
+- Video details: Group the title, description and chapters into a single card, and show the title in the page heading as you type it. [#51480]
+- Video details: Show the current thumbnail beside the control that replaces it, and give subtitles a section of their own. [#51480]
+- Video details: Widen the screen and show the video's settings beside a preview of the video rather than below it. [#51480]
+
+### Fixed
+- Fix a timeout error when updating a video poster from the media library. [#51479]
+
 ## [0.47.1] - 2026-08-20
 ### Changed
 - Update dependencies. [#49464]
@@ -2164,6 +2177,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created empty package [#24952]
 
+[0.47.2]: https://github.com/Automattic/jetpack-videopress/compare/v0.47.1...v0.47.2
 [0.47.1]: https://github.com/Automattic/jetpack-videopress/compare/v0.47.0...v0.47.1
 [0.47.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/Automattic/jetpack-videopress/compare/v0.45.0...v0.46.0

--- a/projects/packages/videopress/changelog/add-to-content-header-action
+++ b/projects/packages/videopress/changelog/add-to-content-header-action
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Video details: move the add-to-content action into the page header, where it can now create a new page as well as a new post.

--- a/projects/packages/videopress/changelog/force-a-release
+++ b/projects/packages/videopress/changelog/force-a-release
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update dependencies.

--- a/projects/packages/videopress/changelog/video-details-card
+++ b/projects/packages/videopress/changelog/video-details-card
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Video details: group the title, description and chapters into a single card, and show the title in the page heading as you type it.

--- a/projects/packages/videopress/changelog/video-details-thumbnail-and-subtitles
+++ b/projects/packages/videopress/changelog/video-details-thumbnail-and-subtitles
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Video details: show the current thumbnail beside the control that replaces it, and give subtitles a section of their own.

--- a/projects/packages/videopress/changelog/vidp-374-poster-timeout
+++ b/projects/packages/videopress/changelog/vidp-374-poster-timeout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Fix a timeout error when updating a video poster from the media library.

--- a/projects/packages/videopress/changelog/widen-video-details-layout
+++ b/projects/packages/videopress/changelog/widen-video-details-layout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Video details: widen the screen and show the video's settings beside a preview of the video rather than below it.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-videopress",
-	"version": "0.47.1",
+	"version": "0.47.2",
 	"private": true,
 	"description": "VideoPress package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/videopress/#readme",

--- a/projects/packages/videopress/src/class-package-version.php
+++ b/projects/packages/videopress/src/class-package-version.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\VideoPress;
  * The Package_Version class.
  */
 class Package_Version {
-	const PACKAGE_VERSION = '0.47.1';
+	const PACKAGE_VERSION = '0.47.2';
 
 	const PACKAGE_SLUG = 'videopress';
 

--- a/projects/plugins/agents-manager/changelog/prerelease#10
+++ b/projects/plugins/agents-manager/changelog/prerelease#10
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/agents-manager/composer.lock
+++ b/projects/plugins/agents-manager/composer.lock
@@ -65,7 +65,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -91,7 +91,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -418,7 +418,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -455,7 +455,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -727,7 +727,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -752,7 +752,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/automattic-for-agencies-client/changelog/prerelease#3
+++ b/projects/plugins/automattic-for-agencies-client/changelog/prerelease#3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -65,7 +65,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -91,7 +91,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -414,7 +414,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -451,7 +451,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -846,7 +846,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -871,7 +871,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/backup/changelog/prerelease#4
+++ b/projects/plugins/backup/changelog/prerelease#4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -141,7 +141,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -167,7 +167,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -827,7 +827,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -864,7 +864,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1917,7 +1917,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1942,7 +1942,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/beta/changelog/prerelease#4
+++ b/projects/plugins/beta/changelog/prerelease#4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/beta/composer.lock
+++ b/projects/plugins/beta/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -38,7 +38,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -377,7 +377,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -402,7 +402,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/boost/changelog/prerelease#3
+++ b/projects/plugins/boost/changelog/prerelease#3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -141,7 +141,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -167,7 +167,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -684,7 +684,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -721,7 +721,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1966,7 +1966,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1991,7 +1991,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/classic-theme-helper-plugin/changelog/prerelease#45
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/prerelease#45
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -128,7 +128,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -154,7 +154,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -599,7 +599,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -636,7 +636,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1091,7 +1091,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1116,7 +1116,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/inspect/changelog/prerelease#15
+++ b/projects/plugins/inspect/changelog/prerelease#15
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -65,7 +65,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -91,7 +91,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -414,7 +414,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -451,7 +451,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -723,7 +723,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -748,7 +748,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -23,12 +23,12 @@
 
 ### Bug fixes
 - AI: Auto-activate the AI module on sites running a 16.2 prerelease build. [#51528]
+- AI: Keep the editor working when another plugin loads an older copy of the Status package. [#51494]
 - Charts: Draw labels at the design system's font weight and size. [#51452]
 - Contact Form: Remove the classic-theme editor margin between a field's label and its input. [#51527]
 - Forms: Allow a single response to scroll when it is taller than the screen. [#51486]
 - Forms: Apply the name typed when creating a form, and stop a dismissed save from reporting into a reopened dialog. [#51371]
 - Forms: Prevent an error that could stop responses from loading when a file upload field was stored without any file data. [#51485]
-- AI: Keep the editor working when another plugin loads an older copy of the Status package. [#51494]
 - My Jetpack: Always label the license activation link "Activate a license", including on sites with a plan but no activated licenses. [#51283]
 - My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen. [#51413]
 - Premium Analytics: Compare date ranges against a previous month or year of the same length while keeping whole-calendar-month comparisons aligned by month. [#51469]

--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ### This is a list detailing changes for all Jetpack releases.
 
+## 16.2-a.3 - 2026-08-25
+### Enhancements
+- Akismet: Link the settings page header logo and title to the Akismet settings page. [#51449]
+- Forms: On small screens, show only the response and its actions instead of a table that scrolls sideways. [#51448]
+- Forms: On small screens, the View action now opens a response the same way tapping its title does. [#51486]
+- Forms: Show each form field as a column when viewing a single form's responses. [#51448]
+- Forms: Show progress while a new form's editor opens, and report it when creating a form fails. [#51371]
+- My Jetpack: Show what Paid Stats actually adds — UTM tracking, device stats, and region & city locations — instead of commercial use. [#51410]
+- Premium Analytics: Add an Ads dashboard section showing WordAds earnings and performance. [#51422]
+- Premium Analytics: Add referrer groups that open folded and expand on demand in the Referrers report. [#51465]
+- Premium Analytics: Click Visitors in the Traffic chart legend to compare it against Views without leaving the metric. Chart legends now name the metric rather than the date range. [#51468]
+- Premium Analytics: Name comparison dates in the dashboard header, omit weekdays from ranges longer than a week, and omit the year when it matches the current range. [#51420]
+- Premium Analytics: Offer only the groupings the selected date range supports in the chart's Group by control. [#51446]
+- Premium Analytics: Show the latest emails sent as a plain list of subjects and rates. [#51425]
+- Stats: Add a Popular hours widget showing the busiest hour and its daily average views. [#51239]
+- Stats: Link the post list views column to the analytics post detail page when the new dashboard is enabled. [#51357]
+- Stats: Set the chart interval once for the whole page instead of per chart widget. [#51278]
+- VideoPress: Redesign the video details page with grouped details, a wider layout, side-by-side player and settings, thumbnail tiles, collapsible sections, and an Add to content action. [#51480]
+
+### Bug fixes
+- AI: Auto-activate the AI module on sites running a 16.2 prerelease build. [#51528]
+- Charts: Draw labels at the design system's font weight and size. [#51452]
+- Contact Form: Remove the classic-theme editor margin between a field's label and its input. [#51527]
+- Forms: Allow a single response to scroll when it is taller than the screen. [#51486]
+- Forms: Apply the name typed when creating a form, and stop a dismissed save from reporting into a reopened dialog. [#51371]
+- Forms: Prevent an error that could stop responses from loading when a file upload field was stored without any file data. [#51485]
+- AI: Keep the editor working when another plugin loads an older copy of the Status package. [#51494]
+- My Jetpack: Always label the license activation link "Activate a license", including on sites with a plan but no activated licenses. [#51283]
+- My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen. [#51413]
+- Premium Analytics: Compare date ranges against a previous month or year of the same length while keeping whole-calendar-month comparisons aligned by month. [#51469]
+- Premium Analytics: Compute date-filter day boundaries in the site's timezone, so visitors west of the site timezone no longer get stretched ranges or wrong chart buckets. [#51419]
+- Premium Analytics: Fix charts getting stuck on their loading skeleton after switching a control that turns one of the underlying requests off. [#51443]
+- Premium Analytics: Fix report and chart dates that could read a day off for sites away from UTC. [#51499]
+- Premium Analytics: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size. [#51445]
+- Premium Analytics: Label Subscribers chart and email timeline points by the bucket they name rather than by the viewer's time zone. [#51499]
+- Premium Analytics: Show the dashboard right away instead of a sync screen, and flag the Store section's numbers as incomplete while store data is still syncing. [#51279]
+- Premium Analytics: Start the Traffic chart's Group by control from the dashboard's interval, and replace Auto with hourly grouping. [#51446]
+- Stats: Keep excluding a visitor IP address from tracking when it is written in another form. [#51349]
+- Stats: Report the same visitor address the rest of Jetpack resolves on sites with a trusted IP header configured. [#51349]
+- Stats: Stop recording a malformed visitor IP address. [#51349]
+- VideoPress: Fix a timeout error when updating a video poster from the media library. [#51479]
+
+### Other changes <!-- Non-user-facing changes go here. This section will not be copied to readme.txt. -->
+- Comments: Load the rebuilt Jetpack Comments form in place of the iframed one when the `jetpack_comments_new_hotness` filter returns true. [#51466]
+
 ## 16.2-a.1 - 2026-08-20
 ### Major Enhancements
 - Update minimum WordPress version to 7.0. [#51370]

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai.php
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Check whether the current visitor should be marked as Automattician traffic.
  *
- * @since $$next-version$$
+ * @since 16.2
  *
  * @return bool True when the visitor is Automattician traffic.
  */

--- a/projects/plugins/jetpack/changelog/add-comments-phase-1
+++ b/projects/plugins/jetpack/changelog/add-comments-phase-1
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Comments: load the rebuilt Jetpack Comments form in place of the iframed one when the jetpack_comments_new_hotness filter returns true.

--- a/projects/plugins/jetpack/changelog/add-forms-per-form-field-columns
+++ b/projects/plugins/jetpack/changelog/add-forms-per-form-field-columns
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: Show each form field as a column when viewing a single form's responses.

--- a/projects/plugins/jetpack/changelog/add-forms-responses-mobile-columns
+++ b/projects/plugins/jetpack/changelog/add-forms-responses-mobile-columns
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Forms: On small screens, show only the response and its actions instead of a table that scrolls sideways.

--- a/projects/plugins/jetpack/changelog/change-emails-widget-plain-list
+++ b/projects/plugins/jetpack/changelog/change-emails-widget-plain-list
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Premium Analytics: show the latest emails sent as a plain list of subjects and rates.

--- a/projects/plugins/jetpack/changelog/charts-254-align-wpds-fallback-values
+++ b/projects/plugins/jetpack/changelog/charts-254-align-wpds-fallback-values
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Charts: draw labels at the design system's font weight and size.

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-1902-chart-wall-clock
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-1902-chart-wall-clock
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Premium Analytics: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size.

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-1902-group-by-range
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-1902-group-by-range
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Premium Analytics: Offer only the groupings the selected date range supports in the chart's Group by control.

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-1902-naive-bucket-stamps
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-1902-naive-bucket-stamps
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Premium Analytics: fix report and chart dates that could read a day off for sites away from UTC.

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-1902-stuck-skeleton
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-1902-stuck-skeleton
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Premium Analytics: Fix charts getting stuck on their loading skeleton after switching a control that turns one of the underlying requests off.

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-1902-traffic-global-interval
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-1902-traffic-global-interval
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Premium Analytics: Start the Traffic chart's Group by control from the dashboard's interval, and replace Auto with hourly grouping.

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-1977-subscribers-wall-clock
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-1977-subscribers-wall-clock
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Premium Analytics: label Subscribers chart and email timeline points by the bucket they name rather than by the viewer's time zone.

--- a/projects/plugins/jetpack/changelog/fix-activate-license-link-text
+++ b/projects/plugins/jetpack/changelog/fix-activate-license-link-text
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-My Jetpack: always label the license activation link 'Activate a license'. It previously read 'Activate a new license' on sites with a plan, even when no licenses had been activated.

--- a/projects/plugins/jetpack/changelog/fix-forms-create-title-and-superseded-save
+++ b/projects/plugins/jetpack/changelog/fix-forms-create-title-and-superseded-save
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Forms: Apply the name typed when creating a form, and stop a dismissed save from reporting into a reopened dialog.

--- a/projects/plugins/jetpack/changelog/fix-forms-file-field-empty-value-fatal
+++ b/projects/plugins/jetpack/changelog/fix-forms-file-field-empty-value-fatal
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Forms: Prevent an error that could stop responses from loading when a file upload field was stored without any file data.

--- a/projects/plugins/jetpack/changelog/fix-forms-single-form-scroll
+++ b/projects/plugins/jetpack/changelog/fix-forms-single-form-scroll
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Forms: Allow a single response to scroll when it is taller than the screen.

--- a/projects/plugins/jetpack/changelog/fix-forms-single-form-scroll-view-action
+++ b/projects/plugins/jetpack/changelog/fix-forms-single-form-scroll-view-action
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Forms: On small screens, the View action now opens a response the same way tapping its title does.

--- a/projects/plugins/jetpack/changelog/fix-forms-spacing-editor
+++ b/projects/plugins/jetpack/changelog/fix-forms-spacing-editor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Contact Form: remove the classic-theme editor margin between a field's label and its input.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-module-first-introduced-alpha
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-module-first-introduced-alpha
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-AI: Auto-activate the AI module on sites running a 16.2 prerelease build.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-status-visitor-guard
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-status-visitor-guard
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Jetpack AI: Keep the editor working when another plugin loads an older copy of the Status package.

--- a/projects/plugins/jetpack/changelog/fix-mu-wpcom-preload-status-visitor
+++ b/projects/plugins/jetpack/changelog/fix-mu-wpcom-preload-status-visitor
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-Tests: Drop the temporary Atomic AI module fallback so the module-as-master tests keep exercising the plugin's own behaviour.

--- a/projects/plugins/jetpack/changelog/remove-unused-memberships-link
+++ b/projects/plugins/jetpack/changelog/remove-unused-memberships-link
@@ -1,3 +1,0 @@
-Significance: patch
-Type: other
-Comment: Remove unused Link helper from newsletter memberships settings.

--- a/projects/plugins/jetpack/changelog/stats-343-stats-admin-blaze-dev-dependency
+++ b/projects/plugins/jetpack/changelog/stats-343-stats-admin-blaze-dev-dependency
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-Comment: Refresh composer.lock after moving Blaze to a dev-only dependency in stats-admin.
-

--- a/projects/plugins/jetpack/changelog/stats-343-status-sanitize-visitor-ip
+++ b/projects/plugins/jetpack/changelog/stats-343-status-sanitize-visitor-ip
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Stats: Stop recording a malformed visitor IP address.

--- a/projects/plugins/jetpack/changelog/stats-343-status-sanitize-visitor-ip-exclusions
+++ b/projects/plugins/jetpack/changelog/stats-343-status-sanitize-visitor-ip-exclusions
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Stats: Keep excluding a visitor IP address from tracking when it is written in another form.

--- a/projects/plugins/jetpack/changelog/stats-343-status-trusted-ip-header
+++ b/projects/plugins/jetpack/changelog/stats-343-status-trusted-ip-header
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Stats: Report the same visitor address the rest of Jetpack resolves on sites with a trusted IP header configured.

--- a/projects/plugins/jetpack/changelog/stats-410-scope-sync-gate-to-store
+++ b/projects/plugins/jetpack/changelog/stats-410-scope-sync-gate-to-store
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Premium Analytics: Show the dashboard right away instead of a sync screen, and flag the Store section's numbers as incomplete while store data is still syncing.

--- a/projects/plugins/jetpack/changelog/stats-447-add-stats-differentiators
+++ b/projects/plugins/jetpack/changelog/stats-447-add-stats-differentiators
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-My Jetpack: Show what Paid Stats actually adds — UTM tracking, device stats, and region & city locations — instead of commercial use.

--- a/projects/plugins/jetpack/changelog/stats-plan-chosen-from-my-jetpack
+++ b/projects/plugins/jetpack/changelog/stats-plan-chosen-from-my-jetpack
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen.

--- a/projects/plugins/jetpack/changelog/update-akismet-header-link-settings
+++ b/projects/plugins/jetpack/changelog/update-akismet-header-link-settings
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Akismet: link the settings page header logo and title to the Akismet settings page.

--- a/projects/plugins/jetpack/changelog/update-akismet-header-link-settings-tests
+++ b/projects/plugins/jetpack/changelog/update-akismet-header-link-settings-tests
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Add unit tests for the Akismet admin chrome.
-
-

--- a/projects/plugins/jetpack/changelog/update-forms-new-form-editor-preload
+++ b/projects/plugins/jetpack/changelog/update-forms-new-form-editor-preload
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Forms: Show progress while a new form's editor opens, and report it when creating a form fails.

--- a/projects/plugins/jetpack/changelog/videopress-video-details-layout
+++ b/projects/plugins/jetpack/changelog/videopress-video-details-layout
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-VideoPress: Redesign the video details page: group details into one card in a wider layout, move the player and settings into a side column, and add thumbnail tiles, collapsible sections, and an Add to content action.

--- a/projects/plugins/jetpack/changelog/vidp-374-poster-timeout
+++ b/projects/plugins/jetpack/changelog/vidp-374-poster-timeout
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-VideoPress: Fix a timeout error when updating a video poster from the media library.

--- a/projects/plugins/jetpack/changelog/wooa7s-1619-ads-section
+++ b/projects/plugins/jetpack/changelog/wooa7s-1619-ads-section
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Premium Analytics: Add an Ads dashboard section showing WordAds earnings and performance.

--- a/projects/plugins/jetpack/changelog/wooa7s-1681-post-list-stats-link
+++ b/projects/plugins/jetpack/changelog/wooa7s-1681-post-list-stats-link
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Stats: link the post list views column to the analytics post detail page when the new dashboard is enabled.

--- a/projects/plugins/jetpack/changelog/wooa7s-1744-collapsible-drilldown
+++ b/projects/plugins/jetpack/changelog/wooa7s-1744-collapsible-drilldown
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Premium Analytics: Add referrer groups that open folded and expand on demand in the Referrers report.

--- a/projects/plugins/jetpack/changelog/wooa7s-1844-views-visitors-pair
+++ b/projects/plugins/jetpack/changelog/wooa7s-1844-views-visitors-pair
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Premium Analytics: Click Visitors in the Traffic chart legend to compare it against Views without leaving the metric. Chart legends now name the metric rather than the date range.

--- a/projects/plugins/jetpack/changelog/wooa7s-1897-popular-hours
+++ b/projects/plugins/jetpack/changelog/wooa7s-1897-popular-hours
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-Stats: Add a Popular hours widget showing the busiest hour and its daily average views.

--- a/projects/plugins/jetpack/changelog/wooa7s-1913-drop-group-by
+++ b/projects/plugins/jetpack/changelog/wooa7s-1913-drop-group-by
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Stats: Set the chart interval once for the whole page instead of per chart widget.

--- a/projects/plugins/jetpack/changelog/wooa7s-1918-comparison-actual-dates
+++ b/projects/plugins/jetpack/changelog/wooa7s-1918-comparison-actual-dates
@@ -1,4 +1,0 @@
-Significance: patch
-Type: enhancement
-
-Premium Analytics: Name the dates a comparison covers in the dashboard header, instead of "Previous period", drop the weekdays from ranges longer than a week, and leave the year off ranges that sit inside the current one.

--- a/projects/plugins/jetpack/changelog/wooa7s-1970-date-math-site-timezone
+++ b/projects/plugins/jetpack/changelog/wooa7s-1970-date-math-site-timezone
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Premium Analytics: Compute date-filter day boundaries in the site's timezone, so visitors west of the site timezone no longer get stretched ranges or wrong chart buckets.

--- a/projects/plugins/jetpack/changelog/wooa7s-1976-comparison-window-length
+++ b/projects/plugins/jetpack/changelog/wooa7s-1976-comparison-window-length
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Premium Analytics: Compare a date range against a previous month or year of the same length, so the percentages no longer measure 30 days against 29. Whole calendar months still compare month to month.

--- a/projects/plugins/jetpack/composer.json
+++ b/projects/plugins/jetpack/composer.json
@@ -118,7 +118,7 @@
 		"platform": {
 			"ext-intl": "0.0.0"
 		},
-		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ16_2_a_1",
+		"autoloader-suffix": "f11009ded9fc4592b6a05b61ce272b3c_jetpackⓥ16_2_a_3",
 		"allow-plugins": {
 			"automattic/jetpack-autoloader": true,
 			"automattic/jetpack-composer-plugin": true

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -272,7 +272,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -298,7 +298,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1249,7 +1249,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1286,7 +1286,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1758,7 +1758,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "4ae53109c613900871b48084c3d7ff554060de17"
+                "reference": "001a7e2b1a5f929a2c30cf000a8597497049e318"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1796,7 +1796,7 @@
                     "link-template": "https://github.com/automattic/jetpack-forms/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "7.25.x-dev"
+                    "dev-trunk": "7.26.x-dev"
                 },
                 "textdomain": "jetpack-forms",
                 "version-constants": {
@@ -3068,7 +3068,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "b73e4e0a54a48c7cf55d26869728add4ff4c9dc2"
+                "reference": "3f75bb031bb04e1a861a65d41c5bc6adf83737a4"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -3098,7 +3098,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-premium-analytics/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 }
             },
             "autoload": {
@@ -3794,7 +3794,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "b57ac9a5d2258772a37d4252bb6ae9c5983b6987"
+                "reference": "3846f5f6010ff5010a6268b635203a01d37c2112"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -3819,7 +3819,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.33.x-dev"
+                    "dev-trunk": "0.34.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {
@@ -3862,7 +3862,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -3887,7 +3887,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/jetpack/jetpack.php
+++ b/projects/plugins/jetpack/jetpack.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://jetpack.com
  * Description: Security, performance, and marketing tools made by WordPress experts. Jetpack keeps your site protected so you can focus on more important things.
  * Author: Automattic
- * Version: 16.2-a.1
+ * Version: 16.2-a.3
  * Author URI: https://jetpack.com
  * License: GPL2+
  * Text Domain: jetpack
@@ -37,7 +37,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! defined( 'JETPACK__VERSION' ) ) {
 	// This breaks the project version checks when a one-liner.
-	define( 'JETPACK__VERSION', '16.2-a.1' );
+	define( 'JETPACK__VERSION', '16.2-a.3' );
 }
 defined( 'JETPACK__MINIMUM_WP_VERSION' ) || define( 'JETPACK__MINIMUM_WP_VERSION', '7.0' );
 defined( 'JETPACK__MINIMUM_PHP_VERSION' ) || define( 'JETPACK__MINIMUM_PHP_VERSION', '7.2' );

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -326,88 +326,47 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 
 == Changelog ==
-### 16.2-a.1 - 2026-08-20
-#### Major Enhancements
-- Update minimum WordPress version to 7.0.
-
+### 16.2-a.3 - 2026-08-25
 #### Enhancements
-- AI: Add a Jetpack AI module as the site-wide master switch on self-hosted and Atomic, preserving explicit opt-outs.
-- AI: Hide the AI sidebar when the writing assistant and SEO enhancer toggles are both off.
-- AI: Make the AI toolbar button follow the writing assistant toggle.
-- AI Assistant: Add feature settings controls for Jetpack AI tools.
-- AI Features: Group the feature toggles into a single Agent capabilities card.
-- AI settings: Make the Try it out links pre-open their target — the AI Assistant sidebar in the editor, and Image Studio's generate mode in the Media Library.
-- Content Guidelines AI: Enable AI guideline suggestions on WordPress VIP sites.
-- Forms: Add a Print action to form responses.
-- Forms: Add form fill duration to feedback entries.
-- Map Block: Add support for wide and full width alignments.
-- Newsletter: Explain why the Everyone audience is unavailable when a post has a paywall block, instead of linking to the block.
-- Newsletter: Rename the Access panel to Audience, describe who can read each post, and link out to set up paid subscribers.
-- Podcast: Add a setting for how many episodes the podcast feed includes.
-- Podcast: Split the Distribution directories into Automatic and Manual submission, explain why a disabled button is disabled, and link to your Pocket Casts show once it is live.
-- Premium Analytics: Clarify traffic chart time-axis labels and bar tooltip periods.
-- REST API: Add the `atomic_email_block` field to the site endpoint response.
-- Search Blocks: Add a customizable No Results block while continuing to render existing Results List messages.
-- Stats: Show the Stats dashboard before the site is connected to WordPress.com, so a plan can be picked and the site connected from there.
-
-#### Improved compatibility
-- Tested up to WordPress 7.1.
+- Akismet: Link the settings page header logo and title to the Akismet settings page.
+- Forms: On small screens, show only the response and its actions instead of a table that scrolls sideways.
+- Forms: On small screens, the View action now opens a response the same way tapping its title does.
+- Forms: Show each form field as a column when viewing a single form's responses.
+- Forms: Show progress while a new form's editor opens, and report it when creating a form fails.
+- My Jetpack: Show what Paid Stats actually adds — UTM tracking, device stats, and region & city locations — instead of commercial use.
+- Premium Analytics: Add an Ads dashboard section showing WordAds earnings and performance.
+- Premium Analytics: Add referrer groups that open folded and expand on demand in the Referrers report.
+- Premium Analytics: Click Visitors in the Traffic chart legend to compare it against Views without leaving the metric. Chart legends now name the metric rather than the date range.
+- Premium Analytics: Name comparison dates in the dashboard header, omit weekdays from ranges longer than a week, and omit the year when it matches the current range.
+- Premium Analytics: Offer only the groupings the selected date range supports in the chart's Group by control.
+- Premium Analytics: Show the latest emails sent as a plain list of subjects and rates.
+- Stats: Add a Popular hours widget showing the busiest hour and its daily average views.
+- Stats: Link the post list views column to the analytics post detail page when the new dashboard is enabled.
+- Stats: Set the chart interval once for the whole page instead of per chart widget.
+- VideoPress: Redesign the video details page with grouped details, a wider layout, side-by-side player and settings, thumbnail tiles, collapsible sections, and an Add to content action.
 
 #### Bug fixes
-- AI Assistant: Scroll the Form block's AI prompt into view when it opens, so it no longer sits over the form.
-- Blocks: Fix an infinite refresh loop in the Goodreads block editor that regenerated the widget ID on every re-render and hammered the REST API.
-- Blocks: Restrict Goodreads scripts to the expected Goodreads widget endpoints.
-- Blocks: Treat WordPress.com public API requests as a block-editor context so editor-only extensions load, restoring block plan availability (such as the core/video upgrade nudge) in the mobile editor.
-- Connection: Stop showing a duplicate account notice when your WordPress.com email differs from your site email only in letter case.
-- Connection: Update wording for some connection error notices.
-- Content Guidelines AI: Keep the empty-state banner from painting over the sticky page header while scrolling.
-- Editor: Refresh the cached plan when returning from a plan purchase so paid blocks (such as the Forms file upload field) stop showing their upgrade nudge once the plan is active.
-- Escape the Premium Content block login button label on output.
-- Fix the premium block upgrade banner rendering collapsed and too narrow on the site frontend.
-- Forms: Fix the first change made to a form after opening a page being discarded when saving.
-- Forms: Keep response field icons and formatting after marking a response as spam.
-- Forms: Make Group and Columns blocks fill the form width so nested fields render full-width.
-- Forms: Preserve line breaks in multi-line answers in the responses dashboard.
-- Forms: Show an empty checkbox icon next to checkbox fields the respondent left unchecked, instead of always showing a ticked one.
-- Harden the subscriber authentication endpoint so it only redirects within the current site.
-- Heartbeat: Restore identity crisis reporting in the WP-CLI status command.
-- Likes: Fix Like buttons sometimes getting stuck on "Loading…" and never appearing.
-- Likes: Include public custom post types in default visibility settings so Likes and Comment Likes render on CPTs without requiring manual configuration.
-- Likes: Keep Settings > Sharing available when sharing buttons are turned off, so the Likes and Comment Likes settings stay reachable.
-- Likes: Rename the settings heading on Settings > Sharing to reflect what it holds when sharing buttons are off.
-- Map Block: Remove the duplicate alignment toolbar in the editor.
-- Media API: Restrict the edit endpoints to attachments, so they no longer accept ordinary post IDs.
-- Memberships: Ensure the configured post access level is evaluated correctly before authorizing access to paywalled content.
-- Newsletter: Make the post-publish email confirmation more visible.
-- Newsletter: Round the dashboard widget footer so it stops covering the rounded bottom corner of the WP Admin box.
-- Newsletter: Save the post before generating an email preview, so the preview reflects the latest saved content (e.g. a newly-set featured image).
-- Newsletter: Send the test email when pressing Enter, and show send errors as a proper error notice.
-- Omnibar: Return admin bar nodes translated in the user's locale.
-- Podcast Player: Keep showing the most recent episodes when a podcast feed becomes slow or unreachable, instead of failing to load.
-- Podcast Player: Stop preloading episode audio before playback to avoid inflating podcast download metrics.
-- Premium Analytics: Fix stray time-axis labels and invalid tooltip dates in mixed or compared charts.
-- Premium Analytics: Keep the full set of ticks on the traffic chart's time axis, which could thin out to two labels on longer date ranges.
-- Premium Analytics: Keep the year and the day on the traffic chart's time axis, which could previously skip the tick that named them, and stop the same label falling on two ticks in a row.
-- Premium Analytics: Stop applying hidden date comparisons in dashboard sections that do not offer the control.
-- Premium Content: Keep subscription login available when a WordPress session lacks a subscription token.
-- Premium Content: Restore the local account link from a verified magic-link token so subscription access persists.
-- Random Redirect: Avoid a fatal error when a theme or plugin already declares the module's redirect function.
-- Require a Jetpack site (blog) token for JSON API endpoints that declare no capabilities, such as the Backup helper script endpoints, and reject user tokens regardless of privilege.
-- Resolve Redirect endpoint: Validate every redirect hop, and return a 400 error when a URL cannot be fetched, is blocked, or exceeds the redirect limit, instead of a 200 response with an empty URL.
-- REST API: Require the admin capability for all settings in a request that also updates Post by Email.
-- Security: Enforce per-item permission checks when editing media through the JSON API.
-- Security: External Media: Ensure imported files are always saved under a safe file name.
-- Security: Verify attachment ownership before removing an uploaded package in the plugin and theme install endpoints.
-- SEO: Hide the post list SEO columns for people who had customized Screen Options before those columns existed.
-- Sharing: Escape Tumblr share title, URL, and button label in official button output.
-- Sharing: Use an unpredictable name for share and Press This popups so another page cannot pre-register the same window name.
-- Sitemaps: Avoid a PHP notice when a sitemap query returns no posts.
-- Stats: Limit Top Posts & Pages processing to the number of posts requested.
-- Subscribers: Restore the option to assign imported subscribers to specific newsletter categories on CSV upload and manual add.
-- Subscriptions: Fix subscribe prompts and paywalled content incorrectly showing or blocking for readers who follow the site but have no active email subscription.
-- Tiled Gallery: Keep VIP gallery images off the external Photon domain and add the `jetpack_skip_photon_domain` filter.
-- WAF: Restrict firewall settings to administrators.
-- WordPress Posts: Escape remote site data before output.
+- AI: Auto-activate the AI module on sites running a 16.2 prerelease build.
+- Charts: Draw labels at the design system's font weight and size.
+- Contact Form: Remove the classic-theme editor margin between a field's label and its input.
+- Forms: Allow a single response to scroll when it is taller than the screen.
+- Forms: Apply the name typed when creating a form, and stop a dismissed save from reporting into a reopened dialog.
+- Forms: Prevent an error that could stop responses from loading when a file upload field was stored without any file data.
+- AI: Keep the editor working when another plugin loads an older copy of the Status package.
+- My Jetpack: Always label the license activation link "Activate a license", including on sites with a plan but no activated licenses.
+- My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen.
+- Premium Analytics: Compare date ranges against a previous month or year of the same length while keeping whole-calendar-month comparisons aligned by month.
+- Premium Analytics: Compute date-filter day boundaries in the site's timezone, so visitors west of the site timezone no longer get stretched ranges or wrong chart buckets.
+- Premium Analytics: Fix charts getting stuck on their loading skeleton after switching a control that turns one of the underlying requests off.
+- Premium Analytics: Fix report and chart dates that could read a day off for sites away from UTC.
+- Premium Analytics: Label chart points by the bucket they name rather than by the viewer's time zone, and format axis ticks and tooltips at the series' declared bucket size.
+- Premium Analytics: Label Subscribers chart and email timeline points by the bucket they name rather than by the viewer's time zone.
+- Premium Analytics: Show the dashboard right away instead of a sync screen, and flag the Store section's numbers as incomplete while store data is still syncing.
+- Premium Analytics: Start the Traffic chart's Group by control from the dashboard's interval, and replace Auto with hourly grouping.
+- Stats: Keep excluding a visitor IP address from tracking when it is written in another form.
+- Stats: Report the same visitor address the rest of Jetpack resolves on sites with a trusted IP header configured.
+- Stats: Stop recording a malformed visitor IP address.
+- VideoPress: Fix a timeout error when updating a video poster from the media library.
 
 --------
 

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -347,12 +347,12 @@ Jetpack Backup can do a full website migration to a new host, migrate theme file
 
 #### Bug fixes
 - AI: Auto-activate the AI module on sites running a 16.2 prerelease build.
+- AI: Keep the editor working when another plugin loads an older copy of the Status package.
 - Charts: Draw labels at the design system's font weight and size.
 - Contact Form: Remove the classic-theme editor margin between a field's label and its input.
 - Forms: Allow a single response to scroll when it is taller than the screen.
 - Forms: Apply the name typed when creating a form, and stop a dismissed save from reporting into a reopened dialog.
 - Forms: Prevent an error that could stop responses from loading when a file upload field was stored without any file data.
-- AI: Keep the editor working when another plugin loads an older copy of the Status package.
 - My Jetpack: Always label the license activation link "Activate a license", including on sites with a plan but no activated licenses.
 - My Jetpack: Stop the Stats dashboard from asking which plan you want again after Start for Free was already chosen.
 - Premium Analytics: Compare date ranges against a previous month or year of the same length while keeping whole-calendar-month comparisons aligned by month.

--- a/projects/plugins/jetpack/readme.txt
+++ b/projects/plugins/jetpack/readme.txt
@@ -1,7 +1,7 @@
 === Jetpack - WP Security, Backup, Speed, & Growth ===
 Contributors: automattic, adamkheckler, adrianmoldovanwp, aduth, akirk, allendav, alternatekev, andy, annamcphee, annezazu, apeatling, arcangelini, arsihasi, azaozz, barry, batmoo, beaulebens, bindlegirl, biskobe, bjorsch, blobaugh, brbrr, brileyhooper, cainm, cena, cfinke, cgastrell, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, daniloercoli, davoraltman, delawski, designsimply, dkmyta, dllh, dlocc, drawmyface, dsmart, dun2mis, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, fgiannar, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, joen, jblz, jeffgolenski, jeherve, jennywp, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, leogermani, lhkowalski, lschuyler, macmanx, martinremy, matt, mattwiebe, matveb, maverick3x6, mcsf, mdawaffe, mdbitz, MichaelArestad, migueluy, miguelxavierpenha, mikeyarce, mkaz, nancythanki, nickmomrik, njweller, nunyvega, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, renatoagds, retrofox, richardmtl, richardmuscat, robertbpugh, roccotripaldi, ryanc413, samhotchkiss, samiff, scarstocea, scottsweb, sdixon194, sdquirk, sermitr, simison, stephdau, thehenridev, tmoorewp, tyxla, Viper007Bond, westi, williamvianas, wpkaren, yoavf, zinigor
 Tags: Security, backup, malware, scan, performance
-Stable tag: 16.2-a.1
+Stable tag: 16.2-a.3
 Requires at least: 7.0
 Requires PHP: 7.2
 Tested up to: 7.1

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#41
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#41
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -128,7 +128,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -154,7 +154,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -775,7 +775,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -812,7 +812,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1916,7 +1916,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "b73e4e0a54a48c7cf55d26869728add4ff4c9dc2"
+                "reference": "3f75bb031bb04e1a861a65d41c5bc6adf83737a4"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1946,7 +1946,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-premium-analytics/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 }
             },
             "autoload": {
@@ -2238,7 +2238,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "b57ac9a5d2258772a37d4252bb6ae9c5983b6987"
+                "reference": "3846f5f6010ff5010a6268b635203a01d37c2112"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2263,7 +2263,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.33.x-dev"
+                    "dev-trunk": "0.34.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {
@@ -2306,7 +2306,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -2331,7 +2331,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/paypal-payment-buttons/changelog/prerelease#16
+++ b/projects/plugins/paypal-payment-buttons/changelog/prerelease#16
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/paypal-payment-buttons/composer.lock
+++ b/projects/plugins/paypal-payment-buttons/composer.lock
@@ -65,7 +65,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -91,7 +91,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -399,7 +399,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -436,7 +436,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -849,7 +849,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -874,7 +874,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/premium-analytics/changelog/prerelease#27
+++ b/projects/plugins/premium-analytics/changelog/prerelease#27
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -128,7 +128,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -154,7 +154,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -477,7 +477,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -514,7 +514,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -844,7 +844,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "b73e4e0a54a48c7cf55d26869728add4ff4c9dc2"
+                "reference": "3f75bb031bb04e1a861a65d41c5bc6adf83737a4"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -874,7 +874,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-premium-analytics/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 }
             },
             "autoload": {
@@ -1100,7 +1100,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1125,7 +1125,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/protect/changelog/prerelease#4
+++ b/projects/plugins/protect/changelog/prerelease#4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -209,7 +209,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -235,7 +235,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -806,7 +806,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -843,7 +843,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1896,7 +1896,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1921,7 +1921,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/search/changelog/prerelease#3
+++ b/projects/plugins/search/changelog/prerelease#3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -141,7 +141,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -167,7 +167,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -684,7 +684,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -721,7 +721,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1927,7 +1927,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1952,7 +1952,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/social/changelog/prerelease#19
+++ b/projects/plugins/social/changelog/prerelease#19
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -204,7 +204,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -230,7 +230,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -747,7 +747,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -784,7 +784,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -2119,7 +2119,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -2144,7 +2144,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/starter-plugin/changelog/prerelease#33
+++ b/projects/plugins/starter-plugin/changelog/prerelease#33
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -65,7 +65,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -91,7 +91,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -645,7 +645,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1698,7 +1698,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1723,7 +1723,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/stats/changelog/prerelease#3
+++ b/projects/plugins/stats/changelog/prerelease#3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/stats/composer.lock
+++ b/projects/plugins/stats/composer.lock
@@ -65,7 +65,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -91,7 +91,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -645,7 +645,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1766,7 +1766,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "b57ac9a5d2258772a37d4252bb6ae9c5983b6987"
+                "reference": "3846f5f6010ff5010a6268b635203a01d37c2112"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1791,7 +1791,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.33.x-dev"
+                    "dev-trunk": "0.34.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {
@@ -1834,7 +1834,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1859,7 +1859,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/videopress/changelog/prerelease#2
+++ b/projects/plugins/videopress/changelog/prerelease#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -141,7 +141,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -167,7 +167,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -684,7 +684,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -721,7 +721,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -1774,7 +1774,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -1799,7 +1799,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/wpcloud-sso/changelog/prerelease#39
+++ b/projects/plugins/wpcloud-sso/changelog/prerelease#39
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcloud-sso/composer.lock
+++ b/projects/plugins/wpcloud-sso/composer.lock
@@ -65,7 +65,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+                "reference": "84bfbc56a19b28c814c2c553ba6bc3bdd0ef4ebb"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -91,7 +91,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -414,7 +414,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b29a56f593b8fc3bd5cb0b0ffa4ef94364551f94"
+                "reference": "5d0cb0687d559e7bfb5569e1c730d60409be8ee5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -451,7 +451,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -778,7 +778,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "f51441bceb73be83e4906a232d56cd26a4dde2aa"
+                "reference": "8478d12eaf8b393eec0cddd178a20199e77a42a1"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -803,7 +803,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/wpcomsh/changelog/prerelease#43
+++ b/projects/plugins/wpcomsh/changelog/prerelease#43
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -176,7 +176,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/admin-ui",
-                "reference": "edc5a654cdffde980eafb17c2c1d98ca755957ad"
+                "reference": "69ef9fbdd09f877ad9d669da0ae159000e61e2ad"
             },
             "require": {
                 "automattic/jetpack-redirect": "@dev",
@@ -202,7 +202,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.9.x-dev"
+                    "dev-trunk": "0.10.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -891,7 +891,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "8a31758b4a04ddbcc06cbab8ddbe9d158091807d"
+                "reference": "89274248ea7ccb23a3482c6037c3d2e675a182d5"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -928,7 +928,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.11.x-dev"
+                    "dev-trunk": "8.12.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
@@ -2097,7 +2097,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "b0e4a584417d814bcb69d1630c0aa3d0bf271197"
+                "reference": "597fdfcb26c961ed78bd819bb3de8bd739693f98"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -2127,7 +2127,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-premium-analytics/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 }
             },
             "autoload": {
@@ -2419,7 +2419,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/stats-admin",
-                "reference": "8c926a1a98e6899a9d82140b06f22924187aece7"
+                "reference": "61a44eda621072696bccce0a1ae601cd52ec49ab"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -2444,7 +2444,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-stats-admin",
                 "branch-alias": {
-                    "dev-trunk": "0.33.x-dev"
+                    "dev-trunk": "0.34.x-dev"
                 },
                 "textdomain": "jetpack-stats-admin",
                 "version-constants": {
@@ -2487,7 +2487,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/status",
-                "reference": "21c270cc5c3f88501060b326967dfbe970d6fb5e"
+                "reference": "a5eb26b1682be4bba5d650ad1146ab4df432a9d0"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -2512,7 +2512,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "6.4.x-dev"
+                    "dev-trunk": "6.5.x-dev"
                 },
                 "dependencies": {
                     "test-only": [


### PR DESCRIPTION
<!--- This template is used for backporting changes made during a plugin release back to trunk. -->

## Proposed changes:
<!--- Explain what functional changes your PR includes -->
Backports changes for jetpack 16.2-a.3

### Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below with a script to run)?

## Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/a
## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No
## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Proofread changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Coordinated release touching visitor IP resolution for Stats, Premium Analytics date/chart behavior, and deprecated connection/admin-ui asset hooks; regressions could affect tracking accuracy or wp-admin styling on edge hosts.
> 
> **Overview**
> Backports the **Jetpack 16.2-a.3** prerelease by bumping the plugin and dependent package versions, folding changelog fragments into each package’s `CHANGELOG.md`, and refreshing `composer.lock` across Jetpack plugins.
> 
> **Premium Analytics (0.4.0)** is the largest functional slice: a new **Ads** section, collapsible referrer groups, views/visitors legend pairing, calendar heatmap paging, post-list views linking into post detail (via a new `jetpack_stats_post_list_column_url` filter in stats-admin), and a batch of **date/timezone and chart-bucketing fixes** (site timezone filters, comparison windows, skeleton loading, sync gating scoped to Store).
> 
> **Forms (7.26.0)** improves the responses admin (per-field columns, mobile layout, create-form progress/errors, file-field crash fix). **@automattic/charts (3.1.0)** adds series visibility APIs and related chart fixes consumed by analytics. **VideoPress** redesigns the video details screen; **My Jetpack** updates Stats upsell copy and plan handoff; **device-detection** adjusts bot/tablet UA handling.
> 
> **Stats-related infrastructure** changes visitor IP resolution in **jetpack-status (6.5.0)** (trusted header only when configured, valid IPs, comma-separated forwarded lists) with matching **stats** exclusion normalization and AMP pixel escaping. **Connection (8.12.0)** and **admin-ui (0.10.0)** switch several admin notices/styles/scripts from printed tags to WordPress enqueue APIs and deprecate the old print helpers. **jetpack-comments** ships **0.1.0** (on-site form behind `jetpack_comments_new_hotness`). **Publicize** limits connection script data to users who can access Publicize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ff2c8ada9a2db7399005d9e0bc28bcc29f20a34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->