### PR TITLE
Premium Analytics: drop Last 24 hours from the Ads chart's date control

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1993-ads-presets
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1993-ads-presets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ads: Drop the Last 24 hours range from the WordAds card, which has no hourly data to chart.

--- a/projects/packages/premium-analytics/packages/fields/README.md
+++ b/projects/packages/premium-analytics/packages/fields/README.md
@@ -35,5 +35,9 @@ const ReportParamsField = createReportParamsField( { withIntervalControl: true }
 attributes: [ { id: 'reportParams', label: 'Range', Edit: ReportParamsField } ]
 ```
 
+`presetIds` narrows the quick presets on offer; pass it where the widget's
+report has no bucket fine enough to fill one of them, as the WordAds chart does
+for "Last 24 hours".
+
 A control that needs per-widget options is built by a factory called once at
 module scope, so the component identity is stable across renders.

--- a/projects/packages/premium-analytics/packages/fields/README.md
+++ b/projects/packages/premium-analytics/packages/fields/README.md
@@ -35,9 +35,9 @@ const ReportParamsField = createReportParamsField( { withIntervalControl: true }
 attributes: [ { id: 'reportParams', label: 'Range', Edit: ReportParamsField } ]
 ```
 
-`presetIds` narrows the quick presets on offer; pass it where the widget's
-report has no bucket fine enough to fill one of them, as the WordAds chart does
-for "Last 24 hours".
-
 A control that needs per-widget options is built by a factory called once at
 module scope, so the component identity is stable across renders.
+
+`presetIds` narrows the quick presets on offer, as the WordAds chart does for
+"Last 24 hours". An instance already saved on a window the widget stops
+offering is migrated to an offered one.

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 /**
@@ -22,13 +22,17 @@ const ATTRIBUTES: ReportParamsFieldAttributes = {
  * as its data. A test holding `data` still would pass on a control that commits
  * a stale draft, because it never sees what the widget ends up with.
  */
-function renderField( withIntervalControl?: boolean, presetIds?: readonly QuickSurfacePresetId[] ) {
+function renderField(
+	withIntervalControl?: boolean,
+	presetIds?: readonly QuickSurfacePresetId[],
+	initialAttributes: ReportParamsFieldAttributes = ATTRIBUTES
+) {
 	const Field = createReportParamsField( { withIntervalControl, presetIds } );
 	const saved: ReportParamsFieldAttributes[] = [];
 	let setFromOutside: ( attributes: ReportParamsFieldAttributes ) => void = () => {};
 
 	function Host() {
-		const [ attributes, setAttributes ] = useState( ATTRIBUTES );
+		const [ attributes, setAttributes ] = useState( initialAttributes );
 
 		setFromOutside = setAttributes;
 
@@ -96,18 +100,47 @@ describe( 'createReportParamsField', () => {
 		).resolves.toBeInTheDocument();
 	} );
 
+	const windowsOnOffer = () =>
+		within( screen.getByRole( 'toolbar', { name: 'Date range' } ) )
+			.getAllByRole( 'button' )
+			.map( button => button.textContent );
+
 	it( 'offers every rolling window when the widget names none', () => {
 		renderField();
 
-		expect( screen.getByRole( 'button', { name: /24 hours/i } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: /7 days/i } ) ).toBeInTheDocument();
+		expect( windowsOnOffer() ).toEqual( [
+			'Last 24 hours',
+			'7 days',
+			'30 days',
+			'12 months',
+			'Custom',
+		] );
 	} );
 
-	it( 'offers only the windows the widget names', () => {
-		renderField( true, [ 'last-7-days', 'last-30-days', 'last-12-months' ] );
+	it( 'offers only the windows the widget names, in that order', () => {
+		renderField( true, [ 'last-12-months', 'last-7-days', 'last-30-days' ] );
 
-		expect( screen.queryByRole( 'button', { name: /24 hours/i } ) ).not.toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: /7 days/i } ) ).toBeInTheDocument();
+		expect( windowsOnOffer() ).toEqual( [ '12 months', '7 days', '30 days', 'Custom' ] );
+	} );
+
+	it( 'moves an instance saved on an unoffered window onto an offered one', () => {
+		const { latest } = renderField( true, [ 'last-7-days', 'last-30-days', 'last-12-months' ], {
+			reportParams: { preset: 'last-24-hours', interval: 'hour' },
+		} );
+
+		expect( latest() ).toEqual( expect.objectContaining( { preset: 'last-30-days' } ) );
+		expect( screen.getByRole( 'button', { name: '30 days' } ) ).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+	} );
+
+	it( 'leaves a custom range alone', () => {
+		const { saved } = renderField( true, [ 'last-7-days', 'last-30-days', 'last-12-months' ], {
+			reportParams: { from: '2026-01-01', to: '2026-01-15', interval: 'day' },
+		} );
+
+		expect( saved ).toHaveLength( 0 );
 	} );
 
 	it( 'saves a bucket change without an Apply step', async () => {

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
@@ -125,10 +125,17 @@ describe( 'createReportParamsField', () => {
 
 	it( 'moves an instance saved on an unoffered window onto an offered one', () => {
 		const { latest } = renderField( true, [ 'last-7-days', 'last-30-days', 'last-12-months' ], {
-			reportParams: { preset: 'last-24-hours', interval: 'hour' },
+			reportParams: {
+				preset: 'last-24-hours',
+				from: '2026-01-14T00:00:00.000Z',
+				to: '2026-01-15T23:59:59.999Z',
+				interval: 'hour',
+			},
 		} );
 
-		expect( latest() ).toEqual( expect.objectContaining( { preset: 'last-30-days' } ) );
+		// The window and bucket leave with the preset, so nothing left in the
+		// preference describes a range the widget no longer offers.
+		expect( latest() ).toEqual( { preset: 'last-30-days' } );
 		expect( screen.getByRole( 'button', { name: '30 days' } ) ).toHaveAttribute(
 			'aria-pressed',
 			'true'

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
  * Internal dependencies
  */
 import { createReportParamsField, type ReportParamsFieldAttributes } from '../report-params-field';
+import type { QuickSurfacePresetId } from '@jetpack-premium-analytics/datetime';
 import type { DataFormControlProps } from '@jetpack-premium-analytics/externals';
 
 // A 30-day window: `getAllowedIntervalsForPreset` offers day and week for it, so
@@ -21,8 +22,8 @@ const ATTRIBUTES: ReportParamsFieldAttributes = {
  * as its data. A test holding `data` still would pass on a control that commits
  * a stale draft, because it never sees what the widget ends up with.
  */
-function renderField( withIntervalControl?: boolean ) {
-	const Field = createReportParamsField( { withIntervalControl } );
+function renderField( withIntervalControl?: boolean, presetIds?: readonly QuickSurfacePresetId[] ) {
+	const Field = createReportParamsField( { withIntervalControl, presetIds } );
 	const saved: ReportParamsFieldAttributes[] = [];
 	let setFromOutside: ( attributes: ReportParamsFieldAttributes ) => void = () => {};
 
@@ -93,6 +94,20 @@ describe( 'createReportParamsField', () => {
 		await expect(
 			screen.findByRole( 'button', { name: 'Chart interval' } )
 		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'offers every rolling window when the widget names none', () => {
+		renderField();
+
+		expect( screen.getByRole( 'button', { name: /24 hours/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /7 days/i } ) ).toBeInTheDocument();
+	} );
+
+	it( 'offers only the windows the widget names', () => {
+		renderField( true, [ 'last-7-days', 'last-30-days', 'last-12-months' ] );
+
+		expect( screen.queryByRole( 'button', { name: /24 hours/i } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /7 days/i } ) ).toBeInTheDocument();
 	} );
 
 	it( 'saves a bucket change without an Apply step', async () => {

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
@@ -12,6 +12,7 @@ import {
 	endOfDayTZ,
 	type IntervalType,
 	isPrimaryPreset,
+	type QuickSurfacePresetId,
 	siteTimeZone,
 	type DateRange,
 } from '@jetpack-premium-analytics/datetime';
@@ -43,6 +44,7 @@ export type ReportParamsFieldAttributes = {
 
 type ReportParamsFieldOptions = {
 	withIntervalControl?: boolean;
+	presetIds?: readonly QuickSurfacePresetId[];
 };
 
 /**
@@ -50,13 +52,26 @@ type ReportParamsFieldOptions = {
  *
  * @param options                     - Field options.
  * @param options.withIntervalControl - Whether to offer the chart bucket control.
+ * @param options.presetIds           - The quick presets to offer, in display
+ *                                    order. Defaults to every rolling window;
+ *                                    narrow it where the widget's report has
+ *                                    no bucket fine enough to fill one.
  * @return A DataForm control component.
  */
-export function createReportParamsField( { withIntervalControl }: ReportParamsFieldOptions = {} ) {
+export function createReportParamsField( {
+	withIntervalControl,
+	presetIds,
+}: ReportParamsFieldOptions = {} ) {
 	return function ReportParamsFieldControl(
 		props: DataFormControlProps< ReportParamsFieldAttributes >
 	) {
-		return <ReportParamsControl { ...props } withIntervalControl={ withIntervalControl } />;
+		return (
+			<ReportParamsControl
+				{ ...props }
+				withIntervalControl={ withIntervalControl }
+				presetIds={ presetIds }
+			/>
+		);
 	};
 }
 
@@ -64,6 +79,7 @@ function ReportParamsControl( {
 	data: attributes,
 	onChange,
 	withIntervalControl,
+	presetIds,
 }: DataFormControlProps< ReportParamsFieldAttributes > & ReportParamsFieldOptions ) {
 	const [ stagedReportParams, setStagedReportParams ] = useState< ReportParams >(
 		attributes?.reportParams
@@ -237,6 +253,7 @@ function ReportParamsControl( {
 				canApply={ isDateRangeDirty }
 				onCancel={ clear }
 				timeZone={ siteTimeZone() }
+				presetIds={ presetIds }
 				withIntervalControl={ withIntervalControl }
 				interval={ reportParams.interval }
 				intervalOptions={ intervalOptions }

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
@@ -12,6 +12,7 @@ import {
 	endOfDayTZ,
 	type IntervalType,
 	isPrimaryPreset,
+	QUICK_SURFACE_PRESETS,
 	type QuickSurfacePresetId,
 	siteTimeZone,
 	type DateRange,
@@ -53,9 +54,7 @@ type ReportParamsFieldOptions = {
  * @param options                     - Field options.
  * @param options.withIntervalControl - Whether to offer the chart bucket control.
  * @param options.presetIds           - The quick presets to offer, in display
- *                                    order. Defaults to every rolling window;
- *                                    narrow it where the widget's report has
- *                                    no bucket fine enough to fill one.
+ *                                    order. Defaults to every rolling window.
  * @return A DataForm control component.
  */
 export function createReportParamsField( {
@@ -133,6 +132,33 @@ function ReportParamsControl( {
 		from: decodeDateSearchParam( appliedParams.from ),
 		to: decodeDateSearchParam( appliedParams.to ),
 	};
+
+	/*
+	 * Migrate an instance saved on a window this widget stopped offering: left
+	 * alone it highlights no pill, reads "Custom", and keeps a bucket menu scoped
+	 * to that window. A custom range or a year is not ours to rewrite.
+	 */
+	const offeredPresetIds = ( presetIds ?? [] ) as readonly string[];
+	const fallbackPreset = offeredPresetIds.includes( defaultPreset )
+		? defaultPreset
+		: presetIds?.[ 0 ];
+
+	const appliedPreset = appliedParams.preset;
+	const isUnofferedPreset =
+		!! appliedPreset &&
+		( QUICK_SURFACE_PRESETS as readonly string[] ).includes( appliedPreset ) &&
+		! offeredPresetIds.includes( appliedPreset );
+
+	const hasMigratedPreset = useRef( false );
+
+	useEffect( () => {
+		if ( hasMigratedPreset.current || ! isUnofferedPreset || ! fallbackPreset ) {
+			return;
+		}
+		hasMigratedPreset.current = true;
+		onChange( { reportParams: { ...committed, preset: fallbackPreset } } );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isUnofferedPreset, fallbackPreset ] );
 
 	const stageDateRange = useCallback(
 		( nextRange?: DateRange, nextPresetId?: string ) => {

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
@@ -138,13 +138,14 @@ function ReportParamsControl( {
 	 * alone it highlights no pill, reads "Custom", and keeps a bucket menu scoped
 	 * to that window. A custom range or a year is not ours to rewrite.
 	 */
-	const offeredPresetIds = ( presetIds ?? [] ) as readonly string[];
-	const fallbackPreset = offeredPresetIds.includes( defaultPreset )
+	const offeredPresetIds = presetIds as readonly string[] | undefined;
+	const fallbackPreset = offeredPresetIds?.includes( defaultPreset )
 		? defaultPreset
 		: presetIds?.[ 0 ];
 
 	const appliedPreset = appliedParams.preset;
 	const isUnofferedPreset =
+		!! offeredPresetIds &&
 		!! appliedPreset &&
 		( QUICK_SURFACE_PRESETS as readonly string[] ).includes( appliedPreset ) &&
 		! offeredPresetIds.includes( appliedPreset );
@@ -156,7 +157,13 @@ function ReportParamsControl( {
 			return;
 		}
 		hasMigratedPreset.current = true;
-		onChange( { reportParams: { ...committed, preset: fallbackPreset } } );
+		// A preset alone, the shape `getDefaultReportParams` writes: the stored
+		// window and bucket describe a range this widget no longer offers.
+		const migrated = { ...committed, preset: fallbackPreset };
+		delete migrated.from;
+		delete migrated.to;
+		delete migrated.interval;
+		onChange( { reportParams: migrated } );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ isUnofferedPreset, fallbackPreset ] );
 

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/__tests__/wordads-chart-tabs.test.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/__tests__/wordads-chart-tabs.test.tsx
@@ -3,8 +3,9 @@
  */
 import { queryClient } from '@jetpack-premium-analytics/data';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import { render, renderHook, screen, waitFor, within } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
+import userEvent from '@testing-library/user-event';
 /**
  * Internal dependencies
  */
@@ -61,8 +62,6 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
-
-const noop = () => {};
 
 // Raw WPCOM `wordads/stats` matrix shape: two monthly buckets, so the summary
 // totals impressions (2000) and revenue (9.75), and CPM is the weighted average
@@ -282,23 +281,55 @@ describe( 'WordAdsChartTabsWidget', () => {
 } );
 
 describe( 'WordAdsChartTabsWidget date control', () => {
-	// WordAds is reported to us a day at a time, so a sub-daily window collapses
-	// to one bucket: no line, and yesterday's totals labelled as the last 24 hours.
-	it( 'offers no window shorter than the report can fill', () => {
-		const [ { Edit } ] = wordAdsChartTabsWidget.attributes;
-		const Field = Edit as ComponentType< DataFormControlProps< WordAdsChartTabsAttributes > >;
+	type FieldProps = DataFormControlProps< WordAdsChartTabsAttributes >;
 
-		render(
-			<Field
-				{ ...( {
-					data: { reportParams: { preset: 'last-30-days', interval: 'day' } },
-					onChange: noop,
-				} as unknown as DataFormControlProps< WordAdsChartTabsAttributes > ) }
-			/>
+	// Only the DataForm plumbing is cast away, so `data` stays type-checked and a
+	// renamed attribute breaks the build rather than passing silently.
+	function renderDateControl( props: Pick< FieldProps, 'data' | 'onChange' > ) {
+		const [ { Edit } ] = wordAdsChartTabsWidget.attributes;
+		const Field = Edit as ComponentType< FieldProps >;
+
+		render( <Field { ...( props as FieldProps ) } /> );
+	}
+
+	it( 'offers no window shorter than the report can fill', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		renderDateControl( {
+			data: { reportParams: { preset: 'last-30-days', interval: 'day' } },
+			onChange,
+		} );
+
+		const toolbar = screen.getByRole( 'toolbar', { name: 'Date range' } );
+
+		expect(
+			within( toolbar )
+				.getAllByRole( 'button' )
+				.map( button => button.textContent )
+		).toEqual( [ '7 days', '30 days', '12 months', 'Custom' ] );
+		expect( screen.getByRole( 'button', { name: '30 days' } ) ).toHaveAttribute(
+			'aria-pressed',
+			'true'
 		);
 
-		expect( screen.queryByRole( 'button', { name: /24 hours/i } ) ).not.toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: /7 days/i } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: /30 days/i } ) ).toBeInTheDocument();
+		await user.click( screen.getByRole( 'button', { name: '7 days' } ) );
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			reportParams: expect.objectContaining( { preset: 'last-7-days' } ),
+		} );
+	} );
+
+	it( 'moves an instance saved on the last 24 hours onto an offered window', () => {
+		const onChange = jest.fn();
+
+		renderDateControl( {
+			data: { reportParams: { preset: 'last-24-hours', interval: 'hour' } },
+			onChange,
+		} );
+
+		expect( onChange ).toHaveBeenCalledWith( {
+			reportParams: expect.objectContaining( { preset: 'last-30-days' } ),
+		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/__tests__/wordads-chart-tabs.test.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/__tests__/wordads-chart-tabs.test.tsx
@@ -3,7 +3,7 @@
  */
 import { queryClient } from '@jetpack-premium-analytics/data';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { render, renderHook, waitFor } from '@testing-library/react';
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -11,8 +11,10 @@ import apiFetch from '@wordpress/api-fetch';
 import { setMockRouteSearch } from '../../../tests/js/route-test-utils';
 import WordAdsChartTabsWidget from '../render';
 import useWordAdsChart from '../use-wordads-chart';
+import wordAdsChartTabsWidget, { type WordAdsChartTabsAttributes } from '../widget';
 import type { ReportParams } from '@jetpack-premium-analytics/data';
-import type { ReactNode } from 'react';
+import type { DataFormControlProps } from '@jetpack-premium-analytics/externals';
+import type { ComponentType, ReactNode } from 'react';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
@@ -59,6 +61,8 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+const noop = () => {};
 
 // Raw WPCOM `wordads/stats` matrix shape: two monthly buckets, so the summary
 // totals impressions (2000) and revenue (9.75), and CPM is the weighted average
@@ -274,5 +278,27 @@ describe( 'WordAdsChartTabsWidget', () => {
 
 		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
 		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalledTimes( 1 ) );
+	} );
+} );
+
+describe( 'WordAdsChartTabsWidget date control', () => {
+	// WordAds is reported to us a day at a time, so a sub-daily window collapses
+	// to one bucket: no line, and yesterday's totals labelled as the last 24 hours.
+	it( 'offers no window shorter than the report can fill', () => {
+		const [ { Edit } ] = wordAdsChartTabsWidget.attributes;
+		const Field = Edit as ComponentType< DataFormControlProps< WordAdsChartTabsAttributes > >;
+
+		render(
+			<Field
+				{ ...( {
+					data: { reportParams: { preset: 'last-30-days', interval: 'day' } },
+					onChange: noop,
+				} as unknown as DataFormControlProps< WordAdsChartTabsAttributes > ) }
+			/>
+		);
+
+		expect( screen.queryByRole( 'button', { name: /24 hours/i } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /7 days/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /30 days/i } ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
@@ -2,6 +2,11 @@
  * External dependencies
  */
 import {
+	PRESET_LAST_7_DAYS,
+	PRESET_LAST_30_DAYS,
+	PRESET_LAST_12_MONTHS,
+} from '@jetpack-premium-analytics/datetime';
+import {
 	createReportParamsField,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/fields';
@@ -19,8 +24,18 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 /** The widget owns its date controls because other Ads widgets accept no dates. */
 export type WordAdsChartTabsAttributes = Partial< ReportParamsFieldAttributes >;
 
+/**
+ * The rolling windows minus "Last 24 hours": WordAds is reported to us daily, so
+ * a sub-daily window collapses to one day-bucket, which draws no line and labels
+ * yesterday's totals as the last 24 hours.
+ */
+const WORDADS_PRESETS = [ PRESET_LAST_7_DAYS, PRESET_LAST_30_DAYS, PRESET_LAST_12_MONTHS ] as const;
+
 // The chart's body is bucketed by the interval, so the control offers it.
-const ReportParamsField = createReportParamsField( { withIntervalControl: true } );
+const ReportParamsField = createReportParamsField( {
+	withIntervalControl: true,
+	presetIds: WORDADS_PRESETS,
+} );
 
 /**
  * WordAds metric tabs with widget-owned date controls. Requires active WordAds.

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
@@ -25,9 +25,8 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 export type WordAdsChartTabsAttributes = Partial< ReportParamsFieldAttributes >;
 
 /**
- * The rolling windows minus "Last 24 hours": WordAds is reported to us daily, so
- * a sub-daily window collapses to one day-bucket, which draws no line and labels
- * yesterday's totals as the last 24 hours.
+ * WordAds is reported to us daily, so a sub-daily window collapses to one
+ * bucket: no line, and yesterday's totals labelled as the last 24 hours.
  */
 const WORDADS_PRESETS = [ PRESET_LAST_7_DAYS, PRESET_LAST_30_DAYS, PRESET_LAST_12_MONTHS ] as const;
 

--- a/projects/plugins/jetpack/changelog/wooa7s-1993-ads-presets
+++ b/projects/plugins/jetpack/changelog/wooa7s-1993-ads-presets
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Premium Analytics: Drop the Last 24 hours range from the Ads WordAds card, which has no hourly data to chart.
+Premium Analytics: Drop the Last 24 hours range from the WordAds card, which has no hourly data to chart.

--- a/projects/plugins/jetpack/changelog/wooa7s-1993-ads-presets
+++ b/projects/plugins/jetpack/changelog/wooa7s-1993-ads-presets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Drop the Last 24 hours range from the Ads WordAds card, which has no hourly data to chart.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-1993-ads-presets
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-1993-ads-presets
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: Drop the Last 24 hours range from the Ads WordAds card, which has no hourly data to chart.
+Premium Analytics: Drop the Last 24 hours range from the WordAds card, which has no hourly data to chart.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-1993-ads-presets
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-1993-ads-presets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Drop the Last 24 hours range from the Ads WordAds card, which has no hourly data to chart.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1993-ads-presets
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1993-ads-presets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ads: Drop the Last 24 hours range from the WordAds card, which has no hourly data to chart.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-1993-ads-presets
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-1993-ads-presets
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: Drop the Last 24 hours range from the Ads WordAds card, which has no hourly data to chart.
+Premium Analytics: Drop the Last 24 hours range from the WordAds card, which has no hourly data to chart.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-1993-ads-presets
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-1993-ads-presets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Drop the Last 24 hours range from the Ads WordAds card, which has no hourly data to chart.


### PR DESCRIPTION
WOOA7S-1993

Follow-up to #51543, which listed this as a known follow-up.

## Proposed changes

* Let `createReportParamsField` take `presetIds`, so a widget can narrow the quick presets its header control offers.
* Drop **Last 24 hours** from the WordAds chart's control, leaving 7 days / 30 days / 12 months / Custom.
* Move a card already saved on a window the widget stops offering onto its default one, so the pill row never reports a range it no longer lists.

WordAds has no hourly bucket anywhere in the stack: `wordads_site_stat` is keyed by `stat_day`, and the ingest jobs run a `-3 days` → `yesterday` window, so today's figures do not exist yet. An hourly range collapsed to `unit=day&quantity=1` — one point, which a line series cannot draw — and that bucket is yesterday's whole day, shown under a "Last 24 hours" label. Upstream Calypso never offered the preset here and always requests a fixed 30 buckets.

## Related product discussion/links

* WOOA7S-1993

## Does this pull request change what data or activity we track or use?

No. It removes a reachable request shape rather than adding one.

## Testing instructions

Setup: a site with WordAds active and Premium Analytics enabled. Open the analytics dashboard and select the **Ads** tab.

* The **WordAds** card's date control offers 7 days / 30 days / 12 months / Custom. **Last 24 hours** is gone.
* Each of those still redraws the chart and updates the Ads Served / Average CPM / Revenue tabs.
* Narrow the card until the control collapses into a dropdown — the same presets are there, and no 24-hour one.
* A card left on **Last 24 hours** before this change opens on 30 days, with that pill selected.
* Every other surface with a date control (Traffic, Subscribers, Insights, the detail pages) still offers Last 24 hours.

## Screenshots

The card's date control, before and after. Captured from the `WidgetDashboardWithWidget` story at the Ads section's real width (4 columns).

**Before** — the pill row leads with Last 24 hours:

![before](https://github.com/Automattic/jetpack/raw/screenshots/change/wooa7s-1993-ads-presets/before.png)

**After** — it starts at 7 days:

![after](https://github.com/Automattic/jetpack/raw/screenshots/change/wooa7s-1993-ads-presets/after.png)

**The bug, on trunk** — Last 24 hours selected. The plot is empty, and the one axis label reads `Aug 26`: yesterday's whole day, presented as the last 24 hours.

![the bug on Last 24 hours](https://github.com/Automattic/jetpack/raw/screenshots/change/wooa7s-1993-ads-presets/bug-24h.png)

## Known follow-ups, not in this PR

* A **custom single-day range** still collapses to one bucket and draws nothing: `getAllowedIntervalsByRange` returns `['hour']` for anything under two days. The general fix is having `MetricTabsChart` render a single point, which would also cover the other chart widgets whose finest bucket is `day` (subscribers, post views, email time series, video detail). That is option 2 on the issue and deserves its own.
* `presetIds` names the pills to hide, but the fact behind it — this report's finest bucket is `day` — also governs the custom picker and the interval menu. Worth revisiting the option's shape before the other daily widgets adopt it.


