### PR TITLE
Backup: show storage usage details under the modernized meter

### DIFF
--- a/projects/packages/backup/changelog/add-backup-storage-usage-details
+++ b/projects/packages/backup/changelog/add-backup-storage-usage-details
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Backup: show the usage readings beside the modernized dashboard's storage meter — "Using 12.4GB of 20GB", and a link to how many days of backups that has bought. Reuses the legacy dashboard's own strings so they arrive already translated. No-op while the modernization filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
@@ -96,7 +96,11 @@ export default function StorageSpace() {
 				storageLimit={ usage.storageLimit }
 				usageLevel={ usage.usageLevel }
 			/>
-			<StorageUsageDetails storageUsed={ usage.storageUsed } storageLimit={ usage.storageLimit } />
+			<StorageUsageDetails
+				storageUsed={ usage.storageUsed }
+				storageLimit={ usage.storageLimit }
+				daysOfBackupsSaved={ usage.daysOfBackupsSaved }
+			/>
 		</section>
 	);
 }

--- a/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
@@ -4,6 +4,7 @@ import { Skeleton, Text } from '@wordpress/ui';
 import { StorageUsageLevels } from '../../data/storage-usage-levels';
 import { useStorageUsage } from '../../hooks/use-storage-usage';
 import StorageMeter from './meter';
+import StorageUsageDetails from './usage-details';
 import './style.scss';
 import type { StorageUsageLevelName } from '../../data/storage-usage-levels';
 
@@ -38,8 +39,8 @@ function sectionHeading( usageLevel: StorageUsageLevelName | null ): string {
  * meter that means nothing. That silence is deliberate and matches the
  * legacy dashboard's own `storageSize !== null && storageLimit > 0` gate.
  *
- * Sibling issues add usage details, the upsell and the help popover
- * inside this same section.
+ * Sibling issues add the upsell and the help popover inside this same
+ * section.
  *
  * @return The storage section, or null when there is nothing to show.
  */
@@ -56,7 +57,7 @@ export default function StorageSpace() {
 	// flight, so the activity list below is not pushed down when they
 	// land — which would happen on precisely the slow connections where
 	// this section matters most. Sized to the rendered article: a 20px
-	// heading line, 12px, a 24px bar.
+	// heading line, 12px, a 24px bar, 8px, a 20px line of usage details.
 	//
 	// Skeletons rather than the real heading over an empty track: both
 	// would assert content we do not have yet, and an empty meter reads
@@ -68,6 +69,7 @@ export default function StorageSpace() {
 				<div className="jpb-storage-meter">
 					<Skeleton className="jpb-storage-meter__placeholder" />
 				</div>
+				<Skeleton className="jpb-storage-space__details-placeholder" />
 			</section>
 		);
 	}
@@ -94,6 +96,7 @@ export default function StorageSpace() {
 				storageLimit={ usage.storageLimit }
 				usageLevel={ usage.usageLevel }
 			/>
+			<StorageUsageDetails storageUsed={ usage.storageUsed } storageLimit={ usage.storageLimit } />
 		</section>
 	);
 }

--- a/projects/packages/backup/src/dashboard/components/storage-space/style.scss
+++ b/projects/packages/backup/src/dashboard/components/storage-space/style.scss
@@ -22,6 +22,24 @@
 		inline-size: 160px;
 		margin-block-end: 12px;
 	}
+
+	// The usage readings under the bar. `Stack` owns the row itself —
+	// direction, gap, wrapping and alignment all come from the primitive,
+	// written as inline styles — so the only thing left here is how far
+	// the row sits from the meter above it.
+	&__details {
+		margin-block-start: 8px;
+	}
+
+	// Stands in for that row while the requests are in flight. Matches the
+	// gap and the `body-md` line box it replaces (8px + 20px), and is
+	// deliberately narrower than the track so the pair does not read as a
+	// second meter stacked under the first.
+	&__details-placeholder {
+		block-size: 20px;
+		inline-size: 240px;
+		margin-block-start: 8px;
+	}
 }
 
 .jpb-storage-meter {

--- a/projects/packages/backup/src/dashboard/components/storage-space/usage-details.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/usage-details.tsx
@@ -1,0 +1,170 @@
+import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { Link, Stack, Text } from '@wordpress/ui';
+import { useSiteSuffix } from '../../hooks/use-connection';
+import { useSiteSizeQuery } from '../../hooks/use-site-size';
+import type { ReactNode } from 'react';
+
+// Binary multiples, as legacy spells them. WordPress.com reports these
+// figures in bytes and sells storage in powers of two, so a 10GB plan is
+// 10 * 2^30 bytes — dividing by 10^9 would advertise it back to the reader
+// as 10.7GB.
+const GIGABYTE = 2 ** 30;
+const TERABYTE = 2 ** 40;
+
+/**
+ * The "Using 12.4GB of 20GB" reading.
+ *
+ * Usage is always stated in gigabytes and only the limit switches unit,
+ * at 1TB — which is what the larger storage add-ons are sold in. A site
+ * that has filled whole terabytes is vanishingly rare, and "0.01TB used"
+ * would answer a question nobody asked.
+ *
+ * Both msgids are legacy's, character for character — including the
+ * unusual `%1.1f`/`%2f` spelling, which is not positional despite reading
+ * as though it were: those are sprintf *widths*, and the arguments are
+ * consumed in order. Keeping them identical is the point, so the strings
+ * arrive already translated rather than waiting a GlotPress cycle.
+ *
+ * @param storageUsed  - Bytes of backup storage in use.
+ * @param storageLimit - The plan's storage limit in bytes.
+ * @return The reading, with the used figure emphasized.
+ */
+function usageText( storageUsed: number, storageLimit: number ): ReactNode {
+	const usedGigabytes = storageUsed / GIGABYTE;
+
+	if ( storageLimit < TERABYTE ) {
+		// translators: Must use unit abbreviation; describes used vs available storage amounts (e.g. 20.0GB of 30GB used, 0.5GB of 20GB used). %1.1f: numeric amount of disk space used, %2f: numeric amount of disk space available.
+		const inGigabytes = __( 'Using <strong>%1.1fGB</strong> of %2fGB', 'jetpack-backup-pkg' );
+
+		return createInterpolateElement(
+			sprintf(
+				inGigabytes,
+				// @ts-expect-error The format string is parsed at the type level, and this spelling defeats that parser — it infers a single argument.
+				usedGigabytes,
+				storageLimit / GIGABYTE
+			),
+			{ strong: <strong /> }
+		);
+	}
+
+	// translators: Must use unit abbreviation; describes used vs available storage amounts (e.g. 20.0GB of 1TB used, 0.5GB of 2TB used). %1$d: numeric amount of disk space used, %2$d: numeric amount of disk space available.
+	const inTerabytes = __( 'Using <strong>%1$dGB</strong> of %2$dTB', 'jetpack-backup-pkg' );
+
+	return createInterpolateElement( sprintf( inTerabytes, usedGigabytes, storageLimit / TERABYTE ), {
+		strong: <strong />,
+	} );
+}
+
+/**
+ * The "N days of backups saved" label, still carrying its `<a>` markup.
+ *
+ * Two singular `__()` msgids rather than one `_n()` pair, which is what
+ * legacy ships. `_n()` would be the better i18n — it is the only form
+ * that serves a language with more than two plural rules — but it is a
+ * different GlotPress entry from either of these, so adopting it here
+ * would throw away every existing translation of a string the flag-off
+ * dashboard is still rendering today. Worth revisiting once legacy's copy
+ * is gone and both can change together.
+ *
+ * Note the ternary picks between two already-extracted `const`s rather
+ * than wrapping the `__()` call itself. Put the choice inside the call and
+ * the minifier factors it out; the text-domain scanner then finds no
+ * literal to extract and drops both msgids without saying so.
+ *
+ * @param days - Days of backups WordPress.com is actually holding.
+ * @return The label, for `createInterpolateElement`.
+ */
+function daysOfBackupsLabel( days: number ): string {
+	const singular = __( '<a>1 day of backups saved</a>', 'jetpack-backup-pkg' );
+	/* translators: %s: Number of days of backups saved. */
+	const plural = __( '<a>%s days of backups saved</a>', 'jetpack-backup-pkg' );
+
+	// Stringified for the `%s` the msgid spells, which `sprintf` types as
+	// taking a string. It would coerce the number itself, but only after
+	// the type-level parse of the format string has already rejected it.
+	return days === 1 ? singular : sprintf( plural, String( days ) );
+}
+
+type Props = {
+	storageUsed: number;
+	storageLimit: number;
+};
+
+/**
+ * The two readings that sit beneath the storage meter.
+ *
+ * The bar says how full; these say how full *of what*, and how much
+ * history that has bought — which is the figure someone weighing an
+ * upgrade actually needs. Rendered only by the section's `hasUsableFigures`
+ * branch, so both byte figures are known numbers by the time they arrive
+ * here and neither needs re-testing.
+ *
+ * Legacy's copy of this also hosts the storage help popover. That is
+ * JETPACK-2332 and deliberately absent, along with the Tracks event its
+ * purchase link fires — there is no Tracks client on the modernized page
+ * yet (JETPACK-2301). Legacy's own orchestrator never passes the
+ * `onClickedPurchase` prop either, so nothing is lost in the meantime.
+ *
+ * @param props              - Component props.
+ * @param props.storageUsed  - Bytes of backup storage in use.
+ * @param props.storageLimit - The plan's storage limit in bytes.
+ * @return The rendered readings.
+ */
+export default function StorageUsageDetails( { storageUsed, storageLimit }: Props ) {
+	const site = useSiteSuffix();
+	const sizeQuery = useSiteSizeQuery();
+
+	// Read straight off the shared `/size` query rather than through
+	// `useStorageUsage()`: one field for one caller does not justify
+	// widening that hook's return, and React Query serves both observers
+	// from the single request either way. The `ok` gate is the same one it
+	// applies — WordPress.com's success flag lives *inside* a 200 body, and
+	// without it the sibling fields carry no meaning.
+	const size = sizeQuery.data?.ok ? sizeQuery.data : null;
+	const daysOfBackupsSaved = size?.days_of_backups_saved ?? null;
+
+	// The key is omitted rather than passed as undefined. `getRedirectUrl`
+	// walks its args with `for…in`, so a present-but-undefined `site` is
+	// encoded — the link would carry the literal string `undefined` — and
+	// its mere presence also suppresses the helper's own site fallback.
+	const backupsSavedUrl = getRedirectUrl(
+		'backup-plugin-storage-backups-saved',
+		site ? { site } : {}
+	);
+
+	return (
+		<Stack
+			className="jpb-storage-space__details"
+			direction="row"
+			justify="space-between"
+			align="baseline"
+			// No breakpoint and no media query: `Stack` writes its flex
+			// properties as inline styles, so a responsive override would
+			// have to reach for `!important`. Letting the row wrap gets the
+			// same result — a single item on the second line sits at the
+			// start under `space-between`, which is exactly the stacked
+			// layout legacy switches to on phones, at legacy's 4px gap.
+			wrap="wrap"
+			gap="xs"
+		>
+			<Text variant="body-md">{ usageText( storageUsed, storageLimit ) }</Text>
+			{ /*
+			 * Omitted rather than shown as "0 days" when the count is
+			 * missing. Legacy renders the plural label over its selector's
+			 * `null` and prints "null days of backups saved"; it only gets
+			 * away with it because a response complete enough to draw the
+			 * meter has always carried this field too. Saying nothing is
+			 * the honest answer if that ever stops being true.
+			 */ }
+			{ daysOfBackupsSaved !== null && (
+				<Text variant="body-sm">
+					{ createInterpolateElement( daysOfBackupsLabel( daysOfBackupsSaved ), {
+						a: <Link openInNewTab href={ backupsSavedUrl } />,
+					} ) }
+				</Text>
+			) }
+		</Stack>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/storage-space/usage-details.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/usage-details.tsx
@@ -3,7 +3,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Link, Stack, Text } from '@wordpress/ui';
 import { useSiteSuffix } from '../../hooks/use-connection';
-import { useSiteSizeQuery } from '../../hooks/use-site-size';
 import type { ReactNode } from 'react';
 
 // Binary multiples, as legacy spells them. WordPress.com reports these
@@ -21,11 +20,35 @@ const TERABYTE = 2 ** 40;
  * that has filled whole terabytes is vanishingly rare, and "0.01TB used"
  * would answer a question nobody asked.
  *
- * Both msgids are legacy's, character for character — including the
- * unusual `%1.1f`/`%2f` spelling, which is not positional despite reading
- * as though it were: those are sprintf *widths*, and the arguments are
- * consumed in order. Keeping them identical is the point, so the strings
- * arrive already translated rather than waiting a GlotPress cycle.
+ * Both msgids are legacy's, character for character, so the strings
+ * arrive already translated rather than waiting a GlotPress cycle. That
+ * carries a known defect across with them, and it is worth being precise
+ * about which one.
+ *
+ * The gigabyte msgid's `%1.1f` and `%2f` are *not* argument references,
+ * despite reading as though they were. They parse as a width and a
+ * precision, and `@tannin/sprintf` — which is what `@wordpress/i18n` uses —
+ * annotates the width group "Min width (unsupported)" and discards it. So
+ * both are plain sequential placeholders, consumed in the order they
+ * appear, and the English source renders correctly at every limit:
+ * `sprintf( 'Using <strong>%1.1fGB</strong> of %2fGB', 3, 5 )` gives
+ * `Using <strong>3.0GB</strong> of 5GB`, with no padding and no stray
+ * space.
+ *
+ * The hazard is not the rendering, it is the reordering. Being sequential,
+ * the two values swap places if a translation fronts the total — which is
+ * natural in plenty of languages: `sprintf( 'Of %2fGB, using
+ * <strong>%1.1fGB</strong>', 12.4, 20 )` gives `Of 12.4GB, using 20.0GB`,
+ * used and total transposed. On the one screen whose job is to say whether
+ * backups are at risk, that tells the reader they are over quota when they
+ * are not. Truly positional placeholders survive the same reorder, which is
+ * why the terabyte msgid below — spelled `%1$d`/`%2$d` — is immune.
+ *
+ * Fixing the gigabyte string means changing legacy and this copy together
+ * so the msgid stays shared, and that is queued as its own change rather
+ * than done here. Until it lands, the translator comment on the string
+ * must not describe these as numbered arguments, or it invites exactly the
+ * reorder that breaks them.
  *
  * @param storageUsed  - Bytes of backup storage in use.
  * @param storageLimit - The plan's storage limit in bytes.
@@ -35,9 +58,16 @@ function usageText( storageUsed: number, storageLimit: number ): ReactNode {
 	const usedGigabytes = storageUsed / GIGABYTE;
 
 	if ( storageLimit < TERABYTE ) {
-		// translators: Must use unit abbreviation; describes used vs available storage amounts (e.g. 20.0GB of 30GB used, 0.5GB of 20GB used). %1.1f: numeric amount of disk space used, %2f: numeric amount of disk space available.
+		// translators: Must use unit abbreviation; describes used vs available storage amounts (e.g. 20.0GB of 30GB used, 0.5GB of 20GB used). %1.1f and %2f are NOT numbered arguments — they are filled in the order they appear, %1.1f first with the amount of disk space used, then %2f with the amount available. Please keep them in that order.
 		const inGigabytes = __( 'Using <strong>%1.1fGB</strong> of %2fGB', 'jetpack-backup-pkg' );
 
+		// Legacy carries `eslint-disable-next-line @wordpress/valid-sprintf`
+		// on its copy of this call, and its absence here is not a clean
+		// bill of health: the rule only inspects a format string it can
+		// resolve, and hoisting the msgid into a `const` — which the
+		// minifier reasoning above requires — puts it out of reach. The
+		// string is exactly as malformed as it was; nothing is checking it
+		// any more. See the note on this function about what that costs.
 		return createInterpolateElement(
 			sprintf(
 				inGigabytes,
@@ -90,6 +120,7 @@ function daysOfBackupsLabel( days: number ): string {
 type Props = {
 	storageUsed: number;
 	storageLimit: number;
+	daysOfBackupsSaved: number | null;
 };
 
 /**
@@ -97,9 +128,12 @@ type Props = {
  *
  * The bar says how full; these say how full *of what*, and how much
  * history that has bought — which is the figure someone weighing an
- * upgrade actually needs. Rendered only by the section's `hasUsableFigures`
- * branch, so both byte figures are known numbers by the time they arrive
- * here and neither needs re-testing.
+ * upgrade actually needs.
+ *
+ * Presentational, like `meter.tsx`: everything arrives as a prop, read
+ * once by the section from `useStorageUsage()`. Rendered only by that
+ * section's `hasUsableFigures` branch, so both byte figures are known
+ * numbers by the time they get here and neither needs re-testing.
  *
  * Legacy's copy of this also hosts the storage help popover. That is
  * JETPACK-2332 and deliberately absent, along with the Tracks event its
@@ -107,23 +141,18 @@ type Props = {
  * yet (JETPACK-2301). Legacy's own orchestrator never passes the
  * `onClickedPurchase` prop either, so nothing is lost in the meantime.
  *
- * @param props              - Component props.
- * @param props.storageUsed  - Bytes of backup storage in use.
- * @param props.storageLimit - The plan's storage limit in bytes.
+ * @param props                    - Component props.
+ * @param props.storageUsed        - Bytes of backup storage in use.
+ * @param props.storageLimit       - The plan's storage limit in bytes.
+ * @param props.daysOfBackupsSaved - Days of history held, or null when unreported.
  * @return The rendered readings.
  */
-export default function StorageUsageDetails( { storageUsed, storageLimit }: Props ) {
+export default function StorageUsageDetails( {
+	storageUsed,
+	storageLimit,
+	daysOfBackupsSaved,
+}: Props ) {
 	const site = useSiteSuffix();
-	const sizeQuery = useSiteSizeQuery();
-
-	// Read straight off the shared `/size` query rather than through
-	// `useStorageUsage()`: one field for one caller does not justify
-	// widening that hook's return, and React Query serves both observers
-	// from the single request either way. The `ok` gate is the same one it
-	// applies — WordPress.com's success flag lives *inside* a 200 body, and
-	// without it the sibling fields carry no meaning.
-	const size = sizeQuery.data?.ok ? sizeQuery.data : null;
-	const daysOfBackupsSaved = size?.days_of_backups_saved ?? null;
 
 	// The key is omitted rather than passed as undefined. `getRedirectUrl`
 	// walks its args with `for…in`, so a present-but-undefined `site` is

--- a/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
@@ -20,12 +20,21 @@ type Figures = {
 	 * forever — which is what makes it safe to reserve layout on.
 	 */
 	isLoading: boolean;
+	/**
+	 * Days of backups WordPress.com is actually holding, or null when the
+	 * response did not carry the figure. Distinct from the plan's promised
+	 * retention: this is what survived the storage limit.
+	 *
+	 * Nullable on its own rather than folded into `hasUsableFigures`,
+	 * because it is genuinely independent of the two byte figures — a
+	 * response can describe storage perfectly well and omit this.
+	 */
+	daysOfBackupsSaved: number | null;
 };
 
 // `last_backup_size` and the plan's own retention are read off these same
-// responses but deliberately not returned: nothing consumes them yet, and
-// the usage details that will are JETPACK-2330. Adding each back is one
-// line when there is a caller.
+// responses but deliberately not returned: nothing consumes them yet.
+// Adding each back is one line when there is a caller.
 
 /**
  * `hasUsableFigures` is a discriminant, not a convenience flag: it is the
@@ -62,7 +71,7 @@ type Result = Figures &
  * response is discarded rather than half-read. Legacy does the same, by
  * dispatching its failure action.
  *
- * @return The two figures, the derived level, and whether to render.
+ * @return The figures, the derived level, and whether to render.
  */
 export function useStorageUsage(): Result {
 	const sizeQuery = useSiteSizeQuery();
@@ -87,18 +96,21 @@ export function useStorageUsage(): Result {
 	// retention policy, not absent.
 	const retentionDays = size?.retention_days || ( policies?.activity_log_limit_days ?? null );
 
+	const daysOfBackupsSaved = size?.days_of_backups_saved ?? null;
+
 	const usageLevel = getUsageLevel(
 		storageUsed,
 		storageLimit,
 		size?.min_days_of_backups_allowed ?? null,
 		size?.days_of_backups_allowed ?? null,
 		retentionDays,
-		size?.days_of_backups_saved ?? null
+		daysOfBackupsSaved
 	);
 
 	const figures: Figures = {
 		usageLevel,
 		isLoading: sizeQuery.isLoading || policiesQuery.isLoading,
+		daysOfBackupsSaved,
 	};
 
 	// A limit of zero is not a limit anyone can be measured against, and a

--- a/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
@@ -58,8 +58,8 @@ type Result = Figures &
  * day-counts, and `/site/backup/policies` reports the limit. A meter
  * drawn from `/size` alone has no denominator.
  *
- * Both halves are read defensively for the same reason. Every legacy
- * bridge answers a non-200 from WordPress.com with a bare `null` body,
+ * Both halves are read defensively for the same reason. A route that
+ * cannot decode WordPress.com's answer still returns a bare `null` body,
  * which WordPress serves as HTTP 200 — so the request resolves, React
  * Query records a success, and the only evidence of failure is the shape
  * of the data. Anything unreadable therefore has to collapse to `null`

--- a/projects/packages/backup/tests/storage-usage-details.test.tsx
+++ b/projects/packages/backup/tests/storage-usage-details.test.tsx
@@ -1,0 +1,216 @@
+// Tests for the usage readings under the Overview's storage meter
+// (JETPACK-2330 / H3b).
+//
+// The bar itself, and the gate that decides whether any of this renders,
+// are covered in `storage-meter.test.tsx`. This file is about what the two
+// lines beside it say — the unit the limit is stated in, and the retention
+// link that answers "how much history is that actually buying me".
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factory above.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import StorageSpace from '../src/dashboard/components/storage-space';
+import type { ReactNode } from 'react';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const GB = 1024 * 1024 * 1024;
+const TB = 1024 * GB;
+const SITE = 'example.wordpress.com';
+
+/**
+ * Render inside an isolated QueryClient.
+ *
+ * @param ui - The tree to render.
+ * @return The testing-library render result.
+ */
+function renderWithClient( ui: ReactNode ) {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	return render( <QueryClientProvider client={ client }>{ ui }</QueryClientProvider> );
+}
+
+/**
+ * Answer the two routes the section reads.
+ *
+ * Defaults to a site holding 10GB of a 100GB plan, with a fortnight of
+ * history behind it.
+ *
+ * @param options          - Overrides.
+ * @param options.size     - What `/site/backup/size` returns.
+ * @param options.policies - What `/site/backup/policies` returns.
+ */
+function mockEndpoints( {
+	size = {} as Record< string, unknown >,
+	policies = {} as Record< string, unknown >,
+} = {} ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/site/backup/policies' ) ) {
+			return Promise.resolve( { policies: { storage_limit_bytes: 100 * GB, ...policies } } );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, size: 10 * GB, days_of_backups_saved: 14, ...size } );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+/**
+ * The usage reading, once it has arrived.
+ *
+ * The copy wraps the used figure in `<strong>`, so the line's own element
+ * holds only the fragments either side of it — and those fragments are all
+ * Testing Library's text matcher reads. Hence a search for the opening
+ * word, and anchored regexes at the call sites: `toHaveTextContent` takes
+ * a bare string as a *substring* match, which would pass on a line that
+ * had grown an extra clause.
+ *
+ * @return The element carrying the line.
+ */
+function usageLine(): Promise< HTMLElement > {
+	return screen.findByText( /^Using/ );
+}
+
+/**
+ * The retention link, once it has arrived.
+ *
+ * Matched on a fragment of its name rather than the whole of it: `Link`
+ * appends an "(opens in a new tab)" image to anything with `openInNewTab`,
+ * so the accessible name is never just the copy.
+ *
+ * @return The anchor.
+ */
+function retentionLink(): Promise< HTMLElement > {
+	return screen.findByRole( 'link', { name: /backups saved/ } );
+}
+
+beforeEach( () => {
+	mockApiFetch.mockReset();
+	mockEndpoints();
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+		siteSuffix: SITE,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'the usage reading', () => {
+	it( 'states both figures in gigabytes on a plan sold in them', async () => {
+		mockEndpoints( { size: { size: 12.4 * GB }, policies: { storage_limit_bytes: 20 * GB } } );
+		renderWithClient( <StorageSpace /> );
+		await expect( usageLine() ).resolves.toHaveTextContent( /^Using 12\.4GB of 20GB$/ );
+	} );
+
+	it( 'switches the limit to terabytes once the plan is sold in them', async () => {
+		// Usage deliberately stays in gigabytes. A site that has filled
+		// whole terabytes is vanishingly rare, and "0.01TB" answers a
+		// question nobody asked.
+		mockEndpoints( { size: { size: 12.4 * GB }, policies: { storage_limit_bytes: TB } } );
+		renderWithClient( <StorageSpace /> );
+		await expect( usageLine() ).resolves.toHaveTextContent( /^Using 12GB of 1TB$/ );
+	} );
+
+	it( 'reads the bytes as binary multiples, as the plans are sold', async () => {
+		// A 10GB plan is 10 * 2^30 bytes. Divide by 10^9 instead and the
+		// same plan is advertised back to the reader as 10.7GB.
+		mockEndpoints( { size: { size: 5 * GB }, policies: { storage_limit_bytes: 10 * GB } } );
+		renderWithClient( <StorageSpace /> );
+		await expect( usageLine() ).resolves.toHaveTextContent( /^Using 5\.0GB of 10GB$/ );
+	} );
+} );
+
+describe( 'the retention line', () => {
+	it( 'reports the days of history behind the meter', async () => {
+		mockEndpoints( { size: { days_of_backups_saved: 14 } } );
+		renderWithClient( <StorageSpace /> );
+		await expect( retentionLink() ).resolves.toHaveTextContent( /^14 days of backups saved$/ );
+	} );
+
+	it( 'says "1 day" rather than "1 days"', async () => {
+		mockEndpoints( { size: { days_of_backups_saved: 1 } } );
+		renderWithClient( <StorageSpace /> );
+		await expect( retentionLink() ).resolves.toHaveTextContent( /^1 day of backups saved$/ );
+	} );
+
+	it( 'still reports a site that is holding nothing', async () => {
+		// Zero is a real answer, and the alarming one — it is what a site
+		// whose backups have all been discarded looks like.
+		mockEndpoints( { size: { days_of_backups_saved: 0 } } );
+		renderWithClient( <StorageSpace /> );
+		await expect( retentionLink() ).resolves.toHaveTextContent( /^0 days of backups saved$/ );
+	} );
+
+	it( 'says nothing when WordPress.com did not report a day count', async () => {
+		// Legacy renders its selector's `null` straight into the plural
+		// string and prints "null days of backups saved". Silence is the
+		// honest answer.
+		mockEndpoints( { size: { days_of_backups_saved: undefined } } );
+		renderWithClient( <StorageSpace /> );
+		// Awaited first, so this is a real absence rather than an assertion
+		// that ran before anything had rendered at all.
+		await expect( usageLine() ).resolves.toHaveTextContent( /^Using 10\.0GB of 100GB$/ );
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'scopes the link to this site and opens it away from the dashboard', async () => {
+		renderWithClient( <StorageSpace /> );
+		const link = await retentionLink();
+		expect( link ).toHaveAttribute(
+			'href',
+			`https://jetpack.com/redirect/?source=backup-plugin-storage-backups-saved&site=${ SITE }`
+		);
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+	} );
+
+	it( 'omits the site entirely when the connection global carries no slug', async () => {
+		// Not merely cosmetic: `getRedirectUrl` walks its args with `for…in`,
+		// so passing the key as undefined encodes the literal string
+		// `undefined` *and* suppresses the helper's own site fallback.
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			siteSuffix: undefined,
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
+		renderWithClient( <StorageSpace /> );
+		await expect( retentionLink() ).resolves.toHaveAttribute(
+			'href',
+			'https://jetpack.com/redirect/?source=backup-plugin-storage-backups-saved'
+		);
+	} );
+} );
+
+describe( 'loading', () => {
+	it( "reserves the row's height alongside the bar's", async () => {
+		// Same shift the meter's own placeholder guards: this row is
+		// another 28px that would otherwise appear from nowhere and push
+		// the activity list down once the two requests land.
+		let release: ( v: unknown ) => void = () => {};
+		const pending = new Promise( resolve => {
+			release = resolve;
+		} );
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) =>
+			( options?.path ?? '' ).includes( '/site/backup/' ) ? pending : Promise.resolve( {} )
+		);
+
+		renderWithClient( <StorageSpace /> );
+
+		// The placeholders are `aria-hidden` by design — there is nothing
+		// worth announcing yet — so no role or label reaches them and the
+		// class is the only handle.
+		/* eslint-disable testing-library/no-node-access -- see above. */
+		await waitFor( () =>
+			expect( document.querySelector( '.jpb-storage-space__details-placeholder' ) ).not.toBeNull()
+		);
+		/* eslint-enable testing-library/no-node-access */
+		expect( screen.queryByText( /^Using/ ) ).not.toBeInTheDocument();
+
+		release( { ok: true, size: 10 * GB, policies: { storage_limit_bytes: 100 * GB } } );
+	} );
+} );

--- a/projects/packages/backup/tests/storage-usage-details.test.tsx
+++ b/projects/packages/backup/tests/storage-usage-details.test.tsx
@@ -92,6 +92,20 @@ function retentionLink(): Promise< HTMLElement > {
 	return screen.findByRole( 'link', { name: /backups saved/ } );
 }
 
+/**
+ * The details row's layout container.
+ *
+ * A layout wrapper carries no role and no accessible name, so its class is
+ * the only handle — the same escape hatch `storage-meter.test.tsx` uses to
+ * reach the bar's modifier classes. Kept out of the `describe` blocks so
+ * the one direct DOM read lives in a single named place.
+ *
+ * @return The row, or null before it has rendered.
+ */
+function detailsRow(): HTMLElement | null {
+	return document.querySelector( '.jpb-storage-space__details' );
+}
+
 beforeEach( () => {
 	mockApiFetch.mockReset();
 	mockEndpoints();
@@ -183,6 +197,46 @@ describe( 'the retention line', () => {
 			'href',
 			'https://jetpack.com/redirect/?source=backup-plugin-storage-backups-saved'
 		);
+	} );
+} );
+
+describe( 'the row itself', () => {
+	it( 'lays the two readings out as a wrapping, space-between row', async () => {
+		// The entire responsive and RTL story, and nothing else asserts it.
+		// There is no breakpoint here on purpose — `Stack` writes these as
+		// inline styles, so a media query would need `!important` to beat
+		// them. Wrapping is what makes the row stack on a narrow viewport,
+		// and `space-between` is what puts the wrapped line flush with the
+		// start rather than pinned to the end. Flexbox resolves both
+		// against the writing direction, which is what keeps the row
+		// mirrored in RTL without a second rule.
+		mockEndpoints();
+		renderWithClient( <StorageSpace /> );
+
+		await waitFor( () => expect( detailsRow() ).not.toBeNull() );
+		expect( detailsRow() ).toHaveStyle( {
+			flexDirection: 'row',
+			flexWrap: 'wrap',
+			justifyContent: 'space-between',
+		} );
+	} );
+
+	it( 'separates the readings by the gap legacy stacks them at', async () => {
+		// `xs` is 4px, which is what legacy's phone-down rule uses. A
+		// larger token would leave the wrapped line floating away from the
+		// bar it belongs to.
+		mockEndpoints();
+		renderWithClient( <StorageSpace /> );
+
+		await waitFor( () => expect( detailsRow() ).not.toBeNull() );
+
+		// The literal fallback is the design system's own: its build injects
+		// one into every token reference, so this pins the token *and* the
+		// value it currently resolves to. A bump that moves `xs` off 4px
+		// should fail here and be looked at rather than land silently.
+		expect( detailsRow() ).toHaveStyle( {
+			gap: 'var(--wpds-dimension-gap-xs, 4px)',
+		} );
 	} );
 } );
 


### PR DESCRIPTION
Fixes #

## Proposed changes

Ports the legacy dashboard's `src/js/components/backup-storage-space/storage-usage-details/` to the modernized Overview, so the storage section says how full *of what* rather than only how full. Sibling of #51580, which landed the meter and the whole data layer this reads.

* A **"Using 12.4GB of 20GB"** reading under the bar. Usage is always stated in gigabytes; the limit switches to terabytes at 1TB, which is what the larger storage add-ons are sold in.
* An **"N days of backups saved"** link beside it, pointing at Jetpack's own explanation of retention and scoped to the site.
* Both msgids are legacy's character for character — including the odd `%1.1f` / `%2f` spelling, which is sequential rather than positional — so the strings arrive already translated instead of waiting a GlotPress cycle.
* The loading skeleton grows a matching line, so the row does not push the activity list down when the two requests land.

No new request and no new query key: the day count comes off the `/site/backup/size` response `useStorageUsage()` already reads to derive the usage level, so the hook now returns it rather than the component re-reading the raw query. `<StorageUsageDetails>` is presentational like `meter.tsx` — everything arrives as a prop.

Two deliberate omissions, both other people's issues:

* **The storage help popover** that legacy embeds in this component. That is a separate issue and is not ported here.
* **The Tracks event** its purchase link fires. There is no Tracks client on the modernized page at all yet. Legacy's own orchestrator never passes the `onClickedPurchase` prop either, so nothing is lost in the meantime.

One small departure from legacy, worth a reviewer's eye: when `/site/backup/size` answers without `days_of_backups_saved`, the retention line is omitted rather than rendered. Legacy interpolates its selector's `null` into the plural string and prints "null days of backups saved"; it only gets away with it because a response complete enough to draw the meter has always carried the field.

### Known defect carried across with the gigabyte msgid

Reusing legacy's msgid means reusing its bug, and it is worth being precise about which bug. `%1.1f` and `%2f` look like argument references but are not — they parse as a width and a precision, and `@tannin/sprintf` discards the width group outright. The English source therefore renders correctly at every limit; there is no padding and no stray space.

The real hazard is that being *sequential*, the two values swap if a translation fronts the total, which is natural in plenty of languages:

```js
sprintf( 'Of %2fGB, using <strong>%1.1fGB</strong>', 12.4, 20 )
// → "Of 12.4GB, using 20.0GB"   ← used and total transposed
```

On the one screen whose job is to say whether backups are at risk, that tells the reader they are over quota when they are not. The terabyte msgid beside it is spelled `%1$d`/`%2$d` and is immune. Fixing the string means changing legacy and this copy together so the msgid stays shared, so it is queued as its own follow-up rather than done here; in the meantime the translator comment explicitly asks translators not to reorder the two.

Related: legacy carries `// eslint-disable-next-line @wordpress/valid-sprintf` on this call. Hoisting the msgid into a `const` — which the minifier/text-domain reasoning requires — puts the format string out of the rule's reach, so the disable is no longer needed. That silence is not a clean bill of health, and there is a comment at the call site saying so.

Everything here is behind the `rsm_jetpack_ui_modernization_backup` filter and is invisible with it off. The legacy dashboard is untouched.

## Related product discussion/links

* Linear: JETPACK-2330 (H3b), under JETPACK-2243
* Builds on #51580 (JETPACK-2300 / H3a)

## Does this pull request change what data or activity we track or use?

No. No new requests, no new fields read from WordPress.com, and no Tracks events — the one Tracks call the legacy component carries is deliberately not ported.

## Testing instructions

1. On a site with an active Backup plan, force the modernized dashboard on:
   ```php
   add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
   ```
2. Go to **Jetpack → VaultPress Backup**.
3. Under the cloud-storage bar you should now see two readings: `Using <n>GB of <n>GB` on the left, and `<n> days of backups saved` on the right, the latter a link that opens in a new tab and carries `?source=backup-plugin-storage-backups-saved&site=<your-site>`.
4. Narrow the browser until the two readings no longer fit on one line. They should stack, the retention line moving to its own row flush with the left edge rather than staying pinned to the right. Note this is **content-driven, not breakpoint-driven** — a deliberate departure from legacy, which switches at a phone-down media query. `Stack` writes its flex properties as inline styles, so a media query here would need `!important` to win; letting the row wrap gets the same result without that. In English the two readings total roughly 280px, so a 375px phone viewport usually still fits them and you will see no stacking — drag the window narrower than that, or switch to a locale with longer strings (German is a good one), to see it.
5. Switch the admin language to an RTL locale (e.g. Arabic) and confirm the row mirrors: the usage reading on the right, the retention link on the left.
6. Throttle the network in devtools and reload. While `/site/backup/size` and `/site/backup/policies` are in flight, a placeholder should hold the row's height, and the activity list below should not jump when they land.
7. Turn the filter back off and confirm the legacy dashboard is unchanged.

To exercise the escalating states without waiting for a real site to fill up, the levels are driven by `/site/backup/policies` `storage_limit_bytes` against `/site/backup/size` `size` — override either in the network tab and reload.

### Automated coverage

`projects/packages/backup/tests/storage-usage-details.test.tsx` — 12 tests covering the unit switch at 1TB, binary-multiple arithmetic, singular/plural/zero day counts, the missing-field silence, the redirect URL with and without a site slug, the row's flex layout, and the loading placeholder.

16 mutations were applied and reverted, each confirmed to fail at least one test: decimal-vs-binary GB, never switching to TB, swapped sprintf arguments, singular pivot moved to 2, the retention guard always-true and as-truthiness, an undefined `site` key, dropped `openInNewTab`, wrong redirect slug, dropped skeleton, unmounted component, the hook dropping the day count, an extra clause appended to the line, and `direction` / `wrap` / `justify` / `gap` each flipped on the row.

### Known pre-existing gap, not fixed here

`index.tsx` wraps the loading state in `<section aria-hidden="true">` with no `role="status"` or `aria-busy`, so the skeletons are announced to nobody. That came in with #51580; this PR adds a third skeleton to the same block and does not change the behaviour either way. Worth its own fix.

```
pnpm test          52 suites, 469 tests passed
pnpm run typecheck clean
eslint             clean at --max-warnings=0 (4 changed files)
stylelint          clean
jp phan            0 issues
```

