### PR TITLE
[Do not merge] CI: measure starting the longest JS test projects first

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,7 +182,36 @@ jobs:
           FAILED=()
           mkdir artifacts
           [[ -n "$COVERAGE_GROUP" ]] && mkdir coverage
-          for P in composer.json projects/*/*/composer.json; do
+          # The loop hands work to the lanes in the order it walks the projects,
+          # which is lexicographic. That leaves every plugins/* project until
+          # last, so the longest-running ones only start once the run is already
+          # a third done and then finish alone while the other lanes sit idle.
+          # Starting the longest ones first uses the same CPU time and ends the
+          # run sooner. [Do not merge] Only test-js is reordered here, so the PHP
+          # jobs in the same run act as a control.
+          SLOW_FIRST=()
+          if [[ "$TEST_SCRIPT" == test-js* ]]; then
+            SLOW_FIRST=(
+              projects/packages/premium-analytics/composer.json
+              projects/packages/publicize/composer.json
+              projects/plugins/jetpack/composer.json
+              projects/js-packages/critical-css-gen/composer.json
+              projects/packages/videopress/composer.json
+            )
+          fi
+          ORDER=( composer.json )
+          for P in "${SLOW_FIRST[@]}"; do
+            [[ -f "$P" ]] && ORDER+=( "$P" )
+          done
+          for P in projects/*/*/composer.json; do
+            for Q in "${SLOW_FIRST[@]}"; do
+              [[ "$P" == "$Q" ]] && continue 2
+            done
+            ORDER+=( "$P" )
+          done
+          echo "Project order: ${ORDER[*]}"
+
+          for P in "${ORDER[@]}"; do
             if [[ ${#PIDS[@]} -ge $MAXPIDS ]]; then
               if ! wait -fn -p PID "${!PIDS[@]}"; then
                 echo "::error::Tests for ${PIDS[$PID]} failed!"


### PR DESCRIPTION
**Not for merge — this is a measurement.** It exists to check on real CI whether the project loop's ordering moves the Tests job wall clock, or whether the idle tail at the end of the run is too small to matter.

Two samples are in. Short version: **the tail is real and this removes it, but longest-first buys the tail back as contention**, so the win is smaller and much less stable than the scheduling math predicts.

## Proposed changes

* Start the five longest-running JS projects before walking the rest lexicographically, in the "Run project tests" loop of `tests.yml`.
* Leave `test-php` alone, so the PHP jobs act as a speed control for the runner.
* Log the resulting order.

The set of projects that runs is unchanged; only the order they are handed to the lanes changes.

## The tail this was aimed at

The loop hands work to `nproc` lanes in the order it walks `composer.json projects/*/*/composer.json`, which is lexicographic, so `plugins/*` always comes last. Ordering cannot change CPU time — the claim was only ever about wall clock, through the tail where lanes go idle waiting on one long job.

Across eight trunk runs of the JS tests job, the loop ends **exactly** when `packages/premium-analytics` ends, in all eight: it takes 391–451s and does not start until +181–205s.

## Result

`Run project tests`, JS tests job:

| Run | JS step | Nearest trunk run | vs that run |
| --- | --- | --- | --- |
| Attempt 1, 03:42 | **508s** | 640s (03:15) | −20.6% |
| Attempt 2, 04:11 | **635s** | 664s (04:09) | −4.4% |

Trunk sits at 596–664s over nine runs. The comparison is against the nearest trunk run rather than the median because the pool swings: the run two minutes before attempt 2 was the slowest trunk run in the sample.

The scheduling part worked exactly as intended, in both attempts:

| | Total work | Longest project | `max(longest, work/4)` | Actual | Gap |
| --- | --- | --- | --- | --- | --- |
| Trunk | 2162s | 423s | 540s | 617s | +76s (14%) |
| Attempt 1 | 2004s | 326s | 501s | 508s | +7s (1.4%) |
| Attempt 2 | 2504s | 401s | 626s | 635s | +9s (1.4%) |

The idle tail collapses from 14% to 1.4%. But **total work is not a constant**, and that is where the win goes.

## What it costs

Running the heavy projects side by side rather than spread out changes how long they take:

| Project | Trunk | Attempt 1 | Attempt 2 |
| --- | --- | --- | --- |
| `js-packages/critical-css-gen` | 155s | 326s | 377s |
| `packages/premium-analytics` | 423s | 316s | 401s |
| `plugins/jetpack` | 166s | 205s | 252s |
| `packages/publicize` | 246s | 185s | 228s |
| **Total work** | **2162s** | **2004s** | **2504s** |

`critical-css-gen` more than doubles. In attempt 2 the extra work cancelled most of the scheduling gain.

`monorepo` also fails, **deterministically in both attempts**: `tools/cli`'s `build command › production flag exists` exceeds its 5000ms per-test timeout. It runs first either way, but its neighbours are now the three heaviest projects instead of three `github-actions/*` projects, and it goes from 8s to 16s.

## What this suggests

Longest-first is the wrong objective on its own. It optimises for a model where per-project durations are fixed, and they are not. Something that spreads the heavy projects out — while still not leaving the longest one until last — would keep the tail fix without the pile-up. Worth deciding before anyone writes the real version.

The same tail exists on `test-php`, where `plugins/jetpack` is 250s of 1072s total work and starts at +132s, giving a 382s loop against a 268s floor. Untouched here on purpose.

## Related product discussion/links

* WOOA7S-1971
* p1787160829896779-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Nothing functional to test. In the JS tests job log, check the `Project order:` line, confirm the same projects still run, and compare the step duration with trunk.
