### PR TITLE
Premium Analytics: add Most popular time to the default Insights layout

### DIFF
--- a/projects/packages/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-i18n
+++ b/projects/packages/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Insights: show the Most popular time day and hour in the site's locale.

--- a/projects/packages/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-i18n
+++ b/projects/packages/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-i18n
@@ -1,4 +1,4 @@
-Significance: Patch
-Type: Fixed
+Significance: patch
+Type: fixed
 
 Insights: Show the Most popular time day and hour in the site's locale.

--- a/projects/packages/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-i18n
+++ b/projects/packages/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-i18n
@@ -1,4 +1,4 @@
-Significance: patch
-Type: fixed
+Significance: Patch
+Type: Fixed
 
-Insights: show the Most popular time day and hour in the site's locale.
+Insights: Show the Most popular time day and hour in the site's locale.

--- a/projects/packages/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-insights
+++ b/projects/packages/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-insights
@@ -1,4 +1,4 @@
-Significance: Minor
-Type: Added
+Significance: minor
+Type: added
 
 Insights: Add the Most popular time card to the default layout.

--- a/projects/packages/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-insights
+++ b/projects/packages/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-insights
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Insights: add the Most popular time card to the default layout.

--- a/projects/packages/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-insights
+++ b/projects/packages/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-insights
@@ -1,4 +1,4 @@
-Significance: minor
-Type: added
+Significance: Minor
+Type: Added
 
-Insights: add the Most popular time card to the default layout.
+Insights: Add the Most popular time card to the default layout.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/insights.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/insights.test.ts
@@ -104,4 +104,32 @@ describe( 'Stats insights normalizer', () => {
 			sanitizeStatsInsightsResponse( { highest_day_of_week: 6, highest_day_percent: 17.4 } )
 		).toMatchObject( { percent: 17 } );
 	} );
+
+	it( 'rejects a share outside 0-100 rather than captioning a peak with it', () => {
+		// The caption formats with `signDisplay: 'never'`, so a negative share
+		// would reach the reader as a plausible positive percent.
+		for ( const highest_day_percent of [ -5, -0.2, 101, 150 ] ) {
+			expect(
+				sanitizeStatsInsightsResponse( { highest_day_of_week: 6, highest_day_percent } )
+			).not.toHaveProperty( 'percent' );
+		}
+
+		expect(
+			sanitizeStatsInsightsResponse( { highest_day_of_week: 6, highest_day_percent: 100 } )
+		).toMatchObject( { percent: 100 } );
+	} );
+
+	it( 'reads each peak field independently of the others', () => {
+		// The sanitizer reports what the endpoint sent; which highlights an absent
+		// field hides is the widget's call, so an unreadable day must not take a
+		// readable hour down with it.
+		const report = sanitizeStatsInsightsResponse( {
+			highest_day_of_week: 'not a day',
+			highest_hour: 19,
+			highest_hour_percent: 5,
+		} );
+
+		expect( report ).not.toHaveProperty( 'dayOfWeek' );
+		expect( report ).toMatchObject( { hourOfDay: 19, hourPercent: 5 } );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/insights.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/insights.test.ts
@@ -9,8 +9,8 @@ describe( 'Stats insights normalizer', () => {
 
 	it( 'normalizes insights using the Calypso payload shape', () => {
 		expect( sanitizeStatsInsightsResponse( insightsFixture ) ).toEqual( {
-			day: 'Sunday',
-			hour: '11:00 AM',
+			dayOfWeek: 6,
+			hourOfDay: 11,
 			hourPercent: 5,
 			percent: 10,
 			hourlyViews: {
@@ -33,5 +33,24 @@ describe( 'Stats insights normalizer', () => {
 				},
 			],
 		} );
+	} );
+
+	it( 'passes the weekday index through Monday-based', () => {
+		// 6 wraps to Sunday in every other case here, which would also pass if the
+		// index were rebased; 0 pins the documented Monday-first contract.
+		expect(
+			sanitizeStatsInsightsResponse( { highest_day_of_week: 0, highest_hour: 0 } )
+		).toMatchObject( { dayOfWeek: 0, hourOfDay: 0 } );
+	} );
+
+	it( 'omits the hour rather than reporting midnight when the payload has none', () => {
+		const report = sanitizeStatsInsightsResponse( {
+			highest_day_of_week: 6,
+			highest_day_percent: 10,
+		} );
+
+		expect( report.dayOfWeek ).toBe( 6 );
+		expect( report ).not.toHaveProperty( 'hourOfDay' );
+		expect( report ).not.toHaveProperty( 'hourPercent' );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/insights.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/insights.test.ts
@@ -2,9 +2,23 @@ import { sanitizeStatsInsightsResponse } from '..';
 import { insightsFixture } from '../__fixtures__/insights';
 
 describe( 'Stats insights normalizer', () => {
-	it( 'returns an empty object for invalid payloads', () => {
-		expect( sanitizeStatsInsightsResponse( undefined ) ).toEqual( {} );
-		expect( sanitizeStatsInsightsResponse( { highest_day_of_week: false } ) ).toEqual( {} );
+	it( 'reports no peak for invalid payloads', () => {
+		expect( sanitizeStatsInsightsResponse( undefined ) ).not.toHaveProperty( 'dayOfWeek' );
+		expect( sanitizeStatsInsightsResponse( { highest_day_of_week: false } ) ).not.toHaveProperty(
+			'dayOfWeek'
+		);
+	} );
+
+	it( 'keeps the years when the payload has no peak day', () => {
+		// One report feeds two widgets: a site with posts but negligible views has
+		// years and no peak, and Annual highlights must still get its totals.
+		const report = sanitizeStatsInsightsResponse( {
+			years: [ { year: '2026', total_posts: 12 } ],
+		} );
+
+		expect( report ).not.toHaveProperty( 'dayOfWeek' );
+		expect( report.years ).toHaveLength( 1 );
+		expect( report.years?.[ 0 ] ).toMatchObject( { year: '2026', total_posts: 12 } );
 	} );
 
 	it( 'normalizes insights using the Calypso payload shape', () => {
@@ -68,7 +82,26 @@ describe( 'Stats insights normalizer', () => {
 		expect(
 			sanitizeStatsInsightsResponse( { highest_day_of_week: 6, highest_hour: 24 } )
 		).not.toHaveProperty( 'hourOfDay' );
-		// An out-of-range weekday is not a peak at all, so the whole report goes.
-		expect( sanitizeStatsInsightsResponse( { highest_day_of_week: 7 } ) ).toEqual( {} );
+		expect( sanitizeStatsInsightsResponse( { highest_day_of_week: 7 } ) ).not.toHaveProperty(
+			'dayOfWeek'
+		);
+		// Salvaged rather than rejected by `parseInt`, which would read as Thursday.
+		expect( sanitizeStatsInsightsResponse( { highest_day_of_week: 3.9 } ) ).not.toHaveProperty(
+			'dayOfWeek'
+		);
+	} );
+
+	it( 'rejects a share it cannot read instead of reporting 0%', () => {
+		for ( const highest_day_percent of [ '', false, 'abc', [], {} ] ) {
+			expect(
+				sanitizeStatsInsightsResponse( { highest_day_of_week: 6, highest_day_percent } )
+			).not.toHaveProperty( 'percent' );
+		}
+	} );
+
+	it( 'rounds a fractional share to a whole percent', () => {
+		expect(
+			sanitizeStatsInsightsResponse( { highest_day_of_week: 6, highest_day_percent: 17.4 } )
+		).toMatchObject( { percent: 17 } );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/insights.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/insights.test.ts
@@ -53,4 +53,22 @@ describe( 'Stats insights normalizer', () => {
 		expect( report ).not.toHaveProperty( 'hourOfDay' );
 		expect( report ).not.toHaveProperty( 'hourPercent' );
 	} );
+
+	it( 'omits a share the payload did not send rather than reporting 0%', () => {
+		const report = sanitizeStatsInsightsResponse( { highest_day_of_week: 6, highest_hour: 19 } );
+
+		expect( report ).not.toHaveProperty( 'percent' );
+		expect( report ).not.toHaveProperty( 'hourPercent' );
+	} );
+
+	it( 'accepts a stringified hour and rejects one out of range', () => {
+		expect(
+			sanitizeStatsInsightsResponse( { highest_day_of_week: 6, highest_hour: '19' } )
+		).toMatchObject( { hourOfDay: 19 } );
+		expect(
+			sanitizeStatsInsightsResponse( { highest_day_of_week: 6, highest_hour: 24 } )
+		).not.toHaveProperty( 'hourOfDay' );
+		// An out-of-range weekday is not a peak at all, so the whole report goes.
+		expect( sanitizeStatsInsightsResponse( { highest_day_of_week: 7 } ) ).toEqual( {} );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/insights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/insights.ts
@@ -1,4 +1,3 @@
-import { format } from 'date-fns';
 import { safeParseFloat, safeParseInt } from '../../utils/parsing';
 import { coerceStatsRecord } from './utils';
 
@@ -18,28 +17,21 @@ export type StatsInsightsYear = {
 export type StatsInsightsHourlyViews = Record< string, number >;
 
 type StatsInsightsData = {
-	day: string;
+	/**
+	 * Peak weekday as the endpoint reports it: a Monday-based index, which the
+	 * WordPress locale table (Sunday-based) does not share. Kept numeric so the
+	 * label is built in the site's locale where it is rendered.
+	 */
+	dayOfWeek: number;
 	percent: number;
-	hour: string;
+	/** Peak hour of the day, 0-23, in the site's timezone. */
+	hourOfDay: number;
 	hourPercent: number;
 	hourlyViews: StatsInsightsHourlyViews;
 	years: StatsInsightsYear[];
 };
 
 export type StatsInsightsResponse = Partial< StatsInsightsData >;
-
-function getDayName( highestDayOfWeek: number ) {
-	const dayOfWeek = ( highestDayOfWeek + 1 ) % 7;
-	const date = new Date( 2026, 0, 4 + dayOfWeek, 12 );
-
-	return format( date, 'EEEE' );
-}
-
-function getHourLabel( hour: unknown ) {
-	const date = new Date( 2026, 0, 4, safeParseInt( hour ) );
-
-	return format( date, 'p' );
-}
 
 function normalizeInsightsYear( year: unknown ): StatsInsightsYear {
 	const payload = coerceStatsRecord( year );
@@ -74,10 +66,16 @@ export function sanitizeStatsInsightsResponse( response: unknown ): StatsInsight
 	}
 
 	return {
-		day: getDayName( payload.highest_day_of_week ),
+		dayOfWeek: payload.highest_day_of_week,
 		percent: Math.round( safeParseFloat( payload.highest_day_percent ) ),
-		hour: getHourLabel( payload.highest_hour ),
-		hourPercent: Math.round( safeParseFloat( payload.highest_hour_percent ) ),
+		// A missing hour is not hour 0. Coercing it would report midnight as the
+		// site's peak, which reads as a real answer rather than a missing one.
+		...( typeof payload.highest_hour === 'number'
+			? {
+					hourOfDay: payload.highest_hour,
+					hourPercent: Math.round( safeParseFloat( payload.highest_hour_percent ) ),
+			  }
+			: {} ),
 		hourlyViews: normalizeHourlyViews( payload.hourly_views ),
 		years: Array.isArray( payload.years ) ? payload.years.map( normalizeInsightsYear ) : [],
 	};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/insights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/insights.ts
@@ -39,18 +39,45 @@ type StatsInsightsData = {
 export type StatsInsightsResponse = Partial< StatsInsightsData >;
 
 /**
- * Reads a bounded index, rejecting anything the endpoint would not have meant:
- * absent, non-numeric, or outside the range. Returning `undefined` rather than a
- * fallback keeps a missing field from reading as a real answer downstream.
+ * Reads a finite number, or nothing when the value cannot be one.
+ *
+ * Returning `undefined` rather than a fallback is the point: a coerced 0 is
+ * indistinguishable downstream from a measured 0.
+ *
+ * @param value - Raw payload value.
+ * @return The number, or `undefined`.
+ */
+function readNumber( value: unknown ): number | undefined {
+	// Numbers and numeric strings only — `Number` reads `[]` as 0 and `[5]` as 5,
+	// so anything else is a shape the endpoint did not mean. `Number`, not
+	// `parseInt`: parsing salvages a leading digit, so `3.9` or `6abc` would
+	// truncate into a neighbouring value that looks like a real answer.
+	if ( typeof value !== 'number' && typeof value !== 'string' ) {
+		return undefined;
+	}
+
+	if ( typeof value === 'string' && value.trim() === '' ) {
+		return undefined;
+	}
+
+	const parsed = Number( value );
+
+	return Number.isFinite( parsed ) ? parsed : undefined;
+}
+
+/**
+ * Reads a bounded whole index, rejecting anything outside the range.
  *
  * @param value - Raw payload value.
  * @param max   - Highest index the field may take.
  * @return The index, or `undefined` when the value cannot be one.
  */
 function readIndex( value: unknown, max: number ): number | undefined {
-	const parsed = safeParseInt( value, NaN );
+	const parsed = readNumber( value );
 
-	return Number.isInteger( parsed ) && parsed >= 0 && parsed <= max ? parsed : undefined;
+	return parsed !== undefined && Number.isInteger( parsed ) && parsed >= 0 && parsed <= max
+		? parsed
+		: undefined;
 }
 
 function normalizeInsightsYear( year: unknown ): StatsInsightsYear {
@@ -71,16 +98,19 @@ function normalizeInsightsYear( year: unknown ): StatsInsightsYear {
 }
 
 /**
- * Reads a share as a whole percent under the given key, or nothing at all.
+ * Reads a share as a whole percent, or nothing when the payload has none.
+ *
+ * Rejects the same junk `readIndex` does rather than only absent values: a
+ * share that fell back to 0 would caption a real peak with "0% of views", which
+ * reads as a measurement rather than a gap.
  *
  * @param value - Raw payload value.
- * @param key   - Field name to emit it under.
- * @return A single-entry object, or an empty one when the share is absent.
+ * @return The whole percent, or `undefined` when the value cannot be one.
  */
-function readShare( value: unknown, key: 'percent' | 'hourPercent' ) {
-	return value === undefined || value === null
-		? {}
-		: { [ key ]: Math.round( safeParseFloat( value ) ) };
+function readShare( value: unknown ): number | undefined {
+	const parsed = readNumber( value );
+
+	return parsed === undefined ? undefined : Math.round( parsed );
 }
 
 function normalizeHourlyViews( hourlyViews: unknown ): StatsInsightsHourlyViews {
@@ -94,22 +124,22 @@ function normalizeHourlyViews( hourlyViews: unknown ): StatsInsightsHourlyViews 
 export function sanitizeStatsInsightsResponse( response: unknown ): StatsInsightsResponse {
 	const payload = coerceStatsRecord( response );
 	const dayOfWeek = readIndex( payload.highest_day_of_week, 6 );
-
-	if ( dayOfWeek === undefined ) {
-		return {};
-	}
-
 	const hourOfDay = readIndex( payload.highest_hour, 23 );
+	const percent = readShare( payload.highest_day_percent );
+	const hourPercent = readShare( payload.highest_hour_percent );
 
-	// Each field is omitted rather than defaulted when the payload lacks it: a
-	// missing hour is not midnight and a missing share is not 0%, and either
-	// coercion reads as a real answer instead of an absent one.
+	// Every field stands or falls on its own. One report feeds two widgets — the
+	// peak highlights and Annual highlights' per-year totals — so a site with
+	// years but no peak day must not lose its years to the missing peak. Within
+	// the peak itself, a missing hour is not midnight and a missing share is not
+	// 0%: either coercion reads as a real answer rather than an absent one.
 	return {
-		dayOfWeek,
-		...readShare( payload.highest_day_percent, 'percent' ),
-		...( hourOfDay === undefined
+		...( dayOfWeek === undefined
 			? {}
-			: { hourOfDay, ...readShare( payload.highest_hour_percent, 'hourPercent' ) } ),
+			: { dayOfWeek, ...( percent === undefined ? {} : { percent } ) } ),
+		...( dayOfWeek === undefined || hourOfDay === undefined
+			? {}
+			: { hourOfDay, ...( hourPercent === undefined ? {} : { hourPercent } ) } ),
 		hourlyViews: normalizeHourlyViews( payload.hourly_views ),
 		years: Array.isArray( payload.years ) ? payload.years.map( normalizeInsightsYear ) : [],
 	};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/insights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/insights.ts
@@ -15,9 +15,9 @@ export type StatsInsightsYear = {
 };
 
 /**
- * Views keyed by hour. Unlike `hourOfDay`, these keys are UTC — the endpoint
- * applies the site's offset to the peak hour but not to this map — so they are
- * not interchangeable and this one must not be fed to an hour formatter.
+ * Views keyed by the hour bucket's own timestamp (`2022-11-26 04:00:00`), not
+ * by hour of day: each key names one dated hour, so they are not
+ * interchangeable with `hourOfDay` and must not be fed to an hour formatter.
  */
 export type StatsInsightsHourlyViews = Record< string, number >;
 
@@ -100,9 +100,11 @@ function normalizeInsightsYear( year: unknown ): StatsInsightsYear {
 /**
  * Reads a share as a whole percent, or nothing when the payload has none.
  *
- * Rejects the same junk `readIndex` does rather than only absent values: a
- * share that fell back to 0 would caption a real peak with "0% of views", which
- * reads as a measurement rather than a gap.
+ * Bounded like `readIndex`, and rejecting junk rather than only absent values:
+ * a share that fell back to 0 would caption a real peak with "0% of views", and
+ * one outside 0-100 is not a measurement either — the caption formats with
+ * `signDisplay: 'never'`, so a negative share would read as a plausible
+ * positive percent.
  *
  * @param value - Raw payload value.
  * @return The whole percent, or `undefined` when the value cannot be one.
@@ -110,7 +112,9 @@ function normalizeInsightsYear( year: unknown ): StatsInsightsYear {
 function readShare( value: unknown ): number | undefined {
 	const parsed = readNumber( value );
 
-	return parsed === undefined ? undefined : Math.round( parsed );
+	// Bounded before rounding, not after: `Math.round( -0.2 )` is `-0`, which
+	// passes a `>= 0` test and captions a peak with "0% of views".
+	return parsed !== undefined && parsed >= 0 && parsed <= 100 ? Math.round( parsed ) : undefined;
 }
 
 function normalizeHourlyViews( hourlyViews: unknown ): StatsInsightsHourlyViews {
@@ -129,17 +133,16 @@ export function sanitizeStatsInsightsResponse( response: unknown ): StatsInsight
 	const hourPercent = readShare( payload.highest_hour_percent );
 
 	// Every field stands or falls on its own. One report feeds two widgets — the
-	// peak highlights and Annual highlights' per-year totals — so a site with
-	// years but no peak day must not lose its years to the missing peak. Within
-	// the peak itself, a missing hour is not midnight and a missing share is not
-	// 0%: either coercion reads as a real answer rather than an absent one.
+	// peak highlights and Year in review's per-year totals — so a site with years
+	// but no peak day must not lose its years to the missing peak. A missing hour
+	// is not midnight and a missing share is not 0%: either coercion reads as a
+	// real answer rather than an absent one. Which highlights an absent field
+	// hides is the widget's call, not this one's.
 	return {
-		...( dayOfWeek === undefined
-			? {}
-			: { dayOfWeek, ...( percent === undefined ? {} : { percent } ) } ),
-		...( dayOfWeek === undefined || hourOfDay === undefined
-			? {}
-			: { hourOfDay, ...( hourPercent === undefined ? {} : { hourPercent } ) } ),
+		...( dayOfWeek === undefined ? {} : { dayOfWeek } ),
+		...( percent === undefined ? {} : { percent } ),
+		...( hourOfDay === undefined ? {} : { hourOfDay } ),
+		...( hourPercent === undefined ? {} : { hourPercent } ),
 		hourlyViews: normalizeHourlyViews( payload.hourly_views ),
 		years: Array.isArray( payload.years ) ? payload.years.map( normalizeInsightsYear ) : [],
 	};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/insights.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/insights.ts
@@ -14,6 +14,11 @@ export type StatsInsightsYear = {
 	avg_images: number;
 };
 
+/**
+ * Views keyed by hour. Unlike `hourOfDay`, these keys are UTC — the endpoint
+ * applies the site's offset to the peak hour but not to this map — so they are
+ * not interchangeable and this one must not be fed to an hour formatter.
+ */
 export type StatsInsightsHourlyViews = Record< string, number >;
 
 type StatsInsightsData = {
@@ -24,7 +29,7 @@ type StatsInsightsData = {
 	 */
 	dayOfWeek: number;
 	percent: number;
-	/** Peak hour of the day, 0-23, in the site's timezone. */
+	/** Peak hour of the day, 0-23, with the site's offset already applied. */
 	hourOfDay: number;
 	hourPercent: number;
 	hourlyViews: StatsInsightsHourlyViews;
@@ -32,6 +37,21 @@ type StatsInsightsData = {
 };
 
 export type StatsInsightsResponse = Partial< StatsInsightsData >;
+
+/**
+ * Reads a bounded index, rejecting anything the endpoint would not have meant:
+ * absent, non-numeric, or outside the range. Returning `undefined` rather than a
+ * fallback keeps a missing field from reading as a real answer downstream.
+ *
+ * @param value - Raw payload value.
+ * @param max   - Highest index the field may take.
+ * @return The index, or `undefined` when the value cannot be one.
+ */
+function readIndex( value: unknown, max: number ): number | undefined {
+	const parsed = safeParseInt( value, NaN );
+
+	return Number.isInteger( parsed ) && parsed >= 0 && parsed <= max ? parsed : undefined;
+}
 
 function normalizeInsightsYear( year: unknown ): StatsInsightsYear {
 	const payload = coerceStatsRecord( year );
@@ -50,6 +70,19 @@ function normalizeInsightsYear( year: unknown ): StatsInsightsYear {
 	};
 }
 
+/**
+ * Reads a share as a whole percent under the given key, or nothing at all.
+ *
+ * @param value - Raw payload value.
+ * @param key   - Field name to emit it under.
+ * @return A single-entry object, or an empty one when the share is absent.
+ */
+function readShare( value: unknown, key: 'percent' | 'hourPercent' ) {
+	return value === undefined || value === null
+		? {}
+		: { [ key ]: Math.round( safeParseFloat( value ) ) };
+}
+
 function normalizeHourlyViews( hourlyViews: unknown ): StatsInsightsHourlyViews {
 	const payload = coerceStatsRecord( hourlyViews );
 
@@ -60,22 +93,23 @@ function normalizeHourlyViews( hourlyViews: unknown ): StatsInsightsHourlyViews 
 
 export function sanitizeStatsInsightsResponse( response: unknown ): StatsInsightsResponse {
 	const payload = coerceStatsRecord( response );
+	const dayOfWeek = readIndex( payload.highest_day_of_week, 6 );
 
-	if ( typeof payload.highest_day_of_week !== 'number' ) {
+	if ( dayOfWeek === undefined ) {
 		return {};
 	}
 
+	const hourOfDay = readIndex( payload.highest_hour, 23 );
+
+	// Each field is omitted rather than defaulted when the payload lacks it: a
+	// missing hour is not midnight and a missing share is not 0%, and either
+	// coercion reads as a real answer instead of an absent one.
 	return {
-		dayOfWeek: payload.highest_day_of_week,
-		percent: Math.round( safeParseFloat( payload.highest_day_percent ) ),
-		// A missing hour is not hour 0. Coercing it would report midnight as the
-		// site's peak, which reads as a real answer rather than a missing one.
-		...( typeof payload.highest_hour === 'number'
-			? {
-					hourOfDay: payload.highest_hour,
-					hourPercent: Math.round( safeParseFloat( payload.highest_hour_percent ) ),
-			  }
-			: {} ),
+		dayOfWeek,
+		...readShare( payload.highest_day_percent, 'percent' ),
+		...( hourOfDay === undefined
+			? {}
+			: { hourOfDay, ...readShare( payload.highest_hour_percent, 'hourPercent' ) } ),
 		hourlyViews: normalizeHourlyViews( payload.hourly_views ),
 		years: Array.isArray( payload.years ) ? payload.years.map( normalizeInsightsYear ) : [],
 	};

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
@@ -6,7 +6,7 @@ import { setSettings } from '@wordpress/date';
  * Internal dependencies
  */
 import { EN_US_SETTINGS, ES_ES_SETTINGS, settingsFor } from '../__fixtures__/wp-date-settings';
-import { formatDate, formatWeekday } from '../format-date';
+import { formatDate, formatMondayFirstWeekday, formatWeekday } from '../format-date';
 
 // Midnight UTC, matching the fixtures' timezone, so no day shift is in play.
 const JUNE_21 = new Date( '2025-06-21T00:00:00+00:00' );
@@ -84,5 +84,14 @@ describe( 'formatDate', () => {
 		setSettings( EN_US_SETTINGS );
 
 		expect( formatDate( JUNE_21, 'dateTime' ) ).toBe( 'June 21, 2025 12:00 am' );
+	} );
+} );
+
+describe( 'formatMondayFirstWeekday', () => {
+	it( 'reads index 0 as Monday and 6 as Sunday', () => {
+		// The offset is the whole point of the helper: a missing or reversed one
+		// still yields a real weekday name, so both ends are pinned.
+		expect( formatMondayFirstWeekday( 0 ) ).toBe( 'Monday' );
+		expect( formatMondayFirstWeekday( 6 ) ).toBe( 'Sunday' );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
@@ -113,6 +113,19 @@ export const formatWeekday = ( weekday: number ): string => {
 	return weekdays[ weekday ] ?? '';
 };
 
+/**
+ * Return a full weekday name in the site's locale, from a Monday-first index.
+ *
+ * Stats payloads and weekday buckets count from Monday; the WordPress locale
+ * table counts from Sunday. Keeping that offset here means a caller cannot get
+ * it the wrong way round.
+ *
+ * @param weekday - Monday-based weekday index (`0` = Monday).
+ * @return The localized full weekday name.
+ */
+export const formatMondayFirstWeekday = ( weekday: number ): string =>
+	formatWeekday( ( weekday + 1 ) % 7 );
+
 /** 12-hour clock tokens, zero-padded and not. */
 const TWELVE_HOUR_TOKENS = new Set( [ 'g', 'h' ] );
 

--- a/projects/packages/premium-analytics/packages/formatters/src/date/index.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/index.ts
@@ -1,4 +1,10 @@
-export { formatDate, formatHourOfDay, formatWeekday, type DateFormatName } from './format-date';
+export {
+	formatDate,
+	formatHourOfDay,
+	formatMondayFirstWeekday,
+	formatWeekday,
+	type DateFormatName,
+} from './format-date';
 export {
 	formatDateRange,
 	formatDateRangeCompact,

--- a/projects/packages/premium-analytics/packages/formatters/src/index.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/index.ts
@@ -1,6 +1,7 @@
 export {
 	formatDate,
 	formatHourOfDay,
+	formatMondayFirstWeekday,
 	formatWeekday,
 	formatDateRange,
 	formatDateRangeCompact,

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -290,24 +290,22 @@ function get_dashboard_default_section_layouts() {
 				4,
 				1
 			),
-			// Row 2: lifetime totals. Full width until Most popular time joins
-			// the row (WOOA7S-2019); WOOA7S-2009 then settles the arrangement.
+			// Row 2: the at-a-glance cards, as the design pairs them. All three are
+			// two rows tall so their display-sized figures fit without scrolling: a
+			// 1x1 tile is 200px, which the two-field cards overflow. WOOA7S-2009
+			// settles the final widths.
 			get_dashboard_default_widget_instance(
 				'default-all-time-stats-widget-instance',
 				'jpa/all-time-stats',
 				1,
-				4,
-				1,
+				2,
+				2,
 				array(
 					// The design shows three totals; the widget's own default adds
 					// Comments, which the comment leaderboards below already cover.
 					'metrics' => array( 'views', 'visitors', 'posts' ),
 				)
 			),
-			// Row 3: most popular day. Two rows tall so both fields fit without
-			// scrolling; a 1x1 tile is 200px, which the two display-sized figures
-			// overflow. The design shares this row with All-time stats and Most
-			// popular time, which WOOA7S-2009 arranges once WOOA7S-2019 lands.
 			get_dashboard_default_widget_instance(
 				'default-most-popular-day-widget-instance',
 				'jpa/most-popular-day',
@@ -315,95 +313,102 @@ function get_dashboard_default_section_layouts() {
 				1,
 				2
 			),
-			// Row 4: posting-activity heatmap.
+			get_dashboard_default_widget_instance(
+				'default-most-popular-time-widget-instance',
+				'jpa/most-popular-time',
+				3,
+				1,
+				2
+			),
+			// Row 3: posting-activity heatmap.
 			get_dashboard_default_widget_instance(
 				'default-posting-activity-widget-instance',
 				'jpa/posting-activity',
-				3,
+				4,
 				4,
 				1
 			),
-			// Row 5: the two post spotlights.
+			// Row 4: the two post spotlights.
 			get_dashboard_default_widget_instance(
 				'default-latest-post-widget-instance',
 				'jpa/latest-post',
-				4,
+				5,
 				2,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-popular-post-widget-instance',
 				'jpa/popular-post',
-				5,
+				6,
 				2,
 				2
 			),
-			// Row 6: the period totals and the weekday and hour-of-day
+			// Row 5: the period totals and the weekday and hour-of-day
 			// distributions.
 			get_dashboard_default_widget_instance(
 				'default-total-views-widget-instance',
 				'jpa/total-views',
-				6,
+				7,
 				1,
 				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-total-visitors-widget-instance',
 				'jpa/total-visitors',
-				7,
+				8,
 				1,
 				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-popular-days-widget-instance',
 				'jpa/popular-days',
-				8,
+				9,
 				1,
 				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-popular-hours-widget-instance',
 				'jpa/popular-hours',
-				9,
+				10,
 				1,
 				1
 			),
-			// Row 7: daily views heatmap. Two rows tall, as in the prototype: the
+			// Row 6: daily views heatmap. Two rows tall, as in the prototype: the
 			// cells are sized from the tile's height, and only at this height do they
 			// grow wide enough to label each day with its view count.
 			get_dashboard_default_widget_instance(
 				'default-traffic-views-activity-widget-instance',
 				'jpa/traffic-views-activity',
-				10,
+				11,
 				4,
 				2
 			),
-			// Row 8: the comment leaderboards, shares, and tags.
+			// Row 7: the comment leaderboards, shares, and tags.
 			get_dashboard_default_widget_instance(
 				'default-most-commented-posts-widget-instance',
 				'jpa/most-commented-posts',
-				11,
+				12,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-commented-authors-widget-instance',
 				'jpa/most-commented-authors',
-				12,
+				13,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-shares-widget-instance',
 				'jpa/shares',
-				13,
+				14,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-tags-widget-instance',
 				'jpa/tags',
-				14,
+				15,
 				1,
 				2
 			),

--- a/projects/packages/premium-analytics/tests/groups/widgets-shared-route-mock-part2.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/widgets-shared-route-mock-part2.test.tsx
@@ -1,6 +1,7 @@
 // See README.md before adding a suite to this group.
 
 import '../../widgets/most-popular-day/__tests__/most-popular-day.test';
+import '../../widgets/most-popular-time/__tests__/most-popular-time.test';
 import '../../widgets/site-overview/__tests__/site-overview.test';
 import '../../widgets/subscriber-highlights/__tests__/subscriber-highlights.test';
 import '../../widgets/tags/__tests__/tags.test';

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -393,26 +393,26 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$layout_by_uuid = array_column( $layout, null, 'uuid' );
 		$layout_types   = array_column( $layout, 'type' );
 
-		// uuid => [ type, width, height, order ]. Most popular day holds one column
-		// of a row All-time stats and Most popular time share in the design;
-		// WOOA7S-2009 arranges it once WOOA7S-2019 lands. Every other row fills
-		// the four-column grid.
+		// uuid => [ type, width, height, order ]. The at-a-glance cards share row 2
+		// as the design pairs them; WOOA7S-2009 settles the final widths. Every row
+		// fills the four-column grid.
 		$expected = array(
 			'default-annual-highlights-widget-instance'    => array( 'jpa/annual-highlights', 4, 1, 0 ),
-			'default-all-time-stats-widget-instance'       => array( 'jpa/all-time-stats', 4, 1, 1 ),
+			'default-all-time-stats-widget-instance'       => array( 'jpa/all-time-stats', 2, 2, 1 ),
 			'default-most-popular-day-widget-instance'     => array( 'jpa/most-popular-day', 1, 2, 2 ),
-			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 4, 1, 3 ),
-			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 4 ),
-			'default-popular-post-widget-instance'         => array( 'jpa/popular-post', 2, 2, 5 ),
-			'default-total-views-widget-instance'          => array( 'jpa/total-views', 1, 1, 6 ),
-			'default-total-visitors-widget-instance'       => array( 'jpa/total-visitors', 1, 1, 7 ),
-			'default-popular-days-widget-instance'         => array( 'jpa/popular-days', 1, 1, 8 ),
-			'default-popular-hours-widget-instance'        => array( 'jpa/popular-hours', 1, 1, 9 ),
-			'default-traffic-views-activity-widget-instance' => array( 'jpa/traffic-views-activity', 4, 2, 10 ),
-			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 11 ),
-			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 12 ),
-			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 13 ),
-			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 14 ),
+			'default-most-popular-time-widget-instance'    => array( 'jpa/most-popular-time', 1, 2, 3 ),
+			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 4, 1, 4 ),
+			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 5 ),
+			'default-popular-post-widget-instance'         => array( 'jpa/popular-post', 2, 2, 6 ),
+			'default-total-views-widget-instance'          => array( 'jpa/total-views', 1, 1, 7 ),
+			'default-total-visitors-widget-instance'       => array( 'jpa/total-visitors', 1, 1, 8 ),
+			'default-popular-days-widget-instance'         => array( 'jpa/popular-days', 1, 1, 9 ),
+			'default-popular-hours-widget-instance'        => array( 'jpa/popular-hours', 1, 1, 10 ),
+			'default-traffic-views-activity-widget-instance' => array( 'jpa/traffic-views-activity', 4, 2, 11 ),
+			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 12 ),
+			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 13 ),
+			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 14 ),
+			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 15 ),
 		);
 
 		$this->assertSame( array_keys( $expected ), array_column( $layout, 'uuid' ) );

--- a/projects/packages/premium-analytics/widgets/most-popular-time/__tests__/most-popular-time.test.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/__tests__/most-popular-time.test.tsx
@@ -4,6 +4,7 @@
 import { queryClient } from '@jetpack-premium-analytics/data';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
+import { getSettings, setSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
@@ -26,6 +27,25 @@ const INSIGHTS_RESPONSE = {
 	highest_hour_percent: 5.2,
 };
 
+/** Whatever `@wordpress/date` ships, captured before a test installs settings. */
+const DEFAULT_DATE_SETTINGS = getSettings();
+
+/**
+ * A Spanish site on a 24-hour clock. Only the fields the two labels read are
+ * varied; the rest is inherited, so the fixture cannot drift from the package's
+ * own defaults. The locale name is unique because `setSettings` skips
+ * redefining one it already knows.
+ */
+const ES_ES_SETTINGS = {
+	...DEFAULT_DATE_SETTINGS,
+	l10n: {
+		...DEFAULT_DATE_SETTINGS.l10n,
+		locale: 'es_ES_most_popular_time_test',
+		weekdays: [ 'domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado' ],
+	},
+	formats: { ...DEFAULT_DATE_SETTINGS.formats, time: 'H:i' },
+};
+
 describe( 'MostPopularTimeWidget', () => {
 	beforeEach( () => {
 		// The data package's query client is a module-level singleton; drop its
@@ -33,6 +53,9 @@ describe( 'MostPopularTimeWidget', () => {
 		queryClient.clear();
 		mockApiFetch.mockReset();
 		mockApiFetch.mockResolvedValue( INSIGHTS_RESPONSE );
+		// Settings are global, so restore them for the tests that read the
+		// English labels after the locale test has installed a Spanish site.
+		setSettings( DEFAULT_DATE_SETTINGS );
 	} );
 
 	it( 'renders the peak day and hour with their share of views', async () => {
@@ -62,6 +85,19 @@ describe( 'MostPopularTimeWidget', () => {
 		expect( path ).not.toContain( '?' );
 	} );
 
+	it( 'labels the peak in the site locale and time format', async () => {
+		// Same payload on a Spanish site with a 24-hour clock: a hardcoded English
+		// weekday table or a fixed 12-hour clock passes every other assertion here,
+		// so this is what covers the wiring into the shared formatters.
+		setSettings( ES_ES_SETTINGS );
+
+		const { container } = render( <MostPopularTimeWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'domingo' ) ).resolves.toBeInTheDocument();
+		expect( container ).toHaveTextContent( 'Best hour19' );
+		expect( container ).not.toHaveTextContent( 'Sunday' );
+	} );
+
 	it( 'keeps the known best day when the payload carries no hour', async () => {
 		// A fabricated "12:00 AM" reads as a real answer, but so does hiding a day
 		// the endpoint did send — drop only the highlight that has no data.
@@ -87,8 +123,9 @@ describe( 'MostPopularTimeWidget', () => {
 	} );
 
 	it( 'shows the empty state when the site has no peak yet', async () => {
-		// The sanitizer drops the whole payload when `highest_day_of_week` is
-		// missing, which is what a site with too little traffic returns.
+		// A site with too little traffic returns no `highest_day_of_week`, and the
+		// card stands on the day — so that alone is what makes it empty. The
+		// sanitizer keeps the rest of the report for the widgets that share it.
 		mockApiFetch.mockResolvedValue( {} );
 
 		render( <MostPopularTimeWidget attributes={ {} } /> );

--- a/projects/packages/premium-analytics/widgets/most-popular-time/__tests__/most-popular-time.test.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/__tests__/most-popular-time.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { fireEvent, render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import MostPopularTimeWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// WidgetRoot reads URL search params as a fallback for report params; outside
+// a matched route the real hook warns and throws.
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+// `highest_day_of_week` is zero-based on Monday, so 6 is Sunday. Both labels are
+// built from the site's locale tables, not from the raw numbers.
+const INSIGHTS_RESPONSE = {
+	highest_day_of_week: 6,
+	highest_day_percent: 17.4,
+	highest_hour: 19,
+	highest_hour_percent: 5.2,
+};
+
+describe( 'MostPopularTimeWidget', () => {
+	beforeEach( () => {
+		// The data package's query client is a module-level singleton; drop its
+		// cache so each test starts from a fresh fetch.
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( INSIGHTS_RESPONSE );
+	} );
+
+	it( 'renders the peak day and hour with their share of views', async () => {
+		const { container } = render( <MostPopularTimeWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'Sunday' ) ).resolves.toBeInTheDocument();
+
+		// Label with value, so a highlight that renders the day's percent under
+		// the hour — or vice versa — cannot pass.
+		expect( container ).toHaveTextContent( 'Best daySunday17% of views' );
+		expect( container ).toHaveTextContent( 'Best hour7 pm5% of views' );
+	} );
+
+	it( 'requests the insights endpoint without date params', async () => {
+		render( <MostPopularTimeWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'Sunday' ) ).resolves.toBeInTheDocument();
+
+		// The peak day and hour come from a fixed server-side window, so sending a
+		// date range would imply a filter the endpoint does not apply.
+		const [ [ request ] ] = mockApiFetch.mock.calls;
+		const path = String( request.path );
+
+		expect( path ).toContain( 'stats/insights' );
+		// Params are serialized into the query string, so no query string at all
+		// pins this more tightly than naming the params one at a time.
+		expect( path ).not.toContain( '?' );
+	} );
+
+	it( 'reports no peak rather than midnight when the payload carries no hour', async () => {
+		// A fabricated "12:00 AM" reads as a real answer; the card must not show
+		// one just because the hour is missing.
+		mockApiFetch.mockResolvedValue( {
+			highest_day_of_week: 6,
+			highest_day_percent: 17.4,
+		} );
+
+		render( <MostPopularTimeWidget attributes={ {} } /> );
+
+		await expect(
+			screen.findByText( 'Not enough data to determine your most popular time yet.' )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Best hour' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the empty state when the site has no peak yet', async () => {
+		// The sanitizer drops the whole payload when `highest_day_of_week` is
+		// missing, which is what a site with too little traffic returns.
+		mockApiFetch.mockResolvedValue( {} );
+
+		render( <MostPopularTimeWidget attributes={ {} } /> );
+
+		await expect(
+			screen.findByText( 'Not enough data to determine your most popular time yet.' )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'keeps the rendered peak when a refetch fails', async () => {
+		render( <MostPopularTimeWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'Sunday' ) ).resolves.toBeInTheDocument();
+
+		// `placeholderData` keeps the prior response, so a transient failure must
+		// not replace numbers that are still on screen with an error.
+		mockApiFetch.mockRejectedValue( { status: 403, code: 'no_connection' } );
+		queryClient.refetchQueries( { queryKey: [ 'stats', 'insights' ] } );
+
+		await expect( screen.findByText( 'Sunday' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Retry' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'offers no retry to a reader without access', async () => {
+		// A plain 403 is a permission failure: retrying cannot fix it, so the
+		// shared error mapper states that neutrally and drops the action.
+		mockApiFetch.mockRejectedValue( { status: 403, message: 'Forbidden' } );
+
+		render( <MostPopularTimeWidget attributes={ {} } /> );
+
+		await expect(
+			screen.findByText( "You don't have access to this data." )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Retry' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the error state and refetches from the Retry action', async () => {
+		// `no_connection` is the proxy's retryable 403 — it heals once the site
+		// reconnects — and a 403 avoids React Query's retry backoff.
+		mockApiFetch.mockRejectedValue( {
+			status: 403,
+			code: 'no_connection',
+			message: 'Site is not connected.',
+		} );
+
+		render( <MostPopularTimeWidget attributes={ {} } /> );
+
+		await expect(
+			screen.findByText( "We couldn't load your most popular time. Please try again in a moment." )
+		).resolves.toBeInTheDocument();
+
+		// The highlights can only render from a successful refetch, since the
+		// initial request rejected.
+		mockApiFetch.mockResolvedValue( INSIGHTS_RESPONSE );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		await expect( screen.findByText( 'Sunday' ) ).resolves.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/most-popular-time/__tests__/most-popular-time.test.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/__tests__/most-popular-time.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { queryClient } from '@jetpack-premium-analytics/data';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -62,20 +62,28 @@ describe( 'MostPopularTimeWidget', () => {
 		expect( path ).not.toContain( '?' );
 	} );
 
-	it( 'reports no peak rather than midnight when the payload carries no hour', async () => {
-		// A fabricated "12:00 AM" reads as a real answer; the card must not show
-		// one just because the hour is missing.
+	it( 'keeps the known best day when the payload carries no hour', async () => {
+		// A fabricated "12:00 AM" reads as a real answer, but so does hiding a day
+		// the endpoint did send — drop only the highlight that has no data.
 		mockApiFetch.mockResolvedValue( {
 			highest_day_of_week: 6,
 			highest_day_percent: 17.4,
 		} );
 
+		const { container } = render( <MostPopularTimeWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'Sunday' ) ).resolves.toBeInTheDocument();
+		expect( container ).toHaveTextContent( 'Best daySunday17% of views' );
+		expect( screen.queryByText( 'Best hour' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'drops the share caption rather than captioning a peak with 0%', async () => {
+		mockApiFetch.mockResolvedValue( { highest_day_of_week: 6, highest_hour: 19 } );
+
 		render( <MostPopularTimeWidget attributes={ {} } /> );
 
-		await expect(
-			screen.findByText( 'Not enough data to determine your most popular time yet.' )
-		).resolves.toBeInTheDocument();
-		expect( screen.queryByText( 'Best hour' ) ).not.toBeInTheDocument();
+		await expect( screen.findByText( 'Sunday' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( /of views/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'shows the empty state when the site has no peak yet', async () => {
@@ -96,11 +104,14 @@ describe( 'MostPopularTimeWidget', () => {
 		await expect( screen.findByText( 'Sunday' ) ).resolves.toBeInTheDocument();
 
 		// `placeholderData` keeps the prior response, so a transient failure must
-		// not replace numbers that are still on screen with an error.
+		// not replace numbers that are still on screen with an error. Awaited on
+		// the refetch itself: "Sunday" is already mounted, so asserting it without
+		// waiting would pass before the rejection could land.
 		mockApiFetch.mockRejectedValue( { status: 403, code: 'no_connection' } );
-		queryClient.refetchQueries( { queryKey: [ 'stats', 'insights' ] } );
+		await queryClient.refetchQueries( { queryKey: [ 'stats', 'insights' ] } );
+		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalledTimes( 2 ) );
 
-		await expect( screen.findByText( 'Sunday' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Sunday' ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: 'Retry' } ) ).not.toBeInTheDocument();
 	} );
 

--- a/projects/packages/premium-analytics/widgets/most-popular-time/package.json
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/package.json
@@ -6,10 +6,12 @@
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/externals": "link:../../packages/externals",
+		"@jetpack-premium-analytics/formatters": "link:../../packages/formatters",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^15.0.0",
-		"@wordpress/widget-primitives": "0.5.0"
+		"@wordpress/widget-primitives": "0.5.0",
+		"react": "18.3.1"
 	},
 	"devDependencies": {
 		"@wordpress/api-fetch": "7.51.0"

--- a/projects/packages/premium-analytics/widgets/most-popular-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/render.tsx
@@ -5,7 +5,7 @@ import { useStatsInsights, type StatsInsightsResponse } from '@jetpack-premium-a
 import {
 	formatHourOfDay,
 	formatMetricValue,
-	formatWeekday,
+	formatMondayFirstWeekday,
 } from '@jetpack-premium-analytics/formatters';
 import {
 	describeError,
@@ -14,7 +14,6 @@ import {
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __, sprintf } from '@wordpress/i18n';
-import { useMemo } from 'react';
 import { scheduled } from '@wordpress/icons';
 import { Stack, Text } from '@jetpack-premium-analytics/externals';
 /**
@@ -42,9 +41,10 @@ type HighlightProps = {
 	 */
 	value: string;
 	/**
-	 * The value's share of total views, as a whole percent (0-100).
+	 * The value's share of total views, as a whole percent (0-100). Absent when
+	 * the endpoint sent no share — the caption is dropped rather than showing 0%.
 	 */
-	percent: number;
+	percent?: number;
 };
 
 /**
@@ -60,17 +60,19 @@ function Highlight( { label, value, percent }: HighlightProps ) {
 			<Text variant="heading-2xl" className={ styles.value }>
 				{ value }
 			</Text>
-			<Text variant="body-md" className={ styles.caption }>
-				{ sprintf(
-					/* translators: %s is a percentage, e.g. "17%". */
-					__( '%s of views', 'jetpack-premium-analytics-pkg' ),
-					// The report carries whole percents; the formatter takes a fraction.
-					formatMetricValue( percent / 100, 'percentage', {
-						decimals: 0,
-						signDisplay: 'never',
-					} )
-				) }
-			</Text>
+			{ percent !== undefined && (
+				<Text variant="body-md" className={ styles.caption }>
+					{ sprintf(
+						/* translators: %s is a percentage, e.g. "17%". */
+						__( '%s of views', 'jetpack-premium-analytics-pkg' ),
+						// The report carries whole percents; the formatter takes a fraction.
+						formatMetricValue( percent / 100, 'percentage', {
+							decimals: 0,
+							signDisplay: 'never',
+						} )
+					) }
+				</Text>
+			) }
 		</Stack>
 	);
 }
@@ -83,19 +85,12 @@ function Highlight( { label, value, percent }: HighlightProps ) {
 function MostPopularTimeReport() {
 	const { data, isLoading, isFetching, isError, error, refetch } = useStatsInsights();
 	const report = data as StatsInsightsResponse | undefined;
-	// Resolved to one nullable value so emptiness and the render read the same
-	// thing; two separate guards could drift and reintroduce the
-	// midnight-for-a-missing-hour reading the sanitizer removed. Compared against
-	// `undefined`, not falsiness: Monday and midnight are both 0.
-	const peak = useMemo( () => {
-		const { dayOfWeek, hourOfDay, percent, hourPercent } = report ?? {};
-
-		if ( dayOfWeek === undefined || hourOfDay === undefined ) {
-			return null;
-		}
-
-		return { dayOfWeek, hourOfDay, percent: percent ?? 0, hourPercent: hourPercent ?? 0 };
-	}, [ report ] );
+	// The card stands on the day alone: the hour is a second highlight the
+	// endpoint may not have sent, and withholding a known best day because of it
+	// would report "not enough data" over data there is. Compared against
+	// `undefined`, not falsiness — Monday and midnight are both 0.
+	const { dayOfWeek, hourOfDay, percent, hourPercent } = report ?? {};
+	const isEmpty = dayOfWeek === undefined;
 
 	return (
 		<div className={ styles.content }>
@@ -104,8 +99,8 @@ function MostPopularTimeReport() {
 				isFetching={ isFetching }
 				// The query keeps the previous response via `placeholderData`, so only
 				// surface the error when there is nothing to show.
-				isError={ isError && ! peak }
-				isEmpty={ ! peak }
+				isError={ isError && isEmpty }
+				isEmpty={ isEmpty }
 				// Mapped rather than hand-written: a 403 from a reader without stats
 				// access is not something retrying fixes, and describeError drops the
 				// Retry action for it.
@@ -124,20 +119,20 @@ function MostPopularTimeReport() {
 					),
 				} }
 			>
-				{ peak && (
+				{ dayOfWeek !== undefined && (
 					<Stack className={ styles.root } direction="column" gap="lg">
 						<Highlight
 							label={ __( 'Best day', 'jetpack-premium-analytics-pkg' ) }
-							// WordPress's locale table is Sunday-first; the endpoint's
-							// index is Monday-first.
-							value={ formatWeekday( ( peak.dayOfWeek + 1 ) % 7 ) }
-							percent={ peak.percent }
+							value={ formatMondayFirstWeekday( dayOfWeek ) }
+							percent={ percent }
 						/>
-						<Highlight
-							label={ __( 'Best hour', 'jetpack-premium-analytics-pkg' ) }
-							value={ formatHourOfDay( peak.hourOfDay ) }
-							percent={ peak.hourPercent }
-						/>
+						{ hourOfDay !== undefined && (
+							<Highlight
+								label={ __( 'Best hour', 'jetpack-premium-analytics-pkg' ) }
+								value={ formatHourOfDay( hourOfDay ) }
+								percent={ hourPercent }
+							/>
+						) }
 					</Stack>
 				) }
 			</WidgetState>

--- a/projects/packages/premium-analytics/widgets/most-popular-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/render.tsx
@@ -3,11 +3,18 @@
  */
 import { useStatsInsights, type StatsInsightsResponse } from '@jetpack-premium-analytics/data';
 import {
+	formatHourOfDay,
+	formatMetricValue,
+	formatWeekday,
+} from '@jetpack-premium-analytics/formatters';
+import {
+	describeError,
 	WidgetRoot,
 	WidgetState,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from 'react';
 import { scheduled } from '@wordpress/icons';
 import { Stack, Text } from '@jetpack-premium-analytics/externals';
 /**
@@ -18,8 +25,9 @@ import type { MostPopularTimeAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
 // Report params are dashboard-driven and injected via `attributes`; the insights
-// endpoint ignores them (it reports across the whole site lifetime with no
-// comparison period), but WidgetRoot still expects them on `attributes`.
+// endpoint ignores them (the peak day and hour come from a fixed server-side
+// window, with no comparison period), but WidgetRoot still expects them on
+// `attributes`.
 type MostPopularTimeRenderAttributes = MostPopularTimeAttributes &
 	Partial< ReportParamsFieldAttributes >;
 type MostPopularTimeWidgetProps = WidgetRenderProps< MostPopularTimeRenderAttributes >;
@@ -30,11 +38,11 @@ type HighlightProps = {
 	 */
 	label: string;
 	/**
-	 * The peak value (e.g. "Tuesday" or "3:00 PM").
+	 * The peak value, already localized (e.g. "Tuesday" or "3 pm").
 	 */
 	value: string;
 	/**
-	 * The value's share of total views, as a whole percent.
+	 * The value's share of total views, as a whole percent (0-100).
 	 */
 	percent: number;
 };
@@ -54,9 +62,13 @@ function Highlight( { label, value, percent }: HighlightProps ) {
 			</Text>
 			<Text variant="body-md" className={ styles.caption }>
 				{ sprintf(
-					/* translators: %d: share of total views as a whole percent. */
-					__( '%d%% of views', 'jetpack-premium-analytics-pkg' ),
-					percent
+					/* translators: %s is a percentage, e.g. "17%". */
+					__( '%s of views', 'jetpack-premium-analytics-pkg' ),
+					// The report carries whole percents; the formatter takes a fraction.
+					formatMetricValue( percent / 100, 'percentage', {
+						decimals: 0,
+						signDisplay: 'never',
+					} )
 				) }
 			</Text>
 		</Stack>
@@ -69,9 +81,21 @@ function Highlight( { label, value, percent }: HighlightProps ) {
  * its share of views.
  */
 function MostPopularTimeReport() {
-	const { data, isLoading, isFetching, isError, refetch } = useStatsInsights();
+	const { data, isLoading, isFetching, isError, error, refetch } = useStatsInsights();
 	const report = data as StatsInsightsResponse | undefined;
-	const isEmpty = ! report?.day || ! report?.hour;
+	// Resolved to one nullable value so emptiness and the render read the same
+	// thing; two separate guards could drift and reintroduce the
+	// midnight-for-a-missing-hour reading the sanitizer removed. Compared against
+	// `undefined`, not falsiness: Monday and midnight are both 0.
+	const peak = useMemo( () => {
+		const { dayOfWeek, hourOfDay, percent, hourPercent } = report ?? {};
+
+		if ( dayOfWeek === undefined || hourOfDay === undefined ) {
+			return null;
+		}
+
+		return { dayOfWeek, hourOfDay, percent: percent ?? 0, hourPercent: hourPercent ?? 0 };
+	}, [ report ] );
 
 	return (
 		<div className={ styles.content }>
@@ -80,20 +104,18 @@ function MostPopularTimeReport() {
 				isFetching={ isFetching }
 				// The query keeps the previous response via `placeholderData`, so only
 				// surface the error when there is nothing to show.
-				isError={ isError && isEmpty }
-				isEmpty={ isEmpty }
-				error={ {
-					description: __(
+				isError={ isError && ! peak }
+				isEmpty={ ! peak }
+				// Mapped rather than hand-written: a 403 from a reader without stats
+				// access is not something retrying fixes, and describeError drops the
+				// Retry action for it.
+				error={ describeError( error, {
+					retryDescription: __(
 						"We couldn't load your most popular time. Please try again in a moment.",
 						'jetpack-premium-analytics-pkg'
 					),
-					actions: [
-						{
-							label: __( 'Retry', 'jetpack-premium-analytics-pkg' ),
-							onClick: () => void refetch(),
-						},
-					],
-				} }
+					onRetry: refetch,
+				} ) }
 				empty={ {
 					icon: scheduled,
 					description: __(
@@ -102,17 +124,19 @@ function MostPopularTimeReport() {
 					),
 				} }
 			>
-				{ report?.day && report?.hour && (
+				{ peak && (
 					<Stack className={ styles.root } direction="column" gap="lg">
 						<Highlight
 							label={ __( 'Best day', 'jetpack-premium-analytics-pkg' ) }
-							value={ report.day }
-							percent={ report.percent ?? 0 }
+							// WordPress's locale table is Sunday-first; the endpoint's
+							// index is Monday-first.
+							value={ formatWeekday( ( peak.dayOfWeek + 1 ) % 7 ) }
+							percent={ peak.percent }
 						/>
 						<Highlight
 							label={ __( 'Best hour', 'jetpack-premium-analytics-pkg' ) }
-							value={ report.hour }
-							percent={ report.hourPercent ?? 0 }
+							value={ formatHourOfDay( peak.hourOfDay ) }
+							percent={ peak.hourPercent }
 						/>
 					</Stack>
 				) }

--- a/projects/packages/premium-analytics/widgets/most-popular-time/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/render.tsx
@@ -91,26 +91,32 @@ function MostPopularTimeReport() {
 	// `undefined`, not falsiness — Monday and midnight are both 0.
 	const { dayOfWeek, hourOfDay, percent, hourPercent } = report ?? {};
 	const isEmpty = dayOfWeek === undefined;
+	// `placeholderData` keeps the prior response on a transient refetch failure,
+	// so the error only surfaces when there is nothing left to show.
+	const showError = isError && isEmpty;
 
 	return (
 		<div className={ styles.content }>
 			<WidgetState
 				isLoading={ isLoading }
 				isFetching={ isFetching }
-				// The query keeps the previous response via `placeholderData`, so only
-				// surface the error when there is nothing to show.
-				isError={ isError && isEmpty }
+				isError={ showError }
 				isEmpty={ isEmpty }
 				// Mapped rather than hand-written: a 403 from a reader without stats
 				// access is not something retrying fixes, and describeError drops the
-				// Retry action for it.
-				error={ describeError( error, {
-					retryDescription: __(
-						"We couldn't load your most popular time. Please try again in a moment.",
-						'jetpack-premium-analytics-pkg'
-					),
-					onRetry: refetch,
-				} ) }
+				// Retry action for it. Gated on the same predicate as `isError` so the
+				// two cannot disagree.
+				error={
+					showError
+						? describeError( error, {
+								retryDescription: __(
+									"We couldn't load your most popular time. Please try again in a moment.",
+									'jetpack-premium-analytics-pkg'
+								),
+								onRetry: refetch,
+						  } )
+						: null
+				}
 				empty={ {
 					icon: scheduled,
 					description: __(

--- a/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
@@ -39,12 +39,12 @@ const INSIGHTS_PATH_FRAGMENT = 'stats/insights';
 /**
  * Forces the insights request into the given state for a story's lifetime.
  *
- * `useStatsInsights()` has a constant query key — the lifetime insights report
- * ignores the dashboard date range — so distinct date presets cannot give the
- * forced-state stories their own cache entries. Instead, drop the cached report
- * from the shared query client so the widget re-fetches and hits the forced
- * mock, and drop it again on cleanup so a forced empty/error result doesn't
- * leak into the other stories' shared cache entry.
+ * `useStatsInsights()` has a constant query key — the insights report covers a
+ * fixed server-side window and ignores the dashboard date range — so distinct
+ * date presets cannot give the forced-state stories their own cache entries.
+ * Instead, drop the cached report from the shared query client so the widget
+ * re-fetches and hits the forced mock, and drop it again on cleanup so a forced
+ * empty/error result doesn't leak into the other stories' shared cache entry.
  */
 function forceInsightsState( state: 'loading' | 'error' | 'empty' ) {
 	queryClient.removeQueries( { queryKey: [ 'stats', 'insights' ] } );
@@ -67,7 +67,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Most popular time" widget. Shows the day of week and hour of day that draw the most views, each with its share of the total. The insights endpoint reports across the whole lifetime of the site, so there is no date range or comparison period.',
+					'The "Most popular time" widget. Shows the day of week and hour of day that draw the most views, each with its share of the total. The insights endpoint reports over a fixed server-side window, so there is no date range or comparison period.',
 			},
 		},
 	},
@@ -109,9 +109,8 @@ export const Error: Story = {
 };
 
 /**
- * Resolved without peak day/hour data: the widget shows its empty state (no
- * icon — the widget's `scheduled` glyph has no neutral counterpart in the
- * analytics icon set).
+ * Resolved without peak day/hour data: the widget shows its empty state, under
+ * the widget's own `scheduled` glyph rather than the error state's icon.
  */
 export const Empty: Story = {
 	render: renderMostPopularTime,

--- a/projects/packages/premium-analytics/widgets/most-popular-time/style.module.css
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/style.module.css
@@ -6,9 +6,12 @@
 	min-height: 0;
 }
 
+/* The default tile is two rows tall, where both highlights fit. Resized down to
+ * one row the display figures outgrow the body, so scroll rather than clip. */
 .root {
 	height: 100%;
-	overflow: hidden;
+	overflow-x: hidden;
+	overflow-y: auto;
 }
 
 .label {

--- a/projects/packages/premium-analytics/widgets/most-popular-time/style.module.css
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/style.module.css
@@ -7,7 +7,9 @@
 }
 
 /* The default tile is two rows tall, where both highlights fit. Resized down to
- * one row the display figures outgrow the body, so scroll rather than clip. */
+ * one row the display figures outgrow the body, so scroll rather than clip.
+ * The design's switch to horizontal stacking at narrow widths is shared with
+ * Most popular day and lands with it in WOOA7S-2035. */
 .root {
 	height: 100%;
 	overflow-x: hidden;

--- a/projects/packages/premium-analytics/widgets/most-popular-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/widget.json
@@ -3,7 +3,13 @@
 	"title": "Most popular time",
 	"description": "The day of week and hour of day when your site gets the most views.",
 	"help": {
-		"content": "The day of week and hour of day when your site gets the most views."
+		"content": "The day of the week and hour of the day when your site typically receives the most views. These figures reflect a longer-term pattern and don't change with the period you select.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://wordpress.com/support/stats/learn-insights-about-your-website/"
+			}
+		]
 	},
 	"category": "stats",
 	"presentation": "framed"

--- a/projects/packages/premium-analytics/widgets/most-popular-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/widget.ts
@@ -6,7 +6,7 @@ import { scheduled } from '@wordpress/icons';
 /**
  * Configurable attributes for the Most popular time widget. The widget has no
  * user-configurable settings — the highlights come straight from the insights
- * endpoint, which reports across the whole lifetime of the site with no date
+ * endpoint, which reports over a fixed server-side window and takes no date
  * range or comparison period.
  */
 export type MostPopularTimeAttributes = Record< never, never >;

--- a/projects/packages/premium-analytics/widgets/popular-days/bucket-views-by-weekday.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/bucket-views-by-weekday.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getDatePart } from '@jetpack-premium-analytics/datetime';
-import { formatWeekday } from '@jetpack-premium-analytics/formatters';
+import { formatMondayFirstWeekday } from '@jetpack-premium-analytics/formatters';
 import { format, getDay, isValid, parse } from 'date-fns';
 
 export type PopularDayBucket = {
@@ -21,8 +21,7 @@ const DATE_PART_FORMAT = 'yyyy-MM-dd';
 const referenceDate = new Date( 2001, 0, 1 );
 
 function weekdayLabel( weekday: number ) {
-	// WordPress's locale table is Sunday-first; the widget's buckets are Monday-first.
-	return formatWeekday( ( weekday + 1 ) % 7 );
+	return formatMondayFirstWeekday( weekday );
 }
 
 // `date_start` labels a calendar bucket rather than marking a real instant, so

--- a/projects/plugins/jetpack/changelog/nova-wooprd-3703-most-popular-time-i18n
+++ b/projects/plugins/jetpack/changelog/nova-wooprd-3703-most-popular-time-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: show the Most popular time day and hour in the site's locale.

--- a/projects/plugins/jetpack/changelog/nova-wooprd-3703-most-popular-time-i18n
+++ b/projects/plugins/jetpack/changelog/nova-wooprd-3703-most-popular-time-i18n
@@ -1,4 +1,4 @@
-Significance: patch
-Type: bugfix
+Significance: Patch
+Type: Bugfix
 
-Premium Analytics: show the Most popular time day and hour in the site's locale.
+Premium Analytics: Show the Most popular time day and hour in the site's locale.

--- a/projects/plugins/jetpack/changelog/nova-wooprd-3703-most-popular-time-i18n
+++ b/projects/plugins/jetpack/changelog/nova-wooprd-3703-most-popular-time-i18n
@@ -1,4 +1,4 @@
-Significance: Patch
-Type: Bugfix
+Significance: patch
+Type: bugfix
 
 Premium Analytics: Show the Most popular time day and hour in the site's locale.

--- a/projects/plugins/jetpack/changelog/nova-wooprd-3703-most-popular-time-insights
+++ b/projects/plugins/jetpack/changelog/nova-wooprd-3703-most-popular-time-insights
@@ -1,4 +1,4 @@
-Significance: Minor
-Type: Enhancement
+Significance: minor
+Type: enhancement
 
 Premium Analytics: Add the Most popular time card to the default Insights layout.

--- a/projects/plugins/jetpack/changelog/nova-wooprd-3703-most-popular-time-insights
+++ b/projects/plugins/jetpack/changelog/nova-wooprd-3703-most-popular-time-insights
@@ -1,4 +1,4 @@
-Significance: minor
-Type: enhancement
+Significance: Minor
+Type: Enhancement
 
-Premium Analytics: add the Most popular time card to the default Insights layout.
+Premium Analytics: Add the Most popular time card to the default Insights layout.

--- a/projects/plugins/jetpack/changelog/nova-wooprd-3703-most-popular-time-insights
+++ b/projects/plugins/jetpack/changelog/nova-wooprd-3703-most-popular-time-insights
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: add the Most popular time card to the default Insights layout.

--- a/projects/plugins/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-i18n
+++ b/projects/plugins/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-i18n
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Insights: show the Most popular time day and hour in the site's locale.

--- a/projects/plugins/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-i18n
+++ b/projects/plugins/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-i18n
@@ -1,4 +1,4 @@
-Significance: Patch
-Type: Fixed
+Significance: patch
+Type: fixed
 
 Insights: Show the Most popular time day and hour in the site's locale.

--- a/projects/plugins/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-i18n
+++ b/projects/plugins/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-i18n
@@ -1,4 +1,4 @@
-Significance: patch
-Type: fixed
+Significance: Patch
+Type: Fixed
 
-Insights: show the Most popular time day and hour in the site's locale.
+Insights: Show the Most popular time day and hour in the site's locale.

--- a/projects/plugins/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-insights
+++ b/projects/plugins/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-insights
@@ -1,4 +1,4 @@
-Significance: Minor
-Type: Added
+Significance: minor
+Type: added
 
 Insights: Add the Most popular time card to the default layout.

--- a/projects/plugins/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-insights
+++ b/projects/plugins/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-insights
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Insights: add the Most popular time card to the default layout.

--- a/projects/plugins/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-insights
+++ b/projects/plugins/premium-analytics/changelog/nova-wooprd-3703-most-popular-time-insights
@@ -1,4 +1,4 @@
-Significance: minor
-Type: added
+Significance: Minor
+Type: Added
 
-Insights: add the Most popular time card to the default layout.
+Insights: Add the Most popular time card to the default layout.


### PR DESCRIPTION
Fixes WOOA7S-2019

## Why

The Insights design has a "Most popular time" card — best day and best hour, each with its share of views — but the widget has been picker-only, so nobody sees it unless they go and add it themselves. This puts it on the page by default.

Making it a default surfaced a few things it got wrong. They were tolerable while it was opt-in, not so much when everyone gets it, so they're fixed here too.

## Proposed changes

* Add `jpa/most-popular-time` to the default Insights layout, sized 1x2 so both highlights fit at the 200px row height. It goes in the row below Highlights, beside All-time stats and Most popular day, which is where the design has the three of them.
* Localize what the card shows. The day and hour came from date-fns with no locale, and the percentages from a bare `%d%%`, so every site read "Sunday", "7:00 PM" and ASCII digits regardless of its language or time format — right next to a Popular days card on the same tab that localizes all three. The sanitizer now carries the raw weekday index and hour, and the widget builds every label with the shared formatters the sibling cards already use.
* Stop inventing a peak hour. A payload with a day but no hour used to coerce the hour to 0 and show "Best hour / 12:00 AM / 0% of views", which reads like a real answer. The hour is omitted when it's absent now.
* Route the error state through `describeError`, as the Stats widget rules require. Before this, a reader without stats access was told to try again in a moment, behind a Retry that could never work.
* Say something about the period in the help text, and add a Learn more link like Popular days and Popular hours have.
* Swap `overflow: hidden` for a scroll fallback, so a tile someone resizes down to one row scrolls instead of quietly clipping Best hour.
* Add `__tests__/` — the widget had none.

### Two things worth a reviewer's eye

**All-time stats narrowed to make room, and that's the bit I'd like a second opinion on.** WOOA7S-2021 and WOOA7S-2011 both landed on trunk while this was in review, so rebasing put all three cards on the same row - All-time stats at 2 columns, Most popular day at 1, this one at 1, all two rows tall. That fills the four-column grid exactly, so the gap the earlier version of this PR had is gone. But All-time stats was 4 wide before and it does get noticeably narrower. WOOA7S-2009 settles the final widths anyway, so if you'd rather it kept its width and Most popular time wrapped onto its own row until then, I'm happy to do that instead - just say the word.

**What period is this, really?** WOOA7S-2019 and a comment in `popular-days/use-popular-days.ts` both say `stats/insights` computes the peak day and hour over a window fixed at ten weeks. But the support doc we link to describes Most popular time under "All-time highlights" and never mentions ten weeks. I couldn't verify it against the server, so the help text only claims what I could actually check — that the figures reflect a longer-term pattern and don't follow the selected period, which holds because the request carries no date params at all. The comments say the window is "fixed and server-side" without naming a length. If someone who knows `stats/insights` can confirm the real window, both the tooltip and that popular-days comment could state it.

## Related product discussion/links

* WOOA7S-2019
* p1787126958522969-slack-C06FSDTSN82

## Does this pull request change what data or activity we track or use?

No. Same `stats/insights` request as before — the widget just renders more of what already comes back, and the request itself is unchanged.

## Testing instructions

* Open **Jetpack → Stats → Insights** on a site that has some traffic, with no saved Insights layout (a fresh user, or hit Reset in Customize).
* Ensure a "Most popular time" card shows up in the row below Highlights, one column wide and two rows tall, sitting to the right of All-time stats and Most popular day, with Best day and Best hour both fully visible and nothing cut off.
* Ensure the hour reads the same way the Popular hours card on the same page reads it (e.g. both `3 pm`), and the weekday matches Popular days' formatting.
* Switch the site to a non-English locale (`Settings → General → Site Language`, e.g. Deutsch) and reload. Ensure the day and hour are translated — before this PR the card stayed English while Popular days switched.
* Change `Settings → General → Time Format` to 24-hour and reload. Ensure Best hour follows it.
* Click the (i) next to the card title. Ensure the help text mentions the period and the Learn more link opens the Insights support page.
* In Customize, drag the card down to one row tall. Ensure the body scrolls to Best hour instead of clipping it.
* On a site where the current user can't view stats (or with the proxy returning a plain 403), ensure the card says you don't have access and shows **no** Retry button. With a `no_connection` 403, ensure Retry appears and recovers.
* Ensure the rest of the Insights page is unchanged apart from All-time stats being narrower — same widgets, same order, nothing else moved.


