### PR TITLE
Publicize: replace @automattic/ui Badge with @wordpress/ui one

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4217,9 +4217,6 @@ importers:
       '@automattic/social-previews':
         specifier: workspace:*
         version: link:../../js-packages/social-previews
-      '@automattic/ui':
-        specifier: 1.0.2
-        version: 1.0.2(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@jetpack-social/init':
         specifier: link:packages/init
         version: link:packages/init

--- a/projects/packages/publicize/_inc/components/services/use-supported-services.tsx
+++ b/projects/packages/publicize/_inc/components/services/use-supported-services.tsx
@@ -1,4 +1,3 @@
-import '@automattic/ui/style.css';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { store as socialStore } from '../../social-store';

--- a/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-status.tsx
+++ b/projects/packages/publicize/_inc/components/unified-modal/sharing-activity/activity-status.tsx
@@ -1,8 +1,8 @@
-import { Badge } from '@automattic/ui';
 import { Button, Dropdown, Flex } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import styles from './styles.module.scss';
 import { SharingActivityItem } from './types';
 
@@ -47,17 +47,17 @@ export function ActivityStatus( { item }: ActivityStatusProps ) {
 	}, [ item ] );
 
 	if ( item.status === 'scheduled' ) {
-		return <Badge intent="info">{ __( 'Scheduled', 'jetpack-publicize-pkg' ) }</Badge>;
+		return <Badge intent="informational">{ __( 'Scheduled', 'jetpack-publicize-pkg' ) }</Badge>;
 	}
 
 	if ( item.status === 'success' ) {
-		return <Badge intent="success">{ __( 'Shared', 'jetpack-publicize-pkg' ) }</Badge>;
+		return <Badge intent="stable">{ __( 'Shared', 'jetpack-publicize-pkg' ) }</Badge>;
 	}
 
 	// Failure status - show badge with error details dropdown
 	return (
 		<Flex justify="start" gap={ 1 }>
-			<Badge intent="error">{ __( 'Failed', 'jetpack-publicize-pkg' ) }</Badge>
+			<Badge intent="high">{ __( 'Failed', 'jetpack-publicize-pkg' ) }</Badge>
 			<Dropdown
 				focusOnMount
 				popoverProps={ { placement: 'top-start' } }

--- a/projects/packages/publicize/changelog/update-sharing-activity-wordpress-ui-badge
+++ b/projects/packages/publicize/changelog/update-sharing-activity-wordpress-ui-badge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sharing activity: update status badges.

--- a/projects/packages/publicize/jest.config.js
+++ b/projects/packages/publicize/jest.config.js
@@ -10,13 +10,6 @@ module.exports = {
 			require.resolve
 		),
 	},
-	moduleNameMapper: {
-		...baseConfig.moduleNameMapper,
-		// Map @automattic/ui CSS imports to stub to prevent Jest parsing errors
-		'@automattic/ui/style\\.css$': require.resolve(
-			'jetpack-js-tools/jest/jest-extensions-asset-stub.js'
-		),
-	},
 	collectCoverageFrom: [
 		'<rootDir>/_inc/**/*.{js,mjs,cjs,jsx,ts,tsx,mts,cts}',
 		...baseConfig.collectCoverageFrom,

--- a/projects/packages/publicize/package.json
+++ b/projects/packages/publicize/package.json
@@ -52,7 +52,6 @@
 		"@automattic/number-formatters": "workspace:*",
 		"@automattic/popup-monitor": "1.0.2",
 		"@automattic/social-previews": "workspace:*",
-		"@automattic/ui": "1.0.2",
 		"@jetpack-social/init": "link:packages/init",
 		"@tanstack/react-query": "5.101.2",
 		"@wordpress/admin-ui": "2.7.0",


### PR DESCRIPTION
Pre-requirement for removal of the Badge from `@automattic/ui` as we're now focusing on `@wordpress/ui` [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs).

Part of https://github.com/Automattic/wp-calypso/issues/113835


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Replace `@automattic/ui` Badge component with `@wordpress/ui` [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test the affected UI
* There are slight visual changes as the badges look a bit different.