### PR TITLE
Premium Analytics: match Latest subscribers row metrics to the design

### DIFF
--- a/projects/packages/premium-analytics/changelog/pa-subscriber-list-row-metrics
+++ b/projects/packages/premium-analytics/changelog/pa-subscriber-list-row-metrics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Subscriber list: Match the row height, avatar size, and footer type to the design.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list-skeleton.module.scss
@@ -1,8 +1,9 @@
 @use "sass:list";
 
 /* Geometry from the design prototype's `list` skeleton variant, on WPDS
- * dimension tokens. Only the proportional widths stay literal — no token
- * expresses them. */
+ * dimension tokens where one exists. The row pitch and avatar size stay literal
+ * because they mirror `SubscriberList`, whose own values are off the token
+ * scale; so do the proportional widths. */
 
 /* These widths stand in for name text, so they vary without trending down — a
  * subscriber's name length says nothing about their place in the list. */
@@ -16,7 +17,7 @@ $name-widths: 85%, 70%, 78%, 58%, 66%, 48%;
 	flex: 1 1 auto;
 	flex-direction: column;
 	justify-content: safe center;
-	gap: var(--wpds-dimension-gap-lg);
+	gap: 6px;
 	min-block-size: 0;
 	overflow: hidden;
 }
@@ -26,15 +27,16 @@ $name-widths: 85%, 70%, 78%, 58%, 66%, 48%;
 	flex: none;
 	align-items: center;
 	column-gap: var(--wpds-dimension-gap-sm);
+	min-block-size: 36px;
 }
 
-/* Circular and 32px, following `SubscriberList`'s own avatar rather than the
+/* Circular and 28px, following `SubscriberList`'s own avatar rather than the
  * prototype's 22px 5px-radius square, so the rows load at the pitch they
  * settle into. */
 .avatar {
 	flex: none;
-	inline-size: var(--wpds-dimension-size-md);
-	block-size: var(--wpds-dimension-size-md);
+	inline-size: 28px;
+	block-size: 28px;
 	border-radius: 50%;
 }
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list-skeleton.module.scss
@@ -1,9 +1,9 @@
 @use "sass:list";
 
 /* Geometry from the design prototype's `list` skeleton variant, on WPDS
- * dimension tokens where one exists. The row pitch and avatar size stay literal
- * because they mirror `SubscriberList`, whose own values are off the token
- * scale; so do the proportional widths. */
+ * dimension tokens where one exists. The row height and avatar size stay
+ * literal because they mirror `SubscriberList`, whose own values are off the
+ * token scale; so do the proportional widths. */
 
 /* These widths stand in for name text, so they vary without trending down — a
  * subscriber's name length says nothing about their place in the list. */
@@ -17,7 +17,7 @@ $name-widths: 85%, 70%, 78%, 58%, 66%, 48%;
 	flex: 1 1 auto;
 	flex-direction: column;
 	justify-content: safe center;
-	gap: 6px;
+	gap: var(--wpds-dimension-gap-xs);
 	min-block-size: 0;
 	overflow: hidden;
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list.module.scss
@@ -9,8 +9,13 @@
 	block-size: 100%;
 }
 
+/* 6px is what wp-admin's `dd, li` rule gives the metric list's rows, so keeping
+ * it here holds the two widgets to the same row rhythm side by side. */
 .list {
+	display: flex;
 	flex: 1 1 auto;
+	flex-direction: column;
+	gap: 6px;
 	min-block-size: 0;
 }
 
@@ -21,7 +26,7 @@
 }
 
 .row {
-	padding-block: var(--wpds-dimension-padding-sm);
+	min-block-size: 36px;
 }
 
 /* flex:1 + min-width:0 lets the name ellipsis, not push "since" off-row. */
@@ -32,8 +37,8 @@
 
 .avatar {
 	flex-shrink: 0;
-	width: 32px;
-	height: 32px;
+	width: 28px;
+	height: 28px;
 	border-radius: 50%;
 	object-fit: cover;
 }
@@ -41,8 +46,8 @@
 /* The DataViews picker grids stretch media-cell images to 100%. Widget
  * previews render inert, so restore the avatar size there. */
 :global([inert]) .row .avatar {
-	width: 32px;
-	height: 32px;
+	width: 28px;
+	height: 28px;
 	object-fit: cover;
 }
 
@@ -69,7 +74,7 @@ a.name:focus {
 
 .more {
 	flex-shrink: 0;
-	padding-block: var(--wpds-dimension-padding-sm);
+	padding-block: var(--wpds-dimension-padding-md) 0;
 	color: var(--wpds-color-foreground-content-neutral-weak);
-	font-size: var(--wpds-typography-font-size-sm);
+	font-size: var(--wpds-typography-font-size-md);
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list.module.scss
@@ -9,13 +9,14 @@
 	block-size: 100%;
 }
 
-/* 6px is what wp-admin's `dd, li` rule gives the metric list's rows, so keeping
- * it here holds the two widgets to the same row rhythm side by side. */
+/* The metric list's rows are separated by wp-admin's own `dd, li` margin; the
+ * nearest token to it separates these, so the two widgets read at the same
+ * rhythm side by side. */
 .list {
 	display: flex;
 	flex: 1 1 auto;
 	flex-direction: column;
-	gap: 6px;
+	gap: var(--wpds-dimension-gap-xs);
 	min-block-size: 0;
 }
 

--- a/projects/plugins/jetpack/changelog/pa-subscriber-list-row-metrics
+++ b/projects/plugins/jetpack/changelog/pa-subscriber-list-row-metrics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: Tighten the Latest subscribers rows so more subscribers fit the widget.

--- a/projects/plugins/premium-analytics/changelog/pa-subscriber-list-row-metrics
+++ b/projects/plugins/premium-analytics/changelog/pa-subscriber-list-row-metrics
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Latest subscribers: Tighten the rows so more subscribers fit the widget.


### PR DESCRIPTION

## Proposed changes
* Row height goes 48px → 36px, the same stable row height the metric list uses, with `--wpds-dimension-gap-xs` between rows.
* Avatar goes 32px → 28px, and the "N more" footer moves to 13px with 12px of top padding.
* The loading skeleton follows the same pitch and avatar size, so rows load at the height they settle into.

One more subscriber now fits the tile at the same widget size.

## Related product discussion/links
* WOOA7S-1996

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open Storybook (`pnpm run storybook` from `projects/packages/premium-analytics`) and go to **Packages/Premium Analytics/Widgets/SubscribersList → WidgetDashboardWithWidget**.
* Rows should measure 36px tall on a 40px pitch with a 28px avatar; check the **Loading** story lines up with the same rhythm.
* Compare against the Latest emails sent widget beside it — the two should read at the same row rhythm.

### Before / after

| Before | After |
|---|---|
| <img width="480" src="https://github.com/Automattic/jetpack/raw/screenshots/change/pa-subscriber-list-row-metrics/before-subscriber-rows.png"> | <img width="480" src="https://github.com/Automattic/jetpack/raw/screenshots/change/pa-subscriber-list-row-metrics/after-subscriber-rows.png"> |


