### PR TITLE
Backup: add the storage meter to the modernized dashboard

### DIFF
--- a/projects/packages/backup/changelog/add-backup-storage-meter
+++ b/projects/packages/backup/changelog/add-backup-storage-meter
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Backup: add the storage meter to the modernized dashboard — a coloured usage bar under a heading that escalates as cloud storage fills up, so a site whose backups have stopped can see why. Reads the limit from /site/backup/policies and usage from /site/backup/size, and renders nothing when either is unreadable. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
@@ -58,7 +58,13 @@ export default function StorageSpace() {
 
 	return (
 		<section className="jpb-storage-space" aria-labelledby={ headingId }>
-			<Text variant="heading-md" render={ <h2 id={ headingId } /> }>
+			{ /*
+			 * `h3` rather than the `h2` legacy uses, to match every other
+			 * heading in this dashboard — the backup and activity detail
+			 * cards are visual siblings of this section, not children of
+			 * it, and an `h2` here would put them under it in the outline.
+			 */ }
+			<Text variant="heading-md" render={ <h3 id={ headingId } /> }>
 				{ sectionHeading( usage.usageLevel ) }
 			</Text>
 			<StorageMeter

--- a/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
@@ -1,6 +1,6 @@
 import { useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Text } from '@wordpress/ui';
+import { Skeleton, Text } from '@wordpress/ui';
 import { StorageUsageLevels } from '../../data/storage-usage-levels';
 import { useStorageUsage } from '../../hooks/use-storage-usage';
 import StorageMeter from './meter';
@@ -52,6 +52,28 @@ export default function StorageSpace() {
 	// "why did my backups stop".
 	const headingId = useId();
 
+	// Hold the section's exact height while the two requests are in
+	// flight, so the activity list below is not pushed down when they
+	// land — which would happen on precisely the slow connections where
+	// this section matters most. Sized to the rendered article: a 20px
+	// heading line, 12px, a 24px bar.
+	//
+	// Skeletons rather than the real heading over an empty track: both
+	// would assert content we do not have yet, and an empty meter reads
+	// as "0% used" rather than as "still looking".
+	if ( usage.isLoading ) {
+		return (
+			<section className="jpb-storage-space" aria-hidden="true">
+				<Skeleton className="jpb-storage-space__heading-placeholder" />
+				<div className="jpb-storage-meter">
+					<Skeleton className="jpb-storage-meter__placeholder" />
+				</div>
+			</section>
+		);
+	}
+
+	// Resolved, and there is nothing to measure against. Silence is
+	// correct here, and matches legacy's gate.
 	if ( ! usage.hasUsableFigures ) {
 		return null;
 	}

--- a/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
@@ -1,3 +1,4 @@
+import { useId } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Text } from '@wordpress/ui';
 import { StorageUsageLevels } from '../../data/storage-usage-levels';
@@ -44,14 +45,20 @@ function sectionHeading( usageLevel: StorageUsageLevelName | null ): string {
  */
 export default function StorageSpace() {
 	const usage = useStorageUsage();
+	// `<section>` is only a `region` landmark when it has an accessible
+	// name; unnamed it is a generic container and buys nothing a `<div>`
+	// would not. Pointing at the heading makes it a landmark a screen
+	// reader can jump to, which is the point of a section that answers
+	// "why did my backups stop".
+	const headingId = useId();
 
 	if ( ! usage.hasUsableFigures ) {
 		return null;
 	}
 
 	return (
-		<section className="jpb-storage-space">
-			<Text variant="heading-md" render={ <h2 /> }>
+		<section className="jpb-storage-space" aria-labelledby={ headingId }>
+			<Text variant="heading-md" render={ <h2 id={ headingId } /> }>
 				{ sectionHeading( usage.usageLevel ) }
 			</Text>
 			<StorageMeter

--- a/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
@@ -1,0 +1,64 @@
+import { __ } from '@wordpress/i18n';
+import { Text } from '@wordpress/ui';
+import { StorageUsageLevels } from '../../data/storage-usage-levels';
+import { useStorageUsage } from '../../hooks/use-storage-usage';
+import StorageMeter from './meter';
+import './style.scss';
+import type { StorageUsageLevelName } from '../../data/storage-usage-levels';
+
+/**
+ * Heading text for a usage level.
+ *
+ * The heading is the only place the calm and alarming readings differ in
+ * words rather than colour, so it carries most of the answer to "why did
+ * my backups stop".
+ *
+ * @param usageLevel - Derived level, or null when it could not be computed.
+ * @return The section heading.
+ */
+function sectionHeading( usageLevel: StorageUsageLevelName | null ): string {
+	if ( usageLevel === StorageUsageLevels.Full ) {
+		return __( 'Cloud storage full', 'jetpack-backup-pkg' );
+	}
+
+	if ( usageLevel === StorageUsageLevels.Critical ) {
+		return __( 'Cloud storage is almost full', 'jetpack-backup-pkg' );
+	}
+
+	return __( 'Cloud storage space', 'jetpack-backup-pkg' );
+}
+
+/**
+ * The Overview screen's storage section.
+ *
+ * Renders nothing at all until both halves of the answer have arrived and
+ * agree there is something to measure — a site with no policy answer has
+ * no denominator, and drawing a bar for it would show a full-width empty
+ * meter that means nothing. That silence is deliberate and matches the
+ * legacy dashboard's own `storageSize !== null && storageLimit > 0` gate.
+ *
+ * Sibling issues add usage details, the upsell and the help popover
+ * inside this same section.
+ *
+ * @return The storage section, or null when there is nothing to show.
+ */
+export default function StorageSpace() {
+	const usage = useStorageUsage();
+
+	if ( ! usage.hasUsableFigures ) {
+		return null;
+	}
+
+	return (
+		<section className="jpb-storage-space">
+			<Text variant="heading-md" render={ <h2 /> }>
+				{ sectionHeading( usage.usageLevel ) }
+			</Text>
+			<StorageMeter
+				storageUsed={ usage.storageUsed }
+				storageLimit={ usage.storageLimit }
+				usageLevel={ usage.usageLevel }
+			/>
+		</section>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/storage-space/meter.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/meter.tsx
@@ -1,0 +1,70 @@
+import { ProgressBar } from '@wordpress/components';
+import { sprintf, __ } from '@wordpress/i18n';
+import { StorageUsageLevels } from '../../data/storage-usage-levels';
+import type { StorageUsageLevelName } from '../../data/storage-usage-levels';
+
+/**
+ * Level → BEM modifier. `BackupsDiscarded` deliberately shares `full`:
+ * both mean storage has already cost the site backups, and the reader
+ * needs one alarm, not two shades of one.
+ */
+// Spelled as literal keys rather than `[ StorageUsageLevels.Normal ]`:
+// the members of that object are typed as the whole union, so a computed
+// key from it widens and the record stops being exhaustive — which is the
+// one thing this table is for.
+const METER_MODIFIERS: Record< StorageUsageLevelName, string > = {
+	Normal: 'normal',
+	Warning: 'warning',
+	Critical: 'critical',
+	Full: 'full',
+	BackupsDiscarded: 'full',
+};
+
+type Props = {
+	storageUsed: number;
+	storageLimit: number;
+	usageLevel: StorageUsageLevelName | null;
+};
+
+/**
+ * The storage usage bar.
+ *
+ * A presentational shell around `<ProgressBar>`: the caller has already
+ * decided there are figures worth drawing, and the level has already been
+ * derived. Percentages above 100 are clamped, because a site can hold
+ * more than its limit and a bar cannot be more than full.
+ *
+ * @param props              - Component props.
+ * @param props.storageUsed  - Bytes of backup storage in use.
+ * @param props.storageLimit - The plan's storage limit in bytes. Must be greater than zero.
+ * @param props.usageLevel   - Derived level, or null when it could not be computed.
+ * @return The rendered meter.
+ */
+export default function StorageMeter( { storageUsed, storageLimit, usageLevel }: Props ) {
+	const percent = Math.min( ( storageUsed / storageLimit ) * 100, 100 );
+	// Fall back to the calm styling rather than an unstyled bar when the
+	// level is unknown: the figures are still real, only the judgement
+	// about them is missing.
+	const modifier = METER_MODIFIERS[ usageLevel ?? StorageUsageLevels.Normal ];
+
+	return (
+		<div className="jpb-storage-meter">
+			{ /*
+			 * `<ProgressBar>` hardcodes `aria-label="Loading …"` but
+			 * spreads the caller's props after it, so this replaces it.
+			 * Without the override a screen reader announces the storage
+			 * meter as a loading indicator — which is what the legacy
+			 * dashboard's bar does today.
+			 */ }
+			<ProgressBar
+				className={ `jpb-storage-meter__bar jpb-storage-meter__bar--${ modifier }` }
+				value={ percent }
+				aria-label={ sprintf(
+					/* translators: %d: percentage of backup storage used. */
+					__( 'Backup storage used: %d%%', 'jetpack-backup-pkg' ),
+					Math.round( percent )
+				) }
+			/>
+		</div>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/storage-space/meter.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/meter.tsx
@@ -4,20 +4,29 @@ import { StorageUsageLevels } from '../../data/storage-usage-levels';
 import type { StorageUsageLevelName } from '../../data/storage-usage-levels';
 
 /**
- * Level → BEM modifier. `BackupsDiscarded` deliberately shares `full`:
- * both mean storage has already cost the site backups, and the reader
- * needs one alarm, not two shades of one.
+ * Level → fill colour.
+ *
+ * Colour only. Geometry is a separate modifier keyed off how full the bar
+ * actually is, because the two do not travel together: `BackupsDiscarded`
+ * is the one level derived from the retention day-counts rather than the
+ * percentage, so it fires at any fill level while carrying the same alarm
+ * colour as `Full`. Folding the two into one modifier drew it as a
+ * fully-rounded pill floating in the track at 50% — the exact shape the
+ * partly-filled treatment exists to avoid.
+ *
+ * `Critical`, `Full` and `BackupsDiscarded` share the error fill
+ * deliberately: the reader needs one alarm, not three shades of one.
  */
 // Spelled as literal keys rather than `[ StorageUsageLevels.Normal ]`:
 // the members of that object are typed as the whole union, so a computed
 // key from it widens and the record stops being exhaustive — which is the
 // one thing this table is for.
-const METER_MODIFIERS: Record< StorageUsageLevelName, string > = {
-	Normal: 'normal',
-	Warning: 'warning',
-	Critical: 'critical',
-	Full: 'full',
-	BackupsDiscarded: 'full',
+const FILL_MODIFIERS: Record< StorageUsageLevelName, string > = {
+	Normal: 'neutral',
+	Warning: 'caution',
+	Critical: 'error',
+	Full: 'error',
+	BackupsDiscarded: 'error',
 };
 
 type Props = {
@@ -45,7 +54,14 @@ export default function StorageMeter( { storageUsed, storageLimit, usageLevel }:
 	// Fall back to the calm styling rather than an unstyled bar when the
 	// level is unknown: the figures are still real, only the judgement
 	// about them is missing.
-	const modifier = METER_MODIFIERS[ usageLevel ?? StorageUsageLevels.Normal ];
+	const fill = FILL_MODIFIERS[ usageLevel ?? StorageUsageLevels.Normal ];
+	// Only a bar that actually reaches the end may take the track's own
+	// rounding on both ends and give up the trailing-edge buffer. Driven
+	// by the measurement, never by the level name.
+	const classNames = [ 'jpb-storage-meter__bar', `jpb-storage-meter__bar--${ fill }` ];
+	if ( percent >= 100 ) {
+		classNames.push( 'jpb-storage-meter__bar--complete' );
+	}
 
 	return (
 		<div className="jpb-storage-meter">
@@ -57,7 +73,7 @@ export default function StorageMeter( { storageUsed, storageLimit, usageLevel }:
 			 * dashboard's bar does today.
 			 */ }
 			<ProgressBar
-				className={ `jpb-storage-meter__bar jpb-storage-meter__bar--${ modifier }` }
+				className={ classNames.join( ' ' ) }
 				value={ percent }
 				aria-label={ sprintf(
 					/* translators: %d: percentage of backup storage used. */

--- a/projects/packages/backup/src/dashboard/components/storage-space/style.scss
+++ b/projects/packages/backup/src/dashboard/components/storage-space/style.scss
@@ -63,8 +63,21 @@
 		background-color: var(--wpds-color-background-interactive-neutral-strong);
 	}
 
+	// The one literal here, and deliberately so. This is legacy's warning
+	// yellow (`--jp-yellow-20`), kept identical so the same site reads the
+	// same with the flag on or off. It cannot be spelled as that token:
+	// the `--jp-*` set is declared by a stylesheet the legacy admin page
+	// enqueues and this route does not, so `var(--jp-yellow-20)` here
+	// computes to nothing, the declaration is dropped, and the fill
+	// silently falls back to `<ProgressBar>`'s near-black default — the
+	// Normal colour, on a bar whose whole job is to not look normal.
+	// The design system has no vivid caution *fill*: its caution family is
+	// two pale tints, a muted tan and this olive
+	// (`--wpds-color-foreground-content-caution-weak`, #826a00), none of
+	// them a saturated yellow. Worth raising with the design-system folks
+	// rather than working around a third time.
 	& &__bar--caution > div {
-		background-color: var(--wpds-color-foreground-content-caution-weak);
+		background-color: #f0c930;
 	}
 
 	& &__bar--error > div {

--- a/projects/packages/backup/src/dashboard/components/storage-space/style.scss
+++ b/projects/packages/backup/src/dashboard/components/storage-space/style.scss
@@ -58,23 +58,26 @@
 	// declared on a modernized page; these are the design-system
 	// equivalents this dashboard already uses elsewhere. No fallbacks:
 	// the design-system build injects those, and hand-written ones go
-	// stale.
-	& &__bar--normal > div {
+	// stale. Colour only — nothing here touches geometry, see `--complete`.
+	& &__bar--neutral > div {
 		background-color: var(--wpds-color-background-interactive-neutral-strong);
 	}
 
-	& &__bar--warning > div {
+	& &__bar--caution > div {
 		background-color: var(--wpds-color-foreground-content-caution-weak);
 	}
 
-	& &__bar--critical > div {
+	& &__bar--error > div {
 		background-color: var(--wpds-color-background-interactive-error-strong);
 	}
 
-	// At full, the fill spans the whole track, so it can take the track's
-	// own rounding on both ends.
-	& &__bar--full > div {
-		background-color: var(--wpds-color-background-interactive-error-strong);
+	// Geometry only, and applied on the measurement rather than the level.
+	// A bar that reaches the end can take the track's own rounding on both
+	// ends and give up the trailing-edge buffer; a bar that does not must
+	// keep the flat trailing edge, whatever colour it is carrying.
+	// `BackupsDiscarded` is why this is separate: it wears the error fill
+	// at any percentage.
+	& &__bar--complete > div {
 		border-radius: 12px;
 		max-inline-size: none;
 	}

--- a/projects/packages/backup/src/dashboard/components/storage-space/style.scss
+++ b/projects/packages/backup/src/dashboard/components/storage-space/style.scss
@@ -1,0 +1,81 @@
+// The storage section sits above the Overview's two-pane grid rather
+// than inside it: `.jpb-overview` is a two-column grid at >= 961px, so a
+// child would be auto-placed into the layout and push the detail pane
+// onto its own row. Same reason the status banners are siblings.
+.jpb-storage-space {
+	inline-size: 100%;
+	margin-block-end: 24px;
+
+	// `<Text render={ <h2 /> }>` renders a real heading, which inherits
+	// wp-admin's own `h2` margins. Reset both so the gap to the bar is
+	// this file's decision.
+	h2 {
+		margin-block: 0 12px;
+	}
+}
+
+.jpb-storage-meter {
+	// `ProgressBar`'s root *is* the track, and it ships 1.5px tall with a
+	// 160px intrinsic width — sized for an inline loading indicator, not
+	// a storage meter. Everything below re-sizes it into a full-width bar.
+	// Deliberately nested rather than written flat.
+	// `@wordpress/components` styles the track through a runtime-injected
+	// emotion class of equal specificity, and emotion appends to `<head>`
+	// after the bundled stylesheet — so a flat `&__bar` rule would lose on
+	// source order no matter where this file sits in the build. One extra
+	// class wins it without reaching for `!important`.
+	& &__bar {
+		block-size: 24px;
+		inline-size: 100%;
+		border-radius: 12px;
+		background-color: var(--wpds-color-background-track-neutral);
+
+		// The filled portion. `ProgressBar` renders it as the track's only
+		// `div` child; the sibling `<progress>` is the visually-hidden
+		// element that carries the value for assistive technology.
+		> div {
+			// Rounded on the leading edge, flat on the trailing one, so a
+			// partly-filled bar reads as a level rather than as a pill
+			// floating in a groove. Logical corners keep that correct in
+			// RTL, where the fill grows from the right.
+			border-radius: 0;
+			border-start-start-radius: 12px;
+			border-end-start-radius: 12px;
+
+			// Some storage is always in use, so keep a radius-sized floor
+			// or the leading corner has nothing to round.
+			min-inline-size: 12px;
+
+			// And a radius-sized ceiling below 100%, so the flat trailing
+			// edge never reaches the track's rounded end and leaves a
+			// square corner poking out of it. Lifted at `--full` below.
+			max-inline-size: calc(100% - 12px);
+		}
+	}
+
+	// Level colours. Legacy's palette was hardcoded Jetpack hex tokens
+	// (`--jp-black`, `--jp-yellow-20`, `--jp-red-40`), none of which are
+	// declared on a modernized page; these are the design-system
+	// equivalents this dashboard already uses elsewhere. No fallbacks:
+	// the design-system build injects those, and hand-written ones go
+	// stale.
+	& &__bar--normal > div {
+		background-color: var(--wpds-color-background-interactive-neutral-strong);
+	}
+
+	& &__bar--warning > div {
+		background-color: var(--wpds-color-foreground-content-caution-weak);
+	}
+
+	& &__bar--critical > div {
+		background-color: var(--wpds-color-background-interactive-error-strong);
+	}
+
+	// At full, the fill spans the whole track, so it can take the track's
+	// own rounding on both ends.
+	& &__bar--full > div {
+		background-color: var(--wpds-color-background-interactive-error-strong);
+		border-radius: 12px;
+		max-inline-size: none;
+	}
+}

--- a/projects/packages/backup/src/dashboard/components/storage-space/style.scss
+++ b/projects/packages/backup/src/dashboard/components/storage-space/style.scss
@@ -6,10 +6,10 @@
 	inline-size: 100%;
 	margin-block-end: 24px;
 
-	// `<Text render={ <h2 /> }>` renders a real heading, which inherits
-	// wp-admin's own `h2` margins. Reset both so the gap to the bar is
+	// `<Text render={ <h3 /> }>` renders a real heading, which inherits
+	// wp-admin's own `h3` margins. Reset both so the gap to the bar is
 	// this file's decision.
-	h2 {
+	h3 {
 		margin-block: 0 12px;
 	}
 }

--- a/projects/packages/backup/src/dashboard/components/storage-space/style.scss
+++ b/projects/packages/backup/src/dashboard/components/storage-space/style.scss
@@ -12,6 +12,16 @@
 	h3 {
 		margin-block: 0 12px;
 	}
+
+	// Stands in for the heading while the two storage requests are in
+	// flight. Matches the rendered heading's line box and its gap to the
+	// bar exactly (measured: 20px + 12px), so the real section replaces it
+	// without moving anything below it.
+	&__heading-placeholder {
+		block-size: 20px;
+		inline-size: 160px;
+		margin-block-end: 12px;
+	}
 }
 
 .jpb-storage-meter {
@@ -82,6 +92,13 @@
 
 	& &__bar--error > div {
 		background-color: var(--wpds-color-background-interactive-error-strong);
+	}
+
+	// Stands in for the bar itself, at the same height and radius.
+	& &__placeholder {
+		block-size: 24px;
+		inline-size: 100%;
+		border-radius: 12px;
 	}
 
 	// Geometry only, and applied on the measurement rather than the level.

--- a/projects/packages/backup/src/dashboard/data/api/policies.ts
+++ b/projects/packages/backup/src/dashboard/data/api/policies.ts
@@ -1,0 +1,34 @@
+import { apiCall, apiPath } from './_helpers';
+
+/**
+ * Response of `GET /jetpack/v4/site/backup/policies`.
+ *
+ * The route forwards WordPress.com's body verbatim, which nests
+ * everything under a `policies` object. That object is the only thing
+ * here worth reading, and it is genuinely nullable: a site whose plan
+ * carries no retention policy answers `{ policies: null }` inside a 200.
+ *
+ * Like every legacy bridge, a non-200 upstream collapses to a bare
+ * `null` body served as HTTP 200 — so `null` at the top level means "we
+ * could not read this", while `{ policies: null }` means "there is no
+ * policy". Callers must not conflate the two with the storage limit
+ * they both produce, which is `null` either way.
+ *
+ * Note `storage_limit_bytes` lives *here* and not on `/site/backup/size`,
+ * despite the name suggesting otherwise. See `site-size.ts`.
+ */
+export type RawSitePolicies = {
+	policies?: {
+		storage_limit_bytes?: number | null;
+		activity_log_limit_days?: number | null;
+	} | null;
+} | null;
+
+/**
+ * Fetch the site's backup retention and storage policies.
+ *
+ * @return WordPress.com's payload, or `null` when it could not be read.
+ */
+export async function fetchSitePolicies(): Promise< RawSitePolicies > {
+	return apiCall< RawSitePolicies >( { path: apiPath( '/site/backup/policies' ) } );
+}

--- a/projects/packages/backup/src/dashboard/data/api/site-size.ts
+++ b/projects/packages/backup/src/dashboard/data/api/site-size.ts
@@ -3,23 +3,40 @@ import { apiCall, apiPath } from './_helpers';
 /**
  * Response of `GET /jetpack/v4/site/backup/size`.
  *
- * WPCOM's own envelope, forwarded verbatim: `ok` reports whether WPCOM
- * itself could answer, so a 200 with `ok: false` carries no usable
- * figures. Like the other legacy routes, a non-200 upstream collapses to
- * a `null` body served with HTTP 200.
+ * WordPress.com's own envelope, forwarded verbatim: `ok` reports whether
+ * WordPress.com itself could answer, so a 200 with `ok: false` carries no
+ * usable figures. Like the other legacy routes, a non-200 upstream
+ * collapses to a `null` body served with HTTP 200.
+ *
+ * The fields below are the ones legacy reads (`src/js/actions/index.js`).
+ * `storage_limit_bytes` is deliberately **not** among them: this response
+ * does not carry a storage limit, despite the route's name. Confirmed
+ * against a live 200, whose keys are `ok`, `error`, `size`,
+ * `days_of_backups_saved`, `days_of_backups_allowed`,
+ * `min_days_of_backups_allowed`, `last_backup_size`, `last_backup_failed`,
+ * `retention_days` and `backups_stopped`. The limit comes from
+ * `/site/backup/policies` — see `policies.ts`.
  */
 export type RawSiteSize = {
 	ok?: boolean;
 	backups_stopped?: boolean;
 	size?: number;
 	last_backup_size?: number;
-	storage_limit_bytes?: number;
+	// Retention actually in force for this site's backups. Falls back to
+	// the plan's `activity_log_limit_days` from `/policies` when zero,
+	// which is how legacy spells it (`backup-storage-space/index.jsx:33`).
+	retention_days?: number;
+	// The three day-counts `getUsageLevel` needs to tell "over limit" from
+	// "over limit and already dropping backups to cope".
+	min_days_of_backups_allowed?: number;
+	days_of_backups_allowed?: number;
+	days_of_backups_saved?: number;
 } | null;
 
 /**
  * Fetch the site's backup storage usage.
  *
- * @return WPCOM's payload, or `null` when it could not be read.
+ * @return WordPress.com's payload, or `null` when it could not be read.
  */
 export async function fetchSiteSize(): Promise< RawSiteSize > {
 	return apiCall< RawSiteSize >( { path: apiPath( '/site/backup/size' ) } );

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -37,6 +37,11 @@ export const keys = {
 	// deliberately does not share the activity-log family's key.
 	backups: () => [ 'backup', 'backups' ] as const,
 	siteSize: () => [ 'backup', 'site-size' ] as const,
+	// The site's retention and storage policies. Separate from
+	// `siteSize` because it is a separate route with a much flatter
+	// change rate — but the storage meter needs both, so the two are
+	// always read together.
+	sitePolicies: () => [ 'backup', 'site-policies' ] as const,
 	// Family prefix for any rewindable-activity-log page. Use as a
 	// query-filter root to scan all cached pages (e.g. when looking up
 	// a row by id across pages).

--- a/projects/packages/backup/src/dashboard/data/storage-usage-levels.ts
+++ b/projects/packages/backup/src/dashboard/data/storage-usage-levels.ts
@@ -1,0 +1,103 @@
+/**
+ * How full a site's backup storage is, as five named levels.
+ *
+ * Ported unchanged in behaviour from
+ * `src/js/components/backup-storage-space/storage-usage-levels.ts`, which
+ * the legacy dashboard still uses. Keep the two in step: the flag-off
+ * dashboard renders the legacy copy, and a divergence would show the same
+ * site two different levels depending on a filter.
+ *
+ * Only the parameter types were widened, from `number` to
+ * `number | null | undefined`. That is what the callers have always
+ * passed — every legacy selector ends in `?? null` — and it is what makes
+ * the function's own `=== null` guards mean something. No branch changed.
+ *
+ * This module is pure: six scalars in, a level name or `null` out. No
+ * store, no globals, no i18n.
+ */
+export type StorageUsageLevelName = 'Full' | 'Critical' | 'Warning' | 'Normal' | 'BackupsDiscarded';
+
+export const StorageUsageLevels: Record< StorageUsageLevelName, StorageUsageLevelName > = {
+	Full: 'Full',
+	Critical: 'Critical',
+	Warning: 'Warning',
+	Normal: 'Normal',
+	BackupsDiscarded: 'BackupsDiscarded',
+} as const;
+
+const THRESHOLDS: Record< number, StorageUsageLevelName > = {
+	100: StorageUsageLevels.Full,
+	80: StorageUsageLevels.Critical,
+	65: StorageUsageLevels.Warning,
+	0: StorageUsageLevels.Normal,
+};
+const THRESHOLD_VALUES = Object.keys( THRESHOLDS )
+	.map( Number )
+	// Sorting from highest to lowest is important for getUsageLevel,
+	// because it looks at the elements *in order*.
+	.sort( ( a, b ) => b - a );
+
+/**
+ * Derive the storage usage level from usage, limit and retention counts.
+ *
+ * Presentation only — the meter's colour, the section heading and the
+ * upsell copy. Whether WordPress.com has actually stopped backing the
+ * site up is a separate, server-owned flag (`backups_stopped`), read by
+ * `use-site-size.ts`. The two can legitimately disagree.
+ *
+ * @param used                    - Bytes of backup storage in use, from `/site/backup/size`.
+ * @param available               - The plan's storage limit in bytes, from `/site/backup/policies`.
+ * @param minDaysOfBackupsAllowed - Fewest days of backups the plan will ever keep.
+ * @param daysOfBackupsAllowed    - Days of backups the current storage allows.
+ * @param retentionDays           - Days of backups the plan promises.
+ * @param daysOfBackupsSaved      - Days of backups actually held right now.
+ * @return The level, or `null` when usage or limit is unknown.
+ */
+export const getUsageLevel = (
+	used: number | null | undefined,
+	available: number | null | undefined,
+	minDaysOfBackupsAllowed: number | null | undefined,
+	daysOfBackupsAllowed: number | null | undefined,
+	retentionDays: number | null | undefined,
+	daysOfBackupsSaved: number | null | undefined
+): StorageUsageLevelName | null => {
+	if ( available === undefined || used === undefined ) {
+		return null;
+	}
+
+	if ( available === null || used === null ) {
+		return null;
+	}
+
+	if (
+		!! minDaysOfBackupsAllowed &&
+		!! daysOfBackupsAllowed &&
+		!! retentionDays &&
+		!! daysOfBackupsSaved
+	) {
+		// if current days of backups saved is less than or equal to the minimum and storage is overlimit.
+		if (
+			minDaysOfBackupsAllowed >= daysOfBackupsSaved &&
+			used > 0 &&
+			available > 0 &&
+			used >= available
+		) {
+			return StorageUsageLevels.Full;
+		}
+
+		// if current allowed days of backups is less than plan's retention days, that means
+		// we discarded some backups to make other fit in current storage limit.
+		if ( daysOfBackupsAllowed < retentionDays ) {
+			return StorageUsageLevels.BackupsDiscarded;
+		}
+	}
+
+	// Guard against divide-by-zero
+	if ( available === 0 ) {
+		return StorageUsageLevels.Normal;
+	}
+
+	const percentUsed = ( 100 * used ) / available;
+	const thresholdValue = THRESHOLD_VALUES.find( value => percentUsed >= value ) ?? 0;
+	return THRESHOLDS[ thresholdValue ];
+};

--- a/projects/packages/backup/src/dashboard/data/test/storage-usage-levels.test.ts
+++ b/projects/packages/backup/src/dashboard/data/test/storage-usage-levels.test.ts
@@ -1,0 +1,183 @@
+import { getUsageLevel, StorageUsageLevels } from '../storage-usage-levels';
+
+const GB = 1024 * 1024 * 1024;
+
+type Overrides = {
+	used?: number | null;
+	available?: number | null;
+	minDaysOfBackupsAllowed?: number | null;
+	daysOfBackupsAllowed?: number | null;
+	retentionDays?: number | null;
+	daysOfBackupsSaved?: number | null;
+};
+
+/**
+ * Call `getUsageLevel` with the four day-counts all truthy by default.
+ *
+ * The day-count block is the part of the derivation most tests want kept
+ * out of the way, and spelling six positional arguments at every call
+ * site hides which one a case is actually varying.
+ *
+ * @param overrides - Fields to replace.
+ * @return The derived level.
+ */
+function level( overrides: Overrides = {} ) {
+	const args = {
+		used: 10 * GB,
+		available: 100 * GB,
+		minDaysOfBackupsAllowed: 7,
+		daysOfBackupsAllowed: 30,
+		retentionDays: 30,
+		daysOfBackupsSaved: 30,
+		...overrides,
+	};
+	return getUsageLevel(
+		args.used,
+		args.available,
+		args.minDaysOfBackupsAllowed,
+		args.daysOfBackupsAllowed,
+		args.retentionDays,
+		args.daysOfBackupsSaved
+	);
+}
+
+describe( 'getUsageLevel', () => {
+	describe( 'unknown inputs', () => {
+		const unknowns: Array< [ string, Overrides ] > = [
+			[ 'used is undefined', { used: undefined } ],
+			[ 'used is null', { used: null } ],
+			[ 'available is undefined', { available: undefined } ],
+			[ 'available is null', { available: null } ],
+		];
+
+		it.each( unknowns )( 'returns null when %s', ( _label, overrides ) => {
+			expect( level( overrides ) ).toBeNull();
+		} );
+
+		it( 'distinguishes "unknown" from "empty" — 0 bytes used is a real answer', () => {
+			expect( level( { used: 0 } ) ).toBe( StorageUsageLevels.Normal );
+		} );
+	} );
+
+	describe( 'percentage thresholds', () => {
+		const thresholds: Array< [ number, string ] > = [
+			[ 0, StorageUsageLevels.Normal ],
+			[ 64, StorageUsageLevels.Normal ],
+			[ 65, StorageUsageLevels.Warning ],
+			[ 79, StorageUsageLevels.Warning ],
+			[ 80, StorageUsageLevels.Critical ],
+			[ 99, StorageUsageLevels.Critical ],
+			[ 100, StorageUsageLevels.Full ],
+			[ 150, StorageUsageLevels.Full ],
+		];
+
+		it.each( thresholds )( 'reads %i%% as %s', ( percent, expected ) => {
+			// Day-counts left un-truthy so only the threshold table runs.
+			expect(
+				level( {
+					used: percent * GB,
+					available: 100 * GB,
+					minDaysOfBackupsAllowed: 0,
+				} )
+			).toBe( expected );
+		} );
+	} );
+
+	describe( 'the day-count block', () => {
+		// This is the behaviour worth pinning: all four counts must be
+		// truthy or the block is skipped entirely and the percentage
+		// table decides on its own. A site missing any one of them —
+		// which is every site whose `/policies` read failed — therefore
+		// never sees `BackupsDiscarded`, and reads exactly-100% as
+		// `Full` on the threshold alone.
+		const missingCounts: Array< [ string, Overrides ] > = [
+			[ 'minDaysOfBackupsAllowed', { minDaysOfBackupsAllowed: 0 } ],
+			[ 'daysOfBackupsAllowed', { daysOfBackupsAllowed: 0 } ],
+			[ 'retentionDays', { retentionDays: 0 } ],
+			[ 'daysOfBackupsSaved', { daysOfBackupsSaved: 0 } ],
+		];
+
+		it.each( missingCounts )(
+			'is skipped when %s is falsy, leaving the threshold table in charge',
+			( _l, zeroed ) => {
+				// Over limit, and holding fewer days than the minimum: the
+				// block would say `Full`. With one count missing it can't run,
+				// and 110% lands on `Full` from the threshold table anyway —
+				// so assert the discriminating case instead, below.
+				expect(
+					level( {
+						used: 50 * GB,
+						available: 100 * GB,
+						daysOfBackupsAllowed: 7,
+						retentionDays: 30,
+						...zeroed,
+					} )
+				).toBe( StorageUsageLevels.Normal );
+			}
+		);
+
+		it( 'reports BackupsDiscarded at only 50% used, when retention was cut short', () => {
+			// The discriminating case: half full by bytes, but the site is
+			// keeping 7 days where the plan promises 30. Only the day-count
+			// block can see this — the threshold table says Normal.
+			expect(
+				level( {
+					used: 50 * GB,
+					available: 100 * GB,
+					daysOfBackupsAllowed: 7,
+					retentionDays: 30,
+				} )
+			).toBe( StorageUsageLevels.BackupsDiscarded );
+		} );
+
+		it( 'reports Full over limit when backups are already down to the minimum', () => {
+			expect(
+				level( {
+					used: 100 * GB,
+					available: 100 * GB,
+					minDaysOfBackupsAllowed: 7,
+					daysOfBackupsSaved: 7,
+				} )
+			).toBe( StorageUsageLevels.Full );
+		} );
+
+		it( 'prefers Full over BackupsDiscarded when both apply', () => {
+			expect(
+				level( {
+					used: 200 * GB,
+					available: 100 * GB,
+					minDaysOfBackupsAllowed: 7,
+					daysOfBackupsAllowed: 7,
+					retentionDays: 30,
+					daysOfBackupsSaved: 7,
+				} )
+			).toBe( StorageUsageLevels.Full );
+		} );
+	} );
+
+	describe( 'divide-by-zero guard', () => {
+		// A zero limit is not "completely full", it is "no limit answer".
+		// Short-circuiting to Normal is what keeps `Infinity%` out of the
+		// threshold table.
+		it( 'short-circuits a zero limit to Normal rather than dividing', () => {
+			expect( level( { used: 10 * GB, available: 0, minDaysOfBackupsAllowed: 0 } ) ).toBe(
+				StorageUsageLevels.Normal
+			);
+		} );
+
+		it( 'still returns Normal for a zero limit with zero usage', () => {
+			expect( level( { used: 0, available: 0, minDaysOfBackupsAllowed: 0 } ) ).toBe(
+				StorageUsageLevels.Normal
+			);
+		} );
+
+		it( 'does not let the day-count block reach the guard first', () => {
+			// `used >= available` is true for 0 >= 0, but the block also
+			// requires `available > 0`, so a zero limit can never be
+			// reported as Full.
+			expect(
+				level( { used: 0, available: 0, minDaysOfBackupsAllowed: 30, daysOfBackupsSaved: 1 } )
+			).toBe( StorageUsageLevels.Normal );
+		} );
+	} );
+} );

--- a/projects/packages/backup/src/dashboard/hooks/use-site-size.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-site-size.ts
@@ -17,6 +17,27 @@ type Result = {
 };
 
 /**
+ * The shared `/site/backup/size` query.
+ *
+ * Exported so the storage meter can read the same response rather than
+ * issuing a second one. Two `useQuery` calls on one key already dedupe
+ * the *request*, but only while their options agree — a second observer
+ * with a shorter `staleTime` considers the cached entry stale on mount
+ * and refetches it. Sharing one definition is what makes that impossible
+ * rather than merely unlikely.
+ *
+ * @return The raw React Query result.
+ */
+export function useSiteSizeQuery() {
+	return useQuery( {
+		queryKey: keys.siteSize(),
+		queryFn: fetchSiteSize,
+		staleTime: SITE_SIZE_STALE_MS,
+		enabled: useCanQueryWpcom(),
+	} );
+}
+
+/**
  * React Query hook exposing WPCOM's "backups stopped" flag.
  *
  * The legacy dashboard reads the same flag, but only as a side effect of
@@ -32,12 +53,7 @@ type Result = {
  * @return The stopped flag and its loading state.
  */
 export function useSiteSize(): Result {
-	const query = useQuery( {
-		queryKey: keys.siteSize(),
-		queryFn: fetchSiteSize,
-		staleTime: SITE_SIZE_STALE_MS,
-		enabled: useCanQueryWpcom(),
-	} );
+	const query = useSiteSizeQuery();
 
 	// `ok` is WPCOM's own success flag inside a 200 response; without it
 	// the sibling fields carry no meaning.

--- a/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
@@ -1,0 +1,109 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchSitePolicies } from '../data/api/policies';
+import { keys } from '../data/query-client';
+import { getUsageLevel, type StorageUsageLevelName } from '../data/storage-usage-levels';
+import { useCanQueryWpcom } from './use-connection';
+import { useSiteSizeQuery } from './use-site-size';
+
+// Policies change when a plan changes, which is rare — but a plan change
+// is exactly the moment the meter is wrong, so this is not cached for the
+// hour it could be.
+const SITE_POLICIES_STALE_MS = 5 * 60_000;
+
+type Figures = {
+	/** Size of the most recent backup in bytes, or null when unknown. */
+	lastBackupSize: number | null;
+	/** Days of backups the plan promises, or null when unknown. */
+	planRetentionDays: number | null;
+	/** Derived level driving the meter's colour and the section heading. */
+	usageLevel: StorageUsageLevelName | null;
+	isLoading: boolean;
+};
+
+/**
+ * `hasUsableFigures` is a discriminant, not a convenience flag: it is the
+ * single statement of legacy's `storageSize !== null && storageLimit > 0`
+ * gate, and when it is true the two figures are narrowed to numbers. That
+ * keeps the predicate in one place — a consumer that re-tested the values
+ * itself could drift from it, and a consumer that trusted the flag while
+ * the figures stayed nullable would need a cast to draw anything.
+ */
+type Result = Figures &
+	(
+		| { hasUsableFigures: true; storageUsed: number; storageLimit: number }
+		| { hasUsableFigures: false; storageUsed: number | null; storageLimit: number | null }
+	);
+
+/**
+ * React Query hook backing the storage meter.
+ *
+ * Fans out to the two routes that between them describe storage, because
+ * neither is sufficient alone: `/site/backup/size` reports usage and the
+ * day-counts, and `/site/backup/policies` reports the limit. A meter
+ * drawn from `/size` alone has no denominator.
+ *
+ * Both halves are read defensively for the same reason. Every legacy
+ * bridge answers a non-200 from WordPress.com with a bare `null` body,
+ * which WordPress serves as HTTP 200 — so the request resolves, React
+ * Query records a success, and the only evidence of failure is the shape
+ * of the data. Anything unreadable therefore has to collapse to `null`
+ * here rather than to a zero, which would read as "you have used none of
+ * your storage" and draw an empty bar over a full site.
+ *
+ * `/size` additionally carries WordPress.com's own `ok` flag *inside* a
+ * 200 body; without it the sibling fields carry no meaning, so the whole
+ * response is discarded rather than half-read. Legacy does the same, by
+ * dispatching its failure action.
+ *
+ * @return Storage figures, the derived level, and whether to render.
+ */
+export function useStorageUsage(): Result {
+	const sizeQuery = useSiteSizeQuery();
+	const policiesQuery = useQuery( {
+		queryKey: keys.sitePolicies(),
+		queryFn: fetchSitePolicies,
+		staleTime: SITE_POLICIES_STALE_MS,
+		enabled: useCanQueryWpcom(),
+	} );
+
+	const size = sizeQuery.data?.ok ? sizeQuery.data : null;
+	const policies = policiesQuery.data?.policies ?? null;
+
+	const storageUsed = size?.size ?? null;
+	const storageLimit = policies?.storage_limit_bytes ?? null;
+	const lastBackupSize = size?.last_backup_size ?? null;
+	const planRetentionDays = policies?.activity_log_limit_days ?? null;
+
+	// Retention is not one field. The site's own `retention_days` wins
+	// when it is set, and the plan's `activity_log_limit_days` stands in
+	// when it is not — legacy spells this `backupRetentionDays ||
+	// planRetentionDays` at `backup-storage-space/index.jsx:33`, and the
+	// `||` is load-bearing: `retention_days` is `0` on a site with no
+	// retention policy, not absent.
+	const retentionDays = size?.retention_days || planRetentionDays;
+
+	const usageLevel = getUsageLevel(
+		storageUsed,
+		storageLimit,
+		size?.min_days_of_backups_allowed ?? null,
+		size?.days_of_backups_allowed ?? null,
+		retentionDays,
+		size?.days_of_backups_saved ?? null
+	);
+
+	const figures: Figures = {
+		lastBackupSize,
+		planRetentionDays,
+		usageLevel,
+		isLoading: sizeQuery.isLoading || policiesQuery.isLoading,
+	};
+
+	// A limit of zero is not a limit anyone can be measured against, and a
+	// site whose policy read came back empty would otherwise render a
+	// full-width empty bar.
+	if ( storageUsed !== null && storageLimit !== null && storageLimit > 0 ) {
+		return { ...figures, hasUsableFigures: true, storageUsed, storageLimit };
+	}
+
+	return { ...figures, hasUsableFigures: false, storageUsed, storageLimit };
+}

--- a/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
@@ -11,14 +11,21 @@ import { useSiteSizeQuery } from './use-site-size';
 const SITE_POLICIES_STALE_MS = 5 * 60_000;
 
 type Figures = {
-	/** Size of the most recent backup in bytes, or null when unknown. */
-	lastBackupSize: number | null;
-	/** Days of backups the plan promises, or null when unknown. */
-	planRetentionDays: number | null;
 	/** Derived level driving the meter's colour and the section heading. */
 	usageLevel: StorageUsageLevelName | null;
+	/**
+	 * True only while a request is genuinely in flight. React Query v5
+	 * defines this as `isPending && isFetching`, so a query disabled by
+	 * `useCanQueryWpcom()` reports `false` rather than staying pending
+	 * forever — which is what makes it safe to reserve layout on.
+	 */
 	isLoading: boolean;
 };
+
+// `last_backup_size` and the plan's own retention are read off these same
+// responses but deliberately not returned: nothing consumes them yet, and
+// the usage details that will are JETPACK-2330. Adding each back is one
+// line when there is a caller.
 
 /**
  * `hasUsableFigures` is a discriminant, not a convenience flag: it is the
@@ -55,7 +62,7 @@ type Result = Figures &
  * response is discarded rather than half-read. Legacy does the same, by
  * dispatching its failure action.
  *
- * @return Storage figures, the derived level, and whether to render.
+ * @return The two figures, the derived level, and whether to render.
  */
 export function useStorageUsage(): Result {
 	const sizeQuery = useSiteSizeQuery();
@@ -71,8 +78,6 @@ export function useStorageUsage(): Result {
 
 	const storageUsed = size?.size ?? null;
 	const storageLimit = policies?.storage_limit_bytes ?? null;
-	const lastBackupSize = size?.last_backup_size ?? null;
-	const planRetentionDays = policies?.activity_log_limit_days ?? null;
 
 	// Retention is not one field. The site's own `retention_days` wins
 	// when it is set, and the plan's `activity_log_limit_days` stands in
@@ -80,7 +85,7 @@ export function useStorageUsage(): Result {
 	// planRetentionDays` at `backup-storage-space/index.jsx:33`, and the
 	// `||` is load-bearing: `retention_days` is `0` on a site with no
 	// retention policy, not absent.
-	const retentionDays = size?.retention_days || planRetentionDays;
+	const retentionDays = size?.retention_days || ( policies?.activity_log_limit_days ?? null );
 
 	const usageLevel = getUsageLevel(
 		storageUsed,
@@ -92,8 +97,6 @@ export function useStorageUsage(): Result {
 	);
 
 	const figures: Figures = {
-		lastBackupSize,
-		planRetentionDays,
 		usageLevel,
 		isLoading: sizeQuery.isLoading || policiesQuery.isLoading,
 	};

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -10,6 +10,7 @@ import BackupStatusPanel, { replacesOverview } from '../components/backup-status
 import BackupStatusBanner, { BackupTroubleBanner } from '../components/backup-status/banner';
 import DashboardLayout from '../components/dashboard-layout';
 import QueryError from '../components/query-error';
+import StorageSpace from '../components/storage-space';
 import {
 	ACTIVITY_LOG_DEFAULT_PER_PAGE,
 	useActivityById,
@@ -172,6 +173,18 @@ export default function OverviewScreen() {
 			 * loading, so the terminal case still reports immediately.
 			 */ }
 			{ ! restorePointsLoading && <BackupTroubleBanner state={ backupsState } /> }
+			{ /*
+			 * Above the list, and a sibling of the grid for the same
+			 * reason the banners are. It answers a question the list
+			 * cannot — a site whose backups have stopped because storage
+			 * ran out sees only an activity log that quietly stops — so it
+			 * belongs where that news is read first, not below the fold.
+			 *
+			 * It renders nothing until it has both a usage figure and a
+			 * limit, so on a site with no retention policy this costs a
+			 * pair of requests and no layout.
+			 */ }
+			<StorageSpace />
 			<div className="jpb-overview">
 				<ActivityList
 					selectedId={ selectedId }

--- a/projects/packages/backup/tests/storage-meter.test.tsx
+++ b/projects/packages/backup/tests/storage-meter.test.tsx
@@ -1,0 +1,247 @@
+// Tests for the Overview's storage section (JETPACK-2300 / H3a).
+//
+// The level derivation itself is unit-tested in
+// `src/dashboard/data/test/storage-usage-levels.test.ts`; this file covers
+// what the two routes together produce, and above all when the section
+// declines to render.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factory above.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import BackupNowButton from '../src/dashboard/components/backup-now-button';
+import StorageSpace from '../src/dashboard/components/storage-space';
+import type { ReactNode } from 'react';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const GB = 1024 * 1024 * 1024;
+
+/**
+ * Render inside an isolated QueryClient.
+ *
+ * @param ui - The tree to render.
+ * @return The testing-library render result.
+ */
+function renderWithClient( ui: ReactNode ) {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	return render( <QueryClientProvider client={ client }>{ ui }</QueryClientProvider> );
+}
+
+/**
+ * Answer the two routes the meter reads.
+ *
+ * Both default to a healthy site well under its limit. `null` for either
+ * response stands for the bridges' failure shape — a bare `null` body
+ * served as HTTP 200.
+ *
+ * @param options          - Overrides.
+ * @param options.size     - What `/site/backup/size` returns.
+ * @param options.policies - What `/site/backup/policies` returns.
+ */
+function mockEndpoints( {
+	size = {} as Record< string, unknown > | null,
+	policies = {} as Record< string, unknown > | null,
+} = {} ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/site/backup/policies' ) ) {
+			return Promise.resolve(
+				policies === null ? null : { policies: { storage_limit_bytes: 100 * GB, ...policies } }
+			);
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( size === null ? null : { ok: true, size: 10 * GB, ...size } );
+		}
+		// `<BackupNowButton>` shares the `/size` read and appears in two
+		// of the tests below; these are the other routes it needs before
+		// it will render at all.
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		if ( path.includes( '/backups' ) ) {
+			return Promise.resolve( [] );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+/**
+ * The rendered meter's fill percentage.
+ *
+ * `ProgressBar` carries the value on a visually-hidden `<progress>`,
+ * whose implicit role is `progressbar` — so this is also a check that the
+ * bar is exposed to assistive technology at all.
+ *
+ * @return The value as a number, or null when no bar rendered.
+ */
+function meterValue(): number | null {
+	const bar = screen.queryByRole( 'progressbar' );
+	return bar ? Number( bar.getAttribute( 'value' ) ) : null;
+}
+
+beforeEach( () => {
+	mockApiFetch.mockReset();
+	mockEndpoints();
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'the render gate', () => {
+	it( 'draws a meter once both a usage figure and a limit have arrived', async () => {
+		renderWithClient( <StorageSpace /> );
+		await expect( screen.findByText( 'Cloud storage space' ) ).resolves.toBeInTheDocument();
+		expect( meterValue() ).toBe( 10 );
+	} );
+
+	it( 'stays silent when the policies read fails, rather than drawing an empty bar', async () => {
+		// The dangerous case. `/policies` answering a non-200 arrives as a
+		// bare `null` with HTTP 200, so nothing rejects and nothing here
+		// gets to see an error — only the missing limit says so.
+		mockEndpoints( { policies: null } );
+		renderWithClient( <StorageSpace /> );
+		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
+		expect( screen.queryByText( 'Cloud storage space' ) ).not.toBeInTheDocument();
+		expect( meterValue() ).toBeNull();
+	} );
+
+	it( 'stays silent for a site whose plan carries no retention policy', async () => {
+		// `{ policies: null }` inside a 200 is a different thing from a
+		// failed read, and produces the same silence for a different
+		// reason: there is no limit to measure against.
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( '/site/backup/policies' ) ) {
+				return Promise.resolve( { policies: null } );
+			}
+			return Promise.resolve( { ok: true, size: 10 * GB } );
+		} );
+		renderWithClient( <StorageSpace /> );
+		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
+		expect( screen.queryByText( 'Cloud storage space' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'stays silent on a zero limit rather than reading it as 100% full', async () => {
+		mockEndpoints( { policies: { storage_limit_bytes: 0 } } );
+		renderWithClient( <StorageSpace /> );
+		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
+		expect( screen.queryByText( 'Cloud storage full' ) ).not.toBeInTheDocument();
+		expect( meterValue() ).toBeNull();
+	} );
+
+	it( 'discards the size response entirely when WordPress.com says `ok: false`', async () => {
+		// The sibling fields carry no meaning without it, so a size of
+		// zero must not be read as "you have used none of your storage".
+		mockEndpoints( { size: { ok: false, size: 0 } } );
+		renderWithClient( <StorageSpace /> );
+		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
+		expect( meterValue() ).toBeNull();
+	} );
+} );
+
+describe( 'the section heading', () => {
+	it( 'escalates to "almost full" past 80%', async () => {
+		mockEndpoints( { size: { size: 85 * GB } } );
+		renderWithClient( <StorageSpace /> );
+		await expect(
+			screen.findByText( 'Cloud storage is almost full' )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'escalates to "full" at the limit', async () => {
+		mockEndpoints( { size: { size: 100 * GB } } );
+		renderWithClient( <StorageSpace /> );
+		await expect( screen.findByText( 'Cloud storage full' ) ).resolves.toBeInTheDocument();
+	} );
+
+	it( 'stays calm at "BackupsDiscarded", which is not a fullness reading', async () => {
+		// Half full by bytes, but retention has already been cut short.
+		// The heading is driven by fullness, so this one keeps the neutral
+		// wording — the sibling upsell issue is what reports it.
+		mockEndpoints( {
+			size: {
+				size: 50 * GB,
+				min_days_of_backups_allowed: 7,
+				days_of_backups_allowed: 7,
+				days_of_backups_saved: 7,
+				retention_days: 30,
+			},
+		} );
+		renderWithClient( <StorageSpace /> );
+		await expect( screen.findByText( 'Cloud storage space' ) ).resolves.toBeInTheDocument();
+	} );
+} );
+
+describe( 'the meter itself', () => {
+	it( 'clamps a site holding more than its limit to a full bar', async () => {
+		mockEndpoints( { size: { size: 150 * GB } } );
+		renderWithClient( <StorageSpace /> );
+		await expect( screen.findByText( 'Cloud storage full' ) ).resolves.toBeInTheDocument();
+		expect( meterValue() ).toBe( 100 );
+	} );
+
+	it( 'labels itself as storage rather than inheriting ProgressBar’s "Loading" label', async () => {
+		mockEndpoints( { size: { size: 42 * GB } } );
+		renderWithClient( <StorageSpace /> );
+		await expect(
+			screen.findByLabelText( 'Backup storage used: 42%' )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'shares one `/size` read with the other consumer on the page', async () => {
+		// `<BackupNowButton>` reads the same route for the server-side
+		// `backups_stopped` flag. Both go through `useSiteSizeQuery`, so
+		// the Overview issues one request for the two of them.
+		renderWithClient(
+			<>
+				<StorageSpace />
+				<BackupNowButton />
+			</>
+		);
+		await expect( screen.findByText( 'Cloud storage space' ) ).resolves.toBeInTheDocument();
+		const paths = mockApiFetch.mock.calls.map( ( [ o ] ) => o?.path );
+		expect( paths.filter( p => p?.includes( '/site/backup/size' ) ) ).toHaveLength( 1 );
+		expect( paths.filter( p => p?.includes( '/site/backup/policies' ) ) ).toHaveLength( 1 );
+	} );
+
+	it( 'leaves the cached `/size` entry alone when the second consumer mounts later', async () => {
+		// The above passes however the two hooks are written: React Query
+		// dedupes observers that mount together, whatever options they
+		// each carry. What the shared definition actually buys is this —
+		// a consumer arriving *after* the entry is cached honours the same
+		// `staleTime` and does not refetch. Give the two different values
+		// and this is the test that notices.
+		const client = new QueryClient( {
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		} );
+
+		const view = render(
+			<QueryClientProvider client={ client }>
+				<StorageSpace />
+			</QueryClientProvider>
+		);
+		await expect( screen.findByText( 'Cloud storage space' ) ).resolves.toBeInTheDocument();
+		view.unmount();
+
+		render(
+			<QueryClientProvider client={ client }>
+				<BackupNowButton />
+			</QueryClientProvider>
+		);
+		await expect( screen.findByRole( 'button' ) ).resolves.toBeInTheDocument();
+
+		const sizeCalls = mockApiFetch.mock.calls
+			.map( ( [ o ] ) => o?.path )
+			.filter( ( path?: string ) => path?.includes( '/site/backup/size' ) );
+		expect( sizeCalls ).toHaveLength( 1 );
+	} );
+} );

--- a/projects/packages/backup/tests/storage-meter.test.tsx
+++ b/projects/packages/backup/tests/storage-meter.test.tsx
@@ -181,6 +181,71 @@ describe( 'the section heading', () => {
 	} );
 } );
 
+describe( 'colour and geometry', () => {
+	/**
+	 * The modifier classes on the bar, which are the contract between
+	 * `meter.tsx` and `style.scss`.
+	 *
+	 * @return The class list, or null when no bar rendered.
+	 */
+	function barModifiers(): string[] | null {
+		// eslint-disable-next-line testing-library/no-node-access -- The class list is the thing under test; no role or label exposes it.
+		const bar = document.querySelector( '.jpb-storage-meter__bar' );
+		return bar ? Array.from( bar.classList ) : null;
+	}
+
+	it( 'takes the full-width geometry only when the bar actually reaches the end', async () => {
+		mockEndpoints( { size: { size: 100 * GB } } );
+		renderWithClient( <StorageSpace /> );
+		await expect( screen.findByText( 'Cloud storage full' ) ).resolves.toBeInTheDocument();
+		expect( barModifiers() ).toContain( 'jpb-storage-meter__bar--complete' );
+	} );
+
+	it( 'keeps the flat trailing edge at BackupsDiscarded, which fires at any fill level', async () => {
+		// The regression this guards: geometry used to be keyed off the
+		// level name, and `BackupsDiscarded` shares `Full`'s alarm colour.
+		// A half-full bar was therefore drawn as a fully-rounded pill
+		// floating in the track — the exact shape the partly-filled
+		// treatment exists to avoid. Colour is shared; geometry is not.
+		mockEndpoints( {
+			size: {
+				size: 50 * GB,
+				min_days_of_backups_allowed: 7,
+				days_of_backups_allowed: 7,
+				days_of_backups_saved: 7,
+				retention_days: 30,
+			},
+		} );
+		renderWithClient( <StorageSpace /> );
+		await expect( screen.findByText( 'Cloud storage space' ) ).resolves.toBeInTheDocument();
+		expect( barModifiers() ).toContain( 'jpb-storage-meter__bar--error' );
+		expect( barModifiers() ).not.toContain( 'jpb-storage-meter__bar--complete' );
+	} );
+
+	it.each( [
+		[ 10, 'jpb-storage-meter__bar--neutral' ],
+		[ 70, 'jpb-storage-meter__bar--caution' ],
+		[ 85, 'jpb-storage-meter__bar--error' ],
+	] )( 'fills %i%% with %s', async ( percent, expected ) => {
+		mockEndpoints( { size: { size: percent * GB } } );
+		renderWithClient( <StorageSpace /> );
+		await waitFor( () => expect( barModifiers() ).not.toBeNull() );
+		expect( barModifiers() ).toContain( expected );
+	} );
+} );
+
+describe( 'landmarks', () => {
+	it( 'exposes the section as a named region, not a bare container', async () => {
+		// `<section>` maps to `region` only when it has an accessible name.
+		// Without one a screen reader cannot jump to the answer to "why did
+		// my backups stop".
+		renderWithClient( <StorageSpace /> );
+		await expect(
+			screen.findByRole( 'region', { name: 'Cloud storage space' } )
+		).resolves.toBeInTheDocument();
+	} );
+} );
+
 describe( 'the meter itself', () => {
 	it( 'clamps a site holding more than its limit to a full bar', async () => {
 		mockEndpoints( { size: { size: 150 * GB } } );
@@ -189,6 +254,15 @@ describe( 'the meter itself', () => {
 		expect( meterValue() ).toBe( 100 );
 	} );
 
+	// Caveat worth knowing: the dashboard route externalizes
+	// `@wordpress/components` to the `wp-components` handle, so the
+	// `<ProgressBar>` that runs in wp-admin is WordPress core's, not the
+	// version pinned here and resolved by jest. This asserts the override
+	// against the pinned copy. It holds because the implementation spreads
+	// caller props *after* its own hardcoded `aria-label="Loading …"` —
+	// prop-spread ordering, which is not a documented contract. If core
+	// ever reverses it the meter silently goes back to announcing itself as
+	// a loading indicator and this test will not notice.
 	it( 'labels itself as storage rather than inheriting ProgressBar’s "Loading" label', async () => {
 		mockEndpoints( { size: { size: 42 * GB } } );
 		renderWithClient( <StorageSpace /> );

--- a/projects/packages/backup/tests/storage-meter.test.tsx
+++ b/projects/packages/backup/tests/storage-meter.test.tsx
@@ -238,10 +238,22 @@ describe( 'landmarks', () => {
 	it( 'exposes the section as a named region, not a bare container', async () => {
 		// `<section>` maps to `region` only when it has an accessible name.
 		// Without one a screen reader cannot jump to the answer to "why did
-		// my backups stop".
+		// my backups stop". Querying by name also proves the `id` survives
+		// `<Text render={ … } />`, which is what `aria-labelledby` points at.
 		renderWithClient( <StorageSpace /> );
 		await expect(
 			screen.findByRole( 'region', { name: 'Cloud storage space' } )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'puts the heading at level 3, level with its siblings', async () => {
+		// Deliberately not legacy's `h2`. The backup and activity detail
+		// cards are `h3` and are visual siblings of this section, so an
+		// `h2` here would read as though they were nested inside cloud
+		// storage.
+		renderWithClient( <StorageSpace /> );
+		await expect(
+			screen.findByRole( 'heading', { level: 3, name: 'Cloud storage space' } )
 		).resolves.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/storage-meter.test.tsx
+++ b/projects/packages/backup/tests/storage-meter.test.tsx
@@ -103,6 +103,34 @@ describe( 'the render gate', () => {
 		expect( meterValue() ).toBe( 10 );
 	} );
 
+	it( "holds the section's height while the requests are in flight", async () => {
+		// The shift this guards: the section used to render `null` until
+		// both requests resolved, so on a slow connection the activity list
+		// rendered first and was then pushed down when they landed.
+		let release: ( v: unknown ) => void = () => {};
+		const pending = new Promise( resolve => {
+			release = resolve;
+		} );
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) =>
+			( options?.path ?? '' ).includes( '/site/backup/' ) ? pending : Promise.resolve( {} )
+		);
+
+		renderWithClient( <StorageSpace /> );
+
+		// The placeholders are `aria-hidden` by design — there is nothing
+		// worth announcing yet — so no role or label reaches them, and the
+		// class is the only handle. Same escape hatch as `barModifiers()`.
+		/* eslint-disable testing-library/no-node-access -- see above. */
+		await waitFor( () => expect( document.querySelector( '.jpb-storage-space' ) ).not.toBeNull() );
+		expect( document.querySelector( '.jpb-storage-meter__placeholder' ) ).not.toBeNull();
+		/* eslint-enable testing-library/no-node-access */
+		// Nothing is claimed while we are still looking.
+		expect( screen.queryByText( 'Cloud storage space' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'progressbar' ) ).not.toBeInTheDocument();
+
+		release( { ok: true, size: 10 * GB, policies: { storage_limit_bytes: 100 * GB } } );
+	} );
+
 	it( 'stays silent when the policies read fails, rather than drawing an empty bar', async () => {
 		// The dangerous case. `/policies` answering a non-200 arrives as a
 		// bare `null` with HTTP 200, so nothing rejects and nothing here


### PR DESCRIPTION
Fixes #

Implements [JETPACK-2300](https://linear.app/a8c/issue/JETPACK-2300) (task H3a of the modernized Backup dashboard port). Behind `rsm_jetpack_ui_modernization_backup`, which is off by default — with the filter off, nothing here runs and the legacy dashboard is untouched.

## Proposed changes

A site whose backups have stopped because cloud storage ran out is never told why: `src/dashboard/` had zero storage files, so the activity log simply stops with no explanation. This adds the data layer and the meter bar. Sibling issues add the usage details ([JETPACK-2330](https://linear.app/a8c/issue/JETPACK-2330)), the upsell ([JETPACK-2331](https://linear.app/a8c/issue/JETPACK-2331)) and the help popover ([JETPACK-2332](https://linear.app/a8c/issue/JETPACK-2332)) inside the same section.

* **`data/api/policies.ts`** — new fetcher for `/jetpack/v4/site/backup/policies`, plus `keys.sitePolicies()`.
* **`hooks/use-storage-usage.ts`** — fans out to both storage routes. Neither can draw a meter alone: `/site/backup/size` reports usage and the retention day-counts, and the storage **limit** lives on `/policies`. It shares its `/size` read with the "Back up now" button through a new `useSiteSizeQuery()`, so the page issues one request rather than two.
* **`data/storage-usage-levels.ts`** — the five-level derivation, ported from `src/js/components/backup-storage-space/storage-usage-levels.ts` with no behavioural change. Only its parameter types were widened to accept `null`, which is what callers have always passed and what makes its own `=== null` guards meaningful.
* **`components/storage-space/`** — the section heading and the bar, mounted in `overview.tsx` as a sibling above the two-pane grid (a third child would be auto-placed into that grid, same reason the status banners are siblings).

Two corrections and one fix that fell out of the port:

* `RawSiteSize` declared a `storage_limit_bytes` that **the response does not carry**, and was missing the four fields the derivation needs (`retention_days` and the three day-counts). Verified against a live 200, whose keys are `ok`, `error`, `size`, `days_of_backups_saved`, `days_of_backups_allowed`, `min_days_of_backups_allowed`, `last_backup_size`, `last_backup_failed`, `retention_days`, `backups_stopped`.
* The bar now labels itself for assistive technology. `<ProgressBar>` hardcodes `aria-label="Loading …"` but spreads caller props after it, so the storage meter no longer announces itself as a loading indicator — which the legacy bar still does.
* Nulls are handled explicitly rather than coerced. Every legacy bridge answers a non-200 from WordPress.com with a bare `null` body served as HTTP 200, so failure is visible only in the shape of the data; anything unreadable collapses to `null` rather than to a zero that would draw an empty bar over a full site. `/size` also carries WordPress.com's own `ok` flag *inside* a 200, so the whole response is discarded when it is false.

The section renders nothing until it has both a usage figure and a limit, matching legacy's `storageSize !== null && storageLimit > 0` gate.

### ⚠️ Do not flip the modernization flag before JETPACK-2331 lands

At the `BackupsDiscarded` level — WordPress.com has already begun deleting older backups to stay under the limit — this slice signals that with **colour alone**. The heading stays neutral ("Cloud storage space", matching legacy) and the meter's accessible name reports only a percentage, so the reading is identical to a healthy site at the same fill level. That is WCAG 1.4.1, and a screen-reader user gets nothing.

Legacy is not in this position: it renders `StorageUsageDetails` and `StorageAddonUpsellPrompt` in the same block, both of which say it in words. This PR ships neither yet — [JETPACK-2330](https://linear.app/a8c/issue/JETPACK-2330) adds the first and [JETPACK-2331](https://linear.app/a8c/issue/JETPACK-2331) the second.

Harmless while the flag is off. **Turning it on before JETPACK-2331 ships a colour-only alarm**, so the two need to land in that order.

### The palette, and the one literal in it

Legacy hardcodes `--jp-black` / `--jp-yellow-20` / `--jp-red-40`. **None of the `--jp-*` tokens resolve on a modernized page** — they are declared by a stylesheet the legacy admin page enqueues and these routes do not — so writing `var(--jp-yellow-20)` here computes to nothing, the declaration is dropped, and the fill silently falls back to `<ProgressBar>`'s near-black default. Three of the four are therefore design-system tokens, and the fourth is a literal:

| Level | Value |
|---|---|
| track | `--wpds-color-background-track-neutral` |
| Normal | `--wpds-color-background-interactive-neutral-strong` |
| Warning | `#f0c930` — literal, matching legacy's `--jp-yellow-20` |
| Critical / Full / BackupsDiscarded | `--wpds-color-background-interactive-error-strong` |

The literal is deliberate. WPDS has no vivid caution *fill*: the whole caution family is two pale tints (`#fee995`, `#fff9ca`), a muted tan (`#cfc28d`) and an olive (`#826a00`). The olive is the only one meeting 3:1 against the track, and it reads brown rather than as a warning — so this matches legacy's yellow instead, and a site looks the same with the flag on or off.

Worth naming the trade honestly: `#f0c930` is **1.16:1** against the `#dbdbdb` track and so does not meet WCAG 1.4.11 for non-text contrast. Neither does legacy, at 1.17:1 against its own track — this is parity, not a regression, and the level is also carried by the heading at Critical and Full. **The real fix is a caution fill token in WPDS**, which is worth raising with the design-system folks rather than working around a fourth time.

## Related product discussion/links

* [JETPACK-2300](https://linear.app/a8c/issue/JETPACK-2300) — this task
* [JETPACK-2243](https://linear.app/a8c/issue/JETPACK-2243) — the audit that generated it
* [JETPACK-2325](https://linear.app/a8c/issue/JETPACK-2325) — the "legacy routes answer failure with HTTP 200" hazard this works around

## Does this pull request change what data or activity we track or use?

No. It reads two routes the legacy dashboard already reads, and adds no tracking.

## Screenshots

Captured on a real wp-admin Backup dashboard. Because the meter needs a plan with a retention policy — which neither a default local environment nor a fresh Jurassic Ninja site has — `/site/backup/policies` was stubbed with a 100 GB limit for the capture. Everything else on screen (plan, connection, activity log) is real, and the same stub was in place for both the before and after shot.

| Before (trunk) | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/add/backup-storage-meter/before-overview.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/add/backup-storage-meter/after-overview.png) |

The five levels:

| Level | |
|---|---|
| **Normal** — 10% used | ![normal](https://github.com/Automattic/jetpack/raw/screenshots/add/backup-storage-meter/level-1-normal.png) |
| **Warning** — 70% used | ![warning](https://github.com/Automattic/jetpack/raw/screenshots/add/backup-storage-meter/level-2-warning.png) |
| **Critical** — 85% used | ![critical](https://github.com/Automattic/jetpack/raw/screenshots/add/backup-storage-meter/level-3-critical.png) |
| **Full** — at the limit | ![full](https://github.com/Automattic/jetpack/raw/screenshots/add/backup-storage-meter/level-4-full.png) |
| **BackupsDiscarded** — 50% used, but retention already cut from 30 days to 7 | ![discarded](https://github.com/Automattic/jetpack/raw/screenshots/add/backup-storage-meter/level-5-discarded.png) |

Note the last one: it is half full by bytes, so only the day-counts can see that something is wrong. It wears Full's error colour but keeps the partly-filled geometry — flat trailing edge, same as Warning — because that level fires at any fill level, so colour and geometry are keyed off different things. The heading stays neutral, matching legacy; see the ordering note above.

## Testing instructions

The meter only renders on a site whose plan reports a storage limit, so the interesting part of testing is arranging one.

**Automated**

* `jp test js packages/backup` — 48 suites, 434 tests. 42 are new: 23 unit tests over the level derivation in `src/dashboard/data/test/storage-usage-levels.test.ts`, and 19 over the section in `tests/storage-meter.test.tsx`.
* `pnpm run typecheck` and `pnpm run lint-style` in `projects/packages/backup`.

**Manual**

1. Turn the modernized dashboard on: `add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );`
2. On a site with a **real** Backup plan and retention policy, go to **Jetpack → VaultPress Backup**. You should see a "Cloud storage space" heading and a bar above the activity list.
3. To walk the levels without waiting for storage to fill, stub the two routes in a mu-plugin. Note this must hook `rest_dispatch_request` — `rest_request_before_callbacks` cannot inject a success, because core overwrites its return with the route callback unless it was a `WP_Error`:

```php
add_filter( 'rest_dispatch_request', function ( $result, $request ) {
    $gb = 1024 * 1024 * 1024;
    if ( '/jetpack/v4/site/backup/policies' === $request->get_route() ) {
        return rest_ensure_response( array( 'policies' => array(
            'storage_limit_bytes'     => 100 * $gb,
            'activity_log_limit_days' => 30,
        ) ) );
    }
    if ( '/jetpack/v4/site/backup/size' === $request->get_route() ) {
        return rest_ensure_response( array(
            'ok'                          => true,
            'size'                        => 85 * $gb, // 10 / 70 / 85 / 100 for the four levels
            'last_backup_size'            => 2 * $gb,
            'retention_days'              => 30,
            'min_days_of_backups_allowed' => 7,
            'days_of_backups_allowed'     => 30, // set to 7 for BackupsDiscarded
            'days_of_backups_saved'       => 30, // set to 7 for BackupsDiscarded
            'backups_stopped'             => false,
        ) );
    }
    return $result;
}, PHP_INT_MAX, 2 );
```

4. Vary `size` to check the thresholds: under 65% is Normal, 65–79% Warning, 80–99% Critical, 100%+ Full. The heading should change at Critical and again at Full.
5. Set `days_of_backups_allowed` and `days_of_backups_saved` to `7` with `size` at 50% — the bar should go red while the heading stays neutral (BackupsDiscarded).
6. **Check the silent cases.** Return `array( 'policies' => null )` from the policies stub, or `array( 'ok' => false )` from the size stub. In both the section should render **nothing at all** — no heading, no empty bar, and no reserved gap above the activity list.
7. Turn the filter back off and confirm the legacy dashboard is unchanged.

8. Confirm the section is reachable as a landmark (it is a named `region`) and that its heading sits at level 3, level with the detail cards beside it rather than above them.

Also verified while developing: the bar is fluid down to a 320px container with no horizontal page overflow, and in RTL the fill grows from the right with the rounding flipped to match.


