### PR TITLE
Footer credit: only strip the separator next to the credit link

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-dotthem-411-footer-widget-pipe-separator
+++ b/projects/plugins/wpcomsh/changelog/fix-dotthem-411-footer-widget-pipe-separator
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Footer credit: stop stripping pipe separators out of footer content. The separator is now only removed where it directly precedes the theme credit link being replaced.

--- a/projects/plugins/wpcomsh/footer-credit/footer-credit-optimizations.php
+++ b/projects/plugins/wpcomsh/footer-credit/footer-credit-optimizations.php
@@ -63,7 +63,7 @@ function wpcom_better_footer_links( $footer ) {
 
 	// Replace separator from content, since we are replacing theme and designer credits.
 	// Any span separator with a .sep class will be matched and replaced by the regular expression.
-	$footer = preg_replace( '/\s\|\s(?=\<a)|\<span class="([^"]+\s)?sep(\s[^"]+)?">.*<\/span>/i', '', $footer );
+	$footer = preg_replace( '/\<span class="([^"]+\s)?sep(\s[^"]+)?">.*<\/span>/i', '', $footer );
 
 	// Handle WP.com footer text.
 	$lang = get_bloginfo( 'language' );
@@ -100,6 +100,12 @@ function wpcom_better_footer_links( $footer ) {
 		// Split the content into two parts, which we will join later on.
 		$before = substr( $footer, 0, $offset );
 		$after  = substr( $footer, $offset );
+
+		// Remove the separator that immediately preceded the credit link, now that the credit
+		// itself is being replaced. Anchored to this offset on purpose: this function runs on an
+		// output buffer covering the whole footer, footer widget areas included, so removing the
+		// separator globally also strips pipes out of content the site owner wrote.
+		$before = preg_replace( '/\s\|\s$/', '', $before );
 
 		// Replace on the last part. Ensure we only do one replacement to avoid duplicates.
 		$after = preg_replace( $credit_regex, $credit_link, $after, 1 );

--- a/projects/plugins/wpcomsh/tests/FooterCreditSeparatorTest.php
+++ b/projects/plugins/wpcomsh/tests/FooterCreditSeparatorTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Footer credit separator handling test file.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Class FooterCreditSeparatorTest.
+ *
+ * The wpcom_better_footer_links() function runs on an output buffer that covers the whole footer,
+ * which includes any footer widget areas the theme renders from footer.php. These tests pin down
+ * that it only removes the separator belonging to the credit it replaces, and leaves separators
+ * in site-owner content alone.
+ */
+class FooterCreditSeparatorTest extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * A fixed credit link, so the assertions do not depend on the site's footercredit option.
+	 *
+	 * @var string
+	 */
+	const CREDIT_LINK = '<a href="https://wordpress.com/?ref=footer_blog">Blog at WordPress.com.</a>';
+
+	/**
+	 * Set up.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		add_filter( 'wpcom_better_footer_credit_apply', '__return_true', PHP_INT_MAX );
+		add_filter( 'wpcom_better_footer_credit_link', array( $this, 'fixed_credit_link' ), PHP_INT_MAX );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'wpcom_better_footer_credit_apply', '__return_true', PHP_INT_MAX );
+		remove_filter( 'wpcom_better_footer_credit_link', array( $this, 'fixed_credit_link' ), PHP_INT_MAX );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Return a fixed credit link.
+	 *
+	 * @return string
+	 */
+	public function fixed_credit_link() {
+		return self::CREDIT_LINK;
+	}
+
+	/**
+	 * A pipe a site owner typed into a footer widget must survive, even when it sits directly in
+	 * front of a link. Regression test for a footer widget losing "Terms | <a>Privacy</a>".
+	 */
+	public function test_separator_in_footer_widget_content_is_preserved() {
+		$footer = '<div class="widget widget_block"><p>Terms &amp; Conditions | <a href="https://example.com/privacy">Privacy Policy</a></p></div>'
+			. '<div class="site-info"><a href="https://wordpress.org/">Proudly powered by WordPress</a></div>';
+
+		$filtered = wpcom_better_footer_links( $footer );
+
+		$this->assertStringContainsString(
+			'Terms &amp; Conditions | <a href="https://example.com/privacy">Privacy Policy</a>',
+			$filtered,
+			'The separator in footer widget content should be left alone.'
+		);
+	}
+
+	/**
+	 * A footer with no WordPress credit link at all should come back untouched. This is the common
+	 * case on themes that do not ship a WordPress colophon, where there is no credit to replace.
+	 */
+	public function test_footer_without_a_credit_link_is_unchanged() {
+		$footer = '<div class="footer-widgets"><p>Shop | <a href="https://example.com/shop">All products</a></p></div>';
+
+		$this->assertSame( $footer, wpcom_better_footer_links( $footer ) );
+	}
+
+	/**
+	 * The separator that belongs to the credit link must still be removed, otherwise replacing the
+	 * credit leaves a dangling pipe behind.
+	 */
+	public function test_separator_before_the_credit_link_is_removed() {
+		$footer = '<div class="site-info"><a href="https://designer.example/">Designer</a> | <a href="https://wordpress.org/">Proudly powered by WordPress</a></div>';
+
+		$filtered = wpcom_better_footer_links( $footer );
+
+		$this->assertSame(
+			'<div class="site-info"><a href="https://designer.example/">Designer</a>' . self::CREDIT_LINK . '</div>',
+			$filtered,
+			'The separator belonging to the credit link should be removed along with the credit.'
+		);
+	}
+
+	/**
+	 * A ".sep" separator span next to the credit is still removed.
+	 */
+	public function test_sep_span_is_removed() {
+		$footer = '<div class="site-info"><span class="sep"> | </span><a href="https://wordpress.org/">Proudly powered by WordPress</a></div>';
+
+		$filtered = wpcom_better_footer_links( $footer );
+
+		$this->assertStringNotContainsString( 'class="sep"', $filtered );
+		$this->assertStringContainsString( self::CREDIT_LINK, $filtered );
+	}
+}


### PR DESCRIPTION
Fixes DOTTHEM-411

## Proposed changes

`wpcom_better_footer_links()` removes the separator that sits between a theme's credit links before it swaps in the WordPress.com credit. It did that with a global replace:

```php
preg_replace( '/\s\|\s(?=\<a)|…/i', '', $footer )
```

`\s\|\s(?=\<a)` matches **any** ` | ` followed by **any** link, anywhere in the string — and the string here is an output buffer opened on `get_footer`, so it covers the entire footer, footer widget areas included. A site owner whose footer widget reads `Terms | <a>Privacy Policy</a>` loses the pipe and its leading space.

This is common in footers, where `|` is a conventional separator for terms/privacy links. It shows up on classic themes that render a widget area from `footer.php` — 90+ themes in the pub and premium catalogs do, plus third-party themes on WoA.

The separator removal still needs to happen, or replacing the credit leaves a dangling ` | `. So instead of dropping it, this moves it next to the credit it belongs to:

* Remove `\s\|\s(?=\<a)` from the global separator regex. The `<span class="sep">` branch is unchanged.
* Re-do that removal anchored with `/\s\|\s$/` to the end of `$before` — the substring the credit-matching code has already split at the credit link's offset.

Because `$before` ends exactly where the credit link begins, the anchored pattern can only ever match a separator immediately preceding the credit being replaced. It runs at most once, and only inside the `if` that found a credit link — so a footer with no WordPress credit link (the usual case on third-party themes) is now left alone entirely, where previously it was still rewritten.

## Related product discussion/links

* https://linear.app/a8c/issue/DOTTHEM-411/vertical-bar-pipe-character-stripped-from-footer-widgets

The Linear issue may be auto-marked "In Progress" by this PR opening. It is not being actively worked by the owning team — this is a Bug Blitz contribution awaiting review.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires a WoA/Atomic site on a **classic** theme that renders a widget area from `footer.php` (Storefront, Astra, Twenty Seventeen). Block themes never call `get_footer()`, so this code does not run on them, and a few classic themes — Twenty Twenty among them — emit their footer widgets from the page template rather than `footer.php`, which also bypasses it.

1. Add a Paragraph block widget to a footer widget area with content like:
   `Terms & Conditions | <a href="https://example.com/privacy">Privacy Policy</a>`
2. View the front end. **Before:** the `|` and its preceding space are gone. **After:** they render as written.
3. Confirm the footer credit itself still works — on a theme whose footer links to wordpress.org, that link should still be replaced with the WordPress.com credit, with no leftover ` | ` in front of it.
4. On Twenty Eleven, confirm `<span class="sep"> | </span>` is still removed.

Automated coverage is in `projects/plugins/wpcomsh/tests/FooterCreditSeparatorTest.php`:

```
jp docker phpunit wpcomsh -- --filter=FooterCreditSeparatorTest
```

The two behavioural tests fail on trunk and pass with this change; the two guarding existing behaviour (separator before the credit is removed, `.sep` span is removed) pass in both.

Also verified end-to-end on a live Atomic site by running the patched function in place of wpcomsh's own, via a temporary mu-plugin, and confirming the widget separator survived while the footer credit was still replaced.
