### PR TITLE
Premium Analytics: drop the stale granularity attribute from the default WordAds chart instance

### DIFF
--- a/projects/packages/premium-analytics/changelog/atlas-wooa7s-1992-wordads-default-granularity
+++ b/projects/packages/premium-analytics/changelog/atlas-wooa7s-1992-wordads-default-granularity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Remove the unused granularity attribute from the default WordAds chart widget instance.

--- a/projects/packages/premium-analytics/changelog/atlas-wooa7s-1992-wordads-default-granularity
+++ b/projects/packages/premium-analytics/changelog/atlas-wooa7s-1992-wordads-default-granularity
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: removed
 
 Remove the unused granularity attribute from the default WordAds chart widget instance.

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -492,10 +492,7 @@ function get_dashboard_default_section_layouts() {
 				'jpa/wordads-chart-tabs',
 				1,
 				4,
-				2,
-				array(
-					'granularity' => 'auto',
-				)
+				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-wordads-earnings-history-widget-instance',

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -546,10 +546,11 @@ class Dashboard_Layout_Test extends BaseTestCase {
 			);
 		}
 
-		$this->assertSame(
-			array( 'granularity' => 'auto' ),
-			$layout_by_uuid['default-wordads-chart-tabs-widget-instance']['attributes']
-		);
+		// The chart's bucket follows the page interval control, so no default
+		// instance seeds attributes any more.
+		foreach ( $layout as $instance ) {
+			$this->assertArrayNotHasKey( 'attributes', $instance, $instance['uuid'] );
+		}
 		$this->assertSame(
 			get_dashboard_default_layout_for( DASHBOARD_ADS_SECTION_ID ),
 			get_dashboard_default_layout_for( 'analytics/ads' )


### PR DESCRIPTION
## Proposed changes

Since #51278 the WordAds chart's bucket size simply follows the dashboard's interval control — there is no Group by setting for a user to see or change, so a `granularity` preference in a layout means nothing to the widget. The bundled default layout was still seeding the default `jpa/wordads-chart-tabs` instance with `'granularity' => 'auto'`: dead data that every fresh Ads tab layout carried around, and the last widget-level `granularity` reference left in the package after #51532.

* Remove the `granularity` attribute from the default `jpa/wordads-chart-tabs` instance in `src/dashboard-layout.php` — the instance now seeds no attributes at all.
* Replace the test assertion that pinned `array( 'granularity' => 'auto' )` with one asserting that no Ads default instance carries an `attributes` key.

No behavior changes: the widget ignored the attribute either way. Saved user layouts that still carry the attribute are unaffected — this only touches the bundled defaults.

## Related product discussion/links

* https://linear.app/a8c/issue/WOOA7S-1992
* Flagged by @Nikschavan in the review of #51532; the widget dropped the attribute in #51278.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run the package's layout tests: `cd projects/packages/premium-analytics && composer phpunit -- --filter Dashboard_Layout_Test` — all pass.
* `git grep granularity projects/packages/premium-analytics/src projects/packages/premium-analytics/tests/php` returns nothing.
* Optionally, on a site without a saved Ads layout, load the Premium Analytics Ads tab: the WordAds chart renders exactly as before, bucketed by the page interval control.
