### PR TITLE
[Do not merge] CI: sample runner memory with the longest JS projects first

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,7 +182,48 @@ jobs:
           FAILED=()
           mkdir artifacts
           [[ -n "$COVERAGE_GROUP" ]] && mkdir coverage
-          for P in composer.json projects/*/*/composer.json; do
+
+          # [Do not merge] Sample runner memory every 2s while the lanes run, so
+          # the peak can be compared between orderings.
+          MEMLOG="$RUNNER_TEMP/memsample.log"
+          (
+            echo "MemTotal_kB=$( awk '/^MemTotal:/{print $2}' /proc/meminfo ) SwapTotal_kB=$( awk '/^SwapTotal:/{print $2}' /proc/meminfo ) nproc=$( nproc )"
+            while :; do
+              echo "$( date +%s ) $( awk '/^MemAvailable:/{a=$2} /^SwapTotal:/{st=$2} /^SwapFree:/{sf=$2} END{printf "avail_kB=%d swapused_kB=%d", a, st-sf}' /proc/meminfo ) node=$( pgrep node | wc -l ) rss_kB=$( ps -eo rss= | awk '{s+=$1} END{print s+0}' )"
+              sleep 2
+            done
+          ) > "$MEMLOG" 2>&1 &
+          MEMPID=$!
+
+          # The loop hands work to the lanes in the order it walks the projects,
+          # which is lexicographic. That leaves every plugins/* project until
+          # last, so the longest-running ones only start once the run is already
+          # a third done and then finish alone while the other lanes sit idle.
+          #
+          # [Do not merge] Only test-js is reordered here, so the PHP jobs in the
+          # same run act as a control.
+          SLOW_FIRST=()
+          if [[ "$TEST_SCRIPT" == test-js* ]]; then
+            SLOW_FIRST=(
+              projects/packages/premium-analytics/composer.json
+              projects/packages/publicize/composer.json
+              projects/plugins/jetpack/composer.json
+              projects/packages/videopress/composer.json
+            )
+          fi
+          ORDER=( composer.json )
+          for P in "${SLOW_FIRST[@]}"; do
+            [[ -f "$P" ]] && ORDER+=( "$P" )
+          done
+          for P in projects/*/*/composer.json; do
+            for Q in "${SLOW_FIRST[@]}"; do
+              [[ "$P" == "$Q" ]] && continue 2
+            done
+            ORDER+=( "$P" )
+          done
+          echo "Project order: ${ORDER[*]}"
+
+          for P in "${ORDER[@]}"; do
             if [[ ${#PIDS[@]} -ge $MAXPIDS ]]; then
               if ! wait -fn -p PID "${!PIDS[@]}"; then
                 echo "::error::Tests for ${PIDS[$PID]} failed!"
@@ -284,6 +325,11 @@ jobs:
             echo "Finished ${PIDS[$PID]}"
             unset PIDS[$PID]
           done
+
+          kill "$MEMPID" 2>/dev/null || true
+          echo "::group::Runner memory samples"
+          cat "$MEMLOG"
+          echo "::endgroup::"
 
           if [[ ${#FAILED[@]} -gt 0 ]]; then
             echo ''


### PR DESCRIPTION
### Proposed changes:

- **[Do not merge]** Adds a background sampler to the "Run project tests" step that records `MemAvailable`, swap used, node process count and total RSS every 2s, and dumps them at the end of the step.
- Treatment arm: this branch starts premium-analytics, publicize, plugins/jetpack and videopress first.
- Paired with `try/ci-mem-sample`, which is the same sampler on the untouched order.

Brad raised on Slack that front-loading the long JS projects may trade CPU idle for RAM pressure — `plugins/jetpack` alone forks two jest runs, and nothing in the repo pins `maxWorkers`, so each jest opens `nproc - 1` workers. Job logs record no memory data, so this measures it.

### Other information:

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?

### Jetpack product discussion

N/A — CI experiment, not for merge.

### Does this pull request change what data or activity we track or use?

No.

### Testing instructions:

Look at the "Runner memory samples" group at the end of the JS tests job.
