### PR TITLE
Jetpack AI: Add audience and surface props to the agent notice events

### DIFF
--- a/projects/plugins/jetpack/changelog/iamchughmayank-agent-notice-events-props
+++ b/projects/plugins/jetpack/changelog/iamchughmayank-agent-notice-events-props
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add the standard audience and surface Tracks properties to the WordPress Agent notice events. Telemetry only, nothing user-facing.
+
+

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/index.tsx
@@ -23,6 +23,7 @@ import {
 	useIsWordPressAgentChatVisible,
 	useIsWordPressAgentReady,
 } from './open-agent';
+import { getTracksAudienceProperties } from './tracks-audience';
 /**
  * Types
  */
@@ -48,13 +49,17 @@ function useEventProperties(
 	placement: WordPressAgentNoticePlacement
 ): WordPressAgentNoticeEventProperties {
 	const { currentTier } = useAiFeature();
-	const postType = useSelect(
-		select => ( select( EDITOR_STORE ) as EditorSelect )?.getCurrentPostType?.(),
-		[]
-	);
+	const { hasEditorStore, postType } = useSelect( select => {
+		const editor = select( EDITOR_STORE ) as EditorSelect | undefined;
+		return { hasEditorStore: !! editor, postType: editor?.getCurrentPostType?.() };
+	}, [] );
 
 	return {
+		// First on purpose: an explicit key below always wins over an audience one.
+		...getTracksAudienceProperties(),
 		placement,
+		// Derived as the family recorder derives it: present while the editor store is.
+		...( hasEditorStore ? { surface: 'block_editor' as const } : {} ),
 		site_type: getSiteType(),
 		...( postType ? { post_type: postType } : {} ),
 		...( currentTier?.slug ? { current_tier_slug: currentTier.slug } : {} ),

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/test/index.test.tsx
@@ -1,7 +1,14 @@
 import { render, renderHook, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { speak } from '@wordpress/a11y';
-import { createReduxStore, dispatch, register, select } from '@wordpress/data';
+import {
+	createRegistry,
+	createReduxStore,
+	dispatch,
+	register,
+	RegistryProvider,
+	select,
+} from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import WordPressAgentNotice, {
 	DISMISSED_PREFERENCE,
@@ -67,6 +74,9 @@ describe( 'WordPressAgentNotice', () => {
 		mockIsAgentReady = true;
 		mockIsChatOnScreen = false;
 		mockIsFeatureAvailable = true;
+		// The audience props read these server-injected globals for real.
+		delete ( globalThis as Record< string, unknown > ).agentsManagerData;
+		delete ( globalThis as Record< string, unknown > ).bigSkyInitialState;
 	} );
 
 	describe( 'useWordPressAgentNotice', () => {
@@ -256,6 +266,33 @@ describe( 'WordPressAgentNotice', () => {
 		expect( propertiesOf( 'jetpack_big_sky_agent_notice_dismiss' ) ).toMatchObject( expected );
 	} );
 
+	it( 'records the surface and audience context with each event', async () => {
+		const user = userEvent.setup();
+		( globalThis as Record< string, unknown > ).agentsManagerData = {
+			isA11n: true,
+			isDevMode: true,
+		};
+		render( <WordPressAgentNotice placement="document-settings" /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'WordPress Agent' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Dismiss' } ) );
+
+		const expected = { surface: 'block_editor', is_test: true, is_a11n: true };
+		expect( propertiesOf( 'jetpack_big_sky_agent_notice_click' ) ).toMatchObject( expected );
+		expect( propertiesOf( 'jetpack_big_sky_agent_notice_dismiss' ) ).toMatchObject( expected );
+	} );
+
+	it( 'omits is_a11n when the server payload does not carry it', async () => {
+		const user = userEvent.setup();
+		render( <WordPressAgentNotice placement="document-settings" /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'WordPress Agent' } ) );
+
+		const properties = propertiesOf( 'jetpack_big_sky_agent_notice_click' );
+		expect( properties ).toMatchObject( { is_test: false } );
+		expect( properties ).not.toHaveProperty( 'is_a11n' );
+	} );
+
 	it.each( [ 'woa', 'jetpack' ] as const )( 'reports a %s site as itself', async siteType => {
 		const user = userEvent.setup();
 		mockSiteType = siteType;
@@ -278,6 +315,24 @@ describe( 'WordPressAgentNotice', () => {
 		expect( propertiesOf( 'jetpack_big_sky_agent_notice_click' ) ).not.toHaveProperty(
 			'post_type'
 		);
+	} );
+
+	it( 'omits the surface where no editor store exists, as the family recorder does', async () => {
+		const user = userEvent.setup();
+		// An isolated registry stands in for a screen without the block editor.
+		const registry = createRegistry();
+		registry.register( preferencesStore );
+		render(
+			<RegistryProvider value={ registry }>
+				<WordPressAgentNotice placement="document-settings" />
+			</RegistryProvider>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'WordPress Agent' } ) );
+
+		const properties = propertiesOf( 'jetpack_big_sky_agent_notice_click' );
+		expect( properties ).not.toHaveProperty( 'surface' );
+		expect( properties ).not.toHaveProperty( 'post_type' );
 	} );
 
 	it( 'omits the plan tier when the site has no tier', async () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/test/tracks-audience.test.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/test/tracks-audience.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Internal dependencies
+ */
+import { getTracksAudienceProperties } from '../tracks-audience';
+
+// Production injects a bare `const agentsManagerData` global. Tests cannot
+// declare a lexical const, so they assign the global-object property, which
+// the same bare-identifier read resolves to in jsdom.
+const setInlineData = ( data: object | undefined ) => {
+	if ( data === undefined ) {
+		delete ( globalThis as Record< string, unknown > ).agentsManagerData;
+		return;
+	}
+	( globalThis as Record< string, unknown > ).agentsManagerData = data;
+};
+
+const setBigSkyState = ( state: object | undefined ) => {
+	if ( state === undefined ) {
+		delete ( globalThis as Record< string, unknown > ).bigSkyInitialState;
+		return;
+	}
+	( globalThis as Record< string, unknown > ).bigSkyInitialState = state;
+};
+
+describe( 'getTracksAudienceProperties', () => {
+	afterEach( () => {
+		setInlineData( undefined );
+		setBigSkyState( undefined );
+	} );
+
+	it( 'reports an ordinary environment when no payload exists at all', () => {
+		expect( getTracksAudienceProperties() ).toEqual( { is_test: false } );
+	} );
+
+	it( 'omits is_a11n rather than guessing when the payload lacks it', () => {
+		setInlineData( { isDevMode: false } );
+
+		expect( getTracksAudienceProperties() ).not.toHaveProperty( 'is_a11n' );
+	} );
+
+	it( 'passes a true is_a11n through', () => {
+		setInlineData( { isA11n: true } );
+
+		expect( getTracksAudienceProperties() ).toMatchObject( { is_a11n: true } );
+	} );
+
+	it( 'passes a false is_a11n through, which differs from omitting it', () => {
+		setInlineData( { isA11n: false } );
+
+		expect( getTracksAudienceProperties() ).toMatchObject( { is_a11n: false } );
+	} );
+
+	it( 'drops a malformed is_a11n instead of recording it', () => {
+		setInlineData( { isA11n: 'true' } );
+
+		expect( getTracksAudienceProperties() ).not.toHaveProperty( 'is_a11n' );
+	} );
+
+	it( 'marks Agents Manager dev mode as test traffic', () => {
+		setInlineData( { isDevMode: true } );
+
+		expect( getTracksAudienceProperties() ).toMatchObject( { is_test: true } );
+	} );
+
+	it( 'marks Big Sky dev mode as test traffic too, as the family recorder does', () => {
+		setBigSkyState( { isDevMode: true } );
+
+		expect( getTracksAudienceProperties() ).toMatchObject( { is_test: true } );
+	} );
+
+	it( 'keeps a plain environment out of the test bucket when signals say false', () => {
+		setInlineData( { isDevMode: false } );
+		setBigSkyState( { isDevMode: false } );
+
+		expect( getTracksAudienceProperties() ).toMatchObject( { is_test: false } );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/tracks-audience.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/tracks-audience.ts
@@ -1,0 +1,50 @@
+/**
+ * Audience properties for the notice's Tracks events, sourced from the same
+ * server-provided signals the `jetpack_big_sky_*` family recorder reads, so the
+ * notice's rows filter and join like the rest of the family. is_a11n is
+ * identity (Automattician or proxied request), omitted when the payload does
+ * not carry it and never coerced to false. is_test is environment only.
+ */
+
+type AgentsManagerInlineData = {
+	isA11n?: boolean;
+	isDevMode?: boolean;
+};
+
+// The Agents Manager injects a bare `const agentsManagerData` global rather
+// than a window property; some hosts assign `window.agentsManagerData` instead.
+// A bare identifier read resolves either through the scope chain, and the
+// typeof guard keeps it safe when neither exists.
+declare const agentsManagerData: AgentsManagerInlineData | undefined;
+
+function getAgentsManagerInlineData(): AgentsManagerInlineData | undefined {
+	return typeof agentsManagerData !== 'undefined' && agentsManagerData
+		? agentsManagerData
+		: undefined;
+}
+
+export type TracksAudienceProperties = {
+	is_test: boolean;
+	is_a11n?: boolean;
+};
+
+/**
+ * Read the audience signals the server injected for this request.
+ *
+ * `is_test` ORs the Agents Manager and Big Sky dev-mode signals, matching the
+ * family recorder's getIsTest() in wp-calypso's agents-manager package.
+ *
+ * @return {TracksAudienceProperties} Audience properties for a Tracks event.
+ */
+export function getTracksAudienceProperties(): TracksAudienceProperties {
+	const inlineData = getAgentsManagerInlineData();
+	// Big Sky injects string flags; truthiness matches the family recorder's read.
+	const bigSkyDevMode = !! (
+		window as Window & { bigSkyInitialState?: { isDevMode?: boolean | string } }
+	 ).bigSkyInitialState?.isDevMode;
+
+	return {
+		is_test: !! inlineData?.isDevMode || bigSkyDevMode,
+		...( typeof inlineData?.isA11n === 'boolean' ? { is_a11n: inlineData.isA11n } : {} ),
+	};
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/types.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/types.ts
@@ -1,3 +1,4 @@
+import type { TracksAudienceProperties } from './tracks-audience';
 import type {
 	PLACEMENT_DOCUMENT_SETTINGS,
 	PLACEMENT_JETPACK_SIDEBAR,
@@ -24,8 +25,10 @@ export type EditorSelect = {
 	getCurrentPostType?: () => string | undefined;
 };
 
-export type WordPressAgentNoticeEventProperties = {
+export type WordPressAgentNoticeEventProperties = TracksAudienceProperties & {
 	placement: WordPressAgentNoticePlacement;
+	// The family's settled editor value, present while the core/editor store is registered.
+	surface?: 'block_editor';
 	site_type: SiteType;
 	post_type?: string;
 	current_tier_slug?: string;


### PR DESCRIPTION
## Proposed changes

* Add the standard audience properties to the two WordPress Agent notice events, `jetpack_big_sky_agent_notice_click` and `jetpack_big_sky_agent_notice_dismiss`:
  * `is_test` (boolean, always present) and `is_a11n` (present only when the server payload carries a boolean, never coerced to false), read from the same server-injected signals the `jetpack_big_sky_*` family recorder uses (`agentsManagerData`, `bigSkyInitialState`).
  * `surface: block_editor`, derived from the presence of the `core/editor` store, the same way `post_type` already is.
* New `tracks-audience.ts` helper beside the notice component, with unit tests for the omission semantics and both dev-mode sources; component tests assert the full prop set on click and dismiss, plus the no-editor-store case.
* Telemetry only — no behaviour change to the notice itself.

## Related product discussion/links

* Builds on #51388 (the base branch of this PR).
* FORNO-445, FORNO-476

## Does this pull request change what data or activity we track or use?

Adds three properties to the two existing notice events: `is_test`, `is_a11n`, and `surface`. They classify the environment (internal testing), the requester (Automattician or proxied), and the surface, so internal traffic can be filtered out of the click/dismiss numbers. No new events, no content data. Note: an absent `is_a11n` means the Agents Manager payload was not on the page, not "not an Automattician".

## Testing instructions

* See #51388.
