### PR TITLE
Newsletter: use Linkbutton instead of Button for links

### DIFF
--- a/projects/packages/newsletter/changelog/update-ui-link-button
+++ b/projects/packages/newsletter/changelog/update-ui-link-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make writing-prompt, paid-plan, and subscribers-announcement actions real links.

--- a/projects/packages/newsletter/routes/subscribers-announcement/stage.tsx
+++ b/projects/packages/newsletter/routes/subscribers-announcement/stage.tsx
@@ -3,7 +3,7 @@ import { getSiteData } from '@automattic/jetpack-script-data';
 import { ToggleControl } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button, Notice, Text } from '@wordpress/ui';
+import { LinkButton, Notice, Text } from '@wordpress/ui';
 import './route.scss';
 
 /**
@@ -41,12 +41,6 @@ const Stage = (): JSX.Element => {
 	const data = getAnnouncementData();
 	const [ menuRemoved, setMenuRemoved ] = useState( Boolean( data?.menuRemoved ) );
 	const [ isSaving, setIsSaving ] = useState( false );
-
-	const goToNewsletter = useCallback( () => {
-		if ( data?.goToNewsletterUrl ) {
-			window.location.href = data.goToNewsletterUrl;
-		}
-	}, [ data?.goToNewsletterUrl ] );
 
 	const toggleMenu = useCallback(
 		( removed: boolean ) => {
@@ -105,9 +99,11 @@ const Stage = (): JSX.Element => {
 						{ __( 'Now it’s part of Jetpack → Newsletter', 'jetpack-newsletter' ) }
 					</Text>
 					<div className="jetpack-subscribers-announcement__cta">
-						<Button onClick={ goToNewsletter }>
-							{ __( 'View my subscribers', 'jetpack-newsletter' ) }
-						</Button>
+						{ data?.goToNewsletterUrl && (
+							<LinkButton href={ data.goToNewsletterUrl }>
+								{ __( 'View my subscribers', 'jetpack-newsletter' ) }
+							</LinkButton>
+						) }
 					</div>
 					<div className="jetpack-subscribers-announcement__remove">
 						<ToggleControl

--- a/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
@@ -52,7 +52,7 @@ export function PaidNewsletterSection( {
 				<Card.Title>{ __( 'Paid newsletter', 'jetpack-newsletter' ) }</Card.Title>
 			</Card.Header>
 			<Card.Content>
-				<Stack direction="column" gap="xl">
+				<Stack direction="column" gap="xl" align="start">
 					<Text variant="body-md" render={ <p /> }>
 						{ __(
 							'Earn money through your Newsletter. Reward your most loyal subscribers with exclusive content or add a paywall to monetize content.',

--- a/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/paid-newsletter-section.tsx
@@ -3,10 +3,9 @@
  */
 import analytics from '@automattic/jetpack-analytics';
 import { getSiteType } from '@automattic/jetpack-script-data';
-import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Card, Stack, Text } from '@wordpress/ui';
+import { Button, Card, LinkButton, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -18,14 +17,7 @@ interface PaidNewsletterSectionProps {
 }
 
 /**
- * Paid Newsletter Section Component
- *
- * Uses `@wordpress/components` Button + a native `<fieldset>` because this is
- * the one button-as-link case in the dashboard. WP UI's Button rendered as
- * `<a>` (`render={ <a /> }`) inherits wp-admin's global `a { color: #2271b1 }`
- * — that rule is unlayered, while WP UI's button color sits in
- * `@layer wp-ui-components`, and unlayered always wins over layered. Worth a
- * Gutenberg-side fix; out of scope for this PR.
+ * Paid Newsletter Section Component.
  *
  * @param {PaidNewsletterSectionProps} props - Component props
  * @return {JSX.Element | null} The paid newsletter section or null if URL not available
@@ -67,19 +59,20 @@ export function PaidNewsletterSection( {
 							'jetpack-newsletter'
 						) }
 					</Text>
-					<fieldset disabled={ ! isNewsletterEnabled }>
-						<Button
-							__next40pxDefaultSize
-							variant="primary"
+					{ isNewsletterEnabled ? (
+						<LinkButton
+							variant="solid"
 							href={ newsletterScriptData.setupPaymentPlansUrl }
-							target="_blank"
-							rel="noopener noreferrer"
-							disabled={ ! isNewsletterEnabled }
+							openInNewTab
 							onClick={ handlePaidPlansClick }
 						>
 							{ buttonText }
+						</LinkButton>
+					) : (
+						<Button variant="solid" disabled>
+							{ buttonText }
 						</Button>
-					</fieldset>
+					) }
 				</Stack>
 			</Card.Content>
 		</Card.Root>

--- a/projects/packages/newsletter/src/writing-prompt/writing-prompt.jsx
+++ b/projects/packages/newsletter/src/writing-prompt/writing-prompt.jsx
@@ -17,7 +17,7 @@ import {
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { arrowLeft, arrowRight } from '@wordpress/icons';
-import { Button, IconButton, Link, Stack, Text } from '@wordpress/ui';
+import { IconButton, Link, LinkButton, Stack, Text } from '@wordpress/ui';
 import { addQueryArgs } from '@wordpress/url';
 
 export default () => {
@@ -55,12 +55,11 @@ export default () => {
 
 	const goToPrevious = useCallback( () => setIndex( current => current - 1 ), [] );
 	const goToNext = useCallback( () => setIndex( current => current + 1 ), [] );
-	const postAnswer = useCallback( () => {
+	const recordPostAnswerClick = useCallback( () => {
 		analytics.tracks.recordEvent( 'jetpack_newsletter_writing_prompt_post_answer_click', {
 			site_type: siteType,
 			prompt_id: prompts[ index ].id,
 		} );
-		document.location = `post-new.php?answer_prompt=${ prompts[ index ].id }`;
 	}, [ prompts, index, siteType ] );
 	const recordViewResponsesClick = useCallback( () => {
 		analytics.tracks.recordEvent( 'jetpack_newsletter_writing_prompt_view_responses_click', {
@@ -136,9 +135,14 @@ export default () => {
 						</Stack>
 					</Stack>
 					<Stack direction="row" justify="space-between" align="center" gap="sm" wrap="wrap">
-						<Button variant="outline" size="compact" onClick={ postAnswer }>
+						<LinkButton
+							variant="outline"
+							size="compact"
+							href={ `post-new.php?answer_prompt=${ prompt.id }` }
+							onClick={ recordPostAnswerClick }
+						>
 							{ __( 'Post your answer', 'jetpack-newsletter' ) }
-						</Button>
+						</LinkButton>
 						{ prompt.answered_users_sample.length > 0 && (
 							<Stack
 								className="wpcom-daily-writing-prompt--answered-users"

--- a/projects/packages/newsletter/tests/writing-prompt.test.tsx
+++ b/projects/packages/newsletter/tests/writing-prompt.test.tsx
@@ -110,7 +110,7 @@ describe( 'WritingPrompt widget empty state', () => {
 		).toHaveAttribute( 'href', 'https://wordpress.com/reader?origin_site_id=12345' );
 
 		// None of the prompt-only controls should render without a prompt.
-		expect( screen.queryByRole( 'button', { name: 'Post your answer' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: 'Post your answer' } ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: /Next/ } ) ).not.toBeInTheDocument();
 	} );
 
@@ -423,24 +423,22 @@ describe( 'WritingPrompt widget analytics', () => {
 	it( 'records a post-answer event with the prompt id when Post your answer is clicked', async () => {
 		render( <WritingPrompt /> );
 
-		const postAnswerButton = await screen.findByRole( 'button', { name: 'Post your answer' } );
-		postAnswerButton.click();
+		const postAnswerLink = await screen.findByRole( 'link', { name: 'Post your answer' } );
+		expect( postAnswerLink ).toHaveAttribute( 'href', 'post-new.php?answer_prompt=1' );
+		postAnswerLink.addEventListener( 'click', event => event.preventDefault() );
+		postAnswerLink.click();
 
 		expect( mockRecordEvent ).toHaveBeenCalledWith(
 			'jetpack_newsletter_writing_prompt_post_answer_click',
 			{ site_type: 'jetpack', prompt_id: 1 }
 		);
-
-		// Posting an answer assigns document.location to navigate to the editor;
-		// jsdom cannot perform that navigation and logs an expected error, which
-		// @wordpress/jest-console requires us to acknowledge.
-		expect( console ).toHaveErrored();
 	} );
 
 	it( 'records a view-responses event with the prompt id when View responses is clicked', async () => {
 		render( <WritingPrompt /> );
 
 		const responsesLink = await screen.findByRole( 'link', { name: /View responses/ } );
+		responsesLink.addEventListener( 'click', event => event.preventDefault() );
 		responsesLink.click();
 
 		expect( mockRecordEvent ).toHaveBeenCalledWith(
@@ -455,6 +453,7 @@ describe( 'WritingPrompt widget analytics', () => {
 		const readerLink = await screen.findByRole( 'link', {
 			name: /Read the blogs and topics you follow/,
 		} );
+		readerLink.addEventListener( 'click', event => event.preventDefault() );
 		readerLink.click();
 
 		expect( mockRecordEvent ).toHaveBeenCalledWith(


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->

*  Replaces workaround of using [Button](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-button--docs) for links with appropiate new [LinkButton](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-linkbutton--docs) component.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test Newsletter settings (setting up paid newsletter) and Subscriber management UIs ("View my subscribers" button)
* Test Writing prompt widget ("Post your answer" button) 
* There should not be any visual or functional changes.