### PR TITLE
Tiled Gallery: stop anchoring the mosaic to a container that is sized by its own content

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-content-sized-flex-anchor
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-content-sized-flex-anchor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Tiled Gallery: fix the gallery growing without bound inside a vertical Group or Stack, and keep its width in step with the space available when a surrounding block is resized or re-aligned.

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.jsx
@@ -16,6 +16,7 @@ export default class Mosaic extends Component {
 	pendingRaf = null;
 	lastWidth = null; // width (px) of the most recent layout pass
 	ro = null; // resizeObserver instance
+	observedContainer = null; // flex container the observer is watching, besides the gallery
 
 	componentDidMount() {
 		this.observeResize();
@@ -34,10 +35,70 @@ export default class Mosaic extends Component {
 	}
 
 	/**
+	 * Whether an element's inline size is decided by its own content rather than by
+	 * its container. Such a box is useless as a layout anchor: measuring it feeds our
+	 * own layout writes straight back into the width we lay out against, which is the
+	 * circular definition this whole anchoring dance exists to escape.
+	 *
+	 * The cases that matter in the block editor are the flex ones, and which axis the
+	 * width falls on decides how to read them. A vertical Group or Stack is
+	 * column-direction, so width is its cross axis: WordPress core defaults every flex
+	 * layout to `align-items: center`, which makes each stacked child shrink-to-fit
+	 * rather than fill the row. A Row is row-direction, so width is its main axis: a
+	 * child that neither grows nor has a definite basis is shrink-to-fit too, which is
+	 * what a Row nested inside a Row gives you. Either way, a flex container in that
+	 * position is sized by whatever it holds. See JETPACK-1726.
+	 *
+	 * @param {HTMLElement} el   - The element to test.
+	 * @param {Window}      view - The element's owning window.
+	 * @return {boolean} True when the element's width follows its content.
+	 */
+	isContentSized( el, view ) {
+		const style = view.getComputedStyle( el );
+		if ( 'inline-flex' === style.display || 'inline-block' === style.display ) {
+			return true;
+		}
+		if ( 'absolute' === style.position || 'fixed' === style.position ) {
+			return true;
+		}
+		if ( style.float && 'none' !== style.float ) {
+			return true;
+		}
+		if ( style.width && /^(max|min|fit)-content/.test( style.width ) ) {
+			return true;
+		}
+		const parent = el.parentElement;
+		if ( ! parent ) {
+			return false;
+		}
+		const parentStyle = view.getComputedStyle( parent );
+		if ( 'flex' !== parentStyle.display && 'inline-flex' !== parentStyle.display ) {
+			return false;
+		}
+		if ( /^column/.test( parentStyle.flexDirection ) ) {
+			// Stacked: width is the cross axis, so the item fills the container only
+			// while it is stretched. `align-self` wins over the container's `align-items`.
+			const align =
+				! style.alignSelf || 'auto' === style.alignSelf ? parentStyle.alignItems : style.alignSelf;
+			return !! align && 'stretch' !== align && 'normal' !== align;
+		}
+		// Side by side: width is the main axis, so an item that neither grows nor has a
+		// definite basis is shrink-to-fit. A Row nested in a Row is the common case.
+		// Reading flex-basis is a pragmatic proxy: a definite `width` resolves to a used
+		// pixel value in the computed style, where it is indistinguishable from `auto`.
+		const basis = style.flexBasis;
+		return '0' === style.flexGrow && ( ! basis || 'auto' === basis || 'content' === basis );
+	}
+
+	/**
 	 * Nearest ancestor that lays the gallery out as a flex item, or null when the
 	 * gallery isn't inside a flex container. The returned element is the flex
 	 * container; its width is determined by the surrounding layout rather than by
 	 * the gallery's own content, so it is a stable target to lay out against.
+	 *
+	 * Flex ancestors that are themselves content-sized are skipped rather than
+	 * returned: anchoring to one reintroduces the circular width it is meant to
+	 * avoid, and the gallery grows without bound. See JETPACK-1726.
 	 *
 	 * @return {?HTMLElement} The flex container, or null.
 	 */
@@ -62,7 +123,10 @@ export default class Mosaic extends Component {
 			}
 			const parent = el.parentElement;
 			const display = view.getComputedStyle( parent ).display;
-			if ( 'flex' === display || 'inline-flex' === display ) {
+			if (
+				( 'flex' === display || 'inline-flex' === display ) &&
+				! this.isContentSized( parent, view )
+			) {
 				return parent;
 			}
 			el = parent;
@@ -115,6 +179,14 @@ export default class Mosaic extends Component {
 			return this.gallery.current ? this.gallery.current.clientWidth : 0;
 		}
 		const view = container.ownerDocument?.defaultView || window;
+		const style = view.getComputedStyle( container );
+		// A column-direction container (a Stack, or a vertical Group) lays its items
+		// out one above the other, so each gets the container's full width. Only a row
+		// makes them share it, and dividing there would strand the gallery at a
+		// fraction of the space it actually has.
+		if ( /^column/.test( style.flexDirection ) ) {
+			return container.clientWidth;
+		}
 		// countFlexItems is a deliberate, pragmatic proxy for "number of flex items",
 		// and the division below assumes those items are equal width — it does not
 		// honor per-item flex-grow/flex-basis. That's enough for the common Row/Stack
@@ -129,8 +201,37 @@ export default class Mosaic extends Component {
 		// own layout and settles to a different value on each reload in Firefox.
 		// Dividing the container width is content-independent, so the result is
 		// stable across browsers/reloads. See JETPACK-1726.
-		const gap = parseFloat( view.getComputedStyle( container ).columnGap ) || 0;
+		const gap = parseFloat( style.columnGap ) || 0;
 		return ( container.clientWidth - gap * ( count - 1 ) ) / count;
+	}
+
+	/**
+	 * Point the observer at the container the layout is currently anchored to.
+	 *
+	 * The anchor cannot be resolved once at mount and left alone. The editor applies
+	 * its layout styles to the canvas after the block mounts, so on the first frame
+	 * the flex ancestors still compute as plain blocks and the walk finds nothing;
+	 * the anchor also moves later, when a block above the gallery is re-aligned.
+	 *
+	 * Without this the observer ends up watching only the gallery, and a gallery whose
+	 * own box is content-sized never changes on its own — so no pass ever runs and it
+	 * keeps a stale width while the space around it changes. See JETPACK-1726.
+	 */
+	syncContainerObservation() {
+		if ( ! this.ro ) {
+			return;
+		}
+		const container = this.getFlexContainer();
+		if ( container === this.observedContainer ) {
+			return;
+		}
+		if ( this.observedContainer ) {
+			this.ro.unobserve( this.observedContainer );
+		}
+		this.observedContainer = container;
+		if ( container ) {
+			this.ro.observe( container );
+		}
 	}
 
 	handleGalleryResize = () => {
@@ -143,6 +244,9 @@ export default class Mosaic extends Component {
 			if ( ! galleryNode ) {
 				return;
 			}
+			// Before any early return below: the anchor must stay observed even on a
+			// pass that changes nothing, or a later resize of it goes unnoticed.
+			this.syncContainerObservation();
 			// Lay out against a stable width rather than the (possibly content-sized)
 			// observed width, so the result is deterministic across browsers/reloads.
 			const width = this.getLayoutWidth();
@@ -187,11 +291,10 @@ export default class Mosaic extends Component {
 			this.ro.observe( this.gallery.current );
 			// Also watch the flex container: when the gallery lays out against the
 			// container's width, a container resize (e.g. window resize) won't
-			// necessarily change the gallery's own box, so observe it directly.
-			const container = this.getFlexContainer();
-			if ( container ) {
-				this.ro.observe( container );
-			}
+			// necessarily change the gallery's own box, so observe it directly. This
+			// first attempt often resolves nothing, because the editor has yet to
+			// style the canvas; every layout pass re-syncs it.
+			this.syncContainerObservation();
 		}
 	}
 
@@ -200,6 +303,7 @@ export default class Mosaic extends Component {
 			this.ro.disconnect();
 			this.ro = null;
 		}
+		this.observedContainer = null;
 		if ( this.pendingRaf ) {
 			cancelAnimationFrame( this.pendingRaf );
 			this.pendingRaf = null;

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.jsx
@@ -35,19 +35,9 @@ export default class Mosaic extends Component {
 	}
 
 	/**
-	 * Whether an element's inline size is decided by its own content rather than by
-	 * its container. Such a box is useless as a layout anchor: measuring it feeds our
-	 * own layout writes straight back into the width we lay out against, which is the
-	 * circular definition this whole anchoring dance exists to escape.
-	 *
-	 * The cases that matter in the block editor are the flex ones, and which axis the
-	 * width falls on decides how to read them. A vertical Group or Stack is
-	 * column-direction, so width is its cross axis: WordPress core defaults every flex
-	 * layout to `align-items: center`, which makes each stacked child shrink-to-fit
-	 * rather than fill the row. A Row is row-direction, so width is its main axis: a
-	 * child that neither grows nor has a definite basis is shrink-to-fit too, which is
-	 * what a Row nested inside a Row gives you. Either way, a flex container in that
-	 * position is sized by whatever it holds. See JETPACK-1726.
+	 * Whether an element's inline size is decided by its own content rather than by its
+	 * container. Such a box is useless as a layout anchor: measuring it feeds our own
+	 * layout writes back into the width we lay out against. See JETPACK-1726.
 	 *
 	 * @param {HTMLElement} el   - The element to test.
 	 * @param {Window}      view - The element's owning window.
@@ -83,9 +73,8 @@ export default class Mosaic extends Component {
 			return !! align && 'stretch' !== align && 'normal' !== align;
 		}
 		// Side by side: width is the main axis, so an item that neither grows nor has a
-		// definite basis is shrink-to-fit. A Row nested in a Row is the common case.
-		// Reading flex-basis is a pragmatic proxy: a definite `width` resolves to a used
-		// pixel value in the computed style, where it is indistinguishable from `auto`.
+		// definite basis is shrink-to-fit. `flex-basis` rather than `width`, which
+		// computes to a used pixel value indistinguishable from `auto`.
 		const basis = style.flexBasis;
 		return '0' === style.flexGrow && ( ! basis || 'auto' === basis || 'content' === basis );
 	}
@@ -96,9 +85,8 @@ export default class Mosaic extends Component {
 	 * container; its width is determined by the surrounding layout rather than by
 	 * the gallery's own content, so it is a stable target to lay out against.
 	 *
-	 * Flex ancestors that are themselves content-sized are skipped rather than
-	 * returned: anchoring to one reintroduces the circular width it is meant to
-	 * avoid, and the gallery grows without bound. See JETPACK-1726.
+	 * Flex ancestors that are themselves content-sized are skipped: anchoring to one
+	 * reintroduces the circular width, and the gallery grows without bound.
 	 *
 	 * @return {?HTMLElement} The flex container, or null.
 	 */
@@ -180,10 +168,8 @@ export default class Mosaic extends Component {
 		}
 		const view = container.ownerDocument?.defaultView || window;
 		const style = view.getComputedStyle( container );
-		// A column-direction container (a Stack, or a vertical Group) lays its items
-		// out one above the other, so each gets the container's full width. Only a row
-		// makes them share it, and dividing there would strand the gallery at a
-		// fraction of the space it actually has.
+		// A column-direction container stacks its items, so each gets the full width.
+		// Only a row makes them share it.
 		if ( /^column/.test( style.flexDirection ) ) {
 			return container.clientWidth;
 		}
@@ -208,14 +194,9 @@ export default class Mosaic extends Component {
 	/**
 	 * Point the observer at the container the layout is currently anchored to.
 	 *
-	 * The anchor cannot be resolved once at mount and left alone. The editor applies
-	 * its layout styles to the canvas after the block mounts, so on the first frame
-	 * the flex ancestors still compute as plain blocks and the walk finds nothing;
-	 * the anchor also moves later, when a block above the gallery is re-aligned.
-	 *
-	 * Without this the observer ends up watching only the gallery, and a gallery whose
-	 * own box is content-sized never changes on its own — so no pass ever runs and it
-	 * keeps a stale width while the space around it changes. See JETPACK-1726.
+	 * Re-resolved every pass rather than once at mount: the editor styles the canvas
+	 * after the block mounts, so the first walk finds nothing, and the anchor moves
+	 * again when a block above the gallery is re-aligned. See JETPACK-1726.
 	 */
 	syncContainerObservation() {
 		if ( ! this.ro ) {
@@ -291,9 +272,8 @@ export default class Mosaic extends Component {
 			this.ro.observe( this.gallery.current );
 			// Also watch the flex container: when the gallery lays out against the
 			// container's width, a container resize (e.g. window resize) won't
-			// necessarily change the gallery's own box, so observe it directly. This
-			// first attempt often resolves nothing, because the editor has yet to
-			// style the canvas; every layout pass re-syncs it.
+			// necessarily change the gallery's own box, so observe it directly. Often
+			// resolves nothing this early; every layout pass re-syncs it.
 			this.syncContainerObservation();
 		}
 	}

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/mosaic.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/mosaic.jsx
@@ -2,15 +2,22 @@ import { render } from '@testing-library/react';
 import Mosaic from '../index';
 
 let observerCallback;
+let mockObserved;
 
 jest.mock( 'resize-observer-polyfill', () => {
 	return class ResizeObserverMock {
 		constructor( cb ) {
 			observerCallback = cb;
 		}
-		observe() {}
-		unobserve() {}
-		disconnect() {}
+		observe( el ) {
+			mockObserved?.add( el );
+		}
+		unobserve( el ) {
+			mockObserved?.delete( el );
+		}
+		disconnect() {
+			mockObserved?.clear();
+		}
 	};
 } );
 
@@ -91,6 +98,81 @@ describe( 'Mosaic resize loop guard', () => {
 		// A genuine resize is still honored.
 		fireResize( 560 );
 		expect( onResize ).toHaveBeenCalledTimes( 2 );
+	} );
+} );
+
+describe( 'Mosaic container observation', () => {
+	let rafSpy;
+	let cafSpy;
+	let computedStyleSpy;
+	let pendingRaf;
+
+	beforeEach( () => {
+		mockObserved = new Set();
+		pendingRaf = undefined;
+		// Hold the queued pass instead of running it, so the test can decide what the
+		// canvas looks like by the time it runs.
+		rafSpy = jest.spyOn( window, 'requestAnimationFrame' ).mockImplementation( cb => {
+			pendingRaf = cb;
+			return 1;
+		} );
+		cafSpy = jest.spyOn( window, 'cancelAnimationFrame' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		rafSpy.mockRestore();
+		cafSpy.mockRestore();
+		computedStyleSpy?.mockRestore();
+		computedStyleSpy = undefined;
+		mockObserved = undefined;
+	} );
+
+	it( 'observes the flex container once the editor has styled the canvas (JETPACK-1726)', () => {
+		// The editor styles the canvas *after* the block mounts, so on the first frame
+		// the flex ancestors still compute as plain blocks and the walk finds nothing.
+		// Resolving the anchor only at mount leaves the observer watching just the
+		// gallery — and a gallery whose own box is content-sized never changes on its
+		// own, so no pass ever runs and it keeps a stale width forever.
+		const flexContainer = document.createElement( 'div' );
+		const item = document.createElement( 'div' );
+		flexContainer.appendChild( item );
+		document.body.appendChild( flexContainer );
+		Object.defineProperty( flexContainer, 'clientWidth', { configurable: true, get: () => 800 } );
+
+		let stylesApplied = false;
+		computedStyleSpy = jest.spyOn( window, 'getComputedStyle' ).mockImplementation( el => ( {
+			display: stylesApplied && el === flexContainer ? 'flex' : 'block',
+			flexDirection: 'row',
+			columnGap: 'normal',
+		} ) );
+
+		const images = [ { width: 100, height: 100 } ];
+		render(
+			<Mosaic
+				align="center"
+				columns={ 1 }
+				images={ images }
+				layoutStyle="rectangular"
+				renderedImages={ images.map( ( img, i ) => (
+					<div className="tiled-gallery__item" key={ i }>
+						<img data-width="100" data-height="100" alt="" />
+					</div>
+				) ) }
+				onResize={ () => {} }
+			/>,
+			{ container: item }
+		);
+
+		// Mount happened before the canvas was styled: nothing but the gallery.
+		expect( mockObserved.has( flexContainer ) ).toBe( false );
+
+		// The editor styles the canvas, then the queued pass runs.
+		stylesApplied = true;
+		pendingRaf();
+
+		expect( mockObserved.has( flexContainer ) ).toBe( true );
+
+		document.body.removeChild( flexContainer );
 	} );
 } );
 
@@ -244,5 +326,195 @@ describe( 'Mosaic layout-width anchoring', () => {
 		const mosaic = instanceFor( galleryA );
 		expect( mosaic.getFlexContainer() ).toBe( container );
 		expect( mosaic.getLayoutWidth() ).toBe( 390 );
+	} );
+
+	it( 'skips a flex ancestor that is itself content-sized and keeps climbing (JETPACK-1726)', () => {
+		// stack(flex, column, align-items:center, 1000)
+		//   > columns(flex, row) > column > wrapper > gallery
+		//
+		// `columns` is a cross-axis child of a column-direction flex container whose
+		// align-items is not stretch, so its width is shrink-to-fit — decided by the
+		// gallery it contains. Anchoring to it feeds our own layout back into the
+		// width we lay out against, and the gallery grows without bound.
+		const stack = document.createElement( 'div' );
+		const columns = document.createElement( 'div' );
+		const column = document.createElement( 'div' );
+		const wrapper = document.createElement( 'div' );
+		const gallery = document.createElement( 'div' );
+		stack.appendChild( columns );
+		columns.appendChild( column );
+		column.appendChild( wrapper );
+		wrapper.appendChild( gallery );
+
+		defineClientWidth( stack, 1000 );
+		defineClientWidth( columns, 7641 ); // already ballooned by the feedback loop
+		defineClientWidth( gallery, 7633 );
+
+		computedStyleSpy = jest.spyOn( window, 'getComputedStyle' ).mockImplementation( el => {
+			if ( el === stack ) {
+				return {
+					display: 'flex',
+					flexDirection: 'column',
+					alignItems: 'center',
+					columnGap: 'normal',
+				};
+			}
+			if ( el === columns ) {
+				return { display: 'flex', flexDirection: 'row', alignSelf: 'auto', columnGap: 'normal' };
+			}
+			return { display: 'block', columnGap: 'normal' };
+		} );
+
+		const mosaic = instanceFor( gallery );
+		// The content-sized `columns` is skipped in favour of the stack, whose own
+		// width is set by the layout around it.
+		expect( mosaic.isContentSized( columns, window ) ).toBe( true );
+		expect( mosaic.getFlexContainer() ).toBe( stack );
+		expect( mosaic.getLayoutWidth() ).toBe( 1000 );
+	} );
+
+	it( 'skips a Row nested in a Row, which is shrink-to-fit on the main axis (JETPACK-1726)', () => {
+		// outerRow(flex, row, 645) > innerRow(flex, row, flex:0 1 auto) > wrapper > gallery
+		//
+		// Width is the main axis here, so `innerRow` neither grows nor has a definite
+		// basis: it is shrink-to-fit, sized by the gallery inside it. Anchoring to it
+		// is circular and the gallery grows without bound.
+		const outerRow = document.createElement( 'div' );
+		const innerRow = document.createElement( 'div' );
+		const wrapper = document.createElement( 'div' );
+		const gallery = document.createElement( 'div' );
+		outerRow.appendChild( innerRow );
+		innerRow.appendChild( wrapper );
+		wrapper.appendChild( gallery );
+
+		defineClientWidth( outerRow, 645 );
+		defineClientWidth( innerRow, 18189 ); // already ballooned by the feedback loop
+
+		computedStyleSpy = jest.spyOn( window, 'getComputedStyle' ).mockImplementation( el => {
+			if ( el === outerRow ) {
+				return { display: 'flex', flexDirection: 'row', flexGrow: '0', columnGap: 'normal' };
+			}
+			if ( el === innerRow ) {
+				return {
+					display: 'flex',
+					flexDirection: 'row',
+					flexGrow: '0',
+					flexBasis: 'auto',
+					columnGap: 'normal',
+				};
+			}
+			return { display: 'block', columnGap: 'normal' };
+		} );
+
+		const mosaic = instanceFor( gallery );
+		expect( mosaic.isContentSized( innerRow, window ) ).toBe( true );
+		expect( mosaic.getFlexContainer() ).toBe( outerRow );
+		// One flex item in the outer row, so the gallery gets its full width.
+		expect( mosaic.getLayoutWidth() ).toBe( 645 );
+	} );
+
+	it( 'still anchors to a row-direction container whose item grows to fill it', () => {
+		// Same shape, but innerRow has flex-grow: 1, so its width is handed to it by
+		// outerRow rather than taken from its content — a perfectly good anchor.
+		const outerRow = document.createElement( 'div' );
+		const innerRow = document.createElement( 'div' );
+		const wrapper = document.createElement( 'div' );
+		const gallery = document.createElement( 'div' );
+		outerRow.appendChild( innerRow );
+		innerRow.appendChild( wrapper );
+		wrapper.appendChild( gallery );
+
+		defineClientWidth( outerRow, 645 );
+		defineClientWidth( innerRow, 645 );
+
+		computedStyleSpy = jest.spyOn( window, 'getComputedStyle' ).mockImplementation( el => {
+			if ( el === outerRow ) {
+				return { display: 'flex', flexDirection: 'row', flexGrow: '0', columnGap: 'normal' };
+			}
+			if ( el === innerRow ) {
+				return {
+					display: 'flex',
+					flexDirection: 'row',
+					flexGrow: '1',
+					flexBasis: 'auto',
+					columnGap: 'normal',
+				};
+			}
+			return { display: 'block', columnGap: 'normal' };
+		} );
+
+		const mosaic = instanceFor( gallery );
+		expect( mosaic.isContentSized( innerRow, window ) ).toBe( false );
+		expect( mosaic.getFlexContainer() ).toBe( innerRow );
+		expect( mosaic.getLayoutWidth() ).toBe( 645 );
+	} );
+
+	it( 'still anchors to a nested flex container that is stretched by its parent', () => {
+		// Same shape, but the stack stretches its children, so `columns` fills the
+		// stack's width and remains a perfectly good anchor.
+		const stack = document.createElement( 'div' );
+		const columns = document.createElement( 'div' );
+		const column = document.createElement( 'div' );
+		const gallery = document.createElement( 'div' );
+		stack.appendChild( columns );
+		columns.appendChild( column );
+		column.appendChild( gallery );
+
+		defineClientWidth( stack, 1000 );
+		defineClientWidth( columns, 1000 );
+
+		computedStyleSpy = jest.spyOn( window, 'getComputedStyle' ).mockImplementation( el => {
+			if ( el === stack ) {
+				return {
+					display: 'flex',
+					flexDirection: 'column',
+					alignItems: 'stretch',
+					columnGap: 'normal',
+				};
+			}
+			if ( el === columns ) {
+				return { display: 'flex', flexDirection: 'row', alignSelf: 'auto', columnGap: 'normal' };
+			}
+			return { display: 'block', columnGap: 'normal' };
+		} );
+
+		const mosaic = instanceFor( gallery );
+		expect( mosaic.isContentSized( columns, window ) ).toBe( false );
+		expect( mosaic.getFlexContainer() ).toBe( columns );
+		expect( mosaic.getLayoutWidth() ).toBe( 1000 );
+	} );
+
+	it( 'gives a stacked gallery the full width instead of a share of it (JETPACK-1726)', () => {
+		// stack(flex, column, 1000) > [paragraph, wrapper > gallery, paragraph]
+		// Stacked items sit one above the other, so the gallery gets the whole 1000px.
+		// Dividing by the item count would strand it at a third of the space.
+		const stack = document.createElement( 'div' );
+		const before = document.createElement( 'p' );
+		const wrapper = document.createElement( 'div' );
+		const after = document.createElement( 'p' );
+		const gallery = document.createElement( 'div' );
+		stack.appendChild( before );
+		stack.appendChild( wrapper );
+		stack.appendChild( after );
+		wrapper.appendChild( gallery );
+
+		defineClientWidth( stack, 1000 );
+		defineClientWidth( gallery, 21 );
+
+		computedStyleSpy = jest.spyOn( window, 'getComputedStyle' ).mockImplementation( el => {
+			if ( el === stack ) {
+				return {
+					display: 'flex',
+					flexDirection: 'column',
+					alignItems: 'stretch',
+					columnGap: '20px',
+				};
+			}
+			return { display: 'block', columnGap: 'normal' };
+		} );
+
+		const mosaic = instanceFor( gallery );
+		expect( mosaic.getFlexContainer() ).toBe( stack );
+		expect( mosaic.getLayoutWidth() ).toBe( 1000 );
 	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/mosaic.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/mosaic.jsx
@@ -128,11 +128,8 @@ describe( 'Mosaic container observation', () => {
 	} );
 
 	it( 'observes the flex container once the editor has styled the canvas (JETPACK-1726)', () => {
-		// The editor styles the canvas *after* the block mounts, so on the first frame
-		// the flex ancestors still compute as plain blocks and the walk finds nothing.
-		// Resolving the anchor only at mount leaves the observer watching just the
-		// gallery — and a gallery whose own box is content-sized never changes on its
-		// own, so no pass ever runs and it keeps a stale width forever.
+		// The editor styles the canvas *after* the block mounts, so a walk done only at
+		// mount finds nothing and leaves the observer watching a box that never changes.
 		const flexContainer = document.createElement( 'div' );
 		const item = document.createElement( 'div' );
 		flexContainer.appendChild( item );
@@ -332,10 +329,8 @@ describe( 'Mosaic layout-width anchoring', () => {
 		// stack(flex, column, align-items:center, 1000)
 		//   > columns(flex, row) > column > wrapper > gallery
 		//
-		// `columns` is a cross-axis child of a column-direction flex container whose
-		// align-items is not stretch, so its width is shrink-to-fit — decided by the
-		// gallery it contains. Anchoring to it feeds our own layout back into the
-		// width we lay out against, and the gallery grows without bound.
+		// `columns` is a cross-axis child of a non-stretching column container, so its
+		// width is shrink-to-fit — decided by the gallery, and circular if anchored to.
 		const stack = document.createElement( 'div' );
 		const columns = document.createElement( 'div' );
 		const column = document.createElement( 'div' );
@@ -377,8 +372,7 @@ describe( 'Mosaic layout-width anchoring', () => {
 		// outerRow(flex, row, 645) > innerRow(flex, row, flex:0 1 auto) > wrapper > gallery
 		//
 		// Width is the main axis here, so `innerRow` neither grows nor has a definite
-		// basis: it is shrink-to-fit, sized by the gallery inside it. Anchoring to it
-		// is circular and the gallery grows without bound.
+		// basis: shrink-to-fit, sized by the gallery inside it, and circular if anchored to.
 		const outerRow = document.createElement( 'div' );
 		const innerRow = document.createElement( 'div' );
 		const wrapper = document.createElement( 'div' );
@@ -487,7 +481,6 @@ describe( 'Mosaic layout-width anchoring', () => {
 	it( 'gives a stacked gallery the full width instead of a share of it (JETPACK-1726)', () => {
 		// stack(flex, column, 1000) > [paragraph, wrapper > gallery, paragraph]
 		// Stacked items sit one above the other, so the gallery gets the whole 1000px.
-		// Dividing by the item count would strand it at a third of the space.
 		const stack = document.createElement( 'div' );
 		const before = document.createElement( 'p' );
 		const wrapper = document.createElement( 'div' );


### PR DESCRIPTION
Fixes #49564

## Proposed changes

The mosaic layout lays itself out against the nearest flex ancestor, on the assumption — stated in `getFlexContainer`'s own docblock — that the ancestor's width is decided by the surrounding layout. That assumption is false whenever the ancestor is itself horizontally content-sized: measuring it feeds the gallery's own layout writes back into the width it lays out against, and the gallery grows without bound. That is the resize loop JETPACK-1726 was meant to end, reached through ancestor shapes that #50016 did not cover.

Which axis the width falls on decides how to recognise such a box, and the fix teaches `isContentSized()` both:

* **Cross axis.** A vertical Group or Stack is column-direction, so width is its cross axis. WordPress core defaults every flex layout to `align-items: center`, which leaves each stacked child shrink-to-fit rather than filling the row — so any flex container nested in one is sized by whatever it holds. This is the reported case: `Columns > Column > vertical Group > Columns > Column > Tiled Gallery`.
* **Main axis.** A Row is row-direction, so width is its main axis, where a child with `flex: 0 1 auto` is shrink-to-fit too. That is what a Row nested inside a Row produces.

Such ancestors are now skipped, and the walk continues to one whose width is genuinely handed to it by the layout around it.

Two further problems in the same code, both found while confirming the first:

* **Stacked galleries were laid out at a fraction of their width.** `getLayoutWidth()` divided the container width by the flex-item count regardless of direction. Column-direction items are stacked and each gets the container's *full* width; only a row makes them share. A gallery in a Stack alongside two sibling blocks was being laid out at a third of the space it had.
* **The gallery never responded to an ancestor being resized or re-aligned.** The anchor was resolved once, in `componentDidMount`. The editor styles the canvas *after* the block mounts, so on that first frame the flex ancestors still compute as plain blocks, the walk finds nothing, and the observer ends up watching only the gallery. A gallery whose own box is content-sized never changes on its own, so no layout pass ever ran and it kept a stale width while the space around it changed. This was latent until the runaway above was fixed — the loop had been accidentally driving the passes. `syncContainerObservation()` now re-resolves the anchor and re-points the observer on every pass, before any early return.

Not a regression: the deployed code matches trunk, and the original #50016 implementation takes an identical path for these shapes. They were simply never covered.

### Real-screen before / after

Captured on a live Jurassic Ninja site in the page editor at 1440×900.

**Nested Columns inside a vertical Group** — the reported shape. Before: the gallery had reached 5296px inside a 1160px canvas and was still growing. After: 1160px, exactly filling the canvas.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/tiled-gallery-content-sized-flex-anchor/before-nested-columns.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/tiled-gallery-content-sized-flex-anchor/after-nested-columns.png) |

**Row inside a Row.** Before: 4460px inside the same 1160px canvas, still growing. After: 620px, filling the outer Row.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/tiled-gallery-content-sized-flex-anchor/before-row-in-row.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/tiled-gallery-content-sized-flex-anchor/after-row-in-row.png) |

## Related product discussion/links

* JETPACK-1726

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

These are editor-only layout bugs — nothing to check on the front end. A block theme is needed so the core flex layout styles apply (Twenty Twenty-Four or Twenty Twenty-Five are both fine).

**1. The reported case — runaway growth (needs the fix)**

* Create a page and add a **Columns** block, set it to **Full width**, with a single column.
* Inside that column add a **Group**, and in its block settings set the layout to **Stack** (vertical) with content justified **Center**.
* Inside the Group add another **Columns** block with a single column.
* Inside that inner column, insert a **Tiled Gallery** and add 5 images.
* On trunk the gallery grows continuously, overflows the canvas and gives the editor a horizontal scrollbar; the post also stays permanently "unsaved" because the block keeps rewriting `columnWidths`. With this branch it settles at the canvas width on the first pass and the post saves clean.

**2. Row inside a Row — runaway growth (needs the fix)**

* Add a **Row** block, and inside it another **Row** block.
* Insert a **Tiled Gallery** into the inner Row and add 3 images.
* Same contrast as above: unbounded growth on trunk, settles at the outer Row's width here.

**3. A gallery in a Stack should use the full width**

* Add a **Stack** block containing a paragraph, a **Tiled Gallery** (3 images), and another paragraph.
* On trunk the gallery is laid out at roughly a third of the Stack's width. With this branch it fills the Stack.

**4. The gallery should follow an alignment change**

* Using the page from step 1, select the outer **Columns** block and switch **Align** between *None*, *Wide width* and *Full width*.
* The gallery should resize to match each one (in a default theme, roughly 645px / 1340px / the canvas width). On trunk it keeps its previous width, so the content overflows and the editor gains a horizontal scrollbar.

**5. Nothing else should change**

* A Tiled Gallery at the top level of a post, in a single Row alongside another gallery, or with `selfStretch: fit` inside a Row/Stack should all behave exactly as before.
* `jetpack test js plugins/jetpack` — the block's suite covers the anchor selection, the direction-aware width and the mount-time observation ordering.
