### PR TITLE
Premium Analytics: scope the four period widgets to the Traffic tab

### DIFF
--- a/projects/packages/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/packages/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Insights: Total views, Total visitors, Popular days, and Popular hours are now offered only on the Traffic tab, and are no longer part of the Insights tab by default. Existing layouts keep them.

--- a/projects/packages/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/packages/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Insights: Drop Total views, Total visitors, Popular days, and Popular hours from the tab and its widget gallery, and add Popular days and Popular hours to the Traffic tab's default layout. Existing layouts keep them.
+Dashboard: Offer Total views, Total visitors, Popular days, and Popular hours from the Traffic tab only, and take them off the Insights default layout. Popular days and Popular hours now ship in Traffic's default instead. Existing layouts keep them.

--- a/projects/packages/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/packages/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Insights: Offer Total views, Total visitors, Popular days, and Popular hours only on the Traffic tab, and drop them from the Insights default layout. Existing layouts keep them.
+Insights: Drop Total views, Total visitors, Popular days, and Popular hours from the tab and its widget gallery, and add Popular days and Popular hours to the Traffic tab's default layout. Existing layouts keep them.

--- a/projects/packages/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/packages/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Insights: Total views, Total visitors, Popular days, and Popular hours are now offered only on the Traffic tab, and are no longer part of the Insights tab by default. Existing layouts keep them.
+Insights: Offer Total views, Total visitors, Popular days, and Popular hours only on the Traffic tab, and drop them from the Insights default layout. Existing layouts keep them.

--- a/projects/packages/premium-analytics/routes/dashboard/config/index.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/index.ts
@@ -16,3 +16,5 @@ export {
 } from './date-filter';
 
 export { isDashboardSectionLayouts, type DashboardSectionLayouts } from './section-layouts';
+
+export { selectSectionWidgetTypes, type SectionScopedWidgetModuleRecord } from './widget-sections';

--- a/projects/packages/premium-analytics/routes/dashboard/config/widget-sections.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/widget-sections.test.ts
@@ -1,0 +1,87 @@
+import { selectSectionWidgetTypes, type SectionScopedWidgetModuleRecord } from './widget-sections';
+import type { WidgetName, WidgetType } from '@wordpress/widget-primitives';
+
+const RECORDS: SectionScopedWidgetModuleRecord[] = [
+	{ name: 'jpa/total-views', sections: [ 'traffic' ] },
+	{ name: 'jpa/popular-days', sections: [ 'traffic', 'insights' ] },
+	{ name: 'jpa/tags', sections: null },
+	// An empty scope names no section, so it is addable from none.
+	{ name: 'jpa/hello-world', sections: [] },
+	// Served by a build that predates the field, the way WPCOM's public-api can
+	// serve this route from its own checkout.
+	{ name: 'jpa/shares' },
+];
+
+const WIDGET_TYPES: WidgetType[] = RECORDS.map( record => ( {
+	apiVersion: 1,
+	name: record.name as WidgetName,
+	title: record.name,
+	renderModule: `${ record.name }/render`,
+} ) );
+
+const NOTHING_PLACED: ReadonlySet< string > = new Set();
+
+describe( 'selectSectionWidgetTypes', () => {
+	it( 'keeps a type whose scope names the section', () => {
+		const names = selectSectionWidgetTypes( WIDGET_TYPES, RECORDS, 'traffic', NOTHING_PLACED ).map(
+			type => type.name
+		);
+
+		expect( names ).toEqual( [ 'jpa/total-views', 'jpa/popular-days', 'jpa/tags', 'jpa/shares' ] );
+	} );
+
+	it( 'drops a type whose scope leaves the section out', () => {
+		const names = selectSectionWidgetTypes( WIDGET_TYPES, RECORDS, 'insights', NOTHING_PLACED ).map(
+			type => type.name
+		);
+
+		expect( names ).toEqual( [ 'jpa/popular-days', 'jpa/tags', 'jpa/shares' ] );
+	} );
+
+	it( 'treats a missing or null scope as every section', () => {
+		const names = selectSectionWidgetTypes(
+			WIDGET_TYPES,
+			RECORDS,
+			'subscribers',
+			NOTHING_PLACED
+		).map( type => type.name );
+
+		expect( names ).toEqual( [ 'jpa/tags', 'jpa/shares' ] );
+	} );
+
+	it( 'reads an empty scope as no section at all', () => {
+		// Distinct from a missing scope: `[]` names nothing, so it is offered
+		// nowhere, while absent means everywhere.
+		const names = selectSectionWidgetTypes( WIDGET_TYPES, RECORDS, 'traffic', NOTHING_PLACED ).map(
+			type => type.name
+		);
+
+		// The pair is the point: both are "no sections named", and only one of
+		// them means "every section".
+		expect( names ).not.toContain( 'jpa/hello-world' );
+		expect( names ).toContain( 'jpa/shares' );
+	} );
+
+	it( 'keeps an out-of-scope type the section already places', () => {
+		// The reader added it before the scope existed, or an older default
+		// seeded it. Dropping it would render the instance as "Missing widget".
+		const names = selectSectionWidgetTypes(
+			WIDGET_TYPES,
+			RECORDS,
+			'insights',
+			new Set( [ 'jpa/total-views' ] )
+		).map( type => type.name );
+
+		expect( names ).toContain( 'jpa/total-views' );
+	} );
+
+	it( 'keeps a type whose record has not arrived', () => {
+		// The types and the records resolve independently; scoping a type away
+		// on a missing record would blank the grid mid-load.
+		const names = selectSectionWidgetTypes( WIDGET_TYPES, null, 'insights', NOTHING_PLACED ).map(
+			type => type.name
+		);
+
+		expect( names ).toEqual( WIDGET_TYPES.map( type => type.name ) );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/dashboard/config/widget-sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/widget-sections.ts
@@ -1,0 +1,74 @@
+/**
+ * Internal dependencies
+ */
+import type { DashboardSectionId } from './sections';
+/**
+ * External dependencies
+ */
+import type { WidgetModuleRecord, WidgetType } from '@wordpress/widget-primitives';
+
+/**
+ * A widget module record carrying the sections its type may be added from.
+ *
+ * `sections` is Premium Analytics' own field on the `/widget-modules` payload,
+ * so it is absent from the upstream `WidgetModuleRecord` contract. Optional for
+ * the same reason the section fields are: WPCOM's public-api serves this route
+ * from its own checkout, so a Simple site can be served a payload built before
+ * the field existed. Missing or `null` means every section.
+ */
+export interface SectionScopedWidgetModuleRecord extends WidgetModuleRecord {
+	sections?: string[] | null;
+}
+
+/**
+ * Whether a widget type's server-declared scope admits a section.
+ *
+ * @param sections  - The type's section scope, as served: section slugs.
+ * @param sectionId - The active section's slug, which is what `useActiveSection`
+ *                  resolves to — never the namespaced `analytics/…` id.
+ * @return Whether the type may be added from that section.
+ */
+function isSectionInScope(
+	sections: string[] | null | undefined,
+	sectionId: DashboardSectionId
+): boolean {
+	return ! Array.isArray( sections ) || sections.includes( sectionId );
+}
+
+/**
+ * The widget types a section's dashboard may hand to `WidgetDashboard`.
+ *
+ * One prop feeds both the grid and the widget gallery, so scoping is a union
+ * rather than a plain filter: a type out of scope here is still returned while
+ * the section's layout places it. Dropping it instead would render every
+ * instance a reader had already placed — or that an older default seeded — as
+ * "Missing widget".
+ *
+ * @param widgetTypes - The resolved widget types, from `useWidgetTypesWithI18n`.
+ * @param records     - The complete `/widget-modules` record set, which carries the scope.
+ *                    Deliberately wider than what `widgetTypes` was resolved from, so a
+ *                    type resolved before its record was needed still finds its scope.
+ * @param sectionId   - The active section's slug.
+ * @param placedTypes - Type names the active section's layout places.
+ * @return The widget types in scope for the section, in their original order.
+ */
+export function selectSectionWidgetTypes(
+	widgetTypes: WidgetType[],
+	records: SectionScopedWidgetModuleRecord[] | null | undefined,
+	sectionId: DashboardSectionId,
+	placedTypes: ReadonlySet< string >
+): WidgetType[] {
+	const scopes = new Map(
+		( records ?? [] ).map( record => [ record.name, record.sections ] as const )
+	);
+
+	const scoped = widgetTypes.filter(
+		widgetType =>
+			placedTypes.has( widgetType.name ) ||
+			isSectionInScope( scopes.get( widgetType.name ), sectionId )
+	);
+
+	// Most sections scope nothing away, and `WidgetDashboard` re-renders on a new
+	// `widgetTypes` array — so hand back the one it already has.
+	return scoped.length === widgetTypes.length ? widgetTypes : scoped;
+}

--- a/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
@@ -20,6 +20,9 @@ import type { ReactNode } from 'react';
 // section is ever in the DOM. The mock below models that: without it, anything
 // the stage renders per section would silently multiply here but not in product.
 let mockActiveSectionSlug = 'insights';
+let mockWidgetModules: { name: string; sections?: string[] | null }[] = [];
+let mockWidgetTypes: { name: string }[] = [];
+let mockSectionLayout: { type: string }[] = [];
 let mockSyncState: { data?: SyncStatus; error: Error | null; isComplete: boolean };
 let mockIsSyncFinished: boolean;
 const mockTriggerSync = jest.fn( () => Promise.resolve() );
@@ -81,7 +84,9 @@ jest.mock( '@wordpress/components', () => ( {
 
 jest.mock( '@wordpress/core-data', () => ( { store: {} } ) );
 
-jest.mock( '@wordpress/data', () => ( { useSelect: () => [] } ) );
+// Blunt on purpose: the stage's only `useSelect` is the widget-module records.
+// A second one added later would receive these too — narrow this then.
+jest.mock( '@wordpress/data', () => ( { useSelect: () => mockWidgetModules } ) );
 
 /**
  * Reads the scope the dashboard declares, from where the header's date controls
@@ -110,7 +115,20 @@ function MockScopeProbe() {
 }
 
 jest.mock( '@wordpress/widget-dashboard', () => {
-	const WidgetDashboard = ( { children }: { children: ReactNode } ) => <div>{ children }</div>;
+	// The gallery and the grid read one `widgetTypes` prop, so what the stage
+	// hands over is the whole of what a section can offer and render.
+	const WidgetDashboard = ( {
+		children,
+		widgetTypes,
+	}: {
+		children: ReactNode;
+		widgetTypes: { name: string }[];
+	} ) => (
+		<div>
+			<span data-testid="widget-types">{ widgetTypes.map( type => type.name ).join( ',' ) }</span>
+			{ children }
+		</div>
+	);
 	WidgetDashboard.Actions = () => null;
 	WidgetDashboard.NoWidgetsState = () => null;
 	WidgetDashboard.Widgets = () => <MockScopeProbe />;
@@ -150,13 +168,13 @@ jest.mock( './components', () => ( {
 
 jest.mock( '../widget-module-i18n', () => ( {
 	resolveWidgetModuleWithI18n: jest.fn(),
-	useWidgetTypesWithI18n: () => [ [], false ],
+	useWidgetTypesWithI18n: () => [ mockWidgetTypes, false ],
 } ) );
 
 jest.mock( './hooks', () => ( {
 	useActiveSection: jest.fn(),
 	useDashboardGridSettings: () => [ {} ],
-	useDashboardSectionLayout: () => [ [], jest.fn(), jest.fn() ],
+	useDashboardSectionLayout: () => [ mockSectionLayout, jest.fn(), jest.fn() ],
 	useDashboardSections: jest.fn(),
 	useSectionDateFilter: jest.fn(),
 } ) );
@@ -165,6 +183,9 @@ beforeEach( () => {
 	mockSyncState = { data: undefined, error: null, isComplete: false };
 	mockIsSyncFinished = false;
 	mockTriggerSync.mockImplementation( () => Promise.resolve() );
+	mockWidgetModules = [];
+	mockWidgetTypes = [];
+	mockSectionLayout = [];
 } );
 
 const useDashboardSectionsMock = jest.mocked( useDashboardSections );
@@ -440,5 +461,71 @@ describe( 'Dashboard header date control', () => {
 
 		expect( screen.getByText( 'header offers comparison' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'subtitle: Jan 1 - Jan 30' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'Dashboard widget type scoping', () => {
+	const RECORDS = [
+		{ name: 'jpa/total-views', sections: [ 'traffic' ] },
+		{ name: 'jpa/tags', sections: null },
+	];
+
+	/**
+	 * Resolve both sections and make one of them active.
+	 *
+	 * @param slug - The active section's slug.
+	 */
+	function mockActiveSection( slug: string ) {
+		useDashboardSectionsMock.mockReturnValue( {
+			sections: [
+				{ slug: 'traffic', label: 'Traffic', title: 'Traffic', date_filter: DATE_FILTER_RANGE },
+				{
+					slug: 'insights',
+					label: 'Insights',
+					title: 'Activity insights',
+					date_filter: DATE_FILTER_YEAR,
+				},
+			],
+			hasResolved: true,
+		} as unknown as ReturnType< typeof useDashboardSections > );
+		useActiveSectionMock.mockReturnValue( [ slug, jest.fn() ] );
+		mockActiveSectionSlug = slug;
+	}
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		useSectionDateFilterMock.mockReturnValue( DATE_FILTER_RANGE );
+		mockWidgetModules = RECORDS;
+		mockWidgetTypes = RECORDS.map( record => ( { name: record.name } ) );
+		mockSectionLayout = [];
+	} );
+
+	it( 'offers a scoped type in the section it names', () => {
+		mockActiveSection( 'traffic' );
+
+		render( <Dashboard /> );
+
+		expect( screen.getByTestId( 'widget-types' ) ).toHaveTextContent( 'jpa/total-views,jpa/tags' );
+	} );
+
+	// The section keys are slugs, not the namespaced `analytics/traffic` ids the
+	// same records carry: reading the wrong one would hide these on Traffic and
+	// offer them on Insights, and every other test would still pass.
+	it( 'withholds a scoped type from a section it does not name', () => {
+		mockActiveSection( 'insights' );
+
+		render( <Dashboard /> );
+
+		expect( screen.getByTestId( 'widget-types' ) ).toHaveTextContent( 'jpa/tags' );
+		expect( screen.getByTestId( 'widget-types' ) ).not.toHaveTextContent( 'jpa/total-views' );
+	} );
+
+	it( 'keeps a scoped type the section already places', () => {
+		mockActiveSection( 'insights' );
+		mockSectionLayout = [ { type: 'jpa/total-views' } ];
+
+		render( <Dashboard /> );
+
+		expect( screen.getByTestId( 'widget-types' ) ).toHaveTextContent( 'jpa/total-views,jpa/tags' );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -22,7 +22,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { WidgetDashboard } from '@wordpress/widget-dashboard';
-import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
 import { isPremiumAnalyticsInitialSyncFinished } from '../site-readiness';
 import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
 import { DashboardSections, RefreshFailureNotice, SectionSyncNotice } from './components';
@@ -31,6 +30,8 @@ import {
 	isSectionAwaitingSync,
 	offersDateComparison,
 	resolveSectionHeading,
+	selectSectionWidgetTypes,
+	type SectionScopedWidgetModuleRecord,
 } from './config';
 import {
 	useActiveSection,
@@ -96,7 +97,7 @@ function Dashboard(): JSX.Element {
 						kind: string,
 						name: string,
 						query?: Record< string, unknown >
-					) => WidgetModuleRecord[] | null;
+					) => SectionScopedWidgetModuleRecord[] | null;
 				}
 			 )
 				// `per_page: -1` returns every widget type. Without it, core-data's default
@@ -117,6 +118,26 @@ function Dashboard(): JSX.Element {
 		visibleNames: hasResolvedSections ? layout.map( widget => widget.type ) : null,
 		includeAll: editMode,
 	} );
+
+	// Keyed on the names themselves rather than the array, the way
+	// `useWidgetTypesWithI18n` keys its own scope: a drag or a resize rewrites
+	// `layout` without changing which types it places, and rebuilding the scoped
+	// list on each of those would hand `WidgetDashboard` a new array for nothing.
+	const placedTypesKey = layout
+		.map( widget => widget.type )
+		.sort()
+		.join( '\n' );
+	const placedTypes = useMemo(
+		() => new Set( placedTypesKey ? placedTypesKey.split( '\n' ) : [] ),
+		[ placedTypesKey ]
+	);
+
+	// A widget type can be scoped to some sections only — the gallery in one
+	// section must not offer a widget whose numbers that section cannot date.
+	const sectionWidgetTypes = useMemo(
+		() => selectSectionWidgetTypes( widgetTypes, widgetModules, activeSection, placedTypes ),
+		[ widgetTypes, widgetModules, activeSection, placedTypes ]
+	);
 
 	/*
 	 * Date-range state lives in the URL search params. The shared controller
@@ -266,7 +287,7 @@ function Dashboard(): JSX.Element {
 			 */ }
 			<ReportScopeProvider offersComparison={ showComparison }>
 				<WidgetDashboard
-					widgetTypes={ widgetTypes }
+					widgetTypes={ sectionWidgetTypes }
 					isResolvingWidgetTypes={ isResolvingWidgetTypes }
 					resolveWidgetModule={ resolveWidgetModuleWithI18n }
 					layout={ layout }

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -313,72 +313,42 @@ function get_dashboard_default_section_layouts() {
 				2,
 				2
 			),
-			// Row 4: the period totals and the weekday and hour-of-day
-			// distributions.
-			get_dashboard_default_widget_instance(
-				'default-total-views-widget-instance',
-				'jpa/total-views',
-				4,
-				1,
-				1
-			),
-			get_dashboard_default_widget_instance(
-				'default-total-visitors-widget-instance',
-				'jpa/total-visitors',
-				5,
-				1,
-				1
-			),
-			get_dashboard_default_widget_instance(
-				'default-popular-days-widget-instance',
-				'jpa/popular-days',
-				6,
-				1,
-				1
-			),
-			get_dashboard_default_widget_instance(
-				'default-popular-hours-widget-instance',
-				'jpa/popular-hours',
-				7,
-				1,
-				1
-			),
-			// Row 5: daily views heatmap. Two rows tall, as in the prototype: the
+			// Row 4: daily views heatmap. Two rows tall, as in the prototype: the
 			// cells are sized from the tile's height, and only at this height do they
 			// grow wide enough to label each day with its view count.
 			get_dashboard_default_widget_instance(
 				'default-traffic-views-activity-widget-instance',
 				'jpa/traffic-views-activity',
-				8,
+				4,
 				4,
 				2
 			),
-			// Row 6: the comment leaderboards, shares, and tags.
+			// Row 5: the comment leaderboards, shares, and tags.
 			get_dashboard_default_widget_instance(
 				'default-most-commented-posts-widget-instance',
 				'jpa/most-commented-posts',
-				9,
+				5,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-commented-authors-widget-instance',
 				'jpa/most-commented-authors',
-				10,
+				6,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-shares-widget-instance',
 				'jpa/shares',
-				11,
+				7,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-tags-widget-instance',
 				'jpa/tags',
-				12,
+				8,
 				1,
 				2
 			),

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -278,6 +278,25 @@ function get_dashboard_default_section_layouts() {
 				1,
 				2
 			),
+			// Row 6: when the traffic above arrives. Both read the section's date
+			// range, which is why they sit here rather than on Insights
+			// (WOOPRD-3702). One row tall, unlike the rest of this tab: they are
+			// compact metric tiles, and over two rows the sparkline stretches into
+			// a single meaningless hump.
+			get_dashboard_default_widget_instance(
+				'default-popular-days-widget-instance',
+				'jpa/popular-days',
+				12,
+				2,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-popular-hours-widget-instance',
+				'jpa/popular-hours',
+				13,
+				2,
+				1
+			),
 		),
 		DASHBOARD_INSIGHTS_SECTION_ID    => array(
 			// Follows the prototype's rows (WOOA7S-1786). Emails lives on the

--- a/projects/packages/premium-analytics/src/widget-modules.php
+++ b/projects/packages/premium-analytics/src/widget-modules.php
@@ -52,6 +52,7 @@ function ensure_widget_registry_ready() {
 
 	require_once __DIR__ . '/widget-types.php';
 	require_once __DIR__ . '/widget-availability.php';
+	require_once __DIR__ . '/widget-sections.php';
 
 	// REST does not load the admin build, so this require is the manifest's only route
 	// in (WOOA7S-1804). Drop it and every widget renders "Widget is no longer
@@ -85,6 +86,9 @@ function get_widget_modules_response() {
 			'description'   => $widget_type->description,
 			'help'          => $widget_type->help,
 			'keywords'      => $widget_type->keywords,
+			// Null for every type the gallery may offer in any section, which is
+			// most of them; see widget-sections.php.
+			'sections'      => get_widget_type_sections( $widget_type->name ),
 		);
 	}
 

--- a/projects/packages/premium-analytics/src/widget-sections.php
+++ b/projects/packages/premium-analytics/src/widget-sections.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Widget section scoping policy (consumer layer).
+ *
+ * Which dashboard sections a widget type may be added from, which the widget
+ * gallery reads off the `/widget-modules` record. Placement is a host concern,
+ * so it lives here rather than on the widget manifest: `Widget_Type` carries
+ * identity and authoring metadata only, and the build pipeline that produces
+ * the manifest has no notion of a dashboard section.
+ *
+ * Scoping is deliberately not a hard hide (widget-availability.php): a type
+ * scoped away from a section stays registered, so an instance a reader already
+ * placed there keeps rendering.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics;
+
+require_once __DIR__ . '/dashboard-layout.php';
+
+/**
+ * Widget types that belong to only some of the dashboard's sections, keyed by
+ * type name and holding section *slugs* (`traffic`), not the namespaced ids
+ * (`analytics/traffic`) the same sections also carry. The client compares
+ * against the active section's slug.
+ *
+ * A type absent from this map may be added from any section.
+ *
+ * The four below draw a sparkline over the section's selected period, which
+ * customer interviews found readers could not interpret (WOOPRD-3672). They
+ * keep the Traffic tab, whose date range is the subject of the page. Insights
+ * is a weaker home for them even today, and becomes an untenable one once
+ * WOOPRD-3699 takes that tab's date control away: the period the numbers cover
+ * would then go unstated.
+ */
+const WIDGET_TYPE_SECTIONS = array(
+	'jpa/total-views'    => array( DASHBOARD_TRAFFIC_SECTION_ID ),
+	'jpa/total-visitors' => array( DASHBOARD_TRAFFIC_SECTION_ID ),
+	'jpa/popular-days'   => array( DASHBOARD_TRAFFIC_SECTION_ID ),
+	'jpa/popular-hours'  => array( DASHBOARD_TRAFFIC_SECTION_ID ),
+);
+
+/**
+ * The sections a widget type may be added from.
+ *
+ * @param string $widget_type_name Widget type name, e.g. `jpa/total-views`.
+ * @return string[]|null Section slugs — `traffic`, not `analytics/traffic` — or
+ *                       null when the type is not scoped.
+ */
+function get_widget_type_sections( $widget_type_name ) {
+	return WIDGET_TYPE_SECTIONS[ $widget_type_name ] ?? null;
+}

--- a/projects/packages/premium-analytics/src/widget-sections.php
+++ b/projects/packages/premium-analytics/src/widget-sections.php
@@ -44,6 +44,8 @@ const WIDGET_TYPE_SECTIONS = array(
 /**
  * The sections a widget type may be added from.
  *
+ * @since $$next-version$$
+ *
  * @param string $widget_type_name Widget type name, e.g. `jpa/total-views`.
  * @return string[]|null Section slugs — `traffic`, not `analytics/traffic` — or
  *                       null when the type is not scoped.

--- a/projects/packages/premium-analytics/tests/php/Analytics_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Analytics_Test.php
@@ -882,9 +882,17 @@ class Analytics_Test extends TestCase {
 	 * registry with no error at all (the #49961 bug).
 	 */
 	public function test_widget_manifest_path_defaults_to_the_generated_manifest() {
-		// Collapse the ".." the default is built from rather than realpath()ing it:
-		// build/ does not exist in a checkout that has not run the JS build.
-		$path = preg_replace( '#/[^/]+/\.\./#', '/', Analytics::widget_manifest_path() );
+		// The suite points this filter at a fixture (see bootstrap.php); lift it so
+		// the assertion sees the real default this test exists to pin.
+		remove_filter( 'jetpack_premium_analytics_widgets_manifest_path', 'jpa_test_widget_manifest_path', 1 );
+
+		try {
+			// Collapse the ".." the default is built from rather than realpath()ing it:
+			// build/ does not exist in a checkout that has not run the JS build.
+			$path = preg_replace( '#/[^/]+/\.\./#', '/', Analytics::widget_manifest_path() );
+		} finally {
+			add_filter( 'jetpack_premium_analytics_widgets_manifest_path', 'jpa_test_widget_manifest_path', 1 );
+		}
 
 		$this->assertSame( dirname( __DIR__, 2 ) . '/build/widgets.php', $path );
 	}

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -399,15 +399,11 @@ class Dashboard_Layout_Test extends BaseTestCase {
 			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 4, 1, 1 ),
 			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 2 ),
 			'default-popular-post-widget-instance'         => array( 'jpa/popular-post', 2, 2, 3 ),
-			'default-total-views-widget-instance'          => array( 'jpa/total-views', 1, 1, 4 ),
-			'default-total-visitors-widget-instance'       => array( 'jpa/total-visitors', 1, 1, 5 ),
-			'default-popular-days-widget-instance'         => array( 'jpa/popular-days', 1, 1, 6 ),
-			'default-popular-hours-widget-instance'        => array( 'jpa/popular-hours', 1, 1, 7 ),
-			'default-traffic-views-activity-widget-instance' => array( 'jpa/traffic-views-activity', 4, 2, 8 ),
-			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 9 ),
-			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 10 ),
-			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 11 ),
-			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 12 ),
+			'default-traffic-views-activity-widget-instance' => array( 'jpa/traffic-views-activity', 4, 2, 4 ),
+			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 5 ),
+			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 6 ),
+			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 7 ),
+			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 8 ),
 		);
 
 		$this->assertSame( array_keys( $expected ), array_column( $layout, 'uuid' ) );
@@ -433,8 +429,15 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$this->assertNotContains( 'jpa/stats-emails', $layout_types );
 		// The Comments module ships as two focused widgets, not one toggled widget.
 		$this->assertNotContains( 'jpa/comments', $layout_types );
-		// Total views and Total visitors carry the totals row instead.
+		// All-time stats is not a default yet; it arrives with WOOPRD-3701.
 		$this->assertNotContains( 'jpa/all-time-stats', $layout_types );
+		// These four moved off Insights: their period sparklines did not read
+		// (WOOPRD-3672), and the tab's own date control is on its way out
+		// (WOOPRD-3699). They stay available on Traffic.
+		$this->assertNotContains( 'jpa/total-views', $layout_types );
+		$this->assertNotContains( 'jpa/total-visitors', $layout_types );
+		$this->assertNotContains( 'jpa/popular-days', $layout_types );
+		$this->assertNotContains( 'jpa/popular-hours', $layout_types );
 
 		// Highlights falls back to the widget's own default metric list.
 		$this->assertArrayNotHasKey(

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -341,32 +341,35 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$layout_types    = array_column( $layout, 'type' );
 		$utm_widget_uuid = 'default-utm-insights-widget-instance';
 
-		// uuid => [ type, width, order ]; widths fill the four-column grid.
+		// uuid => [ type, width, height, order ]; widths fill the four-column grid.
 		$expected = array(
-			'default-traffic-chart-widget-instance'   => array( 'jpa/traffic-chart', 4, 0 ),
-			'default-stats-top-posts-widget-instance' => array( 'jpa/stats-top-posts', 2, 1 ),
-			'default-referrers-widget-instance'       => array( 'jpa/referrers', 1, 2 ),
-			'default-devices-widget-instance'         => array( 'jpa/devices', 1, 3 ),
-			'default-locations-widget-instance'       => array( 'jpa/locations', 3, 4 ),
-			'default-top-platforms-widget-instance'   => array( 'jpa/top-platforms', 1, 5 ),
-			'default-videopress-widget-instance'      => array( 'jpa/videopress', 1, 6 ),
-			'default-clicks-widget-instance'          => array( 'jpa/clicks', 1, 7 ),
-			'default-authors-widget-instance'         => array( 'jpa/authors', 2, 8 ),
-			'default-utm-insights-widget-instance'    => array( 'jpa/utm-insights', 2, 9 ),
-			'default-search-terms-widget-instance'    => array( 'jpa/search-terms', 1, 10 ),
-			'default-file-downloads-widget-instance'  => array( 'jpa/file-downloads', 1, 11 ),
+			'default-traffic-chart-widget-instance'   => array( 'jpa/traffic-chart', 4, 2, 0 ),
+			'default-stats-top-posts-widget-instance' => array( 'jpa/stats-top-posts', 2, 2, 1 ),
+			'default-referrers-widget-instance'       => array( 'jpa/referrers', 1, 2, 2 ),
+			'default-devices-widget-instance'         => array( 'jpa/devices', 1, 2, 3 ),
+			'default-locations-widget-instance'       => array( 'jpa/locations', 3, 2, 4 ),
+			'default-top-platforms-widget-instance'   => array( 'jpa/top-platforms', 1, 2, 5 ),
+			'default-videopress-widget-instance'      => array( 'jpa/videopress', 1, 2, 6 ),
+			'default-clicks-widget-instance'          => array( 'jpa/clicks', 1, 2, 7 ),
+			'default-authors-widget-instance'         => array( 'jpa/authors', 2, 2, 8 ),
+			'default-utm-insights-widget-instance'    => array( 'jpa/utm-insights', 2, 2, 9 ),
+			'default-search-terms-widget-instance'    => array( 'jpa/search-terms', 1, 2, 10 ),
+			'default-file-downloads-widget-instance'  => array( 'jpa/file-downloads', 1, 2, 11 ),
+			// One row tall: compact metric tiles, not full-height charts.
+			'default-popular-days-widget-instance'    => array( 'jpa/popular-days', 2, 1, 12 ),
+			'default-popular-hours-widget-instance'   => array( 'jpa/popular-hours', 2, 1, 13 ),
 		);
 
 		$this->assertSame( array_keys( $expected ), array_column( $layout, 'uuid' ) );
 
 		foreach ( $expected as $uuid => $instance ) {
-			list( $type, $width, $order ) = $instance;
+			list( $type, $width, $height, $order ) = $instance;
 
 			$this->assertSame( $type, $layout_by_uuid[ $uuid ]['type'], $uuid );
 			$this->assertSame(
 				array(
 					'width'  => $width,
-					'height' => 2,
+					'height' => $height,
 					'order'  => $order,
 				),
 				$layout_by_uuid[ $uuid ]['placement'],

--- a/projects/packages/premium-analytics/tests/php/Widget_Metadata_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Metadata_Test.php
@@ -13,6 +13,7 @@ use WorDBless\BaseTestCase;
 
 require_once __DIR__ . '/../../src/widget-types.php';
 require_once __DIR__ . '/../../src/widget-modules.php';
+require_once __DIR__ . '/../../src/widget-sections.php';
 require_once __DIR__ . '/fixtures/widget-modules-manifest.php';
 
 /**
@@ -284,5 +285,41 @@ class Widget_Metadata_Test extends BaseTestCase {
 		$this->assertSame( 'Metadata carrier.', $record['description'], 'The description reaches the record.' );
 		$this->assertSame( array( 'content' => 'Helpful.' ), $record['help'], 'The help note reaches the record.' );
 		$this->assertSame( array( 'sentinel' ), $record['keywords'], 'The keywords reach the record.' );
+	}
+
+	/**
+	 * The section scope is policy, not manifest metadata, so the record is where
+	 * it joins the widget type on the way to the client.
+	 */
+	public function test_widget_modules_record_carries_the_section_scope() {
+		$registry       = Widget_Type_Registry::get_instance();
+		$scoped_name    = 'jpa/total-views';
+		$was_registered = $registry->is_registered( $scoped_name );
+
+		if ( ! $was_registered ) {
+			$registry->register( $scoped_name, array( 'title' => 'Total views' ) );
+		}
+		$registry->register( 'test/unscoped-sentinel', array( 'title' => 'Unscoped' ) );
+
+		// The registry is process-wide, so a failure inside the call below must not
+		// leak these two into every test that runs after this one.
+		try {
+			$records = array_column( get_widget_modules_response()->get_data(), null, 'name' );
+		} finally {
+			$registry->unregister( 'test/unscoped-sentinel' );
+			if ( ! $was_registered ) {
+				$registry->unregister( $scoped_name );
+			}
+		}
+
+		$this->assertSame(
+			array( DASHBOARD_TRAFFIC_SECTION_ID ),
+			$records[ $scoped_name ]['sections'],
+			'A scoped type carries its sections to the client.'
+		);
+		$this->assertNull(
+			$records['test/unscoped-sentinel']['sections'],
+			'An unscoped type carries null, which the gallery reads as every section.'
+		);
 	}
 }

--- a/projects/packages/premium-analytics/tests/php/Widget_Metadata_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Metadata_Test.php
@@ -301,6 +301,8 @@ class Widget_Metadata_Test extends BaseTestCase {
 		}
 		$registry->register( 'test/unscoped-sentinel', array( 'title' => 'Unscoped' ) );
 
+		$records = array();
+
 		// The registry is process-wide, so a failure inside the call below must not
 		// leak these two into every test that runs after this one.
 		try {

--- a/projects/packages/premium-analytics/tests/php/Widget_Sections_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Sections_Test.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Tests for the widget type section scoping layer.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics;
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../src/widget-sections.php';
+
+/**
+ * @covers ::Automattic\Jetpack\PremiumAnalytics\get_widget_type_sections
+ */
+#[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\get_widget_type_sections' )]
+class Widget_Sections_Test extends TestCase {
+
+	/**
+	 * The four period totals belong to the tab whose subject is the date range,
+	 * so the gallery offers them on Traffic and nowhere else.
+	 *
+	 * @return array<string, array{string}> Widget type name, keyed by test name.
+	 */
+	public static function provide_traffic_only_widget_types() {
+		return array(
+			'total views'    => array( 'jpa/total-views' ),
+			'total visitors' => array( 'jpa/total-visitors' ),
+			'popular days'   => array( 'jpa/popular-days' ),
+			'popular hours'  => array( 'jpa/popular-hours' ),
+		);
+	}
+
+	/**
+	 * @dataProvider provide_traffic_only_widget_types
+	 *
+	 * @param string $widget_type_name Widget type scoped to the traffic section.
+	 */
+	#[DataProvider( 'provide_traffic_only_widget_types' )]
+	public function test_period_totals_are_scoped_to_the_traffic_section( $widget_type_name ) {
+		$this->assertSame(
+			array( DASHBOARD_TRAFFIC_SECTION_ID ),
+			get_widget_type_sections( $widget_type_name )
+		);
+	}
+
+	/**
+	 * Null, not an empty array: the gallery reads absence as "every section", so
+	 * an unscoped type must not be mistaken for one scoped to nothing.
+	 */
+	public function test_an_unscoped_widget_type_has_no_sections() {
+		$this->assertNull( get_widget_type_sections( 'jpa/tags' ) );
+	}
+
+	/**
+	 * Section ids on the scope have to be ids the dashboard actually registers,
+	 * or the gallery silently offers the type nowhere.
+	 */
+	public function test_every_scoped_section_is_a_real_dashboard_section() {
+		// Every section the dashboard ships a default layout for, so a section
+		// added later is covered without editing this test. A section registered
+		// with no bundled default would not be — it would redden this instead of
+		// slipping past, which is the safe direction.
+		$known_sections = array_keys( get_dashboard_default_section_layouts() );
+		$this->assertNotEmpty( $known_sections );
+
+		foreach ( WIDGET_TYPE_SECTIONS as $widget_type_name => $sections ) {
+			$this->assertNotEmpty( $sections, $widget_type_name );
+
+			foreach ( $sections as $section_id ) {
+				$this->assertContains( $section_id, $known_sections, $widget_type_name );
+			}
+		}
+	}
+}

--- a/projects/packages/premium-analytics/tests/php/Widget_Sections_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Sections_Test.php
@@ -74,9 +74,9 @@ class Widget_Sections_Test extends TestCase {
 			}
 		}
 
-		// Collected rather than asserted in the loop: every seeded type is
-		// unscoped today, so a per-instance assertion would run zero times and
-		// PHPUnit would rightly call the test risky.
+		// Collected rather than asserted in the loop so the shape survives either
+		// state of the scope map: a per-instance assertion runs zero times the
+		// moment nothing seeded is scoped, and PHPUnit rightly calls that risky.
 		$this->assertSame( array(), $violations );
 		$this->assertNotEmpty( $layouts, 'The default layouts are the input; an empty set would pass vacuously.' );
 	}

--- a/projects/packages/premium-analytics/tests/php/Widget_Sections_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Sections_Test.php
@@ -56,6 +56,32 @@ class Widget_Sections_Test extends TestCase {
 	}
 
 	/**
+	 * The scope map and the default layouts are edited in different files with
+	 * nothing tying them together, so a section could end up seeding a widget its
+	 * own gallery refuses to offer. Only a brand-new user would ever see it.
+	 */
+	public function test_no_default_layout_places_an_out_of_scope_widget_type() {
+		$layouts    = get_dashboard_default_section_layouts();
+		$violations = array();
+
+		foreach ( $layouts as $section_id => $instances ) {
+			foreach ( $instances as $instance ) {
+				$sections = get_widget_type_sections( $instance['type'] );
+
+				if ( null !== $sections && ! in_array( $section_id, $sections, true ) ) {
+					$violations[] = sprintf( '%s is seeded into %s but scoped away from it', $instance['type'], $section_id );
+				}
+			}
+		}
+
+		// Collected rather than asserted in the loop: every seeded type is
+		// unscoped today, so a per-instance assertion would run zero times and
+		// PHPUnit would rightly call the test risky.
+		$this->assertSame( array(), $violations );
+		$this->assertNotEmpty( $layouts, 'The default layouts are the input; an empty set would pass vacuously.' );
+	}
+
+	/**
 	 * Section ids on the scope have to be ids the dashboard actually registers,
 	 * or the gallery silently offers the type nowhere.
 	 */

--- a/projects/packages/premium-analytics/tests/php/bootstrap.php
+++ b/projects/packages/premium-analytics/tests/php/bootstrap.php
@@ -26,3 +26,24 @@ require_once __DIR__ . '/mocks/woocommerce-mocks.php';
 // branch of is_videopress_available() can be driven in both directions. Inert until a
 // test populates $GLOBALS['jpa_test_wpcom_features'].
 require_once __DIR__ . '/mocks/wpcom-feature-mocks.php';
+
+// Point the widget manifest at the fixture stub for the whole suite, so no test ever
+// loads build/widgets.php. On a checkout that has been built, a test that declares the
+// stub's jpa_get_registered_widget_modules() and then reaches
+// ensure_widget_registry_ready() fatals on redeclare — require_once dedupes by path, not
+// by symbol — taking the entire run with it. Filtering here rather than per test because
+// ensure_widget_registry_ready() memoizes on a static, so only the first caller in the
+// process ever performs the require, and which test that is depends on run order.
+//
+// Priority 1, so a test staging its own manifest always wins structurally rather than by
+// insertion order. Named rather than a closure so the test that asserts the *unfiltered*
+// default can lift it.
+/**
+ * The fixture stub standing in for the generated widget manifest.
+ *
+ * @return string Absolute path to the fixture.
+ */
+function jpa_test_widget_manifest_path() {
+	return __DIR__ . '/fixtures/widget-modules-manifest.php';
+}
+add_filter( 'jetpack_premium_analytics_widgets_manifest_path', 'jpa_test_widget_manifest_path', 1 );

--- a/projects/packages/premium-analytics/tests/php/fixtures/widget-modules-manifest.php
+++ b/projects/packages/premium-analytics/tests/php/fixtures/widget-modules-manifest.php
@@ -8,6 +8,13 @@
  * `$GLOBALS['jpa_test_widget_manifest']`, or an empty list when unset, so
  * unrelated tests see a no-op manifest.
  *
+ * This declaration is why bootstrap.php filters
+ * `jetpack_premium_analytics_widgets_manifest_path` to this file for the whole suite:
+ * build/widgets.php declares the same function unguarded, and `require_once` dedupes by
+ * path rather than by symbol, so letting the real manifest load too is a fatal redeclare
+ * on any checkout that has been built. Do not remove that filter without moving this
+ * declaration behind a different name.
+ *
  * @package automattic/jetpack-premium-analytics
  */
 

--- a/projects/plugins/jetpack/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/jetpack/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Premium Analytics: Offer Total views, Total visitors, Popular days, and Popular hours only on the Traffic tab, and drop them from the Insights default layout. Existing layouts keep them.
+Premium Analytics: Drop Total views, Total visitors, Popular days, and Popular hours from the Insights tab and its widget gallery, and add Popular days and Popular hours to the Traffic tab's default layout. Existing layouts keep them.

--- a/projects/plugins/jetpack/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/jetpack/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: Total views, Total visitors, Popular days, and Popular hours are now offered only on the Traffic tab, and are no longer part of the Insights tab by default. Existing layouts keep them.

--- a/projects/plugins/jetpack/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/jetpack/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Premium Analytics: Drop Total views, Total visitors, Popular days, and Popular hours from the Insights tab and its widget gallery, and add Popular days and Popular hours to the Traffic tab's default layout. Existing layouts keep them.
+Premium Analytics: Offer Total views, Total visitors, Popular days, and Popular hours from the Traffic tab only, and take them off the Insights default layout. Popular days and Popular hours now ship in Traffic's default instead. Existing layouts keep them.

--- a/projects/plugins/jetpack/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/jetpack/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Premium Analytics: Total views, Total visitors, Popular days, and Popular hours are now offered only on the Traffic tab, and are no longer part of the Insights tab by default. Existing layouts keep them.
+Premium Analytics: Offer Total views, Total visitors, Popular days, and Popular hours only on the Traffic tab, and drop them from the Insights default layout. Existing layouts keep them.

--- a/projects/plugins/mu-wpcom-plugin/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/mu-wpcom-plugin/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: Offer Total views, Total visitors, Popular days, and Popular hours only on the Traffic tab, and drop them from the Insights default layout. Existing layouts keep them.
+Premium Analytics: Drop Total views, Total visitors, Popular days, and Popular hours from the Insights tab and its widget gallery, and add Popular days and Popular hours to the Traffic tab's default layout. Existing layouts keep them.

--- a/projects/plugins/mu-wpcom-plugin/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/mu-wpcom-plugin/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: Total views, Total visitors, Popular days, and Popular hours are now offered only on the Traffic tab, and are no longer part of the Insights tab by default. Existing layouts keep them.
+Premium Analytics: Offer Total views, Total visitors, Popular days, and Popular hours only on the Traffic tab, and drop them from the Insights default layout. Existing layouts keep them.

--- a/projects/plugins/mu-wpcom-plugin/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/mu-wpcom-plugin/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: Drop Total views, Total visitors, Popular days, and Popular hours from the Insights tab and its widget gallery, and add Popular days and Popular hours to the Traffic tab's default layout. Existing layouts keep them.
+Premium Analytics: Offer Total views, Total visitors, Popular days, and Popular hours from the Traffic tab only, and take them off the Insights default layout. Popular days and Popular hours now ship in Traffic's default instead. Existing layouts keep them.

--- a/projects/plugins/mu-wpcom-plugin/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/mu-wpcom-plugin/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Premium Analytics: Total views, Total visitors, Popular days, and Popular hours are now offered only on the Traffic tab, and are no longer part of the Insights tab by default. Existing layouts keep them.

--- a/projects/plugins/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Insights: Total views, Total visitors, Popular days, and Popular hours are now offered only on the Traffic tab, and are no longer part of the Insights tab by default. Existing layouts keep them.

--- a/projects/plugins/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Insights: Drop Total views, Total visitors, Popular days, and Popular hours from the tab and its widget gallery, and add Popular days and Popular hours to the Traffic tab's default layout. Existing layouts keep them.
+Dashboard: Offer Total views, Total visitors, Popular days, and Popular hours from the Traffic tab only, and take them off the Insights default layout. Popular days and Popular hours now ship in Traffic's default instead. Existing layouts keep them.

--- a/projects/plugins/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Insights: Offer Total views, Total visitors, Popular days, and Popular hours only on the Traffic tab, and drop them from the Insights default layout. Existing layouts keep them.
+Insights: Drop Total views, Total visitors, Popular days, and Popular hours from the tab and its widget gallery, and add Popular days and Popular hours to the Traffic tab's default layout. Existing layouts keep them.

--- a/projects/plugins/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/premium-analytics/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Insights: Total views, Total visitors, Popular days, and Popular hours are now offered only on the Traffic tab, and are no longer part of the Insights tab by default. Existing layouts keep them.
+Insights: Offer Total views, Total visitors, Popular days, and Popular hours only on the Traffic tab, and drop them from the Insights default layout. Existing layouts keep them.

--- a/projects/plugins/wpcomsh/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/wpcomsh/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: Offer Total views, Total visitors, Popular days, and Popular hours only on the Traffic tab, and drop them from the Insights default layout. Existing layouts keep them.
+Premium Analytics: Drop Total views, Total visitors, Popular days, and Popular hours from the Insights tab and its widget gallery, and add Popular days and Popular hours to the Traffic tab's default layout. Existing layouts keep them.

--- a/projects/plugins/wpcomsh/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/wpcomsh/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: Total views, Total visitors, Popular days, and Popular hours are now offered only on the Traffic tab, and are no longer part of the Insights tab by default. Existing layouts keep them.
+Premium Analytics: Offer Total views, Total visitors, Popular days, and Popular hours only on the Traffic tab, and drop them from the Insights default layout. Existing layouts keep them.

--- a/projects/plugins/wpcomsh/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/wpcomsh/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: Drop Total views, Total visitors, Popular days, and Popular hours from the Insights tab and its widget gallery, and add Popular days and Popular hours to the Traffic tab's default layout. Existing layouts keep them.
+Premium Analytics: Offer Total views, Total visitors, Popular days, and Popular hours from the Traffic tab only, and take them off the Insights default layout. Popular days and Popular hours now ship in Traffic's default instead. Existing layouts keep them.

--- a/projects/plugins/wpcomsh/changelog/atlas-wooprd-3702-hide-insights-period-widgets
+++ b/projects/plugins/wpcomsh/changelog/atlas-wooprd-3702-hide-insights-period-widgets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Premium Analytics: Total views, Total visitors, Popular days, and Popular hours are now offered only on the Traffic tab, and are no longer part of the Insights tab by default. Existing layouts keep them.


### PR DESCRIPTION
Fixes WOOA7S-2020

## Why

Insights opens with four tiles — Total views, Total visitors, Popular days and Popular hours — each drawing a sparkline over whatever period the tab's date control is set to. Customer interviews found people couldn't tell what those sparklines were showing, and the tab's date control is itself on its way out (WOOA7S-2012), after which the numbers would sit there with nothing on screen to say what stretch of time they cover. This takes all four off Insights and stops that tab's "Add widget" gallery offering them. They stay on Traffic, where the date range is the subject of the page — and Popular days and Popular hours now ship in Traffic's default layout, so they remain in front of people rather than becoming something you have to know to go looking for. Anyone who has already placed one on Insights keeps it.

**Note on ordering:** WOOA7S-2012 has not landed, so Insights still shows its year picker on this branch. The removal doesn't depend on that — the interview finding stands on its own, and Gary signed it off directly on the parent — but the second half of the rationale only fully bites once 2012 ships.

## Proposed changes

* Drop the four widgets from the Insights default layout and renumber the rows that followed them, and add Popular days and Popular hours to the Traffic default as a row of their own (`src/dashboard-layout.php`).
* Add a section-scoping policy for widget types (`src/widget-sections.php`), served on the `/widget-modules` record as a `sections` field, and filter **every** section's widget gallery by it (`routes/dashboard/config/widget-sections.ts`, `routes/dashboard/stage.tsx`). The scope names `traffic` and nothing else, so the four leave the Subscribers, Store and Ads galleries along with Insights' — they read a period the same way there, so that is the intent, and the changelog entries now say so.
* Guard the widget-manifest `require_once` on its accessor rather than its path, so the PHP suite stops fataling on a built checkout.

### Where the scope lives, and why not `widget.json`

The issue suggested a `sections` field on `widget.json`. That does not reach PHP: `@wordpress/build` writes `build/widgets/registry.php` from a hard-coded field list, so an unknown manifest key is dropped before the registry ever sees it. It is also the wrong layer — `src/class-widget-type.php` states the rule already: *"Placement and host concerns (which page or sidebar uses the widget) live with the consumer, not on the type definition."* Dashboard sections are a Premium Analytics concept with no upstream counterpart, so the scope lives in a consumer-layer policy file next to `widget-availability.php`.

Scoping is deliberately **not** a hard hide. `widget-availability.php` unregisters a type everywhere; a scoped type stays registered, so an instance a reader already placed keeps rendering. `WidgetDashboard` takes one `widgetTypes` prop for both the grid and the gallery, so the scoped list is unioned with the types the active section's layout places. The visible consequence: a reader who already has Total views on Insights keeps it, and the gallery keeps offering it to them until they remove it. Everyone else — new users, and anyone who hits Reset — never sees it there.

## Screenshots

**Insights default layout — the row that changed** (same crop on both, anchored on the post-spotlight row above it):

| Before (trunk) | After (this PR) |
| --- | --- |
| <img width="620" src="https://github.com/user-attachments/assets/8bfaeae6-a904-4a27-b0b3-0752c5ae5ff1" /> | <img width="620" src="https://github.com/user-attachments/assets/0f9c3838-936a-4f2c-a322-13106e7ed275" /> |

**"Add widget" gallery on Insights, searching `Total v`:**

| Before (trunk) | After (this PR) |
| --- | --- |
| <img width="620" src="https://github.com/user-attachments/assets/edf67fe8-b484-44ed-97a4-d45fbcce5e19" /> | <img width="620" src="https://github.com/user-attachments/assets/f0dfe591-3667-4967-a10d-149379c84efe" /> |

**Popular days and Popular hours in the Traffic default** — one row tall, unlike the rest of that tab:

<img width="620" src="https://github.com/user-attachments/assets/6b617d6a-9cd3-4bd0-86dc-7ca45296c9fe" />

More states — Traffic still offering all four in its gallery, Subscribers offering none, and an existing Insights layout still rendering them — in the [screenshots comment](https://github.com/Automattic/jetpack/pull/51637#issuecomment-5435145609).

## Verification

The REST record carries the scope, and the Insights default no longer places the four.

<details>
<summary>Output</summary>

```text
$ wp eval '... get_widget_modules_response() ...'
jpa/total-views      has_key=yes value=["traffic"]
jpa/tags             has_key=yes value=null

$ wp eval '... seed_default_dashboard_layout( array(), "insights" ) ...'
order=0  jpa/annual-highlights
order=1  jpa/posting-activity
order=2  jpa/latest-post
order=3  jpa/popular-post
order=4  jpa/traffic-views-activity
order=5  jpa/most-commented-posts
order=6  jpa/most-commented-authors
order=7  jpa/shares
order=8  jpa/tags
```

</details>

## Related product discussion/links

* WOOA7S-2008 — the parent issue. Gary's answer to the open question on this one ("Let us know if they should be fully un-addable on Insights") was *"I'd remove these from the widget picker for now"*, which is why this PR builds the scoping mechanism rather than only editing the default layout.
* WOOA7S-2012 removes the Insights date control; WOOA7S-2021 / 3703 / 3704 add All-time stats, Most popular time and Most popular day in their place.

Popular days and Popular hours were briefly left in no default layout at all — they had only ever been Insights defaults, and Traffic never seeded them. @kangzj called it: they now ship in Traffic's default. Total views and Total visitors deliberately stay out of it and remain available from the Traffic gallery, since the interview finding was about their visuals rather than their placement.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Open **Jetpack → Stats v2** on a site with the Premium Analytics dashboard.

* [ ] On **Insights**, click **Customize → Add widget** and search for `Total v`, `Popular days`, `Popular hours`. None of the four appear.
* [ ] On **Traffic**, Popular days and Popular hours are in the default layout as the last row, one row tall. Their numbers follow the section's date range — switch between `7 days` and `30 days` and watch them move.
* [ ] On **Traffic**, run the same gallery searches. All four appear, add cleanly, and their numbers follow the section's date range.
* [ ] On **Subscribers** (or **Store**), search `Total v` — no results; the scope is Traffic-only.
* [ ] On **Insights**, use the ⋮ menu → **Reset to default**. The tab opens on Highlights → Posting activity → Latest post + Popular post → Traffic views activity → the comment leaderboards and tags, with no gap where the four used to be.
* [ ] **Existing layouts are untouched.** If you already had the four on Insights, they still render with real data — not "Missing widget". To force this case, seed the layout before loading the page:
  ```bash
  wp eval '
  $p = get_user_meta( 1, "wp_persisted_preferences", true );
  $s = "jetpack-premium-analytics/dashboard";
  $p[ $s ]["dashboardSectionLayouts"]["insights"] = array(
    array( "uuid" => "legacy-total-views", "type" => "jpa/total-views", "placement" => array( "width" => 1, "height" => 1, "order" => 0 ) ),
  );
  update_user_meta( 1, "wp_persisted_preferences", $p );'
  ```
* [ ] **Removal on Insights is one-way, by design.** Once you delete that last legacy instance, the union no longer holds the type in scope, so the Insights gallery stops offering it and you cannot add it back on that tab. Traffic is unaffected.
* [ ] Switch tabs a few times with the console open — no errors, and no widget flashes back to a loading state.


