### PR TITLE
VideoPress: update readme.txt stable tag to 3.4.1

### DIFF
--- a/projects/plugins/videopress/changelog/update-videopress-stable-tag-3.4.1
+++ b/projects/plugins/videopress/changelog/update-videopress-stable-tag-3.4.1
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update the readme.txt stable tag after the 3.4.1 release. No user-facing change.

--- a/projects/plugins/videopress/readme.txt
+++ b/projects/plugins/videopress/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, retrofox, oskosk, thehenridev, renatoagds, lhkowalski,
 Tags: video, video-hosting, video-player, cdn, video-streaming
 Requires at least: 7.0
 Tested up to: 7.1
-Stable tag: 3.4
+Stable tag: 3.4.1
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Update the VideoPress plugin's `readme.txt` stable tag to 3.4.1.
* The 3.4.1 release script run failed before its stable-tag bump step (part of `do_create_prerelease_PR` in `tools/release-plugin.sh`), so the backport PR (#51622) left trunk pointing at 3.4.

## Related product discussion/links
* #51622

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Confirm `projects/plugins/videopress/readme.txt` says `Stable tag: 3.4.1`, matching the released version.
