### PR TITLE
WOOA7S-1994: Drop the quarter bucket from drillDateRange after #51631

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1994-drop-quarter-drill-date-range
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1994-drop-quarter-drill-date-range
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Drop the quarter bucket from drillDateRange; the interval type no longer has it (type fix, no user-facing change).

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/drill-date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/drill-date-range.test.ts
@@ -43,13 +43,6 @@ describe( 'drillDateRange', () => {
 		expect( range?.to?.getTime() ).toBe( Date.parse( '2026-02-28T23:59:59.999Z' ) );
 	} );
 
-	it( 'opens the calendar quarter', () => {
-		const range = drillDateRange( utc( '2026-05-09T00:00:00.000Z' ), 'quarter', NOW );
-
-		expect( range?.from?.getTime() ).toBe( Date.parse( '2026-04-01T00:00:00.000Z' ) );
-		expect( range?.to?.getTime() ).toBe( Date.parse( '2026-06-30T23:59:59.999Z' ) );
-	} );
-
 	it( 'opens the calendar year', () => {
 		const range = drillDateRange( utc( '2026-05-09T00:00:00.000Z' ), 'year', NOW );
 

--- a/projects/packages/premium-analytics/packages/datetime/src/drill-date-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/drill-date-range.ts
@@ -5,12 +5,10 @@ import {
 	endOfDay,
 	endOfISOWeek,
 	endOfMonth,
-	endOfQuarter,
 	endOfYear,
 	startOfDay,
 	startOfISOWeek,
 	startOfMonth,
-	startOfQuarter,
 	startOfYear,
 } from 'date-fns';
 /**
@@ -32,7 +30,6 @@ const BUCKET_BOUNDS: Partial<
 	// ISO weeks, matching how the report's own week buckets are cut.
 	week: { start: startOfISOWeek, end: endOfISOWeek },
 	month: { start: startOfMonth, end: endOfMonth },
-	quarter: { start: startOfQuarter, end: endOfQuarter },
 	year: { start: startOfYear, end: endOfYear },
 };
 

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
@@ -417,15 +417,15 @@ describe( 'useReportDateFilters', () => {
 
 		/*
 		 * A chart that cannot draw the applied interval clamps it — the traffic
-		 * chart draws a quarterly page in months — and names the size it drew, so
+		 * chart draws a yearly page in months — and names the size it drew, so
 		 * the click opens the bar it hit rather than the coarser bucket around it.
 		 */
 		it( 'opens the bucket in the interval the chart drew, not the applied one', () => {
 			const { result, rerender } = renderDateFilters( {
-				from: '2025-08-01T00:00:00.000Z',
+				from: '2023-08-01T00:00:00.000Z',
 				to: '2026-07-31T23:59:59.999Z',
 				preset: 'custom',
-				interval: 'quarter',
+				interval: 'year',
 			} );
 
 			act( () => result.current.drillDown( new Date( '2026-02-14T00:00:00.000Z' ), 'month' ) );

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/render.test.tsx
@@ -126,10 +126,10 @@ describe( 'TrafficChart bucket size', () => {
 } );
 
 describe( 'TrafficChart drill-down', () => {
-	// A quarterly page draws in months here, so the click must name the month:
-	// left to the page interval, a click on March would open the whole quarter.
+	// A yearly page draws in months here, so the click must name the month:
+	// left to the page interval, a click on March would open the whole year.
 	it( 'names the bucket size it drew, not the page interval', () => {
-		render( <TrafficChartRender attributes={ { reportParams: reportParams( 'quarter' ) } } /> );
+		render( <TrafficChartRender attributes={ { reportParams: reportParams( 'year' ) } } /> );
 
 		const clicked = new Date( '2026-02-14T00:00:00.000Z' );
 		chartClickHandler()( clicked );

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -60,8 +60,8 @@ function TrafficChartInner( { chartType }: TrafficChartInnerProps ) {
 	// Bound to whichever route hosts the widget, the same way `reportParams` are.
 	const { drillDown } = useReportDateFilters();
 
-	// Names the bucket size drawn, not the page interval: a quarter or year page
-	// interval clamps to months here, and the click must open the bar it hit.
+	// Names the bucket size drawn, not the page interval: a year page interval
+	// clamps to months here, and the click must open the bar it hit.
 	const openBucket = useCallback(
 		( date: Date ) => drillDown( date, period ),
 		[ drillDown, period ]


### PR DESCRIPTION
Fixes N/A

## Proposed changes

* Trunk no longer type-checks: #51631 removed `quarter` from `INTERVAL_TYPES`, and #51544 (merged shortly before it) added `drillDateRange` with a `quarter` bucket, so the two crossed and every PR now fails the "Type checking" job on the merge run.
* Drop the `quarter` bucket from `drillDateRange` and its test, matching the interval types after #51631. Nothing user-facing: the quarterly interval was already gone from the UI.
* The traffic chart drill-down test from #51544 still rendered a quarterly page, which now coerces to `day`; it and the matching routing test drive a yearly page instead, the interval this chart still clamps to months.

## Related product discussion/links

* WOOA7S-1994
* #51631, #51544

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Nothing to test by hand. The "Type checking" job on this PR should pass, where it fails on trunk and on every other open PR.

