### PR TITLE
Stats: replace Button with LinkButton for a link

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-ui-link-button
+++ b/projects/packages/premium-analytics/changelog/update-ui-link-button
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Make the post-detail View post action a real link.

--- a/projects/packages/premium-analytics/packages/externals/src/index.ts
+++ b/projects/packages/premium-analytics/packages/externals/src/index.ts
@@ -71,6 +71,7 @@ export { DateRangeCalendar } from '@automattic/ui';
 export {
 	Button,
 	EmptyState,
+	LinkButton,
 	Field as FormField,
 	Fieldset,
 	Icon,

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -95,12 +95,3 @@
 	flex: 0 0 auto;
 	margin-inline-start: auto;
 }
-
-// The header action is a Button rendered as an anchor, so it can carry a real
-// href to the live post. @wordpress/ui styles the button inside `@layer wp-ui`,
-// and wp-admin colours bare anchors outside any cascade layer — unlayered wins
-// over layered whatever the specificity, so admin's link blue overrode the
-// button foreground. Re-apply the button's own colour from here (unlayered).
-.viewPost:any-link {
-	color: var(--wp-ui-button-foreground-color);
-}

--- a/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
@@ -188,7 +188,8 @@ describe( 'post detail stage', () => {
 
 		render( stage() );
 
-		const action = screen.getByRole( 'link', { name: 'View post' } );
+		// `openInNewTab` appends a screen-reader hint to the accessible name.
+		const action = screen.getByRole( 'link', { name: 'View post(opens in a new tab)' } );
 		expect( action ).toHaveAttribute( 'href', 'https://example.com/hello-world/' );
 		expect( action ).toHaveAttribute( 'target', '_blank' );
 		expect( action ).toHaveAttribute( 'rel', 'noopener noreferrer' );
@@ -199,11 +200,13 @@ describe( 'post detail stage', () => {
 
 		render( stage() );
 
-		expect( screen.getByRole( 'link', { name: 'View page' } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: 'View page(opens in a new tab)' } ) ).toHaveAttribute(
 			'href',
 			'https://example.com/about/'
 		);
-		expect( screen.queryByRole( 'link', { name: 'View post' } ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'link', { name: 'View post(opens in a new tab)' } )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'omits the action while the post URL is unresolved', () => {

--- a/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
@@ -213,7 +213,7 @@ describe( 'post detail stage', () => {
 
 		render( stage() );
 
-		expect( screen.queryByRole( 'link', { name: /^View (post|page)$/ } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: /^View (post|page)/ } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'omits the action when the post URL carries an unsupported scheme', () => {
@@ -221,7 +221,7 @@ describe( 'post detail stage', () => {
 
 		render( stage() );
 
-		expect( screen.queryByRole( 'link', { name: /^View (post|page)$/ } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: /^View (post|page)/ } ) ).not.toBeInTheDocument();
 	} );
 
 	// One declaration drives both halves: the panel reads it to drop the Compare

--- a/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
@@ -192,7 +192,6 @@ describe( 'post detail stage', () => {
 		const action = screen.getByRole( 'link', { name: 'View post(opens in a new tab)' } );
 		expect( action ).toHaveAttribute( 'href', 'https://example.com/hello-world/' );
 		expect( action ).toHaveAttribute( 'target', '_blank' );
-		expect( action ).toHaveAttribute( 'rel', 'noopener noreferrer' );
 	} );
 
 	it( 'labels the action View page for a page', () => {

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -3,7 +3,7 @@ import {
 	GlobalErrorProvider,
 	ReportScopeProvider,
 } from '@jetpack-premium-analytics/data';
-import { Button } from '@jetpack-premium-analytics/externals';
+import { LinkButton } from '@jetpack-premium-analytics/externals';
 import { useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import {
 	DateFiltersPanel,
@@ -142,19 +142,18 @@ function PostDetail(): JSX.Element {
 					breadcrumbs={ <StatsBreadcrumbs items={ breadcrumbs } /> }
 					actions={
 						publicUrl ? (
-							<Button
+							<LinkButton
 								variant="solid"
 								tone="neutral"
 								size="compact"
-								nativeButton={ false }
-								role="link"
 								className={ styles.viewPost }
-								render={ <a href={ publicUrl } target="_blank" rel="noopener noreferrer" /> }
+								href={ publicUrl }
+								openInNewTab
 							>
 								{ summary.type === 'page'
 									? __( 'View page', 'jetpack-premium-analytics-pkg' )
 									: __( 'View post', 'jetpack-premium-analytics-pkg' ) }
-							</Button>
+							</LinkButton>
 						) : undefined
 					}
 					className={ styles.page }

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -146,7 +146,6 @@ function PostDetail(): JSX.Element {
 								variant="solid"
 								tone="neutral"
 								size="compact"
-								className={ styles.viewPost }
 								href={ publicUrl }
 								openInNewTab
 							>


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Replaces workaround of using [Button](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-button--docs) for links with appropiate new [LinkButton](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-linkbutton--docs) component.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test "View page/post" button
* No visual/functional changes