### PR TITLE
Premium Analytics: link a subscriber's name to their subscriber details page

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2002-subscriber-link
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2002-subscriber-link
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Subscriber list: Link a subscriber's name to their subscriber details page instead of their own site.
+Subscriber list: Link a subscriber's name to their subscriber details page.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2002-subscriber-link
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2002-subscriber-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscriber list: Link a subscriber's name to their subscriber details page.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2002-subscriber-link
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2002-subscriber-link
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Subscriber list: Link a subscriber's name to their subscriber details page.
+Subscriber list: Link a subscriber's name to their subscriber details page instead of their own site.

--- a/projects/packages/premium-analytics/tests/groups/widgets-shared-route-mock-part2.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/widgets-shared-route-mock-part2.test.tsx
@@ -2,6 +2,7 @@
 
 import '../../widgets/site-overview/__tests__/site-overview.test';
 import '../../widgets/subscriber-highlights/__tests__/subscriber-highlights.test';
+import '../../widgets/subscribers-list/__tests__/subscribers-list.test';
 import '../../widgets/tags/__tests__/tags.test';
 import '../../widgets/video-detail-embeds/__tests__/video-detail-embeds.test';
 import '../../widgets/videopress/__tests__/videopress.test';

--- a/projects/packages/premium-analytics/widgets/subscribers-list/__tests__/subscribers-list.test.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/__tests__/subscribers-list.test.tsx
@@ -31,12 +31,13 @@ const FOLLOWERS_RESPONSE = {
 	],
 };
 
-// Restore rather than delete: the suite may share a module registry with
-// others that rely on whatever script data was already on the window.
+// Restore rather than delete: later suites in the group file share this window.
 const originalScriptData = window.JetpackScriptData;
 
-function setSiteData( host: string, suffix?: string ) {
-	window.JetpackScriptData = { site: { host, suffix } } as never;
+function setSiteData( isWpcomPlatform: boolean, suffix?: string ) {
+	window.JetpackScriptData = {
+		site: { is_wpcom_platform: isWpcomPlatform, suffix },
+	} as typeof window.JetpackScriptData;
 }
 
 describe( 'SubscribersListWidget', () => {
@@ -50,11 +51,10 @@ describe( 'SubscribersListWidget', () => {
 
 	afterEach( () => {
 		window.JetpackScriptData = originalScriptData;
-		jest.restoreAllMocks();
 	} );
 
-	it( 'links the name to the subscriber details page on WordPress.com', async () => {
-		setSiteData( 'wpcom', 'example.wordpress.com' );
+	it( 'links the name to WordPress.com on the WordPress.com platform', async () => {
+		setSiteData( true, 'example.wordpress.com' );
 
 		render( <SubscribersListWidget attributes={ {} } /> );
 
@@ -64,8 +64,8 @@ describe( 'SubscribersListWidget', () => {
 		);
 	} );
 
-	it( 'links the name to Jetpack Cloud when the site is not Simple', async () => {
-		setSiteData( 'woa', 'example.com' );
+	it( 'links the name to Jetpack Cloud everywhere else', async () => {
+		setSiteData( false, 'example.com' );
 
 		render( <SubscribersListWidget attributes={ {} } /> );
 
@@ -76,7 +76,7 @@ describe( 'SubscribersListWidget', () => {
 	} );
 
 	it( 'renders the name as plain text when there is no details page to link to', async () => {
-		setSiteData( 'wpcom' );
+		setSiteData( true );
 
 		render( <SubscribersListWidget attributes={ {} } /> );
 
@@ -84,10 +84,9 @@ describe( 'SubscribersListWidget', () => {
 		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders rows without a subscription id as distinct plain-text names', async () => {
-		setSiteData( 'woa', 'example.com' );
-		// No `ID` or `*_subscription_id`, so the normalizer leaves `subscription_id`
-		// undefined and the rows fall back to the index for their key.
+	it( 'renders rows without a subscription id as plain-text names', async () => {
+		setSiteData( false, 'example.com' );
+		// No `ID` or `*_subscription_id`, so `subscription_id` stays undefined.
 		mockApiFetch.mockResolvedValue( {
 			total: 2,
 			subscribers: [
@@ -96,17 +95,10 @@ describe( 'SubscribersListWidget', () => {
 			],
 		} );
 
-		const consoleError = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
-
 		render( <SubscribersListWidget attributes={ {} } /> );
 
 		await expect( screen.findByText( 'Reader One' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Reader Two' ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
-		// A shared key would render both rows and only warn, so assert on the warning.
-		// React passes the key as a format arg, so match the message, not the arity.
-		expect(
-			consoleError.mock.calls.some( ( [ message ] ) => String( message ).includes( 'same key' ) )
-		).toBe( false );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/subscribers-list/__tests__/subscribers-list.test.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/__tests__/subscribers-list.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import SubscribersListWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// WidgetRoot reads URL search params as a fallback for report params; outside
+// a matched route the real hook warns and throws.
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+// `url` is the subscriber's own site, which is what the row used to link to.
+const FOLLOWERS_RESPONSE = {
+	total: 1,
+	subscribers: [
+		{
+			label: 'Ada Lovelace',
+			avatar: 'https://gravatar.com/avatar/ada',
+			url: 'http://ada.wordpress.com',
+			date_subscribed: '2026-08-01T00:00:00+00:00',
+			subscription_id: 4242,
+		},
+	],
+};
+
+// Restore rather than delete: the suite may share a module registry with
+// others that rely on whatever script data was already on the window.
+const originalScriptData = window.JetpackScriptData;
+
+function setSiteData( host: string, suffix?: string ) {
+	window.JetpackScriptData = { site: { host, suffix } } as never;
+}
+
+describe( 'SubscribersListWidget', () => {
+	beforeEach( () => {
+		// The data package's query client is a module-level singleton; drop its
+		// cache so each test starts from a fresh fetch.
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( FOLLOWERS_RESPONSE );
+	} );
+
+	afterEach( () => {
+		window.JetpackScriptData = originalScriptData;
+	} );
+
+	it( 'links the name to the subscriber details page on WordPress.com', async () => {
+		setSiteData( 'wpcom', 'example.wordpress.com' );
+
+		render( <SubscribersListWidget attributes={ {} } /> );
+
+		await expect( screen.findByRole( 'link', { name: /Ada Lovelace/ } ) ).resolves.toHaveAttribute(
+			'href',
+			'https://wordpress.com/subscribers/example.wordpress.com/4242'
+		);
+	} );
+
+	it( 'links the name to Jetpack Cloud when the site is not Simple', async () => {
+		setSiteData( 'woa', 'example.com' );
+
+		render( <SubscribersListWidget attributes={ {} } /> );
+
+		await expect( screen.findByRole( 'link', { name: /Ada Lovelace/ } ) ).resolves.toHaveAttribute(
+			'href',
+			'https://cloud.jetpack.com/subscribers/example.com/4242'
+		);
+	} );
+
+	it( 'renders the name as plain text when there is no details page to link to', async () => {
+		setSiteData( 'wpcom' );
+
+		render( <SubscribersListWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'Ada Lovelace' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/subscribers-list/__tests__/subscribers-list.test.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/__tests__/subscribers-list.test.tsx
@@ -17,7 +17,7 @@ jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mo
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 
-// `url` is the subscriber's own site, which is what the row used to link to.
+// `url` is the subscriber's own site — the name must not point there.
 const FOLLOWERS_RESPONSE = {
 	total: 1,
 	subscribers: [
@@ -50,6 +50,7 @@ describe( 'SubscribersListWidget', () => {
 
 	afterEach( () => {
 		window.JetpackScriptData = originalScriptData;
+		jest.restoreAllMocks();
 	} );
 
 	it( 'links the name to the subscriber details page on WordPress.com', async () => {
@@ -81,5 +82,31 @@ describe( 'SubscribersListWidget', () => {
 
 		await expect( screen.findByText( 'Ada Lovelace' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders rows without a subscription id as distinct plain-text names', async () => {
+		setSiteData( 'woa', 'example.com' );
+		// No `ID` or `*_subscription_id`, so the normalizer leaves `subscription_id`
+		// undefined and the rows fall back to the index for their key.
+		mockApiFetch.mockResolvedValue( {
+			total: 2,
+			subscribers: [
+				{ label: 'Reader One', date_subscribed: '2026-08-02T00:00:00+00:00' },
+				{ label: 'Reader Two', date_subscribed: '2026-08-01T00:00:00+00:00' },
+			],
+		} );
+
+		const consoleError = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+		render( <SubscribersListWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'Reader One' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Reader Two' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+		// A shared key would render both rows and only warn, so assert on the warning.
+		// React passes the key as a format arg, so match the message, not the arity.
+		expect(
+			consoleError.mock.calls.some( ( [ message ] ) => String( message ).includes( 'same key' ) )
+		).toBe( false );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/subscribers-list/package.json
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"type": "module",
 	"dependencies": {
+		"@automattic/jetpack-script-data": "workspace:*",
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/datetime": "link:../../packages/datetime",
 		"@jetpack-premium-analytics/icons": "link:../../packages/icons",

--- a/projects/packages/premium-analytics/widgets/subscribers-list/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/render.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { getSiteData, isSimpleSite } from '@automattic/jetpack-script-data';
+import { getSiteData, isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import {
 	getStatsReportItems,
 	useStatsFollowers,
@@ -29,17 +29,16 @@ import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 /** Base URL for the site's subscriber management pages. */
 function getSubscribersBaseUrl() {
-	// wp-admin always supplies the slug; the null path is for Storybook and other
-	// non-admin mounts.
+	// Only wp-admin supplies the slug; other mounts get no link.
 	const siteSlug = getSiteData()?.suffix;
 
 	if ( ! siteSlug ) {
 		return null;
 	}
 
-	// Atomic goes to Jetpack Cloud, matching the Stats Subscribers module. The
-	// wp-admin Subscribers menu sends Atomic to WordPress.com instead.
-	const host = isSimpleSite() ? 'https://wordpress.com' : 'https://cloud.jetpack.com';
+	// Simple and WoA both go to WordPress.com, matching the wp-admin Subscribers
+	// menu and the Newsletter widget.
+	const host = isWpcomPlatformSite() ? 'https://wordpress.com' : 'https://cloud.jetpack.com';
 
 	return `${ host }/subscribers/${ siteSlug }`;
 }
@@ -60,8 +59,8 @@ function toSubscriberItems(
 		id: item.subscription_id ?? `row-${ index }`,
 		name: item.label,
 		avatarUrl: item.icon,
-		// `link` is the subscriber's own site, not their subscriber record. The id
-		// mirrors Calypso's fallback chain, so it can be a user ID the page won't resolve.
+		// `link` is unreliable: the subscriber's own site on some payloads, a
+		// user-ID Calypso link that 404s on others.
 		href:
 			subscribersBaseUrl && item.subscription_id
 				? `${ subscribersBaseUrl }/${ item.subscription_id }`

--- a/projects/packages/premium-analytics/widgets/subscribers-list/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/render.tsx
@@ -27,18 +27,18 @@ import { useMemo } from 'react';
 import type { SubscribersListAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
-/**
- * Base URL of the subscriber management pages, or null when the site slug is unknown.
- *
- * Simple sites manage subscribers on WordPress.com, everything else on Jetpack Cloud.
- */
+/** Base URL for the site's subscriber management pages. */
 function getSubscribersBaseUrl() {
+	// wp-admin always supplies the slug; the null path is for Storybook and other
+	// non-admin mounts.
 	const siteSlug = getSiteData()?.suffix;
 
 	if ( ! siteSlug ) {
 		return null;
 	}
 
+	// Atomic goes to Jetpack Cloud, matching the Stats Subscribers module. The
+	// wp-admin Subscribers menu sends Atomic to WordPress.com instead.
 	const host = isSimpleSite() ? 'https://wordpress.com' : 'https://cloud.jetpack.com';
 
 	return `${ host }/subscribers/${ siteSlug }`;
@@ -60,8 +60,8 @@ function toSubscriberItems(
 		id: item.subscription_id ?? `row-${ index }`,
 		name: item.label,
 		avatarUrl: item.icon,
-		// The row's `link` is the subscriber's own site, not their subscriber
-		// record, so the name points at the details page instead.
+		// `link` is the subscriber's own site, not their subscriber record. The id
+		// mirrors Calypso's fallback chain, so it can be a user ID the page won't resolve.
 		href:
 			subscribersBaseUrl && item.subscription_id
 				? `${ subscribersBaseUrl }/${ item.subscription_id }`

--- a/projects/packages/premium-analytics/widgets/subscribers-list/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/render.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { getSiteData, isSimpleSite } from '@automattic/jetpack-script-data';
 import {
 	getStatsReportItems,
 	useStatsFollowers,
@@ -27,6 +28,23 @@ import type { SubscribersListAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 /**
+ * Base URL of the subscriber management pages, or null when the site slug is unknown.
+ *
+ * Simple sites manage subscribers on WordPress.com, everything else on Jetpack Cloud.
+ */
+function getSubscribersBaseUrl() {
+	const siteSlug = getSiteData()?.suffix;
+
+	if ( ! siteSlug ) {
+		return null;
+	}
+
+	const host = isSimpleSite() ? 'https://wordpress.com' : 'https://cloud.jetpack.com';
+
+	return `${ host }/subscribers/${ siteSlug }`;
+}
+
+/**
  * Flattens the designated `useStatsFollowers` report into the rows the roster
  * renders.
  */
@@ -34,6 +52,7 @@ function toSubscriberItems(
 	report: StatsNormalizedReport< StatsFollowersItem > | undefined
 ): SubscriberListItem[] {
 	const items = getStatsReportItems( report );
+	const subscribersBaseUrl = getSubscribersBaseUrl();
 
 	return items.map( ( item, index ) => ( {
 		// Subscription id is the stable key; fall back to the row index so two
@@ -41,7 +60,12 @@ function toSubscriberItems(
 		id: item.subscription_id ?? `row-${ index }`,
 		name: item.label,
 		avatarUrl: item.icon,
-		href: item.link,
+		// The row's `link` is the subscriber's own site, not their subscriber
+		// record, so the name points at the details page instead.
+		href:
+			subscribersBaseUrl && item.subscription_id
+				? `${ subscribersBaseUrl }/${ item.subscription_id }`
+				: null,
 		secondaryText: formatRelativeSince( item.date_subscribed ),
 	} ) );
 }

--- a/projects/packages/premium-analytics/widgets/subscribers-list/stories/subscribers-list-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/stories/subscribers-list-widget.stories.tsx
@@ -22,6 +22,16 @@ import type { ComponentType } from 'react';
 
 registerReportMocks();
 
+// The roster builds each subscriber's details URL from `window.JetpackScriptData`,
+// which only wp-admin provides; seed the site slug so the names link in Storybook.
+window.JetpackScriptData = {
+	...window.JetpackScriptData,
+	site: {
+		...window.JetpackScriptData?.site,
+		suffix: 'example.com',
+	},
+} as typeof window.JetpackScriptData;
+
 const SUBSCRIBERS_LIST_RENDER_MODULE = 'storybook/subscribers-list';
 
 const meta = {

--- a/projects/packages/premium-analytics/widgets/subscribers-list/stories/subscribers-list-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/stories/subscribers-list-widget.stories.tsx
@@ -22,8 +22,7 @@ import type { ComponentType } from 'react';
 
 registerReportMocks();
 
-// The roster builds each subscriber's details URL from `window.JetpackScriptData`,
-// which only wp-admin provides; seed the site slug so the names link in Storybook.
+// Only wp-admin supplies the slug; seed it so the names link in Storybook.
 window.JetpackScriptData = {
 	...window.JetpackScriptData,
 	site: {

--- a/projects/plugins/jetpack/changelog/wooa7s-2002-subscriber-link
+++ b/projects/plugins/jetpack/changelog/wooa7s-2002-subscriber-link
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Premium Analytics: Link a subscriber's name to their subscriber details page instead of their own site.
+Premium Analytics: Link a subscriber's name to their subscriber details page.

--- a/projects/plugins/jetpack/changelog/wooa7s-2002-subscriber-link
+++ b/projects/plugins/jetpack/changelog/wooa7s-2002-subscriber-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Link a subscriber's name to their subscriber details page instead of their own site.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2002-subscriber-link
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2002-subscriber-link
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: Link a subscriber's name to their subscriber details page instead of their own site.
+Premium Analytics: Link a subscriber's name to their subscriber details page.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2002-subscriber-link
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2002-subscriber-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Link a subscriber's name to their subscriber details page instead of their own site.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2002-subscriber-link
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2002-subscriber-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Latest subscribers: Link a subscriber's name to their subscriber details page instead of their own site.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2002-subscriber-link
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2002-subscriber-link
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Latest subscribers: Link a subscriber's name to their subscriber details page instead of their own site.
+Latest subscribers: Link a subscriber's name to their subscriber details page.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2002-subscriber-link
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2002-subscriber-link
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: Link a subscriber's name to their subscriber details page instead of their own site.
+Premium Analytics: Link a subscriber's name to their subscriber details page.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2002-subscriber-link
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2002-subscriber-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Link a subscriber's name to their subscriber details page instead of their own site.


### PR DESCRIPTION
Fixes WOOA7S-2002

## Proposed changes
* Latest subscribers put the row's `url` on the name. That is the subscriber's own site on some payloads, and a Calypso link built from their user ID — which 404s on the details lookup — on others.
* Point the name at `/subscribers/{siteSlug}/{subscription_id}` instead: `wordpress.com` on the WordPress.com platform (Simple and WoA), `cloud.jetpack.com` elsewhere, matching the Newsletter widget's link for the same route.
* Fall back to plain text when the site slug or `subscription_id` is missing.
* No UI change — no trailing "open their site" affordance, and the footer stays "N more".

## Related product discussion/links
* WOOA7S-2002

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open **Premium Analytics → Subscribers** on a connected site that has at least one subscriber.
* Hover a name in **Latest subscribers**: it should point at `https://cloud.jetpack.com/subscribers/<site>/<subscription_id>`, or `https://wordpress.com/...` on Simple and WoA.
* Click it and confirm that subscriber's details page opens.
* A row with no `subscription_id` should render as plain text with no external-link marker.
* `jetpack test js packages/premium-analytics` covers all four cases.


