### PR TITLE
Premium Analytics: drop a deleted suite from the no-mocks jest group (trunk hotfix)

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-pa-drop-deleted-suite-from-group
+++ b/projects/packages/premium-analytics/changelog/fix-pa-drop-deleted-suite-from-group
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove a deleted test suite from a jest group listing; no shipped code changes
+
+

--- a/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part3.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/routes-no-mocks-part3.test.tsx
@@ -5,5 +5,4 @@ import '../../routes/reports/search-terms/config/aggregate.test';
 import '../../routes/reports/search-terms/config/fields.test';
 import '../../routes/reports/utm/config/aggregate.test';
 import '../../routes/reports/utm/config/tabs.test';
-import '../../routes/use-detail-chart-intervals.test';
 import '../../routes/video-detail/config/layout.test';


### PR DESCRIPTION
Fixes the JS tests and ESLint failures on trunk (e.g. [Tests run](https://github.com/Automattic/jetpack/actions/runs/32859530366), [Linting run](https://github.com/Automattic/jetpack/actions/runs/32860027889)).

## Proposed changes

* Remove the `routes/use-detail-chart-intervals.test` import from `tests/groups/routes-no-mocks-part3.test.tsx`. Tests-only change; nothing shipped is affected.

Two independently green PRs crossed on trunk today: #51533 deleted `routes/use-detail-chart-intervals(.test).ts` along with the detail pages' interval dropdown, while #51537 created this jest group from a base that still had the suite. The merged result is a group file importing a module that no longer exists, which fails:

* **JS tests**: `tests/js/test-groups.test.ts` ("only lists suites that exist") and the group suite itself (`Cannot find module`).
* **ESLint**: `import/no-unresolved` on the same line.

## Related product discussion/links

* #51533, #51537 — the two PRs whose combination produced the failure.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && TZ=UTC pnpm jest --config=tests/jest.config.cjs tests/js/test-groups` — the group-consistency guard passes (126 tests).
* `pnpm run test` in the same directory (grouped mode, as CI runs it) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
