### PR TITLE
Licensing: replace Button with LinkButton for links

### DIFF
--- a/projects/js-packages/licensing/changelog/update-ui-link-button
+++ b/projects/js-packages/licensing/changelog/update-ui-link-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make license activation success actions real links.

--- a/projects/js-packages/licensing/components/activation-screen-success-info/primary-link/index.jsx
+++ b/projects/js-packages/licensing/components/activation-screen-success-info/primary-link/index.jsx
@@ -1,6 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
+import { Button, LinkButton } from '@wordpress/ui';
 import PropTypes from 'prop-types';
 import useActivePlugins from '../../../hooks/use-active-plugins';
 import { getProductGroup } from '../../activation-screen/utils';
@@ -21,14 +21,6 @@ const PrimaryLink = props => {
 		productGroup === 'jetpack_social_advanced' || productGroup === 'jetpack_social_basic';
 	const isJetpackProtectActive = isPluginActive( 'Jetpack Protect' );
 
-	// The success-screen CTAs only navigate the current tab. Using onClick keeps
-	// a native @wordpress/ui <button> (so its styles render untouched) rather
-	// than rendering it as an anchor.
-	// TODO: replace these onClick navigations with @wordpress/ui `LinkButton` once it ships (Gutenberg #77098).
-	const navigateTo = url => () => {
-		window.location.href = url;
-	};
-
 	if ( isFetching ) {
 		return (
 			<Button
@@ -42,20 +34,20 @@ const PrimaryLink = props => {
 
 	if ( isJetpackSocialProduct && ( isJetpackActive || isJetpackSocialActive ) ) {
 		return (
-			<Button
+			<LinkButton
 				className="jp-license-activation-screen-success-info--button"
-				onClick={ navigateTo(
+				href={
 					siteAdminUrl +
-						( isJetpackActive
-							? 'admin.php?page=jetpack#/recommendations/' +
-							  ( productGroup === 'jetpack_social_advanced'
-									? 'welcome-social-advanced'
-									: 'welcome-social-basic' )
-							: 'admin.php?page=jetpack-social' )
-				) }
+					( isJetpackActive
+						? 'admin.php?page=jetpack#/recommendations/' +
+						  ( productGroup === 'jetpack_social_advanced'
+								? 'welcome-social-advanced'
+								: 'welcome-social-basic' )
+						: 'admin.php?page=jetpack-social' )
+				}
 			>
 				{ __( 'Configure my site', 'jetpack-licensing' ) }
-			</Button>
+			</LinkButton>
 		);
 	}
 
@@ -64,36 +56,34 @@ const PrimaryLink = props => {
 			? siteAdminUrl + 'admin.php?page=jetpack-protect'
 			: getRedirectUrl( 'jetpack-license-activation-success-scan', { site: siteRawUrl } );
 		return (
-			<Button
+			<LinkButton
 				className="jp-license-activation-screen-success-info--button"
-				onClick={ navigateTo( redirectSource ) }
+				href={ redirectSource }
 			>
 				{ __( 'View scan results', 'jetpack-licensing' ) }
-			</Button>
+			</LinkButton>
 		);
 	}
 
 	// If the user has not completed the first step of the Assistant, make the primary button link to it.
 	if ( currentRecommendationsStep === 'not-started' ) {
 		return (
-			<Button
+			<LinkButton
 				className="jp-license-activation-screen-success-info--button"
-				onClick={ navigateTo( siteAdminUrl + 'admin.php?page=jetpack#/recommendations' ) }
+				href={ siteAdminUrl + 'admin.php?page=jetpack#/recommendations' }
 			>
 				{ __( 'Configure my site', 'jetpack-licensing' ) }
-			</Button>
+			</LinkButton>
 		);
 	}
 
 	return (
-		<Button
+		<LinkButton
 			className="jp-license-activation-screen-success-info--button"
-			onClick={ navigateTo(
-				getRedirectUrl( 'license-activation-view-my-plans', { site: siteRawUrl } )
-			) }
+			href={ getRedirectUrl( 'license-activation-view-my-plans', { site: siteRawUrl } ) }
 		>
 			{ __( 'View my plans', 'jetpack-licensing' ) }
-		</Button>
+		</LinkButton>
 	);
 };
 


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/jetpack/pull/50348

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Replaces workaround of using [Button](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-button--docs) for links with appropiate new [LinkButton](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-linkbutton--docs) component.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* See initial instructions from https://github.com/Automattic/jetpack/pull/50348
* See buttons "View my plans", "Configure my site", "View scan results", and "Configure my site".
* No functional or visual changes