### PR TITLE
Forms: fix the Integrations toolbar button not rendering when the settings sidebar is closed

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-integrations-toolbar
+++ b/projects/packages/forms/changelog/fix-forms-integrations-toolbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Restore the Integrations button in the Form block toolbar when the settings sidebar is closed.

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.jsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.jsx
@@ -1,5 +1,5 @@
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { BlockControls } from '@wordpress/block-editor';
+import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 import { ToolbarGroup, ToolbarButton, Button, PanelBody } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useMemo } from '@wordpress/element';
@@ -12,7 +12,12 @@ import ConsentToggle from './jetpack-integrations-modal/components/consent-toggl
 import IntegrationsModal from './jetpack-integrations-modal/index.tsx';
 
 /**
- * Integration controls component containing Panel for settings sidebar and block toolbar.
+ * Integration controls: the "Integrations" inspector panel, the toolbar button that opens the
+ * same modal from the canvas, and the modal itself.
+ *
+ * Placement is the component's own business rather than the call site's, because only the panel
+ * half belongs in the inspector. Render this as a sibling of the block's InspectorControls, not
+ * a child of it -- see the comment on the toolbar below.
  *
  * @param {object}   props               - Component props.
  * @param {object}   props.attributes    - Block attributes.
@@ -40,27 +45,36 @@ export default function IntegrationControls( { attributes, setAttributes } ) {
 
 	return (
 		<>
-			<PanelBody
-				title={ __( 'Integrations', 'jetpack-forms' ) }
-				className="jetpack-contact-form__panel jetpack-contact-form__integrations-panel"
-				initialOpen={ false }
-			>
-				{ showIntegrationIcons !== false && (
-					<ActiveIntegrations
-						integrations={ integrations }
-						attributes={ attributes }
-						isLoading={ isLoading }
-					/>
-				) }
-				<Button
-					variant="secondary"
-					onClick={ () => handleOpenModal( 'block-sidebar' ) }
-					__next40pxDefaultSize={ true }
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Integrations', 'jetpack-forms' ) }
+					className="jetpack-contact-form__panel jetpack-contact-form__integrations-panel"
+					initialOpen={ false }
 				>
-					{ __( 'Manage integrations', 'jetpack-forms' ) }
-				</Button>
-			</PanelBody>
+					{ showIntegrationIcons !== false && (
+						<ActiveIntegrations
+							integrations={ integrations }
+							attributes={ attributes }
+							isLoading={ isLoading }
+						/>
+					) }
+					<Button
+						variant="secondary"
+						onClick={ () => handleOpenModal( 'block-sidebar' ) }
+						__next40pxDefaultSize={ true }
+					>
+						{ __( 'Manage integrations', 'jetpack-forms' ) }
+					</Button>
+				</PanelBody>
+			</InspectorControls>
 
+			{ /* Deliberately outside InspectorControls, along with the modal below. That
+			     component is a slot fill, and a fill renders nothing while its slot is
+			     unmounted -- which is the case whenever the settings sidebar is closed. This
+			     button exists so an author can reach integrations from the canvas, so the one
+			     state it must work in is the one that would have erased it. The rule is
+			     general: anything opened from BlockControls, and any Modal or Popover it
+			     opens, must not be a descendant of InspectorControls. */ }
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.jsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-integration-controls.jsx
@@ -15,9 +15,7 @@ import IntegrationsModal from './jetpack-integrations-modal/index.tsx';
  * Integration controls: the "Integrations" inspector panel, the toolbar button that opens the
  * same modal from the canvas, and the modal itself.
  *
- * Placement is the component's own business rather than the call site's, because only the panel
- * half belongs in the inspector. Render this as a sibling of the block's InspectorControls, not
- * a child of it -- see the comment on the toolbar below.
+ * Owns its own InspectorControls, so render it as a sibling of the block's, never a child.
  *
  * @param {object}   props               - Component props.
  * @param {object}   props.attributes    - Block attributes.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1279,11 +1279,25 @@ function JetpackContactFormEdit( {
 							setAttributes={ setAttributes }
 						/>
 					</PanelBody>
-					{ isIntegrationsEnabled && showBlockIntegrations && (
-						<Suspense fallback={ <div /> }>
-							<IntegrationControls attributes={ attributes } setAttributes={ setAttributes } />
-						</Suspense>
-					) }
+				</InspectorControls>
+
+				{ /* Outside InspectorControls, because IntegrationControls is not only an
+				     inspector panel: it also contributes a BlockControls toolbar button and the
+				     dialog that button opens. InspectorControls is a slot fill, and a fill
+				     renders nothing while its slot is unmounted -- which is the case whenever
+				     the settings sidebar is closed -- so nesting those inside it left the
+				     toolbar entry point dead in exactly the state it exists for. The component
+				     wraps its own panel half in InspectorControls instead, which is why the
+				     inspector is split in two here: this keeps the Integrations panel in its
+				     original position between "Action after submit" and "Webhooks", since fills
+				     are ordered by render order. */ }
+				{ isIntegrationsEnabled && showBlockIntegrations && (
+					<Suspense fallback={ <div /> }>
+						<IntegrationControls attributes={ attributes } setAttributes={ setAttributes } />
+					</Suspense>
+				) }
+
+				<InspectorControls>
 					{ showWebhooks && (
 						<PanelBody
 							title={ __( 'Webhooks', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -1279,25 +1279,6 @@ function JetpackContactFormEdit( {
 							setAttributes={ setAttributes }
 						/>
 					</PanelBody>
-				</InspectorControls>
-
-				{ /* Outside InspectorControls, because IntegrationControls is not only an
-				     inspector panel: it also contributes a BlockControls toolbar button and the
-				     dialog that button opens. InspectorControls is a slot fill, and a fill
-				     renders nothing while its slot is unmounted -- which is the case whenever
-				     the settings sidebar is closed -- so nesting those inside it left the
-				     toolbar entry point dead in exactly the state it exists for. The component
-				     wraps its own panel half in InspectorControls instead, which is why the
-				     inspector is split in two here: this keeps the Integrations panel in its
-				     original position between "Action after submit" and "Webhooks", since fills
-				     are ordered by render order. */ }
-				{ isIntegrationsEnabled && showBlockIntegrations && (
-					<Suspense fallback={ <div /> }>
-						<IntegrationControls attributes={ attributes } setAttributes={ setAttributes } />
-					</Suspense>
-				) }
-
-				<InspectorControls>
 					{ showWebhooks && (
 						<PanelBody
 							title={ __( 'Webhooks', 'jetpack-forms' ) }
@@ -1329,6 +1310,21 @@ function JetpackContactFormEdit( {
 						/>
 					</PanelBody>
 				</InspectorControls>
+
+				{ /* A sibling of InspectorControls, not a child of it: IntegrationControls owns
+				     its own inspector fill, and its other half -- a toolbar button and the dialog
+				     that button opens -- must stay outside one. See the component for why.
+
+				     Gated on selection because it is lazy(): rendered unconditionally, the
+				     import fires on the block's first render, pulling ~30KB gz of chunk into
+				     editor boot for a UI that nothing can reach until the block is selected.
+				     Both halves render nothing when it isn't, so this costs no behaviour. */ }
+				{ isIntegrationsEnabled && showBlockIntegrations && isFormOrChildSelected && (
+					<Suspense fallback={ <div /> }>
+						<IntegrationControls attributes={ attributes } setAttributes={ setAttributes } />
+					</Suspense>
+				) }
+
 				<InspectorAdvancedControls>
 					<TextControl
 						label={ __( 'Accessible name', 'jetpack-forms' ) }

--- a/projects/packages/forms/tests/js/blocks/contact-form/integration-controls.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/contact-form/integration-controls.test.jsx
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// InspectorControls is a slot fill, and a fill renders its children only while a matching slot
+// is mounted -- which, for the block inspector, means only while the settings sidebar is open.
+// A mock that passes children straight through erases that, and with it any test's ability to
+// tell "renders in the sidebar" apart from "renders at all". Modelling the slot keeps the two
+// distinguishable; `isSidebarOpen` is reset to true before each test.
+let isSidebarOpen = true;
+
+await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
+	InspectorControls: ( { children } ) =>
+		isSidebarOpen ? <div data-testid="inspector">{ children }</div> : null,
+	BlockControls: ( { children } ) => <div data-testid="block-toolbar">{ children }</div>,
+} ) );
+
+const mockRecordEvent = jest.fn();
+
+await jest.unstable_mockModule( '@automattic/jetpack-shared-extension-utils', () => ( {
+	useAnalytics: () => ( { tracks: { recordEvent: mockRecordEvent } } ),
+} ) );
+
+const actualData = await import( '@wordpress/data' );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	...actualData,
+	useSelect: mapSelect =>
+		mapSelect( () => ( {
+			getIntegrations: () => [],
+			isIntegrationsLoading: () => false,
+		} ) ),
+	useDispatch: () => ( { refreshIntegrations: jest.fn() } ),
+} ) );
+
+await jest.unstable_mockModule( '../../../../src/hooks/use-config-value.ts', () => ( {
+	__esModule: true,
+	default: () => true,
+} ) );
+
+await jest.unstable_mockModule( '../../../../src/store/integrations/index.ts', () => ( {
+	INTEGRATIONS_STORE: 'jetpack/forms-integrations',
+} ) );
+
+await jest.unstable_mockModule(
+	'../../../../src/blocks/contact-form/components/jetpack-integrations-modal/active-integrations/index.jsx',
+	() => ( { __esModule: true, default: () => <div>Active integrations</div> } )
+);
+
+await jest.unstable_mockModule(
+	'../../../../src/blocks/contact-form/components/jetpack-integrations-modal/components/consent-toggle.tsx',
+	() => ( { __esModule: true, default: () => null } )
+);
+
+// Stood in for, rather than rendered: the real dialog pulls in the whole integrations UI, and
+// what this file is about is whether the dialog gets to render at all from each entry point.
+await jest.unstable_mockModule(
+	'../../../../src/blocks/contact-form/components/jetpack-integrations-modal/index.tsx',
+	() => ( {
+		__esModule: true,
+		default: ( { isOpen } ) => ( isOpen ? <div role="dialog">Integrations</div> : null ),
+	} )
+);
+
+const { default: IntegrationControls } = await import(
+	'../../../../src/blocks/contact-form/components/jetpack-integration-controls.jsx'
+);
+
+const setup = ( { sidebarOpen = true } = {} ) => {
+	isSidebarOpen = sidebarOpen;
+	const setAttributes = jest.fn();
+	render( <IntegrationControls attributes={ {} } setAttributes={ setAttributes } /> );
+	return { setAttributes };
+};
+
+const toolbarButton = () =>
+	within( screen.getByTestId( 'block-toolbar' ) ).getByRole( 'button', { name: 'Integrations' } );
+
+describe( 'IntegrationControls', () => {
+	beforeEach( () => {
+		isSidebarOpen = true;
+		mockRecordEvent.mockClear();
+	} );
+
+	// The toolbar button exists so an author can reach integrations from the canvas, which is
+	// exactly the situation in which the settings sidebar is likely to be closed -- Gutenberg
+	// opens a new post that way. Neither it nor the dialog it opens can therefore live inside
+	// InspectorControls: a fill whose slot is unmounted renders nothing, so the button would
+	// not exist at all, and a click could not have produced a dialog even if it did.
+	it( 'opens the modal from the toolbar while the sidebar is closed', async () => {
+		setup( { sidebarOpen: false } );
+
+		// Guards the premise: with the sidebar closed the inspector panel really is absent,
+		// so the toolbar button is the only way in.
+		expect( screen.queryByTestId( 'inspector' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+
+		await userEvent.click( toolbarButton() );
+
+		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_forms_block_modal_view', {
+			entry_point: 'block-toolbar',
+		} );
+	} );
+
+	it( 'still renders the panel in the inspector while the sidebar is open', async () => {
+		setup();
+
+		const inspector = within( screen.getByTestId( 'inspector' ) );
+		// PanelBody renders collapsed (initialOpen={false}), so nothing inside it exists in
+		// the DOM until the title is activated. The title shares its name with the toolbar
+		// button, hence the index rather than getByRole.
+		await userEvent.click( inspector.getAllByRole( 'button', { name: 'Integrations' } )[ 0 ] );
+
+		// Exactly one panel: a fill rendered from two places is the classic mistake when
+		// splitting a component across the inspector and the toolbar, and this button is
+		// unique to the panel half.
+		expect( screen.getAllByRole( 'button', { name: 'Manage integrations' } ) ).toHaveLength( 1 );
+		await userEvent.click( inspector.getByRole( 'button', { name: 'Manage integrations' } ) );
+
+		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_forms_block_modal_view', {
+			entry_point: 'block-sidebar',
+		} );
+	} );
+
+	it( 'keeps the toolbar entry point working while the sidebar is open', async () => {
+		setup();
+
+		await userEvent.click( toolbarButton() );
+
+		expect( screen.getAllByRole( 'dialog' ) ).toHaveLength( 1 );
+	} );
+} );

--- a/projects/packages/forms/tests/js/blocks/contact-form/integration-controls.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/contact-form/integration-controls.test.jsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 // is mounted -- which, for the block inspector, means only while the settings sidebar is open.
 // A mock that passes children straight through erases that, and with it any test's ability to
 // tell "renders in the sidebar" apart from "renders at all". Modelling the slot keeps the two
-// distinguishable; `isSidebarOpen` is reset to true before each test.
+// distinguishable; setup() sets `isSidebarOpen` per test, defaulting to open.
 let isSidebarOpen = true;
 
 await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
@@ -39,7 +39,7 @@ await jest.unstable_mockModule( '../../../../src/hooks/use-config-value.ts', () 
 } ) );
 
 await jest.unstable_mockModule( '../../../../src/store/integrations/index.ts', () => ( {
-	INTEGRATIONS_STORE: 'jetpack/forms-integrations',
+	INTEGRATIONS_STORE: 'jetpack/forms/integrations',
 } ) );
 
 await jest.unstable_mockModule(
@@ -66,11 +66,12 @@ const { default: IntegrationControls } = await import(
 	'../../../../src/blocks/contact-form/components/jetpack-integration-controls.jsx'
 );
 
+// Hoisted: an inline arrow in JSX props trips react/jsx-no-bind.
+const noop = () => {};
+
 const setup = ( { sidebarOpen = true } = {} ) => {
 	isSidebarOpen = sidebarOpen;
-	const setAttributes = jest.fn();
-	render( <IntegrationControls attributes={ {} } setAttributes={ setAttributes } /> );
-	return { setAttributes };
+	render( <IntegrationControls attributes={ {} } setAttributes={ noop } /> );
 };
 
 const toolbarButton = () =>
@@ -78,7 +79,6 @@ const toolbarButton = () =>
 
 describe( 'IntegrationControls', () => {
 	beforeEach( () => {
-		isSidebarOpen = true;
 		mockRecordEvent.mockClear();
 	} );
 
@@ -129,6 +129,6 @@ describe( 'IntegrationControls', () => {
 
 		await userEvent.click( toolbarButton() );
 
-		expect( screen.getAllByRole( 'dialog' ) ).toHaveLength( 1 );
+		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/fix-forms-integrations-toolbar
+++ b/projects/plugins/jetpack/changelog/fix-forms-integrations-toolbar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Restore the Integrations button in the Form block toolbar when the settings sidebar is closed.


### PR DESCRIPTION
Fixes #

## Proposed changes

The Form block's "Integrations" toolbar button did not exist while the block settings sidebar was closed — which is how Gutenberg opens a new post, and the state that entry point was built for.

`IntegrationControls` renders three things as siblings: an inspector `PanelBody`, a `BlockControls` toolbar button, and `IntegrationsModal`. All three were rendered inside the Form block's `<InspectorControls>`. `InspectorControls` is a slot fill, and a fill renders nothing while its slot is unmounted — the block-inspector slot is only mounted while the settings sidebar is open. So with the sidebar closed the nested `BlockControls` fill never rendered, and the modal could not have rendered even if something had set its open state.

The component now owns its own `<InspectorControls>` around the panel half only, and is rendered as a sibling of the block's `<InspectorControls>` in `edit.tsx`. Placement becomes a property of the component rather than of one call site, its `isModalOpen` state stays internal, and the `lazy()`/`<Suspense>` wrapper is unchanged.

The general rule, now stated in a comment: anything opened from `BlockControls` — and any `Modal` or `Popover` it opens — must not be a descendant of `InspectorControls`.

This is the same class of bug as #51617 fixed for Forms conditional logic, and matches that fix's shape. I grepped every `InspectorControls` user in the package; this was the only remaining occurrence, so it's a second instance rather than a class needing a refactor.

Two consequences reviewers should weigh:

**The Integrations panel moves to the end of the inspector**, below "Responses storage", where it previously sat between "Action after submit" and "Webhooks". Inspector fills are appended in mount order, and the component now contributes its own fill rather than rendering inside the block's. I first tried splitting the block's `<InspectorControls>` in two to hold the old position, but that doesn't actually work — `IntegrationControls` is `lazy()`, so its fill mounts a commit later than its neighbours and gets appended last regardless. The split bought nothing but complexity, so it's gone. Say the word if the original position is worth keeping and I'll make the component non-lazy and push the `lazy()` boundary down to `IntegrationsModal` instead, which would make the ordering real.

**The render is gated on `isFormOrChildSelected`.** Without it, hoisting the `<Suspense>` out of `<InspectorControls>` fires the lazy `import()` on the block's first render — pulling ~30KB gzipped of JS+CSS and two extra requests into editor boot for every post containing a Form block, for UI that nothing can reach until the block is selected. Both halves of the component render nothing when the block isn't selected, so the gate costs no behaviour. Verified: 0 chunk requests at editor boot, 2 on selecting the block.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No. The `jetpack_forms_block_modal_view` Tracks event and its `entry_point` property are unchanged; the `block-toolbar` entry point simply becomes reachable again.

## Testing instructions

Captured on a live Jurassic Ninja site at 1440×900, editing a page containing a Form block, **with the block settings sidebar closed**.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-integrations-toolbar/before-toolbar-crop.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-integrations-toolbar/after-toolbar-crop.png) |

Clicking it opens the modal, correctly styled — it portals to the top document while the block renders inside the editor canvas iframe:

![modal](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-integrations-toolbar/after-modal.png)

To reproduce:

* Add a Form block to a page or post and select it.
* **Close** the block settings sidebar (the Settings toggle in the editor header).
* Confirm an "Integrations" button is present in the block toolbar, and that clicking it opens the Manage integrations modal.
* Re-open the sidebar. Confirm the button is still there, the modal still opens from it, and the "Integrations" panel is present in the inspector exactly once — now at the end of the panel list, below "Responses storage" (see above).
* Confirm "Manage integrations" inside that panel still opens the same modal.

On `trunk`, the first check fails: with the sidebar closed there is no "Integrations" button at all.

### Unit test

`projects/packages/forms/tests/js/blocks/contact-form/integration-controls.test.jsx` covers this. It models the slot honestly — the existing mocks in this package pass `InspectorControls` children straight through, which makes the bug untestable — using a mutable `isSidebarOpen` flag reset per test, following the pattern in `tests/js/blocks/shared/conditional-logic/panel.test.jsx`.

Mutation-tested: with the source change reverted, exactly 1 of 1166 tests in the package fails, and it is the intended one.

I could not verify the panel's new position on a live site — see the caveat below — so that part is reasoned from how inspector fills mount, not observed. Worth a reviewer's eye on a WordPress version where the Form block's panels still render.

### A caveat reviewers should know about

On WordPress 7.1 (what a fresh JN site runs today), the Form block's entire **default** `InspectorControls` group is suppressed by core — not just Integrations, but "Action after submit", "Webhooks", "Responses storage" and "Advanced" too. Core's `InspectorControls` fill bails early when the block-edit context carries `mayDisplayPatternEditingControls`, letting only the `content` and `list` groups through, and it sets that for `jetpack/contact-form`. `core/group` and every Forms *field* block are unaffected on the same site, and it reproduces in both the post editor and the dedicated `jetpack_form` editor. I ruled out `supports.listView`; the cause is still unknown.

That is a separate, larger bug and this PR does not address it. It's why the "before" screenshot above shows no Integrations panel in the sidebar either. It's also why this fix is verifiable at all on current core: `BlockControls` fills still render, so hoisting the toolbar button out of `InspectorControls` restores the only working route to integrations on that WordPress version.
