### PR TITLE
Jetpack AI: record Tracks events for Overview views and video clicks

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -12,6 +12,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { list } from '@wordpress/icons';
 import { Card, Link, LinkButton, Notice, Stack, Text } from '@wordpress/ui';
 import NavRow from '../components/nav-row';
+import { EVENTS, recordAiHubEvent, useRecordOnce } from '../tracks';
 import buildPageThumb from './images/build-page.webp';
 import connectClaudeThumb from './images/connect-claude.webp';
 import mediaLibraryThumb from './images/media-library.webp';
@@ -273,6 +274,9 @@ export default function AiOverview( {
 } ) {
 	const hostBlocked = hostAllowsAi === false;
 	const userUnlinked = isUserConnected === false;
+	useRecordOnce( EVENTS.VIEWED, { tab: 'overview' } );
+	const recordVideoClick = slug => () =>
+		recordAiHubEvent( EVENTS.LINK_CLICK, { link_type: 'video', link: slug } );
 	return (
 		<Stack direction="column" gap="xl">
 			{ !! blogId && hostBlocked && (
@@ -358,6 +362,7 @@ export default function AiOverview( {
 							key={ slug }
 							target="_blank"
 							rel="noopener noreferrer"
+							onClick={ recordVideoClick( slug ) }
 						>
 							{ /* Decorative: the card's title carries the meaning. */ }
 							<img

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -1,15 +1,31 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import apiFetch from '@wordpress/api-fetch';
 import { getSettings as getDateSettings, setSettings as setDateSettings } from '@wordpress/date';
+import analytics from 'lib/analytics';
 import AiOverview from '../index';
 import { freePayload, tieredPayload, unlimitedPayload } from './fixtures';
 
 // The usage hook fetches through @wordpress/api-fetch; stub it so nothing
 // hits the network and each test controls the response.
 jest.mock( '@wordpress/api-fetch' );
+// The component imports the webpack-aliased 'lib/analytics', which does not
+// resolve under jest; provide it virtually.
+jest.mock( 'lib/analytics', () => ( { tracks: { recordEvent: jest.fn() } } ), { virtual: true } );
+
+const callsFor = eventName =>
+	analytics.tracks.recordEvent.mock.calls
+		.filter( call => call[ 0 ] === eventName )
+		.map( call => call[ 1 ] );
+
+// jsdom does not implement navigation; cancel the anchors' default action so
+// clicks still reach React's handlers without a jsdom "not implemented" error.
+const cancelNavigation = event => event.preventDefault();
+beforeEach( () => document.addEventListener( 'click', cancelNavigation ) );
 
 afterEach( () => {
 	jest.resetAllMocks();
+	document.removeEventListener( 'click', cancelNavigation );
 } );
 
 const PROPS = {
@@ -394,5 +410,25 @@ describe( 'AiOverview', () => {
 			const link = screen.getByRole( 'link', { name: new RegExp( name ) } );
 			expect( link ).toHaveAttribute( 'href', expect.stringContaining( slug ) );
 		}
+	} );
+	test( 'tracks: records the overview view once on mount', async () => {
+		apiFetch.mockResolvedValueOnce( freePayload() );
+
+		render( <AiOverview { ...PROPS } /> );
+
+		await expect( screen.findByText( 'Available requests' ) ).resolves.toBeInTheDocument();
+		expect( callsFor( 'jetpack_ai_hub_viewed' ) ).toEqual( [ { tab: 'overview' } ] );
+	} );
+
+	test( 'tracks: a video card click records the video slug', async () => {
+		apiFetch.mockResolvedValueOnce( freePayload() );
+
+		render( <AiOverview { ...PROPS } /> );
+		await expect( screen.findByText( 'Available requests' ) ).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'link', { name: /Connect your site to Claude/ } ) );
+		expect( callsFor( 'jetpack_ai_hub_link_click' ) ).toEqual( [
+			{ link_type: 'video', link: 'jetpack-ai-hub-overview-video-connect-claude' },
+		] );
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -417,7 +417,9 @@ describe( 'AiOverview', () => {
 		render( <AiOverview { ...PROPS } /> );
 
 		await expect( screen.findByText( 'Available requests' ) ).resolves.toBeInTheDocument();
-		expect( callsFor( 'jetpack_ai_hub_viewed' ) ).toEqual( [ { tab: 'overview' } ] );
+		expect( callsFor( 'jetpack_ai_hub_viewed' ) ).toEqual( [
+			{ site_type: 'jetpack', is_a11n: 'false', is_test: 'false', tab: 'overview' },
+		] );
 	} );
 
 	test( 'tracks: a video card click records the video slug', async () => {
@@ -428,7 +430,13 @@ describe( 'AiOverview', () => {
 
 		await userEvent.click( screen.getByRole( 'link', { name: /Connect your site to Claude/ } ) );
 		expect( callsFor( 'jetpack_ai_hub_link_click' ) ).toEqual( [
-			{ link_type: 'video', link: 'jetpack-ai-hub-overview-video-connect-claude' },
+			{
+				site_type: 'jetpack',
+				is_a11n: 'false',
+				is_test: 'false',
+				link_type: 'video',
+				link: 'jetpack-ai-hub-overview-video-connect-claude',
+			},
 		] );
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/ai/test/tracks.js
+++ b/projects/plugins/jetpack/_inc/client/ai/test/tracks.js
@@ -1,0 +1,48 @@
+import { getSiteType } from '@automattic/jetpack-script-data';
+import analytics from 'lib/analytics';
+import { getTrackingSiteType, recordAiHubEvent } from '../tracks';
+
+jest.mock( 'lib/analytics', () => ( { tracks: { recordEvent: jest.fn() } } ), { virtual: true } );
+jest.mock( '@automattic/jetpack-script-data', () => ( { getSiteType: jest.fn() } ) );
+
+afterEach( () => {
+	jest.resetAllMocks();
+	delete window.jetpackAiSettings;
+} );
+
+describe( 'getTrackingSiteType', () => {
+	test.each( [
+		[ 'simple', 'simple' ],
+		[ 'woa', 'atomic' ],
+		[ 'jetpack', 'jetpack' ],
+	] )( 'maps script-data %s to %s', ( scriptData, expected ) => {
+		getSiteType.mockReturnValue( scriptData );
+		expect( getTrackingSiteType() ).toBe( expected );
+	} );
+} );
+
+describe( 'recordAiHubEvent', () => {
+	test( 'adds site_type and the audience props to every event and keeps the caller props', () => {
+		getSiteType.mockReturnValue( 'woa' );
+		window.jetpackAiSettings = { isA11n: true, isTest: false };
+		recordAiHubEvent( 'jetpack_ai_hub_link_click', { link_type: 'video', link: 'x' } );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_ai_hub_link_click', {
+			site_type: 'atomic',
+			is_a11n: 'true',
+			is_test: 'false',
+			link_type: 'video',
+			link: 'x',
+		} );
+	} );
+
+	test( 'audience props default to false strings when the page injects none', () => {
+		getSiteType.mockReturnValue( 'jetpack' );
+		recordAiHubEvent( 'jetpack_ai_hub_viewed', { tab: 'overview' } );
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_ai_hub_viewed', {
+			site_type: 'jetpack',
+			is_a11n: 'false',
+			is_test: 'false',
+			tab: 'overview',
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/client/ai/tracks.js
+++ b/projects/plugins/jetpack/_inc/client/ai/tracks.js
@@ -1,0 +1,35 @@
+/**
+ * Tracks helpers for the Jetpack AI admin page (jetpack_ai_* events).
+ * The MCP tab keeps its own wrapper in ./mcp/tracks.js.
+ */
+
+import { useEffect, useRef } from '@wordpress/element';
+import analytics from 'lib/analytics';
+
+export const EVENTS = {
+	VIEWED: 'jetpack_ai_hub_viewed',
+	LINK_CLICK: 'jetpack_ai_hub_link_click',
+};
+
+/**
+ * Record a Tracks event for the AI page.
+ *
+ * @param {string} eventName - Tracks event name.
+ * @param {object} props     - Event properties.
+ */
+export function recordAiHubEvent( eventName, props = {} ) {
+	analytics.tracks.recordEvent( eventName, props );
+}
+
+/**
+ * Record an event once per mount, with the props as they were at mount.
+ *
+ * @param {string} eventName - Tracks event name.
+ * @param {object} props     - Event properties.
+ */
+export function useRecordOnce( eventName, props = {} ) {
+	const propsRef = useRef( props );
+	useEffect( () => {
+		recordAiHubEvent( eventName, propsRef.current );
+	}, [ eventName ] );
+}

--- a/projects/plugins/jetpack/_inc/client/ai/tracks.js
+++ b/projects/plugins/jetpack/_inc/client/ai/tracks.js
@@ -3,6 +3,7 @@
  * The MCP tab keeps its own wrapper in ./mcp/tracks.js.
  */
 
+import { getSiteType } from '@automattic/jetpack-script-data';
 import { useEffect, useRef } from '@wordpress/element';
 import analytics from 'lib/analytics';
 
@@ -12,13 +13,33 @@ export const EVENTS = {
 };
 
 /**
- * Record a Tracks event for the AI page.
+ * Record a Tracks event for the AI page with the standard site and audience
+ * props. is_a11n and is_test come from the page data, as strings, matching
+ * the jetpack_mcp_* events.
  *
  * @param {string} eventName - Tracks event name.
  * @param {object} props     - Event properties.
  */
 export function recordAiHubEvent( eventName, props = {} ) {
-	analytics.tracks.recordEvent( eventName, props );
+	const { isA11n = false, isTest = false } = window?.jetpackAiSettings ?? {};
+
+	analytics.tracks.recordEvent( eventName, {
+		site_type: getTrackingSiteType(),
+		is_a11n: isA11n ? 'true' : 'false',
+		is_test: isTest ? 'true' : 'false',
+		...props,
+	} );
+}
+
+/**
+ * Site type in the Data-team spelling used by the other AI events
+ * (Image Studio, ai-client): simple | atomic | jetpack.
+ *
+ * @return {string} The site type.
+ */
+export function getTrackingSiteType() {
+	const type = getSiteType();
+	return type === 'woa' ? 'atomic' : type;
 }
 
 /**

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-hub-video-tracks
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-hub-video-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI: Record Tracks events for Overview tab views and walkthrough video clicks.

--- a/projects/plugins/jetpack/tests/jest.config.gui.js
+++ b/projects/plugins/jetpack/tests/jest.config.gui.js
@@ -16,6 +16,7 @@ module.exports = {
 		'<rootDir>/_inc/client/ai/scheduled-tasks/test/index.jsx',
 		'<rootDir>/_inc/client/ai/scheduled-tasks/test/use-scheduled-tasks.js',
 		'<rootDir>/_inc/client/ai/test/main.jsx',
+		'<rootDir>/_inc/client/ai/test/tracks.js',
 		'<rootDir>/_inc/client/sharing/test/component.jsx',
 		'<rootDir>/_inc/client/traffic/test/component.jsx',
 		'<rootDir>/_inc/client/at-a-glance/stats/test/chart-bar-range.js',


### PR DESCRIPTION
Fixes #

## Proposed changes
* Record a Tracks event when the Overview tab of the Jetpack AI page is shown.
* Record a Tracks event when a walkthrough video card is clicked, with the video slug.

| Surface | Event | Props |
|---|---|---|
| Overview tab shown | `jetpack_ai_hub_viewed` | `tab: overview`, `site_type`, `is_a11n`, `is_test` |
| Walkthrough video click | `jetpack_ai_hub_link_click` | `link_type: video`, `link: <slug>`, `site_type`, `is_a11n`, `is_test` |

`site_type` is `simple`, `atomic`, or `jetpack` (self-hosted), the same values the Image Studio and AI client events use. `is_a11n` and `is_test` are the strings `true` or `false`, taken from the page data the same way the `jetpack_mcp_*` events do.

## Related product discussion/links
* p1HpG7-ym2-p2#comment-78476

## Does this pull request change what data or activity we track or use?
Yes. Two new events, listed above. They carry the blog ID, the site type, whether the user is an Automattician, whether the request is from an internal testing environment, the tab name, and the video slug. No user content is sent.

The site type is sent on the event because the Tracks-side join on blog ID only reflects the site's host today, not at the time of the event.

## Testing instructions
You need a site connected to Jetpack, with the Jetpack AI module on, logged in through the Automattic proxy so the Overview tab shows.

1. Open the browser network tab and filter by `t.gif`.
2. Go to `/wp-admin/admin.php?page=jetpack-ai`. You see a request with `jetpack_ai_hub_viewed`, `tab=overview`, and `site_type=jetpack` on a self-hosted site (`atomic` on Atomic).
3. Click one walkthrough video. You see a request with `jetpack_ai_hub_link_click`, `link_type=video`, and the video slug.
4. Reload the page and switch to the MCP Settings tab. You see no `jetpack_ai_hub_viewed` request for that tab.

This description was written by Claude and reviewed by me.
