### PR TITLE
Phan: Update config for PHP 7.4

### DIFF
--- a/.phan/config.base.php
+++ b/.phan/config.base.php
@@ -201,8 +201,6 @@ function make_phan_config( $dir, $options = array() ) {
 				array(
 					// WordPress coding standards do not allow the `?:` operator.
 					'PhanPluginDuplicateConditionalTernaryDuplication',
-					// Temporary, to fix in a followup PR.
-					'PhanPluginDuplicateExpressionAssignmentOperation',
 				),
 				$options['unsuppress_issue_types']
 			),

--- a/projects/packages/assets/changelog/update-phan-config-for-php-7.4
+++ b/projects/packages/assets/changelog/update-phan-config-for-php-7.4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use `??=` where appropriate. Should be no change to functionality.
+
+

--- a/projects/packages/assets/tests/php/AssetsTest.php
+++ b/projects/packages/assets/tests/php/AssetsTest.php
@@ -765,7 +765,7 @@ class AssetsTest extends TestCase {
 				$funcs[] = $this->callback(
 					function ( $value ) use ( $value_sets, $i ) {
 						static $set = null;
-						$set        = $set ?? $value_sets[ $i ]; // @phan-suppress-current-line PhanTypePossiblyInvalidDimOffset -- False positive.
+						$set      ??= $value_sets[ $i ]; // @phan-suppress-current-line PhanTypePossiblyInvalidDimOffset -- False positive.
 						$expect     = array_shift( $set );
 						$expect->evaluate( $value );
 						return true;

--- a/projects/packages/autoloader/changelog/update-phan-config-for-php-7.4
+++ b/projects/packages/autoloader/changelog/update-phan-config-for-php-7.4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use `??=` where appropriate. Should be no change to functionality.
+
+

--- a/projects/packages/autoloader/tests/php/lib/with-consecutive.php
+++ b/projects/packages/autoloader/tests/php/lib/with-consecutive.php
@@ -58,7 +58,7 @@ function with_consecutive( ...$args ) {
 		$funcs[] = new Callback(
 			function ( $value ) use ( $value_sets, $i ) {
 				static $set = null;
-				$set        = $set ?? $value_sets[ $i ]; // @phan-suppress-current-line PhanTypePossiblyInvalidDimOffset -- False positive.
+				$set      ??= $value_sets[ $i ]; // @phan-suppress-current-line PhanTypePossiblyInvalidDimOffset -- False positive.
 				if ( ! $set ) {
 					$n = count( $value_sets[ $i ] ); // @phan-suppress-current-line PhanTypePossiblyInvalidDimOffset -- False positive.
 					throw new InvalidArgumentException( "More calls than argument sets. Use `->expects( \$this->exactly( $n ) )` or the like when mocking the method to avoid this." );

--- a/projects/packages/blaze/changelog/update-phan-config-for-php-7.4
+++ b/projects/packages/blaze/changelog/update-phan-config-for-php-7.4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use `??=` where appropriate. Should be no change to functionality.
+
+

--- a/projects/packages/blaze/src/class-dashboard-rest-controller.php
+++ b/projects/packages/blaze/src/class-dashboard-rest-controller.php
@@ -1526,9 +1526,9 @@ class Dashboard_REST_Controller {
 			}
 		}
 
-		$response_body['code']         = $error_code;
-		$response_body['status']       = $response_code;
-		$response_body['errorMessage'] = $response_body['errorMessage'] ?? 'Unknown remote error';
+		$response_body['code']           = $error_code;
+		$response_body['status']         = $response_code;
+		$response_body['errorMessage'] ??= 'Unknown remote error';
 
 		return new \WP_REST_Response( $response_body, $response_code );
 	}

--- a/projects/packages/forms/changelog/update-phan-config-for-php-7.4
+++ b/projects/packages/forms/changelog/update-phan-config-for-php-7.4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use `??=` where appropriate. Should be no change to functionality.
+
+

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -1752,7 +1752,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			// that use the notch html (`notched-label__leading` has a max-width of `100px` to prevent it from getting too wide).
 			// It prevents large border radius values from disrupting the look and feel of the fields.
 			if ( isset( $style_variation_attributes['border']['radius'] ) ) {
-				$options_styles          = $options_styles ?? '';
+				$options_styles        ??= '';
 				$radius                  = $style_variation_attributes['border']['radius'];
 				$has_split_radius_values = is_array( $radius );
 				$top_left_radius         = $has_split_radius_values ? $radius['topLeft'] : $radius;
@@ -2385,7 +2385,7 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			 * It prevents large border radius values from disrupting the look and feel of the fields.
 			 */
 			if ( isset( $style_variation_attributes['border']['radius'] ) ) {
-				$options_styles          = $options_styles ?? '';
+				$options_styles        ??= '';
 				$radius                  = $style_variation_attributes['border']['radius'];
 				$has_split_radius_values = is_array( $radius );
 				$top_left_radius         = $has_split_radius_values ? $radius['topLeft'] : $radius;

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -835,7 +835,7 @@ class Contact_Form_Plugin {
 					$input_attrs          = self::get_block_support_classes_and_styles( $block_name, $inner_block['attrs'] );
 					$atts['inputclasses'] = isset( $input_attrs['class'] ) ? ' ' . $input_attrs['class'] : '';
 					$atts['inputstyles']  = $input_attrs['style'] ?? null;
-					$atts['iconStyle']    = $atts['iconStyle'] ?? $inner_block['attrs']['iconStyle'] ?? 'stars';
+					$atts['iconStyle']  ??= $inner_block['attrs']['iconStyle'] ?? 'stars';
 					continue;
 				}
 

--- a/projects/packages/podcast/changelog/update-phan-config-for-php-7.4
+++ b/projects/packages/podcast/changelog/update-phan-config-for-php-7.4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use `??=` where appropriate. Should be no change to functionality.
+
+

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -565,7 +565,7 @@ class Tracks {
 	 */
 	private static function record_event( string $event_name, array $properties, ?WP_User $user = null ) {
 		try {
-			$user                   = $user ?? wp_get_current_user();
+			$user                 ??= wp_get_current_user();
 			$properties['blog_id']  = (int) Connection_Manager::get_site_id( true );
 			$properties['platform'] = self::platform();
 

--- a/projects/packages/premium-analytics/changelog/update-phan-config-for-php-7.4
+++ b/projects/packages/premium-analytics/changelog/update-phan-config-for-php-7.4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use `??=` where appropriate. Should be no change to functionality.
+
+

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -977,8 +977,8 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	 * @return WP_REST_Request
 	 */
 	private function build_data_request( string $method, string $endpoint, array $params = array(), ?string $version = null ): WP_REST_Request {
-		$version = $version ?? '2';
-		$request = new WP_REST_Request( $method, '/jetpack-premium-analytics/v1/proxy/v' . $version . '/' . $endpoint );
+		$version ??= '2';
+		$request   = new WP_REST_Request( $method, '/jetpack-premium-analytics/v1/proxy/v' . $version . '/' . $endpoint );
 		// `endpoint` and `version` are both route (URL) captures in production.
 		$request->set_url_params(
 			array(

--- a/projects/packages/premium-analytics/tests/php/Reports/Export/CSVExportScheduler_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Reports/Export/CSVExportScheduler_Test.php
@@ -131,7 +131,7 @@ class CSVExportScheduler_Test extends TestCase {
 	): Csv_Export_Scheduler {
 		$registry = new Report_Registry();
 		$registry->register_controller( new Orders_Over_Time_Controller( $registry ) );
-		$logger          = $logger ?? new Spy_Logger();
+		$logger        ??= new Spy_Logger();
 		$fetcher         = new Fake_Fetcher( $logger );
 		$fetcher->result = $fetch_result;
 		return new Csv_Export_Scheduler( $registry, $fetcher, new Fake_Generator( $logger ), $email, $logger );

--- a/projects/packages/schema/changelog/update-phan-config-for-php-7.4
+++ b/projects/packages/schema/changelog/update-phan-config-for-php-7.4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use `??=` where appropriate. Should be no change to functionality.
+
+

--- a/projects/packages/schema/src/class-schema-parser.php
+++ b/projects/packages/schema/src/class-schema-parser.php
@@ -99,7 +99,7 @@ class Schema_Parser implements Parser {
 	 */
 	public function parse( $value, $context = null ) {
 
-		$context = $context ?? $this->context ?? new Schema_Context( 'unknown' );
+		$context ??= $this->context ?? new Schema_Context( 'unknown' );
 		$context->set_data( $value );
 		$parser = $this->parser;
 

--- a/projects/packages/search/changelog/update-phan-config-for-php-7.4
+++ b/projects/packages/search/changelog/update-phan-config-for-php-7.4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use `??=` where appropriate. Should be no change to functionality.
+
+

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -453,7 +453,7 @@ class Search_Blocks {
 	 */
 	public static function woocommerce_version_supported( ?string $version = null ): bool {
 		// `constant()` keeps static analysis happy — WC isn't a dependency here.
-		$version = $version ?? ( defined( 'WC_VERSION' ) ? (string) constant( 'WC_VERSION' ) : '' );
+		$version ??= ( defined( 'WC_VERSION' ) ? (string) constant( 'WC_VERSION' ) : '' );
 		return '' !== $version && version_compare( $version, self::MIN_WOOCOMMERCE_VERSION, '>=' );
 	}
 

--- a/projects/packages/search/src/search-blocks/class-theme-chrome-slug-resolver.php
+++ b/projects/packages/search/src/search-blocks/class-theme-chrome-slug-resolver.php
@@ -155,9 +155,9 @@ class Theme_Chrome_Slug_Resolver {
 			if ( null === $content ) {
 				continue;
 			}
-			$extracted       = static::extract_from_template_content( $content );
-			$found['header'] = $found['header'] ?? $extracted['header'];
-			$found['footer'] = $found['footer'] ?? $extracted['footer'];
+			$extracted         = static::extract_from_template_content( $content );
+			$found['header'] ??= $extracted['header'];
+			$found['footer'] ??= $extracted['footer'];
 		}
 		return array(
 			'header' => $found['header'] ?? self::DEFAULTS['header'],

--- a/projects/packages/stats-admin/changelog/update-phan-config-for-php-7.4
+++ b/projects/packages/stats-admin/changelog/update-phan-config-for-php-7.4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use `??=` where appropriate. Should be no change to functionality.
+
+

--- a/projects/packages/stats-admin/src/class-wpcom-client.php
+++ b/projects/packages/stats-admin/src/class-wpcom-client.php
@@ -40,7 +40,7 @@ class WPCOM_Client {
 		$use_cache = $use_cache && ! ( isset( $args['method'] ) && strtoupper( $args['method'] ) !== 'GET' ) && ! static::should_bypass_cache();
 
 		// Arrays are serialized without considering the order of objects, but it's okay atm.
-		$cache_key = $cache_key ?? self::CACHE_TRANSIENT_PREFIX . md5( implode( '|', array( $path, $version, wp_json_encode( $args, JSON_UNESCAPED_SLASHES ), wp_json_encode( $body, JSON_UNESCAPED_SLASHES ), $base_api_path ) ) );
+		$cache_key ??= self::CACHE_TRANSIENT_PREFIX . md5( implode( '|', array( $path, $version, wp_json_encode( $args, JSON_UNESCAPED_SLASHES ), wp_json_encode( $body, JSON_UNESCAPED_SLASHES ), $base_api_path ) ) );
 
 		if ( $use_cache ) {
 			$response_body_content = get_transient( $cache_key );

--- a/projects/packages/waf/changelog/update-phan-config-for-php-7.4
+++ b/projects/packages/waf/changelog/update-phan-config-for-php-7.4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Use `??=` where appropriate. Should be no change to functionality.
+
+

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -529,7 +529,7 @@ class Brute_Force_Protection {
 	 * @return void
 	 */
 	public function log_failed_attempt( $username, $error = null ) {
-		$username = $username ?? '';
+		$username ??= '';
 
 		// Skip if Account protection password validation error.
 		if ( is_object( $error ) && isset( $error->errors['password_detection_validation_error'] ) ) {

--- a/projects/packages/waf/src/class-waf-initializer.php
+++ b/projects/packages/waf/src/class-waf-initializer.php
@@ -133,9 +133,9 @@ class Waf_Initializer {
 		$jetpack_text_domains_with_waf = array( 'jetpack', 'jetpack-protect' );
 		$jetpack_plugins_with_waf      = array( 'jetpack/jetpack.php', 'jetpack-protect/jetpack-protect.php' );
 
-		$hook_extra['type']    = $hook_extra['type'] ?? null;
-		$hook_extra['action']  = $hook_extra['action'] ?? null;
-		$hook_extra['plugins'] = $hook_extra['plugins'] ?? array();
+		$hook_extra['type']    ??= null;
+		$hook_extra['action']  ??= null;
+		$hook_extra['plugins'] ??= array();
 
 		// Only run on upgrades affecting plugins
 		if ( 'plugin' !== $hook_extra['type'] ) {

--- a/projects/plugins/jetpack/changelog/update-phan-config-for-php-7.4
+++ b/projects/plugins/jetpack/changelog/update-phan-config-for-php-7.4
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Use `??=` where appropriate. Should be no change to functionality.
+
+

--- a/projects/plugins/jetpack/extensions/blocks/pinterest/pinterest.php
+++ b/projects/plugins/jetpack/extensions/blocks/pinterest/pinterest.php
@@ -228,7 +228,7 @@ function load_assets( $attr, $content ) {
 	if ( ! Request::is_frontend() ) {
 		return $content;
 	}
-	$attr['url'] = $attr['url'] ?? '';
+	$attr['url'] ??= '';
 	if ( Blocks::is_amp_request() ) {
 		return render_amp_pin( $attr );
 	} else {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
@@ -163,7 +163,7 @@ class WPCOM_JSON_API_List_Posts_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 		}
 
 		// let's be explicit about defaulting to 'post'.
-		$args['type'] = $args['type'] ?? 'post';
+		$args['type'] ??= 'post';
 
 		// make sure the user can read or edit the requested post type(s).
 		if ( is_array( $args['type'] ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -188,7 +188,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 		}
 
 		// let's be explicit about defaulting to 'post'.
-		$args['type'] = $args['type'] ?? 'post';
+		$args['type'] ??= 'post';
 
 		// make sure the user can read or edit the requested post type(s).
 		if ( is_array( $args['type'] ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-menus-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-menus-v1-1-endpoint.php
@@ -914,7 +914,7 @@ class WPCOM_JSON_API_Menus_Update_Menu_Endpoint extends WPCOM_JSON_API_Menus_Abs
 		$data = $data[0];
 
 		// Avoid special-case handling of an unset 'items' field in empty menus
-		$data['items'] = $data['items'] ?? array();
+		$data['items'] ??= array();
 
 		$data = $this->create_new_items( $data, $menu_id );
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-post-v1-2-endpoint.php
@@ -610,7 +610,7 @@ class WPCOM_JSON_API_Update_Post_v1_2_Endpoint extends WPCOM_JSON_API_Update_Pos
 				}
 			}
 
-			$insert['post_date'] = $insert['post_date'] ?? '';
+			$insert['post_date'] ??= '';
 
 			if ( $is_dtp_fb_post ) {
 				$insert = $this->dtp_fb_preprocess_post( $insert, $metadata );

--- a/projects/plugins/jetpack/modules/shortcodes/crowdsignal.php
+++ b/projects/plugins/jetpack/modules/shortcodes/crowdsignal.php
@@ -244,8 +244,8 @@ if (
 			 * Rating embed.
 			 */
 			if ( (int) $attributes['rating'] > 0 ) {
-				$post_id = $post instanceof WP_Post ? $post->ID : get_the_ID();
-				$post_id = $post_id ?? '';
+				$post_id   = $post instanceof WP_Post ? $post->ID : get_the_ID();
+				$post_id ??= '';
 
 				if ( empty( $attributes['unique_id'] ) ) {
 					$attributes['unique_id'] = is_page() ? 'wp-page-' . $post_id : 'wp-post-' . $post_id;

--- a/projects/plugins/jetpack/tests/php/modules/widgets/Jetpack_Display_Posts_Widget_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/widgets/Jetpack_Display_Posts_Widget_Test.php
@@ -48,7 +48,7 @@ class Jetpack_Display_Posts_Widget_Test extends WP_UnitTestCase {
 			$funcs[] = static::callback(
 				function ( $value ) use ( $value_sets, $i ) {
 					static $set = null;
-					$set        = $set ?? $value_sets[ $i ]; // @phan-suppress-current-line PhanTypePossiblyInvalidDimOffset -- False positive.
+					$set      ??= $value_sets[ $i ]; // @phan-suppress-current-line PhanTypePossiblyInvalidDimOffset -- False positive.
 					$expect     = array_shift( $set );
 					$expect->evaluate( $value );
 					return true;

--- a/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
+++ b/projects/plugins/jetpack/tests/php/sync/server/class.jetpack-sync-server-eventstore.php
@@ -32,7 +32,7 @@ class Jetpack_Sync_Server_Eventstore {
 	 * @param Callable $filter a custom callable to pass the event object to to be filtered.
 	 **/
 	public function get_all_events( $action_name = null, $blog_id = null, $filter = null ) {
-		$blog_id = $blog_id ?? get_current_blog_id();
+		$blog_id ??= get_current_blog_id();
 
 		if ( ! isset( $this->events[ $blog_id ] ) ) {
 			return array();

--- a/projects/plugins/jetpack/unauth-file-upload.php
+++ b/projects/plugins/jetpack/unauth-file-upload.php
@@ -276,9 +276,9 @@ function handle_file_download() {
 	}
 
 	// Given $file can be manipulated by a filter, make sure everything is as it should be.
-	$file['content'] = $file['content'] ?? '';
-	$file['type']    = $file['type'] ?? 'application/octet-stream';
-	$file['name']    = $file['name'] ?? '';
+	$file['content'] ??= '';
+	$file['type']    ??= 'application/octet-stream';
+	$file['name']    ??= '';
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- The request is already authorized in authorize_file_download() before reaching here.
 	$is_preview = isset( $_GET['preview'] ) && 'true' === $_GET['preview'] && is_file_type_previewable( $file['type'] );


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
This reverts the temporary ignore of
`PhanPluginDuplicateExpressionAssignmentOperation` added in #51515, and fixes all the places where it was reporting.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
Followup to #51515

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?