### PR TITLE
Connection: move the jetpack-ai-jwt REST route out of Agents Manager

### DIFF
--- a/projects/packages/agents-manager/changelog/connect-437-ai-jwt-route
+++ b/projects/packages/agents-manager/changelog/connect-437-ai-jwt-route
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Deprecate `WP_REST_Jetpack_AI_JWT` in favor of `Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT`; the route now lives in the Connection package.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Agents_Manager;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT;
 use Automattic\Jetpack\Constants;
 
 /**
@@ -814,7 +815,7 @@ class Agents_Manager {
 	 */
 	public function register_rest_api() {
 		( new WP_REST_Agents_Manager_Persisted_Open_State() )->register_rest_route();
-		( new WP_REST_Jetpack_AI_JWT() )->register_rest_route();
+		( new REST_Jetpack_AI_JWT() )->register_rest_route();
 	}
 
 	/**

--- a/projects/packages/agents-manager/src/class-wp-rest-jetpack-ai-jwt.php
+++ b/projects/packages/agents-manager/src/class-wp-rest-jetpack-ai-jwt.php
@@ -22,7 +22,7 @@ class WP_REST_Jetpack_AI_JWT extends REST_Jetpack_AI_JWT {
 	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT instead.
 	 */
 	public function __construct() {
-		_deprecated_function( __METHOD__, 'agents-manager-$$next-version$$', 'Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT' );
+		_deprecated_class( __CLASS__, 'agents-manager-$$next-version$$', REST_Jetpack_AI_JWT::class );
 
 		parent::__construct();
 	}

--- a/projects/packages/agents-manager/src/class-wp-rest-jetpack-ai-jwt.php
+++ b/projects/packages/agents-manager/src/class-wp-rest-jetpack-ai-jwt.php
@@ -7,108 +7,23 @@
 
 namespace Automattic\Jetpack\Agents_Manager;
 
-use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Jetpack_Options;
+use Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT;
 
 /**
  * Class WP_REST_Jetpack_AI_JWT.
+ *
+ * @deprecated $$next-version$$ Use Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT instead.
  */
-class WP_REST_Jetpack_AI_JWT extends \WP_REST_Controller {
+class WP_REST_Jetpack_AI_JWT extends REST_Jetpack_AI_JWT {
 
 	/**
 	 * WP_REST_Jetpack_AI_JWT constructor.
+	 *
+	 * @deprecated $$next-version$$ Use Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT instead.
 	 */
 	public function __construct() {
-		$this->namespace = 'jetpack/v4';
-		$this->rest_base = '/jetpack-ai-jwt';
-	}
+		_deprecated_function( __METHOD__, 'agents-manager-$$next-version$$', 'Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT' );
 
-	/**
-	 * Register available routes.
-	 */
-	public function register_rest_route() {
-		/*
-		 * Check if the `jetpack/v4/jetpack-ai-jwt` endpoint is registered
-		 * by the Jetpack plugin to avoid registering it again.
-		 * In case it's not registered, register it
-		 * to make it available for Jetpack products that depend on it.
-		 */
-		if ( $this->is_rest_endpoint_registered() ) {
-			return;
-		}
-
-		register_rest_route(
-			$this->namespace,
-			$this->rest_base,
-			array(
-				array(
-					'methods'             => \WP_REST_Server::EDITABLE,
-					'callback'            => array( $this, 'get_jwt' ),
-					'permission_callback' => array( $this, 'permission_callback' ),
-				),
-			)
-		);
-	}
-
-	/**
-	 * Check if this REST endpoint is already registered.
-	 *
-	 * @return bool True if the endpoint is registered, false otherwise.
-	 */
-	private function is_rest_endpoint_registered() {
-		$server        = rest_get_server();
-		$routes        = $server->get_routes();
-		$full_endpoint = '/' . trim( $this->namespace, '/' ) . $this->rest_base;
-
-		return isset( $routes[ $full_endpoint ] );
-	}
-
-	/**
-	 * Permission callback for the JWT endpoint.
-	 *
-	 * @return bool
-	 */
-	public function permission_callback() {
-		return ( new Connection_Manager( 'jetpack' ) )->is_user_connected() && current_user_can( 'edit_posts' );
-	}
-
-	/**
-	 * Ask WPCOM for a JWT token to use for OpenAI completion.
-	 */
-	public function get_jwt() {
-		$blog_id = Jetpack_Options::get_option( 'id' );
-
-		$response = Client::wpcom_json_api_request_as_user(
-			"/sites/$blog_id/jetpack-openai-query/jwt",
-			'2',
-			array(
-				'method'  => 'POST',
-				'headers' => array( 'Content-Type' => 'application/json; charset=utf-8' ),
-			),
-			wp_json_encode( array(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
-			'wpcom'
-		);
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$json = json_decode( wp_remote_retrieve_body( $response ) );
-
-		if ( ! isset( $json->token ) ) {
-			return new \WP_Error(
-				'no-token',
-				'No token returned from WPCOM',
-				array( 'status' => 500 )
-			);
-		}
-
-		return rest_ensure_response(
-			array(
-				'token'   => $json->token,
-				'blog_id' => $blog_id,
-			)
-		);
+		parent::__construct();
 	}
 }

--- a/projects/packages/agents-manager/tests/php/WP_REST_Jetpack_AI_JWT_Test.php
+++ b/projects/packages/agents-manager/tests/php/WP_REST_Jetpack_AI_JWT_Test.php
@@ -21,7 +21,7 @@ require_once __DIR__ . '/../../src/class-wp-rest-jetpack-ai-jwt.php';
 class WP_REST_Jetpack_AI_JWT_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * Deprecated functions reported while a test ran.
+	 * Deprecated classes reported while a test ran.
 	 *
 	 * @var string[]
 	 */
@@ -33,28 +33,28 @@ class WP_REST_Jetpack_AI_JWT_Test extends \WorDBless\BaseTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		add_filter( 'deprecated_function_trigger_error', '__return_false' );
-		add_action( 'deprecated_function_run', array( $this, 'record_deprecation' ) );
+		add_filter( 'deprecated_class_trigger_error', '__return_false' );
+		add_action( 'deprecated_class_run', array( $this, 'record_deprecation' ) );
 	}
 
 	/**
 	 * Tear down test fixtures.
 	 */
 	public function tear_down() {
-		remove_filter( 'deprecated_function_trigger_error', '__return_false' );
-		remove_action( 'deprecated_function_run', array( $this, 'record_deprecation' ) );
+		remove_filter( 'deprecated_class_trigger_error', '__return_false' );
+		remove_action( 'deprecated_class_run', array( $this, 'record_deprecation' ) );
 		$this->deprecated = array();
 
 		parent::tear_down();
 	}
 
 	/**
-	 * Records a deprecated function call.
+	 * Records a deprecated class instantiation.
 	 *
-	 * @param string $function_name The deprecated function.
+	 * @param string $class_name The deprecated class.
 	 */
-	public function record_deprecation( $function_name ) {
-		$this->deprecated[] = $function_name;
+	public function record_deprecation( $class_name ) {
+		$this->deprecated[] = $class_name;
 	}
 
 	/**
@@ -65,7 +65,7 @@ class WP_REST_Jetpack_AI_JWT_Test extends \WorDBless\BaseTestCase {
 		$controller = new WP_REST_Jetpack_AI_JWT();
 
 		$this->assertInstanceOf( REST_Jetpack_AI_JWT::class, $controller );
-		$this->assertContains( WP_REST_Jetpack_AI_JWT::class . '::__construct', $this->deprecated );
+		$this->assertContains( WP_REST_Jetpack_AI_JWT::class, $this->deprecated );
 	}
 
 	/**

--- a/projects/packages/agents-manager/tests/php/WP_REST_Jetpack_AI_JWT_Test.php
+++ b/projects/packages/agents-manager/tests/php/WP_REST_Jetpack_AI_JWT_Test.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Agents_Manager;
 
-use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 require_once __DIR__ . '/../../src/class-wp-rest-jetpack-ai-jwt.php';
@@ -21,18 +21,11 @@ require_once __DIR__ . '/../../src/class-wp-rest-jetpack-ai-jwt.php';
 class WP_REST_Jetpack_AI_JWT_Test extends \WorDBless\BaseTestCase {
 
 	/**
-	 * The controller instance.
+	 * Deprecated functions reported while a test ran.
 	 *
-	 * @var WP_REST_Jetpack_AI_JWT
+	 * @var string[]
 	 */
-	private $controller;
-
-	/**
-	 * Connected user ID used for JWT API tests.
-	 *
-	 * @var int
-	 */
-	private $connected_user_id;
+	private $deprecated = array();
 
 	/**
 	 * Set up test fixtures.
@@ -40,297 +33,51 @@ class WP_REST_Jetpack_AI_JWT_Test extends \WorDBless\BaseTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
-
-		$this->controller = new WP_REST_Jetpack_AI_JWT();
-	}
-
-	/**
-	 * Sets up a connected user for JWT API tests.
-	 */
-	private function set_up_connected_user() {
-		$this->connected_user_id = wp_insert_user(
-			array(
-				'user_login' => 'jwt_api_user',
-				'user_pass'  => 'password',
-				'role'       => 'editor',
-			)
-		);
-		wp_set_current_user( $this->connected_user_id );
-
-		\Jetpack_Options::update_option(
-			'user_tokens',
-			array( $this->connected_user_id => 'test.token.' . $this->connected_user_id )
-		);
-		\Jetpack_Options::update_option( 'id', 12345 );
+		add_filter( 'deprecated_function_trigger_error', '__return_false' );
+		add_action( 'deprecated_function_run', array( $this, 'record_deprecation' ) );
 	}
 
 	/**
 	 * Tear down test fixtures.
 	 */
 	public function tear_down() {
-		global $wp_rest_server;
-		$wp_rest_server = null;
-
-		wp_set_current_user( 0 );
-		remove_all_filters( 'pre_http_request' );
+		remove_filter( 'deprecated_function_trigger_error', '__return_false' );
+		remove_action( 'deprecated_function_run', array( $this, 'record_deprecation' ) );
+		$this->deprecated = array();
 
 		parent::tear_down();
 	}
 
 	/**
-	 * Tests that the constructor sets the correct namespace.
-	 */
-	public function test_constructor_sets_correct_namespace() {
-		$reflection = new \ReflectionClass( $this->controller );
-		$property   = $reflection->getProperty( 'namespace' );
-		if ( PHP_VERSION_ID < 80500 ) {
-			$property->setAccessible( true );
-		}
-
-		$this->assertEquals( 'jetpack/v4', $property->getValue( $this->controller ) );
-	}
-
-	/**
-	 * Tests that the constructor sets the correct rest_base.
-	 */
-	public function test_constructor_sets_correct_rest_base() {
-		$reflection = new \ReflectionClass( $this->controller );
-		$property   = $reflection->getProperty( 'rest_base' );
-		if ( PHP_VERSION_ID < 80500 ) {
-			$property->setAccessible( true );
-		}
-
-		$this->assertEquals( '/jetpack-ai-jwt', $property->getValue( $this->controller ) );
-	}
-
-	/**
-	 * Tests that register_rest_route registers the expected routes.
-	 */
-	public function test_register_rest_route_registers_routes() {
-		$this->controller->register_rest_route();
-
-		$routes = rest_get_server()->get_routes();
-
-		$this->assertArrayHasKey( '/jetpack/v4/jetpack-ai-jwt', $routes );
-
-		$route_data = $routes['/jetpack/v4/jetpack-ai-jwt'];
-		$methods    = array();
-
-		foreach ( $route_data as $endpoint ) {
-			if ( isset( $endpoint['methods'] ) ) {
-				$methods = array_merge( $methods, array_keys( $endpoint['methods'] ) );
-			}
-		}
-
-		$this->assertContains( 'POST', $methods );
-	}
-
-	/**
-	 * Tests that the endpoint uses the controller permission callback.
-	 */
-	public function test_endpoint_uses_permission_callback() {
-		$this->controller->register_rest_route();
-
-		$routes     = rest_get_server()->get_routes();
-		$route_data = $routes['/jetpack/v4/jetpack-ai-jwt'];
-
-		$post_endpoint = null;
-		foreach ( $route_data as $endpoint ) {
-			if ( isset( $endpoint['methods']['POST'] ) && $endpoint['methods']['POST'] ) {
-				$post_endpoint = $endpoint;
-				break;
-			}
-		}
-
-		$this->assertNotNull( $post_endpoint );
-		$this->assertEquals( array( $this->controller, 'permission_callback' ), $post_endpoint['permission_callback'] );
-	}
-
-	/**
-	 * Tests that register_rest_route does not register a duplicate route.
-	 */
-	public function test_register_rest_route_does_not_register_duplicate_route() {
-		$this->controller->register_rest_route();
-		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentionally calling twice to ensure duplicates are not registered.
-		$this->controller->register_rest_route();
-
-		$routes     = rest_get_server()->get_routes();
-		$route_data = $routes['/jetpack/v4/jetpack-ai-jwt'];
-
-		$this->assertCount( 1, $route_data );
-	}
-
-	/**
-	 * Tests that the controller extends WP_REST_Controller.
-	 */
-	public function test_controller_extends_wp_rest_controller() {
-		$this->assertInstanceOf( \WP_REST_Controller::class, $this->controller );
-	}
-
-	/**
-	 * Tests that permission_callback returns false when the user is not connected.
-	 */
-	public function test_permission_callback_returns_false_when_user_not_connected() {
-		$user_id = wp_insert_user(
-			array(
-				'user_login' => 'jwt_editor',
-				'user_pass'  => 'password',
-				'role'       => 'editor',
-			)
-		);
-		wp_set_current_user( $user_id );
-
-		$this->assertFalse( $this->controller->permission_callback() );
-	}
-
-	/**
-	 * Tests that permission_callback returns false when the user cannot edit posts.
-	 */
-	public function test_permission_callback_returns_false_when_user_cannot_edit_posts() {
-		$user_id = wp_insert_user(
-			array(
-				'user_login' => 'jwt_subscriber',
-				'user_pass'  => 'password',
-				'role'       => 'subscriber',
-			)
-		);
-		wp_set_current_user( $user_id );
-
-		\Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'test.token.' . $user_id ) );
-
-		$this->assertFalse( $this->controller->permission_callback() );
-	}
-
-	/**
-	 * Tests that permission_callback returns true when the user is connected and can edit posts.
-	 */
-	public function test_permission_callback_returns_true_when_user_connected_and_can_edit_posts() {
-		$user_id = wp_insert_user(
-			array(
-				'user_login' => 'jwt_connected_editor',
-				'user_pass'  => 'password',
-				'role'       => 'editor',
-			)
-		);
-		wp_set_current_user( $user_id );
-
-		\Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'test.token.' . $user_id ) );
-
-		$this->assertTrue( $this->controller->permission_callback() );
-	}
-
-	/**
-	 * Tests that get_jwt returns the token and blog ID on success.
-	 */
-	public function test_get_jwt_returns_token_and_blog_id_on_success() {
-		$this->set_up_connected_user();
-
-		add_filter( 'pre_http_request', array( $this, 'mock_jwt_api_success' ), 10, 3 );
-
-		$response = $this->controller->get_jwt();
-
-		remove_filter( 'pre_http_request', array( $this, 'mock_jwt_api_success' ), 10 );
-
-		$this->assertInstanceOf( \WP_REST_Response::class, $response );
-		$this->assertEquals(
-			array(
-				'token'   => 'test-jwt-token',
-				'blog_id' => 12345,
-			),
-			$response->get_data()
-		);
-	}
-
-	/**
-	 * Tests that get_jwt returns an error when WPCOM does not return a token.
-	 */
-	public function test_get_jwt_returns_error_when_no_token_in_response() {
-		$this->set_up_connected_user();
-
-		add_filter( 'pre_http_request', array( $this, 'mock_jwt_api_missing_token' ), 10, 3 );
-
-		$response = $this->controller->get_jwt();
-
-		remove_filter( 'pre_http_request', array( $this, 'mock_jwt_api_missing_token' ), 10 );
-
-		$this->assertInstanceOf( \WP_Error::class, $response );
-		$this->assertEquals( 'no-token', $response->get_error_code() );
-	}
-
-	/**
-	 * Tests that get_jwt returns a WP_Error when the HTTP request fails.
-	 */
-	public function test_get_jwt_returns_wp_error_when_request_fails() {
-		$this->set_up_connected_user();
-
-		add_filter( 'pre_http_request', array( $this, 'mock_jwt_api_error' ), 10, 3 );
-
-		$response = $this->controller->get_jwt();
-
-		remove_filter( 'pre_http_request', array( $this, 'mock_jwt_api_error' ), 10 );
-
-		$this->assertInstanceOf( \WP_Error::class, $response );
-		$this->assertEquals( 'http_request_failed', $response->get_error_code() );
-	}
-
-	/**
-	 * Mock a successful JWT API response.
+	 * Records a deprecated function call.
 	 *
-	 * @param false|array|\WP_Error $response The preemptive HTTP response.
-	 * @param array                 $args     HTTP request arguments.
-	 * @param string                $url      The request URL.
-	 * @return false|array|\WP_Error
+	 * @param string $function_name The deprecated function.
 	 */
-	public function mock_jwt_api_success( $response, $args, $url ) {
-		if ( strpos( $url, '/jetpack-openai-query/jwt' ) === false ) {
-			return $response;
-		}
-
-		return array(
-			'body'     => wp_json_encode( array( 'token' => 'test-jwt-token' ), JSON_UNESCAPED_SLASHES ),
-			'response' => array(
-				'code'    => 200,
-				'message' => 'OK',
-			),
-		);
+	public function record_deprecation( $function_name ) {
+		$this->deprecated[] = $function_name;
 	}
 
 	/**
-	 * Mock a JWT API response without a token.
-	 *
-	 * @param false|array|\WP_Error $response The preemptive HTTP response.
-	 * @param array                 $args     HTTP request arguments.
-	 * @param string                $url      The request URL.
-	 * @return false|array|\WP_Error
+	 * Tests that the class is a deprecated alias of the Connection package controller.
 	 */
-	public function mock_jwt_api_missing_token( $response, $args, $url ) {
-		if ( strpos( $url, '/jetpack-openai-query/jwt' ) === false ) {
-			return $response;
-		}
+	public function test_is_deprecated_alias_of_connection_controller() {
+		// @phan-suppress-next-line PhanDeprecatedClass, PhanDeprecatedFunction -- The deprecated alias is the subject under test.
+		$controller = new WP_REST_Jetpack_AI_JWT();
 
-		return array(
-			'body'     => wp_json_encode( array(), JSON_UNESCAPED_SLASHES ),
-			'response' => array(
-				'code'    => 200,
-				'message' => 'OK',
-			),
-		);
+		$this->assertInstanceOf( REST_Jetpack_AI_JWT::class, $controller );
+		$this->assertContains( WP_REST_Jetpack_AI_JWT::class . '::__construct', $this->deprecated );
 	}
 
 	/**
-	 * Mock a failed JWT API response.
-	 *
-	 * @param false|array|\WP_Error $response The preemptive HTTP response.
-	 * @param array                 $args     HTTP request arguments.
-	 * @param string                $url      The request URL.
-	 * @return false|array|\WP_Error
+	 * Tests that the alias still registers the route.
 	 */
-	public function mock_jwt_api_error( $response, $args, $url ) {
-		if ( strpos( $url, '/jetpack-openai-query/jwt' ) === false ) {
-			return $response;
-		}
+	public function test_alias_registers_route() {
+		// @phan-suppress-next-line PhanDeprecatedClass, PhanDeprecatedFunction -- The deprecated alias is the subject under test.
+		( new WP_REST_Jetpack_AI_JWT() )->register_rest_route();
 
-		return new \WP_Error( 'http_request_failed', 'Connection failed' );
+		$this->assertArrayHasKey( '/jetpack/v4/jetpack-ai-jwt', rest_get_server()->get_routes() );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
 	}
 }

--- a/projects/packages/connection/changelog/connect-437-ai-jwt-route
+++ b/projects/packages/connection/changelog/connect-437-ai-jwt-route
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+REST API: add the `jetpack/v4/jetpack-ai-jwt` route, moved from the Agents Manager package.

--- a/projects/packages/connection/changelog/connect-437-ai-jwt-route
+++ b/projects/packages/connection/changelog/connect-437-ai-jwt-route
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-REST API: add the `jetpack/v4/jetpack-ai-jwt` route, moved from the Agents Manager package.
+REST API: Add the `jetpack/v4/jetpack-ai-jwt` route, moved from the Agents Manager package.

--- a/projects/packages/connection/src/class-rest-jetpack-ai-jwt.php
+++ b/projects/packages/connection/src/class-rest-jetpack-ai-jwt.php
@@ -76,6 +76,8 @@ class REST_Jetpack_AI_JWT extends \WP_REST_Controller {
 
 	/**
 	 * Ask WPCOM for a JWT token to use for OpenAI completion.
+	 *
+	 * @return \WP_REST_Response|\WP_Error The token and blog ID, or the error from WPCOM.
 	 */
 	public function get_jwt() {
 		$blog_id = Jetpack_Options::get_option( 'id' );

--- a/projects/packages/connection/src/class-rest-jetpack-ai-jwt.php
+++ b/projects/packages/connection/src/class-rest-jetpack-ai-jwt.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * REST_Jetpack_AI_JWT file.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Jetpack_Options;
+
+/**
+ * Registers the `jetpack/v4/jetpack-ai-jwt` route, which asks WordPress.com for a JWT that
+ * Jetpack AI clients use to call the AI completion service.
+ *
+ * @since $$next-version$$
+ */
+class REST_Jetpack_AI_JWT extends \WP_REST_Controller {
+
+	/**
+	 * REST_Jetpack_AI_JWT constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'jetpack/v4';
+		$this->rest_base = '/jetpack-ai-jwt';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		/*
+		 * Check if the `jetpack/v4/jetpack-ai-jwt` endpoint is registered
+		 * by the Jetpack plugin to avoid registering it again.
+		 * In case it's not registered, register it
+		 * to make it available for Jetpack products that depend on it.
+		 */
+		if ( $this->is_rest_endpoint_registered() ) {
+			return;
+		}
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'get_jwt' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Check if this REST endpoint is already registered.
+	 *
+	 * @return bool True if the endpoint is registered, false otherwise.
+	 */
+	private function is_rest_endpoint_registered() {
+		$server        = rest_get_server();
+		$routes        = $server->get_routes();
+		$full_endpoint = '/' . trim( $this->namespace, '/' ) . $this->rest_base;
+
+		return isset( $routes[ $full_endpoint ] );
+	}
+
+	/**
+	 * Permission callback for the JWT endpoint.
+	 *
+	 * @return bool
+	 */
+	public function permission_callback() {
+		return ( new Manager( 'jetpack' ) )->is_user_connected() && current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Ask WPCOM for a JWT token to use for OpenAI completion.
+	 */
+	public function get_jwt() {
+		$blog_id = Jetpack_Options::get_option( 'id' );
+
+		$response = Client::wpcom_json_api_request_as_user(
+			"/sites/$blog_id/jetpack-openai-query/jwt",
+			'2',
+			array(
+				'method'  => 'POST',
+				'headers' => array( 'Content-Type' => 'application/json; charset=utf-8' ),
+			),
+			wp_json_encode( array(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+			'wpcom'
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$json = json_decode( wp_remote_retrieve_body( $response ) );
+
+		if ( ! isset( $json->token ) ) {
+			return new \WP_Error(
+				'no-token',
+				'No token returned from WPCOM',
+				array( 'status' => 500 )
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'token'   => $json->token,
+				'blog_id' => $blog_id,
+			)
+		);
+	}
+}

--- a/projects/packages/connection/tests/php/REST_Jetpack_AI_JWT_Test.php
+++ b/projects/packages/connection/tests/php/REST_Jetpack_AI_JWT_Test.php
@@ -1,0 +1,298 @@
+<?php
+/**
+ * Tests for the Jetpack AI JWT endpoint.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Automattic\Jetpack\Constants;
+use Jetpack_Options;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the Jetpack AI JWT endpoint.
+ *
+ * @covers \Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT
+ */
+#[CoversClass( REST_Jetpack_AI_JWT::class )]
+class REST_Jetpack_AI_JWT_Test extends BaseTestCase {
+
+	/**
+	 * The controller instance.
+	 *
+	 * @var REST_Jetpack_AI_JWT
+	 */
+	private $controller;
+
+	/**
+	 * Connected user ID used for JWT API tests.
+	 *
+	 * @var int
+	 */
+	private $connected_user_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		$this->controller = new REST_Jetpack_AI_JWT();
+	}
+
+	/**
+	 * Sets up a connected user for JWT API tests.
+	 */
+	private function set_up_connected_user() {
+		$this->connected_user_id = wp_insert_user(
+			array(
+				'user_login' => 'jwt_api_user',
+				'user_pass'  => 'password',
+				'role'       => 'editor',
+			)
+		);
+		wp_set_current_user( $this->connected_user_id );
+
+		Jetpack_Options::update_option(
+			'user_tokens',
+			array( $this->connected_user_id => 'test.token.' . $this->connected_user_id )
+		);
+		Jetpack_Options::update_option( 'id', 12345 );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		wp_set_current_user( 0 );
+		remove_all_filters( 'pre_http_request' );
+		Constants::clear_constants();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that register_rest_route registers the expected route.
+	 */
+	public function test_register_rest_route_registers_routes() {
+		$this->controller->register_rest_route();
+
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( '/jetpack/v4/jetpack-ai-jwt', $routes );
+
+		$route_data = $routes['/jetpack/v4/jetpack-ai-jwt'];
+		$methods    = array();
+
+		foreach ( $route_data as $endpoint ) {
+			if ( isset( $endpoint['methods'] ) ) {
+				$methods = array_merge( $methods, array_keys( $endpoint['methods'] ) );
+			}
+		}
+
+		$this->assertContains( 'POST', $methods );
+	}
+
+	/**
+	 * Tests that the endpoint uses the controller permission callback.
+	 */
+	public function test_endpoint_uses_permission_callback() {
+		$this->controller->register_rest_route();
+
+		$routes     = rest_get_server()->get_routes();
+		$route_data = $routes['/jetpack/v4/jetpack-ai-jwt'];
+
+		$post_endpoint = null;
+		foreach ( $route_data as $endpoint ) {
+			if ( isset( $endpoint['methods']['POST'] ) && $endpoint['methods']['POST'] ) {
+				$post_endpoint = $endpoint;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $post_endpoint );
+		$this->assertEquals( array( $this->controller, 'permission_callback' ), $post_endpoint['permission_callback'] );
+	}
+
+	/**
+	 * Tests that register_rest_route does not register a duplicate route.
+	 */
+	public function test_register_rest_route_does_not_register_duplicate_route() {
+		$this->controller->register_rest_route();
+		// @phan-suppress-next-line PhanPluginDuplicateAdjacentStatement -- Intentionally calling twice to ensure duplicates are not registered.
+		$this->controller->register_rest_route();
+
+		$routes     = rest_get_server()->get_routes();
+		$route_data = $routes['/jetpack/v4/jetpack-ai-jwt'];
+
+		$this->assertCount( 1, $route_data );
+	}
+
+	/**
+	 * Tests that permission_callback returns false when the user is not connected.
+	 */
+	public function test_permission_callback_returns_false_when_user_not_connected() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jwt_editor',
+				'user_pass'  => 'password',
+				'role'       => 'editor',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		$this->assertFalse( $this->controller->permission_callback() );
+	}
+
+	/**
+	 * Tests that permission_callback returns false when the user cannot edit posts.
+	 */
+	public function test_permission_callback_returns_false_when_user_cannot_edit_posts() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jwt_subscriber',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'test.token.' . $user_id ) );
+
+		$this->assertFalse( $this->controller->permission_callback() );
+	}
+
+	/**
+	 * Tests that permission_callback returns true when the user is connected and can edit posts.
+	 */
+	public function test_permission_callback_returns_true_when_user_connected_and_can_edit_posts() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'jwt_connected_editor',
+				'user_pass'  => 'password',
+				'role'       => 'editor',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'test.token.' . $user_id ) );
+
+		$this->assertTrue( $this->controller->permission_callback() );
+	}
+
+	/**
+	 * Tests that get_jwt returns the token and blog ID on success.
+	 */
+	public function test_get_jwt_returns_token_and_blog_id_on_success() {
+		$this->set_up_connected_user();
+
+		add_filter( 'pre_http_request', array( $this, 'mock_jwt_api_success' ), 10, 3 );
+
+		$response = $this->controller->get_jwt();
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertEquals(
+			array(
+				'token'   => 'test-jwt-token',
+				'blog_id' => 12345,
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Tests that get_jwt returns an error when WPCOM does not return a token.
+	 */
+	public function test_get_jwt_returns_error_when_no_token_in_response() {
+		$this->set_up_connected_user();
+
+		add_filter( 'pre_http_request', array( $this, 'mock_jwt_api_missing_token' ), 10, 3 );
+
+		$response = $this->controller->get_jwt();
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertEquals( 'no-token', $response->get_error_code() );
+	}
+
+	/**
+	 * Tests that get_jwt returns a WP_Error when the HTTP request fails.
+	 */
+	public function test_get_jwt_returns_wp_error_when_request_fails() {
+		$this->set_up_connected_user();
+
+		add_filter( 'pre_http_request', array( $this, 'mock_jwt_api_error' ), 10, 3 );
+
+		$response = $this->controller->get_jwt();
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertEquals( 'http_request_failed', $response->get_error_code() );
+	}
+
+	/**
+	 * Mock a successful JWT API response.
+	 *
+	 * @param false|array|\WP_Error $response The preemptive HTTP response.
+	 * @param array                 $args     HTTP request arguments.
+	 * @param string                $url      The request URL.
+	 * @return false|array|\WP_Error
+	 */
+	public function mock_jwt_api_success( $response, $args, $url ) {
+		if ( strpos( $url, '/jetpack-openai-query/jwt' ) === false ) {
+			return $response;
+		}
+
+		return array(
+			'body'     => wp_json_encode( array( 'token' => 'test-jwt-token' ), JSON_UNESCAPED_SLASHES ),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Mock a JWT API response without a token.
+	 *
+	 * @param false|array|\WP_Error $response The preemptive HTTP response.
+	 * @param array                 $args     HTTP request arguments.
+	 * @param string                $url      The request URL.
+	 * @return false|array|\WP_Error
+	 */
+	public function mock_jwt_api_missing_token( $response, $args, $url ) {
+		if ( strpos( $url, '/jetpack-openai-query/jwt' ) === false ) {
+			return $response;
+		}
+
+		return array(
+			'body'     => wp_json_encode( array(), JSON_UNESCAPED_SLASHES ),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Mock a failed JWT API response.
+	 *
+	 * @param false|array|\WP_Error $response The preemptive HTTP response.
+	 * @param array                 $args     HTTP request arguments.
+	 * @param string                $url      The request URL.
+	 * @return false|array|\WP_Error
+	 */
+	public function mock_jwt_api_error( $response, $args, $url ) {
+		if ( strpos( $url, '/jetpack-openai-query/jwt' ) === false ) {
+			return $response;
+		}
+
+		return new \WP_Error( 'http_request_failed', 'Connection failed' );
+	}
+}

--- a/projects/packages/my-jetpack/changelog/connect-437-ai-jwt-route
+++ b/projects/packages/my-jetpack/changelog/connect-437-ai-jwt-route
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Register the `jetpack/v4/jetpack-ai-jwt` route from the Connection package and drop the Agents Manager dependency.

--- a/projects/packages/my-jetpack/composer.json
+++ b/projects/packages/my-jetpack/composer.json
@@ -6,7 +6,6 @@
 	"require": {
 		"php": ">=7.4",
 		"automattic/jetpack-admin-ui": "@dev",
-		"automattic/jetpack-agents-manager": "@dev",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-boost-speed-score": "@dev",
 		"automattic/jetpack-connection": "@dev",

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -8,7 +8,6 @@
 namespace Automattic\Jetpack\My_Jetpack;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
-use Automattic\Jetpack\Agents_Manager\WP_REST_Jetpack_AI_JWT;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score;
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score_History;
@@ -16,6 +15,7 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+use Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT;
 use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Automattic\Jetpack\ExPlat;
 use Automattic\Jetpack\JITMS\JITM;
@@ -606,7 +606,7 @@ class Initializer {
 		new REST_Products();
 		new REST_Purchases();
 		new REST_Zendesk_Chat();
-		( new WP_REST_Jetpack_AI_JWT() )->register_rest_route();
+		( new REST_Jetpack_AI_JWT() )->register_rest_route();
 		new REST_Recommendations_Evaluation();
 
 		Products::register_product_endpoints();

--- a/projects/packages/my-jetpack/tests/php/Products_Rest_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Products_Rest_Test.php
@@ -112,7 +112,7 @@ class Products_Rest_Test extends TestCase {
 	}
 
 	/**
-	 * Test that My Jetpack registers the jetpack-ai-jwt endpoint via Agents Manager.
+	 * Test that My Jetpack registers the jetpack-ai-jwt endpoint from the Connection package.
 	 */
 	public function test_jetpack_ai_jwt_route_is_registered() {
 		$routes = rest_get_server()->get_routes();

--- a/projects/plugins/backup/changelog/connect-437-ai-jwt-route
+++ b/projects/plugins/backup/changelog/connect-437-ai-jwt-route
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -213,81 +213,6 @@
             }
         },
         {
-            "name": "automattic/jetpack-agents-manager",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/agents-manager",
-                "reference": "740d891a23b01012cc2272429be91d83dd23b760"
-            },
-            "require": {
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autorelease": true,
-                "autotagger": true,
-                "branch-alias": {
-                    "dev-trunk": "0.10.x-dev"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
-                },
-                "mirror-repo": "Automattic/jetpack-agents-manager",
-                "textdomain": "jetpack-agents-manager",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-agents-manager.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-js": [
-                    "pnpm run test"
-                ],
-                "test-js-coverage": [
-                    "pnpm run test-coverage"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "test-php-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Shared AI infrastructure helpers for Automattic plugins",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/jetpack-assets",
             "version": "dev-trunk",
             "dist": {
@@ -1391,11 +1316,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "241d610cbdf17bcc90c53af6b9f1dab01967de4e"
+                "reference": "1263327c84d902bafb3d4ab4a078d9f9d530d196"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-agents-manager": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-boost-speed-score": "@dev",
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/boost/changelog/connect-437-ai-jwt-route
+++ b/projects/plugins/boost/changelog/connect-437-ai-jwt-route
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -213,81 +213,6 @@
             }
         },
         {
-            "name": "automattic/jetpack-agents-manager",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/agents-manager",
-                "reference": "740d891a23b01012cc2272429be91d83dd23b760"
-            },
-            "require": {
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autorelease": true,
-                "autotagger": true,
-                "branch-alias": {
-                    "dev-trunk": "0.10.x-dev"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
-                },
-                "mirror-repo": "Automattic/jetpack-agents-manager",
-                "textdomain": "jetpack-agents-manager",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-agents-manager.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-js": [
-                    "pnpm run test"
-                ],
-                "test-js-coverage": [
-                    "pnpm run test-coverage"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "test-php-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Shared AI infrastructure helpers for Automattic plugins",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/jetpack-assets",
             "version": "dev-trunk",
             "dist": {
@@ -1308,11 +1233,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "241d610cbdf17bcc90c53af6b9f1dab01967de4e"
+                "reference": "1263327c84d902bafb3d4ab4a078d9f9d530d196"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-agents-manager": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-boost-speed-score": "@dev",
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/jetpack/changelog/connect-437-ai-jwt-route
+++ b/projects/plugins/jetpack/changelog/connect-437-ai-jwt-route
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2413,11 +2413,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "241d610cbdf17bcc90c53af6b9f1dab01967de4e"
+                "reference": "1263327c84d902bafb3d4ab4a078d9f9d530d196"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-agents-manager": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-boost-speed-score": "@dev",
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/protect/changelog/connect-437-ai-jwt-route
+++ b/projects/plugins/protect/changelog/connect-437-ai-jwt-route
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -281,81 +281,6 @@
             }
         },
         {
-            "name": "automattic/jetpack-agents-manager",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/agents-manager",
-                "reference": "740d891a23b01012cc2272429be91d83dd23b760"
-            },
-            "require": {
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autorelease": true,
-                "autotagger": true,
-                "branch-alias": {
-                    "dev-trunk": "0.10.x-dev"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
-                },
-                "mirror-repo": "Automattic/jetpack-agents-manager",
-                "textdomain": "jetpack-agents-manager",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-agents-manager.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-js": [
-                    "pnpm run test"
-                ],
-                "test-js-coverage": [
-                    "pnpm run test-coverage"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "test-php-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Shared AI infrastructure helpers for Automattic plugins",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/jetpack-assets",
             "version": "dev-trunk",
             "dist": {
@@ -1370,11 +1295,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "241d610cbdf17bcc90c53af6b9f1dab01967de4e"
+                "reference": "1263327c84d902bafb3d4ab4a078d9f9d530d196"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-agents-manager": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-boost-speed-score": "@dev",
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/search/changelog/connect-437-ai-jwt-route
+++ b/projects/plugins/search/changelog/connect-437-ai-jwt-route
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -213,81 +213,6 @@
             }
         },
         {
-            "name": "automattic/jetpack-agents-manager",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/agents-manager",
-                "reference": "740d891a23b01012cc2272429be91d83dd23b760"
-            },
-            "require": {
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autorelease": true,
-                "autotagger": true,
-                "branch-alias": {
-                    "dev-trunk": "0.10.x-dev"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
-                },
-                "mirror-repo": "Automattic/jetpack-agents-manager",
-                "textdomain": "jetpack-agents-manager",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-agents-manager.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-js": [
-                    "pnpm run test"
-                ],
-                "test-js-coverage": [
-                    "pnpm run test-coverage"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "test-php-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Shared AI infrastructure helpers for Automattic plugins",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/jetpack-assets",
             "version": "dev-trunk",
             "dist": {
@@ -1248,11 +1173,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "241d610cbdf17bcc90c53af6b9f1dab01967de4e"
+                "reference": "1263327c84d902bafb3d4ab4a078d9f9d530d196"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-agents-manager": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-boost-speed-score": "@dev",
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/social/changelog/connect-437-ai-jwt-route
+++ b/projects/plugins/social/changelog/connect-437-ai-jwt-route
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -276,81 +276,6 @@
             }
         },
         {
-            "name": "automattic/jetpack-agents-manager",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/agents-manager",
-                "reference": "740d891a23b01012cc2272429be91d83dd23b760"
-            },
-            "require": {
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autorelease": true,
-                "autotagger": true,
-                "branch-alias": {
-                    "dev-trunk": "0.10.x-dev"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
-                },
-                "mirror-repo": "Automattic/jetpack-agents-manager",
-                "textdomain": "jetpack-agents-manager",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-agents-manager.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-js": [
-                    "pnpm run test"
-                ],
-                "test-js-coverage": [
-                    "pnpm run test-coverage"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "test-php-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Shared AI infrastructure helpers for Automattic plugins",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/jetpack-assets",
             "version": "dev-trunk",
             "dist": {
@@ -1371,11 +1296,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "241d610cbdf17bcc90c53af6b9f1dab01967de4e"
+                "reference": "1263327c84d902bafb3d4ab4a078d9f9d530d196"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-agents-manager": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-boost-speed-score": "@dev",
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/starter-plugin/changelog/connect-437-ai-jwt-route
+++ b/projects/plugins/starter-plugin/changelog/connect-437-ai-jwt-route
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -137,81 +137,6 @@
             }
         },
         {
-            "name": "automattic/jetpack-agents-manager",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/agents-manager",
-                "reference": "740d891a23b01012cc2272429be91d83dd23b760"
-            },
-            "require": {
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autorelease": true,
-                "autotagger": true,
-                "branch-alias": {
-                    "dev-trunk": "0.10.x-dev"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
-                },
-                "mirror-repo": "Automattic/jetpack-agents-manager",
-                "textdomain": "jetpack-agents-manager",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-agents-manager.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-js": [
-                    "pnpm run test"
-                ],
-                "test-js-coverage": [
-                    "pnpm run test-coverage"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "test-php-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Shared AI infrastructure helpers for Automattic plugins",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/jetpack-assets",
             "version": "dev-trunk",
             "dist": {
@@ -1172,11 +1097,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "241d610cbdf17bcc90c53af6b9f1dab01967de4e"
+                "reference": "1263327c84d902bafb3d4ab4a078d9f9d530d196"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-agents-manager": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-boost-speed-score": "@dev",
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/stats/changelog/connect-437-ai-jwt-route
+++ b/projects/plugins/stats/changelog/connect-437-ai-jwt-route
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/stats/composer.lock
+++ b/projects/plugins/stats/composer.lock
@@ -137,81 +137,6 @@
             }
         },
         {
-            "name": "automattic/jetpack-agents-manager",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/agents-manager",
-                "reference": "740d891a23b01012cc2272429be91d83dd23b760"
-            },
-            "require": {
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autorelease": true,
-                "autotagger": true,
-                "branch-alias": {
-                    "dev-trunk": "0.10.x-dev"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
-                },
-                "mirror-repo": "Automattic/jetpack-agents-manager",
-                "textdomain": "jetpack-agents-manager",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-agents-manager.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-js": [
-                    "pnpm run test"
-                ],
-                "test-js-coverage": [
-                    "pnpm run test-coverage"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "test-php-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Shared AI infrastructure helpers for Automattic plugins",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/jetpack-assets",
             "version": "dev-trunk",
             "dist": {
@@ -1172,11 +1097,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "241d610cbdf17bcc90c53af6b9f1dab01967de4e"
+                "reference": "1263327c84d902bafb3d4ab4a078d9f9d530d196"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-agents-manager": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-boost-speed-score": "@dev",
                 "automattic/jetpack-connection": "@dev",

--- a/projects/plugins/videopress/changelog/connect-437-ai-jwt-route
+++ b/projects/plugins/videopress/changelog/connect-437-ai-jwt-route
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -213,81 +213,6 @@
             }
         },
         {
-            "name": "automattic/jetpack-agents-manager",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/agents-manager",
-                "reference": "740d891a23b01012cc2272429be91d83dd23b760"
-            },
-            "require": {
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-constants": "@dev",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autorelease": true,
-                "autotagger": true,
-                "branch-alias": {
-                    "dev-trunk": "0.10.x-dev"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
-                },
-                "mirror-repo": "Automattic/jetpack-agents-manager",
-                "textdomain": "jetpack-agents-manager",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-agents-manager.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-js": [
-                    "pnpm run test"
-                ],
-                "test-js-coverage": [
-                    "pnpm run test-coverage"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "test-php-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Shared AI infrastructure helpers for Automattic plugins",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
             "name": "automattic/jetpack-assets",
             "version": "dev-trunk",
             "dist": {
@@ -1248,11 +1173,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "241d610cbdf17bcc90c53af6b9f1dab01967de4e"
+                "reference": "1263327c84d902bafb3d4ab4a078d9f9d530d196"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-agents-manager": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-boost-speed-score": "@dev",
                 "automattic/jetpack-connection": "@dev",


### PR DESCRIPTION
Fixes CONNECT-437

## Proposed changes

* Add `Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT` to the Connection package. It registers the `jetpack/v4/jetpack-ai-jwt` route, unchanged from the Agents Manager copy: same path, same `is_rest_endpoint_registered()` guard, same permission check (`is_user_connected()` + `edit_posts`), same `Client::wpcom_json_api_request_as_user()` call.
* My Jetpack registers the Connection class and no longer requires `automattic/jetpack-agents-manager`. My Jetpack only needed the package for this one class; the rest (the AI sidebar and its `widgets.wp.com` loader) shipped in every plugin that bundles My Jetpack without ever being initialized.
* Agents Manager registers the Connection class too. Its `WP_REST_Jetpack_AI_JWT` stays as a deprecated alias that extends the Connection class and raises `_deprecated_function()`, so external consumers keep working until the alias is removed.
* Lock files: the 8 plugins that only reached Agents Manager through My Jetpack (Backup, Boost, Protect, Search, Social, Starter Plugin, Stats, VideoPress) drop it from `composer.lock`. The Jetpack plugin and jetpack-mu-wpcom require Agents Manager directly and keep it.

Why Connection: the route is a thin Connection wrapper, it lives in the `jetpack/v4` namespace Connection owns, and every consumer of the route already requires Connection (My Jetpack, Agents Manager, and Woo AI). #49415 moved the route into Agents Manager so plugins with an AI assistant but no My Jetpack could serve it; Connection is one level lower and keeps that covered.

Not in this PR: the Jetpack plugin's own copy of the route (`get_openai_jwt()` in `class.core-rest-api-endpoints.php`), and letting Connection register the route itself from `REST_Connector`. Both can follow separately if the Connection team wants them.

## Related product discussion/links

* Linear: CONNECT-437 (this change), CONNECT-436 (SSO, same review)
* p3hzj1d-7ot-p2
* #49415 — the PR that moved the route from My Jetpack into Agents Manager

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the standalone Stats plugin (`jp build plugins/stats`) and check `projects/plugins/stats/jetpack_vendor/automattic/`: `jetpack-agents-manager` is gone, `jetpack-connection/src/class-rest-jetpack-ai-jwt.php` is present.
* On a site running a standalone plugin with My Jetpack (Stats, Boost, Social...) and a connected user, `POST /wp-json/jetpack/v4/jetpack-ai-jwt` still returns a token (or `401`/`403` for a non-connected user).
* A local Docker site runs in offline mode, and My Jetpack skips `Initializer::init()` in offline mode, so the route returns `404` there before and after this PR. Filter `jetpack_offline_mode` to `false` first: `add_filter( 'jetpack_offline_mode', '__return_false' );`. With that in place, a `404` means the route stopped registering.
* On a site running the Jetpack plugin, the route still works; the Jetpack plugin's own registration wins and the Connection copy no-ops through the guard.
* Package tests: `jp test php packages/connection`, `jp test php packages/my-jetpack`, `jp test php packages/agents-manager`.

