### PR TITLE
Carousel: Keep the loading overlay hidden when the module stylesheet is missing

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-loading-overlay-visible-without-css
+++ b/projects/plugins/jetpack/changelog/fix-carousel-loading-overlay-visible-without-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: Keep the loading overlay hidden when the module stylesheet is missing.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -585,7 +585,7 @@ class Jetpack_Carousel {
 		$required = ( $require_name_email ) ? __( '%s (Required)', 'jetpack' ) : '%s';
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-spinner.php';
 		?>
-		<div id="jp-carousel-loading-overlay">
+		<div id="jp-carousel-loading-overlay" style="display: none;">
 			<div id="jp-carousel-loading-wrapper">
 				<span id="jp-carousel-library-loading"><?php echo Jetpack_Spinner::render( 40 ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- static SVG markup. ?></span>
 			</div>


### PR DESCRIPTION
Fixes JETPACK-2336

## Proposed changes
* Give `#jp-carousel-loading-overlay` an inline `style="display: none;"`, matching the `.jp-carousel-overlay` sibling next to it in [jetpack-carousel.php:588](projects/plugins/jetpack/modules/carousel/jetpack-carousel.php#L588).

The skeleton is printed on `wp_footer` but its hidden state lived only in `jetpack-carousel.css`. On the reported site that stylesheet never reaches the page, so the overlay renders in normal flow at the bottom. Since #47451 the loader holds a self-animating SVG, so it reads as a spinner stuck forever rather than the old invisible `&nbsp;`.

## Related product discussion/links
- JETPACK-2336

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with Carousel enabled, add a gallery to a post and confirm clicking an image still shows the loading spinner while Swiper loads, then opens the carousel.
* Simulate the report: drop `jetpack-carousel` from `style_loader_tag` in an mu-plugin, reload the post, scroll to the bottom. No spinner should appear.
* Note the carousel itself is unstyled in that state — this PR only stops the overlay leaking onto the page. Why the stylesheet goes missing on 2048.studio is still open.

| Before | After |
| --- | --- |
