### PR TITLE
[Do not merge] CI: sample runner memory during the JS test lanes (control)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,6 +182,19 @@ jobs:
           FAILED=()
           mkdir artifacts
           [[ -n "$COVERAGE_GROUP" ]] && mkdir coverage
+
+          # [Do not merge] Sample runner memory every 2s while the lanes run, so
+          # the peak can be compared between orderings.
+          MEMLOG="$RUNNER_TEMP/memsample.log"
+          (
+            echo "MemTotal_kB=$( awk '/^MemTotal:/{print $2}' /proc/meminfo ) SwapTotal_kB=$( awk '/^SwapTotal:/{print $2}' /proc/meminfo ) nproc=$( nproc )"
+            while :; do
+              echo "$( date +%s ) $( awk '/^MemAvailable:/{a=$2} /^SwapTotal:/{st=$2} /^SwapFree:/{sf=$2} END{printf "avail_kB=%d swapused_kB=%d", a, st-sf}' /proc/meminfo ) node=$( pgrep node | wc -l ) rss_kB=$( ps -eo rss= | awk '{s+=$1} END{print s+0}' )"
+              sleep 2
+            done
+          ) > "$MEMLOG" 2>&1 &
+          MEMPID=$!
+
           for P in composer.json projects/*/*/composer.json; do
             if [[ ${#PIDS[@]} -ge $MAXPIDS ]]; then
               if ! wait -fn -p PID "${!PIDS[@]}"; then
@@ -284,6 +297,11 @@ jobs:
             echo "Finished ${PIDS[$PID]}"
             unset PIDS[$PID]
           done
+
+          kill "$MEMPID" 2>/dev/null || true
+          echo "::group::Runner memory samples"
+          cat "$MEMLOG"
+          echo "::endgroup::"
 
           if [[ ${#FAILED[@]} -gt 0 ]]; then
             echo ''


### PR DESCRIPTION
### Proposed changes:

- **[Do not merge]** Adds a background sampler to the "Run project tests" step that records `MemAvailable`, swap used, node process count and total RSS every 2s, and dumps them at the end of the step.
- Control arm for #51592's ordering question: this branch keeps the existing lexicographic project order.
- Paired with `try/ci-mem-sample-v2`, which is the same sampler plus the reordering.

Brad raised on Slack that front-loading the long JS projects may trade CPU idle for RAM pressure — `plugins/jetpack` alone forks two jest runs, and nothing in the repo pins `maxWorkers`, so each jest opens `nproc - 1` workers. Job logs record no memory data, so this measures it.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

### Jetpack product discussion

N/A — CI experiment, not for merge.

### Does this pull request change what data or activity we track or use?

No.

### Testing instructions:

Look at the "Runner memory samples" group at the end of the JS tests job.
