### PR TITLE
Backup: stop the restore button counting a file selection it cannot honour

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-restore-label-scope
+++ b/projects/packages/backup/changelog/fix-backup-restore-label-scope
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: stop the modernized dashboard's Restore action counting the file-browser selection, which it can never honour — a restore point is restored whole. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -34,24 +34,6 @@ function downloadLabel( count: number ): string {
 }
 
 /**
- * Returns the appropriate "Restore" header-label given how many items
- * the visitor has selected in the file browser.
- *
- * @param count - Number of currently selected items.
- * @return Localized button label.
- */
-function restoreLabel( count: number ): string {
-	if ( count === 0 ) {
-		return __( 'Restore to this point', 'jetpack-backup-pkg' );
-	}
-	return sprintf(
-		/* translators: %d count of selected items (files + opaque folders) */
-		_n( 'Restore %d selected item', 'Restore %d selected items', count, 'jetpack-backup-pkg' ),
-		count
-	);
-}
-
-/**
  * Right-pane detail card for a selected backup activity item.
  *
  * Shows the item's title header with Download / Restore actions linking to the
@@ -66,6 +48,9 @@ function restoreLabel( count: number ): string {
  */
 export default function BackupDetail( { item }: Props ) {
 	const [ selection, setSelection ] = useState< FileSelection >( EMPTY_FILE_SELECTION );
+	// `count` labels the Download action only -- Restore beside it is
+	// deliberately unlabelled by selection, see its call site.
+	//
 	// `count` tracks how many opaque server-side download units the
 	// current selection covers — files plus folders whose contents
 	// haven't been loaded yet (each treated as one unit). Loaded
@@ -106,9 +91,17 @@ export default function BackupDetail( { item }: Props ) {
 							<Icon icon={ downloadIcon } size={ 18 } />
 							{ downloadLabel( count ) }
 						</Link>
+						{ /*
+						 * Deliberately not labelled from the file selection, unlike
+						 * Download beside it. A restore point is restored whole:
+						 * there is no upstream shape for restoring a subset of
+						 * files, so a count here would promise a scope no layer can
+						 * deliver. The reader who trusts "Restore 3 selected items"
+						 * confirms a full-site restore believing it is scoped.
+						 */ }
 						<Link to={ `/restore/${ item.rewindId }` } className="jpb-backup-detail__restore">
 							<Icon icon={ rotateLeft } size={ 18 } />
-							{ restoreLabel( count ) }
+							{ __( 'Restore to this point', 'jetpack-backup-pkg' ) }
 						</Link>
 					</Stack>
 				</Stack>

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -38,9 +38,10 @@ function downloadLabel( count: number ): string {
  *
  * Shows the item's title header with Download / Restore actions linking to the
  * matching sibling routes, the backup's summary line, a timestamp by-line,
- * and the file browser. File selection state lives here so the header
- * actions can switch between "Download backup" and "Download N selected
- * files" based on what the visitor has checked in the tree.
+ * and the file browser. File selection state lives here so the Download
+ * action can switch between "Download backup" and "Download %d selected
+ * item" based on what the visitor has checked in the tree. Restore does
+ * not switch — see its call site.
  *
  * @param props      - Component props.
  * @param props.item - The selected backup activity item.
@@ -48,7 +49,7 @@ function downloadLabel( count: number ): string {
  */
 export default function BackupDetail( { item }: Props ) {
 	const [ selection, setSelection ] = useState< FileSelection >( EMPTY_FILE_SELECTION );
-	// `count` labels the Download action only -- Restore beside it is
+	// `count` labels the Download action only — Restore beside it is
 	// deliberately unlabelled by selection, see its call site.
 	//
 	// `count` tracks how many opaque server-side download units the
@@ -57,8 +58,8 @@ export default function BackupDetail( { item }: Props ) {
 	// folders contribute via their leaves, not themselves;
 	// indeterminate folders don't add to the count. FileBrowser owns
 	// the loaded children, so it reports the count back here for the
-	// header labels to swap between "Download backup" and "Download N
-	// items".
+	// Download label to swap between "Download backup" and "Download %d
+	// selected item".
 	const [ count, setCount ] = useState( 0 );
 
 	return (
@@ -92,12 +93,17 @@ export default function BackupDetail( { item }: Props ) {
 							{ downloadLabel( count ) }
 						</Link>
 						{ /*
-						 * Deliberately not labelled from the file selection, unlike
-						 * Download beside it. A restore point is restored whole:
-						 * there is no upstream shape for restoring a subset of
-						 * files, so a count here would promise a scope no layer can
-						 * deliver. The reader who trusts "Restore 3 selected items"
-						 * confirms a full-site restore believing it is scoped.
+						 * Deliberately not labelled from the file selection.
+						 *
+						 * Download beside it does not honour the selection yet
+						 * either — JETPACK-2296 is what wires it. The difference is
+						 * that its count is keepable in principle and this one is
+						 * not: a restore point is restored whole, and there is no
+						 * upstream shape for restoring a subset of files. So a
+						 * count here could only ever promise a scope no layer can
+						 * deliver, and the reader who trusts "Restore 3 selected
+						 * items" confirms a full-site restore believing it is
+						 * scoped.
 						 */ }
 						<Link to={ `/restore/${ item.rewindId }` } className="jpb-backup-detail__restore">
 							<Icon icon={ rotateLeft } size={ 18 } />

--- a/projects/packages/backup/tests/restore-label-scope.test.tsx
+++ b/projects/packages/backup/tests/restore-label-scope.test.tsx
@@ -37,20 +37,14 @@ const ITEM: BackupActivityItem = {
 /**
  * The single root file's own checkbox.
  *
- * Row checkboxes carry `label=""`, so they cannot be addressed by name.
- * Exclude the only named checkbox in the browser — the tree's "N items
- * selected" summary — and require exactly one to remain, rather than
- * taking one by index that could silently become the summary.
+ * Addressed by name, matching `switching-backups-resets-detail.test.tsx`.
+ * Row checkboxes had no accessible name until #51616; before that this had
+ * to exclude the tree's named summary checkbox and count what was left.
  *
  * @return The file row's checkbox.
  */
 function fileRowCheckbox(): HTMLElement {
-	const summary = screen.getByRole( 'checkbox', { name: /items? selected/ } );
-	const rows = screen.getAllByRole( 'checkbox' ).filter( box => box !== summary );
-	if ( rows.length !== 1 ) {
-		throw new Error( `Expected one file row checkbox, found ${ rows.length }` );
-	}
-	return rows[ 0 ];
+	return screen.getByRole( 'checkbox', { name: 'Select wp-config.php' } );
 }
 
 beforeEach( () => {

--- a/projects/packages/backup/tests/restore-label-scope.test.tsx
+++ b/projects/packages/backup/tests/restore-label-scope.test.tsx
@@ -1,0 +1,107 @@
+// Download and Restore sit side by side in the detail header and look
+// symmetric. They are not: a selection can narrow a download, but a
+// restore point is restored whole — there is no upstream shape for
+// restoring a subset of files. So the Restore action must never count
+// the file selection, however the Download action beside it is labelled.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BackupDetail from '../src/dashboard/components/backup-detail';
+import { queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import type { BackupActivityItem } from '../src/dashboard/types/activity';
+
+const ITEM: BackupActivityItem = {
+	id: 'act-cloud',
+	kind: 'backup',
+	title: 'Backup complete',
+	publishedAt: '2026-08-13T18:08:56+00:00',
+	actor: { type: 'Application', name: 'Jetpack' },
+	rewindId: '1786644531.123',
+	stats: '46 plugins, 23 themes',
+	isComplete: true,
+};
+
+/**
+ * The single root file's own checkbox.
+ *
+ * Row checkboxes carry `label=""`, so they cannot be addressed by name.
+ * Exclude the only named checkbox in the browser — the tree's "N items
+ * selected" summary — and require exactly one to remain, rather than
+ * taking one by index that could silently become the summary.
+ *
+ * @return The file row's checkbox.
+ */
+function fileRowCheckbox(): HTMLElement {
+	const summary = screen.getByRole( 'checkbox', { name: /items? selected/ } );
+	const rows = screen.getAllByRole( 'checkbox' ).filter( box => box !== summary );
+	if ( rows.length !== 1 ) {
+		throw new Error( `Expected one file row checkbox, found ${ rows.length }` );
+	}
+	return rows[ 0 ];
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockApiFetch.mockResolvedValue( {
+		contents: {
+			'wp-config.php': { type: 'file', period: '1786644531', manifest_path: 'f5:/wp-config.php' },
+		},
+	} );
+} );
+
+describe( 'Restore action label', () => {
+	it( 'reads "Restore to this point" with nothing selected', async () => {
+		render(
+			<QueryClientProvider>
+				<BackupDetail item={ ITEM } />
+			</QueryClientProvider>
+		);
+
+		await expect(
+			screen.findByRole( 'button', { name: 'File: wp-config.php' } )
+		).resolves.toBeInTheDocument();
+
+		expect( screen.getByText( 'Restore to this point' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Download backup' ) ).toBeInTheDocument();
+	} );
+
+	// The asymmetry is the whole point, so both halves are asserted in one
+	// test. Checking the Restore label alone would still pass if a future
+	// change stopped labelling Download from the selection too, which would
+	// be a different regression rather than this fix holding.
+	it( 'stays unchanged when a file is selected, while Download counts', async () => {
+		render(
+			<QueryClientProvider>
+				<BackupDetail item={ ITEM } />
+			</QueryClientProvider>
+		);
+
+		await expect(
+			screen.findByRole( 'button', { name: 'File: wp-config.php' } )
+		).resolves.toBeInTheDocument();
+		await userEvent.click( fileRowCheckbox() );
+
+		// Download follows the selection: granular download is a real shape.
+		await expect( screen.findByText( 'Download 1 selected item' ) ).resolves.toBeInTheDocument();
+
+		// Restore does not, because granular restore is not.
+		expect( screen.getByText( 'Restore to this point' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Restore \d+ selected item/ ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
+++ b/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
@@ -134,16 +134,17 @@ describe( 'Switching between backups', () => {
 		).resolves.toBeInTheDocument();
 		await userEvent.click( fileRowCheckbox() );
 
-		// Selecting the file swaps both header actions off their defaults.
-		// The mocked `<Link>` renders a plain `<a>` with no `href` (the real
+		// Selecting the file swaps the Download action off its default. The
+		// mocked `<Link>` renders a plain `<a>` with no `href` (the real
 		// component takes `to`), so it carries no implicit `link` role here.
-		// Both are asserted because `BackupDetail` labels them from one
-		// `count`, and a reset that missed either would leave the reader a
-		// header that describes a selection they cannot see.
+		//
+		// Download is the only header action that moves. Restore is
+		// deliberately constant — a restore point is restored whole, so it
+		// never counts the selection — which makes it useless as a reset
+		// signal here. Its constancy is `restore-label-scope.test.tsx`.
 		await expect(
 			screen.findByText( 'Download 1 selected item', undefined, SETTLE )
 		).resolves.toBeInTheDocument();
-		expect( screen.getByText( 'Restore 1 selected item' ) ).toBeInTheDocument();
 
 		// Open the file's preview as well. A regression that cleared the
 		// selection but left `openFile` set would otherwise pass.
@@ -168,8 +169,6 @@ describe( 'Switching between backups', () => {
 		expect( fileRowCheckbox() ).not.toBeChecked();
 		expect( screen.getByText( 'Download backup' ) ).toBeInTheDocument();
 		expect( screen.queryByText( /Download \d+ selected item/ ) ).not.toBeInTheDocument();
-		expect( screen.getByText( 'Restore to this point' ) ).toBeInTheDocument();
-		expect( screen.queryByText( /Restore \d+ selected item/ ) ).not.toBeInTheDocument();
 	} );
 
 	// The other half of the invariant. Keying by `rewindId` makes the


### PR DESCRIPTION
Fixes JETPACK-2305

## Proposed changes

* Stop the modernized dashboard's **Restore** action counting the file-browser selection.

The Restore link was relabelled from the selection count — "Restore 3 selected items" — with nothing downstream to narrow the scope. `screens/restore.tsx` seeds `DEFAULT_RESTORE_ITEMS` (all six categories) and `data/api/restore.ts` posts a whole-site restore. It now reads **"Restore to this point"** whatever is ticked.

### Why not make the count true instead

There is no upstream shape for restoring a subset of files:

* `class-rest-controller.php:41-47` records it: the `paths` allowlist entry "does not carry over to granular *restore*… Granular restore has to establish its own shape against the v2 route before anything here can claim to cover it."
* `Restore_Bridge` registers only `rewind_id` and `types`.
* Calypso's granular restore does not use the v2 route at all — it posts to **v1** with `types` as a bare string, not a map.

A restore point is restored whole, so no count on this button can ever be honest.

### Download is deliberately left alone

The two actions sit side by side and look symmetric. They are not. Granular **download** is a real shape (`include_path_list` / `exclude_path_list`, which Calypso drives in production), so its count is a promise that can be kept — wiring it is JETPACK-2296. Only Restore was claiming something no layer can deliver.

No-op while the modernization filter is off, which it is by default.

## Related product discussion/links

* JETPACK-2305, and JETPACK-2296 for the Download half

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, off by default. Force it on:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

Build the package (`jetpack build packages/backup`), then go to **Jetpack → VaultPress Backup** on a site with a Backup plan and at least one completed backup.

1. Select a backup in the left list. The header reads **Download backup** and **Restore to this point**.
2. In **Files**, tick one file's checkbox.
3. **Download** becomes "Download 1 selected item". **Restore** still reads "Restore to this point" — this is the fix.

**Verified on a live site** with a real VaultPress manifest, reading the rendered header:

```
before selecting : [ "Download backup",            "Restore to this point" ]
after selecting 1: [ "Download 1 selected item",   "Restore to this point" ]
```

**Automated:** `jetpack test js packages/backup`. New suite `tests/restore-label-scope.test.tsx` asserts both labels together — checking Restore alone would still pass if Download stopped counting, which would be a different regression. Mutation-checked: restoring the old `restoreLabel( count )` branch fails the selection test and only it.

### Also confirmed while here

JETPACK-2305 asked for the severity demotion to be checked on a real screen rather than inferred from JSX. Clicking Restore navigates to the Restore screen, which shows the "this cannot be undone" warning, all six checklist items **pre-ticked**, and a separate **Confirm restore** button. Confirmed live (no restore was started):

```
warning notice : present
checklist      : 6 items, all pre-ticked
confirm button : "Confirm restore", separate step
```

So the old label was a misleading entry point rather than a one-click destructive action — the true scope was always on screen before anything happened.
