### PR TITLE
Premium Analytics: decode HTML entities in email subject lines

### DIFF
--- a/projects/packages/premium-analytics/changelog/pa-emails-decode-title-entities
+++ b/projects/packages/premium-analytics/changelog/pa-emails-decode-title-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Emails: Decode HTML entities in email subject lines.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-summary.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-summary.test.ts
@@ -35,6 +35,24 @@ describe( 'Stats email summary normalizer', () => {
 		);
 	} );
 
+	it( 'decodes HTML entities in the subject line', () => {
+		const report = sanitizeStatsEmailSummaryResponse(
+			{
+				posts: [
+					{
+						...emailSummaryFixture.posts[ 0 ],
+						title: 'Easiest &amp; Best Way to Back Up a WordPress Site&#8217;s Data',
+					},
+				],
+			},
+			{ period: 'day', date: '2026-06-16' }
+		);
+
+		expect( report.data[ 0 ].items[ 0 ].label ).toBe(
+			'Easiest & Best Way to Back Up a WordPress Site’s Data'
+		);
+	} );
+
 	it( 'returns empty data for empty email summaries', () => {
 		expect(
 			sanitizeStatsEmailSummaryResponse( {}, { period: 'day', date: '2026-06-16' } )

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/email-summary.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/email-summary.ts
@@ -1,3 +1,4 @@
+import { decodeEntities } from '@wordpress/html-entities';
 import { safeParseFloat } from '../../utils/parsing';
 import { coerceStatsArray, coerceStatsRecord, createStatsListDataPoint } from './utils';
 import type {
@@ -29,7 +30,9 @@ function normalizeStatsEmailSummaryItem( post: StatsRecord ): StatsEmailSummaryI
 
 	return {
 		id: post.id as string | number | undefined,
-		label: post.title,
+		// WPCOM returns the subject line HTML-encoded (`&amp;`, `&#8217;`), and every
+		// consumer renders it as text, so decode once here.
+		label: typeof post.title === 'string' ? decodeEntities( post.title ) : post.title,
 		// Opens is the headline metric for the emails leaderboard; clicks_rate is frequently 0.
 		value: safeParseFloat( post.opens ),
 		link,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -1058,6 +1058,8 @@ function buildVisitsResponse( query: URLSearchParams ) {
  * populated in Storybook. The shape matches what `sanitizeStatsEmailSummaryResponse`
  * expects (`{ posts: [ { title, opens_rate, clicks_rate, … } ] }`); rates are
  * 0–100 percentages and the rows are newest-first to mirror the live endpoint.
+ * One subject line carries HTML entities, because the live endpoint returns them
+ * encoded.
  *
  * @return Raw email-summary response.
  */
@@ -1071,7 +1073,11 @@ function buildEmailSummaryResponse() {
 			opens_rate: 52.4,
 			clicks_rate: 8.93,
 		},
-		{ title: 'WordCamp Europe 2026: What to Expect', opens_rate: 47.9, clicks_rate: 10.25 },
+		{
+			title: 'WordCamp Europe 2026: Talks &amp; Workshops You Shouldn&#8217;t Miss',
+			opens_rate: 47.9,
+			clicks_rate: 10.25,
+		},
 		{
 			title: 'Click, Comment, Done: A Better Way to Collaborate',
 			opens_rate: 44.3,

--- a/projects/plugins/jetpack/changelog/pa-emails-decode-title-entities
+++ b/projects/plugins/jetpack/changelog/pa-emails-decode-title-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Show email subject lines with characters like "&" instead of their HTML codes.

--- a/projects/plugins/premium-analytics/changelog/pa-emails-decode-title-entities
+++ b/projects/plugins/premium-analytics/changelog/pa-emails-decode-title-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Latest emails sent: Show subject lines with characters like "&" instead of their HTML codes.


### PR DESCRIPTION


## Proposed changes
* Decode HTML entities in the `stats/emails/summary` subject line, so `&amp;` and `&#8217;` reach the Latest emails sent widget as `&` and `’`.
* Give one Storybook mock subject line HTML entities, since that is what the live endpoint returns.

## Related product discussion/links
* WOOA7S-1995

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open Storybook (`pnpm run storybook` from `projects/packages/premium-analytics`) and go to **Packages/Premium Analytics/Widgets/Emails → WidgetDashboardWithWidget**.
* The WordCamp Europe row should read `Talks & Workshops You Shouldn’t Miss`, not `Talks &amp; Workshops You Shouldn&#8217;t Miss`.
* `jetpack test js packages/premium-analytics` covers the normalizer.

### Before / after

| Before | After |
|---|---|
| <img width="480" src="https://github.com/Automattic/jetpack/raw/screenshots/fix/pa-emails-decode-title-entities/before-emails-entities.png"> | <img width="480" src="https://github.com/Automattic/jetpack/raw/screenshots/fix/pa-emails-decode-title-entities/after-emails-entities.png"> |

