### PR TITLE
Podcasting: use Linkbutton instead of Button for links

### DIFF
--- a/projects/packages/podcast/changelog/update-ui-link-button
+++ b/projects/packages/podcast/changelog/update-ui-link-button
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Make Create episode, Connect Jetpack, and welcome upgrade actions real links.

--- a/projects/packages/podcast/src/dashboard/connect-prompt/index.tsx
+++ b/projects/packages/podcast/src/dashboard/connect-prompt/index.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { Icon, link } from '@wordpress/icons';
-import { Button, Card, Stack, Text } from '@wordpress/ui';
+import { Card, LinkButton, Stack, Text } from '@wordpress/ui';
 import { getConnectUrl } from '../connection';
 import './style.scss';
 
@@ -41,13 +41,9 @@ const ConnectPrompt = ( { variant }: { variant: ConnectPromptVariant } ) => {
 							{ description }
 						</Text>
 					</Stack>
-					<Button
-						variant="solid"
-						className="podcast-connect-prompt__cta"
-						render={ <a href={ getConnectUrl() } /> }
-					>
+					<LinkButton variant="solid" href={ getConnectUrl() }>
 						{ __( 'Connect Jetpack', 'jetpack-podcast' ) }
-					</Button>
+					</LinkButton>
 				</Stack>
 			</Card.Content>
 		</Card.Root>

--- a/projects/packages/podcast/src/dashboard/connect-prompt/style.scss
+++ b/projects/packages/podcast/src/dashboard/connect-prompt/style.scss
@@ -19,15 +19,4 @@
 		max-width: 420px;
 		color: var(--jp-gray-50, #646970);
 	}
-
-	a#{&}__cta {
-
-		&,
-		&:hover,
-		&:focus,
-		&:active {
-			color: var(--wp-ui-button-foreground-color);
-			-webkit-text-fill-color: var(--wp-ui-button-foreground-color);
-		}
-	}
 }

--- a/projects/packages/podcast/src/dashboard/episodes/index.tsx
+++ b/projects/packages/podcast/src/dashboard/episodes/index.tsx
@@ -8,6 +8,7 @@ import { useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
+import { LinkButton } from '@wordpress/ui';
 import { usePodcastSettings } from '../hooks/use-podcast-settings';
 import LockedPreview from '../locked-preview';
 import './style.scss';
@@ -32,9 +33,9 @@ const EmptyEpisodes = () => (
 		<p>
 			{ __( 'Publish a podcast post in your chosen category to see it here.', 'jetpack-podcast' ) }
 		</p>
-		<Button variant="primary" href={ NEW_EPISODE_URL }>
+		<LinkButton variant="solid" href={ NEW_EPISODE_URL }>
 			{ __( 'Create episode', 'jetpack-podcast' ) }
-		</Button>
+		</LinkButton>
 	</div>
 );
 

--- a/projects/packages/podcast/src/dashboard/index.tsx
+++ b/projects/packages/podcast/src/dashboard/index.tsx
@@ -6,7 +6,7 @@ import { Spinner } from '@wordpress/components';
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
-import { Button, Tabs } from '@wordpress/ui';
+import { LinkButton, Tabs } from '@wordpress/ui';
 import { initializeAnalytics, recordDashboardView } from './analytics';
 import { isSiteConnected } from './connection';
 import ErrorBoundary from './error-boundary';
@@ -230,18 +230,13 @@ const App = () => {
 
 	// Same destination + label for every plan; `New_Episode_Prefill` keys off `?podcast_episode=1`.
 	const headerActions = isSetUp ? (
-		<Button
+		<LinkButton
 			size="compact"
 			variant="solid"
-			render={
-				<a
-					className="podcast__header-cta"
-					href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }
-				/>
-			}
+			href={ getAdminUrl( 'post-new.php?podcast_episode=1' ) }
 		>
 			{ __( 'Create episode', 'jetpack-podcast' ) }
-		</Button>
+		</LinkButton>
 	) : undefined;
 
 	return (

--- a/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
+++ b/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
@@ -1,9 +1,9 @@
 // Locked-preview UX for Episodes + Stats on free plans. Renders a blurred,
 // non-language skeleton of the gated content behind a centered upgrade card.
 
-import { Button } from '@wordpress/components';
 import { useId } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { LinkButton } from '@wordpress/ui';
 import { buildUpgradeCheckoutUrl, getUpgradePlanName } from '../upgrade';
 import './style.scss';
 
@@ -131,8 +131,8 @@ const LockedPreview = ( { variant }: LockedPreviewProps ) => {
 						{ title }
 					</h2>
 					<p className="podcast-locked-preview__description">{ description }</p>
-					<Button
-						variant="primary"
+					<LinkButton
+						variant="solid"
 						href={ checkoutUrl }
 						className="podcast-locked-preview__cta"
 						// eslint-disable-next-line jsx-a11y/no-autofocus
@@ -143,7 +143,7 @@ const LockedPreview = ( { variant }: LockedPreviewProps ) => {
 							__( 'Upgrade to %s', 'jetpack-podcast' ),
 							planName
 						) }
-					</Button>
+					</LinkButton>
 				</div>
 			</div>
 		</div>

--- a/projects/packages/podcast/src/dashboard/locked-preview/style.scss
+++ b/projects/packages/podcast/src/dashboard/locked-preview/style.scss
@@ -55,10 +55,9 @@ $bar-fill-soft: rgba(34, 113, 177, 0.18);
 		line-height: 1.4;
 	}
 
-	&__cta.components-button.is-primary {
+	&__cta {
 		// Match other primary CTAs in the dashboard.
 		min-width: 160px;
-		justify-content: center;
 	}
 
 	// --- Episodes preview table ---------------------------------------------

--- a/projects/packages/podcast/src/dashboard/style.scss
+++ b/projects/packages/podcast/src/dashboard/style.scss
@@ -12,17 +12,6 @@ body.jetpack_page_jetpack-podcast {
 	padding: 48px 0;
 }
 
-// The header CTA is a WP UI solid Button rendered as an `<a>`. wp-admin's
-// unlayered `a`/`a:hover` color beats the button's layered foreground, so
-// re-pin its own color across states with enough specificity to win out. A
-// solid Button keeps one foreground color throughout.
-.podcast__header-cta,
-.podcast__header-cta:hover,
-.podcast__header-cta:focus,
-.podcast__header-cta:active {
-	color: var(--wp-ui-button-foreground-color);
-}
-
 .podcast__tab-content {
 	box-sizing: border-box;
 }

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -1,7 +1,6 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { getAdminUrl, getSiteData, isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import {
-	Button,
 	Card,
 	CardBody,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -14,7 +13,7 @@ import {
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, globe, layout, megaphone } from '@wordpress/icons';
-import { LinkButton } from '@wordpress/ui';
+import { Button, LinkButton } from '@wordpress/ui';
 import { buildUpgradeCheckoutUrl, getUpgradePlanName } from '../upgrade';
 import './style.scss';
 
@@ -188,7 +187,7 @@ const Welcome = ( { onEnable, hasAccess }: WelcomeProps ) => {
 						</>
 					) }
 					<HStack justify="flex-start" expanded={ false }>
-						<Button variant="primary" onClick={ onEnable }>
+						<Button variant="solid" onClick={ onEnable }>
 							{ __( 'Set up podcasting', 'jetpack-podcast' ) }
 						</Button>
 					</HStack>
@@ -212,7 +211,7 @@ const Welcome = ( { onEnable, hasAccess }: WelcomeProps ) => {
 											) }
 										</Text>
 									</VStack>
-									<Button variant="secondary" onClick={ onEnable }>
+									<Button variant="outline" onClick={ onEnable }>
 										{ __( 'Start your podcast', 'jetpack-podcast' ) }
 									</Button>
 									<ul className="podcast__welcome-plan-features">

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -14,6 +14,7 @@ import {
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, globe, layout, megaphone } from '@wordpress/icons';
+import { LinkButton } from '@wordpress/ui';
 import { buildUpgradeCheckoutUrl, getUpgradePlanName } from '../upgrade';
 import './style.scss';
 
@@ -245,13 +246,17 @@ const Welcome = ( { onEnable, hasAccess }: WelcomeProps ) => {
 										</HStack>
 										<Text variant="muted">{ paidDescription }</Text>
 									</VStack>
-									<Button variant="primary" href={ upgradeCheckoutUrl } onClick={ onUpgradeClick }>
+									<LinkButton
+										variant="solid"
+										href={ upgradeCheckoutUrl }
+										onClick={ onUpgradeClick }
+									>
 										{ sprintf(
 											/* translators: %s is the plan name, e.g. "Growth" or "Premium". */
 											__( 'Start your %s podcast', 'jetpack-podcast' ),
 											planName
 										) }
-									</Button>
+									</LinkButton>
 									<ul className="podcast__welcome-plan-features">
 										{ paidFeatures.map( feature => (
 											<li key={ feature } className="podcast__welcome-plan-feature">


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Replaces workaround of using [Button](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-button--docs) for links with appropiate new [LinkButton](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-linkbutton--docs) component.
* While at it, replace a few `@wordpress/components` Button's with newer `@wordpress/ui` Buttons.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test Podcasting UI: check buttons for "Start your podcast", "Start your Growth/Premium podcast", "Connect Jetpack",  and "Create episode'" buttons.
* There should not be any functional or visual changes.