### PR TITLE
Premium Analytics: give the Top locations map vertical breathing room

### DIFF
--- a/projects/packages/premium-analytics/changelog/pa-locations-map-padding
+++ b/projects/packages/premium-analytics/changelog/pa-locations-map-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Top locations: Add breathing room above and below the map.

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -67,6 +67,11 @@
 	display: flex;
 	align-items: center;
 	overflow: hidden;
+
+	/* A wide cell leaves the map height-constrained, so it is drawn edge to edge
+	 * and its bottom lands on the footer divider. Reserve the gap here: the
+	 * chart's aspectRatio caps the width but still fills the full height. */
+	padding-block: var(--wpds-dimension-gap-md);
 }
 
 /* Very narrow containers: hide the map and collapse to a single leaderboard

--- a/projects/plugins/jetpack/changelog/pa-locations-map-padding
+++ b/projects/plugins/jetpack/changelog/pa-locations-map-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: Add breathing room above and below the Top locations map.

--- a/projects/plugins/mu-wpcom-plugin/changelog/pa-locations-map-padding
+++ b/projects/plugins/mu-wpcom-plugin/changelog/pa-locations-map-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: Add breathing room above and below the Top locations map.

--- a/projects/plugins/premium-analytics/changelog/pa-locations-map-padding
+++ b/projects/plugins/premium-analytics/changelog/pa-locations-map-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Top locations: Add breathing room above and below the map.


### PR DESCRIPTION
Related to WOOA7S-1829

## Proposed changes
* On a wide dashboard tile the world map is height-constrained, so it filled the geo cell edge to edge — 0px above and 1px below, with its bottom edge landing on the widget footer divider.
* Reserve the gap with `padding-block: var(--wpds-dimension-gap-md)` on the map cell.
* Not `aspectRatio` on `GeoChart`: it caps the chart box width but still fills the full height, so the vertical insets come out identical (measured 0/1px either way).

## Before / after

Storybook, `Packages/Premium Analytics/Widgets/Locations` → *Widget Dashboard With Widget* at `widgetWidth: 3`, `widgetHeight: 2` — a 1175x416 tile, the same shape as a full-width tile in product. The map's vertical inset goes from 0/1px to 12/13px.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/pa-locations-map-vertical-padding/before-top-locations.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/pa-locations-map-vertical-padding/after-top-locations.png) |

## Related product discussion/links
* n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Premium Analytics dashboard on a site with location data.
* Widen the browser until the Top locations tile is wide enough that the map is limited by height rather than width (a full-width tile on a ~1800px viewport does it).
* Before: the map's bottom edge sits on the divider above "View all", with no gap above it either.
* After: equal space above and below the map, and the divider is clear.
* Narrow the window again — the map keeps its existing centring, just slightly smaller.

