### PR TITLE
AI Launchpad: switch Button to LinkButton for a link

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-ui-link-button
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-ui-link-button
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Make the AI Launchpad "Edit site" button a real link.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/site-preview.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/site-preview.tsx
@@ -1,6 +1,6 @@
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
+import { LinkButton } from '@wordpress/ui';
 import type { ReactNode } from 'react';
 
 interface Props {
@@ -54,9 +54,9 @@ export function SitePreview( { siteUrl, siteTitle, siteEditUrl }: Props ) {
 			<div className="ai-launchpad-tailored-list__preview-frame is-editable">
 				{ thumbnail }
 				<span className="ai-launchpad-tailored-list__preview-edit">
-					<Button variant="solid" size="compact" render={ <a href={ siteEditUrl } /> }>
+					<LinkButton variant="solid" size="compact" href={ siteEditUrl }>
 						{ __( 'Edit site', 'jetpack-mu-wpcom' ) }
-					</Button>
+					</LinkButton>
 				</span>
 			</div>
 		);


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Replaces workaround of using [Button](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-button--docs) for links with appropiate new [LinkButton](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-linkbutton--docs) component.

This will also avoid any bugs caused by styles from `common.css` in WP dashboard messing up with button styles.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Just see that the button "Edit site" still looks and works as before.