### PR TITLE
Connection: reset the memoized connection status when the tokens are deleted

### DIFF
--- a/projects/packages/connection/changelog/reset-connection-status-on-token-deletion
+++ b/projects/packages/connection/changelog/reset-connection-status-on-token-deletion
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Recompute the connection status after the connection tokens are deleted, so a failed reconnection no longer reports the site as still connected.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -209,6 +209,15 @@ class Manager {
 		// Force is_connected() to recompute after important actions.
 		add_action( 'jetpack_site_registered', array( $this, 'reset_connection_status' ) );
 		add_action( 'jetpack_site_disconnected', array( $this, 'reset_connection_status' ) );
+
+		/*
+		 * The `pre_update_jetpack_option_*` invalidators below only cover writes. Deleting the
+		 * tokens goes through `Jetpack_Options::delete_option()`, which fires nothing, so a
+		 * teardown that never reaches `jetpack_site_disconnected` — a `register()` that cleans
+		 * up the old tokens and then fails, for instance — would otherwise leave the memoized
+		 * status reporting a connection whose tokens are already gone.
+		 */
+		add_action( 'jetpack_connection_tokens_deleted', array( $this, 'reset_connection_status' ) );
 		add_action( 'jetpack_sync_register_user', array( $this, 'reset_connection_status' ) );
 		add_action( 'pre_update_jetpack_option_id', array( $this, 'reset_connection_status' ) );
 		add_action( 'pre_update_jetpack_option_blog_token', array( $this, 'reset_connection_status' ) );

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -209,14 +209,7 @@ class Manager {
 		// Force is_connected() to recompute after important actions.
 		add_action( 'jetpack_site_registered', array( $this, 'reset_connection_status' ) );
 		add_action( 'jetpack_site_disconnected', array( $this, 'reset_connection_status' ) );
-
-		/*
-		 * The `pre_update_jetpack_option_*` invalidators below only cover writes. Deleting the
-		 * tokens goes through `Jetpack_Options::delete_option()`, which fires nothing, so a
-		 * teardown that never reaches `jetpack_site_disconnected` — a `register()` that cleans
-		 * up the old tokens and then fails, for instance — would otherwise leave the memoized
-		 * status reporting a connection whose tokens are already gone.
-		 */
+		// Deletion doesn't fire `pre_update_jetpack_option_*`; see the action's docblock in `Tokens::delete_all()`.
 		add_action( 'jetpack_connection_tokens_deleted', array( $this, 'reset_connection_status' ) );
 		add_action( 'jetpack_sync_register_user', array( $this, 'reset_connection_status' ) );
 		add_action( 'pre_update_jetpack_option_id', array( $this, 'reset_connection_status' ) );

--- a/projects/packages/connection/src/class-tokens.php
+++ b/projects/packages/connection/src/class-tokens.php
@@ -40,6 +40,17 @@ class Tokens {
 		);
 
 		$this->remove_lock();
+
+		/**
+		 * Fires after all connection tokens have been deleted from the local site.
+		 *
+		 * `Jetpack_Options::delete_option()` fires no action of its own, so this is the only
+		 * signal that the tokens backing the connection are gone. Anything holding derived
+		 * state — a memoized connection status, a cached credential — must recompute from here.
+		 *
+		 * @since $$next-version$$
+		 */
+		do_action( 'jetpack_connection_tokens_deleted' );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -501,6 +501,49 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
+	 * Deleting the tokens directly must invalidate the memoized connection status.
+	 *
+	 * `Tokens::delete_all()` is reachable without going through a disconnect — `get_access_token()`
+	 * calls it when the token lock names a different site URL — so it has to invalidate on its own.
+	 */
+	public function test_deleting_tokens_invalidates_memoized_connection_status() {
+		Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+		Jetpack_Options::update_option( 'id', 1234 );
+		( new Manager() )->reset_connection_status();
+		$this->assertTrue( ( new Manager() )->is_connected(), 'Test setup failed: site should be connected.' );
+
+		( new Tokens() )->delete_all();
+
+		$this->assertFalse(
+			( new Manager() )->is_connected(),
+			'is_connected() should recompute after the tokens are deleted, without an explicit reset.'
+		);
+	}
+
+	/**
+	 * A failed re-registration must not leave `is_connected()` reporting the pre-teardown state.
+	 *
+	 * `Manager::register()` deletes the existing tokens before requesting new ones. When that
+	 * request fails the site is left with a blog ID and no tokens, and the memoized status has to
+	 * reflect that for the rest of the request.
+	 */
+	public function test_connection_status_is_invalidated_when_tokens_are_deleted_without_a_disconnect() {
+		Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+		Jetpack_Options::update_option( 'id', 1234 );
+		( new Manager() )->reset_connection_status();
+		$this->assertTrue( ( new Manager() )->is_connected(), 'Test setup failed: site should be connected.' );
+
+		// The cleanup `register()` performs before it asks WordPress.com for new tokens.
+		( new Manager() )->delete_all_connection_tokens( true );
+
+		$this->assertSame( 1234, Jetpack_Options::get_option( 'id' ), 'Test setup failed: the blog ID should survive the token deletion.' );
+		$this->assertFalse(
+			( new Manager() )->is_connected(),
+			'is_connected() should be false once the tokens are gone, even though the blog ID remains.'
+		);
+	}
+
+	/**
 	 * Unit test for the "Disconnect from WP" functionality.
 	 */
 	public function test_disconnect_site_wpcom() {


### PR DESCRIPTION
Fixes JETPACK-2360

## Proposed changes

* `Manager::is_connected()` memoizes into a static and invalidates it from a list of hooks that all fire on a *write* — `jetpack_site_registered`, `jetpack_site_disconnected`, `jetpack_sync_register_user`, and the `pre_update_jetpack_option_*` actions. Nothing in that list fires on a *delete*, and `Jetpack_Options::delete_option()` has no action of its own. So once the connection tokens are deleted, the memo keeps answering with the pre-deletion state for the rest of the request.
* The reachable path is `Manager::register()`, which clears leftover tokens before asking WordPress.com for new ones. When that request fails, the site is left with its blog ID, an empty `jetpack_private_options`, and `is_connected()` still returning `true`. `Jetpack::is_connection_ready()`, `load_modules()`, JITMs, and sync all read that value. `Tokens::delete_all()` is reachable without a disconnect too — `get_access_token()` calls it when the token lock names a different site URL.
* `Tokens::delete_all()` now fires a new `jetpack_connection_tokens_deleted` action, and `Manager` hooks `reset_connection_status()` to it. That matches how every other invalidator in the list works, and covers both entry points since they both route through `Tokens::delete_all()`.
* Left the explicit `self::$connection_owner_id = null;` in `delete_all_connection_tokens()` in place. `get_connection_owner_id()` can memoize without `is_connected()` ever running, so the invalidation hooks may not be registered at all and the action wouldn't be heard. `$is_connected` has no equivalent hole — it's only non-null if `is_connected()` ran, and that registers the hooks before computing anything.

The asymmetry is the part worth noting: `delete_all_connection_tokens()` already clears `self::$connection_owner_id` three lines above where it deletes the tokens. One memo got maintained on this path and the neighbor didn't.

## Related product discussion/links

* JETPACK-2360 — https://linear.app/a8c/issue/JETPACK-2360
* PR 39361 added the `is_connected()` memo; the review thread settled on `pre_update_jetpack_option_*` invalidation and deletion never came up.
* PR 44282 added the connection-owner-ID memo and its invalidation inside `delete_all_connection_tokens()`, which is where the two got out of step.
* CONNECT-96 is the same shape one layer out — token deletion had no hook, so Atomic persistent data went stale after a failed delete-then-recreate. Fixed on the wpcom side; the in-process memo never got the equivalent.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated:

* `jetpack test php packages/connection` — 962 tests pass. Two new ones in `ManagerTest` cover this: `test_deleting_tokens_invalidates_memoized_connection_status` and `test_connection_status_is_invalidated_when_tokens_are_deleted_without_a_disconnect`. Both fail on trunk with `Failed asserting that true is false` and pass with the change.

Manual, on a connected site — the key constraint is staying inside one process, since a fresh `wp eval` recomputes from an empty database and gets the right answer anyway:

* Drop an mu-plugin (or use `wp eval-file`) that runs, in this order:

```php
$manager = new Automattic\Jetpack\Connection\Manager();
error_log( 'before: ' . var_export( $manager->is_connected(), true ) );
$manager->delete_all_connection_tokens( true );
error_log( 'after:  ' . var_export( $manager->is_connected(), true ) );
error_log( 'token:  ' . var_export( Jetpack_Options::get_option( 'blog_token' ), true ) );
```

* On trunk: `before: true`, `after: true`, `token: false`.
* With this change: `before: true`, `after: false`, `token: false`.
* Reconnect the site afterwards — the script really does delete the tokens.

Regression check: connect and disconnect a site normally and confirm nothing changed. The disconnect path already reset the memo through `jetpack_site_disconnected`; this adds a second, earlier reset on the same path, which is a no-op for the end state.
