### PR TITLE
Publicize: use LinkButton instead of Button component

### DIFF
--- a/projects/packages/publicize/_inc/components/block-editor/placeholder.tsx
+++ b/projects/packages/publicize/_inc/components/block-editor/placeholder.tsx
@@ -1,6 +1,6 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { PanelBody, Button } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
@@ -38,9 +38,9 @@ export const Placeholder = () => {
 					'jetpack-publicize-pkg'
 				) }
 			</p>
-			<Button onClick={ enablePublicizeModule } variant="link" href={ getSocialAdminPageUrl() }>
+			<Link href={ getSocialAdminPageUrl() } onClick={ enablePublicizeModule }>
 				{ __( 'Activate Jetpack Social', 'jetpack-publicize-pkg' ) }
-			</Button>
+			</Link>
 			<div className="components-placeholder__learn-more">
 				<Link openInNewTab href={ getRedirectUrl( 'jetpack-support-publicize' ) }>
 					{ __( 'Learn more', 'jetpack-publicize-pkg' ) }

--- a/projects/packages/publicize/_inc/components/overview-tab/traffic-chart-card.tsx
+++ b/projects/packages/publicize/_inc/components/overview-tab/traffic-chart-card.tsx
@@ -7,7 +7,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { trendingUp } from '@wordpress/icons';
-import { Button, Card, EmptyState, Notice, Stack, Text, Tooltip } from '@wordpress/ui';
+import { Card, EmptyState, LinkButton, Notice, Stack, Text, Tooltip } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
 import { hasSocialPaidFeatures } from '../../utils';
 import { getRefreshPlanQuery } from '../../utils/script-data';
@@ -79,15 +79,16 @@ export default function TrafficChartCard(): JSX.Element {
 		interval
 	);
 
-	const onUpgrade = useCallback( () => {
+	let upgradeUrl: string | undefined;
+	if ( needsUpgrade ) {
 		const data = getScriptData();
 		const blogID = data?.site?.wpcom?.blog_id;
 		const siteSuffix = data?.site?.suffix;
-		window.location.href = getRedirectUrl( 'jetpack-social-v1-plan-plugin-admin-page', {
+		upgradeUrl = getRedirectUrl( 'jetpack-social-v1-plan-plugin-admin-page', {
 			site: blogID ? String( blogID ) : siteSuffix,
 			query: getRefreshPlanQuery(),
 		} );
-	}, [] );
+	}
 
 	const onIntervalChange = useCallback(
 		( next: string ) => setTrafficInterval( Number( next ) as TrafficInterval ),
@@ -201,7 +202,7 @@ export default function TrafficChartCard(): JSX.Element {
 								withGradientFill={ false }
 							/>
 						</div>
-						{ needsUpgrade && (
+						{ needsUpgrade && upgradeUrl && (
 							<div className="jetpack-social-overview__chart-overlay">
 								<Notice.Root intent="info" className="jetpack-social-overview__upgrade-notice">
 									<Notice.Title>
@@ -214,9 +215,9 @@ export default function TrafficChartCard(): JSX.Element {
 										) }
 									</Notice.Description>
 									<Notice.Actions>
-										<Button variant="solid" size="compact" onClick={ onUpgrade }>
+										<LinkButton variant="solid" size="compact" href={ upgradeUrl }>
 											{ __( 'Upgrade now', 'jetpack-publicize-pkg' ) }
-										</Button>
+										</LinkButton>
 									</Notice.Actions>
 								</Notice.Root>
 							</div>

--- a/projects/packages/publicize/_inc/components/settings-tab/content-creation-card.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/content-creation-card.tsx
@@ -3,7 +3,7 @@ import { SelectControl, ToggleControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button, Card, Link, Stack, Text } from '@wordpress/ui';
+import { Card, Link, LinkButton, Stack, Text } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
 import type { SocialNotesConfig } from '../../social-store/types';
 
@@ -78,14 +78,9 @@ export default function ContentCreationCard(): JSX.Element {
 					{ isEnabled && (
 						<>
 							<Stack direction="row" gap="md" className="jetpack-social-settings__card-actions">
-								<Button
-									variant="outline"
-									size="compact"
-									nativeButton={ false }
-									render={ <a href={ newNoteUrl } /> }
-								>
+								<LinkButton variant="outline" size="compact" href={ newNoteUrl }>
 									{ __( 'Create a note', 'jetpack-publicize-pkg' ) }
-								</Button>
+								</LinkButton>
 							</Stack>
 							<ToggleControl
 								__nextHasNoMarginBottom

--- a/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/pricing-gate.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { Icon, check } from '@wordpress/icons';
-import { Button, Card, Stack, Text } from '@wordpress/ui';
+import { Button, Card, LinkButton, Stack, Text } from '@wordpress/ui';
 import useProductInfo from '../../hooks/use-product-info';
 import { store as socialStore } from '../../social-store';
 import { getRefreshPlanQuery, getSocialScriptData } from '../../utils';
@@ -61,12 +61,10 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 	// the legacy pricing page's behaviour.
 	const { is_publicize_enabled: isSocialEnabled } = getSocialScriptData();
 
-	const onGetSocial = useCallback( () => {
-		window.location.href = getRedirectUrl( 'jetpack-social-v1-plan-plugin-admin-page', {
-			site: blogID ? blogID.toString() : siteSuffix,
-			query: getRefreshPlanQuery(),
-		} );
-	}, [ blogID, siteSuffix ] );
+	const getSocialUrl = getRedirectUrl( 'jetpack-social-v1-plan-plugin-admin-page', {
+		site: blogID ? blogID.toString() : siteSuffix,
+		query: getRefreshPlanQuery(),
+	} );
 
 	const onStartForFree = useCallback( async () => {
 		if ( ! isSocialEnabled ) {
@@ -136,9 +134,9 @@ export default function PricingGate( { onDismiss }: { onDismiss: VoidFunction } 
 						) ) }
 					</Stack>
 					<Stack className="jetpack-social-gate__actions" direction="row" justify="center" gap="md">
-						<Button variant="solid" onClick={ onGetSocial }>
+						<LinkButton variant="solid" href={ getSocialUrl }>
 							{ __( 'Get Social', 'jetpack-publicize-pkg' ) }
-						</Button>
+						</LinkButton>
 						<Button
 							variant="outline"
 							onClick={ onStartForFree }

--- a/projects/packages/publicize/_inc/components/social-gate/test/pricing-gate.test.tsx
+++ b/projects/packages/publicize/_inc/components/social-gate/test/pricing-gate.test.tsx
@@ -7,6 +7,10 @@ const mockUpdateSocialModuleSettings = jest.fn( () => Promise.resolve() );
 
 let mockProductInfo = { currencyCode: 'USD', v1: { price: 10, introOffer: null } };
 
+jest.mock( '@automattic/jetpack-components/tools/jp-redirect', () => ( {
+	__esModule: true,
+	default: () => 'https://example.com/upgrade',
+} ) );
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		setShowPricingPage: mockSetShowPricingPage,
@@ -43,7 +47,7 @@ describe( 'PricingGate', () => {
 
 	it( 'renders the upgrade CTA', () => {
 		render( <PricingGate onDismiss={ jest.fn() } /> );
-		expect( screen.getByRole( 'button', { name: /get social/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: /get social/i } ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders the formatted price', () => {

--- a/projects/packages/publicize/changelog/update-ui-link-button
+++ b/projects/packages/publicize/changelog/update-ui-link-button
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Make Social navigation actions real links by using LinkButton component.


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Replaces workarounds of using [Button](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-button--docs) for links with appropiate new [LinkButton](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-linkbutton--docs) component.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test affected buttons; there should not be any functional or visual changes.
