### PR TITLE
Premium Analytics: decode HTML entities in Stats titles and names

### DIFF
--- a/projects/packages/premium-analytics/changelog/pa-stats-decode-title-entities
+++ b/projects/packages/premium-analytics/changelog/pa-stats-decode-title-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Decode HTML entities in post titles, author names, and other Stats labels.

--- a/projects/packages/premium-analytics/packages/data/src/processing/latest-post/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/latest-post/index.ts
@@ -1,5 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
-import { decodeHtmlText } from '../../utils/text';
+import { decodeHtmlString } from '../../utils/text';
 import { coerceStatsArray, coerceStatsRecord, isStatsRecord } from '../stats/utils';
 import type { StatsRecord } from '../stats/types';
 
@@ -79,7 +79,7 @@ export function sanitizeLatestPostResponse( response: unknown ): LatestPostRespo
 
 	return {
 		id,
-		title: typeof title.rendered === 'string' ? decodeHtmlText( title.rendered ) : '',
+		title: decodeHtmlString( title.rendered ),
 		url: typeof post.link === 'string' ? post.link : '',
 		date: typeof post.date === 'string' ? post.date : '',
 		imageUrl: pickFeaturedImageUrl( media ),

--- a/projects/packages/premium-analytics/packages/data/src/processing/latest-post/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/latest-post/index.ts
@@ -1,5 +1,5 @@
-import { decodeEntities } from '@wordpress/html-entities';
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import { coerceStatsArray, coerceStatsRecord, isStatsRecord } from '../stats/utils';
 import type { StatsRecord } from '../stats/types';
 
@@ -79,8 +79,7 @@ export function sanitizeLatestPostResponse( response: unknown ): LatestPostRespo
 
 	return {
 		id,
-		// `title.rendered` from core is HTML (encoded entities); decode for display.
-		title: typeof title.rendered === 'string' ? decodeEntities( title.rendered ) : '',
+		title: typeof title.rendered === 'string' ? decodeHtmlText( title.rendered ) : '',
 		url: typeof post.link === 'string' ? post.link : '',
 		date: typeof post.date === 'string' ? post.date : '',
 		imageUrl: pickFeaturedImageUrl( media ),

--- a/projects/packages/premium-analytics/packages/data/src/processing/latest-post/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/latest-post/index.ts
@@ -1,5 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
-import { decodeHtmlString } from '../../utils/text';
+import { decodeHtmlText } from '../../utils/text';
 import { coerceStatsArray, coerceStatsRecord, isStatsRecord } from '../stats/utils';
 import type { StatsRecord } from '../stats/types';
 
@@ -79,7 +79,7 @@ export function sanitizeLatestPostResponse( response: unknown ): LatestPostRespo
 
 	return {
 		id,
-		title: decodeHtmlString( title.rendered ),
+		title: decodeHtmlText( title.rendered, '' ),
 		url: typeof post.link === 'string' ? post.link : '',
 		date: typeof post.date === 'string' ? post.date : '',
 		imageUrl: pickFeaturedImageUrl( media ),

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/label-entities.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/label-entities.test.ts
@@ -1,0 +1,244 @@
+import {
+	sanitizeStatsArchivesResponse,
+	sanitizeStatsCommentFollowersResponse,
+	sanitizeStatsCommentsResponse,
+	sanitizeStatsEmailSummaryResponse,
+	sanitizeStatsFollowersResponse,
+	sanitizeStatsPostCommentsResponse,
+	sanitizeStatsPostLikesResponse,
+	sanitizeStatsPostResponse,
+	sanitizeStatsSearchTermsResponse,
+	sanitizeStatsSingleVideoResponse,
+	sanitizeStatsTagsResponse,
+	sanitizeStatsTopAuthorsResponse,
+	sanitizeStatsTopPostsResponse,
+	sanitizeStatsUtmResponse,
+	sanitizeStatsVideoPlaysResponse,
+} from '..';
+
+const ENCODED = 'Tea &amp; Crumpets&#8217; Best';
+const DECODED = 'Tea & Crumpets’ Best';
+
+const DATE = '2026-06-16';
+const DAY_QUERY = { period: 'day', end_date: DATE };
+
+function firstLabel( report: { data: Array< { items: Array< { label: unknown } > } > } ): unknown {
+	return report.data[ 0 ]?.items[ 0 ]?.label;
+}
+
+function firstChildLabel( report: {
+	data: Array< { items: Array< { children?: Array< { label: unknown } > | null } > } >;
+} ): unknown {
+	return report.data[ 0 ]?.items[ 0 ]?.children?.[ 0 ]?.label;
+}
+
+/**
+ * Every normalizer that carries a user-authored title or name. WPCOM returns
+ * these HTML-encoded, so a normalizer missing its decode shows up here rather
+ * than on someone's dashboard.
+ */
+const CASES: Array< [ string, () => unknown ] > = [
+	[
+		'top posts',
+		() =>
+			firstLabel(
+				sanitizeStatsTopPostsResponse(
+					{
+						date: DATE,
+						period: 'day',
+						days: { [ DATE ]: { postviews: [ { id: 1, title: ENCODED, views: 1 } ] } },
+					},
+					DAY_QUERY
+				)
+			),
+	],
+	[
+		'top authors',
+		() =>
+			firstLabel(
+				sanitizeStatsTopAuthorsResponse(
+					{
+						date: DATE,
+						period: 'day',
+						days: { [ DATE ]: { authors: [ { name: ENCODED, views: 1 } ] } },
+					},
+					DAY_QUERY
+				)
+			),
+	],
+	[
+		'top authors posts',
+		() =>
+			firstChildLabel(
+				sanitizeStatsTopAuthorsResponse(
+					{
+						date: DATE,
+						period: 'day',
+						days: {
+							[ DATE ]: {
+								authors: [
+									{ name: 'Author', views: 1, posts: [ { id: 1, title: ENCODED, views: 1 } ] },
+								],
+							},
+						},
+					},
+					DAY_QUERY
+				)
+			),
+	],
+	[
+		'video plays',
+		() =>
+			firstLabel(
+				sanitizeStatsVideoPlaysResponse(
+					{
+						date: DATE,
+						period: 'day',
+						days: { [ DATE ]: { plays: [ { post_id: 1, title: ENCODED, plays: 1 } ] } },
+					},
+					DAY_QUERY
+				)
+			),
+	],
+	[
+		'comment followers',
+		() =>
+			firstLabel(
+				sanitizeStatsCommentFollowersResponse(
+					{ posts: [ { id: 5, title: ENCODED, followers: 1 } ] },
+					DAY_QUERY
+				)
+			),
+	],
+	[
+		'UTM top posts',
+		() =>
+			firstChildLabel(
+				sanitizeStatsUtmResponse(
+					{
+						top_utm_values: { '["newsletter"]': 1 },
+						top_posts: { '["newsletter"]': [ { id: 1, title: ENCODED, views: 1 } ] },
+					},
+					{ date: DATE, utm_param: 'utm_source' }
+				)
+			),
+	],
+	[
+		'comment authors',
+		() =>
+			firstChildLabel(
+				sanitizeStatsCommentsResponse(
+					{ date: DATE, authors: [ { name: ENCODED, comments: 1 } ] },
+					DAY_QUERY
+				)
+			),
+	],
+	[
+		'commented posts',
+		() =>
+			firstChildLabel(
+				sanitizeStatsCommentsResponse(
+					{ date: DATE, posts: [ { id: 1, name: ENCODED, comments: 1 } ] },
+					DAY_QUERY
+				)
+			),
+	],
+	[
+		'tags',
+		() =>
+			(
+				sanitizeStatsTagsResponse(
+					{
+						date: DATE,
+						period: 'day',
+						tags: [ { tags: [ { type: 'tag', name: ENCODED } ], views: 1 } ],
+					},
+					DAY_QUERY
+				).data[ 0 ].items[ 0 ].label as Array< { label: string } >
+			 )[ 0 ].label,
+	],
+	[
+		'subscribers',
+		() =>
+			firstLabel(
+				sanitizeStatsFollowersResponse(
+					{
+						subscribers: [
+							{ ID: 1, display_name: ENCODED, date_subscribed: `${ DATE }T00:00:00+00:00` },
+						],
+					},
+					DAY_QUERY
+				)
+			),
+	],
+	[
+		'archives',
+		() =>
+			firstChildLabel(
+				sanitizeStatsArchivesResponse(
+					{
+						date: DATE,
+						period: 'day',
+						days: {
+							[ DATE ]: {
+								category: [ { value: ENCODED, href: 'https://example.com/c/', views: '2' } ],
+							},
+						},
+					},
+					DAY_QUERY
+				)
+			),
+	],
+	[
+		'search terms',
+		() =>
+			firstLabel(
+				sanitizeStatsSearchTermsResponse(
+					{
+						date: DATE,
+						period: 'day',
+						days: { [ DATE ]: { search_terms: [ { term: ENCODED, views: 1 } ] } },
+					},
+					DAY_QUERY
+				)
+			),
+	],
+	[
+		'email summary',
+		() =>
+			firstLabel(
+				sanitizeStatsEmailSummaryResponse(
+					{ posts: [ { id: 1, title: ENCODED, opens: 1 } ] },
+					DAY_QUERY
+				)
+			),
+	],
+	[
+		'post detail',
+		() => sanitizeStatsPostResponse( { post: { ID: 1, post_title: ENCODED } } ).post?.post_title,
+	],
+	[
+		'video detail',
+		() => sanitizeStatsSingleVideoResponse( { post: { ID: 1, post_title: ENCODED } } ).post?.title,
+	],
+	[
+		'post comments',
+		() =>
+			sanitizeStatsPostCommentsResponse( {
+				found: 1,
+				comments: [ { ID: 1, author: { name: ENCODED } } ],
+			} ).comments[ 0 ].name,
+	],
+	[
+		'post likes',
+		() =>
+			sanitizeStatsPostLikesResponse( { found: 1, likes: [ { ID: 1, name: ENCODED } ] } ).likes[ 0 ]
+				.name,
+	],
+];
+
+describe( 'Stats label HTML entities', () => {
+	it.each( CASES )( 'decodes the %s label', ( _name, run ) => {
+		expect( run() ).toBe( DECODED );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/label-entities.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/label-entities.test.ts
@@ -241,4 +241,26 @@ describe( 'Stats label HTML entities', () => {
 	it.each( CASES )( 'decodes the %s label', ( _name, run ) => {
 		expect( run() ).toBe( DECODED );
 	} );
+
+	it( 'preserves URL search terms and email labels with entity-like text', () => {
+		const url = 'https://example.com/?a=1&copy=2';
+		const email = 'reader&copy=2@example.com';
+
+		expect(
+			firstLabel(
+				sanitizeStatsSearchTermsResponse(
+					{ date: DATE, period: 'day', days: { [ DATE ]: { search_terms: [ { term: url } ] } } },
+					DAY_QUERY
+				)
+			)
+		).toBe( url );
+		expect(
+			firstLabel(
+				sanitizeStatsFollowersResponse(
+					{ subscribers: [ { ID: 1, email, date_subscribed: `${ DATE }T00:00:00+00:00` } ] },
+					DAY_QUERY
+				)
+			)
+		).toBe( email );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/archives.ts
@@ -1,4 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import {
 	coerceStatsArray,
 	coerceStatsRecord,
@@ -34,7 +35,7 @@ function normalizeArchiveChildren(
 			.map( ( [ taxonomy, terms ] ) => {
 				const children = coerceStatsArray< StatsRecord >( terms )
 					.map( term => ( {
-						label: getStatsLabel( term.value ),
+						label: decodeHtmlText( getStatsLabel( term.value ) ),
 						value: safeParseFloat( term.views ),
 						link: term.href,
 						children: null,
@@ -54,7 +55,12 @@ function normalizeArchiveChildren(
 	return coerceStatsArray< StatsRecord >( archiveItems )
 		.filter( item => Boolean( item.value ) )
 		.map( item => ( {
-			label: archiveType === 'home' ? getStatsLabel( item.href ) : getStatsLabel( item.value ),
+			// The `home` archive has no title of its own, so its label is a URL — entity
+			// decoding a URL would corrupt query strings like `?a=1&copy=2`.
+			label:
+				archiveType === 'home'
+					? getStatsLabel( item.href )
+					: decodeHtmlText( getStatsLabel( item.value ) ),
 			value: safeParseFloat( item.views ),
 			link: item.href,
 			children: null,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/comment-followers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/comment-followers.ts
@@ -1,4 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import {
 	coerceStatsArray,
 	coerceStatsRecord,
@@ -42,7 +43,7 @@ export function sanitizeStatsCommentFollowersResponse(
 
 			return {
 				id: typeof item.id === 'number' ? item.id : undefined,
-				label: item.id === 0 ? 'All Posts' : String( item.title ?? '' ),
+				label: item.id === 0 ? 'All Posts' : decodeHtmlText( String( item.title ?? '' ) ),
 				followers,
 				value: followers,
 				link: item.id === 0 || typeof item.url !== 'string' ? null : item.url,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/comments.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/comments.ts
@@ -1,4 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import {
 	coerceStatsArray,
 	coerceStatsRecord,
@@ -107,7 +108,7 @@ export function sanitizeStatsCommentsResponse(
 	const authors: StatsCommentsAuthorItem[] = coerceStatsArray< StatsCommentsRawAuthor >(
 		payload.authors
 	).map( author => ( {
-		label: getStatsLabel( author.name ),
+		label: decodeHtmlText( getStatsLabel( author.name ) ),
 		value: safeParseFloat( author.comments ),
 		iconClassName: 'avatar-user',
 		icon: normalizeCommentAvatar( author.gravatar ),
@@ -125,7 +126,7 @@ export function sanitizeStatsCommentsResponse(
 		payload.posts
 	).map( post => ( {
 		id: post.id,
-		label: getStatsLabel( post.name ?? post.title ),
+		label: decodeHtmlText( getStatsLabel( post.name ?? post.title ) ),
 		value: safeParseFloat( post.comments ),
 		link: typeof post.link === 'string' ? post.link : null,
 		page: post.id ? `/stats/post/${ post.id }` : null,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/email-summary.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/email-summary.ts
@@ -1,5 +1,5 @@
-import { decodeEntities } from '@wordpress/html-entities';
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import { coerceStatsArray, coerceStatsRecord, createStatsListDataPoint } from './utils';
 import type {
 	StatsItemAction,
@@ -30,9 +30,7 @@ function normalizeStatsEmailSummaryItem( post: StatsRecord ): StatsEmailSummaryI
 
 	return {
 		id: post.id as string | number | undefined,
-		// WPCOM returns the subject line HTML-encoded (`&amp;`, `&#8217;`), and every
-		// consumer renders it as text, so decode once here.
-		label: typeof post.title === 'string' ? decodeEntities( post.title ) : post.title,
+		label: decodeHtmlText( post.title ),
 		// Opens is the headline metric for the emails leaderboard; clicks_rate is frequently 0.
 		value: safeParseFloat( post.opens ),
 		link,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/followers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/followers.ts
@@ -1,4 +1,5 @@
 import { isValid, parseISO } from 'date-fns';
+import { decodeHtmlText } from '../../utils/text';
 import {
 	coerceStatsArray,
 	coerceStatsRecord,
@@ -99,7 +100,7 @@ export function sanitizeStatsFollowersResponse(
 	);
 	const items = subscribers.map( item => ( {
 		id: getSubscriptionId( item ),
-		label: item.label ?? item.display_name ?? item.name ?? item.email ?? '',
+		label: decodeHtmlText( item.label ?? item.display_name ?? item.name ?? item.email ?? '' ),
 		value: {
 			type: 'relative-date' as const,
 			value: item.date_subscribed,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post-comments.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post-comments.ts
@@ -1,5 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
-import { decodeHtmlString } from '../../utils/text';
+import { decodeHtmlText } from '../../utils/text';
 import { coerceStatsArray, coerceStatsRecord, isStatsRecord } from './utils';
 
 /**
@@ -30,7 +30,7 @@ function normalizeStatsPostComment( value: unknown ): StatsPostComment[] {
 	const comment = coerceStatsRecord( value );
 	const author = coerceStatsRecord( comment.author );
 	const id = safeParseFloat( comment.ID );
-	const authorName = decodeHtmlString( author.name ).trim();
+	const authorName = decodeHtmlText( author.name, '' ).trim();
 	const authorLogin = typeof author.login === 'string' ? author.login.trim() : '';
 	const name = authorName || authorLogin;
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post-comments.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post-comments.ts
@@ -1,5 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
-import { decodeHtmlText } from '../../utils/text';
+import { decodeHtmlString } from '../../utils/text';
 import { coerceStatsArray, coerceStatsRecord, isStatsRecord } from './utils';
 
 /**
@@ -30,7 +30,7 @@ function normalizeStatsPostComment( value: unknown ): StatsPostComment[] {
 	const comment = coerceStatsRecord( value );
 	const author = coerceStatsRecord( comment.author );
 	const id = safeParseFloat( comment.ID );
-	const authorName = typeof author.name === 'string' ? decodeHtmlText( author.name ).trim() : '';
+	const authorName = decodeHtmlString( author.name ).trim();
 	const authorLogin = typeof author.login === 'string' ? author.login.trim() : '';
 	const name = authorName || authorLogin;
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post-comments.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post-comments.ts
@@ -1,4 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import { coerceStatsArray, coerceStatsRecord, isStatsRecord } from './utils';
 
 /**
@@ -29,7 +30,7 @@ function normalizeStatsPostComment( value: unknown ): StatsPostComment[] {
 	const comment = coerceStatsRecord( value );
 	const author = coerceStatsRecord( comment.author );
 	const id = safeParseFloat( comment.ID );
-	const authorName = typeof author.name === 'string' ? author.name.trim() : '';
+	const authorName = typeof author.name === 'string' ? decodeHtmlText( author.name ).trim() : '';
 	const authorLogin = typeof author.login === 'string' ? author.login.trim() : '';
 	const name = authorName || authorLogin;
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post-likes.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post-likes.ts
@@ -1,5 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
-import { decodeHtmlText } from '../../utils/text';
+import { decodeHtmlString } from '../../utils/text';
 import { coerceStatsArray, coerceStatsRecord, isStatsRecord } from './utils';
 
 /**
@@ -39,7 +39,7 @@ function normalizeStatsPostLike( value: unknown ): StatsPostLike[] {
 
 	const like = coerceStatsRecord( value );
 	const id = safeParseFloat( like.ID );
-	const name = typeof like.name === 'string' ? decodeHtmlText( like.name ).trim() : '';
+	const name = decodeHtmlString( like.name ).trim();
 	const login = typeof like.login === 'string' ? like.login.trim() : '';
 
 	if ( ! id || ( ! name && ! login ) ) {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post-likes.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post-likes.ts
@@ -1,5 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
-import { decodeHtmlString } from '../../utils/text';
+import { decodeHtmlText } from '../../utils/text';
 import { coerceStatsArray, coerceStatsRecord, isStatsRecord } from './utils';
 
 /**
@@ -39,7 +39,7 @@ function normalizeStatsPostLike( value: unknown ): StatsPostLike[] {
 
 	const like = coerceStatsRecord( value );
 	const id = safeParseFloat( like.ID );
-	const name = decodeHtmlString( like.name ).trim();
+	const name = decodeHtmlText( like.name, '' ).trim();
 	const login = typeof like.login === 'string' ? like.login.trim() : '';
 
 	if ( ! id || ( ! name && ! login ) ) {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post-likes.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post-likes.ts
@@ -1,4 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import { coerceStatsArray, coerceStatsRecord, isStatsRecord } from './utils';
 
 /**
@@ -38,7 +39,7 @@ function normalizeStatsPostLike( value: unknown ): StatsPostLike[] {
 
 	const like = coerceStatsRecord( value );
 	const id = safeParseFloat( like.ID );
-	const name = typeof like.name === 'string' ? like.name.trim() : '';
+	const name = typeof like.name === 'string' ? decodeHtmlText( like.name ).trim() : '';
 	const login = typeof like.login === 'string' ? like.login.trim() : '';
 
 	if ( ! id || ( ! name && ! login ) ) {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
@@ -1,5 +1,6 @@
 import { format, isValid, parse } from 'date-fns';
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import { coerceStatsArray, coerceStatsRecord, isStatsRecord } from './utils';
 
 export type StatsPostMonthValues = Record< string, number >;
@@ -176,6 +177,9 @@ function normalizeStatsPostMeta( value: unknown ): StatsPostMeta {
 
 	return {
 		...( meta as StatsPostMeta ),
+		...( typeof meta.post_title === 'string'
+			? { post_title: decodeHtmlText( meta.post_title ) }
+			: {} ),
 		...( meta.comment_count !== undefined
 			? { comment_count: safeParseFloat( meta.comment_count ) }
 			: {} ),

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/search-terms.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/search-terms.ts
@@ -1,4 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import {
 	coerceStatsArray,
 	createStatsDataPoint,
@@ -29,7 +30,7 @@ function getSearchTermKey( item: StatsSearchTermsItem ): string {
 
 function normalizeStatsSearchTerm( item: StatsRecord ): StatsSearchTermsItem {
 	return {
-		label: item.term,
+		label: decodeHtmlText( item.term ),
 		views: safeParseFloat( item.views ),
 		className: 'user-selectable',
 		children: null,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/single-video.ts
@@ -1,4 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import {
 	coerceStatsArray,
 	coerceStatsRecord,
@@ -54,7 +55,9 @@ function sanitizeSingleVideoPost( value: unknown ): StatsSingleVideoPost | null 
 		id > 0
 			? { id }
 			: {} ),
-		...( typeof value.post_title === 'string' ? { title: value.post_title } : {} ),
+		...( typeof value.post_title === 'string'
+			? { title: decodeHtmlText( value.post_title ) }
+			: {} ),
 		...( typeof value.post_date === 'string' ? { date: value.post_date } : {} ),
 		...( typeof value.post_mime_type === 'string' ? { mimeType: value.post_mime_type } : {} ),
 		...( typeof value.poster === 'string' && value.poster !== '' ? { poster: value.poster } : {} ),

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
@@ -1,5 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
-import { decodeHtmlString } from '../../utils/text';
+import { decodeHtmlText } from '../../utils/text';
 import {
 	coerceStatsArray,
 	coerceStatsRecord,
@@ -57,7 +57,7 @@ export interface StatsTagsItem extends StatsNormalizedItemBase< StatsTagsChildIt
 const tagIcon = ( type: unknown ) => ( type === 'category' ? 'folder' : String( type ?? '' ) );
 
 function getTagName( tag: StatsRecord ): string {
-	return decodeHtmlString( tag.name );
+	return decodeHtmlText( tag.name, '' );
 }
 
 function getTagLink( tag: StatsRecord ): string | null {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
@@ -1,5 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
-import { decodeHtmlText } from '../../utils/text';
+import { decodeHtmlString } from '../../utils/text';
 import {
 	coerceStatsArray,
 	coerceStatsRecord,
@@ -57,7 +57,7 @@ export interface StatsTagsItem extends StatsNormalizedItemBase< StatsTagsChildIt
 const tagIcon = ( type: unknown ) => ( type === 'category' ? 'folder' : String( type ?? '' ) );
 
 function getTagName( tag: StatsRecord ): string {
-	return typeof tag.name === 'string' ? decodeHtmlText( tag.name ) : '';
+	return decodeHtmlString( tag.name );
 }
 
 function getTagLink( tag: StatsRecord ): string | null {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/tags.ts
@@ -1,4 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import {
 	coerceStatsArray,
 	coerceStatsRecord,
@@ -56,7 +57,7 @@ export interface StatsTagsItem extends StatsNormalizedItemBase< StatsTagsChildIt
 const tagIcon = ( type: unknown ) => ( type === 'category' ? 'folder' : String( type ?? '' ) );
 
 function getTagName( tag: StatsRecord ): string {
-	return typeof tag.name === 'string' ? tag.name : '';
+	return typeof tag.name === 'string' ? decodeHtmlText( tag.name ) : '';
 }
 
 function getTagLink( tag: StatsRecord ): string | null {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/top-authors.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/top-authors.ts
@@ -1,4 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import {
 	coerceStatsArray,
 	getStatsReportItems,
@@ -112,14 +113,14 @@ export function sanitizeStatsTopAuthorsResponse(
 		summary: normalizeStatsReportSummary( response, query, [ 'authors' ] ),
 		data: mapStatsReportDataPoints( response, query, [ 'authors' ], item => ( {
 			id: getAuthorId( item ),
-			label: item.name || 'Untracked Authors',
+			label: decodeHtmlText( item.name ) || 'Untracked Authors',
 			views: safeParseFloat( item.views ),
 			icon: typeof item.avatar === 'string' ? item.avatar : null,
 			iconClassName: 'avatar-user',
 			className: 'module-content-list-item-large',
 			children: mapNestedItems( coerceStatsArray( item.posts ), post => ( {
 				id: post.id as string | number | undefined,
-				label: post.title,
+				label: decodeHtmlText( post.title ),
 				views: safeParseFloat( post.views ),
 				link: typeof post.url === 'string' ? post.url : null,
 				page: post.id ? `/stats/post/${ post.id }` : null,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/top-posts.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/top-posts.ts
@@ -1,4 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import {
 	coerceStatsArray,
 	getStatsReportItems,
@@ -71,7 +72,7 @@ function normalizeStatsTopPostItem( item: StatsRecord ): StatsTopPostsItem {
 
 	return {
 		id: item.id as string | number | undefined,
-		label: item.title,
+		label: decodeHtmlText( item.title ),
 		views: safeParseFloat( item.views ),
 		link,
 		page: item.id ? `/stats/post/${ item.id }` : null,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
@@ -1,4 +1,5 @@
 import { safeParseFloat, safeParseInt } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import {
 	coerceStatsArray,
 	coerceStatsRecord,
@@ -93,7 +94,7 @@ function normalizeUtmTopPost(
 
 	return {
 		id,
-		label: payload.title ?? '',
+		label: decodeHtmlText( payload.title ?? '' ),
 		value: safeParseFloat( payload.views ),
 		href,
 		page: id ? `/stats/post/${ id }` : null,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/video-plays.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/video-plays.ts
@@ -1,4 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
+import { decodeHtmlText } from '../../utils/text';
 import {
 	createStatsSummaryDataPoint,
 	getStatsArrayFromKeys,
@@ -57,7 +58,7 @@ export function sanitizeStatsVideoPlaysResponse(
 	const videoDataKeys = query?.complete_stats ? [ 'data', 'plays' ] : [ 'plays', 'data' ];
 	const parse = ( item: StatsRecord ): StatsVideoPlaysItem => ( {
 		id: item.post_id as string | number | undefined,
-		label: item.title,
+		label: decodeHtmlText( item.title ),
 		// Complete-stats summary rows use `views` for the play count.
 		plays: safeParseFloat( item.views ?? item.plays ),
 		impressions: safeParseFloat( item.impressions ),

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/text.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/text.test.ts
@@ -1,15 +1,17 @@
-import { decodeHtmlText } from '../text';
+import { decodeHtmlString, decodeHtmlText } from '../text';
 
 describe( 'decodeHtmlText', () => {
 	it( 'decodes HTML entities and leaves non-strings alone', () => {
 		expect( decodeHtmlText( 'Tea &amp; Crumpets&#8217; Best' ) ).toBe( 'Tea & Crumpets’ Best' );
 		expect( decodeHtmlText( undefined ) ).toBeUndefined();
 		expect( decodeHtmlText( 42 ) ).toBe( 42 );
+		expect( decodeHtmlString( undefined ) ).toBe( '' );
+		expect( decodeHtmlString( 'Tea &amp; Crumpets' ) ).toBe( 'Tea & Crumpets' );
 	} );
 
-	it( 'decodes legacy entities without a trailing semicolon, so URLs must not be passed in', () => {
-		expect( decodeHtmlText( 'https://example.com/?a=1&copy=2' ) ).toBe(
-			'https://example.com/?a=1©=2'
+	it( 'preserves entity-like URL query parameters without a trailing semicolon', () => {
+		expect( decodeHtmlText( 'Tea &amp; Crumpets https://example.com/?a=1&copy=2' ) ).toBe(
+			'Tea & Crumpets https://example.com/?a=1&copy=2'
 		);
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/text.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/text.test.ts
@@ -1,0 +1,15 @@
+import { decodeHtmlText } from '../text';
+
+describe( 'decodeHtmlText', () => {
+	it( 'decodes HTML entities and leaves non-strings alone', () => {
+		expect( decodeHtmlText( 'Tea &amp; Crumpets&#8217; Best' ) ).toBe( 'Tea & Crumpets’ Best' );
+		expect( decodeHtmlText( undefined ) ).toBeUndefined();
+		expect( decodeHtmlText( 42 ) ).toBe( 42 );
+	} );
+
+	it( 'decodes legacy entities without a trailing semicolon, so URLs must not be passed in', () => {
+		expect( decodeHtmlText( 'https://example.com/?a=1&copy=2' ) ).toBe(
+			'https://example.com/?a=1©=2'
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/text.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/text.test.ts
@@ -1,12 +1,12 @@
-import { decodeHtmlString, decodeHtmlText } from '../text';
+import { decodeHtmlText } from '../text';
 
 describe( 'decodeHtmlText', () => {
 	it( 'decodes HTML entities and leaves non-strings alone', () => {
 		expect( decodeHtmlText( 'Tea &amp; Crumpets&#8217; Best' ) ).toBe( 'Tea & Crumpets’ Best' );
 		expect( decodeHtmlText( undefined ) ).toBeUndefined();
 		expect( decodeHtmlText( 42 ) ).toBe( 42 );
-		expect( decodeHtmlString( undefined ) ).toBe( '' );
-		expect( decodeHtmlString( 'Tea &amp; Crumpets' ) ).toBe( 'Tea & Crumpets' );
+		expect( decodeHtmlText( undefined, '' ) ).toBe( '' );
+		expect( decodeHtmlText( 'Tea &amp; Crumpets', '' ) ).toBe( 'Tea & Crumpets' );
 	} );
 
 	it( 'preserves entity-like URL query parameters without a trailing semicolon', () => {

--- a/projects/packages/premium-analytics/packages/data/src/utils/text.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/text.ts
@@ -1,12 +1,27 @@
 import { decodeEntities } from '@wordpress/html-entities';
 
+const HTML_ENTITY_PATTERN = /&(?:#\d+|#x[\da-f]+|[a-z][a-z\d]+);/gi;
+
+function decodeHtmlEntities( value: string ): string {
+	// Decode only terminated entities. `decodeEntities()` also accepts legacy entities
+	// without a semicolon, which can corrupt URL query strings such as `&copy=2`.
+	return value.replace( HTML_ENTITY_PATTERN, entity => decodeEntities( entity ) );
+}
+
 /**
  * Decode the HTML entities WordPress and WPCOM return in user-authored titles
- * and names.
+ * and names, while preserving non-string values.
  *
  * Decoding belongs in the data layer rather than in a row component because the
  * same value also reaches report tables, CSV exports, and `title` attributes.
  */
 export function decodeHtmlText< T >( value: T ): T | string {
-	return typeof value === 'string' ? decodeEntities( value ) : value;
+	return typeof value === 'string' ? decodeHtmlEntities( value ) : value;
+}
+
+/**
+ * Decode HTML entities from a field that must always produce a string.
+ */
+export function decodeHtmlString( value: unknown ): string {
+	return typeof value === 'string' ? decodeHtmlEntities( value ) : '';
 }

--- a/projects/packages/premium-analytics/packages/data/src/utils/text.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/text.ts
@@ -1,0 +1,12 @@
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Decode the HTML entities WordPress and WPCOM return in user-authored titles
+ * and names.
+ *
+ * Decoding belongs in the data layer rather than in a row component because the
+ * same value also reaches report tables, CSV exports, and `title` attributes.
+ */
+export function decodeHtmlText< T >( value: T ): T | string {
+	return typeof value === 'string' ? decodeEntities( value ) : value;
+}

--- a/projects/packages/premium-analytics/packages/data/src/utils/text.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/text.ts
@@ -15,13 +15,8 @@ function decodeHtmlEntities( value: string ): string {
  * Decoding belongs in the data layer rather than in a row component because the
  * same value also reaches report tables, CSV exports, and `title` attributes.
  */
-export function decodeHtmlText< T >( value: T ): T | string {
-	return typeof value === 'string' ? decodeHtmlEntities( value ) : value;
-}
-
-/**
- * Decode HTML entities from a field that must always produce a string.
- */
-export function decodeHtmlString( value: unknown ): string {
-	return typeof value === 'string' ? decodeHtmlEntities( value ) : '';
+export function decodeHtmlText< T >( value: T ): T | string;
+export function decodeHtmlText( value: unknown, fallback: string ): string;
+export function decodeHtmlText< T >( value: T, fallback?: string ): T | string {
+	return typeof value === 'string' ? decodeHtmlEntities( value ) : fallback ?? value;
 }

--- a/projects/plugins/jetpack/changelog/pa-stats-decode-title-entities
+++ b/projects/plugins/jetpack/changelog/pa-stats-decode-title-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Show titles and names with characters like "&" instead of their HTML codes.

--- a/projects/plugins/premium-analytics/changelog/pa-stats-decode-title-entities
+++ b/projects/plugins/premium-analytics/changelog/pa-stats-decode-title-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show titles and names with characters like "&" instead of their HTML codes.


### PR DESCRIPTION
Fixes WOOA7S-2003

## Proposed changes

* Add `decodeHtmlText()` in `src/utils/text.ts` and call it from every normalizer carrying a user-authored title or name — 16 label sources (top posts, authors, videos, tags, comments, comment followers, subscribers, search terms, archives, UTM posts, post/video detail headers, post comments and likes).
* Move the Latest emails sent fix (#51596) and the Latest post normalizer onto the same helper, so the package has one decode decision point instead of per-normalizer sprinkling.
* Decode only semicolon-terminated HTML entities. This preserves URL-shaped search terms and subscriber email labels containing entity-like text such as `&copy=2`, while still decoding WPCOM's `&amp;` and `&#8217;` output.
* Add `__tests__/label-entities.test.ts`, a table-driven test running all 16 paths through `&amp;` / `&#8217;`, plus unit coverage for the helper and URL/email regression cases.

Decoding sits in the data layer rather than in a row component (which is where Calypso does it, in `StatsListItem`) because the same `label` also reaches DataViews report tables, CSV exports, and `title` attributes — a render-layer decode would leave a CSV download still showing `&amp;`.

## Related product discussion/links

* WOOA7S-2003
* Follows WOOA7S-1995 / #51596, which fixed only the email summary normalizer.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated:

* `pnpm --filter @automattic/jetpack-premium-analytics run test packages/data/src` — 68 suites, 619 tests.
* To confirm the new test is not vacuous, drop the `decodeHtmlText(...)` call in `top-posts.ts` and re-run: the `top posts` row fails.

Manual, on a site with Premium Analytics:

1. Publish a post titled something like `Tea &amp; Crumpets` (a literal `&` and a curly apostrophe in the title is enough — WPCOM encodes them on the way out).
2. Give it a view, then open the Premium Analytics dashboard.
3. The Most viewed widget, the Posts report, and the post detail header should read `Tea & Crumpets’ Best`, not `Tea &amp; Crumpets&#8217; Best`.
4. Download the Posts report CSV and confirm the title column is decoded too.
