### PR TITLE
VideoPress: Fix private video authorization for synced patterns and Video Playlist blocks

### DIFF
--- a/projects/packages/videopress/.phan/baseline.php
+++ b/projects/packages/videopress/.phan/baseline.php
@@ -9,9 +9,9 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchReturnProbablyReal : 7 occurrences
+    // PhanUndeclaredClassMethod : 7 occurrences
     // PhanTypeMismatchReturn : 6 occurrences
-    // PhanUndeclaredClassMethod : 5 occurrences
+    // PhanTypeMismatchReturnProbablyReal : 5 occurrences
     // PhanCommentOverrideOnNonOverrideMethod : 4 occurrences
     // PhanNonClassMethodCall : 4 occurrences
     // PhanTypeArraySuspiciousNullable : 4 occurrences
@@ -21,10 +21,10 @@ return [
     // PhanTypeInvalidDimOffset : 2 occurrences
     // PhanUndeclaredExtendedClass : 2 occurrences
     // PhanUndeclaredMethod : 2 occurrences
-    // PhanUndeclaredMethodInCallable : 2 occurrences
     // PhanPluginUnreachableCode : 1 occurrence
     // PhanTypeMismatchReturnNullable : 1 occurrence
     // PhanUndeclaredClass : 1 occurrence
+    // PhanUndeclaredMethodInCallable : 1 occurrence
     // PhanUndeclaredTypeThrowsType : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
@@ -36,7 +36,6 @@ return [
         'src/class-plan.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/class-stats.php' => ['PhanTypeArraySuspiciousNullable'],
         'src/class-uploader.php' => ['PhanTypeMismatchArgument'],
-        'src/class-utils.php' => ['PhanTypeMismatchReturnProbablyReal'],
         'src/class-videopresstoken.php' => ['PhanTypeMismatchReturn'],
         'src/class-wpcom-rest-api-v2-attachment-field-videopress.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
         'src/class-wpcom-rest-api-v2-endpoint-videopress.php' => ['PhanTypeInvalidDimOffset', 'PhanTypeMismatchArgument', 'PhanTypeMismatchArgumentProbablyReal'],

--- a/projects/packages/videopress/changelog/fix-vidp-372-synced-patterns-followup
+++ b/projects/packages/videopress/changelog/fix-vidp-372-synced-patterns-followup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, and let private videos preview in the block editor canvas.
+Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, let private videos preview in the block editor canvas, and load live metadata for private playlist entries for authorized viewers.

--- a/projects/packages/videopress/changelog/fix-vidp-372-synced-patterns-followup
+++ b/projects/packages/videopress/changelog/fix-vidp-372-synced-patterns-followup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, and let private videos preview in the block editor canvas.

--- a/projects/packages/videopress/changelog/fix-vidp-372-synced-patterns-followup
+++ b/projects/packages/videopress/changelog/fix-vidp-372-synced-patterns-followup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, let private videos preview in the block editor canvas, and load live metadata for private playlist entries for authorized viewers.
+Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, let private videos preview in the block editor canvas, load live metadata for private playlist entries for authorized viewers, and show a lock placeholder on playlist thumbnails of private videos the viewer cannot access.

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -393,19 +393,20 @@ class Access_Control {
 		$guids = array();
 
 		foreach ( $blocks as $block ) {
-			$block_name = $block['blockName'] ?? null;
+			$block_name  = $block['blockName'] ?? null;
+			$attrs       = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+			$attr_guid   = $attrs['guid'] ?? null;
+			$attr_videos = $attrs['videos'] ?? null;
+			$attr_ref    = $attrs['ref'] ?? null;
 
 			// A VideoPress video block with a GUID.
-			if (
-				'videopress/video' === $block_name
-				&& isset( $block['attrs']['guid'] ) && is_string( $block['attrs']['guid'] )
-			) {
-				$guids[] = $block['attrs']['guid'];
+			if ( 'videopress/video' === $block_name && is_string( $attr_guid ) ) {
+				$guids[] = $attr_guid;
 			}
 
 			// A VideoPress playlist block: each entry carries its own GUID.
-			if ( 'videopress/playlist' === $block_name && ! empty( $block['attrs']['videos'] ) && is_array( $block['attrs']['videos'] ) ) {
-				foreach ( $block['attrs']['videos'] as $entry ) {
+			if ( 'videopress/playlist' === $block_name && is_array( $attr_videos ) ) {
+				foreach ( $attr_videos as $entry ) {
 					if ( is_array( $entry ) && isset( $entry['guid'] ) && is_string( $entry['guid'] ) ) {
 						$guids[] = $entry['guid'];
 					}
@@ -413,8 +414,8 @@ class Access_Control {
 			}
 
 			// A synced pattern: resolve the wp_block ref, which parse_blocks() leaves unexpanded.
-			if ( 'core/block' === $block_name && ! empty( $block['attrs']['ref'] ) ) {
-				$ref = absint( $block['attrs']['ref'] );
+			if ( 'core/block' === $block_name && ! empty( $attr_ref ) ) {
+				$ref = absint( $attr_ref );
 				if ( $ref && ! isset( $visited_refs[ $ref ] ) && count( $visited_refs ) < self::MAX_PATTERN_REFS ) {
 					$visited_refs[ $ref ] = true;
 

--- a/projects/packages/videopress/src/class-access-control.php
+++ b/projects/packages/videopress/src/class-access-control.php
@@ -256,151 +256,27 @@ class Access_Control {
 	}
 
 	/**
-	 * Determines whether a given post actually embeds a given VideoPress GUID.
+	 * How long the per-post GUID list stays cached.
 	 *
-	 * Used to prevent the embedded post id — which arrives from request input — from being
-	 * treated as an authorization context when it has no relationship to the requested video.
-	 * Matching the attachment id itself is not treated as proof of embedding: attachment ids
-	 * are enumerable via the media REST route and would otherwise provide a second path around
-	 * this check whenever the attachment has no parent and falls back to the `read` capability.
-	 *
-	 * @param int    $embedded_post_id The post id claimed as the embedding context.
-	 * @param string $guid             The video guid.
-	 *
-	 * @return bool
+	 * @var int
 	 */
-	private function post_embeds_videopress_guid( $embedded_post_id, $guid ) {
-		$post = get_post( $embedded_post_id );
-		if ( ! $post instanceof WP_Post || empty( $post->post_content ) ) {
-			return false;
-		}
-
-		// If the guid is nowhere in the content, neither the block nor the shortcode scan can match.
-		if ( false === strpos( $post->post_content, $guid ) ) {
-			return false;
-		}
-
-		if ( $this->post_content_has_videopress_block( $post->post_content, $guid ) ) {
-			return true;
-		}
-
-		if ( $this->post_content_has_videopress_shortcode( $post->post_content, $guid ) ) {
-			return true;
-		}
-
-		return $this->post_content_has_videopress_url( $post->post_content, $guid );
-	}
+	const GUID_CACHE_EXPIRATION = 12 * HOUR_IN_SECONDS;
 
 	/**
-	 * Walk parsed blocks (including inner blocks) looking for a videopress/video block
-	 * whose guid attribute matches.
+	 * Maximum number of synced-pattern (wp_block) refs resolved per scan.
 	 *
-	 * @param string $post_content The post content to scan.
-	 * @param string $guid         The video guid to match.
-	 *
-	 * @return bool
+	 * @var int
 	 */
-	private function post_content_has_videopress_block( $post_content, $guid ) {
-		if ( false === strpos( $post_content, 'wp:videopress/video' ) ) {
-			return false;
-		}
-
-		return $this->blocks_contain_videopress_guid( parse_blocks( $post_content ), $guid );
-	}
-
-	/**
-	 * Recursively scans a parsed block tree for a videopress/video block whose guid attribute matches.
-	 *
-	 * @param array  $blocks Parsed blocks (as returned by parse_blocks() or an innerBlocks array).
-	 * @param string $guid   The video guid to match.
-	 *
-	 * @return bool
-	 */
-	private function blocks_contain_videopress_guid( $blocks, $guid ) {
-		foreach ( $blocks as $block ) {
-			if (
-				isset( $block['blockName'] ) && 'videopress/video' === $block['blockName']
-				&& isset( $block['attrs']['guid'] ) && $block['attrs']['guid'] === $guid
-			) {
-				return true;
-			}
-
-			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] )
-				&& $this->blocks_contain_videopress_guid( $block['innerBlocks'], $guid )
-			) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Detect a [videopress GUID] or [wpvideo GUID] shortcode whose first positional
-	 * argument matches the given guid.
-	 *
-	 * @param string $post_content The post content to scan.
-	 * @param string $guid         The video guid to match.
-	 *
-	 * @return bool
-	 */
-	private function post_content_has_videopress_shortcode( $post_content, $guid ) {
-		if ( false === stripos( $post_content, '[videopress' ) && false === stripos( $post_content, '[wpvideo' ) ) {
-			return false;
-		}
-
-		$pattern = get_shortcode_regex( array( 'videopress', 'wpvideo' ) );
-		$count   = preg_match_all( '/' . $pattern . '/', $post_content, $matches, PREG_SET_ORDER );
-		if ( false === $count || 0 === $count ) {
-			return false;
-		}
-
-		foreach ( $matches as $match ) {
-			$atts = shortcode_parse_atts( $match[3] );
-			if ( ! is_array( $atts ) ) {
-				continue;
-			}
-
-			// Only the positional argument identifies the video; named attributes must not satisfy the binding check.
-			if ( isset( $atts[0] ) && is_string( $atts[0] ) && $atts[0] === $guid ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Detect a canonical VideoPress URL referencing the given guid. Covers oEmbed
-	 * inserts, core/embed blocks, core/video blocks, and core [video] shortcodes
-	 * whose src/mp4 attributes resolve to a VideoPress URL.
-	 *
-	 * @param string $post_content The post content to scan.
-	 * @param string $guid         The video guid to match.
-	 *
-	 * @return bool
-	 */
-	private function post_content_has_videopress_url( $post_content, $guid ) {
-		if ( ! preg_match_all( '#https?://[^\s"\'<>)]+#i', $post_content, $matches ) ) {
-			return false;
-		}
-
-		foreach ( $matches[0] as $url ) {
-			$extracted_guid = Utils::extract_videopress_guid_from_url( $url );
-			if ( $extracted_guid === $guid ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
+	const MAX_PATTERN_REFS = 20;
 
 	/**
 	 * Build and cache the list of VideoPress GUIDs present in a post.
 	 *
-	 * Scans the post content for VideoPress blocks (including those in synced patterns),
-	 * shortcodes, and URLs, then caches the GUID list in a transient for fast lookup
-	 * during authorization checks.
+	 * Scans the post content for VideoPress video and playlist blocks, shortcodes, and
+	 * URLs, then caches the GUID list in a transient for fast lookup during authorization
+	 * checks. Synced pattern (core/block) refs are resolved manually: parse_blocks() does
+	 * NOT expand them — their content lives in the referenced wp_block post and is only
+	 * expanded by WordPress at render time.
 	 *
 	 * @param int $post_id The post ID to scan.
 	 * @return array Array of VideoPress GUIDs found in the post.
@@ -421,17 +297,62 @@ class Access_Control {
 
 		$post = get_post( $post_id );
 		if ( ! $post instanceof WP_Post || empty( $post->post_content ) ) {
-			set_transient( $transient_key, array(), 12 * HOUR_IN_SECONDS );
+			set_transient( $transient_key, array(), self::GUID_CACHE_EXPIRATION );
 			return array();
 		}
 
-		$guids = array();
+		$visited_refs = array();
+		$guids        = self::collect_guids_from_content( $post->post_content, $visited_refs );
 
-		// Scan for VideoPress blocks (including those in synced patterns).
-		$guids = array_merge( $guids, self::collect_guids_from_blocks( parse_blocks( $post->post_content ) ) );
+		// Cache and return unique GUIDs.
+		$unique_guids = array_values( array_unique( array_filter( $guids ) ) );
+		set_transient( $transient_key, $unique_guids, self::GUID_CACHE_EXPIRATION );
 
-		// Scan for VideoPress shortcodes and URLs (legacy embedding methods).
-		if ( preg_match_all( '#https?://[^\s"\'<>)]+#i', $post->post_content, $matches ) ) {
+		return $unique_guids;
+	}
+
+	/**
+	 * Ensure the given rendered GUIDs are present in a post's cached GUID list.
+	 *
+	 * Called from block render callbacks, where the block has already been expanded by
+	 * WordPress (synced patterns, templates, template parts, widget areas…): the render
+	 * itself is proof the video is embedded in the page being served for this post, so
+	 * the GUID can be added even when the static content scan cannot see it.
+	 *
+	 * @param int             $post_id The post ID the block is rendering on.
+	 * @param string|string[] $guids   The GUID(s) being rendered.
+	 */
+	public static function ensure_post_guids_cached( $post_id, $guids ) {
+		$post_id = absint( $post_id );
+		$guids   = array_filter( (array) $guids, 'is_string' );
+		if ( ! $post_id || ! $guids ) {
+			return;
+		}
+
+		$cached  = self::build_and_cache_post_guids( $post_id );
+		$missing = array_diff( $guids, $cached );
+		if ( $missing ) {
+			set_transient(
+				"videopress_guids_{$post_id}",
+				array_values( array_merge( $cached, $missing ) ),
+				self::GUID_CACHE_EXPIRATION
+			);
+		}
+	}
+
+	/**
+	 * Collect VideoPress GUIDs from a chunk of post content: blocks (with synced pattern
+	 * refs resolved recursively), VideoPress URLs, and legacy shortcodes.
+	 *
+	 * @param string $content      The post content to scan.
+	 * @param array  $visited_refs Accumulator of wp_block ref ids already resolved, keyed by id.
+	 * @return array Array of VideoPress GUIDs found.
+	 */
+	private static function collect_guids_from_content( $content, &$visited_refs ) {
+		$guids = self::collect_guids_from_blocks( parse_blocks( $content ), $visited_refs );
+
+		// Scan for VideoPress URLs (oEmbed, core/embed, core/video sources).
+		if ( preg_match_all( '#https?://[^\s"\'<>)]+#i', $content, $matches ) ) {
 			foreach ( $matches[0] as $url ) {
 				$guid = Utils::extract_videopress_guid_from_url( $url );
 				if ( $guid ) {
@@ -442,47 +363,14 @@ class Access_Control {
 
 		// Scan for [videopress] and [wpvideo] shortcodes.
 		$pattern = get_shortcode_regex( array( 'videopress', 'wpvideo' ) );
-		$count   = preg_match_all( '/' . $pattern . '/', $post->post_content, $matches, PREG_SET_ORDER );
+		$count   = preg_match_all( '/' . $pattern . '/', $content, $matches, PREG_SET_ORDER );
 		if ( false !== $count && $count > 0 ) {
 			foreach ( $matches as $match ) {
 				$atts = shortcode_parse_atts( $match[3] );
+				// Only the positional argument identifies the video; named attributes must not satisfy the binding check.
 				if ( is_array( $atts ) && isset( $atts[0] ) && is_string( $atts[0] ) ) {
 					$guids[] = $atts[0];
 				}
-			}
-		}
-
-		// Cache for 12 hours and return unique GUIDs.
-		$unique_guids = array_unique( array_filter( $guids ) );
-		set_transient( $transient_key, $unique_guids, 12 * HOUR_IN_SECONDS );
-
-		return $unique_guids;
-	}
-
-	/**
-	 * Recursively collect VideoPress GUIDs from parsed blocks.
-	 *
-	 * Handles both direct VideoPress blocks and those within synced patterns,
-	 * which are automatically expanded by WordPress when parse_blocks() is called.
-	 *
-	 * @param array $blocks Array of parsed blocks.
-	 * @return array Array of VideoPress GUIDs found.
-	 */
-	private static function collect_guids_from_blocks( $blocks ) {
-		$guids = array();
-
-		foreach ( $blocks as $block ) {
-			// Check if this is a VideoPress block with a GUID.
-			if (
-				isset( $block['blockName'] ) && 'videopress/video' === $block['blockName']
-				&& isset( $block['attrs']['guid'] ) && is_string( $block['attrs']['guid'] )
-			) {
-				$guids[] = $block['attrs']['guid'];
-			}
-
-			// Recursively check inner blocks (including synced patterns which have been expanded).
-			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
-				$guids = array_merge( $guids, self::collect_guids_from_blocks( $block['innerBlocks'] ) );
 			}
 		}
 
@@ -490,10 +378,76 @@ class Access_Control {
 	}
 
 	/**
-	 * Check if a post contains a VideoPress GUID, using cached GUID list for fast lookup.
+	 * Recursively collect VideoPress GUIDs from parsed blocks.
 	 *
-	 * Falls back to detailed scanning only if cache misses. This is much faster than
-	 * the previous implementation which always scanned post_content.
+	 * Handles videopress/video blocks, videopress/playlist entries, and synced patterns:
+	 * a core/block ref is resolved by loading the referenced wp_block post and scanning
+	 * its content, mirroring render_block_core_block()'s constraints (published, unlocked
+	 * wp_block posts only) with a visited guard against cycles.
+	 *
+	 * @param array $blocks       Array of parsed blocks.
+	 * @param array $visited_refs Accumulator of wp_block ref ids already resolved, keyed by id.
+	 * @return array Array of VideoPress GUIDs found.
+	 */
+	private static function collect_guids_from_blocks( $blocks, &$visited_refs ) {
+		$guids = array();
+
+		foreach ( $blocks as $block ) {
+			$block_name = $block['blockName'] ?? null;
+
+			// A VideoPress video block with a GUID.
+			if (
+				'videopress/video' === $block_name
+				&& isset( $block['attrs']['guid'] ) && is_string( $block['attrs']['guid'] )
+			) {
+				$guids[] = $block['attrs']['guid'];
+			}
+
+			// A VideoPress playlist block: each entry carries its own GUID.
+			if ( 'videopress/playlist' === $block_name && ! empty( $block['attrs']['videos'] ) && is_array( $block['attrs']['videos'] ) ) {
+				foreach ( $block['attrs']['videos'] as $entry ) {
+					if ( is_array( $entry ) && isset( $entry['guid'] ) && is_string( $entry['guid'] ) ) {
+						$guids[] = $entry['guid'];
+					}
+				}
+			}
+
+			// A synced pattern: resolve the wp_block ref, which parse_blocks() leaves unexpanded.
+			if ( 'core/block' === $block_name && ! empty( $block['attrs']['ref'] ) ) {
+				$ref = absint( $block['attrs']['ref'] );
+				if ( $ref && ! isset( $visited_refs[ $ref ] ) && count( $visited_refs ) < self::MAX_PATTERN_REFS ) {
+					$visited_refs[ $ref ] = true;
+
+					$pattern = get_post( $ref );
+					if (
+						$pattern instanceof WP_Post
+						&& 'wp_block' === $pattern->post_type
+						&& 'publish' === $pattern->post_status
+						&& empty( $pattern->post_password )
+						&& ! empty( $pattern->post_content )
+					) {
+						$guids = array_merge( $guids, self::collect_guids_from_content( $pattern->post_content, $visited_refs ) );
+					}
+				}
+			}
+
+			// Recursively check inner blocks.
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				$guids = array_merge( $guids, self::collect_guids_from_blocks( $block['innerBlocks'], $visited_refs ) );
+			}
+		}
+
+		return $guids;
+	}
+
+	/**
+	 * Check if a post contains a VideoPress GUID, using the cached GUID list for fast lookup.
+	 *
+	 * Used to prevent the embedded post id — which arrives from request input — from being
+	 * treated as an authorization context when it has no relationship to the requested video.
+	 * Matching the attachment id itself is not treated as proof of embedding: attachment ids
+	 * are enumerable via the media REST route and would otherwise provide a second path around
+	 * this check whenever the attachment has no parent and falls back to the `read` capability.
 	 *
 	 * @param int    $embedded_post_id The post id to check.
 	 * @param string $guid             The video guid to find.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -819,6 +819,15 @@ class Initializer {
 		/* translators: %d: number of videos in the playlist. */
 		$count_label = sprintf( _n( '%d video', '%d videos', $count, 'jetpack-videopress-pkg' ), $count );
 
+		/*
+		 * Hidden placeholder shown (via the button's is-locked class) when the view
+		 * script cannot authorize a private video's thumbnail for the viewer.
+		 */
+		$lock_markup = '<span class="videopress-playlist__entry-lock">'
+			. '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false"><path d="M17 10h-1.2V7.3c0-2.1-1.7-3.8-3.8-3.8-2.1 0-3.8 1.7-3.8 3.8V10H7c-.6 0-1 .4-1 1v8c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-8c0-.6-.4-1-1-1Zm-2.7 0H9.7V7.3c0-1.3 1-2.3 2.3-2.3 1.3 0 2.3 1 2.3 2.3V10Z"/></svg>'
+			. '<span class="videopress-playlist__entry-lock-label">' . esc_html__( 'Private video', 'jetpack-videopress-pkg' ) . '</span>'
+			. '</span>';
+
 		$items = '';
 		foreach ( $entries as $index => $entry ) {
 			/*
@@ -860,7 +869,7 @@ class Initializer {
 
 			$items .= sprintf(
 				'<li class="videopress-playlist__entry"><button type="button" class="videopress-playlist__select%1$s"%2$s data-guid="%3$s" data-embed-url="%4$s" data-title="%5$s" data-position="%6$s" data-details="%7$s" data-progress="%8$s">' .
-					'%9$s<span class="videopress-playlist__entry-thumb"><span class="videopress-playlist__entry-flag">%10$s</span>%11$s</span>' .
+					'%9$s<span class="videopress-playlist__entry-thumb"><span class="videopress-playlist__entry-flag">%10$s</span>%15$s%11$s</span>' .
 					'<span class="videopress-playlist__entry-body"><span class="videopress-playlist__entry-title">%12$s</span><span class="videopress-playlist__entry-meta">%13$s%14$s</span></span>' .
 					'</button></li>',
 				0 === $index ? ' is-current' : '',
@@ -876,7 +885,8 @@ class Initializer {
 				$time_markup,
 				esc_html( $title ),
 				$resolution_markup,
-				$duration_markup
+				$duration_markup,
+				$lock_markup
 			);
 		}
 

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -288,11 +288,14 @@ class Initializer {
 	public static function render_videopress_video_block( $block_attributes, $content, $block ) {
 		global $wp_embed;
 
-		// Pre-build and cache the GUID list for this post to optimize authorization checks.
-		// This is called once per page render and caches GUIDs from all VideoPress blocks
-		// (including those in synced patterns), allowing fast O(1) lookups during token requests.
+		// Pre-build and cache the GUID list for this post to optimize authorization checks,
+		// and record the GUID actually being rendered: by render time WordPress has expanded
+		// synced patterns, templates, and template parts, so this covers embedding contexts
+		// the static content scan cannot see.
 		$post_id = $block->context['postId'] ?? get_the_ID();
-		if ( ! empty( $post_id ) ) {
+		if ( ! empty( $post_id ) && isset( $block_attributes['guid'] ) && is_string( $block_attributes['guid'] ) ) {
+			Access_Control::ensure_post_guids_cached( absint( $post_id ), $block_attributes['guid'] );
+		} elseif ( ! empty( $post_id ) ) {
 			Access_Control::build_and_cache_post_guids( absint( $post_id ) );
 		}
 
@@ -746,15 +749,25 @@ class Initializer {
 	/**
 	 * Video Playlist block render callback.
 	 *
-	 * @param array $block_attributes Block attributes.
+	 * @param array          $block_attributes Block attributes.
+	 * @param string         $content          Current block markup.
+	 * @param \WP_Block|null $block            Current block.
 	 *
 	 * @return string Block markup, or an empty string when the playlist has no playable entries.
 	 */
-	public static function render_videopress_playlist_block( $block_attributes ) {
+	public static function render_videopress_playlist_block( $block_attributes, $content = '', $block = null ) {
 		$entries = self::sanitize_playlist_entries( $block_attributes['videos'] ?? null );
 
 		if ( ! $entries ) {
 			return '';
+		}
+
+		// Record the rendered GUIDs in the post's cached GUID list so private playlist
+		// entries pass the playback authorization check, including when the playlist
+		// sits inside a synced pattern, template, or template part.
+		$post_id = isset( $block->context['postId'] ) ? $block->context['postId'] : get_the_ID();
+		if ( ! empty( $post_id ) ) {
+			Access_Control::ensure_post_guids_cached( absint( $post_id ), array_column( $entries, 'guid' ) );
 		}
 
 		$enabled = function ( $key, $default_value = true ) use ( $block_attributes ) {

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -481,7 +481,7 @@ class Initializer {
 		$premium_block_plan_id    = isset( $block->context['premium-content/planId'] ) ? intval( $block->context['premium-content/planId'] ) : 0;
 		$is_premium_content_child = isset( $block->context['isPremiumContentChild'] ) ? (bool) $block->context['isPremiumContentChild'] : false;
 		$maybe_premium_script     = '';
-		if ( $is_premium_content_child ) {
+		if ( $is_premium_content_child && is_string( $guid ) ) {
 			Access_Control::instance()->set_guid_subscription( $guid, $premium_block_plan_id );
 			$escaped_guid         = wp_json_encode( $guid, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
 			$script_content       = "if ( ! window.__guidsToPlanIds ) { window.__guidsToPlanIds = {}; }; window.__guidsToPlanIds[$escaped_guid] = $premium_block_plan_id;";
@@ -765,7 +765,7 @@ class Initializer {
 		// Record the rendered GUIDs in the post's cached GUID list so private playlist
 		// entries pass the playback authorization check, including when the playlist
 		// sits inside a synced pattern, template, or template part.
-		$post_id = isset( $block->context['postId'] ) ? $block->context['postId'] : get_the_ID();
+		$post_id = $block->context['postId'] ?? get_the_ID();
 		if ( ! empty( $post_id ) ) {
 			Access_Control::ensure_post_guids_cached( absint( $post_id ), array_column( $entries, 'guid' ) );
 		}

--- a/projects/packages/videopress/src/class-jwt-token-bridge.php
+++ b/projects/packages/videopress/src/class-jwt-token-bridge.php
@@ -34,6 +34,27 @@ class Jwt_Token_Bridge {
 
 		// Expose the VideoPress token to the WPAdmin context.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_jwt_token_bridge' ), 1 );
+
+		// Expose the VideoPress token to the block editor canvas. In iframed editors the
+		// canvas is a separate document that only receives assets enqueued during
+		// enqueue_block_assets, and an embedded player posts its token request to its
+		// direct parent — the canvas — so the bridge must be listening there for private
+		// videos to preview (e.g. the Video Playlist block's editor preview).
+		add_action( 'enqueue_block_assets', array( __CLASS__, 'enqueue_jwt_token_bridge_for_editor_canvas' ), 1 );
+	}
+
+	/**
+	 * Enqueues the jwt bridge script for the block editor canvas.
+	 *
+	 * Front-end loads are excluded: there the bridge is enqueued per-render only when a
+	 * VideoPress block is actually on the page.
+	 */
+	public static function enqueue_jwt_token_bridge_for_editor_canvas() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		self::enqueue_jwt_token_bridge();
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-utils.php
+++ b/projects/packages/videopress/src/class-utils.php
@@ -14,10 +14,10 @@ class Utils {
 	/**
 	 * Build a VideoPress video URL based on the guid and block attributes.
 	 *
-	 * @param string $guid       - Video GUID.
-	 * @param array  $attributes - Video block attributes. Default is an empty array.
+	 * @param string|null $guid       - Video GUID; null returns null.
+	 * @param array       $attributes - Video block attributes. Default is an empty array.
 	 *
-	 * @return string VideoPress video URL with the specified attributes.
+	 * @return string|null VideoPress video URL with the specified attributes, or null without a guid.
 	 */
 	public static function get_video_press_url( $guid, $attributes = array() ) {
 		if ( ! $guid ) {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -153,9 +153,11 @@ async function liveMetadataWithSignedPoster(
 			} else {
 				// A poster the file host would refuse is worse than the fallback.
 				delete metadata.poster;
+				metadata.isPrivateLocked = true;
 			}
 		} catch {
 			delete metadata.poster;
+			metadata.isPrivateLocked = true;
 		}
 	}
 
@@ -289,11 +291,13 @@ function PlaylistPreview( {
 							<li className="videopress-playlist__entry" key={ `${ entry.guid }-${ index }` }>
 								<button
 									type="button"
-									className={
-										index === currentIndex
-											? 'videopress-playlist__select is-current'
-											: 'videopress-playlist__select'
-									}
+									className={ [
+										'videopress-playlist__select',
+										index === currentIndex ? 'is-current' : '',
+										liveMetadata[ entry.guid ]?.isPrivateLocked ? 'is-locked' : '',
+									]
+										.filter( Boolean )
+										.join( ' ' ) }
 									aria-current={ index === currentIndex ? 'true' : undefined }
 									onClick={ () => onSelect( index ) }
 								>
@@ -308,6 +312,20 @@ function PlaylistPreview( {
 										) }
 										<span className="videopress-playlist__entry-flag">
 											{ __( 'Playing', 'jetpack-videopress-pkg' ) }
+										</span>
+										{ /* Mirrors the server render: shown via the button's is-locked class. */ }
+										<span className="videopress-playlist__entry-lock">
+											<svg
+												viewBox="0 0 24 24"
+												xmlns="http://www.w3.org/2000/svg"
+												aria-hidden="true"
+												focusable="false"
+											>
+												<path d="M17 10h-1.2V7.3c0-2.1-1.7-3.8-3.8-3.8-2.1 0-3.8 1.7-3.8 3.8V10H7c-.6 0-1 .4-1 1v8c0 .6.4 1 1 1h10c.6 0 1-.4 1-1v-8c0-.6-.4-1-1-1Zm-2.7 0H9.7V7.3c0-1.3 1-2.3 2.3-2.3 1.3 0 2.3 1 2.3 2.3V10Z" />
+											</svg>
+											<span className="videopress-playlist__entry-lock-label">
+												{ __( 'Private video', 'jetpack-videopress-pkg' ) }
+											</span>
 										</span>
 										{ formatTimecode( entry.durationMs ) && (
 											<span className="videopress-playlist__entry-time">

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -25,6 +25,7 @@ import { closeSmall, dragHandle, Icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import { fetchVideoItem } from '../../../lib/fetch-video-item';
+import getMediaToken from '../../../lib/get-media-token';
 import { isVideoPressGuid, pickGUIDFromUrl } from '../../../lib/url';
 import { VideoPressIcon } from '../video/components/icons';
 import { VIDEOPRESS_VIDEO_ALLOWED_MEDIA_TYPES } from '../video/constants';
@@ -36,6 +37,7 @@ import {
 	playlistEmbedUrl,
 	playlistRuntimeMs,
 	resolutionLabel,
+	withMetadataToken,
 } from './utils';
 import './editor.scss';
 /**
@@ -122,6 +124,39 @@ function liveMetadataFromApiResponse( item: Record< string, unknown > ): Playlis
 	}
 	if ( typeof item?.poster === 'string' && item.poster ) {
 		metadata.poster = item.poster;
+	}
+
+	return metadata;
+}
+
+/**
+ * Build an entry's live metadata, signing the poster URL for private videos:
+ * the API returns the poster's bare file URL, which the file host refuses
+ * without a token. The token comes from the same local cache fetchVideoItem
+ * used to read the metadata, so this rarely costs an extra request.
+ *
+ * @param guid - The video GUID.
+ * @param item - The videos API response.
+ * @return Live metadata.
+ */
+async function liveMetadataWithSignedPoster(
+	guid: string,
+	item: Record< string, unknown >
+): Promise< PlaylistLiveMetadata > {
+	const metadata = liveMetadataFromApiResponse( item );
+
+	if ( metadata.poster && item?.is_private === true ) {
+		try {
+			const { token } = await getMediaToken( 'playback', { guid } );
+			if ( token ) {
+				metadata.poster = withMetadataToken( metadata.poster, token );
+			} else {
+				// A poster the file host would refuse is worse than the fallback.
+				delete metadata.poster;
+			}
+		} catch {
+			delete metadata.poster;
+		}
 	}
 
 	return metadata;
@@ -398,12 +433,8 @@ export default function PlaylistEdit( {
 			metadataFetchesStarted.current.add( guid );
 
 			fetchVideoItem( { guid, isPrivate: false, skipRatingControl: true } )
-				.then( item =>
-					cacheLiveMetadata(
-						guid,
-						liveMetadataFromApiResponse( item as Record< string, unknown > )
-					)
-				)
+				.then( item => liveMetadataWithSignedPoster( guid, item as Record< string, unknown > ) )
+				.then( metadata => cacheLiveMetadata( guid, metadata ) )
 				.catch( () => {
 					// The entry keeps its GUID fallback when the video data isn't reachable.
 				} );
@@ -458,7 +489,10 @@ export default function PlaylistEdit( {
 		try {
 			const item = await fetchVideoItem( { guid, isPrivate: false, skipRatingControl: true } );
 			metadataFetchesStarted.current.add( guid );
-			cacheLiveMetadata( guid, liveMetadataFromApiResponse( item as Record< string, unknown > ) );
+			cacheLiveMetadata(
+				guid,
+				await liveMetadataWithSignedPoster( guid, item as Record< string, unknown > )
+			);
 			setAttributes( {
 				videos: [ ...videos, entryFromApiResponse( guid, item as Record< string, unknown > ) ],
 			} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/edit.tsx
@@ -161,6 +161,10 @@ async function liveMetadataWithSignedPoster(
 		}
 	}
 
+	if ( metadata.isPrivateLocked ) {
+		metadata.title = __( 'Private video', 'jetpack-videopress-pkg' );
+	}
+
 	return metadata;
 }
 
@@ -453,8 +457,15 @@ export default function PlaylistEdit( {
 			fetchVideoItem( { guid, isPrivate: false, skipRatingControl: true } )
 				.then( item => liveMetadataWithSignedPoster( guid, item as Record< string, unknown > ) )
 				.then( metadata => cacheLiveMetadata( guid, metadata ) )
-				.catch( () => {
-					// The entry keeps its GUID fallback when the video data isn't reachable.
+				.catch( ( error: Error & { cause?: { error?: string } } ) => {
+					// A video this user cannot authorize at all shows the lock
+					// placeholder; anything else keeps the GUID fallback.
+					if ( error?.cause?.error === 'auth' ) {
+						cacheLiveMetadata( guid, {
+							title: __( 'Private video', 'jetpack-videopress-pkg' ),
+							isPrivateLocked: true,
+						} );
+					}
 				} );
 		} );
 	}, [ videos ] );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -184,9 +184,10 @@ describe( 'PlaylistEdit', () => {
 				within( screen.getByRole( 'button', { current: true } ) ).getByRole( 'presentation' )
 			).toHaveAttribute( 'src', 'https://example.com/private-poster.jpg?metadata_token=jwt-token' )
 		);
+		expect( screen.getByRole( 'button', { current: true } ) ).not.toHaveClass( 'is-locked' );
 	} );
 
-	it( 'drops the poster of a private video when no playback token is available', async () => {
+	it( 'shows the lock placeholder instead of the poster when no playback token is available', async () => {
 		mockPlaybackToken = null;
 		fetchVideoItemMock.mockResolvedValue( {
 			title: 'Members only',
@@ -197,11 +198,11 @@ describe( 'PlaylistEdit', () => {
 		renderEdit( { videos: [ { guid: 'abcDEF12' } ] } );
 
 		await waitFor( () =>
-			expect( screen.getAllByText( 'Members only' ).length ).toBeGreaterThan( 0 )
+			expect( screen.getByRole( 'button', { current: true } ) ).toHaveClass( 'is-locked' )
 		);
-		expect(
-			within( screen.getByRole( 'button', { current: true } ) ).queryByRole( 'presentation' )
-		).not.toBeInTheDocument();
+		const entryButton = screen.getByRole( 'button', { current: true } );
+		expect( within( entryButton ).queryByRole( 'presentation' ) ).not.toBeInTheDocument();
+		expect( within( entryButton ).getByText( 'Private video' ) ).toBeInTheDocument();
 	} );
 
 	it( 'accepts a VideoPress URL', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -64,6 +64,13 @@ jest.mock( '../../../../lib/fetch-video-item', () => ( {
 	fetchVideoItem: jest.fn(),
 } ) );
 
+// Token get-media-token resolves with; used to sign private posters.
+let mockPlaybackToken: string | null = null;
+jest.mock( '../../../../lib/get-media-token', () => ( {
+	__esModule: true,
+	default: jest.fn( () => Promise.resolve( { token: mockPlaybackToken } ) ),
+} ) );
+
 const fetchVideoItemMock = fetchVideoItem as unknown as jest.Mock;
 
 const DEFAULT_ATTRIBUTES: PlaylistAttributes = {
@@ -121,6 +128,7 @@ const LIVE_TITLES: Record< string, string > = {
 beforeEach( () => {
 	jest.clearAllMocks();
 	mockMediaSelection = [];
+	mockPlaybackToken = null;
 	// Titles are live data resolved per GUID, never stored in attributes.
 	fetchVideoItemMock.mockImplementation( ( { guid }: { guid: string } ) => {
 		const numbered = guid.match( /^aaaaaaa(\d)$/ );
@@ -158,6 +166,42 @@ describe( 'PlaylistEdit', () => {
 				videos: [ { guid: 'abcDEF12', durationMs: 724000, height: 1080 } ],
 			} )
 		);
+	} );
+
+	it( 'signs private video posters with a playback token', async () => {
+		mockPlaybackToken = 'jwt-token';
+		fetchVideoItemMock.mockResolvedValue( {
+			title: 'Members only',
+			poster: 'https://example.com/private-poster.jpg',
+			is_private: true,
+		} );
+
+		renderEdit( { videos: [ { guid: 'abcDEF12' } ] } );
+
+		await waitFor( () =>
+			// The canvas entry is the aria-current button; its poster img is decorative (alt="").
+			expect(
+				within( screen.getByRole( 'button', { current: true } ) ).getByRole( 'presentation' )
+			).toHaveAttribute( 'src', 'https://example.com/private-poster.jpg?metadata_token=jwt-token' )
+		);
+	} );
+
+	it( 'drops the poster of a private video when no playback token is available', async () => {
+		mockPlaybackToken = null;
+		fetchVideoItemMock.mockResolvedValue( {
+			title: 'Members only',
+			poster: 'https://example.com/private-poster.jpg',
+			is_private: true,
+		} );
+
+		renderEdit( { videos: [ { guid: 'abcDEF12' } ] } );
+
+		await waitFor( () =>
+			expect( screen.getAllByText( 'Members only' ).length ).toBeGreaterThan( 0 )
+		);
+		expect(
+			within( screen.getByRole( 'button', { current: true } ) ).queryByRole( 'presentation' )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'accepts a VideoPress URL', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/edit.test.tsx
@@ -202,7 +202,23 @@ describe( 'PlaylistEdit', () => {
 		);
 		const entryButton = screen.getByRole( 'button', { current: true } );
 		expect( within( entryButton ).queryByRole( 'presentation' ) ).not.toBeInTheDocument();
-		expect( within( entryButton ).getByText( 'Private video' ) ).toBeInTheDocument();
+		// Once in the lock placeholder, once as the entry title.
+		expect( within( entryButton ).getAllByText( 'Private video' ) ).toHaveLength( 2 );
+	} );
+
+	it( 'shows the lock placeholder when the video data request is denied outright', async () => {
+		fetchVideoItemMock.mockRejectedValue(
+			new Error( 'You cannot view this video.', { cause: { error: 'auth' } } )
+		);
+
+		renderEdit( { videos: [ { guid: 'abcDEF12' } ] } );
+
+		await waitFor( () =>
+			expect( screen.getByRole( 'button', { current: true } ) ).toHaveClass( 'is-locked' )
+		);
+		expect(
+			within( screen.getByRole( 'button', { current: true } ) ).getAllByText( 'Private video' )
+		).toHaveLength( 2 );
 	} );
 
 	it( 'accepts a VideoPress URL', async () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/utils.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/utils.test.ts
@@ -5,7 +5,22 @@ import {
 	playlistEmbedUrl,
 	playlistRuntimeMs,
 	resolutionLabel,
+	withMetadataToken,
 } from '../utils';
+
+describe( 'withMetadataToken', () => {
+	it( 'appends the token as the first query parameter', () => {
+		expect( withMetadataToken( 'https://example.com/poster.jpg', 'jwt' ) ).toBe(
+			'https://example.com/poster.jpg?metadata_token=jwt'
+		);
+	} );
+
+	it( 'appends with & and encodes when the URL already has a query', () => {
+		expect( withMetadataToken( 'https://example.com/poster.jpg?w=100', 'a+b' ) ).toBe(
+			'https://example.com/poster.jpg?w=100&metadata_token=a%2Bb'
+		);
+	} );
+} );
 
 describe( 'formatTimecode', () => {
 	it( 'formats minutes and seconds', () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -2,13 +2,28 @@ import { hydratePlaylistMetadata, initPlaylistBlock } from '../view';
 
 // Live metadata the mocked videos API returns, keyed by GUID.
 let mockLiveMetadata: Record< string, { title?: string; poster?: string } > = {};
+// GUIDs whose metadata is only returned when the request carries a metadata_token.
+let mockPrivateGuids: string[] = [];
+// Token the mocked get-media-token resolves with; null simulates an unauthorized viewer.
+let mockPlaybackToken: string | null = null;
+
+jest.mock( '../../../../lib/get-media-token', () => ( {
+	__esModule: true,
+	default: jest.fn( () => Promise.resolve( { token: mockPlaybackToken } ) ),
+} ) );
 
 beforeEach( () => {
+	jest.clearAllMocks();
 	mockLiveMetadata = {};
+	mockPrivateGuids = [];
+	mockPlaybackToken = null;
+	delete ( window as { videopressAjax?: unknown } ).videopressAjax;
 	const fetchMock = jest.fn( ( url: string ) => {
-		const guid = String( url ).split( '/' ).pop();
+		const [ path, query = '' ] = String( url ).split( '?' );
+		const guid = path.split( '/' ).pop();
 		const metadata = guid ? mockLiveMetadata[ guid ] : undefined;
-		if ( ! metadata ) {
+		const needsToken = guid ? mockPrivateGuids.includes( guid ) : false;
+		if ( ! metadata || ( needsToken && ! query.includes( 'metadata_token=' ) ) ) {
 			return Promise.resolve( { ok: false } as Response );
 		}
 		return Promise.resolve( {
@@ -219,6 +234,58 @@ describe( 'initPlaylistBlock', () => {
 		// Unreachable video data keeps the server-rendered fallback.
 		expect( entries[ 2 ].querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
 			'Third'
+		);
+	} );
+
+	it( 'retries private videos with a playback token when the token bridge is configured', async () => {
+		window.videopressAjax = { ajaxUrl: '/wp-admin/admin-ajax.php', bridgeUrl: '', post_id: '12' };
+		mockPlaybackToken = 'jwt-token';
+		mockPrivateGuids = [ 'aaaaaaaa' ];
+		mockLiveMetadata = {
+			aaaaaaaa: { title: 'Private first', poster: 'https://example.com/private.jpg' },
+		};
+
+		const root = setUpPlaylist();
+		await hydratePlaylistMetadata( root );
+
+		const entry = root.querySelector< HTMLButtonElement >( '.videopress-playlist__select' );
+		expect( entry.querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
+			'Private first'
+		);
+		expect( entry.querySelector( '.videopress-playlist__entry-thumb img' ) ).toHaveAttribute(
+			'src',
+			'https://example.com/private.jpg'
+		);
+		expect( global.fetch ).toHaveBeenCalledWith(
+			'https://public-api.wordpress.com/rest/v1.1/videos/aaaaaaaa?metadata_token=jwt-token'
+		);
+	} );
+
+	it( 'keeps the fallback for private videos when no playback token is available', async () => {
+		window.videopressAjax = { ajaxUrl: '/wp-admin/admin-ajax.php', bridgeUrl: '', post_id: '12' };
+		mockPlaybackToken = null;
+		mockPrivateGuids = [ 'aaaaaaaa' ];
+		mockLiveMetadata = { aaaaaaaa: { title: 'Private first' } };
+
+		const root = setUpPlaylist();
+		await hydratePlaylistMetadata( root );
+
+		expect( root.querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
+			'First'
+		);
+	} );
+
+	it( 'does not attempt a token retry without the token bridge configuration', async () => {
+		mockPrivateGuids = [ 'aaaaaaaa' ];
+		mockLiveMetadata = { aaaaaaaa: { title: 'Private first' } };
+		const getMediaToken = jest.requireMock( '../../../../lib/get-media-token' ).default;
+
+		const root = setUpPlaylist();
+		await hydratePlaylistMetadata( root );
+
+		expect( getMediaToken ).not.toHaveBeenCalled();
+		expect( root.querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
+			'First'
 		);
 	} );
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -69,19 +69,19 @@ function setUpPlaylist( autoplayNext = true, loop = false ): HTMLElement {
 					<li><button type="button" class="videopress-playlist__select is-current" aria-current="true"
 						data-guid="aaaaaaaa" data-embed-url="${ EMBED_A }" data-title="First"
 						data-position="1 of 3" data-details="1080p · 12:04" data-progress="1 / 3 · 25:00 total">
-						<span class="videopress-playlist__entry-thumb"></span>
+						<span class="videopress-playlist__entry-thumb"><span class="videopress-playlist__entry-lock"><span class="videopress-playlist__entry-lock-label">Private video</span></span></span>
 						<span class="videopress-playlist__entry-title">First</span>
 					</button></li>
 					<li><button type="button" class="videopress-playlist__select"
 						data-guid="bbbbbbbb" data-embed-url="${ EMBED_B }" data-title="Second"
 						data-position="2 of 3" data-details="4K · 6:41" data-progress="2 / 3 · 25:00 total">
-						<span class="videopress-playlist__entry-thumb"></span>
+						<span class="videopress-playlist__entry-thumb"><span class="videopress-playlist__entry-lock"><span class="videopress-playlist__entry-lock-label">Private video</span></span></span>
 						<span class="videopress-playlist__entry-title">Second</span>
 					</button></li>
 					<li><button type="button" class="videopress-playlist__select"
 						data-guid="cccccccc" data-embed-url="${ EMBED_C }" data-title="Third"
 						data-position="3 of 3" data-details="720p · 6:15" data-progress="3 / 3 · 25:00 total">
-						<span class="videopress-playlist__entry-thumb"></span>
+						<span class="videopress-playlist__entry-thumb"><span class="videopress-playlist__entry-lock"><span class="videopress-playlist__entry-lock-label">Private video</span></span></span>
 						<span class="videopress-playlist__entry-title">Third</span>
 					</button></li>
 				</ol>
@@ -268,7 +268,7 @@ describe( 'initPlaylistBlock', () => {
 		expect( root.querySelector( '.videopress-playlist__select' ) ).not.toHaveClass( 'is-locked' );
 	} );
 
-	it( 'locks the thumbnail and keeps the fallback when no playback token is available', async () => {
+	it( 'locks the thumbnail and titles the entry from the lock label when no playback token is available', async () => {
 		window.videopressAjax = { ajaxUrl: '/wp-admin/admin-ajax.php', bridgeUrl: '', post_id: '12' };
 		mockPlaybackToken = null;
 		mockPrivateGuids = [ 'aaaaaaaa' ];
@@ -277,10 +277,12 @@ describe( 'initPlaylistBlock', () => {
 		const root = setUpPlaylist();
 		await hydratePlaylistMetadata( root );
 
-		expect( root.querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
-			'First'
+		const entry = root.querySelector< HTMLButtonElement >( '.videopress-playlist__select' );
+		expect( entry ).toHaveClass( 'is-locked' );
+		expect( entry.querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
+			'Private video'
 		);
-		expect( root.querySelector( '.videopress-playlist__select' ) ).toHaveClass( 'is-locked' );
+		expect( entry.dataset.title ).toBe( 'Private video' );
 	} );
 
 	it( 'locks the thumbnail without a token retry when the token bridge is not configured', async () => {
@@ -293,7 +295,7 @@ describe( 'initPlaylistBlock', () => {
 
 		expect( getMediaToken ).not.toHaveBeenCalled();
 		expect( root.querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
-			'First'
+			'Private video'
 		);
 		expect( root.querySelector( '.videopress-playlist__select' ) ).toHaveClass( 'is-locked' );
 	} );

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -28,7 +28,8 @@ beforeEach( () => {
 		}
 		return Promise.resolve( {
 			ok: true,
-			json: () => Promise.resolve( metadata ),
+			// A fresh object per call, like a real response.json().
+			json: () => Promise.resolve( { ...metadata } ),
 		} as Response );
 	} );
 	( global as { fetch: unknown } ).fetch = fetchMock;
@@ -252,9 +253,10 @@ describe( 'initPlaylistBlock', () => {
 		expect( entry.querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
 			'Private first'
 		);
+		// The poster's bare file URL is refused by the file host — it must carry the token too.
 		expect( entry.querySelector( '.videopress-playlist__entry-thumb img' ) ).toHaveAttribute(
 			'src',
-			'https://example.com/private.jpg'
+			'https://example.com/private.jpg?metadata_token=jwt-token'
 		);
 		expect( global.fetch ).toHaveBeenCalledWith(
 			'https://public-api.wordpress.com/rest/v1.1/videos/aaaaaaaa?metadata_token=jwt-token'

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -23,8 +23,12 @@ beforeEach( () => {
 		const guid = path.split( '/' ).pop();
 		const metadata = guid ? mockLiveMetadata[ guid ] : undefined;
 		const needsToken = guid ? mockPrivateGuids.includes( guid ) : false;
-		if ( ! metadata || ( needsToken && ! query.includes( 'metadata_token=' ) ) ) {
-			return Promise.resolve( { ok: false } as Response );
+		if ( ! metadata ) {
+			return Promise.resolve( { ok: false, status: 404 } as Response );
+		}
+		if ( needsToken && ! query.includes( 'metadata_token=' ) ) {
+			// Private video, unauthenticated request.
+			return Promise.resolve( { ok: false, status: 403 } as Response );
 		}
 		return Promise.resolve( {
 			ok: true,
@@ -261,9 +265,10 @@ describe( 'initPlaylistBlock', () => {
 		expect( global.fetch ).toHaveBeenCalledWith(
 			'https://public-api.wordpress.com/rest/v1.1/videos/aaaaaaaa?metadata_token=jwt-token'
 		);
+		expect( root.querySelector( '.videopress-playlist__select' ) ).not.toHaveClass( 'is-locked' );
 	} );
 
-	it( 'keeps the fallback for private videos when no playback token is available', async () => {
+	it( 'locks the thumbnail and keeps the fallback when no playback token is available', async () => {
 		window.videopressAjax = { ajaxUrl: '/wp-admin/admin-ajax.php', bridgeUrl: '', post_id: '12' };
 		mockPlaybackToken = null;
 		mockPrivateGuids = [ 'aaaaaaaa' ];
@@ -275,9 +280,10 @@ describe( 'initPlaylistBlock', () => {
 		expect( root.querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
 			'First'
 		);
+		expect( root.querySelector( '.videopress-playlist__select' ) ).toHaveClass( 'is-locked' );
 	} );
 
-	it( 'does not attempt a token retry without the token bridge configuration', async () => {
+	it( 'locks the thumbnail without a token retry when the token bridge is not configured', async () => {
 		mockPrivateGuids = [ 'aaaaaaaa' ];
 		mockLiveMetadata = { aaaaaaaa: { title: 'Private first' } };
 		const getMediaToken = jest.requireMock( '../../../../lib/get-media-token' ).default;
@@ -289,6 +295,18 @@ describe( 'initPlaylistBlock', () => {
 		expect( root.querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
 			'First'
 		);
+		expect( root.querySelector( '.videopress-playlist__select' ) ).toHaveClass( 'is-locked' );
+	} );
+
+	it( 'does not lock entries whose video data is merely unreachable', async () => {
+		window.videopressAjax = { ajaxUrl: '/wp-admin/admin-ajax.php', bridgeUrl: '', post_id: '12' };
+		mockPlaybackToken = 'jwt-token';
+
+		// No metadata at all: the mock responds 404, not an authorization failure.
+		const root = setUpPlaylist();
+		await hydratePlaylistMetadata( root );
+
+		expect( root.querySelector( '.videopress-playlist__select' ) ).not.toHaveClass( 'is-locked' );
 	} );
 
 	it( 'shows the more-videos fade only while entries hide below the scroll', () => {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/types.ts
@@ -19,6 +19,9 @@ export type PlaylistEntry = {
 export type PlaylistLiveMetadata = {
 	title?: string;
 	poster?: string;
+	// The video is private and its thumbnail could not be authorized for this
+	// viewer; the entry shows the lock placeholder instead.
+	isPrivateLocked?: boolean;
 };
 
 export type PlaylistLayout = 'side-rail' | 'grid' | 'strip';

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/utils.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/utils.ts
@@ -132,3 +132,17 @@ export function playlistEmbedUrl( guid: string, autoplay: boolean, muted = false
 
 	return `https://videopress.com/embed/${ encodeURIComponent( guid ) }?${ params.toString() }`;
 }
+
+/**
+ * Append a metadata token to a VideoPress file URL: private videos' files —
+ * posters included — are served from videos.files.wordpress.com only when the
+ * request carries a valid token.
+ *
+ * @param url   - The file URL.
+ * @param token - The playback/metadata JWT.
+ * @return The tokenized URL.
+ */
+export function withMetadataToken( url: string, token: string ): string {
+	const separator = url.includes( '?' ) ? '&' : '?';
+	return `${ url }${ separator }metadata_token=${ encodeURIComponent( token ) }`;
+}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -183,6 +183,46 @@ $vpp-mono: ui-monospace, menlo, monospace;
 		display: none;
 	}
 
+	// Placeholder shown when a private video's thumbnail can't be authorized
+	// for the viewer; hidden until the view script flags the entry.
+	&__entry-lock {
+		position: absolute;
+		inset: 0;
+		display: none;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 2px;
+		padding: 4px;
+		text-align: center;
+		color: var(--vpp-muted);
+
+		svg {
+			inline-size: 16px;
+			block-size: 16px;
+			fill: currentColor;
+		}
+	}
+
+	&__entry-lock-label {
+		font-size: 0.59375rem;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+	}
+
+	&__select.is-locked &__entry-lock {
+		display: flex;
+	}
+
+	&.is-layout-grid &__entry-lock svg {
+		inline-size: 24px;
+		block-size: 24px;
+	}
+
+	&.is-layout-grid &__entry-lock-label {
+		font-size: 0.6875rem;
+	}
+
 	&__entry-time {
 		position: absolute;
 		inset-inline-end: 4px;

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -184,7 +184,8 @@ $vpp-mono: ui-monospace, menlo, monospace;
 	}
 
 	// Placeholder shown when a private video's thumbnail can't be authorized
-	// for the viewer; hidden until the view script flags the entry.
+	// for the viewer; hidden until the view script flags the entry. Sized for
+	// the side rail's 76px thumb; grid and strip scale it up below.
 	&__entry-lock {
 		position: absolute;
 		inset: 0;
@@ -192,20 +193,26 @@ $vpp-mono: ui-monospace, menlo, monospace;
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
-		gap: 2px;
-		padding: 4px;
+		padding: 2px;
+		overflow: hidden;
 		text-align: center;
 		color: var(--vpp-muted);
 
 		svg {
-			inline-size: 16px;
-			block-size: 16px;
+			flex: none;
+			inline-size: 12px;
+			block-size: 12px;
 			fill: currentColor;
 		}
 	}
 
 	&__entry-lock-label {
-		font-size: 0.59375rem;
+		max-inline-size: 100%;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		font-size: 0.5rem;
+		line-height: 1.2;
 		font-weight: 600;
 		letter-spacing: 0.02em;
 	}
@@ -214,12 +221,19 @@ $vpp-mono: ui-monospace, menlo, monospace;
 		display: flex;
 	}
 
-	&.is-layout-grid &__entry-lock svg {
-		inline-size: 24px;
-		block-size: 24px;
+	&.is-layout-grid &__entry-lock,
+	&.is-layout-strip &__entry-lock {
+		gap: 2px;
+		padding: 4px;
+
+		svg {
+			inline-size: 24px;
+			block-size: 24px;
+		}
 	}
 
-	&.is-layout-grid &__entry-lock-label {
+	&.is-layout-grid &__entry-lock-label,
+	&.is-layout-strip &__entry-lock-label {
 		font-size: 0.6875rem;
 	}
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -102,8 +102,19 @@ export function hydratePlaylistMetadata( root: HTMLElement ): Promise< void[] > 
 
 			const result = await fetchLiveMetadata( guid );
 			if ( 'locked' === result ) {
-				// Show the server-rendered lock placeholder in the thumbnail.
+				// Show the server-rendered lock placeholder in the thumbnail, and
+				// reuse its translated label as the entry title in place of the
+				// positional fallback.
 				entry.classList.add( 'is-locked' );
+				const lockLabel = entry.querySelector( '.videopress-playlist__entry-lock-label' )
+					?.textContent;
+				if ( lockLabel ) {
+					entry.dataset.title = lockLabel;
+					const titleElement = entry.querySelector( '.videopress-playlist__entry-title' );
+					if ( titleElement ) {
+						titleElement.textContent = lockLabel;
+					}
+				}
 				return;
 			}
 			if ( ! result ) {

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -5,6 +5,7 @@ import domReady from '@wordpress/dom-ready';
 /**
  * Internal dependencies
  */
+import getMediaToken from '../../../lib/get-media-token';
 import { isAllowedOrigin } from '../../../lib/videopress-allowed-origins';
 import './view.scss';
 
@@ -21,17 +22,42 @@ type LiveVideoMetadata = {
 /**
  * Fetch a video's live display metadata from the public videos API.
  *
- * Lookups are anonymous: private videos (and API failures) return null and
- * the entry keeps its server-rendered fallback.
+ * The first lookup is anonymous. When it is denied — a private video — and the
+ * page carries the token bridge configuration (enqueued whenever the block
+ * renders), the lookup is retried with a playback token so authorized viewers
+ * still get live metadata. Unauthorized viewers (and API failures) return null
+ * and the entry keeps its server-rendered fallback.
  *
  * @param guid - The video GUID.
  * @return The metadata, or null when it can't be read.
  */
 async function fetchLiveMetadata( guid: string ): Promise< LiveVideoMetadata | null > {
+	const endpoint = `https://public-api.wordpress.com/rest/v1.1/videos/${ encodeURIComponent(
+		guid
+	) }`;
+
 	try {
-		const response = await fetch(
-			`https://public-api.wordpress.com/rest/v1.1/videos/${ encodeURIComponent( guid ) }`
-		);
+		const response = await fetch( endpoint );
+		if ( response.ok ) {
+			return ( await response.json() ) as LiveVideoMetadata;
+		}
+	} catch {
+		// Network failure: a token retry would not fare better.
+		return null;
+	}
+
+	if ( ! window.videopressAjax ) {
+		return null;
+	}
+
+	try {
+		const postId = Number( window.videopressAjax.post_id ) || 0;
+		const { token } = await getMediaToken( 'playback', { guid, id: postId } );
+		if ( ! token ) {
+			return null;
+		}
+
+		const response = await fetch( `${ endpoint }?metadata_token=${ encodeURIComponent( token ) }` );
 		if ( ! response.ok ) {
 			return null;
 		}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -26,13 +26,15 @@ type LiveVideoMetadata = {
  * The first lookup is anonymous. When it is denied — a private video — and the
  * page carries the token bridge configuration (enqueued whenever the block
  * renders), the lookup is retried with a playback token so authorized viewers
- * still get live metadata. Unauthorized viewers (and API failures) return null
- * and the entry keeps its server-rendered fallback.
+ * still get live metadata. 'locked' means the video is private and could not be
+ * authorized for this viewer; null means the data is unreachable (network
+ * failure, deleted video) and the entry just keeps its server-rendered
+ * fallback.
  *
  * @param guid - The video GUID.
- * @return The metadata, or null when it can't be read.
+ * @return The metadata, 'locked', or null.
  */
-async function fetchLiveMetadata( guid: string ): Promise< LiveVideoMetadata | null > {
+async function fetchLiveMetadata( guid: string ): Promise< LiveVideoMetadata | 'locked' | null > {
 	const endpoint = `https://public-api.wordpress.com/rest/v1.1/videos/${ encodeURIComponent(
 		guid
 	) }`;
@@ -42,25 +44,28 @@ async function fetchLiveMetadata( guid: string ): Promise< LiveVideoMetadata | n
 		if ( response.ok ) {
 			return ( await response.json() ) as LiveVideoMetadata;
 		}
+		if ( response.status !== 401 && response.status !== 403 ) {
+			return null;
+		}
 	} catch {
 		// Network failure: a token retry would not fare better.
 		return null;
 	}
 
 	if ( ! window.videopressAjax ) {
-		return null;
+		return 'locked';
 	}
 
 	try {
 		const postId = Number( window.videopressAjax.post_id ) || 0;
 		const { token } = await getMediaToken( 'playback', { guid, id: postId } );
 		if ( ! token ) {
-			return null;
+			return 'locked';
 		}
 
 		const response = await fetch( `${ endpoint }?metadata_token=${ encodeURIComponent( token ) }` );
 		if ( ! response.ok ) {
-			return null;
+			return 'locked';
 		}
 		const metadata = ( await response.json() ) as LiveVideoMetadata;
 
@@ -95,10 +100,17 @@ export function hydratePlaylistMetadata( root: HTMLElement ): Promise< void[] > 
 				return;
 			}
 
-			const metadata = await fetchLiveMetadata( guid );
-			if ( ! metadata ) {
+			const result = await fetchLiveMetadata( guid );
+			if ( 'locked' === result ) {
+				// Show the server-rendered lock placeholder in the thumbnail.
+				entry.classList.add( 'is-locked' );
 				return;
 			}
+			if ( ! result ) {
+				return;
+			}
+			entry.classList.remove( 'is-locked' );
+			const metadata = result;
 
 			if ( typeof metadata.title === 'string' && metadata.title ) {
 				entry.dataset.title = metadata.title;

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -7,6 +7,7 @@ import domReady from '@wordpress/dom-ready';
  */
 import getMediaToken from '../../../lib/get-media-token';
 import { isAllowedOrigin } from '../../../lib/videopress-allowed-origins';
+import { withMetadataToken } from './utils';
 import './view.scss';
 
 type PlayerEventMessage = {
@@ -61,7 +62,14 @@ async function fetchLiveMetadata( guid: string ): Promise< LiveVideoMetadata | n
 		if ( ! response.ok ) {
 			return null;
 		}
-		return ( await response.json() ) as LiveVideoMetadata;
+		const metadata = ( await response.json() ) as LiveVideoMetadata;
+
+		// The API returns the private poster's bare file URL, which the file host
+		// refuses without a token — sign it with the same one.
+		if ( typeof metadata.poster === 'string' && metadata.poster ) {
+			return { ...metadata, poster: withMetadataToken( metadata.poster, token ) };
+		}
+		return metadata;
 	} catch {
 		return null;
 	}

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -161,6 +161,14 @@ class Playlist_Block_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'data-title="Video 1"', $markup );
 		$this->assertStringContainsString( '>Video 2<', $markup );
 		$this->assertStringNotContainsString( '<img', $markup );
+
+		// Every thumb carries the hidden lock placeholder the view script shows
+		// when a private video's thumbnail can't be authorized for the viewer.
+		$this->assertSame( 2, substr_count( $markup, 'videopress-playlist__entry-lock"' ) );
+		$this->assertStringContainsString(
+			'<span class="videopress-playlist__entry-lock-label">Private video</span>',
+			$markup
+		);
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/Video_Authorization_Test.php
+++ b/projects/packages/videopress/tests/php/Video_Authorization_Test.php
@@ -15,11 +15,28 @@ use WorDBless\BaseTestCase;
 class Video_Authorization_Test extends BaseTestCase {
 
 	/**
+	 * Set up before each test.
+	 */
+	protected function set_up() {
+		/*
+		 * The WorDBless write pipeline stores the kses-slashed content verbatim, which
+		 * corrupts block-attribute JSON ({"ref":1} becomes {\"ref\":1}). Real inserts by
+		 * users with unfiltered_html skip these filters, so removing them here keeps the
+		 * stored content faithful without changing what is being tested.
+		 */
+		kses_remove_filters();
+	}
+
+	/**
 	 * Clean up after each test.
 	 */
 	protected function tear_down() {
 		wp_set_current_user( 0 );
 		\WorDBless\Posts::init()->clear_all_posts();
+		// Clear cached GUID-list transients: post ids are reused across tests once the
+		// posts table is emptied, so a stale videopress_guids_{id} entry from one test
+		// would otherwise satisfy (or poison) the lookup in the next.
+		\WorDBless\Options::init()->clear_options();
 	}
 
 	/**
@@ -225,6 +242,146 @@ class Video_Authorization_Test extends BaseTestCase {
 		$this->set_current_user_role( 'subscriber' );
 
 		$this->assertFalse( Access_Control::instance()->is_current_user_authed_for_video( 'nOwHeRe0', 0 ) );
+	}
+
+	/**
+	 * A page that embeds the video only through a synced pattern (core/block ref) is a
+	 * legitimate embedding context: parse_blocks() does not expand the ref, so the
+	 * authorization scan must resolve it manually.
+	 */
+	public function test_subscriber_with_synced_pattern_embedded_post_id_is_authorized_for_private_video() {
+		$guid = 'sYnCed12';
+		$this->create_private_videopress_attachment( $guid );
+		$pattern_id = $this->create_synced_pattern(
+			'<!-- wp:videopress/video {"guid":"' . $guid . '"} /-->'
+		);
+		$embedding  = $this->create_embedding_post( '<!-- wp:block {"ref":' . $pattern_id . '} /-->' );
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertTrue( Access_Control::instance()->is_current_user_authed_for_video( $guid, $embedding ) );
+	}
+
+	/**
+	 * A synced pattern nested inside another synced pattern is still resolved.
+	 */
+	public function test_subscriber_with_nested_synced_pattern_embedded_post_id_is_authorized_for_private_video() {
+		$guid = 'nEsTed12';
+		$this->create_private_videopress_attachment( $guid );
+		$inner_id  = $this->create_synced_pattern(
+			'<!-- wp:videopress/video {"guid":"' . $guid . '"} /-->'
+		);
+		$outer_id  = $this->create_synced_pattern(
+			'<!-- wp:block {"ref":' . $inner_id . '} /-->'
+		);
+		$embedding = $this->create_embedding_post( '<!-- wp:block {"ref":' . $outer_id . '} /-->' );
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertTrue( Access_Control::instance()->is_current_user_authed_for_video( $guid, $embedding ) );
+	}
+
+	/**
+	 * A self-referencing synced pattern must terminate and deny when the guid is absent.
+	 */
+	public function test_self_referencing_synced_pattern_terminates_and_denies_unrelated_guid() {
+		$guid = 'cYcLe123';
+		$this->create_private_videopress_attachment( $guid );
+		$pattern_id = $this->create_synced_pattern( 'placeholder' );
+		wp_update_post(
+			array(
+				'ID'           => $pattern_id,
+				'post_content' => '<!-- wp:block {"ref":' . $pattern_id . '} /-->',
+			)
+		);
+		$embedding = $this->create_embedding_post( '<!-- wp:block {"ref":' . $pattern_id . '} /-->' );
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertFalse( Access_Control::instance()->is_current_user_authed_for_video( $guid, $embedding ) );
+	}
+
+	/**
+	 * A ref pointing at a non-published pattern is not proof of embedding — core skips
+	 * rendering those, so authorization must not accept them either.
+	 */
+	public function test_subscriber_with_trashed_synced_pattern_is_denied() {
+		$guid = 'tRaShd12';
+		$this->create_private_videopress_attachment( $guid );
+		$pattern_id = $this->create_synced_pattern(
+			'<!-- wp:videopress/video {"guid":"' . $guid . '"} /-->'
+		);
+		wp_update_post(
+			array(
+				'ID'          => $pattern_id,
+				'post_status' => 'trash',
+			)
+		);
+		$embedding = $this->create_embedding_post( '<!-- wp:block {"ref":' . $pattern_id . '} /-->' );
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertFalse( Access_Control::instance()->is_current_user_authed_for_video( $guid, $embedding ) );
+	}
+
+	/**
+	 * A page embedding the video through a Video Playlist block is a legitimate embedding
+	 * context: the guid lives in the playlist block's videos attribute, not in a
+	 * videopress/video block.
+	 */
+	public function test_subscriber_with_playlist_block_embedded_post_id_is_authorized_for_private_video() {
+		$guid = 'pLaYls12';
+		$this->create_private_videopress_attachment( $guid );
+		$embedding = $this->create_embedding_post(
+			'<!-- wp:videopress/playlist {"videos":[{"guid":"' . $guid . '","durationMs":1000,"height":720}]} /-->'
+		);
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertTrue( Access_Control::instance()->is_current_user_authed_for_video( $guid, $embedding ) );
+	}
+
+	/**
+	 * A playlist block inside a synced pattern combines both resolution paths.
+	 */
+	public function test_subscriber_with_playlist_block_inside_synced_pattern_is_authorized_for_private_video() {
+		$guid = 'pLpAtt12';
+		$this->create_private_videopress_attachment( $guid );
+		$pattern_id = $this->create_synced_pattern(
+			'<!-- wp:videopress/playlist {"videos":[{"guid":"' . $guid . '","durationMs":1000,"height":720}]} /-->'
+		);
+		$embedding  = $this->create_embedding_post( '<!-- wp:block {"ref":' . $pattern_id . '} /-->' );
+		$this->set_current_user_role( 'subscriber' );
+
+		$this->assertTrue( Access_Control::instance()->is_current_user_authed_for_video( $guid, $embedding ) );
+	}
+
+	/**
+	 * Create a synced pattern (wp_block post) with the given content.
+	 *
+	 * @param string $content The pattern content.
+	 * @return int The pattern post id.
+	 */
+	private function create_synced_pattern( $content ) {
+		return (int) wp_insert_post(
+			array(
+				'post_title'   => 'Synced pattern',
+				'post_content' => $content,
+				'post_status'  => 'publish',
+				'post_type'    => 'wp_block',
+			)
+		);
+	}
+
+	/**
+	 * Create a published post embedding the given (possibly block-comment) content.
+	 *
+	 * @param string $content The post content.
+	 * @return int The post id.
+	 */
+	private function create_embedding_post( $content ) {
+		return (int) wp_insert_post(
+			array(
+				'post_title'   => 'Embedding post',
+				'post_content' => $content,
+				'post_status'  => 'publish',
+			)
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-vidp-372-synced-patterns-followup
+++ b/projects/plugins/jetpack/changelog/fix-vidp-372-synced-patterns-followup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-VideoPress: Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, and let private videos preview in the block editor canvas.
+VideoPress: Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, let private videos preview in the block editor canvas, and load live metadata for private playlist entries for authorized viewers.

--- a/projects/plugins/jetpack/changelog/fix-vidp-372-synced-patterns-followup
+++ b/projects/plugins/jetpack/changelog/fix-vidp-372-synced-patterns-followup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-VideoPress: Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, let private videos preview in the block editor canvas, and load live metadata for private playlist entries for authorized viewers.
+VideoPress: Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, let private videos preview in the block editor canvas, load live metadata for private playlist entries for authorized viewers, and show a lock placeholder on playlist thumbnails of private videos the viewer cannot access.

--- a/projects/plugins/jetpack/changelog/fix-vidp-372-synced-patterns-followup
+++ b/projects/plugins/jetpack/changelog/fix-vidp-372-synced-patterns-followup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, and let private videos preview in the block editor canvas.

--- a/projects/plugins/videopress/changelog/fix-vidp-372-synced-patterns-followup
+++ b/projects/plugins/videopress/changelog/fix-vidp-372-synced-patterns-followup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, and let private videos preview in the block editor canvas.
+Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, let private videos preview in the block editor canvas, and load live metadata for private playlist entries for authorized viewers.

--- a/projects/plugins/videopress/changelog/fix-vidp-372-synced-patterns-followup
+++ b/projects/plugins/videopress/changelog/fix-vidp-372-synced-patterns-followup
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, and let private videos preview in the block editor canvas.

--- a/projects/plugins/videopress/changelog/fix-vidp-372-synced-patterns-followup
+++ b/projects/plugins/videopress/changelog/fix-vidp-372-synced-patterns-followup
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, let private videos preview in the block editor canvas, and load live metadata for private playlist entries for authorized viewers.
+Fix private video playback authorization for videos embedded through synced patterns and Video Playlist blocks, let private videos preview in the block editor canvas, load live metadata for private playlist entries for authorized viewers, and show a lock placeholder on playlist thumbnails of private videos the viewer cannot access.


### PR DESCRIPTION
Fixes VIDP-372 — follow-up to #51398.

## Proposed changes

The GUID cache introduced in #51398 was built on a false premise (stated in that PR's commit message): that `parse_blocks()` expands synced patterns. It does not — `core/block` refs are only expanded at render time by `render_block_core_block()`. The cached GUID list for a page containing only `<!-- wp:block {"ref":N} /-->` therefore never contained the pattern's GUIDs, so the playback authorization zeroed the embedding post id and private videos inside synced patterns were **deterministically denied** for any viewer without `upload_files`. The customer's "worked for hours, then reverted overnight" observation matches the 24-hour playback-JWT localStorage cache (`TOKEN_LIFETIME` in `client/lib/get-media-token`) masking the server-side denial during their testing.

This PR fixes that, plus two related gaps in the same authorization path:

* **Resolve synced pattern refs when collecting GUIDs**: `Access_Control::collect_guids_from_blocks()` now loads referenced `wp_block` posts (published, unlocked only, mirroring core's render constraints) and scans their content recursively — including nested patterns — with a visited guard against cycles and a cap on resolved refs. Pattern content also gets the URL/shortcode scans.
* **Collect Video Playlist entry GUIDs**: `videopress/playlist` stores GUIDs in its `videos` attribute rather than in `videopress/video` blocks, so playlist playback authorization never passed for non-admin viewers. Entries are now collected, and the playlist render callback registers them too.
* **Record rendered GUIDs at render time**: new `Access_Control::ensure_post_guids_cached()` is called from both render callbacks. By render time WordPress has expanded patterns, templates, and template parts, so the render itself is proof of embedding — this covers contexts the static content scan cannot see (e.g. FSE templates), and keeps working after the transient expires.
* **Make the token bridge reachable from the editor canvas**: in iframed editors the canvas document is the embedded player's `window.parent` and only receives assets enqueued during `enqueue_block_assets`. The bridge was only hooked to `enqueue_block_editor_assets` / `admin_enqueue_scripts` (top document), so private videos — e.g. the Video Playlist editor preview — showed "This video is private" in the editor while playing fine on the front end. The bridge is now also enqueued on `enqueue_block_assets`, admin-only, so front-end behavior is unchanged.
* Removed the now-unused uncached `post_embeds_videopress_guid()` path and its helpers.

New authorization tests cover: a video in a synced pattern, a nested pattern, a self-referencing pattern (termination), a trashed pattern (denied), a playlist block, and a playlist inside a pattern.

## Related product discussion/links

* https://linear.app/a8c/issue/VIDP-372/private-videopress-videos-intermittently-fail-inside-synced-patterns

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Setup: a site with VideoPress active, one private VideoPress video, and a second user with the Subscriber role.

Synced pattern (the customer regression):

* As admin, create a synced pattern containing a VideoPress Video block with the private video (block privacy set to Private, not Site default).
* Add the pattern to a post and publish.
* As the Subscriber, open the post in a fresh profile/incognito window (avoids the 24h cached playback token): before this PR the player shows "This video is private…"; with this PR it plays.
* `wp transient delete videopress_guids_<post_id>` and reload as the Subscriber — it still plays (AJAX-time rebuild now resolves the ref; this simulates the transient expiring under full-page caching).

Playlist block:

* As admin, add a Video Playlist block containing the private video to a post and publish.
* In the editor, the preview player should now play the private video (previously "This video is private" in the editor canvas).
* As the Subscriber (fresh profile), the playlist should play on the front end.

Regression checks:

* A private video in a regular block still plays for the Subscriber; an unrelated `post_id` on the token request is still denied.
* `jp test php packages/videopress` — 318 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
