### PR TITLE
Prototype: lay a multistep step out with layout supports

### DIFF
--- a/projects/packages/forms/changelog/form-step-drop-align
+++ b/projects/packages/forms/changelog/form-step-drop-align
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Multistep: drop the Step block's alignment control. A step always fills its container, so the control had nothing to change.

--- a/projects/packages/forms/changelog/form-step-layout-supports
+++ b/projects/packages/forms/changelog/form-step-layout-supports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Multistep: lay a step out with WordPress layout support instead of hand-written CSS, so its Justify control works on every block in the step.

--- a/projects/packages/forms/changelog/form-step-layout-supports
+++ b/projects/packages/forms/changelog/form-step-layout-supports
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Multistep: lay a step out with WordPress layout support instead of hand-written CSS, so its Justify control works on every block in the step.
+Multistep: lay a step out with WordPress layout support instead of hand-written CSS, so its Justify control moves headings, paragraphs and fields that have a width set.

--- a/projects/packages/forms/changelog/form-step-single-element
+++ b/projects/packages/forms/changelog/form-step-single-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Multistep: render a step as a single element on both surfaces, so its layout and its visibility live on the same div.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -706,6 +706,28 @@ class Contact_Form_Block {
 							'backgroundImage' => true,
 						),
 					),
+
+					/*
+					 * Mirrors the block's index.js. Declared here as well as there because
+					 * layout classes and the scoped `wp-container-*` rule are generated per
+					 * surface: the editor reads the JS registration, the front end reads
+					 * this one, and a support declared on only one side renders on only one
+					 * side.
+					 */
+					'layout'     => array(
+						'default'                => array(
+							'type'           => 'flex',
+							'orientation'    => 'vertical',
+							'justifyContent' => 'stretch',
+							'flexWrap'       => 'nowrap',
+						),
+						'allowSwitching'         => false,
+						'allowEditing'           => true,
+						'allowOrientation'       => false,
+						'allowJustification'     => true,
+						'allowVerticalAlignment' => false,
+						'allowWrap'              => false,
+					),
 				),
 			)
 		);

--- a/projects/packages/forms/src/blocks/form-step/edit.jsx
+++ b/projects/packages/forms/src/blocks/form-step/edit.jsx
@@ -118,7 +118,6 @@ function StepBreak( { stepLabel, currentIndex, setAttributes, clientId } ) {
 
 export default function Edit( { attributes, setAttributes, clientId, isSelected } ) {
 	const blockProps = useBlockProps();
-	blockProps.className += ' jetpack-form-step__container';
 
 	const ancestorFormClientId = useParentFormClientId( clientId );
 	const steps = useFormSteps( ancestorFormClientId );
@@ -166,14 +165,18 @@ export default function Edit( { attributes, setAttributes, clientId, isSelected 
 		renderAppender = InnerBlocks.ButtonBlockAppender;
 	}
 
-	const innerBlocksProps = useInnerBlocksProps(
-		{ className: 'wp-block-jetpack-form-step jetpack-form-step__container' },
-		{
-			template: getStepTemplate( hasPrevNavigation ),
-			allowedBlocks: ALLOWED_BLOCKS,
-			renderAppender,
-		}
-	);
+	/*
+	 * One element, not two: `blockProps` and the inner-blocks props go on the same
+	 * div so the step has a single wrapper, the way `form-step-container` and the
+	 * front end do. Anything block supports put on the block's own element — the
+	 * layout classes and the scoped `wp-container-*` rule among them — then lands
+	 * on the element that actually lays the step's blocks out.
+	 */
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		template: getStepTemplate( hasPrevNavigation ),
+		allowedBlocks: ALLOWED_BLOCKS,
+		renderAppender,
+	} );
 
 	useEffect( () => {
 		if (
@@ -200,9 +203,11 @@ export default function Edit( { attributes, setAttributes, clientId, isSelected 
 		return null;
 	}
 
+	const { children: innerBlocksChildren, ...stepProps } = innerBlocksProps;
+
 	return (
 		<>
-			<div { ...blockProps }>
+			<div { ...stepProps }>
 				{ ! isSingleStep && (
 					<StepBreak
 						stepLabel={ attributes.stepLabel }
@@ -211,7 +216,7 @@ export default function Edit( { attributes, setAttributes, clientId, isSelected 
 						clientId={ clientId }
 					/>
 				) }
-				<div { ...innerBlocksProps } />
+				{ innerBlocksChildren }
 				<AttributesControls
 					attributes={ attributes }
 					setAttributes={ setAttributes }

--- a/projects/packages/forms/src/blocks/form-step/editor.scss
+++ b/projects/packages/forms/src/blocks/form-step/editor.scss
@@ -7,7 +7,6 @@
 	display: flex;
 	align-items: center;
 	color: currentColor;
-	margin: var(--wp--style--block-gap, 1.5rem) 0;
 
 	// Horizontal lines on both sides, similar to paywall block.
 	&::before,
@@ -34,4 +33,16 @@
 
 .wp-block-jetpack-form-step {
 	box-sizing: border-box;
+}
+
+// The step label is a child of the step's layout container, so core's
+// `.is-layout-flex > :is(*, div) { margin: 0 }` zeroes any margin set on the
+// class alone. Two classes here to beat it.
+// Only the block-start side: the label is the first thing in a step, and its
+// top margin is the only gap between one step and the next in All steps view —
+// steps are siblings of each other, not of the label, so the step's own
+// `gap` never applies there. Below the label that `gap` does apply, and adding
+// a margin as well would double the space.
+.wp-block-jetpack-form-step > .jetpack-form-step__break {
+	margin-block-start: var(--wp--style--block-gap, 1.5rem);
 }

--- a/projects/packages/forms/src/blocks/form-step/editor.scss
+++ b/projects/packages/forms/src/blocks/form-step/editor.scss
@@ -34,8 +34,4 @@
 
 .wp-block-jetpack-form-step {
 	box-sizing: border-box;
-	display: flex;
-	justify-content: flex-start;
-	flex-direction: row;
-	gap: var(--wp--style--block-gap, 1.5rem);
 }

--- a/projects/packages/forms/src/blocks/form-step/editor.scss
+++ b/projects/packages/forms/src/blocks/form-step/editor.scss
@@ -34,9 +34,6 @@
 
 .wp-block-jetpack-form-step {
 	box-sizing: border-box;
-}
-
-.wp-block-jetpack-form-step .jetpack-form-step__container {
 	display: flex;
 	justify-content: flex-start;
 	flex-direction: row;

--- a/projects/packages/forms/src/blocks/form-step/index.js
+++ b/projects/packages/forms/src/blocks/form-step/index.js
@@ -23,6 +23,31 @@ export const settings = {
 		reusable: false,
 		inserter: true,
 		align: true,
+		layout: {
+			/*
+			 * Mirrored in PHP (class-contact-form-block.php) so both surfaces
+			 * generate the same classes and the same scoped container rule.
+			 *
+			 * `justifyContent: 'stretch'` is what makes a step's blocks fill it.
+			 * Core's flex layout maps a vertical container's justification onto
+			 * `align-items`, and only `stretch` leaves a child's width alone; the
+			 * other values shrink every child to its content. Nothing else in core
+			 * stretches flex children, which is why the step needed a `> *` rule
+			 * before this.
+			 */
+			default: {
+				type: 'flex',
+				orientation: 'vertical',
+				justifyContent: 'stretch',
+				flexWrap: 'nowrap',
+			},
+			allowSwitching: false,
+			allowEditing: true,
+			allowOrientation: false,
+			allowJustification: true,
+			allowVerticalAlignment: false,
+			allowWrap: false,
+		},
 		color: {
 			gradients: true,
 			link: true,

--- a/projects/packages/forms/src/blocks/form-step/index.js
+++ b/projects/packages/forms/src/blocks/form-step/index.js
@@ -22,7 +22,6 @@ export const settings = {
 		html: false,
 		reusable: false,
 		inserter: true,
-		align: true,
 		layout: {
 			/*
 			 * Mirrored in PHP (class-contact-form-block.php) so both surfaces
@@ -65,6 +64,13 @@ export const settings = {
 		},
 	},
 	attributes: {
+		/*
+		 * No `align` support: a step always fills its container, so the alignment
+		 * toolbar had nothing to change and only added a control to a block that
+		 * already carries several. The attribute stays declared so a value saved
+		 * while the support existed still round-trips instead of being dropped on
+		 * the next save.
+		 */
 		align: {
 			type: 'string',
 		},

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -944,14 +944,41 @@ class Contact_Form_Plugin {
 			$tags->set_attribute( 'data-wp-on--click', 'actions.previousStep' );
 		}
 
+		/*
+		 * Put the step's interactivity on the block's own element rather than in a
+		 * wrapper around it. The saved markup already opens with the block wrapper —
+		 * `save.jsx` renders a single `<div {...useInnerBlocksProps.save( useBlockProps.save() )} />`
+		 * — and that element is the one the step's layout applies to, both here and in
+		 * the editor. A second element around it put the visibility toggling on one
+		 * element and the flex container on another, which is how the editor and the
+		 * front end came to disagree about which element a step's layout belongs to.
+		 */
+		$tags->seek( 'start' );
+		$tags->add_class( 'jetpack-form-step' );
+		if ( self::$step_count === 1 ) {
+			$tags->add_class( 'is-current-step' );
+		}
+		$tags->set_attribute( 'data-wp-interactive', 'jetpack/form' );
+		$tags->set_attribute( 'data-wp-class--is-before-current', 'state.isBeforeCurrent' );
+		$tags->set_attribute( 'data-wp-class--is-after-current', 'state.isAfterCurrent' );
+		$tags->set_attribute( 'data-wp-class--is-current-step', 'state.isCurrentStep' );
+
+		/*
+		 * The same encoding `wp_interactivity_data_wp_context()` uses; that helper
+		 * returns a whole attribute string, and this needs a bare value to hand to
+		 * the tag processor, which does its own escaping.
+		 */
+		$tags->set_attribute(
+			'data-wp-context',
+			(string) wp_json_encode(
+				array( 'step' => self::$step_count ),
+				JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
+			)
+		);
+
 		$processed_content = $tags->get_updated_html();
 
-		$processed_content = Contact_Form_Block::apply_background_support( $processed_content, $atts, Contact_Form_Block::STEP_BLOCK_CLASS );
-
-		$is_current_step_class = ( self::$step_count === 1 ? 'is-current-step' : '' );
-		return '<div data-wp-interactive="jetpack/form" class="jetpack-form-step ' . $is_current_step_class . ' " data-wp-class--is-before-current="state.isBeforeCurrent" data-wp-class--is-after-current="state.isAfterCurrent" data-wp-class--is-current-step="state.isCurrentStep" ' . wp_interactivity_data_wp_context( array( 'step' => self::$step_count ) ) . ' >'
-				. $processed_content
-			. '</div>';
+		return Contact_Form_Block::apply_background_support( $processed_content, $atts, Contact_Form_Block::STEP_BLOCK_CLASS );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1577,8 +1577,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 				&& wp_verify_nonce( sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ), "contact-form-sent-{$feedback_id}" );
 		}
 
+		/*
+		 * The steps are already rendered by the time the form builds its context, so
+		 * the only record of how many there are is in their markup. Accept the quotes
+		 * inside the attribute either raw or HTML-encoded: a step whose attribute is
+		 * written by `WP_HTML_Tag_Processor::set_attribute()` gets `&quot;`, while one
+		 * written by `wp_interactivity_data_wp_context()` gets `"`, and a form whose
+		 * steps do not match here silently loses `currentStep` and stops paginating.
+		 */
 		$max_steps = 0;
-		if ( preg_match_all( '/data-wp-context=[\'"]?{"step":(\d+)}[\'"]?/', $content, $matches ) ) {
+		if ( preg_match_all( '/data-wp-context=[\'"]?{(?:"|&quot;)step(?:"|&quot;):(\d+)}[\'"]?/', $content, $matches ) ) {
 			if ( ! empty( $matches[1] ) ) {
 				$max_steps = max( array_map( 'intval', $matches[1] ) );
 			}

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -39,7 +39,13 @@
 	z-index: 2;
 }
 
-.jetpack-form-step {
+// The step's own element carries both its visibility and its
+// layout now that the render callback no longer wraps it in a
+// second div, so hide the inactive steps without naming a
+// `display` for the active one — otherwise this would decide
+// the step's display mode and the layout rules would never
+// get to.
+.jetpack-form-step:not(.is-current-step) {
 	display: none;
 }
 
@@ -50,7 +56,6 @@
 	height: auto;
 	overflow: visible;
 	z-index: 2;
-	display: block;
 }
 
 // jetpack/button: is-hidden class is on inner button element

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -568,20 +568,6 @@
 	margin-top: 7px;
 }
 
-.wp-block-jetpack-form-step {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: flex-start;
-	flex-direction: row;
-	flex-grow: 1;
-	gap: var(--wp--style--block-gap, 1.5rem);
-}
-
-.wp-block-jetpack-form-step > * {
-	flex: 0 0 100%;
-	box-sizing: border-box;
-}
-
 :where(.wp-block-jetpack-contact-form.is-classic-layout), // This allows forms even with layout attribute to keep the previous layout.
 :where(.has-no-jetpack-form-layout) .wp-block-jetpack-contact-form,
 .wp-block-jetpack-contact-form:not(.is-layout-flex) {

--- a/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
+++ b/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
@@ -1,26 +1,3 @@
-// Every block in a step is a full-width row. grunion.scss has said so since
-// multistep shipped, with `.wp-block-jetpack-form-step > * { flex: 0 0 100% }`,
-// but it says it on the wrong axis: a multistep form is vertical, which makes
-// the step `flex-direction: column` (below), so that `100%` is a height basis
-// and the width falls to `align-items: flex-start`, i.e. shrink to fit. This is
-// the same axis mistake the container-block rule below corrects, and it
-// applies to every other child too: a paragraph or heading in a step ends up as
-// wide as its text, on the front end as well as in the editor, so aligning its
-// text does nothing visible.
-// This lives here rather than in grunion.scss because grunion.scss is front-end
-// only (registered in class-contact-form-plugin.php, not among the block's
-// `style_handles`), and the editor needs the same rule.
-// One class of specificity is deliberate: high enough to beat a theme styling
-// a bare element, low enough that a field's own width setting still wins
-// (`.grunion-field-width-50-wrap` front end, `.jetpack-field__width-50` editor,
-// both two classes). A button cannot be a step child — `form-step`'s
-// ALLOWED_BLOCKS is the field blocks, the step nav and CORE_BLOCKS — so `*`
-// carries none of the risk it would at form level.
-.wp-block-jetpack-form-step > * {
-	box-sizing: border-box;
-	width: 100%;
-}
-
 // Gutenberg versions will use different classname strategies
 // for layout flex support, make it backwards compatible using both.
 .wp-block-jetpack-contact-form-container.is-layout-flex,
@@ -124,9 +101,9 @@
 			margin-top: var(--wp--style--block-gap, 1.5rem);
 		}
 
+		// The step is its own layout container now, so it only needs to fill the
+		// form; core's generated rule decides how it lays its own blocks out.
 		.wp-block-jetpack-form-step {
-			display: flex;
-			flex-wrap: wrap;
 			width: 100%;
 			box-sizing: border-box;
 		}
@@ -139,39 +116,6 @@
 			align-self: normal;
 		}
 
-		&.is-content-justification-left .wp-block-jetpack-form-step {
-			align-items: flex-start;
-		}
-
-		&.is-content-justification-right .wp-block-jetpack-form-step {
-			align-items: flex-end;
-		}
-
-		&.is-content-justification-center .wp-block-jetpack-form-step {
-			align-items: center;
-		}
-
-
-		&.is-horizontal {
-
-			.wp-block-jetpack-form-step {
-				align-items: flex-end;
-			}
-		}
-
-		&.is-vertical {
-
-			.wp-block-jetpack-form-step {
-				flex-direction: column;
-			}
-		}
-
-		&.is-nowrap {
-
-			.wp-block-jetpack-form-step {
-				flex-wrap: nowrap;
-			}
-		}
 	}
 
 	&.is-style-outlined,

--- a/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
+++ b/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
@@ -106,6 +106,26 @@
 		.wp-block-jetpack-form-step {
 			width: 100%;
 			box-sizing: border-box;
+
+			// Except the gap, which core only writes when the *theme* opts into
+			// block gap: `wp_render_layout_support_flag()` takes
+			// `$has_block_gap_support` from
+			// `isset( $global_settings['spacing']['blockGap'] )`, and core's own
+			// theme.json leaves `settings.spacing.blockGap` null. A classic theme
+			// (no theme.json) never opts in, so core emits no gap at all and the
+			// step falls through to core's shared
+			// `:where(.is-layout-flex) { gap: 0.5em }` — 8px, where the rule this
+			// replaced gave 24px. Declaring `spacing.blockGap` on the block does
+			// not close the gap: the gate is the theme's setting, not the block's
+			// support.
+			// So keep the declaration the deleted rule used. On a block theme the
+			// variable is defined and resolves to the same value core would emit;
+			// on a classic theme the 1.5rem fallback preserves the old spacing.
+			// Note this sits at three classes against core's one, so it wins
+			// wherever core does emit a gap. That is only safe while the step has
+			// no `spacing.blockGap` support: add one and a user's own value would
+			// be overridden here, so this rule has to give way at the same time.
+			gap: var(--wp--style--block-gap, 1.5rem);
 		}
 
 		.jetpack-form-steps-wrapper {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -252,6 +252,20 @@ class Contact_Form_Block_Test extends BaseTestCase {
 							'backgroundImage' => true,
 						),
 					),
+					'layout'     => array(
+						'default'                => array(
+							'type'           => 'flex',
+							'orientation'    => 'vertical',
+							'justifyContent' => 'stretch',
+							'flexWrap'       => 'nowrap',
+						),
+						'allowSwitching'         => false,
+						'allowEditing'           => true,
+						'allowOrientation'       => false,
+						'allowJustification'     => true,
+						'allowVerticalAlignment' => false,
+						'allowWrap'              => false,
+					),
 				),
 			),
 			'jetpack/option'    => array(
@@ -712,9 +726,10 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Integration: the background image must land on the step's own div, not on the
-	 * interactivity wrapper gutenblock_render_form_step() adds around it, and core
-	 * must not apply it a second time.
+	 * Integration: a step renders as one element, and the background image lands on
+	 * it once. The step's interactivity, its style supports and its layout all share
+	 * the block's own div, so there is nothing else here for them to land on — which
+	 * is the point: layout supports attach to exactly one element per block.
 	 */
 	public function test_step_background_lands_on_the_blocks_own_div() {
 		Contact_Form_Block::register_block();
@@ -731,13 +746,59 @@ class Contact_Form_Block_Test extends BaseTestCase {
 		$tags = new \WP_HTML_Tag_Processor( $html );
 
 		$this->assertTrue( $tags->next_tag() );
-		$this->assertTrue( $tags->has_class( 'jetpack-form-step' ), 'First tag should be the interactivity wrapper' );
-		$this->assertNull( $tags->get_attribute( 'style' ), 'Interactivity wrapper must not carry the background' );
-
-		$this->assertTrue( $tags->next_tag() );
-		$this->assertTrue( $tags->has_class( Contact_Form_Block::STEP_BLOCK_CLASS ) );
+		$this->assertTrue( $tags->has_class( Contact_Form_Block::STEP_BLOCK_CLASS ), 'The step opens with the block\'s own element' );
+		$this->assertTrue( $tags->has_class( 'jetpack-form-step' ), 'The same element carries the step interactivity' );
 		$this->assertStringContainsString( 'background-image', (string) $tags->get_attribute( 'style' ) );
 		$this->assertTrue( $tags->has_class( 'has-background' ) );
+
+		$this->assertStringContainsString(
+			'data-wp-context',
+			$html,
+			'The step keeps its interactivity context, which is also how the form counts its steps'
+		);
+	}
+
+	/**
+	 * Integration: a rendered multistep form knows how many steps it has.
+	 *
+	 * Nothing passes the step count from the steps to the form. The steps are already
+	 * rendered by the time Contact_Form::parse() builds the form's interactivity
+	 * context, so it recovers the count by matching each step's `data-wp-context` in
+	 * the rendered markup. That makes the exact spelling of an attribute load-bearing
+	 * for whether the form paginates at all, and the failure is silent: `maxSteps` and
+	 * `currentStep` simply never reach the context, every step evaluates as current,
+	 * and the whole form renders at once with dead navigation.
+	 */
+	public function test_multistep_form_context_counts_its_steps() {
+		Contact_Form_Block::register_block();
+		Contact_Form_Block::register_child_blocks();
+
+		// The step number is a static counter, and an earlier test in this process
+		// may have rendered a step of its own.
+		Contact_Form_Plugin::reset_step();
+
+		$step = function ( $label ) {
+			return '<!-- wp:jetpack/form-step -->'
+				. '<div class="wp-block-jetpack-form-step"><!-- wp:jetpack/field-text {"label":"' . $label . '"} /--></div>'
+				. '<!-- /wp:jetpack/form-step -->';
+		};
+
+		$markup = '<!-- wp:jetpack/contact-form {"subject":"Steps","variationName":"multistep"} -->'
+			. '<div class="wp-block-jetpack-contact-form">'
+			. '<!-- wp:jetpack/form-step-container -->'
+			. '<div class="jetpack-form-steps-wrapper"><div class="wp-block-jetpack-form-step-container">'
+			. $step( 'One' ) . $step( 'Two' )
+			. '</div></div>'
+			. '<!-- /wp:jetpack/form-step-container -->'
+			. '</div>'
+			. '<!-- /wp:jetpack/contact-form -->';
+
+		$html = do_blocks( $markup );
+
+		$this->assertSame( 2, substr_count( $html, 'data-wp-class--is-current-step' ), 'Both steps should have rendered' );
+		$this->assertStringContainsString( '"maxSteps":2', $html, 'The form context should report two steps' );
+		$this->assertStringContainsString( '"isMultiStep":true', $html, 'The form should identify as multistep' );
+		$this->assertStringContainsString( '"currentStep":1', $html, 'The form should start on the first step' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/form-step-drop-align
+++ b/projects/plugins/jetpack/changelog/form-step-drop-align
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: drop a multistep Step's alignment control, which had no effect on a step.

--- a/projects/plugins/jetpack/changelog/form-step-layout-e2e
+++ b/projects/plugins/jetpack/changelog/form-step-layout-e2e
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Add e2e coverage for a centered multistep step and for field widths inside a step.
+
+

--- a/projects/plugins/jetpack/changelog/form-step-layout-supports
+++ b/projects/plugins/jetpack/changelog/form-step-layout-supports
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: give a multistep form's step a working Justify control, and lay the step out with WordPress layout support.

--- a/projects/plugins/jetpack/changelog/form-step-single-element
+++ b/projects/plugins/jetpack/changelog/form-step-single-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Forms: render a multistep form's step as a single element, matching the editor and the front end.

--- a/projects/plugins/jetpack/tests/e2e/specs/forms/layout.test.ts
+++ b/projects/plugins/jetpack/tests/e2e/specs/forms/layout.test.ts
@@ -109,6 +109,18 @@ const MULTISTEP_FORM = `<!-- wp:jetpack/contact-form {"subject":"Multistep layou
 <!-- wp:jetpack/input {"type":"text"} /--></div>
 <!-- /wp:jetpack/field-text -->
 
+<!-- wp:jetpack/field-text {"width":25} -->
+<div><!-- wp:jetpack/label {"label":"Quarter field"} /-->
+
+<!-- wp:jetpack/input {"type":"text"} /--></div>
+<!-- /wp:jetpack/field-text -->
+
+<!-- wp:jetpack/field-text {"width":"auto"} -->
+<div><!-- wp:jetpack/label {"label":"Auto field"} /-->
+
+<!-- wp:jetpack/input {"type":"text"} /--></div>
+<!-- /wp:jetpack/field-text -->
+
 <!-- wp:jetpack/field-name -->
 <div><!-- wp:jetpack/label {"label":"Step name"} /-->
 
@@ -117,6 +129,20 @@ const MULTISTEP_FORM = `<!-- wp:jetpack/contact-form {"subject":"Multistep layou
 <!-- /wp:jetpack/form-step --></div></div>
 <!-- /wp:jetpack/form-step-container --></div>
 <!-- /wp:jetpack/contact-form -->`;
+
+/**
+ * The same form with the *step* justified center.
+ *
+ * A step lays its own blocks out, so this is the step's `layout` attribute rather
+ * than the form's. It is the case that has no coverage and the case that broke: a
+ * step whose children were all forced to `width: 100%` had nothing left for
+ * justification to move, so the control silently stopped working for every block
+ * that does not set its own width.
+ */
+const MULTISTEP_CENTERED_FORM = MULTISTEP_FORM.replace(
+	'<!-- wp:jetpack/form-step {"stepLabel":"Step one"} -->',
+	'<!-- wp:jetpack/form-step {"stepLabel":"Step one","layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"nowrap"}} -->'
+).replace( 'Multistep layout test', 'Multistep centered layout test' );
 
 /**
  * The editor and the front end render the same form from different code, so
@@ -134,6 +160,8 @@ type Selectors = {
 	column: string;
 	step: string;
 	halfField: string;
+	quarterField: string;
+	autoField: string;
 };
 
 const EDITOR_SELECTORS: Selectors = {
@@ -145,7 +173,9 @@ const EDITOR_SELECTORS: Selectors = {
 	para: '[data-type="core/paragraph"]',
 	column: '[data-type="core/column"]',
 	step: '.wp-block-jetpack-form-step',
-	halfField: '[data-type="jetpack/field-text"]',
+	halfField: '.jetpack-field__width-50',
+	quarterField: '.jetpack-field__width-25',
+	autoField: '.jetpack-field__width-auto',
 };
 
 const FRONT_END_SELECTORS: Selectors = {
@@ -158,6 +188,8 @@ const FRONT_END_SELECTORS: Selectors = {
 	column: '.wp-block-column',
 	step: '.wp-block-jetpack-form-step',
 	halfField: '.grunion-field-width-50-wrap',
+	quarterField: '.grunion-field-width-25-wrap',
+	autoField: '.grunion-field-width-auto-wrap',
 };
 
 type SingleStepMetrics = {
@@ -179,6 +211,11 @@ type MultistepMetrics = {
 	halfFieldWidth: number | null;
 	halfFieldOffsetLeft: number | null;
 	halfFieldIsAboutHalf: boolean | null;
+	quarterFieldWidth: number | null;
+	quarterFieldIsAboutQuarter: boolean | null;
+	autoFieldWidth: number | null;
+	autoFieldFillsStep: boolean | null;
+	stepElementCount: number;
 };
 
 /**
@@ -249,11 +286,12 @@ function measureMultistep( root: Locator, sel: Selectors ): Promise< MultistepMe
 			return { left: Math.round( r.left ), width: Math.round( r.width ) };
 		};
 
-		// The editor and the front end both nest an element that repeats the
-		// step class, so take the innermost one — that is the flex row container
-		// whose children are the step's blocks.
+		// A step is one element per surface, which is what lets block supports put
+		// its layout classes and its scoped container rule on the element that
+		// actually lays its blocks out. Count them: a second element repeating the
+		// step class would mean the layout landed on the wrong one.
 		const steps = Array.from( form.querySelectorAll( s.step ) );
-		const step = steps[ steps.length - 1 ] as HTMLElement | undefined;
+		const step = steps[ 0 ] as HTMLElement | undefined;
 		if ( ! step ) {
 			return {
 				stepWidth: null,
@@ -264,6 +302,11 @@ function measureMultistep( root: Locator, sel: Selectors ): Promise< MultistepMe
 				halfFieldWidth: null,
 				halfFieldOffsetLeft: null,
 				halfFieldIsAboutHalf: null,
+				quarterFieldWidth: null,
+				quarterFieldIsAboutQuarter: null,
+				autoFieldWidth: null,
+				autoFieldFillsStep: null,
+				stepElementCount: steps.length,
 			};
 		}
 
@@ -271,6 +314,8 @@ function measureMultistep( root: Locator, sel: Selectors ): Promise< MultistepMe
 		const paraEl = step.querySelector( s.para );
 		const paraBox = box( paraEl );
 		const halfBox = box( step.querySelector( s.halfField ) );
+		const quarterBox = box( step.querySelector( s.quarterField ) );
+		const autoBox = box( step.querySelector( s.autoField ) );
 
 		return {
 			stepWidth: stepBox ? stepBox.width : null,
@@ -288,6 +333,15 @@ function measureMultistep( root: Locator, sel: Selectors ): Promise< MultistepMe
 			// theme's gap rather than tight to today's numbers.
 			halfFieldIsAboutHalf:
 				halfBox && stepBox ? Math.abs( halfBox.width - stepBox.width / 2 ) <= 40 : null,
+			quarterFieldWidth: quarterBox ? quarterBox.width : null,
+			quarterFieldIsAboutQuarter:
+				quarterBox && stepBox ? Math.abs( quarterBox.width - stepBox.width / 4 ) <= 40 : null,
+			autoFieldWidth: autoBox ? autoBox.width : null,
+			// Auto does not hug its content: a field with no width set fills the
+			// step, the same as it does in a single-step form.
+			autoFieldFillsStep:
+				autoBox && stepBox ? Math.abs( autoBox.width - stepBox.width ) <= 2 : null,
+			stepElementCount: steps.length,
 		};
 	}, sel );
 }
@@ -412,6 +466,7 @@ for ( const theme of [ CLASSIC_THEME, BLOCK_THEME ] ) {
 	test.describe( `Form block layout: ${ theme }`, () => {
 		let singleStepPageId: number;
 		let multistepPageId: number;
+		let multistepCenteredPageId: number;
 		let originalTheme: string | null = null;
 
 		test.beforeAll( async ( { requestUtils } ) => {
@@ -436,12 +491,19 @@ for ( const theme of [ CLASSIC_THEME, BLOCK_THEME ] ) {
 				status: 'publish',
 			} );
 			multistepPageId = multi.id;
+
+			const centered = await requestUtils.createPage( {
+				title: `Form layout multistep centered (${ theme })`,
+				content: MULTISTEP_CENTERED_FORM,
+				status: 'publish',
+			} );
+			multistepCenteredPageId = centered.id;
 		} );
 
 		test.afterAll( async ( { requestUtils } ) => {
 			try {
 				// `deletePage` is not bound onto RequestUtils, so go through REST.
-				for ( const id of [ singleStepPageId, multistepPageId ] ) {
+				for ( const id of [ singleStepPageId, multistepPageId, multistepCenteredPageId ] ) {
 					/*
 					 * `beforeAll` can throw before either page exists. Deleting
 					 * `undefined` 404s, and the hook's own error would then bury
@@ -571,6 +633,16 @@ for ( const theme of [ CLASSIC_THEME, BLOCK_THEME ] ) {
 
 			// A field's own width setting still wins over that.
 			expect( metrics.halfFieldIsAboutHalf ).toBe( true );
+			expect( metrics.quarterFieldIsAboutQuarter ).toBe( true );
+
+			// Auto fills the step rather than hugging its content.
+			expect( metrics.autoFieldFillsStep ).toBe( true );
+
+			// One element per step. Layout support attaches a block's classes and its
+			// scoped container rule to exactly one element, so a second element
+			// repeating the step class would mean the step's layout and the element
+			// holding its blocks had come apart again.
+			expect( metrics.stepElementCount ).toBe( 1 );
 		} );
 
 		test( 'front end: a step lays its blocks out the same way', async ( { page } ) => {
@@ -605,6 +677,75 @@ for ( const theme of [ CLASSIC_THEME, BLOCK_THEME ] ) {
 			expect( metrics.paragraphFillsStep ).toBe( true );
 			expect( metrics.paragraphTextAlign ).toBe( 'center' );
 			expect( metrics.halfFieldIsAboutHalf ).toBe( true );
+			expect( metrics.quarterFieldIsAboutQuarter ).toBe( true );
+			expect( metrics.autoFieldFillsStep ).toBe( true );
+			expect( metrics.stepElementCount ).toBe( 1 );
+		} );
+
+		/**
+		 * A centered step is the case the container-width work kept getting wrong.
+		 * A step whose children are all forced to `width: 100%` leaves justification
+		 * nothing to move, so the control appears to do nothing for any block that
+		 * does not set its own width — and it half-works, because percentage-width
+		 * fields still shift. Assert on the paragraph, which is the block with no
+		 * width of its own.
+		 */
+		test( 'editor: a centered step centers every block, not only the sized ones', async ( {
+			admin,
+			page,
+		} ) => {
+			await admin.editPost( multistepCenteredPageId );
+
+			const stepSelector = `${ EDITOR_SELECTORS.form } ${ EDITOR_SELECTORS.step }`;
+			let canvas: Frame;
+			try {
+				canvas = await waitForEditorCanvas( page, stepSelector, 30000 );
+			} catch {
+				test.skip(
+					true,
+					'No form step rendered. Multistep forms may not be available on this site.'
+				);
+				return;
+			}
+
+			const metrics = await measureMultistep(
+				canvas.locator( EDITOR_SELECTORS.form ).first(),
+				EDITOR_SELECTORS
+			);
+			logger.debug( `editor/${ theme } multistep centered: ${ JSON.stringify( metrics ) }` );
+
+			expect( metrics.stepWidth ).not.toBeNull();
+			expect( metrics.stepWidth as number ).toBeGreaterThan( 0 );
+
+			// The paragraph shrinks to its text and sits away from the left edge.
+			expect( metrics.paragraphFillsStep ).toBe( false );
+			expect( metrics.paragraphOffsetLeft ).not.toBeNull();
+			expect( metrics.paragraphOffsetLeft as number ).toBeGreaterThan( 0 );
+
+			// A sized field still gets its width, and moves too.
+			expect( metrics.halfFieldIsAboutHalf ).toBe( true );
+			expect( metrics.halfFieldOffsetLeft as number ).toBeGreaterThan( 0 );
+		} );
+
+		test( 'front end: a centered step centers the same way', async ( { page } ) => {
+			await page.goto( `/?page_id=${ multistepCenteredPageId }` );
+
+			const metrics = await measureMultistep(
+				page.locator( FRONT_END_SELECTORS.form ).first(),
+				FRONT_END_SELECTORS
+			);
+			logger.debug( `front/${ theme } multistep centered: ${ JSON.stringify( metrics ) }` );
+
+			test.skip(
+				metrics.stepWidth === null,
+				'No form step in the response. Multistep forms may not be available on this site.'
+			);
+
+			expect( metrics.stepWidth as number ).toBeGreaterThan( 0 );
+			expect( metrics.paragraphFillsStep ).toBe( false );
+			expect( metrics.paragraphOffsetLeft as number ).toBeGreaterThan( 0 );
+			expect( metrics.halfFieldIsAboutHalf ).toBe( true );
+			expect( metrics.halfFieldOffsetLeft as number ).toBeGreaterThan( 0 );
 		} );
 	} );
 }


### PR DESCRIPTION
## Proposed changes

Draft — opened to share the findings. All six tasks in the brief are done, plus a round
of fixes from Christian's review.

This is a prototype alternative to the CSS approach in PR 51302. It is branched off
`fix/forms-container-width-followups`, not trunk, so the diff reads against that
branch's approach.

**Five commits:**

1. *Give a multistep step one wrapper element on both surfaces.* Independently
   valuable, no rendering change.
2. *Lay the step out with layout support.* Declares `supports.layout` on
   `jetpack/form-step` and deletes the CSS that was standing in for it, including the
   `> * { width: 100% }` rule from PR 51302.
3. *E2E coverage* for a centered step and for Auto and percentage field widths inside
   a step.
4. *Review fixes* — step label spacing, and dropping the step's alignment control.
5. *Keep the step's block gap on classic themes* — core only writes a `gap` into the
   generated layout rule when the theme opts into `settings.spacing.blockGap`, which a
   theme with no `theme.json` never does.

### The answer to the design question

Yes — `orientation: vertical` with **`justifyContent: 'stretch'`** as the default gives
stacked, stretched children with no `> *` rule at all. `stretch` is the whole trick:
core's flex layout maps a vertical container's justification onto `align-items`, and
`stretch` is the only value that leaves a child's width alone. Every other value shrinks
each child to its content. Nothing in core stretches flex children, which is exactly why
the step needed a `> *` rule until now.

Measured on WordPress 7.1 / Twenty Twenty-Five, on a real multistep form, in the editor
and on the front end:

* **Percentage field widths still work.** 50% field 303px, 25% field 142px, both
  identical to before. They set `width` as well as `flex-basis`, and a flex item with a
  definite cross size is not stretched.
* **Auto still behaves.** Full width, as it is today.
* **A step with no layout attribute renders identically to before** — every child's
  width and offset unchanged, on both surfaces. That is every published multistep form.

### The justification bug is gone

With the step justified center, every child centers, the paragraph included: it goes from
645px flush left to 93px centered. Under PR 51302's `> * { width: 100% }` the Justify
control moved only the percentage-width fields and silently did nothing to anything else.

Core's generated rule is three declarations:

```css
.wp-container-jetpack-form-step-is-layout-72f2b20e {
	flex-wrap: nowrap;
	flex-direction: column;
	align-items: center;
}
```

plus core's shared `body .is-layout-flex { display: flex }` and
`.is-layout-flex > :is(*, div) { margin: 0 }`. That replaces about 60 lines of
hand-written CSS across three files.

### Review round

**Step label spacing — fixed.** In All steps view the steps had started running straight
into each other. The label is a child of the step's layout container now, so core's
`.is-layout-flex > :is(*, div) { margin: 0 }` zeroed the margin it was styled with on the
class alone, and that margin was the only thing separating one step from the next: steps
are siblings of each other, not of the label, so the step's own `gap` never reaches
between them. Restored with two classes, block-start side only — adding it below the
label as well would double the space the `gap` already provides. Measured in All steps
view on a three-step form built from the Multistep Form variation and published through
the editor: label to first block 20/19/19px and step to step 19/20px, the same numbers as
the parent branch.

**Alignment control — removed.** A step always fills its container, so the control had
nothing to change. The `align` attribute stays declared so a value saved while the
support existed still round-trips rather than being dropped on the next save; nothing
reads it.

**Layout controls — unchanged, and deliberately minimal.** Justify only:
`allowOrientation: false`, `allowWrap: false`, `allowSwitching: false`,
`allowVerticalAlignment: false`. No direction, no wrap.

**Toolbar step navigation — pre-existing, root cause found, not fixed here.** With a step
selected, picking another step from the toolbar's Edit mode menu does nothing; with the
form selected it works. Verified on `fix/forms-container-width-followups` before any
commit on this branch, so it is not caused by this work. The cause is the effect at
`projects/packages/forms/src/blocks/form-step/edit.jsx:181` — while a step is selected,
it forces the active step back to itself whenever the active step moves away, so the menu
choice is immediately undone. With the form selected no step is `isSelected`, the effect
never fires, and the menu works. Happy to fix it in its own PR; it does not belong in a
layout diff.

### Corrections to the brief

* **The front end had two elements too**, not one. `gutenblock_render_form_step` wrapped
  the saved block wrapper in a second div; `save.jsx` was already a single element. Both
  surfaces are now one element, and `save.jsx` is untouched, so nothing revalidates.
* **The editor and the front end already agreed** on the step's computed flex geometry
  for the fixtures I measured. The `.is-multistep` rules match in the editor as well.

### One behavior change worth a decision

A form-level justification no longer reaches inside the step, because the step has its
own layout now. A published multistep form with the form set to Center loses the partial
centering it had (the percentage fields moved; nothing else did). Options are to accept
it, or to have the step inherit the form's justification when it has no layout attribute
of its own. Flagging rather than deciding.

Two more things for reviewers to weigh in on:

* **Which controls to expose.** Currently Justify only — `allowOrientation: false`,
  `allowSwitching: false`, `allowWrap: false`, `allowVerticalAlignment: false`. A
  horizontal step inside a vertical form is a configuration the rest of the CSS does not
  expect, so it is not offered.
* **Auto-width fields diverge under center justification.** Front end 645px, editor
  273px. The front-end `.grunion-field-wrap` sets `width: 100%` and the editor's
  equivalent does not; `> * { width: 100% }` used to hide the difference. Pre-existing,
  now visible.

### A silent coupling this uncovered

Nothing hands the step count to the form. `Contact_Form::parse()` recovers it by matching
each step's `data-wp-context` in the already-rendered markup, so the attribute's exact
spelling decides whether the form paginates. Writing it with
`WP_HTML_Tag_Processor::set_attribute()` encodes the quotes as `&quot;`, the pattern
stopped matching, and `maxSteps` and `currentStep` never reached the form context — every
step evaluated as current, the whole form rendered at once, and the navigation did
nothing, with no error anywhere. The pattern now accepts either spelling and a test
covers the count.

## Related product discussion/links

* Alternative to PR 51302.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Multistep forms need a paid plan, so on a local install force the editor flag with an
mu-plugin:

```php
add_filter( 'jetpack_block_editor_feature_flags', function ( $f ) {
	$f['multistep-form'] = true;
	return $f;
}, 20 );
```

1. Add a Form block, pick the **Multistep Form** variation, and publish.
2. On the front end and in the editor, confirm the step looks the same as it does on
   `fix/forms-container-width-followups`: blocks stacked full width, flush left, a 50%
   field half width.
3. Select a **Step** and set **Justify** to Center. Every block in the step should
   center, including a paragraph — that is the case PR 51302 cannot do.
4. Set it back to Stretch and confirm the blocks fill the step again.
5. Add a second step with a Step navigation block. Confirm Next advances and hides the
   other step.
6. Repeat on a classic theme (no `theme.json`) — that is where core's 28px block margin
   shows up.

## What was and was not verified

Everything above was measured on a real WordPress 7.1 install with the real blocks, in
the editor canvas and on the front end, on **Twenty Twenty-Five, Twenty Twenty-Four and
the classic fixture theme** — geometry read off `getBoundingClientRect()`, compared
against the same fixtures on the parent branch.

**The e2e spec has now run in CI and passes.** *Jetpack forms e2e tests* is green on both
WP latest and WP 7.0 — 17 passed, none skipped — and that includes the two new
centered-step tests on `e2e-classic-theme` and `twentytwentyfour`, editor and front end.
An earlier revision of this description said the spec had not been executed; that is no
longer true.

`jetpack test php packages/forms` passes apart from
`Form_Webhooks_Test::test_send_webhooks_blocks_localhost_hostname`, which fails
identically on the parent branch. `jetpack test js packages/forms` passes. Phan reports
the same 25 pre-existing issues as the parent branch, none new. PHPCS, ESLint, Stylelint
and `tsgo` are clean.


