### PR TITLE
Forms: fix choice options inheriting the previous option's label

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-option-split-inherits-label
+++ b/projects/packages/forms/changelog/fix-forms-option-split-inherits-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent a new choice option from inheriting the previous option's label when pressing Enter.

--- a/projects/packages/forms/changelog/fix-forms-other-toggle-preserves-label
+++ b/projects/packages/forms/changelog/fix-forms-other-toggle-preserves-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep an option's label when switching it to the "Other" option.

--- a/projects/packages/forms/src/blocks/option/edit.jsx
+++ b/projects/packages/forms/src/blocks/option/edit.jsx
@@ -151,11 +151,8 @@ const OptionEdit = ( {
 						<ToggleControl
 							label={ __( '"Other" option', 'jetpack-forms' ) }
 							checked={ !! isOther }
-							// Only the flag changes. An option the author never named still
-							// reads "Other" once this is on, because an empty label falls back
-							// to `emptyPlaceholder` — so there is nothing to gain by wiping a
-							// label they did write, and a name like "Something else" is exactly
-							// what an author reaches for here.
+							// Leave the label alone: an unnamed option already falls back to
+							// the "Other" placeholder, so there is nothing to gain by wiping one.
 							onChange={ value => setAttributes( { isOther: value } ) }
 							help={ __(
 								'Show as "Other" option with a text input field below it.',

--- a/projects/packages/forms/src/blocks/option/edit.jsx
+++ b/projects/packages/forms/src/blocks/option/edit.jsx
@@ -151,12 +151,12 @@ const OptionEdit = ( {
 						<ToggleControl
 							label={ __( '"Other" option', 'jetpack-forms' ) }
 							checked={ !! isOther }
-							onChange={ value =>
-								setAttributes( {
-									isOther: value,
-									label: value ? '' : label,
-								} )
-							}
+							// Only the flag changes. An option the author never named still
+							// reads "Other" once this is on, because an empty label falls back
+							// to `emptyPlaceholder` — so there is nothing to gain by wiping a
+							// label they did write, and a name like "Something else" is exactly
+							// what an author reaches for here.
+							onChange={ value => setAttributes( { isOther: value } ) }
 							help={ __(
 								'Show as "Other" option with a text input field below it.',
 								'jetpack-forms'

--- a/projects/packages/forms/src/blocks/option/index.jsx
+++ b/projects/packages/forms/src/blocks/option/index.jsx
@@ -47,14 +47,8 @@ const settings = {
 		...attributes,
 		label: ( attributes.label || '' ) + label,
 	} ),
-	// `role: 'content'` is what keeps splitting honest. When Enter splits an option
-	// (or "Insert before/after" adds a sibling), the editor builds the new block by
-	// copying every attribute of the current one EXCEPT those marked as content —
-	// the idea being that a new sibling inherits configuration but starts empty.
-	// Anything left unmarked here therefore rides along into the new option: without
-	// it the new option arrives pre-filled with the previous option's label, and a
-	// sibling of the "Other" option becomes a second "Other" option, which the field's
-	// own toggle can neither produce nor represent.
+	// Splitting an option copies every attribute except those marked as content,
+	// so anything left unmarked here arrives pre-filled from the previous option.
 	attributes: {
 		placeholder: {
 			type: 'string',

--- a/projects/packages/forms/src/blocks/option/index.jsx
+++ b/projects/packages/forms/src/blocks/option/index.jsx
@@ -47,6 +47,14 @@ const settings = {
 		...attributes,
 		label: ( attributes.label || '' ) + label,
 	} ),
+	// `role: 'content'` is what keeps splitting honest. When Enter splits an option
+	// (or "Insert before/after" adds a sibling), the editor builds the new block by
+	// copying every attribute of the current one EXCEPT those marked as content —
+	// the idea being that a new sibling inherits configuration but starts empty.
+	// Anything left unmarked here therefore rides along into the new option: without
+	// it the new option arrives pre-filled with the previous option's label, and a
+	// sibling of the "Other" option becomes a second "Other" option, which the field's
+	// own toggle can neither produce nor represent.
 	attributes: {
 		placeholder: {
 			type: 'string',
@@ -55,6 +63,7 @@ const settings = {
 		label: {
 			type: 'string',
 			default: '',
+			role: 'content',
 		},
 		requiredText: {
 			type: 'string',
@@ -71,10 +80,12 @@ const settings = {
 		isOther: {
 			type: 'boolean',
 			default: false,
+			role: 'content',
 		},
 		otherPlaceholder: {
 			type: 'string',
 			default: __( 'Please specify…', 'jetpack-forms' ),
+			role: 'content',
 		},
 	},
 	usesContext: [

--- a/projects/packages/forms/src/blocks/option/test/edit.test.js
+++ b/projects/packages/forms/src/blocks/option/test/edit.test.js
@@ -44,10 +44,8 @@ await jest.unstable_mockModule( '../../shared/hooks/use-synced-attributes.jsx', 
 const OptionEdit = ( await import( '../edit.jsx' ) ).default;
 
 /**
- * Depth-first search of a returned element tree for the first element of a type.
- *
- * OptionEdit is invoked as a plain function, so nothing below it renders — the
- * control we want is an unrendered element in the returned tree.
+ * Depth-first search for the first element of a type. OptionEdit is invoked as a
+ * plain function, so nothing below it renders.
  *
  * @param {*} node - Element or children to search.
  * @param {*} type - The component type to look for.
@@ -73,7 +71,7 @@ const findElement = ( node, type ) => {
 };
 
 /**
- * Renders a radio option and returns the "Other" toggle's onChange handler.
+ * Returns the "Other" toggle's onChange handler for a radio option.
  *
  * @param {object}   attributes    - The option block's attributes.
  * @param {Function} setAttributes - Spy to capture writes.
@@ -100,9 +98,7 @@ describe( 'the option block\'s "Other" toggle', () => {
 		getOtherToggleOnChange( { label: 'Something else' }, setAttributes )( true );
 
 		expect( setAttributes ).toHaveBeenCalledWith( { isOther: true } );
-		// An explicit `label: ''` would wipe the author's text; asserting on the
-		// exact payload above would pass even for `{ isOther: true, label: '' }`
-		// if the matcher ever loosened, so state the real requirement too.
+		// Stated separately: the payload assertion alone would not pin this down.
 		expect( setAttributes.mock.calls[ 0 ][ 0 ] ).not.toHaveProperty( 'label' );
 	} );
 

--- a/projects/packages/forms/src/blocks/option/test/edit.test.js
+++ b/projects/packages/forms/src/blocks/option/test/edit.test.js
@@ -1,0 +1,117 @@
+import { describe, expect, jest, test } from '@jest/globals';
+
+const ToggleControl = jest.fn( () => null );
+
+await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
+	InspectorControls: jest.fn( () => null ),
+	RichText: jest.fn( () => null ),
+	store: 'core/block-editor',
+	useBlockProps: jest.fn( args => args ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/components', () => ( {
+	PanelBody: jest.fn( () => null ),
+	ToggleControl,
+	VisuallyHidden: jest.fn( () => null ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useDispatch: jest.fn( () => ( { removeBlock: jest.fn() } ) ),
+	useSelect: jest.fn( mapSelect =>
+		mapSelect( () => ( {
+			getBlockCount: () => 2,
+			getBlockRootClientId: () => 'options-client-id',
+			getSelectedBlockClientId: () => null,
+			getSettings: () => ( { isPreviewMode: false } ),
+		} ) )
+	),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/element', () => ( {
+	useState: jest.fn( initial => [ initial, jest.fn() ] ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/i18n', () => ( {
+	__: jest.fn( str => str ),
+} ) );
+
+await jest.unstable_mockModule( '../use-enter.js', () => ( { default: jest.fn( () => null ) } ) );
+
+await jest.unstable_mockModule( '../../shared/hooks/use-synced-attributes.jsx', () => ( {
+	useSyncedAttributes: jest.fn(),
+} ) );
+
+const OptionEdit = ( await import( '../edit.jsx' ) ).default;
+
+/**
+ * Depth-first search of a returned element tree for the first element of a type.
+ *
+ * OptionEdit is invoked as a plain function, so nothing below it renders — the
+ * control we want is an unrendered element in the returned tree.
+ *
+ * @param {*} node - Element or children to search.
+ * @param {*} type - The component type to look for.
+ * @return {*} The matching element, or undefined.
+ */
+const findElement = ( node, type ) => {
+	if ( ! node || typeof node !== 'object' ) {
+		return undefined;
+	}
+	if ( Array.isArray( node ) ) {
+		for ( const child of node ) {
+			const found = findElement( child, type );
+			if ( found ) {
+				return found;
+			}
+		}
+		return undefined;
+	}
+	if ( node.type === type ) {
+		return node;
+	}
+	return findElement( node.props?.children, type );
+};
+
+/**
+ * Renders a radio option and returns the "Other" toggle's onChange handler.
+ *
+ * @param {object}   attributes    - The option block's attributes.
+ * @param {Function} setAttributes - Spy to capture writes.
+ * @return {Function} The toggle's onChange.
+ */
+const getOtherToggleOnChange = ( attributes, setAttributes ) => {
+	const tree = OptionEdit( {
+		attributes: { isStandalone: false, isOther: false, ...attributes },
+		clientId: 'option-client-id',
+		context: { 'jetpack/field-options-type': 'radio' },
+		isSelected: true,
+		mergeBlocks: jest.fn(),
+		name: 'jetpack/option',
+		setAttributes,
+	} );
+
+	return findElement( tree, ToggleControl ).props.onChange;
+};
+
+describe( 'the option block\'s "Other" toggle', () => {
+	test( 'keeps a label the author already wrote when switching the option to "Other"', () => {
+		const setAttributes = jest.fn();
+
+		getOtherToggleOnChange( { label: 'Something else' }, setAttributes )( true );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { isOther: true } );
+		// An explicit `label: ''` would wipe the author's text; asserting on the
+		// exact payload above would pass even for `{ isOther: true, label: '' }`
+		// if the matcher ever loosened, so state the real requirement too.
+		expect( setAttributes.mock.calls[ 0 ][ 0 ] ).not.toHaveProperty( 'label' );
+	} );
+
+	test( 'keeps the label when switching the option back off "Other"', () => {
+		const setAttributes = jest.fn();
+
+		getOtherToggleOnChange( { label: 'Something else', isOther: true }, setAttributes )( false );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { isOther: false } );
+		expect( setAttributes.mock.calls[ 0 ][ 0 ] ).not.toHaveProperty( 'label' );
+	} );
+} );

--- a/projects/packages/forms/src/blocks/option/test/index.test.js
+++ b/projects/packages/forms/src/blocks/option/test/index.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from '@jest/globals';
+import optionBlock from '../index.jsx';
+
+/**
+ * The editor builds a new sibling option — on Enter-to-split, and on "Insert
+ * before/after" — by copying every attribute of the current option EXCEPT the
+ * ones declared with `role: 'content'`. An attribute missing that annotation is
+ * treated as configuration and is inherited, so dropping a role here does not
+ * fail loudly: it silently ships an option that arrives pre-filled with its
+ * neighbour's answer.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/store/actions.js `getSiblingBlockAttributes`
+ */
+describe( 'jetpack/option attribute roles', () => {
+	const { attributes } = optionBlock.settings;
+
+	it.each( [ 'label', 'isOther', 'otherPlaceholder' ] )(
+		'marks `%s` as content so a new sibling option does not inherit it',
+		name => {
+			expect( attributes[ name ].role ).toBe( 'content' );
+		}
+	);
+
+	it.each( [ 'placeholder', 'hideInput', 'isStandalone' ] )(
+		'leaves `%s` unmarked so a new sibling option does inherit it',
+		name => {
+			expect( attributes[ name ].role ).toBeUndefined();
+		}
+	);
+} );

--- a/projects/packages/forms/src/blocks/option/test/index.test.js
+++ b/projects/packages/forms/src/blocks/option/test/index.test.js
@@ -2,12 +2,8 @@ import { describe, expect, it } from '@jest/globals';
 import optionBlock from '../index.jsx';
 
 /**
- * The editor builds a new sibling option — on Enter-to-split, and on "Insert
- * before/after" — by copying every attribute of the current option EXCEPT the
- * ones declared with `role: 'content'`. An attribute missing that annotation is
- * treated as configuration and is inherited, so dropping a role here does not
- * fail loudly: it silently ships an option that arrives pre-filled with its
- * neighbour's answer.
+ * Dropping a role here fails silently — the new sibling option just arrives
+ * pre-filled from its neighbour.
  *
  * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/store/actions.js `getSiblingBlockAttributes`
  */

--- a/projects/plugins/jetpack/changelog/fix-forms-option-split-inherits-label
+++ b/projects/plugins/jetpack/changelog/fix-forms-option-split-inherits-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Prevent a new choice option from inheriting the previous option's label when pressing Enter.

--- a/projects/plugins/jetpack/changelog/fix-forms-other-toggle-preserves-label
+++ b/projects/plugins/jetpack/changelog/fix-forms-other-toggle-preserves-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Keep an option's label when switching it to the "Other" option.


### PR DESCRIPTION
Fixes pdtkmj-4Ub#comment-9473

## Proposed changes

Two fixes to the choice-field option block (`jetpack/option`), both reported while authoring a Single choice (radio) field.

**1. Pressing Enter created a copy of the previous option instead of an empty one.**

Recent Gutenberg builds changed what a split produces. `__unstableSplitSelection` now builds the new sibling via `getSiblingBlockAttributes()`, which copies every attribute of the current block *except* those declared `role: 'content'` (plus `metadata`) — the idea being that a new sibling inherits configuration but starts empty:

```js
const excluded = new Set( getBlockAttributesNamesByRole( blockName, 'content' ) );
excluded.add( 'metadata' );
return Object.fromEntries( Object.entries( attributes ).filter( ( [ key ] ) => ! excluded.has( key ) ) );
```

`jetpack/option` declared no attribute with that role, so `label` counted as configuration and rode along into the new option. The same applied to `isOther`, so pressing Enter at the end of the "Other" option produced a *second* "Other" option — a state the field's own "Include Other option" toggle can neither create nor represent.

This annotates `label`, `isOther` and `otherPlaceholder` as `role: 'content'`. `placeholder`, `requiredText`, `hideInput` and `isStandalone` stay unmarked, because a new sibling *should* inherit those. The two deprecated option blocks (`field-option-radio`, `field-option-checkbox`) already carry the annotation on their label — it was dropped when they were migrated to `jetpack/option` in #43765.

Note this only reproduces where Gutenberg is installed, which includes WordPress.com Simple sites. Core's older `createEmpty()` did a bare `createBlock( name )`, so the released core path was unaffected. `insertAfterBlock` / `insertBeforeBlock` use the same helper, so "Insert before/after" on an option was affected too and is fixed by the same change.

**2. Toggling an option to "Other" wiped a label the author had already written.**

The per-option `"Other" option` toggle set `label: value ? '' : label`, so naming an option "Something else" and then switching it to Other silently discarded that text. That clearing came from #47316, whose goal was that an option switched to Other should read "Other" rather than keep a stale name — but the same PR added the `placeholderValue` fallback that already achieves this: an option with an *empty* label renders the "Other" placeholder on its own. So the wipe is redundant for unnamed options and destructive for named ones. The toggle now only flips the flag.

## Related product discussion/links

* Reported while testing choice fields on a WordPress.com Simple site.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

These changes are only observable with the **Gutenberg plugin active** (or on a WordPress.com Simple site). On stock core the split path differs and the first bug does not reproduce.

**Setup**

* On a site with Jetpack and the **Gutenberg** plugin active, create a page and add a Form block.
* Add a **Single choice (radio)** field.

**1. Enter no longer duplicates the label**

* Click into the first option and type `Apple`.
* Put the caret at the end of `Apple` and press <kbd>Enter</kbd>.
* **Expected:** a new, empty option appears below, showing the `Add option…` placeholder.
* **Before this PR:** the new option read `Apple`.
* Repeat with the caret at the end of a middle option in a three-option list — the new empty option should land directly after it, leaving the following options untouched.

**2. Enter on the "Other" option**

* In the field's sidebar, turn on **Include "Other" option**.
* Click into the `Other` option, put the caret at the end, press <kbd>Enter</kbd>.
* **Expected:** a plain empty option, *not* a second "Other" option (check the block breadcrumb — it should read `Option`, not `Option (other)`, and there should be only one "Please specify…" text input).
* **Before this PR:** a second `Other` option with its own free-text input.

**3. The "Other" toggle keeps your label**

* Type `Something else` into an option.
* With that option selected, open the sidebar and turn on **"Other" option**.
* **Expected:** the label stays `Something else`, and the "Please specify…" input appears beneath it.
* **Before this PR:** the label was wiped and the option showed the `Other` placeholder.
* Turn the toggle back off — the label should still read `Something else`.
* Now do the same on an option you have *not* named: toggling **"Other" option** on should make it display `Other`, as before.

**4. Nothing else about option editing changed**

* Press <kbd>Enter</kbd> on an empty trailing option — it should still exit the list and drop you into a paragraph after the field.
* With options `Apple` and `Banana`, put the caret at the very start of `Banana` and press <kbd>Backspace</kbd> — they should still merge into one option reading `AppleBanana`.
* Deactivate Gutenberg and re-run step 1 — behavior should be unchanged (a new empty option), confirming no regression on stock core.
