### PR TITLE
Boost: raise the speed score wait from 2 minutes to 4

### DIFF
--- a/projects/js-packages/boost-score-api/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
+++ b/projects/js-packages/boost-score-api/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Wait up to four minutes for a speed score instead of two.

--- a/projects/js-packages/boost-score-api/src/index.ts
+++ b/projects/js-packages/boost-score-api/src/index.ts
@@ -6,7 +6,11 @@ import { isJsonObject, JSONObject } from './utils/json-types';
 import pollPromise from './utils/poll-promise';
 import { standardizeError } from './utils/standardize-error';
 
-const pollTimeout = 2 * 60 * 1000;
+// Four minutes covers the large majority of successful runs, including queue
+// and poll overhead. Over seven days of production runs, about 0.9% took
+// longer than two minutes and about 0.04% took longer than four. A timeout
+// here therefore does not mean the run failed.
+const pollTimeout = 4 * 60 * 1000;
 const pollInterval = 5 * 1000;
 
 type SpeedScores = {

--- a/projects/js-packages/boost-score-api/src/index.ts
+++ b/projects/js-packages/boost-score-api/src/index.ts
@@ -7,9 +7,9 @@ import pollPromise from './utils/poll-promise';
 import { standardizeError } from './utils/standardize-error';
 
 // Four minutes covers the large majority of successful runs, including queue
-// and poll overhead. Over seven days of production runs, about 0.9% took
-// longer than two minutes and about 0.04% took longer than four. A timeout
-// here therefore does not mean the run failed.
+// and poll overhead. Over the seven days to 26 August 2026, about 0.9% of
+// production runs took longer than two minutes and about 0.04% took longer
+// than four. A timeout here therefore does not mean the run failed.
 const pollTimeout = 4 * 60 * 1000;
 const pollInterval = 5 * 1000;
 

--- a/projects/js-packages/boost-score-api/src/utils/poll-promise.ts
+++ b/projects/js-packages/boost-score-api/src/utils/poll-promise.ts
@@ -34,12 +34,9 @@ export default async function pollPromise< RetType = void >( {
 		intervalHandle: ReturnType< typeof setInterval >;
 
 	return new Promise< RetType >( ( resolve, reject ) => {
-		timeoutHandle = setTimeout(
-			() => {
-				reject( new Error( timeoutError || __( 'Timed out', 'boost-score-api' ) ) );
-			},
-			timeout || 2 * 60 * 1000
-		);
+		timeoutHandle = setTimeout( () => {
+			reject( new Error( timeoutError || __( 'Timed out', 'boost-score-api' ) ) );
+		}, timeout );
 
 		intervalHandle = setInterval( async () => {
 			try {

--- a/projects/js-packages/boost-score-api/tests/index.test.ts
+++ b/projects/js-packages/boost-score-api/tests/index.test.ts
@@ -31,13 +31,58 @@ describe( 'requestSpeedScores', () => {
 
 	afterEach( () => {
 		jest.restoreAllMocks();
+		jest.useRealTimers();
 	} );
 
 	it( 'should return speed scores', async () => {
 		api.post.mockResolvedValue( mockData );
 
-		const scores = await requestSpeedScores( 'https://example.com' );
+		const scores = await requestSpeedScores(
+			false,
+			'https://example.com/wp-json/',
+			'https://example.com',
+			'nonce'
+		);
 		expect( scores ).toEqual( mockData.scores );
+		expect( api.post ).toHaveBeenCalledWith(
+			'https://example.com/wp-json/',
+			'/speed-scores',
+			{ url: 'https://example.com' },
+			'nonce'
+		);
+	} );
+
+	it( 'waits 240 seconds before giving up on a pending score', async () => {
+		jest.useFakeTimers();
+		api.post.mockResolvedValue( { status: 'pending' } );
+
+		let settled = false;
+		const request = requestSpeedScores(
+			false,
+			'https://example.com/wp-json/',
+			'https://example.com',
+			'nonce'
+		);
+		const outcome = request.then(
+			() => {
+				settled = true;
+				return undefined;
+			},
+			error => {
+				settled = true;
+				return error;
+			}
+		);
+
+		// Let the initial request resolve as pending and start the polling timers.
+		await Promise.resolve();
+		await jest.advanceTimersByTimeAsync( 239999 );
+		expect( settled ).toBe( false );
+
+		await jest.advanceTimersByTimeAsync( 1 );
+		const error = await outcome;
+		expect( error ).toBeInstanceOf( Error );
+		expect( ( error as Error ).message ).toBe( 'Timed out while waiting for speed-score.' );
 	} );
 } );
 

--- a/projects/plugins/backup/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
+++ b/projects/plugins/backup/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost: Wait up to four minutes for slow speed tests in My Jetpack instead of timing out after two.

--- a/projects/plugins/boost/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
+++ b/projects/plugins/boost/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Speed Score: Wait up to four minutes for a slow speed test instead of two.

--- a/projects/plugins/jetpack/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
+++ b/projects/plugins/jetpack/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Boost: Wait up to four minutes for slow speed tests in My Jetpack and At a Glance instead of timing out after two.

--- a/projects/plugins/protect/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
+++ b/projects/plugins/protect/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost: Wait up to four minutes for slow speed tests in My Jetpack instead of timing out after two.

--- a/projects/plugins/search/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
+++ b/projects/plugins/search/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost: Wait up to four minutes for slow speed tests in My Jetpack instead of timing out after two.

--- a/projects/plugins/social/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
+++ b/projects/plugins/social/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost: Wait up to four minutes for slow speed tests in My Jetpack instead of timing out after two.

--- a/projects/plugins/starter-plugin/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
+++ b/projects/plugins/starter-plugin/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost: Wait up to four minutes for slow speed tests in My Jetpack instead of timing out after two.

--- a/projects/plugins/stats/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
+++ b/projects/plugins/stats/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost: Wait up to four minutes for slow speed tests in My Jetpack instead of timing out after two.

--- a/projects/plugins/videopress/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
+++ b/projects/plugins/videopress/changelog/LiamSarsfield-boost-636-raise-the-dashboards-speed-score-wait-from-2-minutes-to-4
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Boost: Wait up to four minutes for slow speed tests in My Jetpack instead of timing out after two.


### PR DESCRIPTION
Fixes BOOST-636

## Proposed changes

The dashboard gave up on a speed score after 120 seconds and showed "Whoops, something went wrong". About 0.9% of successful runs take longer than that, so the error turned up while the test was still going, often moments before the score arrived.

One request measures mobile as well as desktop, and the mobile pass runs with the CPU and network throttled. That is where the time goes. A heavy page full of scripts and third party embeds can spend over two minutes on the mobile pass alone. Turn Boost modules on and a second comparison run without Boost goes out too, so the dashboard is really waiting on whichever of four passes finishes last.

At 240 seconds the dashboard shows the same error notice as before, with its "Try again" action. It still cannot tell a timeout from a real failure, and neither can the two cards. Fixing that means changing all three, and it is worth seeing how many runs still hit the limit at four minutes first.

### Why 240 seconds

Successful runs on Boost Cloud, 7 days to 26 Aug 2026:

| Run took more than | Share of runs |
| -- | -- |
| 100 s | 2.3% |
| 120 s | 0.93% |
| 240 s | 0.04% |
| 300 s | 0.016% |
| longest | 380 s |

The clock also has to cover queue wait, the WordPress.com round trips and the 5 s poll interval, another 15 to 20 s. A failed run does not wait that long, because the cloud reports failure as soon as it happens.

### Who else this affects

`pollTimeout` is shared, so the wait grows everywhere that asks for a score, not just the dashboard the ticket names. None of these is edited here.

* Boost dashboard (`plugins/boost`)
* My Jetpack Boost card (`packages/my-jetpack`), which reaches users of the nine plugins that bundle My Jetpack
* At a Glance Boost card (`plugins/jetpack`)

On slow sites the two cards can now spin for 4 minutes instead of 2. At the limit they behave as before: fall back to a cached score, or hide it when there is no cache.

No server, Boost Cloud or WordPress.com changes.

## Related product discussion/links

* BOOST-636
* BOOST-634

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Run `pnpm --filter @automattic/jetpack-boost-score-api test`. Put `pollTimeout` back to `2 * 60 * 1000` and the new test fails.

Checking by hand is a stopwatch job, since the only visible change is how long you wait:

1. `pnpm jetpack build plugins/boost --deps`
2. In a mu-plugin, filter `pre_http_request` so `/speed-scores` returns `{"status":"pending"}`. Do not commit this.
3. Open the Boost dashboard. The bars load for about 4 minutes instead of 2, then the same old error notice appears.
4. Remove the mock and reload. The score loads.

You cannot force a genuinely slow run, so the mock is the only practical way to see the new limit.