### PR TITLE
Forms: make the PHP test suite independent of test ordering

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-contact-form-test-isolation
+++ b/projects/packages/forms/changelog/fix-forms-contact-form-test-isolation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Contact form tests: stop depending on global state leaked between tests.
+
+

--- a/projects/packages/forms/tests/php/bootstrap.php
+++ b/projects/packages/forms/tests/php/bootstrap.php
@@ -18,6 +18,17 @@ if ( empty( $_SERVER['SCRIPT_FILENAME'] ) ) {
 	$_SERVER['SCRIPT_FILENAME'] = __FILE__;
 }
 
+/*
+ * There is no HTTP request behind a PHPUnit run, but most of this package
+ * describes what happens when a visitor submits a form: the feedback records the
+ * client IP and user agent, and the tests assert on them. Stand in for the
+ * request here rather than leaving each test class to depend on another one
+ * having set these first.
+ */
+$_SERVER['REMOTE_ADDR']     = '127.0.0.1';
+$_SERVER['HTTP_USER_AGENT'] = 'unit-test';
+$_SERVER['HTTP_REFERER']    = 'test';
+
 // Initialize WordPress test environment
 \Automattic\Jetpack\Test_Environment::init();
 
@@ -25,3 +36,32 @@ if ( empty( $_SERVER['SCRIPT_FILENAME'] ) ) {
 if ( ! defined( 'JETPACK__VERSION' ) ) {
 	define( 'JETPACK__VERSION', '10' );
 }
+
+/*
+ * Contact_Form::process_submission() redirects and then exits once a submission
+ * succeeds, taking the whole PHPUnit process down with it. It only returns the
+ * success message instead when DOING_AJAX is set, so every test that submits a
+ * form needs the constant defined.
+ *
+ * A constant can be defined but never undefined, so this cannot be left to
+ * whichever test class happens to run first: it has to be set for the whole run,
+ * or the tests that submit forms only pass in one particular order. Tests that
+ * need a frontend request instead - Request::is_frontend() is false while
+ * wp_doing_ajax() is true, which makes the form block render its fallback link -
+ * opt out per test with the `wp_doing_ajax` filter.
+ */
+if ( ! defined( 'DOING_AJAX' ) ) {
+	define( 'DOING_AJAX', true );
+}
+
+/*
+ * Bring up the plugin the same way a site does. Registering it here rather than
+ * from a test means WorDBless snapshots its hooks as part of the baseline it
+ * restores after every test - Contact_Form_Plugin::init() is a singleton, so a
+ * class that initializes it mid-run adds hooks that WorDBless then strips, and
+ * later calls hand back the cached instance without putting them back.
+ *
+ * Among other things this registers the contact-field shortcode, without which
+ * `new Contact_Form( array() )` cannot build its default form.
+ */
+\Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init();

--- a/projects/packages/forms/tests/php/bootstrap.php
+++ b/projects/packages/forms/tests/php/bootstrap.php
@@ -55,13 +55,16 @@ if ( ! defined( 'DOING_AJAX' ) ) {
 }
 
 /*
- * Bring up the plugin the same way a site does. Registering it here rather than
- * from a test means WorDBless snapshots its hooks as part of the baseline it
- * restores after every test - Contact_Form_Plugin::init() is a singleton, so a
- * class that initializes it mid-run adds hooks that WorDBless then strips, and
- * later calls hand back the cached instance without putting them back.
+ * Bring the plugin up the way a site does. Doing it here rather than from a test
+ * means WorDBless snapshots its hooks as part of the baseline it restores after
+ * every test - Contact_Form_Plugin::init() keeps its instance in a function
+ * static, so a class that initializes it mid-run adds hooks that WorDBless then
+ * strips, and every later call hands back the cached instance without putting
+ * them back.
  *
  * Among other things this registers the contact-field shortcode, without which
- * `new Contact_Form( array() )` cannot build its default form.
+ * `new Contact_Form( array() )` cannot build its default form. What the
+ * constructor wires up is asserted by
+ * Contact_Form_Plugin_Test::test_construction_registers_the_wordpress_integration().
  */
 \Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init();

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Feature_Flag_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Feature_Flag_Test.php
@@ -25,7 +25,7 @@ class Conditional_Logic_Feature_Flag_Test extends BaseTestCase {
 	protected function tear_down() {
 		remove_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
 		parent::tear_down();
-		unset( $_POST );
+		$_POST = array();
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Initial_Render_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Initial_Render_Test.php
@@ -27,7 +27,8 @@ class Conditional_Logic_Initial_Render_Test extends BaseTestCase {
 
 	protected function tear_down() {
 		remove_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
-		unset( $_GET, $_POST );
+		$_GET  = array();
+		$_POST = array();
 		parent::tear_down();
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Required_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Required_Field_Test.php
@@ -40,7 +40,7 @@ class Conditional_Logic_Required_Field_Test extends BaseTestCase {
 	protected function tear_down() {
 		remove_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
 		Contact_Form::reset_seen_refs();
-		unset( $_POST );
+		$_POST = array();
 		parent::tear_down();
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Validation_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Validation_Test.php
@@ -26,7 +26,7 @@ class Conditional_Logic_Validation_Test extends BaseTestCase {
 	protected function tear_down() {
 		remove_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
 		parent::tear_down();
-		unset( $_POST );
+		$_POST = array();
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -745,6 +745,10 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	 * Contact_Form::parse() adds rather than with the block's own element.
 	 */
 	public function test_form_background_lands_on_the_blocks_own_div() {
+		// The form block renders its "Submit a form." fallback unless the request
+		// looks like a frontend one. See tests/php/bootstrap.php.
+		add_filter( 'wp_doing_ajax', '__return_false' );
+
 		Contact_Form_Block::register_block();
 		Contact_Form_Block::register_child_blocks();
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -80,6 +80,14 @@ class Contact_Form_Endpoint_Test extends TestCase {
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 
+		/*
+		 * These tests run as an administrator, and this class extends PHPUnit's
+		 * TestCase rather than WorDBless's, so nothing logs that user back out.
+		 * An administrator has unfiltered_html, which changes how WordPress
+		 * escapes post content on save.
+		 */
+		wp_set_current_user( 0 );
+
 		unset( $_SERVER['REQUEST_METHOD'] );
 		$_GET = array();
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Endpoint_Test.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+require_once __DIR__ . '/class-utility.php';
+
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
@@ -1440,17 +1442,13 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 	 */
 	public function test_counts_with_source_includes_source_filter_sql() {
 		$captured_query = null;
-		add_filter(
-			'wordbless_wpdb_query_results',
-			function ( $results, $query ) use ( &$captured_query ) {
-				if ( strpos( $query, 'SUM(CASE' ) !== false && strpos( $query, 'source_meta' ) !== false ) {
-					$captured_query = $query;
-				}
-				return $results;
-			},
-			10,
-			2
-		);
+		$capture_query  = function ( $results, $query ) use ( &$captured_query ) {
+			if ( strpos( $query, 'SUM(CASE' ) !== false && strpos( $query, 'source_meta' ) !== false ) {
+				$captured_query = $query;
+			}
+			return $results;
+		};
+		add_filter( 'wordbless_wpdb_query_results', $capture_query, 10, 2 );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback/counts' );
 		$request->set_param( 'source', 123 );
@@ -1462,7 +1460,7 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 		$this->assertStringContainsString( 'source_meta.meta_value', $captured_query, 'Counts query should filter by source meta value' );
 		$this->assertStringContainsString( 'post_parent', $captured_query, 'Counts query should include post_parent fallback' );
 
-		remove_all_filters( 'wordbless_wpdb_query_results' );
+		remove_filter( 'wordbless_wpdb_query_results', $capture_query, 10 );
 	}
 
 	/**
@@ -1496,24 +1494,20 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 
 		// Second request without source — capture SQL to verify no leftover filter.
 		$found_source_sql = false;
-		add_filter(
-			'wordbless_wpdb_query_results',
-			function ( $results, $query ) use ( &$found_source_sql ) {
-				if ( strpos( $query, 'source_meta' ) !== false ) {
-					$found_source_sql = true;
-				}
-				return $results;
-			},
-			10,
-			2
-		);
+		$capture_query    = function ( $results, $query ) use ( &$found_source_sql ) {
+			if ( strpos( $query, 'source_meta' ) !== false ) {
+				$found_source_sql = true;
+			}
+			return $results;
+		};
+		add_filter( 'wordbless_wpdb_query_results', $capture_query, 10, 2 );
 
 		$request2 = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
 		$this->server->dispatch( $request2 );
 
 		$this->assertFalse( $found_source_sql, 'Source filter should not leak into subsequent requests' );
 
-		remove_all_filters( 'wordbless_wpdb_query_results' );
+		remove_filter( 'wordbless_wpdb_query_results', $capture_query, 10 );
 	}
 
 	/**
@@ -1522,24 +1516,20 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 	public function test_no_source_filter_without_param() {
 		$found_source_sql = false;
 
-		add_filter(
-			'wordbless_wpdb_query_results',
-			function ( $results, $query ) use ( &$found_source_sql ) {
-				if ( strpos( $query, 'source_meta' ) !== false ) {
-					$found_source_sql = true;
-				}
-				return $results;
-			},
-			10,
-			2
-		);
+		$capture_query = function ( $results, $query ) use ( &$found_source_sql ) {
+			if ( strpos( $query, 'source_meta' ) !== false ) {
+				$found_source_sql = true;
+			}
+			return $results;
+		};
+		add_filter( 'wordbless_wpdb_query_results', $capture_query, 10, 2 );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
 		$this->server->dispatch( $request );
 
 		$this->assertFalse( $found_source_sql, 'SQL should not include source_meta when no source param' );
 
-		remove_all_filters( 'wordbless_wpdb_query_results' );
+		remove_filter( 'wordbless_wpdb_query_results', $capture_query, 10 );
 	}
 
 	/**
@@ -1548,17 +1538,13 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 	public function test_source_filter_with_zero_value_is_ignored() {
 		$found_source_sql = false;
 
-		add_filter(
-			'wordbless_wpdb_query_results',
-			function ( $results, $query ) use ( &$found_source_sql ) {
-				if ( strpos( $query, 'source_meta' ) !== false ) {
-					$found_source_sql = true;
-				}
-				return $results;
-			},
-			10,
-			2
-		);
+		$capture_query = function ( $results, $query ) use ( &$found_source_sql ) {
+			if ( strpos( $query, 'source_meta' ) !== false ) {
+				$found_source_sql = true;
+			}
+			return $results;
+		};
+		add_filter( 'wordbless_wpdb_query_results', $capture_query, 10, 2 );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/feedback' );
 		$request->set_param( 'source', 0 );
@@ -1566,6 +1552,6 @@ JSON_DATA{"1_name":"Test Author","2_email":"author@example.com","3_file":{"field
 
 		$this->assertFalse( $found_source_sql, 'source=0 should not inject source filter SQL' );
 
-		remove_all_filters( 'wordbless_wpdb_query_results' );
+		remove_filter( 'wordbless_wpdb_query_results', $capture_query, 10 );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
@@ -45,7 +45,9 @@ class Contact_Form_Field_Test extends BaseTestCase {
 		global $current_user, $user_identity;
 
 		// Clean up globals
-		unset( $_POST, $_GET, $current_user, $user_identity );
+		$_POST = array();
+		$_GET  = array();
+		unset( $current_user, $user_identity );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
@@ -12,10 +12,12 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 
 /**
- * Test class for Contact_Form
+ * Test class for Contact_Form_Field
  *
+ * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Field
  * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form
  */
+#[CoversClass( Contact_Form_Field::class )]
 #[CoversClass( Contact_Form::class )]
 class Contact_Form_Field_Test extends BaseTestCase {
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+require_once __DIR__ . '/class-utility.php';
+
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard;
 use Automattic\Jetpack\Menu_Badges\Notification_Counts;
@@ -1209,17 +1211,15 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		/*
 		 * The field blocks carry the color and typography supports that
-		 * gutenblock_render_field_*() turns into shortcode attributes, and
-		 * Contact_Form_Plugin's constructor registers the feedback post type
-		 * with its comment settings. Set both up here rather than relying on
-		 * another test class in the same PHPUnit process having done it.
-		 * Registering a block twice is an error, so check first; init() is a
-		 * singleton and already no-ops on later calls.
+		 * gutenblock_render_field_*() turns into shortcode attributes. Register
+		 * them here rather than relying on another test class in the same
+		 * PHPUnit process having done it. (The feedback post type these tests
+		 * also need comes from the plugin, which tests/php/bootstrap.php brings
+		 * up for the whole run.)
 		 */
 		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/label' ) ) {
 			Contact_Form_Block::register_child_blocks();
 		}
-		Contact_Form_Plugin::init();
 	}
 
 	/**
@@ -1993,17 +1993,13 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$plugin = Contact_Form_Plugin::init();
 
 		$captured_query = null;
-		add_filter(
-			'wordbless_wpdb_query_results',
-			function ( $results, $query ) use ( &$captured_query ) {
-				if ( strpos( $query, 'source_meta' ) !== false ) {
-					$captured_query = $query;
-				}
-				return $results;
-			},
-			10,
-			2
-		);
+		$capture_query  = function ( $results, $query ) use ( &$captured_query ) {
+			if ( strpos( $query, 'source_meta' ) !== false ) {
+				$captured_query = $query;
+			}
+			return $results;
+		};
+		add_filter( 'wordbless_wpdb_query_results', $capture_query, 10, 2 );
 
 		$nonce                                 = wp_create_nonce( 'feedback_export' );
 		$_POST['feedback_export_nonce_csv']    = $nonce;
@@ -2018,7 +2014,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			$this->assertStringContainsString( 'source_meta.meta_value', $captured_query, 'Export query should filter by source meta value' );
 			$this->assertStringContainsString( 'post_parent', $captured_query, 'Export query should include the post_parent fallback' );
 		} finally {
-			remove_all_filters( 'wordbless_wpdb_query_results' );
+			remove_filter( 'wordbless_wpdb_query_results', $capture_query, 10 );
 			$cleanup_cap();
 			unset(
 				$_POST['feedback_export_nonce_csv'],
@@ -2040,17 +2036,13 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$plugin = Contact_Form_Plugin::init();
 
 		$found_source_sql = false;
-		add_filter(
-			'wordbless_wpdb_query_results',
-			function ( $results, $query ) use ( &$found_source_sql ) {
-				if ( strpos( $query, 'source_meta' ) !== false ) {
-					$found_source_sql = true;
-				}
-				return $results;
-			},
-			10,
-			2
-		);
+		$capture_query    = function ( $results, $query ) use ( &$found_source_sql ) {
+			if ( strpos( $query, 'source_meta' ) !== false ) {
+				$found_source_sql = true;
+			}
+			return $results;
+		};
+		add_filter( 'wordbless_wpdb_query_results', $capture_query, 10, 2 );
 
 		$nonce                                 = wp_create_nonce( 'feedback_export' );
 		$_POST['feedback_export_nonce_csv']    = $nonce;
@@ -2061,7 +2053,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 			$this->assertFalse( $found_source_sql, 'Export query should not include source filter SQL when $_POST[source] is absent' );
 		} finally {
-			remove_all_filters( 'wordbless_wpdb_query_results' );
+			remove_filter( 'wordbless_wpdb_query_results', $capture_query, 10 );
 			$cleanup_cap();
 			unset(
 				$_POST['feedback_export_nonce_csv'],

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -12,9 +12,9 @@ require_once __DIR__ . '/class-utility.php';
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard;
 use Automattic\Jetpack\Menu_Badges\Notification_Counts;
+use Closure;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use ReflectionClass;
 use WorDBless\BaseTestCase;
 use WP_Block;
 use WP_Block_Type_Registry;
@@ -647,14 +647,21 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	 * assumed.
 	 *
 	 * Contact_Form_Plugin::init() keeps its instance in a function static, so a
-	 * second one has to come from the constructor directly. The duplicate hooks
-	 * it adds go away with the rest of the test's hooks when WorDBless tears
-	 * down.
+	 * second one has to come from the constructor directly. The constructor is
+	 * protected, hence the closure bound to the class's scope - reflection would
+	 * need setAccessible(), which is required before PHP 8.1 and deprecated from
+	 * PHP 8.5. The duplicate hooks it adds go away with the rest of the test's
+	 * hooks when WorDBless tears down.
 	 */
 	public function test_construction_registers_the_wordpress_integration() {
-		$reflection = new ReflectionClass( Contact_Form_Plugin::class );
-		$plugin     = $reflection->newInstanceWithoutConstructor();
-		$reflection->getConstructor()->invoke( $plugin );
+		$construct = Closure::bind(
+			static function () {
+				return new Contact_Form_Plugin();
+			},
+			null,
+			Contact_Form_Plugin::class
+		);
+		$plugin    = $construct();
 
 		$this->assertTrue( shortcode_exists( 'contact-form' ), 'The contact-form shortcode should be registered.' );
 		$this->assertTrue( shortcode_exists( 'contact-field' ), 'The contact-field shortcode should be registered.' );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -14,6 +14,7 @@ use Automattic\Jetpack\Forms\Dashboard\Dashboard;
 use Automattic\Jetpack\Menu_Badges\Notification_Counts;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
 use WorDBless\BaseTestCase;
 use WP_Block;
 use WP_Block_Type_Registry;
@@ -637,6 +638,48 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		);
 	}
 
+	/**
+	 * The constructor is what wires this package into WordPress, and the rest of
+	 * the suite leans on that wiring: the shortcodes the Contact_Form
+	 * constructor parses with, the feedback post type the REST routes hang off,
+	 * the spam and comment filters. tests/php/bootstrap.php runs it once for the
+	 * whole run, so assert here what it registered rather than leaving it to be
+	 * assumed.
+	 *
+	 * Contact_Form_Plugin::init() keeps its instance in a function static, so a
+	 * second one has to come from the constructor directly. The duplicate hooks
+	 * it adds go away with the rest of the test's hooks when WorDBless tears
+	 * down.
+	 */
+	public function test_construction_registers_the_wordpress_integration() {
+		$reflection = new ReflectionClass( Contact_Form_Plugin::class );
+		$plugin     = $reflection->newInstanceWithoutConstructor();
+		$reflection->getConstructor()->invoke( $plugin );
+
+		$this->assertTrue( shortcode_exists( 'contact-form' ), 'The contact-form shortcode should be registered.' );
+		$this->assertTrue( shortcode_exists( 'contact-field' ), 'The contact-field shortcode should be registered.' );
+		$this->assertTrue( shortcode_exists( 'contact-field-option' ), 'The contact-field-option shortcode should be registered.' );
+
+		$this->assertTrue( post_type_exists( 'feedback' ), 'The feedback post type should be registered.' );
+
+		$this->assertNotFalse(
+			has_filter( 'jetpack_contact_form_is_spam', array( $plugin, 'is_spam_blocklist' ) ),
+			'Submissions should be run past the blocklist.'
+		);
+		$this->assertNotFalse(
+			has_filter( 'comments_open', array( $plugin, 'restrict_feedback_comments_to_logged_in' ) ),
+			'Feedback comments should be restricted to logged-in users.'
+		);
+		$this->assertNotFalse(
+			has_action( 'transition_post_status', array( $plugin, 'track_feedback_status_change' ) ),
+			'Feedback status changes should be tracked.'
+		);
+		$this->assertNotFalse(
+			has_filter( 'wp_privacy_personal_data_exporters', array( $plugin, 'register_personal_data_exporter' ) ),
+			'Feedback should be included in a personal data export.'
+		);
+	}
+
 	public function test_process_form_with_jwt() {
 		$this->setup_token_test( null, 'Test User' );
 
@@ -1220,6 +1263,17 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/label' ) ) {
 			Contact_Form_Block::register_child_blocks();
 		}
+
+		/*
+		 * The recount is scheduled on shutdown by the plugin's
+		 * transition_post_status handler, so any test class that has already
+		 * saved an unread feedback has left it scheduled - and if that class was
+		 * one of the two that extend PHPUnit's TestCase rather than
+		 * WorDBless's, it is in the hook baseline WorDBless restores after every
+		 * test. The track_feedback_status_change tests assert on whether they
+		 * scheduled it, so start from not scheduled.
+		 */
+		remove_action( 'shutdown', array( Contact_Form_Plugin::class, 'recalculate_unread_count' ) );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -7,12 +7,14 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard;
 use Automattic\Jetpack\Menu_Badges\Notification_Counts;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 use WP_Block;
+use WP_Block_Type_Registry;
 use WP_Error;
 
 // Load the Form_Submission_Error class for testing.
@@ -26,7 +28,20 @@ require_once __DIR__ . '/../../../src/contact-form/class-form-submission-error.p
 #[CoversClass( Contact_Form_Plugin::class )]
 class Contact_Form_Plugin_Test extends BaseTestCase {
 
-	private $get_current_user;
+	/**
+	 * The `$post` global as it was when the test started, restored in tearDown().
+	 *
+	 * @var \WP_Post|null
+	 */
+	private $post_global_backup;
+
+	/**
+	 * The `$_POST` superglobal as it was when the test started, restored in tearDown().
+	 *
+	 * @var array
+	 */
+	private $post_superglobal_backup;
+
 	/**
 	 * Test that ::revert_that_print works correctly
 	 *
@@ -621,31 +636,27 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	public function test_process_form_with_jwt() {
-		$previous_post = $this->setup_token_test( null, 'Test User' );
+		$this->setup_token_test( null, 'Test User' );
 
 		$plugin = Contact_Form_Plugin::init();
 		$result = $plugin->process_form_submission();
 
 		$this->assertInstanceOf( WP_Error::class, $result, 'Expected a WP_Error when processing the form submission.' );
 		$this->assertEquals( 'check_spam', $result->get_error_code(), 'Expected the error code to be "check_spam".' );
-
-		$this->teardown_post_for_test( $previous_post );
 	}
 
 	public function test_process_form_with_jwt_validation_error() {
-		$previous_post = $this->setup_token_test( null );
+		$this->setup_token_test( null );
 
 		$plugin = Contact_Form_Plugin::init();
 		$result = $plugin->process_form_submission();
 		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when processing the form submission.' );
 		$this->assertEquals( 'Name field is required.', $result->get_error_message(), 'Expected the error message to be "Name field is required.".' );
 		$this->assertTrue( $result->is_validation_type(), 'Expected this to be a validation error.' );
-
-		$this->teardown_post_for_test( $previous_post );
 	}
 
 	public function test_process_form_with_fake_jwt() {
-		$previous_post = $this->setup_token_test( 'fake.jwt.token' );
+		$this->setup_token_test( 'fake.jwt.token' );
 
 		$plugin = Contact_Form_Plugin::init();
 		$result = $plugin->process_form_submission();
@@ -653,14 +664,10 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when processing the form submission with invalid JWT.' );
 		$this->assertEquals( 'invalid_jwt', $result->get_error_code(), 'Expected the error code to be "invalid_jwt".' );
 		$this->assertTrue( $result->is_system_type(), 'Expected this to be a system error.' );
-
-		$this->teardown_post_for_test( $previous_post );
 	}
 
 	public function test_process_form_with_deleted_parent_post() {
-		global $post;
-		$previous_post = $this->setup_token_test( null, 'Test User' );
-		$post_id       = $post->ID;
+		$post_id = $this->setup_token_test( null, 'Test User' );
 
 		// Delete the parent post after JWT is created
 		wp_delete_post( $post_id, true );
@@ -672,19 +679,10 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertEquals( 'form_unavailable', $result->get_error_code(), 'Expected the error code to be "form_unavailable".' );
 		$this->assertEquals( 'This form is no longer available.', $result->get_error_message(), 'Expected appropriate error message.' );
 		$this->assertTrue( $result->is_system_type(), 'Expected this to be a system error.' );
-
-		$post = $previous_post; // Restore the previous post.
-		remove_filter( 'jetpack_contact_form_is_spam', array( $this, 'return_error_for_test' ) );
-		unset( $_POST['contact-form-hash'] );
-		unset( $_POST['jetpack_contact_form_jwt'] );
-		unset( $_POST['contact-form-id'] );
-		unset( $_POST[ 'g' . $post_id . '-name' ] );
 	}
 
 	public function test_process_form_with_trashed_parent_post() {
-		global $post;
-		$previous_post = $this->setup_token_test( null, 'Test User' );
-		$post_id       = $post->ID;
+		$post_id = $this->setup_token_test( null, 'Test User' );
 
 		// Move the parent post to trash after JWT is created
 		wp_trash_post( $post_id );
@@ -696,13 +694,20 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertEquals( 'form_unavailable', $result->get_error_code(), 'Expected the error code to be "form_unavailable".' );
 		$this->assertEquals( 'This form is no longer available.', $result->get_error_message(), 'Expected appropriate error message.' );
 		$this->assertTrue( $result->is_system_type(), 'Expected this to be a system error.' );
-
-		$this->teardown_post_for_test( $previous_post );
 	}
 
+	/**
+	 * Publish a post holding a contact form and stage a submission for it in `$_POST`.
+	 *
+	 * The `$post` global, `$_POST` and the current user are all reset by
+	 * tearDown(), so callers don't have to clean up after themselves.
+	 *
+	 * @param string|null $token The JWT to submit. Defaults to a valid one for the form.
+	 * @param string|null $name  Value for the form's required Name field. Omit to submit it empty.
+	 * @return int The ID of the post holding the form.
+	 */
 	private function setup_token_test( $token = null, $name = null ) {
 		global $post;
-		$this->get_current_user = wp_get_current_user();
 		wp_set_current_user( 0 );
 		$post_id = wp_insert_post(
 			array(
@@ -713,8 +718,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			)
 		);
 
-		$previous_post = $post;
-		$post          = get_post( $post_id );
+		$post = get_post( $post_id );
 		// We do this because we don't currenly have a way to prevent the redirect to happen.
 		add_filter( 'jetpack_contact_form_is_spam', array( $this, 'return_error_for_test' ) );
 		$form                              = new Contact_Form( array( 'to' => 'test@example.com' ), "[contact-field label='Name' type='name' required='1'/]" );
@@ -726,19 +730,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			$_POST[ 'g' . $post_id . '-name' ] = $name;
 		}
 
-		return $previous_post;
-	}
-
-	private function teardown_post_for_test( $previous_post ) {
-		global $post;
-		wp_set_current_user( $this->get_current_user->ID );
-		wp_delete_post( $post->ID, true ); // Clean up the test post.
-		$post = $previous_post; // Restore the previous post.
-		remove_filter( 'jetpack_contact_form_is_spam', array( $this, 'return_error_for_test' ) );
-		unset( $_POST['contact-form-hash'] );
-		unset( $_POST['jetpack_contact_form_jwt'] );
-		unset( $_POST['contact-form-id'] );
-		unset( $_POST[ 'g' . $post->ID . '-name' ] );
+		return $post_id;
 	}
 
 	public function return_error_for_test() {
@@ -1039,7 +1031,13 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		wp_delete_post( $test_id, true );
 	}
 
+	/**
+	 * A feedback whose source post has since been deleted exports the stored
+	 * entry title, flagged as deleted, and no source URL.
+	 */
 	public function test_interpersonal_data_exporter() {
+		// create_legacy_feedback() files the feedback under the `$post` global.
+		$source_post = Utility::create_post_context();
 
 		$post_id = Utility::create_legacy_feedback(
 			array(
@@ -1048,6 +1046,9 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 				'3_email' => 'hello@example.com',
 			)
 		);
+
+		// The feedback outlives the post the form was on.
+		Utility::destroy_post_context( $source_post );
 
 		$plugin   = Contact_Form_Plugin::init();
 		$exporter = $plugin->internal_personal_data_formater( array( $post_id ) );
@@ -1101,6 +1102,36 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 			$exporter[0]
 		);
 		$this->assertIsArray( $exporter, 'Expected the exporter to return an array.' );
+	}
+
+	/**
+	 * While the source post still exists, the exporter reports its current
+	 * title and permalink rather than the values stored with the feedback.
+	 */
+	public function test_interpersonal_data_exporter_with_existing_source_post() {
+		$source_post = Utility::create_post_context();
+
+		$post_id = Utility::create_legacy_feedback( array( '1_field' => 'value1' ) );
+
+		$plugin   = Contact_Form_Plugin::init();
+		$exporter = $plugin->internal_personal_data_formater( array( $post_id ) );
+
+		$this->assertContains(
+			array(
+				'name'  => 'Source Title',
+				'value' => $source_post->post_title,
+			),
+			$exporter[0]['data'],
+			'Expected the exporter to report the live source post title.'
+		);
+		$this->assertContains(
+			array(
+				'name'  => 'Source URL:',
+				'value' => get_permalink( $source_post->ID ),
+			),
+			$exporter[0]['data'],
+			'Expected the exporter to report the live source post permalink.'
+		);
 	}
 
 	public function test_personal_data_search_filter_v2_unicode_search() {
@@ -1162,18 +1193,47 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Reset the menu-badges registry before each unread_count test so entries
-	 * left by other test classes in the same PHPUnit process don't leak in.
+	 * Give each test a clean `$post` and `$_POST` to work from, and reset the
+	 * menu-badges registry so entries left by other test classes in the same
+	 * PHPUnit process don't leak in. The previous values are put back in
+	 * tearDown() so this class doesn't disturb the rest of the suite either.
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		global $post;
+		$this->post_global_backup      = $post;
+		$this->post_superglobal_backup = $_POST ?? array();
+		$post                          = null;
+		$_POST                         = array();
 		Notification_Counts::reset();
+
+		/*
+		 * The field blocks carry the color and typography supports that
+		 * gutenblock_render_field_*() turns into shortcode attributes, and
+		 * Contact_Form_Plugin's constructor registers the feedback post type
+		 * with its comment settings. Set both up here rather than relying on
+		 * another test class in the same PHPUnit process having done it.
+		 * Registering a block twice is an error, so check first; init() is a
+		 * singleton and already no-ops on later calls.
+		 */
+		if ( ! WP_Block_Type_Registry::get_instance()->is_registered( 'jetpack/label' ) ) {
+			Contact_Form_Block::register_child_blocks();
+		}
+		Contact_Form_Plugin::init();
 	}
 
 	/**
-	 * Clean up the menu-badges registry and options after each unread_count test.
+	 * Restore the globals and clean up the menu-badges registry and options.
+	 *
+	 * This runs even when an assertion fails part-way through a test, so no
+	 * test can leave a stale `$post` or extra `$_POST` keys behind for the
+	 * next one. Posts, users, options and hooks are cleared for us by
+	 * WorDBless, which is why none of that is repeated here.
 	 */
 	public function tearDown(): void {
+		global $post;
+		$post  = $this->post_global_backup;
+		$_POST = $this->post_superglobal_backup;
 		Notification_Counts::reset();
 		remove_filter( 'jetpack_forms_alpha', '__return_false' );
 		delete_option( 'jetpack_feedback_unread_count' );
@@ -1541,7 +1601,8 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	public function test_comment_filter_only_affects_feedback_posts() {
 		$regular_post_id = wp_insert_post(
 			array(
-				'post_type' => 'post',
+				'post_type'  => 'post',
+				'post_title' => 'Regular Post',
 			)
 		);
 
@@ -1700,6 +1761,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$post_id = wp_insert_post(
 			array(
 				'post_type'   => 'post',
+				'post_title'  => 'Regular Post',
 				'post_status' => 'publish',
 			)
 		);
@@ -1740,6 +1802,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$post_id = wp_insert_post(
 			array(
 				'post_type'   => $post_type,
+				'post_title'  => 'Test Form',
 				'post_status' => $old_status,
 			)
 		);

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -656,6 +656,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	public function test_construction_registers_the_wordpress_integration() {
 		$construct = Closure::bind(
 			static function () {
+				// @phan-suppress-next-line PhanAccessMethodProtected -- The closure is bound to the class's own scope below, which Phan does not model.
 				return new Contact_Form_Plugin();
 			},
 			null,

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Synced_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Synced_Test.php
@@ -27,6 +27,23 @@ class Contact_Form_Synced_Test extends BaseTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+
+		/*
+		 * These tests render forms as a visitor would see them. The suite defines
+		 * DOING_AJAX so that a successful submission can't exit the PHPUnit process
+		 * (see tests/php/bootstrap.php), but that also makes Request::is_frontend()
+		 * false, which renders the block's "Submit a form." fallback instead of the
+		 * form. Declare a frontend request for the duration of each test.
+		 */
+		add_filter( 'wp_doing_ajax', '__return_false' );
+
+		/*
+		 * A visitor, not an editor: whether a draft synced form renders at all
+		 * turns on current_user_can( 'edit_post' ), and an earlier test class
+		 * leaving an administrator logged in would render it.
+		 */
+		wp_set_current_user( 0 );
+
 		Contact_Form_Block::register_block();
 		Contact_Form_Block::register_child_blocks();
 	}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -9,6 +9,8 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+require_once __DIR__ . '/class-utility.php';
+
 use Automattic\Jetpack\Constants;
 use DOMDocument;
 use DOMElement;
@@ -278,8 +280,6 @@ class Contact_Form_Test extends BaseTestCase {
 	 */
 	#[BeforeClass]
 	public static function set_up_class() {
-		define( 'DOING_AJAX', true ); // Defined so that 'exit' is not called in process_submission.
-
 		// Remove any relevant filters that might exist before running the tests.
 		remove_all_filters( 'grunion_still_email_spam' );
 		remove_all_filters( 'jetpack_contact_form_is_spam' );

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Author_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Author_Test.php
@@ -9,6 +9,8 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+require_once __DIR__ . '/class-utility.php';
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Creation_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Creation_Test.php
@@ -23,11 +23,32 @@ use WorDBless\BaseTestCase;
 class Feedback_Creation_Test extends BaseTestCase {
 
 	/**
+	 * Query stubs this test registered on `wordbless_wpdb_query_results`.
+	 *
+	 * @var callable[]
+	 */
+	private $query_stubs = array();
+
+	/**
 	 * Clean up after each test.
 	 */
 	protected function tear_down() {
+		$this->remove_query_stubs();
 		parent::tear_down();
-		remove_all_filters( 'wordbless_wpdb_query_results' );
+	}
+
+	/**
+	 * Remove the query stubs this test registered.
+	 *
+	 * Only the stubs registered here: `wordbless_wpdb_query_results` is how
+	 * WorDBless answers every query in the suite, so clearing the whole hook
+	 * takes its options, posts, users and meta down with it.
+	 */
+	private function remove_query_stubs() {
+		foreach ( $this->query_stubs as $stub ) {
+			remove_filter( 'wordbless_wpdb_query_results', $stub, 10 );
+		}
+		$this->query_stubs = array();
 	}
 
 	public function test_from_post_id_returns_null_for_invalid_post() {
@@ -99,22 +120,20 @@ class Feedback_Creation_Test extends BaseTestCase {
 	 * @param array $source_ids The source IDs to return from the query.
 	 */
 	private function mock_source_ids_query( $source_ids ) {
-		add_filter(
-			'wordbless_wpdb_query_results',
-			function ( $results, $query ) use ( $source_ids ) {
-				if ( strpos( $query, 'SELECT DISTINCT source_id' ) !== false ) {
-					return array_map(
-						function ( $id ) {
-							return (object) array( 'source_id' => (string) $id );
-						},
-						$source_ids
-					);
-				}
-				return $results;
-			},
-			10,
-			2
-		);
+		$stub = function ( $results, $query ) use ( $source_ids ) {
+			if ( strpos( $query, 'SELECT DISTINCT source_id' ) !== false ) {
+				return array_map(
+					function ( $id ) {
+						return (object) array( 'source_id' => (string) $id );
+					},
+					$source_ids
+				);
+			}
+			return $results;
+		};
+
+		$this->query_stubs[] = $stub;
+		add_filter( 'wordbless_wpdb_query_results', $stub, 10, 2 );
 	}
 
 	/**
@@ -153,7 +172,7 @@ class Feedback_Creation_Test extends BaseTestCase {
 		$this->assertContains( 42, $first_result );
 
 		// Replace mock with different data — cache should still return old result.
-		remove_all_filters( 'wordbless_wpdb_query_results' );
+		$this->remove_query_stubs();
 		$this->mock_source_ids_query( array( 42, 99 ) );
 
 		$second_result = Feedback::get_all_source_post_ids();

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
@@ -9,6 +9,8 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+require_once __DIR__ . '/class-utility.php';
+
 use Automattic\Jetpack\Forms\Dashboard\Dashboard;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Form_Ref_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Form_Ref_Test.php
@@ -44,8 +44,22 @@ class Feedback_Form_Ref_Test extends BaseTestCase {
 		);
 
 		// Mock $_POST data for form submission
-		$_POST['contact-form-id'] = $this->parent_post_id;
-		$_POST['_wpnonce']        = wp_create_nonce( 'contact-form_' . $this->parent_post_id );
+		$_POST = array(
+			'contact-form-id' => $this->parent_post_id,
+			'_wpnonce'        => wp_create_nonce( 'contact-form_' . $this->parent_post_id ),
+		);
+	}
+
+	/**
+	 * Drop the staged submission.
+	 *
+	 * Nothing else clears `$_POST`, and a stale contact-form-id decides which
+	 * form the next test's Contact_Form believes it is, which changes the field
+	 * IDs it generates.
+	 */
+	public function tear_down() {
+		$_POST = array();
+		parent::tear_down();
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Source_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Source_Test.php
@@ -19,6 +19,17 @@ use WorDBless\BaseTestCase;
  */
 #[CoversClass( Feedback_Source::class )]
 class Feedback_Source_Test extends BaseTestCase {
+
+	/**
+	 * Put back the globals get_current() reads, so these tests can't leak a
+	 * source into whatever runs next.
+	 */
+	public function tear_down() {
+		$GLOBALS['post'] = null;
+		unset( $GLOBALS['grunion_block_template_part_id'], $GLOBALS['grunion_block_template_id'] );
+		parent::tear_down();
+	}
+
 	/**
 	 * Test constructor with invalid ID (0 or negative)
 	 */
@@ -365,5 +376,65 @@ class Feedback_Source_Test extends BaseTestCase {
 		// ID should be reset to 0 for non-public posts
 		$this->assertSame( $post_id, $entry->get_id() );
 		$this->assertEquals( 'Fallback Title', $entry->get_title() );
+	}
+
+	/**
+	 * With no widget attribute and neither template global set, the source of a
+	 * form is the post being viewed.
+	 */
+	public function test_get_current_falls_back_to_the_post_being_viewed() {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Source Post',
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		// The current post is read from the `$post` global; tear_down() clears it.
+		$GLOBALS['post'] = get_post( $post_id );
+
+		$source = Feedback_Source::get_current( array() );
+
+		$this->assertSame( $post_id, $source->get_id(), 'The source should be the post being viewed.' );
+		$this->assertSame( 'single', $source->get_source_type() );
+		$this->assertSame( 1, $source->get_page_number(), 'A null $page global should read as page 1.' );
+	}
+
+	/**
+	 * A form in a widget is attributed to the widget, not to whatever post the
+	 * widget happens to appear on.
+	 */
+	public function test_get_current_attributes_a_form_in_a_widget_to_the_widget() {
+		$source = Feedback_Source::get_current( array( 'widget' => 'text-3' ) );
+
+		$this->assertSame( 'text-3', $source->get_id() );
+		$this->assertSame( 'widget', $source->get_source_type() );
+	}
+
+	/**
+	 * A form in a block template part is attributed to the template part. The ID
+	 * comes from a render-scoped global rather than a shortcode attribute, which
+	 * is what stops post content from claiming to be an admin-authored template.
+	 */
+	public function test_get_current_attributes_a_form_in_a_template_part_to_the_template_part() {
+		$GLOBALS['grunion_block_template_part_id'] = 'twentytwentyfive//footer';
+
+		$source = Feedback_Source::get_current( array() );
+
+		$this->assertSame( 'twentytwentyfive//footer', $source->get_id() );
+		$this->assertSame( 'block_template_part', $source->get_source_type() );
+	}
+
+	/**
+	 * The same for a form in a block template.
+	 */
+	public function test_get_current_attributes_a_form_in_a_template_to_the_template() {
+		$GLOBALS['grunion_block_template_id'] = 'twentytwentyfive//home';
+
+		$source = Feedback_Source::get_current( array() );
+
+		$this->assertSame( 'twentytwentyfive//home', $source->get_id() );
+		$this->assertSame( 'block_template', $source->get_source_type() );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Form_Preview_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Form_Preview_Test.php
@@ -45,6 +45,14 @@ class Form_Preview_Test extends BaseTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		/*
+		 * Form_Preview::generate_preview_url() runs its argument through
+		 * get_post(), which falls back to the `$post` global for an ID of 0.
+		 * A REST request in an earlier test class leaves a jetpack_form post
+		 * there, which is enough to make an invalid ID look valid.
+		 */
+		$GLOBALS['post'] = null;
+
 		// Register the form post type.
 		if ( ! post_type_exists( Contact_Form::POST_TYPE ) ) {
 			register_post_type(

--- a/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
@@ -86,6 +86,14 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
 
+		/*
+		 * These tests run as an administrator, and this class extends PHPUnit's
+		 * TestCase rather than WorDBless's, so nothing logs that user back out.
+		 * An administrator has unfiltered_html, which changes how WordPress
+		 * escapes post content on save.
+		 */
+		wp_set_current_user( 0 );
+
 		if ( null !== $this->status_count_filter ) {
 			remove_filter( 'wordbless_wpdb_query_results', $this->status_count_filter, 10 );
 			$this->status_count_filter = null;

--- a/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Jetpack_Form_Endpoint_Test.php
@@ -44,6 +44,14 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 	private $status_count_filter = null;
 
 	/**
+	 * Which of the post types these tests register were already registered when
+	 * the test started, so tearDown() only unregisters the ones it added.
+	 *
+	 * @var array<string,bool>
+	 */
+	private $post_types_registered_on_entry = array();
+
+	/**
 	 * Setting up the test.
 	 */
 	public function setUp(): void {
@@ -54,6 +62,11 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 		$this->server   = $wp_rest_server;
 
 		do_action( 'rest_api_init' );
+
+		$this->post_types_registered_on_entry = array(
+			'jetpack_form' => post_type_exists( 'jetpack_form' ),
+			'feedback'     => post_type_exists( 'feedback' ),
+		);
 
 		self::$user_id = wp_insert_user(
 			array(
@@ -81,9 +94,18 @@ class Jetpack_Form_Endpoint_Test extends TestCase {
 		unset( $_SERVER['REQUEST_METHOD'] );
 		$_GET = array();
 
-		// Unregister the post types if they were registered
-		unregister_post_type( 'jetpack_form' );
-		unregister_post_type( 'feedback' );
+		/*
+		 * Post types are registered process-wide, so put the registry back the way
+		 * this test found it rather than unregistering unconditionally. The suite
+		 * brings the plugin up in tests/php/bootstrap.php, which registers the
+		 * feedback post type; tearing that down here left every class that ran
+		 * afterwards without it, and their REST routes with it.
+		 */
+		foreach ( $this->post_types_registered_on_entry as $post_type => $was_registered ) {
+			if ( ! $was_registered && post_type_exists( $post_type ) ) {
+				unregister_post_type( $post_type );
+			}
+		}
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Classic_Forms_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Classic_Forms_Test.php
@@ -31,46 +31,63 @@ class Dashboard_Classic_Forms_Test extends BaseTestCase {
 	private const STATE_DISMISSED = Dashboard::CLASSIC_FORMS_STATE_DISMISSED;
 
 	/**
+	 * Query stubs this test registered on `wordbless_wpdb_query_results`.
+	 *
+	 * @var callable[]
+	 */
+	private $query_stubs = array();
+
+	/**
 	 * Clean up after each test.
 	 */
 	protected function tear_down() {
-		parent::tear_down();
+		$this->remove_query_stubs();
 		delete_option( self::OPTION_NAME );
-		remove_all_filters( 'wordbless_wpdb_query_results' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Remove the query stubs this test registered.
+	 *
+	 * Only the stubs registered here: `wordbless_wpdb_query_results` is how
+	 * WorDBless answers every query in the suite, so clearing the whole hook
+	 * takes its options, posts, users and meta down with it.
+	 */
+	private function remove_query_stubs() {
+		foreach ( $this->query_stubs as $stub ) {
+			remove_filter( 'wordbless_wpdb_query_results', $stub, 10 );
+		}
+		$this->query_stubs = array();
 	}
 
 	/**
 	 * Simulate detect_classic_forms SQL query returning a result (classic forms found).
 	 */
 	private function simulate_classic_forms_detected() {
-		add_filter(
-			'wordbless_wpdb_query_results',
-			function ( $results, $query ) {
-				if ( strpos( $query, "post_type = 'feedback'" ) !== false && strpos( $query, 'p.ID IS NULL' ) !== false ) {
-					return array( (object) array( '1' => '1' ) );
-				}
-				return $results;
-			},
-			10,
-			2
-		);
+		$stub = function ( $results, $query ) {
+			if ( strpos( $query, "post_type = 'feedback'" ) !== false && strpos( $query, 'p.ID IS NULL' ) !== false ) {
+				return array( (object) array( '1' => '1' ) );
+			}
+			return $results;
+		};
+
+		$this->query_stubs[] = $stub;
+		add_filter( 'wordbless_wpdb_query_results', $stub, 10, 2 );
 	}
 
 	/**
 	 * Simulate detect_classic_forms SQL query returning no result (no classic forms).
 	 */
 	private function simulate_no_classic_forms() {
-		add_filter(
-			'wordbless_wpdb_query_results',
-			function ( $results, $query ) {
-				if ( strpos( $query, "post_type = 'feedback'" ) !== false && strpos( $query, 'p.ID IS NULL' ) !== false ) {
-					return array();
-				}
-				return $results;
-			},
-			10,
-			2
-		);
+		$stub = function ( $results, $query ) {
+			if ( strpos( $query, "post_type = 'feedback'" ) !== false && strpos( $query, 'p.ID IS NULL' ) !== false ) {
+				return array();
+			}
+			return $results;
+		};
+
+		$this->query_stubs[] = $stub;
+		add_filter( 'wordbless_wpdb_query_results', $stub, 10, 2 );
 	}
 
 	/**
@@ -136,7 +153,7 @@ class Dashboard_Classic_Forms_Test extends BaseTestCase {
 		$this->assertEquals( self::STATE_CLASSIC, $state );
 
 		// Remove the SQL simulation — if option caching works, it won't matter.
-		remove_all_filters( 'wordbless_wpdb_query_results' );
+		$this->remove_query_stubs();
 		$this->simulate_no_classic_forms();
 
 		// Second call should use cached option, not re-query.


### PR DESCRIPTION
Fixes #51573

## Proposed changes

The issue was that several tests in `Contact_Form_Plugin_Test.php` only passed because of the order they ran in. Fixing those turned up the same defect throughout the package, so this PR does both: the specific tests the issue names, and the process-wide state they were a symptom of.

**Before:** running the forms suite in a random order ended in `Fatal error: Premature end of PHP process` partway through, and 9 of the 43 test files failed when run on their own.

**After:** the suite passes in file order, with every file run on its own, and under `--order-by=random` across every seed tried. One pre-existing failure remains, discussed at the bottom.

### The tests the issue names

* **`test_interpersonal_data_exporter` asserted against a post it never created.** `Utility::create_legacy_feedback()` files the feedback under whatever is in the `$post` global. `Feedback_Source` only prefixes `(deleted)` and blanks the permalink when that parent no longer resolves. In file order `$post` held a post an earlier test had left behind and WorDBless had since cleared, so the assertion passed on someone else's garbage. Alone, `$post` is null, the feedback gets no parent, and both assertions fail. It now creates its own source post and deletes it. Adds coverage for the live-source branch too, which had none — and whose absence is what let the deleted-source assertion pass for the wrong reason.
* **Per-test cleanup ran after the assertions**, so a failing assertion leaked the extra post and `$_POST` keys into whatever ran next. That moves to `setUp()`/`tearDown()`.
* **`teardown_post_for_test()` is deleted.** WorDBless already clears posts, users, options and hooks after every test, so the only part that mattered was the global cleanup. It was also wrong: it unset `$_POST['g<ID>-name']` *after* restoring `$post`, so it never removed the key it meant to, and PHPUnit reported `Attempt to read property "ID" on null` against four tests.
* **Three tests were asserting against an ambient post.** They called `wp_insert_post()` for a `post` with no title or content; WordPress rejects that and returns `0`, so their `get_post( 0 )` fell through to the `$post` global.

### The process-wide state underneath

* **`DOING_AJAX`** was defined in `Contact_Form_Test`'s `BeforeClass`. It is what stops `Contact_Form::process_submission()` from redirecting and calling `exit()`, so any class that submits a form and ran *before* `Contact_Form_Test` took the whole PHPUnit process down with it — that is the fatal. A constant can never be undefined, so this cannot be left to whichever class runs first; it moves to the bootstrap. Classes that render forms as a visitor need the opposite (`Request::is_frontend()` is false while `wp_doing_ajax()` is true, and the block renders its fallback link), so they opt out per test with the `wp_doing_ajax` filter.
* **`Contact_Form_Plugin::init()`** was likewise left to whichever class called it first — it registers the `contact-field` shortcode and the `feedback` post type. Worse, because it is a singleton, the class that initialized it added hooks that WorDBless then stripped in its teardown, and every later `init()` handed back the cached instance without putting them back. The bootstrap now brings the plugin up so WorDBless snapshots its hooks as part of the baseline it restores.
* **`$_SERVER['REMOTE_ADDR']` and friends** were set by `Contact_Form_Test`, and four other files asserted on the IP and user agent a feedback records. There is no request behind a PHPUnit run, so the bootstrap stands in for one.
* **`remove_all_filters( 'wordbless_wpdb_query_results' )`** appeared in five files as a way to drop a query stub. That hook is how WorDBless answers *every* query in the suite, so clearing it took its options, posts, users and meta with it. After one such call no newly created administrator had any capabilities, and the REST tests returned 401 for the rest of the run — that was the largest single cluster of order-dependent failures. Each site now removes only the stub it added.
* **`Jetpack_Form_Endpoint_Test`** unregistered the `jetpack_form` and `feedback` post types in `tearDown` whether or not it had registered them, leaving every later class without them and their REST routes with them. It now restores the registry to what it found.
* **Two tests read ambient state:** `Form_Preview_Test` expects `generate_preview_url( 0 )` to be null, which `get_post()` resolves against the `$post` global; `Contact_Form_Synced_Test` expects a draft synced form not to render, which turns on who is logged in. Both now set what they depend on.
* **Five files used the `Utility` test helper without requiring it**, relying on another file having done so. PHPUnit loads every test file before running anything, so this never actually broke — but it is the same assumption.
* **`$_POST` was staged and left behind.** `Feedback_Form_Ref_Test` sets up a submission in `set_up()` and never cleared it; a stale `contact-form-id` decides which form the next test's `Contact_Form` believes it is, and so which field IDs it generates — `Feedback_Fields_Test` built its `$_POST` keys against one prefix and read the response back under another. Five other classes *do* clear `$_POST`, but with `unset()`, which leaves the superglobal undefined rather than empty and makes the next read a warning (and warnings fail this suite). They assign an empty array now.
* **The two REST test classes never logged their administrator back out.** They extend PHPUnit's `TestCase` rather than WorDBless's, so nothing does it for them. An administrator has `unfiltered_html`, which changes how WordPress escapes content on save — and `Feedback_Legacy_Compatibility_Test` asserts on exactly that escaping. Those same two classes are why `Contact_Form_Plugin_Test`'s `track_feedback_status_change` tests needed a starting point: saving an unread feedback schedules the recount on `shutdown`, and a class that doesn't restore hooks leaves it scheduled — if it runs first, that ends up in the baseline WorDBless restores after *every* test.

### One thing that is not a test fix

`Contact_Form_Plugin`'s constructor is ~117 lines of hook, shortcode and post type registration, and moving the `init()` call into the bootstrap took those lines out of the coverage report. They were only ever counted because some test happened to trigger `init()` first — executed as a side effect, never asserted on. Rather than leave that as a silent drop, there is now a test for what the constructor registers, so those lines are covered because something checks them.

## Related product discussion/links

* Split out of #51510, per the review threads there on the state leak.

## Does this pull request change what data or activity we track or use?

No. Test-only change — nothing under `src/` is touched.

## Testing instructions

This is a test-only change, so the test run is the test. From `projects/packages/forms` after `composer install`:

**Every method of the class the issue names now passes on its own.** On trunk this prints seven failures, including `test_interpersonal_data_exporter`; on this branch it prints nothing:

```bash
for t in $(grep -oE 'public function test[A-Za-z0-9_]*' tests/php/contact-form/Contact_Form_Plugin_Test.php | sed 's/public function //'); do
  ./vendor/bin/phpunit -c phpunit.12.xml.dist --filter "Contact_Form_Plugin_Test::$t" > /dev/null 2>&1 || echo "FAIL $t"
done
```

**The suite survives randomized ordering.** On trunk this dies with `Fatal error: Premature end of PHP process`; on this branch every seed comes back with the same result as file order:

```bash
for seed in 1 2 3 5 7 11 13 42 77 99 111 333 555 777 999 2024 4242 31337 65536 8675309; do
  ./vendor/bin/phpunit -c phpunit.12.xml.dist --order-by=random --random-order-seed=$seed | tail -3
done
```

All twenty of those seeds come back with the same one pre-existing failure and nothing else.

**Every file passes on its own.** On trunk 9 of 43 fail; on this branch only the pre-existing failure below does. Point a config's `<testsuite>` at a single `<file>` and run each in turn, or eyeball a few of the ones that were broken — `Feedback_Fields_Test`, `Feedback_Browser_Geo_Test`, `Contact_Form_Field_Test`, `Feedback_Author_Metadata_Test`.

**And normally**, at 1191 tests: `jetpack test php packages/forms`.

### The one remaining failure, which this PR does not fix

`Form_Webhooks_Test::test_send_webhooks_blocks_localhost_hostname` fails on macOS, on trunk and on this branch, in every ordering. It is not an ordering problem, and fixing it would mean changing SSRF policy rather than a test, so I left it alone:

* The test stubs `pre_http_request`. WordPress applies that filter *before* `reject_unsafe_urls` / `wp_http_validate_url()`, so `wp_safe_remote_request()` can never be observed blocking anything — the block has to come from `Form_Webhooks::validate_webhook_url()` itself.
* That method blocks IPv6 loopback (`::1`) but not IPv4 loopback (`127.0.0.0/8`) — `is_blocked_ip()` covers only link-local `169.254.0.0/16` and the Azure wire server. So `https://localhost/` is blocked only via the AAAA lookup.
* On Linux `dns_get_record( 'localhost', DNS_AAAA )` returns `::1` and the test passes, which is why CI is green. On macOS it consults DNS and not `/etc/hosts`, returns nothing, and the URL sails through.

Whether `is_blocked_ip()` should treat IPv4 loopback the way it treats IPv6 loopback looks like a real question, but it is a product decision about what webhook destinations to allow, not test cleanup. Happy to open a separate issue for it.
