### PR TITLE
Connection: show a clearer error message when site registration fails

### DIFF
--- a/projects/js-packages/connection/changelog/fix-connection-registration-error-message
+++ b/projects/js-packages/connection/changelog/fix-connection-registration-error-message
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connect screen: Show a clearer error message when the site cannot reach WordPress.com during registration, and export the getConnectScreenErrorMessage helper.

--- a/projects/js-packages/connection/components/connect-screen/action/index.tsx
+++ b/projects/js-packages/connection/components/connect-screen/action/index.tsx
@@ -1,8 +1,9 @@
-import { getRedirectUrl } from '@automattic/jetpack-components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
-import type { MouseEventHandler, ReactNode } from 'react';
+import { getConnectScreenErrorMessage } from '../../../helpers/get-connect-screen-error-message';
+import type { MouseEventHandler } from 'react';
+
+export { getConnectScreenErrorMessage };
 
 export type Props = {
 	// The Connect Button label
@@ -17,61 +18,6 @@ export type Props = {
 	errorCode?: string;
 	// Whether the site is in offline mode
 	isOfflineMode?: boolean;
-};
-
-/**
- * Maps a connection error code (and offline mode) to a user-facing message.
- *
- * @param {string}  errorCode     - The connection error code.
- * @param {boolean} isOfflineMode - Whether the site is in offline mode.
- * @return {import('react').ReactNode} The error message, or undefined if there isn't one.
- */
-export const getConnectScreenErrorMessage = (
-	errorCode?: string,
-	isOfflineMode?: boolean
-): ReactNode => {
-	// Explicit error code takes precedence over the offline mode.
-	switch ( errorCode ) {
-		case 'fail_domain_forbidden':
-		case 'fail_ip_forbidden':
-		case 'fail_domain_tld':
-		case 'fail_subdomain_wpcom':
-		case 'siteurl_private_ip':
-			return __(
-				'Your site host is on a private network. Sites can connect to WordPress.com only on public sites.',
-				'jetpack-connection-js'
-			);
-		case 'connection_disabled':
-			return __( 'This site has been suspended.', 'jetpack-connection-js' );
-		case 'register_http_request_failed':
-			return __(
-				'Your site could not reach WordPress.com. This is usually temporary — try again in a minute. If it keeps happening, ask your hosting provider to allow connections to jetpack.wordpress.com.',
-				'jetpack-connection-js'
-			);
-		case 'wpcom_408':
-		case 'wpcom_5??':
-			return __(
-				'WordPress.com is temporarily unavailable. Please try again in a minute.',
-				'jetpack-connection-js'
-			);
-	}
-
-	if ( isOfflineMode ) {
-		return createInterpolateElement(
-			__( 'Unavailable in <a>Offline Mode</a>', 'jetpack-connection-js' ),
-			{
-				a: (
-					<a
-						href={ getRedirectUrl( 'jetpack-support-development-mode' ) }
-						target="_blank"
-						rel="noopener noreferrer"
-					/>
-				),
-			}
-		);
-	}
-
-	return undefined;
 };
 
 /**

--- a/projects/js-packages/connection/components/connect-screen/action/index.tsx
+++ b/projects/js-packages/connection/components/connect-screen/action/index.tsx
@@ -43,6 +43,17 @@ export const getConnectScreenErrorMessage = (
 			);
 		case 'connection_disabled':
 			return __( 'This site has been suspended.', 'jetpack-connection-js' );
+		case 'register_http_request_failed':
+			return __(
+				'Your site could not reach WordPress.com. This is usually temporary — try again in a minute. If it keeps happening, ask your hosting provider to allow connections to jetpack.wordpress.com.',
+				'jetpack-connection-js'
+			);
+		case 'wpcom_408':
+		case 'wpcom_5??':
+			return __(
+				'WordPress.com is temporarily unavailable. Please try again in a minute.',
+				'jetpack-connection-js'
+			);
 	}
 
 	if ( isOfflineMode ) {

--- a/projects/js-packages/connection/components/connect-screen/action/test/component.tsx
+++ b/projects/js-packages/connection/components/connect-screen/action/test/component.tsx
@@ -1,30 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import ConnectScreenAction, { getConnectScreenErrorMessage } from '../index';
-
-describe( 'getConnectScreenErrorMessage', () => {
-	it( 'maps private network error codes to a message', () => {
-		expect( getConnectScreenErrorMessage( 'siteurl_private_ip' ) ).toBe(
-			'Your site host is on a private network. Sites can connect to WordPress.com only on public sites.'
-		);
-	} );
-
-	it( 'maps a registration HTTP failure to a message about reaching WordPress.com', () => {
-		expect( getConnectScreenErrorMessage( 'register_http_request_failed' ) ).toBe(
-			'Your site could not reach WordPress.com. This is usually temporary — try again in a minute. If it keeps happening, ask your hosting provider to allow connections to jetpack.wordpress.com.'
-		);
-	} );
-
-	it( 'maps WordPress.com server errors and timeouts to a message', () => {
-		const message = 'WordPress.com is temporarily unavailable. Please try again in a minute.';
-		expect( getConnectScreenErrorMessage( 'wpcom_5??' ) ).toBe( message );
-		expect( getConnectScreenErrorMessage( 'wpcom_408' ) ).toBe( message );
-	} );
-
-	it( 'returns undefined for unknown error codes', () => {
-		expect( getConnectScreenErrorMessage( 'some_unknown_code' ) ).toBeUndefined();
-		expect( getConnectScreenErrorMessage( undefined ) ).toBeUndefined();
-	} );
-} );
+import ConnectScreenAction from '../index';
 
 describe( 'ConnectScreenAction', () => {
 	it( 'falls back to a generic message for unknown error codes', () => {

--- a/projects/js-packages/connection/components/connect-screen/action/test/component.tsx
+++ b/projects/js-packages/connection/components/connect-screen/action/test/component.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import ConnectScreenAction, { getConnectScreenErrorMessage } from '../index';
+
+describe( 'getConnectScreenErrorMessage', () => {
+	it( 'maps private network error codes to a message', () => {
+		expect( getConnectScreenErrorMessage( 'siteurl_private_ip' ) ).toBe(
+			'Your site host is on a private network. Sites can connect to WordPress.com only on public sites.'
+		);
+	} );
+
+	it( 'maps a registration HTTP failure to a message about reaching WordPress.com', () => {
+		expect( getConnectScreenErrorMessage( 'register_http_request_failed' ) ).toBe(
+			'Your site could not reach WordPress.com. This is usually temporary — try again in a minute. If it keeps happening, ask your hosting provider to allow connections to jetpack.wordpress.com.'
+		);
+	} );
+
+	it( 'maps WordPress.com server errors and timeouts to a message', () => {
+		const message = 'WordPress.com is temporarily unavailable. Please try again in a minute.';
+		expect( getConnectScreenErrorMessage( 'wpcom_5??' ) ).toBe( message );
+		expect( getConnectScreenErrorMessage( 'wpcom_408' ) ).toBe( message );
+	} );
+
+	it( 'returns undefined for unknown error codes', () => {
+		expect( getConnectScreenErrorMessage( 'some_unknown_code' ) ).toBeUndefined();
+		expect( getConnectScreenErrorMessage( undefined ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'ConnectScreenAction', () => {
+	it( 'falls back to a generic message for unknown error codes', () => {
+		render(
+			<ConnectScreenAction buttonLabel="Set up Jetpack" displayButtonError errorCode="whatever" />
+		);
+		expect( screen.getByText( 'An error occurred. Please try again.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the mapped message for known error codes', () => {
+		render(
+			<ConnectScreenAction
+				buttonLabel="Set up Jetpack"
+				displayButtonError
+				errorCode="register_http_request_failed"
+			/>
+		);
+		expect( screen.getByText( /Your site could not reach WordPress\.com/ ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/js-packages/connection/components/use-connection/types.ts
+++ b/projects/js-packages/connection/components/use-connection/types.ts
@@ -64,7 +64,7 @@ export interface UserConnectionData {
 
 export interface RegistrationError {
 	message?: string;
-	response?: { code?: string };
+	response?: { code?: string; message?: string };
 	[ key: string ]: unknown;
 }
 

--- a/projects/js-packages/connection/helpers/get-connect-screen-error-message.tsx
+++ b/projects/js-packages/connection/helpers/get-connect-screen-error-message.tsx
@@ -1,0 +1,69 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import type { ReactNode } from 'react';
+
+/**
+ * Maps a connection error code (and offline mode) to a user-facing message.
+ *
+ * The Jetpack plugin keeps its own overlapping code→copy map in
+ * `projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx`
+ * (`getErrorFromKey`); when changing copy for a code shared by both, check the other file too.
+ *
+ * @param {string}  errorCode     - The connection error code.
+ * @param {boolean} isOfflineMode - Whether the site is in offline mode.
+ * @return {import('react').ReactNode} The error message, or undefined if there isn't one.
+ */
+export const getConnectScreenErrorMessage = (
+	errorCode?: string,
+	isOfflineMode?: boolean
+): ReactNode => {
+	// Explicit error code takes precedence over the offline mode.
+	switch ( errorCode ) {
+		case 'fail_domain_forbidden':
+		case 'fail_ip_forbidden':
+		case 'fail_domain_tld':
+		case 'fail_subdomain_wpcom':
+		case 'siteurl_private_ip':
+			return __(
+				'Your site host is on a private network. Sites can connect to WordPress.com only on public sites.',
+				'jetpack-connection-js'
+			);
+		case 'connection_disabled':
+			return __( 'This site has been suspended.', 'jetpack-connection-js' );
+		case 'register_http_request_failed':
+			return __(
+				'Your site could not reach WordPress.com. This is usually temporary — try again in a minute. If it keeps happening, ask your hosting provider to allow connections to jetpack.wordpress.com.',
+				'jetpack-connection-js'
+			);
+		case 'wpcom_408':
+		case 'wpcom_5??':
+		case 'wpcom_bad_response':
+			return __(
+				'WordPress.com is temporarily unavailable. Please try again in a minute.',
+				'jetpack-connection-js'
+			);
+		case 'jetpack_id':
+			return __(
+				'WordPress.com returned an unexpected response when registering your site. Please try again in a minute.',
+				'jetpack-connection-js'
+			);
+	}
+
+	if ( isOfflineMode ) {
+		return createInterpolateElement(
+			__( 'Unavailable in <a>Offline Mode</a>', 'jetpack-connection-js' ),
+			{
+				a: (
+					<a
+						href={ getRedirectUrl( 'jetpack-support-development-mode' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			}
+		);
+	}
+
+	return undefined;
+};

--- a/projects/js-packages/connection/helpers/test/get-connect-screen-error-message.tsx
+++ b/projects/js-packages/connection/helpers/test/get-connect-screen-error-message.tsx
@@ -1,0 +1,33 @@
+import { getConnectScreenErrorMessage } from '../get-connect-screen-error-message';
+
+describe( 'getConnectScreenErrorMessage', () => {
+	it( 'maps private network error codes to a message', () => {
+		expect( getConnectScreenErrorMessage( 'siteurl_private_ip' ) ).toBe(
+			'Your site host is on a private network. Sites can connect to WordPress.com only on public sites.'
+		);
+	} );
+
+	it( 'maps a registration HTTP failure to a message about reaching WordPress.com', () => {
+		expect( getConnectScreenErrorMessage( 'register_http_request_failed' ) ).toBe(
+			'Your site could not reach WordPress.com. This is usually temporary — try again in a minute. If it keeps happening, ask your hosting provider to allow connections to jetpack.wordpress.com.'
+		);
+	} );
+
+	it( 'maps WordPress.com server errors, timeouts, and bad responses to a message', () => {
+		const message = 'WordPress.com is temporarily unavailable. Please try again in a minute.';
+		expect( getConnectScreenErrorMessage( 'wpcom_5??' ) ).toBe( message );
+		expect( getConnectScreenErrorMessage( 'wpcom_408' ) ).toBe( message );
+		expect( getConnectScreenErrorMessage( 'wpcom_bad_response' ) ).toBe( message );
+	} );
+
+	it( 'maps an invalid Jetpack ID response to a message', () => {
+		expect( getConnectScreenErrorMessage( 'jetpack_id' ) ).toBe(
+			'WordPress.com returned an unexpected response when registering your site. Please try again in a minute.'
+		);
+	} );
+
+	it( 'returns undefined for unknown error codes', () => {
+		expect( getConnectScreenErrorMessage( 'some_unknown_code' ) ).toBeUndefined();
+		expect( getConnectScreenErrorMessage( undefined ) ).toBeUndefined();
+	} );
+} );

--- a/projects/js-packages/connection/index.jsx
+++ b/projects/js-packages/connection/index.jsx
@@ -37,7 +37,7 @@ export { default as thirdPartyCookiesFallbackHelper } from './helpers/third-part
 export { default as getCalypsoOrigin } from './helpers/get-calypso-origin';
 export * from './helpers/get-user-connection-url.ts';
 export { getReconnectErrorMessage } from './helpers/get-reconnect-error-message.ts';
-export { getConnectScreenErrorMessage } from './components/connect-screen/action';
+export { getConnectScreenErrorMessage } from './helpers/get-connect-screen-error-message';
 
 /**
  * Store

--- a/projects/js-packages/connection/index.jsx
+++ b/projects/js-packages/connection/index.jsx
@@ -37,6 +37,7 @@ export { default as thirdPartyCookiesFallbackHelper } from './helpers/third-part
 export { default as getCalypsoOrigin } from './helpers/get-calypso-origin';
 export * from './helpers/get-user-connection-url.ts';
 export { getReconnectErrorMessage } from './helpers/get-reconnect-error-message.ts';
+export { getConnectScreenErrorMessage } from './components/connect-screen/action';
 
 /**
  * Store

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
@@ -64,6 +64,7 @@ const ConnectionForm = () => {
 			{ registrationError ? (
 				<Notice status="error" isDismissible={ false }>
 					{ getConnectScreenErrorMessage( registrationError.response?.code ) ||
+						registrationError.response?.message ||
 						__( 'An error occurred. Please try again.', 'jetpack-my-jetpack' ) }
 				</Notice>
 			) : null }

--- a/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
+++ b/projects/packages/my-jetpack/_inc/components/onboarding-screen/connection-form/connection-form.tsx
@@ -1,5 +1,5 @@
 import { JetpackLogo, TermsOfService, Text } from '@automattic/jetpack-components';
-import { useConnection } from '@automattic/jetpack-connection';
+import { getConnectScreenErrorMessage, useConnection } from '@automattic/jetpack-connection';
 import { Button, Spinner, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect } from 'react';
@@ -63,7 +63,7 @@ const ConnectionForm = () => {
 
 			{ registrationError ? (
 				<Notice status="error" isDismissible={ false }>
-					{ registrationError.message ||
+					{ getConnectScreenErrorMessage( registrationError.response?.code ) ||
 						__( 'An error occurred. Please try again.', 'jetpack-my-jetpack' ) }
 				</Notice>
 			) : null }

--- a/projects/packages/my-jetpack/changelog/fix-connection-registration-error-message
+++ b/projects/packages/my-jetpack/changelog/fix-connection-registration-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Onboarding: Show a readable error message instead of a raw request error when connecting the site fails.

--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-connection-registration-error-message
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-connection-registration-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Show a clearer error message when the site cannot reach WordPress.com while connecting.

--- a/projects/plugins/backup/changelog/fix-connection-registration-error-message
+++ b/projects/plugins/backup/changelog/fix-connection-registration-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Show a clearer error message when the site cannot reach WordPress.com while connecting.

--- a/projects/plugins/boost/changelog/fix-connection-registration-error-message
+++ b/projects/plugins/boost/changelog/fix-connection-registration-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Show a clearer error message when the site cannot reach WordPress.com while connecting.

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -25,6 +25,11 @@ class JetpackStateNotices extends Component {
 		this.setState( { showNotice: false } );
 	};
 
+	// Several codes below (e.g. `wpcom_408`, `wpcom_5??`, `wpcom_bad_response`,
+	// `register_http_request_failed`, `connection_disabled`) also have copy in the shared
+	// `getConnectScreenErrorMessage` helper in
+	// `projects/js-packages/connection/helpers/get-connect-screen-error-message.tsx`;
+	// when changing copy for a shared code, check that file too.
 	getErrorFromKey = key => {
 		const errorDesc = this.props.jetpackStateNoticesErrorDescription || false;
 		let message;

--- a/projects/plugins/jetpack/changelog/fix-connection-registration-error-message
+++ b/projects/plugins/jetpack/changelog/fix-connection-registration-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Connection: Show a clearer error message when the site cannot reach WordPress.com while connecting.

--- a/projects/plugins/protect/changelog/fix-connection-registration-error-message
+++ b/projects/plugins/protect/changelog/fix-connection-registration-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Show a clearer error message when the site cannot reach WordPress.com while connecting.

--- a/projects/plugins/search/changelog/fix-connection-registration-error-message
+++ b/projects/plugins/search/changelog/fix-connection-registration-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Show a clearer error message when the site cannot reach WordPress.com while connecting.

--- a/projects/plugins/social/changelog/fix-connection-registration-error-message
+++ b/projects/plugins/social/changelog/fix-connection-registration-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Show a clearer error message when the site cannot reach WordPress.com while connecting.

--- a/projects/plugins/starter-plugin/changelog/fix-connection-registration-error-message
+++ b/projects/plugins/starter-plugin/changelog/fix-connection-registration-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Show a clearer error message when the site cannot reach WordPress.com while connecting.

--- a/projects/plugins/stats/changelog/fix-connection-registration-error-message
+++ b/projects/plugins/stats/changelog/fix-connection-registration-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Show a clearer error message when the site cannot reach WordPress.com while connecting.

--- a/projects/plugins/videopress/changelog/fix-connection-registration-error-message
+++ b/projects/plugins/videopress/changelog/fix-connection-registration-error-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Connection: Show a clearer error message when the site cannot reach WordPress.com while connecting.


### PR DESCRIPTION
## Proposed changes

When site registration fails because the site can't reach WordPress.com, the My Jetpack onboarding screen currently shows the raw transport error, e.g.:

> cURL error 28: Connection timed out after 10007 milliseconds (Status 500)

That message comes straight from `wp_remote_post()`: `Manager::validate_remote_register_response()` wraps the timeout as a `register_http_request_failed` `WP_Error` but keeps the raw cURL text as the message, the REST layer returns it as a 500, and the onboarding form rendered `registrationError.message` verbatim.

This PR:

* Adds two new mappings to `getConnectScreenErrorMessage()` in the connection js-package:
  * `register_http_request_failed` → "Your site could not reach WordPress.com. This is usually temporary — try again in a minute. If it keeps happening, ask your hosting provider to allow connections to jetpack.wordpress.com."
  * `wpcom_408` / `wpcom_5??` → "WordPress.com is temporarily unavailable. Please try again in a minute." (Previously these produced a message that was just the numeric status code.)
* Exports `getConnectScreenErrorMessage` from `@automattic/jetpack-connection`'s package index.
* Uses that helper in the My Jetpack onboarding connection form (keyed off `registrationError.response?.code`) instead of rendering the raw error message, falling back to the existing generic "An error occurred. Please try again." for unmapped codes. The raw error is still reported to Tracks via the existing `jetpack_my_jetpack_onboarding_error` event, so debugging detail isn't lost.
* Adds unit tests for the helper and the `ConnectScreenAction` error rendering.

The existing connect screens (`ConnectScreen`, `ConnectScreenRequiredPlan`) already use this helper, so they pick up the new mappings automatically.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with the Jetpack plugin (or any My Jetpack-bundling plugin) that is not connected, make outbound requests to WordPress.com fail — e.g. add a filter that short-circuits the register request:
  ```php
  add_filter( 'pre_http_request', function ( $pre, $args, $url ) {
      if ( str_contains( $url, 'register' ) ) {
          return new WP_Error( 'http_request_failed', 'cURL error 28: Connection timed out after 10007 milliseconds' );
      }
      return $pre;
  }, 10, 3 );
  ```
* Go to the My Jetpack onboarding screen and click **Supercharge my site**.
* Before: the notice shows `cURL error 28: Connection timed out after 10007 milliseconds (Status 500)`.
* After: the notice shows "Your site could not reach WordPress.com. This is usually temporary — try again in a minute. If it keeps happening, ask your hosting provider to allow connections to jetpack.wordpress.com."
* Also verify the standalone plugin connect screens (e.g. Jetpack Backup's connect screen) show the same message under the same condition.
* JS tests: `pnpm run test components/connect-screen` in `projects/js-packages/connection`, and `pnpm run test` in `projects/packages/my-jetpack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
