### PR TITLE
Premium Analytics: make the data package hooks barrel canonical

### DIFF
--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1579-hooks-barrel-canonical
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1579-hooks-barrel-canonical
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Make the data package hooks barrel canonical; no exported API change
+
+

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -3,8 +3,14 @@ export { useReportOrderAttribution } from './use-report-order-attribution';
 export { useReportCoupons } from './use-report-coupons';
 export { useReportCouponsByDate } from './use-report-coupons-by-date';
 export { useReportCustomers } from './use-report-customers';
+export { useReportCustomersByDate } from './use-report-customers-by-date';
 export { useReportConversionRate } from './use-report-conversion-rate';
+export { useReportProducts } from './use-report-products';
+export { useProductImages } from './use-product-images';
+export { useReportVisitors } from './use-report-visitors';
+export { useReportVisitorsByLocation } from './use-report-visitors-by-location';
 export { useReportBookings } from './use-report-bookings';
+export { useReportSessionsByDevice } from './use-report-sessions-by-device';
 export { useStatsSite } from './use-stats-site';
 export {
 	useStatsPost,
@@ -22,6 +28,7 @@ export {
 	type StatsPostLikesParams,
 	type StatsPostLikesResponse,
 } from './use-stats-post-likes';
+export { useStatsQuery } from './use-stats-query';
 export { useStatsTopPosts } from './use-stats-top-posts';
 export { useStatsReferrers } from './use-stats-referrers';
 export { useStatsClicks } from './use-stats-clicks';
@@ -108,6 +115,11 @@ export {
 	type StatsHourOfDayBucket,
 	type StatsHourOfDayReport,
 } from './use-stats-hour-of-day';
+export {
+	useStatsSummary,
+	type StatsSummaryParams,
+	type StatsSummaryResponse,
+} from './use-stats-summary';
 export { useStatsInsights } from './use-stats-insights';
 export type {
 	StatsInsightsParams,
@@ -172,6 +184,7 @@ export {
 	type StatsSingleVideoPost,
 	type StatsSingleVideoParams,
 	type StatsSingleVideoResponse,
+	type StatsSingleVideoTotals,
 } from './use-stats-single-video';
 export {
 	useStatsEmailOpensTimeSeries,
@@ -197,8 +210,3 @@ export type {
 	StatsAppDashboardStoreModule,
 } from './use-stats-app-dashboard-modules';
 export type { UseStatsOptions } from './use-stats-report';
-
-/**
- * @deprecated Use individual hooks instead: useReportOrders, useReportOrderAttribution, useReportCoupons
- */
-export { useReport } from './use-report';

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -2,118 +2,10 @@ export { AnalyticsQueryClientProvider, queryClient } from './providers/query-cli
 export { GlobalErrorProvider, useGlobalError } from './providers/global-error-context';
 export { globalErrorManager, type GlobalErrorType } from './providers/global-error-manager';
 export { ReportScopeProvider, useReportScope, type ReportScope } from './providers/report-scope';
-export { useReportOrders } from './hooks/use-report-orders';
-export { useReportOrderAttribution } from './hooks/use-report-order-attribution';
-export { useReportCoupons } from './hooks/use-report-coupons';
-export { useReportCouponsByDate } from './hooks/use-report-coupons-by-date';
-export { useReportCustomers } from './hooks/use-report-customers';
-export { useReportCustomersByDate } from './hooks/use-report-customers-by-date';
-export { useReportConversionRate } from './hooks/use-report-conversion-rate';
-export { useReportProducts } from './hooks/use-report-products';
-export { useProductImages } from './hooks/use-product-images';
-export { useReportVisitors } from './hooks/use-report-visitors';
-export { useReportVisitorsByLocation } from './hooks/use-report-visitors-by-location';
-export { useReportBookings } from './hooks/use-report-bookings';
-export { useReportSessionsByDevice } from './hooks/use-report-sessions-by-device';
-export { useStatsSite } from './hooks/use-stats-site';
-export { useStatsPost } from './hooks/use-stats-post';
-export type { StatsPostField, StatsPostParams, StatsPostResponse } from './hooks/use-stats-post';
-export { useStatsPostComments } from './hooks/use-stats-post-comments';
-export type {
-	StatsPostCommentsParams,
-	StatsPostCommentsResponse,
-} from './hooks/use-stats-post-comments';
-export { useStatsPostLikes } from './hooks/use-stats-post-likes';
-export type { StatsPostLikesParams, StatsPostLikesResponse } from './hooks/use-stats-post-likes';
-export { useStatsQuery } from './hooks/use-stats-query';
+export * from './hooks';
 export { latestPostQuery, postContentQuery } from './queries/latest-post-query';
 export type { LatestPost, LatestPostResponse } from './processing/latest-post';
-export { useStatsTopPosts } from './hooks/use-stats-top-posts';
-export { useStatsReferrers } from './hooks/use-stats-referrers';
-export { useStatsClicks } from './hooks/use-stats-clicks';
-export { useStatsSearchTerms } from './hooks/use-stats-search-terms';
-export { useStatsFileDownloads } from './hooks/use-stats-file-downloads';
-export { useStatsTopAuthors } from './hooks/use-stats-top-authors';
-export { useStatsLocations } from './hooks/use-stats-locations';
-export { useStatsCountryViews } from './hooks/use-stats-country-views';
-export { useStatsVideoPlays } from './hooks/use-stats-video-plays';
 export { type StatsVideoPlaysSummaryParams } from './queries/stats-video-plays-summary-query';
-export {
-	useStatsAppCommercialClassificationMutation,
-	type StatsAppCommercialClassificationParams,
-} from './hooks/use-stats-app-commercial-classification';
-export {
-	useStatsAppDashboardModuleSettings,
-	useStatsAppDashboardModuleSettingsMutation,
-} from './hooks/use-stats-app-dashboard-module-settings';
-export type { StatsAppDashboardModuleSettings } from './hooks/use-stats-app-dashboard-module-settings';
-export { useStatsAppPlanUsage } from './hooks/use-stats-app-plan-usage';
-export type {
-	StatsAppPlanPeriodUsage,
-	StatsAppPlanPriceTier,
-	StatsAppPlanUsage,
-} from './hooks/use-stats-app-plan-usage';
-export {
-	useStatsAppNotices,
-	useStatsAppNoticeMutation,
-	type StatsAppNoticeId,
-	type StatsAppNoticeMutationParams,
-	type StatsAppNoticeMutationResponse,
-	type StatsAppNotices,
-	type StatsAppNoticesParams,
-	type StatsAppNoticeStatus,
-} from './hooks/use-stats-app-notices';
-export {
-	useStatsAppPurchases,
-	type StatsAppPurchase,
-	type StatsAppPurchaseExpiryStatus,
-	type StatsAppPurchasesParams,
-	type StatsAppPurchasesResponse,
-} from './hooks/use-stats-app-purchases';
-export { useStatsArchives, type StatsArchivesResponse } from './hooks/use-stats-archives';
-export {
-	useStatsCommentFollowers,
-	useStatsCommentFollowersAllPages,
-	type StatsCommentFollowersResponse,
-} from './hooks/use-stats-comment-followers';
-export { useStatsFollowers } from './hooks/use-stats-followers';
-export type { StatsFollowersParams, StatsFollowersResponse } from './hooks/use-stats-followers';
-export {
-	useStatsComments,
-	useStatsCommentsRows,
-	type StatsCommentsParams,
-	type StatsCommentsResponse,
-	type UseStatsCommentsRowsArgs,
-	type UseStatsCommentsRowsResult,
-} from './hooks/use-stats-comments';
-export {
-	useStatsSubscribersCounts,
-	useStatsSubscribersReport,
-	type StatsSubscribersCounts,
-	type StatsSubscribersCountsParams,
-	type StatsSubscribersCountsResponse,
-	type StatsSubscribersParams,
-	type StatsSubscribersResponse,
-	type StatsSubscribersUnit,
-} from './hooks/use-stats-subscribers';
-export {
-	useStatsStreak,
-	type StatsStreakParams,
-	type StatsStreakResponse,
-} from './hooks/use-stats-streak';
-export {
-	useStatsVisits,
-	type StatsVisitsParams,
-	type StatsVisitsResponse,
-	type StatsVisitsStatField,
-	type StatsVisitsStatFields,
-} from './hooks/use-stats-visits';
-export {
-	useStatsHourOfDay,
-	type StatsHourOfDayParams,
-	type StatsHourOfDayBucket,
-	type StatsHourOfDayReport,
-} from './hooks/use-stats-hour-of-day';
 export {
 	aggregateStatsDrilldownRows,
 	bucketStatsTimeSeries,
@@ -132,104 +24,8 @@ export type {
 	StatsDrilldownRowContext,
 	StatsDrilldownSourceReport,
 } from './processing/stats';
-export {
-	useStatsSummary,
-	type StatsSummaryParams,
-	type StatsSummaryResponse,
-} from './hooks/use-stats-summary';
-export { useStatsInsights } from './hooks/use-stats-insights';
-export type {
-	StatsInsightsParams,
-	StatsInsightsResponse,
-	StatsInsightsYear,
-} from './hooks/use-stats-insights';
-export { useStatsUtm } from './hooks/use-stats-utm';
-export type { StatsUtmParams, StatsUtmResponse } from './hooks/use-stats-utm';
-export { useStatsHighlights } from './hooks/use-stats-highlights';
-export type { StatsHighlightsParams, StatsHighlightsResponse } from './hooks/use-stats-highlights';
-export { useStatsTags, type StatsTagsParams, type StatsTagsResponse } from './hooks/use-stats-tags';
-export { useStatsDevices } from './hooks/use-stats-devices';
-export {
-	useStatsAppSiteHasNeverPublishedPost,
-	type StatsAppSiteHasNeverPublishedPostParams,
-	type StatsAppSiteHasNeverPublishedPostResponse,
-} from './hooks/use-stats-app-site-has-never-published-post';
-export {
-	useStatsWordAdsStats,
-	useStatsWordAdsEarnings,
-	type StatsWordAdsEarnings,
-	type StatsWordAdsEarningsBreakdown,
-	type StatsWordAdsEarningsParams,
-	type StatsWordAdsEarningsPeriod,
-	type StatsWordAdsEarningsRaw,
-	type StatsWordAdsEarningsRawBreakdown,
-	type StatsWordAdsEarningsRawPeriod,
-	type StatsWordAdsEarningsRawResponse,
-	type StatsWordAdsEarningsResponse,
-	type StatsWordAdsDataPoint,
-	type StatsWordAdsParams,
-	type StatsWordAdsRawField,
-	type StatsWordAdsRawResponse,
-	type StatsWordAdsResponse,
-} from './hooks/use-stats-wordads';
-export {
-	useStatsAppReferrersSpam,
-	useStatsAppReferrersMarkSpamMutation,
-	useStatsAppReferrersUnmarkSpamMutation,
-} from './hooks/use-stats-app-referrers-spam';
-export type {
-	StatsAppReferrersSpamMutationParams,
-	StatsAppReferrersSpamMutationResponse,
-	StatsAppReferrersSpamResponse,
-} from './hooks/use-stats-app-referrers-spam';
-export {
-	useStatsEmailOpensBreakdown,
-	useStatsEmailClicksBreakdown,
-	type StatsEmailBreakdown,
-	type StatsEmailClicksBreakdown,
-	type StatsEmailOpensBreakdown,
-} from './hooks/use-stats-email-breakdown';
-export {
-	useStatsEmailSummary,
-	type StatsEmailSummary,
-	type StatsEmailSummaryParams,
-	type StatsEmailSummarySortField,
-} from './hooks/use-stats-email-summary';
 export type { StatsEmailSummaryItem } from './processing/stats';
-export {
-	useStatsSingleVideo,
-	type StatsSingleVideoDataPoint,
-	type StatsSingleVideoPage,
-	type StatsSingleVideoPost,
-	type StatsSingleVideoParams,
-	type StatsSingleVideoResponse,
-	type StatsSingleVideoTotals,
-} from './hooks/use-stats-single-video';
-export {
-	useStatsEmailOpensTimeSeries,
-	useStatsEmailClicksTimeSeries,
-	type StatsEmailTimeSeriesParams,
-	type StatsEmailTimeSeriesPeriod,
-	type StatsEmailTimeSeriesReport,
-	type StatsEmailTimeSeriesDataPoint,
-	type StatsEmailTimeSeriesSummary,
-} from './hooks/use-stats-email-time-series';
-export {
-	useStatsAppDashboardModules,
-	useStatsAppDashboardModulesMutation,
-} from './hooks/use-stats-app-dashboard-modules';
-export type {
-	StatsAppDashboardModules,
-	StatsAppDashboardModulesMutationResponse,
-	StatsAppDashboardModuleValue,
-	StatsAppDashboardTrafficModule,
-	StatsAppDashboardInsightsModule,
-	StatsAppDashboardSubscribersModule,
-	StatsAppDashboardWordAdsModule,
-	StatsAppDashboardStoreModule,
-} from './hooks/use-stats-app-dashboard-modules';
 export type { StatsDeviceProperty } from './queries/stats-devices-query';
-export type { UseStatsOptions } from './hooks/use-stats-report';
 export { prefetchReport } from './prefetch';
 export {
 	normalizeReportParams,
@@ -351,7 +147,6 @@ export type {
 	StatsVideoPlaysItem,
 } from './processing/stats';
 export { compareEmailBreakdownItems } from './processing/stats';
-export type { StatsCommentFollowersParams } from './queries/stats-comment-followers-query';
 export type { StatsReportParams } from './queries/stats-query';
 export {
 	getStatsPeriodFromInterval,


### PR DESCRIPTION
Fixes WOOA7S-1579

## Why

`packages/data/src/index.ts` re-exported every hook individually while `packages/data/src/hooks/index.ts` — intended to be the hooks barrel — had drifted and was missing eight public hooks. The duplication meant every new hook had to be exported twice, and forgetting one side silently widened the drift. This follow-up (from a review note on #49778) makes the hooks barrel canonical so hooks are declared in one place.

## Proposed changes

* Add the public hooks that had drifted out of `packages/data/src/hooks/index.ts`: `useReportCustomersByDate`, `useReportProducts`, `useProductImages`, `useReportVisitors`, `useReportVisitorsByLocation`, `useReportSessionsByDevice`, `useStatsQuery`, and `useStatsSummary` (with its param/response types), plus the `StatsSingleVideoTotals` type.
* Replace the per-hook re-export list in `packages/data/src/index.ts` with a single `export * from './hooks'`, and drop the now-duplicated `StatsCommentFollowersParams` re-export.
* Stop exporting the deprecated, internal-only `useReport` from the hooks barrel. It was never exported from the package root, and every internal consumer imports it relatively from `./use-report`, so keeping it out of the barrel keeps it internal instead of newly exposing it via the star re-export.

The package's exported surface is byte-identical: a programmatic before/after comparison of `@jetpack-premium-analytics/data`'s exports shows no names added or removed.

## Verification

No user-visible change — this is a pure re-export refactor, verified statically and against the package build:

<details>
<summary>Output</summary>

```text
$ node export-diff.mjs   # TypeScript checker comparison of the root barrel, origin/trunk vs HEAD
REMOVED from root barrel: (none)
ADDED to root barrel: (none)

$ pnpm run typecheck     # passed
$ pnpm exec jest --config=tests/jest.config.cjs packages/data
Test Suites: 65 passed, 65 total
Tests:       579 passed, 579 total

$ pnpm run build         # premium-analytics package build
🎉 All packages built successfully! (5504ms total)
```

An independent reviewer pass reproduced the export comparison (127 value exports and 205 type exports before and after, no changes) and confirmed no consumer imports `useReport` or the hooks barrel path directly.

</details>

## Related product discussion/links

* WOOA7S-1579
* Originating review note: https://github.com/Automattic/jetpack/pull/49778#discussion_r3449543172

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Confirm `packages/data/src/hooks/index.ts` now exports every public hook (the eight listed above were missing) and no longer exports the deprecated `useReport`.
* Confirm `packages/data/src/index.ts` re-exports hooks via `export * from './hooks'` with no per-hook lines left.
* Run `pnpm run typecheck` and `pnpm run test` in `projects/packages/premium-analytics` — both pass with no changes needed anywhere else, demonstrating the exported surface is unchanged.
