### PR TITLE
Jetpack AI: rename to Jetpack AI and show WP.com links on self-hosted sites 

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -305,7 +305,7 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 							'Your feature settings are saved and will apply again when AI is turned back on.',
 							'jetpack'
 						) }{ ' ' }
-						<Link href="admin.php?page=my-jetpack">
+						<Link href="admin.php?page=my-jetpack#/products">
 							{ __( 'Manage in My Jetpack', 'jetpack' ) }
 						</Link>
 					</Notice.Description>

--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -305,7 +305,10 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 							'Your feature settings are saved and will apply again when AI is turned back on.',
 							'jetpack'
 						) }{ ' ' }
-						<Link href="admin.php?page=my-jetpack#/products">
+						<Link
+							href="admin.php?page=my-jetpack#/products"
+							className="jetpack-ai-features__notice-link"
+						>
 							{ __( 'Manage in My Jetpack', 'jetpack' ) }
 						</Link>
 					</Notice.Description>

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -193,7 +193,7 @@ describe( 'AiFeatures rendering', () => {
 		expect( screen.getByText( 'Jetpack AI is turned off for this site.' ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'link', { name: 'Manage in My Jetpack' } ) ).toHaveAttribute(
 			'href',
-			'admin.php?page=my-jetpack'
+			'admin.php?page=my-jetpack#/products'
 		);
 
 		// The saved value stays visible — the toggle must not misreport it as off.

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -110,8 +110,8 @@ function Breadcrumbs( { view, onNavigate } ) {
 						className="jetpack-ai-admin__breadcrumb-link"
 						onClick={ onNavigate }
 					>
-						{ /** "AI" is a product name and should not be translated. */ }
-						AI
+						{ /** "Jetpack AI" is a product name and should not be translated. */ }
+						Jetpack AI
 					</button>
 				</li>
 				<li>

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -140,7 +140,6 @@ export default function App() {
 		planName,
 		planRenewsOn,
 		planAutoRenew,
-		isWpcomHosted,
 		isUserConnected,
 	} = window?.jetpackAiSettings ?? {};
 	const [ view, setView ] = useState( getViewFromHash );
@@ -241,11 +240,11 @@ export default function App() {
 
 	return (
 		<AdminPage
-			title={ isSubView ? undefined : 'AI' /* "AI" is a product name, not translated. */ }
+			title={ isSubView ? undefined : 'Jetpack AI' /* Product name, not translated. */ }
 			subTitle={
 				isSubView
 					? SUB_VIEW_DESCRIPTIONS[ view ]
-					: __( 'Control how AI agents interact with your site.', 'jetpack' )
+					: __( 'Create, connect, and automate with Jetpack AI.', 'jetpack' )
 			}
 			breadcrumbs={
 				isSubView ? <Breadcrumbs view={ view } onNavigate={ navigateBack } /> : undefined
@@ -357,7 +356,6 @@ export default function App() {
 						planName={ planName }
 						planRenewsOn={ planRenewsOn }
 						planAutoRenew={ planAutoRenew }
-						isWpcomHosted={ isWpcomHosted }
 						isUserConnected={ isUserConnected }
 						hostAllowsAi={ aiSettings?.host_allows_ai }
 						// Same preconditions the MCP hub applies to its copy of the

--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -64,10 +64,6 @@ const DOC_LINKS = [
 	{
 		slug: 'jetpack-ai-hub-overview-docs-agent-setup',
 		title: __( 'Setting up agentic workflows', 'jetpack' ),
-		// The guide covers WordPress.com plans and settings screens, so it has
-		// nothing to tell a site hosted elsewhere. Drop this once the Jetpack
-		// version of the page exists.
-		wpcomOnly: true,
 	},
 	{ slug: 'jetpack-ai-hub-overview-docs-billing', title: __( 'Billing & plans', 'jetpack' ) },
 	{
@@ -256,8 +252,6 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
  * @param {string}  [props.planName]        - Purchase name granting AI, from the page data.
  * @param {string}  [props.planRenewsOn]    - The purchase's renewal date, from the page data.
  * @param {boolean} [props.planAutoRenew]   - Whether that purchase auto-renews, from the page data.
- * @param {boolean} [props.isWpcomHosted]   - Whether the site is hosted on WordPress.com;
- *                                          the video row links to WP.com courses and hides elsewhere.
  * @param {boolean} [props.showActivityLog] - Whether the activity-log row applies: the row's
  *                                          copy promises AI-agent actions, which need MCP.
  * @param {boolean} [props.hostAllowsAi]    - The host's AI switch; when explicitly false, no
@@ -273,7 +267,6 @@ export default function AiOverview( {
 	planName,
 	planRenewsOn,
 	planAutoRenew,
-	isWpcomHosted,
 	showActivityLog,
 	hostAllowsAi,
 	isUserConnected,
@@ -353,62 +346,54 @@ export default function AiOverview( {
 				</Card.Root>
 			) }
 
-			{ isWpcomHosted && (
-				<div className="jetpack-ai-overview__videos">
-					<Text render={ <h2 /> } variant="heading-lg">
-						{ __( 'Walkthrough videos', 'jetpack' ) }
-					</Text>
-					<div className="jetpack-ai-overview__video-grid">
-						{ WALKTHROUGH_VIDEOS.map( ( { slug, title, duration, thumbnail } ) => (
-							<a
-								className="jetpack-ai-overview__video"
-								href={ getRedirectUrl( slug ) }
-								key={ slug }
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{ /* Decorative: the card's title carries the meaning. */ }
-								<img
-									className="jetpack-ai-overview__video-thumb"
-									src={ thumbnail }
-									alt=""
-									width="644"
-									height="348"
-									loading="lazy"
-								/>
-								<span className="jetpack-ai-overview__video-meta">
-									<Text render={ <span /> } variant="heading-md">
-										{ title }
-									</Text>
-									<Text
-										render={ <span /> }
-										variant="body-md"
-										className="jetpack-ai-overview__muted"
-									>
-										{ duration }
-									</Text>
-								</span>
-								{ /* The design leaves the cards unmarked, so announce the
+			<div className="jetpack-ai-overview__videos">
+				<Text render={ <h2 /> } variant="heading-lg">
+					{ __( 'Walkthrough videos', 'jetpack' ) }
+				</Text>
+				<div className="jetpack-ai-overview__video-grid">
+					{ WALKTHROUGH_VIDEOS.map( ( { slug, title, duration, thumbnail } ) => (
+						<a
+							className="jetpack-ai-overview__video"
+							href={ getRedirectUrl( slug ) }
+							key={ slug }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{ /* Decorative: the card's title carries the meaning. */ }
+							<img
+								className="jetpack-ai-overview__video-thumb"
+								src={ thumbnail }
+								alt=""
+								width="644"
+								height="348"
+								loading="lazy"
+							/>
+							<span className="jetpack-ai-overview__video-meta">
+								<Text render={ <span /> } variant="heading-md">
+									{ title }
+								</Text>
+								<Text render={ <span /> } variant="body-md" className="jetpack-ai-overview__muted">
+									{ duration }
+								</Text>
+							</span>
+							{ /* The design leaves the cards unmarked, so announce the
 							     new tab the way ExternalLink does, minus its arrow. */ }
-								<VisuallyHidden>{ __( '(opens in a new tab)', 'jetpack' ) }</VisuallyHidden>
-							</a>
-						) ) }
-					</div>
+							<VisuallyHidden>{ __( '(opens in a new tab)', 'jetpack' ) }</VisuallyHidden>
+						</a>
+					) ) }
 				</div>
-			) }
+			</div>
 
 			<div className="jetpack-ai-overview__docs">
 				<Text render={ <h2 /> } variant="heading-lg">
 					{ __( 'Documentation', 'jetpack' ) }
 				</Text>
 				<Stack direction="column" gap="sm" align="flex-start">
-					{ DOC_LINKS.filter( ( { wpcomOnly } ) => isWpcomHosted || ! wpcomOnly ).map(
-						( { slug, title } ) => (
-							<ExternalLink key={ slug } href={ getRedirectUrl( slug ) }>
-								{ title }
-							</ExternalLink>
-						)
-					) }
+					{ DOC_LINKS.map( ( { slug, title } ) => (
+						<ExternalLink key={ slug } href={ getRedirectUrl( slug ) }>
+							{ title }
+						</ExternalLink>
+					) ) }
 				</Stack>
 			</div>
 		</Stack>

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -16,7 +16,6 @@ const PROPS = {
 	blogId: 1,
 	activityLogUrl: 'https://example.com/activity',
 	upgradeUrl: 'https://example.com/upgrade',
-	isWpcomHosted: true,
 	showActivityLog: true,
 };
 
@@ -296,25 +295,6 @@ describe( 'AiOverview', () => {
 
 		await expect( screen.findByText( 'Available requests' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByRole( 'link', { name: /Activity log/ } ) ).not.toBeInTheDocument();
-	} );
-
-	test( 'walkthrough videos: hidden on sites not hosted on WordPress.com', async () => {
-		// The cards link to WordPress.com courses (i4 thread), so the row only
-		// belongs on WordPress.com-hosted sites — absent flag means hidden.
-		apiFetch.mockResolvedValueOnce( freePayload() );
-
-		render( <AiOverview { ...PROPS } isWpcomHosted={ false } /> );
-
-		await expect( screen.findByText( 'Available requests' ) ).resolves.toBeInTheDocument();
-		expect( screen.queryByText( 'Walkthrough videos' ) ).not.toBeInTheDocument();
-		// The docs section stays, minus the one guide written for
-		// WordPress.com plans and settings screens.
-		expect( screen.getByText( 'Documentation' ) ).toBeInTheDocument();
-		expect(
-			screen.queryByRole( 'link', { name: /Setting up agentic workflows/ } )
-		).not.toBeInTheDocument();
-		expect( screen.getByRole( 'link', { name: /MCP integration guide/ } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'link', { name: /Available capabilities/ } ) ).toBeInTheDocument();
 	} );
 
 	test( 'walkthrough videos: renders the four cards with their durations', async () => {

--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -160,6 +160,11 @@ body.jetpack_page_jetpack-ai {
 	}
 }
 
+// Keeps the notice link on one line, so it does not wrap mid-phrase.
+.jetpack-ai-features__notice-link {
+	white-space: nowrap;
+}
+
 // Feature rows: the design aligns the action link with the label's text
 // column. ToggleControl already indents its own help text; only the link
 // (rendered outside the control) needs the matching offset — 40px, same as

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -299,6 +299,20 @@ describe( 'AI admin page (main.jsx)', () => {
 		await waitFor( () => expect( mcpViewCount() ).toBe( 1 ) );
 	} );
 
+	test( 'MCP sub-views: the breadcrumb root reads Jetpack AI', async () => {
+		mockApiFetch( {
+			mcpGet: { has_mcp_access: true, mcp_abilities: { account: { some_tool: {} }, sites: [] } },
+		} );
+
+		window.location.hash = '#/read';
+		render( <App /> );
+
+		await expect(
+			screen.findByRole( 'button', { name: 'Jetpack AI' } )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'AI' } ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'a11n gate: without showFeaturesView the page is MCP-only with no tab bar', async () => {
 		window.jetpackAiSettings = {};
 		window.location.hash = '';

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -46,7 +46,7 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 		return Admin_Menu::add_menu(
 			// "Jetpack AI" is a product name and should not be translated.
 			'Jetpack AI',
-			'AI',
+			'Jetpack AI',
 			'manage_options',
 			'jetpack-ai',
 			array( $this, 'render' ),
@@ -264,9 +264,6 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 					'featureFlags'     => array(
 						Jetpack_AI_Feature_Flags::SCHEDULED_TASKS => $show_scheduled_tasks_view,
 					),
-					// The walkthrough videos link to WordPress.com courses, so the
-					// Overview only shows them on WordPress.com-hosted sites (i4 thread).
-					'isWpcomHosted'    => ( new Host() )->is_woa_site(),
 					// The usage endpoint proxies as the current user, which needs
 					// their own WordPress.com account linked — not just the site.
 					'isUserConnected'  => ( new Connection_Manager() )->is_user_connected(),

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-page-naming
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-page-naming
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI: Rename the admin page and menu item to Jetpack AI, update the page description, and point the "turned off" notice at Jetpack Products.

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -344,17 +344,6 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The video row only belongs on WordPress.com-hosted sites (i4 thread), and
-	 * the test environment is self-hosted, so the flag rides along as false.
-	 */
-	public function test_video_row_flag_is_false_off_wpcom() {
-		$settings = $this->get_injected_settings();
-
-		$this->assertArrayHasKey( 'isWpcomHosted', $settings );
-		$this->assertFalse( $settings['isWpcomHosted'] );
-	}
-
-	/**
 	 * The usage endpoint proxies as the current user, so the page reports
 	 * whether their own account is linked. The test environment links nobody.
 	 */


### PR DESCRIPTION
Fixes #

## Proposed changes
* Rename the Jetpack submenu item and the page title from "AI" to "Jetpack AI", and change the page description to "Create, connect, and automate with Jetpack AI." The MCP sub-page breadcrumbs use the same name.
* On the WordPress Agent tab, point the "Manage in My Jetpack" link (shown when Jetpack AI is turned off) at the My Jetpack Products list, where the AI toggle lives, and keep the link text on one line.
* On the Overview tab, show the walkthrough videos and all documentation links on every site, not only on WordPress.com hosted sites.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-page-naming/before-menu-header.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-page-naming/after-menu-header.png) |

After, WordPress Agent tab with Jetpack AI turned off, and the My Jetpack Products page the link opens:

| Notice | Where the link lands |
|---|---|
| ![after, AI off notice](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-page-naming/after-ai-off-notice-zoom.png) | ![after, My Jetpack Products](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-page-naming/after-my-jetpack-products.jpg) |

Overview tab on a self-hosted site, with the walkthrough videos and the "Setting up agentic workflows" link showing (the "Before" site did not have the Overview tab yet):

![after, Overview tab](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-page-naming/after-overview-videos.jpg)

Breadcrumbs for MCP

| Before | After |
|---|---|
| <img width="284" height="105" alt="image" src="https://github.com/user-attachments/assets/f858a4f0-dff8-4e4e-a2fa-9081b6994d3c" /> | <img width="266" height="88" alt="image" src="https://github.com/user-attachments/assets/04cedd61-8051-49fd-a104-ac0c102fdc79" /> |

## Related product discussion/links
* p1HpG7-ym2-p2#comment-78476

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
You need a self-hosted site connected to Jetpack, with the Jetpack AI module on, logged in through the Automattic proxy so the Overview and WordPress Agent tabs show.

1. Go to `/wp-admin/`. In the Jetpack menu you see "Jetpack AI" instead of "AI".
2. Click it. The page title reads "Jetpack AI" and the line under it reads "Create, connect, and automate with Jetpack AI." Open MCP Settings, then Read. The breadcrumb starts with "Jetpack AI".
3. Open the Overview tab. You see the "Walkthrough videos" row and, under Documentation, the "Setting up agentic workflows" link.
4. Go to My Jetpack, open Products, and turn the AI toggle off.
5. Go back to `/wp-admin/admin.php?page=jetpack-ai#/features`. You see the "Jetpack AI is turned off for this site" notice, with "Manage in My Jetpack" on a single line. Click it. You land on the My Jetpack Products list.
6. Turn the AI toggle back on.

This description was written by Claude and reviewed by me.
