### PR TITLE
Premium Analytics: order Latest subscribers by subscription date

### DIFF
--- a/projects/packages/premium-analytics/changelog/pa-latest-subscribers-recency-order
+++ b/projects/packages/premium-analytics/changelog/pa-latest-subscribers-recency-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscriber list: Order subscribers by subscription date instead of by subscriber type.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/followers.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/followers.test.ts
@@ -50,14 +50,15 @@ describe( 'Stats followers normalizer', () => {
 	} );
 
 	it( 'orders subscribers by subscription date, newest first', () => {
-		// `type=all` returns the newest email subscribers followed by the newest
-		// WPCOM ones, so an older email row can precede a newer WPCOM one.
+		// Raw rows arrive grouped by subscriber type, not in date order. Rows the
+		// sort key cannot read lead the input so they have to be moved to sort last.
 		const result = sanitizeStatsFollowersResponse( {
 			...followersFixture,
 			subscribers: [
+				{ ID: 3, label: 'Undated Reader' },
+				{ ID: 5, label: 'Unparsable Reader', date_subscribed: 'not-a-date' },
 				{ ID: 1, label: 'older@example.com', date_subscribed: '2025-01-26T00:00:00+00:00' },
 				{ ID: 2, label: 'Newest Reader', date_subscribed: '2026-08-25T00:00:00+00:00' },
-				{ ID: 3, label: 'Undated Reader' },
 				{ ID: 4, label: 'Middle Reader', date_subscribed: '2026-04-28T00:00:00+00:00' },
 			],
 		} );
@@ -67,6 +68,29 @@ describe( 'Stats followers normalizer', () => {
 			'Middle Reader',
 			'older@example.com',
 			'Undated Reader',
+			'Unparsable Reader',
+		] );
+	} );
+
+	it( 'trims the sorted rows to the requested page size', () => {
+		// `type=all` returns up to `max` rows per subscriber type, so only the
+		// newest `max` of the merged list are the newest `max` overall.
+		const result = sanitizeStatsFollowersResponse(
+			{
+				...followersFixture,
+				subscribers: [
+					{ ID: 1, label: 'stale@example.com', date_subscribed: '2025-01-26T00:00:00+00:00' },
+					{ ID: 2, label: 'older@example.com', date_subscribed: '2025-03-30T00:00:00+00:00' },
+					{ ID: 3, label: 'Newest Reader', date_subscribed: '2026-08-25T00:00:00+00:00' },
+					{ ID: 4, label: 'Middle Reader', date_subscribed: '2026-04-28T00:00:00+00:00' },
+				],
+			},
+			{ max: 2 }
+		);
+
+		expect( result.data[ 0 ].items.map( item => item.label ) ).toEqual( [
+			'Newest Reader',
+			'Middle Reader',
 		] );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/followers.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/followers.test.ts
@@ -49,6 +49,27 @@ describe( 'Stats followers normalizer', () => {
 		);
 	} );
 
+	it( 'orders subscribers by subscription date, newest first', () => {
+		// `type=all` returns the newest email subscribers followed by the newest
+		// WPCOM ones, so an older email row can precede a newer WPCOM one.
+		const result = sanitizeStatsFollowersResponse( {
+			...followersFixture,
+			subscribers: [
+				{ ID: 1, label: 'older@example.com', date_subscribed: '2025-01-26T00:00:00+00:00' },
+				{ ID: 2, label: 'Newest Reader', date_subscribed: '2026-08-25T00:00:00+00:00' },
+				{ ID: 3, label: 'Undated Reader' },
+				{ ID: 4, label: 'Middle Reader', date_subscribed: '2026-04-28T00:00:00+00:00' },
+			],
+		} );
+
+		expect( result.data[ 0 ].items.map( item => item.label ) ).toEqual( [
+			'Newest Reader',
+			'Middle Reader',
+			'older@example.com',
+			'Undated Reader',
+		] );
+	} );
+
 	it( 'returns an empty report for missing subscribers', () => {
 		expect(
 			sanitizeStatsFollowersResponse( {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/followers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/followers.ts
@@ -81,7 +81,7 @@ function getSubscriptionId( item: StatsFollowersRawItem ) {
 function subscribedAt( item: StatsFollowersRawItem ) {
 	const date = item.date_subscribed ? parseISO( item.date_subscribed ) : null;
 
-	return date && isValid( date ) ? date.getTime() : -Infinity;
+	return date && isValid( date ) ? date.getTime() : Number.MIN_SAFE_INTEGER;
 }
 
 export function sanitizeStatsFollowersResponse(

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/followers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/followers.ts
@@ -1,7 +1,9 @@
+import { isValid, parseISO } from 'date-fns';
 import {
 	coerceStatsArray,
 	coerceStatsRecord,
 	createStatsListDataPoint,
+	limitStatsRows,
 	normalizeStatsSummary,
 } from './utils';
 import type {
@@ -74,10 +76,12 @@ function getSubscriptionId( item: StatsFollowersRawItem ) {
 	);
 }
 
-function subscribedAt( item: { date_subscribed?: string } ) {
-	const time = Date.parse( item.date_subscribed ?? '' );
+// `parseISO`, not `Date.parse`: the row's date label is parsed the same way, so
+// a string only one of them accepts would sort and render inconsistently.
+function subscribedAt( item: StatsFollowersRawItem ) {
+	const date = item.date_subscribed ? parseISO( item.date_subscribed ) : null;
 
-	return Number.isNaN( time ) ? -Infinity : time;
+	return date && isValid( date ) ? date.getTime() : -Infinity;
 }
 
 export function sanitizeStatsFollowersResponse(
@@ -85,11 +89,14 @@ export function sanitizeStatsFollowersResponse(
 	query?: StatsQueryParams
 ): StatsNormalizedReport< StatsFollowersItem > {
 	const payload = coerceStatsRecord( response ) as StatsFollowersRawResponse & StatsRecord;
-	// `type=all` concatenates the newest `max` email subscribers with the newest
-	// `max` WPCOM ones, so the raw order is grouped by type rather than by date.
-	const subscribers = coerceStatsArray< StatsFollowersRawItem >( payload.subscribers )
-		.slice()
-		.sort( ( a, b ) => subscribedAt( b ) - subscribedAt( a ) );
+	// `type=all` answers with a block per subscriber type, so the raw order is not
+	// date order, and only the newest `max` of the merged blocks are newest overall.
+	const subscribers = limitStatsRows(
+		coerceStatsArray< StatsFollowersRawItem >( payload.subscribers )
+			.slice()
+			.sort( ( a, b ) => subscribedAt( b ) - subscribedAt( a ) ),
+		query?.max
+	);
 	const items = subscribers.map( item => ( {
 		id: getSubscriptionId( item ),
 		label: item.label ?? item.display_name ?? item.name ?? item.email ?? '',

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/followers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/followers.ts
@@ -74,12 +74,22 @@ function getSubscriptionId( item: StatsFollowersRawItem ) {
 	);
 }
 
+function subscribedAt( item: { date_subscribed?: string } ) {
+	const time = Date.parse( item.date_subscribed ?? '' );
+
+	return Number.isNaN( time ) ? -Infinity : time;
+}
+
 export function sanitizeStatsFollowersResponse(
 	response: unknown,
 	query?: StatsQueryParams
 ): StatsNormalizedReport< StatsFollowersItem > {
 	const payload = coerceStatsRecord( response ) as StatsFollowersRawResponse & StatsRecord;
-	const subscribers = coerceStatsArray< StatsFollowersRawItem >( payload.subscribers );
+	// `type=all` concatenates the newest `max` email subscribers with the newest
+	// `max` WPCOM ones, so the raw order is grouped by type rather than by date.
+	const subscribers = coerceStatsArray< StatsFollowersRawItem >( payload.subscribers )
+		.slice()
+		.sort( ( a, b ) => subscribedAt( b ) - subscribedAt( a ) );
 	const items = subscribers.map( item => ( {
 		id: getSubscriptionId( item ),
 		label: item.label ?? item.display_name ?? item.name ?? item.email ?? '',

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -772,14 +772,15 @@ function routeReport( subPath: string, query: URLSearchParams ): unknown {
 }
 
 /**
- * Builds a mock Stats "followers" (subscribers) response with a realistic spread
- * of recent subscription times so the Latest Subscribers widget renders
- * populated in Storybook. The shape matches what `sanitizeStatsFollowersResponse`
- * expects (`{ subscribers, total, … }`); `total` exceeds the shown rows so the
- * "N more" footer appears.
+ * Builds a mock Stats "followers" (subscribers) response for the Latest
+ * Subscribers widget. `type=all` answers with the newest `max` email
+ * subscribers followed by the newest `max` WPCOM ones, so the rows arrive
+ * grouped by type rather than in date order — the mock reproduces that, and an
+ * email-only subscriber has no name, so its `label` is the address. `total`
+ * exceeds the shown rows so the "N more" footer appears.
  *
- * @param max - Page size from the request's `max` query param; `0` or a missing
- *            param returns every row.
+ * @param max - Page size from the request's `max` query param, applied per
+ *            type; `0` or a missing param returns every row.
  * @return Raw followers response.
  */
 function buildFollowersResponse( max: number ) {
@@ -787,29 +788,39 @@ function buildFollowersResponse( max: number ) {
 	const MINUTE = 60 * 1000;
 	const HOUR = 60 * MINUTE;
 	const DAY = 24 * HOUR;
-	const people = [
-		{ name: 'Diego Morales', offset: 20 * 1000 },
-		{ name: 'Olivia Park', offset: 12 * MINUTE },
-		{ name: 'Hiroshi Tanaka', offset: HOUR },
-		{ name: 'Emma Rossi', offset: 3 * HOUR },
-		{ name: 'Aarav Patel', offset: 5 * HOUR },
-		{ name: 'Sofia Nguyen', offset: DAY },
-		{ name: 'Chloe Dubois', offset: 2 * DAY },
-		{ name: 'Liam Carter', offset: 3 * DAY },
-		{ name: 'Mia Andersson', offset: 4 * DAY },
-		{ name: 'Noah Bergström', offset: 5 * DAY },
-		{ name: 'Priya Sharma', offset: 6 * DAY },
-		{ name: 'Tomás Silva', offset: 8 * DAY },
+	const emailPeople = [
+		{ label: 'surfacefrance@example.com', offset: 120 * DAY },
+		{ label: 'crislunamartinez@example.com', offset: 240 * DAY },
+		{ label: 'yebiscats@example.com', offset: 300 * DAY },
+		{ label: 'aciaxhls@example.com', offset: 330 * DAY },
+		{ label: 'hzulfadliey@example.com', offset: 400 * DAY },
+		{ label: 'reputeless@example.com', offset: 430 * DAY },
 	];
-	// Match the requested page size.
-	const subscribers = people.slice( 0, max > 0 ? max : undefined ).map( ( person, index ) => ( {
-		ID: 1000 + index,
-		subscription_id: 1000 + index,
-		display_name: person.name,
-		avatar: `https://i.pravatar.cc/64?img=${ 10 + index }`,
-		url: 'https://example.com',
-		date_subscribed: new Date( now - person.offset ).toISOString(),
-	} ) );
+	const wpcomPeople = [
+		{ label: 'Diego Morales', offset: 20 * 1000 },
+		{ label: 'Olivia Park', offset: 12 * MINUTE },
+		{ label: 'Hiroshi Tanaka', offset: HOUR },
+		{ label: 'Emma Rossi', offset: 3 * HOUR },
+		{ label: 'Aarav Patel', offset: 5 * HOUR },
+		{ label: 'Sofia Nguyen', offset: DAY },
+		{ label: 'Chloe Dubois', offset: 2 * DAY },
+		{ label: 'Liam Carter', offset: 3 * DAY },
+		{ label: 'Mia Andersson', offset: 4 * DAY },
+		{ label: 'Noah Bergström', offset: 5 * DAY },
+		{ label: 'Priya Sharma', offset: 6 * DAY },
+		{ label: 'Tomás Silva', offset: 8 * DAY },
+	];
+	const page = ( people: typeof emailPeople ) => people.slice( 0, max > 0 ? max : undefined );
+	const subscribers = [ ...page( emailPeople ), ...page( wpcomPeople ) ].map(
+		( person, index ) => ( {
+			ID: 1000 + index,
+			subscription_id: 1000 + index,
+			label: person.label,
+			avatar: `https://i.pravatar.cc/64?img=${ 10 + index }`,
+			url: 'https://example.com',
+			date_subscribed: new Date( now - person.offset ).toISOString(),
+		} )
+	);
 	return { subscribers, total: 30, total_email: 18, total_wpcom: 12, page: 1, pages: 5 };
 }
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -773,14 +773,10 @@ function routeReport( subPath: string, query: URLSearchParams ): unknown {
 
 /**
  * Builds a mock Stats "followers" (subscribers) response for the Latest
- * Subscribers widget. `type=all` answers with the newest `max` email
- * subscribers followed by the newest `max` WPCOM ones, so the rows arrive
- * grouped by type rather than in date order — the mock reproduces that, and an
- * email-only subscriber has no name, so its `label` is the address. `total`
- * exceeds the shown rows so the "N more" footer appears.
+ * Subscribers widget. Rows arrive grouped by subscriber type rather than in
+ * date order, and `total` exceeds them so the "N more" footer appears.
  *
- * @param max - Page size from the request's `max` query param, applied per
- *            type; `0` or a missing param returns every row.
+ * @param max - Rows per type; `0` or a missing param returns every row.
  * @return Raw followers response.
  */
 function buildFollowersResponse( max: number ) {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -785,12 +785,12 @@ function buildFollowersResponse( max: number ) {
 	const HOUR = 60 * MINUTE;
 	const DAY = 24 * HOUR;
 	const emailPeople = [
-		{ label: 'surfacefrance@example.com', offset: 120 * DAY },
-		{ label: 'crislunamartinez@example.com', offset: 240 * DAY },
-		{ label: 'yebiscats@example.com', offset: 300 * DAY },
-		{ label: 'aciaxhls@example.com', offset: 330 * DAY },
-		{ label: 'hzulfadliey@example.com', offset: 400 * DAY },
-		{ label: 'reputeless@example.com', offset: 430 * DAY },
+		{ label: 'subscriber-one@example.com', offset: 120 * DAY },
+		{ label: 'subscriber-two@example.com', offset: 240 * DAY },
+		{ label: 'subscriber-three@example.com', offset: 300 * DAY },
+		{ label: 'subscriber-four@example.com', offset: 330 * DAY },
+		{ label: 'subscriber-five@example.com', offset: 400 * DAY },
+		{ label: 'subscriber-six@example.com', offset: 430 * DAY },
 	];
 	const wpcomPeople = [
 		{ label: 'Diego Morales', offset: 20 * 1000 },

--- a/projects/plugins/jetpack/changelog/pa-latest-subscribers-recency-order
+++ b/projects/plugins/jetpack/changelog/pa-latest-subscribers-recency-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Show the most recent subscribers in the Latest subscribers widget.

--- a/projects/plugins/premium-analytics/changelog/pa-latest-subscribers-recency-order
+++ b/projects/plugins/premium-analytics/changelog/pa-latest-subscribers-recency-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Latest subscribers: Show the most recent subscribers instead of a type-grouped mix.


### PR DESCRIPTION

## Proposed changes
* `stats/followers?type=all` returns the newest email subscribers followed by the newest WordPress.com ones, so rows arrive grouped by subscriber type rather than by date.
* Sort the normalized rows by `date_subscribed`, newest first, in the followers normalizer; undated rows sort last. Calypso's Odyssey Stats path sorts the same response the same way.
* The Storybook followers mock now reproduces the type-grouped response instead of a pre-sorted one.

On a site whose newest email subscribers are old, the widget showed months-old rows under a "Latest subscribers" heading and never reached the recent ones.

## Related product discussion/links
* WOOA7S-1997

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open Storybook (`pnpm run storybook` from `projects/packages/premium-analytics`) and go to **Packages/Premium Analytics/Widgets/SubscribersList → WidgetDashboardWithWidget**.
* Rows should run newest first (seconds/minutes/hours ago), not the months-old email rows the mock returns first.
* On a real site with both email and WordPress.com subscribers, compare the widget against the Subscribers module in Jetpack Stats — the two lists should agree.

### Before / after

| Before | After |
|---|---|
| <img width="480" src="https://github.com/Automattic/jetpack/raw/screenshots/fix/pa-latest-subscribers-recency-order/before-subscriber-order.png"> | <img width="480" src="https://github.com/Automattic/jetpack/raw/screenshots/fix/pa-latest-subscribers-recency-order/after-subscriber-order.png"> |

