### PR TITLE
Jetpack AI: record Tracks events for views, links, and upsells

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/components/nav-row/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/components/nav-row/index.jsx
@@ -27,7 +27,7 @@ export default function NavRow( { icon, title, description, href, onClick, tone 
 	// Only the element and its props differ between the two forms: an anchor
 	// when there is a destination, a button when there is a handler.
 	const Tag = href ? 'a' : 'button';
-	const tagProps = href ? { href } : { onClick, type: 'button' };
+	const tagProps = href ? { href, onClick } : { onClick, type: 'button' };
 	const className = tone
 		? `jetpack-ai-nav-row jetpack-ai-nav-row--${ tone }`
 		: 'jetpack-ai-nav-row';

--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -13,7 +13,7 @@ import { ToggleControl } from '@wordpress/components';
 import { Fragment, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Badge, Card, Link, Notice, Popover, Stack, Text, VisuallyHidden } from '@wordpress/ui';
-import analytics from 'lib/analytics';
+import { EVENTS, recordAiHubEvent, useRecordOnce } from '../tracks';
 
 // Server-computed target for the AI SEO row: the dedicated Jetpack SEO page
 // where it exists, the Traffic settings card otherwise. Falls back to Traffic
@@ -173,6 +173,13 @@ function FeatureRow( {
 	);
 
 	const action = checked ? feature.enabledAction : feature.disabledAction;
+	const handleActionClick = useCallback( () => {
+		recordAiHubEvent( EVENTS.LINK_CLICK, {
+			link_type: 'feature_action',
+			feature: feature.key,
+			link: action?.href,
+		} );
+	}, [ feature.key, action?.href ] );
 	// The toggle keeps showing the SAVED value but can't be used while the
 	// connection gate fails (no feature can load without it), while the master
 	// switch is off (the saved choice returns when master does), or while the
@@ -195,11 +202,56 @@ function FeatureRow( {
 					className="jetpack-ai-features__action"
 					href={ action.href }
 					openInNewTab={ !! action.external }
+					onClick={ handleActionClick }
 				>
 					{ action.label }
 				</Link>
 			) }
 		</Stack>
+	);
+}
+
+/**
+ * The "Requires upgrade" badge and its remedy popover for one gated section.
+ * Records the upsell as viewed on mount and as clicked when the popover opens.
+ *
+ * @param {object} props         - Component props.
+ * @param {string} props.section - Section key the badge belongs to.
+ * @param {string} props.tooltip - Remedy copy shown in the popover.
+ * @return {object} Component markup.
+ */
+function UpgradeBadge( { section, tooltip } ) {
+	useRecordOnce( EVENTS.UPSELL_VIEWED, { placement: 'features-badge', section } );
+	const handleOpenChange = useCallback(
+		open => {
+			if ( open ) {
+				recordAiHubEvent( EVENTS.UPSELL_CLICK, { placement: 'features-badge', section } );
+			}
+		},
+		[ section ]
+	);
+
+	return (
+		<Popover.Root onOpenChange={ handleOpenChange }>
+			{ /* A popover rather than a tooltip: click opens it, touch
+			     works, and screen readers announce the remedy copy. The
+			     trigger's accessible name is its visible badge text. */ }
+			<Popover.Trigger
+				openOnHover
+				delay={ 200 }
+				closeDelay={ 200 }
+				className="jetpack-ai-features__upgrade-badge"
+			>
+				<Badge intent="informational">{ __( 'Requires upgrade', 'jetpack' ) }</Badge>
+			</Popover.Trigger>
+			<Popover.Popup>
+				<Popover.Arrow />
+				<VisuallyHidden render={ <Popover.Title /> }>
+					{ __( 'Requires upgrade', 'jetpack' ) }
+				</VisuallyHidden>
+				<Popover.Description>{ tooltip }</Popover.Description>
+			</Popover.Popup>
+		</Popover.Root>
 	);
 }
 
@@ -248,13 +300,15 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 		  );
 
 	const sections = visibleSections( SECTIONS, features );
+	useRecordOnce( EVENTS.VIEWED, { tab: 'features' } );
+	const recordLinkClick = props => () => recordAiHubEvent( EVENTS.LINK_CLICK, props );
 
 	const handleToggle = useCallback(
 		( key, enabled ) => {
 			onUpdate( { features: { [ key ]: enabled } } ).then( saved => {
 				// Track outcomes, not attempts: a failed save changed nothing.
 				if ( saved ) {
-					analytics.tracks.recordEvent( 'jetpack_ai_feature_toggled', {
+					recordAiHubEvent( 'jetpack_ai_feature_toggled', {
 						feature: key,
 						enabled,
 					} );
@@ -289,7 +343,10 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 							'AI features need a connection to run. Your saved settings will apply once the site is connected.',
 							'jetpack'
 						) }{ ' ' }
-						<Link href="admin.php?page=my-jetpack#/connection">
+						<Link
+							href="admin.php?page=my-jetpack#/connection"
+							onClick={ recordLinkClick( { link_type: 'connection' } ) }
+						>
 							{ __( 'Connect Jetpack', 'jetpack' ) }
 						</Link>
 					</Notice.Description>
@@ -305,7 +362,10 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 							'Your feature settings are saved and will apply again when AI is turned back on.',
 							'jetpack'
 						) }{ ' ' }
-						<Link href="admin.php?page=my-jetpack">
+						<Link
+							href="admin.php?page=my-jetpack"
+							onClick={ recordLinkClick( { link_type: 'products' } ) }
+						>
 							{ __( 'Manage in My Jetpack', 'jetpack' ) }
 						</Link>
 					</Notice.Description>
@@ -344,29 +404,7 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 											</Text>
 											{ isConnected &&
 												section.features.some( f => features[ f.key ]?.requires_upgrade ) && (
-													<Popover.Root>
-														{ /* A popover rather than a tooltip: click opens it, touch
-													     works, and screen readers announce the remedy copy —
-													     the shape agreed with design on the PR. The trigger's
-													     accessible name is its visible badge text. */ }
-														<Popover.Trigger
-															openOnHover
-															delay={ 200 }
-															closeDelay={ 200 }
-															className="jetpack-ai-features__upgrade-badge"
-														>
-															<Badge intent="informational">
-																{ __( 'Requires upgrade', 'jetpack' ) }
-															</Badge>
-														</Popover.Trigger>
-														<Popover.Popup>
-															<Popover.Arrow />
-															<VisuallyHidden render={ <Popover.Title /> }>
-																{ __( 'Requires upgrade', 'jetpack' ) }
-															</VisuallyHidden>
-															<Popover.Description>{ upgradeBadgeTooltip }</Popover.Description>
-														</Popover.Popup>
-													</Popover.Root>
+													<UpgradeBadge section={ section.key } tooltip={ upgradeBadgeTooltip } />
 												) }
 										</div>
 										{ section.features.map( feature => renderRow( feature ) ) }

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -9,6 +9,18 @@ import AiFeatures from '../index';
 jest.mock( 'lib/analytics', () => ( { tracks: { recordEvent: jest.fn() } } ), { virtual: true } );
 
 describe( 'AiFeatures rendering', () => {
+	// jsdom does not implement navigation, so cancel the anchors' default
+	// action in link-click tests; React's onClick handlers still run.
+	const cancelNavigation = event => event.preventDefault();
+	beforeEach( () => document.addEventListener( 'click', cancelNavigation ) );
+	afterEach( () => document.removeEventListener( 'click', cancelNavigation ) );
+
+	const callsFor = eventName =>
+		analytics.tracks.recordEvent.mock.calls
+			.filter( call => call[ 0 ] === eventName )
+			.map( call => call[ 1 ] );
+	const toggledCalls = () => callsFor( 'jetpack_ai_feature_toggled' );
+
 	const renderFeatures = ( overrides = {} ) =>
 		render(
 			<AiFeatures
@@ -311,7 +323,7 @@ describe( 'AiFeatures rendering', () => {
 		await userEvent.click( screen.getByRole( 'checkbox', { name: /Writing Assistant/ } ) );
 
 		expect( onUpdate ).not.toHaveBeenCalled();
-		expect( analytics.tracks.recordEvent ).not.toHaveBeenCalled();
+		expect( toggledCalls() ).toHaveLength( 0 );
 	} );
 
 	test( 'toggling a row sends a partial update for just that key', async () => {
@@ -371,7 +383,53 @@ describe( 'AiFeatures rendering', () => {
 
 		await userEvent.click( screen.getByRole( 'checkbox', { name: /Writing Assistant/ } ) );
 
-		expect( analytics.tracks.recordEvent ).not.toHaveBeenCalled();
+		expect( toggledCalls() ).toHaveLength( 0 );
+	} );
+
+	test( 'viewed: records the features tab once on mount', () => {
+		analytics.tracks.recordEvent.mockClear();
+		renderFeatures();
+
+		expect( callsFor( 'jetpack_ai_hub_viewed' ) ).toEqual( [ { tab: 'features' } ] );
+	} );
+
+	test( 'upsell: the badge records a view on mount and a click when the popover opens', async () => {
+		analytics.tracks.recordEvent.mockClear();
+		renderFeatures( { is_connected: true, plan: { supports_ai: true, supports_search: false } } );
+
+		expect( callsFor( 'jetpack_ai_hub_upsell_viewed' ) ).toEqual( [
+			{ placement: 'features-badge', section: 'search' },
+		] );
+		expect( callsFor( 'jetpack_ai_hub_upsell_click' ) ).toHaveLength( 0 );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Requires upgrade' } ) );
+
+		expect( callsFor( 'jetpack_ai_hub_upsell_click' ) ).toEqual( [
+			{ placement: 'features-badge', section: 'search' },
+		] );
+	} );
+
+	test( 'link clicks: notice links and feature action links record their type', async () => {
+		analytics.tracks.recordEvent.mockClear();
+		renderFeatures( { is_connected: false } );
+		await userEvent.click( screen.getByRole( 'link', { name: 'Connect Jetpack' } ) );
+		expect( callsFor( 'jetpack_ai_hub_link_click' ) ).toEqual( [ { link_type: 'connection' } ] );
+
+		analytics.tracks.recordEvent.mockClear();
+		renderFeatures( { is_connected: true, master_enabled: false } );
+		await userEvent.click( screen.getByRole( 'link', { name: 'Manage in My Jetpack' } ) );
+		expect( callsFor( 'jetpack_ai_hub_link_click' ) ).toEqual( [ { link_type: 'products' } ] );
+
+		analytics.tracks.recordEvent.mockClear();
+		renderFeatures();
+		await userEvent.click( screen.getByRole( 'link', { name: 'Try it out in the editor' } ) );
+		expect( callsFor( 'jetpack_ai_hub_link_click' ) ).toEqual( [
+			{
+				link_type: 'feature_action',
+				feature: 'writing_assistant',
+				link: 'post-new.php?openSidebar=jetpack-ai-assistant',
+			},
+		] );
 	} );
 
 	test( 'Feature Clip does not render even when the endpoint reports it', () => {

--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -7,11 +7,12 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink, ProgressBar, Spinner, VisuallyHidden } from '@wordpress/components';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useCallback, useEffect } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { list } from '@wordpress/icons';
 import { Card, Link, LinkButton, Notice, Stack, Text } from '@wordpress/ui';
 import NavRow from '../components/nav-row';
+import { EVENTS, recordAiHubEvent, useRecordOnce } from '../tracks';
 import buildPageThumb from './images/build-page.webp';
 import connectClaudeThumb from './images/connect-claude.webp';
 import mediaLibraryThumb from './images/media-library.webp';
@@ -120,6 +121,18 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 	const meterValue = usage.unlimited
 		? 100
 		: ( usage.requestsAvailable / usage.requestsLimit ) * 100;
+	const showUpgrade = ! isLoading && ! error && usage.showUpgrade && !! upgradeUrl;
+	useEffect( () => {
+		if ( showUpgrade ) {
+			recordAiHubEvent( EVENTS.UPSELL_VIEWED, { placement: 'overview-usage' } );
+		}
+	}, [ showUpgrade ] );
+	const handleUpgradeClick = useCallback( () => {
+		recordAiHubEvent( 'jetpack_ai_upgrade_button', {
+			placement: 'ai-hub-overview',
+			context: 'jetpack-ai',
+		} );
+	}, [] );
 
 	return (
 		<Card.Root>
@@ -210,8 +223,8 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 										{ planLabel }
 									</Text>
 								) }
-								{ usage.showUpgrade && upgradeUrl && (
-									<LinkButton href={ upgradeUrl } size="compact">
+								{ showUpgrade && (
+									<LinkButton href={ upgradeUrl } size="compact" onClick={ handleUpgradeClick }>
 										{ __( 'Upgrade', 'jetpack' ) }
 									</LinkButton>
 								) }
@@ -280,6 +293,8 @@ export default function AiOverview( {
 } ) {
 	const hostBlocked = hostAllowsAi === false;
 	const userUnlinked = isUserConnected === false;
+	useRecordOnce( EVENTS.VIEWED, { tab: 'overview', plan_name: planName ?? '' } );
+	const recordLinkClick = props => () => recordAiHubEvent( EVENTS.LINK_CLICK, props );
 	return (
 		<Stack direction="column" gap="xl">
 			{ !! blogId && hostBlocked && (
@@ -300,7 +315,10 @@ export default function AiOverview( {
 							</Notice.Title>
 							<Notice.Description>
 								{ __( 'Connect your account to see your AI usage.', 'jetpack' ) }{ ' ' }
-								<Link href="admin.php?page=my-jetpack#/connection">
+								<Link
+									href="admin.php?page=my-jetpack#/connection"
+									onClick={ recordLinkClick( { link_type: 'connection' } ) }
+								>
 									{ __( 'Connect account', 'jetpack' ) }
 								</Link>
 							</Notice.Description>
@@ -327,7 +345,10 @@ export default function AiOverview( {
 							</Notice.Title>
 							<Notice.Description>
 								{ __( 'Connect the site to see your AI usage.', 'jetpack' ) }{ ' ' }
-								<Link href="admin.php?page=my-jetpack#/connection">
+								<Link
+									href="admin.php?page=my-jetpack#/connection"
+									onClick={ recordLinkClick( { link_type: 'connection' } ) }
+								>
 									{ __( 'Connect Jetpack', 'jetpack' ) }
 								</Link>
 							</Notice.Description>
@@ -348,6 +369,7 @@ export default function AiOverview( {
 							'jetpack'
 						) }
 						href={ activityLogUrl }
+						onClick={ recordLinkClick( { link_type: 'activity_log' } ) }
 						tone="neutral"
 					/>
 				</Card.Root>
@@ -366,6 +388,7 @@ export default function AiOverview( {
 								key={ slug }
 								target="_blank"
 								rel="noopener noreferrer"
+								onClick={ recordLinkClick( { link_type: 'video', link: slug } ) }
 							>
 								{ /* Decorative: the card's title carries the meaning. */ }
 								<img
@@ -404,7 +427,11 @@ export default function AiOverview( {
 				<Stack direction="column" gap="sm" align="flex-start">
 					{ DOC_LINKS.filter( ( { wpcomOnly } ) => isWpcomHosted || ! wpcomOnly ).map(
 						( { slug, title } ) => (
-							<ExternalLink key={ slug } href={ getRedirectUrl( slug ) }>
+							<ExternalLink
+								key={ slug }
+								href={ getRedirectUrl( slug ) }
+								onClick={ recordLinkClick( { link_type: 'doc', link: slug } ) }
+							>
 								{ title }
 							</ExternalLink>
 						)

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import apiFetch from '@wordpress/api-fetch';
 import { getSettings as getDateSettings, setSettings as setDateSettings } from '@wordpress/date';
+import analytics from 'lib/analytics';
 import AiOverview from '../index';
 import { freePayload, tieredPayload, unlimitedPayload } from './fixtures';
 
@@ -8,7 +10,22 @@ import { freePayload, tieredPayload, unlimitedPayload } from './fixtures';
 // hits the network and each test controls the response.
 jest.mock( '@wordpress/api-fetch' );
 
+// The component imports the webpack-aliased 'lib/analytics', which doesn't
+// resolve under jest; provide it virtually. (jest.mock is hoisted.)
+jest.mock( 'lib/analytics', () => ( { tracks: { recordEvent: jest.fn() } } ), { virtual: true } );
+
+const callsFor = eventName =>
+	analytics.tracks.recordEvent.mock.calls
+		.filter( call => call[ 0 ] === eventName )
+		.map( call => call[ 1 ] );
+
+// jsdom does not implement navigation, so cancel the anchors' default action;
+// React's onClick handlers still run.
+const cancelNavigation = event => event.preventDefault();
+beforeEach( () => document.addEventListener( 'click', cancelNavigation ) );
+
 afterEach( () => {
+	document.removeEventListener( 'click', cancelNavigation );
 	jest.resetAllMocks();
 } );
 
@@ -392,6 +409,63 @@ describe( 'AiOverview', () => {
 			const card = screen.getByRole( 'link', { name: new RegExp( name ) } );
 			expect( card ).toHaveAttribute( 'href', expect.stringContaining( slug ) );
 		}
+	} );
+
+	test( 'tracks: records the overview view once on mount with the plan name', async () => {
+		apiFetch.mockResolvedValueOnce( freePayload() );
+
+		render( <AiOverview { ...PROPS } planName="Jetpack Complete" /> );
+
+		await expect( screen.findByText( 'Available requests' ) ).resolves.toBeInTheDocument();
+		expect( callsFor( 'jetpack_ai_hub_viewed' ) ).toEqual( [
+			{ tab: 'overview', plan_name: 'Jetpack Complete' },
+		] );
+	} );
+
+	test( 'tracks: the upgrade button records a view when it renders and a click', async () => {
+		apiFetch.mockResolvedValueOnce( freePayload() );
+
+		render( <AiOverview { ...PROPS } /> );
+
+		const upgrade = await screen.findByRole( 'link', { name: 'Upgrade' } );
+		expect( callsFor( 'jetpack_ai_hub_upsell_viewed' ) ).toEqual( [
+			{ placement: 'overview-usage' },
+		] );
+
+		await userEvent.click( upgrade );
+		expect( callsFor( 'jetpack_ai_upgrade_button' ) ).toEqual( [
+			{ placement: 'ai-hub-overview', context: 'jetpack-ai' },
+		] );
+	} );
+
+	test( 'tracks: no upsell view is recorded without an upgrade button', async () => {
+		apiFetch.mockResolvedValueOnce( unlimitedPayload() );
+
+		render( <AiOverview { ...PROPS } /> );
+
+		await expect( screen.findByText( 'Available requests' ) ).resolves.toBeInTheDocument();
+		expect( callsFor( 'jetpack_ai_hub_upsell_viewed' ) ).toHaveLength( 0 );
+	} );
+
+	test( 'tracks: video, doc, activity log, and connect links record their type', async () => {
+		apiFetch.mockResolvedValueOnce( freePayload() );
+
+		render( <AiOverview { ...PROPS } /> );
+		await expect( screen.findByText( 'Available requests' ) ).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'link', { name: /Connect your site to Claude/ } ) );
+		await userEvent.click( screen.getByRole( 'link', { name: /MCP integration guide/ } ) );
+		await userEvent.click( screen.getByRole( 'link', { name: /Activity log/ } ) );
+		expect( callsFor( 'jetpack_ai_hub_link_click' ) ).toEqual( [
+			{ link_type: 'video', link: 'jetpack-ai-hub-overview-video-connect-claude' },
+			{ link_type: 'doc', link: 'jetpack-ai-hub-overview-docs-mcp-guide' },
+			{ link_type: 'activity_log' },
+		] );
+
+		analytics.tracks.recordEvent.mockClear();
+		render( <AiOverview { ...PROPS } blogId={ 0 } /> );
+		await userEvent.click( screen.getByRole( 'link', { name: 'Connect Jetpack' } ) );
+		expect( callsFor( 'jetpack_ai_hub_link_click' ) ).toEqual( [ { link_type: 'connection' } ] );
 	} );
 
 	test( 'documentation: renders all five links through the redirect service', async () => {

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -78,6 +78,11 @@ const connectedMcpGet = () => ( {
 	},
 } );
 
+const hubViews = () =>
+	analytics.tracks.recordEvent.mock.calls
+		.filter( call => call[ 0 ] === 'jetpack_ai_hub_viewed' )
+		.map( call => call[ 1 ] );
+
 const mcpViewCount = () =>
 	analytics.tracks.recordEvent.mock.calls.filter(
 		call => call[ 0 ] === 'jetpack_mcp_settings_viewed'
@@ -401,6 +406,25 @@ describe( 'AI admin page (main.jsx)', () => {
 			screen.findByRole( 'checkbox', { name: 'Enable MCP access' } )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByRole( 'link', { name: /Activity log/ } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'hub view tracking: the Overview and Features tabs each record their own view', async () => {
+		mockApiFetch( { mcpGet: connectedMcpGet() } );
+		window.jetpackAiSettings = { showFeaturesView: true, blogId: 1 };
+		window.location.hash = '#/overview';
+		render( <App /> );
+
+		await waitFor( () => {
+			expect( hubViews() ).toEqual( [ expect.objectContaining( { tab: 'overview' } ) ] );
+		} );
+
+		act( () => {
+			window.location.hash = '#/features';
+			window.dispatchEvent( new Event( 'hashchange' ) );
+		} );
+		await waitFor( () => {
+			expect( hubViews().map( p => p.tab ) ).toEqual( [ 'overview', 'features' ] );
+		} );
 	} );
 
 	test( 'MCP view tracking: does not fire on the Features tab', async () => {

--- a/projects/plugins/jetpack/_inc/client/ai/tracks.js
+++ b/projects/plugins/jetpack/_inc/client/ai/tracks.js
@@ -1,0 +1,37 @@
+/**
+ * Tracks helpers for the Jetpack AI admin page (jetpack_ai_* events).
+ * The MCP tab keeps its own wrapper in ./mcp/tracks.js.
+ */
+
+import { useEffect, useRef } from '@wordpress/element';
+import analytics from 'lib/analytics';
+
+export const EVENTS = {
+	VIEWED: 'jetpack_ai_hub_viewed',
+	LINK_CLICK: 'jetpack_ai_hub_link_click',
+	UPSELL_VIEWED: 'jetpack_ai_hub_upsell_viewed',
+	UPSELL_CLICK: 'jetpack_ai_hub_upsell_click',
+};
+
+/**
+ * Record a Tracks event for the AI page.
+ *
+ * @param {string} eventName - Tracks event name.
+ * @param {object} props     - Event properties.
+ */
+export function recordAiHubEvent( eventName, props = {} ) {
+	analytics.tracks.recordEvent( eventName, props );
+}
+
+/**
+ * Record an event once per mount, with the props as they were at mount.
+ *
+ * @param {string} eventName - Tracks event name.
+ * @param {object} props     - Event properties.
+ */
+export function useRecordOnce( eventName, props = {} ) {
+	const propsRef = useRef( props );
+	useEffect( () => {
+		recordAiHubEvent( eventName, propsRef.current );
+	}, [ eventName ] );
+}

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-hub-tracks
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-hub-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI: Record Tracks events for the Jetpack AI page views, links, and upsells.


### PR DESCRIPTION
Fixes #

## Proposed changes
* Record a Tracks event when the Overview or WordPress Agent tab is shown.
* Record a Tracks event when a link on those tabs is clicked, and when an upgrade prompt is shown or clicked.
* Add `_inc/client/ai/tracks.js` with the event names and a helper. MCP events are not changed.

| Tab | Surface | Event | Props |
|---|---|---|---|
| Overview | Tab shown | `jetpack_ai_hub_viewed` | `tab: overview`, `plan_name` |
| Overview | Upgrade button shown | `jetpack_ai_hub_upsell_viewed` | `placement: overview-usage` |
| Overview | Upgrade button click | `jetpack_ai_upgrade_button` (existing) | `placement: ai-hub-overview`, `context: jetpack-ai` |
| Overview | Video card click | `jetpack_ai_hub_link_click` | `link_type: video`, `link: <slug>` |
| Overview | Doc link click | `jetpack_ai_hub_link_click` | `link_type: doc`, `link: <slug>` |
| Overview | Activity log row click | `jetpack_ai_hub_link_click` | `link_type: activity_log` |
| Overview | Connect Jetpack / Connect account link | `jetpack_ai_hub_link_click` | `link_type: connection` |
| WordPress Agent | Tab shown | `jetpack_ai_hub_viewed` | `tab: features` |
| WordPress Agent | Feature toggle saved | `jetpack_ai_feature_toggled` (existing) | `feature`, `enabled` |
| WordPress Agent | Requires upgrade badge shown | `jetpack_ai_hub_upsell_viewed` | `placement: features-badge`, `section` |
| WordPress Agent | Requires upgrade popover opened | `jetpack_ai_hub_upsell_click` | `placement: features-badge`, `section` |
| WordPress Agent | Connect Jetpack link | `jetpack_ai_hub_link_click` | `link_type: connection` |
| WordPress Agent | Manage in My Jetpack link | `jetpack_ai_hub_link_click` | `link_type: products` |
| WordPress Agent | Feature action link (Try it out, Open settings, Learn more) | `jetpack_ai_hub_link_click` | `link_type: feature_action`, `feature`, `link` |

## Related product discussion/links
* p1HpG7-ym2-p2#comment-78476
* Two questions for @saroshaga:
  * Should the `jetpack_ai_*` events also carry the `is_a11n` and `is_test` props the `jetpack_mcp_*` events use?
  * The Requires upgrade badge has no link to act on. The click event records the popover opening only.

## Does this pull request change what data or activity we track or use?
Yes. It adds the events in the table above. They carry the site's blog ID, the tab or placement, and the link slug or feature key. No user content is sent.

## Testing instructions
1. On a site with the internal testing flag on, open `/wp-admin/admin.php?page=jetpack-ai`.
2. Open the browser network tab and filter by `t.gif`.
3. Open the Overview tab. See a `jetpack_ai_hub_viewed` request with `tab=overview`.
4. Click one walkthrough video. See a `jetpack_ai_hub_link_click` request with `link_type=video`.
5. Click one link under Documentation. See a `jetpack_ai_hub_link_click` request with `link_type=doc`.
6. Click Activity log. See a `jetpack_ai_hub_link_click` request with `link_type=activity_log`.
7. On a free plan, see a `jetpack_ai_hub_upsell_viewed` request when the card loads. Click Upgrade. See a `jetpack_ai_upgrade_button` request with `placement=ai-hub-overview`.
8. Open the WordPress Agent tab. See a `jetpack_ai_hub_viewed` request with `tab=features`.
9. Turn a feature off and on. See `jetpack_ai_feature_toggled` requests with `enabled=false` and `enabled=true`.
10. Click Try it out in the editor under Writing Assistant. See a `jetpack_ai_hub_link_click` request with `link_type=feature_action`.
11. On a site without a paid Search plan, see a `jetpack_ai_hub_upsell_viewed` request with `placement=features-badge`. Click the Requires upgrade badge. See a `jetpack_ai_hub_upsell_click` request.
12. Open the MCP Settings tab. See only the existing `jetpack_mcp_settings_viewed` request, no `jetpack_ai_hub_viewed`.

This description was written by Claude and reviewed by me.
