### PR TITLE
My Jetpack: use Linkbutton instead of Button for links

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
@@ -22,12 +22,15 @@ const variantMap = {
 	primary: 'solid',
 	secondary: 'outline',
 	tertiary: 'minimal',
+	link: 'unstyled',
 } as const;
 
 const sizeMap = {
 	normal: 'default',
 	compact: 'compact',
 } as const;
+
+type UiButtonVariant = ( typeof variantMap )[ keyof typeof variantMap ];
 
 const SecondaryButton: FC< SecondaryButtonProps > = props => {
 	const {
@@ -65,7 +68,7 @@ const SecondaryButton: FC< SecondaryButtonProps > = props => {
 		);
 	}
 
-	const mappedVariant = variant === 'link' ? 'unstyled' : variantMap[ variant ];
+	const mappedVariant: UiButtonVariant = variantMap[ variant ];
 
 	const sharedProps = {
 		variant: mappedVariant,

--- a/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/secondary-button.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { Button, Link } from '@wordpress/ui';
+import { Button, Link, LinkButton } from '@wordpress/ui';
 import type { FC, MouseEvent } from 'react';
 
 export type SecondaryButtonProps = {
@@ -50,11 +50,11 @@ const SecondaryButton: FC< SecondaryButtonProps > = props => {
 		return null;
 	}
 
-	if ( variant === 'link' ) {
+	if ( variant === 'link' && href ) {
 		return (
 			<Link
 				id={ id }
-				href={ href ?? '#' }
+				href={ href }
 				openInNewTab={ isExternalLink }
 				onClick={ onClick }
 				className={ className }
@@ -65,43 +65,37 @@ const SecondaryButton: FC< SecondaryButtonProps > = props => {
 		);
 	}
 
+	const mappedVariant = variant === 'link' ? 'unstyled' : variantMap[ variant ];
+
 	const sharedProps = {
-		variant: variantMap[ variant ],
+		variant: mappedVariant,
 		size: sizeMap[ size ],
-		disabled,
-		loading: isLoading,
-		loadingAnnouncement,
 		onClick,
 		className,
 		id,
 		'aria-labelledby': ariaLabelledBy,
 	};
 
-	// @wordpress/ui's Button can't natively render as an anchor, so when we need
-	// a link we keep the Button chrome and swap the element via render={<a/>}.
-	// Revisit this once a first-class LinkButton exists upstream:
-	// https://github.com/WordPress/gutenberg/issues/77098
-	if ( href ) {
+	// A loading or disabled control isn't navigable, so keep a real Button for
+	// the spinner / disabled chrome. Otherwise LinkButton owns href natively.
+	if ( href && ! isLoading && ! disabled ) {
 		return (
-			<Button
-				{ ...sharedProps }
-				nativeButton={ false }
-				render={
-					<a
-						href={ href }
-						{ ...( isExternalLink && {
-							target: '_blank',
-							rel: 'noopener noreferrer',
-						} ) }
-					/>
-				}
-			>
+			<LinkButton { ...sharedProps } href={ href } openInNewTab={ isExternalLink }>
 				{ label }
-			</Button>
+			</LinkButton>
 		);
 	}
 
-	return <Button { ...sharedProps }>{ label }</Button>;
+	return (
+		<Button
+			{ ...sharedProps }
+			disabled={ disabled }
+			loading={ isLoading }
+			loadingAnnouncement={ loadingAnnouncement }
+		>
+			{ label }
+		</Button>
+	);
 };
 
 export default SecondaryButton;

--- a/projects/packages/my-jetpack/_inc/components/module-toggle/test/index.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/module-toggle/test/index.test.tsx
@@ -27,9 +27,24 @@ jest.mock( '@wordpress/components', () => {
 
 jest.mock( '@wordpress/ui', () => {
 	const react = jest.requireActual( 'react' );
+	const Anchor = ( { children, ...props } ) => {
+		// Anchor-only props that shouldn't land on the DOM node.
+		delete props.variant;
+		delete props.tone;
+		delete props.size;
+		delete props.openInNewTab;
+		delete props.nativeButton;
+		delete props.loading;
+		delete props.loadingAnnouncement;
+		return react.createElement( 'a', props, children );
+	};
 	return {
 		Button: ( { children, render: renderProp, ...props } ) => {
 			// Button-only props that shouldn't land on the DOM node.
+			delete props.variant;
+			delete props.tone;
+			delete props.size;
+			delete props.openInNewTab;
 			delete props.nativeButton;
 			delete props.loading;
 			delete props.loadingAnnouncement;
@@ -37,7 +52,8 @@ jest.mock( '@wordpress/ui', () => {
 				? react.cloneElement( renderProp, props, children )
 				: react.createElement( 'button', props, children );
 		},
-		Link: ( { children, ...props } ) => react.createElement( 'a', props, children ),
+		Link: Anchor,
+		LinkButton: Anchor,
 	};
 } );
 

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/product-interstitial-modal-cta.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial-modal/product-interstitial-modal-cta.tsx
@@ -1,6 +1,6 @@
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
+import { Button, LinkButton } from '@wordpress/ui';
 import { useCallback, type FC } from 'react';
 import useProduct from '../../data/products/use-product';
 import { getMyJetpackWindowInitialState } from '../../data/utils/get-my-jetpack-window-state';
@@ -77,26 +77,16 @@ const ProductInterstitialModalCta: FC< ProductInterstitialModalCtaProps > = ( {
 	const isLoading = isProductLoading || hasMainCheckoutStarted;
 	const label = buttonLabel || __( 'Upgrade', 'jetpack-my-jetpack' );
 
-	if ( href ) {
+	if ( href && ! isDisabled && ! isLoading ) {
 		return (
-			<Button
+			<LinkButton
 				variant="solid"
-				loading={ isLoading }
+				href={ href }
+				openInNewTab={ isExternalLink }
 				onClick={ mainCheckoutRedirect }
-				disabled={ isDisabled }
-				nativeButton={ false }
-				render={
-					<a
-						href={ href }
-						{ ...( isExternalLink && {
-							target: '_blank',
-							rel: 'noopener noreferrer',
-						} ) }
-					/>
-				}
 			>
 				{ label }
-			</Button>
+			</LinkButton>
 		);
 	}
 

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/more-requests.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/jetpack-ai/more-requests.jsx
@@ -9,11 +9,11 @@ import {
 	H3,
 	getRedirectUrl,
 } from '@automattic/jetpack-components';
+import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
+import { LinkButton } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback } from 'react';
-import { Link } from 'react-router';
 /**
  * Internal dependencies
  */
@@ -66,20 +66,16 @@ export function JetpackAIInterstitialMoreRequests( { onClickGoBack = () => {} } 
 									<H3>{ title }</H3>
 									<Text mb={ 3 }>{ longDescription }</Text>
 									<div className={ styles[ 'buttons-row' ] }>
-										<Button
-											nativeButton={ false }
-											render={ <a href={ contactHref } /> }
-											onClick={ trackClickHandler }
-										>
+										<LinkButton href={ contactHref } onClick={ trackClickHandler }>
 											{ __( 'Contact Us', 'jetpack-my-jetpack' ) }
-										</Button>
-										<Button
+										</LinkButton>
+										<LinkButton
 											variant="outline"
-											nativeButton={ false }
-											render={ <Link to="/products" onClick={ onClickGoBack } /> }
+											href={ getMyJetpackUrl( '#/products' ) }
+											onClick={ onClickGoBack }
 										>
 											{ __( 'Back', 'jetpack-my-jetpack' ) }
-										</Button>
+										</LinkButton>
 									</div>
 								</div>
 							</div>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
@@ -15,7 +15,7 @@ import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { getScriptData, getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
+import { Button, LinkButton } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 /**
  * Internal dependencies
@@ -389,15 +389,14 @@ export default function PricingInterstitial( { slug } ) {
 				/>
 			}
 			actions={
-				<Button
+				<LinkButton
 					size="compact"
 					variant="outline"
-					nativeButton={ false }
-					render={ <a href={ getMyJetpackUrl( '#/add-license' ) } /> }
+					href={ getMyJetpackUrl( '#/add-license' ) }
 					onClick={ handleLicenseActivationClick }
 				>
 					{ __( 'Use license key', 'jetpack-my-jetpack' ) }
-				</Button>
+				</LinkButton>
 			}
 		>
 			<Container

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
@@ -4,7 +4,7 @@
 import { AdminPage, Col, Container, TermsOfService } from '@automattic/jetpack-components';
 import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
+import { LinkButton } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useEffect } from 'react';
 /**
@@ -210,14 +210,9 @@ export default function ProductInterstitial( {
 			}
 			actions={
 				existingLicenseKeyUrl ? (
-					<Button
-						size="compact"
-						variant="outline"
-						nativeButton={ false }
-						render={ <a href={ existingLicenseKeyUrl } /> }
-					>
+					<LinkButton size="compact" variant="outline" href={ existingLicenseKeyUrl }>
 						{ __( 'Use license key', 'jetpack-my-jetpack' ) }
-					</Button>
+					</LinkButton>
 				) : null
 			}
 		>

--- a/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
@@ -158,23 +158,21 @@ const StatsSection = () => {
 		recordEvent( 'jetpack_myjetpack_stats_card_seedetailedstats_click', {
 			product: slug,
 		} );
-
-		if ( ! manageUrl ) {
-			return;
-		}
-
-		// The Stats page caches its report, so the legacy link asks it to refresh.
-		// The dashboard fetches on load and has no such param.
-		window.location.href = premiumAnalyticsEnabled ? manageUrl : `${ manageUrl }&force_refresh=1`;
-	}, [ recordEvent, manageUrl, premiumAnalyticsEnabled ] );
+	}, [ recordEvent ] );
 
 	const shouldShowSecondaryButton = useCallback(
 		() => !! ( status === PRODUCT_STATUSES.CAN_UPGRADE && manageUrl ),
 		[ status, manageUrl ]
 	);
 
+	const viewStatsHref = ! manageUrl
+		? undefined
+		: premiumAnalyticsEnabled
+		? manageUrl
+		: `${ manageUrl }&force_refresh=1`;
+
 	const viewStatsButton = {
-		href: manageUrl,
+		href: viewStatsHref,
 		label: __( 'View detailed stats', 'jetpack-my-jetpack' ),
 		onClick: onDetailedStatsClick,
 		shouldShowButton: shouldShowSecondaryButton,

--- a/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
@@ -165,11 +165,8 @@ const StatsSection = () => {
 		[ status, manageUrl ]
 	);
 
-	const viewStatsHref = ! manageUrl
-		? undefined
-		: premiumAnalyticsEnabled
-		? manageUrl
-		: `${ manageUrl }&force_refresh=1`;
+	const viewStatsQuery = premiumAnalyticsEnabled ? '' : '&force_refresh=1';
+	const viewStatsHref = manageUrl ? `${ manageUrl }${ viewStatsQuery }` : undefined;
 
 	const viewStatsButton = {
 		href: viewStatsHref,

--- a/projects/packages/my-jetpack/_inc/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/style.module.scss
@@ -39,24 +39,6 @@
 		}
 	}
 
-	// Defend @wordpress/ui Button against wp-admin's unlayered anchor styles
-	// when Button renders as an <a> via nativeButton={false} + render={<a/>}.
-	// The root cause is that @wordpress/ui has no link-button component yet, so
-	// we render a Button-as-anchor; this whole block can go once one exists:
-	// https://github.com/WordPress/gutenberg/issues/77098
-	// @wordpress/ui's component rules live inside @layer wp-ui-components and
-	// per CSS Cascade Layers unlayered wp-admin rules like `a { color, …}`
-	// override them, so the rendered anchor inherits wp-admin's link color
-	// and underline instead of the Button's intended chrome — and worse,
-	// `is-loading { color: transparent }` also loses, so the label stays
-	// visible behind the spinner. `revert-layer` short-circuits the implicit
-	// unlayered layer entirely and falls back to the @wordpress/ui-computed
-	// value, picking up `is-loading` overrides for free.
-	#my-jetpack-container a[class*="__button"] {
-		color: revert-layer;
-		text-decoration: revert-layer;
-	}
-
 	#my-jetpack-container {
 		height: 100%;
 

--- a/projects/packages/my-jetpack/changelog/update-ui-link-button
+++ b/projects/packages/my-jetpack/changelog/update-ui-link-button
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Make product action and interstitial navigation buttons real links.


### PR DESCRIPTION


## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Replaces workaround of using [Button](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-button--docs) for links with appropiate new [LinkButton](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-linkbutton--docs) component.
* Undo any CSS overrides that were protecting `common.css` styles leaking into previous usage of button.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test My Jetpack instances I've touched; there should not be any visual or functional changes.
