### PR TITLE
ci: Fix job concurrency in gardening action

### DIFF
--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -34,7 +34,7 @@ jobs:
 
     # See above.
     concurrency:
-      group: gardening-xjobqueue-${{ github.ref }}
+      group: gardening-xjobqueue-${{ github.head_ref || github.ref }}
       queue: max
 
     steps:


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
PR #49061 intended for the job-level concurrency to group by branch. But it didn't do so (or else GitHub changed things), because `github.ref` on a `pull_request_target` refers to the base branch, not the PR branch like it does for `pull_request`.

Use `github.head_ref` instead, which really should refer to the PR branch on PRs. Fall back to `github.ref` when that's not set (e.g. on push).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷