### PR TITLE
Admin bar: add free domain upsell chip for omnibar experiment treatment

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/.phan/config.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/config.php
@@ -16,6 +16,9 @@ return make_phan_config(
 		'+stubs'                          => array( 'full-site-editing', 'gutenberg', 'photon-opencv', 'wpcom' ),
 		'exclude_file_list'               => array(
 			'tests/lib/class-wpcom-features.php',
+			// Conditional test doubles for wpcom-only \ExPlat\ helpers; analyzing them
+			// collides with the wpcom stubs and shadows the real declarations.
+			'tests/php/features/wpcom-admin-bar/explat-doubles.php',
 		),
 		'exclude_file_regex'              => array(
 			'build/',

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-omnibar-free-domain-upsell-chip
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-omnibar-free-domain-upsell-chip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Admin bar: Add a "Free domain" upsell chip and hide the free-to-paid sidebar notice for users in the omnibar upsell experiment treatment.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-omnibar-free-domain-upsell-chip
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-omnibar-free-domain-upsell-chip
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Admin bar: Add a "Free domain" upsell chip and hide the free-to-paid sidebar notice for users in the omnibar upsell experiment treatment.
+Admin bar: Add a "Free domain" upsell chip and hide the matching free-to-paid and monthly-to-annual sidebar notices for users in the omnibar upsell experiment treatment.

--- a/projects/packages/jetpack-mu-wpcom/src/common/class-free-domain-upsell-experiment.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/class-free-domain-upsell-experiment.php
@@ -7,14 +7,17 @@
 
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Host;
 
 /**
  * Reads the omnibar free-domain upsell variation for the current user.
  *
- * The experiment moves the free-to-paid upsell from the wp-admin sidebar notice
- * (control) to a persistent "Free domain" chip in the admin bar / omnibar
- * (treatment). It only targets Free Simple sites, so there is no Atomic path.
+ * The experiment moves the "Free domain with an annual plan" upsell from the
+ * wp-admin sidebar notice (control; the free_to_paid_plan and
+ * monthly_to_annual_plan messages) to a persistent "Free domain" chip in the
+ * admin bar / omnibar (treatment). It only targets Simple sites, so there is
+ * no Atomic path.
  *
  * On Simple sites, a real page render (wp-admin or front end) uses the assigning
  * ExPlat call, so eligible users are enrolled where the two experiences diverge.
@@ -101,7 +104,7 @@ class Free_Domain_Upsell_Experiment {
 	 * @return bool
 	 */
 	private static function is_page_render() {
-		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		if ( Constants::is_true( 'REST_REQUEST' ) ) {
 			return false;
 		}
 		if ( wp_doing_ajax() || wp_doing_cron() ) {

--- a/projects/packages/jetpack-mu-wpcom/src/common/class-free-domain-upsell-experiment.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/class-free-domain-upsell-experiment.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Resolves the calypso_omnibar_free_domain_upsell_20260825 experiment variation server-side.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+use Automattic\Jetpack\Status\Host;
+
+/**
+ * Reads the omnibar free-domain upsell variation for the current user.
+ *
+ * The experiment moves the free-to-paid upsell from the wp-admin sidebar notice
+ * (control) to a persistent "Free domain" chip in the admin bar / omnibar
+ * (treatment). It only targets Free Simple sites, so there is no Atomic path.
+ *
+ * On Simple sites, a real page render (wp-admin or front end) uses the assigning
+ * ExPlat call, so eligible users are enrolled where the two experiences diverge.
+ * Non-page contexts (REST — including the omnibar admin-bar endpoint — AJAX and
+ * cron) use the non-assigning read: serving data must never create an assignment.
+ * The resolved variation is transient-cached per user, mirroring
+ * Launchpad_Personalization_Experiment.
+ */
+class Free_Domain_Upsell_Experiment {
+
+	const EXPERIMENT_NAME = 'calypso_omnibar_free_domain_upsell_20260825';
+
+	/**
+	 * The current user's variation: 'control' or 'treatment'.
+	 *
+	 * @return string
+	 */
+	public static function get_variation() {
+		/**
+		 * Overrides the resolved variation (testing / manual QA). Return 'treatment' or 'control', or null to use ExPlat.
+		 *
+		 * @param string|null $override The forced variation, or null.
+		 */
+		$override = apply_filters( 'wpcom_free_domain_upsell_variation', null );
+		if ( null !== $override ) {
+			return self::normalize( $override );
+		}
+
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return 'control';
+		}
+
+		$cache_key = 'free-domain-upsell-variation-' . $user_id;
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return (string) $cached;
+		}
+
+		$raw = self::fetch_variation();
+
+		// An unassigned user reads as null. Don't cache that, so the next page
+		// render can still create the assignment.
+		if ( null === $raw ) {
+			return 'control';
+		}
+
+		$variation = self::normalize( $raw );
+		set_transient( $cache_key, $variation, HOUR_IN_SECONDS );
+
+		return $variation;
+	}
+
+	/**
+	 * Fetch the raw variation name from ExPlat, or null.
+	 *
+	 * @return string|null
+	 */
+	private static function fetch_variation() {
+		if ( ! ( new Host() )->is_wpcom_simple() ) {
+			return null;
+		}
+
+		if ( self::is_page_render() ) {
+			if ( function_exists( '\ExPlat\assign_current_user' ) ) {
+				return \ExPlat\assign_current_user( self::EXPERIMENT_NAME );
+			}
+			return null;
+		}
+
+		if ( function_exists( '\ExPlat\get_current_user_assignment' ) ) {
+			// The \ExPlat\ helpers live in wpcom, outside this monorepo, so Phan can't see this one.
+			// @phan-suppress-next-line PhanUndeclaredFunction
+			return \ExPlat\get_current_user_assignment( self::EXPERIMENT_NAME );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether this request renders a page a user actually sees, as opposed to a
+	 * data request (REST, AJAX, cron) that must never create an assignment.
+	 *
+	 * @return bool
+	 */
+	private static function is_page_render() {
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return false;
+		}
+		if ( wp_doing_ajax() || wp_doing_cron() ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Map any variation onto a known value; unknown becomes 'control'.
+	 *
+	 * @param string|null $variation The raw variation name.
+	 * @return string
+	 */
+	private static function normalize( $variation ) {
+		return 'treatment' === $variation ? 'treatment' : 'control';
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/common/class-free-domain-upsell-experiment.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/class-free-domain-upsell-experiment.php
@@ -31,6 +31,113 @@ class Free_Domain_Upsell_Experiment {
 	const EXPERIMENT_NAME = 'calypso_omnibar_free_domain_upsell_20260825';
 
 	/**
+	 * Which sidebar JITM the current user/site would qualify for, or null.
+	 *
+	 * Mirrors the conditions of the two sidebar JITMs the chip is tested against,
+	 * which share the "Free domain with an annual plan" message and CTA:
+	 * - `free_to_paid_plan`: Free plan, Simple, admin, not a domain-only site, no
+	 *   mapped primary domain.
+	 * - `monthly_to_annual_plan`: any monthly plan, Simple, admin, no mapped
+	 *   primary domain.
+	 * Matches the Calypso-side predicate for the same chip.
+	 *
+	 * @return string|null 'free_to_paid_plan', 'monthly_to_annual_plan', or null.
+	 */
+	public static function get_upsell_source() {
+		if ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) {
+			return null;
+		}
+
+		if ( ! ( new Host() )->is_wpcom_simple() ) {
+			return null;
+		}
+
+		if ( (bool) get_option( 'wpcom_is_staging_site' ) ) {
+			return null;
+		}
+
+		// No mapped primary domain: a Simple site with a mapped domain serves from
+		// its custom domain, so the `.wordpress.com` host check covers the rule.
+		$host = wp_parse_url( home_url(), PHP_URL_HOST );
+		if ( ! is_string( $host ) || ! str_ends_with( $host, '.wordpress.com' ) ) {
+			return null;
+		}
+
+		$current_plan = self::get_current_plan();
+		if ( ! is_array( $current_plan ) ) {
+			return null;
+		}
+
+		if ( ! empty( $current_plan['is_free'] ) && empty( get_option( 'options' )['is_domain_only'] ) ) {
+			return 'free_to_paid_plan';
+		}
+
+		if ( str_ends_with( (string) ( $current_plan['product_slug'] ?? '' ), '-monthly' ) ) {
+			return 'monthly_to_annual_plan';
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether the current user/site is eligible for the omnibar free-domain upsell.
+	 *
+	 * @return bool
+	 */
+	public static function is_eligible() {
+		return null !== self::get_upsell_source();
+	}
+
+	/**
+	 * Whether the winning sidebar notice should be suppressed for this user.
+	 *
+	 * Only the two messages the experiment moves into the admin bar are ever
+	 * suppressed, only for eligible users (so nobody is enrolled — or loses the
+	 * notice — without getting the chip), and only in the treatment.
+	 *
+	 * @param string $notice_id The id of the winning sidebar notice.
+	 * @return bool
+	 */
+	public static function should_suppress_sidebar_notice( $notice_id ) {
+		if ( ! in_array( $notice_id, array( 'free_to_paid_plan', 'monthly_to_annual_plan' ), true ) ) {
+			return false;
+		}
+
+		// Eligibility first: get_variation() assigns on page renders, and
+		// ineligible users must never be enrolled by the suppression path.
+		if ( ! self::is_eligible() ) {
+			return false;
+		}
+
+		return 'treatment' === self::get_variation();
+	}
+
+	/**
+	 * The current plan data for this blog, or null when unavailable.
+	 *
+	 * @return array|null
+	 */
+	private static function get_current_plan() {
+		/**
+		 * Overrides the plan data used for chip eligibility (testing / manual QA).
+		 *
+		 * @param array|null $plan The plan data (needs `is_free` and `product_slug`), or null to read from the store.
+		 */
+		$override = apply_filters( 'wpcom_free_domain_upsell_current_plan', null );
+		if ( null !== $override ) {
+			return is_array( $override ) ? $override : null;
+		}
+
+		if ( ! class_exists( '\WPCOM_Store_API' ) ) {
+			return null;
+		}
+
+		$plan = \WPCOM_Store_API::get_current_plan( get_current_blog_id() );
+
+		return is_array( $plan ) ? $plan : null;
+	}
+
+	/**
 	 * The current user's variation: 'control' or 'treatment'.
 	 *
 	 * @return string

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
@@ -16,4 +16,18 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			wpcomTrackEvent( 'wpcom_adminbar_command_palette_clicked' );
 		} );
 	}
+
+	const freeDomainUpsell = document.querySelector( '#wp-admin-bar-wpcom-free-domain-upsell a' );
+	if ( freeDomainUpsell ) {
+		wpcomTrackEvent( 'wpcom_omnibar_upsell_impression', {
+			upsell_id: 'omnibar-free-domain',
+			surface: 'wp-admin',
+		} );
+		freeDomainUpsell.addEventListener( 'click', () => {
+			wpcomTrackEvent( 'wpcom_omnibar_upsell_click', {
+				upsell_id: 'omnibar-free-domain',
+				surface: 'wp-admin',
+			} );
+		} );
+	}
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
@@ -20,15 +20,17 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const freeDomainUpsell = document.querySelector( '#wp-admin-bar-wpcom-free-domain-upsell a' );
 	if ( freeDomainUpsell ) {
 		const surface = window.wpcomAdminBarTrackingSurface || 'wp_admin';
-		wpcomTrackEvent( 'wpcom_omnibar_upsell_impression', {
+		const props = {
 			upsell_id: 'omnibar-free-domain',
 			surface,
-		} );
+		};
+		// Which of the two sidebar JITMs this chip replaces, for cohort analysis.
+		if ( window.wpcomFreeDomainUpsellSource ) {
+			props.upsell_source = window.wpcomFreeDomainUpsellSource;
+		}
+		wpcomTrackEvent( 'wpcom_omnibar_upsell_impression', props );
 		freeDomainUpsell.addEventListener( 'click', () => {
-			wpcomTrackEvent( 'wpcom_omnibar_upsell_click', {
-				upsell_id: 'omnibar-free-domain',
-				surface,
-			} );
+			wpcomTrackEvent( 'wpcom_omnibar_upsell_click', props );
 		} );
 	}
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
@@ -19,14 +19,15 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	const freeDomainUpsell = document.querySelector( '#wp-admin-bar-wpcom-free-domain-upsell a' );
 	if ( freeDomainUpsell ) {
+		const surface = window.wpcomAdminBarTrackingSurface || 'wp_admin';
 		wpcomTrackEvent( 'wpcom_omnibar_upsell_impression', {
 			upsell_id: 'omnibar-free-domain',
-			surface: 'wp-admin',
+			surface,
 		} );
 		freeDomainUpsell.addEventListener( 'click', () => {
 			wpcomTrackEvent( 'wpcom_omnibar_upsell_click', {
 				upsell_id: 'omnibar-free-domain',
-				surface: 'wp-admin',
+				surface,
 			} );
 		} );
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -79,6 +79,12 @@ function wpcom_enqueue_admin_bar_assets() {
 		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-admin-bar/wpcom-admin-bar.css' )
 	);
 
+	wp_add_inline_script(
+		'wpcom-admin-bar',
+		'var wpcomAdminBarTrackingSurface = ' . wp_json_encode( wpcom_admin_bar_tracking_surface() ) . ';',
+		'before'
+	);
+
 	/**
 	 * Force the Atomic debug bar menu to be the first menu at the top-right.
 	 */
@@ -524,9 +530,15 @@ function wpcom_add_stats_to_site_menu( $wp_admin_bar ) {
 add_action( 'admin_bar_menu', 'wpcom_add_stats_to_site_menu', 40 );
 
 /**
- * Whether the current user/site is eligible for the omnibar free-domain upsell:
- * an administrator of a Free Simple site that is not a staging site. Mirrors
- * the Calypso-side predicate for the same chip.
+ * Whether the current user/site is eligible for the omnibar free-domain upsell.
+ *
+ * Mirrors the conditions of the two sidebar JITMs the chip is tested against,
+ * which share the "Free domain with an annual plan" message and CTA:
+ * - `free_to_paid_plan`: Free plan, Simple, admin, not a domain-only site, no
+ *   mapped domain.
+ * - `monthly_to_annual_plan`: any monthly plan, Simple, admin, no mapped
+ *   domain.
+ * Matches the Calypso-side predicate for the same chip.
  *
  * @return bool
  */
@@ -543,12 +555,43 @@ function wpcom_free_domain_upsell_is_eligible() {
 		return false;
 	}
 
+	// No mapped primary domain: a Simple site with a mapped domain serves from
+	// its custom domain, so the `.wordpress.com` host check covers the rule.
+	$host = wp_parse_url( home_url(), PHP_URL_HOST );
+	if ( ! is_string( $host ) || ! str_ends_with( $host, '.wordpress.com' ) ) {
+		return false;
+	}
+
 	if ( ! class_exists( '\WPCOM_Store_API' ) ) {
 		return false;
 	}
 	$current_plan = WPCOM_Store_API::get_current_plan( get_current_blog_id() );
 
-	return ! empty( $current_plan['is_free'] );
+	$matches_free_to_paid      = ! empty( $current_plan['is_free'] ) && empty( get_option( 'options' )['is_domain_only'] );
+	$matches_monthly_to_annual = str_ends_with( (string) ( $current_plan['product_slug'] ?? '' ), '-monthly' );
+
+	return $matches_free_to_paid || $matches_monthly_to_annual;
+}
+
+/**
+ * Which surface the admin bar is rendering on, for per-surface tracking.
+ *
+ * @return string One of 'site_frontend', 'site_editor', 'post_editor', 'wp_admin'.
+ */
+function wpcom_admin_bar_tracking_surface() {
+	if ( ! is_admin() ) {
+		return 'site_frontend';
+	}
+
+	$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+	if ( $screen && 'site-editor' === $screen->id ) {
+		return 'site_editor';
+	}
+	if ( $screen && $screen->is_block_editor() ) {
+		return 'post_editor';
+	}
+
+	return 'wp_admin';
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -10,7 +10,9 @@
 use Automattic\Jetpack\Connection\Urls;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Free_Domain_Upsell_Experiment;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Status\Host;
 
 // The $icon-color variable for admin color schemes.
 // See: https://github.com/WordPress/wordpress-develop/blob/679cc0c4a261a77bd8fdb140cd9b0b2ff80ebf37/src/wp-admin/css/colors/_variables.scss#L9
@@ -520,3 +522,77 @@ function wpcom_add_stats_to_site_menu( $wp_admin_bar ) {
 	);
 }
 add_action( 'admin_bar_menu', 'wpcom_add_stats_to_site_menu', 40 );
+
+/**
+ * Whether the current user/site is eligible for the omnibar free-domain upsell:
+ * an administrator of a Free Simple site that is not a staging site. Mirrors
+ * the Calypso-side predicate for the same chip.
+ *
+ * @return bool
+ */
+function wpcom_free_domain_upsell_is_eligible() {
+	if ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) {
+		return false;
+	}
+
+	if ( ! ( new Host() )->is_wpcom_simple() ) {
+		return false;
+	}
+
+	if ( (bool) get_option( 'wpcom_is_staging_site' ) ) {
+		return false;
+	}
+
+	if ( ! class_exists( '\WPCOM_Store_API' ) ) {
+		return false;
+	}
+	$current_plan = WPCOM_Store_API::get_current_plan( get_current_blog_id() );
+
+	return ! empty( $current_plan['is_free'] );
+}
+
+/**
+ * Adds a "Free domain" upsell chip to the admin bar for users in the treatment
+ * of the omnibar upsell experiment.
+ *
+ * The node is deliberately top-level so it is NOT returned by the site
+ * admin-bar REST endpoint (which only keeps a fixed set of top-level ids):
+ * Calypso surfaces render their own chip, so returning this one would
+ * duplicate it there.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
+ */
+function wpcom_add_free_domain_upsell_chip( $wp_admin_bar ) {
+	if ( ! wpcom_free_domain_upsell_is_eligible() ) {
+		return;
+	}
+
+	require_once __DIR__ . '/../../common/class-free-domain-upsell-experiment.php';
+	if ( 'treatment' !== Free_Domain_Upsell_Experiment::get_variation() ) {
+		return;
+	}
+
+	$icon = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path d="M18.9397 9.87999L15.4197 6.06999L15.3597 6.00999C15.2897 5.93999 15.1997 5.89999 15.0997 5.89999H8.87973C8.77973 5.89999 8.68973 5.93999 8.61973 6.00999L5.05973 9.87999C4.93973 10.01 4.93973 10.21 5.05973 10.34L11.5397 17.86C11.6497 17.99 11.8197 18.07 11.9997 18.07C12.1797 18.07 12.3397 17.99 12.4597 17.86L18.9397 10.34C19.0597 10.21 19.0497 10.01 18.9397 9.87999ZM15.4097 7.53999L17.3297 9.63999H15.1697L15.4097 7.53999ZM14.4297 6.83999L14.1097 9.63999H10.2897L9.64973 6.83999H14.4297ZM8.68973 7.42999L9.19973 9.63999H6.66973L8.68973 7.42999ZM6.61973 10.6H9.42973L10.8397 15.49L6.61973 10.6ZM12.0397 15.87L10.5297 10.6H13.8597L12.0397 15.87ZM14.9697 10.6H17.3797L13.3697 15.24L14.9697 10.6Z" fill="currentColor" />
+	</svg>';
+
+	$wp_admin_bar->add_menu(
+		array(
+			'id'     => 'wpcom-free-domain-upsell',
+			'parent' => null,
+			'title'  => '<span class="ab-icon" aria-hidden="true">' . $icon . '</span><span class="ab-label">' . esc_html__( 'Free domain', 'jetpack-mu-wpcom' ) . '</span>',
+			'href'   => add_query_arg(
+				array(
+					'siteSlug' => wpcom_get_site_slug(),
+					'ref'      => 'wp-admin',
+				),
+				'https://wordpress.com/setup/domain-and-plan'
+			),
+			'meta'   => array(
+				'class' => 'wpcom-free-domain-upsell',
+				'title' => __( 'Free domain with an annual plan', 'jetpack-mu-wpcom' ),
+			),
+		)
+	);
+}
+add_action( 'admin_bar_menu', 'wpcom_add_free_domain_upsell_chip', 500 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -12,7 +12,6 @@ use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Free_Domain_Upsell_Experiment;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Status\Host;
 
 // The $icon-color variable for admin color schemes.
 // See: https://github.com/WordPress/wordpress-develop/blob/679cc0c4a261a77bd8fdb140cd9b0b2ff80ebf37/src/wp-admin/css/colors/_variables.scss#L9
@@ -79,9 +78,11 @@ function wpcom_enqueue_admin_bar_assets() {
 		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-admin-bar/wpcom-admin-bar.css' )
 	);
 
+	require_once __DIR__ . '/../../common/class-free-domain-upsell-experiment.php';
 	wp_add_inline_script(
 		'wpcom-admin-bar',
-		'var wpcomAdminBarTrackingSurface = ' . wp_json_encode( wpcom_admin_bar_tracking_surface() ) . ';',
+		'var wpcomAdminBarTrackingSurface = ' . wp_json_encode( wpcom_admin_bar_tracking_surface(), JSON_HEX_TAG | JSON_HEX_AMP ) . ';'
+		. 'var wpcomFreeDomainUpsellSource = ' . wp_json_encode( Free_Domain_Upsell_Experiment::get_upsell_source(), JSON_HEX_TAG | JSON_HEX_AMP ) . ';',
 		'before'
 	);
 
@@ -530,50 +531,6 @@ function wpcom_add_stats_to_site_menu( $wp_admin_bar ) {
 add_action( 'admin_bar_menu', 'wpcom_add_stats_to_site_menu', 40 );
 
 /**
- * Whether the current user/site is eligible for the omnibar free-domain upsell.
- *
- * Mirrors the conditions of the two sidebar JITMs the chip is tested against,
- * which share the "Free domain with an annual plan" message and CTA:
- * - `free_to_paid_plan`: Free plan, Simple, admin, not a domain-only site, no
- *   mapped domain.
- * - `monthly_to_annual_plan`: any monthly plan, Simple, admin, no mapped
- *   domain.
- * Matches the Calypso-side predicate for the same chip.
- *
- * @return bool
- */
-function wpcom_free_domain_upsell_is_eligible() {
-	if ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) {
-		return false;
-	}
-
-	if ( ! ( new Host() )->is_wpcom_simple() ) {
-		return false;
-	}
-
-	if ( (bool) get_option( 'wpcom_is_staging_site' ) ) {
-		return false;
-	}
-
-	// No mapped primary domain: a Simple site with a mapped domain serves from
-	// its custom domain, so the `.wordpress.com` host check covers the rule.
-	$host = wp_parse_url( home_url(), PHP_URL_HOST );
-	if ( ! is_string( $host ) || ! str_ends_with( $host, '.wordpress.com' ) ) {
-		return false;
-	}
-
-	if ( ! class_exists( '\WPCOM_Store_API' ) ) {
-		return false;
-	}
-	$current_plan = WPCOM_Store_API::get_current_plan( get_current_blog_id() );
-
-	$matches_free_to_paid      = ! empty( $current_plan['is_free'] ) && empty( get_option( 'options' )['is_domain_only'] );
-	$matches_monthly_to_annual = str_ends_with( (string) ( $current_plan['product_slug'] ?? '' ), '-monthly' );
-
-	return $matches_free_to_paid || $matches_monthly_to_annual;
-}
-
-/**
  * Which surface the admin bar is rendering on, for per-surface tracking.
  *
  * @return string One of 'site_frontend', 'site_editor', 'post_editor', 'wp_admin'.
@@ -606,11 +563,12 @@ function wpcom_admin_bar_tracking_surface() {
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
  */
 function wpcom_add_free_domain_upsell_chip( $wp_admin_bar ) {
-	if ( ! wpcom_free_domain_upsell_is_eligible() ) {
+	require_once __DIR__ . '/../../common/class-free-domain-upsell-experiment.php';
+
+	if ( ! Free_Domain_Upsell_Experiment::is_eligible() ) {
 		return;
 	}
 
-	require_once __DIR__ . '/../../common/class-free-domain-upsell-experiment.php';
 	if ( 'treatment' !== Free_Domain_Upsell_Experiment::get_variation() ) {
 		return;
 	}
@@ -627,7 +585,9 @@ function wpcom_add_free_domain_upsell_chip( $wp_admin_bar ) {
 			'href'   => add_query_arg(
 				array(
 					'siteSlug' => wpcom_get_site_slug(),
-					'ref'      => 'wp-admin',
+					// The chip renders wherever the admin bar does, so the ref
+					// reflects the actual surface (matches the `surface` Tracks prop).
+					'ref'      => wpcom_admin_bar_tracking_surface(),
 				),
 				'https://wordpress.com/setup/domain-and-plan'
 			),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -492,23 +492,10 @@
 			height: auto;
 			line-height: 24px;
 		}
-	}
 
-	&:hover > .ab-item,
-	> .ab-item:focus-visible {
-		background: rgba(56, 88, 233, 0.42);
-		box-shadow: inset 0 0 0 1px rgba(150, 175, 255, 0.8);
-		color: #fff;
-
-		.ab-icon svg {
-			fill: #b8c8ff;
-		}
-	}
-
-	// Keep the full pill (icon + label) on mobile, where core hides ab-labels
-	// and squeezes items to 46px.
-	@media screen and (max-width: 782px) {
-		> .ab-item {
+		// Keep the full pill (icon + label) on mobile, where core hides
+		// ab-labels and squeezes items to 46px.
+		@media screen and (max-width: 782px) {
 			width: auto;
 			height: 24px;
 			margin-block: 11px;
@@ -523,6 +510,17 @@
 				padding: 0;
 				font-size: 0;
 			}
+		}
+	}
+
+	&:hover > .ab-item,
+	> .ab-item:focus-visible {
+		background: rgba(56, 88, 233, 0.42);
+		box-shadow: inset 0 0 0 1px rgba(150, 175, 255, 0.8);
+		color: #fff;
+
+		.ab-icon svg {
+			fill: #b8c8ff;
 		}
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -449,3 +449,80 @@
 		}
 	}
 }
+
+// "Free domain" upsell chip (omnibar upsell experiment treatment).
+// Quiet translucent pill matching the Calypso omnibar chip.
+#wpadminbar #wp-admin-bar-wpcom-free-domain-upsell {
+	display: flex;
+	align-items: center;
+
+	> .ab-item {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		height: 24px;
+		margin-inline: 6px;
+		padding-inline: 4px 8px;
+		border-radius: 4px;
+		background: rgba(56, 88, 233, 0.22);
+		box-shadow: inset 0 0 0 1px rgba(120, 150, 255, 0.45);
+		color: #dcdcde;
+		font-size: 12px;
+		font-weight: 500;
+		line-height: 24px;
+		white-space: nowrap;
+		transition: background 0.12s linear, box-shadow 0.12s linear, color 0.12s linear;
+
+		.ab-icon {
+			display: inline-flex;
+			align-items: center;
+			height: auto;
+			margin: 0;
+			padding: 0;
+			font-size: 0;
+
+			svg {
+				display: block;
+				fill: #8ba4ff;
+				transition: fill 0.12s linear;
+			}
+		}
+
+		.ab-label {
+			height: auto;
+			line-height: 24px;
+		}
+	}
+
+	&:hover > .ab-item,
+	> .ab-item:focus-visible {
+		background: rgba(56, 88, 233, 0.42);
+		box-shadow: inset 0 0 0 1px rgba(150, 175, 255, 0.8);
+		color: #fff;
+
+		.ab-icon svg {
+			fill: #b8c8ff;
+		}
+	}
+
+	// Keep the full pill (icon + label) on mobile, where core hides ab-labels
+	// and squeezes items to 46px.
+	@media screen and (max-width: 782px) {
+		> .ab-item {
+			width: auto;
+			height: 24px;
+			margin-block: 11px;
+
+			.ab-label {
+				display: inline;
+			}
+
+			.ab-icon {
+				width: auto;
+				height: auto;
+				padding: 0;
+				font-size: 0;
+			}
+		}
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -105,11 +105,9 @@ function wpcom_get_sidebar_notice() {
 	// The omnibar upsell experiment moves these messages (same copy and CTA)
 	// into the admin bar for treatment users, so the sidebar copy is hidden for
 	// them. Other messages are not part of the experiment and stay untouched.
-	if ( in_array( $cached_notice['id'], array( 'free_to_paid_plan', 'monthly_to_annual_plan' ), true ) ) {
-		require_once __DIR__ . '/../../common/class-free-domain-upsell-experiment.php';
-		if ( 'treatment' === \Automattic\Jetpack\Jetpack_Mu_Wpcom\Free_Domain_Upsell_Experiment::get_variation() ) {
-			$cached_notice = null;
-		}
+	require_once __DIR__ . '/../../common/class-free-domain-upsell-experiment.php';
+	if ( \Automattic\Jetpack\Jetpack_Mu_Wpcom\Free_Domain_Upsell_Experiment::should_suppress_sidebar_notice( $cached_notice['id'] ) ) {
+		$cached_notice = null;
 	}
 
 	return $cached_notice;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -102,10 +102,10 @@ function wpcom_get_sidebar_notice() {
 		'tracks'        => $message->tracks ?? null,
 	);
 
-	// The omnibar upsell experiment moves this message into the admin bar for
-	// treatment users, so the sidebar copy is hidden for them. Other messages
-	// are not part of the experiment and stay untouched.
-	if ( 'free_to_paid_plan' === $cached_notice['id'] ) {
+	// The omnibar upsell experiment moves these messages (same copy and CTA)
+	// into the admin bar for treatment users, so the sidebar copy is hidden for
+	// them. Other messages are not part of the experiment and stay untouched.
+	if ( in_array( $cached_notice['id'], array( 'free_to_paid_plan', 'monthly_to_annual_plan' ), true ) ) {
 		require_once __DIR__ . '/../../common/class-free-domain-upsell-experiment.php';
 		if ( 'treatment' === \Automattic\Jetpack\Jetpack_Mu_Wpcom\Free_Domain_Upsell_Experiment::get_variation() ) {
 			$cached_notice = null;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -102,6 +102,16 @@ function wpcom_get_sidebar_notice() {
 		'tracks'        => $message->tracks ?? null,
 	);
 
+	// The omnibar upsell experiment moves this message into the admin bar for
+	// treatment users, so the sidebar copy is hidden for them. Other messages
+	// are not part of the experiment and stay untouched.
+	if ( 'free_to_paid_plan' === $cached_notice['id'] ) {
+		require_once __DIR__ . '/../../common/class-free-domain-upsell-experiment.php';
+		if ( 'treatment' === \Automattic\Jetpack\Jetpack_Mu_Wpcom\Free_Domain_Upsell_Experiment::get_variation() ) {
+			$cached_notice = null;
+		}
+	}
+
 	return $cached_notice;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/Free_Domain_Upsell_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/Free_Domain_Upsell_Test.php
@@ -46,14 +46,18 @@ namespace {
 	if ( ! class_exists( 'WPCOM_Store_API' ) ) {
 		/**
 		 * Test double for the wpcom-only store API.
+		 *
+		 * This class leaks into other test files in the same process, so when no
+		 * test plan is configured it delegates to Current_Plan::get() — the exact
+		 * path production code takes when the class is absent.
 		 */
 		class WPCOM_Store_API {
 			/**
-			 * The plan returned by get_current_plan().
+			 * The plan returned by get_current_plan(), or null to delegate.
 			 *
-			 * @var array
+			 * @var array|null
 			 */
-			public static $current_plan = array();
+			public static $current_plan = null;
 
 			/**
 			 * Returns the configured test plan.
@@ -62,6 +66,9 @@ namespace {
 			 * @return array
 			 */
 			public static function get_current_plan( $blog_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				if ( null === self::$current_plan ) {
+					return \Automattic\Jetpack\Current_Plan::get();
+				}
 				return self::$current_plan;
 			}
 		}
@@ -115,6 +122,7 @@ namespace {
 		public function tear_down() {
 			delete_transient( 'free-domain-upsell-variation-' . $this->admin_id );
 			remove_all_filters( 'wpcom_free_domain_upsell_variation' );
+			WPCOM_Store_API::$current_plan = null;
 			Constants::clear_constants();
 			unset(
 				$GLOBALS['explat_assign_calls'],

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/Free_Domain_Upsell_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/Free_Domain_Upsell_Test.php
@@ -14,11 +14,6 @@ require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-admin-bar/wpcom-adm
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/common/class-free-domain-upsell-experiment.php';
 require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
 
-if ( ! function_exists( 'get_current_screen' ) ) {
-	require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
-	require_once ABSPATH . 'wp-admin/includes/screen.php';
-}
-
 /**
  * Tests for the free-domain upsell chip eligibility, experiment resolution,
  * sidebar-notice suppression, tracking surface, and admin bar node.
@@ -122,56 +117,19 @@ class Free_Domain_Upsell_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Fakes the current screen so is_admin() and get_current_screen() see it.
+	 * Sets a real admin screen, same pattern as Survicate_Test.
 	 *
-	 * @param string $id              The screen id.
+	 * @param string $screen_id       The screen id.
 	 * @param bool   $is_block_editor Whether the screen hosts the block editor.
 	 */
-	private function fake_admin_screen( $id, $is_block_editor = false ) {
-		$GLOBALS['current_screen'] = new class( $id, $is_block_editor ) {
-			/**
-			 * The screen id.
-			 *
-			 * @var string
-			 */
-			public $id;
-
-			/**
-			 * Whether the screen hosts the block editor.
-			 *
-			 * @var bool
-			 */
-			private $block_editor;
-
-			/**
-			 * Constructor.
-			 *
-			 * @param string $id              The screen id.
-			 * @param bool   $is_block_editor Whether the screen hosts the block editor.
-			 */
-			public function __construct( $id, $is_block_editor ) {
-				$this->id           = $id;
-				$this->block_editor = $is_block_editor;
-			}
-
-			/**
-			 * Mirrors WP_Screen::in_admin() for is_admin().
-			 *
-			 * @return bool
-			 */
-			public function in_admin() {
-				return true;
-			}
-
-			/**
-			 * Mirrors WP_Screen::is_block_editor().
-			 *
-			 * @return bool
-			 */
-			public function is_block_editor() {
-				return $this->block_editor;
-			}
-		};
+	private function set_admin_screen( $screen_id, $is_block_editor = false ) {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( $screen_id );
+		if ( $is_block_editor ) {
+			$screen   = get_current_screen();
+			$property = ( new \ReflectionClass( $screen ) )->getProperty( 'is_block_editor' );
+			$property->setValue( $screen, true );
+		}
 	}
 
 	// ---- Eligibility ----
@@ -397,7 +355,7 @@ class Free_Domain_Upsell_Test extends \WorDBless\BaseTestCase {
 	 * A regular admin screen reports wp_admin.
 	 */
 	public function test_tracking_surface_wp_admin() {
-		$this->fake_admin_screen( 'edit-post' );
+		$this->set_admin_screen( 'edit-post' );
 		$this->assertSame( 'wp_admin', wpcom_admin_bar_tracking_surface() );
 	}
 
@@ -405,7 +363,7 @@ class Free_Domain_Upsell_Test extends \WorDBless\BaseTestCase {
 	 * A block editor screen reports post_editor.
 	 */
 	public function test_tracking_surface_post_editor() {
-		$this->fake_admin_screen( 'post', true );
+		$this->set_admin_screen( 'post', true );
 		$this->assertSame( 'post_editor', wpcom_admin_bar_tracking_surface() );
 	}
 
@@ -413,7 +371,7 @@ class Free_Domain_Upsell_Test extends \WorDBless\BaseTestCase {
 	 * The site editor reports site_editor (checked before is_block_editor()).
 	 */
 	public function test_tracking_surface_site_editor() {
-		$this->fake_admin_screen( 'site-editor', true );
+		$this->set_admin_screen( 'site-editor', true );
 		$this->assertSame( 'site_editor', wpcom_admin_bar_tracking_surface() );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/Free_Domain_Upsell_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/Free_Domain_Upsell_Test.php
@@ -1,0 +1,338 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Test class for the omnibar free-domain upsell chip and its experiment gate.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace ExPlat {
+	if ( ! function_exists( 'ExPlat\assign_current_user' ) ) {
+		/**
+		 * Test double for the wpcom-only assigning ExPlat call.
+		 *
+		 * @param string $experiment_name The experiment name.
+		 * @return string|null
+		 */
+		function assign_current_user( string $experiment_name ): ?string {
+			$GLOBALS['explat_assign_calls'][] = $experiment_name;
+			return $GLOBALS['explat_assign_return'] ?? null;
+		}
+	}
+
+	if ( ! function_exists( 'ExPlat\get_current_user_assignment' ) ) {
+		/**
+		 * Test double for the wpcom-only non-assigning ExPlat read.
+		 *
+		 * @param string $experiment_name The experiment name.
+		 * @return string|null
+		 */
+		function get_current_user_assignment( string $experiment_name ): ?string {
+			$GLOBALS['explat_read_calls'][] = $experiment_name;
+			return $GLOBALS['explat_read_return'] ?? null;
+		}
+	}
+}
+
+namespace {
+
+	use Automattic\Jetpack\Constants;
+	use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+	use Automattic\Jetpack\Jetpack_Mu_Wpcom\Free_Domain_Upsell_Experiment;
+
+	require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-admin-bar/wpcom-admin-bar.php';
+	require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/common/class-free-domain-upsell-experiment.php';
+	require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+
+	if ( ! class_exists( 'WPCOM_Store_API' ) ) {
+		/**
+		 * Test double for the wpcom-only store API.
+		 */
+		class WPCOM_Store_API {
+			/**
+			 * The plan returned by get_current_plan().
+			 *
+			 * @var array
+			 */
+			public static $current_plan = array();
+
+			/**
+			 * Returns the configured test plan.
+			 *
+			 * @param int $blog_id The blog ID (unused).
+			 * @return array
+			 */
+			public static function get_current_plan( $blog_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+				return self::$current_plan;
+			}
+		}
+	}
+
+	/**
+	 * Tests for the free-domain upsell chip eligibility, experiment resolution,
+	 * and admin bar node.
+	 */
+	class Free_Domain_Upsell_Test extends \WorDBless\BaseTestCase {
+
+		/**
+		 * The test admin user ID.
+		 *
+		 * @var int
+		 */
+		private $admin_id;
+
+		/**
+		 * Set up an eligible environment: Simple site, Free plan, admin user,
+		 * `.wordpress.com` primary domain.
+		 */
+		public function set_up() {
+			parent::set_up();
+
+			$this->admin_id = wp_insert_user(
+				array(
+					'user_login' => 'free_domain_admin',
+					'user_pass'  => 'password',
+					'role'       => 'administrator',
+				)
+			);
+			wp_set_current_user( $this->admin_id );
+
+			Constants::set_constant( 'IS_WPCOM', true );
+			update_option( 'home', 'https://testsite.wordpress.com' );
+			WPCOM_Store_API::$current_plan = array(
+				'is_free'      => true,
+				'product_slug' => 'free_plan',
+			);
+
+			$GLOBALS['explat_assign_calls']  = array();
+			$GLOBALS['explat_read_calls']    = array();
+			$GLOBALS['explat_assign_return'] = null;
+			$GLOBALS['explat_read_return']   = null;
+		}
+
+		/**
+		 * Clean up globals, constants, filters, and the per-user transient.
+		 */
+		public function tear_down() {
+			delete_transient( 'free-domain-upsell-variation-' . $this->admin_id );
+			remove_all_filters( 'wpcom_free_domain_upsell_variation' );
+			Constants::clear_constants();
+			unset(
+				$GLOBALS['explat_assign_calls'],
+				$GLOBALS['explat_read_calls'],
+				$GLOBALS['explat_assign_return'],
+				$GLOBALS['explat_read_return']
+			);
+			parent::tear_down();
+		}
+
+		/**
+		 * Runs the chip registration against a fresh admin bar and returns the node.
+		 *
+		 * @return object|null
+		 */
+		private function get_chip_node() {
+			$admin_bar = new \WP_Admin_Bar();
+			wpcom_add_free_domain_upsell_chip( $admin_bar );
+			return $admin_bar->get_node( 'wpcom-free-domain-upsell' );
+		}
+
+		/**
+		 * Forces the experiment variation via the QA filter.
+		 *
+		 * @param string $variation The variation to force.
+		 */
+		private function force_variation( $variation ) {
+			add_filter(
+				'wpcom_free_domain_upsell_variation',
+				function () use ( $variation ) {
+					return $variation;
+				}
+			);
+		}
+
+		// ---- Eligibility ----
+
+		/**
+		 * The baseline environment (Free Simple admin) is eligible.
+		 */
+		public function test_eligible_for_free_simple_admin() {
+			$this->assertTrue( wpcom_free_domain_upsell_is_eligible() );
+		}
+
+		/**
+		 * A monthly-plan site is eligible (monthly_to_annual_plan counterpart).
+		 */
+		public function test_eligible_for_monthly_plan_site() {
+			WPCOM_Store_API::$current_plan = array(
+				'is_free'      => false,
+				'product_slug' => 'personal-bundle-monthly',
+			);
+			$this->assertTrue( wpcom_free_domain_upsell_is_eligible() );
+		}
+
+		/**
+		 * A yearly paid plan is not eligible.
+		 */
+		public function test_not_eligible_for_yearly_paid_plan() {
+			WPCOM_Store_API::$current_plan = array(
+				'is_free'      => false,
+				'product_slug' => 'personal-bundle',
+			);
+			$this->assertFalse( wpcom_free_domain_upsell_is_eligible() );
+		}
+
+		/**
+		 * Non-admins are not eligible.
+		 */
+		public function test_not_eligible_for_non_admin() {
+			$subscriber = wp_insert_user(
+				array(
+					'user_login' => 'free_domain_subscriber',
+					'user_pass'  => 'password',
+					'role'       => 'subscriber',
+				)
+			);
+			wp_set_current_user( $subscriber );
+			$this->assertFalse( wpcom_free_domain_upsell_is_eligible() );
+		}
+
+		/**
+		 * Sites with a mapped primary domain are not eligible.
+		 */
+		public function test_not_eligible_with_mapped_primary_domain() {
+			update_option( 'home', 'https://example.com' );
+			$this->assertFalse( wpcom_free_domain_upsell_is_eligible() );
+		}
+
+		/**
+		 * Staging sites are not eligible.
+		 */
+		public function test_not_eligible_for_staging_site() {
+			update_option( 'wpcom_is_staging_site', true );
+			$this->assertFalse( wpcom_free_domain_upsell_is_eligible() );
+		}
+
+		/**
+		 * Domain-only free sites are not eligible.
+		 */
+		public function test_not_eligible_for_domain_only_site() {
+			update_option( 'options', array( 'is_domain_only' => true ) );
+			$this->assertFalse( wpcom_free_domain_upsell_is_eligible() );
+		}
+
+		/**
+		 * Non-Simple (e.g. Atomic/self-hosted) environments are not eligible.
+		 */
+		public function test_not_eligible_outside_wpcom_simple() {
+			Constants::clear_single_constant( 'IS_WPCOM' );
+			$this->assertFalse( wpcom_free_domain_upsell_is_eligible() );
+		}
+
+		// ---- Experiment resolution ----
+
+		/**
+		 * The QA override filter wins without any ExPlat call.
+		 */
+		public function test_variation_filter_override_wins() {
+			$this->force_variation( 'treatment' );
+			$this->assertSame( 'treatment', Free_Domain_Upsell_Experiment::get_variation() );
+			$this->assertSame( array(), $GLOBALS['explat_assign_calls'] );
+			$this->assertSame( array(), $GLOBALS['explat_read_calls'] );
+		}
+
+		/**
+		 * Unknown variations normalize to control.
+		 */
+		public function test_unknown_variation_normalizes_to_control() {
+			$this->force_variation( 'something_else' );
+			$this->assertSame( 'control', Free_Domain_Upsell_Experiment::get_variation() );
+		}
+
+		/**
+		 * A page render uses the assigning call, and the result is cached: a
+		 * second read resolves from the transient without another ExPlat call.
+		 */
+		public function test_page_render_assigns_and_caches() {
+			$GLOBALS['explat_assign_return'] = 'treatment';
+
+			$this->assertSame( 'treatment', Free_Domain_Upsell_Experiment::get_variation() );
+			$this->assertCount( 1, $GLOBALS['explat_assign_calls'] );
+			$this->assertSame(
+				Free_Domain_Upsell_Experiment::EXPERIMENT_NAME,
+				$GLOBALS['explat_assign_calls'][0]
+			);
+
+			$this->assertSame( 'treatment', Free_Domain_Upsell_Experiment::get_variation() );
+			$this->assertCount( 1, $GLOBALS['explat_assign_calls'] );
+		}
+
+		/**
+		 * A REST request (e.g. the omnibar admin-bar endpoint) uses the
+		 * non-assigning read and never assigns.
+		 */
+		public function test_rest_request_reads_without_assigning() {
+			Constants::set_constant( 'REST_REQUEST', true );
+			$GLOBALS['explat_read_return'] = 'treatment';
+
+			$this->assertSame( 'treatment', Free_Domain_Upsell_Experiment::get_variation() );
+			$this->assertSame( array(), $GLOBALS['explat_assign_calls'] );
+			$this->assertCount( 1, $GLOBALS['explat_read_calls'] );
+		}
+
+		/**
+		 * An unassigned user resolves to control without caching, so a later
+		 * page render can still create the assignment.
+		 */
+		public function test_unassigned_resolves_to_control_without_caching() {
+			$GLOBALS['explat_assign_return'] = null;
+
+			$this->assertSame( 'control', Free_Domain_Upsell_Experiment::get_variation() );
+			$this->assertSame( 'control', Free_Domain_Upsell_Experiment::get_variation() );
+			// No transient was written, so both reads hit ExPlat.
+			$this->assertCount( 2, $GLOBALS['explat_assign_calls'] );
+		}
+
+		/**
+		 * Logged-out users resolve to control without any ExPlat call.
+		 */
+		public function test_logged_out_resolves_to_control() {
+			wp_set_current_user( 0 );
+			$this->assertSame( 'control', Free_Domain_Upsell_Experiment::get_variation() );
+			$this->assertSame( array(), $GLOBALS['explat_assign_calls'] );
+		}
+
+		// ---- Admin bar node ----
+
+		/**
+		 * The chip node is added for an eligible admin in the treatment.
+		 */
+		public function test_chip_added_for_treatment() {
+			$this->force_variation( 'treatment' );
+
+			$node = $this->get_chip_node();
+			$this->assertNotNull( $node );
+			$this->assertStringContainsString( '/setup/domain-and-plan', $node->href );
+			$this->assertStringContainsString( 'Free domain', $node->title );
+		}
+
+		/**
+		 * No chip node for control users.
+		 */
+		public function test_chip_not_added_for_control() {
+			$this->force_variation( 'control' );
+			$this->assertNull( $this->get_chip_node() );
+		}
+
+		/**
+		 * No chip node when the site is not eligible, even in the treatment.
+		 */
+		public function test_chip_not_added_when_not_eligible() {
+			$this->force_variation( 'treatment' );
+			WPCOM_Store_API::$current_plan = array(
+				'is_free'      => false,
+				'product_slug' => 'business-bundle',
+			);
+			$this->assertNull( $this->get_chip_node() );
+		}
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/Free_Domain_Upsell_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/Free_Domain_Upsell_Test.php
@@ -5,342 +5,454 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
-namespace ExPlat {
-	if ( ! function_exists( 'ExPlat\assign_current_user' ) ) {
-		/**
-		 * Test double for the wpcom-only assigning ExPlat call.
-		 *
-		 * @param string $experiment_name The experiment name.
-		 * @return string|null
-		 */
-		function assign_current_user( string $experiment_name ): ?string {
-			$GLOBALS['explat_assign_calls'][] = $experiment_name;
-			return $GLOBALS['explat_assign_return'] ?? null;
-		}
-	}
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Free_Domain_Upsell_Experiment;
 
-	if ( ! function_exists( 'ExPlat\get_current_user_assignment' ) ) {
-		/**
-		 * Test double for the wpcom-only non-assigning ExPlat read.
-		 *
-		 * @param string $experiment_name The experiment name.
-		 * @return string|null
-		 */
-		function get_current_user_assignment( string $experiment_name ): ?string {
-			$GLOBALS['explat_read_calls'][] = $experiment_name;
-			return $GLOBALS['explat_read_return'] ?? null;
-		}
-	}
+require_once __DIR__ . '/explat-doubles.php';
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-admin-bar/wpcom-admin-bar.php';
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/common/class-free-domain-upsell-experiment.php';
+require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+
+if ( ! function_exists( 'get_current_screen' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
+	require_once ABSPATH . 'wp-admin/includes/screen.php';
 }
 
-namespace {
+/**
+ * Tests for the free-domain upsell chip eligibility, experiment resolution,
+ * sidebar-notice suppression, tracking surface, and admin bar node.
+ */
+class Free_Domain_Upsell_Test extends \WorDBless\BaseTestCase {
 
-	use Automattic\Jetpack\Constants;
-	use Automattic\Jetpack\Jetpack_Mu_Wpcom;
-	use Automattic\Jetpack\Jetpack_Mu_Wpcom\Free_Domain_Upsell_Experiment;
+	/**
+	 * The test admin user ID.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
 
-	require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-admin-bar/wpcom-admin-bar.php';
-	require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/common/class-free-domain-upsell-experiment.php';
-	require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+	/**
+	 * Set up an eligible environment: Simple site, Free plan, admin user,
+	 * `.wordpress.com` primary domain.
+	 */
+	public function set_up() {
+		parent::set_up();
 
-	if ( ! class_exists( 'WPCOM_Store_API' ) ) {
-		/**
-		 * Test double for the wpcom-only store API.
-		 *
-		 * This class leaks into other test files in the same process, so when no
-		 * test plan is configured it delegates to Current_Plan::get() — the exact
-		 * path production code takes when the class is absent.
-		 */
-		class WPCOM_Store_API {
-			/**
-			 * The plan returned by get_current_plan(), or null to delegate.
-			 *
-			 * @var array|null
-			 */
-			public static $current_plan = null;
+		$this->admin_id = wp_insert_user(
+			array(
+				'user_login' => 'free_domain_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $this->admin_id );
 
-			/**
-			 * Returns the configured test plan.
-			 *
-			 * @param int $blog_id The blog ID (unused).
-			 * @return array
-			 */
-			public static function get_current_plan( $blog_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-				if ( null === self::$current_plan ) {
-					return \Automattic\Jetpack\Current_Plan::get();
-				}
-				return self::$current_plan;
-			}
-		}
+		Constants::set_constant( 'IS_WPCOM', true );
+		update_option( 'home', 'https://testsite.wordpress.com' );
+		$this->set_plan(
+			array(
+				'is_free'      => true,
+				'product_slug' => 'free_plan',
+			)
+		);
+
+		$GLOBALS['explat_assign_calls']  = array();
+		$GLOBALS['explat_read_calls']    = array();
+		$GLOBALS['explat_assign_return'] = null;
+		$GLOBALS['explat_read_return']   = null;
 	}
 
 	/**
-	 * Tests for the free-domain upsell chip eligibility, experiment resolution,
-	 * and admin bar node.
+	 * Clean up globals, constants, filters, and the per-user transient.
 	 */
-	class Free_Domain_Upsell_Test extends \WorDBless\BaseTestCase {
+	public function tear_down() {
+		delete_transient( 'free-domain-upsell-variation-' . $this->admin_id );
+		remove_all_filters( 'wpcom_free_domain_upsell_variation' );
+		remove_all_filters( 'wpcom_free_domain_upsell_current_plan' );
+		Constants::clear_constants();
+		unset(
+			$GLOBALS['current_screen'],
+			$GLOBALS['explat_assign_calls'],
+			$GLOBALS['explat_read_calls'],
+			$GLOBALS['explat_assign_return'],
+			$GLOBALS['explat_read_return']
+		);
+		parent::tear_down();
+	}
 
-		/**
-		 * The test admin user ID.
-		 *
-		 * @var int
-		 */
-		private $admin_id;
+	/**
+	 * Sets the plan data eligibility reads, via the QA/testing filter.
+	 *
+	 * @param array $plan The plan data (is_free, product_slug).
+	 */
+	private function set_plan( array $plan ) {
+		remove_all_filters( 'wpcom_free_domain_upsell_current_plan' );
+		add_filter(
+			'wpcom_free_domain_upsell_current_plan',
+			function () use ( $plan ) {
+				return $plan;
+			}
+		);
+	}
 
-		/**
-		 * Set up an eligible environment: Simple site, Free plan, admin user,
-		 * `.wordpress.com` primary domain.
-		 */
-		public function set_up() {
-			parent::set_up();
+	/**
+	 * Runs the chip registration against a fresh admin bar and returns the node.
+	 *
+	 * @return object|null
+	 */
+	private function get_chip_node() {
+		$admin_bar = new \WP_Admin_Bar();
+		wpcom_add_free_domain_upsell_chip( $admin_bar );
+		return $admin_bar->get_node( 'wpcom-free-domain-upsell' );
+	}
 
-			$this->admin_id = wp_insert_user(
-				array(
-					'user_login' => 'free_domain_admin',
-					'user_pass'  => 'password',
-					'role'       => 'administrator',
-				)
-			);
-			wp_set_current_user( $this->admin_id );
+	/**
+	 * Forces the experiment variation via the QA filter.
+	 *
+	 * @param string $variation The variation to force.
+	 */
+	private function force_variation( $variation ) {
+		add_filter(
+			'wpcom_free_domain_upsell_variation',
+			function () use ( $variation ) {
+				return $variation;
+			}
+		);
+	}
 
-			Constants::set_constant( 'IS_WPCOM', true );
-			update_option( 'home', 'https://testsite.wordpress.com' );
-			WPCOM_Store_API::$current_plan = array(
-				'is_free'      => true,
-				'product_slug' => 'free_plan',
-			);
+	/**
+	 * Fakes the current screen so is_admin() and get_current_screen() see it.
+	 *
+	 * @param string $id              The screen id.
+	 * @param bool   $is_block_editor Whether the screen hosts the block editor.
+	 */
+	private function fake_admin_screen( $id, $is_block_editor = false ) {
+		$GLOBALS['current_screen'] = new class( $id, $is_block_editor ) {
+			/**
+			 * The screen id.
+			 *
+			 * @var string
+			 */
+			public $id;
 
-			$GLOBALS['explat_assign_calls']  = array();
-			$GLOBALS['explat_read_calls']    = array();
-			$GLOBALS['explat_assign_return'] = null;
-			$GLOBALS['explat_read_return']   = null;
-		}
+			/**
+			 * Whether the screen hosts the block editor.
+			 *
+			 * @var bool
+			 */
+			private $block_editor;
 
-		/**
-		 * Clean up globals, constants, filters, and the per-user transient.
-		 */
-		public function tear_down() {
-			delete_transient( 'free-domain-upsell-variation-' . $this->admin_id );
-			remove_all_filters( 'wpcom_free_domain_upsell_variation' );
-			WPCOM_Store_API::$current_plan = null;
-			Constants::clear_constants();
-			unset(
-				$GLOBALS['explat_assign_calls'],
-				$GLOBALS['explat_read_calls'],
-				$GLOBALS['explat_assign_return'],
-				$GLOBALS['explat_read_return']
-			);
-			parent::tear_down();
-		}
+			/**
+			 * Constructor.
+			 *
+			 * @param string $id              The screen id.
+			 * @param bool   $is_block_editor Whether the screen hosts the block editor.
+			 */
+			public function __construct( $id, $is_block_editor ) {
+				$this->id           = $id;
+				$this->block_editor = $is_block_editor;
+			}
 
-		/**
-		 * Runs the chip registration against a fresh admin bar and returns the node.
-		 *
-		 * @return object|null
-		 */
-		private function get_chip_node() {
-			$admin_bar = new \WP_Admin_Bar();
-			wpcom_add_free_domain_upsell_chip( $admin_bar );
-			return $admin_bar->get_node( 'wpcom-free-domain-upsell' );
-		}
+			/**
+			 * Mirrors WP_Screen::in_admin() for is_admin().
+			 *
+			 * @return bool
+			 */
+			public function in_admin() {
+				return true;
+			}
 
-		/**
-		 * Forces the experiment variation via the QA filter.
-		 *
-		 * @param string $variation The variation to force.
-		 */
-		private function force_variation( $variation ) {
-			add_filter(
-				'wpcom_free_domain_upsell_variation',
-				function () use ( $variation ) {
-					return $variation;
-				}
-			);
-		}
+			/**
+			 * Mirrors WP_Screen::is_block_editor().
+			 *
+			 * @return bool
+			 */
+			public function is_block_editor() {
+				return $this->block_editor;
+			}
+		};
+	}
 
-		// ---- Eligibility ----
+	// ---- Eligibility ----
 
-		/**
-		 * The baseline environment (Free Simple admin) is eligible.
-		 */
-		public function test_eligible_for_free_simple_admin() {
-			$this->assertTrue( wpcom_free_domain_upsell_is_eligible() );
-		}
+	/**
+	 * The baseline environment (Free Simple admin) is eligible, via the Free branch.
+	 */
+	public function test_eligible_for_free_simple_admin() {
+		$this->assertTrue( Free_Domain_Upsell_Experiment::is_eligible() );
+		$this->assertSame( 'free_to_paid_plan', Free_Domain_Upsell_Experiment::get_upsell_source() );
+	}
 
-		/**
-		 * A monthly-plan site is eligible (monthly_to_annual_plan counterpart).
-		 */
-		public function test_eligible_for_monthly_plan_site() {
-			WPCOM_Store_API::$current_plan = array(
+	/**
+	 * A monthly-plan site is eligible (monthly_to_annual_plan counterpart).
+	 */
+	public function test_eligible_for_monthly_plan_site() {
+		$this->set_plan(
+			array(
 				'is_free'      => false,
 				'product_slug' => 'personal-bundle-monthly',
-			);
-			$this->assertTrue( wpcom_free_domain_upsell_is_eligible() );
-		}
+			)
+		);
+		$this->assertTrue( Free_Domain_Upsell_Experiment::is_eligible() );
+		$this->assertSame( 'monthly_to_annual_plan', Free_Domain_Upsell_Experiment::get_upsell_source() );
+	}
 
-		/**
-		 * A yearly paid plan is not eligible.
-		 */
-		public function test_not_eligible_for_yearly_paid_plan() {
-			WPCOM_Store_API::$current_plan = array(
+	/**
+	 * A yearly paid plan is not eligible.
+	 */
+	public function test_not_eligible_for_yearly_paid_plan() {
+		$this->set_plan(
+			array(
 				'is_free'      => false,
 				'product_slug' => 'personal-bundle',
-			);
-			$this->assertFalse( wpcom_free_domain_upsell_is_eligible() );
-		}
+			)
+		);
+		$this->assertFalse( Free_Domain_Upsell_Experiment::is_eligible() );
+	}
 
-		/**
-		 * Non-admins are not eligible.
-		 */
-		public function test_not_eligible_for_non_admin() {
-			$subscriber = wp_insert_user(
-				array(
-					'user_login' => 'free_domain_subscriber',
-					'user_pass'  => 'password',
-					'role'       => 'subscriber',
-				)
-			);
-			wp_set_current_user( $subscriber );
-			$this->assertFalse( wpcom_free_domain_upsell_is_eligible() );
-		}
+	/**
+	 * Non-admins are not eligible.
+	 */
+	public function test_not_eligible_for_non_admin() {
+		$subscriber = wp_insert_user(
+			array(
+				'user_login' => 'free_domain_subscriber',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $subscriber );
+		$this->assertFalse( Free_Domain_Upsell_Experiment::is_eligible() );
+	}
 
-		/**
-		 * Sites with a mapped primary domain are not eligible.
-		 */
-		public function test_not_eligible_with_mapped_primary_domain() {
-			update_option( 'home', 'https://example.com' );
-			$this->assertFalse( wpcom_free_domain_upsell_is_eligible() );
-		}
+	/**
+	 * Sites with a mapped primary domain are not eligible.
+	 */
+	public function test_not_eligible_with_mapped_primary_domain() {
+		update_option( 'home', 'https://example.com' );
+		$this->assertFalse( Free_Domain_Upsell_Experiment::is_eligible() );
+	}
 
-		/**
-		 * Staging sites are not eligible.
-		 */
-		public function test_not_eligible_for_staging_site() {
-			update_option( 'wpcom_is_staging_site', true );
-			$this->assertFalse( wpcom_free_domain_upsell_is_eligible() );
-		}
+	/**
+	 * Staging sites are not eligible.
+	 */
+	public function test_not_eligible_for_staging_site() {
+		update_option( 'wpcom_is_staging_site', true );
+		$this->assertFalse( Free_Domain_Upsell_Experiment::is_eligible() );
+	}
 
-		/**
-		 * Domain-only free sites are not eligible.
-		 */
-		public function test_not_eligible_for_domain_only_site() {
-			update_option( 'options', array( 'is_domain_only' => true ) );
-			$this->assertFalse( wpcom_free_domain_upsell_is_eligible() );
-		}
+	/**
+	 * Domain-only free sites are not eligible.
+	 */
+	public function test_not_eligible_for_domain_only_site() {
+		update_option( 'options', array( 'is_domain_only' => true ) );
+		$this->assertFalse( Free_Domain_Upsell_Experiment::is_eligible() );
+	}
 
-		/**
-		 * Non-Simple (e.g. Atomic/self-hosted) environments are not eligible.
-		 */
-		public function test_not_eligible_outside_wpcom_simple() {
-			Constants::clear_single_constant( 'IS_WPCOM' );
-			$this->assertFalse( wpcom_free_domain_upsell_is_eligible() );
-		}
+	/**
+	 * Non-Simple (e.g. Atomic/self-hosted) environments are not eligible.
+	 */
+	public function test_not_eligible_outside_wpcom_simple() {
+		Constants::clear_single_constant( 'IS_WPCOM' );
+		$this->assertFalse( Free_Domain_Upsell_Experiment::is_eligible() );
+	}
 
-		// ---- Experiment resolution ----
+	// ---- Experiment resolution ----
 
-		/**
-		 * The QA override filter wins without any ExPlat call.
-		 */
-		public function test_variation_filter_override_wins() {
-			$this->force_variation( 'treatment' );
-			$this->assertSame( 'treatment', Free_Domain_Upsell_Experiment::get_variation() );
-			$this->assertSame( array(), $GLOBALS['explat_assign_calls'] );
-			$this->assertSame( array(), $GLOBALS['explat_read_calls'] );
-		}
+	/**
+	 * The QA override filter wins without any ExPlat call.
+	 */
+	public function test_variation_filter_override_wins() {
+		$this->force_variation( 'treatment' );
+		$this->assertSame( 'treatment', Free_Domain_Upsell_Experiment::get_variation() );
+		$this->assertSame( array(), $GLOBALS['explat_assign_calls'] );
+		$this->assertSame( array(), $GLOBALS['explat_read_calls'] );
+	}
 
-		/**
-		 * Unknown variations normalize to control.
-		 */
-		public function test_unknown_variation_normalizes_to_control() {
-			$this->force_variation( 'something_else' );
-			$this->assertSame( 'control', Free_Domain_Upsell_Experiment::get_variation() );
-		}
+	/**
+	 * Unknown variations normalize to control.
+	 */
+	public function test_unknown_variation_normalizes_to_control() {
+		$this->force_variation( 'something_else' );
+		$this->assertSame( 'control', Free_Domain_Upsell_Experiment::get_variation() );
+	}
 
-		/**
-		 * A page render uses the assigning call, and the result is cached: a
-		 * second read resolves from the transient without another ExPlat call.
-		 */
-		public function test_page_render_assigns_and_caches() {
-			$GLOBALS['explat_assign_return'] = 'treatment';
+	/**
+	 * A page render uses the assigning call, and the result is cached: a
+	 * second read resolves from the transient without another ExPlat call.
+	 */
+	public function test_page_render_assigns_and_caches() {
+		$GLOBALS['explat_assign_return'] = 'treatment';
 
-			$this->assertSame( 'treatment', Free_Domain_Upsell_Experiment::get_variation() );
-			$this->assertCount( 1, $GLOBALS['explat_assign_calls'] );
-			$this->assertSame(
-				Free_Domain_Upsell_Experiment::EXPERIMENT_NAME,
-				$GLOBALS['explat_assign_calls'][0]
-			);
+		$this->assertSame( 'treatment', Free_Domain_Upsell_Experiment::get_variation() );
+		$this->assertCount( 1, $GLOBALS['explat_assign_calls'] );
+		$this->assertSame(
+			Free_Domain_Upsell_Experiment::EXPERIMENT_NAME,
+			$GLOBALS['explat_assign_calls'][0]
+		);
 
-			$this->assertSame( 'treatment', Free_Domain_Upsell_Experiment::get_variation() );
-			$this->assertCount( 1, $GLOBALS['explat_assign_calls'] );
-		}
+		$this->assertSame( 'treatment', Free_Domain_Upsell_Experiment::get_variation() );
+		$this->assertCount( 1, $GLOBALS['explat_assign_calls'] );
+	}
 
-		/**
-		 * A REST request (e.g. the omnibar admin-bar endpoint) uses the
-		 * non-assigning read and never assigns.
-		 */
-		public function test_rest_request_reads_without_assigning() {
-			Constants::set_constant( 'REST_REQUEST', true );
-			$GLOBALS['explat_read_return'] = 'treatment';
+	/**
+	 * A REST request (e.g. the omnibar admin-bar endpoint) uses the
+	 * non-assigning read and never assigns.
+	 */
+	public function test_rest_request_reads_without_assigning() {
+		Constants::set_constant( 'REST_REQUEST', true );
+		$GLOBALS['explat_read_return'] = 'treatment';
 
-			$this->assertSame( 'treatment', Free_Domain_Upsell_Experiment::get_variation() );
-			$this->assertSame( array(), $GLOBALS['explat_assign_calls'] );
-			$this->assertCount( 1, $GLOBALS['explat_read_calls'] );
-		}
+		$this->assertSame( 'treatment', Free_Domain_Upsell_Experiment::get_variation() );
+		$this->assertSame( array(), $GLOBALS['explat_assign_calls'] );
+		$this->assertCount( 1, $GLOBALS['explat_read_calls'] );
+	}
 
-		/**
-		 * An unassigned user resolves to control without caching, so a later
-		 * page render can still create the assignment.
-		 */
-		public function test_unassigned_resolves_to_control_without_caching() {
-			$GLOBALS['explat_assign_return'] = null;
+	/**
+	 * An unassigned user resolves to control without caching, so a later
+	 * page render can still create the assignment.
+	 */
+	public function test_unassigned_resolves_to_control_without_caching() {
+		$GLOBALS['explat_assign_return'] = null;
 
-			$this->assertSame( 'control', Free_Domain_Upsell_Experiment::get_variation() );
-			$this->assertSame( 'control', Free_Domain_Upsell_Experiment::get_variation() );
-			// No transient was written, so both reads hit ExPlat.
-			$this->assertCount( 2, $GLOBALS['explat_assign_calls'] );
-		}
+		$this->assertSame( 'control', Free_Domain_Upsell_Experiment::get_variation() );
+		$this->assertFalse( get_transient( 'free-domain-upsell-variation-' . $this->admin_id ) );
+		$this->assertSame( 'control', Free_Domain_Upsell_Experiment::get_variation() );
+		// No transient was written, so both reads hit ExPlat.
+		$this->assertCount( 2, $GLOBALS['explat_assign_calls'] );
+	}
 
-		/**
-		 * Logged-out users resolve to control without any ExPlat call.
-		 */
-		public function test_logged_out_resolves_to_control() {
-			wp_set_current_user( 0 );
-			$this->assertSame( 'control', Free_Domain_Upsell_Experiment::get_variation() );
-			$this->assertSame( array(), $GLOBALS['explat_assign_calls'] );
-		}
+	/**
+	 * Logged-out users resolve to control without any ExPlat call.
+	 */
+	public function test_logged_out_resolves_to_control() {
+		wp_set_current_user( 0 );
+		$this->assertSame( 'control', Free_Domain_Upsell_Experiment::get_variation() );
+		$this->assertSame( array(), $GLOBALS['explat_assign_calls'] );
+	}
 
-		// ---- Admin bar node ----
+	// ---- Sidebar-notice suppression ----
 
-		/**
-		 * The chip node is added for an eligible admin in the treatment.
-		 */
-		public function test_chip_added_for_treatment() {
-			$this->force_variation( 'treatment' );
+	/**
+	 * The winning target notice is suppressed for an eligible treatment user.
+	 */
+	public function test_sidebar_notice_suppressed_for_treatment() {
+		$this->force_variation( 'treatment' );
+		$this->assertTrue( Free_Domain_Upsell_Experiment::should_suppress_sidebar_notice( 'free_to_paid_plan' ) );
+		$this->assertTrue( Free_Domain_Upsell_Experiment::should_suppress_sidebar_notice( 'monthly_to_annual_plan' ) );
+	}
 
-			$node = $this->get_chip_node();
-			$this->assertNotNull( $node );
-			$this->assertStringContainsString( '/setup/domain-and-plan', $node->href );
-			$this->assertStringContainsString( 'Free domain', $node->title );
-		}
+	/**
+	 * Control users keep the sidebar notice.
+	 */
+	public function test_sidebar_notice_retained_for_control() {
+		$this->force_variation( 'control' );
+		$this->assertFalse( Free_Domain_Upsell_Experiment::should_suppress_sidebar_notice( 'free_to_paid_plan' ) );
+	}
 
-		/**
-		 * No chip node for control users.
-		 */
-		public function test_chip_not_added_for_control() {
-			$this->force_variation( 'control' );
-			$this->assertNull( $this->get_chip_node() );
-		}
+	/**
+	 * Notices outside the experiment are never suppressed, even in treatment.
+	 */
+	public function test_sidebar_notice_retained_for_other_jitm() {
+		$this->force_variation( 'treatment' );
+		$this->assertFalse( Free_Domain_Upsell_Experiment::should_suppress_sidebar_notice( 'domain_upsell_nudge' ) );
+	}
 
-		/**
-		 * No chip node when the site is not eligible, even in the treatment.
-		 */
-		public function test_chip_not_added_when_not_eligible() {
-			$this->force_variation( 'treatment' );
-			WPCOM_Store_API::$current_plan = array(
+	/**
+	 * An ineligible user keeps the notice AND is never enrolled: the
+	 * eligibility gate runs before the assigning variation read.
+	 */
+	public function test_sidebar_notice_retained_and_no_assignment_when_ineligible() {
+		$this->set_plan(
+			array(
+				'is_free'      => false,
+				'product_slug' => 'personal-bundle',
+			)
+		);
+		$GLOBALS['explat_assign_return'] = 'treatment';
+
+		$this->assertFalse( Free_Domain_Upsell_Experiment::should_suppress_sidebar_notice( 'free_to_paid_plan' ) );
+		$this->assertSame( array(), $GLOBALS['explat_assign_calls'] );
+	}
+
+	/**
+	 * An eligible but unassigned user keeps the notice (resolves to control).
+	 */
+	public function test_sidebar_notice_retained_while_unassigned() {
+		$GLOBALS['explat_assign_return'] = null;
+		$this->assertFalse( Free_Domain_Upsell_Experiment::should_suppress_sidebar_notice( 'free_to_paid_plan' ) );
+	}
+
+	// ---- Tracking surface ----
+
+	/**
+	 * Without an admin screen the surface is the site frontend.
+	 */
+	public function test_tracking_surface_site_frontend() {
+		$this->assertSame( 'site_frontend', wpcom_admin_bar_tracking_surface() );
+	}
+
+	/**
+	 * A regular admin screen reports wp_admin.
+	 */
+	public function test_tracking_surface_wp_admin() {
+		$this->fake_admin_screen( 'edit-post' );
+		$this->assertSame( 'wp_admin', wpcom_admin_bar_tracking_surface() );
+	}
+
+	/**
+	 * A block editor screen reports post_editor.
+	 */
+	public function test_tracking_surface_post_editor() {
+		$this->fake_admin_screen( 'post', true );
+		$this->assertSame( 'post_editor', wpcom_admin_bar_tracking_surface() );
+	}
+
+	/**
+	 * The site editor reports site_editor (checked before is_block_editor()).
+	 */
+	public function test_tracking_surface_site_editor() {
+		$this->fake_admin_screen( 'site-editor', true );
+		$this->assertSame( 'site_editor', wpcom_admin_bar_tracking_surface() );
+	}
+
+	// ---- Admin bar node ----
+
+	/**
+	 * The chip node is added for an eligible admin in the treatment, linking to
+	 * the upsell flow with the site slug and a surface-accurate ref.
+	 */
+	public function test_chip_added_for_treatment() {
+		$this->force_variation( 'treatment' );
+
+		$node = $this->get_chip_node();
+		$this->assertNotNull( $node );
+		$this->assertStringContainsString( '/setup/domain-and-plan', $node->href );
+		$this->assertStringContainsString( 'siteSlug=testsite.wordpress.com', $node->href );
+		$this->assertStringContainsString( 'ref=site_frontend', $node->href );
+		$this->assertStringContainsString( 'Free domain', $node->title );
+	}
+
+	/**
+	 * No chip node for control users.
+	 */
+	public function test_chip_not_added_for_control() {
+		$this->force_variation( 'control' );
+		$this->assertNull( $this->get_chip_node() );
+	}
+
+	/**
+	 * No chip node when the site is not eligible, even in the treatment.
+	 */
+	public function test_chip_not_added_when_not_eligible() {
+		$this->force_variation( 'treatment' );
+		$this->set_plan(
+			array(
 				'is_free'      => false,
 				'product_slug' => 'business-bundle',
-			);
-			$this->assertNull( $this->get_chip_node() );
-		}
+			)
+		);
+		$this->assertNull( $this->get_chip_node() );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/explat-doubles.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/explat-doubles.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Test doubles for the wpcom-only \ExPlat\ helpers.
+ *
+ * Loaded by Free_Domain_Upsell_Test.php. Kept in a separate file so the test
+ * file holds a single class in the global namespace.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace ExPlat;
+
+if ( ! function_exists( 'ExPlat\assign_current_user' ) ) {
+	/**
+	 * Test double for the wpcom-only assigning ExPlat call.
+	 *
+	 * @param string $experiment_name The experiment name.
+	 * @return string|null
+	 */
+	function assign_current_user( string $experiment_name ): ?string {
+		$GLOBALS['explat_assign_calls'][] = $experiment_name;
+		return $GLOBALS['explat_assign_return'] ?? null;
+	}
+}
+
+if ( ! function_exists( 'ExPlat\get_current_user_assignment' ) ) {
+	/**
+	 * Test double for the wpcom-only non-assigning ExPlat read.
+	 *
+	 * @param string $experiment_name The experiment name.
+	 * @return string|null
+	 */
+	function get_current_user_assignment( string $experiment_name ): ?string {
+		$GLOBALS['explat_read_calls'][] = $experiment_name;
+		return $GLOBALS['explat_read_return'] ?? null;
+	}
+}

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-omnibar-free-domain-upsell-chip
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-omnibar-free-domain-upsell-chip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Admin bar: Add a "Free domain" upsell chip and hide the free-to-paid sidebar notice for users in the omnibar upsell experiment treatment.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-omnibar-free-domain-upsell-chip
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-omnibar-free-domain-upsell-chip
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Admin bar: Add a "Free domain" upsell chip and hide the free-to-paid sidebar notice for users in the omnibar upsell experiment treatment.
+Admin bar: Add a "Free domain" upsell chip and hide the matching free-to-paid and monthly-to-annual sidebar notices for users in the omnibar upsell experiment treatment.


### PR DESCRIPTION
## Proposed changes

This is the wp-admin half of the omnibar free-domain upsell AB test (`calypso_omnibar_free_domain_upsell_20260825`, DOTMSD-1529). The Calypso half lives in Automattic/wp-calypso#113748 and Automattic/wp-calypso#113823.

* Add a "Free domain" chip to the admin bar for administrators assigned to the experiment treatment. Eligibility mirrors the two sidebar JITMs the chip replaces, which share the same copy and CTA: `free_to_paid_plan` (Free plan, not a domain-only site) and `monthly_to_annual_plan` (any monthly plan) — both Simple, admin, no mapped primary domain. It links to the `/setup/domain-and-plan` flow, mirroring the Calypso omnibar chip.
* The chip node is deliberately top-level (`parent => null`) so the site admin-bar REST endpoint does not return it — Calypso surfaces render their own chip, and returning this node would duplicate it there.
* Hide the `free_to_paid_plan` and `monthly_to_annual_plan` sidebar notices for treatment users. Control users keep the sidebar notice unchanged; other notices are untouched. **Update (review round):** suppression now also requires chip eligibility, checked before the assigning variation read — so nobody can be enrolled, or lose the notice, without getting the chip. The decision lives in `Free_Domain_Upsell_Experiment::should_suppress_sidebar_notice()`, shared with the sidebar-notice feature and unit-tested.
* New `Free_Domain_Upsell_Experiment` class (modeled on `Launchpad_Personalization_Experiment`): assigning ExPlat call on real page renders (that is where the two experiences diverge), non-assigning read for REST/AJAX/cron so serving the admin-bar endpoint never creates assignments, per-user transient cache (unassigned results are not cached, so a later page render can still assign), and a `wpcom_free_domain_upsell_variation` filter for QA overrides. Eligibility (`get_upsell_source()` / `is_eligible()`) also lives here, shared by the chip and the suppression path, with a `wpcom_free_domain_upsell_current_plan` filter for QA/testing.
* The chip link's `ref` now reflects the actual surface (`wp_admin`, `post_editor`, `site_editor`, `site_frontend`) instead of a hardcoded `wp-admin`, matching the `surface` Tracks prop.
* PHPUnit coverage: eligibility matrix (free, monthly, yearly paid, non-admin, mapped domain, staging, domain-only, non-Simple), assign-on-page-render + caching, non-assigning REST read, unassigned-not-cached, logged-out, filter override, normalization, the admin bar node per variation, sidebar suppression (treatment suppresses the two target ids; control, other ids, ineligible, and unassigned all retain — with ineligible users provably never assigned), and the tracking surface values.

Kill-switch note: stopping the experiment in ExPlat reverts this side to control within the 1h per-user transient. There is no separate server-side flag; the Calypso-side config flag only affects Calypso and must not be used alone mid-test.

## Related product discussion/links

* DOTMSD-1529

## Does this pull request change what data or activity we track or use?

Two new Tracks events fired from WordPress-rendered pages, matching the Calypso-side events for the same experiment:

* `wpcom_omnibar_upsell_impression` with `upsell_id: omnibar-free-domain`, a `surface` prop, and an `upsell_source` prop (`free_to_paid_plan` or `monthly_to_annual_plan`), when the chip is rendered.
* `wpcom_omnibar_upsell_click` with the same props, when the chip is clicked.

The `surface` and `upsell_source` props are computed server-side at enqueue time. `surface` is one of `wp_admin`, `post_editor`, `site_editor`, or `site_frontend`; `upsell_source` names which of the two sidebar JITMs the site matches, for per-cohort analysis (Free volume would otherwise drown a monthly signal).

## Testing instructions

On a sandboxed Free Simple site (admin user), with the experiment not yet created, force the variation:

```php
add_filter( 'wpcom_free_domain_upsell_variation', fn () => 'treatment' );
```

* wp-admin: the "Free domain" chip appears in the admin bar (pill with diamond icon, tooltip "Free domain with an annual plan"); the sidebar upsell notice is gone.
* Site front end (logged in): the chip appears in the admin bar there too. Post editor and Site Editor: the chip appears where the admin bar renders, and events carry the matching `surface`.
* Repeat on a Simple site with a monthly plan: same chip, and the `monthly_to_annual_plan` sidebar notice is suppressed.
* Click the chip: lands on the domain-and-plan flow; `wpcom_omnibar_upsell_click` fires. Impressions fire once per page view.
* Force `'control'` (or remove the filter): no chip, and the sidebar notice is back.
* Verify `/wpcom/v2/sites/:id/admin-bar` does not include the `wpcom-free-domain-upsell` node and creates no ExPlat assignment.
* Yearly paid, Atomic, staging, mapped-domain, or domain-only site: no chip, sidebar notice unchanged.
* `jp test php packages/jetpack-mu-wpcom` runs the new `Free_Domain_Upsell_Test` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

