### PR TITLE
WP Build Polyfills: continue the admin menu color behind the boot frame

### DIFF
--- a/projects/packages/wp-build-polyfills/README.md
+++ b/projects/packages/wp-build-polyfills/README.md
@@ -69,6 +69,10 @@ The version threshold for force-replacements can be overridden with a third para
 WP_Build_Polyfills::register( 'my-plugin', array( 'wp-notices' ), '7.1' );
 ```
 
+## Admin frame backdrop
+
+`WP_Build_Admin_Frame` makes the `@wordpress/boot` single-page backdrop continue the wp-admin menu color. `@wordpress/admin-ui` only knows Core's color schemes and paints a near-black backdrop for WordPress.com and third-party ones, and on WordPress 7.0+ the boot module that runs is Core's bundled copy, so the override is applied from PHP: `WP_Build_Polyfills::register()` arms it, and it prints a stylesheet on `admin_head` plus a script on `in_admin_header` that samples the `#adminmenuback` background into `--wp-build-admin-menu-background`. It lives here because this package is the one runtime every wp-build page already loads, and it is temporary until wp-build or boot ship the same behavior.
+
 ## Boot module asset file
 
 Packages that use `@wordpress/build` to generate pages get a hardcoded reference to `build/modules/boot/index.min.asset.php` in the generated page templates. This file provides the classic script dependencies and version hash needed to bootstrap the page.

--- a/projects/packages/wp-build-polyfills/changelog/fix-wp-build-admin-frame-backdrop
+++ b/projects/packages/wp-build-polyfills/changelog/fix-wp-build-admin-frame-backdrop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Continue the wp-admin menu color behind the boot page frame on WordPress.com and third-party admin color schemes.

--- a/projects/packages/wp-build-polyfills/src/class-wp-build-admin-frame.php
+++ b/projects/packages/wp-build-polyfills/src/class-wp-build-admin-frame.php
@@ -35,19 +35,25 @@ class WP_Build_Admin_Frame {
 	/**
 	 * Print the backdrop override.
 	 *
-	 * `#wpcontent .boot-layout--single-page` outranks the `.boot-layout` rule
-	 * boot injects at runtime. The fallbacks keep boot's own colors when the
-	 * sampling script did not run.
+	 * Both selectors are (1,1,0), so they outrank the layout rule boot injects
+	 * at runtime. The fallbacks keep boot's own colors when the sampling script
+	 * did not run.
 	 *
 	 * @return void
 	 */
 	public static function print_styles() {
+		// The layout root is `.boot-layout--single-page` up to boot 0.20. From
+		// boot 0.21 (WordPress/gutenberg#81756, Gutenberg 23.9) the styles are
+		// CSS Modules and the class is `_<hash>__layout-single-page`, so the
+		// attribute selector matches the local name whatever the hash is.
 		?>
 		<style id="wp-build-admin-frame-css">
-			#wpcontent .boot-layout--single-page {
+			#wpcontent .boot-layout--single-page,
+			#wpcontent [class*="__layout-single-page"] {
 				background: var(--wp-build-admin-menu-background, var(--wpds-color-background-surface-neutral-weak));
 			}
-			body:has(.boot-layout--single-page) {
+			body:has(.boot-layout--single-page),
+			body:has([class*="__layout-single-page"]) {
 				background: var(--wp-build-admin-menu-background, #fff);
 			}
 		</style>

--- a/projects/packages/wp-build-polyfills/src/class-wp-build-admin-frame.php
+++ b/projects/packages/wp-build-polyfills/src/class-wp-build-admin-frame.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Backdrop for the `@wordpress/boot` single-page layout in wp-admin.
+ *
+ * @package automattic/jetpack-wp-build-polyfills
+ */
+
+namespace Automattic\Jetpack\WP_Build_Polyfills;
+
+/**
+ * Makes the boot single-page backdrop continue the wp-admin menu color.
+ *
+ * `@wordpress/admin-ui` derives the backdrop from a fixed map of Core color
+ * schemes and falls back to a near-black `modern` seed for any other scheme,
+ * WordPress.com and third-party ones included. On WordPress 7.0+ the boot
+ * module that runs is Core's bundled copy, so the override is applied from
+ * PHP around the page: a stylesheet printed on `admin_head` and a script
+ * printed on `in_admin_header` that samples the rendered menu background into
+ * a custom property on the root element.
+ *
+ * Pages without a boot layout are unaffected: the selectors match nothing.
+ */
+class WP_Build_Admin_Frame {
+
+	/**
+	 * Hook the stylesheet and the sampling script. Safe to call repeatedly.
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		add_action( 'admin_head', array( self::class, 'print_styles' ) );
+		add_action( 'in_admin_header', array( self::class, 'print_script' ) );
+	}
+
+	/**
+	 * Print the backdrop override.
+	 *
+	 * `#wpcontent .boot-layout--single-page` outranks the `.boot-layout` rule
+	 * boot injects at runtime. The fallbacks keep boot's own colors when the
+	 * sampling script did not run.
+	 *
+	 * @return void
+	 */
+	public static function print_styles() {
+		?>
+		<style id="wp-build-admin-frame-css">
+			#wpcontent .boot-layout--single-page {
+				background: var(--wp-build-admin-menu-background, var(--wpds-color-background-surface-neutral-weak));
+			}
+			body:has(.boot-layout--single-page) {
+				background: var(--wp-build-admin-menu-background, #fff);
+			}
+		</style>
+		<?php
+	}
+
+	/**
+	 * Print the script that samples the admin menu background.
+	 *
+	 * Runs right after `#adminmenuback` is printed and before the layout
+	 * mounts, which is why the property goes on the root element.
+	 *
+	 * @return void
+	 */
+	public static function print_script() {
+		$script = <<<'JS'
+( function () {
+	var menu = document.getElementById( 'adminmenuback' );
+	if ( ! menu ) {
+		return;
+	}
+	var color = window.getComputedStyle( menu ).backgroundColor;
+	if ( ! color || 'rgba(0, 0, 0, 0)' === color || 'transparent' === color ) {
+		return;
+	}
+	document.documentElement.style.setProperty( '--wp-build-admin-menu-background', color );
+} )();
+JS;
+
+		wp_print_inline_script_tag( $script, array( 'id' => 'wp-build-admin-frame-js' ) );
+	}
+}

--- a/projects/packages/wp-build-polyfills/src/class-wp-build-polyfills.php
+++ b/projects/packages/wp-build-polyfills/src/class-wp-build-polyfills.php
@@ -103,6 +103,9 @@ class WP_Build_Polyfills {
 	 * load time. Those companions show up in get_consumers() under the
 	 * requesting consumer's name.
 	 *
+	 * Every call also arms WP_Build_Admin_Frame for the request, so the boot
+	 * single-page backdrop follows the wp-admin menu color on every wp-build page.
+	 *
 	 * @param string   $consumer             A unique identifier for the consumer (e.g. plugin slug).
 	 * @param string[] $polyfills             List of polyfill handles/module IDs to register.
 	 *                                        Use class constants SCRIPT_HANDLES and MODULE_IDS for reference.
@@ -110,6 +113,8 @@ class WP_Build_Polyfills {
 	 *                                        are applied. Defaults to '7.0'.
 	 */
 	public static function register( $consumer, $polyfills, $wp_version_threshold = '7.0' ) {
+		WP_Build_Admin_Frame::register();
+
 		foreach ( $polyfills as $handle ) {
 			if ( ! in_array( $handle, self::SCRIPT_HANDLES, true ) && ! in_array( $handle, self::MODULE_IDS, true ) ) {
 				continue;

--- a/projects/packages/wp-build-polyfills/tests/php/WP_Build_Admin_Frame_Test.php
+++ b/projects/packages/wp-build-polyfills/tests/php/WP_Build_Admin_Frame_Test.php
@@ -94,19 +94,22 @@ class WP_Build_Admin_Frame_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The stylesheet targets the boot single-page layout and the body behind it.
+	 * The stylesheet targets the boot single-page layout, in its global-class and
+	 * CSS Modules forms, and the body behind it.
 	 */
 	public function test_styles_override_the_boot_layout_with_the_menu_color() {
 		ob_start();
 		WP_Build_Admin_Frame::print_styles();
 		$css = ob_get_clean();
 
-		$this->assertStringContainsString( '#wpcontent .boot-layout--single-page {', $css );
+		$this->assertStringContainsString( '#wpcontent .boot-layout--single-page,', $css );
+		$this->assertStringContainsString( '#wpcontent [class*="__layout-single-page"] {', $css );
 		$this->assertStringContainsString(
 			'background: var(--wp-build-admin-menu-background, var(--wpds-color-background-surface-neutral-weak));',
 			$css
 		);
-		$this->assertStringContainsString( 'body:has(.boot-layout--single-page) {', $css );
+		$this->assertStringContainsString( 'body:has(.boot-layout--single-page),', $css );
+		$this->assertStringContainsString( 'body:has([class*="__layout-single-page"]) {', $css );
 		$this->assertStringContainsString( 'background: var(--wp-build-admin-menu-background, #fff);', $css );
 	}
 

--- a/projects/packages/wp-build-polyfills/tests/php/WP_Build_Admin_Frame_Test.php
+++ b/projects/packages/wp-build-polyfills/tests/php/WP_Build_Admin_Frame_Test.php
@@ -1,0 +1,131 @@
+<?php
+namespace Automattic\Jetpack\WP_Build_Polyfills\Tests;
+
+use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Admin_Frame;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the WP_Build_Admin_Frame class.
+ */
+class WP_Build_Admin_Frame_Test extends BaseTestCase {
+
+	/**
+	 * Hooks the class prints on.
+	 */
+	const HOOKS = array( 'admin_head', 'in_admin_header' );
+
+	/**
+	 * Callbacks attached to HOOKS before the test, restored afterwards.
+	 *
+	 * @var array<string, \WP_Hook|null>
+	 */
+	private $original_hooks = array();
+
+	/**
+	 * Start every test with empty admin header hooks.
+	 *
+	 * @before
+	 */
+	#[Before]
+	public function set_up() {
+		parent::set_up();
+
+		global $wp_filter;
+		foreach ( self::HOOKS as $hook ) {
+			$this->original_hooks[ $hook ] = isset( $wp_filter[ $hook ] ) ? clone $wp_filter[ $hook ] : null;
+			remove_all_actions( $hook );
+		}
+	}
+
+	/**
+	 * Restore the admin header hooks.
+	 *
+	 * @after
+	 */
+	#[After]
+	public function tear_down() {
+		global $wp_filter;
+		foreach ( self::HOOKS as $hook ) {
+			if ( null === $this->original_hooks[ $hook ] ) {
+				unset( $wp_filter[ $hook ] );
+			} else {
+				$wp_filter[ $hook ] = $this->original_hooks[ $hook ];
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Run the admin header hooks the way admin-header.php does and capture the output.
+	 *
+	 * @return string
+	 */
+	private function render_admin_header() {
+		ob_start();
+		do_action( 'admin_head' );
+		do_action( 'in_admin_header' );
+		return ob_get_clean();
+	}
+
+	/**
+	 * Nothing is printed on requests where no consumer registered.
+	 */
+	public function test_prints_nothing_without_a_registration() {
+		$this->assertSame( '', $this->render_admin_header() );
+	}
+
+	/**
+	 * Both blocks are printed exactly once, however many times register() ran.
+	 */
+	public function test_prints_both_blocks_once_after_registration() {
+		WP_Build_Admin_Frame::register();
+		WP_Build_Admin_Frame::register();
+
+		$output = $this->render_admin_header();
+
+		$this->assertSame( 1, substr_count( $output, '<style id="wp-build-admin-frame-css">' ) );
+		$this->assertSame( 1, substr_count( $output, '</style>' ) );
+		$this->assertSame( 1, substr_count( $output, 'id="wp-build-admin-frame-js"' ) );
+		$this->assertSame( 1, substr_count( $output, '</script>' ) );
+		$this->assertLessThan( strpos( $output, '<script' ), strpos( $output, '<style' ) );
+	}
+
+	/**
+	 * The stylesheet targets the boot single-page layout and the body behind it.
+	 */
+	public function test_styles_override_the_boot_layout_with_the_menu_color() {
+		ob_start();
+		WP_Build_Admin_Frame::print_styles();
+		$css = ob_get_clean();
+
+		$this->assertStringContainsString( '#wpcontent .boot-layout--single-page {', $css );
+		$this->assertStringContainsString(
+			'background: var(--wp-build-admin-menu-background, var(--wpds-color-background-surface-neutral-weak));',
+			$css
+		);
+		$this->assertStringContainsString( 'body:has(.boot-layout--single-page) {', $css );
+		$this->assertStringContainsString( 'background: var(--wp-build-admin-menu-background, #fff);', $css );
+	}
+
+	/**
+	 * The script samples #adminmenuback into the custom property on the root element.
+	 */
+	public function test_script_samples_the_admin_menu_into_the_custom_property() {
+		ob_start();
+		WP_Build_Admin_Frame::print_script();
+		$js = ob_get_clean();
+
+		$this->assertStringStartsWith( '<script', ltrim( $js ) );
+		$this->assertStringContainsString( "document.getElementById( 'adminmenuback' )", $js );
+		$this->assertStringContainsString( 'getComputedStyle( menu ).backgroundColor', $js );
+		$this->assertStringContainsString( "'rgba(0, 0, 0, 0)' === color", $js );
+		$this->assertStringContainsString(
+			"document.documentElement.style.setProperty( '--wp-build-admin-menu-background', color )",
+			$js
+		);
+		$this->assertStringNotContainsString( 'jQuery', $js );
+	}
+}

--- a/projects/packages/wp-build-polyfills/tests/php/WP_Build_Admin_Frame_Test.php
+++ b/projects/packages/wp-build-polyfills/tests/php/WP_Build_Admin_Frame_Test.php
@@ -82,6 +82,7 @@ class WP_Build_Admin_Frame_Test extends BaseTestCase {
 	 */
 	public function test_prints_both_blocks_once_after_registration() {
 		WP_Build_Admin_Frame::register();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- The second call must be a no-op.
 		WP_Build_Admin_Frame::register();
 
 		$output = $this->render_admin_header();

--- a/projects/packages/wp-build-polyfills/tests/php/WP_Build_Polyfills_Test.php
+++ b/projects/packages/wp-build-polyfills/tests/php/WP_Build_Polyfills_Test.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\Jetpack\WP_Build_Polyfills\Tests;
 
+use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Admin_Frame;
 use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\Before;
@@ -103,6 +104,9 @@ class WP_Build_Polyfills_Test extends BaseTestCase {
 			$threshold->setAccessible( true );
 		}
 		$threshold->setValue( null, '7.0' );
+
+		remove_action( 'admin_head', array( WP_Build_Admin_Frame::class, 'print_styles' ) );
+		remove_action( 'in_admin_header', array( WP_Build_Admin_Frame::class, 'print_script' ) );
 
 		$this->recursive_rmdir( $this->build_dir );
 
@@ -791,6 +795,16 @@ class WP_Build_Polyfills_Test extends BaseTestCase {
 		global $wp_filter;
 		$this->assertArrayHasKey( 'wp_default_scripts', $wp_filter );
 		$this->assertArrayHasKey( 20, $wp_filter['wp_default_scripts']->callbacks );
+	}
+
+	/**
+	 * Test that register arms the admin frame backdrop for the request.
+	 */
+	public function test_register_arms_the_admin_frame() {
+		WP_Build_Polyfills::register( 'test-plugin', array( 'wp-notices' ) );
+
+		$this->assertSame( 10, has_action( 'admin_head', array( WP_Build_Admin_Frame::class, 'print_styles' ) ) );
+		$this->assertSame( 10, has_action( 'in_admin_header', array( WP_Build_Admin_Frame::class, 'print_script' ) ) );
 	}
 
 	/**

--- a/projects/plugins/backup/changelog/fix-wp-build-admin-frame-backdrop
+++ b/projects/plugins/backup/changelog/fix-wp-build-admin-frame-backdrop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Continue the wp-admin menu color behind the page frame on WordPress.com and third-party admin color schemes.

--- a/projects/plugins/boost/changelog/fix-wp-build-admin-frame-backdrop
+++ b/projects/plugins/boost/changelog/fix-wp-build-admin-frame-backdrop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Activity Log: Continue the wp-admin menu color behind the page frame on WordPress.com and third-party admin color schemes.

--- a/projects/plugins/jetpack/changelog/fix-wp-build-admin-frame-backdrop
+++ b/projects/plugins/jetpack/changelog/fix-wp-build-admin-frame-backdrop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Admin dashboards: Continue the wp-admin menu color behind the page frame on WordPress.com and third-party admin color schemes.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-wp-build-admin-frame-backdrop
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-wp-build-admin-frame-backdrop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site setup: Continue the wp-admin menu color behind the page frame on WordPress.com admin color schemes.

--- a/projects/plugins/premium-analytics/changelog/fix-wp-build-admin-frame-backdrop
+++ b/projects/plugins/premium-analytics/changelog/fix-wp-build-admin-frame-backdrop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Continue the wp-admin menu color behind the page frame on WordPress.com and third-party admin color schemes.

--- a/projects/plugins/protect/changelog/fix-wp-build-admin-frame-backdrop
+++ b/projects/plugins/protect/changelog/fix-wp-build-admin-frame-backdrop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Activity Log: Continue the wp-admin menu color behind the page frame on WordPress.com and third-party admin color schemes.

--- a/projects/plugins/search/changelog/fix-wp-build-admin-frame-backdrop
+++ b/projects/plugins/search/changelog/fix-wp-build-admin-frame-backdrop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Activity Log: Continue the wp-admin menu color behind the page frame on WordPress.com and third-party admin color schemes.

--- a/projects/plugins/social/changelog/fix-wp-build-admin-frame-backdrop
+++ b/projects/plugins/social/changelog/fix-wp-build-admin-frame-backdrop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Continue the wp-admin menu color behind the page frame on WordPress.com and third-party admin color schemes.

--- a/projects/plugins/videopress/changelog/fix-wp-build-admin-frame-backdrop
+++ b/projects/plugins/videopress/changelog/fix-wp-build-admin-frame-backdrop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Continue the wp-admin menu color behind the page frame on WordPress.com and third-party admin color schemes.

--- a/projects/plugins/wpcomsh/changelog/fix-wp-build-admin-frame-backdrop
+++ b/projects/plugins/wpcomsh/changelog/fix-wp-build-admin-frame-backdrop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site setup: Continue the wp-admin menu color behind the page frame on WordPress.com admin color schemes.


### PR DESCRIPTION
## Proposed changes

On trunk, every admin page generated by `@wordpress/build` (Forms, Premium Analytics, Newsletter, Backup, Scan, SEO, Social, VideoPress, Podcast, Activity Log, site setup in jetpack-mu-wpcom) renders inside the `@wordpress/boot` single-page layout: a white stage with rounded corners over a backdrop that is meant to continue the wp-admin menu. `@wordpress/admin-ui` maps nine core color schemes to theme seeds and falls back to `modern` for anything else, so on every WordPress.com scheme (`nightfall`, `aquatic`, `classic-blue`, `classic-bright`, `classic-dark`, `contrast`, `powder-snow`, `sakura`, `sunset`) and on any third-party scheme registered with `wp_admin_css_color()` the backdrop is near-black (`#1e1e1e`) next to a menu of another color: a black notch under the admin bar and black bands in the bottom and right margins of the frame.

With this PR the backdrop follows the menu on every scheme, with no changes in the consuming packages:

* `WP_Build_Polyfills::register()` also arms a new `WP_Build_Admin_Frame` class in `packages/wp-build-polyfills`, the one runtime every wp-build page already loads.
* On `admin_head` it prints a stylesheet that paints `.boot-layout--single-page` and the body with `--wp-build-admin-menu-background`, falling back to boot's own colors when the property is not set.
* On `in_admin_header`, right after `#adminmenuback` is printed and before the layout mounts, it prints an inline script that samples that element's computed background into the custom property on the root element.

<img width="1019" height="997" alt="image" src="https://github.com/user-attachments/assets/31f8a9bb-e516-4eae-8eb7-47d60f562562" />

<img width="1019" height="999" alt="image" src="https://github.com/user-attachments/assets/bcfeb93e-9b7d-4c3f-8e94-6fe75fbc083d" />

<img width="1019" height="858" alt="image" src="https://github.com/user-attachments/assets/a6c3388c-76ee-4aa6-b148-80d121ba1f78" />

<img width="1020" height="998" alt="image" src="https://github.com/user-attachments/assets/94fee517-4f57-4190-a219-a020a90791eb" />

### How it works

The layout rule boot injects at runtime is `.boot-layout { background: var(--wpds-color-background-surface-neutral-weak) }`, specificity (0,1,0), appended to `<head>` after the page stylesheets. `#wpcontent .boot-layout--single-page` is (1,1,0), so the override wins on specificity rather than order. The second selector covers boot 0.21 (WordPress/gutenberg#81756, Gutenberg 23.9), where the layout styles are CSS Modules and the root class is `_<hash>__layout-single-page`: wp-build keeps the local name in production builds (checked on `@wordpress/boot@0.21.0`), so `[class*="__layout-single-page"]` matches whatever the hash is, at the same specificity. `body:has(.boot-layout--single-page)` keeps the elastic-scroll area consistent without relying on boot's body sync; it is a separate rule so browsers without `:has()` still apply the layout rule.

Sampling the rendered menu instead of mapping schemes is the point: one mechanism covers core schemes on older cores, WordPress.com schemes and third-party schemes, and the property is only set when the sample is a real color. Pages without a boot layout are unaffected by construction: the selectors match nothing.

The fix lives in PHP because on WordPress 7.0+ the boot module that runs is core's bundled copy. `WP_Script_Modules::register()` ignores an id that is already registered, so bumping `@wordpress/boot` in a package changes nothing on WordPress.com. Core already made its nine schemes' menu color equal the ramp output (r62454), which is why only unknown schemes break.

### Notes for reviewers

* The class is self-contained (`src/class-wp-build-admin-frame.php`) so it can be removed in one commit once wp-build or boot ship the same behavior. The upstream direction is structured per-scheme seeds in `wp_admin_css_color()`, see WordPress/gutenberg#80766 and WordPress/gutenberg#81980.
* The accent color inside the app (`--wp-admin-theme-color`, primary buttons) still comes from the `modern` seed on unknown schemes. Same upstream problem, out of scope here.
* Plugin changelog entries are in a separate commit: the change is visible to the users of every plugin that ships a wp-build page.
* Which boot runs where: the Gutenberg plugin overrides core's `@wordpress/boot` module through the wp-build module registration (deregister, then register), so WordPress.com runs boot 0.21 once it moves from Gutenberg 23.8 to 23.9. Jetpack's own builds register only their `@jetpack-*` modules and keep core's boot. Both class forms were checked on a live page by renaming the layout root to the 0.21 class names: layout and body keep the menu color, and any other local name does not match.

## Related product discussion/links

* [WOOA7S-1990](https://linear.app/a8c/issue/WOOA7S-1990), split from [WOOA7S-1982](https://linear.app/a8c/issue/WOOA7S-1982)
* WordPress/gutenberg#80766 and WordPress/gutenberg#81980 for the upstream fix

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Register a throwaway third-party scheme in a mu-plugin, then pick **Navy** in **Users → Profile → Admin Color Scheme**:

```php
add_action( 'admin_init', function () {
	wp_admin_css_color(
		'navy',
		'Navy',
		plugin_dir_url( __FILE__ ) . 'navy/colors.css',
		array( '#02395c', '#043959', '#2271b1', '#9ec2e6' ),
		array( 'base' => '#9ec2e6', 'focus' => '#fff', 'current' => '#fff' )
	);
} );
```

with `navy/colors.css` containing `#adminmenu, #adminmenuback, #adminmenuwrap { background: #02395c; }`. Any Masterbar scheme on a WordPress.com site behaves the same way.

### Unknown scheme

* Open **Jetpack → Forms** (`admin.php?page=jetpack-forms-responses-wp-admin`), **Jetpack → Stats** (`admin.php?page=jetpack-premium-analytics-wp-admin`) and **Jetpack → Activity Log**. The corner under the admin bar and the bottom and right margins around the frame must be `#02395c`, on load and after scrolling. On trunk they are near-black.
* In DevTools, `getComputedStyle( document.documentElement ).getPropertyValue( '--wp-build-admin-menu-background' )` returns `rgb(2, 57, 92)` and `document.querySelectorAll( '#wp-build-admin-frame-css, #wp-build-admin-frame-js' ).length` returns `2`.

### Boot 0.21

* With Gutenberg 23.9 (RC1 or later) active, repeat the Navy checks: the layout root now carries `_<hash>__layout-single-page` and the frame must still be `#02395c`.

### Core schemes

* Switch to **Blue**, then **Light**: the frame continues the menu in both (`rgb(36, 82, 120)` and `rgb(229, 229, 229)`), so nothing regresses on the schemes that already worked.

### Pages without a boot layout

* Open **Dashboard** and **Posts**: nothing changes, and neither id is in the DOM (the `querySelectorAll` above returns `0`).

### Narrow viewport

* Below 782px the layout goes full-screen; nothing of this is visible or broken.

### Tests

* `jp test php packages/wp-build-polyfills`
