### PR TITLE
Premium Analytics: drop the quarterly chart interval the API never serves

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1994-drop-quarter-interval
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1994-drop-quarter-interval
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: Remove the quarterly interval option, which never changed the chart.

--- a/projects/packages/premium-analytics/packages/data/README.md
+++ b/projects/packages/premium-analytics/packages/data/README.md
@@ -244,7 +244,7 @@ Returns the default (finest allowed) interval for a preset / date range.
 - `from`: `string` - Start date
 - `to`: `string` - End date
 
-**Returns:** `IntervalType` - `'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year'`
+**Returns:** `IntervalType` - `'hour' | 'day' | 'week' | 'month' | 'year'`
 
 **Example:**
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -1129,13 +1129,13 @@ describe( 'Stats query factories', () => {
 
 	it( 'clamps unsupported intervals to a supported subscribers unit', () => {
 		const query = statsSubscribersReportQuery( {
-			from: '2026-01-01',
+			from: '2026-06-29',
 			to: '2026-06-30',
-			interval: 'quarter',
+			interval: 'hour',
 		} as StatsReportParams );
 
 		expect( query.queryKey[ 5 ] ).toEqual(
-			expect.objectContaining( { unit: 'month', quantity: 6, date: '2026-06-30' } )
+			expect.objectContaining( { unit: 'day', quantity: 2, date: '2026-06-30' } )
 		);
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
@@ -10,8 +10,8 @@ export const statsSubscribersDefaultStatFields = 'subscribers,subscribers_paid';
 
 /**
  * Granularities the `stats/subscribers` endpoint supports as its `unit`. The
- * dashboard's finer/coarser intervals (`hour`, `quarter`) have no subscriber
- * bucket, so they collapse onto these.
+ * dashboard's `hour` interval has no subscriber bucket, so it collapses onto
+ * these.
  */
 export type StatsSubscribersUnit = 'day' | 'week' | 'month' | 'year';
 

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/interval.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/interval.test.ts
@@ -108,6 +108,25 @@ describe( 'resolveIntervalForRange', () => {
 		).toEqual( [ 'day' ] );
 	} );
 
+	it( 'never offers quarters on the year-length ranges', () => {
+		expect( getAllowedIntervalsForPreset( 'last-12-months', 'a', 'b' ) ).toEqual( [ 'month' ] );
+		expect( getAllowedIntervalsForPreset( 'last-365-days', 'a', 'b' ) ).toEqual( [ 'month' ] );
+		expect( getAllowedIntervalsForPreset( 'last-year', 'a', 'b' ) ).toEqual( [ 'month' ] );
+		expect(
+			getAllowedIntervalsForPreset(
+				'all-time',
+				'2020-01-01T00:00:00.000Z',
+				'2026-06-30T23:59:59.999Z'
+			)
+		).toEqual( [ 'month', 'year' ] );
+	} );
+
+	it( 'coerces a stored quarter onto the range default', () => {
+		expect(
+			resolveIntervalForRange( 'last-12-months', '2025-07-01', '2026-06-30', 'quarter' )
+		).toBe( 'month' );
+	} );
+
 	it( 'defaults when no current interval is provided', () => {
 		expect( getDefaultIntervalForPeriod( 'last-30-days', 'a', 'b' ) ).toBe( 'day' );
 		expect( resolveIntervalForRange( 'last-30-days', 'a', 'b' ) ).toBe( 'day' );

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/interval.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/interval.test.ts
@@ -109,7 +109,13 @@ describe( 'resolveIntervalForRange', () => {
 	} );
 
 	it( 'never offers quarters on the year-length ranges', () => {
-		expect( getAllowedIntervalsForPreset( 'last-12-months', 'a', 'b' ) ).toEqual( [ 'month' ] );
+		expect(
+			getAllowedIntervalsForPreset(
+				'last-12-months',
+				'2025-07-01T00:00:00.000Z',
+				'2026-06-30T23:59:59.999Z'
+			)
+		).toEqual( [ 'month' ] );
 		expect( getAllowedIntervalsForPreset( 'last-365-days', 'a', 'b' ) ).toEqual( [ 'month' ] );
 		expect( getAllowedIntervalsForPreset( 'last-year', 'a', 'b' ) ).toEqual( [ 'month' ] );
 		expect(
@@ -119,6 +125,26 @@ describe( 'resolveIntervalForRange', () => {
 				'2026-06-30T23:59:59.999Z'
 			)
 		).toEqual( [ 'month', 'year' ] );
+	} );
+
+	// The year surface carries a `year-YYYY` preset the switch does not know, so
+	// its list comes from the range instead and needs its own guard.
+	it( 'offers months alone on a year-length range with no matching preset', () => {
+		expect(
+			getAllowedIntervalsForPreset(
+				'year-2025',
+				'2025-01-01T00:00:00.000Z',
+				'2025-12-31T23:59:59.999Z'
+			)
+		).toEqual( [ 'month' ] );
+		expect(
+			resolveIntervalForRange(
+				'year-2025',
+				'2025-01-01T00:00:00.000Z',
+				'2025-12-31T23:59:59.999Z',
+				'quarter'
+			)
+		).toBe( 'month' );
 	} );
 
 	it( 'coerces a stored quarter onto the range default', () => {

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -14,9 +14,9 @@ describe( 'getStatsPeriodFromInterval', () => {
 		[ 'day', 'day' ],
 		[ 'week', 'week' ],
 		[ 'month', 'month' ],
-		[ 'quarter', 'month' ],
 		[ 'year', 'year' ],
 		[ undefined, 'day' ],
+		[ 'nonsense', 'day' ],
 	] )( 'maps %s to %s', ( interval, period ) => {
 		expect( getStatsPeriodFromInterval( interval ) ).toBe( period );
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/utils/interval.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/interval.ts
@@ -57,7 +57,7 @@ function getAllowedIntervalsByRange( from: string, to: string ): IntervalType[] 
 		Math.abs( differenceInHours( localTZDate( to ), localTZDate( from ) ) / 24 )
 	);
 
-	// No `quarter`: Stats has no quarterly bucket, and nothing regroups monthly points.
+	// No bucket between month and year: Stats has no quarterly one.
 	if ( daysDiff >= 1095 ) {
 		return [ 'month', 'year' ];
 	} else if ( daysDiff >= 365 ) {
@@ -164,8 +164,6 @@ export function getDateFormatFromInterval(
 			return 'MMM d';
 		case 'month':
 			return 'MMM yyyy';
-		case 'quarter':
-			return 'qqq yyyy';
 		case 'year':
 			return 'yyyy';
 		default:

--- a/projects/packages/premium-analytics/packages/data/src/utils/interval.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/interval.ts
@@ -57,10 +57,11 @@ function getAllowedIntervalsByRange( from: string, to: string ): IntervalType[] 
 		Math.abs( differenceInHours( localTZDate( to ), localTZDate( from ) ) / 24 )
 	);
 
+	// No `quarter`: Stats has no quarterly bucket, and nothing regroups monthly points.
 	if ( daysDiff >= 1095 ) {
-		return [ 'quarter', 'year' ];
+		return [ 'month', 'year' ];
 	} else if ( daysDiff >= 365 ) {
-		return [ 'month', 'quarter' ];
+		return [ 'month' ];
 	} else if ( daysDiff >= 90 ) {
 		return [ 'week', 'month' ];
 	} else if ( daysDiff >= 28 ) {
@@ -112,7 +113,7 @@ export function getAllowedIntervalsForPreset(
 		case PRESET_LAST_12_MONTHS:
 		case PRESET_LAST_365_DAYS:
 		case PRESET_LAST_YEAR:
-			return [ 'month', 'quarter' ];
+			return [ 'month' ];
 		default:
 			return getAllowedIntervalsByRange( from, to );
 	}

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -65,7 +65,6 @@ export function getStatsPeriodFromInterval( interval?: string ): StatsPeriod {
 		case 'week':
 			return 'week';
 		case 'month':
-		case 'quarter':
 			return 'month';
 		case 'year':
 			return 'year';

--- a/projects/packages/premium-analytics/packages/datetime/src/interval.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/interval.ts
@@ -1,7 +1,7 @@
 /**
  * Report time-series bucket sizes, ordered finest first.
  */
-export const INTERVAL_TYPES = [ 'hour', 'day', 'week', 'month', 'quarter', 'year' ] as const;
+export const INTERVAL_TYPES = [ 'hour', 'day', 'week', 'month', 'year' ] as const;
 
 /**
  * A report time-series bucket size, derived from the runtime tuple so both stay

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
@@ -110,7 +110,7 @@ describe( 'createReportParamsField', () => {
 	 * `onApply` back to back in one tick. A commit reading the staged state
 	 * writes the previous selection back over the new one, so the widget lands a
 	 * click behind — and on the first click, on the range it already had, which
-	 * is why picking "Last 24 hours" left months and quarters on offer.
+	 * is why picking "Last 24 hours" left the previous range's buckets on offer.
 	 */
 	it( 'applies the clicked quick preset, not the one before it', async () => {
 		const user = userEvent.setup();

--- a/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/__tests__/date-interval-dropdown.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/__tests__/date-interval-dropdown.test.tsx
@@ -44,13 +44,13 @@ describe( 'DateIntervalDropdown', () => {
 		// The coercion in report params makes this transient, but the menu must
 		// not invent a selection while it lasts.
 		render(
-			<DateIntervalDropdown options={ [ 'month', 'quarter' ] } value="day" onChange={ jest.fn() } />
+			<DateIntervalDropdown options={ [ 'month', 'year' ] } value="day" onChange={ jest.fn() } />
 		);
 
 		await user.click( screen.getByRole( 'button', { name: 'Chart interval' } ) );
 
 		expect( screen.getAllByRole( 'menuitemradio' ) ).toHaveLength( 2 );
 		expect( screen.getByRole( 'menuitemradio', { name: 'By months' } ) ).not.toBeChecked();
-		expect( screen.getByRole( 'menuitemradio', { name: 'By quarters' } ) ).not.toBeChecked();
+		expect( screen.getByRole( 'menuitemradio', { name: 'By years' } ) ).not.toBeChecked();
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/date-interval-dropdown.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/date-interval-dropdown.tsx
@@ -43,8 +43,6 @@ function getIntervalLabel( interval: IntervalType ): string {
 			return __( 'By weeks', 'jetpack-premium-analytics-pkg' );
 		case 'month':
 			return __( 'By months', 'jetpack-premium-analytics-pkg' );
-		case 'quarter':
-			return __( 'By quarters', 'jetpack-premium-analytics-pkg' );
 		case 'year':
 			return __( 'By years', 'jetpack-premium-analytics-pkg' );
 	}

--- a/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/stories/date-interval-dropdown.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/stories/date-interval-dropdown.stories.tsx
@@ -62,6 +62,6 @@ export const SingleOption: Story = {
  */
 export const CoarseRange: Story = {
 	render: () => (
-		<DateIntervalDropdownWithState options={ [ 'quarter', 'year' ] } initialValue="quarter" />
+		<DateIntervalDropdownWithState options={ [ 'month', 'year' ] } initialValue="month" />
 	),
 };

--- a/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/stories/story-interval-options.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/stories/story-interval-options.ts
@@ -10,8 +10,8 @@ const STORY_INTERVAL_OPTIONS: Partial< Record< PrimaryPresetId, IntervalType[] >
 	'last-24-hours': [ 'hour', 'day' ],
 	'last-7-days': [ 'day' ],
 	'last-30-days': [ 'day', 'week' ],
-	'last-12-months': [ 'month', 'quarter' ],
-	'all-time': [ 'quarter', 'year' ],
+	'last-12-months': [ 'month' ],
+	'all-time': [ 'month', 'year' ],
 };
 
 /**
@@ -26,7 +26,7 @@ export function getStoryIntervalOptions( presetId?: PrimaryPresetId ): IntervalT
 
 	// A calendar year is long enough to bucket by month, but not by year.
 	if ( presetId.startsWith( 'year-' ) ) {
-		return [ 'month', 'quarter' ];
+		return [ 'month' ];
 	}
 
 	return STORY_INTERVAL_OPTIONS[ presetId ] ?? fallback;

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/__tests__/get-section-subtitle.test.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/__tests__/get-section-subtitle.test.ts
@@ -177,16 +177,16 @@ describe( 'getSectionSubtitle', () => {
 				getSectionSubtitle( {
 					range: { from: at( 2021, 1, 1 ), to: endOf( 2026, 7, 30 ) },
 					presetId: 'all-time',
-					interval: 'quarter',
+					interval: 'year',
 				} )
-			).toBe( 'January 1, 2021 – July 30, 2026 (quarterly)' );
+			).toBe( 'January 1, 2021 – July 30, 2026 (yearly)' );
 		} );
 
 		it( 'stays out of the copy on a surface carrying no interval control', () => {
 			const subtitle = getSectionSubtitle( { range: currentYearRange( 7 ) } );
 
 			expect( subtitle ).toContain( '(7 days)' );
-			expect( subtitle ).not.toMatch( /hourly|daily|weekly|monthly|quarterly|yearly/ );
+			expect( subtitle ).not.toMatch( /hourly|daily|weekly|monthly|yearly/ );
 		} );
 
 		it( 'stays inside the parenthetical, ahead of the comparison', () => {

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/get-section-subtitle.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/get-section-subtitle.ts
@@ -96,8 +96,6 @@ function getIntervalCadenceLabel( interval: IntervalType ): string {
 			return __( 'weekly', 'jetpack-premium-analytics-pkg' );
 		case 'month':
 			return __( 'monthly', 'jetpack-premium-analytics-pkg' );
-		case 'quarter':
-			return __( 'quarterly', 'jetpack-premium-analytics-pkg' );
 		case 'year':
 			return __( 'yearly', 'jetpack-premium-analytics-pkg' );
 	}

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/get-section-subtitle.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/get-section-subtitle.ts
@@ -122,7 +122,7 @@ function getIntervalCadenceLabel( interval: IntervalType ): string {
  * getSectionSubtitle( { range, interval } )
  *   // 'Tuesday, July 21 – Monday, July 27 (7 days, daily)'
  *   // with comparison: '… (7 days, daily) vs. July 14 – 20, 2026'
- *   // year surface: 'January 1, 2021 – July 30, 2026 (quarterly)'
+ *   // year surface: 'January 1, 2021 – July 30, 2026 (monthly)'
  *
  * @return The subtitle, or undefined when the range is incomplete.
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/__tests__/report-page-layout.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/__tests__/report-page-layout.test.tsx
@@ -113,7 +113,7 @@ describe( 'ReportPageLayout', () => {
 
 		const subtitle = screen.getByText( /2024/ );
 
-		expect( subtitle ).not.toHaveTextContent( /hourly|daily|weekly|monthly|quarterly|yearly/ );
+		expect( subtitle ).not.toHaveTextContent( /hourly|daily|weekly|monthly|yearly/ );
 		expect( subtitle ).not.toHaveTextContent( /vs\.|Previous period|Previous month/ );
 	} );
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/default-period-for-interval.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/default-period-for-interval.test.ts
@@ -14,7 +14,6 @@ describe( 'defaultPeriodForInterval', () => {
 		it.each( [
 			[ 'week', 'week' ],
 			[ 'month', 'month' ],
-			[ 'quarter', 'month' ],
 			// No year option in the dropdown, so year clamps to the coarsest allowed.
 			[ 'year', 'month' ],
 			[ 'day', 'day' ],
@@ -30,7 +29,6 @@ describe( 'defaultPeriodForInterval', () => {
 		it.each( [
 			[ 'week', 'week' ],
 			[ 'month', 'month' ],
-			[ 'quarter', 'month' ],
 			// Year is offered here, so it is kept rather than collapsed.
 			[ 'year', 'year' ],
 			[ 'day', 'day' ],
@@ -46,9 +44,9 @@ describe( 'defaultPeriodForInterval', () => {
 			[ 'hour', 'hour' ],
 			[ 'day', 'day' ],
 			[ 'week', 'week' ],
-			[ 'quarter', 'month' ],
 			[ 'year', 'month' ],
 			[ undefined, 'day' ],
+			[ 'nonsense', 'day' ],
 		] )( 'maps %s to %s', ( interval, expected ) => {
 			expect( defaultPeriodForInterval( interval, HOUR_DAY_WEEK_MONTH ) ).toBe( expected );
 		} );

--- a/projects/packages/premium-analytics/src/Reports/Export/class-abstract-csv-report-controller.php
+++ b/projects/packages/premium-analytics/src/Reports/Export/class-abstract-csv-report-controller.php
@@ -321,17 +321,16 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Get the label for a time interval.
 	 *
-	 * @param string|null $interval The time interval (hour, day, week, month, quarter, year).
+	 * @param string|null $interval The time interval (hour, day, week, month, year).
 	 * @return string The translated interval label.
 	 */
 	protected function get_interval_label( ?string $interval = null ): string {
 		$labels = array(
-			'hour'    => __( 'Hour', 'jetpack-premium-analytics-pkg' ),
-			'day'     => __( 'Day', 'jetpack-premium-analytics-pkg' ),
-			'week'    => __( 'Week', 'jetpack-premium-analytics-pkg' ),
-			'month'   => __( 'Month', 'jetpack-premium-analytics-pkg' ),
-			'quarter' => __( 'Quarter', 'jetpack-premium-analytics-pkg' ),
-			'year'    => __( 'Year', 'jetpack-premium-analytics-pkg' ),
+			'hour'  => __( 'Hour', 'jetpack-premium-analytics-pkg' ),
+			'day'   => __( 'Day', 'jetpack-premium-analytics-pkg' ),
+			'week'  => __( 'Week', 'jetpack-premium-analytics-pkg' ),
+			'month' => __( 'Month', 'jetpack-premium-analytics-pkg' ),
+			'year'  => __( 'Year', 'jetpack-premium-analytics-pkg' ),
 		);
 
 		return $labels[ $interval ?? '' ] ?? __( 'Date', 'jetpack-premium-analytics-pkg' );

--- a/projects/packages/premium-analytics/src/Reports/Export/class-csv-export-controller.php
+++ b/projects/packages/premium-analytics/src/Reports/Export/class-csv-export-controller.php
@@ -177,7 +177,7 @@ class Csv_Export_Controller extends WC_REST_Controller implements Registrable_In
 				'description'       => __( 'Time interval for grouping data.', 'jetpack-premium-analytics-pkg' ),
 				'type'              => 'string',
 				'default'           => 'day',
-				'enum'              => array( 'hour', 'day', 'week', 'month', 'quarter', 'year' ),
+				'enum'              => array( 'hour', 'day', 'week', 'month', 'year' ),
 				'validate_callback' => 'rest_validate_request_arg',
 			),
 			'date_type'       => array(

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/render.test.tsx
@@ -22,15 +22,13 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 
 const mockUseTrafficChart = jest.mocked( useTrafficChart );
 
-// The dashboard only lets a range carry the intervals it can draw, and
-// `normalizeReportParams` coerces anything else away — so each interval needs a
-// range long enough to keep it.
+// `normalizeReportParams` coerces away an interval the range disallows, so each
+// one needs a range long enough to survive reaching the widget.
 const RANGE_FOR_INTERVAL: Record< string, { from: string; to: string } > = {
 	hour: { from: '2026-06-29', to: '2026-06-30' },
 	day: { from: '2026-06-01', to: '2026-06-30' },
 	week: { from: '2026-01-01', to: '2026-06-30' },
 	month: { from: '2025-01-01', to: '2026-06-30' },
-	quarter: { from: '2023-01-01', to: '2026-06-30' },
 	year: { from: '2023-01-01', to: '2026-06-30' },
 };
 
@@ -69,17 +67,13 @@ describe( 'TrafficChart bucket size', () => {
 		expect( requestedBucket() ).toBe( interval );
 	} );
 
-	// `quarter` maps straight onto `month`, a bucket this chart draws; `year`
-	// maps onto one it does not, so it is the case that reaches the clamp to
-	// the coarsest offered.
-	it.each( [ 'quarter', 'year' ] )(
-		'resolves a page interval this chart cannot draw to one it can: %s',
-		interval => {
-			render( <TrafficChartRender attributes={ { reportParams: reportParams( interval ) } } /> );
+	// `year` is the only interval the dashboard still offers that this chart has
+	// no bucket for, so it is what reaches the clamp to the coarsest offered.
+	it( 'resolves a page interval this chart cannot draw to one it can', () => {
+		render( <TrafficChartRender attributes={ { reportParams: reportParams( 'year' ) } } /> );
 
-			expect( requestedBucket() ).toBe( 'month' );
-		}
-	);
+		expect( requestedBucket() ).toBe( 'month' );
+	} );
 
 	// The Group by attribute this widget used to declare (WOOA7S-1987): a saved
 	// layout can still carry it, and it must not override the page.

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/__tests__/wordads-chart-tabs.test.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/__tests__/wordads-chart-tabs.test.tsx
@@ -220,13 +220,13 @@ describe( 'WordAdsChartTabsWidget', () => {
 		expect( requestedPath ).toContain( 'unit=week' );
 	} );
 
-	// `quarter` is an interval the range allows and the header control can save,
-	// but this chart has no bucket for, so it clamps to the nearest one it does.
+	// This chart draws day through year, so `hour` is the one interval the range
+	// can still carry that it has no bucket for, and it clamps to the finest.
 	it( 'clamps an unsupported interval to the closest supported bucket', async () => {
 		render(
 			<WordAdsChartTabsWidget
 				attributes={ {
-					reportParams: { from: '2023-01-01', to: '2026-06-30', interval: 'quarter' },
+					reportParams: { from: '2026-06-29', to: '2026-06-30', interval: 'hour' },
 				} }
 			/>
 		);
@@ -234,7 +234,7 @@ describe( 'WordAdsChartTabsWidget', () => {
 		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
 
 		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
-		expect( requestedPath ).toContain( 'unit=month' );
+		expect( requestedPath ).toContain( 'unit=day' );
 	} );
 
 	/*

--- a/projects/plugins/jetpack/changelog/wooa7s-1994-drop-quarter-interval
+++ b/projects/plugins/jetpack/changelog/wooa7s-1994-drop-quarter-interval
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Remove the quarterly chart interval option, which never changed the chart.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-1994-drop-quarter-interval
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-1994-drop-quarter-interval
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Remove the quarterly chart interval option, which never changed the chart.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1994-drop-quarter-interval
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1994-drop-quarter-interval
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: Remove the quarterly interval option, which never changed the chart.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-1994-drop-quarter-interval
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-1994-drop-quarter-interval
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Remove the quarterly chart interval option, which never changed the chart.


### PR DESCRIPTION
## Proposed changes

* Drop `quarter` from the chart interval control. The Stats API has no quarterly bucket and nothing regroups monthly points, so picking **By quarters** changed nothing — same request, same monthly axis, only the checkmark moved.
* The year-length presets (12 months / 365 days / last year) now offer `By months` alone.
* `All time` previously *defaulted* to `quarter`, so it drew monthly points under a quarterly label out of the box. It now defaults to `By months` — same drawn output as today — with `By years` as the coarser option.
* Traffic's section subtitle no longer reports "quarterly" for a chart it isn't drawing.
* The CSV export endpoint's `interval` enum drops `quarter` too, so the REST contract stops advertising a bucket nothing produces.

The prototype dashboard doesn't offer a quarterly bucket either, so this matches the reference rather than dropping something it has.

A stored `interval=quarter` (deep link or saved widget instance) coerces to `month` via the existing `resolveIntervalForRange`, so nothing gets stuck. `quarter` also comes out of `INTERVAL_TYPES`, which is what makes the sweep verifiable — every leftover `case 'quarter'` became a type error, so the compiler found them rather than grep.

## Related product discussion/links

* WOOA7S-1994
* WOOA7S-1979 — surfaced this while testing the widget-owned Ads range.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Analytics dashboard and pick **Last 12 months**.
* Open the chart interval control (the bar-chart glyph). It lists **By months** only — no **By quarters**.
* Check the Traffic section subtitle: `… (12 months, monthly)`.
* Switch to the **All time** year preset. The control lists **By months** (checked) and **By years**; picking **By years** actually redraws the chart in yearly bars.
* Deep-link an old URL with `&interval=quarter` — it resolves to `month` rather than breaking.

<img width="789" height="409" alt="Screenshot 2026-08-27 at 12 43 39 PM" src="https://github.com/user-attachments/assets/1be19dd5-4f37-45b0-ba94-ca56b4ebc33b" />

