### PR TITLE
Podcast Episode block: serve sized cover art renditions for the poster

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-episode-poster-renditions
+++ b/projects/packages/podcast/changelog/fix-podcast-episode-poster-renditions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast Episode block: serve a sized cover art rendition with srcset for the visible poster instead of the full-size image, and keep the poster square when width/height attributes are present.

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -197,6 +197,37 @@ class Podcast_Episode_Block {
 	}
 
 	/**
+	 * Resolve the attachment ID backing the cover art, mirroring the URL
+	 * fallback chain in resolve_cover_art_url(): episode override → post
+	 * featured image → show-level `podcasting_image_id` option. Returns 0
+	 * when the winning source is a bare URL with no local attachment (e.g.
+	 * externally hosted cover art), so callers can fall back to plain
+	 * markup for it.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param \WP_Post $post       Episode post.
+	 * @return int
+	 */
+	private static function resolve_cover_art_id( array $attributes, $post ) {
+		if ( isset( $attributes['coverArt'] ) && is_array( $attributes['coverArt'] ) && ! empty( $attributes['coverArt']['url'] ) ) {
+			$override_id = isset( $attributes['coverArt']['id'] ) ? (int) $attributes['coverArt']['id'] : 0;
+			return $override_id && wp_attachment_is_image( $override_id ) ? $override_id : 0;
+		}
+
+		$featured_id = (int) get_post_thumbnail_id( $post );
+		if ( $featured_id && wp_attachment_is_image( $featured_id ) ) {
+			return $featured_id;
+		}
+
+		if ( '' !== (string) get_option( 'podcasting_image', '' ) ) {
+			$show_id = (int) get_option( 'podcasting_image_id', 0 );
+			return $show_id && wp_attachment_is_image( $show_id ) ? $show_id : 0;
+		}
+
+		return 0;
+	}
+
+	/**
 	 * Render callback. Full player in every context so the RSS feed carries it
 	 * (how the WPCOM Reader shows it on Atomic/Jetpack). Email uses render_email().
 	 *
@@ -298,8 +329,25 @@ class Podcast_Episode_Block {
 		$show_email     = (string) get_option( 'podcasting_email', '' );
 
 		// Resolve cover art unconditionally so schema always carries the image;
-		// `$show_poster` only gates the visible figure/poster.
+		// `$show_poster` only gates the visible figure/poster. Schema keeps the
+		// full-size URL; the visible poster serves a sized rendition when the
+		// cover art is backed by a local attachment.
 		$image_url = self::resolve_cover_art_url( $attributes, $post, 'full' );
+		$image_id  = self::resolve_cover_art_id( $attributes, $post );
+
+		$poster_img = $image_id ? wp_get_attachment_image(
+			$image_id,
+			'medium_large',
+			false,
+			array(
+				'alt'      => '',
+				'itemprop' => 'image',
+				'loading'  => 'lazy',
+				// The poster renders at 160px except on small screens, where
+				// it spans the card (max-width 600px media query in the CSS).
+				'sizes'    => '(max-width: 600px) 100vw, 160px',
+			)
+		) : '';
 
 		$media_object_type = 'video' === $media_type ? 'VideoObject' : 'AudioObject';
 
@@ -314,12 +362,16 @@ class Podcast_Episode_Block {
 				<?php endif; ?>
 				<?php if ( $image_url && $show_poster ) : ?>
 					<figure class="jetpack-podcast-episode__poster">
-						<img
-							src="<?php echo esc_url( $image_url ); ?>"
-							alt=""
-							itemprop="image"
-							loading="lazy"
-						/>
+						<?php if ( '' !== $poster_img ) : ?>
+							<?php echo $poster_img; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_get_attachment_image() returns escaped markup. ?>
+						<?php else : ?>
+							<img
+								src="<?php echo esc_url( $image_url ); ?>"
+								alt=""
+								itemprop="image"
+								loading="lazy"
+							/>
+						<?php endif; ?>
 					</figure>
 				<?php elseif ( $image_url ) : ?>
 					<meta itemprop="image" content="<?php echo esc_url( $image_url ); ?>" />

--- a/projects/packages/podcast/src/blocks/podcast-episode/style.scss
+++ b/projects/packages/podcast/src/blocks/podcast-episode/style.scss
@@ -32,6 +32,11 @@ $jetpack-podcast-episode-gap: 16px;
 		// what the feed serves (Photon center-crops covers to 1:1).
 		img {
 			inline-size: 100%;
+			// The rendered img carries width/height attributes (from
+			// wp_get_attachment_image(), and image CDNs inject their own);
+			// an attribute height would defeat the aspect-ratio, so keep
+			// the block size automatic.
+			block-size: auto;
 			aspect-ratio: 1;
 			object-fit: cover;
 			border-radius: calc(#{$jetpack-podcast-episode-radius} - 2px);


### PR DESCRIPTION
#### Proposed changes:

The visible poster in the Podcast Episode block renders the raw cover art URL — the episode override and show-level `podcasting_image` are echoed as stored, and the featured-image path requests the `'full'` size — with no `srcset` or dimension handling. A typical 3000×3000 show cover (Apple Podcasts' recommended size, ~1MB) ships into a 160px display slot on every episode page.

- Add `resolve_cover_art_id()` mirroring the existing URL fallback chain (episode override → featured image → `podcasting_image_id` option), returning 0 when the winning source is a bare URL with no local attachment.
- Render the visible poster via `wp_get_attachment_image( $id, 'medium_large', … )` when an ID resolves — bringing `srcset`, `sizes` (matched to the block's 160px / mobile-100vw layout), width/height attributes, and lazy-loading — and keep the existing plain `<img>` path for externally hosted art.
- Schema output (`itemprop="image"` meta when the poster is hidden, and the `partOfSeries` reference) still carries the full-size URL.
- Add `block-size: auto` to the poster image CSS so the emitted (or CDN-injected) width/height attributes can't defeat the `aspect-ratio: 1` — without it, an attribute height stretches square covers into a tall crop.

As a side benefit, correct dimension attributes make the unstyled first paint render at a sane size on sites where critical-CSS tooling (e.g. Jetpack Boost) defers the block stylesheet — today that flashes the full-size cover before the CSS arrives.

#### Other information:

- [ ] Have you written new tests for your changes, if applicable? — existing render tests cover the fallback chain and the URL-only path; happy to add an attachment-backed render test if wanted
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable? — not yet tested via Jetpack Beta; the underlying behavior was observed on a WoA site running the shipped package

#### Jetpack product discussion

Found while rolling the block out on a WoA podcast site (distributed.blog staging): the show cover is 923KB at 3000×3000, and every episode page shipped it for a 160px poster. The tall-crop attribute bug was also observed there via the image CDN's injected width/height.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

1. On a site with the Podcast package active, set a show cover in the Podcast settings (or a featured image / episode cover art on a post) backed by a media library image.
2. Add a Podcast Episode block to a post and view it on the front end.
3. The poster `<img>` should have `srcset`/`sizes` and width/height attributes, and the network panel should show a small rendition (~medium_large or smaller) being downloaded, not the original.
4. Set the block's Cover art to an external URL (not in the media library): the poster should render the plain `<img src>` exactly as before.
5. Verify the poster stays square (no tall crop) with the width/height attributes present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01538ZhDx7CTsTzxHjUbqLWk
