### PR TITLE
Premium Analytics: chart the email timeline's selected hourly window, not every fetched bucket

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1840-email-hourly-overfetch
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1840-email-hourly-overfetch
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Email timeline: request only the hourly buckets the selected window needs and trim the chart and totals to that window.
+Email timeline: request the smallest hourly window the endpoint can serve and trim the chart and totals to the selected window.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1840-email-hourly-overfetch
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1840-email-hourly-overfetch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Email timeline: request only the hourly buckets the selected window needs and trim the chart and totals to that window.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -236,6 +236,72 @@ describe( 'Stats time-series normalizer', () => {
 		expect( result.summary ).toEqual( expect.objectContaining( { clicks_count: 11 } ) );
 	} );
 
+	it( 'trims buckets outside a start_date/end_date window and sums only the rest', () => {
+		// The last-24-hours shape: the endpoint anchors hourly buckets on the
+		// start day's midnight, so the payload carries leading buckets before
+		// the window's 09:00 start that must not be plotted or summed.
+		const result = sanitizeStatsEmailTimeSeriesResponse(
+			{
+				timeline: {
+					unit: 'hour',
+					fields: [ 'date', 'hour', 'opens_count' ],
+					data: [
+						[ '2026-06-14', 8, 1 ],
+						[ '2026-06-14', 9, 2 ],
+						[ '2026-06-15', 8, 4 ],
+						[ '2026-06-15', 9, 8 ],
+					],
+				},
+			},
+			{
+				period: 'hour',
+				start_date: '2026-06-14T09:00:00.000-04:00',
+				end_date: '2026-06-15T08:59:59.999-04:00',
+			}
+		);
+
+		expect( result.data.map( point => point.time_interval ) ).toEqual( [
+			'2026-06-14 09:00',
+			'2026-06-15 08:00',
+		] );
+		expect( result.summary ).toEqual(
+			expect.objectContaining( {
+				opens_count: 6,
+				date_start: '2026-06-14T09:00:00',
+				date_end: '2026-06-15T08:59:59',
+			} )
+		);
+	} );
+
+	it( 'widens bare-date window bounds to whole days and needs both bounds to trim', () => {
+		const timeline = {
+			timeline: {
+				unit: 'day',
+				fields: [ 'date', 'opens_count' ],
+				data: [
+					[ '2026-06-15', 3 ],
+					[ '2026-06-16', 5 ],
+				],
+			},
+		};
+
+		const windowed = sanitizeStatsEmailTimeSeriesResponse( timeline, {
+			period: 'day',
+			start_date: '2026-06-15',
+			end_date: '2026-06-16',
+		} );
+		expect( windowed.data ).toHaveLength( 2 );
+		expect( windowed.summary ).toEqual( expect.objectContaining( { opens_count: 8 } ) );
+
+		// Range-bounded endpoints (e.g. visits) reach the sanitizer with a
+		// start_date but never an end_date; a lone bound must not trim.
+		const oneBound = sanitizeStatsEmailTimeSeriesResponse( timeline, {
+			period: 'day',
+			start_date: '2026-06-16',
+		} );
+		expect( oneBound.data ).toHaveLength( 2 );
+	} );
+
 	it( 'normalizes hour 0 and string-typed hour values into padded per-hour buckets', () => {
 		const result = sanitizeStatsEmailTimeSeriesResponse(
 			{

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -236,7 +236,7 @@ describe( 'Stats time-series normalizer', () => {
 		expect( result.summary ).toEqual( expect.objectContaining( { clicks_count: 11 } ) );
 	} );
 
-	it( 'trims buckets outside a start_date/end_date window and sums only the rest', () => {
+	it( 'trims buckets outside a window_start/window_end window and sums only the rest', () => {
 		// The last-24-hours shape: the endpoint anchors hourly buckets on the
 		// start day's midnight, so the payload carries leading buckets before
 		// the window's 09:00 start that must not be plotted or summed.
@@ -255,8 +255,8 @@ describe( 'Stats time-series normalizer', () => {
 			},
 			{
 				period: 'hour',
-				start_date: '2026-06-14T09:00:00.000-04:00',
-				end_date: '2026-06-15T08:59:59.999-04:00',
+				window_start: '2026-06-14T09:00:00.000-04:00',
+				window_end: '2026-06-15T08:59:59.999-04:00',
 			}
 		);
 
@@ -292,8 +292,8 @@ describe( 'Stats time-series normalizer', () => {
 
 		const spaceSeparated = sanitizeStatsEmailTimeSeriesResponse( timeline, {
 			period: 'hour',
-			start_date: '2026-06-14 09:00:00-04:00',
-			end_date: '2026-06-15 08:59:59-04:00',
+			window_start: '2026-06-14 09:00:00-04:00',
+			window_end: '2026-06-15 08:59:59-04:00',
 		} );
 		expect( spaceSeparated.data.map( point => point.time_interval ) ).toEqual( [
 			'2026-06-14 09:00',
@@ -302,8 +302,8 @@ describe( 'Stats time-series normalizer', () => {
 
 		const noSeconds = sanitizeStatsEmailTimeSeriesResponse( timeline, {
 			period: 'hour',
-			start_date: '2026-06-14T09:00-04:00',
-			end_date: '2026-06-15T08:59-04:00',
+			window_start: '2026-06-14T09:00-04:00',
+			window_end: '2026-06-15T08:59-04:00',
 		} );
 		expect( noSeconds.data.map( point => point.time_interval ) ).toEqual( [
 			'2026-06-14 09:00',
@@ -325,7 +325,7 @@ describe( 'Stats time-series normalizer', () => {
 					],
 				},
 			},
-			{ period: 'day', start_date: '2026-06-15', end_date: '2026-06-15' }
+			{ period: 'day', window_start: '2026-06-15', window_end: '2026-06-15' }
 		);
 
 		expect( result.data ).toHaveLength( 2 );
@@ -346,19 +346,27 @@ describe( 'Stats time-series normalizer', () => {
 
 		const windowed = sanitizeStatsEmailTimeSeriesResponse( timeline, {
 			period: 'day',
-			start_date: '2026-06-15',
-			end_date: '2026-06-16',
+			window_start: '2026-06-15',
+			window_end: '2026-06-16',
 		} );
 		expect( windowed.data ).toHaveLength( 2 );
 		expect( windowed.summary ).toEqual( expect.objectContaining( { opens_count: 8 } ) );
 
-		// Range-bounded endpoints (e.g. visits) reach the sanitizer with a
-		// start_date but never an end_date; a lone bound must not trim.
+		// A lone bound must not trim, and neither must the generic
+		// start_date/end_date request params — range-bounded endpoints (e.g.
+		// visits) reach this sanitizer with those and must keep every bucket.
 		const oneBound = sanitizeStatsEmailTimeSeriesResponse( timeline, {
 			period: 'day',
-			start_date: '2026-06-16',
+			window_start: '2026-06-16',
 		} );
 		expect( oneBound.data ).toHaveLength( 2 );
+
+		const requestDates = sanitizeStatsEmailTimeSeriesResponse( timeline, {
+			period: 'day',
+			start_date: '2026-06-16',
+			end_date: '2026-06-16',
+		} );
+		expect( requestDates.data ).toHaveLength( 2 );
 	} );
 
 	it( 'normalizes hour 0 and string-typed hour values into padded per-hour buckets', () => {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -273,10 +273,7 @@ describe( 'Stats time-series normalizer', () => {
 		);
 	} );
 
-	it( 'reads window bounds as the wall clock written, in every accepted timestamp shape', () => {
-		// Report params can carry a space-separated time or omit the seconds
-		// (the datetime package's SITE_TIMESTAMP shapes); the trim must read
-		// the same wall clock from all of them.
+	it( 'reads window bounds as the wall clock written, only in pipeline-supported shapes', () => {
 		const timeline = {
 			timeline: {
 				unit: 'hour',
@@ -290,16 +287,8 @@ describe( 'Stats time-series normalizer', () => {
 			},
 		};
 
-		const spaceSeparated = sanitizeStatsEmailTimeSeriesResponse( timeline, {
-			period: 'hour',
-			window_start: '2026-06-14 09:00:00-04:00',
-			window_end: '2026-06-15 08:59:59-04:00',
-		} );
-		expect( spaceSeparated.data.map( point => point.time_interval ) ).toEqual( [
-			'2026-06-14 09:00',
-			'2026-06-15 08:00',
-		] );
-
+		// A seconds-less T-separated bound reads the same wall clock as the
+		// full ISO shape the presets emit.
 		const noSeconds = sanitizeStatsEmailTimeSeriesResponse( timeline, {
 			period: 'hour',
 			window_start: '2026-06-14T09:00-04:00',
@@ -309,6 +298,16 @@ describe( 'Stats time-series normalizer', () => {
 			'2026-06-14 09:00',
 			'2026-06-15 08:00',
 		] );
+
+		// Space-separated datetimes degrade upstream (getDatePart splits on T
+		// only, so the day count is already wrong before the request is sized);
+		// the trim must stay disabled for them rather than half-apply.
+		const spaceSeparated = sanitizeStatsEmailTimeSeriesResponse( timeline, {
+			period: 'hour',
+			window_start: '2026-06-14 09:00:00-04:00',
+			window_end: '2026-06-15 08:59:59-04:00',
+		} );
+		expect( spaceSeparated.data ).toHaveLength( 4 );
 	} );
 
 	it( 'keeps rows whose bucket bounds are not comparable wall clocks', () => {
@@ -367,6 +366,22 @@ describe( 'Stats time-series normalizer', () => {
 			end_date: '2026-06-16',
 		} );
 		expect( requestDates.data ).toHaveLength( 2 );
+
+		// A bound the timestamp reader rejects, or an inverted window, must
+		// disable the trim rather than silently empty the chart.
+		const invalidBound = sanitizeStatsEmailTimeSeriesResponse( timeline, {
+			period: 'day',
+			window_start: '2026-06-15',
+			window_end: '2026-06-16T99:00:00',
+		} );
+		expect( invalidBound.data ).toHaveLength( 2 );
+
+		const inverted = sanitizeStatsEmailTimeSeriesResponse( timeline, {
+			period: 'day',
+			window_start: '2026-06-16',
+			window_end: '2026-06-15',
+		} );
+		expect( inverted.data ).toHaveLength( 2 );
 	} );
 
 	it( 'normalizes hour 0 and string-typed hour values into padded per-hour buckets', () => {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -273,6 +273,65 @@ describe( 'Stats time-series normalizer', () => {
 		);
 	} );
 
+	it( 'reads window bounds as the wall clock written, in every accepted timestamp shape', () => {
+		// Report params can carry a space-separated time or omit the seconds
+		// (the datetime package's SITE_TIMESTAMP shapes); the trim must read
+		// the same wall clock from all of them.
+		const timeline = {
+			timeline: {
+				unit: 'hour',
+				fields: [ 'date', 'hour', 'opens_count' ],
+				data: [
+					[ '2026-06-14', 8, 1 ],
+					[ '2026-06-14', 9, 2 ],
+					[ '2026-06-15', 8, 4 ],
+					[ '2026-06-15', 9, 8 ],
+				],
+			},
+		};
+
+		const spaceSeparated = sanitizeStatsEmailTimeSeriesResponse( timeline, {
+			period: 'hour',
+			start_date: '2026-06-14 09:00:00-04:00',
+			end_date: '2026-06-15 08:59:59-04:00',
+		} );
+		expect( spaceSeparated.data.map( point => point.time_interval ) ).toEqual( [
+			'2026-06-14 09:00',
+			'2026-06-15 08:00',
+		] );
+
+		const noSeconds = sanitizeStatsEmailTimeSeriesResponse( timeline, {
+			period: 'hour',
+			start_date: '2026-06-14T09:00-04:00',
+			end_date: '2026-06-15T08:59-04:00',
+		} );
+		expect( noSeconds.data.map( point => point.time_interval ) ).toEqual( [
+			'2026-06-14 09:00',
+			'2026-06-15 08:00',
+		] );
+	} );
+
+	it( 'keeps rows whose bucket bounds are not comparable wall clocks', () => {
+		// An unparseable period label echoes back verbatim as its own bounds;
+		// the trim must not silently discard such a row (and its counts).
+		const result = sanitizeStatsEmailTimeSeriesResponse(
+			{
+				timeline: {
+					unit: 'day',
+					fields: [ 'date', 'opens_count' ],
+					data: [
+						[ '2026-06-15', 3 ],
+						[ 'not-a-date', 5 ],
+					],
+				},
+			},
+			{ period: 'day', start_date: '2026-06-15', end_date: '2026-06-15' }
+		);
+
+		expect( result.data ).toHaveLength( 2 );
+		expect( result.summary ).toEqual( expect.objectContaining( { opens_count: 8 } ) );
+	} );
+
 	it( 'widens bare-date window bounds to whole days and needs both bounds to trim', () => {
 		const timeline = {
 			timeline: {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/bucket-window.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/bucket-window.ts
@@ -1,0 +1,138 @@
+/**
+ * The trim window for quantity-based time-series endpoints — the email
+ * timeline's special case, owned end to end by this module. That endpoint
+ * resolves its `date` param to a calendar day and returns `quantity` buckets
+ * forward from that day's midnight regardless of the time of day the window
+ * starts (verified against production), so a mid-day window comes back with
+ * leading out-of-window buckets. The query side sizes the request with
+ * `windowEndHour` and sends the window through `toStatsBucketWindowParams`;
+ * only `sanitizeStatsEmailTimeSeriesResponse` turns those params back into a
+ * bucket filter (`createStatsBucketWindowFilter`) and passes it to the shared
+ * sanitizer — for every other sanitizer the pair is inert, so range-bounded
+ * endpoints (visits, subscribers, wordads) can never be trimmed.
+ */
+
+/**
+ * External dependencies
+ */
+import { formatDatePartWithTime, readSiteTimestamp } from '@jetpack-premium-analytics/datetime';
+/**
+ * Internal dependencies
+ */
+import type { StatsQueryParams } from '../../utils/stats-params';
+
+// One reader decides which timestamp shapes the window supports: bare dates
+// and T-separated datetimes, exactly what the stats-params pipeline itself
+// carries — getDatePart, which derives day counts upstream, splits on T
+// alone, so a space-separated datetime already degrades there and must not
+// size or trim a window here either.
+function readWindowTimestamp( value: unknown ) {
+	const timestamp = typeof value === 'string' ? readSiteTimestamp( value ) : null;
+
+	return timestamp?.isValid && ! timestamp.value.includes( ' ' ) ? timestamp : null;
+}
+
+/**
+ * The wall-clock hour a window's end names; a bare date, or a value the
+ * reader rejects, ends at hour 23.
+ *
+ * @param value - The window's end timestamp, as the report params carry it.
+ * @return The end hour, 0–23.
+ */
+export function windowEndHour( value?: string ): number {
+	const timestamp = readWindowTimestamp( value );
+
+	return timestamp && timestamp.value.includes( 'T' ) ? timestamp.parts[ 3 ] : 23;
+}
+
+const padTimePart = ( part: number ) => String( part ).padStart( 2, '0' );
+
+const EDGE_FALLBACKS = {
+	start: { time: '00:00:00', seconds: '00' },
+	end: { time: '23:59:59', seconds: '59' },
+} as const;
+
+// A window bound in the same timezone-naive wall-clock shape the bucket
+// labels carry: the value's own date and time parts as written, any offset
+// ignored. A bare date widens to its edge's whole-day time; a seconds-less
+// time takes the edge's seconds.
+function toWindowBound( value: unknown, edge: keyof typeof EDGE_FALLBACKS ) {
+	const timestamp = readWindowTimestamp( value );
+
+	if ( ! timestamp ) {
+		return undefined;
+	}
+
+	const [ year, month, day, hours, minutes, seconds ] = timestamp.parts;
+	const datePart = `${ String( year ).padStart( 4, '0' ) }-${ padTimePart(
+		month + 1
+	) }-${ padTimePart( day ) }`;
+	// The reader guarantees these shapes, so the probes only ask what was
+	// written: a time at all, and seconds within it.
+	const hasTime = timestamp.value.includes( 'T' );
+	const hasSeconds = /T\d{2}:\d{2}:\d{2}/.test( timestamp.value );
+	const time = hasTime
+		? `${ padTimePart( hours ) }:${ padTimePart( minutes ) }:${
+				hasSeconds ? padTimePart( seconds ) : EDGE_FALLBACKS[ edge ].seconds
+		  }`
+		: EDGE_FALLBACKS[ edge ].time;
+
+	return formatDatePartWithTime( datePart, time );
+}
+
+// Bucket bounds are comparable against a window bound only in this shape; a
+// row whose bounds fall outside it (an unparseable period label echoed back
+// verbatim) is kept rather than silently discarded.
+const isWallClockStamp = ( value: string ) => /^\d{4}-\d{2}-\d{2}T/.test( value );
+
+export type StatsBucketFilter = ( range: { date_start: string; date_end: string } ) => boolean;
+
+/**
+ * The sanitizer-side half of the window contract: turns the
+ * `window_start`/`window_end` sanitizer params back into a bucket filter, or
+ * `undefined` when the query names no usable window — a missing or invalid
+ * bound, and an inverted window (a hand-edited deep link), all mean "keep
+ * every bucket" rather than a silently emptied chart.
+ *
+ * @param query - The sanitizer's merged query params.
+ * @return The filter to keep in-window buckets, or `undefined` for no trim.
+ */
+export function createStatsBucketWindowFilter(
+	query?: StatsQueryParams
+): StatsBucketFilter | undefined {
+	const start = toWindowBound( query?.window_start, 'start' );
+	const end = toWindowBound( query?.window_end, 'end' );
+
+	if ( ! start || ! end || start > end ) {
+		return undefined;
+	}
+
+	// Raw lexicographic comparison — the same rule as the shared sanitizer's
+	// compareBucketBounds, never localeCompare (a collation may ignore the
+	// separators these bounds carry).
+	return range =>
+		! isWallClockStamp( range.date_start ) ||
+		! isWallClockStamp( range.date_end ) ||
+		( range.date_end >= start && range.date_start <= end );
+}
+
+/**
+ * The query-side half of the window contract: the sanitizer params a
+ * windowed query opts into trimming with. Dedicated names, never the generic
+ * `start_date`/`end_date` — those reach the shared sanitizer from
+ * range-bounded endpoints that must not be trimmed — and stripped from the
+ * HTTP request by `statsQueryParamsToApiParams`.
+ *
+ * @param params            - The query's stats params.
+ * @param params.start_date - The window's start timestamp.
+ * @param params.end_date   - The window's end timestamp.
+ * @return The window pair, or `undefined` when the params name no full window.
+ */
+export function toStatsBucketWindowParams( params: {
+	start_date?: string;
+	end_date?: string;
+} ): Pick< StatsQueryParams, 'window_start' | 'window_end' > | undefined {
+	return params.start_date && params.end_date
+		? { window_start: params.start_date, window_end: params.end_date }
+		: undefined;
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -48,6 +48,7 @@ export {
 	sanitizeStatsTimeSeriesResponse,
 	sanitizeStatsEmailTimeSeriesResponse,
 } from './time-series';
+export { toStatsBucketWindowParams, windowEndHour, type StatsBucketFilter } from './bucket-window';
 export { sanitizeStatsVisitsResponse } from './visits';
 export { sanitizeStatsHourOfDayResponse } from './hour-of-day';
 export { sanitizeStatsInsightsResponse } from './insights';

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -1,8 +1,4 @@
-import {
-	formatDatePartWithTime,
-	getDatePart,
-	readSiteTimestamp,
-} from '@jetpack-premium-analytics/datetime';
+import { formatDatePartWithTime, getDatePart } from '@jetpack-premium-analytics/datetime';
 import {
 	endOfISOWeek,
 	endOfMonth,
@@ -15,6 +11,7 @@ import {
 	startOfYear,
 } from 'date-fns';
 import { safeParseFloat } from '../../utils/parsing';
+import { createStatsBucketWindowFilter, type StatsBucketFilter } from './bucket-window';
 import {
 	coerceStatsArray,
 	coerceStatsRecord,
@@ -267,47 +264,6 @@ function getTimeSeriesSummarySidecars( response: StatsRecord ) {
 	};
 }
 
-const padTimePart = ( part: number ) => String( part ).padStart( 2, '0' );
-
-// A trim-window bound in the same timezone-naive wall-clock shape the bucket
-// labels carry: the value's own date and time parts as written, any offset
-// ignored. Validated by the datetime package's single timestamp reader so the
-// accepted shapes cannot drift from the rest of the package, then narrowed to
-// what the stats-params pipeline itself accepts — bare dates and T-separated
-// datetimes; getDatePart splits on T only, so a space-separated value already
-// degrades the day count upstream and must not trim here either. An invalid
-// or unsupported value yields no bound (and so no trim). A bare date widens
-// to the whole day via the fallback time; a seconds-less time takes the
-// fallback seconds.
-function toWallClockBound( value: unknown, fallbackTime: string, fallbackSeconds: string ) {
-	const timestamp = typeof value === 'string' ? readSiteTimestamp( value ) : null;
-
-	if ( ! timestamp?.isValid || timestamp.value.includes( ' ' ) ) {
-		return undefined;
-	}
-
-	const [ year, month, day, hours, minutes, seconds ] = timestamp.parts;
-	const datePart = `${ String( year ).padStart( 4, '0' ) }-${ padTimePart(
-		month + 1
-	) }-${ padTimePart( day ) }`;
-	// The reader guarantees these shapes, so the probes only ask what was
-	// written: a time at all, and seconds within it.
-	const hasTime = timestamp.value.includes( 'T' );
-	const hasSeconds = /T\d{2}:\d{2}:\d{2}/.test( timestamp.value );
-	const time = hasTime
-		? `${ padTimePart( hours ) }:${ padTimePart( minutes ) }:${
-				hasSeconds ? padTimePart( seconds ) : fallbackSeconds
-		  }`
-		: fallbackTime;
-
-	return formatDatePartWithTime( datePart, time );
-}
-
-// Bucket bounds are comparable against a window bound only in this shape;
-// a row whose bounds fall outside it (an unparseable period label echoed
-// back verbatim) is kept rather than silently discarded.
-const isWallClockStamp = ( value: string ) => /^\d{4}-\d{2}-\d{2}T/.test( value );
-
 export function isStatsTimeSeriesPayload( payload: unknown ) {
 	const response = coerceStatsRecord( payload );
 
@@ -327,7 +283,8 @@ export function isStatsTimeSeriesPayload( payload: unknown ) {
 
 export function sanitizeStatsTimeSeriesResponse(
 	payload: unknown,
-	query?: StatsQueryParams
+	query?: StatsQueryParams,
+	keepBucket?: StatsBucketFilter
 ): StatsTimeSeriesReport {
 	const response = coerceStatsRecord( payload );
 	const unit = String( response.unit ?? query?.period ?? 'day' );
@@ -336,30 +293,10 @@ export function sanitizeStatsTimeSeriesResponse(
 
 		return { row, range: getRowIntervalFields( row, rawPeriod, unit ) };
 	} );
-	// Trim to the caller's window when it names one — before the summary, so
-	// out-of-window buckets inflate neither the totals nor the chart.
-	// Quantity-based endpoints (the email timeline) anchor hourly buckets on
-	// the start day's midnight regardless of the requested time of day, so a
-	// mid-day window comes back with leading out-of-window buckets. The opt-in
-	// is the dedicated `window_start`/`window_end` pair (sent via
-	// `sanitizerParams`), never the generic `start_date`/`end_date` request
-	// params — those reach this sanitizer from range-bounded endpoints (visits,
-	// subscribers, wordads) that must not have buckets dropped. Rows whose
-	// bounds aren't comparable wall clocks are kept, not dropped.
-	const windowStart = toWallClockBound( query?.window_start, '00:00:00', '00' );
-	const windowEnd = toWallClockBound( query?.window_end, '23:59:59', '59' );
-	// An inverted window (a hand-edited deep link) falls back to no trim
-	// rather than silently emptying the chart.
-	const kept =
-		windowStart && windowEnd && windowStart <= windowEnd
-			? buckets.filter(
-					( { range } ) =>
-						! isWallClockStamp( range.date_start ) ||
-						! isWallClockStamp( range.date_end ) ||
-						( compareBucketBounds( range.date_end, windowStart ) >= 0 &&
-							compareBucketBounds( range.date_start, windowEnd ) <= 0 )
-			  )
-			: buckets;
+	// Filter before the summary, so dropped buckets inflate neither the totals
+	// nor the chart. Only an endpoint-specific sanitizer supplies a filter (see
+	// bucket-window.ts); the shared path keeps every bucket.
+	const kept = keepBucket ? buckets.filter( ( { range } ) => keepBucket( range ) ) : buckets;
 	const summary = kept.reduce< Record< string, number > >( ( totals, { row } ) => {
 		Object.entries( row ).forEach( ( [ key, value ] ) => {
 			if ( ! nonMetricFields.includes( key ) && typeof value === 'number' ) {
@@ -432,5 +369,11 @@ export function sanitizeStatsEmailTimeSeriesResponse(
 			? { ...timeline, fields: [ ...fields, 'hour' ] }
 			: timeline;
 
-	return sanitizeStatsTimeSeriesResponse( normalizedTimeline, query );
+	// The email timeline is quantity-based and midnight-anchored, so its
+	// query opts into the bucket-window trim (see bucket-window.ts).
+	return sanitizeStatsTimeSeriesResponse(
+		normalizedTimeline,
+		query,
+		createStatsBucketWindowFilter( query )
+	);
 }

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -273,7 +273,7 @@ const WALL_CLOCK_PARTS = /^(\d{4}-\d{2}-\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))
 // labels carry: the value's own date and time parts as written, any offset
 // ignored. A bare date widens to the whole day via the fallback time, whose
 // seconds also fill in for a seconds-less time.
-function toWallClockBound( value: string | undefined, fallbackTime: string ) {
+function toWallClockBound( value: unknown, fallbackTime: string ) {
 	const match = typeof value === 'string' ? WALL_CLOCK_PARTS.exec( value.trim() ) : null;
 
 	if ( ! match ) {
@@ -325,13 +325,14 @@ export function sanitizeStatsTimeSeriesResponse(
 	// out-of-window buckets inflate neither the totals nor the chart.
 	// Quantity-based endpoints (the email timeline) anchor hourly buckets on
 	// the start day's midnight regardless of the requested time of day, so a
-	// mid-day window comes back with leading out-of-window buckets. Request
-	// params never reach a sanitizer as `end_date` (statsQueryParamsToApiParams
-	// renames it to `date` — an invariant pinned in the stats-params tests), so
-	// only callers passing a window through `sanitizerParams` opt in. Rows
-	// whose bounds aren't comparable wall clocks are kept, not dropped.
-	const windowStart = toWallClockBound( query?.start_date, '00:00:00' );
-	const windowEnd = toWallClockBound( query?.end_date, '23:59:59' );
+	// mid-day window comes back with leading out-of-window buckets. The opt-in
+	// is the dedicated `window_start`/`window_end` pair (sent via
+	// `sanitizerParams`), never the generic `start_date`/`end_date` request
+	// params — those reach this sanitizer from range-bounded endpoints (visits,
+	// subscribers, wordads) that must not have buckets dropped. Rows whose
+	// bounds aren't comparable wall clocks are kept, not dropped.
+	const windowStart = toWallClockBound( query?.window_start, '00:00:00' );
+	const windowEnd = toWallClockBound( query?.window_end, '23:59:59' );
 	const kept =
 		windowStart && windowEnd
 			? buckets.filter(

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -263,6 +263,21 @@ function getTimeSeriesSummarySidecars( response: StatsRecord ) {
 	};
 }
 
+// A trim-window bound in the same timezone-naive wall-clock shape the bucket
+// labels carry: the value's own date and time parts as written, any offset
+// ignored. A bare date widens to the whole day via the fallback time.
+function toWallClockBound( value: string | undefined, fallbackTime: string ) {
+	const datePart = getDatePart( value );
+
+	if ( ! datePart || ! /^\d{4}-\d{2}-\d{2}$/.test( datePart ) ) {
+		return undefined;
+	}
+
+	const time = typeof value === 'string' && value.match( /[T ](\d{2}:\d{2}:\d{2})/ );
+
+	return formatDatePartWithTime( datePart, time ? time[ 1 ] : fallbackTime );
+}
+
 export function isStatsTimeSeriesPayload( payload: unknown ) {
 	const response = coerceStatsRecord( payload );
 
@@ -286,8 +301,30 @@ export function sanitizeStatsTimeSeriesResponse(
 ): StatsTimeSeriesReport {
 	const response = coerceStatsRecord( payload );
 	const unit = String( response.unit ?? query?.period ?? 'day' );
-	const rows = parseTimeSeriesRows( payload );
-	const summary = rows.reduce< Record< string, number > >( ( totals, row ) => {
+	const buckets = parseTimeSeriesRows( payload ).map( row => {
+		const rawPeriod = row.period ?? row.time_interval ?? row.date_start ?? row.date;
+
+		return { row, range: getRowIntervalFields( row, rawPeriod, unit ) };
+	} );
+	// Trim to the caller's window when it names one — before the summary, so
+	// out-of-window buckets inflate neither the totals nor the chart.
+	// Quantity-based endpoints (the email timeline) anchor hourly buckets on
+	// the start day's midnight regardless of the requested time of day, so a
+	// mid-day window comes back with leading out-of-window buckets. Request
+	// params never reach a sanitizer as `end_date` (statsQueryParamsToApiParams
+	// renames it to `date`), so only callers passing a window through
+	// `sanitizerParams` opt in.
+	const windowStart = toWallClockBound( query?.start_date, '00:00:00' );
+	const windowEnd = toWallClockBound( query?.end_date, '23:59:59' );
+	const kept =
+		windowStart && windowEnd
+			? buckets.filter(
+					( { range } ) =>
+						compareBucketBounds( range.date_end, windowStart ) >= 0 &&
+						compareBucketBounds( range.date_start, windowEnd ) <= 0
+			  )
+			: buckets;
+	const summary = kept.reduce< Record< string, number > >( ( totals, { row } ) => {
 		Object.entries( row ).forEach( ( [ key, value ] ) => {
 			if ( ! nonMetricFields.includes( key ) && typeof value === 'number' ) {
 				totals[ key ] = ( totals[ key ] ?? 0 ) + value;
@@ -296,10 +333,8 @@ export function sanitizeStatsTimeSeriesResponse(
 
 		return totals;
 	}, {} );
-	const data = rows
-		.map< StatsTimeSeriesDataPoint >( row => {
-			const rawPeriod = row.period ?? row.time_interval ?? row.date_start ?? row.date;
-			const range = getRowIntervalFields( row, rawPeriod, unit );
+	const data = kept
+		.map< StatsTimeSeriesDataPoint >( ( { row, range } ) => {
 			const value = safeParseFloat( getPrimaryMetricValue( row ) );
 
 			return {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -1,4 +1,8 @@
-import { formatDatePartWithTime, getDatePart } from '@jetpack-premium-analytics/datetime';
+import {
+	formatDatePartWithTime,
+	getDatePart,
+	readSiteTimestamp,
+} from '@jetpack-premium-analytics/datetime';
 import {
 	endOfISOWeek,
 	endOfMonth,
@@ -263,26 +267,37 @@ function getTimeSeriesSummarySidecars( response: StatsRecord ) {
 	};
 }
 
-// The timestamp shapes report params can carry (a subset of the datetime
-// package's SITE_TIMESTAMP): a calendar date, optionally followed by a
-// T- or space-separated wall time with optional seconds; any offset or
-// milliseconds after that are irrelevant to a wall-clock bound.
-const WALL_CLOCK_PARTS = /^(\d{4}-\d{2}-\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/;
+const padTimePart = ( part: number ) => String( part ).padStart( 2, '0' );
 
 // A trim-window bound in the same timezone-naive wall-clock shape the bucket
 // labels carry: the value's own date and time parts as written, any offset
-// ignored. A bare date widens to the whole day via the fallback time, whose
-// seconds also fill in for a seconds-less time.
-function toWallClockBound( value: unknown, fallbackTime: string ) {
-	const match = typeof value === 'string' ? WALL_CLOCK_PARTS.exec( value.trim() ) : null;
+// ignored. Validated by the datetime package's single timestamp reader so the
+// accepted shapes cannot drift from the rest of the package, then narrowed to
+// what the stats-params pipeline itself accepts — bare dates and T-separated
+// datetimes; getDatePart splits on T only, so a space-separated value already
+// degrades the day count upstream and must not trim here either. An invalid
+// or unsupported value yields no bound (and so no trim). A bare date widens
+// to the whole day via the fallback time; a seconds-less time takes the
+// fallback seconds.
+function toWallClockBound( value: unknown, fallbackTime: string, fallbackSeconds: string ) {
+	const timestamp = typeof value === 'string' ? readSiteTimestamp( value ) : null;
 
-	if ( ! match ) {
+	if ( ! timestamp?.isValid || timestamp.value.includes( ' ' ) ) {
 		return undefined;
 	}
 
-	const [ , datePart, hours, minutes, seconds ] = match;
-	const time = hours
-		? `${ hours }:${ minutes }:${ seconds ?? fallbackTime.slice( 6 ) }`
+	const [ year, month, day, hours, minutes, seconds ] = timestamp.parts;
+	const datePart = `${ String( year ).padStart( 4, '0' ) }-${ padTimePart(
+		month + 1
+	) }-${ padTimePart( day ) }`;
+	// The reader guarantees these shapes, so the probes only ask what was
+	// written: a time at all, and seconds within it.
+	const hasTime = timestamp.value.includes( 'T' );
+	const hasSeconds = /T\d{2}:\d{2}:\d{2}/.test( timestamp.value );
+	const time = hasTime
+		? `${ padTimePart( hours ) }:${ padTimePart( minutes ) }:${
+				hasSeconds ? padTimePart( seconds ) : fallbackSeconds
+		  }`
 		: fallbackTime;
 
 	return formatDatePartWithTime( datePart, time );
@@ -331,10 +346,12 @@ export function sanitizeStatsTimeSeriesResponse(
 	// params — those reach this sanitizer from range-bounded endpoints (visits,
 	// subscribers, wordads) that must not have buckets dropped. Rows whose
 	// bounds aren't comparable wall clocks are kept, not dropped.
-	const windowStart = toWallClockBound( query?.window_start, '00:00:00' );
-	const windowEnd = toWallClockBound( query?.window_end, '23:59:59' );
+	const windowStart = toWallClockBound( query?.window_start, '00:00:00', '00' );
+	const windowEnd = toWallClockBound( query?.window_end, '23:59:59', '59' );
+	// An inverted window (a hand-edited deep link) falls back to no trim
+	// rather than silently emptying the chart.
 	const kept =
-		windowStart && windowEnd
+		windowStart && windowEnd && windowStart <= windowEnd
 			? buckets.filter(
 					( { range } ) =>
 						! isWallClockStamp( range.date_start ) ||

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -263,20 +263,35 @@ function getTimeSeriesSummarySidecars( response: StatsRecord ) {
 	};
 }
 
+// The timestamp shapes report params can carry (a subset of the datetime
+// package's SITE_TIMESTAMP): a calendar date, optionally followed by a
+// T- or space-separated wall time with optional seconds; any offset or
+// milliseconds after that are irrelevant to a wall-clock bound.
+const WALL_CLOCK_PARTS = /^(\d{4}-\d{2}-\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?/;
+
 // A trim-window bound in the same timezone-naive wall-clock shape the bucket
 // labels carry: the value's own date and time parts as written, any offset
-// ignored. A bare date widens to the whole day via the fallback time.
+// ignored. A bare date widens to the whole day via the fallback time, whose
+// seconds also fill in for a seconds-less time.
 function toWallClockBound( value: string | undefined, fallbackTime: string ) {
-	const datePart = getDatePart( value );
+	const match = typeof value === 'string' ? WALL_CLOCK_PARTS.exec( value.trim() ) : null;
 
-	if ( ! datePart || ! /^\d{4}-\d{2}-\d{2}$/.test( datePart ) ) {
+	if ( ! match ) {
 		return undefined;
 	}
 
-	const time = typeof value === 'string' && value.match( /[T ](\d{2}:\d{2}:\d{2})/ );
+	const [ , datePart, hours, minutes, seconds ] = match;
+	const time = hours
+		? `${ hours }:${ minutes }:${ seconds ?? fallbackTime.slice( 6 ) }`
+		: fallbackTime;
 
-	return formatDatePartWithTime( datePart, time ? time[ 1 ] : fallbackTime );
+	return formatDatePartWithTime( datePart, time );
 }
+
+// Bucket bounds are comparable against a window bound only in this shape;
+// a row whose bounds fall outside it (an unparseable period label echoed
+// back verbatim) is kept rather than silently discarded.
+const isWallClockStamp = ( value: string ) => /^\d{4}-\d{2}-\d{2}T/.test( value );
 
 export function isStatsTimeSeriesPayload( payload: unknown ) {
 	const response = coerceStatsRecord( payload );
@@ -312,16 +327,19 @@ export function sanitizeStatsTimeSeriesResponse(
 	// the start day's midnight regardless of the requested time of day, so a
 	// mid-day window comes back with leading out-of-window buckets. Request
 	// params never reach a sanitizer as `end_date` (statsQueryParamsToApiParams
-	// renames it to `date`), so only callers passing a window through
-	// `sanitizerParams` opt in.
+	// renames it to `date` — an invariant pinned in the stats-params tests), so
+	// only callers passing a window through `sanitizerParams` opt in. Rows
+	// whose bounds aren't comparable wall clocks are kept, not dropped.
 	const windowStart = toWallClockBound( query?.start_date, '00:00:00' );
 	const windowEnd = toWallClockBound( query?.end_date, '23:59:59' );
 	const kept =
 		windowStart && windowEnd
 			? buckets.filter(
 					( { range } ) =>
-						compareBucketBounds( range.date_end, windowStart ) >= 0 &&
-						compareBucketBounds( range.date_start, windowEnd ) <= 0
+						! isWallClockStamp( range.date_start ) ||
+						! isWallClockStamp( range.date_end ) ||
+						( compareBucketBounds( range.date_end, windowStart ) >= 0 &&
+							compareBucketBounds( range.date_start, windowEnd ) <= 0 )
 			  )
 			: buckets;
 	const summary = kept.reduce< Record< string, number > >( ( totals, { row } ) => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -294,6 +294,31 @@ describe( 'Stats query factories', () => {
 		} );
 	} );
 
+	it( 'reads the end hour from every timestamp shape the datetime reader accepts', () => {
+		const quantityFor = ( from: string, to: string ) =>
+			(
+				statsEmailClicksTimeSeriesQuery( 41, { from, to, interval: 'hour' } ).queryKey[ 5 ] as {
+					quantity: number;
+				}
+			 ).quantity;
+
+		// A seconds-less end must size the same window as the full ISO shape,
+		// so quantity and the sanitizer trim stay agreed.
+		expect( quantityFor( '2026-06-14T09:00-04:00', '2026-06-15T08:59-04:00' ) ).toBe( 33 );
+
+		// Space-separated datetimes degrade upstream (getDatePart, which
+		// derives `days`, splits on T only), so the end hour falls back to 23
+		// there too — one whole degraded day, matching pre-fix behavior, with
+		// the sanitizer trim disabled by the same narrowing.
+		expect( quantityFor( '2026-06-14 09:00:00-04:00', '2026-06-15 08:59:59-04:00' ) ).toBe( 24 );
+
+		// An end the reader rejects falls back to hour 23 — the old full-day
+		// request — and the sanitizer, sharing the reader, disables its trim.
+		expect( quantityFor( '2026-06-14T09:00:00.000-04:00', '2026-06-15T99:00:00.000-04:00' ) ).toBe(
+			48
+		);
+	} );
+
 	it( 'disables email time series queries without a positive integer post ID or a date', () => {
 		const range = { from: '2026-06-01', to: '2026-06-07', interval: 'day' } as const;
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -231,7 +231,7 @@ describe( 'Stats query factories', () => {
 			{ period: 'day', quantity: 7, date: '2026-06-01', stats_fields: 'timeline' },
 			undefined,
 			'emailTimeSeries',
-			{ start_date: '2026-06-01', end_date: '2026-06-07' },
+			{ window_start: '2026-06-01', window_end: '2026-06-07' },
 		] );
 	} );
 
@@ -274,7 +274,8 @@ describe( 'Stats query factories', () => {
 		// 08:xx June 15 = 33 buckets, not 24 from 09:00, and not 24 per calendar
 		// day touched — the 48-bucket over-fetch was WOOA7S-1840). The leading
 		// out-of-window buckets the midnight anchor forces are trimmed by the
-		// sanitizer via the window passed in sanitizerParams (query key slot 8).
+		// sanitizer via the window_start/window_end pair passed in
+		// sanitizerParams (query key slot 8).
 		const { queryKey } = statsEmailClicksTimeSeriesQuery( 41, {
 			from: '2026-06-14T09:00:00.000-04:00',
 			to: '2026-06-15T08:59:59.999-04:00',
@@ -288,8 +289,8 @@ describe( 'Stats query factories', () => {
 			stats_fields: 'timeline',
 		} );
 		expect( queryKey[ 8 ] ).toEqual( {
-			start_date: '2026-06-14T09:00:00.000-04:00',
-			end_date: '2026-06-15T08:59:59.999-04:00',
+			window_start: '2026-06-14T09:00:00.000-04:00',
+			window_end: '2026-06-15T08:59:59.999-04:00',
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -231,6 +231,7 @@ describe( 'Stats query factories', () => {
 			{ period: 'day', quantity: 7, date: '2026-06-01', stats_fields: 'timeline' },
 			undefined,
 			'emailTimeSeries',
+			{ start_date: '2026-06-01', end_date: '2026-06-07' },
 		] );
 	} );
 
@@ -262,31 +263,33 @@ describe( 'Stats query factories', () => {
 		).toEqual( { period: 'hour', quantity: 48, date: '2026-06-14', stats_fields: 'timeline' } );
 	} );
 
-	it( 'sends an offset-bearing hourly window end through untrimmed', () => {
+	it( 'sizes an offset-bearing hourly window from its start day midnight through its end hour', () => {
 		// The shape the last-24-hours preset produces: hour-aligned, mid-day, and
 		// spanning two calendar days. `date` is the window START for this
-		// endpoint and now carries the time, but the endpoint resolves it to the
+		// endpoint and carries the time, but the endpoint resolves it to the
 		// calendar day and buckets from midnight regardless — verified against
 		// production, where a bare `2026-08-06` and `2026-08-06T09:00:00.000-04:00`
-		// return byte-identical hour-0..23 windows. So the untrimmed value is
-		// inert here rather than shifting the window; do not "fix" `quantity` on
-		// the assumption that the buckets start at 09:00.
-		//
-		// `quantity` stays 24 per calendar day the window touches — a 24-hour
-		// window spanning two days still asks for 48 buckets. That over-fetch
-		// predates offset-bearing dates and is tracked in WOOA7S-1840; pinned
-		// here so a fix to it is a deliberate change rather than an accident.
-		expect(
-			statsEmailClicksTimeSeriesQuery( 41, {
-				from: '2026-06-14T09:00:00.000-04:00',
-				to: '2026-06-15T08:59:59.999-04:00',
-				interval: 'hour',
-			} ).queryKey[ 5 ]
-		).toEqual( {
+		// return byte-identical hour-0..23 windows. So `quantity` must span from
+		// that midnight through the window's end hour (hours 00:00 June 14 →
+		// 08:xx June 15 = 33 buckets, not 24 from 09:00, and not 24 per calendar
+		// day touched — the 48-bucket over-fetch was WOOA7S-1840). The leading
+		// out-of-window buckets the midnight anchor forces are trimmed by the
+		// sanitizer via the window passed in sanitizerParams (query key slot 8).
+		const { queryKey } = statsEmailClicksTimeSeriesQuery( 41, {
+			from: '2026-06-14T09:00:00.000-04:00',
+			to: '2026-06-15T08:59:59.999-04:00',
+			interval: 'hour',
+		} );
+
+		expect( queryKey[ 5 ] ).toEqual( {
 			period: 'hour',
-			quantity: 48,
+			quantity: 33,
 			date: '2026-06-14T09:00:00.000-04:00',
 			stats_fields: 'timeline',
+		} );
+		expect( queryKey[ 8 ] ).toEqual( {
+			start_date: '2026-06-14T09:00:00.000-04:00',
+			end_date: '2026-06-15T08:59:59.999-04:00',
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
@@ -58,7 +58,9 @@ function emailTimeSeriesQuery(
 	const emailParams: StatsProxyParams = {
 		period,
 		quantity:
-			period === 'hour' ? 24 * ( days - 1 ) + endHourOfDay( statsParams.end_date ) + 1 : days,
+			period === 'hour'
+				? Math.max( 1, 24 * ( days - 1 ) + endHourOfDay( statsParams.end_date ) + 1 )
+				: days,
 		...( statsParams.start_date ? { date: statsParams.start_date } : {} ),
 		stats_fields: 'timeline',
 	};

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { readSiteTimestamp } from '@jetpack-premium-analytics/datetime';
+/**
  * Internal dependencies
  */
 import { reportParamsToStatsQueryParams } from '../utils/stats-params';
@@ -31,12 +35,17 @@ const hasValidPostId = ( postId: number ) => Number.isInteger( postId ) && postI
 const toEmailPeriod = ( period?: string ): StatsEmailTimeSeriesPeriod =>
 	period === 'hour' ? 'hour' : 'day';
 
-// The wall-clock hour a window's end names, read from the string as written;
-// a bare date ends at hour 23.
+// The wall-clock hour a window's end names, read by the datetime package's
+// single timestamp reader so it cannot disagree with the sanitizer's trim
+// bounds, then narrowed the same way (T-separated only — getDatePart, which
+// derives `days`, splits on T alone); a bare date, or anything the reader
+// rejects or the pipeline can't carry, ends at hour 23 as before.
 const endHourOfDay = ( value?: string ): number => {
-	const match = typeof value === 'string' && value.match( /[T ](\d{2}):/ );
+	const timestamp = typeof value === 'string' ? readSiteTimestamp( value ) : null;
 
-	return match ? Number( match[ 1 ] ) : 23;
+	return timestamp?.isValid && ! timestamp.value.includes( ' ' ) && timestamp.value.includes( 'T' )
+		? timestamp.parts[ 3 ]
+		: 23;
 };
 
 // Mirror Calypso's requestEmailStats: the timeline is period-scoped and always sends period,

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
@@ -1,10 +1,7 @@
 /**
- * External dependencies
- */
-import { readSiteTimestamp } from '@jetpack-premium-analytics/datetime';
-/**
  * Internal dependencies
  */
+import { toStatsBucketWindowParams, windowEndHour } from '../processing/stats';
 import { reportParamsToStatsQueryParams } from '../utils/stats-params';
 import {
 	statsProxyQuery,
@@ -35,27 +32,17 @@ const hasValidPostId = ( postId: number ) => Number.isInteger( postId ) && postI
 const toEmailPeriod = ( period?: string ): StatsEmailTimeSeriesPeriod =>
 	period === 'hour' ? 'hour' : 'day';
 
-// The wall-clock hour a window's end names, read by the datetime package's
-// single timestamp reader so it cannot disagree with the sanitizer's trim
-// bounds, then narrowed the same way (T-separated only — getDatePart, which
-// derives `days`, splits on T alone); a bare date, or anything the reader
-// rejects or the pipeline can't carry, ends at hour 23 as before.
-const endHourOfDay = ( value?: string ): number => {
-	const timestamp = typeof value === 'string' ? readSiteTimestamp( value ) : null;
-
-	return timestamp?.isValid && ! timestamp.value.includes( ' ' ) && timestamp.value.includes( 'T' )
-		? timestamp.parts[ 3 ]
-		: 23;
-};
+// The endpoint anchors hourly buckets on the start day's midnight regardless
+// of the time of day `date` carries (see bucket-window.ts), so an hourly
+// request must span that midnight through the window's end hour; the
+// sanitizer trims the leading out-of-window buckets.
+const hourlyQuantity = ( days: number, endDate?: string ) =>
+	Math.max( 1, 24 * ( days - 1 ) + windowEndHour( endDate ) + 1 );
 
 // Mirror Calypso's requestEmailStats: the timeline is period-scoped and always sends period,
 // quantity, date, and stats_fields=timeline. Unlike the other stats endpoints (where `date`
 // is the window's END), the email timeline reads `date` as the window's START and returns
-// `quantity` buckets going forward — one per day, or 24 per day for hourly. The endpoint
-// resolves `date` to its calendar day and anchors hourly buckets on that day's midnight
-// regardless of the time of day it carries (verified against production), so a mid-day
-// window needs buckets from that midnight through the window's end hour, and the leading
-// out-of-window buckets are trimmed off by the sanitizer via the window in sanitizerParams.
+// `quantity` buckets going forward — one per day, or 24 per day for hourly.
 function emailTimeSeriesQuery(
 	statType: 'opens' | 'clicks',
 	postId: number,
@@ -64,12 +51,10 @@ function emailTimeSeriesQuery(
 	const statsParams = reportParamsToStatsQueryParams( params );
 	const period = toEmailPeriod( statsParams.period );
 	const days = statsParams.days ?? ( period === 'hour' ? 1 : 30 );
+	const window = toStatsBucketWindowParams( statsParams );
 	const emailParams: StatsProxyParams = {
 		period,
-		quantity:
-			period === 'hour'
-				? Math.max( 1, 24 * ( days - 1 ) + endHourOfDay( statsParams.end_date ) + 1 )
-				: days,
+		quantity: period === 'hour' ? hourlyQuantity( days, statsParams.end_date ) : days,
 		...( statsParams.start_date ? { date: statsParams.start_date } : {} ),
 		stats_fields: 'timeline',
 	};
@@ -80,14 +65,7 @@ function emailTimeSeriesQuery(
 		endpoint: `stats/${ statType }/emails/${ postId }`,
 		params: emailParams,
 		sanitizer: 'emailTimeSeries',
-		...( statsParams.start_date && statsParams.end_date
-			? {
-					sanitizerParams: {
-						window_start: statsParams.start_date,
-						window_end: statsParams.end_date,
-					},
-			  }
-			: {} ),
+		...( window ? { sanitizerParams: window } : {} ),
 		enabled: hasValidPostId( postId ) && !! emailParams.date,
 	} );
 }

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
@@ -31,11 +31,22 @@ const hasValidPostId = ( postId: number ) => Number.isInteger( postId ) && postI
 const toEmailPeriod = ( period?: string ): StatsEmailTimeSeriesPeriod =>
 	period === 'hour' ? 'hour' : 'day';
 
+// The wall-clock hour a window's end names, read from the string as written;
+// a bare date ends at hour 23.
+const endHourOfDay = ( value?: string ): number => {
+	const match = typeof value === 'string' && value.match( /[T ](\d{2}):/ );
+
+	return match ? Number( match[ 1 ] ) : 23;
+};
+
 // Mirror Calypso's requestEmailStats: the timeline is period-scoped and always sends period,
 // quantity, date, and stats_fields=timeline. Unlike the other stats endpoints (where `date`
 // is the window's END), the email timeline reads `date` as the window's START and returns
-// `quantity` buckets going forward, so it gets the range start and a quantity spanning the
-// whole requested range — 24 buckets per day for hourly, one per day otherwise.
+// `quantity` buckets going forward — one per day, or 24 per day for hourly. The endpoint
+// resolves `date` to its calendar day and anchors hourly buckets on that day's midnight
+// regardless of the time of day it carries (verified against production), so a mid-day
+// window needs buckets from that midnight through the window's end hour, and the leading
+// out-of-window buckets are trimmed off by the sanitizer via the window in sanitizerParams.
 function emailTimeSeriesQuery(
 	statType: 'opens' | 'clicks',
 	postId: number,
@@ -46,7 +57,8 @@ function emailTimeSeriesQuery(
 	const days = statsParams.days ?? ( period === 'hour' ? 1 : 30 );
 	const emailParams: StatsProxyParams = {
 		period,
-		quantity: period === 'hour' ? 24 * days : days,
+		quantity:
+			period === 'hour' ? 24 * ( days - 1 ) + endHourOfDay( statsParams.end_date ) + 1 : days,
 		...( statsParams.start_date ? { date: statsParams.start_date } : {} ),
 		stats_fields: 'timeline',
 	};
@@ -57,6 +69,14 @@ function emailTimeSeriesQuery(
 		endpoint: `stats/${ statType }/emails/${ postId }`,
 		params: emailParams,
 		sanitizer: 'emailTimeSeries',
+		...( statsParams.start_date && statsParams.end_date
+			? {
+					sanitizerParams: {
+						start_date: statsParams.start_date,
+						end_date: statsParams.end_date,
+					},
+			  }
+			: {} ),
 		enabled: hasValidPostId( postId ) && !! emailParams.date,
 	} );
 }

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
@@ -74,8 +74,8 @@ function emailTimeSeriesQuery(
 		...( statsParams.start_date && statsParams.end_date
 			? {
 					sanitizerParams: {
-						start_date: statsParams.start_date,
-						end_date: statsParams.end_date,
+						window_start: statsParams.start_date,
+						window_end: statsParams.end_date,
 					},
 			  }
 			: {} ),

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -141,14 +141,14 @@ describe( 'reportParamsToStatsQueryParams', () => {
 	} );
 
 	it( 'maps the semantic end date to the Stats API date param', () => {
-		expect(
-			statsQueryParamsToApiParams( {
-				period: 'day',
-				start_date: '2026-06-01',
-				end_date: '2026-06-07',
-				days: 7,
-			} )
-		).toEqual(
+		const apiParams = statsQueryParamsToApiParams( {
+			period: 'day',
+			start_date: '2026-06-01',
+			end_date: '2026-06-07',
+			days: 7,
+		} );
+
+		expect( apiParams ).toEqual(
 			expect.objectContaining( {
 				period: 'day',
 				date: '2026-06-07',
@@ -156,6 +156,11 @@ describe( 'reportParamsToStatsQueryParams', () => {
 				days: 7,
 			} )
 		);
+		// Load-bearing beyond naming: the shared time-series sanitizer trims to
+		// a window only when it receives BOTH start_date and end_date, so
+		// end_date must never survive into API params or every range-bounded
+		// endpoint would start dropping buckets.
+		expect( apiParams ).not.toHaveProperty( 'end_date' );
 	} );
 
 	it( 'falls back to one day for invalid date ranges', () => {

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -162,6 +162,17 @@ describe( 'reportParamsToStatsQueryParams', () => {
 		expect( apiParams ).not.toHaveProperty( 'end_date' );
 	} );
 
+	it( 'strips the sanitizer-only window bounds from API params', () => {
+		const apiParams = statsQueryParamsToApiParams( {
+			period: 'hour',
+			window_start: '2026-06-14T09:00:00.000-04:00',
+			window_end: '2026-06-15T08:59:59.999-04:00',
+		} );
+
+		expect( apiParams ).not.toHaveProperty( 'window_start' );
+		expect( apiParams ).not.toHaveProperty( 'window_end' );
+	} );
+
 	it( 'falls back to one day for invalid date ranges', () => {
 		expect(
 			reportParamsToStatsQueryParams( {

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -156,10 +156,9 @@ describe( 'reportParamsToStatsQueryParams', () => {
 				days: 7,
 			} )
 		);
-		// Load-bearing beyond naming: the shared time-series sanitizer trims to
-		// a window only when it receives BOTH start_date and end_date, so
-		// end_date must never survive into API params or every range-bounded
-		// endpoint would start dropping buckets.
+		// The semantic end_date must not survive alongside the API's date param
+		// — endpoints read `date`, and a stray end_date would leak into query
+		// keys and request URLs.
 		expect( apiParams ).not.toHaveProperty( 'end_date' );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -31,9 +31,10 @@ export type StatsQueryParamFields = {
 	summarize?: number | boolean;
 	complete_stats?: number | boolean;
 	skip_archives?: number | boolean;
-	// Sanitizer-only: the wall-clock window the time-series sanitizer trims
-	// to, sent via `sanitizerParams`. Deliberately absent from statsParamKeys
-	// so report params can never carry them into a request.
+	// Sanitizer-only: the trim window owned by processing/stats/bucket-window.ts,
+	// sent via `sanitizerParams` and honored only by the email time-series
+	// sanitizer — inert for every other sanitizer. Deliberately absent from
+	// statsParamKeys so report params can never carry them into a request.
 	window_start?: string;
 	window_end?: string;
 };

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -31,6 +31,11 @@ export type StatsQueryParamFields = {
 	summarize?: number | boolean;
 	complete_stats?: number | boolean;
 	skip_archives?: number | boolean;
+	// Sanitizer-only: the wall-clock window the time-series sanitizer trims
+	// to, sent via `sanitizerParams`. Deliberately absent from statsParamKeys
+	// so report params can never carry them into a request.
+	window_start?: string;
+	window_end?: string;
 };
 
 export type StatsQueryParams = StatsProxyParams & StatsQueryParamFields;

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -186,7 +186,13 @@ export function reportParamsToStatsQueryParams(
 }
 
 export function statsQueryParamsToApiParams( params: StatsQueryParams = {} ): StatsProxyParams {
+	// window_start/window_end are sanitizer-only (see StatsQueryParamFields):
+	// stripped here so a caller that passes them in request params by mistake
+	// cannot leak them into request URLs and query keys.
 	const { end_date: endDate, ...apiParams } = params;
+
+	delete apiParams.window_start;
+	delete apiParams.window_end;
 
 	return {
 		...apiParams,

--- a/projects/packages/premium-analytics/packages/datetime/src/index.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/index.ts
@@ -24,6 +24,8 @@ export { stepDateRange, canStepForward, type StepDirection } from './step-date-r
 
 export { parseSiteDateTime } from './site-datetime';
 
+export { readSiteTimestamp, type SiteTimestamp, type TimestampParts } from './site-timestamp';
+
 export { siteTimeZone } from './site-time-zone';
 
 export {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.test.ts
@@ -40,4 +40,20 @@ describe( 'buildEmailTimelineResponse', () => {
 			] )
 		);
 	} );
+
+	it( 'anchors hourly buckets on the start day midnight whatever time of day date carries', () => {
+		// The production endpoint resolves `date` to its calendar day and
+		// buckets from midnight; a mid-day last-24-hours request must roll into
+		// the next day at hour 0, not start at the requested hour.
+		const response = buildEmailTimelineResponse(
+			'clicks',
+			'/stats/clicks/emails/1234?period=hour&quantity=26&date=2026-06-17T09%3A00%3A00.000-04%3A00&stats_fields=timeline'
+		) as EmailTimelineResponse;
+
+		const hours = response.timeline.data.map( row => [ row[ 0 ], row[ 1 ] ] );
+		expect( hours[ 0 ] ).toEqual( [ '2026-06-17', 0 ] );
+		expect( hours[ 23 ] ).toEqual( [ '2026-06-17', 23 ] );
+		expect( hours[ 24 ] ).toEqual( [ '2026-06-18', 0 ] );
+		expect( hours[ 25 ] ).toEqual( [ '2026-06-18', 1 ] );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { addDays, addHours, format, isValid, parseISO } from 'date-fns';
+import { addDays, format, isValid, parse } from 'date-fns';
 
 /**
  * The timeline matrix `stats/<opens|clicks>/emails/<postId>?stats_fields=timeline`
@@ -32,9 +32,11 @@ function emailTimelineCount( metric: 'opens' | 'clicks', index: number ): number
 
 /**
  * Builds a mock email timeline response for the "Email performance" widget. The
- * email timeline endpoint treats `date` as the first requested bucket and
- * returns `quantity` periods going forward. Mirroring that behaviour keeps a
- * story's chart aligned with its dashboard date range.
+ * email timeline endpoint reads `date` as the window start, resolves it to its
+ * calendar day, and returns `quantity` periods going forward — hourly buckets
+ * anchored on that day's midnight. Mirroring that behaviour keeps a story's
+ * chart aligned with its dashboard date range, including the out-of-window
+ * buckets the data layer is expected to trim.
  *
  * @param metric      - Which timeline to return.
  * @param requestPath - The request path; `period`, `quantity`, and `date` are read off its query.
@@ -50,26 +52,34 @@ export function buildEmailTimelineResponse(
 	const quantity = Number.isInteger( parsedQuantity )
 		? Math.min( Math.max( parsedQuantity, 1 ), 24 * 90 )
 		: 30;
-	const parsedDate = parseISO( query.get( 'date' ) ?? '' );
-	const startDate = isValid( parsedDate ) ? parsedDate : new Date();
+	// Only the date part matters: the endpoint resolves `date` to its calendar
+	// day (hourly buckets anchor on that day's midnight whatever time of day it
+	// carries), and parsing the part in the runner's own zone keeps the emitted
+	// wall-clock labels aligned with the requested day in any browser timezone.
+	const dayPart = ( query.get( 'date' ) ?? '' ).match( /^\d{4}-\d{2}-\d{2}/ )?.[ 0 ] ?? '';
+	const parsedDay = parse( dayPart, 'yyyy-MM-dd', new Date() );
+	const startDay = isValid( parsedDay ) ? parsedDay : new Date();
 	const field = metric === 'opens' ? 'opens_count' : 'clicks_count';
 
 	const data: EmailTimelineRow[] = [];
 
 	// Nudge the curve by the window start so a comparison window draws a
 	// visibly different (but still deterministic) line than the primary.
-	const windowNudge = ( startDate.getUTCDate() % 7 ) * 2;
+	const windowNudge = ( startDay.getDate() % 7 ) * 2;
 
 	for ( let index = 0; index < quantity; index++ ) {
 		// Preserve the existing send-decay shape while emitting buckets from
-		// the requested start date forward.
+		// the start day forward.
 		const count = emailTimelineCount( metric, quantity - 1 - index ) + windowNudge;
 
 		if ( period === 'hour' ) {
-			const bucket = addHours( startDate, index );
-			data.push( [ format( bucket, 'yyyy-MM-dd' ), bucket.getHours(), count ] );
+			data.push( [
+				format( addDays( startDay, Math.floor( index / 24 ) ), 'yyyy-MM-dd' ),
+				index % 24,
+				count,
+			] );
 		} else {
-			data.push( [ format( addDays( startDate, index ), 'yyyy-MM-dd' ), count ] );
+			data.push( [ format( addDays( startDay, index ), 'yyyy-MM-dd' ), count ] );
 		}
 	}
 

--- a/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
@@ -167,6 +167,50 @@ describe( 'EmailTimeSeriesWidget', () => {
 		expect( requestedPath ).toContain( 'stats/clicks/emails/1234' );
 	} );
 
+	it( 'draws exactly the selected hourly window from a midnight-anchored payload', async () => {
+		// The endpoint anchors hourly buckets on the start day's midnight and
+		// returns `quantity` buckets forward, so a last-24-hours window (09:00
+		// → 08:59 next day) is served as 33 buckets from hour 0. The widget
+		// must chart and sum only the 24 in-window hours.
+		mockApiFetch.mockResolvedValue( {
+			timeline: {
+				unit: 'hour',
+				fields: [ 'date', 'hour', 'opens_count' ],
+				data: [
+					...Array.from( { length: 24 }, ( _, hour ) => [ '2026-07-04', hour, hour ] ),
+					...Array.from( { length: 9 }, ( _, hour ) => [ '2026-07-05', hour, hour ] ),
+				],
+			},
+		} );
+
+		render(
+			<EmailTimeSeriesWidget
+				attributes={ {
+					reportParams: {
+						...getDefaultQueryParams( false ),
+						preset: undefined,
+						from: '2026-07-04T09:00:00.000+08:00',
+						to: '2026-07-05T08:59:59.999+08:00',
+						interval: 'hour',
+						post_id: 1234,
+					},
+					metric: 'opens',
+				} }
+			/>
+		);
+
+		const chart = await screen.findByTestId( 'metric-tabs-chart' );
+		const values = String( chart.getAttribute( 'data-values' ) ).split( ',' );
+		expect( values ).toHaveLength( 24 );
+		expect( values[ 0 ] ).toBe( '9' );
+		expect( values[ 23 ] ).toBe( '8' );
+		// Hours 9–23 of day one plus 0–8 of day two.
+		expect( chart ).toHaveAttribute( 'data-metric-total', '276' );
+
+		const requestedPath = String( mockApiFetch.mock.calls[ 0 ][ 0 ].path );
+		expect( new URLSearchParams( requestedPath.split( '?' )[ 1 ] ).get( 'quantity' ) ).toBe( '33' );
+	} );
+
 	it( 'ignores comparison report params: one request, single series', async () => {
 		mockApiFetch.mockResolvedValue( OPENS_TIMELINE_RESPONSE );
 

--- a/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
@@ -208,7 +208,11 @@ describe( 'EmailTimeSeriesWidget', () => {
 		expect( chart ).toHaveAttribute( 'data-metric-total', '276' );
 
 		const requestedPath = String( mockApiFetch.mock.calls[ 0 ][ 0 ].path );
-		expect( new URLSearchParams( requestedPath.split( '?' )[ 1 ] ).get( 'quantity' ) ).toBe( '33' );
+		const requestParams = new URLSearchParams( requestedPath.split( '?' )[ 1 ] );
+		expect( requestParams.get( 'quantity' ) ).toBe( '33' );
+		// The trim window is sanitizer-only and must never reach the API.
+		expect( requestParams.get( 'window_start' ) ).toBeNull();
+		expect( requestParams.get( 'window_end' ) ).toBeNull();
 	} );
 
 	it( 'ignores comparison report params: one request, single series', async () => {

--- a/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
@@ -48,6 +48,16 @@ jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mo
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 
+// An explicit window covering the fixture buckets below: the data layer trims
+// buckets to the requested window, so a default (today-relative) preset would
+// trim these fixed July dates away.
+const JULY_WEEK_PARAMS = {
+	...getDefaultQueryParams( false ),
+	preset: undefined,
+	from: '2026-07-01T00:00:00.000+08:00',
+	to: '2026-07-07T23:59:59.999+08:00',
+};
+
 // Raw WPCOM email timeline shape (`stats_fields=timeline`): a matrix nested
 // under `timeline`, one daily row per bucket. 2026-07-04/05 fall in one ISO
 // week (Mon 2026-06-29) and 2026-07-06 opens the next, so weekly grouping
@@ -78,7 +88,7 @@ describe( 'EmailTimeSeriesWidget', () => {
 		render(
 			<EmailTimeSeriesWidget
 				attributes={ {
-					reportParams: { ...getDefaultQueryParams( false ), post_id: 1234 },
+					reportParams: { ...JULY_WEEK_PARAMS, post_id: 1234 },
 					metric: 'opens',
 				} }
 			/>
@@ -111,7 +121,7 @@ describe( 'EmailTimeSeriesWidget', () => {
 			render(
 				<EmailTimeSeriesWidget
 					attributes={ {
-						reportParams: { ...getDefaultQueryParams( false ), post_id: 1234 },
+						reportParams: { ...JULY_WEEK_PARAMS, post_id: 1234 },
 						metric: 'opens',
 					} }
 				/>
@@ -143,7 +153,7 @@ describe( 'EmailTimeSeriesWidget', () => {
 		render(
 			<EmailTimeSeriesWidget
 				attributes={ {
-					reportParams: { ...getDefaultQueryParams( false ), post_id: 1234 },
+					reportParams: { ...JULY_WEEK_PARAMS, post_id: 1234 },
 					metric: 'clicks',
 				} }
 			/>
@@ -199,7 +209,15 @@ describe( 'EmailTimeSeriesWidget', () => {
 		render(
 			<EmailTimeSeriesWidget
 				attributes={ {
-					reportParams: { ...getDefaultQueryParams( false ), interval: 'week', post_id: 1234 },
+					// A 35-day window (weekly needs >= 28 days) covering both ISO weeks.
+					reportParams: {
+						...getDefaultQueryParams( false ),
+						preset: undefined,
+						from: '2026-06-08T00:00:00.000+08:00',
+						to: '2026-07-12T23:59:59.999+08:00',
+						interval: 'week',
+						post_id: 1234,
+					},
 					metric: 'opens',
 				} }
 			/>

--- a/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
@@ -64,8 +64,9 @@ type EmailTimeSeriesReportProps = {
 /**
  * Fetches the selected email's opens or clicks timeline over the dashboard
  * date range and draws it with the window total as the metric headline. The
- * endpoint reports daily buckets; weekly/monthly intervals aggregate them
- * client-side. Only the active metric's query runs. The post detail design
+ * endpoint reports hourly or daily buckets; weekly/monthly intervals
+ * aggregate the daily ones client-side. Only the active metric's query runs.
+ * The post detail design
  * has no period-over-period comparison, so comparison report params are
  * ignored — they ride along in the URL untouched so dashboard state survives
  * the round trip, and every widget on this page disregards them.

--- a/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
@@ -115,7 +115,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Email performance" widget. Draws a single sent email\'s opens or clicks per day as a line chart, spanning the dashboard date range — the chart section of the legacy email detail page. The bucket size follows the page\'s chart interval control; weekly and monthly grouping aggregate the daily buckets client-side because the endpoint only reports hourly/daily. Scoped to one email via a mocked `reportParams.post_id`. The post detail page has no comparison control, so comparison report params are ignored.',
+					'The "Email performance" widget. Draws a single sent email\'s opens or clicks per day as a line chart, spanning the dashboard date range — the chart section of the legacy email detail page. The bucket size follows the page\'s chart interval control: an hourly window (the last-24-hours preset) draws the hourly buckets directly, while weekly and monthly grouping aggregate the daily buckets client-side because the endpoint only reports hourly/daily. Scoped to one email via a mocked `reportParams.post_id`. The post detail page has no comparison control, so comparison report params are ignored.',
 			},
 		},
 	},
@@ -158,10 +158,10 @@ export const ByWeeks: Story = {
  * days. The endpoint anchors its hourly buckets on the start day's midnight,
  * so the mock returns buckets from before the window opens — the data layer
  * trims them, and the chart draws exactly the selected 24 hours (WOOA7S-1840).
- * The page interval is pinned to `hour` by the preset, so the interval
- * control is hidden here.
+ * The preset pins the page interval to `hour`, so the interval control is
+ * hidden here and no interval arg is wired.
  */
-export const LastTwentyFourHours: Story = {
+export const LastTwentyFourHours: StoryObj< Omit< EmailTimeSeriesStoryControls, 'interval' > > = {
 	render: ( { metric, chartType } ) => (
 		<EmailTimeSeriesRender
 			attributes={ {
@@ -174,8 +174,8 @@ export const LastTwentyFourHours: Story = {
 			} }
 		/>
 	),
-	args: { metric: 'opens', interval: 'day', chartType: 'line' },
-	argTypes: { interval: { table: { disable: true } } },
+	args: { metric: 'opens', chartType: 'line' },
+	parameters: { controls: { exclude: [ 'interval' ] } },
 	decorators: [ withWidgetCanvas ],
 };
 

--- a/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
@@ -15,6 +15,7 @@
  * External dependencies
  */
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { PRESET_LAST_24_HOURS } from '@jetpack-premium-analytics/datetime';
 /**
  * Internal dependencies
  */
@@ -149,6 +150,32 @@ export const Clicks: Story = {
 export const ByWeeks: Story = {
 	render: renderEmailTimeSeries,
 	args: { metric: 'opens', interval: 'week', chartType: 'line' },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * The last-24-hours preset: an hourly window that usually spans two calendar
+ * days. The endpoint anchors its hourly buckets on the start day's midnight,
+ * so the mock returns buckets from before the window opens — the data layer
+ * trims them, and the chart draws exactly the selected 24 hours (WOOA7S-1840).
+ * The page interval is pinned to `hour` by the preset, so the interval
+ * control is hidden here.
+ */
+export const LastTwentyFourHours: Story = {
+	render: ( { metric, chartType } ) => (
+		<EmailTimeSeriesRender
+			attributes={ {
+				reportParams: {
+					...getDefaultQueryParams( false, PRESET_LAST_24_HOURS ),
+					post_id: MOCK_EMAIL_ID,
+				},
+				metric,
+				chartType,
+			} }
+		/>
+	),
+	args: { metric: 'opens', interval: 'day', chartType: 'line' },
+	argTypes: { interval: { table: { disable: true } } },
 	decorators: [ withWidgetCanvas ],
 };
 

--- a/projects/plugins/jetpack/changelog/wooa7s-1840-email-hourly-overfetch
+++ b/projects/plugins/jetpack/changelog/wooa7s-1840-email-hourly-overfetch
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Stats: Fix the email opens/clicks timeline charting hours outside the selected window.
+Premium Analytics: Fix the email opens/clicks timeline charting hours outside the selected window.

--- a/projects/plugins/jetpack/changelog/wooa7s-1840-email-hourly-overfetch
+++ b/projects/plugins/jetpack/changelog/wooa7s-1840-email-hourly-overfetch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Stats: Fix the email opens/clicks timeline charting hours outside the selected window.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1840-email-hourly-overfetch
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1840-email-hourly-overfetch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the email opens/clicks timeline charting hours outside the selected window.


### PR DESCRIPTION
Fixes WOOA7S-1840

## Why

Picking "Last 24 hours" on an email's performance chart showed roughly twice the range asked for: the chart spanned two full calendar days of hourly buckets and the headline total summed all of them, so the number on screen wasn't the number of opens/clicks in the selected 24 hours. Now the chart and the total cover exactly the window the date picker names.

## Proposed changes

* Right-size the email timeline's hourly `quantity`. The endpoint reads `date` as the window start, resolves it to its calendar day, and returns `quantity` hourly buckets anchored on that day's **midnight** regardless of the time of day the param carries (verified against production — a bare `2026-08-06` and `2026-08-06T09:00:00.000-04:00` return byte-identical hour-0..23 windows). So instead of 24 buckets per calendar day touched (48 for a mid-day 24-hour window), the query now asks for buckets from that midnight through the window's end hour (33 for the same window).
* Trim the returned series to the requested window. The midnight anchor makes some leading out-of-window buckets unavoidable, so the query passes a dedicated `window_start`/`window_end` pair through `sanitizerParams` and `sanitizeStatsTimeSeriesResponse` drops buckets outside it — before the summary is computed, so out-of-window buckets inflate neither the chart nor the totals. The opt-in is deliberately not the generic `start_date`/`end_date` request params, which reach the shared sanitizer from range-bounded endpoints (`stats/visits`, subscribers, WordAds) that must never have buckets dropped — pinned by test.
* Make the Storybook email-timeline mock anchor hourly buckets on the start day's midnight the way production does (and parse the date part in the runner's own timezone so labels stay on the requested day in any browser), and add a `LastTwentyFourHours` story so the trimmed hourly window is reviewable: the mock returns out-of-window buckets and the chart must draw exactly the selected 24 hours.
* Update the pinned query test (the 48-bucket over-fetch was pinned there referencing this issue), add sanitizer trim tests, and pin explicit windows in the widget tests whose fixtures relied on buckets never being trimmed.
* Hardening from local review: window bounds are read in every timestamp shape report params can carry (space-separated and seconds-less times included, mirroring the datetime package's `SITE_TIMESTAMP`); rows whose bucket bounds aren't comparable wall clocks are kept rather than silently dropped; both the trim bound and the end-hour sizing go through the datetime package's single `readSiteTimestamp` reader (narrowed to the shapes the stats-params pipeline itself carries) so they cannot drift apart; an inverted window disables the trim instead of emptying the chart; the hourly `quantity` is floored at 1; and a widget test covers the three layers composed (33 midnight-anchored buckets in → 24 in-window points and their sum out).

## Screenshots

Captured from the new `LastTwentyFourHours` story, which exercises the real query → mock → sanitizer → chart pipeline (the mock reads `period`/`quantity`/`date` off the actual request and returns midnight-anchored buckets, exactly the production shape):

<img width="1644" height="920" alt="Before: the chart spans two full days (48 hourly buckets) and the total sums all of them. After: the chart spans exactly the selected 24 hours and the total sums only the window." src="https://github.com/user-attachments/assets/833d39f3-a5f8-4285-9770-432dbd16953d" />

Quantitatively: before, the chart's line path had 48 points and the total summed 48 buckets; after, 24 points and the window-only total.

## Related product discussion/links

* WOOA7S-1840
* WOOA7S-1656 / WOOA7S-1664 — the offset-bearing date work that moved the surplus from leading to trailing (the over-fetch itself predates it)
* #50916 — the PR that surfaced the bug and pinned the old behavior in a test

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

From the issue's acceptance criteria:

* [ ] `emailTimeSeriesQuery()` no longer requests `24 × calendar days` hourly buckets for an hourly window: a "Last 24 hours" selection spanning two calendar days requests 33 buckets (midnight of the start day through the window's end hour), not 48 — pinned in `packages/data/src/queries/__tests__/stats-queries.test.ts` ("sizes an offset-bearing hourly window from its start day midnight through its end hour").
* [ ] The plotted series is filtered to the selected window: buckets outside `[from, to]` are neither drawn nor summed into the headline total — pinned in `packages/data/src/processing/stats/__tests__/time-series.test.ts` ("trims buckets outside a window_start/window_end window and sums only the rest").
* [ ] Bare-date (whole-day) hourly and daily windows behave as before: 24 buckets per day, `days` buckets for daily, nothing trimmed.
* [ ] Other time-series endpoints (`stats/visits`, subscribers, etc.) are unaffected — the trim activates only on the dedicated `window_start`/`window_end` sanitizer params, never on the generic request date params.

To review visually: `pnpm run storybook:dev` in `projects/js-packages/storybook`, open **Packages/Premium Analytics/Widgets/EmailTimeSeries → LastTwentyFourHours**. The chart must span exactly the last 24 hours (the mock intentionally returns midnight-anchored out-of-window buckets). To see the old behavior, revert the `quantity` line in `stats-email-time-series-query.ts` and the trim in `time-series.ts` and reload — the chart stretches to two full days.

Run the suite:

```
cd projects/packages/premium-analytics
TZ=UTC pnpm jest --config=tests/jest.config.cjs packages/data widgets/email-time-series
pnpm run typecheck
```
