### PR TITLE
Premium Analytics: scroll the dashboard with the page, not in its own scroll area

### DIFF
--- a/projects/packages/premium-analytics/.gitignore
+++ b/projects/packages/premium-analytics/.gitignore
@@ -2,5 +2,6 @@ vendor/
 node_modules/
 build/
 build-module/
+build-style/
 composer.lock
 .phpunit.cache/

--- a/projects/packages/premium-analytics/changelog/wooa7s-1991
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1991
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix scrolling on the dashboard when the wp-admin menu is taller than the window.

--- a/projects/packages/premium-analytics/packages/init/src/admin-shell.scss
+++ b/projects/packages/premium-analytics/packages/init/src/admin-shell.scss
@@ -1,0 +1,28 @@
+@use "@wordpress/base-styles/breakpoints";
+@use "@wordpress/base-styles/variables" as vars;
+
+/*
+ * Let the page be the only scroll container on desktop. A scroller inside the
+ * shell plus the document's own — wp-admin grows `#wpwrap` to the admin menu's
+ * height — latch a wheel gesture one at a time, so scrolling stalls at
+ * whichever end it reaches first. Below `$break-medium` boot fixes its own
+ * surfaces.
+ */
+@media (min-width: #{breakpoints.$break-medium + 1}) {
+
+	.boot-layout-container .boot-layout.boot-layout--single-page {
+		position: static;
+		block-size: auto;
+	}
+
+	.boot-layout__surfaces,
+	.boot-layout__stage {
+		block-size: auto;
+		overflow: visible;
+	}
+
+	// admin-ui pins the Page header at 0, which the admin bar then covers.
+	.boot-layout__stage > .admin-ui-navigable-region > :first-child {
+		inset-block-start: var(--wp-admin--admin-bar--height, #{vars.$admin-bar-height});
+	}
+}

--- a/projects/packages/premium-analytics/packages/init/src/index.ts
+++ b/projects/packages/premium-analytics/packages/init/src/index.ts
@@ -7,6 +7,10 @@ import apiFetch from '@wordpress/api-fetch';
 import { store as bootStore } from '@wordpress/boot';
 import { dispatch } from '@wordpress/data';
 import { chartBar } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import './admin-shell.scss';
 
 // apiFetch middleware registers onto a shared, process-wide chain. Guard so
 // repeated init() calls (re-mount, HMR, a future second boot) don't stack

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
@@ -1,26 +1,26 @@
-// Flex column so the section panel fills the remaining viewport height and
-// scrolls internally instead of collapsing to its content height. Otherwise
-// the panel grows with the widget grid, and the grid (fixed row height)
-// resizes it back, so the two oscillate while resizing a widget (flicker).
+@use "@wordpress/base-styles/breakpoints";
+
 .root {
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 auto;
 	min-block-size: 0;
 
-	// The section's scroll container. Scrolling here rather than the boot
-	// stage keeps the page header out of the scroll flow entirely: `Page` is
-	// `height: 100%`, so a sticky header inside it runs out of containing
-	// block one viewport in and slides away. The tab list scrolls away with
-	// the content, which is interim until the sections move into `Page`'s
-	// navigation slot (WordPress/gutenberg#79746, not yet in
-	// `@wordpress/admin-ui`; WOOA7S-1931).
+	// Below `$break-medium` boot fixes its surfaces to the viewport, so the
+	// panel has to scroll itself; on desktop the page is the only scroller
+	// (WOOA7S-1991). The tab list scrolls away either way, until the sections
+	// move into `Page`'s navigation slot (WordPress/gutenberg#79746; WOOA7S-1931).
 	overflow-y: auto;
 
 	// Own stacking context, so in-panel layers (the sticky section header,
 	// widget focus rings) never compete with the page header above.
 	position: relative;
 	z-index: 0;
+
+	@media (min-width: #{breakpoints.$break-medium + 1}) {
+		min-block-size: auto;
+		overflow-y: visible;
+	}
 }
 
 // Scoped under the root to outweigh the shared tab bar's own single-class rule

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/index.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/index.ts
@@ -2,4 +2,5 @@ export { useActiveSection } from './use-active-section';
 export { useDashboardGridSettings } from './use-dashboard-grid-settings';
 export { useDashboardSectionLayout } from './use-dashboard-section-layout';
 export { useDashboardSections } from './use-dashboard-sections';
+export { usePinnedHeaderOffset } from './use-pinned-header-offset';
 export { useSectionDateFilter } from './use-section-date-filter';

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-pinned-header-offset.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-pinned-header-offset.ts
@@ -1,0 +1,34 @@
+import { useLayoutEffect } from 'react';
+import styles from '../stage.module.scss';
+
+const CUSTOM_PROPERTY = '--pa-pinned-header-block-size';
+
+/**
+ * Publishes the pinned page header's height for the section header to rest below.
+ *
+ * The page scrolls, so both bands pin against the viewport and would otherwise
+ * overlap. The height is admin-ui's to decide and changes when the subtitle
+ * wraps, so it is measured rather than restated here.
+ *
+ * @param sectionHeader - The section header element, used to reach the page.
+ */
+export function usePinnedHeaderOffset( sectionHeader: HTMLElement | null ) {
+	useLayoutEffect( () => {
+		const page = sectionHeader?.closest< HTMLElement >( `.${ styles.dashboard }` );
+		const header = page?.firstElementChild;
+
+		if ( ! page || ! header ) {
+			return;
+		}
+
+		const observer = new ResizeObserver( () => {
+			page.style.setProperty( CUSTOM_PROPERTY, `${ header.getBoundingClientRect().height }px` );
+		} );
+		observer.observe( header );
+
+		return () => {
+			observer.disconnect();
+			page.style.removeProperty( CUSTOM_PROPERTY );
+		};
+	}, [ sectionHeader ] );
+}

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -1,3 +1,6 @@
+@use "@wordpress/base-styles/breakpoints";
+@use "@wordpress/base-styles/variables" as vars;
+
 .dashboard {
 	min-block-size: 0;
 
@@ -105,11 +108,17 @@
 }
 
 .sectionHeader {
-	// Pins at 0 rather than under the page header's height: the scroll
-	// container is the sections root, which begins where the page header ends.
+	// Pins at 0 while the sections root is the scroll container, which begins
+	// where the page header ends. On desktop the page scrolls instead, so the
+	// band has to clear the admin bar and the page header pinned above it
+	// (published by `usePinnedHeaderOffset`).
 	position: sticky;
 	inset-block-start: 0;
 	z-index: 1;
+
+	@media (min-width: #{breakpoints.$break-medium + 1}) {
+		inset-block-start: calc(var(--wp-admin--admin-bar--height, #{vars.$admin-bar-height}) + var(--pa-pinned-header-block-size, 0px));
+	}
 
 	/*
 	 * A stuck header must be opaque, and it takes the page header's fill: this

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -37,6 +37,7 @@ import {
 	useDashboardGridSettings,
 	useDashboardSectionLayout,
 	useDashboardSections,
+	usePinnedHeaderOffset,
 	useSectionDateFilter,
 } from './hooks';
 import styles from './stage.module.scss';
@@ -185,6 +186,7 @@ function Dashboard(): JSX.Element {
 
 	// Container element for the date filters panel responsive layout.
 	const [ containerElement, setContainerElement ] = useState< HTMLDivElement | null >( null );
+	usePinnedHeaderOffset( containerElement );
 
 	// The sections carry each section's default layout, so until the entity
 	// resolves the layout above is transiently empty. WidgetDashboard treats an

--- a/projects/plugins/jetpack/changelog/wooa7s-1991
+++ b/projects/plugins/jetpack/changelog/wooa7s-1991
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: fix scrolling on the dashboard when the wp-admin menu is taller than the window.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1991
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1991
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix scrolling on the dashboard when the wp-admin menu is taller than the window.


### PR DESCRIPTION
Fixes WOOA7S-1991

## Proposed changes

* Make the page the only scroll container on desktop, so one wheel gesture scrolls the dashboard from top to bottom.
* Keep the pinned page header and section header behaving as they do today, now offset against the viewport instead of the panel.
* Publish the page header's measured height so the section header rests below it, rather than restating admin-ui's padding tokens.
* Scope to the dashboard route; the detail and report routes pin different things and need their own pass.

wp-admin grows `#wpwrap` to the admin menu's height, so a menu taller than the window makes the document scrollable. The shell also scrolled internally, and a wheel gesture latches to one scroller at a time — so scrolling stalled at whichever end it reached first, and the document scroll dragged the whole app off-screen behind the shell's rounded corners.

Pinning the shell (the first approach on this branch) stopped the app moving but left both scrollers in place, so the stall remained. Letting the app's content flow into the page removes the second scroller entirely.

The comment guarding the panel's scroller warned that removing it would make the panel and the widget grid oscillate while resizing a widget. That no longer applies: `@wordpress/grid` takes a fixed pixel `rowHeight` snapped to presets, so there is no container-to-grid feedback, and a sampled resize drag (1350 frames) showed the grid height move once, with zero direction reversals.

## Related product discussion/links

* WOOA7S-1991
* Upstream context on why the document stays scrollable: WordPress/gutenberg#4445, WordPress/gutenberg#4587, WordPress/gutenberg#4629
* Follow-up: the tab list still scrolls away pending WordPress/gutenberg#79746 (WOOA7S-1931)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Premium Analytics dashboard (Stats v2) in wp-admin on a desktop-width window, with an admin menu taller than the window — shrink the window to ~600px tall, or add menu items.
* Scroll from the top of the page to the bottom in one continuous gesture with the pointer over the dashboard. It should scroll all the way without stalling and needing a second gesture.
* While scrolling, the "Stats" header should stay pinned below the admin bar and the section header ("Site traffic" plus the date controls) directly below it, with no overlap or gap. The tab list scrolls away, as it does today.
* Collapse the admin menu and repeat; the dashboard should sit flush against the 36px menu.
* Hover a menu item with a submenu — the flyout must still appear and not be clipped.
* Enter Customize, resize a widget, and confirm the layout does not flicker.
* Below 783px wide, nothing should change: boot fixes its own surfaces there and the panel keeps its own scroller.
