### PR TITLE
VideoPress: align the welcome modal with the design system

### DIFF
--- a/projects/packages/videopress/changelog/update-welcome-modal-ds-alignment
+++ b/projects/packages/videopress/changelog/update-welcome-modal-ds-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Align the welcome modal with the design system: derive the media band's control colors from a ThemeProvider seed, use the dialog's own type scale, and the Jetpack brand token for the card icons.

--- a/projects/packages/videopress/src/dashboard/components/onboarding-modal/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/onboarding-modal/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Icon, cloudUpload, share, video } from '@wordpress/icons';
 import { useNavigate, useSearch } from '@wordpress/route';
+import { ThemeProvider } from '@wordpress/theme';
 import { Button, Dialog, LinkButton, Text } from '@wordpress/ui';
 // The dismissal flag lives with the other first-run storage helpers so the
 // redirect and the modal can't drift onto different keys.
@@ -346,22 +347,33 @@ export default function OnboardingModal(): ReactElement | null {
 						} as CSSProperties
 					}
 				>
-					<Dialog.CloseIcon
-						className="vp-onboarding-modal__close"
-						label={ __( 'Close', 'jetpack-videopress-pkg' ) }
-					/>
-					<IntroVideo />
+					{ /*
+					 * The band is the brand's deep forest green, so the design
+					 * system is re-seeded with it: the close button and anything
+					 * else rendered over the band resolve their colors from the
+					 * derived dark scheme instead of hand-picked literals.
+					 * ThemeProvider renders `display: contents`, so the close
+					 * affordance still positions against the band itself.
+					 */ }
+					<ThemeProvider color={ { background: '#003010' } }>
+						<Dialog.CloseIcon
+							className="vp-onboarding-modal__close"
+							label={ __( 'Close', 'jetpack-videopress-pkg' ) }
+						/>
+						<IntroVideo />
+					</ThemeProvider>
 				</div>
 
 				<Dialog.Content className="vp-onboarding-modal__body">
 					{ /*
-					 * Dialog.Title/Description pin their own internal type
-					 * variants (20px/13px) and expose no variant prop, so the
-					 * spec's 32px headline and 15px lede are applied in the
-					 * stylesheet with the tokens `heading-2xl` and `body-lg`
-					 * resolve to. See style.scss.
+					 * Title and lede render at the design system's own dialog
+					 * type scale. The Figma spec drew them larger (32px/15px),
+					 * but Dialog.Title/Description expose no size variant, and
+					 * overriding their internals is not a stable API — if the
+					 * larger scale is wanted back, the ask is a variant prop on
+					 * the components, not a local override.
 					 */ }
-					<Dialog.Title className="vp-onboarding-modal__headline">
+					<Dialog.Title>
 						{ __( 'Your Video. Your Player.', 'jetpack-videopress-pkg' ) }
 					</Dialog.Title>
 					<Dialog.Description className="vp-onboarding-modal__lede">

--- a/projects/packages/videopress/src/dashboard/components/onboarding-modal/style.scss
+++ b/projects/packages/videopress/src/dashboard/components/onboarding-modal/style.scss
@@ -71,31 +71,15 @@
 		object-fit: cover;
 	}
 
-	// Over the video, so it takes a light foreground and its own scrim instead
-	// of the Dialog default, which assumes a light surface behind it. The
-	// white and the black scrims are literals for the same reason as the
-	// band's green: the design system has no overlay/inverse tokens for
-	// content floating over video.
+	// Colors come from the design system: the component re-seeds a
+	// ThemeProvider with the band's deep green (see index.tsx), so the close
+	// button's foreground, hover and focus treatments resolve from the derived
+	// dark scheme instead of hand-picked literals. Only placement lives here.
 	&__close {
 		position: absolute;
 		inset-block-start: var(--wpds-dimension-padding-lg);
 		inset-inline-end: var(--wpds-dimension-padding-lg);
 		z-index: 1;
-		color: #fff;
-		background: rgba(0, 0, 0, 0.5);
-
-		&:hover {
-			color: #fff;
-			background: rgba(0, 0, 0, 0.7);
-		}
-
-		// The DS focus ring is brand blue tuned for light surfaces; on the
-		// dark band it fails the 3:1 non-text contrast minimum. White ring,
-		// same justification as the foreground above.
-		&:focus-visible {
-			outline: 2px solid #fff;
-			outline-offset: 2px;
-		}
 
 		// A lone control floating over video earns a 44px hit target; the
 		// visual stays 32px.
@@ -120,32 +104,12 @@
 		container-type: inline-size;
 	}
 
-	// Dialog.Title pins its own internal heading variant (20px) and exposes
-	// no variant prop, so the spec's Semibold 32/40 is applied with the same
-	// tokens `heading-2xl` resolves to. The `--_gcd-*` custom properties are
-	// the design system's global-css-defense channel — its heading reset
-	// reads font size from them, so they must be overridden alongside the
-	// plain declarations or the internal 20px wins.
-	&__headline {
-		--_gcd-heading-font-size: var(--wpds-typography-font-size-2xl);
-
-		color: var(--wpds-color-foreground-content-neutral);
-		font-size: var(--wpds-typography-font-size-2xl);
-		line-height: var(--wpds-typography-line-height-2xl);
-		font-weight: var(--wpds-typography-font-weight-emphasis);
-	}
-
-	// Same mechanism as the headline: Dialog.Description hard-codes 13px
-	// internally; the spec's 15px lede is `body-lg`'s tokens, applied direct.
-	// It intentionally runs the full modal width; `text-wrap: pretty` keeps
-	// the second line from breaking mid-phrase.
+	// Title and lede type comes from Dialog.Title/Description's own variants —
+	// no size overrides (the design system's internals are not a stable API to
+	// override; if the Figma spec's larger scale returns, the ask is a variant
+	// prop on the components). The lede runs the full modal width;
+	// `text-wrap: pretty` keeps its second line from breaking mid-phrase.
 	&__lede {
-		--_gcd-p-font-size: var(--wpds-typography-font-size-lg);
-		--_gcd-p-line-height: var(--wpds-typography-line-height-md);
-
-		color: var(--wpds-color-foreground-content-neutral-weak);
-		font-size: var(--wpds-typography-font-size-lg);
-		line-height: var(--wpds-typography-line-height-md);
 		text-wrap: pretty;
 	}
 
@@ -191,12 +155,13 @@
 	}
 
 	// The brand's one accent, used exactly once per card — on the glyph.
-	// Literal Jetpack green: the design system has no non-interactive brand
-	// foreground token, and the interactive one describes links/buttons.
+	// `--jp-green` is the Jetpack brand token from
+	// @automattic/jetpack-base-styles' root variables, which the admin page
+	// chrome loads on every dashboard route; the literal is only the fallback.
 	&__card-icon {
 		display: inline-flex;
 		margin-block-end: var(--wpds-dimension-gap-sm);
-		color: #069e08;
+		color: var(--jp-green, #069e08);
 
 		svg {
 			fill: currentColor;


### PR DESCRIPTION
## Proposed changes

Follow-up to the review feedback on #51520 (merged), removing the design-system overrides the welcome modal carried:

* **Close button over the media band** — instead of fixed `#fff` foreground, black scrims, and a hand-tuned white focus ring, the band's children now render inside a `ThemeProvider` seeded with the band's deep green (`color.background: '#003010'`). The close affordance resolves its colors from the derived dark scheme; only placement remains in the stylesheet. (ThemeProvider renders `display: contents`, so the absolute positioning against the band is unchanged.)
* **Headline and lede type** — dropped the `--_gcd-*` internal-variable overrides that forced the Figma spec's 32px/15px scale onto `Dialog.Title`/`Dialog.Description`. They now render at the design system's own dialog type scale. If design wants the larger scale back, the right ask is a size-variant prop on the Dialog components rather than overriding their internals — happy to open that request upstream if we decide the spec's scale should stand.
* **Card icon green** — replaced the literal `#069e08` with the `--jp-green` brand token (literal kept only as fallback).

Net: the stylesheet keeps layout, spacing (public `--wpds-dimension-*` tokens), and the artwork band; all color and type decisions now come from the design system.

## Related product discussion/links

* Addresses the review feedback on #51520.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build with `jetpack build plugins/jetpack --deps`, use a Jetpack-connected site with no VideoPress videos (or append `&welcome=1` to the dashboard URL).
* Open **Jetpack → VideoPress**: in the welcome modal, verify the close button is legible over the dark band in idle, hover, and keyboard-focus states, the headline/lede render at the dialog's standard scale, and the three card icons are Jetpack green.
* `jetpack test js packages/videopress` — passes.
