### PR TITLE
Podcast Episode block: fix stale cover art help text location

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-episode-cover-art-help-location
+++ b/projects/packages/podcast/changelog/fix-podcast-episode-cover-art-help-location
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast Episode block: point the cover art help text at the Podcast settings page instead of the removed Settings → Writing → Podcasting screen.

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -654,7 +654,7 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 						</MediaUploadCheck>
 						<p className="components-base-control__help">
 							{ __(
-								'Defaults to the post’s featured image, then the show cover art from Settings → Writing → Podcasting.',
+								'Defaults to the post’s featured image, then the show cover art from the Podcast settings.',
 								'jetpack-podcast'
 							) }
 						</p>


### PR DESCRIPTION
#### Proposed changes:

The Podcast Episode block's cover art help text pointed at **Settings → Writing → Podcasting**, a screen the package's own Podcast dashboard has replaced (the legacy stack is removed per the package docs). Anyone following the instruction hits a dead end — the setting now lives on the **Podcast** admin page's Settings tab (which writes the same `podcasting_image` option the block reads).

- Update the help string to: "Defaults to the post's featured image, then the show cover art from the Podcast settings."

#### Other information:

- [ ] Have you written new tests for your changes, if applicable? — n/a, string-only change
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable? — not yet tested via Jetpack Beta; the underlying behavior was observed on a WoA site running the shipped package

#### Jetpack product discussion

Found while integrating the Podcast Episode block on a WoA site: the site owner searched Settings → Writing for the cover art location and couldn't find it, then discovered the Podcast dashboard independently.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

1. On a site with the Podcast package active, add a Podcast Episode block to a post.
2. In the block sidebar, open the Cover art control and read the help text below the media picker.
3. It should reference "the Podcast settings" (the Podcast admin page), not Settings → Writing → Podcasting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01538ZhDx7CTsTzxHjUbqLWk
