### PR TITLE
Forms: replace Button with LinkButton for links

### DIFF
--- a/projects/packages/forms/changelog/update-ui-link-button
+++ b/projects/packages/forms/changelog/update-ui-link-button
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Make form navigation actions real links.

--- a/projects/packages/forms/changelog/update-ui-link-button
+++ b/projects/packages/forms/changelog/update-ui-link-button
@@ -1,3 +1,4 @@
 Significance: patch
 Type: changed
-Comment: Make form navigation actions real links.
+
+Make form navigation actions real links so they can be opened in a new tab.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -1183,7 +1183,13 @@
 .jetpack-contact-form__responses-storage-panel,
 .jetpack-contact-form__integrations-panel {
 
-	.components-button.is-secondary {
+	/*
+	 * `LinkButton` renders an anchor with @wordpress/ui classes rather than
+	 * `.components-button`, so it needs naming here to stay full-width alongside
+	 * the panel's other buttons.
+	 */
+	.components-button.is-secondary,
+	.jetpack-contact-form__view-responses-button {
 		width: 100%;
 		justify-content: center;
 	}

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.jsx
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.jsx
@@ -18,7 +18,11 @@ const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
 				__nextHasNoMarginBottom={ true }
 			/>
 			{ saveResponses && (
-				<LinkButton variant="outline" href={ responsesHref }>
+				<LinkButton
+					className="jetpack-contact-form__view-responses-button"
+					variant="outline"
+					href={ responsesHref }
+				>
 					{ __( 'View form responses', 'jetpack-forms' ) }
 				</LinkButton>
 			) }

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.jsx
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.jsx
@@ -1,5 +1,6 @@
-import { Button, ToggleControl } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { LinkButton } from '@wordpress/ui';
 import { getResponsesUrl } from '../../../form-editor/plugins/utils.ts';
 import { FULL_RESPONSES_PATH } from '../../../util/get-preferred-responses-view.js';
 
@@ -17,9 +18,9 @@ const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
 				__nextHasNoMarginBottom={ true }
 			/>
 			{ saveResponses && (
-				<Button variant="secondary" href={ responsesHref } __next40pxDefaultSize={ true }>
+				<LinkButton variant="outline" href={ responsesHref }>
 					{ __( 'View form responses', 'jetpack-forms' ) }
-				</Button>
+				</LinkButton>
 			) }
 		</>
 	);

--- a/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
@@ -1,14 +1,17 @@
 /**
  * External dependencies
  */
+import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { LinkButton } from '@wordpress/ui';
+import { Button, LinkButton } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
 import useConfigValue from '../../../hooks/use-config-value';
+import { CONFIG_STORE } from '../../../store/config/index.ts';
 import { getFormEditUrl } from '../../utils.ts';
+import type { ConfigSelectors } from '../../../store/config/types.ts';
 
 type EditFormButtonProps = {
 	formId: number;
@@ -28,10 +31,34 @@ export default function EditFormButton( {
 	onClick: onClickProp,
 }: EditFormButtonProps ): JSX.Element {
 	const adminUrl = ( useConfigValue( 'adminUrl' ) as string ) || '';
+	const configFailed = useSelect(
+		select => !! ( select( CONFIG_STORE ) as ConfigSelectors ).getConfigError(),
+		[]
+	);
 
 	const onClick = useCallback( () => {
 		onClickProp?.();
 	}, [ onClickProp ] );
+
+	const label = __( 'Edit form', 'jetpack-forms' );
+
+	/*
+	 * `adminUrl` arrives asynchronously from the config store, and an href built
+	 * without it would be relative — resolving against the wrong base in external
+	 * admin contexts. A disabled control isn't navigable, so hold the slot with a
+	 * real Button while we wait, then let LinkButton own the href.
+	 *
+	 * If the config request failed outright there is nothing left to wait for, so
+	 * fall through to the relative URL rather than disable the action forever. It
+	 * still resolves correctly from wp-admin, which is where this can be reached.
+	 */
+	if ( ! adminUrl && ! configFailed ) {
+		return (
+			<Button size="compact" variant="outline" disabled>
+				{ label }
+			</Button>
+		);
+	}
 
 	return (
 		<LinkButton
@@ -40,7 +67,7 @@ export default function EditFormButton( {
 			href={ getFormEditUrl( formId, adminUrl ) }
 			onClick={ onClick }
 		>
-			{ __( 'Edit form', 'jetpack-forms' ) }
+			{ label }
 		</LinkButton>
 	);
 }

--- a/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/edit-form-button/index.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { LinkButton } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -31,12 +31,16 @@ export default function EditFormButton( {
 
 	const onClick = useCallback( () => {
 		onClickProp?.();
-		window.location.href = getFormEditUrl( formId, adminUrl );
-	}, [ adminUrl, formId, onClickProp ] );
+	}, [ onClickProp ] );
 
 	return (
-		<Button size="compact" variant="secondary" onClick={ onClick }>
+		<LinkButton
+			size="compact"
+			variant="outline"
+			href={ getFormEditUrl( formId, adminUrl ) }
+			onClick={ onClick }
+		>
 			{ __( 'Edit form', 'jetpack-forms' ) }
-		</Button>
+		</LinkButton>
 	);
 }

--- a/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/empty-responses/index.tsx
@@ -6,7 +6,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { createInterpolateElement, useCallback, useMemo } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { caution, page, search, shield, trash } from '@wordpress/icons';
-import { Button, EmptyState, Link } from '@wordpress/ui';
+import { Button, EmptyState, Link, LinkButton } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -261,9 +261,9 @@ const EmptyResponses = ( {
 				</EmptyState.Description>
 				{ notCollectingEditUrl && (
 					<EmptyState.Actions>
-						<Button variant="outline" render={ <a href={ notCollectingEditUrl } /> }>
+						<LinkButton variant="outline" href={ notCollectingEditUrl }>
 							{ __( 'Choose where responses go', 'jetpack-forms' ) }
-						</Button>
+						</LinkButton>
 					</EmptyState.Actions>
 				) }
 			</EmptyState.Root>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/file.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/file.tsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import { Button, Icon, Tooltip } from '@wordpress/components';
+import { Icon, Tooltip } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
-import { Link } from '@wordpress/ui';
+import { Link, LinkButton } from '@wordpress/ui';
 import clsx from 'clsx';
 /**
  * Internal dependencies
@@ -66,9 +66,16 @@ const FieldFile = ( { file, onClick } ) => {
 				<div className={ iconClass } style={ iconStyle }></div>
 				<div className="jp-forms__inbox-response-file__name">
 					{ file.is_previewable && (
-						<Button target="_blank" variant="link" onClick={ onClick }>
+						<LinkButton
+							variant="unstyled"
+							href={ file.url }
+							onClick={ event => {
+								event.preventDefault();
+								onClick( event );
+							} }
+						>
 							{ decodeEntities( file.name ) }
-						</Button>
+						</LinkButton>
 					) }
 					{ ! file.is_previewable && (
 						<Link openInNewTab href={ file.url + '&preview=true' }>
@@ -87,9 +94,9 @@ const FieldFile = ( { file, onClick } ) => {
 			</div>
 			<span className="jp-forms__inbox-response-file__item-actions">
 				<Tooltip text={ __( 'Download', 'jetpack-forms' ) }>
-					<Button variant="secondary" href={ file.url } target="_blank">
+					<LinkButton variant="outline" href={ file.url } openInNewTab>
 						<Icon icon={ download } />
-					</Button>
+					</LinkButton>
 				</Tooltip>
 			</span>
 		</div>

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/file.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/file.tsx
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import { Icon, Tooltip } from '@wordpress/components';
+import { Button, Icon, Tooltip } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
-import { Link, LinkButton } from '@wordpress/ui';
+import { Link } from '@wordpress/ui';
 import clsx from 'clsx';
 /**
  * Internal dependencies
@@ -66,16 +66,9 @@ const FieldFile = ( { file, onClick } ) => {
 				<div className={ iconClass } style={ iconStyle }></div>
 				<div className="jp-forms__inbox-response-file__name">
 					{ file.is_previewable && (
-						<LinkButton
-							variant="unstyled"
-							href={ file.url }
-							onClick={ event => {
-								event.preventDefault();
-								onClick( event );
-							} }
-						>
+						<Button target="_blank" variant="link" onClick={ onClick }>
 							{ decodeEntities( file.name ) }
-						</LinkButton>
+						</Button>
 					) }
 					{ ! file.is_previewable && (
 						<Link openInNewTab href={ file.url + '&preview=true' }>
@@ -94,9 +87,9 @@ const FieldFile = ( { file, onClick } ) => {
 			</div>
 			<span className="jp-forms__inbox-response-file__item-actions">
 				<Tooltip text={ __( 'Download', 'jetpack-forms' ) }>
-					<LinkButton variant="outline" href={ file.url } openInNewTab>
+					<Button variant="secondary" href={ file.url } target="_blank">
 						<Icon icon={ download } />
-					</LinkButton>
+					</Button>
 				</Tooltip>
 			</span>
 		</div>

--- a/projects/packages/forms/src/form-editor/plugins/header-actions.scss
+++ b/projects/packages/forms/src/form-editor/plugins/header-actions.scss
@@ -1,0 +1,16 @@
+@use "@automattic/jetpack-base-styles/gutenberg-base-styles" as gb;
+
+/*
+ * `@wordpress/interface` hides pinned items on narrow viewports so the list
+ * doesn't wreak havoc on the header layout, but it does so with a
+ * `.interface-pinned-items .components-button` rule. `LinkButton` renders an
+ * anchor carrying only `@wordpress/ui` classes, so it slips past that rule —
+ * reapply the same breakpoint here.
+ */
+.jetpack-form-header-actions__view-responses {
+	display: none;
+
+	@include gb.break-small() {
+		display: inline-flex;
+	}
+}

--- a/projects/packages/forms/src/form-editor/plugins/header-actions.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/header-actions.tsx
@@ -9,6 +9,7 @@ import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { LinkButton } from '@wordpress/ui';
+import './header-actions.scss';
 import { getResponsesUrl } from './utils';
 
 export const HEADER_ACTIONS_PLUGIN = 'jetpack-form-header-actions';
@@ -31,7 +32,12 @@ export const HeaderActions = () => {
 
 	return (
 		<Fill name="PinnedItems/core">
-			<LinkButton variant="outline" size="compact" href={ getResponsesUrl( postId ) }>
+			<LinkButton
+				className="jetpack-form-header-actions__view-responses"
+				variant="outline"
+				size="compact"
+				href={ getResponsesUrl( postId ) }
+			>
 				{ __( 'View responses', 'jetpack-forms' ) }
 			</LinkButton>
 		</Fill>

--- a/projects/packages/forms/src/form-editor/plugins/header-actions.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/header-actions.tsx
@@ -4,11 +4,11 @@
  * Adds "View responses" button to the form editor header.
  */
 
-import { Button, Fill } from '@wordpress/components';
+import { Fill } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { LinkButton } from '@wordpress/ui';
 import { getResponsesUrl } from './utils';
 
 export const HEADER_ACTIONS_PLUGIN = 'jetpack-form-header-actions';
@@ -25,21 +25,15 @@ export const HeaderActions = () => {
 		};
 	} );
 
-	const handleViewResponses = useCallback( () => {
-		if ( postId ) {
-			window.location.href = getResponsesUrl( postId );
-		}
-	}, [ postId ] );
-
 	if ( ! postId || isNewPost ) {
 		return null;
 	}
 
 	return (
 		<Fill name="PinnedItems/core">
-			<Button variant="secondary" size="compact" onClick={ handleViewResponses }>
+			<LinkButton variant="outline" size="compact" href={ getResponsesUrl( postId ) }>
 				{ __( 'View responses', 'jetpack-forms' ) }
-			</Button>
+			</LinkButton>
 		</Fill>
 	);
 };

--- a/projects/packages/forms/tests/js/dashboard/components/edit-form-button/index.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/components/edit-form-button/index.test.jsx
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/*
+ * The config store resolver fetches `/wp/v2/feedback/config` as soon as a config
+ * value is read. Hand it a promise that never settles so each test controls the
+ * store state explicitly instead of racing the resolver.
+ */
+await jest.unstable_mockModule( '@wordpress/api-fetch', () => ( {
+	default: jest.fn( () => new Promise( () => {} ) ),
+} ) );
+
+const { createRegistry, RegistryProvider } = await import( '@wordpress/data' );
+const { store: configStore, CONFIG_STORE } = await import( '../../../../../src/store/config' );
+const { default: EditFormButton } = await import(
+	'../../../../../src/dashboard/components/edit-form-button'
+);
+
+const ADMIN_URL = 'https://example.com/wp-admin/';
+
+describe( 'EditFormButton', () => {
+	let registry;
+	let wrapper;
+
+	beforeEach( () => {
+		registry = createRegistry();
+		registry.register( configStore );
+
+		wrapper = ( { children } ) => (
+			<RegistryProvider value={ registry }>{ children }</RegistryProvider>
+		);
+	} );
+
+	it( 'holds the slot with a non-navigable button while the admin URL is still loading', () => {
+		render( <EditFormButton formId={ 42 } />, { wrapper } );
+
+		// The control stays in the DOM so the header does not shift once config lands.
+		expect( screen.getByRole( 'button', { name: 'Edit form' } ) ).toBeInTheDocument();
+
+		// It must not be a link yet — an href built without adminUrl would be relative.
+		expect( screen.queryByRole( 'link', { name: 'Edit form' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders an absolute link once the admin URL resolves', () => {
+		registry.dispatch( CONFIG_STORE ).receiveConfig( { adminUrl: ADMIN_URL } );
+
+		render( <EditFormButton formId={ 42 } />, { wrapper } );
+
+		const link = screen.getByRole( 'link', { name: 'Edit form' } );
+		expect( link ).toHaveAttribute( 'href', `${ ADMIN_URL }post.php?post=42&action=edit` );
+	} );
+
+	it( 'falls back to a relative link when the config request fails, rather than staying disabled', () => {
+		registry.dispatch( CONFIG_STORE ).setConfigError( 'Request failed' );
+
+		render( <EditFormButton formId={ 42 } />, { wrapper } );
+
+		// There is nothing left to wait for, so the action must stay usable.
+		const link = screen.getByRole( 'link', { name: 'Edit form' } );
+		expect( link ).toHaveAttribute( 'href', 'post.php?post=42&action=edit' );
+	} );
+
+	it( 'fires onClick when the resolved link is activated', async () => {
+		const user = userEvent.setup();
+		const onClick = jest.fn();
+		registry.dispatch( CONFIG_STORE ).receiveConfig( { adminUrl: ADMIN_URL } );
+
+		// It is a real anchor now, so let jsdom dispatch the click without
+		// trying to follow the href (which it cannot do, and warns about).
+		const preventNavigation = event => event.preventDefault();
+		document.addEventListener( 'click', preventNavigation );
+
+		try {
+			render( <EditFormButton formId={ 42 } onClick={ onClick } />, { wrapper } );
+
+			await user.click( screen.getByRole( 'link', { name: 'Edit form' } ) );
+		} finally {
+			document.removeEventListener( 'click', preventNavigation );
+		}
+
+		expect( onClick ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/projects/packages/forms/tests/js/form-editor/plugins/header-actions.test.jsx
+++ b/projects/packages/forms/tests/js/form-editor/plugins/header-actions.test.jsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+const mockEditor = {
+	getCurrentPostId: jest.fn(),
+	isEditedPostNew: jest.fn(),
+};
+
+// `Fill` needs a matching Slot to render anything, so stand it in for the test.
+await jest.unstable_mockModule( '@wordpress/components', () => ( {
+	Fill: ( { children } ) => <div data-testid="pinned-items">{ children }</div>,
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useSelect: selector => selector( () => mockEditor ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/editor', () => ( {
+	store: 'core/editor',
+} ) );
+
+const { HeaderActions } = await import( '../../../../src/form-editor/plugins/header-actions' );
+
+describe( 'HeaderActions', () => {
+	beforeEach( () => {
+		mockEditor.getCurrentPostId.mockReset();
+		mockEditor.isEditedPostNew.mockReset();
+	} );
+
+	it( 'renders nothing before the form has been saved', () => {
+		mockEditor.getCurrentPostId.mockReturnValue( 0 );
+		mockEditor.isEditedPostNew.mockReturnValue( true );
+
+		const { container } = render( <HeaderActions /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders nothing for a new post that already has an ID', () => {
+		mockEditor.getCurrentPostId.mockReturnValue( 7 );
+		mockEditor.isEditedPostNew.mockReturnValue( true );
+
+		const { container } = render( <HeaderActions /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders a real link to the responses for a saved form', () => {
+		mockEditor.getCurrentPostId.mockReturnValue( 7 );
+		mockEditor.isEditedPostNew.mockReturnValue( false );
+
+		render( <HeaderActions /> );
+
+		const link = screen.getByRole( 'link', { name: 'View responses' } );
+		expect( link ).toHaveAttribute( 'href', expect.stringContaining( 'sourceId%3D7' ) );
+	} );
+
+	it( 'keeps the class the stylesheet uses to hide it on narrow viewports', () => {
+		mockEditor.getCurrentPostId.mockReturnValue( 7 );
+		mockEditor.isEditedPostNew.mockReturnValue( false );
+
+		render( <HeaderActions /> );
+
+		/*
+		 * `@wordpress/interface` hides pinned items below its small breakpoint via a
+		 * `.interface-pinned-items .components-button` rule that this anchor does not
+		 * match, so header-actions.scss reapplies it against this class. Dropping the
+		 * class would silently bring the button back on narrow viewports.
+		 */
+		expect( screen.getByRole( 'link', { name: 'View responses' } ) ).toHaveClass(
+			'jetpack-form-header-actions__view-responses'
+		);
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/update-ui-link-button
+++ b/projects/plugins/jetpack/changelog/update-ui-link-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Forms: Make form navigation actions real links so they can be opened in a new tab.


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Replaces workaround of using [Button](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-button--docs) for links with appropiate new [LinkButton](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-linkbutton--docs) component.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test empty responses "Choose where responses go" button
* "View responses" button in form editor
* "Edit form" button at dashboard
* "View form responses" button from the block
* No visual or functional changes