### PR TITLE
Docker: put pnpm's bin directory on PATH in the monorepo image

### DIFF
--- a/tools/docker/Dockerfile.monorepo
+++ b/tools/docker/Dockerfile.monorepo
@@ -12,7 +12,7 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     JETPACK_MONOREPO_ENV=1 \
     PNPM_HOME=/usr/local/pnpm \
-    PATH="/usr/local/pnpm:${PATH}" \
+    PATH="/usr/local/pnpm/bin:${PATH}" \
     pnpm_config_update_notifier=false
 
 WORKDIR /app


### PR DESCRIPTION
## Proposed changes
* Put `/usr/local/pnpm/bin` on `PATH` in `Dockerfile.monorepo` instead of `/usr/local/pnpm`, so `pnpm` resolves inside the monorepo image again.

PR #51554 swapped the image's pnpm install from `npm install --global pnpm@$PNPM_VERSION && pnpm setup` over to pnpm's own installer. `npm install --global` put pnpm in `/usr/bin`, which is always on `PATH`, so the hardcoded `PATH` entry in the image never had to be correct. The new installer honors `PNPM_HOME`, and its layout is version-dependent:

| pnpm | binaries land in | installer exports |
|---|---|---|
| 10.28.2 | `$PNPM_HOME/pnpm` | `PATH="$PNPM_HOME:$PATH"` |
| 11.5.2 | `$PNPM_HOME/bin/pnpm` | `PATH="$PNPM_HOME/bin:$PATH"` |

We build with `PNPM_VERSION=11.5.2`, so pnpm installs to `/usr/local/pnpm/bin`, while the image still declares `PATH="/usr/local/pnpm:${PATH}"` — the pnpm 10 layout that `pnpm setup` used to produce.

The result is that every `jp` command fails before it starts:

```
$ jp install -r
Running command in monorepo container: pnpm jetpack install -r
Status: Image is up to date for automattic/jetpack-monorepo:latest
docker: Error response from daemon: failed to create task for container: ...
exec: "pnpm": executable file not found in $PATH
```

The installer does append the right `PATH` line to `/root/.bashrc`, but `docker run` never sources it, and `tools/docker/bin/monorepo` bind-mounts the host data directory over `/root` anyway, so that line is masked as well.

No CI job runs inside this image — `build-docker-monorepo.yml` only builds and pushes it — which is why the image build stayed green and this reached `latest`.

## Related product discussion/links
* None

## Does this pull request change what data or activity we track or use?
No

## Testing instructions

Confirm the bug on the published image first:

```
docker pull automattic/jetpack-monorepo:latest
docker run --rm automattic/jetpack-monorepo:latest bash -c 'command -v pnpm || echo MISSING; ls /usr/local/pnpm/bin'
```

`pnpm` is reported missing, yet `/usr/local/pnpm/bin/pnpm` exists.

Then, on this branch, rebuild the image locally and run a real command through it:

```
FORCE_PULL=1 BUILD_LOCAL=1 jp install -r
```

It should complete instead of dying with `exec: "pnpm": executable file not found in $PATH`. Any other `jp` subcommand (`jp changelog --help`, `jp build packages/connection`) is enough to confirm.

I verified this on a branch off `trunk` at `afd683d192`: `jp install -r` failed as above with the published image, and with this one-line change the locally rebuilt image ran the full install to completion (`Done in 6m 42.2s using pnpm v11.5.2`, both the pnpm and composer stages completed, exit 0).

Note that `tools/` is outside `/projects`, so no changelog entry is needed.
