### PR TITLE
Activity Log: Ensure long content wraps cleanly to next line

### DIFF
--- a/projects/packages/activity-log/changelog/fix-activity-log-event-content-wrap
+++ b/projects/packages/activity-log/changelog/fix-activity-log-event-content-wrap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure table content wraps neatly onto a new line if long.

--- a/projects/packages/activity-log/src/js/components/ActivityLog/activity-event.scss
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/activity-event.scss
@@ -24,6 +24,7 @@
 .site-activity-logs__event-content {
 	flex: 1 0 0;
 	flex-wrap: wrap;
+	white-space: normal;
 
 	> span {
 		color: var(--wpds-color-foreground-content-neutral-weak);

--- a/projects/plugins/jetpack/changelog/fix-activity-log-event-content-wrap
+++ b/projects/plugins/jetpack/changelog/fix-activity-log-event-content-wrap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Activity Log: Ensure table content wraps neatly onto a new line if long.


### PR DESCRIPTION
Fixes ACTLOG-83

## Proposed changes

* This PR adds some CSS to prevent content in the Activity Log dataviews table (in wp-admin specifically) from continuing unbroken horizontally. This was causing a poor visual experience, with text overlapping other columns and also rsulting in a horizontal scroll bar to view all the text.
* Now the long content will wrap to multiple lines as needed.
* The other alternative would be to add ellipsis and truncate the text, however where the content is long it would seem valuable to show that content.

## Related product discussion/links

* See above Linear link.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a Jetpack-connected site, apply this PR locally or using the Jetpack Beta tester plugin.

* Visit the Activity Log page in wp-admin: `/wp-admin/admin.php?page=jetpack-activity-log`
* Ensure you have some content in the Activity Log. The quickest way to reproduce the issue is to use the browser inspector and highlight some content in the event column (not an event title, but it's following content). Via the inspector, modify the content to include a significant amount of text. The example in the issue included the following, which can be copied over: 'Akismet Anti Spam: Spam Protection 5.7.1, Contact Form 7 6.1.7, Contact From CFDB7 1.4.0, Formidable Forms 6.34, Jetpack Boost 4.7.0, Spectra Legacy 2.20.1, WooCommerce 11.0.1, WordFence Security 9.0.0 and WordPress Beta Tester 4.0.1'
* This content should wrap onto the next line.
* Check with different screen sizes to ensure the wrapping looks reasonable.
* On trunk, the content should not wrap.

Before:

<img width="1327" height="64" alt="Screenshot 2026-08-26 at 10 44 10" src="https://github.com/user-attachments/assets/a6f1aab2-0b0e-4d07-b711-b5eb3b78b4f2" />

After:

<img width="1313" height="110" alt="Screenshot 2026-08-26 at 10 44 45" src="https://github.com/user-attachments/assets/4d441e5a-3841-4b34-950e-f2761fe03ff0" />


