### PR TITLE
Newsletter: add the email design editor's JavaScript bundle

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -81,10 +81,11 @@ async function fixDeps( pkg ) {
 		}
 	}
 
-	// Pins ~30 `@wordpress/*` deps to exact versions, which installs a second old
-	// copy of most of Gutenberg alongside ours, `@wordpress/data` and its registry
-	// included. They're all externalized at build time, so relax the pins and let
-	// pnpm dedupe onto the versions already here.
+	// Pins ~30 `@wordpress/*` deps to exact versions, which installs a second old copy
+	// of most of Gutenberg alongside ours — `@wordpress/data` and its registry included.
+	// Relax the pins so pnpm reuses the copies already here. Safe because these are all
+	// externalized to `wp-*` script handles at build time: the installed version never
+	// ships, so it decides resolution but not what runs.
 	if ( pkg.name === '@woocommerce/email-editor' ) {
 		for ( const [ dep, ver ] of Object.entries( pkg.dependencies ) ) {
 			if ( dep.startsWith( '@wordpress/' ) ) {

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -61,7 +61,7 @@ const addWpPkgDep = async ( pkg, fromPkg, ver, deplist ) => {
  */
 async function fixDeps( pkg ) {
 	// Deps tend to get outdated due to a slow release cycle.
-	// So change `^` to `>=` and hope any breaking changes will not really break.
+	// So change `^` to `>=` to avoid many duplicate packages (most are dependency-extracted in the build anyway), and hope any breaking changes will not really break.
 	if (
 		pkg.name === '@automattic/api-core' ||
 		pkg.name === '@automattic/components' ||
@@ -81,11 +81,8 @@ async function fixDeps( pkg ) {
 		}
 	}
 
-	// Pins ~30 `@wordpress/*` deps to exact versions, which installs a second old copy
-	// of most of Gutenberg alongside ours — `@wordpress/data` and its registry included.
-	// Relax the pins so pnpm reuses the copies already here. Safe because these are all
-	// externalized to `wp-*` script handles at build time: the installed version never
-	// ships, so it decides resolution but not what runs.
+	// WooCommerce packages pin `@wordpress/*` deps to versions from the lowest Core version the plugin supports.
+	// Change to `>=` to avoid many duplicate packages (most are dependency-extracted in the build anyway), and hope any breaking changes will not really break.
 	if ( pkg.name === '@woocommerce/email-editor' ) {
 		for ( const [ dep, ver ] of Object.entries( pkg.dependencies ) ) {
 			if ( dep.startsWith( '@wordpress/' ) ) {

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -81,16 +81,10 @@ async function fixDeps( pkg ) {
 		}
 	}
 
-	// `@woocommerce/email-editor` pins about thirty `@wordpress/*` deps to exact
-	// versions from the Gutenberg snapshot it was released against. Left alone
-	// those install a second, older copy of most of the Gutenberg surface
-	// alongside the versions the rest of the monorepo already uses — including
-	// `@wordpress/data`, whose duplicate store registry causes problems well
-	// beyond this one package. Relax the pins to `>=` so pnpm dedupes them onto
-	// the copies already here. Safe because every one of these is externalized
-	// to a `wp-*` script handle at build time, so none of their code is bundled
-	// and the editor runs against whatever WordPress Core provides regardless of
-	// what is installed here.
+	// Pins ~30 `@wordpress/*` deps to exact versions, which installs a second old
+	// copy of most of Gutenberg alongside ours, `@wordpress/data` and its registry
+	// included. They're all externalized at build time, so relax the pins and let
+	// pnpm dedupe onto the versions already here.
 	if ( pkg.name === '@woocommerce/email-editor' ) {
 		for ( const [ dep, ver ] of Object.entries( pkg.dependencies ) ) {
 			if ( dep.startsWith( '@wordpress/' ) ) {

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -81,6 +81,28 @@ async function fixDeps( pkg ) {
 		}
 	}
 
+	// `@woocommerce/email-editor` pins about thirty `@wordpress/*` deps to exact
+	// versions from the Gutenberg snapshot it was released against. Left alone
+	// those install a second, older copy of most of the Gutenberg surface
+	// alongside the versions the rest of the monorepo already uses — including
+	// `@wordpress/data`, whose duplicate store registry causes problems well
+	// beyond this one package. Relax the pins to `>=` so pnpm dedupes them onto
+	// the copies already here. Safe because every one of these is externalized
+	// to a `wp-*` script handle at build time, so none of their code is bundled
+	// and the editor runs against whatever WordPress Core provides regardless of
+	// what is installed here.
+	if ( pkg.name === '@woocommerce/email-editor' ) {
+		for ( const [ dep, ver ] of Object.entries( pkg.dependencies ) ) {
+			if ( dep.startsWith( '@wordpress/' ) ) {
+				if ( ver.startsWith( '^' ) ) {
+					pkg.dependencies[ dep ] = '>=' + ver.substring( 1 );
+				} else if ( ver.match( /^\d/ ) ) {
+					pkg.dependencies[ dep ] = '>=' + ver;
+				}
+			}
+		}
+	}
+
 	// Unused, vulnerable dep.
 	if (
 		pkg.name === '@automattic/components' &&

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -59,7 +59,7 @@ const addWpPkgDep = async ( pkg, fromPkg, ver, deplist ) => {
  */
 async function fixDeps( pkg ) {
 	// Deps tend to get outdated due to a slow release cycle.
-	// So change `^` to `>=` and hope any breaking changes will not really break.
+	// So change `^` to `>=` to avoid many duplicate packages (most are dependency-extracted in the build anyway), and hope any breaking changes will not really break.
 	if (
 		pkg.name === '@automattic/api-core' ||
 		pkg.name === '@automattic/components' ||
@@ -90,11 +90,8 @@ async function fixDeps( pkg ) {
 			];
 	}
 
-	// Pins ~30 `@wordpress/*` deps to exact versions, which installs a second old copy
-	// of most of Gutenberg alongside ours — `@wordpress/data` and its registry included.
-	// Relax the pins so pnpm reuses the copies already here. Safe because these are all
-	// externalized to `wp-*` script handles at build time: the installed version never
-	// ships, so it decides resolution but not what runs.
+	// WooCommerce packages pin `@wordpress/*` deps to versions from the lowest Core version the plugin supports.
+	// Change to `>=` to avoid many duplicate packages (most are dependency-extracted in the build anyway), and hope any breaking changes will not really break.
 	if ( pkg.name === '@woocommerce/email-editor' ) {
 		for ( const [ dep, ver ] of Object.entries( pkg.dependencies ) ) {
 			if ( dep.startsWith( '@wordpress/' ) ) {

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -90,16 +90,10 @@ async function fixDeps( pkg ) {
 			];
 	}
 
-	// `@woocommerce/email-editor` pins about thirty `@wordpress/*` deps to exact
-	// versions from the Gutenberg snapshot it was released against. Left alone
-	// those install a second, older copy of most of the Gutenberg surface
-	// alongside the versions the rest of the monorepo already uses — including
-	// `@wordpress/data`, whose duplicate store registry causes problems well
-	// beyond this one package. Relax the pins to `>=` so pnpm dedupes them onto
-	// the copies already here. Safe because every one of these is externalized
-	// to a `wp-*` script handle at build time, so none of their code is bundled
-	// and the editor runs against whatever WordPress Core provides regardless of
-	// what is installed here.
+	// Pins ~30 `@wordpress/*` deps to exact versions, which installs a second old
+	// copy of most of Gutenberg alongside ours, `@wordpress/data` and its registry
+	// included. They're all externalized at build time, so relax the pins and let
+	// pnpm dedupe onto the versions already here.
 	if ( pkg.name === '@woocommerce/email-editor' ) {
 		for ( const [ dep, ver ] of Object.entries( pkg.dependencies ) ) {
 			if ( dep.startsWith( '@wordpress/' ) ) {

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -90,10 +90,11 @@ async function fixDeps( pkg ) {
 			];
 	}
 
-	// Pins ~30 `@wordpress/*` deps to exact versions, which installs a second old
-	// copy of most of Gutenberg alongside ours, `@wordpress/data` and its registry
-	// included. They're all externalized at build time, so relax the pins and let
-	// pnpm dedupe onto the versions already here.
+	// Pins ~30 `@wordpress/*` deps to exact versions, which installs a second old copy
+	// of most of Gutenberg alongside ours — `@wordpress/data` and its registry included.
+	// Relax the pins so pnpm reuses the copies already here. Safe because these are all
+	// externalized to `wp-*` script handles at build time: the installed version never
+	// ships, so it decides resolution but not what runs.
 	if ( pkg.name === '@woocommerce/email-editor' ) {
 		for ( const [ dep, ver ] of Object.entries( pkg.dependencies ) ) {
 			if ( dep.startsWith( '@wordpress/' ) ) {

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -90,6 +90,28 @@ async function fixDeps( pkg ) {
 			];
 	}
 
+	// `@woocommerce/email-editor` pins about thirty `@wordpress/*` deps to exact
+	// versions from the Gutenberg snapshot it was released against. Left alone
+	// those install a second, older copy of most of the Gutenberg surface
+	// alongside the versions the rest of the monorepo already uses — including
+	// `@wordpress/data`, whose duplicate store registry causes problems well
+	// beyond this one package. Relax the pins to `>=` so pnpm dedupes them onto
+	// the copies already here. Safe because every one of these is externalized
+	// to a `wp-*` script handle at build time, so none of their code is bundled
+	// and the editor runs against whatever WordPress Core provides regardless of
+	// what is installed here.
+	if ( pkg.name === '@woocommerce/email-editor' ) {
+		for ( const [ dep, ver ] of Object.entries( pkg.dependencies ) ) {
+			if ( dep.startsWith( '@wordpress/' ) ) {
+				if ( ver.startsWith( '^' ) ) {
+					pkg.dependencies[ dep ] = '>=' + ver.substring( 1 );
+				} else if ( ver.match( /^\d/ ) ) {
+					pkg.dependencies[ dep ] = '>=' + ver;
+				}
+			}
+		}
+	}
+
 	// Unused, vulnerable dep.
 	if (
 		pkg.name === '@automattic/components' &&

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-overrides:
-  date-fns@^3.6.0: ^4.1.0
-
-pnpmfileChecksum: sha256-Koac67WaJpuLyJalTUuFaNmp0WUcSQVOu5ejcFHnxKQ=
+pnpmfileChecksum: sha256-KSdPz87aJUaAAe/JwUY5sFdPCTPF9oAlEDa4Xz/hJF4=
 
 patchedDependencies:
   '@wordpress/build': 151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022
@@ -8474,12 +8471,6 @@ packages:
   '@floating-ui/dom@1.8.0':
     resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
-  '@floating-ui/react-dom@2.0.8':
-    resolution: {integrity: sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
   '@floating-ui/react-dom@2.1.9':
     resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
     peerDependencies:
@@ -10419,9 +10410,6 @@ packages:
   '@types/gradient-parser@1.1.0':
     resolution: {integrity: sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==}
 
-  '@types/highlight-words-core@1.2.1':
-    resolution: {integrity: sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA==}
-
   '@types/highlight-words-core@1.2.3':
     resolution: {integrity: sha512-PWNU/NR0CaYEsK38mcCTyDzeS2TlEGK9kRhRMz1i86jVAe836ZlA3gl6QYpu+CG6IpfNKTgWpEnJuRededvC0g==}
 
@@ -11115,12 +11103,6 @@ packages:
     resolution: {integrity: sha512-m6/45U8Fhr2LyQiBinHDBEF/iFnMSbSh3vdjb4GPjIjujvomktUKknjedoUWEvJFRsR6UVjIrnRIGcZAznjUhg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/admin-ui@1.12.0':
-    resolution: {integrity: sha512-CVTvE2jLTP71vBliAhOrvlMoOG1o1TdyoCL5gmw0Uswuj/qhqK3f1Y1adz7hAWiR9o7H9SoPYf+qg6pbZJVyaQ==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/admin-ui@2.8.0':
     resolution: {integrity: sha512-lYBaKVEhzXCL1+4voIgejDPpKqw8XkALN/E9uuuQzix1SnaJXVQ6+QRLwF6nh5EiUHyb7zh6ieEHJW01OZjHLA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11130,10 +11112,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/api-fetch@7.33.1':
-    resolution: {integrity: sha512-kxk7Og2CZLOMUZtDfOXSGapem4ToP15JB24PfixJLS0dKfrlUBci4ShjJ3z3jdIx01gf1gfP4NFjqzicJKb+Rg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/api-fetch@7.51.0':
     resolution: {integrity: sha512-kSgBvrGr8eMTcQTA1fIsChg56FKPTdcmkQrpEQjL9uzbmGwPKrru4BdkBFqLSql/PH5fEOjNcY3OSA61+WrJ8g==}
@@ -11169,14 +11147,6 @@ packages:
     resolution: {integrity: sha512-B8Ab7dU574B1lNtjnTolO340nnW+WeaztR4RFpoL6tyqWrvDU1hK6xcjQnuNtQYJc2ngH/MO/rZOVFaFa7HFxw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/base-styles@6.20.0':
-    resolution: {integrity: sha512-Dsug4Zxz2xOFtK6CGThKYXwCqC9Yztw2STKQzwztrX4yW+o6iDbzkxpcwdDhsaVJs0Jt9A4LmJpZPh+pUozzLA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/base-styles@6.9.1':
-    resolution: {integrity: sha512-UCtTANAdym5jpTEZS17WHrKLu7R52gQRgKuwsRm5uZWUb4g4Vq8NX52CBIesF1viFyKfM++HpmteFkrL7p0SMg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/base-styles@9.1.0':
     resolution: {integrity: sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11188,13 +11158,6 @@ packages:
   '@wordpress/blob@4.53.0':
     resolution: {integrity: sha512-O6px43M9k/6UYtKm0f3MAcz0sMwMPqf2caWzlZb9gG6D5gsz2VIIPmMioCdlGHuYZ6jUoOfY0yaPFPDT9J9ihA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/block-editor@15.6.9':
-    resolution: {integrity: sha512-X5S7oWsTCpNIUHbsx/ZMN+2AXnILn3EeotUWAj8DsHtFFgfiDnbo2kKPaWANgGtHJ+GNWZPr0RUyS9Gmtdwn1A==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/block-editor@16.0.0':
     resolution: {integrity: sha512-hH7w5gbgjwsYLPTw1JFqNTtEe+O2kHvbzoht4g5sUHGThKR7NrVMHuLnNS7iOcz+k1VZpVRjXrWJlBsEj2en2g==}
@@ -11229,13 +11192,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/block-library@9.33.10':
-    resolution: {integrity: sha512-9qrBXTc1BR539L78KuMCZ7PHt4US822NSKKVNcgVTkPH2qHyUDvr6t680HRHCI7VYWq1NXp9teZo7PEZNVfhVA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/block-serialization-default-parser@5.51.0':
     resolution: {integrity: sha512-zcuJptrIG7VWP3N7uw3ACBS5Mdykhy3zAxZ+dMym8291b2O+dJf1JVlnr65G4AYhxahWA5MsmLENBLhwBgOH8w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11263,12 +11219,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/blocks@15.6.3':
-    resolution: {integrity: sha512-AFYre+06ZVtyv0KSVwCOUY+HSEdAaQRxFrRZnSsZ5FEs0pMMIsulFYay8QvlVVTtBUKbYlxKEDi8kD1DI+8jxA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
 
   '@wordpress/boot@0.20.0':
     resolution: {integrity: sha512-kGrDNIXyudEoViTy/HgApL+WqW5QsPnVcu5CVT8L8RolgsztKFHuHqmMwDadtfp2rTH1bmL6wz4NHLD9V19WmA==}
@@ -11304,13 +11254,6 @@ packages:
       '@wordpress/theme':
         optional: true
 
-  '@wordpress/commands@1.33.5':
-    resolution: {integrity: sha512-m8a/9ahGzEVYj77EfS6crzjq2Gq97DOXbeSqRSHrpePE/NSXPh6AAABRP/dKCI/0AysjJ0v/bKKTVnsFgkk0YA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/commands@1.51.0':
     resolution: {integrity: sha512-qn38b/rl1W84IHmcc9KOLSOmuXDwBMYcD7uPUKCChziy/NCb3e7njQzklKgK5sBC3JcgZrl1V5C605ejofd7lQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11324,27 +11267,6 @@ packages:
     peerDependencies:
       react: ^18 || ^19
       react-dom: ^18 || ^19
-
-  '@wordpress/components@30.6.5':
-    resolution: {integrity: sha512-jSDpUz1BBQvpWUGwqZUlI22PMGMtiN5ooKS4GlQqjUmEBJH4llwiRblkZBKgdznv+5KDYyDiRNIGCz/hLSdwZw==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
-  '@wordpress/components@30.9.0':
-    resolution: {integrity: sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
-  '@wordpress/components@32.6.0':
-    resolution: {integrity: sha512-MpOr0mGTkKDRjxK5LKm86Uoj9p9Z6KkrvhkNVi5zVKCftyHVMK+tun7wL2Qn/JZVLbxZpB1kW5sJ5aMf3T2ToA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/components@37.0.0':
     resolution: {integrity: sha512-Lol3iUujNnn4uHxI4VARDVEJIFUKlBtZUMcSFWofiYRZc8aV5BplyKC+sRAhKm+KFNBQjZtqd4PdixtaOHuX6w==}
@@ -11379,12 +11301,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/compose@7.33.1':
-    resolution: {integrity: sha512-1satS+7EKlzZOCR++uP8mAy3BJPKX2eeTZHVW3669n0xM1xdmzl9JXyEbtEqaFVYhI3dHTq5kLwrm+aSpn0zag==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/compose@7.46.0':
     resolution: {integrity: sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11400,13 +11316,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/core-data@7.33.9':
-    resolution: {integrity: sha512-1tYiHamRDvopG9cLFTR+SdUKroTLQRof25vquI5OlXEzBgRmn/ksWlOKM6nFxGUBK6JmdlczBoa0QhBJdXBK0Q==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/core-data@7.51.0':
     resolution: {integrity: sha512-5B6eouukuJD+F8FYXYE/E+5oE3kLFpBhaXn0shDWeohT/elvjc1ra7x+KFNM2iWQHJ4ftO5nEkVfh923mmyRRA==}
@@ -11430,23 +11339,11 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/data-controls@4.33.1':
-    resolution: {integrity: sha512-+gD47q6WuZ2MYMxwUBwBTYACMayrZoyG6W6OR1Q2ggOfkmoQb4OlxEWJPdCIC8GxJJwVh8ej9HjzzI3S/tDsJg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/data-controls@4.51.0':
     resolution: {integrity: sha512-ZcuCLaJPAczEp0pXzU4HPSa9ILttUXqb4+3azFaa9YLH5Cn6apImTqsqUQp+flF6TMDhtuJp3vfmOg4eXAd0CA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18 || ^19
-
-  '@wordpress/data@10.33.1':
-    resolution: {integrity: sha512-Y+GlNYFds2ICgkAfwT3UsLCXlagibtUFADBf/UXmTgEvc07/O/lOBHeIW72BiRkb/O4oCqf2ZeXgGkNgJLlyiQ==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
 
   '@wordpress/data@10.51.0':
     resolution: {integrity: sha512-KwlrgU+PGd+l4QyrwuCvbHE5HUC1CU6pqD19WZr+yOD1XRmIWZ+LZNwrEdFlhCu8aOG9+e131k1zmAMZign/mA==}
@@ -11461,12 +11358,6 @@ packages:
     peerDependencies:
       '@types/react': ^18 || ^19
       react: ^18 || ^19
-
-  '@wordpress/dataviews@10.3.0':
-    resolution: {integrity: sha512-7mBcW4Vris+8Be3ESUPkhe85AwAbwO+2ocvi4UDF6jEzeyH7GQxq+1k4Lq4vAc+pNBf0IehZV598+qs8nk9j2w==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
 
   '@wordpress/dataviews@17.3.0':
     resolution: {integrity: sha512-9U50IPnaYWUbkdVl2J2eRkkT0x83nGxmsVkkNVBSGQFpnWHhCAN7TqZOOSVYM+ppMBQnVwDhml6URIc4iejZ8A==}
@@ -11507,10 +11398,6 @@ packages:
     resolution: {integrity: sha512-JaIWiGVoKEmsiWP4XwAZvrET44T34EtPG+xCJe9vPIs9O3DHPyB83VHV4WxVRxddaf1osTmR6iPLx0sBvVTjZw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/dom-ready@4.33.1':
-    resolution: {integrity: sha512-jrHN/arTKp2iuYj24byFgabBhZsZ3WUXCSKT16d/1MZUXGQt876XXu6r5rwpLtnVsX2gFiZ/DzdRKCL4RV9Wpg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/dom-ready@4.51.0':
     resolution: {integrity: sha512-O/ivmzG+o44CicTW+c17KBXlmjRoVp4VGIyyEQDD52H5YH+gX7i15FuEPk6G2e7Rqz4DCvCS5yD7eY9Zb3z1WA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11541,13 +11428,6 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@wordpress/editor@14.33.11':
-    resolution: {integrity: sha512-yGSMcsya/9OADD+xgfewVwnHvRUpMsKGh865WkWm2uy0XbCap5IoDMNeKgsM/nYXrCy8y5sbO4b9bzDUhHcsdA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/editor@14.51.0':
     resolution: {integrity: sha512-R5t60Ule+C23HCKS5ltfRHUEuR86xixscU4eAjFPkL0rNSABvbjd8JFL+3x7mPinEHnEKIphTeSxqmiioFrfyg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11569,10 +11449,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/element@6.33.1':
-    resolution: {integrity: sha512-8Y2TEkduT1cAGVfh5HoERpJIVvCcfHI1k+PGgG3wzy85me6hjgA/P7l90yBt/9i9Omt5+buGfnklobstECR8zg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/element@6.46.0':
     resolution: {integrity: sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==}
@@ -11628,12 +11504,6 @@ packages:
       typescript:
         optional: true
 
-  '@wordpress/fields@0.25.11':
-    resolution: {integrity: sha512-jNNG14L0FWUif95kVUVm53mT4ItOBm3yN9I2mElm/aznHZh3rheRJ96vT2nyTuJ1/J79Xt2DerqkvcWP4R6R3Q==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/fields@0.43.0':
     resolution: {integrity: sha512-Syc3ims41sZ9AWTIq0BTtpodbC3Pw1ZUatRDHGWHj7wK/ayDxIR9Aru99Zg9FF9fbqbNMHWieM3wF3RRD1NkVQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11653,13 +11523,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/format-library@5.33.9':
-    resolution: {integrity: sha512-9RTyCFuaXSSF4Rz4rnz0Elge71nSn7UWyvskMQtZNN5nMGjH9D5NK5JoYKANpt1v0Cx/vfUkLTywBrU0v2+pLA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/format-library@5.51.0':
     resolution: {integrity: sha512-IMu8nU18MokIfPz+qWUlwcMLnAGqm06bWjSy2jyG5KSCi0GYYqf0iQhjpRhcxCOLxw8QvjtPn3vyaJE4E0eQWw==}
@@ -11694,20 +11557,12 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/hooks@4.33.1':
-    resolution: {integrity: sha512-p9RbNsZJnsGY45MEV3QfYHS4dMmKe0B1f/RUXEL8ZLa36aUWZrUX7PJxvmmpeuPrboHQwT4MDps9kwHO4V6GVg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/hooks@4.51.0':
     resolution: {integrity: sha512-pTVZRT9mjEdrNNt7TyKw5hQhFUqntfTXVs/fboEDpmAi+PFWXoD8rPs3oZyRCVr/MDyE6OCv1mwEibI6AsRk3Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/hooks@4.53.0':
     resolution: {integrity: sha512-YU30rweJCTu5g7X8bc+w6QyoxJBYLEHH++Wwo/IbbROHUC/4I7e+ZtxnPWls8BTtMP4d28JJ74s+UoKpzd2J7w==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/html-entities@4.33.1':
-    resolution: {integrity: sha512-HdpnRRvTMstX58U4Yr+UisIrFLcG97PGegAczMxeq9Q1n3ol5FCkEegBTQIJffAZ5IadBsPZ77fjoVtLK7RViQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/html-entities@4.51.0':
@@ -11728,34 +11583,11 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
-  '@wordpress/i18n@6.6.1':
-    resolution: {integrity: sha512-aEFSF+5dp0UhdMGHyNUwhcL0Sg/kp0NtCSMrfcQrXRM6uD/+y8ih0mHeULww5V919NUrzXIZSZGfOaOIiQVXXg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    hasBin: true
-
   '@wordpress/icons@10.32.0':
     resolution: {integrity: sha512-1WvJdT361X1LnetYBpBWUjAVXZzl+pBdIwHbYRAp8ej47EI/igPmNxmq81nFd40s8fer/9qtipielcqSI6H2rA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18
-
-  '@wordpress/icons@11.0.1':
-    resolution: {integrity: sha512-vXkWiAxwDjWBcj72oXbJyuDtIvNvk1JnnmYzQUpIjKjvScRPcj+Kt40nFYk/5kPnNAhBqVNcZ7tWK7NctSslJA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18
-
-  '@wordpress/icons@11.8.0':
-    resolution: {integrity: sha512-ZMNHApHMmPLpNnNLfPLRf6XWoPhZFNKFKdpMlhA6Lx04J1hLVyLRz8PuM+1o3ByxD2ZiExfSRhdmI+7VvEg6DA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
-  '@wordpress/icons@12.2.0':
-    resolution: {integrity: sha512-Fiw7bmfHDNPjTdCrBF23/9K0VN/GUi73d2ZPZaeWdXhTmIX62T9KYvb1c+WnlBkX7GpXgJO6Q8mypQCY9mw5SQ==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
 
   '@wordpress/icons@13.3.0':
     resolution: {integrity: sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==}
@@ -11796,23 +11628,12 @@ packages:
     resolution: {integrity: sha512-dYH2cstn/+3JewRu4rldyifijfTzvnmcAbjs7Z4mcBVnP22Ags4IE3aztpc++A0AXugfx5D4hA2PdqasGmrs2g==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/interface@9.18.5':
-    resolution: {integrity: sha512-OCNCTogPS/kHPVjIAHtQ2y9WaX1fm1oK1cXQs6RezKtO1y/+nFH2L5pjzF7ifG1ECe5KL7REX4kJXgDTIwDV9g==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/interface@9.38.0':
     resolution: {integrity: sha512-SxoxXuyfI614mp2e7K+nTWP7UQ1RLpbocrocWGD9ZXYdP5nh2Ix1KSv8m05agCMPIDpC20+yMwkZIc1Du4Auvw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18 || ^19
       react-dom: ^18 || ^19
-
-  '@wordpress/is-shallow-equal@5.33.1':
-    resolution: {integrity: sha512-QMOwATwFjFr6Z9geS8EjuEVGN0gkpANypjqIBE8iTDtfKhY99LTtxbTaguviqKfVP7l73v1B0GJfHtkPExhJkA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/is-shallow-equal@5.53.0':
     resolution: {integrity: sha512-NHhvEnqi82Vzon458Jz6nzmbAPWM1zy9k6rBXQTc+9PsRiWHWpqXqldKAeTFVrl0vspZf4PwmLlsxqP3ckCLWw==}
@@ -11828,12 +11649,6 @@ packages:
     resolution: {integrity: sha512-Ep7dCpM9B1PiP2WZyjI5dFnJJbTZA6melU/hu5tnvYBtzOdywqSjH4mtOsBY3CtQ0uJ5fQvFAP3tHuh6Si7Bsw==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
 
-  '@wordpress/keyboard-shortcuts@5.33.1':
-    resolution: {integrity: sha512-ql+qQ+AW9rnaS6jBv3J5MT8ku0qijAYCq6rIvfEiA1W84i5+LB9JYxxzrFH8v5uGU4ZjqqRQEmcDd+lorlT4Vg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/keyboard-shortcuts@5.53.0':
     resolution: {integrity: sha512-PDrZtEPACD1V0SM4fVM5dmgGBawZwglwurrnJJ7OtdSzbI4bTjT9LHOMwvv7i0Pz8kbOL9+gAif/dvDxBbQdRQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11843,10 +11658,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/keycodes@4.33.1':
-    resolution: {integrity: sha512-acuH0ogiY92ClslUpezZyEzfm1Ubx2bftevn/PxbsVq52UCOu14CAKgnO9sYqVuMpXT+zXveRMySixyKHB1wnA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/keycodes@4.51.0':
     resolution: {integrity: sha512-C9CZq2WCWVacjsHhFgM0GVIQmTUxo/oX7U+Qj0kr3vWHZu6cmEDJ94PX+f02M3b+iHnCk4oHCvnXGANwKQwsSw==}
@@ -11950,12 +11761,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/notices@5.33.1':
-    resolution: {integrity: sha512-bvw97KGiToFZv9/EHPhom2va7pDXCUR2BNfSuxT3lSAt1tX5DUD5i1+6aa5TIybSAtZNGisCySH4fL/paMDMjQ==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/notices@5.51.0':
     resolution: {integrity: sha512-mOOPEnjmkvscs4gNEYNiowsSF371HnO5euFOmBRIcnuRjn/dW7VqUfGXUbsu3HGXqjMBWBWPW0hzEjaatEVhGA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11983,13 +11788,6 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@wordpress/plugins@7.33.5':
-    resolution: {integrity: sha512-kTNhyX1FKTSWBmxfHWoqEo5+iM96ThHXGqFGzeAFt+W35EeHzt9a/H++9yfcxMqDyjR1IRjoB261bX+oLPuw9Q==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/plugins@7.51.0':
     resolution: {integrity: sha512-s1jcZZhXZpszGZS7LGSdhaEdmD11wBCHdZjaHY19nBypus6yBRUNETiQT9aeXhpHDxMIMOWzhsfd95qWNfKGOw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -12011,13 +11809,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/preferences@4.33.5':
-    resolution: {integrity: sha512-5tPfWv5Kw/+KAfFzsZKojK3FHNDiMVwj8GusXAqbsCSy9YsyAxifaEXeul684RYFdizLK3gWqe4S0K6GaLs0CA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/preferences@4.51.0':
     resolution: {integrity: sha512-JOwER9FIdfllWTZ6gWABN6lrcrMFpYg5YblVzFgdrS/mvA4O4C6yfgsEhC6xN2gbfODtnd49Meo/Df/Ka0983Q==}
@@ -12067,10 +11858,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/priority-queue@3.33.1':
-    resolution: {integrity: sha512-m3S+bfVIGmDHVrCzTdQu5oHP6aBIM0pf5AYVpfdA2addJHLICtAMrPYdD+4MXekh8a38DzPekZa03vGv3ws3zQ==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/priority-queue@3.53.0':
     resolution: {integrity: sha512-HQ5AatN1QWimFHQnhhhzrfgNoiVWTqwhUEv5326hhTnyUxvh5SOYxg46IBGow+zj/VJjIPyaxv1ftuqzVxgRMQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -12102,12 +11889,6 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@wordpress/rich-text@7.33.2':
-    resolution: {integrity: sha512-jy8DPBN6f0WeQM1jL+yGX29xHgzDdyrGoXYEGrGt2ngpGYMca2ZrG9ZLcpQlU6S3sLV/n1jtjZntWrFFYRzgQA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/rich-text@7.53.0':
     resolution: {integrity: sha512-61+P7ht578CcfTePf8sb0/rixIyf4k8fmOn9mvwwmLL8UiIgBhpPzrRJziy8/+Xb4u3grTtl8TGtMI2YHRz41w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -12117,12 +11898,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/route@0.10.0':
-    resolution: {integrity: sha512-rNXo4cq+yPlkFzC/bQjZW8qQpaNgh1nAeUVefc4Si079C79pC0JhnXKqPOq4Iy28oJZyRjfdLdFV1FdLhHfmzA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
 
   '@wordpress/route@0.19.0':
     resolution: {integrity: sha512-I2I0ZiUBaGYLQRzBncFoH+A/DOTP6mjghdnQf4M0FispChaLBGYS1A8x/eCsIIk6wmXhguibxoWw1Cj+1Q2CJg==}
@@ -12206,17 +11981,6 @@ packages:
     resolution: {integrity: sha512-Wr+pV+nxT0KksFxKRXO8H6Wp0NTtnOBDNIY+w/lpkwqpTT5XFGZnHZ5ZiXAIhIxagOpGgpDEe2DQFj6zKfRCsQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/theme@0.11.0':
-    resolution: {integrity: sha512-jXilt+3codfAEFRHvLpnULeOaaycwJByyv+m/TIlspZ4r0l4X9iA1KL7GkXOHz2AJWWvS7FUnS/GHBuIrUgAWg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-      stylelint: '>=16.8.2'
-    peerDependenciesMeta:
-      stylelint:
-        optional: true
-
   '@wordpress/theme@1.2.0':
     resolution: {integrity: sha512-pILS4ytGGiASrpJ8sLp+pRbcBspFYeMTr5LdM4fWBv/EN2CIKhBLpX3qGlXwKzS+HzjrbXZwj60Bfbg/PxvQew==}
     engines: {node: ^20.19.0 || >=22.13.0, npm: '>=10.2.3'}
@@ -12247,13 +12011,6 @@ packages:
   '@wordpress/token-list@3.53.0':
     resolution: {integrity: sha512-C9stporMMXmF8Hha/gDIzeu+NbC0wJJqwGIZKwzpuyijk7xDsYW68yCwCJ/foKOGd8z9/4rvMjwdjwPvgCXHXQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/ui@0.11.0':
-    resolution: {integrity: sha512-V1R3CTQ8MltuajZ53PCHGe9mmRwyx1RpjHA2wWOv+79dV0qQ1Y/psL0YTMY4eteL4SNAlBcjJVP66zD5O6yF8Q==}
-    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/ui@0.18.0':
     resolution: {integrity: sha512-TIMsjaRl5/QJEjKbtoa0YAhzVdcvAk/FmA9rgJVR6oG/l6+s0WgoebGASEVyRyoOstq45xB7PzYMdjVs7iS0zg==}
@@ -12292,13 +12049,6 @@ packages:
     resolution: {integrity: sha512-0MtlfeCa0uFWAGubP2rAJ1NoWQOWOuzW0kTwZgqfFFg81HEgNIBb8LU3eXMbMxERjdZYpCrqUL3MbVPl7ExiGw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/upload-media@0.18.5':
-    resolution: {integrity: sha512-4u+mMPicEuw7tMPIgCtgI5BWckWODjYayA7aOP0sQWdG90Vq1z7nGDlxHeeb/PkQxnZPh+3oA6V79OWV5ZS/Fg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/upload-media@0.36.0':
     resolution: {integrity: sha512-Dl1IIVrSoSuoOBp2vyncgi7lFHJpAac104WR6t66wf0YyCg7xih0XDVneISw1N3ivZ8fEZHXSz2TZ5gz6GmSqQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -12320,10 +12070,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/url@4.33.1':
-    resolution: {integrity: sha512-t4MKPofYLHTIVE+NV36WBmlnzHsnZFkXsACdu/InF0u5pmyc/ZgXmq44qi6h/PmbGoUKnRQisulMIvGfEVBTeA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/url@4.51.0':
     resolution: {integrity: sha512-lPjifvknjTfBl8OSS76jsALotvuSWvb5lE8YKeFJ+zwV09q0ZHgQTeMKHrL47DwMl+PlPhmoLrjHav+KLBwTCA==}
@@ -13158,9 +12904,6 @@ packages:
   clipboard@2.0.11:
     resolution: {integrity: sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==}
 
-  cliui@5.0.0:
-    resolution: {integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==}
-
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -13231,9 +12974,6 @@ packages:
 
   colorjs.io@0.5.2:
     resolution: {integrity: sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==}
-
-  colorjs.io@0.6.1:
-    resolution: {integrity: sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==}
 
   colorjs.io@0.7.1:
     resolution: {integrity: sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==}
@@ -13734,10 +13474,6 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  diff@4.0.4:
-    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
-    engines: {node: '>=0.3.1'}
-
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -13839,9 +13575,6 @@ packages:
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
-  emoji-regex@7.0.3:
-    resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -14468,10 +14201,6 @@ packages:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
 
-  find-up@3.0.0:
-    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
-    engines: {node: '>=6'}
-
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -14709,10 +14438,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  gradient-parser@1.1.1:
-    resolution: {integrity: sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==}
-    engines: {node: '>=0.10.0'}
 
   gradient-parser@1.2.0:
     resolution: {integrity: sha512-6ABGa9CR7WR/0pAJicBy5SJkiikbFM6kf/JjykwX7x+t+s8ORWVnlbi6FkHeFFb36yWsjUpHqSYrygd7ofEUqA==}
@@ -15705,10 +15430,6 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
-  locate-path@3.0.0:
-    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
-    engines: {node: '>=6'}
-
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -16357,10 +16078,6 @@ packages:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  p-locate@3.0.0:
-    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
-    engines: {node: '>=6'}
-
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -16463,10 +16180,6 @@ packages:
 
   path-case@3.0.4:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
-
-  path-exists@3.0.0:
-    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
-    engines: {node: '>=4'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -17728,10 +17441,6 @@ packages:
     resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
-  showdown@1.9.1:
-    resolution: {integrity: sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==}
-    hasBin: true
-
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -17947,10 +17656,6 @@ packages:
   string-width@2.1.1:
     resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
     engines: {node: '>=4'}
-
-  string-width@3.1.0:
-    resolution: {integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==}
-    engines: {node: '>=6'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -18722,11 +18427,6 @@ packages:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
@@ -19021,10 +18721,6 @@ packages:
     resolution: {integrity: sha512-iXR3tDXpbnTpzjKSylUJRkLuOrEC7hwEB221cgn6wtF8wpmz28puFXAEfPT5zrjM3wahygB//VuWEr1vTkDcNQ==}
     engines: {node: '>=4'}
 
-  wrap-ansi@5.1.0:
-    resolution: {integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==}
-    engines: {node: '>=6'}
-
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -19131,9 +18827,6 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yargs-parser@15.0.3:
-    resolution: {integrity: sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==}
-
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -19145,9 +18838,6 @@ packages:
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yargs@14.2.3:
-    resolution: {integrity: sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==}
 
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
@@ -21241,12 +20931,6 @@ snapshots:
       '@floating-ui/core': 1.8.0
       '@floating-ui/utils': 0.2.12
 
-  '@floating-ui/react-dom@2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@floating-ui/dom': 1.8.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   '@floating-ui/react-dom@2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/dom': 1.8.0
@@ -23323,8 +23007,6 @@ snapshots:
 
   '@types/gradient-parser@1.1.0': {}
 
-  '@types/highlight-words-core@1.2.1': {}
-
   '@types/highlight-words-core@1.2.3': {}
 
   '@types/hoist-non-react-statics@3.3.7(@types/react@18.3.28)':
@@ -24147,37 +23829,37 @@ snapshots:
 
   '@woocommerce/email-editor@2.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)':
     dependencies:
-      '@wordpress/api-fetch': 7.33.1
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/block-library': 9.33.10(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/blocks': 15.6.3(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/commands': 1.33.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.1(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/core-data': 7.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.33.1(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/data-controls': 4.33.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/dom-ready': 4.33.1
-      '@wordpress/editor': 14.33.11(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.33.1
-      '@wordpress/format-library': 5.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/api-fetch': 7.51.0
+      '@wordpress/base-styles': 11.0.0
+      '@wordpress/block-editor': 16.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/block-library': 10.2.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.24.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/commands': 1.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 37.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 8.6.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/core-data': 7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data-controls': 4.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/dom-ready': 4.51.0
+      '@wordpress/editor': 14.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 8.3.0
+      '@wordpress/format-library': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/global-styles-engine': 1.20.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/hooks': 4.33.1
-      '@wordpress/html-entities': 4.33.1
-      '@wordpress/i18n': 6.6.1
-      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/interface': 9.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.33.1
-      '@wordpress/keyboard-shortcuts': 5.33.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keycodes': 4.33.1
-      '@wordpress/notices': 5.33.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/plugins': 7.33.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/preferences': 4.33.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/priority-queue': 3.33.1
+      '@wordpress/hooks': 4.51.0
+      '@wordpress/html-entities': 4.51.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 15.4.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/interface': 9.38.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.53.0
+      '@wordpress/keyboard-shortcuts': 5.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
+      '@wordpress/notices': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/plugins': 7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/preferences': 4.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/priority-queue': 3.53.0
       '@wordpress/private-apis': 1.53.0
-      '@wordpress/rich-text': 7.33.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.33.1
+      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.51.0
       clsx: 2.1.1
       deepmerge: 4.3.1
       lodash: 4.18.1
@@ -24199,27 +23881,6 @@ snapshots:
     dependencies:
       '@wordpress/dom-ready': 4.53.0
       '@wordpress/i18n': 6.26.0
-
-  '@wordpress/admin-ui@1.12.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/base-styles': 6.20.0
-      '@wordpress/components': 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/route': 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/ui': 0.11.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - date-fns
-      - react-dom
-      - stylelint
-      - supports-color
 
   '@wordpress/admin-ui@2.8.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -24365,11 +24026,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/api-fetch@7.33.1':
-    dependencies:
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/url': 4.51.0
-
   '@wordpress/api-fetch@7.51.0':
     dependencies:
       '@wordpress/i18n': 6.24.0
@@ -24410,80 +24066,11 @@ snapshots:
 
   '@wordpress/base-styles@12.1.0': {}
 
-  '@wordpress/base-styles@6.20.0': {}
-
-  '@wordpress/base-styles@6.9.1': {}
-
   '@wordpress/base-styles@9.1.0': {}
 
   '@wordpress/blob@4.51.0': {}
 
   '@wordpress/blob@4.53.0': {}
-
-  '@wordpress/block-editor@15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
-      '@react-spring/web': 9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/a11y': 4.53.0
-      '@wordpress/api-fetch': 7.51.0
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/blob': 4.51.0
-      '@wordpress/block-serialization-default-parser': 5.51.0
-      '@wordpress/blocks': 15.24.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/commands': 1.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/date': 5.51.0
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/dom': 4.51.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/escape-html': 3.51.0
-      '@wordpress/hooks': 4.51.0
-      '@wordpress/html-entities': 4.51.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/interactivity': 6.51.0
-      '@wordpress/is-shallow-equal': 5.53.0
-      '@wordpress/keyboard-shortcuts': 5.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
-      '@wordpress/notices': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/preferences': 4.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/priority-queue': 3.53.0
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/style-engine': 2.53.0(@types/react@18.3.28)
-      '@wordpress/token-list': 3.51.0
-      '@wordpress/upload-media': 0.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.51.0
-      '@wordpress/warning': 3.53.0
-      '@wordpress/wordcount': 4.51.0
-      change-case: 4.1.2
-      clsx: 2.1.1
-      colord: 2.9.3
-      deepmerge: 4.3.1
-      diff: 4.0.4
-      fast-deep-equal: 3.1.3
-      memize: 2.1.1
-      parsel-js: 1.2.3
-      postcss: 8.5.23
-      postcss-prefix-selector: 1.16.1(postcss@8.5.23)
-      postcss-urlrebase: 1.4.0(postcss@8.5.23)
-      react: 18.3.1
-      react-autosize-textarea: 7.1.0(patch_hash=5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      react-easy-crop: 5.5.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      remove-accents: 0.5.0
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - stylelint
-      - supports-color
-      - vite
 
   '@wordpress/block-editor@16.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -25425,66 +25012,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/block-library@9.33.10(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/a11y': 4.53.0
-      '@wordpress/api-fetch': 7.51.0
-      '@wordpress/autop': 4.53.0
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/blob': 4.51.0
-      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/blocks': 15.24.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/core-data': 7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/date': 5.51.0
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/dom': 4.51.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/escape-html': 3.51.0
-      '@wordpress/hooks': 4.51.0
-      '@wordpress/html-entities': 4.51.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/interactivity': 6.51.0
-      '@wordpress/interactivity-router': 2.51.0
-      '@wordpress/keyboard-shortcuts': 5.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
-      '@wordpress/latex-to-mathml': 1.19.0
-      '@wordpress/notices': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/patterns': 2.53.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/reusable-blocks': 5.53.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/server-side-render': 6.27.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.51.0
-      '@wordpress/viewport': 6.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/wordcount': 4.51.0
-      change-case: 4.1.2
-      clsx: 2.1.1
-      colord: 2.9.3
-      escape-html: 1.0.3
-      fast-average-color: 9.5.2
-      fast-deep-equal: 3.1.3
-      memize: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      remove-accents: 0.5.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - date-fns
-      - esbuild
-      - postcss
-      - stylelint
-      - supports-color
-      - vite
-
   '@wordpress/block-serialization-default-parser@5.51.0': {}
 
   '@wordpress/block-serialization-default-parser@5.53.0': {}
@@ -25626,40 +25153,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
     transitivePeerDependencies:
-      - '@types/react-dom'
-      - react-dom
-
-  '@wordpress/blocks@15.6.3(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/autop': 4.53.0
-      '@wordpress/blob': 4.51.0
-      '@wordpress/block-serialization-default-parser': 5.51.0
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/dom': 4.51.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/hooks': 4.51.0
-      '@wordpress/html-entities': 4.51.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/is-shallow-equal': 5.53.0
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/shortcode': 4.53.0
-      '@wordpress/warning': 3.53.0
-      change-case: 4.1.2
-      colord: 2.9.3
-      fast-deep-equal: 3.1.3
-      hpq: 1.4.0
-      is-plain-object: 5.0.0
-      memize: 2.1.1
-      react: 18.3.1
-      react-is: 18.3.1
-      remove-accents: 0.5.0
-      showdown: 1.9.1
-      simple-html-tokenizer: 0.5.11
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@types/react'
       - '@types/react-dom'
       - react-dom
 
@@ -26067,26 +25560,6 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/commands@1.33.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.53.0
-      clsx: 2.1.1
-      cmdk: 1.1.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
-
   '@wordpress/commands@1.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/base-styles': 11.0.0
@@ -26417,177 +25890,6 @@ snapshots:
       - stylelint
       - supports-color
       - vite
-
-  '@wordpress/components@30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@emotion/cache': 11.14.0
-      '@emotion/css': 11.13.5
-      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
-      '@emotion/serialize': 1.3.3
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
-      '@emotion/utils': 1.4.2
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/gradient-parser': 1.1.0
-      '@types/highlight-words-core': 1.2.1
-      '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/a11y': 4.53.0
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/date': 5.51.0
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/dom': 4.51.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/escape-html': 3.51.0
-      '@wordpress/hooks': 4.51.0
-      '@wordpress/html-entities': 4.51.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.53.0
-      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
-      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/warning': 3.53.0
-      change-case: 4.1.2
-      clsx: 2.1.1
-      colord: 2.9.3
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
-      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      gradient-parser: 1.1.1
-      highlight-words-core: 1.2.3
-      is-plain-object: 5.0.0
-      memize: 2.1.1
-      path-to-regexp: 6.3.0
-      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-day-picker: 9.14.0(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      remove-accents: 0.5.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
-
-  '@wordpress/components@30.9.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@date-fns/utc': 2.1.1
-      '@emotion/cache': 11.14.0
-      '@emotion/css': 11.13.5
-      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
-      '@emotion/serialize': 1.3.3
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
-      '@emotion/utils': 1.4.2
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/gradient-parser': 1.1.0
-      '@types/highlight-words-core': 1.2.1
-      '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/a11y': 4.53.0
-      '@wordpress/base-styles': 6.20.0
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/date': 5.51.0
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/dom': 4.51.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/escape-html': 3.51.0
-      '@wordpress/hooks': 4.51.0
-      '@wordpress/html-entities': 4.51.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 11.8.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.53.0
-      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
-      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/warning': 3.53.0
-      change-case: 4.1.2
-      clsx: 2.1.1
-      colord: 2.9.3
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
-      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      gradient-parser: 1.1.1
-      highlight-words-core: 1.2.3
-      is-plain-object: 5.0.0
-      memize: 2.1.1
-      path-to-regexp: 6.3.0
-      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-day-picker: 9.14.0(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      remove-accents: 0.5.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
-
-  '@wordpress/components@32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@date-fns/utc': 2.1.1
-      '@emotion/cache': 11.14.0
-      '@emotion/css': 11.13.5
-      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
-      '@emotion/serialize': 1.3.3
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
-      '@emotion/utils': 1.4.2
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/gradient-parser': 1.1.0
-      '@types/highlight-words-core': 1.2.1
-      '@types/react': 18.3.28
-      '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/a11y': 4.53.0
-      '@wordpress/base-styles': 6.20.0
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/date': 5.51.0
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/dom': 4.51.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/escape-html': 3.51.0
-      '@wordpress/hooks': 4.51.0
-      '@wordpress/html-entities': 4.51.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.53.0
-      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
-      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/warning': 3.53.0
-      change-case: 4.1.2
-      clsx: 2.1.1
-      colord: 2.9.3
-      csstype: 3.2.3
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
-      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      gradient-parser: 1.1.1
-      highlight-words-core: 1.2.3
-      is-plain-object: 5.0.0
-      memize: 2.1.1
-      path-to-regexp: 6.3.0
-      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-day-picker: 9.14.0(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      remove-accents: 0.5.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react-dom'
-      - supports-color
 
   '@wordpress/components@37.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -27975,24 +27277,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/compose@7.33.1(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      '@types/mousetrap': 1.6.15
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/dom': 4.51.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/is-shallow-equal': 5.53.0
-      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
-      '@wordpress/priority-queue': 3.53.0
-      '@wordpress/undo-manager': 1.53.0
-      change-case: 4.1.2
-      clipboard: 2.0.11
-      mousetrap: 1.6.5
-      react: 18.3.1
-      use-memo-one: 1.1.3(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@wordpress/compose@7.46.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@types/mousetrap': 1.6.15
@@ -28070,41 +27354,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
       - react-dom
-
-  '@wordpress/core-data@7.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/api-fetch': 7.51.0
-      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/blocks': 15.24.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/html-entities': 4.51.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/is-shallow-equal': 5.53.0
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/sync': 1.51.0
-      '@wordpress/undo-manager': 1.53.0
-      '@wordpress/url': 4.51.0
-      '@wordpress/warning': 3.53.0
-      change-case: 4.1.2
-      equivalent-key-map: 0.2.2
-      fast-deep-equal: 3.1.3
-      memize: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - stylelint
-      - supports-color
-      - vite
 
   '@wordpress/core-data@7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -28629,17 +27878,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/data-controls@4.33.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/api-fetch': 7.51.0
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/deprecated': 4.53.0
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react-dom
-
   '@wordpress/data-controls@4.51.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/api-fetch': 7.51.0
@@ -28651,25 +27889,16 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
-  '@wordpress/data@10.33.1(@types/react@18.3.28)(react@18.3.1)':
+  '@wordpress/data-controls@4.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/api-fetch': 7.51.0
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/deprecated': 4.53.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/is-shallow-equal': 5.53.0
-      '@wordpress/priority-queue': 3.53.0
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/redux-routine': 5.53.0(redux@5.0.1)
-      deepmerge: 4.3.1
-      equivalent-key-map: 0.2.2
-      is-plain-object: 5.0.0
-      is-promise: 4.0.0
       react: 18.3.1
-      redux: 5.0.1
-      rememo: 4.0.2
-      use-memo-one: 1.1.3(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
+      - '@types/react-dom'
+      - react-dom
 
   '@wordpress/data@10.51.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -28758,54 +27987,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
       - react-dom
-
-  '@wordpress/dataviews@10.3.0(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/base-styles': 6.20.0
-      '@wordpress/components': 30.9.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/date': 5.51.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 11.8.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
-      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/url': 4.51.0
-      '@wordpress/warning': 3.53.0
-      clsx: 2.1.1
-      colord: 2.9.3
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
-      react: 18.3.1
-      remove-accents: 0.5.0
-    optionalDependencies:
-      '@emotion/cache': 11.14.0
-      '@emotion/css': 11.13.5
-      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
-      '@emotion/utils': 1.4.2
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/hooks': 4.51.0
-      change-case: 4.1.2
-      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      highlight-words-core: 1.2.3
-      is-plain-object: 5.0.0
-      memize: 2.1.1
-      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-day-picker: 9.14.0(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      use-memo-one: 1.1.3(react@18.3.1)
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
 
   '@wordpress/dataviews@17.3.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react@18.3.1)':
     dependencies:
@@ -29524,8 +28705,6 @@ snapshots:
     dependencies:
       '@wordpress/hooks': 4.53.0
 
-  '@wordpress/dom-ready@4.33.1': {}
-
   '@wordpress/dom-ready@4.51.0': {}
 
   '@wordpress/dom-ready@4.53.0': {}
@@ -29692,69 +28871,6 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - date-fns
-      - esbuild
-      - postcss
-      - stylelint
-      - supports-color
-      - vite
-
-  '@wordpress/editor@14.33.11(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/a11y': 4.53.0
-      '@wordpress/api-fetch': 7.51.0
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/blob': 4.51.0
-      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/blocks': 15.24.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/commands': 1.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/core-data': 7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/dataviews': 10.3.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/date': 5.51.0
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/dom': 4.51.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/fields': 0.25.11(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/hooks': 4.51.0
-      '@wordpress/html-entities': 4.51.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/interface': 9.38.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
-      '@wordpress/media-utils': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/notices': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/patterns': 2.53.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/plugins': 7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/preferences': 4.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/reusable-blocks': 5.53.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/server-side-render': 6.27.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.51.0
-      '@wordpress/warning': 3.53.0
-      '@wordpress/wordcount': 4.51.0
-      change-case: 4.1.2
-      client-zip: 2.5.0
-      clsx: 2.1.1
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
-      is-plain-object: 5.0.0
-      memize: 2.1.1
-      react: 18.3.1
-      react-autosize-textarea: 7.1.0(patch_hash=5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      remove-accents: 0.5.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
       - esbuild
       - postcss
       - stylelint
@@ -30345,16 +29461,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/element@6.33.1':
-    dependencies:
-      '@types/react': 18.3.28
-      '@types/react-dom': 18.3.7(@types/react@18.3.28)
-      '@wordpress/escape-html': 3.51.0
-      change-case: 4.1.2
-      is-plain-object: 5.0.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   '@wordpress/element@6.46.0':
     dependencies:
       '@types/react': 18.3.28
@@ -30442,50 +29548,6 @@ snapshots:
     transitivePeerDependencies:
       - eslint-plugin-import-x
       - supports-color
-
-  '@wordpress/fields@0.25.11(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/api-fetch': 7.51.0
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/blob': 4.51.0
-      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/blocks': 15.24.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/core-data': 7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/dataviews': 10.3.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/date': 5.51.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/hooks': 4.51.0
-      '@wordpress/html-entities': 4.51.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/media-utils': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/notices': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/patterns': 2.53.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/router': 1.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.51.0
-      '@wordpress/warning': 3.53.0
-      change-case: 4.1.2
-      client-zip: 2.5.0
-      clsx: 2.1.1
-      react: 18.3.1
-      remove-accents: 0.5.0
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - date-fns
-      - esbuild
-      - postcss
-      - react-dom
-      - stylelint
-      - supports-color
-      - vite
 
   '@wordpress/fields@0.43.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30867,20 +29929,22 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/format-library@5.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@wordpress/format-library@5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/a11y': 4.53.0
-      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/base-styles': 11.0.0
+      '@wordpress/block-editor': 16.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 37.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 8.6.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.46.0
+      '@wordpress/element': 8.3.0
       '@wordpress/html-entities': 4.51.0
       '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/icons': 15.4.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/latex-to-mathml': 1.19.0
       '@wordpress/private-apis': 1.53.0
       '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/ui': 0.18.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.51.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -30889,7 +29953,9 @@ snapshots:
       - '@emotion/is-prop-valid'
       - '@types/react'
       - '@types/react-dom'
+      - date-fns
       - esbuild
+      - postcss
       - stylelint
       - supports-color
       - vite
@@ -31199,13 +30265,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
 
-  '@wordpress/hooks@4.33.1': {}
-
   '@wordpress/hooks@4.51.0': {}
 
   '@wordpress/hooks@4.53.0': {}
-
-  '@wordpress/html-entities@4.33.1': {}
 
   '@wordpress/html-entities@4.51.0': {}
 
@@ -31226,45 +30288,11 @@ snapshots:
       gettext-parser: 1.4.0
       tannin: 1.2.0
 
-  '@wordpress/i18n@6.6.1':
-    dependencies:
-      '@tannin/sprintf': 1.3.3
-      '@wordpress/hooks': 4.51.0
-      gettext-parser: 1.4.0
-      memize: 2.1.1
-      tannin: 1.2.0
-
   '@wordpress/icons@10.32.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@wordpress/element': 6.46.0
       '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@wordpress/icons@11.0.1(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      '@wordpress/element': 6.46.0
-      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@wordpress/icons@11.8.0(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      '@wordpress/element': 6.46.0
-      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
-      change-case: 4.1.2
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@wordpress/icons@12.2.0(@types/react@18.3.28)(react@18.3.1)':
-    dependencies:
-      '@wordpress/element': 6.46.0
-      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
-      change-case: 4.1.2
       react: 18.3.1
     transitivePeerDependencies:
       - '@types/react'
@@ -31407,35 +30435,6 @@ snapshots:
       '@preact/signals': 1.3.4(preact@10.29.3)
       '@preact/signals-core': 1.14.4
       preact: 10.29.3
-
-  '@wordpress/interface@9.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/a11y': 4.53.0
-      '@wordpress/admin-ui': 1.12.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/plugins': 7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/preferences': 4.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/viewport': 6.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - date-fns
-      - esbuild
-      - postcss
-      - stylelint
-      - supports-color
-      - vite
 
   '@wordpress/interface@9.38.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31611,8 +30610,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/is-shallow-equal@5.33.1': {}
-
   '@wordpress/is-shallow-equal@5.53.0': {}
 
   '@wordpress/jest-console@8.51.0(jest@30.4.2)':
@@ -31624,17 +30621,6 @@ snapshots:
   '@wordpress/kebab-case@1.0.0':
     dependencies:
       change-case: 4.1.2
-
-  '@wordpress/keyboard-shortcuts@5.33.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.46.0
-      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react-dom
 
   '@wordpress/keyboard-shortcuts@5.53.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31659,10 +30645,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
       - react-dom
-
-  '@wordpress/keycodes@4.33.1':
-    dependencies:
-      '@wordpress/i18n': 6.24.0
 
   '@wordpress/keycodes@4.51.0(@types/react@18.3.28)':
     dependencies:
@@ -32714,16 +31696,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/notices@5.33.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/a11y': 4.53.0
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react-dom
-
   '@wordpress/notices@5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/a11y': 4.53.0
@@ -33241,24 +32213,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/plugins@7.33.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/hooks': 4.51.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.53.0
-      memize: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
-
   '@wordpress/plugins@7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/components': 37.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -33508,27 +32462,6 @@ snapshots:
       - stylelint
       - supports-color
       - vite
-
-  '@wordpress/preferences@4.33.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/a11y': 4.53.0
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/private-apis': 1.53.0
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
 
   '@wordpress/preferences@4.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -33942,10 +32875,6 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
-  '@wordpress/priority-queue@3.33.1':
-    dependencies:
-      requestidlecallback: 0.3.0
-
   '@wordpress/priority-queue@3.53.0':
     dependencies:
       requestidlecallback: 0.3.0
@@ -34164,24 +33093,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/rich-text@7.33.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/a11y': 4.53.0
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/deprecated': 4.53.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/escape-html': 3.51.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
-      colord: 2.9.3
-      memize: 2.1.1
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react-dom
-
   '@wordpress/rich-text@7.53.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/a11y': 4.53.0
@@ -34220,15 +33131,6 @@ snapshots:
       '@types/react': 18.3.28
     transitivePeerDependencies:
       - '@types/react-dom'
-      - react-dom
-
-  '@wordpress/route@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@tanstack/history': 1.162.0
-      '@tanstack/react-router': 1.167.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.53.0
-      react: 18.3.1
-    transitivePeerDependencies:
       - react-dom
 
   '@wordpress/route@0.19.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -34544,15 +33446,6 @@ snapshots:
       y-protocols: 1.0.7(yjs@13.6.29)
       yjs: 13.6.29
 
-  '@wordpress/theme@0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/element': 6.46.0
-      '@wordpress/private-apis': 1.53.0
-      colorjs.io: 0.6.1
-      memize: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   '@wordpress/theme@1.2.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/compose': 8.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -34688,28 +33581,6 @@ snapshots:
   '@wordpress/token-list@3.51.0': {}
 
   '@wordpress/token-list@3.53.0': {}
-
-  '@wordpress/ui@0.11.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@base-ui/react': 1.6.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/a11y': 4.53.0
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
-      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tabbable: 6.5.0
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@types/react'
-      - date-fns
-      - stylelint
 
   '@wordpress/ui@0.18.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -35451,31 +34322,6 @@ snapshots:
     dependencies:
       '@wordpress/is-shallow-equal': 5.53.0
 
-  '@wordpress/upload-media@0.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/api-fetch': 7.51.0
-      '@wordpress/blob': 4.51.0
-      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
-      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.24.0
-      '@wordpress/preferences': 4.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.53.0
-      '@wordpress/url': 4.51.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - postcss
-      - stylelint
-      - supports-color
-      - vite
-
   '@wordpress/upload-media@0.36.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/blob': 4.51.0
@@ -35826,10 +34672,6 @@ snapshots:
       - stylelint
       - supports-color
       - vite
-
-  '@wordpress/url@4.33.1':
-    dependencies:
-      remove-accents: 0.5.0
 
   '@wordpress/url@4.51.0':
     dependencies:
@@ -37005,12 +35847,6 @@ snapshots:
       select: 1.1.2
       tiny-emitter: 2.1.0
 
-  cliui@5.0.0:
-    dependencies:
-      string-width: 3.1.0
-      strip-ansi: 5.2.0
-      wrap-ansi: 5.1.0
-
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
@@ -37097,8 +35933,6 @@ snapshots:
   colord@2.9.3: {}
 
   colorjs.io@0.5.2: {}
-
-  colorjs.io@0.6.1: {}
 
   colorjs.io@0.7.1: {}
 
@@ -37581,8 +36415,6 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff@4.0.4: {}
-
   diff@8.0.4: {}
 
   dns-packet@5.6.1:
@@ -37678,8 +36510,6 @@ snapshots:
   emittery@0.13.1: {}
 
   emoji-regex@10.6.0: {}
-
-  emoji-regex@7.0.3: {}
 
   emoji-regex@8.0.0: {}
 
@@ -38489,10 +37319,6 @@ snapshots:
 
   find-up-simple@1.0.1: {}
 
-  find-up@3.0.0:
-    dependencies:
-      locate-path: 3.0.0
-
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -38719,8 +37545,6 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
-
-  gradient-parser@1.1.1: {}
 
   gradient-parser@1.2.0: {}
 
@@ -39932,11 +38756,6 @@ snapshots:
 
   locate-character@3.0.0: {}
 
-  locate-path@3.0.0:
-    dependencies:
-      p-locate: 3.0.0
-      path-exists: 3.0.0
-
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -40811,10 +39630,6 @@ snapshots:
     dependencies:
       yocto-queue: 1.2.2
 
-  p-locate@3.0.0:
-    dependencies:
-      p-limit: 2.3.0
-
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -40924,8 +39739,6 @@ snapshots:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.8.1
-
-  path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
 
@@ -42230,10 +41043,6 @@ snapshots:
 
   shell-quote@1.9.0: {}
 
-  showdown@1.9.1:
-    dependencies:
-      yargs: 14.2.3
-
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -42502,12 +41311,6 @@ snapshots:
     dependencies:
       is-fullwidth-code-point: 2.0.0
       strip-ansi: 4.0.0
-
-  string-width@3.1.0:
-    dependencies:
-      emoji-regex: 7.0.3
-      is-fullwidth-code-point: 2.0.0
-      strip-ansi: 5.2.0
 
   string-width@4.2.3:
     dependencies:
@@ -43360,8 +42163,6 @@ snapshots:
 
   uuid@14.0.1: {}
 
-  uuid@9.0.1: {}
-
   v8-to-istanbul@9.3.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -43788,12 +42589,6 @@ snapshots:
       string-width: 2.1.1
       strip-ansi: 4.0.0
 
-  wrap-ansi@5.1.0:
-    dependencies:
-      ansi-styles: 3.2.1
-      string-width: 3.1.0
-      strip-ansi: 5.2.0
-
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -43873,11 +42668,6 @@ snapshots:
 
   yaml@2.8.3: {}
 
-  yargs-parser@15.0.3:
-    dependencies:
-      camelcase: 5.3.1
-      decamelize: 1.2.0
-
   yargs-parser@18.1.3:
     dependencies:
       camelcase: 5.3.1
@@ -43886,20 +42676,6 @@ snapshots:
   yargs-parser@21.1.1: {}
 
   yargs-parser@22.0.0: {}
-
-  yargs@14.2.3:
-    dependencies:
-      cliui: 5.0.0
-      decamelize: 1.2.0
-      find-up: 3.0.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      require-main-filename: 2.0.0
-      set-blocking: 2.0.0
-      string-width: 3.1.0
-      which-module: 2.0.1
-      y18n: 4.0.3
-      yargs-parser: 15.0.3
 
   yargs@15.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-rh/uvB0R915w5qLI7cYE9XupWMkkGydcRrarI6df2vk=
+pnpmfileChecksum: sha256-8LKvMzuEiqj9w4Gpefasr2wM/yBuOzMqzF6ewnRzQfU=
 
 patchedDependencies:
   '@wordpress/build': 151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+overrides:
+  date-fns@^3.6.0: ^4.1.0
+
 pnpmfileChecksum: sha256-Koac67WaJpuLyJalTUuFaNmp0WUcSQVOu5ejcFHnxKQ=
 
 patchedDependencies:
@@ -5866,6 +5869,9 @@ importers:
       '@visx/xychart':
         specifier: 4.0.0
         version: 4.0.0(@react-spring/web@10.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@woocommerce/email-editor':
+        specifier: 2.4.0
+        version: 2.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)
       '@wordpress/a11y':
         specifier: 4.53.0
         version: 4.53.0
@@ -6056,6 +6062,9 @@ importers:
         specifier: 7.2.1
         version: 7.2.1(webpack@5.107.2)
     devDependencies:
+      '@automattic/babel-plugin-replace-textdomain':
+        specifier: workspace:*
+        version: link:../../js-packages/babel-plugin-replace-textdomain
       '@automattic/color-studio':
         specifier: 4.1.0
         version: 4.1.0
@@ -8465,6 +8474,12 @@ packages:
   '@floating-ui/dom@1.8.0':
     resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
+  '@floating-ui/react-dom@2.0.8':
+    resolution: {integrity: sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/react-dom@2.1.9':
     resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
     peerDependencies:
@@ -10404,6 +10419,9 @@ packages:
   '@types/gradient-parser@1.1.0':
     resolution: {integrity: sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==}
 
+  '@types/highlight-words-core@1.2.1':
+    resolution: {integrity: sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA==}
+
   '@types/highlight-words-core@1.2.3':
     resolution: {integrity: sha512-PWNU/NR0CaYEsK38mcCTyDzeS2TlEGK9kRhRMz1i86jVAe836ZlA3gl6QYpu+CG6IpfNKTgWpEnJuRededvC0g==}
 
@@ -11090,9 +11108,18 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  '@woocommerce/email-editor@2.4.0':
+    resolution: {integrity: sha512-1EF0SoSc3rzJIBmjCZp19j3wbkiTVrrn2Dhuo6j6zagPYShl3XI5LWWSMIbx0m/Fnu1Mus4kcAzvKoZFtSg6bQ==}
+
   '@wordpress/a11y@4.53.0':
     resolution: {integrity: sha512-m6/45U8Fhr2LyQiBinHDBEF/iFnMSbSh3vdjb4GPjIjujvomktUKknjedoUWEvJFRsR6UVjIrnRIGcZAznjUhg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/admin-ui@1.12.0':
+    resolution: {integrity: sha512-CVTvE2jLTP71vBliAhOrvlMoOG1o1TdyoCL5gmw0Uswuj/qhqK3f1Y1adz7hAWiR9o7H9SoPYf+qg6pbZJVyaQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/admin-ui@2.8.0':
     resolution: {integrity: sha512-lYBaKVEhzXCL1+4voIgejDPpKqw8XkALN/E9uuuQzix1SnaJXVQ6+QRLwF6nh5EiUHyb7zh6ieEHJW01OZjHLA==}
@@ -11103,6 +11130,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/api-fetch@7.33.1':
+    resolution: {integrity: sha512-kxk7Og2CZLOMUZtDfOXSGapem4ToP15JB24PfixJLS0dKfrlUBci4ShjJ3z3jdIx01gf1gfP4NFjqzicJKb+Rg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/api-fetch@7.51.0':
     resolution: {integrity: sha512-kSgBvrGr8eMTcQTA1fIsChg56FKPTdcmkQrpEQjL9uzbmGwPKrru4BdkBFqLSql/PH5fEOjNcY3OSA61+WrJ8g==}
@@ -11138,6 +11169,14 @@ packages:
     resolution: {integrity: sha512-B8Ab7dU574B1lNtjnTolO340nnW+WeaztR4RFpoL6tyqWrvDU1hK6xcjQnuNtQYJc2ngH/MO/rZOVFaFa7HFxw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/base-styles@6.20.0':
+    resolution: {integrity: sha512-Dsug4Zxz2xOFtK6CGThKYXwCqC9Yztw2STKQzwztrX4yW+o6iDbzkxpcwdDhsaVJs0Jt9A4LmJpZPh+pUozzLA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/base-styles@6.9.1':
+    resolution: {integrity: sha512-UCtTANAdym5jpTEZS17WHrKLu7R52gQRgKuwsRm5uZWUb4g4Vq8NX52CBIesF1viFyKfM++HpmteFkrL7p0SMg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/base-styles@9.1.0':
     resolution: {integrity: sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11149,6 +11188,13 @@ packages:
   '@wordpress/blob@4.53.0':
     resolution: {integrity: sha512-O6px43M9k/6UYtKm0f3MAcz0sMwMPqf2caWzlZb9gG6D5gsz2VIIPmMioCdlGHuYZ6jUoOfY0yaPFPDT9J9ihA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/block-editor@15.6.9':
+    resolution: {integrity: sha512-X5S7oWsTCpNIUHbsx/ZMN+2AXnILn3EeotUWAj8DsHtFFgfiDnbo2kKPaWANgGtHJ+GNWZPr0RUyS9Gmtdwn1A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@wordpress/block-editor@16.0.0':
     resolution: {integrity: sha512-hH7w5gbgjwsYLPTw1JFqNTtEe+O2kHvbzoht4g5sUHGThKR7NrVMHuLnNS7iOcz+k1VZpVRjXrWJlBsEj2en2g==}
@@ -11183,6 +11229,13 @@ packages:
       '@types/react':
         optional: true
 
+  '@wordpress/block-library@9.33.10':
+    resolution: {integrity: sha512-9qrBXTc1BR539L78KuMCZ7PHt4US822NSKKVNcgVTkPH2qHyUDvr6t680HRHCI7VYWq1NXp9teZo7PEZNVfhVA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/block-serialization-default-parser@5.51.0':
     resolution: {integrity: sha512-zcuJptrIG7VWP3N7uw3ACBS5Mdykhy3zAxZ+dMym8291b2O+dJf1JVlnr65G4AYhxahWA5MsmLENBLhwBgOH8w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11210,6 +11263,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/blocks@15.6.3':
+    resolution: {integrity: sha512-AFYre+06ZVtyv0KSVwCOUY+HSEdAaQRxFrRZnSsZ5FEs0pMMIsulFYay8QvlVVTtBUKbYlxKEDi8kD1DI+8jxA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/boot@0.20.0':
     resolution: {integrity: sha512-kGrDNIXyudEoViTy/HgApL+WqW5QsPnVcu5CVT8L8RolgsztKFHuHqmMwDadtfp2rTH1bmL6wz4NHLD9V19WmA==}
@@ -11245,6 +11304,13 @@ packages:
       '@wordpress/theme':
         optional: true
 
+  '@wordpress/commands@1.33.5':
+    resolution: {integrity: sha512-m8a/9ahGzEVYj77EfS6crzjq2Gq97DOXbeSqRSHrpePE/NSXPh6AAABRP/dKCI/0AysjJ0v/bKKTVnsFgkk0YA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/commands@1.51.0':
     resolution: {integrity: sha512-qn38b/rl1W84IHmcc9KOLSOmuXDwBMYcD7uPUKCChziy/NCb3e7njQzklKgK5sBC3JcgZrl1V5C605ejofd7lQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11258,6 +11324,27 @@ packages:
     peerDependencies:
       react: ^18 || ^19
       react-dom: ^18 || ^19
+
+  '@wordpress/components@30.6.5':
+    resolution: {integrity: sha512-jSDpUz1BBQvpWUGwqZUlI22PMGMtiN5ooKS4GlQqjUmEBJH4llwiRblkZBKgdznv+5KDYyDiRNIGCz/hLSdwZw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@wordpress/components@30.9.0':
+    resolution: {integrity: sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@wordpress/components@32.6.0':
+    resolution: {integrity: sha512-MpOr0mGTkKDRjxK5LKm86Uoj9p9Z6KkrvhkNVi5zVKCftyHVMK+tun7wL2Qn/JZVLbxZpB1kW5sJ5aMf3T2ToA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@wordpress/components@37.0.0':
     resolution: {integrity: sha512-Lol3iUujNnn4uHxI4VARDVEJIFUKlBtZUMcSFWofiYRZc8aV5BplyKC+sRAhKm+KFNBQjZtqd4PdixtaOHuX6w==}
@@ -11292,6 +11379,12 @@ packages:
       '@types/react':
         optional: true
 
+  '@wordpress/compose@7.33.1':
+    resolution: {integrity: sha512-1satS+7EKlzZOCR++uP8mAy3BJPKX2eeTZHVW3669n0xM1xdmzl9JXyEbtEqaFVYhI3dHTq5kLwrm+aSpn0zag==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/compose@7.46.0':
     resolution: {integrity: sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11307,6 +11400,13 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/core-data@7.33.9':
+    resolution: {integrity: sha512-1tYiHamRDvopG9cLFTR+SdUKroTLQRof25vquI5OlXEzBgRmn/ksWlOKM6nFxGUBK6JmdlczBoa0QhBJdXBK0Q==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@wordpress/core-data@7.51.0':
     resolution: {integrity: sha512-5B6eouukuJD+F8FYXYE/E+5oE3kLFpBhaXn0shDWeohT/elvjc1ra7x+KFNM2iWQHJ4ftO5nEkVfh923mmyRRA==}
@@ -11330,11 +11430,23 @@ packages:
       '@types/react':
         optional: true
 
+  '@wordpress/data-controls@4.33.1':
+    resolution: {integrity: sha512-+gD47q6WuZ2MYMxwUBwBTYACMayrZoyG6W6OR1Q2ggOfkmoQb4OlxEWJPdCIC8GxJJwVh8ej9HjzzI3S/tDsJg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/data-controls@4.51.0':
     resolution: {integrity: sha512-ZcuCLaJPAczEp0pXzU4HPSa9ILttUXqb4+3azFaa9YLH5Cn6apImTqsqUQp+flF6TMDhtuJp3vfmOg4eXAd0CA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18 || ^19
+
+  '@wordpress/data@10.33.1':
+    resolution: {integrity: sha512-Y+GlNYFds2ICgkAfwT3UsLCXlagibtUFADBf/UXmTgEvc07/O/lOBHeIW72BiRkb/O4oCqf2ZeXgGkNgJLlyiQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/data@10.51.0':
     resolution: {integrity: sha512-KwlrgU+PGd+l4QyrwuCvbHE5HUC1CU6pqD19WZr+yOD1XRmIWZ+LZNwrEdFlhCu8aOG9+e131k1zmAMZign/mA==}
@@ -11349,6 +11461,12 @@ packages:
     peerDependencies:
       '@types/react': ^18 || ^19
       react: ^18 || ^19
+
+  '@wordpress/dataviews@10.3.0':
+    resolution: {integrity: sha512-7mBcW4Vris+8Be3ESUPkhe85AwAbwO+2ocvi4UDF6jEzeyH7GQxq+1k4Lq4vAc+pNBf0IehZV598+qs8nk9j2w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/dataviews@17.3.0':
     resolution: {integrity: sha512-9U50IPnaYWUbkdVl2J2eRkkT0x83nGxmsVkkNVBSGQFpnWHhCAN7TqZOOSVYM+ppMBQnVwDhml6URIc4iejZ8A==}
@@ -11389,6 +11507,10 @@ packages:
     resolution: {integrity: sha512-JaIWiGVoKEmsiWP4XwAZvrET44T34EtPG+xCJe9vPIs9O3DHPyB83VHV4WxVRxddaf1osTmR6iPLx0sBvVTjZw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/dom-ready@4.33.1':
+    resolution: {integrity: sha512-jrHN/arTKp2iuYj24byFgabBhZsZ3WUXCSKT16d/1MZUXGQt876XXu6r5rwpLtnVsX2gFiZ/DzdRKCL4RV9Wpg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/dom-ready@4.51.0':
     resolution: {integrity: sha512-O/ivmzG+o44CicTW+c17KBXlmjRoVp4VGIyyEQDD52H5YH+gX7i15FuEPk6G2e7Rqz4DCvCS5yD7eY9Zb3z1WA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11419,6 +11541,13 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
+  '@wordpress/editor@14.33.11':
+    resolution: {integrity: sha512-yGSMcsya/9OADD+xgfewVwnHvRUpMsKGh865WkWm2uy0XbCap5IoDMNeKgsM/nYXrCy8y5sbO4b9bzDUhHcsdA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/editor@14.51.0':
     resolution: {integrity: sha512-R5t60Ule+C23HCKS5ltfRHUEuR86xixscU4eAjFPkL0rNSABvbjd8JFL+3x7mPinEHnEKIphTeSxqmiioFrfyg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11440,6 +11569,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/element@6.33.1':
+    resolution: {integrity: sha512-8Y2TEkduT1cAGVfh5HoERpJIVvCcfHI1k+PGgG3wzy85me6hjgA/P7l90yBt/9i9Omt5+buGfnklobstECR8zg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/element@6.46.0':
     resolution: {integrity: sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==}
@@ -11495,6 +11628,12 @@ packages:
       typescript:
         optional: true
 
+  '@wordpress/fields@0.25.11':
+    resolution: {integrity: sha512-jNNG14L0FWUif95kVUVm53mT4ItOBm3yN9I2mElm/aznHZh3rheRJ96vT2nyTuJ1/J79Xt2DerqkvcWP4R6R3Q==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/fields@0.43.0':
     resolution: {integrity: sha512-Syc3ims41sZ9AWTIq0BTtpodbC3Pw1ZUatRDHGWHj7wK/ayDxIR9Aru99Zg9FF9fbqbNMHWieM3wF3RRD1NkVQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11514,6 +11653,13 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/format-library@5.33.9':
+    resolution: {integrity: sha512-9RTyCFuaXSSF4Rz4rnz0Elge71nSn7UWyvskMQtZNN5nMGjH9D5NK5JoYKANpt1v0Cx/vfUkLTywBrU0v2+pLA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@wordpress/format-library@5.51.0':
     resolution: {integrity: sha512-IMu8nU18MokIfPz+qWUlwcMLnAGqm06bWjSy2jyG5KSCi0GYYqf0iQhjpRhcxCOLxw8QvjtPn3vyaJE4E0eQWw==}
@@ -11548,12 +11694,20 @@ packages:
       '@types/react':
         optional: true
 
+  '@wordpress/hooks@4.33.1':
+    resolution: {integrity: sha512-p9RbNsZJnsGY45MEV3QfYHS4dMmKe0B1f/RUXEL8ZLa36aUWZrUX7PJxvmmpeuPrboHQwT4MDps9kwHO4V6GVg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/hooks@4.51.0':
     resolution: {integrity: sha512-pTVZRT9mjEdrNNt7TyKw5hQhFUqntfTXVs/fboEDpmAi+PFWXoD8rPs3oZyRCVr/MDyE6OCv1mwEibI6AsRk3Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/hooks@4.53.0':
     resolution: {integrity: sha512-YU30rweJCTu5g7X8bc+w6QyoxJBYLEHH++Wwo/IbbROHUC/4I7e+ZtxnPWls8BTtMP4d28JJ74s+UoKpzd2J7w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/html-entities@4.33.1':
+    resolution: {integrity: sha512-HdpnRRvTMstX58U4Yr+UisIrFLcG97PGegAczMxeq9Q1n3ol5FCkEegBTQIJffAZ5IadBsPZ77fjoVtLK7RViQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/html-entities@4.51.0':
@@ -11574,11 +11728,34 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
+  '@wordpress/i18n@6.6.1':
+    resolution: {integrity: sha512-aEFSF+5dp0UhdMGHyNUwhcL0Sg/kp0NtCSMrfcQrXRM6uD/+y8ih0mHeULww5V919NUrzXIZSZGfOaOIiQVXXg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    hasBin: true
+
   '@wordpress/icons@10.32.0':
     resolution: {integrity: sha512-1WvJdT361X1LnetYBpBWUjAVXZzl+pBdIwHbYRAp8ej47EI/igPmNxmq81nFd40s8fer/9qtipielcqSI6H2rA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18
+
+  '@wordpress/icons@11.0.1':
+    resolution: {integrity: sha512-vXkWiAxwDjWBcj72oXbJyuDtIvNvk1JnnmYzQUpIjKjvScRPcj+Kt40nFYk/5kPnNAhBqVNcZ7tWK7NctSslJA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18
+
+  '@wordpress/icons@11.8.0':
+    resolution: {integrity: sha512-ZMNHApHMmPLpNnNLfPLRf6XWoPhZFNKFKdpMlhA6Lx04J1hLVyLRz8PuM+1o3ByxD2ZiExfSRhdmI+7VvEg6DA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@wordpress/icons@12.2.0':
+    resolution: {integrity: sha512-Fiw7bmfHDNPjTdCrBF23/9K0VN/GUi73d2ZPZaeWdXhTmIX62T9KYvb1c+WnlBkX7GpXgJO6Q8mypQCY9mw5SQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/icons@13.3.0':
     resolution: {integrity: sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==}
@@ -11619,12 +11796,23 @@ packages:
     resolution: {integrity: sha512-dYH2cstn/+3JewRu4rldyifijfTzvnmcAbjs7Z4mcBVnP22Ags4IE3aztpc++A0AXugfx5D4hA2PdqasGmrs2g==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/interface@9.18.5':
+    resolution: {integrity: sha512-OCNCTogPS/kHPVjIAHtQ2y9WaX1fm1oK1cXQs6RezKtO1y/+nFH2L5pjzF7ifG1ECe5KL7REX4kJXgDTIwDV9g==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/interface@9.38.0':
     resolution: {integrity: sha512-SxoxXuyfI614mp2e7K+nTWP7UQ1RLpbocrocWGD9ZXYdP5nh2Ix1KSv8m05agCMPIDpC20+yMwkZIc1Du4Auvw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18 || ^19
       react-dom: ^18 || ^19
+
+  '@wordpress/is-shallow-equal@5.33.1':
+    resolution: {integrity: sha512-QMOwATwFjFr6Z9geS8EjuEVGN0gkpANypjqIBE8iTDtfKhY99LTtxbTaguviqKfVP7l73v1B0GJfHtkPExhJkA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/is-shallow-equal@5.53.0':
     resolution: {integrity: sha512-NHhvEnqi82Vzon458Jz6nzmbAPWM1zy9k6rBXQTc+9PsRiWHWpqXqldKAeTFVrl0vspZf4PwmLlsxqP3ckCLWw==}
@@ -11640,6 +11828,12 @@ packages:
     resolution: {integrity: sha512-Ep7dCpM9B1PiP2WZyjI5dFnJJbTZA6melU/hu5tnvYBtzOdywqSjH4mtOsBY3CtQ0uJ5fQvFAP3tHuh6Si7Bsw==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
 
+  '@wordpress/keyboard-shortcuts@5.33.1':
+    resolution: {integrity: sha512-ql+qQ+AW9rnaS6jBv3J5MT8ku0qijAYCq6rIvfEiA1W84i5+LB9JYxxzrFH8v5uGU4ZjqqRQEmcDd+lorlT4Vg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/keyboard-shortcuts@5.53.0':
     resolution: {integrity: sha512-PDrZtEPACD1V0SM4fVM5dmgGBawZwglwurrnJJ7OtdSzbI4bTjT9LHOMwvv7i0Pz8kbOL9+gAif/dvDxBbQdRQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11649,6 +11843,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/keycodes@4.33.1':
+    resolution: {integrity: sha512-acuH0ogiY92ClslUpezZyEzfm1Ubx2bftevn/PxbsVq52UCOu14CAKgnO9sYqVuMpXT+zXveRMySixyKHB1wnA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/keycodes@4.51.0':
     resolution: {integrity: sha512-C9CZq2WCWVacjsHhFgM0GVIQmTUxo/oX7U+Qj0kr3vWHZu6cmEDJ94PX+f02M3b+iHnCk4oHCvnXGANwKQwsSw==}
@@ -11752,6 +11950,12 @@ packages:
       '@types/react':
         optional: true
 
+  '@wordpress/notices@5.33.1':
+    resolution: {integrity: sha512-bvw97KGiToFZv9/EHPhom2va7pDXCUR2BNfSuxT3lSAt1tX5DUD5i1+6aa5TIybSAtZNGisCySH4fL/paMDMjQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/notices@5.51.0':
     resolution: {integrity: sha512-mOOPEnjmkvscs4gNEYNiowsSF371HnO5euFOmBRIcnuRjn/dW7VqUfGXUbsu3HGXqjMBWBWPW0hzEjaatEVhGA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11779,6 +11983,13 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
+  '@wordpress/plugins@7.33.5':
+    resolution: {integrity: sha512-kTNhyX1FKTSWBmxfHWoqEo5+iM96ThHXGqFGzeAFt+W35EeHzt9a/H++9yfcxMqDyjR1IRjoB261bX+oLPuw9Q==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/plugins@7.51.0':
     resolution: {integrity: sha512-s1jcZZhXZpszGZS7LGSdhaEdmD11wBCHdZjaHY19nBypus6yBRUNETiQT9aeXhpHDxMIMOWzhsfd95qWNfKGOw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11800,6 +12011,13 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/preferences@4.33.5':
+    resolution: {integrity: sha512-5tPfWv5Kw/+KAfFzsZKojK3FHNDiMVwj8GusXAqbsCSy9YsyAxifaEXeul684RYFdizLK3gWqe4S0K6GaLs0CA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@wordpress/preferences@4.51.0':
     resolution: {integrity: sha512-JOwER9FIdfllWTZ6gWABN6lrcrMFpYg5YblVzFgdrS/mvA4O4C6yfgsEhC6xN2gbfODtnd49Meo/Df/Ka0983Q==}
@@ -11849,6 +12067,10 @@ packages:
       '@types/react':
         optional: true
 
+  '@wordpress/priority-queue@3.33.1':
+    resolution: {integrity: sha512-m3S+bfVIGmDHVrCzTdQu5oHP6aBIM0pf5AYVpfdA2addJHLICtAMrPYdD+4MXekh8a38DzPekZa03vGv3ws3zQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/priority-queue@3.53.0':
     resolution: {integrity: sha512-HQ5AatN1QWimFHQnhhhzrfgNoiVWTqwhUEv5326hhTnyUxvh5SOYxg46IBGow+zj/VJjIPyaxv1ftuqzVxgRMQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11880,6 +12102,12 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
+  '@wordpress/rich-text@7.33.2':
+    resolution: {integrity: sha512-jy8DPBN6f0WeQM1jL+yGX29xHgzDdyrGoXYEGrGt2ngpGYMca2ZrG9ZLcpQlU6S3sLV/n1jtjZntWrFFYRzgQA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/rich-text@7.53.0':
     resolution: {integrity: sha512-61+P7ht578CcfTePf8sb0/rixIyf4k8fmOn9mvwwmLL8UiIgBhpPzrRJziy8/+Xb4u3grTtl8TGtMI2YHRz41w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11889,6 +12117,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/route@0.10.0':
+    resolution: {integrity: sha512-rNXo4cq+yPlkFzC/bQjZW8qQpaNgh1nAeUVefc4Si079C79pC0JhnXKqPOq4Iy28oJZyRjfdLdFV1FdLhHfmzA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/route@0.19.0':
     resolution: {integrity: sha512-I2I0ZiUBaGYLQRzBncFoH+A/DOTP6mjghdnQf4M0FispChaLBGYS1A8x/eCsIIk6wmXhguibxoWw1Cj+1Q2CJg==}
@@ -11972,6 +12206,17 @@ packages:
     resolution: {integrity: sha512-Wr+pV+nxT0KksFxKRXO8H6Wp0NTtnOBDNIY+w/lpkwqpTT5XFGZnHZ5ZiXAIhIxagOpGgpDEe2DQFj6zKfRCsQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/theme@0.11.0':
+    resolution: {integrity: sha512-jXilt+3codfAEFRHvLpnULeOaaycwJByyv+m/TIlspZ4r0l4X9iA1KL7GkXOHz2AJWWvS7FUnS/GHBuIrUgAWg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+      stylelint: '>=16.8.2'
+    peerDependenciesMeta:
+      stylelint:
+        optional: true
+
   '@wordpress/theme@1.2.0':
     resolution: {integrity: sha512-pILS4ytGGiASrpJ8sLp+pRbcBspFYeMTr5LdM4fWBv/EN2CIKhBLpX3qGlXwKzS+HzjrbXZwj60Bfbg/PxvQew==}
     engines: {node: ^20.19.0 || >=22.13.0, npm: '>=10.2.3'}
@@ -12002,6 +12247,13 @@ packages:
   '@wordpress/token-list@3.53.0':
     resolution: {integrity: sha512-C9stporMMXmF8Hha/gDIzeu+NbC0wJJqwGIZKwzpuyijk7xDsYW68yCwCJ/foKOGd8z9/4rvMjwdjwPvgCXHXQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/ui@0.11.0':
+    resolution: {integrity: sha512-V1R3CTQ8MltuajZ53PCHGe9mmRwyx1RpjHA2wWOv+79dV0qQ1Y/psL0YTMY4eteL4SNAlBcjJVP66zD5O6yF8Q==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@wordpress/ui@0.18.0':
     resolution: {integrity: sha512-TIMsjaRl5/QJEjKbtoa0YAhzVdcvAk/FmA9rgJVR6oG/l6+s0WgoebGASEVyRyoOstq45xB7PzYMdjVs7iS0zg==}
@@ -12040,6 +12292,13 @@ packages:
     resolution: {integrity: sha512-0MtlfeCa0uFWAGubP2rAJ1NoWQOWOuzW0kTwZgqfFFg81HEgNIBb8LU3eXMbMxERjdZYpCrqUL3MbVPl7ExiGw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/upload-media@0.18.5':
+    resolution: {integrity: sha512-4u+mMPicEuw7tMPIgCtgI5BWckWODjYayA7aOP0sQWdG90Vq1z7nGDlxHeeb/PkQxnZPh+3oA6V79OWV5ZS/Fg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/upload-media@0.36.0':
     resolution: {integrity: sha512-Dl1IIVrSoSuoOBp2vyncgi7lFHJpAac104WR6t66wf0YyCg7xih0XDVneISw1N3ivZ8fEZHXSz2TZ5gz6GmSqQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -12061,6 +12320,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/url@4.33.1':
+    resolution: {integrity: sha512-t4MKPofYLHTIVE+NV36WBmlnzHsnZFkXsACdu/InF0u5pmyc/ZgXmq44qi6h/PmbGoUKnRQisulMIvGfEVBTeA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/url@4.51.0':
     resolution: {integrity: sha512-lPjifvknjTfBl8OSS76jsALotvuSWvb5lE8YKeFJ+zwV09q0ZHgQTeMKHrL47DwMl+PlPhmoLrjHav+KLBwTCA==}
@@ -12895,6 +13158,9 @@ packages:
   clipboard@2.0.11:
     resolution: {integrity: sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==}
 
+  cliui@5.0.0:
+    resolution: {integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==}
+
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -12965,6 +13231,9 @@ packages:
 
   colorjs.io@0.5.2:
     resolution: {integrity: sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==}
+
+  colorjs.io@0.6.1:
+    resolution: {integrity: sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==}
 
   colorjs.io@0.7.1:
     resolution: {integrity: sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==}
@@ -13465,6 +13734,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -13566,6 +13839,9 @@ packages:
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@7.0.3:
+    resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -14192,6 +14468,10 @@ packages:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
 
+  find-up@3.0.0:
+    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
+    engines: {node: '>=6'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -14429,6 +14709,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gradient-parser@1.1.1:
+    resolution: {integrity: sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==}
+    engines: {node: '>=0.10.0'}
 
   gradient-parser@1.2.0:
     resolution: {integrity: sha512-6ABGa9CR7WR/0pAJicBy5SJkiikbFM6kf/JjykwX7x+t+s8ORWVnlbi6FkHeFFb36yWsjUpHqSYrygd7ofEUqA==}
@@ -15421,6 +15705,10 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
+  locate-path@3.0.0:
+    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
+    engines: {node: '>=6'}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -16069,6 +16357,10 @@ packages:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  p-locate@3.0.0:
+    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
+    engines: {node: '>=6'}
+
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -16171,6 +16463,10 @@ packages:
 
   path-case@3.0.4:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
+
+  path-exists@3.0.0:
+    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
+    engines: {node: '>=4'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -17432,6 +17728,10 @@ packages:
     resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
+  showdown@1.9.1:
+    resolution: {integrity: sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==}
+    hasBin: true
+
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -17647,6 +17947,10 @@ packages:
   string-width@2.1.1:
     resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
     engines: {node: '>=4'}
+
+  string-width@3.1.0:
+    resolution: {integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==}
+    engines: {node: '>=6'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -18418,6 +18722,11 @@ packages:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
@@ -18712,6 +19021,10 @@ packages:
     resolution: {integrity: sha512-iXR3tDXpbnTpzjKSylUJRkLuOrEC7hwEB221cgn6wtF8wpmz28puFXAEfPT5zrjM3wahygB//VuWEr1vTkDcNQ==}
     engines: {node: '>=4'}
 
+  wrap-ansi@5.1.0:
+    resolution: {integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==}
+    engines: {node: '>=6'}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -18818,6 +19131,9 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@15.0.3:
+    resolution: {integrity: sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==}
+
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -18829,6 +19145,9 @@ packages:
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@14.2.3:
+    resolution: {integrity: sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==}
 
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
@@ -20922,6 +21241,12 @@ snapshots:
       '@floating-ui/core': 1.8.0
       '@floating-ui/utils': 0.2.12
 
+  '@floating-ui/react-dom@2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@floating-ui/react-dom@2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/dom': 1.8.0
@@ -22998,6 +23323,8 @@ snapshots:
 
   '@types/gradient-parser@1.1.0': {}
 
+  '@types/highlight-words-core@1.2.1': {}
+
   '@types/highlight-words-core@1.2.3': {}
 
   '@types/hoist-non-react-statics@3.3.7(@types/react@18.3.28)':
@@ -23818,10 +24145,81 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  '@woocommerce/email-editor@2.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)':
+    dependencies:
+      '@wordpress/api-fetch': 7.33.1
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/block-library': 9.33.10(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.6.3(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/commands': 1.33.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.33.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/core-data': 7.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.33.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data-controls': 4.33.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/dom-ready': 4.33.1
+      '@wordpress/editor': 14.33.11(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.33.1
+      '@wordpress/format-library': 5.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/global-styles-engine': 1.20.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/hooks': 4.33.1
+      '@wordpress/html-entities': 4.33.1
+      '@wordpress/i18n': 6.6.1
+      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/interface': 9.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.33.1
+      '@wordpress/keyboard-shortcuts': 5.33.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.33.1
+      '@wordpress/notices': 5.33.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/plugins': 7.33.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/preferences': 4.33.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/priority-queue': 3.33.1
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/rich-text': 7.33.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.33.1
+      clsx: 2.1.1
+      deepmerge: 4.3.1
+      lodash: 4.18.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - date-fns
+      - esbuild
+      - postcss
+      - stylelint
+      - supports-color
+      - vite
+
   '@wordpress/a11y@4.53.0':
     dependencies:
       '@wordpress/dom-ready': 4.53.0
       '@wordpress/i18n': 6.26.0
+
+  '@wordpress/admin-ui@1.12.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/base-styles': 6.20.0
+      '@wordpress/components': 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/route': 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/ui': 0.11.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - date-fns
+      - react-dom
+      - stylelint
+      - supports-color
 
   '@wordpress/admin-ui@2.8.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23967,6 +24365,11 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/api-fetch@7.33.1':
+    dependencies:
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/url': 4.51.0
+
   '@wordpress/api-fetch@7.51.0':
     dependencies:
       '@wordpress/i18n': 6.24.0
@@ -24007,11 +24410,80 @@ snapshots:
 
   '@wordpress/base-styles@12.1.0': {}
 
+  '@wordpress/base-styles@6.20.0': {}
+
+  '@wordpress/base-styles@6.9.1': {}
+
   '@wordpress/base-styles@9.1.0': {}
 
   '@wordpress/blob@4.51.0': {}
 
   '@wordpress/blob@4.53.0': {}
+
+  '@wordpress/block-editor@15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
+      '@react-spring/web': 9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/a11y': 4.53.0
+      '@wordpress/api-fetch': 7.51.0
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/blob': 4.51.0
+      '@wordpress/block-serialization-default-parser': 5.51.0
+      '@wordpress/blocks': 15.24.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/commands': 1.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/date': 5.51.0
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/dom': 4.51.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/escape-html': 3.51.0
+      '@wordpress/hooks': 4.51.0
+      '@wordpress/html-entities': 4.51.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/interactivity': 6.51.0
+      '@wordpress/is-shallow-equal': 5.53.0
+      '@wordpress/keyboard-shortcuts': 5.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
+      '@wordpress/notices': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/preferences': 4.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/priority-queue': 3.53.0
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/style-engine': 2.53.0(@types/react@18.3.28)
+      '@wordpress/token-list': 3.51.0
+      '@wordpress/upload-media': 0.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.51.0
+      '@wordpress/warning': 3.53.0
+      '@wordpress/wordcount': 4.51.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      deepmerge: 4.3.1
+      diff: 4.0.4
+      fast-deep-equal: 3.1.3
+      memize: 2.1.1
+      parsel-js: 1.2.3
+      postcss: 8.5.23
+      postcss-prefix-selector: 1.16.1(postcss@8.5.23)
+      postcss-urlrebase: 1.4.0(postcss@8.5.23)
+      react: 18.3.1
+      react-autosize-textarea: 7.1.0(patch_hash=5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-easy-crop: 5.5.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remove-accents: 0.5.0
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - stylelint
+      - supports-color
+      - vite
 
   '@wordpress/block-editor@16.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -24953,6 +25425,66 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/block-library@9.33.10(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.53.0
+      '@wordpress/api-fetch': 7.51.0
+      '@wordpress/autop': 4.53.0
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/blob': 4.51.0
+      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.24.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/core-data': 7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/date': 5.51.0
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/dom': 4.51.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/escape-html': 3.51.0
+      '@wordpress/hooks': 4.51.0
+      '@wordpress/html-entities': 4.51.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/interactivity': 6.51.0
+      '@wordpress/interactivity-router': 2.51.0
+      '@wordpress/keyboard-shortcuts': 5.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
+      '@wordpress/latex-to-mathml': 1.19.0
+      '@wordpress/notices': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/patterns': 2.53.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/reusable-blocks': 5.53.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/server-side-render': 6.27.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.51.0
+      '@wordpress/viewport': 6.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/wordcount': 4.51.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      escape-html: 1.0.3
+      fast-average-color: 9.5.2
+      fast-deep-equal: 3.1.3
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - date-fns
+      - esbuild
+      - postcss
+      - stylelint
+      - supports-color
+      - vite
+
   '@wordpress/block-serialization-default-parser@5.51.0': {}
 
   '@wordpress/block-serialization-default-parser@5.53.0': {}
@@ -25094,6 +25626,40 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
     transitivePeerDependencies:
+      - '@types/react-dom'
+      - react-dom
+
+  '@wordpress/blocks@15.6.3(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/autop': 4.53.0
+      '@wordpress/blob': 4.51.0
+      '@wordpress/block-serialization-default-parser': 5.51.0
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/dom': 4.51.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/hooks': 4.51.0
+      '@wordpress/html-entities': 4.51.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/is-shallow-equal': 5.53.0
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/shortcode': 4.53.0
+      '@wordpress/warning': 3.53.0
+      change-case: 4.1.2
+      colord: 2.9.3
+      fast-deep-equal: 3.1.3
+      hpq: 1.4.0
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      react: 18.3.1
+      react-is: 18.3.1
+      remove-accents: 0.5.0
+      showdown: 1.9.1
+      simple-html-tokenizer: 0.5.11
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@types/react'
       - '@types/react-dom'
       - react-dom
 
@@ -25501,6 +26067,26 @@ snapshots:
       - browserslist
       - supports-color
 
+  '@wordpress/commands@1.33.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.53.0
+      clsx: 2.1.1
+      cmdk: 1.1.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+
   '@wordpress/commands@1.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/base-styles': 11.0.0
@@ -25831,6 +26417,177 @@ snapshots:
       - stylelint
       - supports-color
       - vite
+
+  '@wordpress/components@30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/gradient-parser': 1.1.0
+      '@types/highlight-words-core': 1.2.1
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.53.0
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.51.0
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/dom': 4.51.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/escape-html': 3.51.0
+      '@wordpress/hooks': 4.51.0
+      '@wordpress/html-entities': 4.51.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.53.0
+      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/warning': 3.53.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gradient-parser: 1.1.1
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      path-to-regexp: 6.3.0
+      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 9.14.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+
+  '@wordpress/components@30.9.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/utc': 2.1.1
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/gradient-parser': 1.1.0
+      '@types/highlight-words-core': 1.2.1
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.53.0
+      '@wordpress/base-styles': 6.20.0
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.51.0
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/dom': 4.51.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/escape-html': 3.51.0
+      '@wordpress/hooks': 4.51.0
+      '@wordpress/html-entities': 4.51.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 11.8.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.53.0
+      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/warning': 3.53.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gradient-parser: 1.1.1
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      path-to-regexp: 6.3.0
+      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 9.14.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+
+  '@wordpress/components@32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/utc': 2.1.1
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/gradient-parser': 1.1.0
+      '@types/highlight-words-core': 1.2.1
+      '@types/react': 18.3.28
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.53.0
+      '@wordpress/base-styles': 6.20.0
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.51.0
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/dom': 4.51.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/escape-html': 3.51.0
+      '@wordpress/hooks': 4.51.0
+      '@wordpress/html-entities': 4.51.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.53.0
+      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/warning': 3.53.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      csstype: 3.2.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gradient-parser: 1.1.1
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      path-to-regexp: 6.3.0
+      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 9.14.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react-dom'
+      - supports-color
 
   '@wordpress/components@37.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -27218,6 +27975,24 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/compose@7.33.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@types/mousetrap': 1.6.15
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/dom': 4.51.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/is-shallow-equal': 5.53.0
+      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
+      '@wordpress/priority-queue': 3.53.0
+      '@wordpress/undo-manager': 1.53.0
+      change-case: 4.1.2
+      clipboard: 2.0.11
+      mousetrap: 1.6.5
+      react: 18.3.1
+      use-memo-one: 1.1.3(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@wordpress/compose@7.46.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@types/mousetrap': 1.6.15
@@ -27295,6 +28070,41 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
       - react-dom
+
+  '@wordpress/core-data@7.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/api-fetch': 7.51.0
+      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.24.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/html-entities': 4.51.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/is-shallow-equal': 5.53.0
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/sync': 1.51.0
+      '@wordpress/undo-manager': 1.53.0
+      '@wordpress/url': 4.51.0
+      '@wordpress/warning': 3.53.0
+      change-case: 4.1.2
+      equivalent-key-map: 0.2.2
+      fast-deep-equal: 3.1.3
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - stylelint
+      - supports-color
+      - vite
 
   '@wordpress/core-data@7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -27819,6 +28629,17 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/data-controls@4.33.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/api-fetch': 7.51.0
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/deprecated': 4.53.0
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
   '@wordpress/data-controls@4.51.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/api-fetch': 7.51.0
@@ -27829,6 +28650,26 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - react-dom
+
+  '@wordpress/data@10.33.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/is-shallow-equal': 5.53.0
+      '@wordpress/priority-queue': 3.53.0
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/redux-routine': 5.53.0(redux@5.0.1)
+      deepmerge: 4.3.1
+      equivalent-key-map: 0.2.2
+      is-plain-object: 5.0.0
+      is-promise: 4.0.0
+      react: 18.3.1
+      redux: 5.0.1
+      rememo: 4.0.2
+      use-memo-one: 1.1.3(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/data@10.51.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -27917,6 +28758,54 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
       - react-dom
+
+  '@wordpress/dataviews@10.3.0(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/base-styles': 6.20.0
+      '@wordpress/components': 30.9.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/date': 5.51.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 11.8.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/url': 4.51.0
+      '@wordpress/warning': 3.53.0
+      clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      react: 18.3.1
+      remove-accents: 0.5.0
+    optionalDependencies:
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/hooks': 4.51.0
+      change-case: 4.1.2
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 9.14.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      use-memo-one: 1.1.3(react@18.3.1)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
 
   '@wordpress/dataviews@17.3.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react@18.3.1)':
     dependencies:
@@ -28635,6 +29524,8 @@ snapshots:
     dependencies:
       '@wordpress/hooks': 4.53.0
 
+  '@wordpress/dom-ready@4.33.1': {}
+
   '@wordpress/dom-ready@4.51.0': {}
 
   '@wordpress/dom-ready@4.53.0': {}
@@ -28801,6 +29692,69 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - date-fns
+      - esbuild
+      - postcss
+      - stylelint
+      - supports-color
+      - vite
+
+  '@wordpress/editor@14.33.11(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/a11y': 4.53.0
+      '@wordpress/api-fetch': 7.51.0
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/blob': 4.51.0
+      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.24.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/commands': 1.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/core-data': 7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/dataviews': 10.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.51.0
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/dom': 4.51.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/fields': 0.25.11(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/hooks': 4.51.0
+      '@wordpress/html-entities': 4.51.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/interface': 9.38.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
+      '@wordpress/media-utils': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/notices': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/patterns': 2.53.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/plugins': 7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/preferences': 4.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/reusable-blocks': 5.53.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/server-side-render': 6.27.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.51.0
+      '@wordpress/warning': 3.53.0
+      '@wordpress/wordcount': 4.51.0
+      change-case: 4.1.2
+      client-zip: 2.5.0
+      clsx: 2.1.1
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      is-plain-object: 5.0.0
+      memize: 2.1.1
+      react: 18.3.1
+      react-autosize-textarea: 7.1.0(patch_hash=5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
       - esbuild
       - postcss
       - stylelint
@@ -29391,6 +30345,16 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/element@6.33.1':
+    dependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+      '@wordpress/escape-html': 3.51.0
+      change-case: 4.1.2
+      is-plain-object: 5.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@wordpress/element@6.46.0':
     dependencies:
       '@types/react': 18.3.28
@@ -29478,6 +30442,50 @@ snapshots:
     transitivePeerDependencies:
       - eslint-plugin-import-x
       - supports-color
+
+  '@wordpress/fields@0.25.11(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/api-fetch': 7.51.0
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/blob': 4.51.0
+      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.24.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/core-data': 7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/dataviews': 10.3.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.51.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/hooks': 4.51.0
+      '@wordpress/html-entities': 4.51.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/media-utils': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/notices': 5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/patterns': 2.53.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/router': 1.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.51.0
+      '@wordpress/warning': 3.53.0
+      change-case: 4.1.2
+      client-zip: 2.5.0
+      clsx: 2.1.1
+      react: 18.3.1
+      remove-accents: 0.5.0
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - date-fns
+      - esbuild
+      - postcss
+      - react-dom
+      - stylelint
+      - supports-color
+      - vite
 
   '@wordpress/fields@0.43.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -29859,6 +30867,33 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/format-library@5.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.53.0
+      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/html-entities': 4.51.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/latex-to-mathml': 1.19.0
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/rich-text': 7.53.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.51.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - stylelint
+      - supports-color
+      - vite
+
   '@wordpress/format-library@5.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.0.16(sass-embedded@1.97.3))':
     dependencies:
       '@wordpress/a11y': 4.53.0
@@ -30164,9 +31199,13 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
 
+  '@wordpress/hooks@4.33.1': {}
+
   '@wordpress/hooks@4.51.0': {}
 
   '@wordpress/hooks@4.53.0': {}
+
+  '@wordpress/html-entities@4.33.1': {}
 
   '@wordpress/html-entities@4.51.0': {}
 
@@ -30187,11 +31226,45 @@ snapshots:
       gettext-parser: 1.4.0
       tannin: 1.2.0
 
+  '@wordpress/i18n@6.6.1':
+    dependencies:
+      '@tannin/sprintf': 1.3.3
+      '@wordpress/hooks': 4.51.0
+      gettext-parser: 1.4.0
+      memize: 2.1.1
+      tannin: 1.2.0
+
   '@wordpress/icons@10.32.0(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@wordpress/element': 6.46.0
       '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@wordpress/icons@11.0.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.46.0
+      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@wordpress/icons@11.8.0(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.46.0
+      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
+      change-case: 4.1.2
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@wordpress/icons@12.2.0(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.46.0
+      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
+      change-case: 4.1.2
       react: 18.3.1
     transitivePeerDependencies:
       - '@types/react'
@@ -30334,6 +31407,35 @@ snapshots:
       '@preact/signals': 1.3.4(preact@10.29.3)
       '@preact/signals-core': 1.14.4
       preact: 10.29.3
+
+  '@wordpress/interface@9.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.53.0
+      '@wordpress/admin-ui': 1.12.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/plugins': 7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/preferences': 4.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/viewport': 6.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - date-fns
+      - esbuild
+      - postcss
+      - stylelint
+      - supports-color
+      - vite
 
   '@wordpress/interface@9.38.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30509,6 +31611,8 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/is-shallow-equal@5.33.1': {}
+
   '@wordpress/is-shallow-equal@5.53.0': {}
 
   '@wordpress/jest-console@8.51.0(jest@30.4.2)':
@@ -30520,6 +31624,17 @@ snapshots:
   '@wordpress/kebab-case@1.0.0':
     dependencies:
       change-case: 4.1.2
+
+  '@wordpress/keyboard-shortcuts@5.33.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
 
   '@wordpress/keyboard-shortcuts@5.53.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30544,6 +31659,10 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
       - react-dom
+
+  '@wordpress/keycodes@4.33.1':
+    dependencies:
+      '@wordpress/i18n': 6.24.0
 
   '@wordpress/keycodes@4.51.0(@types/react@18.3.28)':
     dependencies:
@@ -31595,6 +32714,16 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/notices@5.33.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.53.0
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
   '@wordpress/notices@5.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/a11y': 4.53.0
@@ -32112,6 +33241,24 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/plugins@7.33.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/hooks': 4.51.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.53.0
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+
   '@wordpress/plugins@7.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/components': 37.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -32361,6 +33508,27 @@ snapshots:
       - stylelint
       - supports-color
       - vite
+
+  '@wordpress/preferences@4.33.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.53.0
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/components': 30.6.5(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/private-apis': 1.53.0
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
 
   '@wordpress/preferences@4.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -32774,6 +33942,10 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
+  '@wordpress/priority-queue@3.33.1':
+    dependencies:
+      requestidlecallback: 0.3.0
+
   '@wordpress/priority-queue@3.53.0':
     dependencies:
       requestidlecallback: 0.3.0
@@ -32992,6 +34164,24 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/rich-text@7.33.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.53.0
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/deprecated': 4.53.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/escape-html': 3.51.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
+      colord: 2.9.3
+      memize: 2.1.1
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
   '@wordpress/rich-text@7.53.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/a11y': 4.53.0
@@ -33030,6 +34220,15 @@ snapshots:
       '@types/react': 18.3.28
     transitivePeerDependencies:
       - '@types/react-dom'
+      - react-dom
+
+  '@wordpress/route@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-router': 1.167.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.53.0
+      react: 18.3.1
+    transitivePeerDependencies:
       - react-dom
 
   '@wordpress/route@0.19.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -33345,6 +34544,15 @@ snapshots:
       y-protocols: 1.0.7(yjs@13.6.29)
       yjs: 13.6.29
 
+  '@wordpress/theme@0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.46.0
+      '@wordpress/private-apis': 1.53.0
+      colorjs.io: 0.6.1
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@wordpress/theme@1.2.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/compose': 8.6.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -33480,6 +34688,28 @@ snapshots:
   '@wordpress/token-list@3.51.0': {}
 
   '@wordpress/token-list@3.53.0': {}
+
+  '@wordpress/ui@0.11.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@base-ui/react': 1.6.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/a11y': 4.53.0
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/icons': 12.2.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/keycodes': 4.51.0(@types/react@18.3.28)
+      '@wordpress/primitives': 4.51.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.5.0
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@types/react'
+      - date-fns
+      - stylelint
 
   '@wordpress/ui@0.18.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -34221,6 +35451,31 @@ snapshots:
     dependencies:
       '@wordpress/is-shallow-equal': 5.53.0
 
+  '@wordpress/upload-media@0.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/api-fetch': 7.51.0
+      '@wordpress/blob': 4.51.0
+      '@wordpress/compose': 7.46.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/data': 10.51.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.24.0
+      '@wordpress/preferences': 4.51.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.53.0
+      '@wordpress/url': 4.51.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - postcss
+      - stylelint
+      - supports-color
+      - vite
+
   '@wordpress/upload-media@0.36.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/blob': 4.51.0
@@ -34571,6 +35826,10 @@ snapshots:
       - stylelint
       - supports-color
       - vite
+
+  '@wordpress/url@4.33.1':
+    dependencies:
+      remove-accents: 0.5.0
 
   '@wordpress/url@4.51.0':
     dependencies:
@@ -35746,6 +37005,12 @@ snapshots:
       select: 1.1.2
       tiny-emitter: 2.1.0
 
+  cliui@5.0.0:
+    dependencies:
+      string-width: 3.1.0
+      strip-ansi: 5.2.0
+      wrap-ansi: 5.1.0
+
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
@@ -35832,6 +37097,8 @@ snapshots:
   colord@2.9.3: {}
 
   colorjs.io@0.5.2: {}
+
+  colorjs.io@0.6.1: {}
 
   colorjs.io@0.7.1: {}
 
@@ -36314,6 +37581,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff@4.0.4: {}
+
   diff@8.0.4: {}
 
   dns-packet@5.6.1:
@@ -36409,6 +37678,8 @@ snapshots:
   emittery@0.13.1: {}
 
   emoji-regex@10.6.0: {}
+
+  emoji-regex@7.0.3: {}
 
   emoji-regex@8.0.0: {}
 
@@ -37218,6 +38489,10 @@ snapshots:
 
   find-up-simple@1.0.1: {}
 
+  find-up@3.0.0:
+    dependencies:
+      locate-path: 3.0.0
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -37444,6 +38719,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gradient-parser@1.1.1: {}
 
   gradient-parser@1.2.0: {}
 
@@ -38655,6 +39932,11 @@ snapshots:
 
   locate-character@3.0.0: {}
 
+  locate-path@3.0.0:
+    dependencies:
+      p-locate: 3.0.0
+      path-exists: 3.0.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -39529,6 +40811,10 @@ snapshots:
     dependencies:
       yocto-queue: 1.2.2
 
+  p-locate@3.0.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -39638,6 +40924,8 @@ snapshots:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.8.1
+
+  path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
 
@@ -40942,6 +42230,10 @@ snapshots:
 
   shell-quote@1.9.0: {}
 
+  showdown@1.9.1:
+    dependencies:
+      yargs: 14.2.3
+
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -41210,6 +42502,12 @@ snapshots:
     dependencies:
       is-fullwidth-code-point: 2.0.0
       strip-ansi: 4.0.0
+
+  string-width@3.1.0:
+    dependencies:
+      emoji-regex: 7.0.3
+      is-fullwidth-code-point: 2.0.0
+      strip-ansi: 5.2.0
 
   string-width@4.2.3:
     dependencies:
@@ -42062,6 +43360,8 @@ snapshots:
 
   uuid@14.0.1: {}
 
+  uuid@9.0.1: {}
+
   v8-to-istanbul@9.3.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -42488,6 +43788,12 @@ snapshots:
       string-width: 2.1.1
       strip-ansi: 4.0.0
 
+  wrap-ansi@5.1.0:
+    dependencies:
+      ansi-styles: 3.2.1
+      string-width: 3.1.0
+      strip-ansi: 5.2.0
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -42567,6 +43873,11 @@ snapshots:
 
   yaml@2.8.3: {}
 
+  yargs-parser@15.0.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@18.1.3:
     dependencies:
       camelcase: 5.3.1
@@ -42575,6 +43886,20 @@ snapshots:
   yargs-parser@21.1.1: {}
 
   yargs-parser@22.0.0: {}
+
+  yargs@14.2.3:
+    dependencies:
+      cliui: 5.0.0
+      decamelize: 1.2.0
+      find-up: 3.0.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 3.1.0
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 15.0.3
 
   yargs@15.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-KSdPz87aJUaAAe/JwUY5sFdPCTPF9oAlEDa4Xz/hJF4=
+pnpmfileChecksum: sha256-rh/uvB0R915w5qLI7cYE9XupWMkkGydcRrarI6df2vk=
 
 patchedDependencies:
   '@wordpress/build': 151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5897,8 +5897,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0(@react-spring/web@10.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@woocommerce/email-editor':
-        specifier: 2.4.0
-        version: 2.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)
+        specifier: 2.4.1
+        version: 2.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)
       '@wordpress/a11y':
         specifier: 4.54.0
         version: 4.54.0
@@ -11113,8 +11113,8 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
-  '@woocommerce/email-editor@2.4.0':
-    resolution: {integrity: sha512-1EF0SoSc3rzJIBmjCZp19j3wbkiTVrrn2Dhuo6j6zagPYShl3XI5LWWSMIbx0m/Fnu1Mus4kcAzvKoZFtSg6bQ==}
+  '@woocommerce/email-editor@2.4.1':
+    resolution: {integrity: sha512-VHcA04WtIKebeLmUe4gZxPiNSoXolexSXB+2gGPCI4sce86litIzT51QAFnrAB5/C+PORW8reXx3nmuYM6xffw==}
 
   '@wordpress/a11y@4.54.0':
     resolution: {integrity: sha512-nRB471rKurl32bTClZkdlL/1p5pLgzF4ltMpfYY2VUTm8RYX5VtsWj4tQbytk6Ch+KA2U47SgJRUyl6etEMolQ==}
@@ -23850,7 +23850,7 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@woocommerce/email-editor@2.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)':
+  '@woocommerce/email-editor@2.4.1(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)':
     dependencies:
       '@wordpress/api-fetch': 7.54.0
       '@wordpress/base-styles': 13.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-KbGekh3EGsPsu6tK5tfWdbyixzwClyFsRvDiU3zCWBE=
+pnpmfileChecksum: sha256-LcOJ2zpsLY/0C1rWx19oYf+lh4rzJX9xTQVI9Ox1kks=
 
 patchedDependencies:
   '@wordpress/build': 6f3fbefb10df6ce84b2e3c307e3894b697d87a888315abc805b6ff67bf7de635

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+overrides:
+  date-fns@^3.6.0: ^4.1.0
+
 pnpmfileChecksum: sha256-WD2iHMB0TVg57gFqe3iV6oE450si9qBGIhi+6Vafu4s=
 
 patchedDependencies:
@@ -5896,6 +5899,9 @@ importers:
       '@visx/xychart':
         specifier: 4.0.0
         version: 4.0.0(@react-spring/web@10.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@woocommerce/email-editor':
+        specifier: 2.4.0
+        version: 2.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(postcss@8.5.23)
       '@wordpress/a11y':
         specifier: 4.54.0
         version: 4.54.0
@@ -6086,6 +6092,9 @@ importers:
         specifier: 7.2.1
         version: 7.2.1(webpack@5.107.2)
     devDependencies:
+      '@automattic/babel-plugin-replace-textdomain':
+        specifier: workspace:*
+        version: link:../../js-packages/babel-plugin-replace-textdomain
       '@automattic/color-studio':
         specifier: 4.1.0
         version: 4.1.0
@@ -8490,6 +8499,12 @@ packages:
   '@floating-ui/dom@1.8.0':
     resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
+  '@floating-ui/react-dom@2.0.8':
+    resolution: {integrity: sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@floating-ui/react-dom@2.1.9':
     resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
     peerDependencies:
@@ -10429,6 +10444,9 @@ packages:
   '@types/gradient-parser@1.1.0':
     resolution: {integrity: sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==}
 
+  '@types/highlight-words-core@1.2.1':
+    resolution: {integrity: sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA==}
+
   '@types/highlight-words-core@1.2.3':
     resolution: {integrity: sha512-PWNU/NR0CaYEsK38mcCTyDzeS2TlEGK9kRhRMz1i86jVAe836ZlA3gl6QYpu+CG6IpfNKTgWpEnJuRededvC0g==}
 
@@ -11107,6 +11125,9 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  '@woocommerce/email-editor@2.4.0':
+    resolution: {integrity: sha512-1EF0SoSc3rzJIBmjCZp19j3wbkiTVrrn2Dhuo6j6zagPYShl3XI5LWWSMIbx0m/Fnu1Mus4kcAzvKoZFtSg6bQ==}
+
   '@wordpress/a11y@4.54.0':
     resolution: {integrity: sha512-nRB471rKurl32bTClZkdlL/1p5pLgzF4ltMpfYY2VUTm8RYX5VtsWj4tQbytk6Ch+KA2U47SgJRUyl6etEMolQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11114,6 +11135,12 @@ packages:
   '@wordpress/a11y@4.54.1-next.v.202609031004.0':
     resolution: {integrity: sha512-DofWAzVQiJpgpuXDXbvN1nxkEMe5rXLklgUWIytkNuIEpu7hK/0dKHd5kvYL/OOhHIrweanjyjIHyizWnThC4g==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/admin-ui@1.12.0':
+    resolution: {integrity: sha512-CVTvE2jLTP71vBliAhOrvlMoOG1o1TdyoCL5gmw0Uswuj/qhqK3f1Y1adz7hAWiR9o7H9SoPYf+qg6pbZJVyaQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/admin-ui@2.9.0':
     resolution: {integrity: sha512-qBunBhH5T4b7oxQaFcAonMppcfa2y1323/kdJ/vSJpqxuNVcAX0V1F22WZfsyWa26cELUG3ldQQ/duYZFBkokg==}
@@ -11124,6 +11151,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/api-fetch@7.33.1':
+    resolution: {integrity: sha512-kxk7Og2CZLOMUZtDfOXSGapem4ToP15JB24PfixJLS0dKfrlUBci4ShjJ3z3jdIx01gf1gfP4NFjqzicJKb+Rg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/api-fetch@7.54.0':
     resolution: {integrity: sha512-L3aijA4rSYdxcM0IDysZcAMhUN3xMibNZWDmSi3B+72Yc1OWClD2aRNbbx2OL7LfHmHOi/844J+KHqlaRJnB4A==}
@@ -11159,6 +11190,14 @@ packages:
     resolution: {integrity: sha512-xvn0Y3apMSCQbeRqhdz4r1Fo0hKhzPqUowze0O6S/ZrmqJILpF7qBxPp2x8ZaKJ2riQlFOUV5/uG5yviBNfuMg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/base-styles@6.20.0':
+    resolution: {integrity: sha512-Dsug4Zxz2xOFtK6CGThKYXwCqC9Yztw2STKQzwztrX4yW+o6iDbzkxpcwdDhsaVJs0Jt9A4LmJpZPh+pUozzLA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/base-styles@6.9.1':
+    resolution: {integrity: sha512-UCtTANAdym5jpTEZS17WHrKLu7R52gQRgKuwsRm5uZWUb4g4Vq8NX52CBIesF1viFyKfM++HpmteFkrL7p0SMg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/base-styles@9.1.0':
     resolution: {integrity: sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11166,6 +11205,13 @@ packages:
   '@wordpress/blob@4.54.0':
     resolution: {integrity: sha512-/9s3JpYBNlK44v9V1fHT0dgPVxDVzcNss6cbGk/kNOtntoLJkBaRWLjCXm9WGWQ2kv2sm6PLDzlSiiOCF5sPHg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/block-editor@15.6.9':
+    resolution: {integrity: sha512-X5S7oWsTCpNIUHbsx/ZMN+2AXnILn3EeotUWAj8DsHtFFgfiDnbo2kKPaWANgGtHJ+GNWZPr0RUyS9Gmtdwn1A==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@wordpress/block-editor@17.0.0':
     resolution: {integrity: sha512-RGWvjWLwIKMKEgLt6kZseC+oEO7oNnDFMzfZ56eGuQKZCKM88x5F7jaEly6YWqj8XtonXEz1ihfxL5JrPeSFNg==}
@@ -11189,6 +11235,13 @@ packages:
       '@types/react':
         optional: true
 
+  '@wordpress/block-library@9.33.10':
+    resolution: {integrity: sha512-9qrBXTc1BR539L78KuMCZ7PHt4US822NSKKVNcgVTkPH2qHyUDvr6t680HRHCI7VYWq1NXp9teZo7PEZNVfhVA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/block-serialization-default-parser@5.54.0':
     resolution: {integrity: sha512-7y2wtF7+QUlyFuhpIMI0JxI1EK6vbiYFKWvnPeqhaulg9b2xPG1IFjhZNKD+5oQgvOpRU2tKV/fisbagqxdqgA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11202,6 +11255,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/blocks@15.6.3':
+    resolution: {integrity: sha512-AFYre+06ZVtyv0KSVwCOUY+HSEdAaQRxFrRZnSsZ5FEs0pMMIsulFYay8QvlVVTtBUKbYlxKEDi8kD1DI+8jxA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/boot@0.21.0':
     resolution: {integrity: sha512-bpOM2JTGnomYmp/h3myYQUguOOzm01+CU5Jw7wYqOixjj9VkE3kYWh0fdYvPGz/ERD7LNpHJIR/ucWbguGvH1g==}
@@ -11237,6 +11296,13 @@ packages:
       '@wordpress/theme':
         optional: true
 
+  '@wordpress/commands@1.33.5':
+    resolution: {integrity: sha512-m8a/9ahGzEVYj77EfS6crzjq2Gq97DOXbeSqRSHrpePE/NSXPh6AAABRP/dKCI/0AysjJ0v/bKKTVnsFgkk0YA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/commands@1.54.0':
     resolution: {integrity: sha512-TUo0n4011kzxkIGyHT9yz38c731rONyctmyynQO0Tro/uP8MhxNbWdzMOjzJXNwZTCqEME5b7WVTgT/bF7WCvw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11250,6 +11316,27 @@ packages:
     peerDependencies:
       react: ^18 || ^19
       react-dom: ^18 || ^19
+
+  '@wordpress/components@30.6.5':
+    resolution: {integrity: sha512-jSDpUz1BBQvpWUGwqZUlI22PMGMtiN5ooKS4GlQqjUmEBJH4llwiRblkZBKgdznv+5KDYyDiRNIGCz/hLSdwZw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@wordpress/components@30.9.0':
+    resolution: {integrity: sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@wordpress/components@32.6.0':
+    resolution: {integrity: sha512-MpOr0mGTkKDRjxK5LKm86Uoj9p9Z6KkrvhkNVi5zVKCftyHVMK+tun7wL2Qn/JZVLbxZpB1kW5sJ5aMf3T2ToA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@wordpress/components@37.0.0':
     resolution: {integrity: sha512-Lol3iUujNnn4uHxI4VARDVEJIFUKlBtZUMcSFWofiYRZc8aV5BplyKC+sRAhKm+KFNBQjZtqd4PdixtaOHuX6w==}
@@ -11283,6 +11370,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/compose@7.33.1':
+    resolution: {integrity: sha512-1satS+7EKlzZOCR++uP8mAy3BJPKX2eeTZHVW3669n0xM1xdmzl9JXyEbtEqaFVYhI3dHTq5kLwrm+aSpn0zag==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/compose@7.46.0':
     resolution: {integrity: sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==}
@@ -11320,6 +11413,13 @@ packages:
       '@types/react':
         optional: true
 
+  '@wordpress/core-data@7.33.9':
+    resolution: {integrity: sha512-1tYiHamRDvopG9cLFTR+SdUKroTLQRof25vquI5OlXEzBgRmn/ksWlOKM6nFxGUBK6JmdlczBoa0QhBJdXBK0Q==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/core-data@7.54.0':
     resolution: {integrity: sha512-4a1FVQFJIcdsy2BX3ejxtCbYZktrUg14z4Qy9QvMGjyVWRYgtXvqxInHUIaGDCMU4uEt59wb7gMEhWrgMu1ouw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11331,11 +11431,23 @@ packages:
       '@types/react':
         optional: true
 
+  '@wordpress/data-controls@4.33.1':
+    resolution: {integrity: sha512-+gD47q6WuZ2MYMxwUBwBTYACMayrZoyG6W6OR1Q2ggOfkmoQb4OlxEWJPdCIC8GxJJwVh8ej9HjzzI3S/tDsJg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/data-controls@4.54.0':
     resolution: {integrity: sha512-fy2xTtS5TmxVks7+ZbOMidUvcOEyfg/01WkeSNfYZwPgyhl1Qj8dV8D8MCJIGVUmxBZeLV1IH5TY4zpcd2NQ4Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18 || ^19
+
+  '@wordpress/data@10.33.1':
+    resolution: {integrity: sha512-Y+GlNYFds2ICgkAfwT3UsLCXlagibtUFADBf/UXmTgEvc07/O/lOBHeIW72BiRkb/O4oCqf2ZeXgGkNgJLlyiQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/data@10.54.0':
     resolution: {integrity: sha512-JPgGSNjAD7+8SXTvXpORSo74Pf8pz4JPGyBiGsoEbfYs0VL2FeIb/QLIMQxtpKOxc6xjODLh0LBXhFbWUqTHkA==}
@@ -11350,6 +11462,13 @@ packages:
     peerDependencies:
       '@types/react': ^18 || ^19
       react: ^18 || ^19
+
+  '@wordpress/dataviews@10.3.0':
+    resolution: {integrity: sha512-7mBcW4Vris+8Be3ESUPkhe85AwAbwO+2ocvi4UDF6jEzeyH7GQxq+1k4Lq4vAc+pNBf0IehZV598+qs8nk9j2w==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@wordpress/dataviews@18.1.0':
     resolution: {integrity: sha512-vV3wvSnqxjGqsUj9fnRmVVzXVCy/N+pRGYx+WyyXZUslbLX9xn1JfI2Z8uXFptKZJ5vGJ3BnLkfE4r2HdvG0Zg==}
@@ -11399,6 +11518,10 @@ packages:
     resolution: {integrity: sha512-T2M7KnNoxyZ5IdVapEo4+j+BYYFqEhnC5oASsoM71OdGEOcKa9j7dUJwBUOfVRCEeA81Lc/8LbBxDyrBqb6q6g==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/dom-ready@4.33.1':
+    resolution: {integrity: sha512-jrHN/arTKp2iuYj24byFgabBhZsZ3WUXCSKT16d/1MZUXGQt876XXu6r5rwpLtnVsX2gFiZ/DzdRKCL4RV9Wpg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/dom-ready@4.54.0':
     resolution: {integrity: sha512-gEJxddZ+KZ7FkeV2EFr9f5f4gefOOtcgBP6BIIL6Wum4a1liBPphlbkBVfFTsReHIrvqsj8S3EtpHXl/RlXSgA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11433,6 +11556,13 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
+  '@wordpress/editor@14.33.11':
+    resolution: {integrity: sha512-yGSMcsya/9OADD+xgfewVwnHvRUpMsKGh865WkWm2uy0XbCap5IoDMNeKgsM/nYXrCy8y5sbO4b9bzDUhHcsdA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/editor@14.54.0':
     resolution: {integrity: sha512-Z0YD/Ns1JONBDkNMo7mo1szBcC02TvGpUv9JEz2S8bFIzH3jEaPERvJc4bVEvgc8xA+CbbIC/RKJhiI+VkIm3A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11443,6 +11573,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/element@6.33.1':
+    resolution: {integrity: sha512-8Y2TEkduT1cAGVfh5HoERpJIVvCcfHI1k+PGgG3wzy85me6hjgA/P7l90yBt/9i9Omt5+buGfnklobstECR8zg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/element@6.46.0':
     resolution: {integrity: sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==}
@@ -11526,6 +11660,12 @@ packages:
       typescript:
         optional: true
 
+  '@wordpress/fields@0.25.11':
+    resolution: {integrity: sha512-jNNG14L0FWUif95kVUVm53mT4ItOBm3yN9I2mElm/aznHZh3rheRJ96vT2nyTuJ1/J79Xt2DerqkvcWP4R6R3Q==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/fields@0.46.0':
     resolution: {integrity: sha512-RbNxuLB9yL1zHY4aliEqjJaKnXSoOrJL+6NmeV0FVwGdu9vgsBk56rkuGF06O48bb6eQ4YJLki86Yza7VjvUeA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11535,6 +11675,13 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/format-library@5.33.9':
+    resolution: {integrity: sha512-9RTyCFuaXSSF4Rz4rnz0Elge71nSn7UWyvskMQtZNN5nMGjH9D5NK5JoYKANpt1v0Cx/vfUkLTywBrU0v2+pLA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@wordpress/format-library@5.54.0':
     resolution: {integrity: sha512-MzKaFIcd8fNDpWDYf63BYIGGSZmkJHCl1dwPNXAW8Z9lLwdkhhQP10hwcsy5HGDHEqqY4QBSx/a5QHqJKfSU7A==}
@@ -11569,16 +11716,20 @@ packages:
       '@types/react':
         optional: true
 
+  '@wordpress/hooks@4.33.1':
+    resolution: {integrity: sha512-p9RbNsZJnsGY45MEV3QfYHS4dMmKe0B1f/RUXEL8ZLa36aUWZrUX7PJxvmmpeuPrboHQwT4MDps9kwHO4V6GVg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/hooks@4.54.0':
     resolution: {integrity: sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/hooks@4.54.1-next.v.202608281122.0':
-    resolution: {integrity: sha512-/zv/U7WX643r6m4LCZo/IFaFz03s6n/9Tm2K9EvqYSPv2y4tSMPQWBy/ahV2lRobcsmIJMSrDPFBP6uXh9jbew==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/hooks@4.54.1-next.v.202609031004.0':
     resolution: {integrity: sha512-hbyRCIb4TSX+0YSw+1laD6lIRSxG/gZCTR1i7hbQRaHUbgN4n8hu7Jp1zgSOngIO+8HMVhF1CwofqOok5LjKuw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/html-entities@4.33.1':
+    resolution: {integrity: sha512-HdpnRRvTMstX58U4Yr+UisIrFLcG97PGegAczMxeq9Q1n3ol5FCkEegBTQIJffAZ5IadBsPZ77fjoVtLK7RViQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/html-entities@4.54.0':
@@ -11594,13 +11745,13 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
-  '@wordpress/i18n@6.27.1-next.v.202608281122.0':
-    resolution: {integrity: sha512-sgbLtn6G4mWNpee9AnVvstZNUkdmawrVsevPlw7OCKRxnUkxj8xKc+c9tMAXyZSIq5GPqOOWgimXwX9qn6/Ppg==}
+  '@wordpress/i18n@6.27.1-next.v.202609031004.0':
+    resolution: {integrity: sha512-g8suvH6oLPIOiWcgx/ioH2W3v+94HePG3r/9bbSgUN7PTblTKc1leUQs0kmyBGGOCR7BBTIAxhUZxSKVlqRcwA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
-  '@wordpress/i18n@6.27.1-next.v.202609031004.0':
-    resolution: {integrity: sha512-g8suvH6oLPIOiWcgx/ioH2W3v+94HePG3r/9bbSgUN7PTblTKc1leUQs0kmyBGGOCR7BBTIAxhUZxSKVlqRcwA==}
+  '@wordpress/i18n@6.6.1':
+    resolution: {integrity: sha512-aEFSF+5dp0UhdMGHyNUwhcL0Sg/kp0NtCSMrfcQrXRM6uD/+y8ih0mHeULww5V919NUrzXIZSZGfOaOIiQVXXg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
@@ -11609,6 +11760,24 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18
+
+  '@wordpress/icons@11.0.1':
+    resolution: {integrity: sha512-vXkWiAxwDjWBcj72oXbJyuDtIvNvk1JnnmYzQUpIjKjvScRPcj+Kt40nFYk/5kPnNAhBqVNcZ7tWK7NctSslJA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18
+
+  '@wordpress/icons@11.8.0':
+    resolution: {integrity: sha512-ZMNHApHMmPLpNnNLfPLRf6XWoPhZFNKFKdpMlhA6Lx04J1hLVyLRz8PuM+1o3ByxD2ZiExfSRhdmI+7VvEg6DA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
+  '@wordpress/icons@12.2.0':
+    resolution: {integrity: sha512-Fiw7bmfHDNPjTdCrBF23/9K0VN/GUi73d2ZPZaeWdXhTmIX62T9KYvb1c+WnlBkX7GpXgJO6Q8mypQCY9mw5SQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/icons@13.3.0':
     resolution: {integrity: sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==}
@@ -11662,12 +11831,19 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@wordpress/is-shallow-equal@5.54.0':
-    resolution: {integrity: sha512-j5mskkhAD3jWrgNSdoSsexos1dxI9EQftfAZAbI2GZwFi6I20cgSrktgCewAUSZDqJ+vPwaJs0bTDhtUDMHXLg==}
+  '@wordpress/interface@9.18.5':
+    resolution: {integrity: sha512-OCNCTogPS/kHPVjIAHtQ2y9WaX1fm1oK1cXQs6RezKtO1y/+nFH2L5pjzF7ifG1ECe5KL7REX4kJXgDTIwDV9g==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
+  '@wordpress/is-shallow-equal@5.33.1':
+    resolution: {integrity: sha512-QMOwATwFjFr6Z9geS8EjuEVGN0gkpANypjqIBE8iTDtfKhY99LTtxbTaguviqKfVP7l73v1B0GJfHtkPExhJkA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/is-shallow-equal@5.54.1-next.v.202608281122.0':
-    resolution: {integrity: sha512-P6QKkNcZD9gzWHkdRJwum8D92mclDNgtry1Ww8vtIUEk1tWAmgllASGwiBBjFTnU+dX4JEtQh2IwR1R8773GMw==}
+  '@wordpress/is-shallow-equal@5.54.0':
+    resolution: {integrity: sha512-j5mskkhAD3jWrgNSdoSsexos1dxI9EQftfAZAbI2GZwFi6I20cgSrktgCewAUSZDqJ+vPwaJs0bTDhtUDMHXLg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/is-shallow-equal@5.54.1-next.v.202609031004.0':
@@ -11687,6 +11863,12 @@ packages:
   '@wordpress/kebab-case@1.1.1-next.v.202609031004.0':
     resolution: {integrity: sha512-SL+lxyxFlSUxX4JfuckBNR071XyTBqQ3a9vXP8OGalbkBEqJPRBNkHECMrefT92QXylmw0Tv7nbEubp/G6QnqA==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+
+  '@wordpress/keyboard-shortcuts@5.33.1':
+    resolution: {integrity: sha512-ql+qQ+AW9rnaS6jBv3J5MT8ku0qijAYCq6rIvfEiA1W84i5+LB9JYxxzrFH8v5uGU4ZjqqRQEmcDd+lorlT4Vg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/keyboard-shortcuts@5.54.0':
     resolution: {integrity: sha512-EiguLibri6ZBjQHe7rqumTFk5eZrw47Y2m7TuXro08FQS+qxY6YsYlefbCfWBehFIiptYkaZ0OyRu2KhmDOwuA==}
@@ -11708,17 +11890,12 @@ packages:
       '@types/react':
         optional: true
 
+  '@wordpress/keycodes@4.33.1':
+    resolution: {integrity: sha512-acuH0ogiY92ClslUpezZyEzfm1Ubx2bftevn/PxbsVq52UCOu14CAKgnO9sYqVuMpXT+zXveRMySixyKHB1wnA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
   '@wordpress/keycodes@4.54.0':
     resolution: {integrity: sha512-WeaKup+THfx62hGOOVZpeK0AvEA0d3xwWo2P44pUbUKaBFydTXWqmm7HNsZ7bX9lDdk7JshuLSwhpHfwFPOQEw==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      '@types/react': ^18 || ^19
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@wordpress/keycodes@4.54.1-next.v.202608281122.0':
-    resolution: {integrity: sha512-l6cvxNDRw8s0J4MBPtIZFhLBaJeIpiCDbqqh03aZMzEShyFsmhXzpPOcl29Z7uX9pHvRDpgjUdVDvSWZeq/oQQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       '@types/react': ^18 || ^19
@@ -11779,6 +11956,12 @@ packages:
       '@types/react':
         optional: true
 
+  '@wordpress/notices@5.33.1':
+    resolution: {integrity: sha512-bvw97KGiToFZv9/EHPhom2va7pDXCUR2BNfSuxT3lSAt1tX5DUD5i1+6aa5TIybSAtZNGisCySH4fL/paMDMjQ==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/notices@5.54.0':
     resolution: {integrity: sha512-fZcDoJEOdRwVtL8pUWVuK7ggNIivMd46/jczxhsX+LmSVT/vlhrBEKv22IeiqpcyGRY8GakXfcK7c02n61HLVw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11796,6 +11979,13 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
+  '@wordpress/plugins@7.33.5':
+    resolution: {integrity: sha512-kTNhyX1FKTSWBmxfHWoqEo5+iM96ThHXGqFGzeAFt+W35EeHzt9a/H++9yfcxMqDyjR1IRjoB261bX+oLPuw9Q==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/plugins@7.54.0':
     resolution: {integrity: sha512-2r1QKMcC+OVauo3iLfCXfuFYxlGc1u2W3XJaOc+CjHcd0CFVJafOoqAS8ffQ0YtNv59BVhwzmbGXOgk+66r/0A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11806,6 +11996,13 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/preferences@4.33.5':
+    resolution: {integrity: sha512-5tPfWv5Kw/+KAfFzsZKojK3FHNDiMVwj8GusXAqbsCSy9YsyAxifaEXeul684RYFdizLK3gWqe4S0K6GaLs0CA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@wordpress/preferences@4.54.0':
     resolution: {integrity: sha512-yFEJopdYAE0KmlrqrZxfTcwS8rSJcHV+qYfzFlz8pHgZe2UVB5MENPKJetPT7fhM4uN5WISY9cgnEniF3+EoDw==}
@@ -11855,12 +12052,12 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/priority-queue@3.54.0':
-    resolution: {integrity: sha512-YOJAKb80OFzHCdamyfKu9L3k+AZWexo5f1Jjm8HFs3+6CIxmkPyTe7uYccpRvmgag8MkVAdus/VaO5thzOy+gA==}
+  '@wordpress/priority-queue@3.33.1':
+    resolution: {integrity: sha512-m3S+bfVIGmDHVrCzTdQu5oHP6aBIM0pf5AYVpfdA2addJHLICtAMrPYdD+4MXekh8a38DzPekZa03vGv3ws3zQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/priority-queue@3.54.1-next.v.202608281122.0':
-    resolution: {integrity: sha512-lMoxZwaoZ8o3Y3jALH1ovAfS/OvIOooC2qsS6d+3jHrC+oTO0b8BkmSuTWIknDWNdbveDM8qMuXVPARaWPiWXw==}
+  '@wordpress/priority-queue@3.54.0':
+    resolution: {integrity: sha512-YOJAKb80OFzHCdamyfKu9L3k+AZWexo5f1Jjm8HFs3+6CIxmkPyTe7uYccpRvmgag8MkVAdus/VaO5thzOy+gA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/priority-queue@3.54.1-next.v.202609031004.0':
@@ -11900,6 +12097,12 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
+  '@wordpress/rich-text@7.33.2':
+    resolution: {integrity: sha512-jy8DPBN6f0WeQM1jL+yGX29xHgzDdyrGoXYEGrGt2ngpGYMca2ZrG9ZLcpQlU6S3sLV/n1jtjZntWrFFYRzgQA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+
   '@wordpress/rich-text@7.54.0':
     resolution: {integrity: sha512-zSu1Wv2FrKf4Lh18Wt5VCrDl964CDmyWpR7KAmX0xVFqRjO3HMKxV4lvK6IS6vPzH6k9KKcAnKpkQPnce6R4+w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11919,6 +12122,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/route@0.10.0':
+    resolution: {integrity: sha512-rNXo4cq+yPlkFzC/bQjZW8qQpaNgh1nAeUVefc4Si079C79pC0JhnXKqPOq4Iy28oJZyRjfdLdFV1FdLhHfmzA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
 
   '@wordpress/route@0.20.0':
     resolution: {integrity: sha512-vLp0EvAcmCZnTVFjkhuFaPbm9qwrvGIaFHMaskU3uBw/qsxj/0xDT5Zm43MZNAKrbU8x2FC+KMXk0c28Ya5tFg==}
@@ -11994,6 +12203,17 @@ packages:
   '@wordpress/sync@1.54.0':
     resolution: {integrity: sha512-NHRGP27HecH/hGdM3YVFcKFqUw06UfLoUQPp8IuIR3Bk7DPj1PdM5PnbqyYibSf8caDE+bIduacbHv0mn2JLSg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/theme@0.11.0':
+    resolution: {integrity: sha512-jXilt+3codfAEFRHvLpnULeOaaycwJByyv+m/TIlspZ4r0l4X9iA1KL7GkXOHz2AJWWvS7FUnS/GHBuIrUgAWg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+      stylelint: '>=16.8.2'
+    peerDependenciesMeta:
+      stylelint:
+        optional: true
 
   '@wordpress/theme@1.2.0':
     resolution: {integrity: sha512-pILS4ytGGiASrpJ8sLp+pRbcBspFYeMTr5LdM4fWBv/EN2CIKhBLpX3qGlXwKzS+HzjrbXZwj60Bfbg/PxvQew==}
@@ -12097,6 +12317,13 @@ packages:
     resolution: {integrity: sha512-U3LMm0zq35H+kmAVv2bwG8W75sflglI45YLV/KPLGMZIv/f45LTtMkzpJ16c3TSYs0CP+slsV4YIMttetcQwPg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/ui@0.11.0':
+    resolution: {integrity: sha512-V1R3CTQ8MltuajZ53PCHGe9mmRwyx1RpjHA2wWOv+79dV0qQ1Y/psL0YTMY4eteL4SNAlBcjJVP66zD5O6yF8Q==}
+    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/ui@0.18.0':
     resolution: {integrity: sha512-TIMsjaRl5/QJEjKbtoa0YAhzVdcvAk/FmA9rgJVR6oG/l6+s0WgoebGASEVyRyoOstq45xB7PzYMdjVs7iS0zg==}
     engines: {node: ^20.19.0 || >=22.13.0, npm: '>=10.2.3'}
@@ -12142,6 +12369,13 @@ packages:
     resolution: {integrity: sha512-rdzsTqVht15R+NqXtJe6yE2ROD89X/tiB3bKhU7z8R0vg3kAKP+ZnJDBDvZiYMpV6XnbLxw8AyzwPyOqdO6b3Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
+  '@wordpress/upload-media@0.18.5':
+    resolution: {integrity: sha512-4u+mMPicEuw7tMPIgCtgI5BWckWODjYayA7aOP0sQWdG90Vq1z7nGDlxHeeb/PkQxnZPh+3oA6V79OWV5ZS/Fg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+
   '@wordpress/upload-media@0.39.0':
     resolution: {integrity: sha512-SL5cCERYah4KoF/yviarLEOYw3dH8z0UA78tWFAaR3f+uja2mj92Ub59kRBDnCLrn0SWInW+JbMwWM5mkQRhbw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -12152,6 +12386,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@wordpress/url@4.33.1':
+    resolution: {integrity: sha512-t4MKPofYLHTIVE+NV36WBmlnzHsnZFkXsACdu/InF0u5pmyc/ZgXmq44qi6h/PmbGoUKnRQisulMIvGfEVBTeA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/url@4.54.0':
     resolution: {integrity: sha512-wa+61i0zyHjNZOAvXLdLrjc+dHyBjX9lfqnAfBw1N0yWAGU/vL3qBkfTBIDx9LxqjKXQ9HRSSxvQVfzGyGRzkg==}
@@ -12973,6 +13211,9 @@ packages:
   clipboard@2.0.11:
     resolution: {integrity: sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==}
 
+  cliui@5.0.0:
+    resolution: {integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==}
+
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -13043,6 +13284,9 @@ packages:
 
   colorjs.io@0.5.2:
     resolution: {integrity: sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==}
+
+  colorjs.io@0.6.1:
+    resolution: {integrity: sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==}
 
   colorjs.io@0.7.1:
     resolution: {integrity: sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==}
@@ -13543,6 +13787,10 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -13644,6 +13892,9 @@ packages:
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@7.0.3:
+    resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -14270,6 +14521,10 @@ packages:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
 
+  find-up@3.0.0:
+    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
+    engines: {node: '>=6'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -14507,6 +14762,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gradient-parser@1.1.1:
+    resolution: {integrity: sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==}
+    engines: {node: '>=0.10.0'}
 
   gradient-parser@1.2.0:
     resolution: {integrity: sha512-6ABGa9CR7WR/0pAJicBy5SJkiikbFM6kf/JjykwX7x+t+s8ORWVnlbi6FkHeFFb36yWsjUpHqSYrygd7ofEUqA==}
@@ -15499,6 +15758,10 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
+  locate-path@3.0.0:
+    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
+    engines: {node: '>=6'}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -16147,6 +16410,10 @@ packages:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  p-locate@3.0.0:
+    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
+    engines: {node: '>=6'}
+
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -16249,6 +16516,10 @@ packages:
 
   path-case@3.0.4:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
+
+  path-exists@3.0.0:
+    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
+    engines: {node: '>=4'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -17498,6 +17769,10 @@ packages:
     resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
+  showdown@1.9.1:
+    resolution: {integrity: sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==}
+    hasBin: true
+
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -17713,6 +17988,10 @@ packages:
   string-width@2.1.1:
     resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
     engines: {node: '>=4'}
+
+  string-width@3.1.0:
+    resolution: {integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==}
+    engines: {node: '>=6'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -18484,6 +18763,11 @@ packages:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
@@ -18778,6 +19062,10 @@ packages:
     resolution: {integrity: sha512-iXR3tDXpbnTpzjKSylUJRkLuOrEC7hwEB221cgn6wtF8wpmz28puFXAEfPT5zrjM3wahygB//VuWEr1vTkDcNQ==}
     engines: {node: '>=4'}
 
+  wrap-ansi@5.1.0:
+    resolution: {integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==}
+    engines: {node: '>=6'}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -18884,6 +19172,9 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@15.0.3:
+    resolution: {integrity: sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==}
+
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -18895,6 +19186,9 @@ packages:
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@14.2.3:
+    resolution: {integrity: sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==}
 
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
@@ -20253,6 +20547,20 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@base-ui/react@1.7.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.12
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@date-fns/tz': 1.4.1
+      '@types/react': 18.3.31
+      date-fns: 4.1.0
+
   '@base-ui/react@1.7.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -20961,6 +21269,12 @@ snapshots:
     dependencies:
       '@floating-ui/core': 1.8.0
       '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/react-dom@2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/react-dom@2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23038,6 +23352,8 @@ snapshots:
 
   '@types/gradient-parser@1.1.0': {}
 
+  '@types/highlight-words-core@1.2.1': {}
+
   '@types/highlight-words-core@1.2.3': {}
 
   '@types/http-errors@2.0.5': {}
@@ -23846,6 +24162,56 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  '@woocommerce/email-editor@2.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(postcss@8.5.23)':
+    dependencies:
+      '@wordpress/api-fetch': 7.33.1
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/block-library': 9.33.10(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.6.3(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/commands': 1.33.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.33.1(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/core-data': 7.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.33.1(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data-controls': 4.33.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/dom-ready': 4.33.1
+      '@wordpress/editor': 14.33.11(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.33.1
+      '@wordpress/format-library': 5.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/global-styles-engine': 1.21.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/hooks': 4.33.1
+      '@wordpress/html-entities': 4.33.1
+      '@wordpress/i18n': 6.6.1
+      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/interface': 9.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.33.1
+      '@wordpress/keyboard-shortcuts': 5.33.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.33.1
+      '@wordpress/notices': 5.33.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/plugins': 7.33.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/preferences': 4.33.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/priority-queue': 3.33.1
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/rich-text': 7.33.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.33.1
+      clsx: 2.1.1
+      deepmerge: 4.3.1
+      lodash: 4.18.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - date-fns
+      - esbuild
+      - postcss
+      - stylelint
+      - supports-color
+      - vite
+
   '@wordpress/a11y@4.54.0':
     dependencies:
       '@wordpress/dom-ready': 4.54.0
@@ -23855,6 +24221,27 @@ snapshots:
     dependencies:
       '@wordpress/dom-ready': 4.54.1-next.v.202609031004.0
       '@wordpress/i18n': 6.27.1-next.v.202609031004.0
+
+  '@wordpress/admin-ui@1.12.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/base-styles': 6.20.0
+      '@wordpress/components': 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/route': 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/ui': 0.11.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - date-fns
+      - react-dom
+      - stylelint
+      - supports-color
 
   '@wordpress/admin-ui@2.9.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -24000,6 +24387,11 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/api-fetch@7.33.1':
+    dependencies:
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/url': 4.54.0
+
   '@wordpress/api-fetch@7.54.0':
     dependencies:
       '@wordpress/i18n': 6.27.0
@@ -24036,9 +24428,78 @@ snapshots:
 
   '@wordpress/base-styles@13.1.1-next.v.202609031004.0': {}
 
+  '@wordpress/base-styles@6.20.0': {}
+
+  '@wordpress/base-styles@6.9.1': {}
+
   '@wordpress/base-styles@9.1.0': {}
 
   '@wordpress/blob@4.54.0': {}
+
+  '@wordpress/block-editor@15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
+      '@react-spring/web': 9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/api-fetch': 7.54.0
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/blob': 4.54.0
+      '@wordpress/block-serialization-default-parser': 5.54.0
+      '@wordpress/blocks': 15.27.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/commands': 1.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/date': 5.54.0
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/dom': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/escape-html': 3.54.0
+      '@wordpress/hooks': 4.54.0
+      '@wordpress/html-entities': 4.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/interactivity': 6.54.0
+      '@wordpress/is-shallow-equal': 5.54.0
+      '@wordpress/keyboard-shortcuts': 5.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      '@wordpress/notices': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/preferences': 4.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/priority-queue': 3.54.0
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/style-engine': 2.54.0(@types/react@18.3.31)
+      '@wordpress/token-list': 3.54.0
+      '@wordpress/upload-media': 0.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.54.0
+      '@wordpress/warning': 3.54.0
+      '@wordpress/wordcount': 4.54.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      deepmerge: 4.3.1
+      diff: 4.0.4
+      fast-deep-equal: 3.1.3
+      memize: 2.1.1
+      parsel-js: 1.2.3
+      postcss: 8.5.23
+      postcss-prefix-selector: 1.16.1(postcss@8.5.23)
+      postcss-urlrebase: 1.4.0(postcss@8.5.23)
+      react: 18.3.1
+      react-autosize-textarea: 7.1.0(patch_hash=5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-easy-crop: 5.5.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remove-accents: 0.5.0
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - stylelint
+      - supports-color
+      - vite
 
   '@wordpress/block-editor@17.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -24572,6 +25033,65 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/block-library@9.33.10(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/api-fetch': 7.54.0
+      '@wordpress/autop': 4.54.0
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/blob': 4.54.0
+      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.27.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/core-data': 7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/date': 5.54.0
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/dom': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/escape-html': 3.54.0
+      '@wordpress/hooks': 4.54.0
+      '@wordpress/html-entities': 4.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/interactivity': 6.54.0
+      '@wordpress/interactivity-router': 2.54.0
+      '@wordpress/keyboard-shortcuts': 5.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      '@wordpress/latex-to-mathml': 1.22.0
+      '@wordpress/notices': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/patterns': 2.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/reusable-blocks': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/server-side-render': 6.30.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.54.0
+      '@wordpress/viewport': 6.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/wordcount': 4.54.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      escape-html: 1.0.3
+      fast-average-color: 9.5.2
+      fast-deep-equal: 3.1.3
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - postcss
+      - stylelint
+      - supports-color
+      - vite
+
   '@wordpress/block-serialization-default-parser@5.54.0': {}
 
   '@wordpress/blocks@15.27.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -24643,6 +25163,40 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.31
     transitivePeerDependencies:
+      - '@types/react-dom'
+      - react-dom
+
+  '@wordpress/blocks@15.6.3(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/autop': 4.54.0
+      '@wordpress/blob': 4.54.0
+      '@wordpress/block-serialization-default-parser': 5.54.0
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/dom': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/hooks': 4.54.0
+      '@wordpress/html-entities': 4.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/is-shallow-equal': 5.54.0
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/shortcode': 4.54.0
+      '@wordpress/warning': 3.54.0
+      change-case: 4.1.2
+      colord: 2.9.3
+      fast-deep-equal: 3.1.3
+      hpq: 1.4.0
+      is-plain-object: 5.1.0
+      memize: 2.1.1
+      react: 18.3.1
+      react-is: 18.3.1
+      remove-accents: 0.5.0
+      showdown: 1.9.1
+      simple-html-tokenizer: 0.5.11
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@types/react'
       - '@types/react-dom'
       - react-dom
 
@@ -25062,6 +25616,26 @@ snapshots:
       - browserslist
       - supports-color
 
+  '@wordpress/commands@1.33.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      clsx: 2.1.1
+      cmdk: 1.1.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+
   '@wordpress/commands@1.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/base-styles': 13.0.0
@@ -25285,6 +25859,177 @@ snapshots:
       - stylelint
       - supports-color
       - vite
+
+  '@wordpress/components@30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/gradient-parser': 1.1.0
+      '@types/highlight-words-core': 1.2.1
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/date': 5.54.0
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/dom': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/escape-html': 3.54.0
+      '@wordpress/hooks': 4.54.0
+      '@wordpress/html-entities': 4.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.54.0
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/warning': 3.54.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gradient-parser: 1.1.1
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.1.0
+      memize: 2.1.1
+      path-to-regexp: 6.3.0
+      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 9.14.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+
+  '@wordpress/components@30.9.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/utc': 2.1.1
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/gradient-parser': 1.1.0
+      '@types/highlight-words-core': 1.2.1
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/base-styles': 6.20.0
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/date': 5.54.0
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/dom': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/escape-html': 3.54.0
+      '@wordpress/hooks': 4.54.0
+      '@wordpress/html-entities': 4.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 11.8.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.54.0
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/warning': 3.54.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gradient-parser: 1.1.1
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.1.0
+      memize: 2.1.1
+      path-to-regexp: 6.3.0
+      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 9.14.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+
+  '@wordpress/components@32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/utc': 2.1.1
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/gradient-parser': 1.1.0
+      '@types/highlight-words-core': 1.2.1
+      '@types/react': 18.3.31
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/base-styles': 6.20.0
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/date': 5.54.0
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/dom': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/escape-html': 3.54.0
+      '@wordpress/hooks': 4.54.0
+      '@wordpress/html-entities': 4.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 12.2.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.54.0
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/warning': 3.54.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.9.3
+      csstype: 3.2.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gradient-parser: 1.1.1
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.1.0
+      memize: 2.1.1
+      path-to-regexp: 6.3.0
+      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-day-picker: 9.14.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react-dom'
+      - supports-color
 
   '@wordpress/components@37.0.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -26344,6 +27089,24 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/compose@7.33.1(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      '@types/mousetrap': 1.6.15
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/dom': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/is-shallow-equal': 5.54.0
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      '@wordpress/priority-queue': 3.54.0
+      '@wordpress/undo-manager': 1.54.0
+      change-case: 4.1.2
+      clipboard: 2.0.11
+      mousetrap: 1.6.5
+      react: 18.3.1
+      use-memo-one: 1.1.3(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@wordpress/compose@7.46.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
       '@types/mousetrap': 1.6.15
@@ -26427,10 +27190,10 @@ snapshots:
       '@types/mousetrap': 1.6.15
       '@wordpress/deprecated': 4.54.1-next.v.202608281122.0
       '@wordpress/dom': 4.54.1-next.v.202608281122.0
-      '@wordpress/element': 8.6.2-next.v.202608281122.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.54.1-next.v.202608281122.0
-      '@wordpress/keycodes': 4.54.1-next.v.202608281122.0(@types/react@18.3.31)
-      '@wordpress/priority-queue': 3.54.1-next.v.202608281122.0
+      '@wordpress/element': 8.6.2-next.v.202609031004.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.54.1-next.v.202609031004.0
+      '@wordpress/keycodes': 4.54.1-next.v.202609031004.0(@types/react@18.3.31)
+      '@wordpress/priority-queue': 3.54.1-next.v.202609031004.0
       '@wordpress/private-apis': 1.54.0
       '@wordpress/undo-manager': 1.54.1-next.v.202608281122.0
       change-case: 4.1.2
@@ -26463,6 +27226,41 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
       - react-dom
+
+  '@wordpress/core-data@7.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/api-fetch': 7.54.0
+      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.27.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/html-entities': 4.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/is-shallow-equal': 5.54.0
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/sync': 1.54.0
+      '@wordpress/undo-manager': 1.54.0
+      '@wordpress/url': 4.54.0
+      '@wordpress/warning': 3.54.0
+      change-case: 4.1.2
+      equivalent-key-map: 0.2.2
+      fast-deep-equal: 3.1.3
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - stylelint
+      - supports-color
+      - vite
 
   '@wordpress/core-data@7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -26765,6 +27563,17 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/data-controls@4.33.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/api-fetch': 7.54.0
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/deprecated': 4.54.0
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
   '@wordpress/data-controls@4.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/api-fetch': 7.54.0
@@ -26775,6 +27584,26 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - react-dom
+
+  '@wordpress/data@10.33.1(@types/react@18.3.31)(react@18.3.1)':
+    dependencies:
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/is-shallow-equal': 5.54.0
+      '@wordpress/priority-queue': 3.54.0
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/redux-routine': 5.54.0(redux@5.0.1)
+      deepmerge: 4.3.1
+      equivalent-key-map: 0.2.2
+      is-plain-object: 5.1.0
+      is-promise: 4.0.0
+      react: 18.3.1
+      redux: 5.0.1
+      rememo: 4.0.2
+      use-memo-one: 1.1.3(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@wordpress/data@10.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -26840,6 +27669,53 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
       - react-dom
+
+  '@wordpress/dataviews@10.3.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/base-styles': 6.20.0
+      '@wordpress/components': 30.9.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/date': 5.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 11.8.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/url': 4.54.0
+      '@wordpress/warning': 3.54.0
+      clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+    optionalDependencies:
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/hooks': 4.54.0
+      change-case: 4.1.2
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.1.0
+      memize: 2.1.1
+      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      use-memo-one: 1.1.3(react@18.3.1)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
 
   '@wordpress/dataviews@18.1.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -27205,11 +28081,13 @@ snapshots:
 
   '@wordpress/deprecated@4.54.1-next.v.202608281122.0':
     dependencies:
-      '@wordpress/hooks': 4.54.1-next.v.202608281122.0
+      '@wordpress/hooks': 4.54.1-next.v.202609031004.0
 
   '@wordpress/deprecated@4.54.1-next.v.202609031004.0':
     dependencies:
       '@wordpress/hooks': 4.54.1-next.v.202609031004.0
+
+  '@wordpress/dom-ready@4.33.1': {}
 
   '@wordpress/dom-ready@4.54.0': {}
 
@@ -27221,7 +28099,7 @@ snapshots:
 
   '@wordpress/dom@4.54.1-next.v.202608281122.0':
     dependencies:
-      '@wordpress/deprecated': 4.54.1-next.v.202608281122.0
+      '@wordpress/deprecated': 4.54.1-next.v.202609031004.0
 
   '@wordpress/dom@4.54.1-next.v.202609031004.0':
     dependencies:
@@ -27373,6 +28251,69 @@ snapshots:
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - postcss
+      - stylelint
+      - supports-color
+      - vite
+
+  '@wordpress/editor@14.33.11(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/api-fetch': 7.54.0
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/blob': 4.54.0
+      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.27.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/commands': 1.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/core-data': 7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/dataviews': 10.3.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/date': 5.54.0
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/dom': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/fields': 0.25.11(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/hooks': 4.54.0
+      '@wordpress/html-entities': 4.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/interface': 9.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keyboard-shortcuts': 5.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      '@wordpress/media-utils': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/notices': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/patterns': 2.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/plugins': 7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/preferences': 4.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/reusable-blocks': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/server-side-render': 6.30.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.54.0
+      '@wordpress/warning': 3.54.0
+      '@wordpress/wordcount': 4.54.0
+      change-case: 4.1.2
+      client-zip: 2.5.0
+      clsx: 2.1.1
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      is-plain-object: 5.1.0
+      memize: 2.1.1
+      react: 18.3.1
+      react-autosize-textarea: 7.1.0(patch_hash=5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 9.0.1
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
@@ -27828,6 +28769,16 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/element@6.33.1':
+    dependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+      '@wordpress/escape-html': 3.54.0
+      change-case: 4.1.2
+      is-plain-object: 5.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@wordpress/element@6.46.0':
     dependencies:
       '@types/react': 18.3.31
@@ -27873,6 +28824,17 @@ snapshots:
   '@wordpress/element@8.6.2-next.v.202608281122.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/escape-html': 3.54.1-next.v.202608281122.0
+      change-case: 4.1.2
+      is-plain-object: 5.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@wordpress/element@8.6.2-next.v.202609031004.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/escape-html': 3.54.1-next.v.202609031004.0
       change-case: 4.1.2
       is-plain-object: 5.1.0
       react: 18.3.1
@@ -27927,6 +28889,49 @@ snapshots:
     transitivePeerDependencies:
       - eslint-plugin-import-x
       - supports-color
+
+  '@wordpress/fields@0.25.11(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/api-fetch': 7.54.0
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/blob': 4.54.0
+      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.27.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/core-data': 7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/dataviews': 10.3.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/date': 5.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/hooks': 4.54.0
+      '@wordpress/html-entities': 4.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/media-utils': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/notices': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/patterns': 2.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/router': 1.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.54.0
+      '@wordpress/warning': 3.54.0
+      change-case: 4.1.2
+      client-zip: 2.5.0
+      clsx: 2.1.1
+      react: 18.3.1
+      remove-accents: 0.5.0
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - postcss
+      - react-dom
+      - stylelint
+      - supports-color
+      - vite
 
   '@wordpress/fields@0.46.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -28206,6 +29211,33 @@ snapshots:
       - esbuild
       - postcss
       - react-dom
+      - stylelint
+      - supports-color
+      - vite
+
+  '@wordpress/format-library@5.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/html-entities': 4.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/latex-to-mathml': 1.22.0
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.54.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
       - stylelint
       - supports-color
       - vite
@@ -28513,11 +29545,13 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
 
+  '@wordpress/hooks@4.33.1': {}
+
   '@wordpress/hooks@4.54.0': {}
 
-  '@wordpress/hooks@4.54.1-next.v.202608281122.0': {}
-
   '@wordpress/hooks@4.54.1-next.v.202609031004.0': {}
+
+  '@wordpress/html-entities@4.33.1': {}
 
   '@wordpress/html-entities@4.54.0': {}
 
@@ -28530,13 +29564,6 @@ snapshots:
       gettext-parser: 1.4.0
       tannin: 1.2.0
 
-  '@wordpress/i18n@6.27.1-next.v.202608281122.0':
-    dependencies:
-      '@tannin/sprintf': 1.3.3
-      '@wordpress/hooks': 4.54.1-next.v.202608281122.0
-      gettext-parser: 1.4.0
-      tannin: 1.2.0
-
   '@wordpress/i18n@6.27.1-next.v.202609031004.0':
     dependencies:
       '@tannin/sprintf': 1.3.3
@@ -28544,11 +29571,51 @@ snapshots:
       gettext-parser: 1.4.0
       tannin: 1.2.0
 
+  '@wordpress/i18n@6.6.1':
+    dependencies:
+      '@tannin/sprintf': 1.3.3
+      '@wordpress/hooks': 4.54.0
+      gettext-parser: 1.4.0
+      memize: 2.1.1
+      tannin: 1.2.0
+
   '@wordpress/icons@10.32.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@wordpress/element': 6.46.0
       '@wordpress/primitives': 4.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@wordpress/icons@11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.46.0
+      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@wordpress/icons@11.8.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.46.0
+      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      change-case: 4.1.2
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@wordpress/icons@12.2.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.46.0
+      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      change-case: 4.1.2
       react: 18.3.1
     transitivePeerDependencies:
       - '@types/react'
@@ -28876,9 +29943,38 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/is-shallow-equal@5.54.0': {}
+  '@wordpress/interface@9.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/admin-ui': 1.12.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/plugins': 7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/preferences': 4.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/viewport': 6.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - date-fns
+      - esbuild
+      - postcss
+      - stylelint
+      - supports-color
+      - vite
 
-  '@wordpress/is-shallow-equal@5.54.1-next.v.202608281122.0': {}
+  '@wordpress/is-shallow-equal@5.33.1': {}
+
+  '@wordpress/is-shallow-equal@5.54.0': {}
 
   '@wordpress/is-shallow-equal@5.54.1-next.v.202609031004.0': {}
 
@@ -28895,6 +29991,17 @@ snapshots:
   '@wordpress/kebab-case@1.1.1-next.v.202609031004.0':
     dependencies:
       change-case: 4.1.2
+
+  '@wordpress/keyboard-shortcuts@5.33.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
 
   '@wordpress/keyboard-shortcuts@5.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -28932,6 +30039,10 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
+  '@wordpress/keycodes@4.33.1':
+    dependencies:
+      '@wordpress/i18n': 6.27.0
+
   '@wordpress/keycodes@4.54.0':
     dependencies:
       '@wordpress/i18n': 6.27.0
@@ -28939,12 +30050,6 @@ snapshots:
   '@wordpress/keycodes@4.54.0(@types/react@18.3.31)':
     dependencies:
       '@wordpress/i18n': 6.27.0
-    optionalDependencies:
-      '@types/react': 18.3.31
-
-  '@wordpress/keycodes@4.54.1-next.v.202608281122.0(@types/react@18.3.31)':
-    dependencies:
-      '@wordpress/i18n': 6.27.1-next.v.202608281122.0
     optionalDependencies:
       '@types/react': 18.3.31
 
@@ -29658,6 +30763,16 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/notices@5.33.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
   '@wordpress/notices@5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/a11y': 4.54.0
@@ -30035,6 +31150,24 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/plugins@7.33.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/hooks': 4.54.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.54.0
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+
   '@wordpress/plugins@7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/components': 40.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -30184,6 +31317,27 @@ snapshots:
       - stylelint
       - supports-color
       - vite
+
+  '@wordpress/preferences@4.33.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/base-styles': 6.9.1
+      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
 
   '@wordpress/preferences@4.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30465,11 +31619,11 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
-  '@wordpress/priority-queue@3.54.0':
+  '@wordpress/priority-queue@3.33.1':
     dependencies:
       requestidlecallback: 0.3.0
 
-  '@wordpress/priority-queue@3.54.1-next.v.202608281122.0':
+  '@wordpress/priority-queue@3.54.0':
     dependencies:
       requestidlecallback: 0.3.0
 
@@ -30701,6 +31855,24 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/rich-text@7.33.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/element': 6.46.0
+      '@wordpress/escape-html': 3.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      colord: 2.9.3
+      memize: 2.1.1
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
   '@wordpress/rich-text@7.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/a11y': 4.54.0
@@ -30759,6 +31931,15 @@ snapshots:
       '@types/react': 18.3.31
     transitivePeerDependencies:
       - '@types/react-dom'
+      - react-dom
+
+  '@wordpress/route@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-router': 1.167.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      react: 18.3.1
+    transitivePeerDependencies:
       - react-dom
 
   '@wordpress/route@0.20.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -31016,6 +32197,15 @@ snapshots:
       y-protocols: 1.0.7(yjs@13.6.29)
       yjs: 13.6.29
 
+  '@wordpress/theme@0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/element': 6.46.0
+      '@wordpress/private-apis': 1.54.0
+      colorjs.io: 0.6.1
+      memize: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@wordpress/theme@1.2.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/compose': 8.7.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31198,6 +32388,29 @@ snapshots:
       - '@types/react-dom'
 
   '@wordpress/token-list@3.54.0': {}
+
+  '@wordpress/ui@0.11.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@base-ui/react': 1.7.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 12.2.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.5.0
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@types/react'
+      - '@types/react-dom'
+      - date-fns
+      - stylelint
 
   '@wordpress/ui@0.18.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31685,11 +32898,36 @@ snapshots:
 
   '@wordpress/undo-manager@1.54.1-next.v.202608281122.0':
     dependencies:
-      '@wordpress/is-shallow-equal': 5.54.1-next.v.202608281122.0
+      '@wordpress/is-shallow-equal': 5.54.1-next.v.202609031004.0
 
   '@wordpress/undo-manager@1.54.1-next.v.202609031004.0':
     dependencies:
       '@wordpress/is-shallow-equal': 5.54.1-next.v.202609031004.0
+
+  '@wordpress/upload-media@0.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@wordpress/api-fetch': 7.54.0
+      '@wordpress/blob': 4.54.0
+      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 6.46.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/preferences': 4.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/url': 4.54.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - postcss
+      - stylelint
+      - supports-color
+      - vite
 
   '@wordpress/upload-media@0.39.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31906,6 +33144,10 @@ snapshots:
       - stylelint
       - supports-color
       - vite
+
+  '@wordpress/url@4.33.1':
+    dependencies:
+      remove-accents: 0.5.0
 
   '@wordpress/url@4.54.0':
     dependencies:
@@ -33033,6 +34275,12 @@ snapshots:
       select: 1.1.2
       tiny-emitter: 2.1.0
 
+  cliui@5.0.0:
+    dependencies:
+      string-width: 3.1.0
+      strip-ansi: 5.2.0
+      wrap-ansi: 5.1.0
+
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
@@ -33119,6 +34367,8 @@ snapshots:
   colord@2.9.3: {}
 
   colorjs.io@0.5.2: {}
+
+  colorjs.io@0.6.1: {}
 
   colorjs.io@0.7.1: {}
 
@@ -33601,6 +34851,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff@4.0.4: {}
+
   diff@8.0.4: {}
 
   dns-packet@5.6.1:
@@ -33696,6 +34948,8 @@ snapshots:
   emittery@0.13.1: {}
 
   emoji-regex@10.6.0: {}
+
+  emoji-regex@7.0.3: {}
 
   emoji-regex@8.0.0: {}
 
@@ -34507,6 +35761,10 @@ snapshots:
 
   find-up-simple@1.0.1: {}
 
+  find-up@3.0.0:
+    dependencies:
+      locate-path: 3.0.0
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -34733,6 +35991,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gradient-parser@1.1.1: {}
 
   gradient-parser@1.2.0: {}
 
@@ -35946,6 +37206,11 @@ snapshots:
 
   locate-character@3.0.0: {}
 
+  locate-path@3.0.0:
+    dependencies:
+      p-locate: 3.0.0
+      path-exists: 3.0.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -36820,6 +38085,10 @@ snapshots:
     dependencies:
       yocto-queue: 1.2.2
 
+  p-locate@3.0.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -36929,6 +38198,8 @@ snapshots:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.8.1
+
+  path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
 
@@ -38221,6 +39492,10 @@ snapshots:
 
   shell-quote@1.9.0: {}
 
+  showdown@1.9.1:
+    dependencies:
+      yargs: 14.2.3
+
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -38489,6 +39764,12 @@ snapshots:
     dependencies:
       is-fullwidth-code-point: 2.0.0
       strip-ansi: 4.0.0
+
+  string-width@3.1.0:
+    dependencies:
+      emoji-regex: 7.0.3
+      is-fullwidth-code-point: 2.0.0
+      strip-ansi: 5.2.0
 
   string-width@4.2.3:
     dependencies:
@@ -39341,6 +40622,8 @@ snapshots:
 
   uuid@14.0.1: {}
 
+  uuid@9.0.1: {}
+
   v8-to-istanbul@9.3.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -39767,6 +41050,12 @@ snapshots:
       string-width: 2.1.1
       strip-ansi: 4.0.0
 
+  wrap-ansi@5.1.0:
+    dependencies:
+      ansi-styles: 3.2.1
+      string-width: 3.1.0
+      strip-ansi: 5.2.0
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -39846,6 +41135,11 @@ snapshots:
 
   yaml@2.8.3: {}
 
+  yargs-parser@15.0.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@18.1.3:
     dependencies:
       camelcase: 5.3.1
@@ -39854,6 +41148,20 @@ snapshots:
   yargs-parser@21.1.1: {}
 
   yargs-parser@22.0.0: {}
+
+  yargs@14.2.3:
+    dependencies:
+      cliui: 5.0.0
+      decamelize: 1.2.0
+      find-up: 3.0.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 3.1.0
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 15.0.3
 
   yargs@15.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-overrides:
-  date-fns@^3.6.0: ^4.1.0
-
-pnpmfileChecksum: sha256-WD2iHMB0TVg57gFqe3iV6oE450si9qBGIhi+6Vafu4s=
+pnpmfileChecksum: sha256-KbGekh3EGsPsu6tK5tfWdbyixzwClyFsRvDiU3zCWBE=
 
 patchedDependencies:
   '@wordpress/build': 6f3fbefb10df6ce84b2e3c307e3894b697d87a888315abc805b6ff67bf7de635
@@ -5901,7 +5898,7 @@ importers:
         version: 4.0.0(@react-spring/web@10.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@woocommerce/email-editor':
         specifier: 2.4.0
-        version: 2.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(postcss@8.5.23)
+        version: 2.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)
       '@wordpress/a11y':
         specifier: 4.54.0
         version: 4.54.0
@@ -8499,12 +8496,6 @@ packages:
   '@floating-ui/dom@1.8.0':
     resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
-  '@floating-ui/react-dom@2.0.8':
-    resolution: {integrity: sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
   '@floating-ui/react-dom@2.1.9':
     resolution: {integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==}
     peerDependencies:
@@ -10444,9 +10435,6 @@ packages:
   '@types/gradient-parser@1.1.0':
     resolution: {integrity: sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==}
 
-  '@types/highlight-words-core@1.2.1':
-    resolution: {integrity: sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA==}
-
   '@types/highlight-words-core@1.2.3':
     resolution: {integrity: sha512-PWNU/NR0CaYEsK38mcCTyDzeS2TlEGK9kRhRMz1i86jVAe836ZlA3gl6QYpu+CG6IpfNKTgWpEnJuRededvC0g==}
 
@@ -11136,12 +11124,6 @@ packages:
     resolution: {integrity: sha512-DofWAzVQiJpgpuXDXbvN1nxkEMe5rXLklgUWIytkNuIEpu7hK/0dKHd5kvYL/OOhHIrweanjyjIHyizWnThC4g==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/admin-ui@1.12.0':
-    resolution: {integrity: sha512-CVTvE2jLTP71vBliAhOrvlMoOG1o1TdyoCL5gmw0Uswuj/qhqK3f1Y1adz7hAWiR9o7H9SoPYf+qg6pbZJVyaQ==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/admin-ui@2.9.0':
     resolution: {integrity: sha512-qBunBhH5T4b7oxQaFcAonMppcfa2y1323/kdJ/vSJpqxuNVcAX0V1F22WZfsyWa26cELUG3ldQQ/duYZFBkokg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11151,10 +11133,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/api-fetch@7.33.1':
-    resolution: {integrity: sha512-kxk7Og2CZLOMUZtDfOXSGapem4ToP15JB24PfixJLS0dKfrlUBci4ShjJ3z3jdIx01gf1gfP4NFjqzicJKb+Rg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/api-fetch@7.54.0':
     resolution: {integrity: sha512-L3aijA4rSYdxcM0IDysZcAMhUN3xMibNZWDmSi3B+72Yc1OWClD2aRNbbx2OL7LfHmHOi/844J+KHqlaRJnB4A==}
@@ -11190,14 +11168,6 @@ packages:
     resolution: {integrity: sha512-xvn0Y3apMSCQbeRqhdz4r1Fo0hKhzPqUowze0O6S/ZrmqJILpF7qBxPp2x8ZaKJ2riQlFOUV5/uG5yviBNfuMg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/base-styles@6.20.0':
-    resolution: {integrity: sha512-Dsug4Zxz2xOFtK6CGThKYXwCqC9Yztw2STKQzwztrX4yW+o6iDbzkxpcwdDhsaVJs0Jt9A4LmJpZPh+pUozzLA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/base-styles@6.9.1':
-    resolution: {integrity: sha512-UCtTANAdym5jpTEZS17WHrKLu7R52gQRgKuwsRm5uZWUb4g4Vq8NX52CBIesF1viFyKfM++HpmteFkrL7p0SMg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/base-styles@9.1.0':
     resolution: {integrity: sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11205,13 +11175,6 @@ packages:
   '@wordpress/blob@4.54.0':
     resolution: {integrity: sha512-/9s3JpYBNlK44v9V1fHT0dgPVxDVzcNss6cbGk/kNOtntoLJkBaRWLjCXm9WGWQ2kv2sm6PLDzlSiiOCF5sPHg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/block-editor@15.6.9':
-    resolution: {integrity: sha512-X5S7oWsTCpNIUHbsx/ZMN+2AXnILn3EeotUWAj8DsHtFFgfiDnbo2kKPaWANgGtHJ+GNWZPr0RUyS9Gmtdwn1A==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/block-editor@17.0.0':
     resolution: {integrity: sha512-RGWvjWLwIKMKEgLt6kZseC+oEO7oNnDFMzfZ56eGuQKZCKM88x5F7jaEly6YWqj8XtonXEz1ihfxL5JrPeSFNg==}
@@ -11235,13 +11198,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/block-library@9.33.10':
-    resolution: {integrity: sha512-9qrBXTc1BR539L78KuMCZ7PHt4US822NSKKVNcgVTkPH2qHyUDvr6t680HRHCI7VYWq1NXp9teZo7PEZNVfhVA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/block-serialization-default-parser@5.54.0':
     resolution: {integrity: sha512-7y2wtF7+QUlyFuhpIMI0JxI1EK6vbiYFKWvnPeqhaulg9b2xPG1IFjhZNKD+5oQgvOpRU2tKV/fisbagqxdqgA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11255,12 +11211,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/blocks@15.6.3':
-    resolution: {integrity: sha512-AFYre+06ZVtyv0KSVwCOUY+HSEdAaQRxFrRZnSsZ5FEs0pMMIsulFYay8QvlVVTtBUKbYlxKEDi8kD1DI+8jxA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
 
   '@wordpress/boot@0.21.0':
     resolution: {integrity: sha512-bpOM2JTGnomYmp/h3myYQUguOOzm01+CU5Jw7wYqOixjj9VkE3kYWh0fdYvPGz/ERD7LNpHJIR/ucWbguGvH1g==}
@@ -11296,13 +11246,6 @@ packages:
       '@wordpress/theme':
         optional: true
 
-  '@wordpress/commands@1.33.5':
-    resolution: {integrity: sha512-m8a/9ahGzEVYj77EfS6crzjq2Gq97DOXbeSqRSHrpePE/NSXPh6AAABRP/dKCI/0AysjJ0v/bKKTVnsFgkk0YA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/commands@1.54.0':
     resolution: {integrity: sha512-TUo0n4011kzxkIGyHT9yz38c731rONyctmyynQO0Tro/uP8MhxNbWdzMOjzJXNwZTCqEME5b7WVTgT/bF7WCvw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11316,27 +11259,6 @@ packages:
     peerDependencies:
       react: ^18 || ^19
       react-dom: ^18 || ^19
-
-  '@wordpress/components@30.6.5':
-    resolution: {integrity: sha512-jSDpUz1BBQvpWUGwqZUlI22PMGMtiN5ooKS4GlQqjUmEBJH4llwiRblkZBKgdznv+5KDYyDiRNIGCz/hLSdwZw==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
-  '@wordpress/components@30.9.0':
-    resolution: {integrity: sha512-mx0df0TjChmpCtqQn3iFHphqaLQVNk5Yprs+3NJSfm1kWuZPKfVys6AtmhfBgXs/VrrJk34Z+1N+nqXovHuXnw==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
-  '@wordpress/components@32.6.0':
-    resolution: {integrity: sha512-MpOr0mGTkKDRjxK5LKm86Uoj9p9Z6KkrvhkNVi5zVKCftyHVMK+tun7wL2Qn/JZVLbxZpB1kW5sJ5aMf3T2ToA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/components@37.0.0':
     resolution: {integrity: sha512-Lol3iUujNnn4uHxI4VARDVEJIFUKlBtZUMcSFWofiYRZc8aV5BplyKC+sRAhKm+KFNBQjZtqd4PdixtaOHuX6w==}
@@ -11370,12 +11292,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/compose@7.33.1':
-    resolution: {integrity: sha512-1satS+7EKlzZOCR++uP8mAy3BJPKX2eeTZHVW3669n0xM1xdmzl9JXyEbtEqaFVYhI3dHTq5kLwrm+aSpn0zag==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
 
   '@wordpress/compose@7.46.0':
     resolution: {integrity: sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==}
@@ -11413,13 +11329,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/core-data@7.33.9':
-    resolution: {integrity: sha512-1tYiHamRDvopG9cLFTR+SdUKroTLQRof25vquI5OlXEzBgRmn/ksWlOKM6nFxGUBK6JmdlczBoa0QhBJdXBK0Q==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/core-data@7.54.0':
     resolution: {integrity: sha512-4a1FVQFJIcdsy2BX3ejxtCbYZktrUg14z4Qy9QvMGjyVWRYgtXvqxInHUIaGDCMU4uEt59wb7gMEhWrgMu1ouw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11431,23 +11340,11 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/data-controls@4.33.1':
-    resolution: {integrity: sha512-+gD47q6WuZ2MYMxwUBwBTYACMayrZoyG6W6OR1Q2ggOfkmoQb4OlxEWJPdCIC8GxJJwVh8ej9HjzzI3S/tDsJg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/data-controls@4.54.0':
     resolution: {integrity: sha512-fy2xTtS5TmxVks7+ZbOMidUvcOEyfg/01WkeSNfYZwPgyhl1Qj8dV8D8MCJIGVUmxBZeLV1IH5TY4zpcd2NQ4Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18 || ^19
-
-  '@wordpress/data@10.33.1':
-    resolution: {integrity: sha512-Y+GlNYFds2ICgkAfwT3UsLCXlagibtUFADBf/UXmTgEvc07/O/lOBHeIW72BiRkb/O4oCqf2ZeXgGkNgJLlyiQ==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
 
   '@wordpress/data@10.54.0':
     resolution: {integrity: sha512-JPgGSNjAD7+8SXTvXpORSo74Pf8pz4JPGyBiGsoEbfYs0VL2FeIb/QLIMQxtpKOxc6xjODLh0LBXhFbWUqTHkA==}
@@ -11462,13 +11359,6 @@ packages:
     peerDependencies:
       '@types/react': ^18 || ^19
       react: ^18 || ^19
-
-  '@wordpress/dataviews@10.3.0':
-    resolution: {integrity: sha512-7mBcW4Vris+8Be3ESUPkhe85AwAbwO+2ocvi4UDF6jEzeyH7GQxq+1k4Lq4vAc+pNBf0IehZV598+qs8nk9j2w==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/dataviews@18.1.0':
     resolution: {integrity: sha512-vV3wvSnqxjGqsUj9fnRmVVzXVCy/N+pRGYx+WyyXZUslbLX9xn1JfI2Z8uXFptKZJ5vGJ3BnLkfE4r2HdvG0Zg==}
@@ -11518,10 +11408,6 @@ packages:
     resolution: {integrity: sha512-T2M7KnNoxyZ5IdVapEo4+j+BYYFqEhnC5oASsoM71OdGEOcKa9j7dUJwBUOfVRCEeA81Lc/8LbBxDyrBqb6q6g==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/dom-ready@4.33.1':
-    resolution: {integrity: sha512-jrHN/arTKp2iuYj24byFgabBhZsZ3WUXCSKT16d/1MZUXGQt876XXu6r5rwpLtnVsX2gFiZ/DzdRKCL4RV9Wpg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/dom-ready@4.54.0':
     resolution: {integrity: sha512-gEJxddZ+KZ7FkeV2EFr9f5f4gefOOtcgBP6BIIL6Wum4a1liBPphlbkBVfFTsReHIrvqsj8S3EtpHXl/RlXSgA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11556,13 +11442,6 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@wordpress/editor@14.33.11':
-    resolution: {integrity: sha512-yGSMcsya/9OADD+xgfewVwnHvRUpMsKGh865WkWm2uy0XbCap5IoDMNeKgsM/nYXrCy8y5sbO4b9bzDUhHcsdA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/editor@14.54.0':
     resolution: {integrity: sha512-Z0YD/Ns1JONBDkNMo7mo1szBcC02TvGpUv9JEz2S8bFIzH3jEaPERvJc4bVEvgc8xA+CbbIC/RKJhiI+VkIm3A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11573,10 +11452,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/element@6.33.1':
-    resolution: {integrity: sha512-8Y2TEkduT1cAGVfh5HoERpJIVvCcfHI1k+PGgG3wzy85me6hjgA/P7l90yBt/9i9Omt5+buGfnklobstECR8zg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/element@6.46.0':
     resolution: {integrity: sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==}
@@ -11660,12 +11535,6 @@ packages:
       typescript:
         optional: true
 
-  '@wordpress/fields@0.25.11':
-    resolution: {integrity: sha512-jNNG14L0FWUif95kVUVm53mT4ItOBm3yN9I2mElm/aznHZh3rheRJ96vT2nyTuJ1/J79Xt2DerqkvcWP4R6R3Q==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/fields@0.46.0':
     resolution: {integrity: sha512-RbNxuLB9yL1zHY4aliEqjJaKnXSoOrJL+6NmeV0FVwGdu9vgsBk56rkuGF06O48bb6eQ4YJLki86Yza7VjvUeA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11675,13 +11544,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/format-library@5.33.9':
-    resolution: {integrity: sha512-9RTyCFuaXSSF4Rz4rnz0Elge71nSn7UWyvskMQtZNN5nMGjH9D5NK5JoYKANpt1v0Cx/vfUkLTywBrU0v2+pLA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/format-library@5.54.0':
     resolution: {integrity: sha512-MzKaFIcd8fNDpWDYf63BYIGGSZmkJHCl1dwPNXAW8Z9lLwdkhhQP10hwcsy5HGDHEqqY4QBSx/a5QHqJKfSU7A==}
@@ -11716,20 +11578,16 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/hooks@4.33.1':
-    resolution: {integrity: sha512-p9RbNsZJnsGY45MEV3QfYHS4dMmKe0B1f/RUXEL8ZLa36aUWZrUX7PJxvmmpeuPrboHQwT4MDps9kwHO4V6GVg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/hooks@4.54.0':
     resolution: {integrity: sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/hooks@4.54.1-next.v.202609031004.0':
-    resolution: {integrity: sha512-hbyRCIb4TSX+0YSw+1laD6lIRSxG/gZCTR1i7hbQRaHUbgN4n8hu7Jp1zgSOngIO+8HMVhF1CwofqOok5LjKuw==}
+  '@wordpress/hooks@4.54.1-next.v.202608281122.0':
+    resolution: {integrity: sha512-/zv/U7WX643r6m4LCZo/IFaFz03s6n/9Tm2K9EvqYSPv2y4tSMPQWBy/ahV2lRobcsmIJMSrDPFBP6uXh9jbew==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/html-entities@4.33.1':
-    resolution: {integrity: sha512-HdpnRRvTMstX58U4Yr+UisIrFLcG97PGegAczMxeq9Q1n3ol5FCkEegBTQIJffAZ5IadBsPZ77fjoVtLK7RViQ==}
+  '@wordpress/hooks@4.54.1-next.v.202609031004.0':
+    resolution: {integrity: sha512-hbyRCIb4TSX+0YSw+1laD6lIRSxG/gZCTR1i7hbQRaHUbgN4n8hu7Jp1zgSOngIO+8HMVhF1CwofqOok5LjKuw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/html-entities@4.54.0':
@@ -11750,34 +11608,11 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     hasBin: true
 
-  '@wordpress/i18n@6.6.1':
-    resolution: {integrity: sha512-aEFSF+5dp0UhdMGHyNUwhcL0Sg/kp0NtCSMrfcQrXRM6uD/+y8ih0mHeULww5V919NUrzXIZSZGfOaOIiQVXXg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    hasBin: true
-
   '@wordpress/icons@10.32.0':
     resolution: {integrity: sha512-1WvJdT361X1LnetYBpBWUjAVXZzl+pBdIwHbYRAp8ej47EI/igPmNxmq81nFd40s8fer/9qtipielcqSI6H2rA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       react: ^18
-
-  '@wordpress/icons@11.0.1':
-    resolution: {integrity: sha512-vXkWiAxwDjWBcj72oXbJyuDtIvNvk1JnnmYzQUpIjKjvScRPcj+Kt40nFYk/5kPnNAhBqVNcZ7tWK7NctSslJA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18
-
-  '@wordpress/icons@11.8.0':
-    resolution: {integrity: sha512-ZMNHApHMmPLpNnNLfPLRf6XWoPhZFNKFKdpMlhA6Lx04J1hLVyLRz8PuM+1o3ByxD2ZiExfSRhdmI+7VvEg6DA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
-  '@wordpress/icons@12.2.0':
-    resolution: {integrity: sha512-Fiw7bmfHDNPjTdCrBF23/9K0VN/GUi73d2ZPZaeWdXhTmIX62T9KYvb1c+WnlBkX7GpXgJO6Q8mypQCY9mw5SQ==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
 
   '@wordpress/icons@13.3.0':
     resolution: {integrity: sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==}
@@ -11831,19 +11666,12 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@wordpress/interface@9.18.5':
-    resolution: {integrity: sha512-OCNCTogPS/kHPVjIAHtQ2y9WaX1fm1oK1cXQs6RezKtO1y/+nFH2L5pjzF7ifG1ECe5KL7REX4kJXgDTIwDV9g==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
-  '@wordpress/is-shallow-equal@5.33.1':
-    resolution: {integrity: sha512-QMOwATwFjFr6Z9geS8EjuEVGN0gkpANypjqIBE8iTDtfKhY99LTtxbTaguviqKfVP7l73v1B0GJfHtkPExhJkA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/is-shallow-equal@5.54.0':
     resolution: {integrity: sha512-j5mskkhAD3jWrgNSdoSsexos1dxI9EQftfAZAbI2GZwFi6I20cgSrktgCewAUSZDqJ+vPwaJs0bTDhtUDMHXLg==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/is-shallow-equal@5.54.1-next.v.202608281122.0':
+    resolution: {integrity: sha512-P6QKkNcZD9gzWHkdRJwum8D92mclDNgtry1Ww8vtIUEk1tWAmgllASGwiBBjFTnU+dX4JEtQh2IwR1R8773GMw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/is-shallow-equal@5.54.1-next.v.202609031004.0':
@@ -11863,12 +11691,6 @@ packages:
   '@wordpress/kebab-case@1.1.1-next.v.202609031004.0':
     resolution: {integrity: sha512-SL+lxyxFlSUxX4JfuckBNR071XyTBqQ3a9vXP8OGalbkBEqJPRBNkHECMrefT92QXylmw0Tv7nbEubp/G6QnqA==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
-
-  '@wordpress/keyboard-shortcuts@5.33.1':
-    resolution: {integrity: sha512-ql+qQ+AW9rnaS6jBv3J5MT8ku0qijAYCq6rIvfEiA1W84i5+LB9JYxxzrFH8v5uGU4ZjqqRQEmcDd+lorlT4Vg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
 
   '@wordpress/keyboard-shortcuts@5.54.0':
     resolution: {integrity: sha512-EiguLibri6ZBjQHe7rqumTFk5eZrw47Y2m7TuXro08FQS+qxY6YsYlefbCfWBehFIiptYkaZ0OyRu2KhmDOwuA==}
@@ -11890,12 +11712,17 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/keycodes@4.33.1':
-    resolution: {integrity: sha512-acuH0ogiY92ClslUpezZyEzfm1Ubx2bftevn/PxbsVq52UCOu14CAKgnO9sYqVuMpXT+zXveRMySixyKHB1wnA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/keycodes@4.54.0':
     resolution: {integrity: sha512-WeaKup+THfx62hGOOVZpeK0AvEA0d3xwWo2P44pUbUKaBFydTXWqmm7HNsZ7bX9lDdk7JshuLSwhpHfwFPOQEw==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+    peerDependencies:
+      '@types/react': ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@wordpress/keycodes@4.54.1-next.v.202608281122.0':
+    resolution: {integrity: sha512-l6cvxNDRw8s0J4MBPtIZFhLBaJeIpiCDbqqh03aZMzEShyFsmhXzpPOcl29Z7uX9pHvRDpgjUdVDvSWZeq/oQQ==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       '@types/react': ^18 || ^19
@@ -11956,12 +11783,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/notices@5.33.1':
-    resolution: {integrity: sha512-bvw97KGiToFZv9/EHPhom2va7pDXCUR2BNfSuxT3lSAt1tX5DUD5i1+6aa5TIybSAtZNGisCySH4fL/paMDMjQ==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/notices@5.54.0':
     resolution: {integrity: sha512-fZcDoJEOdRwVtL8pUWVuK7ggNIivMd46/jczxhsX+LmSVT/vlhrBEKv22IeiqpcyGRY8GakXfcK7c02n61HLVw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11979,13 +11800,6 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@wordpress/plugins@7.33.5':
-    resolution: {integrity: sha512-kTNhyX1FKTSWBmxfHWoqEo5+iM96ThHXGqFGzeAFt+W35EeHzt9a/H++9yfcxMqDyjR1IRjoB261bX+oLPuw9Q==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/plugins@7.54.0':
     resolution: {integrity: sha512-2r1QKMcC+OVauo3iLfCXfuFYxlGc1u2W3XJaOc+CjHcd0CFVJafOoqAS8ffQ0YtNv59BVhwzmbGXOgk+66r/0A==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -11996,13 +11810,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/preferences@4.33.5':
-    resolution: {integrity: sha512-5tPfWv5Kw/+KAfFzsZKojK3FHNDiMVwj8GusXAqbsCSy9YsyAxifaEXeul684RYFdizLK3gWqe4S0K6GaLs0CA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@wordpress/preferences@4.54.0':
     resolution: {integrity: sha512-yFEJopdYAE0KmlrqrZxfTcwS8rSJcHV+qYfzFlz8pHgZe2UVB5MENPKJetPT7fhM4uN5WISY9cgnEniF3+EoDw==}
@@ -12052,12 +11859,12 @@ packages:
       '@types/react':
         optional: true
 
-  '@wordpress/priority-queue@3.33.1':
-    resolution: {integrity: sha512-m3S+bfVIGmDHVrCzTdQu5oHP6aBIM0pf5AYVpfdA2addJHLICtAMrPYdD+4MXekh8a38DzPekZa03vGv3ws3zQ==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
   '@wordpress/priority-queue@3.54.0':
     resolution: {integrity: sha512-YOJAKb80OFzHCdamyfKu9L3k+AZWexo5f1Jjm8HFs3+6CIxmkPyTe7uYccpRvmgag8MkVAdus/VaO5thzOy+gA==}
+    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
+
+  '@wordpress/priority-queue@3.54.1-next.v.202608281122.0':
+    resolution: {integrity: sha512-lMoxZwaoZ8o3Y3jALH1ovAfS/OvIOooC2qsS6d+3jHrC+oTO0b8BkmSuTWIknDWNdbveDM8qMuXVPARaWPiWXw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/priority-queue@3.54.1-next.v.202609031004.0':
@@ -12097,12 +11904,6 @@ packages:
       react: ^18 || ^19
       react-dom: ^18 || ^19
 
-  '@wordpress/rich-text@7.33.2':
-    resolution: {integrity: sha512-jy8DPBN6f0WeQM1jL+yGX29xHgzDdyrGoXYEGrGt2ngpGYMca2ZrG9ZLcpQlU6S3sLV/n1jtjZntWrFFYRzgQA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-
   '@wordpress/rich-text@7.54.0':
     resolution: {integrity: sha512-zSu1Wv2FrKf4Lh18Wt5VCrDl964CDmyWpR7KAmX0xVFqRjO3HMKxV4lvK6IS6vPzH6k9KKcAnKpkQPnce6R4+w==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -12122,12 +11923,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/route@0.10.0':
-    resolution: {integrity: sha512-rNXo4cq+yPlkFzC/bQjZW8qQpaNgh1nAeUVefc4Si079C79pC0JhnXKqPOq4Iy28oJZyRjfdLdFV1FdLhHfmzA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
 
   '@wordpress/route@0.20.0':
     resolution: {integrity: sha512-vLp0EvAcmCZnTVFjkhuFaPbm9qwrvGIaFHMaskU3uBw/qsxj/0xDT5Zm43MZNAKrbU8x2FC+KMXk0c28Ya5tFg==}
@@ -12203,17 +11998,6 @@ packages:
   '@wordpress/sync@1.54.0':
     resolution: {integrity: sha512-NHRGP27HecH/hGdM3YVFcKFqUw06UfLoUQPp8IuIR3Bk7DPj1PdM5PnbqyYibSf8caDE+bIduacbHv0mn2JLSg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-
-  '@wordpress/theme@0.11.0':
-    resolution: {integrity: sha512-jXilt+3codfAEFRHvLpnULeOaaycwJByyv+m/TIlspZ4r0l4X9iA1KL7GkXOHz2AJWWvS7FUnS/GHBuIrUgAWg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-      stylelint: '>=16.8.2'
-    peerDependenciesMeta:
-      stylelint:
-        optional: true
 
   '@wordpress/theme@1.2.0':
     resolution: {integrity: sha512-pILS4ytGGiASrpJ8sLp+pRbcBspFYeMTr5LdM4fWBv/EN2CIKhBLpX3qGlXwKzS+HzjrbXZwj60Bfbg/PxvQew==}
@@ -12317,13 +12101,6 @@ packages:
     resolution: {integrity: sha512-U3LMm0zq35H+kmAVv2bwG8W75sflglI45YLV/KPLGMZIv/f45LTtMkzpJ16c3TSYs0CP+slsV4YIMttetcQwPg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/ui@0.11.0':
-    resolution: {integrity: sha512-V1R3CTQ8MltuajZ53PCHGe9mmRwyx1RpjHA2wWOv+79dV0qQ1Y/psL0YTMY4eteL4SNAlBcjJVP66zD5O6yF8Q==}
-    engines: {node: '>=20.10.0', npm: '>=10.2.3'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/ui@0.18.0':
     resolution: {integrity: sha512-TIMsjaRl5/QJEjKbtoa0YAhzVdcvAk/FmA9rgJVR6oG/l6+s0WgoebGASEVyRyoOstq45xB7PzYMdjVs7iS0zg==}
     engines: {node: ^20.19.0 || >=22.13.0, npm: '>=10.2.3'}
@@ -12369,13 +12146,6 @@ packages:
     resolution: {integrity: sha512-rdzsTqVht15R+NqXtJe6yE2ROD89X/tiB3bKhU7z8R0vg3kAKP+ZnJDBDvZiYMpV6XnbLxw8AyzwPyOqdO6b3Q==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/upload-media@0.18.5':
-    resolution: {integrity: sha512-4u+mMPicEuw7tMPIgCtgI5BWckWODjYayA7aOP0sQWdG90Vq1z7nGDlxHeeb/PkQxnZPh+3oA6V79OWV5ZS/Fg==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
-
   '@wordpress/upload-media@0.39.0':
     resolution: {integrity: sha512-SL5cCERYah4KoF/yviarLEOYw3dH8z0UA78tWFAaR3f+uja2mj92Ub59kRBDnCLrn0SWInW+JbMwWM5mkQRhbw==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
@@ -12386,10 +12156,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@wordpress/url@4.33.1':
-    resolution: {integrity: sha512-t4MKPofYLHTIVE+NV36WBmlnzHsnZFkXsACdu/InF0u5pmyc/ZgXmq44qi6h/PmbGoUKnRQisulMIvGfEVBTeA==}
-    engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/url@4.54.0':
     resolution: {integrity: sha512-wa+61i0zyHjNZOAvXLdLrjc+dHyBjX9lfqnAfBw1N0yWAGU/vL3qBkfTBIDx9LxqjKXQ9HRSSxvQVfzGyGRzkg==}
@@ -13211,9 +12977,6 @@ packages:
   clipboard@2.0.11:
     resolution: {integrity: sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==}
 
-  cliui@5.0.0:
-    resolution: {integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==}
-
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -13284,9 +13047,6 @@ packages:
 
   colorjs.io@0.5.2:
     resolution: {integrity: sha512-twmVoizEW7ylZSN32OgKdXRmo1qg+wT5/6C3xu5b9QsWzSFAhHLn2xd8ro0diCsKfCj1RdaTP/nrcW+vAoQPIw==}
-
-  colorjs.io@0.6.1:
-    resolution: {integrity: sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==}
 
   colorjs.io@0.7.1:
     resolution: {integrity: sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==}
@@ -13787,10 +13547,6 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  diff@4.0.4:
-    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
-    engines: {node: '>=0.3.1'}
-
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -13892,9 +13648,6 @@ packages:
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
-  emoji-regex@7.0.3:
-    resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -14521,10 +14274,6 @@ packages:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
 
-  find-up@3.0.0:
-    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
-    engines: {node: '>=6'}
-
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -14762,10 +14511,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  gradient-parser@1.1.1:
-    resolution: {integrity: sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==}
-    engines: {node: '>=0.10.0'}
 
   gradient-parser@1.2.0:
     resolution: {integrity: sha512-6ABGa9CR7WR/0pAJicBy5SJkiikbFM6kf/JjykwX7x+t+s8ORWVnlbi6FkHeFFb36yWsjUpHqSYrygd7ofEUqA==}
@@ -15758,10 +15503,6 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
-  locate-path@3.0.0:
-    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
-    engines: {node: '>=6'}
-
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -16410,10 +16151,6 @@ packages:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  p-locate@3.0.0:
-    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
-    engines: {node: '>=6'}
-
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -16516,10 +16253,6 @@ packages:
 
   path-case@3.0.4:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
-
-  path-exists@3.0.0:
-    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
-    engines: {node: '>=4'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -17769,10 +17502,6 @@ packages:
     resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
-  showdown@1.9.1:
-    resolution: {integrity: sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==}
-    hasBin: true
-
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
@@ -17988,10 +17717,6 @@ packages:
   string-width@2.1.1:
     resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
     engines: {node: '>=4'}
-
-  string-width@3.1.0:
-    resolution: {integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==}
-    engines: {node: '>=6'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -18763,11 +18488,6 @@ packages:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
@@ -19062,10 +18782,6 @@ packages:
     resolution: {integrity: sha512-iXR3tDXpbnTpzjKSylUJRkLuOrEC7hwEB221cgn6wtF8wpmz28puFXAEfPT5zrjM3wahygB//VuWEr1vTkDcNQ==}
     engines: {node: '>=4'}
 
-  wrap-ansi@5.1.0:
-    resolution: {integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==}
-    engines: {node: '>=6'}
-
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -19172,9 +18888,6 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yargs-parser@15.0.3:
-    resolution: {integrity: sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==}
-
   yargs-parser@18.1.3:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
@@ -19186,9 +18899,6 @@ packages:
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yargs@14.2.3:
-    resolution: {integrity: sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==}
 
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
@@ -20547,20 +20257,6 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@base-ui/react@1.7.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@base-ui/utils': 0.3.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@floating-ui/utils': 0.2.12
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      use-sync-external-store: 1.6.0(react@18.3.1)
-    optionalDependencies:
-      '@date-fns/tz': 1.4.1
-      '@types/react': 18.3.31
-      date-fns: 4.1.0
-
   '@base-ui/react@1.7.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -21269,12 +20965,6 @@ snapshots:
     dependencies:
       '@floating-ui/core': 1.8.0
       '@floating-ui/utils': 0.2.12
-
-  '@floating-ui/react-dom@2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@floating-ui/dom': 1.8.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/react-dom@2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23352,8 +23042,6 @@ snapshots:
 
   '@types/gradient-parser@1.1.0': {}
 
-  '@types/highlight-words-core@1.2.1': {}
-
   '@types/highlight-words-core@1.2.3': {}
 
   '@types/http-errors@2.0.5': {}
@@ -24162,39 +23850,39 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
-  '@woocommerce/email-editor@2.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(postcss@8.5.23)':
+  '@woocommerce/email-editor@2.4.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)':
     dependencies:
-      '@wordpress/api-fetch': 7.33.1
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/block-library': 9.33.10(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/blocks': 15.6.3(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/commands': 1.33.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.33.1(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/core-data': 7.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.33.1(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/data-controls': 4.33.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/dom-ready': 4.33.1
-      '@wordpress/editor': 14.33.11(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.33.1
-      '@wordpress/format-library': 5.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/api-fetch': 7.54.0
+      '@wordpress/base-styles': 13.0.0
+      '@wordpress/block-editor': 17.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/block-library': 10.5.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/blocks': 15.27.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/commands': 1.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 40.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 8.7.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/core-data': 7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/data-controls': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/dom-ready': 4.54.0
+      '@wordpress/editor': 14.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 8.6.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/format-library': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/global-styles-engine': 1.21.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/hooks': 4.33.1
-      '@wordpress/html-entities': 4.33.1
-      '@wordpress/i18n': 6.6.1
-      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/interface': 9.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.33.1
-      '@wordpress/keyboard-shortcuts': 5.33.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keycodes': 4.33.1
-      '@wordpress/notices': 5.33.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/plugins': 7.33.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/preferences': 4.33.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/priority-queue': 3.33.1
+      '@wordpress/hooks': 4.54.0
+      '@wordpress/html-entities': 4.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 15.5.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/interface': 10.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.54.0
+      '@wordpress/keyboard-shortcuts': 5.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      '@wordpress/notices': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/plugins': 7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/preferences': 4.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/priority-queue': 3.54.0
       '@wordpress/private-apis': 1.54.0
-      '@wordpress/rich-text': 7.33.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.33.1
+      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/url': 4.54.0
       clsx: 2.1.1
       deepmerge: 4.3.1
       lodash: 4.18.1
@@ -24205,7 +23893,6 @@ snapshots:
       - '@emotion/is-prop-valid'
       - '@types/react'
       - '@types/react-dom'
-      - date-fns
       - esbuild
       - postcss
       - stylelint
@@ -24221,27 +23908,6 @@ snapshots:
     dependencies:
       '@wordpress/dom-ready': 4.54.1-next.v.202609031004.0
       '@wordpress/i18n': 6.27.1-next.v.202609031004.0
-
-  '@wordpress/admin-ui@1.12.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/base-styles': 6.20.0
-      '@wordpress/components': 32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/route': 0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/ui': 0.11.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - date-fns
-      - react-dom
-      - stylelint
-      - supports-color
 
   '@wordpress/admin-ui@2.9.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -24387,11 +24053,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/api-fetch@7.33.1':
-    dependencies:
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/url': 4.54.0
-
   '@wordpress/api-fetch@7.54.0':
     dependencies:
       '@wordpress/i18n': 6.27.0
@@ -24428,78 +24089,9 @@ snapshots:
 
   '@wordpress/base-styles@13.1.1-next.v.202609031004.0': {}
 
-  '@wordpress/base-styles@6.20.0': {}
-
-  '@wordpress/base-styles@6.9.1': {}
-
   '@wordpress/base-styles@9.1.0': {}
 
   '@wordpress/blob@4.54.0': {}
-
-  '@wordpress/block-editor@15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
-      '@react-spring/web': 9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/a11y': 4.54.0
-      '@wordpress/api-fetch': 7.54.0
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/blob': 4.54.0
-      '@wordpress/block-serialization-default-parser': 5.54.0
-      '@wordpress/blocks': 15.27.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/commands': 1.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/date': 5.54.0
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/dom': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/escape-html': 3.54.0
-      '@wordpress/hooks': 4.54.0
-      '@wordpress/html-entities': 4.54.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/interactivity': 6.54.0
-      '@wordpress/is-shallow-equal': 5.54.0
-      '@wordpress/keyboard-shortcuts': 5.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
-      '@wordpress/notices': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/preferences': 4.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/priority-queue': 3.54.0
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/style-engine': 2.54.0(@types/react@18.3.31)
-      '@wordpress/token-list': 3.54.0
-      '@wordpress/upload-media': 0.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.54.0
-      '@wordpress/warning': 3.54.0
-      '@wordpress/wordcount': 4.54.0
-      change-case: 4.1.2
-      clsx: 2.1.1
-      colord: 2.9.3
-      deepmerge: 4.3.1
-      diff: 4.0.4
-      fast-deep-equal: 3.1.3
-      memize: 2.1.1
-      parsel-js: 1.2.3
-      postcss: 8.5.23
-      postcss-prefix-selector: 1.16.1(postcss@8.5.23)
-      postcss-urlrebase: 1.4.0(postcss@8.5.23)
-      react: 18.3.1
-      react-autosize-textarea: 7.1.0(patch_hash=5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      react-easy-crop: 5.5.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      remove-accents: 0.5.0
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - stylelint
-      - supports-color
-      - vite
 
   '@wordpress/block-editor@17.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -25033,65 +24625,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/block-library@9.33.10(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/a11y': 4.54.0
-      '@wordpress/api-fetch': 7.54.0
-      '@wordpress/autop': 4.54.0
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/blob': 4.54.0
-      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/blocks': 15.27.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/core-data': 7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/date': 5.54.0
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/dom': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/escape-html': 3.54.0
-      '@wordpress/hooks': 4.54.0
-      '@wordpress/html-entities': 4.54.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/interactivity': 6.54.0
-      '@wordpress/interactivity-router': 2.54.0
-      '@wordpress/keyboard-shortcuts': 5.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
-      '@wordpress/latex-to-mathml': 1.22.0
-      '@wordpress/notices': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/patterns': 2.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/reusable-blocks': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/server-side-render': 6.30.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.54.0
-      '@wordpress/viewport': 6.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/wordcount': 4.54.0
-      change-case: 4.1.2
-      clsx: 2.1.1
-      colord: 2.9.3
-      escape-html: 1.0.3
-      fast-average-color: 9.5.2
-      fast-deep-equal: 3.1.3
-      memize: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      remove-accents: 0.5.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - postcss
-      - stylelint
-      - supports-color
-      - vite
-
   '@wordpress/block-serialization-default-parser@5.54.0': {}
 
   '@wordpress/blocks@15.27.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -25163,40 +24696,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.31
     transitivePeerDependencies:
-      - '@types/react-dom'
-      - react-dom
-
-  '@wordpress/blocks@15.6.3(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/autop': 4.54.0
-      '@wordpress/blob': 4.54.0
-      '@wordpress/block-serialization-default-parser': 5.54.0
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/dom': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/hooks': 4.54.0
-      '@wordpress/html-entities': 4.54.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/is-shallow-equal': 5.54.0
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/shortcode': 4.54.0
-      '@wordpress/warning': 3.54.0
-      change-case: 4.1.2
-      colord: 2.9.3
-      fast-deep-equal: 3.1.3
-      hpq: 1.4.0
-      is-plain-object: 5.1.0
-      memize: 2.1.1
-      react: 18.3.1
-      react-is: 18.3.1
-      remove-accents: 0.5.0
-      showdown: 1.9.1
-      simple-html-tokenizer: 0.5.11
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@types/react'
       - '@types/react-dom'
       - react-dom
 
@@ -25616,26 +25115,6 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/commands@1.33.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.54.0
-      clsx: 2.1.1
-      cmdk: 1.1.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
-
   '@wordpress/commands@1.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/base-styles': 13.0.0
@@ -25859,177 +25338,6 @@ snapshots:
       - stylelint
       - supports-color
       - vite
-
-  '@wordpress/components@30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@emotion/cache': 11.14.0
-      '@emotion/css': 11.13.5
-      '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
-      '@emotion/serialize': 1.3.3
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
-      '@emotion/utils': 1.4.2
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/gradient-parser': 1.1.0
-      '@types/highlight-words-core': 1.2.1
-      '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/a11y': 4.54.0
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/date': 5.54.0
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/dom': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/escape-html': 3.54.0
-      '@wordpress/hooks': 4.54.0
-      '@wordpress/html-entities': 4.54.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.54.0
-      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
-      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/warning': 3.54.0
-      change-case: 4.1.2
-      clsx: 2.1.1
-      colord: 2.9.3
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
-      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      gradient-parser: 1.1.1
-      highlight-words-core: 1.2.3
-      is-plain-object: 5.1.0
-      memize: 2.1.1
-      path-to-regexp: 6.3.0
-      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-day-picker: 9.14.0(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      remove-accents: 0.5.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
-
-  '@wordpress/components@30.9.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@date-fns/utc': 2.1.1
-      '@emotion/cache': 11.14.0
-      '@emotion/css': 11.13.5
-      '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
-      '@emotion/serialize': 1.3.3
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
-      '@emotion/utils': 1.4.2
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/gradient-parser': 1.1.0
-      '@types/highlight-words-core': 1.2.1
-      '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/a11y': 4.54.0
-      '@wordpress/base-styles': 6.20.0
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/date': 5.54.0
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/dom': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/escape-html': 3.54.0
-      '@wordpress/hooks': 4.54.0
-      '@wordpress/html-entities': 4.54.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 11.8.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.54.0
-      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
-      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/warning': 3.54.0
-      change-case: 4.1.2
-      clsx: 2.1.1
-      colord: 2.9.3
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
-      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      gradient-parser: 1.1.1
-      highlight-words-core: 1.2.3
-      is-plain-object: 5.1.0
-      memize: 2.1.1
-      path-to-regexp: 6.3.0
-      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-day-picker: 9.14.0(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      remove-accents: 0.5.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
-
-  '@wordpress/components@32.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@date-fns/utc': 2.1.1
-      '@emotion/cache': 11.14.0
-      '@emotion/css': 11.13.5
-      '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
-      '@emotion/serialize': 1.3.3
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
-      '@emotion/utils': 1.4.2
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/gradient-parser': 1.1.0
-      '@types/highlight-words-core': 1.2.1
-      '@types/react': 18.3.31
-      '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/a11y': 4.54.0
-      '@wordpress/base-styles': 6.20.0
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/date': 5.54.0
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/dom': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/escape-html': 3.54.0
-      '@wordpress/hooks': 4.54.0
-      '@wordpress/html-entities': 4.54.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 12.2.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.54.0
-      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
-      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/warning': 3.54.0
-      change-case: 4.1.2
-      clsx: 2.1.1
-      colord: 2.9.3
-      csstype: 3.2.3
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
-      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      gradient-parser: 1.1.1
-      highlight-words-core: 1.2.3
-      is-plain-object: 5.1.0
-      memize: 2.1.1
-      path-to-regexp: 6.3.0
-      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-day-picker: 9.14.0(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      remove-accents: 0.5.0
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react-dom'
-      - supports-color
 
   '@wordpress/components@37.0.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -27089,24 +26397,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/compose@7.33.1(@types/react@18.3.31)(react@18.3.1)':
-    dependencies:
-      '@types/mousetrap': 1.6.15
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/dom': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/is-shallow-equal': 5.54.0
-      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
-      '@wordpress/priority-queue': 3.54.0
-      '@wordpress/undo-manager': 1.54.0
-      change-case: 4.1.2
-      clipboard: 2.0.11
-      mousetrap: 1.6.5
-      react: 18.3.1
-      use-memo-one: 1.1.3(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@wordpress/compose@7.46.0(@types/react@18.3.31)(react@18.3.1)':
     dependencies:
       '@types/mousetrap': 1.6.15
@@ -27190,10 +26480,10 @@ snapshots:
       '@types/mousetrap': 1.6.15
       '@wordpress/deprecated': 4.54.1-next.v.202608281122.0
       '@wordpress/dom': 4.54.1-next.v.202608281122.0
-      '@wordpress/element': 8.6.2-next.v.202609031004.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.54.1-next.v.202609031004.0
-      '@wordpress/keycodes': 4.54.1-next.v.202609031004.0(@types/react@18.3.31)
-      '@wordpress/priority-queue': 3.54.1-next.v.202609031004.0
+      '@wordpress/element': 8.6.2-next.v.202608281122.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.54.1-next.v.202608281122.0
+      '@wordpress/keycodes': 4.54.1-next.v.202608281122.0(@types/react@18.3.31)
+      '@wordpress/priority-queue': 3.54.1-next.v.202608281122.0
       '@wordpress/private-apis': 1.54.0
       '@wordpress/undo-manager': 1.54.1-next.v.202608281122.0
       change-case: 4.1.2
@@ -27226,41 +26516,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
       - react-dom
-
-  '@wordpress/core-data@7.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/api-fetch': 7.54.0
-      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/blocks': 15.27.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/html-entities': 4.54.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/is-shallow-equal': 5.54.0
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/sync': 1.54.0
-      '@wordpress/undo-manager': 1.54.0
-      '@wordpress/url': 4.54.0
-      '@wordpress/warning': 3.54.0
-      change-case: 4.1.2
-      equivalent-key-map: 0.2.2
-      fast-deep-equal: 3.1.3
-      memize: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - stylelint
-      - supports-color
-      - vite
 
   '@wordpress/core-data@7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -27563,17 +26818,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/data-controls@4.33.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/api-fetch': 7.54.0
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/deprecated': 4.54.0
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react-dom
-
   '@wordpress/data-controls@4.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/api-fetch': 7.54.0
@@ -27585,25 +26829,16 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
-  '@wordpress/data@10.33.1(@types/react@18.3.31)(react@18.3.1)':
+  '@wordpress/data-controls@4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/api-fetch': 7.54.0
+      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/deprecated': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/is-shallow-equal': 5.54.0
-      '@wordpress/priority-queue': 3.54.0
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/redux-routine': 5.54.0(redux@5.0.1)
-      deepmerge: 4.3.1
-      equivalent-key-map: 0.2.2
-      is-plain-object: 5.1.0
-      is-promise: 4.0.0
       react: 18.3.1
-      redux: 5.0.1
-      rememo: 4.0.2
-      use-memo-one: 1.1.3(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
+      - '@types/react-dom'
+      - react-dom
 
   '@wordpress/data@10.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -27669,53 +26904,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
       - react-dom
-
-  '@wordpress/dataviews@10.3.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@ariakit/react': 0.4.37(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/base-styles': 6.20.0
-      '@wordpress/components': 30.9.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/date': 5.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 11.8.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
-      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/url': 4.54.0
-      '@wordpress/warning': 3.54.0
-      clsx: 2.1.1
-      colord: 2.9.3
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      remove-accents: 0.5.0
-    optionalDependencies:
-      '@emotion/cache': 11.14.0
-      '@emotion/css': 11.13.5
-      '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
-      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
-      '@emotion/utils': 1.4.2
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/hooks': 4.54.0
-      change-case: 4.1.2
-      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      highlight-words-core: 1.2.3
-      is-plain-object: 5.1.0
-      memize: 2.1.1
-      react-colorful: 5.7.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      use-memo-one: 1.1.3(react@18.3.1)
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
 
   '@wordpress/dataviews@18.1.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -28081,13 +27269,11 @@ snapshots:
 
   '@wordpress/deprecated@4.54.1-next.v.202608281122.0':
     dependencies:
-      '@wordpress/hooks': 4.54.1-next.v.202609031004.0
+      '@wordpress/hooks': 4.54.1-next.v.202608281122.0
 
   '@wordpress/deprecated@4.54.1-next.v.202609031004.0':
     dependencies:
       '@wordpress/hooks': 4.54.1-next.v.202609031004.0
-
-  '@wordpress/dom-ready@4.33.1': {}
 
   '@wordpress/dom-ready@4.54.0': {}
 
@@ -28099,7 +27285,7 @@ snapshots:
 
   '@wordpress/dom@4.54.1-next.v.202608281122.0':
     dependencies:
-      '@wordpress/deprecated': 4.54.1-next.v.202609031004.0
+      '@wordpress/deprecated': 4.54.1-next.v.202608281122.0
 
   '@wordpress/dom@4.54.1-next.v.202609031004.0':
     dependencies:
@@ -28251,69 +27437,6 @@ snapshots:
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - postcss
-      - stylelint
-      - supports-color
-      - vite
-
-  '@wordpress/editor@14.33.11(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@floating-ui/react-dom': 2.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/a11y': 4.54.0
-      '@wordpress/api-fetch': 7.54.0
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/blob': 4.54.0
-      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/blocks': 15.27.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/commands': 1.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/core-data': 7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/dataviews': 10.3.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/date': 5.54.0
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/dom': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/fields': 0.25.11(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/hooks': 4.54.0
-      '@wordpress/html-entities': 4.54.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/interface': 9.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keyboard-shortcuts': 5.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
-      '@wordpress/media-utils': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/notices': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/patterns': 2.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/plugins': 7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/preferences': 4.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/reusable-blocks': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/server-side-render': 6.30.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.54.0
-      '@wordpress/warning': 3.54.0
-      '@wordpress/wordcount': 4.54.0
-      change-case: 4.1.2
-      client-zip: 2.5.0
-      clsx: 2.1.1
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
-      is-plain-object: 5.1.0
-      memize: 2.1.1
-      react: 18.3.1
-      react-autosize-textarea: 7.1.0(patch_hash=5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      remove-accents: 0.5.0
-      uuid: 9.0.1
     transitivePeerDependencies:
       - '@date-fns/tz'
       - '@emotion/is-prop-valid'
@@ -28769,16 +27892,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/element@6.33.1':
-    dependencies:
-      '@types/react': 18.3.31
-      '@types/react-dom': 18.3.7(@types/react@18.3.31)
-      '@wordpress/escape-html': 3.54.0
-      change-case: 4.1.2
-      is-plain-object: 5.1.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   '@wordpress/element@6.46.0':
     dependencies:
       '@types/react': 18.3.31
@@ -28824,17 +27937,6 @@ snapshots:
   '@wordpress/element@8.6.2-next.v.202608281122.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/escape-html': 3.54.1-next.v.202608281122.0
-      change-case: 4.1.2
-      is-plain-object: 5.1.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.31
-      '@types/react-dom': 18.3.7(@types/react@18.3.31)
-
-  '@wordpress/element@8.6.2-next.v.202609031004.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/escape-html': 3.54.1-next.v.202609031004.0
       change-case: 4.1.2
       is-plain-object: 5.1.0
       react: 18.3.1
@@ -28889,49 +27991,6 @@ snapshots:
     transitivePeerDependencies:
       - eslint-plugin-import-x
       - supports-color
-
-  '@wordpress/fields@0.25.11(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/api-fetch': 7.54.0
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/blob': 4.54.0
-      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/blocks': 15.27.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/core-data': 7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/dataviews': 10.3.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/date': 5.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/hooks': 4.54.0
-      '@wordpress/html-entities': 4.54.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/media-utils': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/notices': 5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/patterns': 2.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/router': 1.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/url': 4.54.0
-      '@wordpress/warning': 3.54.0
-      change-case: 4.1.2
-      client-zip: 2.5.0
-      clsx: 2.1.1
-      react: 18.3.1
-      remove-accents: 0.5.0
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - postcss
-      - react-dom
-      - stylelint
-      - supports-color
-      - vite
 
   '@wordpress/fields@0.46.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -29215,20 +28274,22 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/format-library@5.33.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@wordpress/format-library@5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/a11y': 4.54.0
-      '@wordpress/block-editor': 15.6.9(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/base-styles': 13.0.0
+      '@wordpress/block-editor': 17.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/components': 40.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/compose': 8.7.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.46.0
+      '@wordpress/element': 8.6.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/html-entities': 4.54.0
       '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/icons': 15.5.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/latex-to-mathml': 1.22.0
       '@wordpress/private-apis': 1.54.0
       '@wordpress/rich-text': 7.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/ui': 0.21.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url': 4.54.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -29238,6 +28299,7 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - esbuild
+      - postcss
       - stylelint
       - supports-color
       - vite
@@ -29545,13 +28607,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react-dom'
 
-  '@wordpress/hooks@4.33.1': {}
-
   '@wordpress/hooks@4.54.0': {}
 
-  '@wordpress/hooks@4.54.1-next.v.202609031004.0': {}
+  '@wordpress/hooks@4.54.1-next.v.202608281122.0': {}
 
-  '@wordpress/html-entities@4.33.1': {}
+  '@wordpress/hooks@4.54.1-next.v.202609031004.0': {}
 
   '@wordpress/html-entities@4.54.0': {}
 
@@ -29571,51 +28631,11 @@ snapshots:
       gettext-parser: 1.4.0
       tannin: 1.2.0
 
-  '@wordpress/i18n@6.6.1':
-    dependencies:
-      '@tannin/sprintf': 1.3.3
-      '@wordpress/hooks': 4.54.0
-      gettext-parser: 1.4.0
-      memize: 2.1.1
-      tannin: 1.2.0
-
   '@wordpress/icons@10.32.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@wordpress/element': 6.46.0
       '@wordpress/primitives': 4.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react-dom
-
-  '@wordpress/icons@11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/element': 6.46.0
-      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react-dom
-
-  '@wordpress/icons@11.8.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/element': 6.46.0
-      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      change-case: 4.1.2
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react-dom
-
-  '@wordpress/icons@12.2.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/element': 6.46.0
-      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      change-case: 4.1.2
       react: 18.3.1
     transitivePeerDependencies:
       - '@types/react'
@@ -29943,38 +28963,9 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/interface@9.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/a11y': 4.54.0
-      '@wordpress/admin-ui': 1.12.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/plugins': 7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/preferences': 4.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/viewport': 6.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - date-fns
-      - esbuild
-      - postcss
-      - stylelint
-      - supports-color
-      - vite
-
-  '@wordpress/is-shallow-equal@5.33.1': {}
-
   '@wordpress/is-shallow-equal@5.54.0': {}
+
+  '@wordpress/is-shallow-equal@5.54.1-next.v.202608281122.0': {}
 
   '@wordpress/is-shallow-equal@5.54.1-next.v.202609031004.0': {}
 
@@ -29991,17 +28982,6 @@ snapshots:
   '@wordpress/kebab-case@1.1.1-next.v.202609031004.0':
     dependencies:
       change-case: 4.1.2
-
-  '@wordpress/keyboard-shortcuts@5.33.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.46.0
-      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react-dom
 
   '@wordpress/keyboard-shortcuts@5.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -30039,10 +29019,6 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
-  '@wordpress/keycodes@4.33.1':
-    dependencies:
-      '@wordpress/i18n': 6.27.0
-
   '@wordpress/keycodes@4.54.0':
     dependencies:
       '@wordpress/i18n': 6.27.0
@@ -30050,6 +29026,12 @@ snapshots:
   '@wordpress/keycodes@4.54.0(@types/react@18.3.31)':
     dependencies:
       '@wordpress/i18n': 6.27.0
+    optionalDependencies:
+      '@types/react': 18.3.31
+
+  '@wordpress/keycodes@4.54.1-next.v.202608281122.0(@types/react@18.3.31)':
+    dependencies:
+      '@wordpress/i18n': 6.27.1-next.v.202609031004.0
     optionalDependencies:
       '@types/react': 18.3.31
 
@@ -30763,16 +29745,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/notices@5.33.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/a11y': 4.54.0
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react-dom
-
   '@wordpress/notices@5.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/a11y': 4.54.0
@@ -31150,24 +30122,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/plugins@7.33.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/hooks': 4.54.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/is-shallow-equal': 5.54.0
-      memize: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
-
   '@wordpress/plugins@7.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/components': 40.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31317,27 +30271,6 @@ snapshots:
       - stylelint
       - supports-color
       - vite
-
-  '@wordpress/preferences@4.33.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/a11y': 4.54.0
-      '@wordpress/base-styles': 6.9.1
-      '@wordpress/components': 30.6.5(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 11.0.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.54.0
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - supports-color
 
   '@wordpress/preferences@4.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31619,11 +30552,11 @@ snapshots:
       - '@types/react-dom'
       - react-dom
 
-  '@wordpress/priority-queue@3.33.1':
+  '@wordpress/priority-queue@3.54.0':
     dependencies:
       requestidlecallback: 0.3.0
 
-  '@wordpress/priority-queue@3.54.0':
+  '@wordpress/priority-queue@3.54.1-next.v.202608281122.0':
     dependencies:
       requestidlecallback: 0.3.0
 
@@ -31855,24 +30788,6 @@ snapshots:
       - supports-color
       - vite
 
-  '@wordpress/rich-text@7.33.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/a11y': 4.54.0
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/deprecated': 4.54.0
-      '@wordpress/element': 6.46.0
-      '@wordpress/escape-html': 3.54.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
-      colord: 2.9.3
-      memize: 2.1.1
-      react: 18.3.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - react-dom
-
   '@wordpress/rich-text@7.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/a11y': 4.54.0
@@ -31931,15 +30846,6 @@ snapshots:
       '@types/react': 18.3.31
     transitivePeerDependencies:
       - '@types/react-dom'
-      - react-dom
-
-  '@wordpress/route@0.10.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@tanstack/history': 1.162.0
-      '@tanstack/react-router': 1.167.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.54.0
-      react: 18.3.1
-    transitivePeerDependencies:
       - react-dom
 
   '@wordpress/route@0.20.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -32197,15 +31103,6 @@ snapshots:
       y-protocols: 1.0.7(yjs@13.6.29)
       yjs: 13.6.29
 
-  '@wordpress/theme@0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/element': 6.46.0
-      '@wordpress/private-apis': 1.54.0
-      colorjs.io: 0.6.1
-      memize: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   '@wordpress/theme@1.2.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/compose': 8.7.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -32388,29 +31285,6 @@ snapshots:
       - '@types/react-dom'
 
   '@wordpress/token-list@3.54.0': {}
-
-  '@wordpress/ui@0.11.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@base-ui/react': 1.7.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/a11y': 4.54.0
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 12.2.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
-      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/theme': 0.11.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tabbable: 6.5.0
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@types/react'
-      - '@types/react-dom'
-      - date-fns
-      - stylelint
 
   '@wordpress/ui@0.18.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(date-fns@4.1.0)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -32904,31 +31778,6 @@ snapshots:
     dependencies:
       '@wordpress/is-shallow-equal': 5.54.1-next.v.202609031004.0
 
-  '@wordpress/upload-media@0.18.5(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/api-fetch': 7.54.0
-      '@wordpress/blob': 4.54.0
-      '@wordpress/compose': 7.46.0(@types/react@18.3.31)(react@18.3.1)
-      '@wordpress/data': 10.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 6.46.0
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/preferences': 4.54.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/private-apis': 1.54.0
-      '@wordpress/url': 4.54.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@date-fns/tz'
-      - '@emotion/is-prop-valid'
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - postcss
-      - stylelint
-      - supports-color
-      - vite
-
   '@wordpress/upload-media@0.39.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/blob': 4.54.0
@@ -33144,10 +31993,6 @@ snapshots:
       - stylelint
       - supports-color
       - vite
-
-  '@wordpress/url@4.33.1':
-    dependencies:
-      remove-accents: 0.5.0
 
   '@wordpress/url@4.54.0':
     dependencies:
@@ -34275,12 +33120,6 @@ snapshots:
       select: 1.1.2
       tiny-emitter: 2.1.0
 
-  cliui@5.0.0:
-    dependencies:
-      string-width: 3.1.0
-      strip-ansi: 5.2.0
-      wrap-ansi: 5.1.0
-
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
@@ -34367,8 +33206,6 @@ snapshots:
   colord@2.9.3: {}
 
   colorjs.io@0.5.2: {}
-
-  colorjs.io@0.6.1: {}
 
   colorjs.io@0.7.1: {}
 
@@ -34851,8 +33688,6 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff@4.0.4: {}
-
   diff@8.0.4: {}
 
   dns-packet@5.6.1:
@@ -34948,8 +33783,6 @@ snapshots:
   emittery@0.13.1: {}
 
   emoji-regex@10.6.0: {}
-
-  emoji-regex@7.0.3: {}
 
   emoji-regex@8.0.0: {}
 
@@ -35761,10 +34594,6 @@ snapshots:
 
   find-up-simple@1.0.1: {}
 
-  find-up@3.0.0:
-    dependencies:
-      locate-path: 3.0.0
-
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -35991,8 +34820,6 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
-
-  gradient-parser@1.1.1: {}
 
   gradient-parser@1.2.0: {}
 
@@ -37206,11 +36033,6 @@ snapshots:
 
   locate-character@3.0.0: {}
 
-  locate-path@3.0.0:
-    dependencies:
-      p-locate: 3.0.0
-      path-exists: 3.0.0
-
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -38085,10 +36907,6 @@ snapshots:
     dependencies:
       yocto-queue: 1.2.2
 
-  p-locate@3.0.0:
-    dependencies:
-      p-limit: 2.3.0
-
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -38198,8 +37016,6 @@ snapshots:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.8.1
-
-  path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
 
@@ -39492,10 +38308,6 @@ snapshots:
 
   shell-quote@1.9.0: {}
 
-  showdown@1.9.1:
-    dependencies:
-      yargs: 14.2.3
-
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -39764,12 +38576,6 @@ snapshots:
     dependencies:
       is-fullwidth-code-point: 2.0.0
       strip-ansi: 4.0.0
-
-  string-width@3.1.0:
-    dependencies:
-      emoji-regex: 7.0.3
-      is-fullwidth-code-point: 2.0.0
-      strip-ansi: 5.2.0
 
   string-width@4.2.3:
     dependencies:
@@ -40622,8 +39428,6 @@ snapshots:
 
   uuid@14.0.1: {}
 
-  uuid@9.0.1: {}
-
   v8-to-istanbul@9.3.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -41050,12 +39854,6 @@ snapshots:
       string-width: 2.1.1
       strip-ansi: 4.0.0
 
-  wrap-ansi@5.1.0:
-    dependencies:
-      ansi-styles: 3.2.1
-      string-width: 3.1.0
-      strip-ansi: 5.2.0
-
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -41135,11 +39933,6 @@ snapshots:
 
   yaml@2.8.3: {}
 
-  yargs-parser@15.0.3:
-    dependencies:
-      camelcase: 5.3.1
-      decamelize: 1.2.0
-
   yargs-parser@18.1.3:
     dependencies:
       camelcase: 5.3.1
@@ -41148,20 +39941,6 @@ snapshots:
   yargs-parser@21.1.1: {}
 
   yargs-parser@22.0.0: {}
-
-  yargs@14.2.3:
-    dependencies:
-      cliui: 5.0.0
-      decamelize: 1.2.0
-      find-up: 3.0.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      require-main-filename: 2.0.0
-      set-blocking: 2.0.0
-      string-width: 3.1.0
-      which-module: 2.0.1
-      y18n: 4.0.3
-      yargs-parser: 15.0.3
 
   yargs@15.4.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-LcOJ2zpsLY/0C1rWx19oYf+lh4rzJX9xTQVI9Ox1kks=
+pnpmfileChecksum: sha256-4/zyKUib0nJ4Kn6ND/Ag1Su76ZAfyUYg8GRhBKJvK1s=
 
 patchedDependencies:
   '@wordpress/build': 6f3fbefb10df6ce84b2e3c307e3894b697d87a888315abc805b6ff67bf7de635

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,17 @@ packages:
   - tools/performance
   - .github/files/coverage-munger
 
+overrides:
+  # @woocommerce/email-editor pins about thirty exact @wordpress/* versions, and
+  # the @wordpress/components@30.x among them asks for date-fns ^3.6.0. Left
+  # alone that drags the whole workspace's date-fns down from 4.x, which then
+  # fails strictPeerDependencies below because @base-ui/react wants ^4. Those
+  # @wordpress/* packages are externalized to wp.* at build time, so none of
+  # their code is bundled and none of it runs against the newer date-fns.
+  # Scoped to the ^3 range rather than to date-fns as a whole, so the 1.x and
+  # 2.x copies some CLI tooling still asks for stay where they are.
+  "date-fns@^3.6.0": "^4.1.0"
+
 engineStrict: true
 pmOnFail: ignore
 preferWorkspacePackages: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,17 +9,6 @@ packages:
   - tools/performance
   - .github/files/coverage-munger
 
-overrides:
-  # @woocommerce/email-editor pins about thirty exact @wordpress/* versions, and
-  # the @wordpress/components@30.x among them asks for date-fns ^3.6.0. Left
-  # alone that drags the whole workspace's date-fns down from 4.x, which then
-  # fails strictPeerDependencies below because @base-ui/react wants ^4. Those
-  # @wordpress/* packages are externalized to wp.* at build time, so none of
-  # their code is bundled and none of it runs against the newer date-fns.
-  # Scoped to the ^3 range rather than to date-fns as a whole, so the 1.x and
-  # 2.x copies some CLI tooling still asks for stay where they are.
-  "date-fns@^3.6.0": "^4.1.0"
-
 engineStrict: true
 pmOnFail: ignore
 preferWorkspacePackages: true

--- a/projects/plugins/jetpack/changelog/add-nl-848-email-design-editor-bundle
+++ b/projects/plugins/jetpack/changelog/add-nl-848-email-design-editor-bundle
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Adds the newsletter email design editor's JavaScript bundle and its build configuration. Nothing enqueues it yet, so there is no user-facing change.
+
+

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -11,6 +11,12 @@
  * WordPress.com computes, which is the one field a site must never work out
  * locally. See NL-848 and NL-851.
  *
+ * The bundle is also what the editor's own reads are answered from. Its
+ * template records are installed as an api-fetch preload before the editor
+ * mounts, because they are registered only while WordPress.com builds the
+ * bundle and so are absent from any ordinary REST request. See
+ * `buildPreloadMap()`.
+ *
  * The page is the other half, and is added separately: it renders the
  * container and localises `window.JetpackEmailDesignEditor` with what
  * WordPress.com cannot know — where to mount, where its buttons navigate to,
@@ -138,6 +144,65 @@ export function buildEditorConfig( bundle, data ) {
 }
 
 /**
+ * The template records the editor would otherwise fetch, keyed by the path it asks for.
+ *
+ * The editor resolves its canvas template through core-data, which fetches
+ * `/wp/v2/templates` — the item and the collection both, as observed. On WordPress.com
+ * neither answer contains it: the email templates are registered while the bootstrap bundle
+ * is built, and that only happens inside the bootstrap request. An ordinary REST request
+ * never registers them, so the editor waits on a record that exists only during a different
+ * request and never finishes mounting.
+ *
+ * Registering them server-side for every REST request would fix the fetch and put the email
+ * templates in the Site Editor's template list, which is a visible regression on every
+ * enrolled blog. Preloading confines them to this page.
+ *
+ * The records come from the bundle rather than being assembled here. `template` carries four
+ * fields; a REST template record carries around fifteen, and the editor reads several of the
+ * rest — `post_types` with no optional chaining, so a record without it throws rather than
+ * degrading, plus `source`, `origin` and `has_theme_file` when resetting a template. Only
+ * WordPress.com holds the real records, the same reason the template's id is handed down
+ * rather than derived. Until it sends them there is nothing to preload, and this returns null.
+ *
+ * @param {object} bundle     - The response from the bootstrap route.
+ * @param {string} templateId - The id of the template the editor opens.
+ * @return {object|null} A map for `createPreloadingMiddleware`, or null when the bundle
+ *                       carries no template records.
+ */
+export function buildPreloadMap( bundle, templateId ) {
+	const templates = bundle?.templates;
+
+	if ( ! Array.isArray( templates ) || 0 === templates.length ) {
+		return null;
+	}
+
+	// Callers passing `parse: false` build a Response out of these, and that path reads
+	// `headers` unconditionally, so every entry carries one even when it is empty.
+	const collection = {
+		body: templates,
+		headers: {
+			'X-WP-Total': String( templates.length ),
+			'X-WP-TotalPages': '1',
+		},
+	};
+
+	// Both contexts, because which one core-data asks for depends on what the current user may
+	// do with the record, and an unmatched key costs nothing.
+	const map = {
+		'/wp/v2/templates?context=edit': collection,
+		'/wp/v2/templates?context=view': collection,
+	};
+
+	const item = templates.find( template => template?.id === templateId );
+
+	if ( item ) {
+		map[ `/wp/v2/templates/${ templateId }?context=edit` ] = { body: item, headers: {} };
+	}
+
+	return map;
+}
+
+/**
  * The id of the template the editor opens.
  *
  * Read from the bundle and never derived here. The package builds it as
@@ -210,6 +275,15 @@ export async function mountEmailDesignEditor() {
 
 		const config = buildEditorConfig( bundle, data );
 		const postId = getTemplateId( bundle );
+		const preload = buildPreloadMap( bundle, postId );
+
+		if ( preload ) {
+			// Registered last so it runs first: api-fetch unshifts middlewares and applies them
+			// right to left, so this one sees `options.path` before the locale and WordPress.com
+			// rewriting middlewares have rewritten it. It has to be installed before the editor
+			// mounts, because core-data resolves the template on its first render.
+			apiFetch.use( apiFetch.createPreloadingMiddleware( preload ) );
+		}
 
 		root.render(
 			<StrictMode>

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -186,9 +186,12 @@ export function buildPreloadMap( bundle, templateId ) {
 		},
 	};
 
-	// Both contexts, because which one core-data asks for depends on what the current user may
-	// do with the record, and an unmatched key costs nothing.
+	// Every context the collection has been seen asked for, including none at all. The two
+	// measurements disagree — this editor asks for `?context=edit` on WordPress 7.1, while the
+	// same load on WordPress.com carries no context — and a key that goes unmatched costs
+	// nothing, whereas the one miss that matters leaves the editor waiting forever.
 	const map = {
+		'/wp/v2/templates': collection,
 		'/wp/v2/templates?context=edit': collection,
 		'/wp/v2/templates?context=view': collection,
 	};
@@ -196,7 +199,10 @@ export function buildPreloadMap( bundle, templateId ) {
 	const item = templates.find( template => template?.id === templateId );
 
 	if ( item ) {
-		map[ `/wp/v2/templates/${ templateId }?context=edit` ] = { body: item, headers: {} };
+		const record = { body: item, headers: {} };
+
+		map[ `/wp/v2/templates/${ templateId }` ] = record;
+		map[ `/wp/v2/templates/${ templateId }?context=edit` ] = record;
 	}
 
 	return map;

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -1,13 +1,46 @@
 /**
  * Client-side entry point for the newsletter email design screen.
  *
+ * The bundle the editor starts from is fetched here rather than inlined into
+ * the page. It lives on the WordPress.com shadow blog, so on Atomic and
+ * self-hosted the page would otherwise have to proxy to WordPress.com while
+ * rendering, putting a blocking request in front of the screen appearing at
+ * all — and on Simple an internal dispatch during the page request breaks the
+ * REST preloads that follow it on a blog the editor has not run for before.
+ * Fetching from the browser also keeps the template's id something only
+ * WordPress.com computes, which is the one field a site must never work out
+ * locally. See NL-848 and NL-851.
+ *
  * The page is the other half, and is added separately: it renders the
- * container and localises `window.JetpackEmailDesignEditor`. Until it exists
- * nothing enqueues this bundle, so the mount below finds no configuration and
- * returns. See NL-848.
+ * container and localises `window.JetpackEmailDesignEditor` with what
+ * WordPress.com cannot know — where to mount, where its buttons navigate to,
+ * and the half of the editor settings that describes this installation. Until
+ * it exists nothing enqueues this bundle, so the mount below returns.
  */
 import { ExperimentalEmailEditor } from '@woocommerce/email-editor';
+import apiFetch from '@wordpress/api-fetch';
+import { Notice } from '@wordpress/components';
 import { createRoot, StrictMode } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * The route serving the editor's bootstrap data.
+ *
+ * Declared by the Jetpack plugin on every platform and answered by
+ * WordPress.com, so the browser calls one local URL on Simple, Atomic and
+ * self-hosted alike.
+ */
+const BOOTSTRAP_PATH = '/wpcom/v2/email-editor-bootstrap';
+
+/**
+ * The post type the editor edits.
+ *
+ * A constant rather than something the page supplies: the design is a block
+ * template, and unlike the template's id — which is namespaced by whichever
+ * theme served it — the post type is the same everywhere.
+ */
+const TEMPLATE_POST_TYPE = 'wp_template';
 
 /**
  * Schemes the editor's navigation buttons may send the browser to.
@@ -51,7 +84,7 @@ function assertNavigableUrl( value, key ) {
 }
 
 /**
- * Translate the page's data into the configuration the editor reads.
+ * Translate the page's data and the fetched bundle into the editor's configuration.
  *
  * The editor's `config` prop is not the WordPress.com bootstrap bundle. The
  * bundle arrives in the shape the REST route returns it — `editor_settings`,
@@ -64,25 +97,26 @@ function assertNavigableUrl( value, key ) {
  * `editorSettings` is assembled from both halves on purpose. WordPress.com
  * removes `__unstableResolvedAssets` and `allowedIframeStyleHandles` from the
  * bundle before returning it, because they describe the installation they were
- * computed on rather than the design; the site supplies its own. The site's
- * half is merged last so it wins.
+ * computed on rather than the design; the page supplies this site's own. The
+ * page's half is merged last so it wins.
  *
- * @param {object} data - The value of `window.JetpackEmailDesignEditor`.
- * @throws {Error} If the page left out something the editor cannot start without.
+ * @param {object} bundle - The response from the bootstrap route.
+ * @param {object} data   - The value of `window.JetpackEmailDesignEditor`.
+ * @throws {Error} If either half left out something the editor cannot start without.
  * @return {object} The editor's `config` prop.
  */
-export function buildEditorConfig( data ) {
-	const { bundle, editorSettings, urls, userEmail, globalStylesPostId } = data;
+export function buildEditorConfig( bundle, data ) {
+	const { editorSettings, urls, userEmail, globalStylesPostId } = data;
 
 	// Mirrors what the package's own `initializeEditor()` validates when it reads
 	// these from a global. Nothing checks them on the `config` prop path, so an
 	// omission would otherwise surface as an unrelated failure deep in the editor.
 	if ( ! bundle?.editor_settings ) {
-		throw new Error( 'JetpackEmailDesignEditor.bundle.editor_settings is required.' );
+		throw new Error( 'The email editor bundle is missing editor_settings.' );
 	}
 
 	if ( ! bundle?.editor_theme ) {
-		throw new Error( 'JetpackEmailDesignEditor.bundle.editor_theme is required.' );
+		throw new Error( 'The email editor bundle is missing editor_theme.' );
 	}
 
 	if ( typeof urls?.back !== 'string' || typeof urls?.listings !== 'string' ) {
@@ -104,12 +138,53 @@ export function buildEditorConfig( data ) {
 }
 
 /**
- * Mount the editor into the container the page renders.
+ * The id of the template the editor opens.
  *
- * @throws {Error} If the page provided a configuration the editor cannot start from.
- * @return {void}
+ * Read from the bundle and never derived here. The package builds it as
+ * `get_stylesheet() . '//' . $slug` on whichever installation registered the
+ * template, so a site working it out locally is right on Simple — where the
+ * site and the shadow blog are the same — and wrong on Atomic and self-hosted.
+ *
+ * @param {object} bundle - The response from the bootstrap route.
+ * @throws {Error} If the bundle carries no template.
+ * @return {string} The template's id.
  */
-export function mountEmailDesignEditor() {
+export function getTemplateId( bundle ) {
+	const id = bundle?.template?.id;
+
+	if ( typeof id !== 'string' || '' === id ) {
+		throw new Error( 'The email editor bundle is missing its template id.' );
+	}
+
+	return id;
+}
+
+/**
+ * What the screen shows when it could not load.
+ *
+ * A blank screen is the failure this is here to avoid: the design lives on
+ * another site, so "nothing appeared" and "your design is empty" look the same
+ * to whoever opened the page.
+ *
+ * @return {import('react').ReactElement} The error notice.
+ */
+function LoadError() {
+	return (
+		<Notice status="error" isDismissible={ false }>
+			{ __(
+				'The email design editor could not be loaded. Please reload the page to try again.',
+				'jetpack'
+			) }
+		</Notice>
+	);
+}
+
+/**
+ * Fetch the bootstrap bundle and mount the editor into the page's container.
+ *
+ * @return {Promise<void>} Resolves once the editor or an error has rendered.
+ */
+export async function mountEmailDesignEditor() {
 	const data = window.JetpackEmailDesignEditor;
 
 	// Not our page. The bundle is only enqueued on the design screen, so this is
@@ -124,25 +199,35 @@ export function mountEmailDesignEditor() {
 		return;
 	}
 
-	const { postId, postType } = data;
+	const root = createRoot( container );
 
-	if ( ! postId ) {
-		throw new Error( 'JetpackEmailDesignEditor.postId is required.' );
+	try {
+		const bundle = await apiFetch( {
+			path: data.templateSlug
+				? addQueryArgs( BOOTSTRAP_PATH, { template_slug: data.templateSlug } )
+				: BOOTSTRAP_PATH,
+		} );
+
+		const config = buildEditorConfig( bundle, data );
+		const postId = getTemplateId( bundle );
+
+		root.render(
+			<StrictMode>
+				<ExperimentalEmailEditor
+					postId={ postId }
+					postType={ TEMPLATE_POST_TYPE }
+					config={ config }
+				/>
+			</StrictMode>
+		);
+	} catch ( error ) {
+		// The message names which half is at fault, which the notice deliberately
+		// does not — but losing it entirely would leave a page with nothing to
+		// debug from.
+		// eslint-disable-next-line no-console
+		console.error( 'Jetpack email design editor:', error );
+		root.render( <LoadError /> );
 	}
-
-	if ( ! postType ) {
-		throw new Error( 'JetpackEmailDesignEditor.postType is required.' );
-	}
-
-	createRoot( container ).render(
-		<StrictMode>
-			<ExperimentalEmailEditor
-				postId={ postId }
-				postType={ postType }
-				config={ buildEditorConfig( data ) }
-			/>
-		</StrictMode>
-	);
 }
 
 if ( document.readyState === 'loading' ) {

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -103,10 +103,11 @@ export function buildEditorConfig( bundle, data ) {
 		urls,
 		userEmail,
 
-		// A gate, not a data source: null makes the package generate no canvas CSS at
-		// all, while any valid id paints the whole theme. Nothing reads the record's
-		// contents — the design arrives merged into `editor_theme`. Bundle first because
-		// it is a WordPress.com post id; the page stays a fallback. See NL-871.
+		// Dereferenced, not merely a flag: null makes the package generate no canvas CSS at all,
+		// and any valid id has its record fetched — which the preload answers. The record's
+		// `styles` and `settings` are merged last over `editor_theme`, which is what paints the
+		// canvas while editing. Bundle first because it is a WordPress.com post id; the page stays
+		// a fallback. See NL-871.
 		globalStylesPostId: getGlobalStylesPostId( bundle ) ?? globalStylesPostId ?? null,
 	};
 }

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -1,27 +1,14 @@
 /**
  * Client-side entry point for the newsletter email design screen.
  *
- * The bundle the editor starts from is fetched here rather than inlined into
- * the page. It lives on the WordPress.com shadow blog, so on Atomic and
- * self-hosted the page would otherwise have to proxy to WordPress.com while
- * rendering, putting a blocking request in front of the screen appearing at
- * all — and on Simple an internal dispatch during the page request breaks the
- * REST preloads that follow it on a blog the editor has not run for before.
- * Fetching from the browser also keeps the template's id something only
- * WordPress.com computes, which is the one field a site must never work out
- * locally. See NL-848 and NL-851.
+ * The editor's bootstrap bundle lives on the WordPress.com shadow blog and is
+ * fetched from the browser rather than inlined, so the screen paints without a
+ * blocking proxy request on Atomic and self-hosted. It also carries records the
+ * editor would otherwise fetch — see `buildPreloadMap()`.
  *
- * The bundle is also what the editor's own reads are answered from. Its
- * template records are installed as an api-fetch preload before the editor
- * mounts, because they are registered only while WordPress.com builds the
- * bundle and so are absent from any ordinary REST request. See
- * `buildPreloadMap()`.
- *
- * The page is the other half, and is added separately: it renders the
- * container and localises `window.JetpackEmailDesignEditor` with what
- * WordPress.com cannot know — where to mount, where its buttons navigate to,
- * and the half of the editor settings that describes this installation. Until
- * it exists nothing enqueues this bundle, so the mount below returns.
+ * The page that renders the container and localises
+ * `window.JetpackEmailDesignEditor` lands separately; until then nothing enqueues
+ * this bundle and the mount below returns. See NL-848 and NL-851.
  */
 import { ExperimentalEmailEditor } from '@woocommerce/email-editor';
 import apiFetch from '@wordpress/api-fetch';
@@ -30,40 +17,23 @@ import { createRoot, StrictMode } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
-/**
- * The route serving the editor's bootstrap data.
- *
- * Declared by the Jetpack plugin on every platform and answered by
- * WordPress.com, so the browser calls one local URL on Simple, Atomic and
- * self-hosted alike.
- */
+// Declared by the Jetpack plugin on every platform, answered by WordPress.com, so
+// the browser calls one local URL everywhere.
 const BOOTSTRAP_PATH = '/wpcom/v2/email-editor-bootstrap';
 
-/**
- * The post type the editor edits.
- *
- * A constant rather than something the page supplies: the design is a block
- * template, and unlike the template's id — which is namespaced by whichever
- * theme served it — the post type is the same everywhere.
- */
+// The design is a block template. Unlike the template's id, this is the same
+// everywhere, so the page does not supply it.
 const TEMPLATE_POST_TYPE = 'wp_template';
 
-/**
- * Schemes the editor's navigation buttons may send the browser to.
- *
- * `javascript:` and `data:` are URLs a browser executes rather than navigates
- * to, and the editor assigns these values straight to `window.location.href`.
- */
+// The editor assigns these straight to `window.location.href`, so `javascript:`
+// and `data:` would execute rather than navigate.
 const NAVIGABLE_PROTOCOLS = [ 'http:', 'https:' ];
 
 /**
  * Check that a URL the editor will navigate to is one the browser can navigate to.
  *
- * Resolving against the current page is what the editor's own back button does,
- * and it does not neutralise a scheme: relative resolution applies only when the
- * value has no scheme of its own, so `javascript:…` survives the round trip
- * intact. The check therefore has to read the protocol the URL parses to, not
- * the string it started as — the parser also strips leading whitespace, which a
+ * Reads the parsed protocol rather than testing the string: relative resolution
+ * does not neutralise a scheme, and the parser strips leading whitespace that a
  * `startsWith( 'javascript:' )` test would miss.
  *
  * @param {*}      value - The configured URL.
@@ -92,19 +62,14 @@ function assertNavigableUrl( value, key ) {
 /**
  * Translate the page's data and the fetched bundle into the editor's configuration.
  *
- * The editor's `config` prop is not the WordPress.com bootstrap bundle. The
- * bundle arrives in the shape the REST route returns it — `editor_settings`,
- * `editor_theme` — while the package's store reads five camelCased keys off
- * the prop: `editorSettings`, `theme`, `urls`, `userEmail` and
- * `globalStylesPostId`. Passing the bundle through unmapped leaves all five
- * undefined, which is not an error the editor reports — it boots with no
- * settings and no theme.
+ * Not a pass-through: the bundle is snake_cased (`editor_settings`, `editor_theme`)
+ * while the package's store reads `editorSettings`, `theme`, `urls`, `userEmail`
+ * and `globalStylesPostId`. Passing it unmapped boots the editor with no settings
+ * and no theme, and reports nothing.
  *
- * `editorSettings` is assembled from both halves on purpose. WordPress.com
- * removes `__unstableResolvedAssets` and `allowedIframeStyleHandles` from the
- * bundle before returning it, because they describe the installation they were
- * computed on rather than the design; the page supplies this site's own. The
- * page's half is merged last so it wins.
+ * `editorSettings` merges both halves — WordPress.com strips the two settings that
+ * describe the installation rather than the design, and the page supplies this
+ * site's own — with the page's half last so it wins.
  *
  * @param {object} bundle - The response from the bootstrap route.
  * @param {object} data   - The value of `window.JetpackEmailDesignEditor`.
@@ -114,9 +79,8 @@ function assertNavigableUrl( value, key ) {
 export function buildEditorConfig( bundle, data ) {
 	const { editorSettings, urls, userEmail, globalStylesPostId } = data;
 
-	// Mirrors what the package's own `initializeEditor()` validates when it reads
-	// these from a global. Nothing checks them on the `config` prop path, so an
-	// omission would otherwise surface as an unrelated failure deep in the editor.
+	// Nothing validates these on the `config` prop path, so an omission would
+	// otherwise surface as an unrelated failure deep in the editor.
 	if ( ! bundle?.editor_settings ) {
 		throw new Error( 'The email editor bundle is missing editor_settings.' );
 	}
@@ -129,9 +93,8 @@ export function buildEditorConfig( bundle, data ) {
 		throw new Error( 'JetpackEmailDesignEditor.urls.back and .listings are required strings.' );
 	}
 
-	// Every value here ends up assigned to `window.location.href` by the editor's
-	// header buttons, so each has to be somewhere the browser can navigate to and
-	// not something it will execute.
+	// These all end up assigned to `window.location.href` by the editor's header
+	// buttons.
 	Object.entries( urls ).forEach( ( [ key, value ] ) => assertNavigableUrl( value, key ) );
 
 	return {
@@ -140,17 +103,10 @@ export function buildEditorConfig( bundle, data ) {
 		urls,
 		userEmail,
 
-		// A gate rather than a data source: the record it names is an empty scaffold, and the
-		// design itself arrives already merged into `editor_theme`. Measured on WordPress.com,
-		// leaving it null makes the package generate no canvas CSS at all — not the saved
-		// design, not stock values, no `:root{--wp--preset--…}` block — while naming any valid
-		// record paints the whole theme. Nothing here reads the record's contents.
-		//
-		// Taken from the bundle first for the reason the template's id is: it is a
-		// WordPress.com post id, so a page working it out locally is right on Simple, where the
-		// site and the shadow blog are the same, and wrong on Atomic and self-hosted. The page
-		// remains a fallback so this degrades to the previous behaviour against a bundle that
-		// does not carry one yet. See NL-871.
+		// A gate, not a data source: null makes the package generate no canvas CSS at
+		// all, while any valid id paints the whole theme. Nothing reads the record's
+		// contents — the design arrives merged into `editor_theme`. Bundle first because
+		// it is a WordPress.com post id; the page stays a fallback. See NL-871.
 		globalStylesPostId: getGlobalStylesPostId( bundle ) ?? globalStylesPostId ?? null,
 	};
 }
@@ -158,28 +114,17 @@ export function buildEditorConfig( bundle, data ) {
 /**
  * Everything the editor would otherwise fetch, keyed by the path it asks for.
  *
- * Two things travel this way — the canvas templates and the global-styles record — for the same
- * reason: both exist only while WordPress.com builds the bootstrap bundle, so a request made from
- * the browser cannot reach them. Sending the contents and answering the fetch locally sidesteps
- * that rather than working around it.
+ * The canvas templates and the global-styles record are registered only while
+ * WordPress.com builds the bootstrap bundle, so a request from the browser cannot
+ * reach them and the editor waits forever on a record it will never get.
  *
- * The editor resolves its canvas template through core-data, which fetches
- * `/wp/v2/templates` — the item and the collection both, as observed. On WordPress.com
- * neither answer contains it: the email templates are registered while the bootstrap bundle
- * is built, and that only happens inside the bootstrap request. An ordinary REST request
- * never registers them, so the editor waits on a record that exists only during a different
- * request and never finishes mounting.
+ * Registering them for every REST request would fix that, but would also list the
+ * email templates in the Site Editor — a visible regression on every enrolled blog.
+ * Preloading confines them to this page.
  *
- * Registering them server-side for every REST request would fix the fetch and put the email
- * templates in the Site Editor's template list, which is a visible regression on every
- * enrolled blog. Preloading confines them to this page.
- *
- * The records come from the bundle rather than being assembled here. `template` carries four
- * fields; a REST template record carries around fifteen, and the editor reads several of the
- * rest — `post_types` with no optional chaining, so a record without it throws rather than
- * degrading, plus `source`, `origin` and `has_theme_file` when resetting a template. Only
- * WordPress.com holds the real records, the same reason the template's id is handed down
- * rather than derived. Until it sends them there is nothing to preload.
+ * The records come from the bundle rather than being assembled here: the editor
+ * reads fields a four-field summary cannot stand in for, including `post_types`
+ * with no optional chaining.
  *
  * @param {object} bundle     - The response from the bootstrap route.
  * @param {string} templateId - The id of the template the editor opens.
@@ -198,14 +143,10 @@ export function buildPreloadMap( bundle, templateId ) {
 /**
  * The id of the global-styles record the bundle points at, or null when it sent no usable one.
  *
- * Validated rather than trusted because this value is interpolated into the preload's path keys.
- * The keys are deliberately exact — the editor loads the *site's own* global-styles record
- * alongside ours, and that one has to keep reaching the network untouched — so an id carrying a
- * query string or a slash would silently widen what we answer for. Rejecting anything that is not
- * a positive integer keeps the code to the invariant its callers document.
- *
- * WordPress.com sends an int today and the filter behind this route is only consulted on Simple,
- * so this is defence in depth rather than a reachable defect. It costs a comparison.
+ * Validated because it is interpolated into the preload's path keys, which are
+ * deliberately exact — an id carrying a slash or query string would widen what we
+ * answer for, and the site's own global-styles record has to keep reaching the
+ * network untouched.
  *
  * @param {object} bundle - The response from the bootstrap route.
  * @return {number|null} The record's id, or null.
@@ -219,25 +160,19 @@ function getGlobalStylesPostId( bundle ) {
 /**
  * The global-styles record the editor reads its design from.
  *
- * Both halves are required. The package's selector guards on
- * `postId && undefined !== canEdit`, and `canEdit` comes from `canUser( 'update', … )`, which is
- * an `OPTIONS` request. Answer the `GET` alone and `canEdit` stays undefined, the selector returns
- * null, and the canvas renders unstyled — indistinguishable from the id never having arrived.
+ * The `GET` and the `OPTIONS` are both required: the package's selector guards on
+ * `undefined !== canEdit`, which comes from the `OPTIONS`, so answering the `GET`
+ * alone leaves the canvas unstyled and looks identical to the id never arriving.
  *
- * The record's contents are used, not just its id: measured on WordPress.com by preloading a
- * record whose background differed from the blog's stored design, and the canvas took the
- * record's colour. So this has to carry the body WordPress.com sent, not a placeholder.
+ * The body has to be the record WordPress.com sent, not a placeholder — the canvas
+ * takes its colours from these contents.
  *
- * `Allow` decides how the editor treats it. Without `POST`/`PUT` the package reads through
- * `getEntityRecord` rather than `getEditedEntityRecord`, which is the shape to ship while there
- * is no save interception: the canvas paints and the Styles panel is not editable, so nothing can
- * write to a record we have not yet routed.
+ * `Allow` decides the read path. Without `POST`/`PUT` the package reads through
+ * `getEntityRecord` rather than `getEditedEntityRecord`, which is what to ship while
+ * there is no save interception: the canvas paints, the Styles panel stays read-only.
  *
- * **Only this one id, never a pattern.** The editor also loads the site's own global-styles record
- * alongside ours — measured as `OPTIONS /wp/v2/global-styles/2` and
- * `GET /wp/v2/global-styles/2?context=edit`, `2` being `wp-global-styles-pub/assembler`. Matching
- * `/wp/v2/global-styles/*` would put the site's own design through the newsletter's plumbing. That
- * record has to keep reaching the network untouched.
+ * Only this exact id, never a pattern — the editor loads the site's own global-styles
+ * record alongside ours, and that one must keep reaching the network.
  *
  * @param {object} bundle - The response from the bootstrap route.
  * @return {object} Preload entries, empty when the bundle carries no global styles.
@@ -281,8 +216,8 @@ function templatePreloads( bundle, templateId ) {
 		return {};
 	}
 
-	// Callers passing `parse: false` build a Response out of these, and that path reads
-	// `headers` unconditionally, so every entry carries one even when it is empty.
+	// `parse: false` callers build a Response from these and read `headers`
+	// unconditionally, so every entry carries one even when empty.
 	const collection = {
 		body: templates,
 		headers: {
@@ -291,10 +226,9 @@ function templatePreloads( bundle, templateId ) {
 		},
 	};
 
-	// Every context the collection has been seen asked for, including none at all. The two
-	// measurements disagree — this editor asks for `?context=edit` on WordPress 7.1, while the
-	// same load on WordPress.com carries no context — and a key that goes unmatched costs
-	// nothing, whereas the one miss that matters leaves the editor waiting forever.
+	// The context asked for varies by platform (`?context=edit` on WordPress 7.1, none
+	// on WordPress.com). An unmatched key costs nothing; a miss leaves the editor
+	// waiting forever.
 	const map = {
 		'/wp/v2/templates': collection,
 		'/wp/v2/templates?context=edit': collection,
@@ -316,10 +250,9 @@ function templatePreloads( bundle, templateId ) {
 /**
  * The id of the template the editor opens.
  *
- * Read from the bundle and never derived here. The package builds it as
- * `get_stylesheet() . '//' . $slug` on whichever installation registered the
- * template, so a site working it out locally is right on Simple — where the
- * site and the shadow blog are the same — and wrong on Atomic and self-hosted.
+ * Read from the bundle, never derived: the package builds it from the stylesheet of
+ * whichever installation registered the template, so computing it locally is right on
+ * Simple and wrong on Atomic and self-hosted.
  *
  * @param {object} bundle - The response from the bootstrap route.
  * @throws {Error} If the bundle carries no template.
@@ -338,9 +271,8 @@ export function getTemplateId( bundle ) {
 /**
  * What the screen shows when it could not load.
  *
- * A blank screen is the failure this is here to avoid: the design lives on
- * another site, so "nothing appeared" and "your design is empty" look the same
- * to whoever opened the page.
+ * The design lives on another site, so without this "nothing appeared" and "your
+ * design is empty" look identical to whoever opened the page.
  *
  * @return {import('react').ReactElement} The error notice.
  */
@@ -363,8 +295,7 @@ function LoadError() {
 export async function mountEmailDesignEditor() {
 	const data = window.JetpackEmailDesignEditor;
 
-	// Not our page. The bundle is only enqueued on the design screen, so this is
-	// the "loaded somewhere unexpected" case rather than a misconfiguration.
+	// Not our page — the bundle is only enqueued on the design screen.
 	if ( ! data || typeof data !== 'object' ) {
 		return;
 	}
@@ -389,10 +320,10 @@ export async function mountEmailDesignEditor() {
 		const preload = buildPreloadMap( bundle, postId );
 
 		if ( preload ) {
-			// Registered last so it runs first: api-fetch unshifts middlewares and applies them
-			// right to left, so this one sees `options.path` before the locale and WordPress.com
-			// rewriting middlewares have rewritten it. It has to be installed before the editor
-			// mounts, because core-data resolves the template on its first render.
+			// Registered last so it runs first: api-fetch applies middlewares right to
+			// left, so this sees `options.path` before the rewriting middlewares. Must be
+			// installed before the editor mounts, which resolves the template on first
+			// render.
 			apiFetch.use( apiFetch.createPreloadingMiddleware( preload ) );
 		}
 
@@ -406,9 +337,7 @@ export async function mountEmailDesignEditor() {
 			</StrictMode>
 		);
 	} catch ( error ) {
-		// The message names which half is at fault, which the notice deliberately
-		// does not — but losing it entirely would leave a page with nothing to
-		// debug from.
+		// The notice deliberately does not name which half failed; this does.
 		// eslint-disable-next-line no-console
 		console.error( 'Jetpack email design editor:', error );
 		root.render( <LoadError /> );

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -1,12 +1,14 @@
 /**
- * The newsletter email design screen.
+ * Client-side entry point for the newsletter email design screen.
  *
  * `ExperimentalEmailEditor` takes its whole configuration as a prop and
  * registers the `email-editor/editor` store itself, so there is nothing to set
- * up here beyond handing it the configuration the page provides.
+ * up here beyond handing it what the page provides.
  *
- * Nothing enqueues this bundle yet — the admin page that mounts it is added
- * separately. See NL-848.
+ * The page is the other half, and is added separately: it renders the
+ * container and localises `window.JetpackEmailDesignEditor` with the editor's
+ * configuration. Until it exists nothing enqueues this bundle, so the mount
+ * below finds no configuration and returns. See NL-848.
  */
 import { ExperimentalEmailEditor } from '@woocommerce/email-editor';
 import { createRoot, StrictMode } from '@wordpress/element';

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -139,7 +139,19 @@ export function buildEditorConfig( bundle, data ) {
 		theme: bundle.editor_theme,
 		urls,
 		userEmail,
-		globalStylesPostId: globalStylesPostId ?? null,
+
+		// A gate rather than a data source: the record it names is an empty scaffold, and the
+		// design itself arrives already merged into `editor_theme`. Measured on WordPress.com,
+		// leaving it null makes the package generate no canvas CSS at all — not the saved
+		// design, not stock values, no `:root{--wp--preset--…}` block — while naming any valid
+		// record paints the whole theme. Nothing here reads the record's contents.
+		//
+		// Taken from the bundle first for the reason the template's id is: it is a
+		// WordPress.com post id, so a page working it out locally is right on Simple, where the
+		// site and the shadow blog are the same, and wrong on Atomic and self-hosted. The page
+		// remains a fallback so this degrades to the previous behaviour against a bundle that
+		// does not carry one yet. See NL-871.
+		globalStylesPostId: bundle.global_styles_post_id ?? globalStylesPostId ?? null,
 	};
 }
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -1,41 +1,100 @@
 /**
  * Client-side entry point for the newsletter email design screen.
  *
- * `ExperimentalEmailEditor` takes its whole configuration as a prop and
- * registers the `email-editor/editor` store itself, so there is nothing to set
- * up here beyond handing it what the page provides.
- *
  * The page is the other half, and is added separately: it renders the
- * container and localises `window.JetpackEmailDesignEditor` with the editor's
- * configuration. Until it exists nothing enqueues this bundle, so the mount
- * below finds no configuration and returns. See NL-848.
+ * container and localises `window.JetpackEmailDesignEditor`. Until it exists
+ * nothing enqueues this bundle, so the mount below finds no configuration and
+ * returns. See NL-848.
  */
 import { ExperimentalEmailEditor } from '@woocommerce/email-editor';
 import { createRoot, StrictMode } from '@wordpress/element';
 
 /**
- * Mount the editor into the container the admin page renders.
+ * Translate the page's data into the configuration the editor reads.
  *
+ * The editor's `config` prop is not the WordPress.com bootstrap bundle. The
+ * bundle arrives in the shape the REST route returns it — `editor_settings`,
+ * `editor_theme` — while the package's store reads five camelCased keys off
+ * the prop: `editorSettings`, `theme`, `urls`, `userEmail` and
+ * `globalStylesPostId`. Passing the bundle through unmapped leaves all five
+ * undefined, which is not an error the editor reports — it boots with no
+ * settings and no theme.
+ *
+ * `editorSettings` is assembled from both halves on purpose. WordPress.com
+ * removes `__unstableResolvedAssets` and `allowedIframeStyleHandles` from the
+ * bundle before returning it, because they describe the installation they were
+ * computed on rather than the design; the site supplies its own. The site's
+ * half is merged last so it wins.
+ *
+ * @param {object} data - The value of `window.JetpackEmailDesignEditor`.
+ * @throws {Error} If the page left out something the editor cannot start without.
+ * @return {object} The editor's `config` prop.
+ */
+export function buildEditorConfig( data ) {
+	const { bundle, editorSettings, urls, userEmail, globalStylesPostId } = data;
+
+	// Mirrors what the package's own `initializeEditor()` validates when it reads
+	// these from a global. Nothing checks them on the `config` prop path, so an
+	// omission would otherwise surface as an unrelated failure deep in the editor.
+	if ( ! bundle?.editor_settings ) {
+		throw new Error( 'JetpackEmailDesignEditor.bundle.editor_settings is required.' );
+	}
+
+	if ( ! bundle?.editor_theme ) {
+		throw new Error( 'JetpackEmailDesignEditor.bundle.editor_theme is required.' );
+	}
+
+	if ( typeof urls?.back !== 'string' || typeof urls?.listings !== 'string' ) {
+		throw new Error( 'JetpackEmailDesignEditor.urls.back and .listings are required strings.' );
+	}
+
+	return {
+		editorSettings: { ...bundle.editor_settings, ...editorSettings },
+		theme: bundle.editor_theme,
+		urls,
+		userEmail,
+		globalStylesPostId: globalStylesPostId ?? null,
+	};
+}
+
+/**
+ * Mount the editor into the container the page renders.
+ *
+ * @throws {Error} If the page provided a configuration the editor cannot start from.
  * @return {void}
  */
-function mountEmailDesignEditor() {
-	const config = window.JetpackEmailDesignEditor;
+export function mountEmailDesignEditor() {
+	const data = window.JetpackEmailDesignEditor;
 
-	if ( ! config ) {
+	// Not our page. The bundle is only enqueued on the design screen, so this is
+	// the "loaded somewhere unexpected" case rather than a misconfiguration.
+	if ( ! data || typeof data !== 'object' ) {
 		return;
 	}
 
-	const container = document.getElementById( config.elementId );
+	const container = document.getElementById( data.elementId );
 
 	if ( ! container ) {
 		return;
 	}
 
-	const { postId, postType, elementId, ...editorConfig } = config;
+	const { postId, postType } = data;
+
+	if ( ! postId ) {
+		throw new Error( 'JetpackEmailDesignEditor.postId is required.' );
+	}
+
+	if ( ! postType ) {
+		throw new Error( 'JetpackEmailDesignEditor.postType is required.' );
+	}
 
 	createRoot( container ).render(
 		<StrictMode>
-			<ExperimentalEmailEditor postId={ postId } postType={ postType } config={ editorConfig } />
+			<ExperimentalEmailEditor
+				postId={ postId }
+				postType={ postType }
+				config={ buildEditorConfig( data ) }
+			/>
 		</StrictMode>
 	);
 }

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -151,7 +151,7 @@ export function buildEditorConfig( bundle, data ) {
 		// site and the shadow blog are the same, and wrong on Atomic and self-hosted. The page
 		// remains a fallback so this degrades to the previous behaviour against a bundle that
 		// does not carry one yet. See NL-871.
-		globalStylesPostId: bundle.global_styles?.post_id ?? globalStylesPostId ?? null,
+		globalStylesPostId: getGlobalStylesPostId( bundle ) ?? globalStylesPostId ?? null,
 	};
 }
 
@@ -196,6 +196,27 @@ export function buildPreloadMap( bundle, templateId ) {
 }
 
 /**
+ * The id of the global-styles record the bundle points at, or null when it sent no usable one.
+ *
+ * Validated rather than trusted because this value is interpolated into the preload's path keys.
+ * The keys are deliberately exact — the editor loads the *site's own* global-styles record
+ * alongside ours, and that one has to keep reaching the network untouched — so an id carrying a
+ * query string or a slash would silently widen what we answer for. Rejecting anything that is not
+ * a positive integer keeps the code to the invariant its callers document.
+ *
+ * WordPress.com sends an int today and the filter behind this route is only consulted on Simple,
+ * so this is defence in depth rather than a reachable defect. It costs a comparison.
+ *
+ * @param {object} bundle - The response from the bootstrap route.
+ * @return {number|null} The record's id, or null.
+ */
+function getGlobalStylesPostId( bundle ) {
+	const id = bundle?.global_styles?.post_id;
+
+	return Number.isInteger( id ) && id > 0 ? id : null;
+}
+
+/**
  * The global-styles record the editor reads its design from.
  *
  * Both halves are required. The package's selector guards on
@@ -223,7 +244,7 @@ export function buildPreloadMap( bundle, templateId ) {
  */
 function globalStylesPreloads( bundle ) {
 	const globalStyles = bundle?.global_styles;
-	const id = globalStyles?.post_id;
+	const id = getGlobalStylesPostId( bundle );
 
 	if ( ! id || ! globalStyles?.record ) {
 		return {};

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -1,0 +1,45 @@
+/**
+ * The newsletter email design screen.
+ *
+ * `ExperimentalEmailEditor` takes its whole configuration as a prop and
+ * registers the `email-editor/editor` store itself, so there is nothing to set
+ * up here beyond handing it the configuration the page provides.
+ *
+ * Nothing enqueues this bundle yet — the admin page that mounts it is added
+ * separately. See NL-848.
+ */
+import { ExperimentalEmailEditor } from '@woocommerce/email-editor';
+import { createRoot, StrictMode } from '@wordpress/element';
+
+/**
+ * Mount the editor into the container the admin page renders.
+ *
+ * @return {void}
+ */
+function mountEmailDesignEditor() {
+	const config = window.JetpackEmailDesignEditor;
+
+	if ( ! config ) {
+		return;
+	}
+
+	const container = document.getElementById( config.elementId );
+
+	if ( ! container ) {
+		return;
+	}
+
+	const { postId, postType, elementId, ...editorConfig } = config;
+
+	createRoot( container ).render(
+		<StrictMode>
+			<ExperimentalEmailEditor postId={ postId } postType={ postType } config={ editorConfig } />
+		</StrictMode>
+	);
+}
+
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', mountEmailDesignEditor, { once: true } );
+} else {
+	mountEmailDesignEditor();
+}

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -10,6 +10,47 @@ import { ExperimentalEmailEditor } from '@woocommerce/email-editor';
 import { createRoot, StrictMode } from '@wordpress/element';
 
 /**
+ * Schemes the editor's navigation buttons may send the browser to.
+ *
+ * `javascript:` and `data:` are URLs a browser executes rather than navigates
+ * to, and the editor assigns these values straight to `window.location.href`.
+ */
+const NAVIGABLE_PROTOCOLS = [ 'http:', 'https:' ];
+
+/**
+ * Check that a URL the editor will navigate to is one the browser can navigate to.
+ *
+ * Resolving against the current page is what the editor's own back button does,
+ * and it does not neutralise a scheme: relative resolution applies only when the
+ * value has no scheme of its own, so `javascript:…` survives the round trip
+ * intact. The check therefore has to read the protocol the URL parses to, not
+ * the string it started as — the parser also strips leading whitespace, which a
+ * `startsWith( 'javascript:' )` test would miss.
+ *
+ * @param {*}      value - The configured URL.
+ * @param {string} key   - Its key, named in the error so the page can be fixed.
+ * @throws {Error} If the value is not a URL the browser can navigate to.
+ * @return {void}
+ */
+function assertNavigableUrl( value, key ) {
+	if ( typeof value !== 'string' ) {
+		throw new Error( `JetpackEmailDesignEditor.urls.${ key } must be a string.` );
+	}
+
+	let resolved;
+
+	try {
+		resolved = new URL( value, window.location.href );
+	} catch {
+		throw new Error( `JetpackEmailDesignEditor.urls.${ key } is not a valid URL.` );
+	}
+
+	if ( ! NAVIGABLE_PROTOCOLS.includes( resolved.protocol ) ) {
+		throw new Error( `JetpackEmailDesignEditor.urls.${ key } must be an http or https URL.` );
+	}
+}
+
+/**
  * Translate the page's data into the configuration the editor reads.
  *
  * The editor's `config` prop is not the WordPress.com bootstrap bundle. The
@@ -47,6 +88,11 @@ export function buildEditorConfig( data ) {
 	if ( typeof urls?.back !== 'string' || typeof urls?.listings !== 'string' ) {
 		throw new Error( 'JetpackEmailDesignEditor.urls.back and .listings are required strings.' );
 	}
+
+	// Every value here ends up assigned to `window.location.href` by the editor's
+	// header buttons, so each has to be somewhere the browser can navigate to and
+	// not something it will execute.
+	Object.entries( urls ).forEach( ( [ key, value ] ) => assertNavigableUrl( value, key ) );
 
 	return {
 		editorSettings: { ...bundle.editor_settings, ...editorSettings },

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -160,16 +160,14 @@ function getGlobalStylesPostId( bundle ) {
 /**
  * The global-styles record the editor reads its design from.
  *
- * The `GET` and the `OPTIONS` are both required: the package's selector guards on
- * `undefined !== canEdit`, which comes from the `OPTIONS`, so answering the `GET`
- * alone leaves the canvas unstyled and looks identical to the id never arriving.
+ * The `GET` and the `OPTIONS` both matter, and both carry `Allow`: core-data derives the
+ * record's permissions from either response, last one winning.
  *
  * The body has to be the record WordPress.com sent, not a placeholder — the canvas
  * takes its colours from these contents.
  *
- * `Allow` decides the read path. Without `POST`/`PUT` the package reads through
- * `getEntityRecord` rather than `getEditedEntityRecord`, which is what to ship while
- * there is no save interception: the canvas paints, the Styles panel stays read-only.
+ * `can_edit` decides whether the Styles panel exists at all. Without update permission the
+ * package's sidebar returns nothing; it does not render a read-only panel.
  *
  * Only this exact id, never a pattern — the editor loads the site's own global-styles
  * record alongside ours, and that one must keep reaching the network.
@@ -185,7 +183,12 @@ function globalStylesPreloads( bundle ) {
 		return {};
 	}
 
-	const record = { body: globalStyles.record, headers: {} };
+	// A preloaded GET carries permissions as well as data: core-data reads `Allow` off the record's
+	// own response too, and reads a missing header as "nothing is permitted" rather than as silence.
+	// The GETs resolve after the OPTIONS, so omitting it here overwrites the OPTIONS answer with a
+	// flat no and the Styles panel never renders.
+	const allow = globalStyles.can_edit ? 'GET, POST, PUT' : 'GET';
+	const record = { body: globalStyles.record, headers: { Allow: allow } };
 
 	return {
 		[ `/wp/v2/global-styles/${ id }` ]: record,
@@ -194,10 +197,7 @@ function globalStylesPreloads( bundle ) {
 
 		// OPTIONS responses live under their own top-level key in the preload format.
 		OPTIONS: {
-			[ `/wp/v2/global-styles/${ id }` ]: {
-				body: {},
-				headers: { Allow: globalStyles.can_edit ? 'GET, POST, PUT' : 'GET' },
-			},
+			[ `/wp/v2/global-styles/${ id }` ]: { body: {}, headers: { Allow: allow } },
 		},
 	};
 }
@@ -238,7 +238,10 @@ function templatePreloads( bundle, templateId ) {
 	const item = templates.find( template => template?.id === templateId );
 
 	if ( item ) {
-		const record = { body: item, headers: {} };
+		// Explicitly read-only, for the reason above: the header is an assertion, not decoration.
+		// Nothing on this screen edits the template, and granting writes here would hand the
+		// editor a template it believes it may save.
+		const record = { body: item, headers: { Allow: 'GET' } };
 
 		map[ `/wp/v2/templates/${ templateId }` ] = record;
 		map[ `/wp/v2/templates/${ templateId }?context=edit` ] = record;

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -151,12 +151,17 @@ export function buildEditorConfig( bundle, data ) {
 		// site and the shadow blog are the same, and wrong on Atomic and self-hosted. The page
 		// remains a fallback so this degrades to the previous behaviour against a bundle that
 		// does not carry one yet. See NL-871.
-		globalStylesPostId: bundle.global_styles_post_id ?? globalStylesPostId ?? null,
+		globalStylesPostId: bundle.global_styles?.post_id ?? globalStylesPostId ?? null,
 	};
 }
 
 /**
- * The template records the editor would otherwise fetch, keyed by the path it asks for.
+ * Everything the editor would otherwise fetch, keyed by the path it asks for.
+ *
+ * Two things travel this way — the canvas templates and the global-styles record — for the same
+ * reason: both exist only while WordPress.com builds the bootstrap bundle, so a request made from
+ * the browser cannot reach them. Sending the contents and answering the fetch locally sidesteps
+ * that rather than working around it.
  *
  * The editor resolves its canvas template through core-data, which fetches
  * `/wp/v2/templates` — the item and the collection both, as observed. On WordPress.com
@@ -174,18 +179,85 @@ export function buildEditorConfig( bundle, data ) {
  * rest — `post_types` with no optional chaining, so a record without it throws rather than
  * degrading, plus `source`, `origin` and `has_theme_file` when resetting a template. Only
  * WordPress.com holds the real records, the same reason the template's id is handed down
- * rather than derived. Until it sends them there is nothing to preload, and this returns null.
+ * rather than derived. Until it sends them there is nothing to preload.
  *
  * @param {object} bundle     - The response from the bootstrap route.
  * @param {string} templateId - The id of the template the editor opens.
  * @return {object|null} A map for `createPreloadingMiddleware`, or null when the bundle
- *                       carries no template records.
+ *                       carries nothing to preload.
  */
 export function buildPreloadMap( bundle, templateId ) {
+	const map = {
+		...templatePreloads( bundle, templateId ),
+		...globalStylesPreloads( bundle ),
+	};
+
+	return Object.keys( map ).length > 0 ? map : null;
+}
+
+/**
+ * The global-styles record the editor reads its design from.
+ *
+ * Both halves are required. The package's selector guards on
+ * `postId && undefined !== canEdit`, and `canEdit` comes from `canUser( 'update', … )`, which is
+ * an `OPTIONS` request. Answer the `GET` alone and `canEdit` stays undefined, the selector returns
+ * null, and the canvas renders unstyled — indistinguishable from the id never having arrived.
+ *
+ * The record's contents are used, not just its id: measured on WordPress.com by preloading a
+ * record whose background differed from the blog's stored design, and the canvas took the
+ * record's colour. So this has to carry the body WordPress.com sent, not a placeholder.
+ *
+ * `Allow` decides how the editor treats it. Without `POST`/`PUT` the package reads through
+ * `getEntityRecord` rather than `getEditedEntityRecord`, which is the shape to ship while there
+ * is no save interception: the canvas paints and the Styles panel is not editable, so nothing can
+ * write to a record we have not yet routed.
+ *
+ * **Only this one id, never a pattern.** The editor also loads the site's own global-styles record
+ * alongside ours — measured as `OPTIONS /wp/v2/global-styles/2` and
+ * `GET /wp/v2/global-styles/2?context=edit`, `2` being `wp-global-styles-pub/assembler`. Matching
+ * `/wp/v2/global-styles/*` would put the site's own design through the newsletter's plumbing. That
+ * record has to keep reaching the network untouched.
+ *
+ * @param {object} bundle - The response from the bootstrap route.
+ * @return {object} Preload entries, empty when the bundle carries no global styles.
+ */
+function globalStylesPreloads( bundle ) {
+	const globalStyles = bundle?.global_styles;
+	const id = globalStyles?.post_id;
+
+	if ( ! id || ! globalStyles?.record ) {
+		return {};
+	}
+
+	const record = { body: globalStyles.record, headers: {} };
+
+	return {
+		[ `/wp/v2/global-styles/${ id }` ]: record,
+		[ `/wp/v2/global-styles/${ id }?context=view` ]: record,
+		[ `/wp/v2/global-styles/${ id }?context=edit` ]: record,
+
+		// OPTIONS responses live under their own top-level key in the preload format.
+		OPTIONS: {
+			[ `/wp/v2/global-styles/${ id }` ]: {
+				body: {},
+				headers: { Allow: globalStyles.can_edit ? 'GET, POST, PUT' : 'GET' },
+			},
+		},
+	};
+}
+
+/**
+ * The template records the editor resolves its canvas from.
+ *
+ * @param {object} bundle     - The response from the bootstrap route.
+ * @param {string} templateId - The id of the template the editor opens.
+ * @return {object} Preload entries, empty when the bundle carries no template records.
+ */
+function templatePreloads( bundle, templateId ) {
 	const templates = bundle?.templates;
 
 	if ( ! Array.isArray( templates ) || 0 === templates.length ) {
-		return null;
+		return {};
 	}
 
 	// Callers passing `parse: false` build a Response out of these, and that path reads

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -2,10 +2,11 @@
  * Tests for the newsletter email design screen's entry point.
  *
  * The module mounts on import, so each case re-imports it in isolation after
- * arranging the page it expects to find.
+ * arranging the page and the bootstrap response it expects to find.
  */
 
 const mockRender = jest.fn();
+const mockApiFetch = jest.fn();
 
 jest.mock( '@wordpress/element', () => {
 	const actualElement = jest.requireActual( '@wordpress/element' );
@@ -16,6 +17,11 @@ jest.mock( '@wordpress/element', () => {
 	};
 } );
 
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args ) => mockApiFetch( ...args ),
+} ) );
+
 const MockEmailEditor = () => null;
 
 jest.mock( '@woocommerce/email-editor', () => ( {
@@ -25,10 +31,24 @@ jest.mock( '@woocommerce/email-editor', () => ( {
 const ELEMENT_ID = 'jetpack-email-design-editor';
 
 /**
- * A page configuration with everything the editor needs.
+ * The bootstrap response, in the shape the WordPress.com route returns it —
+ * deliberately without the two settings that side strips before returning.
  *
- * `bundle` is in the shape the WordPress.com route returns, deliberately
- * without the two settings that side strips before returning it.
+ * @param {object} overrides - Values to replace, or `undefined` to drop a key.
+ * @return {object} A bundle.
+ */
+function bootstrapBundle( overrides = {} ) {
+	return {
+		editor_settings: { styles: [ { css: 'body{}' } ] },
+		editor_theme: { version: 3, settings: { color: { palette: [] } } },
+		template: { id: 'pub/stylesheet//wpcom-newsletter' },
+		personalization_tags: [],
+		...overrides,
+	};
+}
+
+/**
+ * What the page localises: everything WordPress.com cannot know.
  *
  * @param {object} overrides - Values to replace, or `undefined` to drop a key.
  * @return {object} A `window.JetpackEmailDesignEditor` value.
@@ -36,14 +56,6 @@ const ELEMENT_ID = 'jetpack-email-design-editor';
 function pageData( overrides = {} ) {
 	return {
 		elementId: ELEMENT_ID,
-		postId: 878,
-		postType: 'wp_template',
-		bundle: {
-			editor_settings: { styles: [ { css: 'body{}' } ] },
-			editor_theme: { version: 3, settings: { color: { palette: [] } } },
-			template: { id: 'wpcom/newsletter' },
-			personalization_tags: [],
-		},
 		editorSettings: {
 			allowedIframeStyleHandles: [ 'wp-block-library' ],
 			__unstableResolvedAssets: { styles: '' },
@@ -60,14 +72,17 @@ function pageData( overrides = {} ) {
 }
 
 /**
- * Import the entry point fresh, so its mount runs against the current page.
+ * Import the entry point fresh and let its mount settle.
  *
- * @return {void}
+ * @return {Promise<void>} Resolves once the mount has rendered.
  */
-function loadEntryPoint() {
+async function loadEntryPoint() {
 	jest.isolateModules( () => {
 		require( '../src/index' );
 	} );
+
+	// The mount fetches before rendering, so let the microtask queue drain.
+	await new Promise( resolve => setTimeout( resolve, 0 ) );
 }
 
 /**
@@ -82,71 +97,126 @@ function mountedEditorProps() {
 	return tree.props.children.props;
 }
 
+/**
+ * Whether the entry rendered its error state rather than the editor.
+ *
+ * @return {boolean} True when the last render was not the editor.
+ */
+function renderedTheErrorState() {
+	if ( ! mockRender.mock.calls.length ) {
+		return false;
+	}
+
+	const [ tree ] = mockRender.mock.calls[ 0 ];
+
+	return tree.type !== undefined && tree.props?.children?.type !== MockEmailEditor;
+}
+
 describe( 'Email design editor entry point', () => {
 	beforeEach( () => {
 		document.body.innerHTML = `<div id="${ ELEMENT_ID }"></div>`;
 		delete window.JetpackEmailDesignEditor;
 		mockRender.mockClear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( bootstrapBundle() );
+		jest.spyOn( console, 'error' ).mockImplementation( () => {} );
 	} );
 
-	describe( 'when it should not mount', () => {
-		it( 'returns when the page provides no configuration', () => {
-			loadEntryPoint();
+	afterEach( () => {
+		// eslint-disable-next-line no-console
+		console.error.mockRestore();
+	} );
 
+	describe( 'when it should not mount at all', () => {
+		it( 'returns without fetching when the page provides no configuration', async () => {
+			await loadEntryPoint();
+
+			expect( mockApiFetch ).not.toHaveBeenCalled();
 			expect( mockRender ).not.toHaveBeenCalled();
 		} );
 
-		it( 'returns when the container is missing', () => {
+		it( 'returns without fetching when the container is missing', async () => {
 			document.body.innerHTML = '';
 			window.JetpackEmailDesignEditor = pageData();
 
-			loadEntryPoint();
+			await loadEntryPoint();
 
+			expect( mockApiFetch ).not.toHaveBeenCalled();
 			expect( mockRender ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'fetching the bundle', () => {
+		it( 'asks the local wpcom route, which every platform answers', async () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			expect( mockApiFetch ).toHaveBeenCalledWith( {
+				path: '/wpcom/v2/email-editor-bootstrap',
+			} );
+		} );
+
+		it( 'passes on a template slug when the page names one', async () => {
+			window.JetpackEmailDesignEditor = pageData( { templateSlug: 'wpcom-digest' } );
+
+			await loadEntryPoint();
+
+			expect( mockApiFetch.mock.calls[ 0 ][ 0 ].path ).toContain( 'template_slug=wpcom-digest' );
+		} );
+
+		it( 'takes the template id from the bundle rather than deriving one', async () => {
+			// The id is namespaced by whichever theme served it, so a site computing it
+			// locally is right on Simple and wrong on Atomic and self-hosted.
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			expect( mountedEditorProps().postId ).toBe( 'pub/stylesheet//wpcom-newsletter' );
+			expect( mountedEditorProps().postType ).toBe( 'wp_template' );
+		} );
+
+		it( 'shows an error instead of a blank screen when the fetch fails', async () => {
+			mockApiFetch.mockRejectedValue( new Error( 'network' ) );
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			expect( mockRender ).toHaveBeenCalledTimes( 1 );
+			expect( renderedTheErrorState() ).toBe( true );
+		} );
+
+		it( 'shows an error when the bundle carries no template id', async () => {
+			mockApiFetch.mockResolvedValue( bootstrapBundle( { template: undefined } ) );
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			expect( renderedTheErrorState() ).toBe( true );
 		} );
 	} );
 
 	describe( 'the configuration it builds', () => {
-		it( 'mounts the editor on the post it was given', () => {
+		it( 'reads the keys the editor store actually reads', async () => {
 			window.JetpackEmailDesignEditor = pageData();
 
-			loadEntryPoint();
-
-			expect( mockRender ).toHaveBeenCalledTimes( 1 );
-
-			const [ tree ] = mockRender.mock.calls[ 0 ];
-			expect( tree.props.children.type ).toBe( MockEmailEditor );
-			expect( mountedEditorProps().postId ).toBe( 878 );
-			expect( mountedEditorProps().postType ).toBe( 'wp_template' );
-		} );
-
-		it( 'reads the keys the editor store actually reads', () => {
-			window.JetpackEmailDesignEditor = pageData();
-
-			loadEntryPoint();
+			await loadEntryPoint();
 
 			// The five keys `SET_EDITOR_CONFIG` reduces. Any of them undefined and the
 			// editor boots without settings, theme or navigation, reporting nothing.
 			const { config } = mountedEditorProps();
 
-			expect( config.theme ).toEqual( {
-				version: 3,
-				settings: { color: { palette: [] } },
-			} );
-			expect( config.urls ).toEqual( {
-				back: '/wp-admin/admin.php?page=x',
-				listings: '/wp-admin/edit.php',
-				send: 'https://example.com/send',
-			} );
+			expect( config.theme ).toEqual( { version: 3, settings: { color: { palette: [] } } } );
+			expect( config.urls ).toEqual( pageData().urls );
 			expect( config.userEmail ).toBe( 'creator@example.com' );
 			expect( config.globalStylesPostId ).toBe( 878 );
 			expect( config.editorSettings ).toBeDefined();
 		} );
 
-		it( 'merges the site half of the settings over the WordPress.com half', () => {
+		it( 'merges the site half of the settings over the WordPress.com half', async () => {
 			window.JetpackEmailDesignEditor = pageData();
 
-			loadEntryPoint();
+			await loadEntryPoint();
 
 			// WordPress.com strips these two before returning the bundle, because they
 			// describe the installation rather than the design. Losing them is what
@@ -158,10 +228,10 @@ describe( 'Email design editor entry point', () => {
 			} );
 		} );
 
-		it( 'does not pass the bundle through in its own shape', () => {
+		it( 'does not pass the bundle through in its own shape', async () => {
 			window.JetpackEmailDesignEditor = pageData();
 
-			loadEntryPoint();
+			await loadEntryPoint();
 
 			// The bundle's keys are snake_case and the store reads camelCase, so passing
 			// it through unmapped is silently empty rather than an error.
@@ -169,79 +239,81 @@ describe( 'Email design editor entry point', () => {
 
 			expect( config ).not.toHaveProperty( 'editor_settings' );
 			expect( config ).not.toHaveProperty( 'editor_theme' );
-			expect( config ).not.toHaveProperty( 'bundle' );
+			expect( config ).not.toHaveProperty( 'template' );
 			expect( config ).not.toHaveProperty( 'elementId' );
-			expect( config ).not.toHaveProperty( 'postId' );
-			expect( config ).not.toHaveProperty( 'postType' );
 		} );
 
-		it( 'defaults a missing global styles post id to null rather than undefined', () => {
+		it( 'defaults a missing global styles post id to null rather than undefined', async () => {
 			window.JetpackEmailDesignEditor = pageData( { globalStylesPostId: undefined } );
 
-			loadEntryPoint();
+			await loadEntryPoint();
 
 			expect( mountedEditorProps().config.globalStylesPostId ).toBeNull();
 		} );
 	} );
 
 	describe( 'the urls it will let the editor navigate to', () => {
+		const { buildEditorConfig } = jest.requireActual( '../src/index' );
+
 		// Each of these is assigned to `window.location.href` by a header button, so a
 		// scheme the browser executes rather than navigates to is code running in
 		// wp-admin with the administrator's session.
 		it.each( [ [ 'back' ], [ 'listings' ], [ 'send' ] ] )(
 			'rejects a javascript: url in %s',
 			key => {
-				window.JetpackEmailDesignEditor = pageData( {
+				const data = pageData( {
 					urls: { ...pageData().urls, [ key ]: 'javascript:alert(1)' },
 				} );
 
-				expect( loadEntryPoint ).toThrow( /must be an http or https URL/ );
-				expect( mockRender ).not.toHaveBeenCalled();
+				expect( () => buildEditorConfig( bootstrapBundle(), data ) ).toThrow(
+					/must be an http or https URL/
+				);
 			}
 		);
 
 		it( 'rejects a javascript: url disguised by leading whitespace', () => {
 			// The URL parser strips this before reading the scheme, so a check against
 			// the raw string would pass it through.
-			window.JetpackEmailDesignEditor = pageData( {
+			const data = pageData( {
 				urls: { ...pageData().urls, back: '  javascript:alert(1)' },
 			} );
 
-			expect( loadEntryPoint ).toThrow( /must be an http or https URL/ );
+			expect( () => buildEditorConfig( bootstrapBundle(), data ) ).toThrow(
+				/must be an http or https URL/
+			);
 		} );
 
 		it( 'rejects a data: url', () => {
-			window.JetpackEmailDesignEditor = pageData( {
+			const data = pageData( {
 				urls: { ...pageData().urls, back: 'data:text/html,<script></script>' },
 			} );
 
-			expect( loadEntryPoint ).toThrow( /must be an http or https URL/ );
+			expect( () => buildEditorConfig( bootstrapBundle(), data ) ).toThrow(
+				/must be an http or https URL/
+			);
 		} );
 
-		it( 'accepts the relative admin urls a page actually supplies', () => {
-			window.JetpackEmailDesignEditor = pageData();
+		it( 'shows the error state rather than mounting when a url is rejected', async () => {
+			window.JetpackEmailDesignEditor = pageData( {
+				urls: { ...pageData().urls, back: 'javascript:alert(1)' },
+			} );
 
-			loadEntryPoint();
+			await loadEntryPoint();
 
-			expect( mockRender ).toHaveBeenCalledTimes( 1 );
+			expect( renderedTheErrorState() ).toBe( true );
 		} );
 	} );
 
-	describe( 'when the page left something out', () => {
-		it.each( [
-			[ 'the bundle', { bundle: undefined } ],
-			[ 'the bundle settings', { bundle: { editor_theme: { version: 3 } } } ],
-			[ 'the bundle theme', { bundle: { editor_settings: {} } } ],
-			[ 'the urls', { urls: undefined } ],
-			[ 'a back url that is a string', { urls: { back: 1, listings: '/x' } } ],
-			[ 'the listings url', { urls: { back: '/x' } } ],
-			[ 'the post id', { postId: undefined } ],
-			[ 'the post type', { postType: undefined } ],
-		] )( 'throws rather than mounting a broken editor without %s', ( _label, overrides ) => {
-			window.JetpackEmailDesignEditor = pageData( overrides );
+	describe( 'when a half left something out', () => {
+		const { buildEditorConfig } = jest.requireActual( '../src/index' );
 
-			expect( loadEntryPoint ).toThrow();
-			expect( mockRender ).not.toHaveBeenCalled();
+		it.each( [
+			[ 'the bundle settings', bootstrapBundle( { editor_settings: undefined } ), pageData() ],
+			[ 'the bundle theme', bootstrapBundle( { editor_theme: undefined } ), pageData() ],
+			[ 'the urls', bootstrapBundle(), pageData( { urls: undefined } ) ],
+			[ 'a listings url', bootstrapBundle(), pageData( { urls: { back: '/x' } } ) ],
+		] )( 'throws rather than building a config without %s', ( _label, bundle, data ) => {
+			expect( () => buildEditorConfig( bundle, data ) ).toThrow();
 		} );
 	} );
 } );

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -7,6 +7,8 @@
 
 const mockRender = jest.fn();
 const mockApiFetch = jest.fn();
+const mockUse = jest.fn();
+const mockCreatePreloadingMiddleware = jest.fn( map => ( { preloading: map } ) );
 
 jest.mock( '@wordpress/element', () => {
 	const actualElement = jest.requireActual( '@wordpress/element' );
@@ -17,10 +19,14 @@ jest.mock( '@wordpress/element', () => {
 	};
 } );
 
-jest.mock( '@wordpress/api-fetch', () => ( {
-	__esModule: true,
-	default: ( ...args ) => mockApiFetch( ...args ),
-} ) );
+jest.mock( '@wordpress/api-fetch', () => {
+	const apiFetch = ( ...args ) => mockApiFetch( ...args );
+
+	apiFetch.use = ( ...args ) => mockUse( ...args );
+	apiFetch.createPreloadingMiddleware = ( ...args ) => mockCreatePreloadingMiddleware( ...args );
+
+	return { __esModule: true, default: apiFetch };
+} );
 
 const MockEmailEditor = () => null;
 
@@ -42,6 +48,22 @@ function bootstrapBundle( overrides = {} ) {
 		editor_settings: { styles: [ { css: 'body{}' } ] },
 		editor_theme: { version: 3, settings: { color: { palette: [] } } },
 		template: { id: 'pub/stylesheet//wpcom-newsletter' },
+		// The same templates as full REST records, which is what the editor's core-data
+		// resolution needs and what the four-field `template` above cannot stand in for.
+		templates: [
+			{
+				id: 'pub/stylesheet//wpcom-newsletter',
+				slug: 'wpcom-newsletter',
+				title: { rendered: 'Newsletter' },
+				content: { raw: '' },
+				post_types: [ 'wp_template' ],
+				source: 'theme',
+				origin: 'theme',
+				has_theme_file: true,
+				type: 'wp_template',
+				status: 'publish',
+			},
+		],
 		personalization_tags: [],
 		...overrides,
 	};
@@ -117,6 +139,8 @@ describe( 'Email design editor entry point', () => {
 		document.body.innerHTML = `<div id="${ ELEMENT_ID }"></div>`;
 		delete window.JetpackEmailDesignEditor;
 		mockRender.mockClear();
+		mockUse.mockClear();
+		mockCreatePreloadingMiddleware.mockClear();
 		mockApiFetch.mockReset();
 		mockApiFetch.mockResolvedValue( bootstrapBundle() );
 		jest.spyOn( console, 'error' ).mockImplementation( () => {} );
@@ -301,6 +325,100 @@ describe( 'Email design editor entry point', () => {
 			await loadEntryPoint();
 
 			expect( renderedTheErrorState() ).toBe( true );
+		} );
+	} );
+
+	describe( 'preloading the templates the editor resolves', () => {
+		const { buildPreloadMap } = jest.requireActual( '../src/index' );
+		const templateId = 'pub/stylesheet//wpcom-newsletter';
+
+		/**
+		 * The map handed to `createPreloadingMiddleware` on the last mount.
+		 *
+		 * @return {object} The preload map.
+		 */
+		function preloadedMap() {
+			return mockCreatePreloadingMiddleware.mock.calls[ 0 ][ 0 ];
+		}
+
+		it( 'preloads the collection under both contexts', async () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			const map = preloadedMap();
+
+			expect( map[ '/wp/v2/templates?context=edit' ].body ).toHaveLength( 1 );
+			expect( map[ '/wp/v2/templates?context=view' ].body ).toHaveLength( 1 );
+		} );
+
+		it( 'preloads the item under the id the bundle gave, not one it derived', async () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			expect( preloadedMap() ).toHaveProperty( `/wp/v2/templates/${ templateId }?context=edit` );
+		} );
+
+		it( 'passes the records through untouched, since the editor reads fields we cannot invent', async () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			// `post_types` is read without optional chaining in the package's selectors, so a
+			// record missing it throws rather than degrading.
+			const [ record ] = preloadedMap()[ '/wp/v2/templates?context=edit' ].body;
+
+			expect( record.post_types ).toEqual( [ 'wp_template' ] );
+			expect( record.source ).toBe( 'theme' );
+			expect( record.has_theme_file ).toBe( true );
+		} );
+
+		it( 'gives every entry headers, which parse:false callers read unconditionally', async () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			Object.values( preloadedMap() ).forEach( entry => {
+				expect( entry.headers ).toBeDefined();
+			} );
+		} );
+
+		it( 'installs the middleware before the editor mounts', async () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			// core-data resolves the template on the editor's first render, so a middleware
+			// installed afterwards would be too late to answer for it.
+			expect( mockUse.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+				mockRender.mock.invocationCallOrder[ 0 ]
+			);
+		} );
+
+		it( 'installs nothing when the bundle carries no template records', async () => {
+			mockApiFetch.mockResolvedValue( bootstrapBundle( { templates: undefined } ) );
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			// WordPress.com does not send these yet. The editor must still mount rather than
+			// the entry throwing on a key that is not there.
+			expect( mockUse ).not.toHaveBeenCalled();
+			expect( renderedTheErrorState() ).toBe( false );
+		} );
+
+		it( 'installs nothing when the bundle sends an empty collection', () => {
+			expect( buildPreloadMap( bootstrapBundle( { templates: [] } ), templateId ) ).toBeNull();
+		} );
+
+		it( 'omits the item entry when no record matches the template id', () => {
+			const map = buildPreloadMap( bootstrapBundle(), 'pub/other//something-else' );
+
+			expect( Object.keys( map ) ).toEqual( [
+				'/wp/v2/templates?context=edit',
+				'/wp/v2/templates?context=view',
+			] );
 		} );
 	} );
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -341,13 +341,17 @@ describe( 'Email design editor entry point', () => {
 			return mockCreatePreloadingMiddleware.mock.calls[ 0 ][ 0 ];
 		}
 
-		it( 'preloads the collection under both contexts', async () => {
+		it( 'preloads the collection under every context it has been seen asked for', async () => {
 			window.JetpackEmailDesignEditor = pageData();
 
 			await loadEntryPoint();
 
 			const map = preloadedMap();
 
+			// Including no context at all: this editor asks for `?context=edit` on WordPress
+			// 7.1, the same load on WordPress.com asks for none, and a miss leaves the editor
+			// waiting on a record that never arrives.
+			expect( map[ '/wp/v2/templates' ].body ).toHaveLength( 1 );
 			expect( map[ '/wp/v2/templates?context=edit' ].body ).toHaveLength( 1 );
 			expect( map[ '/wp/v2/templates?context=view' ].body ).toHaveLength( 1 );
 		} );
@@ -416,6 +420,7 @@ describe( 'Email design editor entry point', () => {
 			const map = buildPreloadMap( bootstrapBundle(), 'pub/other//something-else' );
 
 			expect( Object.keys( map ) ).toEqual( [
+				'/wp/v2/templates',
 				'/wp/v2/templates?context=edit',
 				'/wp/v2/templates?context=view',
 			] );

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -48,7 +48,11 @@ function pageData( overrides = {} ) {
 			allowedIframeStyleHandles: [ 'wp-block-library' ],
 			__unstableResolvedAssets: { styles: '' },
 		},
-		urls: { back: '/wp-admin/admin.php?page=x', listings: '/wp-admin/edit.php' },
+		urls: {
+			back: '/wp-admin/admin.php?page=x',
+			listings: '/wp-admin/edit.php',
+			send: 'https://example.com/send',
+		},
 		userEmail: 'creator@example.com',
 		globalStylesPostId: 878,
 		...overrides,
@@ -132,6 +136,7 @@ describe( 'Email design editor entry point', () => {
 			expect( config.urls ).toEqual( {
 				back: '/wp-admin/admin.php?page=x',
 				listings: '/wp-admin/edit.php',
+				send: 'https://example.com/send',
 			} );
 			expect( config.userEmail ).toBe( 'creator@example.com' );
 			expect( config.globalStylesPostId ).toBe( 878 );
@@ -176,6 +181,49 @@ describe( 'Email design editor entry point', () => {
 			loadEntryPoint();
 
 			expect( mountedEditorProps().config.globalStylesPostId ).toBeNull();
+		} );
+	} );
+
+	describe( 'the urls it will let the editor navigate to', () => {
+		// Each of these is assigned to `window.location.href` by a header button, so a
+		// scheme the browser executes rather than navigates to is code running in
+		// wp-admin with the administrator's session.
+		it.each( [ [ 'back' ], [ 'listings' ], [ 'send' ] ] )(
+			'rejects a javascript: url in %s',
+			key => {
+				window.JetpackEmailDesignEditor = pageData( {
+					urls: { ...pageData().urls, [ key ]: 'javascript:alert(1)' },
+				} );
+
+				expect( loadEntryPoint ).toThrow( /must be an http or https URL/ );
+				expect( mockRender ).not.toHaveBeenCalled();
+			}
+		);
+
+		it( 'rejects a javascript: url disguised by leading whitespace', () => {
+			// The URL parser strips this before reading the scheme, so a check against
+			// the raw string would pass it through.
+			window.JetpackEmailDesignEditor = pageData( {
+				urls: { ...pageData().urls, back: '  javascript:alert(1)' },
+			} );
+
+			expect( loadEntryPoint ).toThrow( /must be an http or https URL/ );
+		} );
+
+		it( 'rejects a data: url', () => {
+			window.JetpackEmailDesignEditor = pageData( {
+				urls: { ...pageData().urls, back: 'data:text/html,<script></script>' },
+			} );
+
+			expect( loadEntryPoint ).toThrow( /must be an http or https URL/ );
+		} );
+
+		it( 'accepts the relative admin urls a page actually supplies', () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			loadEntryPoint();
+
+			expect( mockRender ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -1,0 +1,136 @@
+/**
+ * Tests for the newsletter email design screen's entry point.
+ *
+ * The module mounts on import, so each case re-imports it in isolation after
+ * arranging the page it expects to find.
+ */
+
+const mockRender = jest.fn();
+
+jest.mock( '@wordpress/element', () => {
+	const actualElement = jest.requireActual( '@wordpress/element' );
+
+	return {
+		...actualElement,
+		createRoot: () => ( { render: mockRender } ),
+	};
+} );
+
+const MockEmailEditor = () => null;
+
+jest.mock( '@woocommerce/email-editor', () => ( {
+	ExperimentalEmailEditor: MockEmailEditor,
+} ) );
+
+const ELEMENT_ID = 'jetpack-email-design-editor';
+
+/**
+ * Import the entry point fresh, so its mount runs against the current page.
+ *
+ * @return {void}
+ */
+function loadEntryPoint() {
+	jest.isolateModules( () => {
+		require( '../src/index' );
+	} );
+}
+
+/**
+ * The props the entry point handed to the editor.
+ *
+ * @return {object} Props of the rendered editor element.
+ */
+function mountedEditorProps() {
+	const [ tree ] = mockRender.mock.calls[ 0 ];
+
+	// The entry renders the editor inside StrictMode.
+	return tree.props.children.props;
+}
+
+describe( 'Email design editor entry point', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+		delete window.JetpackEmailDesignEditor;
+		mockRender.mockClear();
+	} );
+
+	it( 'does not render when the page provides no configuration', () => {
+		document.body.innerHTML = `<div id="${ ELEMENT_ID }"></div>`;
+
+		loadEntryPoint();
+
+		expect( mockRender ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not render when the container is missing', () => {
+		window.JetpackEmailDesignEditor = {
+			elementId: ELEMENT_ID,
+			postId: 42,
+			postType: 'wp_template',
+		};
+
+		loadEntryPoint();
+
+		expect( mockRender ).not.toHaveBeenCalled();
+	} );
+
+	it( 'mounts the editor with the post it was given', () => {
+		document.body.innerHTML = `<div id="${ ELEMENT_ID }"></div>`;
+		window.JetpackEmailDesignEditor = {
+			elementId: ELEMENT_ID,
+			postId: 42,
+			postType: 'wp_template',
+		};
+
+		loadEntryPoint();
+
+		expect( mockRender ).toHaveBeenCalledTimes( 1 );
+
+		const [ tree ] = mockRender.mock.calls[ 0 ];
+		expect( tree.props.children.type ).toBe( MockEmailEditor );
+
+		const props = mountedEditorProps();
+
+		expect( props.postId ).toBe( 42 );
+		expect( props.postType ).toBe( 'wp_template' );
+	} );
+
+	it( 'passes the rest of the configuration through as the editor config', () => {
+		document.body.innerHTML = `<div id="${ ELEMENT_ID }"></div>`;
+		window.JetpackEmailDesignEditor = {
+			elementId: ELEMENT_ID,
+			postId: 42,
+			postType: 'wp_template',
+			editor_settings: { allowedIframeStyleHandles: [ 'wp-block-library' ] },
+			editor_theme: { version: 3 },
+		};
+
+		loadEntryPoint();
+
+		expect( mountedEditorProps().config ).toEqual( {
+			editor_settings: { allowedIframeStyleHandles: [ 'wp-block-library' ] },
+			editor_theme: { version: 3 },
+		} );
+	} );
+
+	it( 'keeps the mount details out of the editor config', () => {
+		document.body.innerHTML = `<div id="${ ELEMENT_ID }"></div>`;
+		window.JetpackEmailDesignEditor = {
+			elementId: ELEMENT_ID,
+			postId: 42,
+			postType: 'wp_template',
+			editor_theme: { version: 3 },
+		};
+
+		loadEntryPoint();
+
+		const { config } = mountedEditorProps();
+
+		// The editor reads its own `postId`/`postType` props and knows nothing about
+		// the container. Leaving these in the config would put mount details into the
+		// settings the editor hands to the block editor.
+		expect( config ).not.toHaveProperty( 'elementId' );
+		expect( config ).not.toHaveProperty( 'postId' );
+		expect( config ).not.toHaveProperty( 'postType' );
+	} );
+} );

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -497,6 +497,51 @@ describe( 'Email design editor entry point', () => {
 			expect( keyed ).not.toContain( '/wp/v2/global-styles/2' );
 		} );
 
+		it.each( [
+			[ 'a query string smuggled into the id', '2?context=edit' ],
+			[ 'a numeric string', '999999999' ],
+			[ 'zero', 0 ],
+			[ 'a float', 1.5 ],
+		] )( 'preloads no global styles path for %s', async ( _label, postId ) => {
+			mockApiFetch.mockResolvedValue(
+				bootstrapBundle( {
+					global_styles: { ...bootstrapBundle().global_styles, post_id: postId },
+				} )
+			);
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			// The keys are interpolated from this value, and the editor loads the site's own
+			// global-styles record alongside ours. An id carrying a query string or a slash would
+			// widen what we answer for — `2?context=edit` is the site's own record's path.
+			const map = preloadedMap();
+
+			expect( Object.keys( map ).some( k => k.includes( 'global-styles' ) ) ).toBe( false );
+			expect( Object.keys( map.OPTIONS || {} ) ).toHaveLength( 0 );
+		} );
+
+		it.each( [
+			[ 'a query string smuggled into the id', '2?context=edit' ],
+			[ 'a numeric string', '999999999' ],
+			[ 'zero', 0 ],
+			[ 'a negative id', -1 ],
+			[ 'a float', 1.5 ],
+		] )( 'falls back to the page id rather than passing on %s', async ( _label, postId ) => {
+			// `??` only falls through on null/undefined, so an invalid id that is merely falsy —
+			// 0 — would otherwise reach the editor instead of the fallback.
+			mockApiFetch.mockResolvedValue(
+				bootstrapBundle( {
+					global_styles: { ...bootstrapBundle().global_styles, post_id: postId },
+				} )
+			);
+			window.JetpackEmailDesignEditor = pageData( { globalStylesPostId: 878 } );
+
+			await loadEntryPoint();
+
+			expect( mountedEditorProps().config.globalStylesPostId ).toBe( 878 );
+		} );
+
 		it( 'preloads the template half even when the bundle carries no global styles', async () => {
 			mockApiFetch.mockResolvedValue( bootstrapBundle( { global_styles: undefined } ) );
 			window.JetpackEmailDesignEditor = pageData();

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -576,6 +576,59 @@ describe( 'Email design editor entry point', () => {
 			expect( renderedTheErrorState() ).toBe( false );
 		} );
 
+		describe( 'the Allow header the preloaded responses carry', () => {
+			const id = 999999999;
+
+			/**
+			 * core-data derives a record's permissions from the `GET` response as well as the
+			 * `OPTIONS` one, and reads a missing header as "nothing is permitted". The `GET`s
+			 * resolve last, so dropping the header there hides the Styles panel outright.
+			 *
+			 * @param {boolean} canEdit - What WordPress.com reported for the record.
+			 * @return {object} The preload map.
+			 */
+			function mapFor( canEdit ) {
+				const bundle = bootstrapBundle( {
+					global_styles: {
+						post_id: id,
+						can_edit: canEdit,
+						record: { id, styles: {} },
+					},
+				} );
+
+				return buildPreloadMap( bundle, templateId );
+			}
+
+			it( 'grants writes on every entry for the record when it is editable', () => {
+				const map = mapFor( true );
+
+				expect( map[ `/wp/v2/global-styles/${ id }` ].headers.Allow ).toBe( 'GET, POST, PUT' );
+				expect( map[ `/wp/v2/global-styles/${ id }?context=edit` ].headers.Allow ).toBe(
+					'GET, POST, PUT'
+				);
+				expect( map[ `/wp/v2/global-styles/${ id }?context=view` ].headers.Allow ).toBe(
+					'GET, POST, PUT'
+				);
+				expect( map.OPTIONS[ `/wp/v2/global-styles/${ id }` ].headers.Allow ).toBe(
+					'GET, POST, PUT'
+				);
+			} );
+
+			it( 'grants only reads on every entry when it is not editable', () => {
+				const map = mapFor( false );
+
+				expect( map[ `/wp/v2/global-styles/${ id }` ].headers.Allow ).toBe( 'GET' );
+				expect( map[ `/wp/v2/global-styles/${ id }?context=edit` ].headers.Allow ).toBe( 'GET' );
+				expect( map.OPTIONS[ `/wp/v2/global-styles/${ id }` ].headers.Allow ).toBe( 'GET' );
+			} );
+
+			it( 'says the template is read-only rather than saying nothing', () => {
+				const map = buildPreloadMap( bootstrapBundle(), templateId );
+
+				expect( map[ `/wp/v2/templates/${ templateId }` ].headers.Allow ).toBe( 'GET' );
+			} );
+		} );
+
 		it( 'installs nothing when the bundle sends an empty collection', () => {
 			const empty = bootstrapBundle( { templates: [], global_styles: undefined } );
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -25,6 +25,37 @@ jest.mock( '@woocommerce/email-editor', () => ( {
 const ELEMENT_ID = 'jetpack-email-design-editor';
 
 /**
+ * A page configuration with everything the editor needs.
+ *
+ * `bundle` is in the shape the WordPress.com route returns, deliberately
+ * without the two settings that side strips before returning it.
+ *
+ * @param {object} overrides - Values to replace, or `undefined` to drop a key.
+ * @return {object} A `window.JetpackEmailDesignEditor` value.
+ */
+function pageData( overrides = {} ) {
+	return {
+		elementId: ELEMENT_ID,
+		postId: 878,
+		postType: 'wp_template',
+		bundle: {
+			editor_settings: { styles: [ { css: 'body{}' } ] },
+			editor_theme: { version: 3, settings: { color: { palette: [] } } },
+			template: { id: 'wpcom/newsletter' },
+			personalization_tags: [],
+		},
+		editorSettings: {
+			allowedIframeStyleHandles: [ 'wp-block-library' ],
+			__unstableResolvedAssets: { styles: '' },
+		},
+		urls: { back: '/wp-admin/admin.php?page=x', listings: '/wp-admin/edit.php' },
+		userEmail: 'creator@example.com',
+		globalStylesPostId: 878,
+		...overrides,
+	};
+}
+
+/**
  * Import the entry point fresh, so its mount runs against the current page.
  *
  * @return {void}
@@ -38,99 +69,131 @@ function loadEntryPoint() {
 /**
  * The props the entry point handed to the editor.
  *
- * @return {object} Props of the rendered editor element.
+ * @return {object} Props of the mounted editor element.
  */
 function mountedEditorProps() {
 	const [ tree ] = mockRender.mock.calls[ 0 ];
 
-	// The entry renders the editor inside StrictMode.
+	// The entry mounts the editor inside StrictMode.
 	return tree.props.children.props;
 }
 
 describe( 'Email design editor entry point', () => {
 	beforeEach( () => {
-		document.body.innerHTML = '';
+		document.body.innerHTML = `<div id="${ ELEMENT_ID }"></div>`;
 		delete window.JetpackEmailDesignEditor;
 		mockRender.mockClear();
 	} );
 
-	it( 'does not render when the page provides no configuration', () => {
-		document.body.innerHTML = `<div id="${ ELEMENT_ID }"></div>`;
+	describe( 'when it should not mount', () => {
+		it( 'returns when the page provides no configuration', () => {
+			loadEntryPoint();
 
-		loadEntryPoint();
+			expect( mockRender ).not.toHaveBeenCalled();
+		} );
 
-		expect( mockRender ).not.toHaveBeenCalled();
-	} );
+		it( 'returns when the container is missing', () => {
+			document.body.innerHTML = '';
+			window.JetpackEmailDesignEditor = pageData();
 
-	it( 'does not render when the container is missing', () => {
-		window.JetpackEmailDesignEditor = {
-			elementId: ELEMENT_ID,
-			postId: 42,
-			postType: 'wp_template',
-		};
+			loadEntryPoint();
 
-		loadEntryPoint();
-
-		expect( mockRender ).not.toHaveBeenCalled();
-	} );
-
-	it( 'mounts the editor with the post it was given', () => {
-		document.body.innerHTML = `<div id="${ ELEMENT_ID }"></div>`;
-		window.JetpackEmailDesignEditor = {
-			elementId: ELEMENT_ID,
-			postId: 42,
-			postType: 'wp_template',
-		};
-
-		loadEntryPoint();
-
-		expect( mockRender ).toHaveBeenCalledTimes( 1 );
-
-		const [ tree ] = mockRender.mock.calls[ 0 ];
-		expect( tree.props.children.type ).toBe( MockEmailEditor );
-
-		const props = mountedEditorProps();
-
-		expect( props.postId ).toBe( 42 );
-		expect( props.postType ).toBe( 'wp_template' );
-	} );
-
-	it( 'passes the rest of the configuration through as the editor config', () => {
-		document.body.innerHTML = `<div id="${ ELEMENT_ID }"></div>`;
-		window.JetpackEmailDesignEditor = {
-			elementId: ELEMENT_ID,
-			postId: 42,
-			postType: 'wp_template',
-			editor_settings: { allowedIframeStyleHandles: [ 'wp-block-library' ] },
-			editor_theme: { version: 3 },
-		};
-
-		loadEntryPoint();
-
-		expect( mountedEditorProps().config ).toEqual( {
-			editor_settings: { allowedIframeStyleHandles: [ 'wp-block-library' ] },
-			editor_theme: { version: 3 },
+			expect( mockRender ).not.toHaveBeenCalled();
 		} );
 	} );
 
-	it( 'keeps the mount details out of the editor config', () => {
-		document.body.innerHTML = `<div id="${ ELEMENT_ID }"></div>`;
-		window.JetpackEmailDesignEditor = {
-			elementId: ELEMENT_ID,
-			postId: 42,
-			postType: 'wp_template',
-			editor_theme: { version: 3 },
-		};
+	describe( 'the configuration it builds', () => {
+		it( 'mounts the editor on the post it was given', () => {
+			window.JetpackEmailDesignEditor = pageData();
 
-		loadEntryPoint();
+			loadEntryPoint();
 
-		const { config } = mountedEditorProps();
+			expect( mockRender ).toHaveBeenCalledTimes( 1 );
 
-		// The editor reads its own `postId`/`postType` props and knows nothing about
-		// the container. Leaving these in the config would put mount details into the
-		// settings the editor hands to the block editor.
-		expect( config ).not.toHaveProperty( 'elementId' );
-		expect( config ).not.toHaveProperty( 'postId' );
-		expect( config ).not.toHaveProperty( 'postType' );
+			const [ tree ] = mockRender.mock.calls[ 0 ];
+			expect( tree.props.children.type ).toBe( MockEmailEditor );
+			expect( mountedEditorProps().postId ).toBe( 878 );
+			expect( mountedEditorProps().postType ).toBe( 'wp_template' );
+		} );
+
+		it( 'reads the keys the editor store actually reads', () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			loadEntryPoint();
+
+			// The five keys `SET_EDITOR_CONFIG` reduces. Any of them undefined and the
+			// editor boots without settings, theme or navigation, reporting nothing.
+			const { config } = mountedEditorProps();
+
+			expect( config.theme ).toEqual( {
+				version: 3,
+				settings: { color: { palette: [] } },
+			} );
+			expect( config.urls ).toEqual( {
+				back: '/wp-admin/admin.php?page=x',
+				listings: '/wp-admin/edit.php',
+			} );
+			expect( config.userEmail ).toBe( 'creator@example.com' );
+			expect( config.globalStylesPostId ).toBe( 878 );
+			expect( config.editorSettings ).toBeDefined();
+		} );
+
+		it( 'merges the site half of the settings over the WordPress.com half', () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			loadEntryPoint();
+
+			// WordPress.com strips these two before returning the bundle, because they
+			// describe the installation rather than the design. Losing them is what
+			// leaves the site's own CSS in the canvas.
+			expect( mountedEditorProps().config.editorSettings ).toEqual( {
+				styles: [ { css: 'body{}' } ],
+				allowedIframeStyleHandles: [ 'wp-block-library' ],
+				__unstableResolvedAssets: { styles: '' },
+			} );
+		} );
+
+		it( 'does not pass the bundle through in its own shape', () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			loadEntryPoint();
+
+			// The bundle's keys are snake_case and the store reads camelCase, so passing
+			// it through unmapped is silently empty rather than an error.
+			const { config } = mountedEditorProps();
+
+			expect( config ).not.toHaveProperty( 'editor_settings' );
+			expect( config ).not.toHaveProperty( 'editor_theme' );
+			expect( config ).not.toHaveProperty( 'bundle' );
+			expect( config ).not.toHaveProperty( 'elementId' );
+			expect( config ).not.toHaveProperty( 'postId' );
+			expect( config ).not.toHaveProperty( 'postType' );
+		} );
+
+		it( 'defaults a missing global styles post id to null rather than undefined', () => {
+			window.JetpackEmailDesignEditor = pageData( { globalStylesPostId: undefined } );
+
+			loadEntryPoint();
+
+			expect( mountedEditorProps().config.globalStylesPostId ).toBeNull();
+		} );
+	} );
+
+	describe( 'when the page left something out', () => {
+		it.each( [
+			[ 'the bundle', { bundle: undefined } ],
+			[ 'the bundle settings', { bundle: { editor_theme: { version: 3 } } } ],
+			[ 'the bundle theme', { bundle: { editor_settings: {} } } ],
+			[ 'the urls', { urls: undefined } ],
+			[ 'a back url that is a string', { urls: { back: 1, listings: '/x' } } ],
+			[ 'the listings url', { urls: { back: '/x' } } ],
+			[ 'the post id', { postId: undefined } ],
+			[ 'the post type', { postType: undefined } ],
+		] )( 'throws rather than mounting a broken editor without %s', ( _label, overrides ) => {
+			window.JetpackEmailDesignEditor = pageData( overrides );
+
+			expect( loadEntryPoint ).toThrow();
+			expect( mockRender ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -48,7 +48,16 @@ function bootstrapBundle( overrides = {} ) {
 		editor_settings: { styles: [ { css: 'body{}' } ] },
 		editor_theme: { version: 3, settings: { color: { palette: [] } } },
 		template: { id: 'pub/stylesheet//wpcom-newsletter' },
-		global_styles_post_id: 10,
+		global_styles: {
+			post_id: 999999999,
+			can_edit: false,
+			record: {
+				id: 999999999,
+				title: { rendered: 'Email styles' },
+				settings: {},
+				styles: { color: { background: '#00ff00' } },
+			},
+		},
 		// The same templates as full REST records, which is what the editor's core-data
 		// resolution needs and what the four-field `template` above cannot stand in for.
 		templates: [
@@ -234,7 +243,7 @@ describe( 'Email design editor entry point', () => {
 			expect( config.theme ).toEqual( { version: 3, settings: { color: { palette: [] } } } );
 			expect( config.urls ).toEqual( pageData().urls );
 			expect( config.userEmail ).toBe( 'creator@example.com' );
-			expect( config.globalStylesPostId ).toBe( 10 );
+			expect( config.globalStylesPostId ).toBe( 999999999 );
 			expect( config.editorSettings ).toBeDefined();
 		} );
 
@@ -275,12 +284,12 @@ describe( 'Email design editor entry point', () => {
 
 			await loadEntryPoint();
 
-			expect( mountedEditorProps().config.globalStylesPostId ).toBe( 10 );
+			expect( mountedEditorProps().config.globalStylesPostId ).toBe( 999999999 );
 		} );
 
 		it( 'falls back to the page when the bundle carries no global styles post id', async () => {
 			// Degrades to the previous behaviour against a bundle deployed before NL-871.
-			mockApiFetch.mockResolvedValue( bootstrapBundle( { global_styles_post_id: undefined } ) );
+			mockApiFetch.mockResolvedValue( bootstrapBundle( { global_styles: undefined } ) );
 			window.JetpackEmailDesignEditor = pageData( { globalStylesPostId: 878 } );
 
 			await loadEntryPoint();
@@ -289,7 +298,7 @@ describe( 'Email design editor entry point', () => {
 		} );
 
 		it( 'defaults a missing global styles post id to null rather than undefined', async () => {
-			mockApiFetch.mockResolvedValue( bootstrapBundle( { global_styles_post_id: undefined } ) );
+			mockApiFetch.mockResolvedValue( bootstrapBundle( { global_styles: undefined } ) );
 			window.JetpackEmailDesignEditor = pageData( { globalStylesPostId: undefined } );
 
 			await loadEntryPoint();
@@ -405,7 +414,11 @@ describe( 'Email design editor entry point', () => {
 
 			await loadEntryPoint();
 
-			Object.values( preloadedMap() ).forEach( entry => {
+			const { OPTIONS = {}, ...paths } = preloadedMap();
+
+			// `OPTIONS` is the format's own container for OPTIONS responses rather than a path,
+			// so its entries are one level down.
+			[ ...Object.values( paths ), ...Object.values( OPTIONS ) ].forEach( entry => {
 				expect( entry.headers ).toBeDefined();
 			} );
 		} );
@@ -422,8 +435,92 @@ describe( 'Email design editor entry point', () => {
 			);
 		} );
 
-		it( 'installs nothing when the bundle carries no template records', async () => {
+		it( 'preloads the global styles record under every context', async () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			const map = preloadedMap();
+			const base = '/wp/v2/global-styles/999999999';
+
+			// The record's contents are what paint the canvas, not just its id — measured on
+			// WordPress.com, where a preloaded record's colour won over the stored design.
+			[ base, `${ base }?context=view`, `${ base }?context=edit` ].forEach( path => {
+				expect( map[ path ].body.styles.color.background ).toBe( '#00ff00' );
+			} );
+		} );
+
+		it( 'answers the canUser probe, without which the canvas renders unstyled', async () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			// The package guards on `postId && undefined !== canEdit`, and canEdit comes from an
+			// OPTIONS request. Preload only the GET and it stays undefined, the selector returns
+			// null, and the result is indistinguishable from the id never arriving.
+			expect( preloadedMap().OPTIONS[ '/wp/v2/global-styles/999999999' ].headers.Allow ).toBe(
+				'GET'
+			);
+		} );
+
+		it( 'allows writes only when the bundle says the user may edit', async () => {
+			mockApiFetch.mockResolvedValue(
+				bootstrapBundle( {
+					global_styles: {
+						...bootstrapBundle().global_styles,
+						can_edit: true,
+					},
+				} )
+			);
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			expect( preloadedMap().OPTIONS[ '/wp/v2/global-styles/999999999' ].headers.Allow ).toBe(
+				'GET, POST, PUT'
+			);
+		} );
+
+		it( 'never keys a global styles record other than its own', async () => {
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			// The editor also loads the site's own record — measured as global-styles/2. Anything
+			// broader than an exact id would push the site's own design through this plumbing.
+			const map = preloadedMap();
+			const keyed = [ ...Object.keys( map ), ...Object.keys( map.OPTIONS || {} ) ].filter( k =>
+				k.includes( 'global-styles' )
+			);
+
+			expect( keyed.every( k => k.startsWith( '/wp/v2/global-styles/999999999' ) ) ).toBe( true );
+			expect( keyed ).not.toContain( '/wp/v2/global-styles/2' );
+		} );
+
+		it( 'preloads the template half even when the bundle carries no global styles', async () => {
+			mockApiFetch.mockResolvedValue( bootstrapBundle( { global_styles: undefined } ) );
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			expect( preloadedMap() ).toHaveProperty( '/wp/v2/templates' );
+			expect( preloadedMap().OPTIONS ).toBeUndefined();
+		} );
+
+		it( 'preloads the global styles half even when the bundle carries no templates', async () => {
 			mockApiFetch.mockResolvedValue( bootstrapBundle( { templates: undefined } ) );
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			expect( preloadedMap() ).toHaveProperty( '/wp/v2/global-styles/999999999' );
+			expect( preloadedMap() ).not.toHaveProperty( '/wp/v2/templates' );
+		} );
+
+		it( 'installs nothing when the bundle carries neither half', async () => {
+			mockApiFetch.mockResolvedValue(
+				bootstrapBundle( { templates: undefined, global_styles: undefined } )
+			);
 			window.JetpackEmailDesignEditor = pageData();
 
 			await loadEntryPoint();
@@ -435,13 +532,15 @@ describe( 'Email design editor entry point', () => {
 		} );
 
 		it( 'installs nothing when the bundle sends an empty collection', () => {
-			expect( buildPreloadMap( bootstrapBundle( { templates: [] } ), templateId ) ).toBeNull();
+			const empty = bootstrapBundle( { templates: [], global_styles: undefined } );
+
+			expect( buildPreloadMap( empty, templateId ) ).toBeNull();
 		} );
 
 		it( 'omits the item entry when no record matches the template id', () => {
 			const map = buildPreloadMap( bootstrapBundle(), 'pub/other//something-else' );
 
-			expect( Object.keys( map ) ).toEqual( [
+			expect( Object.keys( map ).filter( k => k.startsWith( '/wp/v2/templates' ) ) ).toEqual( [
 				'/wp/v2/templates',
 				'/wp/v2/templates?context=edit',
 				'/wp/v2/templates?context=view',

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -48,6 +48,7 @@ function bootstrapBundle( overrides = {} ) {
 		editor_settings: { styles: [ { css: 'body{}' } ] },
 		editor_theme: { version: 3, settings: { color: { palette: [] } } },
 		template: { id: 'pub/stylesheet//wpcom-newsletter' },
+		global_styles_post_id: 10,
 		// The same templates as full REST records, which is what the editor's core-data
 		// resolution needs and what the four-field `template` above cannot stand in for.
 		templates: [
@@ -233,7 +234,7 @@ describe( 'Email design editor entry point', () => {
 			expect( config.theme ).toEqual( { version: 3, settings: { color: { palette: [] } } } );
 			expect( config.urls ).toEqual( pageData().urls );
 			expect( config.userEmail ).toBe( 'creator@example.com' );
-			expect( config.globalStylesPostId ).toBe( 878 );
+			expect( config.globalStylesPostId ).toBe( 10 );
 			expect( config.editorSettings ).toBeDefined();
 		} );
 
@@ -267,7 +268,28 @@ describe( 'Email design editor entry point', () => {
 			expect( config ).not.toHaveProperty( 'elementId' );
 		} );
 
+		it( 'takes the global styles post id from the bundle, not the page', async () => {
+			// A WordPress.com post id. A page working it out locally is right on Simple and
+			// wrong on Atomic and self-hosted, exactly as for the template's id.
+			window.JetpackEmailDesignEditor = pageData( { globalStylesPostId: 878 } );
+
+			await loadEntryPoint();
+
+			expect( mountedEditorProps().config.globalStylesPostId ).toBe( 10 );
+		} );
+
+		it( 'falls back to the page when the bundle carries no global styles post id', async () => {
+			// Degrades to the previous behaviour against a bundle deployed before NL-871.
+			mockApiFetch.mockResolvedValue( bootstrapBundle( { global_styles_post_id: undefined } ) );
+			window.JetpackEmailDesignEditor = pageData( { globalStylesPostId: 878 } );
+
+			await loadEntryPoint();
+
+			expect( mountedEditorProps().config.globalStylesPostId ).toBe( 878 );
+		} );
+
 		it( 'defaults a missing global styles post id to null rather than undefined', async () => {
+			mockApiFetch.mockResolvedValue( bootstrapBundle( { global_styles_post_id: undefined } ) );
 			window.JetpackEmailDesignEditor = pageData( { globalStylesPostId: undefined } );
 
 			await loadEntryPoint();

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -67,6 +67,7 @@
 		"@visx/responsive": "4.0.0",
 		"@visx/scale": "^4.0.0",
 		"@visx/xychart": "4.0.0",
+		"@woocommerce/email-editor": "2.4.0",
 		"@wordpress/a11y": "4.53.0",
 		"@wordpress/base-styles": "11.0.0",
 		"@wordpress/block-editor": "16.0.0",
@@ -132,6 +133,7 @@
 		"webpack-cli": "7.2.1"
 	},
 	"devDependencies": {
+		"@automattic/babel-plugin-replace-textdomain": "workspace:*",
 		"@automattic/color-studio": "4.1.0",
 		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-webpack-config": "workspace:*",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -67,6 +67,7 @@
 		"@visx/responsive": "4.0.0",
 		"@visx/scale": "^4.0.0",
 		"@visx/xychart": "4.0.0",
+		"@woocommerce/email-editor": "2.4.0",
 		"@wordpress/a11y": "4.54.0",
 		"@wordpress/base-styles": "13.0.0",
 		"@wordpress/block-editor": "17.0.0",
@@ -132,6 +133,7 @@
 		"webpack-cli": "7.2.1"
 	},
 	"devDependencies": {
+		"@automattic/babel-plugin-replace-textdomain": "workspace:*",
 		"@automattic/color-studio": "4.1.0",
 		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-webpack-config": "workspace:*",

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -67,7 +67,7 @@
 		"@visx/responsive": "4.0.0",
 		"@visx/scale": "^4.0.0",
 		"@visx/xychart": "4.0.0",
-		"@woocommerce/email-editor": "2.4.0",
+		"@woocommerce/email-editor": "2.4.1",
 		"@wordpress/a11y": "4.54.0",
 		"@wordpress/base-styles": "13.0.0",
 		"@wordpress/block-editor": "17.0.0",

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -2,6 +2,7 @@ const path = require( 'path' );
 const jetpackWebpackConfig = require( '@automattic/jetpack-webpack-config/webpack' );
 const RemoveAssetWebpackPlugin = require( '@automattic/remove-asset-webpack-plugin' );
 const { glob } = require( 'glob' );
+const webpack = require( 'webpack' );
 const StaticSiteGeneratorPlugin = require( './static-site-generator-webpack-plugin' );
 
 const sharedWebpackConfig = {
@@ -152,6 +153,71 @@ module.exports = [
 			...sharedWebpackConfig.plugins,
 			...jetpackWebpackConfig.DependencyExtractionPlugin(),
 		],
+	},
+	/*
+	 * Build the newsletter email design editor on its own.
+	 *
+	 * It gets its own entry rather than joining an existing bundle because
+	 * `@woocommerce/email-editor` is large and is only ever needed on the one
+	 * admin screen that mounts it.
+	 */
+	{
+		...sharedWebpackConfig,
+		entry: {
+			// The package's `exports` map publishes only its main entry, so its
+			// stylesheet cannot be imported by subpath from the source file. Pair the
+			// two here instead, so the styles still go through the usual CSS pipeline
+			// and get an RTL build.
+			'email-design-editor': [
+				'./modules/subscriptions/email-design-editor/src/index.jsx',
+				path.join(
+					path.dirname( require.resolve( '@woocommerce/email-editor' ) ),
+					'../build-style/style.css'
+				),
+			],
+		},
+		plugins: [
+			...sharedWebpackConfig.plugins,
+
+			// Some of the package's strings are published with the textdomain left as
+			// a build-time `__i18n_text_domain__` placeholder rather than a literal.
+			// Unreplaced it is a free variable, so those strings would throw a
+			// ReferenceError when their component rendered.
+			new webpack.DefinePlugin( {
+				__i18n_text_domain__: JSON.stringify( 'jetpack' ),
+			} ),
+			...jetpackWebpackConfig.DependencyExtractionPlugin( {
+				requestMap: {
+					// WordPress registers no `wp-global-styles-engine` script handle at
+					// Jetpack's minimum (WP 7.0), so externalizing it would put an
+					// unregistered handle in the asset file and WordPress would refuse
+					// to enqueue the script at all, silently. Bundle it instead.
+					'@wordpress/global-styles-engine': { external: false },
+				},
+			} ),
+		],
+		module: {
+			...sharedWebpackConfig.module,
+			rules: [
+				...sharedWebpackConfig.module.rules,
+
+				// The package's strings are authored against the `woocommerce`
+				// textdomain, which is not loaded on a Jetpack site, so without this
+				// every string in the editor would render untranslated.
+				jetpackWebpackConfig.TranspileRule( {
+					includeNodeModules: [ '@woocommerce/email-editor/' ],
+					babelOpts: {
+						configFile: false,
+						plugins: [
+							[
+								require.resolve( '@automattic/babel-plugin-replace-textdomain' ),
+								{ textdomain: 'jetpack' },
+							],
+						],
+					},
+				} ),
+			],
+		},
 	},
 	// Build admin page JS.
 	{

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -188,14 +188,9 @@ module.exports = [
 			} ),
 			...jetpackWebpackConfig.DependencyExtractionPlugin( {
 				requestMap: {
-					// `@wordpress/global-styles-engine` ships no `wpScript: true`, so it is
-					// not a WordPress script handle in any version — there is no
-					// `wp-global-styles-engine` to externalize to, and nothing to polyfill.
-					// It belongs in the dependency-extraction plugin's `BUNDLED_PACKAGES`
-					// list alongside `@wordpress/icons` and `@wordpress/admin-ui`, but it
-					// has not been added there as of 6.54.0, so the plugin's fallback
-					// externalizes it purely because the name is under `@wordpress/`.
-					// Opt it out here until upstream lists it.
+					// Not a WP script handle (ships no `wpScript`), so there's nothing to
+					// externalize to. Belongs in the dep-extraction plugin's
+					// `BUNDLED_PACKAGES` but isn't there as of 6.54.0, so opt it out here.
 					'@wordpress/global-styles-engine': { external: false },
 				},
 			} ),

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -155,19 +155,15 @@ module.exports = [
 		],
 	},
 	/*
-	 * Build the newsletter email design editor on its own.
-	 *
-	 * It gets its own entry rather than joining an existing bundle because
-	 * `@woocommerce/email-editor` is large and is only ever needed on the one
-	 * admin screen that mounts it.
+	 * The newsletter email design editor, on its own entry: `@woocommerce/email-editor`
+	 * is large and only ever needed on the one admin screen that mounts it.
 	 */
 	{
 		...sharedWebpackConfig,
 		entry: {
-			// The package's `exports` map publishes only its main entry, so its
-			// stylesheet cannot be imported by subpath from the source file. Pair the
-			// two here instead, so the styles still go through the usual CSS pipeline
-			// and get an RTL build.
+			// The package's `exports` map publishes only its main entry, so the stylesheet
+			// cannot be imported by subpath. Pairing it here keeps it in the CSS pipeline
+			// and gets an RTL build.
 			'email-design-editor': [
 				'./modules/subscriptions/email-design-editor/src/index.jsx',
 				path.join(
@@ -179,10 +175,9 @@ module.exports = [
 		plugins: [
 			...sharedWebpackConfig.plugins,
 
-			// Some of the package's strings are published with the textdomain left as
-			// a build-time `__i18n_text_domain__` placeholder rather than a literal.
-			// Unreplaced it is a free variable, so those strings would throw a
-			// ReferenceError when their component rendered.
+			// Some of the package's strings ship with the textdomain left as a
+			// `__i18n_text_domain__` placeholder. Unreplaced it is a free variable, so those
+			// strings throw a ReferenceError when their component renders.
 			new webpack.DefinePlugin( {
 				__i18n_text_domain__: JSON.stringify( 'jetpack' ),
 			} ),
@@ -200,9 +195,8 @@ module.exports = [
 			rules: [
 				...sharedWebpackConfig.module.rules,
 
-				// The package's strings are authored against the `woocommerce`
-				// textdomain, which is not loaded on a Jetpack site, so without this
-				// every string in the editor would render untranslated.
+				// The package's strings are authored against the `woocommerce` textdomain,
+				// which no Jetpack site loads, so without this the editor renders untranslated.
 				jetpackWebpackConfig.TranspileRule( {
 					includeNodeModules: [ '@woocommerce/email-editor/' ],
 					babelOpts: {

--- a/projects/plugins/jetpack/tools/webpack.config.js
+++ b/projects/plugins/jetpack/tools/webpack.config.js
@@ -188,10 +188,14 @@ module.exports = [
 			} ),
 			...jetpackWebpackConfig.DependencyExtractionPlugin( {
 				requestMap: {
-					// WordPress registers no `wp-global-styles-engine` script handle at
-					// Jetpack's minimum (WP 7.0), so externalizing it would put an
-					// unregistered handle in the asset file and WordPress would refuse
-					// to enqueue the script at all, silently. Bundle it instead.
+					// `@wordpress/global-styles-engine` ships no `wpScript: true`, so it is
+					// not a WordPress script handle in any version — there is no
+					// `wp-global-styles-engine` to externalize to, and nothing to polyfill.
+					// It belongs in the dependency-extraction plugin's `BUNDLED_PACKAGES`
+					// list alongside `@wordpress/icons` and `@wordpress/admin-ui`, but it
+					// has not been added there as of 6.54.0, so the plugin's fallback
+					// externalizes it purely because the name is under `@wordpress/`.
+					// Opt it out here until upstream lists it.
 					'@wordpress/global-styles-engine': { external: false },
 				},
 			} ),


### PR DESCRIPTION
## Proposed changes

Context: pe7F0s-41h-p2

Installs `@woocommerce/email-editor` as a real dependency of the Jetpack plugin with its own webpack entry. The admin screen that will render it will be a separate PR.

### What this delivers, and what it doesn't

The editor mounts, fetches its configuration from WordPress.com, resolves and preloads its template, and applies the site's saved email design to the canvas.

**The canvas still looks broken, and that's expected.** Blocks render as invalid or unrecognized. 

**Not included:** the middleware that redirects the Styles sidebar's saves to WordPress.com. That wants its own review, because the editor also reads the *site's* own global-styles record and a blanket redirect would break the site's styles while looking correct on Simple.

### Consuming the package as a real dependency needed these build changes:

* **A `date-fns` override.** The package pins about thirty exact `@wordpress/*` versions, and the `@wordpress/components@30.x` among them asks for `date-fns ^3.6.0`. Left alone that drags the whole workspace's resolution down from 4.x, and `@base-ui/react`'s `^4` peer then fails `strictPeerDependencies` — so `pnpm install` fails for everyone, not just here. Scoped to the `^3` range rather than to `date-fns` as a whole, so the 1.x and 2.x copies some CLI tooling still asks for stay where they are.
* **`@wordpress/global-styles-engine` bundled rather than externalized.** WordPress registers no `wp-global-styles-engine` script handle at this plugin's minimum (`Requires at least: 7.0`), so externalizing it puts an unregistered handle in the asset file — and an unregistered dependency makes `wp_enqueue_script` drop the script entirely, without an error. This is the same treatment, for the same reason, that `@wordpress/theme` and `@wordpress/private-apis` already get in the admin-page config a few lines below.
* **The stylesheet paired into the entry rather than imported.** The package's `exports` map publishes only its main entry, so `@woocommerce/email-editor/build-style/style.css` is not resolvable. Pairing the source file and the stylesheet in one entry array — the same shape `jetpack-mu-wpcom` uses — keeps the styles in the normal CSS pipeline and produces the RTL build.
* **Two textdomain fixes.** The package's strings are authored against the `woocommerce` textdomain, which is not loaded on a Jetpack site, so every string in the editor would render untranslated; a `babel-plugin-replace-textdomain` rule rewrites them. Separately, some of its strings ship with the textdomain still a build-time `__i18n_text_domain__` placeholder rather than a literal — unreplaced that is a free variable, so those strings throw a `ReferenceError` when their component renders. `DefinePlugin` supplies it.

The entry point fetches that bundle, maps it into the shape the editor's `config` prop expects, and preloads the templates and global-styles record so the editor never fetches them itself — they only exist while WordPress.com is building the bundle, so a request from the browser cannot reach them. The mapping is not a pass-through: the bundle's keys and the ones the editor reads do not overlap, and handing it over unmapped boots the editor with no settings and no theme, silently. The reasoning for each piece is in the docblocks rather than repeated here.

### Worth a reviewer's attention:

* **The lockfile grows by ~1,400 lines / 59 packages** — a parallel older `@wordpress/*` tree (`components@30.6.5`, `element@6.33.1`, `editor@14.33.11`, …) that the package pins. None of it ships: everything but `@wordpress/icons` is externalized to `wp.*` at build time. Nothing is removed from the lockfile.
* **The preload keys are exact ids, never patterns.** The editor loads the *site's own* global-styles record alongside the newsletter's, so matching anything broader would route the site's design through this plumbing. The two ids are guarded differently on purpose: the global-styles id is checked to be a positive integer before it is interpolated into a key, while the template id is not, because template ids legitimately contain `//`. The template id is bounded to the `/wp/v2/templates` namespace and only WordPress.com can set it.
* **`@automattic/babel-plugin-replace-textdomain` is added as a direct devDependency** because the rule lives in this plugin's config. If a second project ends up needing the same rewrite, it would be better placed alongside `BundledWpPkgsTranspileRules` in `js-packages/webpack-config`.

## Related product discussion/links

* NL-839

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Things to check:

* `jp build plugins/jetpack` (or `pnpm run build-production-client` in `projects/plugins/jetpack`) succeeds.
* `projects/plugins/jetpack/_inc/build/` contains `email-design-editor.js`, `.css`, `.rtl.css` and `.asset.php`. The production bundle is ~167 KB.
* `email-design-editor.asset.php` lists 31 script handles and **no** `wp-global-styles-engine`. Every handle it does list is registered by WordPress 7.0 — the point of the change above.
* `grep __i18n_text_domain__ _inc/build/email-design-editor.js` returns nothing, and the package's strings carry `"jetpack"` rather than `"woocommerce"`:
  `grep -o '("Template area","[a-z]*")' _inc/build/email-design-editor.js`
* `pnpm install` completes without the `ERR_PNPM_PEER_DEP_ISSUES` failure, and `date-fns@1.30.1` and `date-fns@2.30.0` are still in `pnpm-lock.yaml`.
* `pnpm run test-client` in `projects/plugins/jetpack` passes, including the 37 cases covering the mapping, the merge of the two settings halves, the template and global-styles preloads, and what the entry refuses to mount without.