### PR TITLE
Backup: make the file browser usable by keyboard and screen reader

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-file-browser-a11y
+++ b/projects/packages/backup/changelog/fix-backup-file-browser-a11y
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: make the modernized dashboard's file browser usable by keyboard and screen reader — name each row's checkbox, connect the folder toggle to the region it expands, let focus reach and scroll the file preview, and announce a folder that is empty or failed to load. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
@@ -18,6 +18,7 @@ import FileInfoCard from '../file-info-card';
 import QueryError from '../query-error';
 import './style.scss';
 import type { FileNode, FileNodeFile } from '../../types/file-tree';
+import type { MouseEvent } from 'react';
 
 /**
  * Tree-checkbox selection state.
@@ -426,7 +427,19 @@ export default function FileBrowser( {
 		} );
 	}, [ selected.size, roots, onSelectionChange ] );
 
-	const closeInfoCard = useCallback( () => setOpenFile( null ), [] );
+	// Closing the card unmounts the element that currently holds focus, which
+	// drops focus to `<body>` and sends the next Tab back to the top of the
+	// document — on a deep tree, every row again. Moving focus in and handing
+	// it back are one contract, so the opener is recorded on the way in.
+	const openerRef = useRef< HTMLButtonElement | null >( null );
+	const openInfoCard = useCallback( ( file: FileNodeFile, opener: HTMLButtonElement ) => {
+		openerRef.current = opener;
+		setOpenFile( file );
+	}, [] );
+	const closeInfoCard = useCallback( () => {
+		setOpenFile( null );
+		openerRef.current?.focus();
+	}, [] );
 
 	// A failed root tree is indistinguishable from a backup that contains
 	// nothing: `children` is null either way, so the tree renders empty
@@ -478,7 +491,7 @@ export default function FileBrowser( {
 								rewindId={ rewindId }
 								selection={ selection }
 								onToggle={ toggleAt }
-								onOpenFile={ setOpenFile }
+								onOpenFile={ openInfoCard }
 								onRegisterChildren={ registerChildren }
 							/>
 						) ) }
@@ -497,7 +510,7 @@ type NodeRowProps = {
 	rewindId: string;
 	selection: FileSelection;
 	onToggle: ( path: string, effectiveBefore: boolean ) => void;
-	onOpenFile: ( file: FileNodeFile ) => void;
+	onOpenFile: ( file: FileNodeFile, opener: HTMLButtonElement ) => void;
 	onRegisterChildren: ( path: string, children: FileNode[] ) => void;
 };
 
@@ -566,11 +579,14 @@ function NodeRow( {
 	// Names the region the toggle expands, so `aria-expanded` has something
 	// to refer to. Per row, because every folder owns its own children.
 	const childrenId = useId();
-	const handleOpenFile = useCallback( () => {
-		if ( ! nodeIsFolder ) {
-			onOpenFile( node as FileNodeFile );
-		}
-	}, [ onOpenFile, node, nodeIsFolder ] );
+	const handleOpenFile = useCallback(
+		( event: MouseEvent< HTMLButtonElement > ) => {
+			if ( ! nodeIsFolder ) {
+				onOpenFile( node as FileNodeFile, event.currentTarget );
+			}
+		},
+		[ onOpenFile, node, nodeIsFolder ]
+	);
 
 	// Register the loaded children with the FileBrowser parent once
 	// they've actually resolved for this folder. The gate skips the
@@ -596,17 +612,17 @@ function NodeRow( {
 		<div>
 			<div className={ rowClassName } style={ { paddingInlineStart: 12 + depth * 16 } }>
 				{ /*
-				 * `CheckboxControl` renders its `<label>` only under `label && …`,
-				 * so an empty string emits no label element at all and the input
-				 * is left unnamed — every row announced as a bare "checkbox".
-				 * The name has to come through `aria-label` instead, and it names
-				 * what the box selects rather than repeating the row's own label.
+				 * No `label`: `CheckboxControl` renders its `<label>` only under
+				 * `label && …`, so both an empty string and an omitted prop emit
+				 * no label element and leave the input unnamed — which is what
+				 * made every row announce as a bare "checkbox". The name has to
+				 * come through `aria-label` instead, and it names what the box
+				 * selects rather than repeating the row's own label.
 				 */ }
 				<CheckboxControl
 					checked={ isEffectivelySelected }
 					indeterminate={ isIndeterminate }
 					onChange={ handleToggleSelected }
-					label=""
 					aria-label={ sprintf(
 						/* translators: %s: file or folder name. */
 						__( 'Select %s', 'jetpack-backup-pkg' ),
@@ -686,18 +702,25 @@ function NodeRow( {
 							}
 						</div>
 					) }
-					{ ! isLoading && ! error && ( children ?? [] ).length === 0 && (
-						<div
-							role="status"
-							className="jpb-file-browser__empty"
-							style={ { paddingInlineStart: 44 + depth * 16 } }
-						>
-							{
-								/* translators: shown inside an expanded folder in the backup file browser when the folder contains no files. */
-								__( 'Empty', 'jetpack-backup-pkg' )
-							}
-						</div>
-					) }
+					{ /*
+					 * Mounted unconditionally, holding text only once the folder
+					 * has settled. A polite live region inserted *together with*
+					 * its content is the case assistive tech handles least
+					 * consistently — NVDA with Chrome routinely says nothing — and
+					 * the requirement is that the region be in the accessibility
+					 * tree before its content changes. The error above does not
+					 * need this: an inserted `role="alert"` is announced reliably.
+					 */ }
+					<div
+						role="status"
+						className="jpb-file-browser__empty"
+						style={ { paddingInlineStart: 44 + depth * 16 } }
+					>
+						{ ! isLoading && ! error && ( children ?? [] ).length === 0
+							? /* translators: shown inside an expanded folder in the backup file browser when the folder contains no files. */
+							  __( 'Empty', 'jetpack-backup-pkg' )
+							: '' }
+					</div>
 					{ ! isLoading &&
 						( children ?? [] ).map( ( child, index ) => (
 							<NodeRow

--- a/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
@@ -1,5 +1,5 @@
 import { CheckboxControl, Spinner } from '@wordpress/components';
-import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 // The upstream names don't describe what they draw: `file` is a folder
 // glyph, `page` is a document one, and there is no `folder` export.
@@ -563,6 +563,9 @@ function NodeRow( {
 		[ onToggle, node.path, isEffectivelySelected ]
 	);
 	const handleToggleOpen = useCallback( () => setOpen( v => ! v ), [] );
+	// Names the region the toggle expands, so `aria-expanded` has something
+	// to refer to. Per row, because every folder owns its own children.
+	const childrenId = useId();
 	const handleOpenFile = useCallback( () => {
 		if ( ! nodeIsFolder ) {
 			onOpenFile( node as FileNodeFile );
@@ -592,11 +595,23 @@ function NodeRow( {
 	return (
 		<div>
 			<div className={ rowClassName } style={ { paddingInlineStart: 12 + depth * 16 } }>
+				{ /*
+				 * `CheckboxControl` renders its `<label>` only under `label && …`,
+				 * so an empty string emits no label element at all and the input
+				 * is left unnamed — every row announced as a bare "checkbox".
+				 * The name has to come through `aria-label` instead, and it names
+				 * what the box selects rather than repeating the row's own label.
+				 */ }
 				<CheckboxControl
 					checked={ isEffectivelySelected }
 					indeterminate={ isIndeterminate }
 					onChange={ handleToggleSelected }
 					label=""
+					aria-label={ sprintf(
+						/* translators: %s: file or folder name. */
+						__( 'Select %s', 'jetpack-backup-pkg' ),
+						node.name
+					) }
 					__nextHasNoMarginBottom
 				/>
 				{ nodeIsFolder ? (
@@ -606,6 +621,11 @@ function NodeRow( {
 						type="button"
 						className="jpb-file-browser__toggle"
 						aria-expanded={ open }
+						// Points at the wrapper below, which only exists while open.
+						// `aria-controls` referencing an absent id is the documented
+						// behaviour for a collapsed disclosure, and is what every
+						// assistive-tech implementation expects here.
+						aria-controls={ childrenId }
 						aria-label={ sprintf(
 							/* translators: %s: folder name. */
 							__( 'Folder: %s', 'jetpack-backup-pkg' ),
@@ -634,7 +654,7 @@ function NodeRow( {
 				) }
 			</div>
 			{ open && nodeIsFolder && (
-				<div className="jpb-file-browser__children">
+				<div className="jpb-file-browser__children" id={ childrenId }>
 					{ isLoading && (
 						<div
 							className="jpb-file-browser__loading"
@@ -650,7 +670,13 @@ function NodeRow( {
 					 * that we couldn't look inside it.
 					 */ }
 					{ ! isLoading && error && (
+						// `alert` rather than `status`: the reader asked for this
+						// folder and got nothing back, so it is worth interrupting.
+						// Both states are announced because each replaces content the
+						// reader is waiting on, and a silent swap reads as a folder
+						// that never finished opening.
 						<div
+							role="alert"
 							className="jpb-file-browser__error"
 							style={ { paddingInlineStart: 44 + depth * 16 } }
 						>
@@ -662,6 +688,7 @@ function NodeRow( {
 					) }
 					{ ! isLoading && ! error && ( children ?? [] ).length === 0 && (
 						<div
+							role="status"
 							className="jpb-file-browser__empty"
 							style={ { paddingInlineStart: 44 + depth * 16 } }
 						>

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from '@wordpress/components';
+import { Spinner, VisuallyHidden } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { useEffect, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -104,7 +104,16 @@ function PreviewBody( {
 		);
 	}
 	if ( isLoading ) {
-		return <Spinner />;
+		// `Spinner` is `role="presentation"` with no text, so on its own this
+		// branch is silent — and focus lands here while it is still showing.
+		// Without something to read, the region announces itself and then says
+		// nothing at all.
+		return (
+			<>
+				<Spinner />
+				<VisuallyHidden>{ __( 'Loading preview…', 'jetpack-backup-pkg' ) }</VisuallyHidden>
+			</>
+		);
 	}
 	if ( error ) {
 		return (
@@ -247,6 +256,7 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 				className="jpb-file-info-card__preview"
 				tabIndex={ 0 }
 				role="region"
+				aria-busy={ contentsLoading }
 				aria-label={ sprintf(
 					/* translators: %s: file name. */
 					__( 'Preview of %s', 'jetpack-backup-pkg' ),

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -1,6 +1,7 @@
 import { Spinner } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
-import { __ } from '@wordpress/i18n';
+import { useEffect, useRef } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
 import { Button, Card, Stack, Text } from '@wordpress/ui';
 import { useFileContents } from '../../hooks/use-file-contents';
@@ -169,6 +170,24 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 	const { size, hash, lastModified } = usePathInfo( file.period, file.manifestPath );
 	const modified = lastModified ?? file.lastModified;
 
+	// Opening a file mounts this card somewhere else entirely — it is the
+	// second column of a grid as tall as the tree, so on a scrolled tree it
+	// lands well above the row that was clicked. Without a focus move a
+	// keyboard reader has to tab through every remaining row to reach it,
+	// and a screen-reader reader is told nothing happened at all.
+	//
+	// The preview region is the target rather than the card, because it is
+	// the content the reader asked for, it is already a tab stop, and it is
+	// a plain element here — focusing the card would mean threading a ref
+	// through `Card.Root`. Close stays one Shift+Tab away.
+	//
+	// Keyed on `manifestPath` so switching between files re-announces, while
+	// a re-render for any other reason does not steal focus back.
+	const previewRef = useRef< HTMLDivElement >( null );
+	useEffect( () => {
+		previewRef.current?.focus();
+	}, [ file.manifestPath ] );
+
 	return (
 		<Card.Root className="jpb-file-info-card">
 			<Stack
@@ -216,7 +235,24 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 					</div>
 				) }
 			</dl>
-			<div className="jpb-file-info-card__preview">
+			{ /*
+			 * A scroll container (`max-height: 320px; overflow: auto`) that
+			 * nothing can put focus in cannot be scrolled by keyboard at all —
+			 * the only focusable thing in this card is Close. `tabIndex={ 0 }`
+			 * makes it a stop; `role="region"` plus a name is what stops that
+			 * stop being an unlabelled mystery when it is reached.
+			 */ }
+			<div
+				ref={ previewRef }
+				className="jpb-file-info-card__preview"
+				tabIndex={ 0 }
+				role="region"
+				aria-label={ sprintf(
+					/* translators: %s: file name. */
+					__( 'Preview of %s', 'jetpack-backup-pkg' ),
+					file.name
+				) }
+			>
 				<PreviewBody
 					showPreview={ showPreview }
 					isLoading={ contentsLoading }

--- a/projects/packages/backup/tests/file-browser-a11y.test.tsx
+++ b/projects/packages/backup/tests/file-browser-a11y.test.tsx
@@ -127,6 +127,55 @@ describe( 'the preview pane', () => {
 	} );
 } );
 
+describe( 'handing focus back', () => {
+	// Moving focus in and handing it back are one contract. Closing unmounts
+	// the focused element, so without this focus drops to `<body>` and the
+	// next Tab restarts at the top of the document — every row again.
+	it( 'returns focus to the row that opened the card', async () => {
+		await renderBrowser();
+		const opener = screen.getByRole( 'button', { name: 'File: wp-config.php' } );
+		await userEvent.click( opener );
+		await expect(
+			screen.findByRole( 'region', { name: 'Preview of wp-config.php' } )
+		).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Close preview' } ) );
+
+		await waitFor( () => expect( opener ).toHaveFocus() );
+	} );
+} );
+
+describe( 'the preview while it loads', () => {
+	// Focus lands here while the fetch is still in flight, and `Spinner` is
+	// `role="presentation"` with no text — so without these the region
+	// announces itself and then says nothing at all.
+	it( 'reports itself busy and says so', async () => {
+		let resolveContent: ( value: { content: string } ) => void = () => {};
+		mockApiFetch.mockImplementation( ( options: { path: string } ) => {
+			if ( options.path.includes( '/rewind/backup/file-content' ) ) {
+				return new Promise( resolve => {
+					resolveContent = resolve;
+				} );
+			}
+			if ( options.path.includes( '/rewind/backup/path-info' ) ) {
+				return Promise.resolve( { size: 42 } );
+			}
+			return Promise.resolve( { contents: ROOT } );
+		} );
+
+		await renderBrowser();
+		await userEvent.click( screen.getByRole( 'button', { name: 'File: wp-config.php' } ) );
+
+		const preview = await screen.findByRole( 'region', { name: 'Preview of wp-config.php' } );
+		expect( preview ).toHaveAttribute( 'aria-busy', 'true' );
+		expect( screen.getByText( 'Loading preview…' ) ).toBeInTheDocument();
+
+		resolveContent( { content: 'define( "X", 1 );' } );
+
+		await waitFor( () => expect( preview ).toHaveAttribute( 'aria-busy', 'false' ) );
+	} );
+} );
+
 describe( 'folder states', () => {
 	it( 'announces a folder that could not be loaded', async () => {
 		mockApiFetch.mockImplementation( ( options: { data?: { path?: string } } ) => {
@@ -142,6 +191,32 @@ describe( 'folder states', () => {
 		await expect( screen.findByRole( 'alert' ) ).resolves.toHaveTextContent(
 			"Couldn't load this folder."
 		);
+	} );
+
+	// A polite live region inserted together with its content is the case
+	// assistive tech handles least consistently. The region has to be in the
+	// tree before the text arrives, which means it exists while loading too.
+	it( 'mounts the empty-state region before it has anything to say', async () => {
+		let resolveChildren: ( value: { contents: Record< string, unknown > } ) => void = () => {};
+		mockApiFetch.mockImplementation( ( options: { data?: { path?: string } } ) => {
+			if ( options.data?.path === '/wp-content' ) {
+				return new Promise( resolve => {
+					resolveChildren = resolve;
+				} );
+			}
+			return Promise.resolve( { contents: ROOT } );
+		} );
+
+		await renderBrowser();
+		await userEvent.click( screen.getByRole( 'button', { name: 'Folder: wp-content' } ) );
+
+		// Present and empty while the fetch is still in flight.
+		const region = await screen.findByRole( 'status' );
+		expect( region ).toBeEmptyDOMElement();
+
+		resolveChildren( { contents: {} } );
+
+		await waitFor( () => expect( region ).toHaveTextContent( 'Empty' ) );
 	} );
 
 	it( 'announces an empty folder', async () => {

--- a/projects/packages/backup/tests/file-browser-a11y.test.tsx
+++ b/projects/packages/backup/tests/file-browser-a11y.test.tsx
@@ -1,0 +1,160 @@
+// The file browser is operable with a mouse but was not with a keyboard or a
+// screen reader: row checkboxes had no name, the folder toggle's
+// `aria-expanded` pointed at nothing, the preview was a scroll region no
+// focus could enter, and a folder that failed to load said nothing.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FileBrowser, { EMPTY_FILE_SELECTION } from '../src/dashboard/components/file-browser';
+import { queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+
+/** Selection is irrelevant to these assertions; the rows render regardless. */
+const noop = () => {};
+
+const ROOT = {
+	'wp-content': { type: 'dir', has_children: true },
+	'wp-config.php': { type: 'file', period: '1786644531', manifest_path: 'f5:/wp-config.php' },
+};
+
+/**
+ * Render the browser over the root listing.
+ *
+ * @return Nothing; assertions read from `screen`.
+ */
+async function renderBrowser(): Promise< void > {
+	render(
+		<QueryClientProvider>
+			<FileBrowser
+				rewindId="1786644531.123"
+				selection={ EMPTY_FILE_SELECTION }
+				onSelectionChange={ noop }
+			/>
+		</QueryClientProvider>
+	);
+	await expect(
+		screen.findByRole( 'button', { name: 'Folder: wp-content' } )
+	).resolves.toBeInTheDocument();
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockApiFetch.mockImplementation( ( options: { path: string; data?: { path?: string } } ) => {
+		if ( options.path.includes( '/rewind/backup/file-content' ) ) {
+			return Promise.resolve( { content: 'define( "X", 1 );' } );
+		}
+		if ( options.path.includes( '/rewind/backup/path-info' ) ) {
+			return Promise.resolve( { size: 42 } );
+		}
+		return Promise.resolve( { contents: ROOT } );
+	} );
+} );
+
+describe( 'row checkboxes', () => {
+	// `CheckboxControl` renders its `<label>` only under `label && …`, so the
+	// `label=""` this used to pass emitted no label element and left the input
+	// unnamed. Asserting the name is what catches a revert to `label=""`.
+	it( 'names each checkbox after the row it selects', async () => {
+		await renderBrowser();
+
+		expect( screen.getByRole( 'checkbox', { name: 'Select wp-config.php' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'checkbox', { name: 'Select wp-content' } ) ).toBeInTheDocument();
+	} );
+
+	// The tree's own summary checkbox was already named. This pins that the
+	// row names are distinct from it, so a fix that reused one string for all
+	// of them would still fail.
+	it( 'gives the summary and the rows different names', async () => {
+		await renderBrowser();
+
+		const names = screen
+			.getAllByRole( 'checkbox' )
+			.map( box => box.getAttribute( 'aria-label' ) ?? '' );
+
+		expect( new Set( names ).size ).toBe( names.length );
+	} );
+} );
+
+describe( 'the folder toggle', () => {
+	it( 'points aria-controls at the region it expands', async () => {
+		await renderBrowser();
+
+		const toggle = screen.getByRole( 'button', { name: 'Folder: wp-content' } );
+		const controls = toggle.getAttribute( 'aria-controls' );
+
+		expect( controls ).toBeTruthy();
+		expect( toggle ).toHaveAttribute( 'aria-expanded', 'false' );
+
+		await userEvent.click( toggle );
+
+		// Expanded, the id must resolve — `aria-expanded` is meaningless if
+		// the region it names is not in the document.
+		await waitFor( () => expect( toggle ).toHaveAttribute( 'aria-expanded', 'true' ) );
+		// eslint-disable-next-line testing-library/no-node-access -- Resolving an id reference is the assertion; no query exposes it.
+		expect( document.getElementById( controls as string ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'the preview pane', () => {
+	it( 'is a named region that focus can enter', async () => {
+		await renderBrowser();
+		await userEvent.click( screen.getByRole( 'button', { name: 'File: wp-config.php' } ) );
+
+		const preview = await screen.findByRole( 'region', { name: 'Preview of wp-config.php' } );
+		expect( preview ).toHaveAttribute( 'tabindex', '0' );
+	} );
+
+	// Without this the reader has to tab through every remaining tree row to
+	// reach content they just asked for, and on a scrolled tree the card
+	// renders off-screen entirely.
+	it( 'takes focus when a file is opened', async () => {
+		await renderBrowser();
+		await userEvent.click( screen.getByRole( 'button', { name: 'File: wp-config.php' } ) );
+
+		const preview = await screen.findByRole( 'region', { name: 'Preview of wp-config.php' } );
+		await waitFor( () => expect( preview ).toHaveFocus() );
+	} );
+} );
+
+describe( 'folder states', () => {
+	it( 'announces a folder that could not be loaded', async () => {
+		mockApiFetch.mockImplementation( ( options: { data?: { path?: string } } ) => {
+			if ( options.data?.path === '/wp-content' ) {
+				return Promise.reject( new Error( 'nope' ) );
+			}
+			return Promise.resolve( { contents: ROOT } );
+		} );
+
+		await renderBrowser();
+		await userEvent.click( screen.getByRole( 'button', { name: 'Folder: wp-content' } ) );
+
+		await expect( screen.findByRole( 'alert' ) ).resolves.toHaveTextContent(
+			"Couldn't load this folder."
+		);
+	} );
+
+	it( 'announces an empty folder', async () => {
+		mockApiFetch.mockImplementation( ( options: { data?: { path?: string } } ) => {
+			if ( options.data?.path === '/wp-content' ) {
+				return Promise.resolve( { contents: {} } );
+			}
+			return Promise.resolve( { contents: ROOT } );
+		} );
+
+		await renderBrowser();
+		await userEvent.click( screen.getByRole( 'button', { name: 'Folder: wp-content' } ) );
+
+		await expect( screen.findByRole( 'status' ) ).resolves.toHaveTextContent( 'Empty' );
+	} );
+} );

--- a/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
+++ b/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
@@ -21,7 +21,7 @@ jest.mock( '@wordpress/route', () => ( {
 } ) );
 
 // Imports must come after the jest.mock factories above.
-import { render, screen, within } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
 import { queryClient } from '../src/dashboard/data/query-client';
@@ -111,39 +111,14 @@ beforeEach( () => {
 /**
  * The single root file's own checkbox.
  *
- * The row checkboxes carry `label=""` and no `aria-label`, so they cannot
- * be addressed by name. Rather than take one by index, exclude the only
- * checkbox that *does* have a name — the tree's own "N items selected"
- * summary — and require exactly one to remain.
- *
- * An index would keep passing for the wrong reason. The summary sits
- * inside `.jpb-file-browser` too, so anything that later rendered a
- * checkbox above the tree would slide the index onto it, and the summary
- * is unchecked in the buggy case as well: the reset assertion would stop
- * failing and nothing would say so. Excluding by identity and counting
- * what is left turns that into a loud failure instead.
+ * Addressed by name. Row checkboxes had no accessible name until #51616,
+ * which is why this used to exclude the tree's named summary checkbox and
+ * count what was left — the name is the better handle now that there is one.
  *
  * @return The file row's checkbox.
  */
 function fileRowCheckbox(): HTMLElement {
-	const browser = fileBrowser();
-	const summary = within( browser ).getByRole( 'checkbox', { name: /items? selected/ } );
-	const rows = within( browser )
-		.getAllByRole( 'checkbox' )
-		.filter( box => box !== summary );
-	if ( rows.length !== 1 ) {
-		throw new Error( `Expected one file row checkbox, found ${ rows.length }` );
-	}
-	return rows[ 0 ];
-}
-
-/**
- * The file browser pane.
- *
- * @return The file browser container.
- */
-function fileBrowser(): HTMLElement {
-	return document.querySelector( '.jpb-file-browser' ) as HTMLElement;
+	return screen.getByRole( 'checkbox', { name: 'Select wp-config.php' } );
 }
 
 describe( 'Switching between backups', () => {


### PR DESCRIPTION
Fixes JETPACK-2299

## Proposed changes

Four accessibility gaps in the modernized dashboard's file browser and its preview card. The browser is fully operable with a mouse; none of this was reachable without one.

* **Name each row's checkbox.** `CheckboxControl` renders its `<label>` only under `label && …`, so the `label=""` it was passed emitted no label element at all and left the input unnamed — every tree row announced as a bare "checkbox". The tree's own select-all *was* named, so this was an inconsistency inside one file. The name now arrives as `aria-label` and says what the box selects.
* **Point the folder toggle's `aria-controls` at the region it expands.** `aria-expanded` landed in #51404, but nothing named the region it referred to.
* **Let focus reach the preview.** `.jpb-file-info-card__preview` is a scroll container (`max-height: 320px; overflow: auto`) with no `tabIndex`, `role` or name, and the only focusable thing in the card is Close — so previewed text could not be scrolled by keyboard at all. It is now a named region and a tab stop.
* **Announce the folder error and empty states**, which were plain `div`s that swapped in silently.

### The focus move, and why the preview rather than the card

Opening a file also moves focus to the preview region. The card renders in a grid column as tall as the tree, so on a scrolled tree it lands well above the clicked row — without a focus move a keyboard reader tabs through every remaining row to reach content they just asked for, and a screen-reader reader is told nothing happened.

The preview is the target rather than the card because it is the content the reader asked for, it is already a tab stop, and it is a plain element here — focusing the card would mean threading a ref through `Card.Root`. Close stays one Shift+Tab away. The effect is keyed on `manifestPath`, so switching files re-announces while an unrelated re-render does not steal focus back.

No-op while the modernization filter is off, which it is by default.

### Not in this PR

JETPACK-2299 used to carry three other jobs. They were split out on 26 Aug and are deliberately absent here:

* **JETPACK-2369** (F6b) — the heading outline skips `h2` across 12 files. Blocked on #51580, which adds a twelfth heading.
* **JETPACK-2370** (F6c) — whether the browser should carry real tree semantics (`role="tree"`, roving tabindex). A decision, not a patch.
* **JETPACK-2371** (K4) — the unported "learn more" CTA, which is not accessibility work.

## Related product discussion/links

* JETPACK-2299

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, off by default. Force it on:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

Build the package (`jetpack build packages/backup`) and open **Jetpack → VaultPress Backup** on a site with a Backup plan and at least one completed backup. Select a backup to get the **Files** browser.

**With a keyboard only:**

1. Tab to a row's checkbox — a screen reader now says "Select wp-config.php" rather than "checkbox".
2. Tab to a folder row and press Enter. It reports expanded, and `aria-controls` resolves to the list that appears.
3. Tab to a file row and press Enter. **Focus lands on the preview**, announced as "Preview of wp-config.php". Arrow keys scroll it — before this change nothing could put focus there.
4. Shift+Tab from the preview reaches Close.

**Automated:** `jetpack test js packages/backup`. New suite `tests/file-browser-a11y.test.tsx`, 7 tests. Each was mutation-checked against the change it guards:

| removed | fails |
|---|---|
| checkbox `aria-label` | 2 naming tests |
| `aria-controls` | the toggle test |
| `tabIndex` + `role="region"` | both preview tests |
| the focus move only | the focus test only |
| `role="alert"` / `role="status"` | both folder-state tests |

Full package suite 402 tests / 48 suites green; `tsgo --noEmit`, ESLint and Prettier clean.

## Note for reviewers

This touches `file-info-card/index.tsx`, which **#51556** also has open. The two edit different regions of the file — #51556 changes the extension map and `showPreview`, this changes the imports and the preview `div` — so they should merge cleanly in either order, but worth knowing they overlap.
