### PR TITLE
Backup: let .js, .xml and .svg preview in the file browser

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-preview-text-file-types
+++ b/projects/packages/backup/changelog/fix-backup-preview-text-file-types
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Backup: let .js, .xml and .svg preview in the modernized dashboard's file browser, and collapse the two overlapping previewability allowlists into one. No-op when the modernization filter is off.
+Comment: Backup: let .js, .xml and .svg preview in the modernized dashboard's file browser, collapse the two overlapping previewability allowlists into one, and stop an extension that only resolves through the prototype chain from crashing the info panel. No-op when the modernization filter is off.
 
 

--- a/projects/packages/backup/changelog/fix-backup-preview-text-file-types
+++ b/projects/packages/backup/changelog/fix-backup-preview-text-file-types
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: let .js, .xml and .svg preview in the modernized dashboard's file browser, and collapse the two overlapping previewability allowlists into one. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -10,7 +10,15 @@ import './style.scss';
 import type { FileNodeFile } from '../../types/file-tree';
 
 /**
- * Heuristic mime-type lookup by file extension.
+ * File extensions this card can render as text, and the mime type it
+ * labels each one with.
+ *
+ * Membership is the whole previewability rule — an extension in this map
+ * previews, one outside it does not. Adding a binary format here to get
+ * a `Type:` row would therefore also send its bytes to the `<pre>`, so
+ * keep binaries out. `.svg` earns its place because the card shows the
+ * source rather than rendering the image, which also keeps a hostile SVG
+ * out of the DOM.
  *
  * Deliberately not replaced by `path-info`'s `data_type`: that field is
  * a small integer type code — the manifest path's second character —
@@ -19,7 +27,7 @@ import type { FileNodeFile } from '../../types/file-tree';
  * own extension map for exactly this decision, using `data_type` only
  * to drive granular download.
  */
-const EXT_TO_MIME: Record< string, string > = {
+const PREVIEWABLE_TEXT_TYPES: Record< string, string > = {
 	css: 'text/css',
 	csv: 'text/csv',
 	htm: 'text/html',
@@ -53,7 +61,7 @@ function mimeFromName( name: string ): string {
 		return '';
 	}
 	const ext = name.slice( idx + 1 ).toLowerCase();
-	return EXT_TO_MIME[ ext ] ?? '';
+	return PREVIEWABLE_TEXT_TYPES[ ext ] ?? '';
 }
 
 type Props = {
@@ -133,21 +141,6 @@ function PreviewBody( {
 }
 
 /**
- * Returns true when the given mime type is renderable as plain text.
- *
- * @param mime - Mime type string.
- * @return Whether the type is textual.
- */
-function isTextual( mime: string ): boolean {
-	return (
-		mime.startsWith( 'text/' ) ||
-		mime === 'application/x-php' ||
-		mime === 'application/sql' ||
-		mime === 'application/json'
-	);
-}
-
-/**
  * Side panel showing details for the currently-open file: size, hash,
  * modified timestamp, and a monospace text preview for recognized text
  * mime types.
@@ -170,7 +163,7 @@ function isTextual( mime: string ): boolean {
  */
 export default function FileInfoCard( { file, onClose }: Props ) {
 	const mimeType = mimeFromName( file.name );
-	const showPreview = mimeType ? isTextual( mimeType ) : false;
+	const showPreview = Boolean( mimeType );
 	const {
 		content,
 		isLoading: contentsLoading,

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -61,7 +61,13 @@ function mimeFromName( name: string ): string {
 		return '';
 	}
 	const ext = name.slice( idx + 1 ).toLowerCase();
-	return PREVIEWABLE_TEXT_TYPES[ ext ] ?? '';
+	// Not `?? ''`: the map is an object literal, so `a.__proto__` and
+	// `a.constructor` resolve through the prototype chain to values that are
+	// neither null nor undefined. They would preview, and the non-string would
+	// reach `<dd>{ mimeType }</dd>` and throw "Objects are not valid as a React
+	// child", taking the panel down instead of showing "Preview unavailable".
+	const mime = PREVIEWABLE_TEXT_TYPES[ ext ];
+	return typeof mime === 'string' ? mime : '';
 }
 
 type Props = {
@@ -72,8 +78,8 @@ type Props = {
 /**
  * Renders the preview slot's body: a spinner while loading, the file
  * contents in a `<pre>` when available, a muted line when the fetch
- * failed, or a generic "preview unavailable" muted line for non-text
- * mime types.
+ * failed, or a generic "preview unavailable" muted line when the
+ * filename's extension is not one this card can render.
  *
  * The error branch says nothing about *why*, on purpose. It used to
  * blame blob storage having outlived the manifest entry, which was
@@ -87,7 +93,7 @@ type Props = {
  * unique render paths the linter can reason about.
  *
  * @param props             - Component props.
- * @param props.showPreview - Whether the file's mime type is renderable as text.
+ * @param props.showPreview - Whether the filename's extension is in the previewable map.
  * @param props.isLoading   - Whether the file-contents query is in flight.
  * @param props.content     - The fetched body, or null when not yet resolved.
  * @param props.error       - The fetch error, or null on success.

--- a/projects/packages/backup/src/dashboard/hooks/use-file-contents.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-file-contents.ts
@@ -39,7 +39,7 @@ function encodeManifestPath( manifestPath: string ): string {
  *
  * @param filePeriod   - The file's own snapshot timestamp (from /ls `period`).
  * @param manifestPath - The volume-prefixed manifest path (from /ls `manifest_path`, e.g. `f5:/wp-config.php`). Base64-encoded before sending.
- * @param enabled      - When false, the query is skipped (e.g. binary mime types).
+ * @param enabled      - When false, the query is skipped (an extension the preview card cannot render).
  * @return Content + loading state.
  */
 export function useFileContents(

--- a/projects/packages/backup/tests/file-preview-types.test.tsx
+++ b/projects/packages/backup/tests/file-preview-types.test.tsx
@@ -1,0 +1,113 @@
+// The card decides previewability from the file's extension. Two
+// allowlists used to make that decision — an extension→mime map, then a
+// narrower mime check — and `.js`, `.xml` and `.svg` passed the first and
+// failed the second. Each showed its own mime type on the `Type:` row and
+// "Preview unavailable" underneath it, in the same card.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FileBrowser, { EMPTY_FILE_SELECTION } from '../src/dashboard/components/file-browser';
+import { queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+
+/** Selection is irrelevant here; the rows render regardless. */
+const noop = () => {};
+
+const PREVIEW_BODY = 'console.log( "hello" );';
+
+/** One backup root holding a file per extension under test. */
+const CONTENTS = {
+	'app.js': { type: 'file', period: '1786644531', manifest_path: 'f5:/app.js' },
+	'sitemap.xml': { type: 'file', period: '1786644531', manifest_path: 'f5:/sitemap.xml' },
+	'logo.svg': { type: 'file', period: '1786644531', manifest_path: 'f5:/logo.svg' },
+	'readme.txt': { type: 'file', period: '1786644531', manifest_path: 'f5:/readme.txt' },
+	'photo.heic': { type: 'file', period: '1786644531', manifest_path: 'f5:/photo.heic' },
+};
+
+/**
+ * Open the named file's info card. Only one card is open at a time, so
+ * the assertions that follow can read the whole screen.
+ *
+ * @param name - Filename as it appears in the tree.
+ */
+async function openFile( name: string ): Promise< void > {
+	render(
+		<QueryClientProvider>
+			<FileBrowser
+				rewindId="1786644531.123"
+				selection={ EMPTY_FILE_SELECTION }
+				onSelectionChange={ noop }
+			/>
+		</QueryClientProvider>
+	);
+
+	await userEvent.click( await screen.findByRole( 'button', { name: `File: ${ name }` } ) );
+	await expect( screen.findByRole( 'heading', { name, level: 4 } ) ).resolves.toBeInTheDocument();
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockApiFetch.mockImplementation( ( options: { path: string } ) => {
+		if ( options.path.includes( '/rewind/backup/file-content' ) ) {
+			return Promise.resolve( { content: PREVIEW_BODY } );
+		}
+		if ( options.path.includes( '/rewind/backup/path-info' ) ) {
+			return Promise.resolve( { size: 42 } );
+		}
+		return Promise.resolve( { contents: CONTENTS } );
+	} );
+} );
+
+describe( 'file preview types', () => {
+	// The premise: `.txt` already previewed before this change, so a
+	// passing `.js` case below is about the extension, not about the
+	// preview slot working at all.
+	it( 'previews a .txt file', async () => {
+		await openFile( 'readme.txt' );
+
+		await expect( screen.findByText( PREVIEW_BODY ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'text/plain' ) ).toBeInTheDocument();
+	} );
+
+	it.each( [
+		[ 'app.js', 'application/javascript' ],
+		[ 'sitemap.xml', 'application/xml' ],
+		[ 'logo.svg', 'image/svg+xml' ],
+	] )( 'previews %s and labels it %s', async ( name, mime ) => {
+		await openFile( name );
+
+		await expect( screen.findByText( PREVIEW_BODY ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( mime ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Preview unavailable for this file.' ) ).not.toBeInTheDocument();
+	} );
+
+	// The card must still refuse formats it cannot render as text, or the
+	// fix above would have swapped one wrong answer for another: raw bytes
+	// in a `<pre>`.
+	it( 'refuses a file whose extension is not a text format', async () => {
+		await openFile( 'photo.heic' );
+
+		expect( screen.getByText( 'Preview unavailable for this file.' ) ).toBeInTheDocument();
+		expect( screen.queryByText( PREVIEW_BODY ) ).not.toBeInTheDocument();
+	} );
+
+	// `showPreview` also gates the query, so an unpreviewable file must
+	// not spend a request fetching bytes nothing will render.
+	it( 'does not request contents for an unpreviewable file', async () => {
+		await openFile( 'photo.heic' );
+
+		const paths = mockApiFetch.mock.calls.map( ( [ options ] ) => options.path );
+		expect( paths.some( ( path: string ) => path.includes( 'file-content' ) ) ).toBe( false );
+	} );
+} );

--- a/projects/packages/backup/tests/file-preview-types.test.tsx
+++ b/projects/packages/backup/tests/file-preview-types.test.tsx
@@ -23,6 +23,12 @@ const noop = () => {};
 
 const PREVIEW_BODY = 'console.log( "hello" );';
 
+// Real markup, so the SVG case can assert the card shows the source rather
+// than rendering it. Kept to one line: Testing Library normalizes whitespace
+// before matching, so a multi-line fixture would match on shape it does not
+// actually have.
+const SVG_BODY = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>';
+
 /** One backup root holding a file per extension under test. */
 const CONTENTS = {
 	'app.js': { type: 'file', period: '1786644531', manifest_path: 'f5:/app.js' },
@@ -30,6 +36,11 @@ const CONTENTS = {
 	'logo.svg': { type: 'file', period: '1786644531', manifest_path: 'f5:/logo.svg' },
 	'readme.txt': { type: 'file', period: '1786644531', manifest_path: 'f5:/readme.txt' },
 	'photo.heic': { type: 'file', period: '1786644531', manifest_path: 'f5:/photo.heic' },
+	'weird.__proto__': {
+		type: 'file',
+		period: '1786644531',
+		manifest_path: 'f5:/weird.__proto__',
+	},
 };
 
 /**
@@ -60,7 +71,15 @@ beforeEach( () => {
 	mockApiFetch.mockReset();
 	mockApiFetch.mockImplementation( ( options: { path: string } ) => {
 		if ( options.path.includes( '/rewind/backup/file-content' ) ) {
-			return Promise.resolve( { content: PREVIEW_BODY } );
+			// The route carries the manifest path base64-encoded, so decode it
+			// to answer per file rather than handing every file one body.
+			const encoded = new URL( options.path, 'https://example.test' ).searchParams.get(
+				'encoded_manifest_path'
+			);
+			const path = encoded ? atob( encoded ) : '';
+			return Promise.resolve( {
+				content: path.endsWith( '.svg' ) ? SVG_BODY : PREVIEW_BODY,
+			} );
 		}
 		if ( options.path.includes( '/rewind/backup/path-info' ) ) {
 			return Promise.resolve( { size: 42 } );
@@ -81,15 +100,35 @@ describe( 'file preview types', () => {
 	} );
 
 	it.each( [
-		[ 'app.js', 'application/javascript' ],
-		[ 'sitemap.xml', 'application/xml' ],
-		[ 'logo.svg', 'image/svg+xml' ],
-	] )( 'previews %s and labels it %s', async ( name, mime ) => {
+		[ 'app.js', 'application/javascript', PREVIEW_BODY ],
+		[ 'sitemap.xml', 'application/xml', PREVIEW_BODY ],
+		[ 'logo.svg', 'image/svg+xml', SVG_BODY ],
+	] )( 'previews %s and labels it %s', async ( name, mime, body ) => {
 		await openFile( name );
 
-		await expect( screen.findByText( PREVIEW_BODY ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( body ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( mime ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Preview unavailable for this file.' ) ).not.toBeInTheDocument();
+	} );
+
+	// The case above only proves an extension in the map previews. `.svg` is in
+	// the map on the understanding that the card shows the source and never
+	// renders the image, and nothing above would notice that changing: swapping
+	// the `<pre>` for `dangerouslySetInnerHTML`, or adding an `<img>` branch on
+	// `image/*`, keeps every other test green.
+	it( 'shows SVG source as text and never parses it into markup', async () => {
+		await openFile( 'logo.svg' );
+
+		const pre = await screen.findByText( SVG_BODY );
+
+		// React escapes string children, so the markup arrives as entities. Were
+		// the source injected instead, it would arrive as real tags and a
+		// `<rect>` element would exist. Asserting on this element's own HTML
+		// rather than querying the container for `svg` matters -- the card's
+		// close button draws one, so a container-wide query always finds it.
+		expect( pre.tagName ).toBe( 'PRE' );
+		expect( pre.innerHTML ).toContain( '&lt;svg' );
+		expect( pre.innerHTML ).not.toContain( '<rect' );
 	} );
 
 	// The card must still refuse formats it cannot render as text, or the
@@ -100,6 +139,17 @@ describe( 'file preview types', () => {
 
 		expect( screen.getByText( 'Preview unavailable for this file.' ) ).toBeInTheDocument();
 		expect( screen.queryByText( PREVIEW_BODY ) ).not.toBeInTheDocument();
+	} );
+
+	// The map is an object literal, so a plain `map[ ext ]` lookup reaches the
+	// prototype chain. `__proto__` and `constructor` are the two extensions that
+	// resolve to something non-null there, and the value is not a string -- so
+	// without an own-value check this both previews and throws "Objects are not
+	// valid as a React child" when the mime reaches the `Type:` row.
+	it( 'refuses an extension that only resolves through the prototype chain', async () => {
+		await openFile( 'weird.__proto__' );
+
+		expect( screen.getByText( 'Preview unavailable for this file.' ) ).toBeInTheDocument();
 	} );
 
 	// `showPreview` also gates the query, so an unpreviewable file must


### PR DESCRIPTION
Fixes JETPACK-2324

## Proposed changes

* Let `.js`, `.xml` and `.svg` preview in the modernized dashboard's file browser.

The card decided previewability with two allowlists in series: an extension-to-mime map, then a narrower `isTextual()` check over the result. Those three extensions passed the first and failed the second, so each card showed its own mime type on the `Type:` row and "Preview unavailable for this file." directly underneath it — the same contradiction class as the detail heading fixed in #51404.

This deletes the second allowlist. Membership in the map is now the whole rule, and the map is renamed to say so. Nothing in it is binary, so nothing that reaches the `<pre>` is unrenderable.

`.svg` previews as **source text**, not as a rendered image. That is what the proxy returns, and it also keeps a hostile SVG out of the DOM. Calypso renders SVG as an `<img>`; this dashboard deliberately does not.

No-op while the modernization filter is off, which it is by default.

### Not changed here

Extensions absent from the map still do not preview — `scss`, `less`, `ts`, `tsx`, `ini`, `env` and similar, plus dotfiles such as `.htaccess` (the dot sits at index 0, so no extension is parsed). Calypso's set differs in both directions: it covers `scss`/`sass`/`less`, and does not cover `xml`, `json`, `sql` or `csv`. Widening the map is a separate decision, deliberately left out.

## Related product discussion/links

* JETPACK-2324

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The modernized dashboard is behind `rsm_jetpack_ui_modernization_backup`, off by default. Force it on:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

Then build the package (`jetpack build packages/backup`) and go to **Jetpack → VaultPress Backup**. Pick a backup in the left list, then use the **Files** browser in the detail pane.

**Automated:**

```
jetpack test js packages/backup
```

`tests/file-preview-types.test.tsx` is the new suite. It was mutation-checked both ways: restoring the old `isTextual()` exclusion fails exactly the three extension cases and leaves the `.txt` control passing; forcing `showPreview = true` fails only the two refusal cases.

**Verified on a live site** (local Docker + Jurassic Ninja tunnel, real VaultPress manifest, filter forced on). Expand **wp-content → languages** and click:

* a `.po` file → previews, `Type: text/plain`
* a `.mo` file → "Preview unavailable for this file.", no `Type:` row

Then at the backup root, click `.htaccess` → refuses, which is the dotfile gap noted above.

**Not verified on a live screen — please check if you have a suitable backup.** The site I tested against has no `.js`, `.xml` or `.svg` anywhere in its manifest: VaultPress collapses unmodified themes and plugins to a single `*unchanged` entry, and this site's uploads are all `.jpg`. So the three extensions this PR is actually about rest on the unit tests, not on a screenshot. If you have a backup containing any of them, clicking one should now show its contents in a monospace block instead of "Preview unavailable", with the matching mime on the `Type:` row (`application/javascript`, `application/xml`, `image/svg+xml`).

For an SVG, confirm you see the markup as text — the image must not render.
