### PR TITLE
Premium Analytics: move the remaining leaderboard widgets onto the shared row

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -759,10 +759,12 @@ wire a handler in `routeStatsReport()` inside `register-report-mocks.ts`. See
   add a second in-widget `<Text variant="heading-md" render={ <h3 /> }>` title for framed Stats
   widgets.
 - View count format: `dataFormat={ { type: 'number', options: { useMultipliers: true, decimals: 0 } } }`
-- Leaderboard rows: build them with `LeaderboardRow` / `buildLeaderboardRow` /
-  `LeaderboardPostLabel` — a hand-written copy drifts from the shared row box. `video-detail-embeds`
-  is the one exception, a plain list rather than a leaderboard, and matches `.row` in
-  `chart-leaderboard/leaderboard-label.module.scss` by hand.
+- Leaderboard rows: spread `buildLeaderboardRow()` into the chart entry — it carries the
+  drill-down `onClick`/`ariaLabel` that a bare `<LeaderboardRow>` label silently drops. Use
+  `<LeaderboardRow>` directly only outside a chart, as `widgets/tags` does for its drilled-in
+  member list. A hand-written copy drifts from the shared row box. `video-detail-embeds` is the
+  one exception, a plain list rather than a leaderboard, and matches the shared row's 36px height
+  and `padding-inline` by hand — not the rest of `.row`.
 - Loading / error / empty state: render through `<WidgetState>` (see "Loading / error / empty
   state" above), not `LeaderboardChart`'s `emptyStateText` or a hand-rolled `data.length === 0`
   branch. Empty uses a neutral glyph distinct from the error icon.

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -760,9 +760,9 @@ wire a handler in `routeStatsReport()` inside `register-report-mocks.ts`. See
   widgets.
 - View count format: `dataFormat={ { type: 'number', options: { useMultipliers: true, decimals: 0 } } }`
 - Leaderboard rows: prefer `LeaderboardRow` / `buildLeaderboardRow` / `LeaderboardPostLabel` over
-  a hand-written label — they carry the shared row box, and a copy drifts from it. A label that
-  must be custom should match `.row` in `chart-leaderboard/leaderboard-label.module.scss`;
-  several widgets predate that and have not been migrated yet.
+  a hand-written label — a copy drifts from the shared row box. `utm-insights` and
+  `video-detail-embeds` are the last two that still draw their own, and match `.row` in
+  `chart-leaderboard/leaderboard-label.module.scss` by hand.
 - Loading / error / empty state: render through `<WidgetState>` (see "Loading / error / empty
   state" above), not `LeaderboardChart`'s `emptyStateText` or a hand-rolled `data.length === 0`
   branch. Empty uses a neutral glyph distinct from the error icon.

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -759,9 +759,9 @@ wire a handler in `routeStatsReport()` inside `register-report-mocks.ts`. See
   add a second in-widget `<Text variant="heading-md" render={ <h3 /> }>` title for framed Stats
   widgets.
 - View count format: `dataFormat={ { type: 'number', options: { useMultipliers: true, decimals: 0 } } }`
-- Leaderboard rows: prefer `LeaderboardRow` / `buildLeaderboardRow` / `LeaderboardPostLabel` over
-  a hand-written label — a copy drifts from the shared row box. `utm-insights` and
-  `video-detail-embeds` are the last two that still draw their own, and match `.row` in
+- Leaderboard rows: build them with `LeaderboardRow` / `buildLeaderboardRow` /
+  `LeaderboardPostLabel` — a hand-written copy drifts from the shared row box. `video-detail-embeds`
+  is the one exception, a plain list rather than a leaderboard, and matches `.row` in
   `chart-leaderboard/leaderboard-label.module.scss` by hand.
 - Loading / error / empty state: render through `<WidgetState>` (see "Loading / error / empty
   state" above), not `LeaderboardChart`'s `emptyStateText` or a hand-rolled `data.length === 0`

--- a/projects/packages/premium-analytics/changelog/wooa7s-1989-migrate-remaining-labels
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1989-migrate-remaining-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Leaderboards: Match the remaining row labels to the other leaderboard widgets.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/README.md
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/README.md
@@ -163,7 +163,7 @@ Pass `section` to `LeaderboardPostLabel` to open a named tab on the detail page,
 There is no `LeaderboardVideoLabel`, so a widget building a `videoLink` action takes that same
 window from `useWidgetNavigationSearch()` and passes it as `search`.
 
-`LeaderboardRowMedia` provides five semantic media variants. The variant owns its size,
+`LeaderboardRowMedia` provides six semantic media variants. The variant owns its size,
 fallback, and default alt-text policy:
 
 | Kind        | Size      | Missing or failed image behavior |
@@ -172,7 +172,15 @@ fallback, and default alt-text policy:
 | `favicon`   | 16 × 16px | Hidden; always decorative        |
 | `flag`      | 28px wide | Placeholder; proportional height |
 | `thumbnail` | 28 × 28px | Placeholder                      |
+| `icon`      | 20 × 20px | No image; takes a glyph          |
 | `none`      | No media  | Renders text only                |
+
+`icon` takes a `@wordpress/icons` glyph rather than a URL, for rows whose media is a symbol
+instead of a picture:
+
+```tsx
+media: { kind: 'icon', icon: category },
+```
 
 Use `resolveLeaderboardRowAction` when raw data can contain both an external URL and children.
 It applies the shared precedence: drill-down for rows with children, external links for

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/README.md
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/README.md
@@ -175,12 +175,7 @@ fallback, and default alt-text policy:
 | `icon`      | 20 × 20px | No image; takes a glyph          |
 | `none`      | No media  | Renders text only                |
 
-`icon` takes a `@wordpress/icons` glyph rather than a URL, for rows whose media is a symbol
-instead of a picture:
-
-```tsx
-media: { kind: 'icon', icon: category },
-```
+`icon` takes a `@wordpress/icons` glyph rather than a URL: `media: { kind: 'icon', icon: category }`.
 
 Use `resolveLeaderboardRowAction` when raw data can contain both an external URL and children.
 It applies the shared precedence: drill-down for rows with children, external links for

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/__tests__/leaderboard-row.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/__tests__/leaderboard-row.test.tsx
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { fireEvent, render, screen } from '@testing-library/react';
-import { category } from '@wordpress/icons';
+import { category, tag } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
 import { LeaderboardLabel } from '../leaderboard-label';
 import { buildLeaderboardRow, resolveLeaderboardRowAction } from '../leaderboard-row';
-import type { AnchorHTMLAttributes, ReactNode } from 'react';
+import type { AnchorHTMLAttributes, ReactElement, ReactNode } from 'react';
 
 type MockRouteLinkProps = {
 	to: string;
@@ -46,6 +46,20 @@ jest.mock( '@wordpress/route', () => {
 	};
 } );
 
+function glyphPath( root: Element | null | undefined ) {
+	return root?.querySelector( 'path' )?.getAttribute( 'd' );
+}
+
+// `@wordpress/icons` exports elements, so naming a glyph means rendering that
+// icon on its own and comparing the two paths.
+function iconPath( icon: ReactElement ) {
+	const { container, unmount } = render( icon );
+	const path = glyphPath( container );
+
+	unmount();
+	return path;
+}
+
 describe( 'LeaderboardLabel', () => {
 	it( 'renders media and text without adding row actions', () => {
 		render(
@@ -68,16 +82,19 @@ describe( 'LeaderboardLabel', () => {
 		expect( screen.queryByRole( 'img' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders a glyph for icon media without announcing it', () => {
+	it( 'renders the glyph it was handed, hidden from assistive technology', () => {
 		const { container } = render(
 			<LeaderboardLabel label="Recipes" media={ { kind: 'icon', icon: category } } />
 		);
-		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the glyph is aria-hidden by design, so the DOM is the only place to assert it.
-		const glyphPath = container.querySelector( 'svg path' )?.getAttribute( 'd' );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the glyph is aria-hidden by design, so the DOM is the only place to reach it.
+		const glyph = container.querySelector( 'svg' );
 
 		expect( screen.getByText( 'Recipes' ) ).toBeInTheDocument();
-		expect( glyphPath ).toBeTruthy();
-		expect( screen.queryByRole( 'img' ) ).not.toBeInTheDocument();
+		expect( glyph ).toHaveAttribute( 'aria-hidden', 'true' );
+		// Naming the glyph rather than just counting one: an icon kind exists so a
+		// widget can pick between glyphs, so the wrong one has to fail here.
+		expect( glyphPath( glyph ) ).toBe( iconPath( category ) );
+		expect( glyphPath( glyph ) ).not.toBe( iconPath( tag ) );
 	} );
 } );
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/__tests__/leaderboard-row.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/__tests__/leaderboard-row.test.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { fireEvent, render, screen } from '@testing-library/react';
+import { category } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
@@ -64,6 +65,18 @@ describe( 'LeaderboardLabel', () => {
 		render( <LeaderboardLabel label="Desktop" media={ { kind: 'none' } } /> );
 
 		expect( screen.getByText( 'Desktop' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'img' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a glyph for icon media without announcing it', () => {
+		const { container } = render(
+			<LeaderboardLabel label="Recipes" media={ { kind: 'icon', icon: category } } />
+		);
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the glyph is aria-hidden by design, so the DOM is the only place to assert it.
+		const glyphPath = container.querySelector( 'svg path' )?.getAttribute( 'd' );
+
+		expect( screen.getByText( 'Recipes' ) ).toBeInTheDocument();
+		expect( glyphPath ).toBeTruthy();
 		expect( screen.queryByRole( 'img' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.module.scss
@@ -93,3 +93,7 @@
 	height: var(--jpa-leaderboard-image-height);
 	object-fit: var(--jpa-leaderboard-image-fit);
 }
+
+.icon {
+	flex: none;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Stack } from '@jetpack-premium-analytics/externals';
+import { Icon, Stack } from '@jetpack-premium-analytics/externals';
 import { __, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useState } from 'react';
@@ -9,12 +9,14 @@ import { useState } from 'react';
  * Internal dependencies
  */
 import styles from './leaderboard-label.module.scss';
+import type { ComponentProps } from 'react';
 
 export type LeaderboardRowMedia =
 	| { kind: 'avatar'; url?: string; name: string }
 	| { kind: 'favicon'; url?: string }
 	| { kind: 'flag'; url?: string; country: string }
 	| { kind: 'thumbnail'; url?: string; alt: string }
+	| { kind: 'icon'; icon: ComponentProps< typeof Icon >[ 'icon' ] }
 	| { kind: 'none' };
 
 export type LeaderboardLabelProps = {
@@ -30,7 +32,9 @@ export type LeaderboardLabelProps = {
 const DEFAULT_IMAGE_URL =
 	'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50"><rect width="50" height="50" fill="%23e5e7eb"/></svg>';
 
-function getMediaDetails( media: Exclude< LeaderboardRowMedia, { kind: 'none' } > ) {
+function getMediaDetails(
+	media: Exclude< LeaderboardRowMedia, { kind: 'none' } | { kind: 'icon' } >
+) {
 	switch ( media.kind ) {
 		case 'avatar':
 			return {
@@ -82,7 +86,8 @@ export function LeaderboardLabel( {
 	decorativeMedia = false,
 }: LeaderboardLabelProps ) {
 	const [ failedImageUrl, setFailedImageUrl ] = useState< string >();
-	const mediaDetails = media.kind === 'none' ? null : getMediaDetails( media );
+	const mediaDetails =
+		media.kind === 'none' || media.kind === 'icon' ? null : getMediaDetails( media );
 	const shouldRenderImage =
 		mediaDetails &&
 		( mediaDetails.fallback === 'placeholder' || Boolean( mediaDetails.url ) ) &&
@@ -95,6 +100,9 @@ export function LeaderboardLabel( {
 			align="center"
 			className={ clsx( styles.container, mediaDetails?.className ) }
 		>
+			{ media.kind === 'icon' && (
+				<Icon icon={ media.icon } size={ 20 } className={ styles.icon } />
+			) }
 			{ shouldRenderImage && (
 				<img
 					src={ mediaDetails.url || DEFAULT_IMAGE_URL }

--- a/projects/packages/premium-analytics/tests/groups/widgets-shared-route-mock-part2.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/widgets-shared-route-mock-part2.test.tsx
@@ -2,6 +2,7 @@
 
 import '../../widgets/site-overview/__tests__/site-overview.test';
 import '../../widgets/subscriber-highlights/__tests__/subscriber-highlights.test';
+import '../../widgets/tags/__tests__/tags.test';
 import '../../widgets/video-detail-embeds/__tests__/video-detail-embeds.test';
 import '../../widgets/videopress/__tests__/videopress.test';
 import '../../widgets/wordads-highlights/__tests__/wordads-highlights.test';

--- a/projects/packages/premium-analytics/widgets/file-downloads/render.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/render.tsx
@@ -18,9 +18,9 @@ import {
 	getCombinedPeriodMax,
 	safeHttpUrl,
 	LeaderboardChart,
-	LeaderboardRow,
 	LeaderboardSkeleton,
 	ReportLink,
+	buildLeaderboardRow,
 	resolveLeaderboardRowAction,
 	sharePercentage,
 	WidgetFooter,
@@ -78,13 +78,11 @@ function buildLeaderboardData(
 
 		return {
 			id: `${ index }-${ row.href ?? row.label }`,
-			label: (
-				<LeaderboardRow
-					label={ row.label }
-					media={ { kind: 'none' } }
-					action={ resolveLeaderboardRowAction( { href: row.href, hasChildren: false } ) }
-				/>
-			),
+			...buildLeaderboardRow( {
+				label: row.label,
+				media: { kind: 'none' },
+				action: resolveLeaderboardRowAction( { href: row.href, hasChildren: false } ),
+			} ),
 			currentValue: row.value,
 			currentShare: sharePercentage( row.value, maxValue ),
 			previousValue,

--- a/projects/packages/premium-analytics/widgets/file-downloads/render.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/render.tsx
@@ -12,15 +12,16 @@ import {
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
-import { Link } from '@jetpack-premium-analytics/externals';
 import {
 	WIDGET_ROW_LIMIT,
 	calculateDelta,
 	getCombinedPeriodMax,
 	safeHttpUrl,
 	LeaderboardChart,
+	LeaderboardRow,
 	LeaderboardSkeleton,
 	ReportLink,
+	resolveLeaderboardRowAction,
 	sharePercentage,
 	WidgetFooter,
 	WidgetRoot,
@@ -77,20 +78,12 @@ function buildLeaderboardData(
 
 		return {
 			id: `${ index }-${ row.href ?? row.label }`,
-			label: row.href ? (
-				<Link
-					className={ styles.labelLink }
-					href={ row.href }
-					variant="unstyled"
-					openInNewTab
-					title={ row.label }
-				>
-					{ row.label }
-				</Link>
-			) : (
-				<span className={ styles.labelText } title={ row.label }>
-					{ row.label }
-				</span>
+			label: (
+				<LeaderboardRow
+					label={ row.label }
+					media={ { kind: 'none' } }
+					action={ resolveLeaderboardRowAction( { href: row.href, hasChildren: false } ) }
+				/>
 			),
 			currentValue: row.value,
 			currentShare: sharePercentage( row.value, maxValue ),

--- a/projects/packages/premium-analytics/widgets/file-downloads/style.module.css
+++ b/projects/packages/premium-analytics/widgets/file-downloads/style.module.css
@@ -1,29 +1,3 @@
-.labelLink {
-	display: block;
-
-	padding-block: var(--wpds-dimension-padding-md);
-	padding-inline-start: var(--wpds-dimension-padding-sm);
-	overflow: hidden;
-	color: inherit;
-	text-decoration: none;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.labelLink:hover,
-.labelLink:focus {
-	text-decoration: underline;
-}
-
-.labelText {
-	display: block;
-	padding-block: var(--wpds-dimension-padding-md);
-	padding-inline-start: var(--wpds-dimension-padding-sm);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
 .root {
 	container-type: inline-size;
 	display: flex;

--- a/projects/packages/premium-analytics/widgets/search-terms/render.tsx
+++ b/projects/packages/premium-analytics/widgets/search-terms/render.tsx
@@ -7,12 +7,12 @@ import {
 	describeError,
 	getCombinedPeriodMax,
 	LeaderboardChart,
-	LeaderboardRow,
 	LeaderboardSkeleton,
 	ReportLink,
 	WidgetFooter,
 	WidgetRoot,
 	WidgetState,
+	buildLeaderboardRow,
 	sharePercentage,
 	useWidgetRootContext,
 	type LeaderboardChartData,
@@ -56,13 +56,11 @@ function SearchTermsInner() {
 
 			return {
 				id: `${ index }-${ term.label }`,
-				label: (
-					<LeaderboardRow
-						label={ term.label }
-						media={ { kind: 'none' } }
-						action={ { kind: 'static' } }
-					/>
-				),
+				...buildLeaderboardRow( {
+					label: term.label,
+					media: { kind: 'none' },
+					action: { kind: 'static' },
+				} ),
 				currentValue: term.views,
 				previousValue: previousViews,
 				currentShare: sharePercentage( term.views, maxValue ),

--- a/projects/packages/premium-analytics/widgets/search-terms/render.tsx
+++ b/projects/packages/premium-analytics/widgets/search-terms/render.tsx
@@ -7,6 +7,7 @@ import {
 	describeError,
 	getCombinedPeriodMax,
 	LeaderboardChart,
+	LeaderboardRow,
 	LeaderboardSkeleton,
 	ReportLink,
 	WidgetFooter,
@@ -20,7 +21,7 @@ import {
 import { search } from '@jetpack-premium-analytics/icons';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Stack, Text } from '@jetpack-premium-analytics/externals';
+import { Stack } from '@jetpack-premium-analytics/externals';
 /**
  * Internal dependencies
  */
@@ -56,9 +57,11 @@ function SearchTermsInner() {
 			return {
 				id: `${ index }-${ term.label }`,
 				label: (
-					<Stack align="center" className={ styles.itemLabel }>
-						<Text className={ styles.itemLabelText }>{ term.label }</Text>
-					</Stack>
+					<LeaderboardRow
+						label={ term.label }
+						media={ { kind: 'none' } }
+						action={ { kind: 'static' } }
+					/>
 				),
 				currentValue: term.views,
 				previousValue: previousViews,

--- a/projects/packages/premium-analytics/widgets/search-terms/style.module.css
+++ b/projects/packages/premium-analytics/widgets/search-terms/style.module.css
@@ -13,15 +13,3 @@
 	flex: 1 1 0;
 	min-height: 0;
 }
-
-.itemLabel {
-	padding: var(--wpds-dimension-padding-sm);
-	min-width: 0;
-	overflow: hidden;
-}
-
-.itemLabelText {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}

--- a/projects/packages/premium-analytics/widgets/shares/render.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/render.tsx
@@ -3,6 +3,7 @@
  */
 import {
 	LeaderboardChart,
+	LeaderboardRow,
 	LeaderboardSkeleton,
 	WIDGET_ROW_LIMIT,
 	WidgetRoot,
@@ -14,7 +15,7 @@ import {
 import { megaphone } from '@jetpack-premium-analytics/icons';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Stack, Text } from '@jetpack-premium-analytics/externals';
+import { Stack } from '@jetpack-premium-analytics/externals';
 /**
  * Internal dependencies
  */
@@ -41,9 +42,11 @@ function SharesInner() {
 		return data.map( ( service, index ) => ( {
 			id: `${ index }-${ service.service }`,
 			label: (
-				<Stack align="center" className={ styles.itemLabel }>
-					<Text className={ styles.itemLabelText }>{ service.label }</Text>
-				</Stack>
+				<LeaderboardRow
+					label={ service.label }
+					media={ { kind: 'none' } }
+					action={ { kind: 'static' } }
+				/>
 			),
 			currentValue: service.value,
 			currentShare: sharePercentage( service.value, maxValue ),

--- a/projects/packages/premium-analytics/widgets/shares/render.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/render.tsx
@@ -3,11 +3,11 @@
  */
 import {
 	LeaderboardChart,
-	LeaderboardRow,
 	LeaderboardSkeleton,
 	WIDGET_ROW_LIMIT,
 	WidgetRoot,
 	WidgetState,
+	buildLeaderboardRow,
 	sharePercentage,
 	type LeaderboardChartData,
 	type ReportParamsFieldAttributes,
@@ -41,13 +41,11 @@ function SharesInner() {
 
 		return data.map( ( service, index ) => ( {
 			id: `${ index }-${ service.service }`,
-			label: (
-				<LeaderboardRow
-					label={ service.label }
-					media={ { kind: 'none' } }
-					action={ { kind: 'static' } }
-				/>
-			),
+			...buildLeaderboardRow( {
+				label: service.label,
+				media: { kind: 'none' },
+				action: { kind: 'static' },
+			} ),
 			currentValue: service.value,
 			currentShare: sharePercentage( service.value, maxValue ),
 		} ) );

--- a/projects/packages/premium-analytics/widgets/shares/style.module.css
+++ b/projects/packages/premium-analytics/widgets/shares/style.module.css
@@ -13,15 +13,3 @@
 	flex: 1 1 0;
 	min-height: 0;
 }
-
-.itemLabel {
-	padding: var(--wpds-dimension-padding-sm);
-	min-width: 0;
-	overflow: hidden;
-}
-
-.itemLabelText {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}

--- a/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
+import { fireEvent, render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { category, tag } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import TagsWidget from '../render';
+import type { ReactElement } from 'react';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+// `type: 'category'` is the only value the sanitizer turns into the `folder`
+// glyph key, so the fixture pairs one of each against a grouped row.
+const TAGS_RESPONSE = {
+	date: '2026-06-22',
+	period: 'month',
+	tags: [
+		{
+			tags: [
+				{ type: 'category', name: 'Recipes', link: 'https://example.com/category/recipes/' },
+			],
+			views: 1240,
+		},
+		{
+			tags: [ { type: 'tag', name: 'vegan', link: 'https://example.com/tag/vegan/' } ],
+			views: 980,
+		},
+		{
+			tags: [
+				{ type: 'category', name: 'Desserts', link: 'https://example.com/category/desserts/' },
+				{ type: 'tag', name: 'chocolate', link: 'https://example.com/tag/chocolate/' },
+			],
+			views: 760,
+		},
+	],
+};
+
+function glyphPath( root: Element | null | undefined ) {
+	return root?.querySelector( 'svg path' )?.getAttribute( 'd' );
+}
+
+// `@wordpress/icons` exports elements, so the only way to name the glyph a row
+// drew is to compare it against that icon rendered on its own.
+function iconPath( icon: ReactElement ) {
+	const { container, unmount } = render( icon );
+	const path = glyphPath( container );
+
+	unmount();
+	return path;
+}
+
+// The label text sits next to the glyph inside the row's media wrapper.
+function rowGlyphPath( label: string ) {
+	return glyphPath( screen.getByText( label ).parentElement );
+}
+
+// Queried through the label rather than the accessible name, which the design
+// system extends with its own "opens in a new tab" copy.
+function rowLink( label: string ) {
+	return screen.getByText( label ).closest( 'a' );
+}
+
+describe( 'TagsWidget', () => {
+	beforeEach( () => {
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( TAGS_RESPONSE );
+	} );
+
+	it( 'draws the category glyph on a category row and the tag glyph on a tag row', async () => {
+		render( <TagsWidget attributes={ { reportParams: getDefaultQueryParams() } } /> );
+
+		await expect( screen.findByText( 'Recipes' ) ).resolves.toBeInTheDocument();
+
+		const categoryPath = iconPath( category );
+		const tagPath = iconPath( tag );
+
+		expect( categoryPath ).not.toBe( tagPath );
+		expect( rowGlyphPath( 'Recipes' ) ).toBe( categoryPath );
+		expect( rowGlyphPath( 'vegan' ) ).toBe( tagPath );
+	} );
+
+	it( 'links a single tag row and wraps its glyph in the anchor', async () => {
+		render( <TagsWidget attributes={ { reportParams: getDefaultQueryParams() } } /> );
+
+		await expect( screen.findByText( 'vegan' ) ).resolves.toBeInTheDocument();
+
+		const link = rowLink( 'vegan' );
+
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/tag/vegan/' );
+		expect( glyphPath( link ) ).toBe( iconPath( tag ) );
+	} );
+
+	it( 'drills a grouped row into its members and back', async () => {
+		render( <TagsWidget attributes={ { reportParams: getDefaultQueryParams() } } /> );
+
+		const groupButton = await screen.findByRole( 'button', {
+			name: /view the tags and categories in desserts, chocolate/i,
+		} );
+
+		// A grouped row has no combined archive URL, so it must not be a link.
+		expect( rowLink( 'Desserts, chocolate' ) ).toBeNull();
+
+		fireEvent.click( groupButton ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		// Members carry their own glyph and archive URL, unlike the group row.
+		await expect( screen.findByText( 'Desserts' ) ).resolves.toBeInTheDocument();
+		expect( rowLink( 'Desserts' ) ).toHaveAttribute(
+			'href',
+			'https://example.com/category/desserts/'
+		);
+		expect( rowGlyphPath( 'Desserts' ) ).toBe( iconPath( category ) );
+		expect( rowGlyphPath( 'chocolate' ) ).toBe( iconPath( tag ) );
+
+		fireEvent.click( screen.getByRole( 'button', { name: /all tags & categories/i } ) ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		await expect( screen.findByText( 'Recipes' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'chocolate' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/tags/render.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/render.tsx
@@ -3,6 +3,7 @@
  */
 import {
 	LeaderboardChart,
+	LeaderboardRow,
 	LeaderboardSkeleton,
 	ReportLink,
 	WIDGET_ROW_LIMIT,
@@ -10,6 +11,8 @@ import {
 	WidgetFooter,
 	WidgetRoot,
 	WidgetState,
+	buildLeaderboardRow,
+	resolveLeaderboardRowAction,
 	safeHttpUrl,
 	sharePercentage,
 	useWidgetDrillDown,
@@ -21,7 +24,7 @@ import { tag as tagIllustration } from '@jetpack-premium-analytics/icons';
 import { useEffect, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { category, tag as tagGlyph } from '@wordpress/icons';
-import { Icon, Link, Stack } from '@jetpack-premium-analytics/externals';
+import { Stack } from '@jetpack-premium-analytics/externals';
 /**
  * Internal dependencies
  */
@@ -37,45 +40,11 @@ type TagsWidgetProps = WidgetRenderProps< TagsRenderAttributes >;
 // row is a tag.
 const rowGlyph = ( labelIcon: string ) => ( labelIcon === 'folder' ? category : tagGlyph );
 
-// Icon + label fields shared by the leaderboard rows and the drilled-in members;
-// documented on TagChildView.
-type TagLabelProps = Pick< TagChildView, 'labelIcon' | 'label' | 'link' >;
-
 interface TagGroupMembersProps {
 	/**
 	 * The selected group's individual tags/categories.
 	 */
 	members: TagChildView[];
-}
-
-/**
- * Icon + label for a single tag/category, shared by the leaderboard rows and the
- * drilled-in group members. A member with an archive URL renders an external
- * link; one without renders plain text.
- */
-function TagLabel( { labelIcon, label, link }: TagLabelProps ) {
-	const href = safeHttpUrl( link );
-
-	return (
-		<>
-			<Icon icon={ rowGlyph( labelIcon ) } size={ 20 } className={ styles.itemIcon } />
-			{ href ? (
-				<Link
-					className={ styles.itemLabelText }
-					href={ href }
-					variant="unstyled"
-					openInNewTab
-					title={ label }
-				>
-					{ label }
-				</Link>
-			) : (
-				<span className={ styles.itemLabelText } title={ label }>
-					{ label }
-				</span>
-			) }
-		</>
-	);
 }
 
 /**
@@ -87,9 +56,15 @@ function TagGroupMembers( { members }: TagGroupMembersProps ) {
 	return (
 		<Stack direction="column" className={ styles.childList }>
 			{ members.map( member => (
-				<div key={ member.id } className={ styles.childRow }>
-					<TagLabel labelIcon={ member.labelIcon } label={ member.label } link={ member.link } />
-				</div>
+				<LeaderboardRow
+					key={ member.id }
+					label={ member.label }
+					media={ { kind: 'icon', icon: rowGlyph( member.labelIcon ) } }
+					action={ resolveLeaderboardRowAction( {
+						href: safeHttpUrl( member.link ) ?? undefined,
+						hasChildren: false,
+					} ) }
+				/>
 			) ) }
 		</Stack>
 	);
@@ -130,22 +105,25 @@ function TagsInner() {
 
 			return {
 				id: row.id,
-				label: (
-					<Stack align="center" className={ styles.itemLabel }>
-						<TagLabel labelIcon={ row.labelIcon } label={ row.label } link={ row.link } />
-					</Stack>
-				),
 				currentValue: row.value,
 				currentShare: sharePercentage( row.value, maxValue ),
 				// Grouped rows have no single archive URL, so a click drills into
 				// their members instead. Single tag/category rows link out directly.
-				...( isGroup && {
-					onClick: () => selectGroup( row.label ),
-					ariaLabel: sprintf(
-						/* translators: %s is the grouped tags and categories label */
-						__( 'View the tags and categories in %s', 'jetpack-premium-analytics-pkg' ),
-						row.label
-					),
+				...buildLeaderboardRow( {
+					label: row.label,
+					media: { kind: 'icon', icon: rowGlyph( row.labelIcon ) },
+					action: resolveLeaderboardRowAction( {
+						href: safeHttpUrl( row.link ) ?? undefined,
+						hasChildren: isGroup,
+						drillDown: {
+							onClick: () => selectGroup( row.label ),
+							ariaLabel: sprintf(
+								/* translators: %s is the grouped tags and categories label */
+								__( 'View the tags and categories in %s', 'jetpack-premium-analytics-pkg' ),
+								row.label
+							),
+						},
+					} ),
 				} ),
 			};
 		} );

--- a/projects/packages/premium-analytics/widgets/tags/style.module.css
+++ b/projects/packages/premium-analytics/widgets/tags/style.module.css
@@ -14,32 +14,6 @@
 	min-height: 0;
 }
 
-/* Icon + label row for the leaderboard. min-height keeps a stable 36px row for
-   both single tag/category rows and grouped (drill-down) rows. */
-.itemLabel {
-	gap: var(--wpds-dimension-padding-sm);
-	min-height: 36px;
-	min-width: 0;
-	padding-inline: var(--wpds-dimension-padding-sm);
-	overflow: hidden;
-}
-
-/* Keep the category/tag glyph from shrinking when the label is long. */
-.itemIcon {
-	flex-shrink: 0;
-}
-
-.itemLabelText {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-a.itemLabelText:hover,
-a.itemLabelText:focus {
-	text-decoration: underline;
-}
-
 /* Drilled-in group members: a scrollable list of the individual
    tags/categories. The Stats endpoint reports no per-member views, so these
    rows are links only, without leaderboard bars. */
@@ -47,13 +21,4 @@ a.itemLabelText:focus {
 	flex: 1 1 0;
 	min-height: 0;
 	overflow-y: auto;
-}
-
-.childRow {
-	display: flex;
-	align-items: center;
-	gap: var(--wpds-dimension-padding-sm);
-	min-height: 36px;
-	padding-inline: var(--wpds-dimension-padding-sm);
-	overflow: hidden;
 }

--- a/projects/packages/premium-analytics/widgets/top-platforms/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/render.tsx
@@ -12,8 +12,8 @@ import {
 	describeError,
 	getCombinedPeriodMax,
 	LeaderboardChart,
-	LeaderboardRow,
 	LeaderboardSkeleton,
+	buildLeaderboardRow,
 	sharePercentage,
 	WidgetRoot,
 	WidgetState,
@@ -66,13 +66,11 @@ function TopPlatformsInner( { platformDimension }: TopPlatformsInnerProps ) {
 
 		return {
 			id: `${ index }-${ item.key }`,
-			label: (
-				<LeaderboardRow
-					label={ item.label }
-					media={ { kind: 'none' } }
-					action={ { kind: 'static' } }
-				/>
-			),
+			...buildLeaderboardRow( {
+				label: item.label,
+				media: { kind: 'none' },
+				action: { kind: 'static' },
+			} ),
 			currentValue: item.views,
 			currentShare: sharePercentage( item.views, maxViews ),
 			previousValue,

--- a/projects/packages/premium-analytics/widgets/top-platforms/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/render.tsx
@@ -6,13 +6,13 @@ import { device } from '@jetpack-premium-analytics/icons';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Stack, Text } from '@jetpack-premium-analytics/externals';
 import {
 	WIDGET_ROW_LIMIT,
 	calculateDelta,
 	describeError,
 	getCombinedPeriodMax,
 	LeaderboardChart,
+	LeaderboardRow,
 	LeaderboardSkeleton,
 	sharePercentage,
 	WidgetRoot,
@@ -67,9 +67,11 @@ function TopPlatformsInner( { platformDimension }: TopPlatformsInnerProps ) {
 		return {
 			id: `${ index }-${ item.key }`,
 			label: (
-				<Stack align="center" className={ styles.itemLabel }>
-					<Text>{ item.label }</Text>
-				</Stack>
+				<LeaderboardRow
+					label={ item.label }
+					media={ { kind: 'none' } }
+					action={ { kind: 'static' } }
+				/>
 			),
 			currentValue: item.views,
 			currentShare: sharePercentage( item.views, maxViews ),

--- a/projects/packages/premium-analytics/widgets/top-platforms/style.module.css
+++ b/projects/packages/premium-analytics/widgets/top-platforms/style.module.css
@@ -13,7 +13,3 @@
 	flex: 1 1 0;
 	min-height: 0;
 }
-
-.itemLabel {
-	padding: var(--wpds-dimension-padding-sm);
-}

--- a/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
@@ -3,7 +3,6 @@
  */
 import { useEffect, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Text } from '@jetpack-premium-analytics/externals';
 import {
 	WIDGET_ROW_LIMIT,
 	calculateDelta,
@@ -12,6 +11,7 @@ import {
 	LeaderboardChart,
 	LeaderboardSkeleton,
 	LeaderboardPostLabel,
+	LeaderboardRow,
 	ReportLink,
 	WidgetBackLink,
 	WidgetFooter,
@@ -139,11 +139,11 @@ function UtmInsightsInner( { utmDimension, showReportLink }: UtmInsightsInnerPro
 						link={ postRow.href }
 					/>
 				) : (
-					<span className={ styles.itemLabel }>
-						<Text className={ styles.itemLabelText } variant="body-sm">
-							{ item.label }
-						</Text>
-					</span>
+					<LeaderboardRow
+						label={ item.label }
+						media={ { kind: 'none' } }
+						action={ { kind: 'static' } }
+					/>
 				),
 				currentValue: item.value,
 				currentShare: sharePercentage( item.value, maxValue ),

--- a/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
@@ -11,12 +11,13 @@ import {
 	LeaderboardChart,
 	LeaderboardSkeleton,
 	LeaderboardPostLabel,
-	LeaderboardRow,
 	ReportLink,
 	WidgetBackLink,
 	WidgetFooter,
 	WidgetRoot,
 	WidgetState,
+	buildLeaderboardRow,
+	resolveLeaderboardRowAction,
 	sharePercentage,
 	useWidgetDrillDown,
 	useWidgetRootContext,
@@ -129,22 +130,35 @@ function UtmInsightsInner( { utmDimension, showReportLink }: UtmInsightsInnerPro
 		return activeData.map( ( item, index ) => {
 			const previousValue = item.previousValue;
 			const postRow = 'postId' in item ? item : null;
+			const hasChildren = ! isDrillDown && 'children' in item && Boolean( item.children?.length );
 
 			return {
 				id: `${ index }-${ item.label }`,
-				label: postRow ? (
-					<LeaderboardPostLabel
-						id={ postRow.postId }
-						label={ postRow.label }
-						link={ postRow.href }
-					/>
-				) : (
-					<LeaderboardRow
-						label={ item.label }
-						media={ { kind: 'none' } }
-						action={ { kind: 'static' } }
-					/>
-				),
+				...( postRow
+					? {
+							label: (
+								<LeaderboardPostLabel
+									id={ postRow.postId }
+									label={ postRow.label }
+									link={ postRow.href }
+								/>
+							),
+					  }
+					: buildLeaderboardRow( {
+							label: item.label,
+							media: { kind: 'none' },
+							action: resolveLeaderboardRowAction( {
+								hasChildren,
+								drillDown: {
+									onClick: () => selectUtmLabel( item.label ),
+									ariaLabel: sprintf(
+										/* translators: %s is the UTM value label. */
+										__( 'View posts for %s', 'jetpack-premium-analytics-pkg' ),
+										item.label
+									),
+								},
+							} ),
+					  } ) ),
 				currentValue: item.value,
 				currentShare: sharePercentage( item.value, maxValue ),
 				previousValue,
@@ -156,16 +170,6 @@ function UtmInsightsInner( { utmDimension, showReportLink }: UtmInsightsInnerPro
 					withComparison && previousValue !== undefined
 						? calculateDelta( item.value, previousValue )
 						: undefined,
-				...( ! isDrillDown &&
-					'children' in item &&
-					item.children?.length && {
-						onClick: () => selectUtmLabel( item.label ),
-						ariaLabel: sprintf(
-							/* translators: %s is the UTM value label. */
-							__( 'View posts for %s', 'jetpack-premium-analytics-pkg' ),
-							item.label
-						),
-					} ),
 			};
 		} );
 	}, [ activeData, isDrillDown, selectUtmLabel, withComparison ] );

--- a/projects/packages/premium-analytics/widgets/utm-insights/style.module.css
+++ b/projects/packages/premium-analytics/widgets/utm-insights/style.module.css
@@ -19,19 +19,3 @@
 	min-inline-size: 0;
 	margin-block-end: 0;
 }
-
-/* Matches the shared leaderboard row so these sit level with the post rows,
-   which render through `LeaderboardPostLabel`. */
-.itemLabel {
-	display: flex;
-	align-items: center;
-	min-block-size: 36px;
-	min-inline-size: 0;
-	padding-inline: var(--wpds-dimension-padding-md);
-}
-
-.itemLabelText {
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/style.module.css
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/style.module.css
@@ -42,7 +42,7 @@
 	display: block;
 	min-block-size: 36px;
 	padding-block: var(--wpds-dimension-padding-sm);
-	padding-inline: var(--wpds-dimension-padding-sm);
+	padding-inline: var(--wpds-dimension-padding-md);
 	overflow: hidden;
 	color: var(--wpds-color-foreground-interactive-brand);
 	text-overflow: ellipsis;

--- a/projects/plugins/jetpack/changelog/wooa7s-1989-migrate-remaining-labels
+++ b/projects/plugins/jetpack/changelog/wooa7s-1989-migrate-remaining-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: Match the remaining leaderboard row labels to the other widgets.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1989-migrate-remaining-labels
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1989-migrate-remaining-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Leaderboards: Match the remaining row labels to the other leaderboard widgets.


### PR DESCRIPTION
## Proposed changes

- Six more leaderboard widgets — **Top platforms**, **Searched terms**, **Shares**, **File downloads**, **Tags & categories**, and **Top UTM** — drop their hand-written labels and render through the shared row, so every leaderboard in the dashboard now uses one 36px box with `padding-inline: md`.
- `LeaderboardRowMedia` gains an `icon` kind. Every kind that draws something took an image URL, and Tags & categories needs a `@wordpress/icons` glyph.
- Tags & categories loses its local `TagLabel`: the leaderboard rows and the drilled-in member list now build the same shared row, so the two views stay level with each other and with every other widget.
- ~110 lines of per-widget label CSS go away.
- `video-detail-embeds` is a plain list rather than a leaderboard, so it keeps its own markup; only its inset moves from `sm` to `md` to line up with the rest.

Last of a few PRs aligning the leaderboard widgets with the design prototype. Stacked on #51599.

Three deliberate behaviour changes, all bringing these widgets in line with what the shared row already does elsewhere:

- File downloads rows drop from 44px to 36px, and their link hover gains the brand colour alongside the existing underline.
- In Tags & categories the anchor now wraps the glyph as well as the text, matching how Top referrers and Top locations have always treated their favicon and flag.
- Shares, Searched terms and Top platforms lose a point of label type. Their hand-written labels were a default `<Text>` (`body-md`, `--wpds-typography-font-size-md` = 13px); the shared `.label` is `--wpds-typography-font-size-sm` = 12px. That is the size every already-migrated leaderboard renders at, so this converges on the norm rather than changing it — but it is a type change, so worth a designer's eye.

## Screenshots

Captured from Storybook at a 760px widget width.

**Tags & categories** — the glyph moves inside the anchor, and the drilled-in member list is rebuilt out of the same rows.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1989-migrate-remaining-labels/before-tags.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1989-migrate-remaining-labels/after-tags.png) |

**File downloads** — the largest visual change: rows drop from 44px to 36px, so the list tightens up.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1989-migrate-remaining-labels/before-file-downloads.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1989-migrate-remaining-labels/after-file-downloads.png) |

The last three shift by the same 4px inset and drop from 13px to 12px labels; nothing else changes.

**Top platforms**

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1989-migrate-remaining-labels/before-top-platforms.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1989-migrate-remaining-labels/after-top-platforms.png) |

**Searched terms**

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1989-migrate-remaining-labels/before-search-terms.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1989-migrate-remaining-labels/after-search-terms.png) |

**Shares**

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1989-migrate-remaining-labels/before-shares.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1989-migrate-remaining-labels/after-shares.png) |

## Related product discussion/links

- WOOA7S-1989

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Run Storybook: `pnpm run storybook` from `projects/packages/premium-analytics`.
- Open **Widgets / Tags → Default**. Rows are 36px with a 12px inset, the tag and category glyphs still render, and linked rows show the outbound arrow.
- Click a grouped row ("Desserts, chocolate"). The drilled-in members should be the same 36px rows at the same inset — before this change they were a separate 8px-inset list.
- Open **Widgets / FileDownloads → Default**. Linked rows should turn blue and underline on hover; rows without a URL should not.
- Open **TopPlatforms**, **SearchTerms**, and **Shares → Default** and confirm each row sits at the same inset as the widgets above.
- Open **UtmInsights → Default** and drill into a UTM value. The value rows and the post rows below should stay the same height and inset.
- On a dashboard, put several leaderboard widgets side by side and confirm the rows line up across all of them.



