### PR TITLE
[Do not merge] CI: front-load the longest JS projects, minus critical-css-gen

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,7 +182,42 @@ jobs:
           FAILED=()
           mkdir artifacts
           [[ -n "$COVERAGE_GROUP" ]] && mkdir coverage
-          for P in composer.json projects/*/*/composer.json; do
+          # The loop hands work to the lanes in the order it walks the projects,
+          # which is lexicographic. That leaves every plugins/* project until
+          # last, so the longest-running ones only start once the run is already
+          # a third done and then finish alone while the other lanes sit idle.
+          # Starting the longest ones first uses the same CPU time and ends the
+          # run sooner.
+          #
+          # js-packages/critical-css-gen is deliberately NOT in this list. It is
+          # 150s of mostly-headless-Chrome work that today runs early alongside
+          # small projects, and #51591 showed it more than doubling when it was
+          # moved next to the other long projects.
+          #
+          # [Do not merge] Only test-js is reordered here, so the PHP jobs in the
+          # same run act as a control.
+          SLOW_FIRST=()
+          if [[ "$TEST_SCRIPT" == test-js* ]]; then
+            SLOW_FIRST=(
+              projects/packages/premium-analytics/composer.json
+              projects/packages/publicize/composer.json
+              projects/plugins/jetpack/composer.json
+              projects/packages/videopress/composer.json
+            )
+          fi
+          ORDER=( composer.json )
+          for P in "${SLOW_FIRST[@]}"; do
+            [[ -f "$P" ]] && ORDER+=( "$P" )
+          done
+          for P in projects/*/*/composer.json; do
+            for Q in "${SLOW_FIRST[@]}"; do
+              [[ "$P" == "$Q" ]] && continue 2
+            done
+            ORDER+=( "$P" )
+          done
+          echo "Project order: ${ORDER[*]}"
+
+          for P in "${ORDER[@]}"; do
             if [[ ${#PIDS[@]} -ge $MAXPIDS ]]; then
               if ! wait -fn -p PID "${!PIDS[@]}"; then
                 echo "::error::Tests for ${PIDS[$PID]} failed!"


### PR DESCRIPTION
**Not for merge — this is a measurement**, and a follow-up to #51591. Same idea, one variable changed: front-load the same list **minus `js-packages/critical-css-gen`**.

Result: it fixes what it set out to fix, and then the second run of the same config came in slower than trunk. Together with #51591 that is four reordered runs, and the spread across them is wider than the effect.

## Why `critical-css-gen` was dropped

It is the most stable project in the JS job across eight trunk runs — 141, 147, 147, 148, 149, 151, 155, 156s — and then #51591 put it next to three long projects and it went to 326s and 377s. On trunk it runs at +22s and finishes around +177s, before `packages/premium-analytics` even starts, so today it never shares the box with another long project.

Dropping it works. In the first run here it landed at +274s and took **136s**, and `monorepo` stayed under the timeout that fails in #51591, so the job went green.

## All four reordered runs

| Run | `critical-css-gen` | Total work | `max(longest, work/4)` | Actual | Gap |
| --- | --- | --- | --- | --- | --- |
| Trunk | 155s | 2162s | 540s | 617s | +76s (14%) |
| #51591 attempt 1 | 326s | 2004s | 501s | 508s | +7s |
| #51591 attempt 2 | 377s | 2504s | 626s | 635s | +9s |
| This PR, attempt 1 | **136s** | **1960s** | 490s | **498s** | +8s |
| This PR, attempt 2 | 181s | **2789s** | 697s | **707s** | +10s |

The scheduling half is settled: the idle tail collapses from 14% to ~1.5% in all four, and mean lane occupancy goes from 3.50 to 3.94 of 4.

The wall clock half is not. Normalising each run against its own PHP jobs, which this change does not touch:

| Run | JS step | PHP median | Ratio | vs trunk median 1.76 |
| --- | --- | --- | --- | --- |
| Trunk, 8 runs | 596–664s | 328–380s | 1.64–1.92 | — |
| #51591 attempt 1 | 508s | 377s | 1.35 | −23% |
| This PR, attempt 1 | 498s | 381s | 1.31 | **−26%** |
| This PR, attempt 2 | 707s | 351s | 2.01 | **+14%** |

(#51591's second attempt only re-ran the failed job, so its PHP numbers are carried over from the first attempt and it has no control. Raw, it was 635s against 664s on the trunk run two minutes earlier.)

Attempt 2 here is the same commit and the same ordering as attempt 1, with total work 42% higher, while its PHP jobs were *faster* than attempt 1's. So it is not a uniformly slow machine.

## What that suggests

Packing the lanes trades slack for utilisation. Today's ordering leaves 12% of the lane-time idle, and that idle time is also headroom. Removing it makes a good box faster and a bad box slower, which is what the four runs show.

The fragility is the concrete part: `monorepo` fails in three of the four, always the same test — `tools/cli`'s `build command › production flag exists`, a 5000ms per-test timeout. `monorepo` goes from 8s on trunk to 12–17s once its neighbours are long projects.

More samples would settle the size of the win. Whether the win is worth a CI run that is more sensitive to the box it lands on is the more interesting question.

## Related product discussion/links

* WOOA7S-1971
* p1787160829896779-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Nothing functional to test. Check the `Project order:` line in the JS tests job log and compare step durations with trunk and with #51591.
