### PR TITLE
Backup: answer a WordPress.com failure with an error, not an empty 200

### DIFF
--- a/projects/packages/backup/.phan/baseline.php
+++ b/projects/packages/backup/.phan/baseline.php
@@ -9,13 +9,12 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchReturnProbablyReal : 15+ occurrences
-    // PhanTypeMismatchReturn : 6 occurrences
-    // PhanUndeclaredStaticMethod : 2 occurrences
+    // PhanTypeMismatchReturnProbablyReal : 9 occurrences
+    // PhanTypeMismatchReturn : 2 occurrences
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
-        'src/class-jetpack-backup.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredStaticMethod'],
+        'src/class-jetpack-backup.php' => ['PhanTypeMismatchReturn'],
         'src/class-rest-controller.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/packages/backup/changelog/fix-backup-routes-report-failures
+++ b/projects/packages/backup/changelog/fix-backup-routes-report-failures
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Report a failed WordPress.com request as an error instead of an empty success, so the dashboard shows a failure notice rather than an empty backup list.

--- a/projects/packages/backup/changelog/fix-backup-routes-report-failures
+++ b/projects/packages/backup/changelog/fix-backup-routes-report-failures
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Report a failed WordPress.com request as an error instead of an empty success, so the dashboard shows a failure notice rather than an empty backup list.
+Report a failed WordPress.com request as an error instead of an empty success, and let the "Back up now" button recover when a backup could not be queued.

--- a/projects/packages/backup/changelog/fix-backup-routes-report-failures
+++ b/projects/packages/backup/changelog/fix-backup-routes-report-failures
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Report a failed WordPress.com request as an error instead of an empty success, and let the "Back up now" button recover when a backup could not be queued.
+Show a real failure message when your backup status cannot be read, instead of the "your first backup will be ready soon" screen, and let the "Back up now" button recover when a backup could not be queued.

--- a/projects/packages/backup/src/abilities/class-backup-abilities.php
+++ b/projects/packages/backup/src/abilities/class-backup-abilities.php
@@ -757,8 +757,9 @@ class Backup_Abilities extends Registrar {
 	/**
 	 * Normalize a Jetpack_Backup helper result (WP_REST_Response, array, null,
 	 * or WP_Error) to a plain value or null. Jetpack_Backup uses
-	 * `rest_ensure_response()` on success and returns null on http failure, so
-	 * abilities need both shapes flattened before summarising.
+	 * `rest_ensure_response()` on success; on failure its routes return a
+	 * WP_Error and `list_backup_events()` returns null, so abilities need
+	 * every shape flattened before summarising.
 	 *
 	 * @param mixed $maybe_response Result of a Jetpack_Backup helper call.
 	 * @return mixed

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -472,12 +472,39 @@ class Jetpack_Backup {
 	}
 
 	/**
+	 * The error a route answers with when its WordPress.com request did not come
+	 * back with a 200.
+	 *
+	 * Returning `null` instead — which these routes used to do — is served as an
+	 * HTTP 200 carrying a `null` body, so `apiFetch` resolves and nothing throws.
+	 * A WordPress.com blip then reaches the dashboard as an empty success, which
+	 * is how a paying customer ends up looking at the first-run screen. A
+	 * WP_Error makes the REST layer answer with a status, so every caller's
+	 * existing failure path runs.
+	 *
+	 * @param int $status The upstream response code, already cast to an int, or 0
+	 *                    when the request never reached WordPress.com.
+	 * @return WP_Error
+	 */
+	private static function get_failed_fetch_error( $status = 0 ) {
+		return new WP_Error(
+			'failed_to_fetch_data',
+			esc_html__( 'Unable to fetch the requested data.', 'jetpack-backup-pkg' ),
+			array(
+				// A transport failure has no status at all, and `status_header( 0 )`
+				// emits an invalid status line — so anything falsy becomes a 500.
+				'status' => $status ? $status : 500,
+			)
+		);
+	}
+
+	/**
 	 * Get information about recent backups
 	 *
 	 * @access public
 	 * @static
 	 *
-	 * @return array An array of recent backups
+	 * @return \WP_REST_Response|WP_Error The recent backups, or a WP_Error if WordPress.com could not be reached.
 	 */
 	public static function get_recent_backups() {
 		$blog_id = Jetpack_Options::get_option( 'id' );
@@ -490,8 +517,10 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return null;
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $response_code ) {
+			return self::get_failed_fetch_error( $response_code );
 		}
 
 		return rest_ensure_response(
@@ -543,7 +572,7 @@ class Jetpack_Backup {
 	 * @access public
 	 * @static
 	 *
-	 * @return array An array of capabilities
+	 * @return \WP_REST_Response|WP_Error The site capabilities, or a WP_Error if WordPress.com could not be reached.
 	 */
 	public static function get_backup_capabilities() {
 		$blog_id = Jetpack_Options::get_option( 'id' );
@@ -556,8 +585,10 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return null;
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $response_code ) {
+			return self::get_failed_fetch_error( $response_code );
 		}
 
 		return rest_ensure_response(
@@ -571,7 +602,7 @@ class Jetpack_Backup {
 	 * @access public
 	 * @static
 	 *
-	 * @return array An array of recent restores
+	 * @return \WP_REST_Response|WP_Error The recent restores, or a WP_Error if WordPress.com could not be reached.
 	 */
 	public static function get_recent_restores() {
 		$blog_id  = Jetpack_Options::get_option( 'id' );
@@ -583,8 +614,10 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return null;
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $response_code ) {
+			return self::get_failed_fetch_error( $response_code );
 		}
 
 		return rest_ensure_response(
@@ -733,7 +766,7 @@ class Jetpack_Backup {
 	/**
 	 * Returns the result of `/upgrades` endpoint call.
 	 *
-	 * @return array of site purchases.
+	 * @return \WP_REST_Response|WP_Error The site purchases, or a WP_Error if WordPress.com could not be reached.
 	 */
 	public static function get_site_current_purchases() {
 
@@ -778,7 +811,7 @@ class Jetpack_Backup {
 	/**
 	 * Get site storage size
 	 *
-	 * @return string|WP_Error A JSON object with the site storage size if the request was successful, or a WP_Error otherwise.
+	 * @return \WP_REST_Response|WP_Error The site storage size, or a WP_Error if WordPress.com could not be reached.
 	 */
 	public static function get_site_backup_size() {
 		$blog_id = Jetpack_Options::get_option( 'id' );
@@ -791,8 +824,10 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return null;
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $response_code ) {
+			return self::get_failed_fetch_error( $response_code );
 		}
 
 		return rest_ensure_response(
@@ -803,8 +838,7 @@ class Jetpack_Backup {
 	/**
 	 * Get site policies from WPCOM. It includes the storage limit and activity log limit, if apply.
 	 *
-	 * @return string|WP_Error A JSON object with the site storage policies if the request was successful,
-	 *                         or a WP_Error otherwise.
+	 * @return \WP_REST_Response|WP_Error The site storage policies, or a WP_Error if WordPress.com could not be reached.
 	 */
 	public static function get_site_backup_policies() {
 		$blog_id = Jetpack_Options::get_option( 'id' );
@@ -817,8 +851,10 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return null;
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $response_code ) {
+			return self::get_failed_fetch_error( $response_code );
 		}
 
 		return rest_ensure_response(
@@ -912,8 +948,7 @@ class Jetpack_Backup {
 	/**
 	 * Enqueue a new backup on demand
 	 *
-	 * @return string|WP_Error A JSON object with `success` if the request was successful,
-	 * or a WP_Error otherwise.
+	 * @return \WP_REST_Response|WP_Error The enqueue result, or a WP_Error if WordPress.com could not be reached.
 	 */
 	public static function enqueue_backup() {
 		$blog_id  = Jetpack_Options::get_option( 'id' );
@@ -929,8 +964,10 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return null;
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $response_code ) {
+			return self::get_failed_fetch_error( $response_code );
 		}
 
 		return rest_ensure_response(
@@ -941,7 +978,7 @@ class Jetpack_Backup {
 	/**
 	 * Get site backup schedule time
 	 *
-	 * @return string|WP_Error A JSON object with the backup schedule time if the request was successful, or a WP_Error otherwise.
+	 * @return \WP_REST_Response|WP_Error The backup schedule time, or a WP_Error if WordPress.com could not be reached.
 	 */
 	public static function get_site_backup_schedule_time() {
 		$blog_id = Jetpack_Options::get_option( 'id' );
@@ -954,8 +991,10 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return null;
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $response_code ) {
+			return self::get_failed_fetch_error( $response_code );
 		}
 
 		return rest_ensure_response(

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -778,8 +778,10 @@ class Jetpack_Backup {
 			return self::get_failed_fetch_error();
 		}
 
-		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
-			return self::get_failed_fetch_error();
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $response_code ) {
+			return self::get_failed_fetch_error( $response_code );
 		}
 
 		return rest_ensure_response(

--- a/projects/packages/backup/src/dashboard/components/query-error/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/query-error/index.tsx
@@ -8,9 +8,10 @@ type Props = {
 	title: string;
 	/**
 	 * The query's error, when there is one. Nullable because not every
-	 * failure produces one: a route that answers a non-200 with a bare
-	 * `null` body is served as HTTP 200, so the request resolves and the
-	 * caller's only evidence is its own derived state. Those callers still
+	 * failure produces one: a route that cannot decode WordPress.com's
+	 * answer still returns a bare `null` body served as HTTP 200, so the
+	 * request resolves and the caller's only evidence is its own derived
+	 * state. Those callers still
 	 * need to report the failure — they just have no detail line to add.
 	 */
 	error?: Error | null;

--- a/projects/packages/backup/src/dashboard/data/api/backups.ts
+++ b/projects/packages/backup/src/dashboard/data/api/backups.ts
@@ -32,10 +32,10 @@ export type RawBackupEntry = {
  * Fetch the site's ten most recent backup attempts.
  *
  * **`null` is a reachable, non-exceptional response.**
- * `Jetpack_Backup::get_recent_backups()` returns bare `null` on any
- * non-200 from WPCOM, which WordPress serves as HTTP 200 with a `null`
- * body — so `apiFetch` resolves rather than rejecting and no `ApiError`
- * is ever constructed. Callers must treat `null` as a failure to read
+ * `Jetpack_Backup::get_recent_backups()` returns bare `null` for a 200
+ * from WPCOM whose body will not decode, which WordPress serves as HTTP
+ * 200 with a `null` body — so `apiFetch` resolves rather than rejecting
+ * and no `ApiError` is ever constructed. Callers must treat `null` as a failure to read
  * the state, never as "this site has no backups": conflating the two
  * renders a WPCOM outage as the brand-new-customer screen.
  *
@@ -49,9 +49,9 @@ export async function fetchBackups(): Promise< RawBackupEntry[] | null > {
  * Response of `POST /jetpack/v4/site/backup/enqueue`.
  *
  * Two different failures are encoded in the body rather than the status
- * code: `null` for any non-200 WPCOM reply (same mechanism as
- * `fetchBackups`), and `{ success: false, error }` for a 200 that WPCOM
- * nonetheless refused. Only the second carries a reason.
+ * code: `null` for a WPCOM reply the route could not decode (same
+ * mechanism as `fetchBackups`), and `{ success: false, error }` for a
+ * 200 that WPCOM nonetheless refused. Only the second carries a reason.
  */
 export type EnqueueBackupResponse = {
 	success?: boolean;

--- a/projects/packages/backup/src/dashboard/data/api/policies.ts
+++ b/projects/packages/backup/src/dashboard/data/api/policies.ts
@@ -8,7 +8,7 @@ import { apiCall, apiPath } from './_helpers';
  * here worth reading, and it is genuinely nullable: a site whose plan
  * carries no retention policy answers `{ policies: null }` inside a 200.
  *
- * Like every legacy bridge, a non-200 upstream collapses to a bare
+ * An upstream answer the route cannot decode still collapses to a bare
  * `null` body served as HTTP 200 — so `null` at the top level means "we
  * could not read this", while `{ policies: null }` means "there is no
  * policy". Callers must not conflate the two with the storage limit

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -234,10 +234,10 @@ export async function fetchRestoreStatus( restoreId: number ): Promise< RestoreS
  * the one who started the restore.
  *
  * Used to recover a restore id that WPCOM accepted but did not return.
- * Note the route follows the legacy convention of answering a non-200
- * from WPCOM with a bare `null`, which WordPress serves as HTTP 200 — so
- * this resolves rather than rejecting, and the empty list it returns in
- * that case means "could not read", not "no restores".
+ * Note the route follows the legacy convention of answering a WPCOM
+ * reply it cannot decode with a bare `null`, which WordPress serves as
+ * HTTP 200 — so this resolves rather than rejecting, and the empty list
+ * it returns in that case means "could not read", not "no restores".
  *
  * Returns `null` — not an empty list — when the read failed, because the
  * two mean opposite things to a caller deciding whether it is safe to

--- a/projects/packages/backup/src/dashboard/data/api/site-size.ts
+++ b/projects/packages/backup/src/dashboard/data/api/site-size.ts
@@ -5,8 +5,8 @@ import { apiCall, apiPath } from './_helpers';
  *
  * WordPress.com's own envelope, forwarded verbatim: `ok` reports whether
  * WordPress.com itself could answer, so a 200 with `ok: false` carries no
- * usable figures. Like the other legacy routes, a non-200 upstream
- * collapses to a `null` body served with HTTP 200.
+ * usable figures. Like the other legacy routes, an upstream answer it
+ * cannot decode collapses to a `null` body served with HTTP 200.
  *
  * The fields below are the ones legacy reads (`src/js/actions/index.js`).
  * `storage_limit_bytes` is deliberately **not** among them: this response

--- a/projects/packages/backup/src/dashboard/data/api/test/restore.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/restore.test.ts
@@ -23,9 +23,9 @@ describe( 'fetchRecentRestores', () => {
 	}
 
 	test( 'distinguishes a failed read from an empty collection', async () => {
-		// The legacy route answers a non-200 from WordPress.com with a
-		// bare `null`, which WordPress then serves as HTTP 200 — so this
-		// resolves rather than rejecting. Returning `[]` for it would tell
+		// The legacy route answers a WordPress.com reply it cannot decode
+		// with a bare `null`, which WordPress then serves as HTTP 200 — so
+		// this resolves rather than rejecting. Returning `[]` for it would tell
 		// a caller deciding whether to start a destructive restore that
 		// nothing is running, which is the opposite of what it knows.
 		respondWith( null );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-backups.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-backups.test.ts
@@ -170,9 +170,9 @@ describe( 'useBackups', () => {
 	} );
 
 	// The regression this hook exists to avoid. `get_recent_backups()`
-	// returns bare `null` on any non-200 from WPCOM, which WordPress
-	// serves as HTTP 200 — so the request RESOLVES and no error is ever
-	// thrown. The legacy selector coerces that to `[]`, which reads as
+	// returns bare `null` for a 200 from WPCOM whose body will not
+	// decode, which WordPress serves as HTTP 200 — so the request
+	// RESOLVES and no error is ever thrown. The legacy selector coerces that to `[]`, which reads as
 	// "this site has no backups" and shows a paying customer the
 	// brand-new-site screen every time WPCOM has a bad minute.
 	it( 'reports a null body as an error rather than as an empty site', async () => {

--- a/projects/packages/backup/src/dashboard/hooks/test/use-enqueue-backup.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-enqueue-backup.test.ts
@@ -40,11 +40,11 @@ describe( 'useEnqueueBackup', () => {
 		);
 	} );
 
-	// `enqueue_backup()` returns bare `null` for every non-200 from WPCOM,
-	// which WordPress serves as HTTP 200 — so the request resolves and
-	// nothing throws. The legacy button has no rejection handler and
-	// discards the body, so it reports "Backup enqueued" and then polls
-	// for a backup that was never queued.
+	// `enqueue_backup()` returns bare `null` for a WPCOM reply it cannot
+	// decode, which WordPress serves as HTTP 200 — so the request
+	// resolves and nothing throws. The legacy button discards the body,
+	// so it still reports "Backup enqueued" and then polls for a backup
+	// that was never queued.
 	it( 'reports a null body as a failure, not a success', async () => {
 		mockedApiFetch.mockResolvedValue( null );
 		const { wrapper } = makeWrapper();

--- a/projects/packages/backup/src/dashboard/hooks/test/use-refresh-activity-on-backup-complete.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-refresh-activity-on-backup-complete.test.ts
@@ -53,8 +53,8 @@ describe( 'useRefreshActivityOnBackupComplete', () => {
 		expect( invalidate ).not.toHaveBeenCalled();
 	} );
 
-	// `useBackups`' most common failure mode — a non-200 from WPCOM
-	// served as HTTP 200 with a `null` body — lands here. There is no new
+	// A `useBackups` failure mode — a WPCOM reply the route could not
+	// decode, served as HTTP 200 with a `null` body — lands here. There is no new
 	// restore point to fetch, and `pollInterval()` deliberately stops
 	// polling rather than hammering an upstream that just failed.
 	it( 'does not refresh when a running backup drops to an error', () => {

--- a/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
@@ -1068,7 +1068,7 @@ describe( 'useRestore — a restore that starts after the screen loaded', () => 
 				return Promise.resolve( { id: 5, rewind_id: REWIND_ID } );
 			}
 			if ( ( options?.path ?? '' ).includes( '/restores' ) ) {
-				// The legacy route's non-200: a bare null, served as 200.
+				// The legacy route's undecodable body: a null, served as 200.
 				return Promise.resolve( null );
 			}
 			return Promise.resolve( statusPayload( { id: 5, status: 'running' } ) );

--- a/projects/packages/backup/src/dashboard/hooks/use-backups.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backups.ts
@@ -165,10 +165,10 @@ type Args = {
 type Result = BackupsSummary & {
 	backups: Backup[];
 	/**
-	 * The query's own failure. Note that the most common failure mode of
-	 * this route does *not* populate it: a non-200 from WPCOM is served
-	 * as HTTP 200 with a `null` body, which resolves. Branch on
-	 * `state === 'error'`, which covers both.
+	 * The query's own failure. Note that not every failure of this route
+	 * populates it: a 200 from WPCOM whose body will not decode reaches
+	 * the client as HTTP 200 with a `null` body, which resolves. Branch
+	 * on `state === 'error'`, which covers both.
 	 */
 	error: Error | null;
 	/**
@@ -215,8 +215,8 @@ export function useBackups( { forcePoll = false }: Args = {} ): Result {
 	// when it refetches after a *rejection*, so without this both `error`
 	// and the derived `'error'` state evaporate the moment the reader
 	// clicks the retry button — taking the only control that can ask
-	// again with them. The route's other failure mode, a `null` body
-	// served as HTTP 200, resolves and so is unaffected.
+	// again with them. The route's other failure mode, an undecodable
+	// body served as HTTP 200 with `null`, resolves and so is unaffected.
 	const error = useStickyError( query.error, query.isFetching );
 
 	const backups = useMemo(

--- a/projects/packages/backup/src/dashboard/hooks/use-enqueue-backup.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-enqueue-backup.ts
@@ -21,13 +21,15 @@ type Result = {
  * `POST /jetpack/v4/site/backup/enqueue` reports failure in three
  * different ways and only one of them is an HTTP error, so the success
  * path is validated rather than assumed. A rejected request (no
- * permission, network, expired nonce) throws. A non-200 from WPCOM is
- * flattened by PHP into HTTP 200 with a `null` body, which resolves.
- * And WPCOM can answer 200 with `{ success: false, error }`.
+ * permission, network, an unreachable WordPress.com, an expired nonce)
+ * throws. A 200 whose body will not decode is flattened by PHP into HTTP
+ * 200 with a `null` body, which resolves. And WPCOM can answer 200 with
+ * `{ success: false, error }`.
  *
- * The legacy button checks none of these — it has no rejection handler
- * and discards the body — so it reports "Backup enqueued" for every
- * outcome, then polls for a backup that will never arrive.
+ * The legacy button checks only the first — it clears its busy state on
+ * a rejection but discards the body — so it still reports "Backup
+ * enqueued" for the other two, then polls for a backup that will never
+ * arrive.
  *
  * @return Enqueue state and controls.
  */

--- a/projects/packages/backup/src/dashboard/hooks/use-refresh-activity-on-backup-complete.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-refresh-activity-on-backup-complete.ts
@@ -7,8 +7,8 @@ import type { BackupsState } from '../types/backup';
  * States that mean "the run that was going is over".
  *
  * `error` is deliberately absent. It is not an outcome of the backup but
- * of the *request* — and per `useBackups`, the most common failure of
- * `/jetpack/v4/backups` is a non-200 served as HTTP 200 with a `null`
+ * of the *request* — and per `useBackups`, a `/jetpack/v4/backups`
+ * answer whose body will not decode is served as HTTP 200 with a `null`
  * body, which lands exactly here. Refetching the activity log on it
  * would aim a round trip at an upstream that just failed, for an answer
  * that cannot contain the finished backup. `loading` is absent for the

--- a/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
@@ -49,8 +49,8 @@ type Result = Figures &
  * day-counts, and `/site/backup/policies` reports the limit. A meter
  * drawn from `/size` alone has no denominator.
  *
- * Both halves are read defensively for the same reason. A route that
- * cannot decode WordPress.com's answer still returns a bare `null` body,
+ * Both halves are read defensively for the same reason. Every legacy
+ * bridge answers a non-200 from WordPress.com with a bare `null` body,
  * which WordPress serves as HTTP 200 — so the request resolves, React
  * Query records a success, and the only evidence of failure is the shape
  * of the data. Anything unreadable therefore has to collapse to `null`

--- a/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
@@ -49,8 +49,8 @@ type Result = Figures &
  * day-counts, and `/site/backup/policies` reports the limit. A meter
  * drawn from `/size` alone has no denominator.
  *
- * Both halves are read defensively for the same reason. Every legacy
- * bridge answers a non-200 from WordPress.com with a bare `null` body,
+ * Both halves are read defensively for the same reason. A route that
+ * cannot decode WordPress.com's answer still returns a bare `null` body,
  * which WordPress serves as HTTP 200 — so the request resolves, React
  * Query records a success, and the only evidence of failure is the shape
  * of the data. Anything unreadable therefore has to collapse to `null`

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -143,11 +143,11 @@ export default function OverviewScreen() {
 			 * activity log managed to load is still worth showing, and this
 			 * failure says nothing about it.
 			 *
-			 * `error` is very often null on this path and that is not a bug.
-			 * The route answers a non-200 from WPCOM with a bare `null`
-			 * body, which WordPress serves as HTTP 200 — so the request
-			 * resolves, React Query records a success, and the only signal
-			 * left is the derived state. That is also why the retry button
+			 * `error` can be null on this path and that is not a bug. The
+			 * route answers a WPCOM reply it cannot decode with a bare
+			 * `null` body, which WordPress serves as HTTP 200 — so the
+			 * request resolves, React Query records a success, and the only
+			 * signal left is the derived state. That is also why the retry button
 			 * matters more here than elsewhere: nothing else will ask again.
 			 * The poll stops deliberately on an unreadable response rather
 			 * than hammering a failing upstream.

--- a/projects/packages/backup/src/js/components/Backups.jsx
+++ b/projects/packages/backup/src/js/components/Backups.jsx
@@ -3,6 +3,7 @@ import {
 	getRedirectUrl,
 	LoadingPlaceholder,
 } from '@automattic/jetpack-components';
+import { Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { getDate, dateI18n } from '@wordpress/date';
 import { createInterpolateElement, useCallback } from '@wordpress/element';
@@ -29,7 +30,8 @@ import NextScheduledBackup from './next-scheduled-backup';
 
 /* eslint react/react-in-jsx-scope: 0 */
 export const Backups = () => {
-	const { backupState, isInitialBackup, latestTime, progress, stats } = useBackupsState();
+	const { backupState, fetchBackupsState, isInitialBackup, latestTime, progress, stats } =
+		useBackupsState();
 
 	return (
 		<div className="jp-wrap jp-content backup-panel">
@@ -49,6 +51,39 @@ export const Backups = () => {
 				<CompleteBackup latestTime={ latestTime } stats={ stats } />
 			) }
 			{ BACKUP_STATE.NO_GOOD_BACKUPS === backupState && <NoGoodBackups /> }
+			{ BACKUP_STATE.FETCH_FAILED === backupState && <FetchFailed onRetry={ fetchBackupsState } /> }
+		</div>
+	);
+};
+
+/**
+ * The backup list could not be read.
+ *
+ * Deliberately not `NoGoodBackups`, which is the nearest-looking screen: that
+ * one tells the reader their backups are broken and to open a support ticket.
+ * A WordPress.com blip is usually neither, and sending every reader who hits
+ * one to support would be worse than the empty screen this replaces.
+ *
+ * Both strings here are already in this text domain — the heading from the
+ * modernized dashboard's `overview.tsx`, the button from its `QueryError` —
+ * so a new state costs no new translations.
+ *
+ * @param {object}   props         - Component props.
+ * @param {Function} props.onRetry - Refetches the backup list.
+ * @return {object} The rendered failure screen.
+ */
+const FetchFailed = ( { onRetry } ) => {
+	return (
+		<div className="jp-row">
+			<div className="lg-col-span-5 md-col-span-4 sm-col-span-4">
+				<img src={ CloudAlertIcon } alt="" />
+				<h1>{ __( "We couldn't check your site's backup status.", 'jetpack-backup-pkg' ) }</h1>
+				<Button variant="primary" onClick={ onRetry }>
+					{ __( 'Try again', 'jetpack-backup-pkg' ) }
+				</Button>
+			</div>
+			<div className="lg-col-span-1 md-col-span-4 sm-col-span-0"></div>
+			<div className="lg-col-span-6 md-col-span-2 sm-col-span-2"></div>
 		</div>
 	);
 };

--- a/projects/packages/backup/src/js/components/back-up-now/index.jsx
+++ b/projects/packages/backup/src/js/components/back-up-now/index.jsx
@@ -15,6 +15,7 @@ export const BackupNowButton = ( { children, tooltipText, tracksEventName, onCli
 	const [ currentTooltip, setCurrentTooltip ] = useState( tooltipText );
 	const [ isEnqueuing, setIsEnqueuing ] = useState( false );
 	const [ enqueued, setEnqueued ] = useState( false );
+	const [ enqueueFailed, setEnqueueFailed ] = useState( false );
 	const areBackupsStopped = useSelect( select => select( STORE_ID ).getBackupStoppedFlag() );
 	const { backupState, fetchBackupsState } = useBackupsState( enqueued );
 	const backupCurrentlyInProgress = backupState === BACKUP_STATE.IN_PROGRESS;
@@ -26,12 +27,22 @@ export const BackupNowButton = ( { children, tooltipText, tracksEventName, onCli
 			}
 
 			setIsEnqueuing( true );
+			setEnqueueFailed( false );
 
-			apiFetch( { method: 'POST', path: `/jetpack/v4/site/backup/enqueue` } ).then( () => {
-				setIsEnqueuing( false );
-				setEnqueued( true );
-				fetchBackupsState();
-			} );
+			apiFetch( { method: 'POST', path: `/jetpack/v4/site/backup/enqueue` } ).then(
+				() => {
+					setIsEnqueuing( false );
+					setEnqueued( true );
+					fetchBackupsState();
+				},
+				() => {
+					// The route reports an unreachable WordPress.com as an error rather
+					// than an empty success, so without this branch the click leaves the
+					// button busy for good, with no way to retry short of a page reload.
+					setIsEnqueuing( false );
+					setEnqueueFailed( true );
+				}
+			);
 
 			if ( onClick ) {
 				onClick( event );
@@ -67,6 +78,11 @@ export const BackupNowButton = ( { children, tooltipText, tracksEventName, onCli
 		} else if ( enqueued ) {
 			setButtonContent( statusLabels.QUEUED );
 			setCurrentTooltip( statusTooltipTexts.QUEUED );
+		} else if ( enqueueFailed ) {
+			setButtonContent( children );
+			setCurrentTooltip(
+				__( 'The backup could not be queued. Please try again.', 'jetpack-backup-pkg' )
+			);
 		} else {
 			setButtonContent( children );
 			setCurrentTooltip( tooltipText );
@@ -78,6 +94,7 @@ export const BackupNowButton = ( { children, tooltipText, tracksEventName, onCli
 		children,
 		areBackupsStopped,
 		isEnqueuing,
+		enqueueFailed,
 	] );
 
 	const button = (

--- a/projects/packages/backup/src/js/constants.js
+++ b/projects/packages/backup/src/js/constants.js
@@ -5,4 +5,10 @@ export const BACKUP_STATE = {
 	NO_BACKUPS_RETRY: 3,
 	NO_GOOD_BACKUPS: 4,
 	COMPLETE: 5,
+	// The backup list could not be read at all. Distinct from every state
+	// above, each of which asserts something about the site's backups:
+	// NO_BACKUPS says there are none yet, NO_BACKUPS_RETRY says one failed
+	// and will be retried, NO_GOOD_BACKUPS says they are broken and sends
+	// the reader to support. After a failed read we know none of that.
+	FETCH_FAILED: 6,
 };

--- a/projects/packages/backup/src/js/hooks/test/useBackupsState.js
+++ b/projects/packages/backup/src/js/hooks/test/useBackupsState.js
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { BACKUP_STATE } from '../../constants';
 import useBackupsState from '../useBackupsState';
@@ -138,6 +138,27 @@ jest.mock( '@wordpress/data', () => ( {
 describe( 'useBackupsState', () => {
 	let dispatchMock;
 
+	/**
+	 * Point `useSelect` at a store, defaulting to "loaded, not fetching, no
+	 * failure" so each test states only what it is actually about.
+	 *
+	 * @param {object} overrides - Selectors to replace.
+	 */
+	const mockStore = ( overrides = {} ) => {
+		useSelect.mockImplementation( selector => {
+			if ( typeof selector === 'function' ) {
+				return selector( () => ( {
+					getBackups: () => fixtures.no_backups,
+					isFetchingBackups: () => false,
+					hasLoadedBackups: () => true,
+					hasBackupsFetchFailed: () => false,
+					...overrides,
+				} ) );
+			}
+			return [];
+		} );
+	};
+
 	beforeEach( () => {
 		dispatchMock = {
 			getBackups: jest.fn(),
@@ -147,20 +168,11 @@ describe( 'useBackupsState', () => {
 
 	afterEach( () => {
 		jest.clearAllMocks();
+		jest.useRealTimers();
 	} );
 
 	it( 'backupState should be NO_BACKUPS when the site has no backups', async () => {
-		// Provide a mock implementation for useSelect
-		useSelect.mockImplementation( selector => {
-			if ( typeof selector === 'function' ) {
-				return selector( () => ( {
-					getBackups: () => fixtures.no_backups,
-					isFetchingBackups: () => false,
-					hasLoadedBackups: () => true,
-				} ) );
-			}
-			return [];
-		} );
+		mockStore( { getBackups: () => fixtures.no_backups } );
 
 		const { result } = renderHook( () => useBackupsState() );
 
@@ -170,16 +182,7 @@ describe( 'useBackupsState', () => {
 	} );
 
 	it( 'backupState should be NO_BACKUPS_RETRY when last backup has a retry state', async () => {
-		useSelect.mockImplementation( selector => {
-			if ( typeof selector === 'function' ) {
-				return selector( () => ( {
-					getBackups: () => fixtures.no_backups_retry,
-					isFetchingBackups: () => false,
-					hasLoadedBackups: () => true,
-				} ) );
-			}
-			return [];
-		} );
+		mockStore( { getBackups: () => fixtures.no_backups_retry } );
 
 		const { result } = renderHook( () => useBackupsState() );
 
@@ -189,16 +192,7 @@ describe( 'useBackupsState', () => {
 	} );
 
 	it( 'backupState should be COMPLETE when last backup has finished successfully', async () => {
-		useSelect.mockImplementation( selector => {
-			if ( typeof selector === 'function' ) {
-				return selector( () => ( {
-					getBackups: () => fixtures.complete,
-					isFetchingBackups: () => false,
-					hasLoadedBackups: () => true,
-				} ) );
-			}
-			return [];
-		} );
+		mockStore( { getBackups: () => fixtures.complete } );
 
 		const { result } = renderHook( () => useBackupsState() );
 
@@ -208,16 +202,7 @@ describe( 'useBackupsState', () => {
 	} );
 
 	it( 'backupState should be NO_GOOD_BACKUPS when last backup finished with no stats', async () => {
-		useSelect.mockImplementation( selector => {
-			if ( typeof selector === 'function' ) {
-				return selector( () => ( {
-					getBackups: () => fixtures.no_good_backups,
-					isFetchingBackups: () => false,
-					hasLoadedBackups: () => true,
-				} ) );
-			}
-			return [];
-		} );
+		mockStore( { getBackups: () => fixtures.no_good_backups } );
 
 		const { result } = renderHook( () => useBackupsState() );
 
@@ -227,16 +212,7 @@ describe( 'useBackupsState', () => {
 	} );
 
 	it( 'backupState should be NO_GOOD_BACKUPS when last backup finished as discarded', async () => {
-		useSelect.mockImplementation( selector => {
-			if ( typeof selector === 'function' ) {
-				return selector( () => ( {
-					getBackups: () => fixtures.discarded,
-					isFetchingBackups: () => false,
-					hasLoadedBackups: () => true,
-				} ) );
-			}
-			return [];
-		} );
+		mockStore( { getBackups: () => fixtures.discarded } );
 
 		const { result } = renderHook( () => useBackupsState() );
 
@@ -246,15 +222,39 @@ describe( 'useBackupsState', () => {
 	} );
 
 	it( 'backupState should be COMPLETE by selecting the latest non-discarded finished backup', async () => {
-		useSelect.mockImplementation( selector => {
-			if ( typeof selector === 'function' ) {
-				return selector( () => ( {
-					getBackups: () => fixtures.complete_and_discarded,
-					isFetchingBackups: () => false,
-					hasLoadedBackups: () => true,
-				} ) );
-			}
-			return [];
+		mockStore( { getBackups: () => fixtures.complete_and_discarded } );
+
+		const { result } = renderHook( () => useBackupsState() );
+
+		await waitFor( () => {
+			expect( result.current.backupState ).toBe( BACKUP_STATE.COMPLETE );
+		} );
+	} );
+
+	// The regression this state exists to prevent. An empty list and a failed
+	// read both arrive here as `backups: []` with `loaded: true`, so before
+	// the `fetchFailed` flag a WordPress.com blip reported NO_BACKUPS and a
+	// paying customer was shown the first-run "your first backup will be
+	// ready soon" screen.
+	it( 'backupState should be FETCH_FAILED when the read failed with nothing loaded', async () => {
+		mockStore( {
+			getBackups: () => fixtures.no_backups,
+			hasBackupsFetchFailed: () => true,
+		} );
+
+		const { result } = renderHook( () => useBackupsState() );
+
+		await waitFor( () => {
+			expect( result.current.backupState ).toBe( BACKUP_STATE.FETCH_FAILED );
+		} );
+	} );
+
+	// A blip on a poll tick must not throw away a screen that is already
+	// showing real backups. The error state is only for having nothing.
+	it( 'keeps reporting COMPLETE when a later read fails but a list is loaded', async () => {
+		mockStore( {
+			getBackups: () => fixtures.complete,
+			hasBackupsFetchFailed: () => true,
 		} );
 
 		const { result } = renderHook( () => useBackupsState() );
@@ -262,5 +262,38 @@ describe( 'useBackupsState', () => {
 		await waitFor( () => {
 			expect( result.current.backupState ).toBe( BACKUP_STATE.COMPLETE );
 		} );
+	} );
+
+	// The deliberate half of the poll decision: a failed read waits to be
+	// asked rather than retrying a failing WordPress.com once a second.
+	it( 'stops polling after a failed read', () => {
+		jest.useFakeTimers();
+		mockStore( {
+			getBackups: () => fixtures.no_backups,
+			hasBackupsFetchFailed: () => true,
+		} );
+
+		renderHook( () => useBackupsState() );
+
+		act( () => {
+			jest.advanceTimersByTime( 10000 );
+		} );
+
+		expect( dispatchMock.getBackups ).not.toHaveBeenCalled();
+	} );
+
+	// The control for the test above: without it, that one would pass even if
+	// the hook had stopped polling entirely.
+	it( 'keeps polling while the site is waiting for its first backup', () => {
+		jest.useFakeTimers();
+		mockStore( { getBackups: () => fixtures.no_backups } );
+
+		renderHook( () => useBackupsState() );
+
+		act( () => {
+			jest.advanceTimersByTime( 10000 );
+		} );
+
+		expect( dispatchMock.getBackups ).toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/backup/src/js/hooks/useBackupsState.js
+++ b/projects/packages/backup/src/js/hooks/useBackupsState.js
@@ -22,6 +22,7 @@ const useBackupsState = ( shouldPoll = false ) => {
 	const backups = useSelect( select => select( STORE_ID ).getBackups() );
 	const isFetching = useSelect( select => select( STORE_ID ).isFetchingBackups() );
 	const hasLoaded = useSelect( select => select( STORE_ID ).hasLoadedBackups() );
+	const fetchFailed = useSelect( select => select( STORE_ID ).hasBackupsFetchFailed() );
 	const fetchBackupsState = useCallback( () => {
 		if ( ! isFetching ) {
 			dispatch.getBackups();
@@ -46,9 +47,18 @@ const useBackupsState = ( shouldPoll = false ) => {
 
 		let latestBackup = null;
 
+		// Nothing loaded and the last read failed. Worth its own state: an
+		// empty list means "this site has no backups yet", and a failed read
+		// means we do not know — but both arrive here as an empty `backups`,
+		// which is why a WordPress.com blip used to show a paying customer
+		// the first-run screen.
+		const readFailed = hasLoaded && fetchFailed && backups.length === 0;
+
 		// If we have no backups don't load up stats.
 		if ( hasLoaded ) {
-			if ( backups.length === 0 ) {
+			if ( readFailed ) {
+				setBackupState( BACKUP_STATE.FETCH_FAILED );
+			} else if ( backups.length === 0 ) {
 				setBackupState( BACKUP_STATE.NO_BACKUPS );
 			} else if ( backups.length === 1 && 'error-will-retry' === backups[ 0 ].status ) {
 				setBackupState( BACKUP_STATE.NO_BACKUPS_RETRY );
@@ -97,11 +107,24 @@ const useBackupsState = ( shouldPoll = false ) => {
 			}
 		}
 
-		// Repeat query for NO_BACKUPS (before first) and IN_PROGRESS
+		// Repeat query for NO_BACKUPS (before first) and IN_PROGRESS.
+		//
+		// A failed read is deliberately excluded. This fires once a second,
+		// and an empty list is one of its trigger conditions, so retrying
+		// through an outage would put a signed WordPress.com request on the
+		// wire every second for as long as the tab stays open — filling the
+		// site's own error log on the way. The modernized dashboard already
+		// settled this the same way (`pollInterval()` in
+		// `dashboard/hooks/use-backups.ts` returns false and "waits to be
+		// asked"), which is what the error state's Try again button is for.
+		// Note this only stops the poll when nothing is loaded: a tick that
+		// fails against an in-progress backup still has a list on screen to
+		// keep refreshing.
 		if (
-			shouldPoll ||
-			backups.length === 0 ||
-			( latestBackup && 'started' === latestBackup.status )
+			! readFailed &&
+			( shouldPoll ||
+				backups.length === 0 ||
+				( latestBackup && 'started' === latestBackup.status ) )
 		) {
 			fetchIntervalRef.current = setInterval( fetchBackupsState, progressInterval );
 		} else {
@@ -114,6 +137,7 @@ const useBackupsState = ( shouldPoll = false ) => {
 		backups,
 		clearFetchInterval,
 		fetchBackupsState,
+		fetchFailed,
 		hasLoaded,
 		isFetching,
 		progressInterval,

--- a/projects/packages/backup/src/js/reducers/site-backups.js
+++ b/projects/packages/backup/src/js/reducers/site-backups.js
@@ -8,6 +8,7 @@ const initialState = {
 	isFetching: false,
 	loaded: false,
 	backups: [],
+	fetchFailed: false,
 };
 
 const siteBackups = ( state = initialState, action ) => {
@@ -26,13 +27,20 @@ const siteBackups = ( state = initialState, action ) => {
 				isFetching: false,
 				loaded: true,
 				backups: action.payload,
+				fetchFailed: false,
 			};
 		}
 		case SITE_BACKUPS_GET_FAILED: {
+			// `backups` is deliberately left alone. A poll tick that fails
+			// against a site that already loaded its list should not blank the
+			// screen — the list on it is still the last thing WordPress.com
+			// actually said. Only a failure with nothing loaded is reported to
+			// the reader, which `useBackupsState` decides.
 			return {
 				...state,
 				isFetching: false,
 				loaded: true,
+				fetchFailed: true,
 			};
 		}
 		default:

--- a/projects/packages/backup/src/js/reducers/test/site-backups.js
+++ b/projects/packages/backup/src/js/reducers/test/site-backups.js
@@ -12,16 +12,21 @@ describe( 'reducer', () => {
 			isFetching: false,
 			loaded: false,
 			backups: [],
+			fetchFailed: false,
 		},
 		fetchingState: {
 			isFetching: true,
 			loaded: false,
 			backups: [],
+			fetchFailed: false,
 		},
+		// The flag the dashboard reads to tell "this site has no backups"
+		// apart from "we could not find out". Both leave `backups` empty.
 		failedState: {
 			isFetching: false,
 			loaded: true,
 			backups: [],
+			fetchFailed: true,
 		},
 	};
 
@@ -70,6 +75,7 @@ describe( 'reducer', () => {
 				expected: {
 					isFetching: false,
 					loaded: true,
+					fetchFailed: false,
 					backups: [
 						{
 							id: '588085172',
@@ -106,6 +112,32 @@ describe( 'reducer', () => {
 			},
 		] )( 'should return expected state', ( { state, action, expected } ) => {
 			expect( siteBackups( state, action ) ).toEqual( expected );
+		} );
+
+		// A poll tick that fails against a site that already loaded its list
+		// must not blank the screen: what is on it is still the last thing
+		// WordPress.com actually said.
+		it( 'keeps an already-loaded list when a later read fails', () => {
+			const loaded = siteBackups( fixtures.initialState, {
+				type: SITE_BACKUPS_GET_SUCCESS,
+				payload: [ { id: '588003950', status: 'finished', discarded: '0' } ],
+			} );
+
+			const afterFailure = siteBackups( loaded, { type: SITE_BACKUPS_GET_FAILED } );
+
+			expect( afterFailure.backups ).toEqual( loaded.backups );
+			expect( afterFailure.fetchFailed ).toBe( true );
+		} );
+
+		it( 'clears the failure once a read succeeds again', () => {
+			const failed = siteBackups( fixtures.initialState, { type: SITE_BACKUPS_GET_FAILED } );
+
+			const recovered = siteBackups( failed, {
+				type: SITE_BACKUPS_GET_SUCCESS,
+				payload: [ { id: '588003950', status: 'finished', discarded: '0' } ],
+			} );
+
+			expect( recovered.fetchFailed ).toBe( false );
 		} );
 	} );
 } );

--- a/projects/packages/backup/src/js/selectors/site-backup.js
+++ b/projects/packages/backup/src/js/selectors/site-backup.js
@@ -24,6 +24,10 @@ const siteBackupSelectors = {
 	getBackups: state => state.siteBackups.backups ?? [],
 	hasLoadedBackups: state => state.siteBackups.loaded,
 	isFetchingBackups: state => state.siteBackups.isFetching,
+	// Whether the last read failed. `getBackups` floors a missing list to
+	// `[]`, so without this a failed read is indistinguishable from a site
+	// that genuinely has no backups yet.
+	hasBackupsFetchFailed: state => state.siteBackups.fetchFailed ?? false,
 };
 
 export default siteBackupSelectors;

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -46,16 +46,24 @@ class Jetpack_Backup_Test extends TestCase {
 	private $wpcom_status = 200;
 
 	/**
+	 * How many times a route reached the mocked transport.
+	 *
+	 * @var int
+	 */
+	private $http_requests = 0;
+
+	/**
 	 * Undo the request mocking. Done here rather than after each assertion so
 	 * that a failing assertion cannot leak a filter into the next test.
 	 */
 	protected function tearDown(): void {
 		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
-		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_unreachable' ) );
 		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ) );
 		wp_set_current_user( 0 );
 
-		$this->wpcom_status = 200;
+		$this->wpcom_status  = 200;
+		$this->http_requests = 0;
 
 		parent::tearDown();
 	}
@@ -115,16 +123,22 @@ class Jetpack_Backup_Test extends TestCase {
 	 * A transport failure has no status at all. Reporting the 0 that casting
 	 * produces would leave the REST layer emitting an invalid status line.
 	 *
+	 * The request count is asserted because a 500 alone proves nothing here: a
+	 * request that is never signed is refused before the wire and reports a
+	 * status of 0 too, so this would pass with neither the sign-in nor the
+	 * transport mock in place.
+	 *
 	 * @param string $callback Name of the route callback.
 	 * @dataProvider provide_wpcom_backed_route_callbacks
 	 */
 	#[DataProvider( 'provide_wpcom_backed_route_callbacks' )]
 	public function test_route_reports_a_transport_failure_as_500( $callback ) {
 		$this->sign_in_as_connected_admin();
-		add_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_unreachable' ) );
 
 		$result = call_user_func( array( Jetpack_Backup::class, $callback ) );
 
+		$this->assertSame( 1, $this->http_requests, $callback );
 		$this->assertInstanceOf( WP_Error::class, $result, $callback );
 		$this->assertSame( 500, $result->get_error_data()['status'], $callback );
 	}
@@ -450,10 +464,26 @@ class Jetpack_Backup_Test extends TestCase {
 	 * @return array
 	 */
 	public function mock_wpcom_response() {
+		++$this->http_requests;
+
 		return array(
 			'response' => array( 'code' => $this->wpcom_status ),
 			'body'     => '{}',
 		);
+	}
+
+	/**
+	 * Mock a request that leaves this site but never reaches WordPress.com.
+	 *
+	 * Kept separate from `mock_request_as_wp_error()` so the route tests can
+	 * count how far the request got.
+	 *
+	 * @return WP_Error
+	 */
+	public function mock_wpcom_unreachable() {
+		++$this->http_requests;
+
+		return new WP_Error( 'http_request_failed', 'The request failed.' );
 	}
 
 	/**

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -7,9 +7,11 @@
 
 namespace Automattic\Jetpack\Backup\V0005;
 
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WP_Error;
+use WP_REST_Request;
 use WP_REST_Response;
 
 class Jetpack_Backup_Test extends TestCase {
@@ -36,34 +38,168 @@ class Jetpack_Backup_Test extends TestCase {
 	 */
 	private $catalogue_status = 200;
 
-	public function test_get_backup_capabilities_handles_wp_error() {
-		add_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+	/**
+	 * Status for the next mocked WordPress.com response.
+	 *
+	 * @var int|string
+	 */
+	private $wpcom_status = 200;
 
-		$result = Jetpack_Backup::get_backup_capabilities();
-
-		$this->assertNull( $result );
-
+	/**
+	 * Undo the request mocking. Done here rather than after each assertion so
+	 * that a failing assertion cannot leak a filter into the next test.
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
 		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ) );
+		wp_set_current_user( 0 );
+
+		$this->wpcom_status = 200;
+
+		parent::tearDown();
 	}
 
-	public function test_get_recent_backups_handles_wp_error() {
-		add_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+	/**
+	 * A WordPress.com blip must not read as an empty success. These routes used
+	 * to `return null`, which WordPress serves as HTTP 200 with a `null` body —
+	 * so `apiFetch` resolved and no consumer's failure path ever ran.
+	 *
+	 * Asserted through the REST server rather than against the callback's return
+	 * value, because the served status is the thing that was wrong.
+	 *
+	 * 503 and not 500: 500 is also what the no-status fallback produces, so
+	 * asserting it here would pass whether or not the upstream status was
+	 * forwarded at all.
+	 *
+	 * @param string $route       The registered REST route.
+	 * @param string $http_method The route's HTTP method.
+	 * @dataProvider provide_wpcom_backed_route_requests
+	 */
+	#[DataProvider( 'provide_wpcom_backed_route_requests' )]
+	public function test_route_is_served_with_the_upstream_status( $route, $http_method ) {
+		$this->sign_in_as_connected_admin();
+		$this->wpcom_status = 503;
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
 
-		$result = Jetpack_Backup::get_recent_backups();
+		rest_get_server();
+		Jetpack_Backup::register_rest_routes();
 
-		$this->assertNull( $result );
+		$response = rest_do_request( new WP_REST_Request( $http_method, $route ) );
 
-		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+		$this->assertTrue( $response->is_error(), $route );
+		$this->assertSame( 503, $response->get_status(), $route );
 	}
 
-	public function test_get_recent_restores_handles_wp_error() {
+	/**
+	 * The callback reports the upstream status, so the REST layer has something
+	 * to serve other than a generic 500.
+	 *
+	 * @param string $callback Name of the route callback.
+	 * @dataProvider provide_wpcom_backed_route_callbacks
+	 */
+	#[DataProvider( 'provide_wpcom_backed_route_callbacks' )]
+	public function test_route_forwards_a_non_200( $callback ) {
+		$this->sign_in_as_connected_admin();
+		$this->wpcom_status = 503;
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
+
+		$result = call_user_func( array( Jetpack_Backup::class, $callback ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result, $callback );
+		$this->assertSame( 'failed_to_fetch_data', $result->get_error_code(), $callback );
+		$this->assertSame( 503, $result->get_error_data()['status'], $callback );
+	}
+
+	/**
+	 * A transport failure has no status at all. Reporting the 0 that casting
+	 * produces would leave the REST layer emitting an invalid status line.
+	 *
+	 * @param string $callback Name of the route callback.
+	 * @dataProvider provide_wpcom_backed_route_callbacks
+	 */
+	#[DataProvider( 'provide_wpcom_backed_route_callbacks' )]
+	public function test_route_reports_a_transport_failure_as_500( $callback ) {
+		$this->sign_in_as_connected_admin();
 		add_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
 
-		$result = Jetpack_Backup::get_recent_restores();
+		$result = call_user_func( array( Jetpack_Backup::class, $callback ) );
 
-		$this->assertNull( $result );
+		$this->assertInstanceOf( WP_Error::class, $result, $callback );
+		$this->assertSame( 500, $result->get_error_data()['status'], $callback );
+	}
 
-		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_wp_error' ) );
+	/**
+	 * A good answer still comes back as a response.
+	 *
+	 * The status is mocked as the *string* `'200'` deliberately: the transport
+	 * may report it that way, and a strict comparison against the integer 200
+	 * would send a perfectly good answer down the failure path.
+	 *
+	 * @param string $callback Name of the route callback.
+	 * @dataProvider provide_wpcom_backed_route_callbacks
+	 */
+	#[DataProvider( 'provide_wpcom_backed_route_callbacks' )]
+	public function test_route_returns_a_response_on_a_string_status_200( $callback ) {
+		$this->sign_in_as_connected_admin();
+		$this->wpcom_status = '200';
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
+
+		$result = call_user_func( array( Jetpack_Backup::class, $callback ) );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result, $callback );
+		$this->assertSame( array(), $result->get_data(), $callback );
+	}
+
+	/**
+	 * The seven unconditionally-registered routes that answer out of
+	 * WordPress.com, as route path => array( callback, HTTP method ).
+	 *
+	 * One list, two providers, so that adding a route here covers it
+	 * everywhere.
+	 *
+	 * @return array[]
+	 */
+	private static function wpcom_backed_routes() {
+		return array(
+			'/jetpack/v4/backups'              => array( 'get_recent_backups', 'GET' ),
+			'/jetpack/v4/backup-capabilities'  => array( 'get_backup_capabilities', 'GET' ),
+			'/jetpack/v4/restores'             => array( 'get_recent_restores', 'GET' ),
+			'/jetpack/v4/site/backup/size'     => array( 'get_site_backup_size', 'GET' ),
+			'/jetpack/v4/site/backup/policies' => array( 'get_site_backup_policies', 'GET' ),
+			'/jetpack/v4/site/backup/enqueue'  => array( 'enqueue_backup', 'POST' ),
+			'/jetpack/v4/site/backup/schedule' => array( 'get_site_backup_schedule_time', 'GET' ),
+		);
+	}
+
+	/**
+	 * The route callbacks, keyed by route so a failure names the endpoint.
+	 *
+	 * @return array[]
+	 */
+	public static function provide_wpcom_backed_route_callbacks() {
+		$sets = array();
+
+		foreach ( self::wpcom_backed_routes() as $route => $spec ) {
+			$sets[ $route ] = array( $spec[0] );
+		}
+
+		return $sets;
+	}
+
+	/**
+	 * The same routes as REST requests: route path and HTTP method.
+	 *
+	 * @return array[]
+	 */
+	public static function provide_wpcom_backed_route_requests() {
+		$sets = array();
+
+		foreach ( self::wpcom_backed_routes() as $route => $spec ) {
+			$sets[ $route ] = array( $route, $spec[1] );
+		}
+
+		return $sets;
 	}
 
 	public function test_list_backup_events_returns_null_on_wp_error() {
@@ -269,6 +405,54 @@ class Jetpack_Backup_Test extends TestCase {
 		return array(
 			'response' => array( 'code' => $this->catalogue_status ),
 			'body'     => $body,
+		);
+	}
+
+	/**
+	 * Sign in an administrator and mock the connection tokens, so that both the
+	 * as-blog and as-user wpcom requests are signed and actually reach the
+	 * `pre_http_request` mock rather than being refused before the wire.
+	 *
+	 * WorDBless does not reset the database between tests in this class, so the
+	 * user is created once and reused.
+	 */
+	private function sign_in_as_connected_admin() {
+		// `Client::validate_args_for_wpcom_json_api_request()` reads
+		// `JETPACK__WPCOM_JSON_API_BASE` before `build_signed_request()` installs
+		// the filter that supplies its default, so without this the first signed
+		// request of the process is built against a host-less URL and refused
+		// before the wire — making these tests depend on execution order. Plugins
+		// prime the constants at bootstrap; tests have to do it themselves.
+		Connection_Utils::init_default_constants();
+
+		$user = get_user_by( 'login', 'backup_routes_admin' );
+
+		if ( $user ) {
+			$user_id = $user->ID;
+		} else {
+			$user_id = wp_insert_user(
+				array(
+					'user_login' => 'backup_routes_admin',
+					'user_pass'  => 'pass',
+					'role'       => 'administrator',
+				)
+			);
+		}
+
+		wp_set_current_user( $user_id );
+		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10, 2 );
+	}
+
+	/**
+	 * Mock a WordPress.com request with the configured status and an empty JSON
+	 * object, so the status is the only thing under test.
+	 *
+	 * @return array
+	 */
+	public function mock_wpcom_response() {
+		return array(
+			'response' => array( 'code' => $this->wpcom_status ),
+			'body'     => '{}',
 		);
 	}
 

--- a/projects/plugins/backup/changelog/fix-backup-routes-report-failures
+++ b/projects/plugins/backup/changelog/fix-backup-routes-report-failures
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show a failure message when your backup status cannot be read, rather than the screen that says your first backup is on its way, and let the "Back up now" button recover when a backup could not be queued.

--- a/projects/plugins/jetpack/changelog/fix-backup-routes-report-failures
+++ b/projects/plugins/jetpack/changelog/fix-backup-routes-report-failures
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Backup: show a failure message when your backup status cannot be read, rather than the screen that says your first backup is on its way, and let the "Back up now" button recover when a backup could not be queued.


### PR DESCRIPTION
Fixes JETPACK-2325

## Proposed changes

Seven unconditionally-registered legacy Backup routes returned `null` when WordPress.com answered non-200. WordPress serves that as **HTTP 200 with a `null` body**, so `apiFetch` resolves and nothing throws — a failure is indistinguishable from an empty success.

* `/jetpack/v4/backups`, `/backup-capabilities`, `/restores`, `/site/backup/size`, `/site/backup/policies`, `/site/backup/enqueue` and `/site/backup/schedule` now return a `WP_Error` carrying the upstream status.
* Follows the shape `get_backup_promoted_product_info()` was hardened into last week: the response code is cast, so a numeric-string `'200'` is no longer read as a failure, and a status of `0` (a transport failure, which has no status at all) never reaches `status_header()` — it becomes a 500.
* The shared helper is named `get_failed_fetch_error()`, which `get_site_current_purchases()` **already called but nothing defined**. That call was a fatal on any failure. Defining the helper fixes it, and its non-200 branch now forwards the status it already had in hand instead of flattening a 403 to a 500.
* Docblocks on the touched methods updated — several claimed `@return array` or `@return string` while returning a `WP_REST_Response`.
* **The legacy dashboard now has a state for "we could not read your backups"** — a new `BACKUP_STATE.FETCH_FAILED`, plumbed through the reducer, a selector and `useBackupsState`. Without it the PHP change alone would not have fixed the reported symptom (see below).
* `src/js/components/back-up-now/index.jsx` gets the rejection handler it never had (see below).
* Fifteen comments across `src/dashboard/` and `src/abilities/` corrected: they described the PHP contract as "a non-200 is served as HTTP 200 with a `null` body", which is no longer the cause. A sixteenth, in `src/dashboard/hooks/use-storage-usage.ts`, is deliberately left alone — #51627 is restructuring that file and carries the corrected wording, so correcting it here too would only conflict. Until #51627 lands, `grep -rn "non-200" projects/packages/backup/src` returns that one hit.
* `.phan/baseline.php` shrinks: defining the missing helper retires `PhanUndeclaredStaticMethod` and the docblock corrections retire `PhanTypeMismatchReturnProbablyReal` for this file.

### Fixing the reported symptom on the dashboard that ships

The PHP change alone would **not** have fixed JETPACK-2325's headline symptom. Traced through `src/js`: `SITE_BACKUPS_GET_SUCCESS` with a `null` payload floors to `[]` at `selectors/site-backup.js` (`state.siteBackups.backups ?? []`), and `SITE_BACKUPS_GET_FAILED` left `backups` at its initial `[]`. Both set `loaded: true`, both reached `BACKUP_STATE.NO_BACKUPS`, and both rendered `<InProgressBackup />` — the "your first cloud backup will be ready soon" screen. The legacy dashboard could not tell *"this site has no backups yet"* from *"we could not find out"*.

Per @dhasilva, this PR opens an exception and fixes the legacy tree too rather than leaving the symptom in production. The reducer now records `fetchFailed`, `hasBackupsFetchFailed` exposes it, and `useBackupsState` forks into a new `BACKUP_STATE.FETCH_FAILED` that `Backups.jsx` renders as a heading plus a Try again button.

**A new state, but the failure screen adds no new translatable strings.** Its heading is the one the modernized dashboard already uses in `overview.tsx` ("We couldn't check your site's backup status.") and its button is `QueryError`'s "Try again" — both already in `jetpack-backup-pkg`, verified as exact matches, so the screen costs nothing to translate. **The branch as a whole does add one new msgid**, from the enqueue fix below: `'The backup could not be queued. Please try again.'` — that one is genuinely new, confirmed absent from trunk. So the translation cost of this PR is one string, not zero. It is deliberately *not* `NO_GOOD_BACKUPS`, the nearest-looking existing state: that one tells the reader their backups are broken and to contact support, and pointing everyone who hits a 30-second blip at support would be worse than the screen it replaces.

Two behaviours worth reviewing:

* **The 1 Hz poll stops on a failed read.** An empty list is one of its trigger conditions, so retrying through an outage would put a signed WordPress.com request on the wire every second for as long as the tab stays open. The modernized dashboard already settled this the same way — `pollInterval()` returns `false` and "waits to be asked" — which is what the Try again button is for. It only stops when nothing is loaded: a tick that fails against an in-progress backup still has a list on screen to keep refreshing.
* **A failure with a list already loaded keeps the list.** The reducer leaves `backups` alone on failure and the hook's `readFailed` requires an empty list, so a poll tick that fails mid-session does not blank a screen showing real backups. The error state is for having nothing *and* failing.

Per route:

| Route | Legacy consumer | Today, on a wpcom failure | After | Visible? |
| -- | -- | -- | -- | -- |
| `/backups` | `actions/index.js` `getBackups` → `useBackupsState` | `_SUCCESS` with `backups: null` → floors to `[]` → `NO_BACKUPS` → the first-run "your first cloud backup will be ready soon" screen | `_GET_FAILED` → `fetchFailed` → `FETCH_FAILED` → "We couldn't check your site's backup status." with a Try again button | **yes** — this is the reported symptom |
| `/backup-capabilities` | `hooks/useCapabilities.js` | `res.capabilities` throws a TypeError inside the success handler — the sibling `onRejected` does not catch it, so `capabilitiesLoaded` never flips and `Admin/index.jsx` renders `<BackupsLoadingPlaceholder />` forever | the existing `fetch_capabilities_failed` branch: "Failed to fetch site capabilities" | **yes** — permanent skeleton becomes an error message |
| `/restores` | `Admin/index.jsx` `useRestores` | `setRestores( null )`, then `ReviewMessage` evaluates `restores[ 0 ]` during render and throws | `setRestores( [] )`, the existing branch | **yes** — a thrown TypeError becomes nothing |
| `/site/backup/enqueue` | `components/back-up-now/index.jsx` | `.then()` with no `onRejected`: reports "Backup enqueued" for a backup that was never enqueued | clears the busy state, offers a retry, and says the backup could not be queued | **yes**, via the fix in this PR |
| `/site/backup/size` | `actions/index.js` `getSiteSize` | `! res.ok` throws the same way, so `_GET_FAILED` never dispatches and the store stays `{ isFetching: true, loaded: false }` — wedged, and `BackupStorageSpace` will not re-ask | `_GET_FAILED`; the meter is hidden either way (`storageSize !== null && storageLimit > 0`) | no — but the store is no longer stuck mid-fetch |
| `/site/backup/policies` | `actions/index.js` `getSitePolicies` | `res.policies?.…` throws the same way (the `?.` guards `policies`, not `res`) | as above | no — same |
| `/site/backup/schedule` | `use-scheduled-time-query.ts` | `select` throws, react-query reports an error, `hasLoaded` stays false → permanent placeholder | query rejects, same permanent placeholder | no |

So: four routes improve visibly — including the one the issue is about — two stop wedging their store, and one is unchanged.

### The enqueue button

`components/back-up-now/index.jsx` had no `onRejected` at all. Once the route starts rejecting, the click would leave `isEnqueuing` true forever — a permanently busy button with no way back short of a page reload. It now clears the busy state and surfaces the failure in the tooltip, so the click is retryable. This is also the first time that failure is reported to the user at all rather than dressed up as "Backup enqueued" — and it is the one new translatable string this branch adds: `'The backup could not be queued. Please try again.'`.

### Out of scope by design

* `list_backup_events()` still returns `null` on a non-200 — because it is a helper, not a route. (The earlier claim that `unwrap_response()` forced this was wrong: it maps `WP_Error` and `null` identically, so converting it would have been safe. The reason is simply that it is not a route.)
* Consumer-side null guards (`use-site-size.ts`'s `data?.ok`, `fetchBackups`' `null` handling, and the rest) are left alone. They are **still load-bearing, for a narrower reason**: only the cause changed. A 200 carrying a body that will not decode still passes through `rest_ensure_response()` as `null`. Do not delete them in the cleanup pass.
* `src/abilities/class-backup-abilities.php:493-497` and `:544-548` flatten an outage into an empty list, so an agent calling `list-backups` during a WordPress.com outage is told the site has no backups — the same defect this PR exists to remove, one surface over. Noted, not fixed here.

## Related product discussion/links

* JETPACK-2325 (split out of JETPACK-2309; was I4 on JETPACK-2243)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

```
jp test php packages/backup     # 259 tests, 715 assertions
jp test js packages/backup      # 51 suites, 463 tests
jp phan packages/backup         # exit 0, baseline stable
vendor/bin/phpcs -s projects/packages/backup/src/class-jetpack-backup.php projects/packages/backup/tests/php/Jetpack_Backup_Test.php projects/packages/backup/src/abilities/class-backup-abilities.php
```

`tests/php/Jetpack_Backup_Test.php` drives all seven routes through four cases each (28 tests):

* `test_route_is_served_with_the_upstream_status` dispatches each route through the REST server and asserts the **served** status, because the served status is what was wrong. 503 rather than 500 deliberately: 500 is also the no-status fallback, so asserting it would pass whether or not the upstream status was forwarded.
* `test_route_forwards_a_non_200` asserts the callback's `WP_Error` code and status.
* `test_route_reports_a_transport_failure_as_500` asserts a request that never reached WordPress.com does not report a status of 0 — **and that the mocked transport was actually reached**, because a request that is never signed is refused before the wire and reports 0 too, so the status assertion alone passed with neither the sign-in nor the mock in place.
* `test_route_returns_a_response_on_a_string_status_200` mocks the status as the string `'200'`, covering the cast.

Every assertion is mutation-tested: reverting to `return null` fails 21, dropping the zero-guard fails 7, dropping the cast fails 7, hard-coding the status to 500 fails 14, and removing the sign-in from the transport test fails all 7.

On the JS side, `src/js/reducers/test/site-backups.js` and `src/js/hooks/test/useBackupsState.js` gain six tests covering the new flag and state. Mutation-tested the same way, each killed by a distinct test: never setting `FETCH_FAILED` fails 1, dropping `fetchFailed` from the reducer fails 2, blanking `backups` on failure fails 1, removing the poll guard fails 1, and letting `readFailed` ignore whether a list is loaded fails 1.

By hand on a connected site, filter `pre_http_request` to return a 503 for `public-api.wordpress.com` and load **Jetpack → Backup**:

* Before: the first-run "your first cloud backup will be ready soon" screen, as though the site were brand new. After: "We couldn't check your site's backup status." with a Try again button. Drop the filter and click it — the real dashboard comes back without a reload.
* Before: a permanent loading skeleton (capabilities never resolve). After: "Failed to fetch site capabilities".
* Click **Back up now**. Before: the button claims "Backup enqueued" and polls forever. After: it stops being busy and the tooltip says the backup could not be queued.

### Follow-ups

* Changelog entries are filed in all three projects: `packages/backup`, plus `plugins/jetpack` (`bugfix`, prefixed `Backup:`) and `plugins/backup` (`fixed`, unprefixed — the plugin is named for the product) per `AGENTS.md`. Both plugins bundle this package, and Jetpack's changelog already carries `Backup:` entries for package UI changes of exactly this kind (#47448, #39914).
* The legacy `BackupNowButton` still has no jest coverage — it had none before this PR either, and the equivalent path is covered on the modernized side by `use-enqueue-backup.test.ts`. The reducer, selector and `useBackupsState` changes *are* covered, in the two existing legacy suites.



