### PR TITLE
Forms: fix checkbox and consent field alignment in the editor on classic themes

### DIFF
--- a/projects/packages/forms/changelog/fix-checkbox-field-classic-themes
+++ b/projects/packages/forms/changelog/fix-checkbox-field-classic-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix checkbox and consent field alignment in the editor on classic themes.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -438,6 +438,11 @@
 		display: flex;
 		align-items: center;
 		justify-content: flex-start;
+		margin: unset; /* Override default margin on classic theme wp-block */
+
+		.wp-block {
+			margin: unset; /* Override default margin on classic theme wp-block */
+		}
 	}
 
 }

--- a/projects/plugins/jetpack/changelog/fix-checkbox-field-classic-themes
+++ b/projects/plugins/jetpack/changelog/fix-checkbox-field-classic-themes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Fix checkbox and consent field alignment in the editor on classic themes.


### PR DESCRIPTION
Fixes #

## Proposed changes

Classic themes (any theme with no `theme.json`) load core's `edit-post/classic.min.css` into the block editor, which gives every `.wp-block` a 28px vertical margin. Forms already zeroes that margin in several places, but the single **Checkbox** and **Consent** fields were missed: both hold a standalone `jetpack/option` block, and the existing reset at `[data-type="jetpack/field-checkbox-multiple"], [data-type="jetpack/field-radio"]` only covers the multiple-choice and single-choice fields. The result was a checkbox pushed 28px away from its own label in the editor.

* In `projects/packages/forms/src/blocks/contact-form/editor.scss`, zero the margin on `.jetpack-field .jetpack-field-option` and on the blocks nested inside it.
* Editor-only change — the front end never loads `classic.min.css`, so rendered output is unchanged.

## Related product discussion/links

* Follow-up to #51527, which zeroed the same classic-theme margin on field labels and the file dropzone.
* Related: #51302 (the regression that first surfaced this class of bug).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Activate a **classic theme with no `theme.json`** — Twenty Sixteen or Twenty Twenty works. The bug does not reproduce on a block theme such as Twenty Twenty-Four, because those never load core's `classic.min.css`.
2. Create a new post or page and add a **Form** block.
3. Add a **Checkbox** field to the form (Add Field → Checkbox).
4. **Before this change:** the checkbox sits roughly 28px above its label, with an obvious gap tearing the two apart.
   **After this change:** the checkbox and its label sit on one line, tight together, matching how they render on the front end.
5. Repeat with a **Terms/Consent** field — same before/after.
6. Sanity check that nothing else moved:
   * A **Multiple choice** and a **Single choice** field still lay out correctly (these were already covered by an existing rule).
   * View the published page on the front end — spacing should be identical before and after this PR, since the change is scoped to the editor.
7. Switch to a block theme (Twenty Twenty-Four) and confirm all of the above fields still look right there too.
