### PR TITLE
Backup: show the price on the modernized no-plan gate

### DIFF
--- a/projects/packages/backup/changelog/add-backup-no-plan-gate-price
+++ b/projects/packages/backup/changelog/add-backup-no-plan-gate-price
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Backup: show what a subscription costs on the modernized dashboard's no-plan screen, and stop the promoted-product route reading through a catalogue it could not parse. The new screen is a no-op while the modernization filter is off.
+
+

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -666,7 +666,6 @@ class Jetpack_Backup {
 		$response_code = (int) wp_remote_retrieve_response_code( $wpcom_request );
 
 		if ( 200 !== $response_code ) {
-			// Something went wrong so we'll just return the response without caching.
 			return new WP_Error(
 				'failed_to_fetch_data',
 				esc_html__( 'Unable to fetch the requested data.', 'jetpack-backup-pkg' ),

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -656,26 +656,47 @@ class Jetpack_Backup {
 	/**
 	 * Gets information about the currently promoted backup product.
 	 *
-	 * @return string|WP_Error A JSON object of the current backup product being promoted if the request was successful, or a WP_Error otherwise.
+	 * @return object|WP_Error The promoted product, or a WP_Error if it could not be read.
 	 */
 	public static function get_backup_promoted_product_info() {
 		$request_url   = 'https://public-api.wordpress.com/rest/v1.1/products?locale=' . get_user_locale() . '&type=jetpack';
 		$wpcom_request = wp_remote_get( esc_url_raw( $request_url ) );
-		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
-		if ( 200 === $response_code ) {
-			$products = json_decode( wp_remote_retrieve_body( $wpcom_request ) );
-			return $products->{self::JETPACK_BACKUP_PROMOTED_PRODUCT};
-		} else {
+		// Cast: the transport may report the status as a numeric string, which
+		// a strict comparison against 200 sends down the failure path.
+		$response_code = (int) wp_remote_retrieve_response_code( $wpcom_request );
+
+		if ( 200 !== $response_code ) {
 			// Something went wrong so we'll just return the response without caching.
 			return new WP_Error(
 				'failed_to_fetch_data',
 				esc_html__( 'Unable to fetch the requested data.', 'jetpack-backup-pkg' ),
 				array(
-					'status'  => $response_code,
+					// A transport failure has no status at all; reporting 0 would
+					// leave the REST layer with nothing to serve.
+					'status'  => $response_code ? $response_code : 500,
 					'request' => $wpcom_request,
 				)
 			);
 		}
+
+		$products = json_decode( wp_remote_retrieve_body( $wpcom_request ) );
+
+		// A 200 is not a promise that the promoted product is in the body. A
+		// truncated response decodes to null, and the slug is a constant here
+		// but a catalogue entry upstream — retiring it there leaves this a 200
+		// with the key absent. Reading through either emits a PHP warning and
+		// yields null, which the route then serves as a 200 carrying `null`:
+		// indistinguishable, to a caller, from a priced answer it failed to
+		// read. Refusing says which of the two happened.
+		if ( ! is_object( $products ) || ! isset( $products->{ self::JETPACK_BACKUP_PROMOTED_PRODUCT } ) ) {
+			return new WP_Error(
+				'promoted_product_unreadable',
+				esc_html__( 'Unable to read the promoted product information.', 'jetpack-backup-pkg' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return $products->{ self::JETPACK_BACKUP_PROMOTED_PRODUCT };
 	}
 
 	/**

--- a/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
@@ -4,6 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
 import { useSiteSuffix } from '../../hooks/use-connection';
 import LicenseKeyLink from './license-key-link';
+import PromotedPrice from './promoted-price';
 
 /**
  * Fallback shown when the site is fully connected but has no active
@@ -45,6 +46,7 @@ export default function NoBackupPlanScreen() {
 						'jetpack-backup-pkg'
 					) }
 				</Notice>
+				<PromotedPrice />
 				{ /*
 				 * Same tab, as legacy did. An upgrade flow that opens a new
 				 * one strands the page the reader started from, and returns

--- a/projects/packages/backup/src/dashboard/components/gates/promoted-price.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/promoted-price.tsx
@@ -1,0 +1,75 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { __ } from '@wordpress/i18n';
+import { Stack, Text } from '@wordpress/ui';
+import { usePromotedProduct } from '../../hooks/use-promoted-product';
+
+/**
+ * What a Backup subscription costs, for the no-plan screen.
+ *
+ * Renders nothing until a price is known, and nothing at all if one
+ * never arrives. That is deliberate: this screen is the only purchase
+ * path a site without Backup has, and a catalogue that is slow or down
+ * must not be able to delay or withhold the button that leads to
+ * checkout. The price is an argument for pressing it, not a
+ * precondition.
+ *
+ * @return The price block, or null while there is no price to show.
+ */
+export default function PromotedPrice() {
+	const { monthlyPrice, introMonthlyPrice, currencyCode } = usePromotedProduct();
+
+	if ( monthlyPrice === null || ! currencyCode ) {
+		return null;
+	}
+
+	const effectivePrice =
+		introMonthlyPrice !== null && introMonthlyPrice < monthlyPrice
+			? introMonthlyPrice
+			: monthlyPrice;
+
+	const fullText = formatCurrency( monthlyPrice, currencyCode );
+	const effectiveText = formatCurrency( effectivePrice, currencyCode );
+
+	// Compared as rendered, not as numbers. Two amounts that differ below
+	// the currency's precision format identically, and striking through a
+	// figure to show the same one again reads as a bug rather than a
+	// saving.
+	const hasDiscount = effectiveText !== fullText;
+
+	// Every string here is the legacy no-plan card's, unchanged, so they
+	// arrive already translated instead of waiting a GlotPress cycle.
+	//
+	// One const per string, rather than a `__()` call chosen inside a
+	// ternary: the minifier factors the shared call out and leaves the
+	// msgid a variable, which the text-domain scanner then drops.
+	const basicInfoText = __( '14 day money back guarantee.', 'jetpack-backup-pkg' );
+	const introductoryInfoText = __(
+		'Special introductory pricing, all renewals are at full price. 14 day money back guarantee.',
+		'jetpack-backup-pkg'
+	);
+	const infoText = hasDiscount ? introductoryInfoText : basicInfoText;
+	const priceDetails = __( 'per month, billed yearly', 'jetpack-backup-pkg' );
+
+	return (
+		<Stack direction="column" gap="xs" align="center">
+			<Stack direction="row" gap="xs" align="baseline" justify="center" wrap="wrap">
+				{ /*
+				 * Hidden from assistive tech rather than read out. A
+				 * strikethrough carries no meaning a screen reader
+				 * conveys, so announcing it gives two bare amounts and no
+				 * hint which one is charged. The sentence below says what
+				 * the strikethrough means in words, which is the accessible
+				 * version of the same information.
+				 */ }
+				{ hasDiscount && (
+					<Text variant="body-lg" render={ <s /> } aria-hidden="true">
+						{ fullText }
+					</Text>
+				) }
+				<Text variant="heading-lg">{ effectiveText }</Text>
+			</Stack>
+			<Text variant="body-sm">{ priceDetails }</Text>
+			<Text variant="body-sm">{ infoText }</Text>
+		</Stack>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/gates/promoted-price.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/promoted-price.tsx
@@ -1,5 +1,6 @@
 import { formatCurrency } from '@automattic/number-formatters';
-import { __ } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
 import { usePromotedProduct } from '../../hooks/use-promoted-product';
 
@@ -36,8 +37,8 @@ export default function PromotedPrice() {
 	// saving.
 	const hasDiscount = effectiveText !== fullText;
 
-	// Every string here is the legacy no-plan card's, unchanged, so they
-	// arrive already translated instead of waiting a GlotPress cycle.
+	// These three are the legacy no-plan card's, unchanged, so they arrive
+	// already translated instead of waiting a GlotPress cycle.
 	//
 	// One const per string, rather than a `__()` call chosen inside a
 	// ternary: the minifier factors the shared call out and leaves the
@@ -50,6 +51,22 @@ export default function PromotedPrice() {
 	const infoText = hasDiscount ? introductoryInfoText : basicInfoText;
 	const priceDetails = __( 'per month, billed yearly', 'jetpack-backup-pkg' );
 
+	// The one string here that is not legacy's, so the one that waits a
+	// GlotPress cycle. It earns that: the struck-through figure is the
+	// only place the renewal amount appears, and it is hidden below, so
+	// without this a screen reader is told a full price exists and never
+	// told what it is.
+	//
+	// Deliberately says nothing about *when* it renews. The offer's
+	// interval is a year today and the hook handles monthly ones too, so
+	// naming a period here would be wrong for the case that handling
+	// exists for.
+	const renewalText = sprintf(
+		/* translators: %s is the full monthly price the subscription renews at. */
+		__( 'Renews at %s per month.', 'jetpack-backup-pkg' ),
+		fullText
+	);
+
 	return (
 		<Stack direction="column" gap="xs" align="center">
 			<Stack direction="row" gap="xs" align="baseline" justify="center" wrap="wrap">
@@ -57,9 +74,12 @@ export default function PromotedPrice() {
 				 * Hidden from assistive tech rather than read out. A
 				 * strikethrough carries no meaning a screen reader
 				 * conveys, so announcing it gives two bare amounts and no
-				 * hint which one is charged. The sentence below says what
-				 * the strikethrough means in words, which is the accessible
-				 * version of the same information.
+				 * hint which one is charged.
+				 *
+				 * Hiding it is only half the fix. "All renewals are at
+				 * full price" establishes that a full price exists and
+				 * never says what it is, so the amount itself is restored
+				 * further down as visually-hidden text.
 				 */ }
 				{ hasDiscount && (
 					<Text variant="body-lg" render={ <s /> } aria-hidden="true">
@@ -69,6 +89,7 @@ export default function PromotedPrice() {
 				<Text variant="heading-lg">{ effectiveText }</Text>
 			</Stack>
 			<Text variant="body-sm">{ priceDetails }</Text>
+			{ hasDiscount && <VisuallyHidden>{ renewalText }</VisuallyHidden> }
 			<Text variant="body-sm">{ infoText }</Text>
 		</Stack>
 	);

--- a/projects/packages/backup/src/dashboard/data/api/promoted-product.ts
+++ b/projects/packages/backup/src/dashboard/data/api/promoted-product.ts
@@ -1,0 +1,40 @@
+import { apiCall, apiPath } from './_helpers';
+
+/**
+ * Response of `GET /jetpack/v4/backup-promoted-product-info`.
+ *
+ * One entry from WordPress.com's public product catalogue, forwarded
+ * verbatim. Two things about it are easy to assume wrongly:
+ *
+ * `cost` is the price of a full term, and the promoted product is a
+ * yearly one — so it is roughly twelve times the figure this screen
+ * shows.
+ *
+ * `currency_code` is chosen by WordPress.com from where the *site*
+ * appears to be, not from the reader's locale or any site setting, so
+ * neither the currency nor the magnitude of the amount can be assumed.
+ * Nothing here may be formatted with a hardcoded symbol.
+ *
+ * Fields are optional because a 200 does not promise a priced entry.
+ * The route refuses the two shapes that used to be fatal — an
+ * undecodable body, and the promoted slug missing from the catalogue —
+ * but not an entry that carries no price.
+ */
+export type RawPromotedProduct = {
+	cost?: number;
+	currency_code?: string;
+	introductory_offer?: {
+		cost_per_interval?: number;
+		interval_unit?: string;
+		interval_count?: number;
+	} | null;
+} | null;
+
+/**
+ * Fetch the Backup product currently being promoted.
+ *
+ * @return The catalogue entry, or `null` when it could not be read.
+ */
+export async function fetchPromotedProduct(): Promise< RawPromotedProduct > {
+	return apiCall< RawPromotedProduct >( { path: apiPath( '/backup-promoted-product-info' ) } );
+}

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -42,6 +42,10 @@ export const keys = {
 	// change rate — but the storage meter needs both, so the two are
 	// always read together.
 	sitePolicies: () => [ 'backup', 'site-policies' ] as const,
+	// The Backup product being promoted, for the no-plan screen's price.
+	// Not keyed on anything: WordPress.com picks the currency from the
+	// site, so one site only ever sees one answer.
+	promotedProduct: () => [ 'backup', 'promoted-product' ] as const,
 	// Family prefix for any rewindable-activity-log page. Use as a
 	// query-filter root to scan all cached pages (e.g. when looking up
 	// a row by id across pages).

--- a/projects/packages/backup/src/dashboard/hooks/use-promoted-product.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-promoted-product.ts
@@ -1,0 +1,109 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchPromotedProduct } from '../data/api/promoted-product';
+import { keys } from '../data/query-client';
+
+/**
+ * Prices move on a catalogue's schedule, not a session's. An hour is
+ * long enough that opening the screen twice costs one request, and
+ * short enough that a price change reaches a tab left open all day.
+ */
+const PROMOTED_PRODUCT_STALE_MS = 60 * 60_000;
+
+const MONTHS_PER_YEAR = 12;
+
+type Result = {
+	/**
+	 * The full monthly price, or null when no price could be read.
+	 * Callers must treat null as "render no price", never as free.
+	 */
+	monthlyPrice: number | null;
+	/**
+	 * The monthly price while an introductory offer is running, or null
+	 * when there is no offer — or when its interval is one this cannot
+	 * convert to months.
+	 */
+	introMonthlyPrice: number | null;
+	/**
+	 * The currency WordPress.com priced this in. Null whenever
+	 * `monthlyPrice` is null; there is no default, and assuming one
+	 * would mislabel every non-USD site.
+	 */
+	currencyCode: string | null;
+};
+
+const EMPTY: Result = { monthlyPrice: null, introMonthlyPrice: null, currencyCode: null };
+
+/**
+ * Months covered by one interval of an introductory offer.
+ *
+ * The legacy screen divides `cost_per_interval` by 12 unconditionally,
+ * which is right only while the offer's interval is a single year — the
+ * shape the catalogue happens to ship today. A monthly offer would
+ * render at a twelfth of what it costs.
+ *
+ * An unrecognized unit returns null so the caller shows no introductory
+ * price at all. The full price still renders, which is the accurate
+ * half; a wrong discount is worse than a missing one.
+ *
+ * @param unit  - The offer's interval unit.
+ * @param count - How many of those units one interval spans.
+ * @return Months per interval, or null if the unit is not understood.
+ */
+function intervalMonths( unit?: string, count?: number ): number | null {
+	const intervals = typeof count === 'number' && count > 0 ? count : 1;
+
+	if ( unit === 'year' ) {
+		return intervals * MONTHS_PER_YEAR;
+	}
+
+	if ( unit === 'month' ) {
+		return intervals;
+	}
+
+	return null;
+}
+
+/**
+ * React Query hook exposing the promoted Backup product's monthly price.
+ *
+ * Deliberately not gated on `useCanQueryWpcom()`, unlike every other
+ * hook here. The route it reads is an unauthenticated `wp_remote_get`
+ * against the public product catalogue — it needs `manage_options` and
+ * nothing else, so gating it on the site's WordPress.com connection
+ * would copy a constraint that does not apply to it.
+ *
+ * Its one caller is the no-plan screen, which mounts only for a site
+ * that has no Backup plan. That is what keeps this from becoming
+ * another request issued behind the gate: the query cannot start
+ * anywhere the reader could not act on the answer.
+ *
+ * @return The monthly prices and their currency, or nulls throughout.
+ */
+export function usePromotedProduct(): Result {
+	const query = useQuery( {
+		queryKey: keys.promotedProduct(),
+		queryFn: fetchPromotedProduct,
+		staleTime: PROMOTED_PRODUCT_STALE_MS,
+	} );
+
+	const product = query.data;
+	const cost = typeof product?.cost === 'number' ? product.cost : null;
+	const currencyCode = typeof product?.currency_code === 'string' ? product.currency_code : null;
+
+	// Both halves or neither: an amount cannot be formatted without a
+	// currency, and this catalogue's currency varies by site rather than
+	// being implicitly USD.
+	if ( cost === null || ! currencyCode ) {
+		return EMPTY;
+	}
+
+	const monthlyPrice = cost / MONTHS_PER_YEAR;
+
+	const offer = product?.introductory_offer;
+	const offerCost = typeof offer?.cost_per_interval === 'number' ? offer.cost_per_interval : null;
+	const months = offer ? intervalMonths( offer.interval_unit, offer.interval_count ) : null;
+
+	const introMonthlyPrice = offerCost !== null && months !== null ? offerCost / months : null;
+
+	return { monthlyPrice, introMonthlyPrice, currencyCode };
+}

--- a/projects/packages/backup/src/dashboard/hooks/use-promoted-product.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-promoted-product.ts
@@ -84,6 +84,13 @@ export function usePromotedProduct(): Result {
 		queryKey: keys.promotedProduct(),
 		queryFn: fetchPromotedProduct,
 		staleTime: PROMOTED_PRODUCT_STALE_MS,
+		// Overrides the client's `retry: 1`. Each attempt costs the *site*
+		// an uncached, blocking request to the product catalogue, so a
+		// retry doubles the expensive hop rather than the cheap one — and
+		// buys a figure the screen is designed to work without. React
+		// Query's default guards the browser-to-site hop; the one that
+		// fails here is site-to-WordPress.com.
+		retry: false,
 	} );
 
 	const product = query.data;

--- a/projects/packages/backup/tests/no-plan-gate.test.tsx
+++ b/projects/packages/backup/tests/no-plan-gate.test.tsx
@@ -10,6 +10,11 @@
 // `admin.php?page=jetpack` is a `__return_null` placeholder without the
 // Jetpack plugin, and the Jetpack React app with it — and that app has no
 // `/connection` route, so the hash bounced to `#/dashboard`.
+//
+// And the screen never said what Backup costs, so the only way to find out
+// was to press a button labelled "Get VaultPress Backup" and see where it
+// led. The price comes from the product catalogue, which prices per site —
+// so these tests assert that the currency travels with the amount.
 
 const mockApiFetch = jest.fn();
 
@@ -30,9 +35,31 @@ import { render, screen } from '@testing-library/react';
 import NoBackupPlanScreen from '../src/dashboard/components/gates/no-backup-plan';
 import NotConnectedScreen from '../src/dashboard/components/gates/not-connected';
 import SecondaryAdminScreen from '../src/dashboard/components/gates/secondary-admin';
+import { queryClient } from '../src/dashboard/data/query-client';
 import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
 
 const SITE_SUFFIX = 'example.com';
+
+/**
+ * A catalogue entry as WordPress.com actually ships it, currency and all.
+ *
+ * BRL rather than USD on purpose: the catalogue prices from where the
+ * site appears to be, so a fixture in dollars would let a hardcoded `$`
+ * pass. `cost` is the yearly term price — the promoted product is a
+ * yearly one — and the offer's interval is a year, which is what makes
+ * dividing it by twelve correct here and wrong for a monthly one.
+ */
+const PRICED_PRODUCT = {
+	cost: 539.4,
+	currency_code: 'BRL',
+	introductory_offer: {
+		interval_unit: 'year',
+		interval_count: 1,
+		cost_per_interval: 275.4,
+	},
+};
+
+const PRICE_PATH = '/jetpack/v4/backup-promoted-product-info';
 
 /**
  * Render a gate screen.
@@ -53,6 +80,15 @@ function renderScreen( Screen: () => JSX.Element ) {
 
 beforeEach( () => {
 	mockApiFetch.mockReset();
+	// The price query would otherwise be answered from the previous
+	// test's cache: the client is a module singleton and the price is
+	// held for an hour, so without this the first test to resolve it
+	// decides what every later one sees.
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+	// Default to a catalogue that answers with nothing, so the tests that
+	// are not about the price render without one.
+	mockApiFetch.mockResolvedValue( null );
 
 	window.JP_CONNECTION_INITIAL_STATE = {
 		...window.JP_CONNECTION_INITIAL_STATE,
@@ -64,7 +100,7 @@ describe( 'No-plan gate', () => {
 	it( 'sends the site through to checkout rather than a generic marketing page', async () => {
 		renderScreen( NoBackupPlanScreen );
 
-		const cta = screen.getByRole( 'link', { name: /^Get VaultPress Backup$/ } );
+		const cta = await screen.findByRole( 'link', { name: /^Get VaultPress Backup$/ } );
 
 		// Site-scoped: without this the reader lands on a page that has no
 		// idea which site they came from. And on the redirect service, as
@@ -81,10 +117,9 @@ describe( 'No-plan gate', () => {
 		// on the modernized page, so the absolute `adminUrl` the legacy
 		// header used is not available — and does not need to be, since
 		// this renders inside wp-admin already.
-		expect( screen.getByRole( 'link', { name: /^Use license key$/ } ) ).toHaveAttribute(
-			'href',
-			'admin.php?page=my-jetpack#/add-license'
-		);
+		await expect(
+			screen.findByRole( 'link', { name: /^Use license key$/ } )
+		).resolves.toHaveAttribute( 'href', 'admin.php?page=my-jetpack#/add-license' );
 	} );
 
 	it( 'omits the site rather than sending the word "undefined"', async () => {
@@ -99,28 +134,114 @@ describe( 'No-plan gate', () => {
 
 		renderScreen( NoBackupPlanScreen );
 
-		expect( screen.getByRole( 'link', { name: /^Get VaultPress Backup$/ } ) ).not.toHaveAttribute(
-			'href',
-			expect.stringContaining( 'undefined' )
-		);
+		await expect(
+			screen.findByRole( 'link', { name: /^Get VaultPress Backup$/ } )
+		).resolves.not.toHaveAttribute( 'href', expect.stringContaining( 'undefined' ) );
 	} );
 
 	it( 'keeps the reader in the same tab', async () => {
 		// An upgrade flow that strands the tab it came from is worse, and
 		// legacy did not do it either.
 		renderScreen( NoBackupPlanScreen );
+		await expect(
+			screen.findByRole( 'link', { name: /^Get VaultPress Backup$/ } )
+		).resolves.toBeInTheDocument();
 
 		for ( const link of screen.getAllByRole( 'link' ) ) {
 			expect( link ).not.toHaveAttribute( 'target', '_blank' );
 		}
 	} );
 
-	it( 'issues no requests', async () => {
-		// This screen renders below the capabilities gate, but it must not
-		// add fetches of its own — the gates' zero-request property is a
-		// deliberate design commitment.
+	it( 'asks for the price and nothing else', async () => {
+		// This screen used to issue no requests at all, and the other two
+		// gates still do not. The price is the one thing worth fetching
+		// here: it is the only request on this screen whose answer the
+		// reader can act on, which is the same test JETPACK-2322 applies
+		// to the four the Overview issues behind this gate.
 		renderScreen( NoBackupPlanScreen );
-		expect( mockApiFetch ).not.toHaveBeenCalled();
+		await expect(
+			screen.findByRole( 'link', { name: /^Get VaultPress Backup$/ } )
+		).resolves.toBeInTheDocument();
+
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( mockApiFetch ).toHaveBeenCalledWith( expect.objectContaining( { path: PRICE_PATH } ) );
+	} );
+
+	it( 'shows the monthly price in the currency the catalogue named', async () => {
+		mockApiFetch.mockResolvedValue( { ...PRICED_PRODUCT, introductory_offer: null } );
+
+		renderScreen( NoBackupPlanScreen );
+
+		// 539.40 a year is 44.95 a month. The figure the reader compares
+		// against competitors is the monthly one, which is why the screen
+		// divides rather than showing the term price.
+		const price = await screen.findByText( /44[.,]95/ );
+
+		// Rendered from `currency_code`, not from a symbol written here.
+		// The legacy screen hardcodes `$` in one of its price strings,
+		// which is wrong for every site this fixture represents.
+		expect( price ).toHaveTextContent( 'R$' );
+		expect( screen.getByText( '14 day money back guarantee.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'leads with the introductory price and explains the renewal', async () => {
+		mockApiFetch.mockResolvedValue( PRICED_PRODUCT );
+
+		renderScreen( NoBackupPlanScreen );
+
+		// 275.40 for the first year is 22.95 a month; 44.95 after it.
+		await expect( screen.findByText( /22[.,]95/ ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( /44[.,]95/ ) ).toBeInTheDocument();
+
+		// Two amounts on screen is only honest if the screen says which
+		// one recurs.
+		expect( screen.getByText( /all renewals are at full price/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not read the superseded price out as a second price', async () => {
+		// A strikethrough is invisible to a screen reader, so announcing
+		// both amounts gives two prices and no way to tell which is
+		// charged. The sentence below them carries that in words.
+		mockApiFetch.mockResolvedValue( PRICED_PRODUCT );
+
+		renderScreen( NoBackupPlanScreen );
+
+		const superseded = await screen.findByText( /44[.,]95/ );
+		expect( superseded ).toHaveAttribute( 'aria-hidden', 'true' );
+	} );
+
+	it( 'converts a monthly introductory offer by its own interval', async () => {
+		// The legacy screen divides `cost_per_interval` by twelve whatever
+		// the interval is, so a monthly offer renders at a twelfth of what
+		// it costs. Here the offer is 9.99 for one month, and 9.99 is what
+		// must appear — not 0.83.
+		mockApiFetch.mockResolvedValue( {
+			...PRICED_PRODUCT,
+			introductory_offer: {
+				interval_unit: 'month',
+				interval_count: 1,
+				cost_per_interval: 9.99,
+			},
+		} );
+
+		renderScreen( NoBackupPlanScreen );
+
+		await expect( screen.findByText( /9[.,]99/ ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( /0[.,]83/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'still offers the purchase path when the catalogue cannot be read', async () => {
+		// This screen is the only way a site without Backup can buy one.
+		// A catalogue that is down may cost the reader the price; it must
+		// not cost them the button.
+		mockApiFetch.mockRejectedValue( new Error( 'catalogue unavailable' ) );
+
+		renderScreen( NoBackupPlanScreen );
+
+		await expect(
+			screen.findByRole( 'link', { name: /^Get VaultPress Backup$/ } )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( /per month, billed yearly/ ) ).not.toBeInTheDocument();
 	} );
 } );
 
@@ -143,5 +264,14 @@ describe.each( [
 		// only on the no-plan screen — see `useShowActivateLicenseLink`.
 		renderScreen( Screen );
 		expect( screen.getByRole( 'link', { name: /^Use license key$/ } ) ).toBeInTheDocument();
+	} );
+
+	it( 'issues no requests', async () => {
+		// The no-plan screen fetches a price; these two must not fetch
+		// anything. Neither reader can buy from where they are standing —
+		// one has no connection and the other is not the connected user —
+		// so a price would be an answer to a question they cannot ask yet.
+		renderScreen( Screen );
+		expect( mockApiFetch ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/backup/tests/no-plan-gate.test.tsx
+++ b/projects/packages/backup/tests/no-plan-gate.test.tsx
@@ -62,6 +62,14 @@ const PRICED_PRODUCT = {
 const PRICE_PATH = '/jetpack/v4/backup-promoted-product-info';
 
 /**
+ * The full price and nothing else — which is the struck-through element,
+ * since the visually-hidden renewal line wraps the same figure in words.
+ * Anchored so it cannot also match that sentence, and spelled with `R$`
+ * so it doubles as a check that the fixture's currency reached the DOM.
+ */
+const PRICE_ALONE = /^R\$\s?44[.,]95$/;
+
+/**
  * Render a gate screen.
  *
  * `screen` is safe for this file, unlike the retry suite next door:
@@ -85,7 +93,6 @@ beforeEach( () => {
 	// held for an hour, so without this the first test to resolve it
 	// decides what every later one sees.
 	queryClient.clear();
-	queryClient.setDefaultOptions( { queries: { retry: false } } );
 	// Default to a catalogue that answers with nothing, so the tests that
 	// are not about the price render without one.
 	mockApiFetch.mockResolvedValue( null );
@@ -191,7 +198,7 @@ describe( 'No-plan gate', () => {
 
 		// 275.40 for the first year is 22.95 a month; 44.95 after it.
 		await expect( screen.findByText( /22[.,]95/ ) ).resolves.toBeInTheDocument();
-		expect( screen.getByText( /44[.,]95/ ) ).toBeInTheDocument();
+		expect( screen.getByText( PRICE_ALONE ) ).toBeInTheDocument();
 
 		// Two amounts on screen is only honest if the screen says which
 		// one recurs.
@@ -201,13 +208,37 @@ describe( 'No-plan gate', () => {
 	it( 'does not read the superseded price out as a second price', async () => {
 		// A strikethrough is invisible to a screen reader, so announcing
 		// both amounts gives two prices and no way to tell which is
-		// charged. The sentence below them carries that in words.
+		// charged.
+		mockApiFetch.mockResolvedValue( PRICED_PRODUCT );
+
+		renderScreen( NoBackupPlanScreen );
+		await expect( screen.findByText( /Renews at/ ) ).resolves.toBeInTheDocument();
+
+		expect( screen.getByText( PRICE_ALONE ) ).toHaveAttribute( 'aria-hidden', 'true' );
+	} );
+
+	it( 'still tells assistive tech what the price renews at', async () => {
+		// Hiding the strikethrough is only half the fix. "All renewals are
+		// at full price" says a full price exists and never says what it
+		// is, so hiding the only place the figure appears would leave a
+		// screen reader with strictly fewer facts than a sighted reader —
+		// on the screen whose entire job is to inform a purchase.
 		mockApiFetch.mockResolvedValue( PRICED_PRODUCT );
 
 		renderScreen( NoBackupPlanScreen );
 
-		const superseded = await screen.findByText( /44[.,]95/ );
-		expect( superseded ).toHaveAttribute( 'aria-hidden', 'true' );
+		const renewal = await screen.findByText( /Renews at .*44[.,]95 per month/ );
+		expect( renewal ).not.toHaveAttribute( 'aria-hidden' );
+	} );
+
+	it( 'says nothing about renewal when there is no introductory offer', async () => {
+		// One price, nothing superseded, nothing to explain.
+		mockApiFetch.mockResolvedValue( { ...PRICED_PRODUCT, introductory_offer: null } );
+
+		renderScreen( NoBackupPlanScreen );
+
+		await expect( screen.findByText( /44[.,]95/ ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( /Renews at/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'converts a monthly introductory offer by its own interval', async () => {

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -150,7 +150,6 @@ class Jetpack_Backup_Test extends TestCase {
 		$result = Jetpack_Backup::get_backup_promoted_product_info();
 
 		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ) );
-		$this->catalogue_status = 200;
 
 		$this->assertIsObject( $result );
 		$this->assertSame( 'BRL', $result->currency_code );
@@ -174,7 +173,6 @@ class Jetpack_Backup_Test extends TestCase {
 		$result = Jetpack_Backup::get_backup_promoted_product_info();
 
 		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ) );
-		$this->catalogue_body = null;
 
 		$this->assertInstanceOf( WP_Error::class, $result, $label );
 		$this->assertSame( 'promoted_product_unreadable', $result->get_error_code(), $label );
@@ -203,18 +201,24 @@ class Jetpack_Backup_Test extends TestCase {
 	}
 
 	/**
-	 * A non-200 is reported with the upstream status.
+	 * A non-200 is reported with the upstream status, not a generic one.
+	 *
+	 * 403 and not 500 deliberately. 500 is also what the no-status
+	 * fallback produces, so asserting it here would pass whether or not
+	 * the status was forwarded at all — and would leave this testing the
+	 * same thing as the transport-failure case below.
 	 */
 	public function test_promoted_product_info_forwards_a_non_200() {
-		add_filter( 'pre_http_request', array( $this, 'mock_request_as_server_error' ) );
+		$this->catalogue_status = 403;
+		add_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ), 10, 3 );
 
 		$result = Jetpack_Backup::get_backup_promoted_product_info();
 
-		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_server_error' ) );
+		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ) );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'failed_to_fetch_data', $result->get_error_code() );
-		$this->assertSame( 500, $result->get_error_data()['status'] );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
 	}
 
 	/**

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Backup\V0005;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WP_Error;
 use WP_REST_Response;
@@ -19,6 +20,21 @@ class Jetpack_Backup_Test extends TestCase {
 	 * @var string
 	 */
 	private $captured_url = '';
+
+	/**
+	 * Body for the next mocked product-catalogue response. Null means
+	 * "the well-formed catalogue".
+	 *
+	 * @var string|null
+	 */
+	private $catalogue_body = null;
+
+	/**
+	 * Status for the next mocked product-catalogue response.
+	 *
+	 * @var int|string
+	 */
+	private $catalogue_status = 200;
 
 	public function test_get_backup_capabilities_handles_wp_error() {
 		add_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
@@ -105,6 +121,151 @@ class Jetpack_Backup_Test extends TestCase {
 		$this->assertStringContainsString( 'backup_complete_full', $this->captured_url );
 		$this->assertStringNotContainsString( 'should_be_overridden', $this->captured_url );
 		$this->assertStringContainsString( 'number=5', urldecode( $this->captured_url ) );
+	}
+
+	/**
+	 * A 200 carrying the promoted product returns it.
+	 */
+	public function test_promoted_product_info_returns_the_promoted_product() {
+		add_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ), 10, 3 );
+
+		$result = Jetpack_Backup::get_backup_promoted_product_info();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ) );
+
+		$this->assertIsObject( $result );
+		$this->assertSame( 539.4, $result->cost );
+		$this->assertSame( 'BRL', $result->currency_code );
+	}
+
+	/**
+	 * The transport may report the status as a numeric string, which a
+	 * strict comparison against the integer 200 sends down the failure
+	 * path — reporting a perfectly good catalogue as unreachable.
+	 */
+	public function test_promoted_product_info_treats_a_string_status_as_its_number() {
+		$this->catalogue_status = '200';
+		add_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ), 10, 3 );
+
+		$result = Jetpack_Backup::get_backup_promoted_product_info();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ) );
+		$this->catalogue_status = 200;
+
+		$this->assertIsObject( $result );
+		$this->assertSame( 'BRL', $result->currency_code );
+	}
+
+	/**
+	 * A 200 whose body will not decode is refused rather than read
+	 * through. `json_decode` returns null there, and reading a property
+	 * off it warns and evaluates to null — so the route answered 200 with
+	 * `null`, which no caller can tell from a price it could not parse.
+	 *
+	 * @param string $label Human-readable case name.
+	 * @param string $body  The response body.
+	 * @dataProvider provide_unreadable_catalogues
+	 */
+	#[DataProvider( 'provide_unreadable_catalogues' )]
+	public function test_promoted_product_info_refuses_an_unreadable_catalogue( $label, $body ) {
+		$this->catalogue_body = $body;
+		add_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ), 10, 3 );
+
+		$result = Jetpack_Backup::get_backup_promoted_product_info();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ) );
+		$this->catalogue_body = null;
+
+		$this->assertInstanceOf( WP_Error::class, $result, $label );
+		$this->assertSame( 'promoted_product_unreadable', $result->get_error_code(), $label );
+		$this->assertSame( 500, $result->get_error_data()['status'], $label );
+	}
+
+	/**
+	 * Bodies a 200 can carry that hold no promoted product.
+	 *
+	 * The absent-slug cases are not hypothetical: the slug is a constant
+	 * here but a catalogue entry upstream, so retiring it there produces
+	 * exactly this — a 200, a well-formed catalogue, and no key.
+	 *
+	 * @return array[]
+	 */
+	public static function provide_unreadable_catalogues() {
+		return array(
+			array( 'an empty body', '' ),
+			array( 'a gateway HTML page', '<html><body>502</body></html>' ),
+			array( 'a truncated document', '{"jetpack_backup_t1_yearly":' ),
+			array( 'JSON null', 'null' ),
+			array( 'a JSON list', '[]' ),
+			array( 'a catalogue without the promoted slug', '{"jetpack_scan":{"cost":10}}' ),
+			array( 'the promoted slug set to null', '{"jetpack_backup_t1_yearly":null}' ),
+		);
+	}
+
+	/**
+	 * A non-200 is reported with the upstream status.
+	 */
+	public function test_promoted_product_info_forwards_a_non_200() {
+		add_filter( 'pre_http_request', array( $this, 'mock_request_as_server_error' ) );
+
+		$result = Jetpack_Backup::get_backup_promoted_product_info();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_server_error' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'failed_to_fetch_data', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A transport failure has no status at all. Reporting the 0 that
+	 * casting produces leaves the REST layer with no status to serve.
+	 */
+	public function test_promoted_product_info_reports_a_transport_failure_as_500() {
+		add_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+
+		$result = Jetpack_Backup::get_backup_promoted_product_info();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Mock the product catalogue endpoint.
+	 *
+	 * @param false  $preempt     Short-circuit value (unused).
+	 * @param array  $parsed_args Request args (unused).
+	 * @param string $url         The request URL.
+	 * @return array
+	 */
+	public function mock_request_as_product_catalogue( $preempt, $parsed_args, $url ) {
+		$this->captured_url = (string) $url;
+
+		$body = $this->catalogue_body;
+
+		if ( null === $body ) {
+			$body = wp_json_encode(
+				array(
+					'jetpack_backup_t1_yearly' => array(
+						'cost'               => 539.4,
+						'currency_code'      => 'BRL',
+						'introductory_offer' => array(
+							'interval_unit'     => 'year',
+							'interval_count'    => 1,
+							'cost_per_interval' => 275.4,
+						),
+					),
+				),
+				JSON_UNESCAPED_SLASHES
+			);
+		}
+
+		return array(
+			'response' => array( 'code' => $this->catalogue_status ),
+			'body'     => $body,
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

The modernized Backup dashboard's no-plan gate now says what a subscription costs. #51455 gave that screen a site-scoped upgrade link and a license-key path and deliberately deferred the price; this is the remaining half of H2.

`/jetpack/v4/backup-promoted-product-info` has been registered since long before the modernized dashboard and had no consumer under `src/dashboard/` at all — so this is a data layer, a hook and a component. No new route, no new PHP surface.

* **The price renders progressively.** The CTA and the license link mount immediately; the price appears when it arrives, and never at all if it doesn't. This screen is the only purchase path a site without Backup has, so a catalogue that is slow or down may cost the reader the price — it must not be able to cost them the button.
* **The currency is not ours to assume.** WordPress.com prices this catalogue from where the *site* appears to be, not from the reader's locale, so `cost` arrives paired with a `currency_code` that is often neither USD nor the site language's currency. Everything is formatted through `formatCurrency` with that code. Legacy's own price string hardcodes a `$` — `'trial for the first month, then $%s /month'` — which is wrong for every site the tests' BRL fixture represents. It is not ported.
* **An introductory offer is converted by its own interval.** Legacy divides `cost_per_interval` by twelve whatever the interval is, which is right only while the offer runs for a year, as today's does; a monthly offer would have rendered at a twelfth of its price. An interval unit this does not recognise yields no introductory price at all and the full price still shows — a missing discount beats a wrong one.
* **The superseded price is `aria-hidden`, and its amount is restored as visually-hidden text.** A strikethrough conveys nothing to a screen reader, so announcing both amounts leaves two bare figures and no way to tell which recurs — but hiding it is only half the fix, since *"all renewals are at full price"* establishes that a full price exists without ever saying what it is. A visually-hidden `Renews at %s per month.` carries the figure, and deliberately names no period: the offer's interval is a year today and the hook handles monthly ones too.
* **The route could not tell "no price" from "unreadable".** A 200 is not a promise that the promoted product is in the body: a truncated response decodes to `null`, and the slug is a constant here but a catalogue entry upstream, so retiring it there leaves a 200 with the key absent. Reading through either warned and evaluated to `null`, which the route then served as a 200 carrying `null` — indistinguishable, to a caller, from a priced answer it failed to parse. It refuses both now. Also casts the response code (a string `'200'` took the failure branch) and reports a transport failure as 500 rather than a status of `0`.

### Two things worth a reviewer's attention

**This screen now issues one request, where the gates issued none.** That was written down in the tests as a deliberate design commitment, so it deserves saying what replaced it rather than quietly deleting the assertion: the price is the one request on this screen whose answer the reader can act on, which is the same test #2322 (F12) applies to the four requests the Overview issues behind this gate. The other two gate screens still fetch nothing, and now assert it explicitly where they previously did not.

**Bundle cost: +15,720 bytes minified** on the dashboard route (716,268 → 731,988, +2.2%), almost all of it the currency formatter. It is not code-split, so it loads for readers who never see this gate. `React.lazy` around the price block would split it; not done here because 2.2% on a route that already ships 700KB didn't seem worth the machinery. Happy to add it if you disagree.

The legacy dashboard reads the same route and is unaffected in what it shows — it rendered no price in these cases either.

### Addressed from review

* **Accessibility** — the renewal amount now reaches assistive tech, as above. Both new assertions were mutation-tested: removing the visually-hidden line fails two of them, removing `aria-hidden` fails one.
* **Retry** — the price query sets `retry: false`. The client defaults to `retry: 1`, and this PR widened what reaches it: an unreadable catalogue used to resolve with `null` and retry nothing. Each attempt costs the *site* an uncached blocking request upstream, so retrying doubles the expensive hop to buy a figure the screen works without. Caching that route is the larger fix and is tracked separately, not in this PR.
* **A test that could not fail** — `test_promoted_product_info_forwards_a_non_200` mocked a 500, which is also the no-status fallback, so it passed whether or not the status was forwarded. It mocks a 403 now; mutation-verified.

The visible rendering is unchanged by any of this, so the screenshots below still show what ships.

## Real-screen before / after

Captured at 1440×900 on a live, WordPress.com-connected site at `admin.php?page=jetpack-backup`, with the modernization flag on. Same site, same moment, same catalogue — the only difference is this branch.

| Before (trunk) | After (this branch) |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/add/backup-no-plan-gate-price/before-no-plan-gate.jpg) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/add/backup-no-plan-gate-price/after-no-plan-gate.jpg) |

**The site in these shots has a Backup plan.** The no-plan gate only renders without one, so the capture faked WordPress.com's answer at the HTTP layer rather than at the REST response — `pre_http_request` returning `{"capabilities": []}` for `/rewind/capabilities`. That is the literal answer a site without Backup gets, so the bridge's projection, its unreadable-body guard and the whole gate decision tree all ran for real; only the upstream answer was substituted.

**Worth noting what the currency proves.** The shot reads `R̶$̶4̶4̶.̶9̶5̶ R$22.95`, not dollars, because WordPress.com priced the catalogue from where the site appears to be. Every jest test here mocks the catalogue, so this screenshot is the only evidence in the PR that the `currency_code` actually threads through end to end — the exact path the legacy screen's hardcoded `$` gets wrong.

The introductory offer is live in the real catalogue right now (R$275.40 for the first year against R$539.40), which is why the discounted layout is the one on screen rather than the single-price one.

## Related product discussion/links

* [JETPACK-2303](https://linear.app/a8c/issue/JETPACK-2303/h2-show-a-price-on-the-no-plan-gate) — H2, the issue this closes
* [Backup: modernized dashboard](https://linear.app/a8c/project/backup-modernized-dashboard-736b571c0f4b) — the project
* #51455 — the first half of H2, which this builds on

## Does this pull request change what data or activity we track or use?

No. No Tracks events are added — there is still no Tracks client on the modernized page, which is [JETPACK-2301](https://linear.app/a8c/issue/JETPACK-2301/h1b-send-tracks-events-from-the-modernized-dashboard)'s job (#51403). The product catalogue is fetched from `public-api.wordpress.com` by the site, as it already was for the legacy dashboard; no new data leaves the site, and the request carries no site identifier.

## Testing instructions

The modernized dashboard is behind `rsm_jetpack_ui_modernization_backup`, which is off by default. You need a **connected site with no Backup plan** — the gate does not render otherwise.

1. On a Jetpack-connected site, force the flag on:
   ```php
   add_filter( 'jetpack_feature_flag_enabled_rsm_jetpack_ui_modernization_backup', '__return_true' );
   ```
2. If your test site **has** a Backup plan, the gate will not render — fake the upstream answer rather than hunting for a plan-less connected site. This is what the screenshots above were taken with:
   ```php
   add_filter( 'pre_http_request', function ( $preempt, $args, $url ) {
       if ( ! is_string( $url ) || false === strpos( $url, '/rewind/capabilities' ) ) {
           return $preempt;
       }
       return array(
           'headers'  => array(),
           'body'     => wp_json_encode( array( 'capabilities' => array() ) ),
           'response' => array( 'code' => 200, 'message' => 'OK' ),
           'cookies'  => array(),
           'filename' => null,
       );
   }, 10, 3 );
   ```
   An empty `capabilities` list is the real answer a site without Backup gets, so everything downstream of it still runs for real.
3. Go to **Jetpack → VaultPress Backup**. You should see the no-plan gate with a price above "Get VaultPress Backup": one amount, "per month, billed yearly", and a guarantee line.
4. If the catalogue is running an introductory offer, the full price appears struck through beside the discounted one and the guarantee line changes to mention renewals. Today's catalogue does run one, so this is the path you'll hit.
5. **Check the currency.** WordPress.com prices from the site's apparent location, so a site outside the US should show its own currency, not dollars. This is the case legacy gets wrong.
6. **Check it degrades.** Block the request (DevTools → Network → block `backup-promoted-product-info`) and reload. The price should vanish; the "Get VaultPress Backup" button and the license-key link must both still be there and still work.
7. **Check nothing regressed with the flag off.** Turn the filter back off and confirm the legacy no-plan screen still renders its pricing card as before.

Automated:

```
jp test js packages/backup     # 399 passed (was 392)
jp test php packages/backup    # 222 tests, 617 assertions (was 211/586)
jp phan packages/backup        # 0 issues
```

Also run: `pnpm run typecheck` in the package, ESLint (zero warnings), Prettier, PHPCS.
