### PR TITLE
Handle plugin install and settings actions within the plugin

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/backups.jsx
@@ -27,7 +27,7 @@ import {
 	getVaultPressData,
 } from 'state/at-a-glance';
 import { hasConnectedOwner, isOfflineMode, connectUser } from 'state/connection';
-import { getPartnerCoupon, showBackups } from 'state/initial-state';
+import { getPartnerCoupon, getSiteAdminUrl, showBackups } from 'state/initial-state';
 import { siteHasFeature, isFetchingSiteData } from 'state/site';
 import { isPluginInstalled } from 'state/site/plugins';
 import BackupGettingStarted from './backup-getting-started';
@@ -70,6 +70,7 @@ class DashBackups extends Component {
 		trackUpgradeButtonView: PropTypes.func,
 
 		// Connected props
+		siteAdminUrl: PropTypes.string.isRequired,
 		vaultPressData: PropTypes.any.isRequired,
 		hasBackups: PropTypes.bool.isRequired,
 		hasRealTimeBackups: PropTypes.bool.isRequired,
@@ -82,6 +83,7 @@ class DashBackups extends Component {
 
 	static defaultProps = {
 		siteRawUrl: '',
+		siteAdminUrl: '',
 		getOptionValue: noop,
 		vaultPressData: '',
 		isOfflineMode: false,
@@ -188,7 +190,7 @@ class DashBackups extends Component {
 			isFetchingSite,
 			isVaultPressInstalled,
 			getOptionValue,
-			siteRawUrl,
+			siteAdminUrl,
 			vaultPressData,
 		} = this.props;
 
@@ -228,12 +230,7 @@ class DashBackups extends Component {
 						{
 							a: (
 								<a
-									href={ getRedirectUrl( 'calypso-plugins-setup', {
-										site: siteRawUrl,
-										query: 'only=backups',
-									} ) }
-									target="_blank"
-									rel="noopener noreferrer"
+									href={ `${ siteAdminUrl }plugin-install.php?tab=search&type=term&s=vaultpress` }
 								/>
 							),
 						}
@@ -530,6 +527,7 @@ class DashBackups extends Component {
 export default connect(
 	state => {
 		return {
+			siteAdminUrl: getSiteAdminUrl( state ),
 			vaultPressData: getVaultPressData( state ),
 			isOfflineMode: isOfflineMode( state ),
 			isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' ),

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/scan.jsx
@@ -239,9 +239,7 @@ class DashScan extends Component {
 						{
 							a: (
 								<a
-									href={ getRedirectUrl( 'calypso-plugins-vaultpress' ) }
-									target="_blank"
-									rel="noopener noreferrer"
+									href={ `${ this.props.siteAdminUrl }plugin-install.php?tab=search&type=term&s=vaultpress` }
 								/>
 							),
 						}

--- a/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
+++ b/projects/plugins/jetpack/_inc/client/my-plan/my-plan-body.jsx
@@ -219,11 +219,7 @@ class MyPlanBody extends Component {
 								rna
 							>
 								<Link
-									openInNewTab
-									href={ getRedirectUrl( 'calypso-plugins-setup', {
-										site: this.props.blogID ?? this.props.siteRawUrl,
-										query: 'only=vaultpress',
-									} ) }
+									href={ `${ this.props.siteAdminUrl }plugin-install.php?tab=search&type=term&s=vaultpress` }
 								>
 									{ __( 'View settings', 'jetpack' ) }
 								</Link>
@@ -381,11 +377,7 @@ class MyPlanBody extends Component {
 										rna
 									>
 										<Link
-											openInNewTab
-											href={ getRedirectUrl( 'calypso-plugins-setup', {
-												site: this.props.blogID ?? this.props.siteRawUrl,
-												query: 'only=akismet',
-											} ) }
+											href={ `${ this.props.siteAdminUrl }admin.php?page=my-jetpack#/add-akismet` }
 										>
 											{ __( 'View settings', 'jetpack' ) }
 										</Link>

--- a/projects/plugins/jetpack/_inc/client/pro-status/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/pro-status/index.jsx
@@ -19,7 +19,7 @@ import {
 	isFetchingAkismetData,
 } from 'state/at-a-glance';
 import { isOfflineMode } from 'state/connection';
-import { getSiteRawUrl, getSiteAdminUrl } from 'state/initial-state';
+import { getSiteAdminUrl } from 'state/initial-state';
 import { getRewindStatus } from 'state/rewind';
 import { getScanStatus } from 'state/scan';
 import { getSitePlan, siteHasFeature, isFetchingSiteData } from 'state/site';
@@ -172,15 +172,31 @@ class ProStatus extends Component {
 	 * @return {import('react').ReactElement} A Button component.
 	 */
 	getSetUpButton = feature => {
+		// Akismet backs the 'akismet' feature; the rest are all backed by VaultPress.
+		const isAkismet = 'akismet' === feature;
+		const pluginFile = isAkismet ? 'akismet/akismet.php' : 'vaultpress/vaultpress.php';
+
+		let setUpUrl;
+		if ( this.props.pluginActive( pluginFile ) ) {
+			// The plugin is already running, so send the user to its own settings screen.
+			// Akismet lands here when it is active but has no valid key.
+			setUpUrl = isAkismet
+				? `${ this.props.siteAdminUrl }admin.php?page=akismet-key-config`
+				: `${ this.props.siteAdminUrl }admin.php?page=vaultpress`;
+		} else if ( isAkismet ) {
+			// My Jetpack installs and activates Akismet, so it covers both remaining states.
+			setUpUrl = `${ this.props.siteAdminUrl }admin.php?page=my-jetpack#/add-akismet`;
+		} else {
+			// The plugin search offers Install or Activate, whichever the site needs.
+			setUpUrl = `${ this.props.siteAdminUrl }plugin-install.php?tab=search&type=term&s=vaultpress`;
+		}
+
 		return (
 			<Button
 				onClick={ handleClickForTracking( 'set_up', feature ) }
 				compact={ true }
 				primary={ true }
-				href={ getRedirectUrl( 'calypso-plugins-setup', {
-					site: this.props.siteRawUrl,
-					query: `only=${ feature }`,
-				} ) }
+				href={ setUpUrl }
 			>
 				{ _x( 'Set up', 'Caption for a button to set up a feature.', 'jetpack' ) }
 			</Button>
@@ -306,7 +322,6 @@ export default connect( state => {
 	const sitePlan = getSitePlan( state );
 
 	return {
-		siteRawUrl: getSiteRawUrl( state ),
 		siteAdminUrl: getSiteAdminUrl( state ),
 		getScanThreats: () => getVaultPressScanThreatCount( state ),
 		getVaultPressData: () => getVaultPressData( state ),

--- a/projects/plugins/jetpack/changelog/update-plugin-setup-links-in-wp-admin
+++ b/projects/plugins/jetpack/changelog/update-plugin-setup-links-in-wp-admin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Point plugin setup links at wp-admin instead of the WordPress.com plugin setup flow.


### PR DESCRIPTION
## Proposed changes

Plugin install and settings actions in the Jetpack dashboard linked out to Calypso's plugin setup flow. This moves them to be handled within the plugin, in wp-admin.

* Akismet, when not active, links to My Jetpack, which installs and activates it.
* VaultPress, when not active, links to the plugin search, which offers Install or Activate depending on what the site already has.
* Either plugin, when already active, links to its own settings screen (`akismet-key-config` / `vaultpress`) instead of an install flow.

Affects `at-a-glance/backups.jsx`, `at-a-glance/scan.jsx`, `my-plan/my-plan-body.jsx`, and `pro-status/index.jsx`. These surfaces have no menu entry — reach them by URL (see below).

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Connect a site with a paid plan that includes Anti-spam (Security or Complete).
* With Akismet **not installed**, go to `wp-admin/admin.php?page=jetpack#/my-plan` and find the Anti-spam card. Confirm "View settings" opens My Jetpack's Akismet interstitial in the same tab, and that Install/Activate there works.
* Install and activate Akismet, but leave it without a valid key. Go to `wp-admin/admin.php?page=jetpack#/dashboard` and find the Anti-spam card. Confirm its "Set up" button now goes to `admin.php?page=akismet-key-config` rather than an install flow.
* With Akismet installed but **deactivated**, confirm "View settings" on My Plan still goes to My Jetpack, and that the Activate action there works.

### The following only applies when sites are using the legacy backup service. This is is an edge case.
* On a site with a legacy plan (Personal/Premium/Business) and VaultPress not installed, confirm the Site security card's "View settings" on My Plan opens the plugin search prefilled with `vaultpress`, showing an Install button.
* With VaultPress installed but deactivated, confirm that same link shows an **Activate** button in the search results.
* On the At a Glance page, confirm the Backups card's "install and activate" link and the Scan card's "please install" link both go to the same prefilled plugin search.
