### PR TITLE
Backup: surface WordPress.com's own reason when a bridge request fails

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-surface-upstream-error-reasons
+++ b/projects/packages/backup/changelog/fix-backup-surface-upstream-error-reasons
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: surface WordPress.com's own reason when a modernized-dashboard request fails, instead of one fixed sentence per operation — a lapsed connection, a rejected account and a backup-service fault now say so, and the upstream reason travels on the error for support. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/changelog/fix-backup-surface-upstream-error-reasons
+++ b/projects/packages/backup/changelog/fix-backup-surface-upstream-error-reasons
@@ -1,5 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: Backup: surface WordPress.com's own reason when a modernized-dashboard request fails, instead of one fixed sentence per operation — a lapsed connection, a rejected account and a backup-service fault now say so, and the upstream reason travels on the error for support. No-op when the modernization filter is off.
-
-
+Comment: Backup: surface WordPress.com's own reason when a modernized-dashboard request fails, instead of one fixed sentence per operation. A site that cannot start a restore because one is already running now says so, and the reason travels on the error for support either way. No-op when the modernization filter is off.

--- a/projects/packages/backup/src/dashboard/data/api/_helpers.ts
+++ b/projects/packages/backup/src/dashboard/data/api/_helpers.ts
@@ -58,9 +58,16 @@ export function toIntRewindId( rewindId: string ): string {
 }
 
 /**
- * Error thrown by the data-layer fetchers when WPCOM (via the bridge)
- * responds with a known error code. Consumers branch on `code` to pick
- * the right user-facing message.
+ * Error thrown by the data-layer fetchers when a request fails.
+ *
+ * `code` is the bridge's own code for the operation, and every failure of
+ * one operation carries the same one — all three ways a restore can fail
+ * to start are `restore_initiate_failed` — so it names what failed and
+ * never why. Nothing branches on it, and nothing should: the parts that
+ * carry a verdict live on `data`, which is where both
+ * `isAmbiguousFailure` and `upstreamMessage` read. It is kept because it
+ * is the field `apiFetch` rejections already have, and because it names
+ * the operation in a bug report.
  */
 export class ApiError extends Error {
 	public readonly code: string;
@@ -193,8 +200,76 @@ export function requireTypes( items: Record< string, boolean > ): Record< string
 }
 
 /**
- * Thin wrapper around `@wordpress/api-fetch` that re-throws bridge errors
- * as `ApiError` so React Query's onError handlers can branch on `code`.
+ * The reason WordPress.com gave, as the bridges forward it.
+ *
+ * Both halves are optional and only one usually arrives: `code` when
+ * WordPress.com refused with a `WP_Error`, `message` when the refusal was
+ * prose (see `Rest_Controller::upstream_reason()`, which decides which is
+ * which). Neither is ever rendered.
+ */
+type UpstreamReason = { code?: string; message?: string };
+
+/**
+ * The code WordPress.com refused with, when the bridge forwarded one.
+ *
+ * @param data - The `data` from a bridge failure.
+ * @return The upstream code, or an empty string when there is none.
+ */
+function upstreamCode( data: unknown ): string {
+	const wpcom = ( data as { wpcom?: UpstreamReason } | undefined )?.wpcom;
+	return typeof wpcom?.code === 'string' ? wpcom.code : '';
+}
+
+/**
+ * Copy for the WordPress.com refusals a reader can do something about.
+ *
+ * This is the half of the change that the bridges' new `data.wpcom` is
+ * for. Without a branch here, forwarding the reason would improve
+ * nothing anyone sees: the three surfaces that report a failure —
+ * `<QueryError>`, `<CapabilitiesErrorScreen>` and the error boundary —
+ * render `error.message` and nothing else, and the message they were
+ * getting is the bridge's single line per operation. "Could not fetch
+ * site capabilities." reads the same whether the plan lapsed or the
+ * token did.
+ *
+ * Only recognised codes are translated. Everything else keeps the
+ * bridge's generic line rather than being handed the upstream text,
+ * which is unbounded English written for whoever reads the logs — it
+ * still travels in `data.wpcom` for them.
+ *
+ * A `switch` rather than a lookup table so each `__()` runs when it is
+ * needed. At module scope they would all run before this bundle's locale
+ * data has finished loading, and every one of them would be evaluated in
+ * English and cached that way.
+ *
+ * @param code - The code WordPress.com refused with.
+ * @return Translated copy, or null when there is nothing better to say.
+ */
+function upstreamMessage( code: string ): string | null {
+	switch ( code ) {
+		case 'no_connected_jetpack':
+			// Deliberately the same msgid the bridge's own `not_connected`
+			// uses. The reader is being told the same fact by a different
+			// route, and reusing it means the string is already translated.
+			return __( 'This site is not connected to Jetpack.', 'jetpack-backup-pkg' );
+		case 'authorization_required':
+			return __(
+				'Your WordPress.com account is not allowed to manage this site.',
+				'jetpack-backup-pkg'
+			);
+		case 'rewind_error':
+			return __(
+				'The backup service ran into a problem. Try again in a few minutes, and contact support if it keeps happening.',
+				'jetpack-backup-pkg'
+			);
+		default:
+			return null;
+	}
+}
+
+/**
+ * Thin wrapper around `@wordpress/api-fetch` that re-throws every failure
+ * as an `ApiError`, so one place decides what a failed request says.
  *
  * Options are typed `APIFetchOptions< true >` — the parsing variant —
  * because every fetcher here wants the decoded JSON body rather than the
@@ -209,9 +284,11 @@ export async function apiCall< T >( options: APIFetchOptions< true > ): Promise<
 		return await apiFetch< T >( options );
 	} catch ( raw ) {
 		const err = raw as { code?: string; message?: string; data?: unknown };
+		const fallback = __( 'Request failed', 'jetpack-backup-pkg' );
+		const bridgeMessage = typeof err.message === 'string' ? err.message : fallback;
 		throw new ApiError(
 			typeof err.code === 'string' ? err.code : 'unknown',
-			typeof err.message === 'string' ? err.message : __( 'Request failed', 'jetpack-backup-pkg' ),
+			upstreamMessage( upstreamCode( err.data ) ) ?? bridgeMessage,
 			err.data
 		);
 	}

--- a/projects/packages/backup/src/dashboard/data/api/_helpers.ts
+++ b/projects/packages/backup/src/dashboard/data/api/_helpers.ts
@@ -1,5 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import type { APIFetchOptions } from '@wordpress/api-fetch';
 
@@ -65,7 +65,7 @@ export function toIntRewindId( rewindId: string ): string {
  * to start are `restore_initiate_failed` — so it names what failed and
  * never why. Nothing branches on it, and nothing should: the parts that
  * carry a verdict live on `data`, which is where both
- * `isAmbiguousFailure` and `upstreamMessage` read. It is kept because it
+ * `isAmbiguousFailure` and `failureMessage` read. It is kept because it
  * is the field `apiFetch` rejections already have, and because it names
  * the operation in a bug report.
  */
@@ -202,69 +202,116 @@ export function requireTypes( items: Record< string, boolean > ): Record< string
 /**
  * The reason WordPress.com gave, as the bridges forward it.
  *
- * Both halves are optional and only one usually arrives: `code` when
- * WordPress.com refused with a `WP_Error`, `message` when the refusal was
- * prose (see `Rest_Controller::upstream_reason()`, which decides which is
- * which). Neither is ever rendered.
+ * Both halves are optional: `code` when WordPress.com refused with a
+ * `WP_Error`, `message` when the refusal was prose (see
+ * `Rest_Controller::upstream_reason()`, which decides which is which).
+ * The bridge flattens and clips `message` to 200 characters, which is
+ * what makes it safe to put in front of a reader at all.
  */
 type UpstreamReason = { code?: string; message?: string };
 
 /**
- * The code WordPress.com refused with, when the bridge forwarded one.
+ * The reason the bridge forwarded, if it forwarded one.
  *
  * @param data - The `data` from a bridge failure.
- * @return The upstream code, or an empty string when there is none.
+ * @return The reason, with both halves normalized to strings.
  */
-function upstreamCode( data: unknown ): string {
+function upstreamReason( data: unknown ): UpstreamReason {
 	const wpcom = ( data as { wpcom?: UpstreamReason } | undefined )?.wpcom;
-	return typeof wpcom?.code === 'string' ? wpcom.code : '';
+	return {
+		code: typeof wpcom?.code === 'string' ? wpcom.code : '',
+		message: typeof wpcom?.message === 'string' ? wpcom.message : '',
+	};
 }
 
 /**
- * Copy for the WordPress.com refusals a reader can do something about.
+ * What a failed request should say, given what WordPress.com said.
  *
- * This is the half of the change that the bridges' new `data.wpcom` is
- * for. Without a branch here, forwarding the reason would improve
- * nothing anyone sees: the three surfaces that report a failure —
- * `<QueryError>`, `<CapabilitiesErrorScreen>` and the error boundary —
- * render `error.message` and nothing else, and the message they were
- * getting is the bridge's single line per operation. "Could not fetch
+ * This is the half of the change the bridges' `data.wpcom` exists for.
+ * Without it, forwarding the reason would improve nothing anyone sees:
+ * every surface that reports a failure — `<QueryError>`,
+ * `<CapabilitiesErrorScreen>`, the error boundary, and both screens —
+ * renders a `message` and nothing else, and the message they were
+ * getting is the bridge's one fixed line per operation. "Could not fetch
  * site capabilities." reads the same whether the plan lapsed or the
  * token did.
  *
- * Only recognised codes are translated. Everything else keeps the
- * bridge's generic line rather than being handed the upstream text,
- * which is unbounded English written for whoever reads the logs — it
- * still travels in `data.wpcom` for them.
+ * The rule is: anything we can enumerate, map; anything we cannot,
+ * render. Which side a code falls on is a question about the code, not
+ * about how much we like the copy, and WordPress.com answers it.
  *
- * A `switch` rather than a lookup table so each `__()` runs when it is
- * needed. At module scope they would all run before this bundle's locale
- * data has finished loading, and every one of them would be evaluated in
- * English and cached that way.
+ * `no_connected_jetpack` is enumerable. It belongs to a small documented
+ * vocabulary of rewind-unavailability reasons — `missing_plan`,
+ * `wpcom_site`, `multisite_not_supported`, `host_not_supported`,
+ * `site_new` and a few more — where the code is itself the meaning and
+ * the message adds nothing. So it gets copy of our own, and any sibling
+ * added here later should too.
  *
- * @param code - The code WordPress.com refused with.
- * @return Translated copy, or null when there is nothing better to say.
+ * `rewind_error` is not a meaning, it is a container. Upstream builds it
+ * from VaultPress's own sentence passed through verbatim, from
+ * "Unexpected response from VaultPress." as a 502, and from "You cannot
+ * enable Rewind for a free Jetpack site" and "…for a multisite" as 400s.
+ * One code, four unrelated situations, and the reason lives entirely in
+ * the message. Canned copy here was not merely vague but wrong: it
+ * prescribed a retry that can never succeed for the last two.
+ *
+ * `authorization_required` is a WordPress.com-wide generic, used by
+ * billing, domains, keyring and social alike. Within the rewind
+ * endpoints it covers "You are not allowed to rewind this site", "…to
+ * query this state", "…to rewind to the staging site" and an a12s-only
+ * guard. The message separates those; the code cannot. It also must not
+ * carry copy blaming the reader's account: `get_restore_status()` signs
+ * `as_blog`, so the credential at fault there is the site's token, not
+ * the person's.
+ *
+ * So everything that is not enumerable renders, inside a frame that says
+ * whose words these are. The frame is this package's existing pattern —
+ * `use-download.ts` already does `sprintf( __( 'Download failed: %s' ),
+ * … )` — and this is the safer version of it, because `use-download.ts`
+ * renders upstream text unbounded while the bridge has already flattened
+ * and clipped this to 200 characters. Keep that clip.
+ *
+ * The rendered half will usually be English even when the frame is
+ * translated. That is a real cost and a deliberate one: a specific
+ * reason in the wrong language beats an accurate translation of nothing.
+ * Naming WordPress.com in the frame is what makes it legible rather than
+ * merely untranslated — the reader can see the sentence is a quotation.
+ * Please do not "fix" this by canning the copy again; that is the change
+ * this function was rewritten to undo.
+ *
+ * Everything is a plain string that callers render as React children,
+ * which is what escapes it. Never put it through `dangerouslySetInnerHTML`
+ * or into an attribute.
+ *
+ * @param bridgeMessage - The bridge's own line, naming what failed.
+ * @param reason        - What WordPress.com said, if anything.
+ * @return The message to show the reader.
  */
-function upstreamMessage( code: string ): string | null {
-	switch ( code ) {
-		case 'no_connected_jetpack':
-			// Deliberately the same msgid the bridge's own `not_connected`
-			// uses. The reader is being told the same fact by a different
-			// route, and reusing it means the string is already translated.
-			return __( 'This site is not connected to Jetpack.', 'jetpack-backup-pkg' );
-		case 'authorization_required':
-			return __(
-				'Your WordPress.com account is not allowed to manage this site.',
-				'jetpack-backup-pkg'
-			);
-		case 'rewind_error':
-			return __(
-				'The backup service ran into a problem. Try again in a few minutes, and contact support if it keeps happening.',
-				'jetpack-backup-pkg'
-			);
-		default:
-			return null;
+function failureMessage( bridgeMessage: string, reason: UpstreamReason ): string {
+	// The enumerable side. Wording borrowed from My Jetpack, which has
+	// said this to Jetpack users for years — for familiarity, not for a
+	// free translation: that copy lives in the `jetpack-my-jetpack` text
+	// domain and GlotPress translates per domain, so this string starts
+	// its own cycle like any other.
+	if ( 'no_connected_jetpack' === reason.code ) {
+		return __(
+			"The site doesn't appear to be connected. Backup requires an active Jetpack connection in order to function properly.",
+			'jetpack-backup-pkg'
+		);
 	}
+
+	if ( reason.message ) {
+		return sprintf(
+			/* translators: 1: what failed, in our own words. 2: the reason WordPress.com gave, usually in English. */
+			__( '%1$s WordPress.com said: %2$s', 'jetpack-backup-pkg' ),
+			bridgeMessage,
+			reason.message
+		);
+	}
+
+	// A code with nothing beside it. Rendering the bare token would put
+	// `rewind_error` on screen, which is worse than the bridge's sentence.
+	return bridgeMessage;
 }
 
 /**
@@ -288,7 +335,7 @@ export async function apiCall< T >( options: APIFetchOptions< true > ): Promise<
 		const bridgeMessage = typeof err.message === 'string' ? err.message : fallback;
 		throw new ApiError(
 			typeof err.code === 'string' ? err.code : 'unknown',
-			upstreamMessage( upstreamCode( err.data ) ) ?? bridgeMessage,
+			failureMessage( bridgeMessage, upstreamReason( err.data ) ),
 			err.data
 		);
 	}

--- a/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
@@ -94,64 +94,153 @@ describe( 'apiCall', () => {
 		} );
 	} );
 
-	// The client half of the bridges' `data.wpcom`. Without this branch the
-	// bridges' new reason would improve nothing anyone sees: every surface
-	// that reports a failure renders `error.message`, and the message is one
-	// fixed line per operation.
-	test.each( [
-		[
-			'a lapsed connection',
-			'no_connected_jetpack',
-			'TRANSLATED:This site is not connected to Jetpack.',
-		],
-		[
-			'a rejected token',
-			'authorization_required',
-			'TRANSLATED:Your WordPress.com account is not allowed to manage this site.',
-		],
-	] )( 'says what happened for %s', async ( _label, code, expected ) => {
+	// The enumerable side of the rule. `no_connected_jetpack` belongs to a
+	// documented vocabulary where the code is the meaning, so it gets copy
+	// of our own and the upstream message is not shown.
+	test( 'maps the one code whose meaning is the code', async () => {
 		mockedApiFetch.mockRejectedValue( {
 			code: 'capabilities_fetch_failed',
 			message: 'Could not fetch site capabilities.',
-			data: { status: 412, wpcom: { code } },
-		} );
-
-		await expect( apiCall( { path: '/x' } ) ).rejects.toMatchObject( { message: expected } );
-	} );
-
-	// The bridge's own code is not the one being read. Both fixtures below
-	// carry the same one, and only the upstream half differs — so a
-	// mapping wired to `code` instead of `data.wpcom.code` fails here.
-	test( 'keeps the bridge message for an upstream code it does not know', async () => {
-		mockedApiFetch.mockRejectedValue( {
-			code: 'capabilities_fetch_failed',
-			message: 'Could not fetch site capabilities.',
-			data: { status: 500, wpcom: { code: 'something_new_upstream' } },
+			data: {
+				status: 412,
+				wpcom: { code: 'no_connected_jetpack', message: 'This site is not connected.' },
+			},
 		} );
 
 		await expect( apiCall( { path: '/x' } ) ).rejects.toMatchObject( {
-			message: 'Could not fetch site capabilities.',
+			message:
+				"TRANSLATED:The site doesn't appear to be connected. Backup requires an active Jetpack connection in order to function properly.",
 		} );
 	} );
 
-	// The reason is prose — a VaultPress refusal, which the bridge puts in
-	// `message` precisely because nothing may branch on it. Rendering
-	// unbounded upstream English at a reader who may not read English is
-	// not an improvement on a translated generic line.
-	test( 'never shows the upstream prose to the reader', async () => {
+	// The other side. `rewind_error` is a container, not a meaning: upstream
+	// builds it from VaultPress's own sentence, from "Unexpected response
+	// from VaultPress.", and from two 400s about free and multisite plans
+	// that no amount of retrying will clear. Canned copy prescribed a retry
+	// for all four, so the sentence has to come through.
+	test( 'renders the reason for a code that spans unrelated situations', async () => {
 		mockedApiFetch.mockRejectedValue( {
 			code: 'restore_initiate_failed',
 			message: 'Could not start the backup restore.',
-			data: { status: 500, wpcom: { message: 'There is already a restore in progress' } },
+			data: {
+				status: 400,
+				wpcom: {
+					code: 'rewind_error',
+					message: 'You cannot enable Rewind for a free Jetpack site',
+				},
+			},
+		} );
+
+		const thrown = await apiCall( { path: '/x' } ).catch( ( e: ApiError ) => e );
+
+		expect( thrown.message ).toContain( 'You cannot enable Rewind for a free Jetpack site' );
+		// The frame attributes it, so the reader can see the English half is
+		// a quotation rather than our own untranslated copy.
+		expect( thrown.message ).toContain( 'Could not start the backup restore.' );
+		expect( thrown.message ).toContain( 'WordPress.com said' );
+	} );
+
+	// `authorization_required` is a WordPress.com-wide generic. Its messages
+	// distinguish "not allowed to rewind this site" from "not allowed to
+	// query this state"; its code cannot. It must also not blame the
+	// reader's account — `get_restore_status()` signs `as_blog`, so the
+	// credential at fault there is the site's token.
+	test( 'renders the reason for a generic code without blaming the account', async () => {
+		mockedApiFetch.mockRejectedValue( {
+			code: 'restore_status_fetch_failed',
+			message: 'Could not fetch restore progress.',
+			data: {
+				status: 401,
+				wpcom: {
+					code: 'authorization_required',
+					message: 'You are not allowed to query this state',
+				},
+			},
+		} );
+
+		const thrown = await apiCall( { path: '/x' } ).catch( ( e: ApiError ) => e );
+
+		expect( thrown.message ).toContain( 'You are not allowed to query this state' );
+		expect( thrown.message ).not.toContain( 'account' );
+	} );
+
+	// "Anything you cannot enumerate, render" is the rule, not a list — so a
+	// code nobody has seen before still gets its sentence through.
+	test( 'renders the reason for a code it has never seen', async () => {
+		mockedApiFetch.mockRejectedValue( {
+			code: 'capabilities_fetch_failed',
+			message: 'Could not fetch site capabilities.',
+			data: {
+				status: 500,
+				wpcom: { code: 'something_new_upstream', message: 'The vault is being migrated.' },
+			},
+		} );
+
+		const thrown = await apiCall( { path: '/x' } ).catch( ( e: ApiError ) => e );
+
+		expect( thrown.message ).toContain( 'The vault is being migrated.' );
+	} );
+
+	// The VaultPress refusal that arrives inside a 200, which carries a
+	// sentence and no code at all. This is the headline case for rendering:
+	// "a restore is already running" is the whole of what the reader needs
+	// and no canned line can say it.
+	test( 'renders a reason that arrived with no code beside it', async () => {
+		mockedApiFetch.mockRejectedValue( {
+			code: 'restore_initiate_failed',
+			message: 'Could not start the backup restore.',
+			data: {
+				status: 500,
+				wpcom: { message: 'There is already a restore in progress' },
+			},
+		} );
+
+		const thrown = await apiCall( { path: '/x' } ).catch( ( e: ApiError ) => e );
+
+		expect( thrown.message ).toContain( 'There is already a restore in progress' );
+	} );
+
+	// A bare token is worse on screen than the bridge's sentence, so a
+	// reason with no message degrades to the sentence rather than to
+	// `rewind_error`.
+	test( 'keeps the bridge message when the reason carries no sentence', async () => {
+		mockedApiFetch.mockRejectedValue( {
+			code: 'capabilities_fetch_failed',
+			message: 'Could not fetch site capabilities.',
+			data: { status: 500, wpcom: { code: 'rewind_error' } },
 		} );
 
 		await expect( apiCall( { path: '/x' } ) ).rejects.toMatchObject( {
-			message: 'Could not start the backup restore.',
+			message: 'Could not fetch site capabilities.',
 		} );
 	} );
 
+	// Upstream text is arbitrary, and it now goes through a `sprintf`
+	// frame — so a percent sign in it is a live hazard. It is safe because
+	// `sprintf` only ever interprets the *format*, never the arguments,
+	// but "safe because of how a dependency works" is exactly the kind of
+	// claim that deserves a test. A regression here would not merely
+	// mangle the text: `@wordpress/i18n` logs a `console.error` on a
+	// malformed format, and this repo's jest setup fails a test that logs
+	// one, so this would go red rather than quiet.
+	test.each( [
+		[ 'a bare percent', 'Disk 95% full' ],
+		[ 'a positional token', 'Value %1$s was rejected' ],
+		[ 'a bare format token', 'Got %s and %d' ],
+	] )( 'passes %s through the frame untouched', async ( _label, upstream ) => {
+		mockedApiFetch.mockRejectedValue( {
+			code: 'restore_initiate_failed',
+			message: 'Could not start the backup restore.',
+			data: { status: 500, wpcom: { code: 'rewind_error', message: upstream } },
+		} );
+
+		const thrown = await apiCall( { path: '/x' } ).catch( ( e: ApiError ) => e );
+
+		expect( thrown.message ).toContain( upstream );
+	} );
+
 	// It still has to reach a support agent, so it travels on `data`
-	// untouched — including for the codes that did get mapped.
+	// untouched — including for the code that got mapped instead of shown.
 	test( 'passes the upstream reason through on data', async () => {
 		const data = { status: 412, wpcom: { code: 'no_connected_jetpack' } };
 		mockedApiFetch.mockRejectedValue( { code: 'capabilities_fetch_failed', data } );

--- a/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/_helpers.test.ts
@@ -2,13 +2,17 @@ import apiFetch from '@wordpress/api-fetch';
 import { ApiError, apiCall, isAmbiguousFailure, requireTypes, toIntRewindId } from '../_helpers';
 
 jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
-// `__` returns a sentinel rather than its input, so a message that reached
-// the reader untranslated is distinguishable from one that did not. The rest
-// of the module is preserved: replacing it wholesale would leave `sprintf`
-// and `_n` undefined for everything in this file's module graph.
+// `__` prefixes a sentinel rather than returning its input, so a message that
+// reached the reader untranslated is distinguishable from one that did not.
+// The msgid is kept on the end because the branch that picks *which* string to
+// show is the thing under test here — a bare sentinel would make every branch
+// return the same value, and an assertion that cannot tell them apart passes
+// whichever one runs. The rest of the module is preserved: replacing it
+// wholesale would leave `sprintf` and `_n` undefined for everything in this
+// file's module graph.
 jest.mock( '@wordpress/i18n', () => ( {
 	...jest.requireActual( '@wordpress/i18n' ),
-	__: jest.fn( () => 'TRANSLATED' ),
+	__: jest.fn( ( text: string ) => `TRANSLATED:${ text }` ),
 } ) );
 
 const mockedApiFetch = apiFetch as unknown as jest.Mock;
@@ -86,7 +90,83 @@ describe( 'apiCall', () => {
 		mockedApiFetch.mockRejectedValue( { code: 'some_code' } );
 
 		await expect( apiCall( { path: '/x' } ) ).rejects.toMatchObject( {
-			message: 'TRANSLATED',
+			message: 'TRANSLATED:Request failed',
+		} );
+	} );
+
+	// The client half of the bridges' `data.wpcom`. Without this branch the
+	// bridges' new reason would improve nothing anyone sees: every surface
+	// that reports a failure renders `error.message`, and the message is one
+	// fixed line per operation.
+	test.each( [
+		[
+			'a lapsed connection',
+			'no_connected_jetpack',
+			'TRANSLATED:This site is not connected to Jetpack.',
+		],
+		[
+			'a rejected token',
+			'authorization_required',
+			'TRANSLATED:Your WordPress.com account is not allowed to manage this site.',
+		],
+	] )( 'says what happened for %s', async ( _label, code, expected ) => {
+		mockedApiFetch.mockRejectedValue( {
+			code: 'capabilities_fetch_failed',
+			message: 'Could not fetch site capabilities.',
+			data: { status: 412, wpcom: { code } },
+		} );
+
+		await expect( apiCall( { path: '/x' } ) ).rejects.toMatchObject( { message: expected } );
+	} );
+
+	// The bridge's own code is not the one being read. Both fixtures below
+	// carry the same one, and only the upstream half differs — so a
+	// mapping wired to `code` instead of `data.wpcom.code` fails here.
+	test( 'keeps the bridge message for an upstream code it does not know', async () => {
+		mockedApiFetch.mockRejectedValue( {
+			code: 'capabilities_fetch_failed',
+			message: 'Could not fetch site capabilities.',
+			data: { status: 500, wpcom: { code: 'something_new_upstream' } },
+		} );
+
+		await expect( apiCall( { path: '/x' } ) ).rejects.toMatchObject( {
+			message: 'Could not fetch site capabilities.',
+		} );
+	} );
+
+	// The reason is prose — a VaultPress refusal, which the bridge puts in
+	// `message` precisely because nothing may branch on it. Rendering
+	// unbounded upstream English at a reader who may not read English is
+	// not an improvement on a translated generic line.
+	test( 'never shows the upstream prose to the reader', async () => {
+		mockedApiFetch.mockRejectedValue( {
+			code: 'restore_initiate_failed',
+			message: 'Could not start the backup restore.',
+			data: { status: 500, wpcom: { message: 'There is already a restore in progress' } },
+		} );
+
+		await expect( apiCall( { path: '/x' } ) ).rejects.toMatchObject( {
+			message: 'Could not start the backup restore.',
+		} );
+	} );
+
+	// It still has to reach a support agent, so it travels on `data`
+	// untouched — including for the codes that did get mapped.
+	test( 'passes the upstream reason through on data', async () => {
+		const data = { status: 412, wpcom: { code: 'no_connected_jetpack' } };
+		mockedApiFetch.mockRejectedValue( { code: 'capabilities_fetch_failed', data } );
+
+		await expect( apiCall( { path: '/x' } ) ).rejects.toMatchObject( { data } );
+	} );
+
+	// A failure from the browser → site hop carries no `data` at all, and
+	// reading into it must not throw a second error on top of the first.
+	test( 'survives a rejection with no data', async () => {
+		mockedApiFetch.mockRejectedValue( { code: 'fetch_error', message: 'Network down.' } );
+
+		await expect( apiCall( { path: '/x' } ) ).rejects.toMatchObject( {
+			code: 'fetch_error',
+			message: 'Network down.',
 		} );
 	} );
 } );

--- a/projects/packages/backup/src/rest/class-activity-log-bridge.php
+++ b/projects/packages/backup/src/rest/class-activity-log-bridge.php
@@ -115,10 +115,10 @@ class Activity_Log_Bridge {
 
 		$status_code = wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
-			return new WP_Error(
+			return Rest_Controller::upstream_error(
+				$response,
 				'activity_log_fetch_failed',
-				__( 'Could not fetch the site activity log.', 'jetpack-backup-pkg' ),
-				array( 'status' => is_int( $status_code ) && $status_code > 0 ? $status_code : 500 )
+				__( 'Could not fetch the site activity log.', 'jetpack-backup-pkg' )
 			);
 		}
 

--- a/projects/packages/backup/src/rest/class-capabilities-bridge.php
+++ b/projects/packages/backup/src/rest/class-capabilities-bridge.php
@@ -72,14 +72,14 @@ class Capabilities_Bridge {
 		// Cast: `wp_remote_retrieve_response_code()` returns whatever the
 		// transport put there, and a numeric string fails a strict
 		// comparison against 200 — sending a perfectly good response down
-		// the failure branch, where the `is_int()` test below would then
-		// report it as a 500.
+		// the failure branch, and reporting it as a failure rather than as
+		// the success it was.
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
-			return new WP_Error(
+			return Rest_Controller::upstream_error(
+				$response,
 				'capabilities_fetch_failed',
-				__( 'Could not fetch site capabilities.', 'jetpack-backup-pkg' ),
-				array( 'status' => $status_code > 0 ? $status_code : 500 )
+				__( 'Could not fetch site capabilities.', 'jetpack-backup-pkg' )
 			);
 		}
 

--- a/projects/packages/backup/src/rest/class-download-bridge.php
+++ b/projects/packages/backup/src/rest/class-download-bridge.php
@@ -140,10 +140,10 @@ class Download_Bridge {
 
 		$status_code = wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
-			return new WP_Error(
+			return Rest_Controller::upstream_error(
+				$response,
 				'download_initiate_failed',
-				__( 'Could not start the backup download.', 'jetpack-backup-pkg' ),
-				array( 'status' => is_int( $status_code ) && $status_code > 0 ? $status_code : 500 )
+				__( 'Could not start the backup download.', 'jetpack-backup-pkg' )
 			);
 		}
 
@@ -201,10 +201,10 @@ class Download_Bridge {
 
 		$status_code = wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
-			return new WP_Error(
+			return Rest_Controller::upstream_error(
+				$response,
 				'download_status_fetch_failed',
-				__( 'Could not fetch download status.', 'jetpack-backup-pkg' ),
-				array( 'status' => is_int( $status_code ) && $status_code > 0 ? $status_code : 500 )
+				__( 'Could not fetch download status.', 'jetpack-backup-pkg' )
 			);
 		}
 

--- a/projects/packages/backup/src/rest/class-file-browser-bridge.php
+++ b/projects/packages/backup/src/rest/class-file-browser-bridge.php
@@ -282,10 +282,10 @@ class File_Browser_Bridge {
 
 		$url_status = wp_remote_retrieve_response_code( $url_response );
 		if ( 200 !== $url_status ) {
-			return new WP_Error(
+			return Rest_Controller::upstream_error(
+				$url_response,
 				'backup_file_content_url_failed',
-				__( 'Could not resolve file download URL.', 'jetpack-backup-pkg' ),
-				array( 'status' => is_int( $url_status ) && $url_status > 0 ? $url_status : 500 )
+				__( 'Could not resolve file download URL.', 'jetpack-backup-pkg' )
 			);
 		}
 
@@ -324,10 +324,18 @@ class File_Browser_Bridge {
 
 		$stream_status = wp_remote_retrieve_response_code( $stream_response );
 		if ( 200 !== $stream_status ) {
-			return new WP_Error(
+			// The one failure here whose reason does not come from the JSON
+			// API: this response is the storage host's, so its error bodies
+			// are usually XML and `upstream_reason()` finds nothing in them.
+			// Asking anyway costs a `json_decode` on a path that has already
+			// failed, and the storage host does sometimes answer in JSON.
+			//
+			// It cannot pick up file content by mistake — a 200 never
+			// reaches this branch.
+			return Rest_Controller::upstream_error(
+				$stream_response,
 				'backup_file_content_stream_failed',
-				__( 'Could not fetch file content.', 'jetpack-backup-pkg' ),
-				array( 'status' => is_int( $stream_status ) && $stream_status > 0 ? $stream_status : 500 )
+				__( 'Could not fetch file content.', 'jetpack-backup-pkg' )
 			);
 		}
 
@@ -340,6 +348,11 @@ class File_Browser_Bridge {
 	 * with bridge-level error codes the front-end branches on, so cURL's
 	 * own text never reaches the reader.
 	 *
+	 * Both wrappers keep what WordPress.com actually said one level down,
+	 * under `transport` and `wpcom` respectively — the reader gets
+	 * `$message` in their own language, and the reason survives for
+	 * whoever has to work out what went wrong.
+	 *
 	 * @param array|\WP_Error $response The wp_remote_* response.
 	 * @param string          $code     Error code for a transport failure or a non-200.
 	 * @param string          $message  Translated error message for a non-200.
@@ -351,11 +364,7 @@ class File_Browser_Bridge {
 		}
 		$status_code = wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
-			return new WP_Error(
-				$code,
-				$message,
-				array( 'status' => is_int( $status_code ) && $status_code > 0 ? $status_code : 500 )
-			);
+			return Rest_Controller::upstream_error( $response, $code, $message );
 		}
 		return rest_ensure_response( json_decode( wp_remote_retrieve_body( $response ), true ) );
 	}

--- a/projects/packages/backup/src/rest/class-file-browser-bridge.php
+++ b/projects/packages/backup/src/rest/class-file-browser-bridge.php
@@ -325,13 +325,25 @@ class File_Browser_Bridge {
 		$stream_status = wp_remote_retrieve_response_code( $stream_response );
 		if ( 200 !== $stream_status ) {
 			// The one failure here whose reason does not come from the JSON
-			// API: this response is the storage host's, so its error bodies
-			// are usually XML and `upstream_reason()` finds nothing in them.
-			// Asking anyway costs a `json_decode` on a path that has already
-			// failed, and the storage host does sometimes answer in JSON.
+			// API. This response is the storage host's, not WordPress.com's,
+			// so two caveats ride along with reusing the shared wrapper.
 			//
-			// It cannot pick up file content by mistake — a 200 never
-			// reaches this branch.
+			// Its error bodies are usually XML, which `upstream_reason()`
+			// reads nothing out of; asking anyway costs one `json_decode`
+			// on a path that has already failed, and the host does
+			// sometimes answer in JSON. When it does, the reason is filed
+			// under a key named `wpcom`, which misnames its origin — worth
+			// knowing before anyone reads that field as WordPress.com's.
+			//
+			// And the body it reads is not guaranteed to be an error body.
+			// `200 !== $stream_status` is not type-safe, so a `'200'` from
+			// a transport that reports statuses as strings arrives here
+			// with the previewed file's own bytes in hand. Harmless — the
+			// caller is the admin who asked for that file, and the clamp in
+			// `upstream_error()` reports the status as 500 rather than
+			// forwarding a success code — but it is not the same claim as
+			// "a 200 never reaches this branch", which is what this comment
+			// used to say and is not true.
 			return Rest_Controller::upstream_error(
 				$stream_response,
 				'backup_file_content_stream_failed',

--- a/projects/packages/backup/src/rest/class-file-browser-bridge.php
+++ b/projects/packages/backup/src/rest/class-file-browser-bridge.php
@@ -361,9 +361,10 @@ class File_Browser_Bridge {
 	 * own text never reaches the reader.
 	 *
 	 * Both wrappers keep what WordPress.com actually said one level down,
-	 * under `transport` and `wpcom` respectively — the reader gets
-	 * `$message` in their own language, and the reason survives for
-	 * whoever has to work out what went wrong.
+	 * under `transport` and `wpcom` respectively, so `$message` names the
+	 * operation and the reason survives beside it rather than replacing
+	 * it. The client frames the two together when the reason is one only
+	 * a sentence can carry.
 	 *
 	 * @param array|\WP_Error $response The wp_remote_* response.
 	 * @param string          $code     Error code for a transport failure or a non-200.

--- a/projects/packages/backup/src/rest/class-rest-controller.php
+++ b/projects/packages/backup/src/rest/class-rest-controller.php
@@ -278,13 +278,29 @@ class Rest_Controller {
 	 * Only those two fields are forwarded, never the body — an error body
 	 * is unbounded and can echo the request that produced it.
 	 *
-	 * The status is cast before it is forwarded, because the retrieval
-	 * helper returns whatever the transport put there. A zero or an
-	 * unparseable value must never reach a `WP_Error`, since core hands
-	 * the status to `status_header()`, and a zero there emits an invalid
-	 * status line. The client is equally literal about the type:
-	 * `isAmbiguousFailure()` only reads a status that is already a number,
-	 * and treats a failure with no readable status as ambiguous.
+	 * The status is clamped to the failure range rather than merely tested
+	 * for truthiness, and that is load-bearing. The retrieval helper hands
+	 * back whatever the transport put there, so a *success* code can reach
+	 * this function: four of the callers compare `200 !== $status_code`
+	 * without casting, which a numeric-string `'200'` fails, routing a
+	 * perfectly good response into the failure branch. Forwarding it would then set `data.status` to 200, WordPress
+	 * would serve the error envelope as HTTP 200, `apiFetch` would resolve
+	 * instead of rejecting, and `apiCall()` would never throw — so a
+	 * failed restore would run the mutation's `onSuccess` and report a
+	 * restore that never started. A visible failure becoming an invisible
+	 * false success is the worst outcome available on a destructive
+	 * operation, so anything outside 4xx/5xx becomes a 500.
+	 *
+	 * The same clamp is what keeps junk out. `(int)` is a total function:
+	 * `'2 Bad'` is 2, `3.7` is 3, `true` is 1, and a zero must never reach
+	 * a `WP_Error` at all, because core hands the status to
+	 * `status_header()` and a zero there emits an invalid status line.
+	 *
+	 * What the cast does buy, and the reason it is here rather than an
+	 * `is_int()` test, is that a genuine `'404'` from a transport that
+	 * reports statuses as strings now travels as 404 instead of being
+	 * flattened to 500. The client is literal about the type too:
+	 * `isAmbiguousFailure()` only reads a status that is already a number.
 	 *
 	 * @param array|\WP_Error $response The wp_remote_* response. Non-200 by the time it gets here.
 	 * @param string          $code     Bridge error code for the operation that failed.
@@ -294,7 +310,7 @@ class Rest_Controller {
 	public static function upstream_error( $response, $code, $message ) {
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
 
-		$data = array( 'status' => $status_code > 0 ? $status_code : 500 );
+		$data = array( 'status' => $status_code >= 400 && $status_code <= 599 ? $status_code : 500 );
 
 		$reason = self::upstream_reason( wp_remote_retrieve_body( $response ) );
 		if ( ! empty( $reason ) ) {
@@ -322,6 +338,18 @@ class Rest_Controller {
 	 * become a key that can never match — the reason lost again, in a
 	 * quieter way.
 	 *
+	 * Sorting is all it does, though: nothing is ever discarded. When
+	 * `error` holds a sentence *and* `message` holds another — which is
+	 * what a VaultPress refusal wrapped in a generic envelope looks like —
+	 * both are kept, `error` first, because that is the specific half. An
+	 * earlier revision promoted `error` only when `message` was empty, and
+	 * so threw away the specific reason in exactly the shape this function
+	 * exists to read.
+	 *
+	 * `/u` on the whitespace test is not cosmetic. Without it `\s` is
+	 * ASCII-only, so a sentence spaced with U+00A0 has "no whitespace" and
+	 * lands in `code` — the precise outcome the sort is here to prevent.
+	 *
 	 * @param string|array $body Raw response body, or one already decoded.
 	 * @return array<string, string> `code` and/or `message`; empty when the body names no reason.
 	 */
@@ -341,16 +369,24 @@ class Rest_Controller {
 
 		$prose = isset( $decoded['message'] ) && is_string( $decoded['message'] ) ? trim( $decoded['message'] ) : '';
 
-		$reason = array();
-		if ( '' !== $token && ! preg_match( '/\s/', $token ) ) {
+		$reason    = array();
+		$sentences = array();
+
+		if ( '' !== $token && ! preg_match( '/\s/u', $token ) ) {
 			$reason['code'] = self::clip_reason( $token );
-		} elseif ( '' === $prose ) {
-			// The token slot held a sentence and nothing else carried one.
-			$prose = $token;
+		} elseif ( '' !== $token ) {
+			$sentences[] = $token;
 		}
 
-		if ( '' !== $prose ) {
-			$reason['message'] = self::clip_reason( $prose );
+		// Guarded against the duplicate rather than assumed away: some
+		// envelopes repeat the same text in both keys, and joining it to
+		// itself would say everything twice inside a budget meant for one.
+		if ( '' !== $prose && ! in_array( $prose, $sentences, true ) ) {
+			$sentences[] = $prose;
+		}
+
+		if ( ! empty( $sentences ) ) {
+			$reason['message'] = self::clip_reason( implode( ' ', $sentences ) );
 		}
 
 		return $reason;
@@ -360,17 +396,36 @@ class Rest_Controller {
 	 * Flatten and shorten one half of an upstream reason.
 	 *
 	 * Newlines go first so a multi-line upstream message cannot spend the
-	 * whole budget on indentation before it says anything. `mb_substr()`
-	 * rather than `substr()` because the cut would otherwise land inside a
-	 * multi-byte character and produce a field that is not valid UTF-8,
-	 * which `wp_json_encode()` drops entirely — losing the reason to the
-	 * very code meant to preserve it.
+	 * whole budget on indentation before it says anything.
+	 *
+	 * `mb_substr()` rather than `substr()`, and the reason is mostly not
+	 * the exotic one. A byte-wise cut spends the budget in bytes, so a
+	 * reason written in a script that costs three bytes a character keeps
+	 * a third of what it was allotted — 67 characters of 200, in the test
+	 * that pins this. The encoding damage is the smaller half: the cut
+	 * lands inside a character and leaves the field invalid UTF-8, which
+	 * `wp_json_encode()` does not reject — its sanity check silently
+	 * rewrites the broken bytes, so the reason arrives with a `?` on the
+	 * end and nothing anywhere says why.
+	 *
+	 * The flatten runs in Unicode mode so a non-breaking or ideographic
+	 * space collapses like any other, which also means it returns null on
+	 * invalid UTF-8. The ASCII pass stands behind it so the bound is still
+	 * enforced in that case. Unreachable in practice — every string that
+	 * gets here came out of a `json_decode()`, which refuses invalid
+	 * UTF-8 outright — but a silent null would turn the whole reason into
+	 * an empty string, which is a poor way to find out.
 	 *
 	 * @param string $value Raw upstream text.
 	 * @return string
 	 */
 	private static function clip_reason( $value ) {
-		$value = trim( preg_replace( '/\s+/', ' ', $value ) );
+		$flattened = preg_replace( '/\s+/u', ' ', $value );
+		if ( null === $flattened ) {
+			$flattened = preg_replace( '/\s+/', ' ', $value );
+		}
+
+		$value = trim( (string) $flattened );
 
 		if ( mb_strlen( $value, 'UTF-8' ) <= self::REASON_MAX_LENGTH ) {
 			return $value;

--- a/projects/packages/backup/src/rest/class-rest-controller.php
+++ b/projects/packages/backup/src/rest/class-rest-controller.php
@@ -245,4 +245,137 @@ class Rest_Controller {
 			)
 		);
 	}
+
+	/**
+	 * Longest either half of a forwarded upstream reason may be.
+	 *
+	 * Neither field is bounded upstream and both travel to the browser on
+	 * every failed request, so a VaultPress stack trace in `message` would
+	 * otherwise be copied out verbatim.
+	 *
+	 * @var int
+	 */
+	private const REASON_MAX_LENGTH = 200;
+
+	/**
+	 * Convert a non-200 answer from WordPress.com into a bridge error.
+	 *
+	 * The counterpart of `transport_error()`, for the failure where the
+	 * request did arrive and WordPress.com refused it. Every bridge used to
+	 * spell this branch out for itself, and every spelling threw away the
+	 * only part that says *why*: a plan problem and an expired token both
+	 * reached a support agent as `restore_initiate_failed` / "Could not
+	 * start the backup restore.", distinguishable only by a status code.
+	 *
+	 * WordPress.com's own reason is preserved under `wpcom`, deliberately
+	 * shaped like `transport_error()`'s `transport` key and kept there for
+	 * the same reason: it is support-facing English, so it travels in
+	 * `data` rather than being spliced into a message the reader expects in
+	 * their own language. The client maps the codes it recognises onto
+	 * copy of its own (see `upstreamMessage` in `_helpers.ts`); the rest
+	 * still reach whoever reads the response.
+	 *
+	 * Only those two fields are forwarded, never the body — an error body
+	 * is unbounded and can echo the request that produced it.
+	 *
+	 * The status is cast before it is forwarded, because the retrieval
+	 * helper returns whatever the transport put there. A zero or an
+	 * unparseable value must never reach a `WP_Error`, since core hands
+	 * the status to `status_header()`, and a zero there emits an invalid
+	 * status line. The client is equally literal about the type:
+	 * `isAmbiguousFailure()` only reads a status that is already a number,
+	 * and treats a failure with no readable status as ambiguous.
+	 *
+	 * @param array|\WP_Error $response The wp_remote_* response. Non-200 by the time it gets here.
+	 * @param string          $code     Bridge error code for the operation that failed.
+	 * @param string          $message  Translated message for the reader.
+	 * @return WP_Error
+	 */
+	public static function upstream_error( $response, $code, $message ) {
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+
+		$data = array( 'status' => $status_code > 0 ? $status_code : 500 );
+
+		$reason = self::upstream_reason( wp_remote_retrieve_body( $response ) );
+		if ( ! empty( $reason ) ) {
+			$data['wpcom'] = $reason;
+		}
+
+		return new WP_Error( $code, $message, $data );
+	}
+
+	/**
+	 * Read WordPress.com's own reason out of a response body.
+	 *
+	 * Three shapes have to be read here and they disagree about where the
+	 * reason lives. A wpcom/v2 route serializes a `WP_Error` as `{ code,
+	 * message, data }`. The older v1 envelope names that same token `error`
+	 * and keeps prose beside it in `message`. And the restore endpoint's
+	 * own `{ ok: false, error }` body puts VaultPress's sentence directly
+	 * in `error`, with no token anywhere.
+	 *
+	 * So `error` is sometimes a token and sometimes a sentence, and the
+	 * only thing separating them is shape: a `WP_Error` code has no
+	 * whitespace in it, and a VaultPress refusal is a sentence. Sorting on
+	 * that is what keeps the two halves honest. The client matches `code`
+	 * against a list of codes it knows, so a sentence landing there would
+	 * become a key that can never match — the reason lost again, in a
+	 * quieter way.
+	 *
+	 * @param string|array $body Raw response body, or one already decoded.
+	 * @return array<string, string> `code` and/or `message`; empty when the body names no reason.
+	 */
+	public static function upstream_reason( $body ) {
+		$decoded = is_array( $body ) ? $body : json_decode( (string) $body, true );
+		if ( ! is_array( $decoded ) ) {
+			return array();
+		}
+
+		$token = '';
+		foreach ( array( 'code', 'error' ) as $key ) {
+			if ( isset( $decoded[ $key ] ) && is_string( $decoded[ $key ] ) && '' !== trim( $decoded[ $key ] ) ) {
+				$token = trim( $decoded[ $key ] );
+				break;
+			}
+		}
+
+		$prose = isset( $decoded['message'] ) && is_string( $decoded['message'] ) ? trim( $decoded['message'] ) : '';
+
+		$reason = array();
+		if ( '' !== $token && ! preg_match( '/\s/', $token ) ) {
+			$reason['code'] = self::clip_reason( $token );
+		} elseif ( '' === $prose ) {
+			// The token slot held a sentence and nothing else carried one.
+			$prose = $token;
+		}
+
+		if ( '' !== $prose ) {
+			$reason['message'] = self::clip_reason( $prose );
+		}
+
+		return $reason;
+	}
+
+	/**
+	 * Flatten and shorten one half of an upstream reason.
+	 *
+	 * Newlines go first so a multi-line upstream message cannot spend the
+	 * whole budget on indentation before it says anything. `mb_substr()`
+	 * rather than `substr()` because the cut would otherwise land inside a
+	 * multi-byte character and produce a field that is not valid UTF-8,
+	 * which `wp_json_encode()` drops entirely — losing the reason to the
+	 * very code meant to preserve it.
+	 *
+	 * @param string $value Raw upstream text.
+	 * @return string
+	 */
+	private static function clip_reason( $value ) {
+		$value = trim( preg_replace( '/\s+/', ' ', $value ) );
+
+		if ( mb_strlen( $value, 'UTF-8' ) <= self::REASON_MAX_LENGTH ) {
+			return $value;
+		}
+
+		return rtrim( mb_substr( $value, 0, self::REASON_MAX_LENGTH, 'UTF-8' ) ) . '…';
+	}
 }

--- a/projects/packages/backup/src/rest/class-rest-controller.php
+++ b/projects/packages/backup/src/rest/class-rest-controller.php
@@ -268,12 +268,18 @@ class Rest_Controller {
 	 * start the backup restore.", distinguishable only by a status code.
 	 *
 	 * WordPress.com's own reason is preserved under `wpcom`, deliberately
-	 * shaped like `transport_error()`'s `transport` key and kept there for
-	 * the same reason: it is support-facing English, so it travels in
-	 * `data` rather than being spliced into a message the reader expects in
-	 * their own language. The client maps the codes it recognises onto
-	 * copy of its own (see `upstreamMessage` in `_helpers.ts`); the rest
-	 * still reach whoever reads the response.
+	 * shaped like `transport_error()`'s `transport` key. The client decides
+	 * what to do with it: `failureMessage()` in `_helpers.ts` maps the
+	 * codes whose meaning is the code itself, and *renders* the message for
+	 * the ones — `rewind_error`, `authorization_required` — where one code
+	 * spans several unrelated situations and only the sentence tells them
+	 * apart.
+	 *
+	 * That the message can reach a reader is why the flattening and the
+	 * 200-character clip below are not housekeeping. They are the whole
+	 * reason it is safe to render, so do not relax them. It stays a plain
+	 * string all the way out; the client escapes it by rendering it as
+	 * React children.
 	 *
 	 * Only those two fields are forwarded, never the body — an error body
 	 * is unbounded and can echo the request that produced it.

--- a/projects/packages/backup/src/rest/class-restore-bridge.php
+++ b/projects/packages/backup/src/rest/class-restore-bridge.php
@@ -150,10 +150,10 @@ class Restore_Bridge {
 
 		$status_code = wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
-			return new WP_Error(
+			return Rest_Controller::upstream_error(
+				$response,
 				'restore_initiate_failed',
-				__( 'Could not start the backup restore.', 'jetpack-backup-pkg' ),
-				array( 'status' => is_int( $status_code ) && $status_code > 0 ? $status_code : 500 )
+				__( 'Could not start the backup restore.', 'jetpack-backup-pkg' )
 			);
 		}
 
@@ -172,10 +172,27 @@ class Restore_Bridge {
 		// distinguished the two cases anyway: `(int) null` and `(int) 0`
 		// are both `0`.
 		if ( empty( $decoded['ok'] ) ) {
+			$data = array( 'status' => 500 );
+
+			// The `error` beside it is the whole of what went wrong —
+			// "There is already a restore in progress" and its like — and
+			// it was being dropped on the floor, leaving a reader who
+			// cannot start a second restore with no way to learn why.
+			//
+			// It arrives as prose with no machine code beside it, which is
+			// why `upstream_reason()` sorts on shape rather than on which
+			// key a value came from. The v2 route usually turns this
+			// answer into a 500 `rewind_error` before it ever reaches us,
+			// so what this branch catches is the shape upstream does not.
+			$reason = Rest_Controller::upstream_reason( $decoded );
+			if ( ! empty( $reason ) ) {
+				$data['wpcom'] = $reason;
+			}
+
 			return new WP_Error(
 				'restore_initiate_failed',
 				__( 'Could not start the backup restore.', 'jetpack-backup-pkg' ),
-				array( 'status' => 500 )
+				$data
 			);
 		}
 
@@ -277,10 +294,10 @@ class Restore_Bridge {
 		}
 
 		if ( 200 !== $status_code ) {
-			return new WP_Error(
+			return Rest_Controller::upstream_error(
+				$response,
 				'restore_status_fetch_failed',
-				__( 'Could not fetch restore progress.', 'jetpack-backup-pkg' ),
-				array( 'status' => is_int( $status_code ) && $status_code > 0 ? $status_code : 500 )
+				__( 'Could not fetch restore progress.', 'jetpack-backup-pkg' )
 			);
 		}
 

--- a/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
@@ -135,4 +135,55 @@ class Rest_Activity_Log_Bridge_Test extends TestCase {
 
 		$this->assertStringContainsString( '_locale=es_ES', $this->captured_url );
 	}
+
+	/**
+	 * A non-200 becomes the bridge's error, carrying the status and the
+	 * reason WordPress.com gave.
+	 *
+	 * This route had no non-200 coverage at all, which mattered more than
+	 * it looks: it is one of the four callers that compares
+	 * `200 !== $status_code` without casting, so it is a route where a
+	 * mis-clamped status would reach the client unnoticed.
+	 *
+	 * 403 rather than 500, because 500 is also the fallback for a status
+	 * outside the failure range — a test written against it would pass
+	 * whether or not the status was forwarded.
+	 */
+	public function test_reports_a_non_200_with_the_upstream_reason() {
+		$this->arrange_wpcom(
+			array(
+				'code'    => 'authorization_required',
+				'message' => 'An active access token must be used.',
+			),
+			403
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/site/rewindable-activity' );
+		$response = Activity_Log_Bridge::get_activity_log( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'activity_log_fetch_failed', $response->get_error_code() );
+		$this->assertSame( 403, $response->get_error_data()['status'] );
+		$this->assertSame( 'authorization_required', $response->get_error_data()['wpcom']['code'] );
+	}
+
+	/**
+	 * A success code reported as a string is never served as one.
+	 *
+	 * This route compares `200 !== $status_code` uncast, so a transport
+	 * that reports statuses as strings sends a perfectly good response
+	 * down the failure branch. What must not then happen is the 200
+	 * travelling on as the error's own status: WordPress would serve the
+	 * error envelope as HTTP 200 and the client would read a failure as a
+	 * success.
+	 */
+	public function test_never_serves_a_string_200_as_a_success() {
+		$this->arrange_wpcom_raw( '{"current":{"orderedItems":[]}}', '200' );
+
+		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/site/rewindable-activity' );
+		$response = Activity_Log_Bridge::get_activity_log( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 500, $response->get_error_data()['status'] );
+	}
 }

--- a/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
@@ -24,6 +24,7 @@ use function add_filter;
 use function do_action;
 use function remove_action;
 use function remove_filter;
+use function wp_json_encode;
 
 /**
  * Tests that the modernization filter is the only thing standing between
@@ -305,5 +306,208 @@ class Rest_Bridge_Gating_Test extends TestCase {
 
 		$this->assertSame( 'http_request_failed', $data['transport']['code'] );
 		$this->assertSame( 'cURL error 6: Could not resolve host', $data['transport']['message'] );
+	}
+
+	/**
+	 * The reason is read out of all three shapes WordPress.com answers in.
+	 *
+	 * The shapes disagree about which key holds the machine token, and one
+	 * of them has no token at all — so what separates them is whether the
+	 * value is a word or a sentence. Getting that sorting wrong is silent:
+	 * a sentence in `code` is simply a key the client can never match.
+	 *
+	 * @param string $label    What this body is.
+	 * @param string $body     Raw body WordPress.com answers with.
+	 * @param array  $expected The reason it should yield.
+	 * @dataProvider provide_upstream_bodies
+	 */
+	#[DataProvider( 'provide_upstream_bodies' )]
+	public function test_upstream_reason_reads_each_envelope( $label, $body, array $expected ) {
+		$this->assertSame( $expected, Rest_Controller::upstream_reason( $body ), $label );
+	}
+
+	/**
+	 * Bodies WordPress.com answers a failed request with.
+	 *
+	 * @return array
+	 */
+	public static function provide_upstream_bodies() {
+		return array(
+			// wpcom/v2 serializes a WP_Error. This is the shape the restore
+			// and capabilities routes refuse in.
+			'a v2 WP_Error envelope'       => array(
+				'a v2 WP_Error envelope',
+				'{"code":"no_connected_jetpack","message":"This site is not connected.","data":{"status":412}}',
+				array(
+					'code'    => 'no_connected_jetpack',
+					'message' => 'This site is not connected.',
+				),
+			),
+			// The older v1 envelope names the same token `error`.
+			'a v1 error envelope'          => array(
+				'a v1 error envelope',
+				'{"error":"authorization_required","message":"An active access token must be used."}',
+				array(
+					'code'    => 'authorization_required',
+					'message' => 'An active access token must be used.',
+				),
+			),
+			// VaultPress's own 200 body. `error` is a sentence here, so it
+			// must land in `message` — the half nothing branches on.
+			'a VaultPress refusal'         => array(
+				'a VaultPress refusal',
+				'{"ok":false,"error":"There is already a restore in progress"}',
+				array( 'message' => 'There is already a restore in progress' ),
+			),
+			'a token with no prose beside' => array(
+				'a token with no prose beside',
+				'{"error":"rewind_error"}',
+				array( 'code' => 'rewind_error' ),
+			),
+			// Everything below names no reason, and must not invent one.
+			'an HTML gateway page'         => array( 'an HTML gateway page', '<html>502 Bad Gateway</html>', array() ),
+			'an empty body'                => array( 'an empty body', '', array() ),
+			'a body with no reason keys'   => array( 'a body with no reason keys', '{"capabilities":["backup"]}', array() ),
+			'a blank reason'               => array( 'a blank reason', '{"code":"   ","message":""}', array() ),
+			// A non-string `code` is upstream drift, not a reason. Casting
+			// it would put `Array` or `1` in front of a support agent.
+			'a non-string code'            => array( 'a non-string code', '{"code":{"nested":true}}', array() ),
+		);
+	}
+
+	/**
+	 * A multi-line upstream message is flattened before it is forwarded.
+	 *
+	 * Newlines go first so an indented stack trace cannot spend the length
+	 * budget on whitespace before it says anything.
+	 */
+	public function test_upstream_reason_flattens_whitespace() {
+		$reason = Rest_Controller::upstream_reason( "{\"message\":\"Restore failed.\\n\\n    Disk full.\"}" );
+
+		$this->assertSame( 'Restore failed. Disk full.', $reason['message'] );
+	}
+
+	/**
+	 * A long upstream message is clipped rather than copied out whole.
+	 *
+	 * Neither half is bounded upstream and both are forwarded on every
+	 * failed request, so this is the only thing standing between a
+	 * VaultPress stack trace and the browser.
+	 */
+	public function test_upstream_reason_clips_a_long_message() {
+		$reason = Rest_Controller::upstream_reason(
+			wp_json_encode( array( 'message' => str_repeat( 'a', 500 ) ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
+		);
+
+		$this->assertSame( str_repeat( 'a', 200 ) . '…', $reason['message'] );
+	}
+
+	/**
+	 * The clip lands between characters, not inside one.
+	 *
+	 * `substr()` would cut a multi-byte character in half and produce a
+	 * field that is not valid UTF-8, which `wp_json_encode()` then drops —
+	 * losing the reason to the very code meant to preserve it.
+	 */
+	public function test_upstream_reason_clips_on_character_boundaries() {
+		$reason = Rest_Controller::upstream_reason(
+			wp_json_encode( array( 'message' => str_repeat( 'é', 500 ) ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
+		);
+
+		$this->assertSame( str_repeat( 'é', 200 ) . '…', $reason['message'] );
+		$this->assertNotFalse( wp_json_encode( $reason, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+	}
+
+	/**
+	 * A non-200 keeps WordPress.com's status and its reason, under the
+	 * bridge's own code and translated message.
+	 *
+	 * 412 rather than 500 on purpose: 500 is also what an unreadable
+	 * status falls back to, so a test written against it would pass
+	 * whether the status was forwarded or thrown away.
+	 */
+	public function test_upstream_error_forwards_status_and_reason() {
+		$response = array(
+			'response' => array( 'code' => 412 ),
+			'body'     => '{"code":"no_connected_jetpack","message":"This site is not connected."}',
+		);
+
+		$error = Rest_Controller::upstream_error( $response, 'restore_initiate_failed', 'Could not start the backup restore.' );
+		$data  = $error->get_error_data();
+
+		$this->assertSame( 'restore_initiate_failed', $error->get_error_code() );
+		$this->assertSame( 'Could not start the backup restore.', $error->get_error_message() );
+		$this->assertSame( 412, $data['status'] );
+		$this->assertSame( 'no_connected_jetpack', $data['wpcom']['code'] );
+		$this->assertSame( 'This site is not connected.', $data['wpcom']['message'] );
+	}
+
+	/**
+	 * A status the transport reports as a string still travels as a number.
+	 *
+	 * The client reads `data.status` numerically — `isAmbiguousFailure()`
+	 * tests it with `typeof … === 'number'` and would call a string-status
+	 * failure ambiguous, which for the restore mutation means offering to
+	 * start a second one.
+	 */
+	public function test_upstream_error_casts_a_string_status() {
+		$response = array(
+			'response' => array( 'code' => '401' ),
+			'body'     => '',
+		);
+
+		$data = Rest_Controller::upstream_error( $response, 'capabilities_fetch_failed', 'x' )->get_error_data();
+
+		$this->assertSame( 401, $data['status'] );
+	}
+
+	/**
+	 * A response with no readable status is reported as 500, never as 0.
+	 *
+	 * `status_header( 0 )` emits an invalid status line, so a zero must not
+	 * be allowed to reach the response at all.
+	 *
+	 * @param string $label    What is wrong with this response.
+	 * @param array  $response The wp_remote_* response.
+	 * @dataProvider provide_responses_without_a_status
+	 */
+	#[DataProvider( 'provide_responses_without_a_status' )]
+	public function test_upstream_error_never_forwards_a_zero_status( $label, array $response ) {
+		$data = Rest_Controller::upstream_error( $response, 'download_status_fetch_failed', 'x' )->get_error_data();
+
+		$this->assertSame( 500, $data['status'], $label );
+	}
+
+	/**
+	 * Responses whose status cannot be read as a number.
+	 *
+	 * @return array
+	 */
+	public static function provide_responses_without_a_status() {
+		return array(
+			'no response key'       => array( 'no response key', array( 'body' => '' ) ),
+			'an empty status'       => array( 'an empty status', array( 'response' => array( 'code' => '' ) ) ),
+			'a literal zero'        => array( 'a literal zero', array( 'response' => array( 'code' => 0 ) ) ),
+			'an unparseable status' => array( 'an unparseable status', array( 'response' => array( 'code' => 'weird' ) ) ),
+		);
+	}
+
+	/**
+	 * A body that names no reason adds no key.
+	 *
+	 * An always-present `wpcom` holding an empty array would read, to
+	 * anyone looking at a failed request, as "WordPress.com said nothing"
+	 * being indistinguishable from "we did not look".
+	 */
+	public function test_upstream_error_omits_the_reason_when_there_is_none() {
+		$response = array(
+			'response' => array( 'code' => 503 ),
+			'body'     => '<html>503 Service Unavailable</html>',
+		);
+
+		$data = Rest_Controller::upstream_error( $response, 'activity_log_fetch_failed', 'x' )->get_error_data();
+
+		$this->assertSame( 503, $data['status'] );
+		$this->assertArrayNotHasKey( 'wpcom', $data );
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
@@ -403,19 +403,34 @@ class Rest_Bridge_Gating_Test extends TestCase {
 	}
 
 	/**
-	 * The clip lands between characters, not inside one.
+	 * The clip counts characters, and lands between them rather than
+	 * inside one.
 	 *
-	 * `substr()` would cut a multi-byte character in half and produce a
-	 * field that is not valid UTF-8, which `wp_json_encode()` then drops —
-	 * losing the reason to the very code meant to preserve it.
+	 * Three bytes per character on purpose, and both assertions depend on
+	 * it. An earlier version used `é` at two bytes, where a 200-byte cut
+	 * lands on a character boundary anyway — so the value stayed valid
+	 * UTF-8 no matter what the implementation did, and that half of the
+	 * test could not fail. 200 is not a multiple of 3, so this one
+	 * genuinely splits a character when the clip counts bytes.
+	 *
+	 * The validity check is asserted first because PHPUnit stops at the
+	 * first failure, and behind the length check it would never run under
+	 * the mutation it exists to catch.
+	 *
+	 * `mb_check_encoding()` and not `wp_json_encode() !== false`: WordPress
+	 * does not reject an invalid string, it rewrites it. The broken bytes
+	 * come back as a `?` and the encode succeeds, so an assertion phrased
+	 * that way would pass over exactly the damage it was written for.
 	 */
 	public function test_upstream_reason_clips_on_character_boundaries() {
 		$reason = Rest_Controller::upstream_reason(
-			wp_json_encode( array( 'message' => str_repeat( 'é', 500 ) ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
+			wp_json_encode( array( 'message' => str_repeat( '日', 500 ) ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
 		);
 
-		$this->assertSame( str_repeat( 'é', 200 ) . '…', $reason['message'] );
-		$this->assertNotFalse( wp_json_encode( $reason, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+		$this->assertTrue( mb_check_encoding( $reason['message'], 'UTF-8' ) );
+		// And the budget is spent in characters, which is the larger half
+		// of the harm: a byte-wise clip keeps 67 of these, not 200.
+		$this->assertSame( str_repeat( '日', 200 ) . '…', $reason['message'] );
 	}
 
 	/**
@@ -509,5 +524,138 @@ class Rest_Bridge_Gating_Test extends TestCase {
 
 		$this->assertSame( 503, $data['status'] );
 		$this->assertArrayNotHasKey( 'wpcom', $data );
+	}
+
+	/**
+	 * A success code never reaches `data.status`, however it arrives.
+	 *
+	 * The most dangerous input this function takes, and the reason the
+	 * status is clamped to the failure range rather than tested for
+	 * truthiness. Four of the callers compare `200 !== $status_code`
+	 * without casting, so a numeric-string `'200'` fails that comparison
+	 * and lands here — carrying a success code into a failure. Forwarded,
+	 * it would make WordPress serve the error envelope as HTTP 200:
+	 * `apiFetch` resolves, `apiCall()` never throws, `isAmbiguousFailure()`
+	 * never runs, and the restore mutation's `onSuccess` reports a restore
+	 * that never started.
+	 *
+	 * The junk cases ride along because `(int)` is total — `'2 Bad'` is 2
+	 * and `true` is 1 — and a low status is no more servable than a zero.
+	 *
+	 * @param string $label    What this response carries.
+	 * @param mixed  $upstream The status code the transport reports.
+	 * @dataProvider provide_statuses_that_are_not_failures
+	 */
+	#[DataProvider( 'provide_statuses_that_are_not_failures' )]
+	public function test_upstream_error_never_forwards_a_success_status( $label, $upstream ) {
+		$response = array(
+			'response' => array( 'code' => $upstream ),
+			'body'     => '{"code":"rewind_error"}',
+		);
+
+		$data = Rest_Controller::upstream_error( $response, 'restore_initiate_failed', 'x' )->get_error_data();
+
+		$this->assertSame( 500, $data['status'], $label );
+	}
+
+	/**
+	 * Statuses that must never be forwarded as the failure's own.
+	 *
+	 * @return array
+	 */
+	public static function provide_statuses_that_are_not_failures() {
+		return array(
+			// The one that matters: this is what an un-cast caller routes
+			// into the failure branch on a perfectly good response.
+			'a 200 reported as a string' => array( 'a 200 reported as a string', '200' ),
+			'a 204 reported as a string' => array( 'a 204 reported as a string', '204' ),
+			'a real 200'                 => array( 'a real 200', 200 ),
+			'a 3xx'                      => array( 'a 3xx', 302 ),
+			'a status with a suffix'     => array( 'a status with a suffix', '2 Bad' ),
+			'a float'                    => array( 'a float', 3.7 ),
+			'a boolean'                  => array( 'a boolean', true ),
+			'a status above the range'   => array( 'a status above the range', 600 ),
+		);
+	}
+
+	/**
+	 * Two sentences are both kept, specific one first.
+	 *
+	 * A VaultPress refusal wrapped in a generic envelope puts the reason
+	 * in `error` and boilerplate in `message`. An earlier revision
+	 * promoted `error` only when `message` was empty, so this shape —
+	 * the one the restore bridge exists to read — silently kept the
+	 * boilerplate and dropped the reason.
+	 */
+	public function test_upstream_reason_keeps_both_sentences() {
+		$reason = Rest_Controller::upstream_reason(
+			'{"ok":false,"error":"There is already a restore in progress","message":"Rewind failed"}'
+		);
+
+		$this->assertSame( 'There is already a restore in progress Rewind failed', $reason['message'] );
+		$this->assertArrayNotHasKey( 'code', $reason );
+	}
+
+	/**
+	 * The same text in both keys is not said twice.
+	 */
+	public function test_upstream_reason_does_not_repeat_a_duplicated_sentence() {
+		$reason = Rest_Controller::upstream_reason(
+			'{"error":"Rewind failed for this site","message":"Rewind failed for this site"}'
+		);
+
+		$this->assertSame( 'Rewind failed for this site', $reason['message'] );
+	}
+
+	/**
+	 * A code beside a sentence still keeps both halves.
+	 *
+	 * The v1 envelope's ordinary shape, pinned so the two-sentence fix
+	 * above cannot regress it into folding the token in with the prose.
+	 */
+	public function test_upstream_reason_keeps_a_code_and_its_prose() {
+		$reason = Rest_Controller::upstream_reason(
+			'{"error":"authorization_required","message":"An active access token must be used."}'
+		);
+
+		$this->assertSame( 'authorization_required', $reason['code'] );
+		$this->assertSame( 'An active access token must be used.', $reason['message'] );
+	}
+
+	/**
+	 * Whitespace is judged in Unicode, not in ASCII.
+	 *
+	 * `\s` without `/u` is ASCII-only, so a sentence spaced with U+00A0
+	 * has no whitespace as far as the sort is concerned and lands in
+	 * `code` — a key the client can never match, which is the exact
+	 * outcome the sort exists to prevent.
+	 *
+	 * @param string $label     What separates the words.
+	 * @param string $separator The space character to use.
+	 * @dataProvider provide_unicode_spaces
+	 */
+	#[DataProvider( 'provide_unicode_spaces' )]
+	public function test_upstream_reason_reads_unicode_spaces_as_whitespace( $label, $separator ) {
+		$sentence = 'Restore' . $separator . 'already' . $separator . 'running';
+
+		$reason = Rest_Controller::upstream_reason( array( 'error' => $sentence ) );
+
+		$this->assertArrayNotHasKey( 'code', $reason, $label );
+		// And the flatten normalises it, so the message is not carrying
+		// exotic spacing into the response either.
+		$this->assertSame( 'Restore already running', $reason['message'], $label );
+	}
+
+	/**
+	 * Space characters that are not an ASCII space.
+	 *
+	 * @return array
+	 */
+	public static function provide_unicode_spaces() {
+		return array(
+			'a non-breaking space' => array( 'a non-breaking space', "\u{00A0}" ),
+			'an ideographic space' => array( 'an ideographic space', "\u{3000}" ),
+			'a thin space'         => array( 'a thin space', "\u{2009}" ),
+		);
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
@@ -186,6 +186,35 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 	}
 
 	/**
+	 * A non-200 keeps WordPress.com's reason as well as its status.
+	 *
+	 * This is the screen behind `<Gates>`, and the two answers it most
+	 * needs to tell apart are the two this route cannot distinguish on its
+	 * own: a site whose connection has gone and a site whose plan has. Both
+	 * arrive as `capabilities_fetch_failed` with the same sentence, so the
+	 * upstream code is the whole of the difference.
+	 *
+	 * 412 rather than 500 deliberately — 500 is also the fallback for an
+	 * unreadable status, so a test written against it would pass whether or
+	 * not the status survived.
+	 */
+	public function test_forwards_the_upstream_reason() {
+		$this->arrange_wpcom(
+			array(
+				'code'    => 'no_connected_jetpack',
+				'message' => 'This site is not connected.',
+			),
+			412
+		);
+
+		$data = Capabilities_Bridge::get_capabilities()->get_error_data();
+
+		$this->assertSame( 412, $data['status'] );
+		$this->assertSame( 'no_connected_jetpack', $data['wpcom']['code'] );
+		$this->assertSame( 'This site is not connected.', $data['wpcom']['message'] );
+	}
+
+	/**
 	 * A status that arrives as a numeric string is still a success.
 	 *
 	 * `wp_remote_retrieve_response_code()` returns the value uncast, so a

--- a/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
@@ -346,6 +346,36 @@ class Rest_Download_Bridge_Test extends TestCase {
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'download_status_fetch_failed', $result->get_error_code() );
 		$this->assertSame( 502, $result->get_error_data()['status'] );
+		// This body names no reason, so none is invented. An always-present
+		// key would make "WordPress.com said nothing" and "we did not look"
+		// look the same to whoever reads the failure.
+		$this->assertArrayNotHasKey( 'wpcom', $result->get_error_data() );
+	}
+
+	/**
+	 * The status route keeps WordPress.com's reason when it gives one.
+	 *
+	 * 401 rather than 500, because 500 is also the fallback for a status
+	 * that cannot be read — a test written against it would pass whether
+	 * or not the status was forwarded.
+	 */
+	public function test_status_forwards_the_upstream_reason() {
+		$this->arrange_wpcom(
+			array(
+				'error'   => 'authorization_required',
+				'message' => 'An active access token must be used.',
+			),
+			401
+		);
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/backups/download/123/status' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'download_id', 55 );
+		$data = Download_Bridge::get_download_status( $request )->get_error_data();
+
+		$this->assertSame( 401, $data['status'] );
+		$this->assertSame( 'authorization_required', $data['wpcom']['code'] );
+		$this->assertSame( 'An active access token must be used.', $data['wpcom']['message'] );
 	}
 
 	/**

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -173,6 +173,35 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
+	 * A non-200 on the directory listing keeps WordPress.com's reason.
+	 *
+	 * The other half of `forward_response()`, which every pass-through
+	 * bridge shares — so this covers the shared non-200 path the same way
+	 * the test above covers the shared transport path.
+	 *
+	 * 412 rather than 500, because 500 is also what an unreadable status
+	 * falls back to.
+	 */
+	public function test_list_directory_forwards_the_upstream_reason() {
+		$this->arrange_wpcom(
+			array(
+				'code'    => 'no_connected_jetpack',
+				'message' => 'This site is not connected.',
+			),
+			412
+		);
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/backups/123/ls' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'path', '/' );
+		$data = File_Browser_Bridge::list_directory( $request )->get_error_data();
+
+		$this->assertSame( 412, $data['status'] );
+		$this->assertSame( 'no_connected_jetpack', $data['wpcom']['code'] );
+		$this->assertSame( 'This site is not connected.', $data['wpcom']['message'] );
+	}
+
+	/**
 	 * A manifest path that is not base64 is refused before dispatch.
 	 *
 	 * The value is interpolated into the WPCOM URL *path* unescaped —

--- a/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
@@ -314,6 +314,75 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	}
 
 	/**
+	 * The refusal that comes back inside a 200 keeps its reason too.
+	 *
+	 * VaultPress says why in prose, under `error`, and this branch used to
+	 * drop it — leaving a reader who cannot start a restore with a generic
+	 * sentence and no way to learn that one is already running.
+	 *
+	 * It lands in `message` rather than `code` because it is a sentence,
+	 * and the client only ever matches `code` against tokens it knows.
+	 */
+	public function test_initiate_keeps_the_reason_from_a_refusal_in_a_200() {
+		$this->arrange_wpcom(
+			array(
+				'ok'    => false,
+				'error' => 'There is already a restore in progress',
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/to/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$response = Restore_Bridge::initiate_restore( $request );
+		$data     = $response->get_error_data();
+
+		$this->assertSame( 'There is already a restore in progress', $data['wpcom']['message'] );
+		$this->assertArrayNotHasKey( 'code', $data['wpcom'] );
+		// Unchanged: WordPress.com answered and said no, so nothing was
+		// queued and `isAmbiguousFailure()` must keep reading this as safe
+		// to retry.
+		$this->assertSame( 500, $data['status'] );
+	}
+
+	/**
+	 * A refusal that names nothing adds no reason.
+	 */
+	public function test_initiate_omits_the_reason_when_the_refusal_is_silent() {
+		$this->arrange_wpcom( array( 'ok' => false ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/to/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$response = Restore_Bridge::initiate_restore( $request );
+
+		$this->assertArrayNotHasKey( 'wpcom', $response->get_error_data() );
+	}
+
+	/**
+	 * A non-200 on initiate carries WordPress.com's own code.
+	 *
+	 * The bridge's code cannot say why on its own — all three initiate
+	 * failures are `restore_initiate_failed` — so a support agent looking
+	 * at a failed restore has only this to go on. 412 rather than 500,
+	 * because 500 is also the fallback for an unreadable status.
+	 */
+	public function test_initiate_forwards_the_upstream_reason() {
+		$this->arrange_wpcom(
+			array(
+				'code'    => 'no_connected_jetpack',
+				'message' => 'This site is not connected.',
+			),
+			412
+		);
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/to/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$data = Restore_Bridge::initiate_restore( $request )->get_error_data();
+
+		$this->assertSame( 412, $data['status'] );
+		$this->assertSame( 'no_connected_jetpack', $data['wpcom']['code'] );
+	}
+
+	/**
 	 * The status poll targets the v2 route and is signed with the blog
 	 * token.
 	 *
@@ -424,5 +493,8 @@ class Rest_Restore_Bridge_Test extends TestCase {
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'restore_status_fetch_failed', $response->get_error_code() );
 		$this->assertSame( 502, $response->get_error_data()['status'] );
+		// And the reason survives the wrapping, which is what lets the
+		// client say something better than "could not fetch progress".
+		$this->assertSame( 'rewind_error', $response->get_error_data()['wpcom']['code'] );
 	}
 }


### PR DESCRIPTION
Fixes JETPACK-2306

## Proposed changes

Every dashboard bridge answered a non-200 from WordPress.com by substituting a fixed code and one fixed sentence per operation, and forwarding only the status. A lapsed plan and an expired token both arrived as `restore_initiate_failed` / "Could not start the backup restore.", with nothing to tell them apart. The restore bridge additionally discarded VaultPress's `error` field from a **200** body, which is where "there is already a restore in progress" was going.

### Bridge side

* Collapse the nine hand-rolled non-200 branches (`class-capabilities-bridge.php`, `class-activity-log-bridge.php`, `class-restore-bridge.php` ×2, `class-download-bridge.php` ×2, `class-file-browser-bridge.php` ×3, the last of which is the shared `forward_response()`) onto a new `Rest_Controller::upstream_error()`.
* It keeps WordPress.com's reason under `data.wpcom = { code, message }`, deliberately shaped like the `transport` key that its sibling `transport_error()` already uses. Only those two fields travel, never the body.
* **The status is clamped to 400–599, not merely tested for truthiness.** Four of the callers compare `200 !== $status_code` without casting, so a numeric-string `'200'` fails that comparison and reaches the failure branch carrying a *success* code. Forwarding it would make WordPress serve the error envelope as HTTP 200 — `apiFetch` resolves, `apiCall()` never throws, and the restore mutation's `onSuccess` reports a restore that never started. Anything outside the failure range becomes 500. What the cast is still there for: a genuine `'404'` now travels as 404 rather than being flattened.
* Reading the reason takes some care, because three shapes disagree about where it lives: wpcom/v2 serializes a `WP_Error` as `{ code, message }`, the older v1 envelope calls that same token `error`, and VaultPress's own `{ ok: false, error }` body puts a whole sentence in `error` with no token at all. `upstream_reason()` sorts on **shape** — a `WP_Error` code has no whitespace in it — so a sentence never lands in the half the client matches against. The test runs in Unicode mode (`/u`), so a sentence spaced with U+00A0 sorts correctly rather than passing as a token. Sorting is all it does: when both keys hold sentences, both are kept, specific one first, de-duplicated.
* Both halves are whitespace-flattened and clipped to 200 **characters** (`mb_substr`). That clip is not housekeeping — it is what makes the message safe to put in front of a reader, per the next section.

### Client side, and why it is half the change

`ApiError.code` had zero consumers — every `.code` hit under `src/dashboard/` was a write — and the six surfaces that report a failure render a `message` and nothing else. A bridge-side mapping on its own would have changed nothing anyone sees.

`failureMessage()` in `_helpers.ts` applies one rule: **anything we can enumerate, map; anything we cannot, render.** Which side a code falls on is a fact about the code, and WordPress.com answers it.

* **`rewind_error` renders.** It is not a meaning, it is a container. Upstream builds it from VaultPress's own sentence verbatim (`sites-rewind-restores.php:379,438` and six sites in `class.wpcom-json-api-activity-log-rewind.php`), from `'Unexpected response from VaultPress.'` as a 502, and from `'You cannot enable Rewind for a free Jetpack site'` and `'…for a multisite'` as 400s. One code, four unrelated situations. Canned copy here was not merely vague but wrong: it prescribed a retry that can never succeed for the last two.
* **`authorization_required` renders.** It is a WordPress.com-wide generic shared with billing, domains, keyring and social. Within the rewind endpoints alone it covers "You are not allowed to rewind this site", "…to query this state", "…to rewind to the staging site" and an a12s-only guard. The message separates them; the code cannot. Its previous copy also blamed the reader's *account*, which is wrong on `get_restore_status()` — that signs `as_blog`, so the credential at fault is the site's token.
* **`no_connected_jetpack` stays canned.** It is the one that is genuinely enumerable, belonging to a documented vocabulary alongside `missing_plan`, `multisite_not_supported`, `host_not_supported` and the rest, where the code *is* the meaning. Wording now matches My Jetpack's, for familiarity of voice — not for a free translation: that copy is in the `jetpack-my-jetpack` domain and GlotPress translates per domain, so this string starts its own cycle.
* Anything with a reason but no recognised code renders too. A reason with a code and no sentence degrades to the bridge's line, rather than putting `rewind_error` on screen.

Rendered text sits inside a frame that names whose words it is — `'%1$s WordPress.com said: %2$s'`. That is this package's existing pattern from `use-download.ts`, and the safer version of it: that precedent renders upstream text unbounded, while this has already been flattened and clipped. The inner sentence will usually be English even when the frame is translated — a known, accepted trade, and attributing it is what makes it read as a quotation rather than as our own untranslated copy. The comment says so, so nobody re-cans it later.

Escaping: all six render sites take it as React children, and the dashboard contains no `dangerouslySetInnerHTML` at all. Verified, and stated in the docblock.

`isAmbiguousFailure()` is untouched, including its deliberate ambiguous-by-default. `data.wpcom` is a sibling key it ignores.

## Related product discussion/links

* JETPACK-2306 (D2 on the JETPACK-2243 cluster). D8, the untranslated `'Request failed'` fallback described in the same issue, was already fixed on trunk by #51518.

## Does this pull request change what data or activity we track or use?

No new tracking. It does add two fields to the error payload the bridges return to the browser — WordPress.com's error code and message — both flattened and clipped to 200 characters, and only on a failed request. The message can now reach the screen inside an attributed frame; the clip and the flatten are what make that safe, and should not be relaxed.

One caveat worth naming: the file browser's stream fetch talks to a third-party storage host rather than to WordPress.com, so on a non-200 there the reason is filed under a key named `wpcom` that misnames its origin. Documented in place.

## Testing instructions

All of this is behind the modernization filter and is a no-op with the flag off.

Automated:

* `jp test php packages/backup` — **275 tests, 715 assertions**.
* `pnpm test` from `projects/packages/backup` — **51 suites, 468 tests**.
* `pnpm run typecheck`, `npx eslint --max-warnings=0` on the changed TS, `jp phan packages/backup` (0 issues), and `vendor/bin/phpcs -s` on the changed PHP (0 errors, 0 warnings).

Every new assertion was mutation-tested: **31 deliberate breakages, all 31 caught, none survived** (18 PHP, 13 JS). Among them: reverting the status clamp to the truthiness test, dropping either of its bounds, restoring the `elseif` that discarded the prose reason, removing `/u` from either regex, clipping on bytes instead of characters, swapping either rendered code back to canned copy, dropping the attribution out of the frame, and rendering the bare code when no sentence arrived.

By hand, with the modernization filter on:

* Sandbox or otherwise arrange for a bridge route to answer non-200 — e.g. hook `rest_request_before_callbacks` at `PHP_INT_MAX` on `/jetpack/v4/site/capabilities`, or point the site at a blog id with no connected Jetpack.
* With `no_connected_jetpack`: the capabilities error screen reads "The site doesn't appear to be connected. Backup requires an active Jetpack connection in order to function properly."
* Start a restore while one is already running: the notice reads "Could not start the backup restore. WordPress.com said: There is already a restore in progress" rather than a generic line.
* With an unrecognised code carrying a message: the message is rendered inside the same frame.
* The failure still arrives as an HTTP error, not a 200 — the response status in the network panel matches `data.status`, and the screen reports a failure rather than a silent success.
