### PR TITLE
Premium Analytics: add the All-time stats widget to the Insights page

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooprd-3701-insights-all-time-stats
+++ b/projects/packages/premium-analytics/changelog/wooprd-3701-insights-all-time-stats
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Insights: Add the All-time stats widget to the default page.
+Insights: Add the All-time stats widget to the default layout.

--- a/projects/packages/premium-analytics/changelog/wooprd-3701-insights-all-time-stats
+++ b/projects/packages/premium-analytics/changelog/wooprd-3701-insights-all-time-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Insights: Add the All-time stats widget to the default page.

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -290,95 +290,113 @@ function get_dashboard_default_section_layouts() {
 				4,
 				1
 			),
-			// Row 2: posting-activity heatmap.
+			// Row 2: lifetime totals. Full width for now: the design pairs a
+			// narrow All-time stats card with Most popular time and Most popular
+			// day, and neither is in the default layout yet (WOOPRD-3703,
+			// WOOPRD-3704). A 1-wide card here would leave three empty columns —
+			// the grid packs sparsely, and the next row is a full-width tile.
+			// WOOPRD-3708 narrows it once those two join the row.
+			get_dashboard_default_widget_instance(
+				'default-all-time-stats-widget-instance',
+				'jpa/all-time-stats',
+				1,
+				4,
+				1,
+				array(
+					// The design shows three totals; the widget's own default adds
+					// Comments, which the comment leaderboards below already cover.
+					'metrics' => array( 'views', 'visitors', 'posts' ),
+				)
+			),
+			// Row 3: posting-activity heatmap.
 			get_dashboard_default_widget_instance(
 				'default-posting-activity-widget-instance',
 				'jpa/posting-activity',
-				1,
+				2,
 				4,
 				1
 			),
-			// Row 3: the two post spotlights.
+			// Row 4: the two post spotlights.
 			get_dashboard_default_widget_instance(
 				'default-latest-post-widget-instance',
 				'jpa/latest-post',
-				2,
+				3,
 				2,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-popular-post-widget-instance',
 				'jpa/popular-post',
-				3,
+				4,
 				2,
 				2
 			),
-			// Row 4: the period totals and the weekday and hour-of-day
+			// Row 5: the period totals and the weekday and hour-of-day
 			// distributions.
 			get_dashboard_default_widget_instance(
 				'default-total-views-widget-instance',
 				'jpa/total-views',
-				4,
+				5,
 				1,
 				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-total-visitors-widget-instance',
 				'jpa/total-visitors',
-				5,
+				6,
 				1,
 				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-popular-days-widget-instance',
 				'jpa/popular-days',
-				6,
+				7,
 				1,
 				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-popular-hours-widget-instance',
 				'jpa/popular-hours',
-				7,
+				8,
 				1,
 				1
 			),
-			// Row 5: daily views heatmap. Two rows tall, as in the prototype: the
+			// Row 6: daily views heatmap. Two rows tall, as in the prototype: the
 			// cells are sized from the tile's height, and only at this height do they
 			// grow wide enough to label each day with its view count.
 			get_dashboard_default_widget_instance(
 				'default-traffic-views-activity-widget-instance',
 				'jpa/traffic-views-activity',
-				8,
+				9,
 				4,
 				2
 			),
-			// Row 6: the comment leaderboards, shares, and tags.
+			// Row 7: the comment leaderboards, shares, and tags.
 			get_dashboard_default_widget_instance(
 				'default-most-commented-posts-widget-instance',
 				'jpa/most-commented-posts',
-				9,
+				10,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-commented-authors-widget-instance',
 				'jpa/most-commented-authors',
-				10,
+				11,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-shares-widget-instance',
 				'jpa/shares',
-				11,
+				12,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-tags-widget-instance',
 				'jpa/tags',
-				12,
+				13,
 				1,
 				2
 			),

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -396,18 +396,19 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		// uuid => [ type, width, height, order ]; each row fills the four-column grid.
 		$expected = array(
 			'default-annual-highlights-widget-instance'    => array( 'jpa/annual-highlights', 4, 1, 0 ),
-			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 4, 1, 1 ),
-			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 2 ),
-			'default-popular-post-widget-instance'         => array( 'jpa/popular-post', 2, 2, 3 ),
-			'default-total-views-widget-instance'          => array( 'jpa/total-views', 1, 1, 4 ),
-			'default-total-visitors-widget-instance'       => array( 'jpa/total-visitors', 1, 1, 5 ),
-			'default-popular-days-widget-instance'         => array( 'jpa/popular-days', 1, 1, 6 ),
-			'default-popular-hours-widget-instance'        => array( 'jpa/popular-hours', 1, 1, 7 ),
-			'default-traffic-views-activity-widget-instance' => array( 'jpa/traffic-views-activity', 4, 2, 8 ),
-			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 9 ),
-			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 10 ),
-			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 11 ),
-			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 12 ),
+			'default-all-time-stats-widget-instance'       => array( 'jpa/all-time-stats', 4, 1, 1 ),
+			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 4, 1, 2 ),
+			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 3 ),
+			'default-popular-post-widget-instance'         => array( 'jpa/popular-post', 2, 2, 4 ),
+			'default-total-views-widget-instance'          => array( 'jpa/total-views', 1, 1, 5 ),
+			'default-total-visitors-widget-instance'       => array( 'jpa/total-visitors', 1, 1, 6 ),
+			'default-popular-days-widget-instance'         => array( 'jpa/popular-days', 1, 1, 7 ),
+			'default-popular-hours-widget-instance'        => array( 'jpa/popular-hours', 1, 1, 8 ),
+			'default-traffic-views-activity-widget-instance' => array( 'jpa/traffic-views-activity', 4, 2, 9 ),
+			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 10 ),
+			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 11 ),
+			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 12 ),
+			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 13 ),
 		);
 
 		$this->assertSame( array_keys( $expected ), array_column( $layout, 'uuid' ) );
@@ -433,13 +434,19 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$this->assertNotContains( 'jpa/stats-emails', $layout_types );
 		// The Comments module ships as two focused widgets, not one toggled widget.
 		$this->assertNotContains( 'jpa/comments', $layout_types );
-		// Total views and Total visitors carry the totals row instead.
-		$this->assertNotContains( 'jpa/all-time-stats', $layout_types );
 
 		// Highlights falls back to the widget's own default metric list.
 		$this->assertArrayNotHasKey(
 			'attributes',
 			$layout_by_uuid['default-annual-highlights-widget-instance']
+		);
+
+		// All-time stats narrows the widget's own default, which also has Comments.
+		$this->assertSame(
+			array(
+				'metrics' => array( 'views', 'visitors', 'posts' ),
+			),
+			$layout_by_uuid['default-all-time-stats-widget-instance']['attributes']
 		);
 
 		$this->assertSame(

--- a/projects/packages/premium-analytics/widgets/all-time-stats/widget.ts
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/widget.ts
@@ -15,6 +15,12 @@ import { ArrayCheckboxField } from '@jetpack-premium-analytics/fields';
  * and label of each metric. Single source for the settings checkboxes and the
  * rendered tiles so the two cannot drift apart; `render.tsx` maps the ids to
  * icons and summary fields.
+ *
+ * The Insights default layout hardcodes a subset of these ids server-side
+ * (`src/dashboard-layout.php`, the `jpa/all-time-stats` instance), so renaming
+ * an id means updating both. A rename here alone is silent: unknown ids are
+ * filtered out in `render.tsx` and the default instance falls through to the
+ * "select a metric" empty state.
  */
 export const ALL_TIME_STATS_METRICS = [
 	{ id: 'views', label: __( 'Views', 'jetpack-premium-analytics-pkg' ) },

--- a/projects/plugins/jetpack/changelog/wooprd-3701-insights-all-time-stats
+++ b/projects/plugins/jetpack/changelog/wooprd-3701-insights-all-time-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Stats: Show all-time views, visitors, and posts on the default Insights page.

--- a/projects/plugins/jetpack/changelog/wooprd-3701-insights-all-time-stats
+++ b/projects/plugins/jetpack/changelog/wooprd-3701-insights-all-time-stats
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Stats: Show all-time views, visitors, and posts on the default Insights page.
+Premium Analytics: Show all-time views, visitors, and posts in the default Insights layout.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooprd-3701-insights-all-time-stats
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooprd-3701-insights-all-time-stats
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Stats: Show all-time views, visitors, and posts on the default Insights page.
+Premium Analytics: Show all-time views, visitors, and posts in the default Insights layout.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooprd-3701-insights-all-time-stats
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooprd-3701-insights-all-time-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Show all-time views, visitors, and posts on the default Insights page.

--- a/projects/plugins/premium-analytics/changelog/wooprd-3701-insights-all-time-stats
+++ b/projects/plugins/premium-analytics/changelog/wooprd-3701-insights-all-time-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Insights: Show all-time views, visitors, and posts on the default page.

--- a/projects/plugins/premium-analytics/changelog/wooprd-3701-insights-all-time-stats
+++ b/projects/plugins/premium-analytics/changelog/wooprd-3701-insights-all-time-stats
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Insights: Show all-time views, visitors, and posts on the default page.
+Insights: Show all-time views, visitors, and posts in the default layout.

--- a/projects/plugins/wpcomsh/changelog/wooprd-3701-insights-all-time-stats
+++ b/projects/plugins/wpcomsh/changelog/wooprd-3701-insights-all-time-stats
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Stats: Show all-time views, visitors, and posts on the default Insights page.
+Premium Analytics: Show all-time views, visitors, and posts in the default Insights layout.

--- a/projects/plugins/wpcomsh/changelog/wooprd-3701-insights-all-time-stats
+++ b/projects/plugins/wpcomsh/changelog/wooprd-3701-insights-all-time-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Show all-time views, visitors, and posts on the default Insights page.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-2021/add-the-all-time-stats-widget-to-the-insights-page.

## Why

Site owners on the Insights page couldn't see their lifetime totals anywhere. The page opened on the yearly highlights and never showed how many views, visitors and posts the site has collected since day one, so people had to go back to the old Stats screen for that. Now those totals sit right under Year in review and they're there as soon as the page loads.

## Proposed changes

* Add `jpa/all-time-stats` to the Insights default layout, right after Highlights, which is where the design puts it.
* Pass `metrics` on the default instance so it shows Views / Visitors / Posts. The widget's own default also turns on Comments, but the comment leaderboards further down the page already cover that.
* Size it 4×1 for now. The design pairs a narrow All-time stats card with Most popular time and Most popular day, and neither of those is in the default layout yet (WOOPRD-3703, WOOPRD-3704). A 1-wide card today would leave three empty columns, because the grid packs sparsely and the next row is a full-width tile. WOOPRD-3708 narrows it once those two join the row.
* Renumber the `order` args after it, and update the row comments.

The widget itself is untouched - it was already registered and already in the "Add widget" picker, it just wasn't in the default layout.

## Screenshots

Insights page, `1456x824`, all-time filter.

| Before | After |
| --- | --- |
| <img width="720" src="https://github.com/user-attachments/assets/dea6c758-6ba5-4589-8f92-c4f9bbb482af" /> | <img width="720" src="https://github.com/user-attachments/assets/c46a95d7-22c7-49d2-acc0-70062738bfb9" /> |

The card is all-time regardless of the year filter. On 2021 this site has nothing, so Highlights and Posting activity go empty while All-time stats keeps its totals:

<img width="720" src="https://github.com/user-attachments/assets/3db32b06-847a-4aa6-a2d3-ecce5b6bfd7f" />

## Verification

The resolved default layout, dumped from the running site, showing the new entry at order 1 with its metrics attribute:

<details>
<summary>Output</summary>

```text
$ wp eval 'foreach ( get_dashboard_default_layout_for( "analytics/insights" ) as $w ) { ... }'

 0  jpa/annual-highlights            w=4 h=1
 1  jpa/all-time-stats               w=4 h=1  attributes={"metrics":["views","visitors","posts"]}
 2  jpa/posting-activity             w=4 h=1
 3  jpa/latest-post                  w=2 h=2
 4  jpa/popular-post                 w=2 h=2
 5  jpa/total-views                  w=1 h=1
 6  jpa/total-visitors               w=1 h=1
 7  jpa/popular-days                 w=1 h=1
 8  jpa/popular-hours                w=1 h=1
 9  jpa/traffic-views-activity       w=4 h=2
10  jpa/most-commented-posts         w=1 h=2
11  jpa/most-commented-authors       w=1 h=2
13  jpa/tags                         w=1 h=2
```

(order 12 is `jpa/shares`, which is stripped on non-Simple sites - existing behaviour.)

</details>

<details>
<summary>Tests</summary>

```text
$ composer phpunit
OK (486 tests, 1593 assertions)
```

</details>

## Related product discussion/links

* WOOPRD-3701
* Parent issue: WOOPRD-3672

## Does this pull request change what data or activity we track or use?

No. The widget reads the all-time site summary through `useStatsSite()`, which the dashboard already fetches for other widgets.

## Testing instructions

* Build the package: `jp build packages/premium-analytics --deps`.
* Go to **Stats v2 → Insights** in wp-admin.
* If you've customised the Insights layout before, the new default won't show up - your saved layout wins. Hit **Customize → ⋮ → Reset** first (or clear the `jetpack-premium-analytics/dashboard` scope from your `wp_persisted_preferences` user meta).
* Ensure an **All-time stats** card shows up as the second row, directly under Highlights / Year in review.
* Ensure it shows exactly three tiles - Views, Visitors and Posts - and no Comments tile.
* Ensure the numbers are the site's lifetime totals, not the selected period. Switch the year filter between **All time** and a single year and ensure the All-time stats numbers don't change.
* Ensure the rest of the page still fills the 4-column grid with no empty gaps - Posting activity, the two post spotlights, the totals row, the views heatmap and the leaderboards should all sit where they did before, just one row lower.
* Ensure the widget is still addable from **Add widget** and that removing it from the layout works as usual.
* On a Jetpack (non-Simple) site the Shares widget is stripped from the last row as before - that's unrelated to this change but worth not being surprised by.
