### PR TITLE
Premium Analytics: add Most popular day to the default Insights layout

### DIFF
--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-clipping
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-clipping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Most popular day: show the whole card on a short tile instead of clipping it.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-insights
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-insights
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Insights: add the Most popular day widget to the default layout.
+Insights: add the Most popular day widget to the default layout, and say in its help note that its figures are all-time.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-insights
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-insights
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Insights: add the Most popular day widget to the default layout.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-states
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-states
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Most popular day: state a share of views only when there is an all-time total to take it from, and drop the Retry a reader without stats access cannot use.
+Most popular day: give the Day and Views labels the weight the design has them at and the heading structure a screen reader can navigate, state a share of views only when there is an all-time total to take it from, and drop the Retry a reader without stats access cannot use.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-states
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-states
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Most popular day: state a share of views only when there is an all-time total to take it from, and drop the Retry a reader without stats access cannot use.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -172,7 +172,7 @@ const requestCounters: Record< string, number > = {};
  * action; `loading` returns a promise that never settles; `empty` resolves with
  * a valid response that has no rows.
  */
-type ReportMockState = 'error' | 'error-retryable' | 'loading' | 'empty';
+export type ReportMockState = 'error' | 'error-retryable' | 'loading' | 'empty';
 
 const mockStateOverrides = new Map< string, ReportMockState >();
 

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -290,12 +290,8 @@ function get_dashboard_default_section_layouts() {
 				4,
 				1
 			),
-			// Row 2: lifetime totals. Full width for now: the design pairs a
-			// narrow All-time stats card with Most popular time and Most popular
-			// day, and neither is in the default layout yet (WOOPRD-3703,
-			// WOOPRD-3704). A 1-wide card here would leave three empty columns —
-			// the grid packs sparsely, and the next row is a full-width tile.
-			// WOOPRD-3708 narrows it once those two join the row.
+			// Row 2: lifetime totals. Full width until Most popular time joins
+			// the row (WOOA7S-2019); WOOA7S-2009 then settles the arrangement.
 			get_dashboard_default_widget_instance(
 				'default-all-time-stats-widget-instance',
 				'jpa/all-time-stats',
@@ -308,95 +304,106 @@ function get_dashboard_default_section_layouts() {
 					'metrics' => array( 'views', 'visitors', 'posts' ),
 				)
 			),
-			// Row 3: posting-activity heatmap.
+			// Row 3: most popular day. Two rows tall so both fields fit without
+			// scrolling; a 1x1 tile is 200px, which the two display-sized figures
+			// overflow. The design shares this row with All-time stats and Most
+			// popular time, which WOOA7S-2009 arranges once WOOA7S-2019 lands.
+			get_dashboard_default_widget_instance(
+				'default-most-popular-day-widget-instance',
+				'jpa/most-popular-day',
+				2,
+				1,
+				2
+			),
+			// Row 4: posting-activity heatmap.
 			get_dashboard_default_widget_instance(
 				'default-posting-activity-widget-instance',
 				'jpa/posting-activity',
-				2,
+				3,
 				4,
 				1
 			),
-			// Row 4: the two post spotlights.
+			// Row 5: the two post spotlights.
 			get_dashboard_default_widget_instance(
 				'default-latest-post-widget-instance',
 				'jpa/latest-post',
-				3,
+				4,
 				2,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-popular-post-widget-instance',
 				'jpa/popular-post',
-				4,
+				5,
 				2,
 				2
 			),
-			// Row 5: the period totals and the weekday and hour-of-day
+			// Row 6: the period totals and the weekday and hour-of-day
 			// distributions.
 			get_dashboard_default_widget_instance(
 				'default-total-views-widget-instance',
 				'jpa/total-views',
-				5,
+				6,
 				1,
 				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-total-visitors-widget-instance',
 				'jpa/total-visitors',
-				6,
+				7,
 				1,
 				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-popular-days-widget-instance',
 				'jpa/popular-days',
-				7,
+				8,
 				1,
 				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-popular-hours-widget-instance',
 				'jpa/popular-hours',
-				8,
+				9,
 				1,
 				1
 			),
-			// Row 6: daily views heatmap. Two rows tall, as in the prototype: the
+			// Row 7: daily views heatmap. Two rows tall, as in the prototype: the
 			// cells are sized from the tile's height, and only at this height do they
 			// grow wide enough to label each day with its view count.
 			get_dashboard_default_widget_instance(
 				'default-traffic-views-activity-widget-instance',
 				'jpa/traffic-views-activity',
-				9,
+				10,
 				4,
 				2
 			),
-			// Row 7: the comment leaderboards, shares, and tags.
+			// Row 8: the comment leaderboards, shares, and tags.
 			get_dashboard_default_widget_instance(
 				'default-most-commented-posts-widget-instance',
 				'jpa/most-commented-posts',
-				10,
+				11,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-commented-authors-widget-instance',
 				'jpa/most-commented-authors',
-				11,
+				12,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-shares-widget-instance',
 				'jpa/shares',
-				12,
+				13,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-tags-widget-instance',
 				'jpa/tags',
-				13,
+				14,
 				1,
 				2
 			),

--- a/projects/packages/premium-analytics/tests/groups/widgets-shared-route-mock-part2.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/widgets-shared-route-mock-part2.test.tsx
@@ -1,5 +1,6 @@
 // See README.md before adding a suite to this group.
 
+import '../../widgets/most-popular-day/__tests__/most-popular-day.test';
 import '../../widgets/site-overview/__tests__/site-overview.test';
 import '../../widgets/subscriber-highlights/__tests__/subscriber-highlights.test';
 import '../../widgets/tags/__tests__/tags.test';

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -393,22 +393,26 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$layout_by_uuid = array_column( $layout, null, 'uuid' );
 		$layout_types   = array_column( $layout, 'type' );
 
-		// uuid => [ type, width, height, order ]; each row fills the four-column grid.
+		// uuid => [ type, width, height, order ]. Most popular day holds one column
+		// of a row All-time stats and Most popular time share in the design;
+		// WOOA7S-2009 arranges it once WOOA7S-2019 lands. Every other row fills
+		// the four-column grid.
 		$expected = array(
 			'default-annual-highlights-widget-instance'    => array( 'jpa/annual-highlights', 4, 1, 0 ),
 			'default-all-time-stats-widget-instance'       => array( 'jpa/all-time-stats', 4, 1, 1 ),
-			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 4, 1, 2 ),
-			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 3 ),
-			'default-popular-post-widget-instance'         => array( 'jpa/popular-post', 2, 2, 4 ),
-			'default-total-views-widget-instance'          => array( 'jpa/total-views', 1, 1, 5 ),
-			'default-total-visitors-widget-instance'       => array( 'jpa/total-visitors', 1, 1, 6 ),
-			'default-popular-days-widget-instance'         => array( 'jpa/popular-days', 1, 1, 7 ),
-			'default-popular-hours-widget-instance'        => array( 'jpa/popular-hours', 1, 1, 8 ),
-			'default-traffic-views-activity-widget-instance' => array( 'jpa/traffic-views-activity', 4, 2, 9 ),
-			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 10 ),
-			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 11 ),
-			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 12 ),
-			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 13 ),
+			'default-most-popular-day-widget-instance'     => array( 'jpa/most-popular-day', 1, 2, 2 ),
+			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 4, 1, 3 ),
+			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 4 ),
+			'default-popular-post-widget-instance'         => array( 'jpa/popular-post', 2, 2, 5 ),
+			'default-total-views-widget-instance'          => array( 'jpa/total-views', 1, 1, 6 ),
+			'default-total-visitors-widget-instance'       => array( 'jpa/total-visitors', 1, 1, 7 ),
+			'default-popular-days-widget-instance'         => array( 'jpa/popular-days', 1, 1, 8 ),
+			'default-popular-hours-widget-instance'        => array( 'jpa/popular-hours', 1, 1, 9 ),
+			'default-traffic-views-activity-widget-instance' => array( 'jpa/traffic-views-activity', 4, 2, 10 ),
+			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 11 ),
+			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 12 ),
+			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 13 ),
+			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 14 ),
 		);
 
 		$this->assertSame( array_keys( $expected ), array_column( $layout, 'uuid' ) );

--- a/projects/packages/premium-analytics/widgets/most-popular-day/__tests__/most-popular-day.test.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/__tests__/most-popular-day.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import MostPopularDayWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// WidgetRoot reads URL search params as a fallback for report params; outside
+// a matched route the real hook warns and throws.
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+// `views_best_day` is a site-local calendar day, and `views` is the all-time
+// total the best day's share is taken against — here 0.16% of it.
+const SITE_SUMMARY_RESPONSE = {
+	stats: {
+		views: 64144375,
+		views_best_day: '2011-10-17',
+		views_best_day_total: 102631,
+	},
+};
+
+describe( 'MostPopularDayWidget', () => {
+	beforeEach( () => {
+		// The data package's query client is a module-level singleton; drop its
+		// cache so each test starts from a fresh fetch.
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( SITE_SUMMARY_RESPONSE );
+	} );
+
+	it( 'renders the best day and its views with their captions', async () => {
+		const { container } = render( <MostPopularDayWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'October 17' ) ).resolves.toBeInTheDocument();
+
+		// Label with value and caption, so a field that renders the year under the
+		// view count — or vice versa — cannot pass.
+		expect( container ).toHaveTextContent( 'DayOctober 172011' );
+		expect( container ).toHaveTextContent( 'Views102.6K0.16% of views' );
+	} );
+
+	it( 'requests the site summary without date params', async () => {
+		render( <MostPopularDayWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'October 17' ) ).resolves.toBeInTheDocument();
+
+		// The best day is all-time, so sending a date range would imply a filter
+		// the endpoint does not apply.
+		const [ [ request ] ] = mockApiFetch.mock.calls;
+		const path = String( request.path );
+
+		expect( path ).toContain( 'proxy/v1.1/stats' );
+		// Params are serialized into the query string, so no query string at all
+		// pins this more tightly than naming the params one at a time.
+		expect( path ).not.toContain( '?' );
+	} );
+
+	it( 'drops the share caption rather than captioning the best day with 0%', async () => {
+		// A summary with no all-time total to divide by: "0% of views" would read
+		// as a measurement rather than a missing one.
+		mockApiFetch.mockResolvedValue( {
+			stats: { views_best_day: '2011-10-17', views_best_day_total: 102631 },
+		} );
+
+		const { container } = render( <MostPopularDayWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'October 17' ) ).resolves.toBeInTheDocument();
+
+		expect( container ).toHaveTextContent( 'Views102.6K' );
+		expect( screen.queryByText( /of views/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the empty state when the site has no best day yet', async () => {
+		mockApiFetch.mockResolvedValue( { stats: { views: 0 } } );
+
+		render( <MostPopularDayWidget attributes={ {} } /> );
+
+		await expect(
+			screen.findByText( 'Not enough views yet to pick a most popular day.' )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'keeps the rendered day when a refetch fails', async () => {
+		render( <MostPopularDayWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'October 17' ) ).resolves.toBeInTheDocument();
+
+		// `placeholderData` keeps the prior response, so a transient failure must
+		// not replace figures that are still on screen with an error. Awaited on
+		// the refetch itself: "October 17" is already mounted, so asserting it
+		// without waiting would pass before the rejection could land.
+		mockApiFetch.mockRejectedValue( { status: 403, code: 'no_connection' } );
+		await queryClient.refetchQueries( { queryKey: [ 'stats', 'site' ] } );
+		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalledTimes( 2 ) );
+
+		expect( screen.getByText( 'October 17' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Retry' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'offers no retry to a reader without access', async () => {
+		// A plain 403 is a permission failure: retrying cannot fix it, so the
+		// shared error mapper states that neutrally and drops the action.
+		mockApiFetch.mockRejectedValue( { status: 403, message: 'Forbidden' } );
+
+		render( <MostPopularDayWidget attributes={ {} } /> );
+
+		await expect(
+			screen.findByText( "You don't have access to this data." )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Retry' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the error state and refetches from the Retry action', async () => {
+		// `no_connection` is the proxy's retryable 403 — it heals once the site
+		// reconnects — and a 403 avoids React Query's retry backoff.
+		mockApiFetch.mockRejectedValue( {
+			status: 403,
+			code: 'no_connection',
+			message: 'Site is not connected.',
+		} );
+
+		render( <MostPopularDayWidget attributes={ {} } /> );
+
+		await expect(
+			screen.findByText( "We couldn't load your most popular day. Please try again in a moment." )
+		).resolves.toBeInTheDocument();
+
+		// The highlight can only render from a successful refetch, since the
+		// initial request rejected.
+		mockApiFetch.mockResolvedValue( SITE_SUMMARY_RESPONSE );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		await expect( screen.findByText( 'October 17' ) ).resolves.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/most-popular-day/__tests__/most-popular-day.test.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/__tests__/most-popular-day.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { queryClient } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
@@ -64,6 +64,21 @@ describe( 'MostPopularDayWidget', () => {
 		// Params are serialized into the query string, so no query string at all
 		// pins this more tightly than naming the params one at a time.
 		expect( path ).not.toContain( '?' );
+	} );
+
+	it( 'ignores the report params the host injects', async () => {
+		// The pitfall this guards is the opposite of the usual one: the card is
+		// all-time, so host report params must reach WidgetRoot (the contract) and
+		// still leave both the request and the figures untouched.
+		render(
+			<MostPopularDayWidget attributes={ { reportParams: getDefaultQueryParams( true ) } } />
+		);
+
+		await expect( screen.findByText( 'October 17' ) ).resolves.toBeInTheDocument();
+
+		const [ [ request ] ] = mockApiFetch.mock.calls;
+
+		expect( String( request.path ) ).not.toContain( '?' );
 	} );
 
 	it( 'drops the share caption rather than captioning the best day with 0%', async () => {

--- a/projects/packages/premium-analytics/widgets/most-popular-day/__tests__/most-popular-day.test.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/__tests__/most-popular-day.test.tsx
@@ -44,7 +44,10 @@ describe( 'MostPopularDayWidget', () => {
 		// Label with value and caption, so a field that renders the year under the
 		// view count — or vice versa — cannot pass.
 		expect( container ).toHaveTextContent( 'DayOctober 172011' );
-		expect( container ).toHaveTextContent( 'Views102.6K0.16% of views' );
+		// The count appears twice by design: the abbreviated headline is hidden
+		// from assistive tech, and the exact count beside it is hidden visually.
+		expect( container ).toHaveTextContent( 'Views102.6K102,6310.16% of views' );
+		expect( screen.getByText( '102.6K' ) ).toHaveAttribute( 'aria-hidden', 'true' );
 	} );
 
 	it( 'requests the site summary without date params', async () => {
@@ -76,6 +79,22 @@ describe( 'MostPopularDayWidget', () => {
 
 		expect( container ).toHaveTextContent( 'Views102.6K' );
 		expect( screen.queryByText( /of views/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders a count below the first multiplier whole', async () => {
+		// `decimals: 1` alone renders 110 views as "110.0", which reads as a
+		// measurement to one decimal rather than a count of 110.
+		mockApiFetch.mockResolvedValue( {
+			stats: { views: 732, views_best_day: '2011-10-17', views_best_day_total: 110 },
+		} );
+
+		const { container } = render( <MostPopularDayWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'October 17' ) ).resolves.toBeInTheDocument();
+
+		// Nothing to abbreviate, so the count is rendered once and read as it
+		// stands — no hidden duplicate the way the compacted headline needs.
+		expect( container ).toHaveTextContent( 'Views11015.03% of views' );
 	} );
 
 	it( 'shows the empty state when the site has no best day yet', async () => {

--- a/projects/packages/premium-analytics/widgets/most-popular-day/__tests__/most-popular-day.test.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/__tests__/most-popular-day.test.tsx
@@ -44,6 +44,10 @@ describe( 'MostPopularDayWidget', () => {
 		// Label with value and caption, so a field that renders the year under the
 		// view count — or vice versa — cannot pass.
 		expect( container ).toHaveTextContent( 'DayOctober 172011' );
+		// The labels carry the card's structure, so they are headings under the
+		// widget title the host renders.
+		expect( screen.getByRole( 'heading', { level: 4, name: 'Day' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { level: 4, name: 'Views' } ) ).toBeInTheDocument();
 		// The count appears twice by design: the abbreviated headline is hidden
 		// from assistive tech, and the exact count beside it is hidden visually.
 		expect( container ).toHaveTextContent( 'Views102.6K102,6310.16% of views' );
@@ -120,6 +124,21 @@ describe( 'MostPopularDayWidget', () => {
 		await expect(
 			screen.findByText( 'Not enough views yet to pick a most popular day.' )
 		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'shows the empty state for a best day that drew no views', async () => {
+		// A day named with a zero total is the same "not enough views yet" case;
+		// rendering "Views 0" would present it as a measurement.
+		mockApiFetch.mockResolvedValue( {
+			stats: { views: 0, views_best_day: '2011-10-17', views_best_day_total: 0 },
+		} );
+
+		render( <MostPopularDayWidget attributes={ {} } /> );
+
+		await expect(
+			screen.findByText( 'Not enough views yet to pick a most popular day.' )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'October 17' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'keeps the rendered day when a refetch fails', async () => {

--- a/projects/packages/premium-analytics/widgets/most-popular-day/package.json
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/package.json
@@ -12,6 +12,11 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^15.0.0",
-		"@wordpress/widget-primitives": "0.5.0"
+		"@wordpress/widget-primitives": "0.5.0",
+		"react": "18.3.1"
+	},
+	"devDependencies": {
+		"@testing-library/react": "16.3.2",
+		"@wordpress/api-fetch": "7.51.0"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
@@ -48,7 +48,7 @@ type MostPopularDayHighlightProps = {
 type MostPopularDayFieldProps = {
 	label: string;
 	value: ReactNode;
-	/** The unabbreviated value, when `value` renders a shortened form of it. */
+	/** The unabbreviated value, exposed as a tooltip. */
 	valueTitle?: string;
 	caption?: string;
 };

--- a/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
@@ -12,7 +12,7 @@ import {
 	WidgetState,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { Stack, Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
 /**
  * Internal dependencies
@@ -59,7 +59,12 @@ type MostPopularDayFieldProps = {
  */
 const MostPopularDayField = ( { label, value, valueTitle, caption }: MostPopularDayFieldProps ) => (
 	<Stack direction="column" gap="xs">
-		<Text variant="body-md">{ label }</Text>
+		{ /* Heading, matching the Most popular time card this one sits beside: the
+		     labels carry the card's structure, so they should read as structure to
+		     a screen reader too. */ }
+		<Text variant="heading-md" render={ <h4 /> }>
+			{ label }
+		</Text>
 		<Text variant="heading-2xl" title={ valueTitle }>
 			{ value }
 		</Text>
@@ -94,12 +99,20 @@ export const MostPopularDayHighlight = ( { date, views, share }: MostPopularDayH
 	return (
 		<Stack className={ styles.highlight } direction="column" gap="xl" justify="center">
 			<MostPopularDayField
-				label={ __( 'Day', 'jetpack-premium-analytics-pkg' ) }
+				label={ _x(
+					'Day',
+					'label for the calendar date a site drew the most views',
+					'jetpack-premium-analytics-pkg'
+				) }
 				value={ formatDate( date, 'short' ) }
 				caption={ formatDate( date, 'year' ) }
 			/>
 			<MostPopularDayField
-				label={ __( 'Views', 'jetpack-premium-analytics-pkg' ) }
+				label={ _x(
+					'Views',
+					'label for how many views the best day drew',
+					'jetpack-premium-analytics-pkg'
+				) }
 				// An abbreviated headline is read aloud as "102.6 K", so the exact
 				// count is what reaches a screen reader.
 				value={

--- a/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
@@ -13,13 +13,14 @@ import {
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __, sprintf } from '@wordpress/i18n';
-import { Stack, Text } from '@jetpack-premium-analytics/externals';
+import { Stack, Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
 /**
  * Internal dependencies
  */
 import styles from './style.module.css';
 import type { MostPopularDayAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ReactNode } from 'react';
 
 // Report params are dashboard-driven — WidgetRoot resolves them from the date
 // picker — but this highlight is site-wide and ignores them. The host (and
@@ -46,7 +47,9 @@ type MostPopularDayHighlightProps = {
 
 type MostPopularDayFieldProps = {
 	label: string;
-	value: string;
+	value: ReactNode;
+	/** The unabbreviated value, when `value` renders a shortened form of it. */
+	valueTitle?: string;
 	caption?: string;
 };
 
@@ -54,10 +57,12 @@ type MostPopularDayFieldProps = {
  * A single labelled highlight: a small label, the prominent value, and a muted
  * caption beneath it (e.g. "Day" / "August 18" / "2020").
  */
-const MostPopularDayField = ( { label, value, caption }: MostPopularDayFieldProps ) => (
+const MostPopularDayField = ( { label, value, valueTitle, caption }: MostPopularDayFieldProps ) => (
 	<Stack direction="column" gap="xs">
 		<Text variant="body-md">{ label }</Text>
-		<Text variant="heading-2xl">{ value }</Text>
+		<Text variant="heading-2xl" title={ valueTitle }>
+			{ value }
+		</Text>
 		{ caption !== undefined && (
 			<Text variant="body-md" className={ styles.caption }>
 				{ caption }
@@ -66,36 +71,63 @@ const MostPopularDayField = ( { label, value, caption }: MostPopularDayFieldProp
 	</Stack>
 );
 
+// `decimals: 0` would round 102,631 to "103K"; the design's headline keeps the
+// digit ("102.6K"). Below the first multiplier that digit is only ever ".0", so
+// the count renders whole there — the same split Total views makes.
+const ABBREVIATED_COUNT_OPTIONS = { useMultipliers: true, decimals: 1 };
+const PLAIN_COUNT_OPTIONS = { decimals: 0 };
+
 /**
  * Presentational body for the "Most popular day" widget: the all-time best day
  * for views and how many views it drew. Loading / error / empty are handled by
  * `<WidgetState>` in the report component, so this only renders the populated
  * highlight.
  */
-export const MostPopularDayHighlight = ( { date, views, share }: MostPopularDayHighlightProps ) => (
-	<Stack className={ styles.highlight } direction="column" gap="xl" justify="center">
-		<MostPopularDayField
-			label={ __( 'Day', 'jetpack-premium-analytics-pkg' ) }
-			value={ formatDate( date, 'short' ) }
-			caption={ formatDate( date, 'year' ) }
-		/>
-		<MostPopularDayField
-			label={ __( 'Views', 'jetpack-premium-analytics-pkg' ) }
-			value={ formatMetricValue( views, 'number', { useMultipliers: true, decimals: 1 } ) }
-			// A summary without an all-time total gives no share to state; "0% of
-			// views" would read as a measurement rather than a missing one.
-			caption={
-				share === undefined
-					? undefined
-					: sprintf(
-							/* translators: %s is a percentage, e.g. "0.32%". */
-							__( '%s of views', 'jetpack-premium-analytics-pkg' ),
-							formatMetricValue( share, 'percentage', { decimals: 2, signDisplay: 'never' } )
-					  )
-			}
-		/>
-	</Stack>
-);
+export const MostPopularDayHighlight = ( { date, views, share }: MostPopularDayHighlightProps ) => {
+	const fullViews = formatMetricValue( views, 'number', PLAIN_COUNT_OPTIONS );
+	const headlineViews = formatMetricValue(
+		views,
+		'number',
+		views >= 1000 ? ABBREVIATED_COUNT_OPTIONS : PLAIN_COUNT_OPTIONS
+	);
+
+	return (
+		<Stack className={ styles.highlight } direction="column" gap="xl" justify="center">
+			<MostPopularDayField
+				label={ __( 'Day', 'jetpack-premium-analytics-pkg' ) }
+				value={ formatDate( date, 'short' ) }
+				caption={ formatDate( date, 'year' ) }
+			/>
+			<MostPopularDayField
+				label={ __( 'Views', 'jetpack-premium-analytics-pkg' ) }
+				// An abbreviated headline is read aloud as "102.6 K", so the exact
+				// count is what reaches a screen reader.
+				value={
+					headlineViews === fullViews ? (
+						headlineViews
+					) : (
+						<>
+							<span aria-hidden="true">{ headlineViews }</span>
+							<VisuallyHidden>{ fullViews }</VisuallyHidden>
+						</>
+					)
+				}
+				valueTitle={ fullViews }
+				// A summary without an all-time total gives no share to state; "0% of
+				// views" would read as a measurement rather than a missing one.
+				caption={
+					share === undefined
+						? undefined
+						: sprintf(
+								/* translators: %s is a percentage, e.g. "0.32%". */
+								__( '%s of views', 'jetpack-premium-analytics-pkg' ),
+								formatMetricValue( share, 'percentage', { decimals: 2, signDisplay: 'never' } )
+						  )
+				}
+			/>
+		</Stack>
+	);
+};
 
 function readBestDay( summary: Record< string, unknown > | undefined ) {
 	return parseSiteDateTime( summary?.views_best_day );

--- a/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
@@ -12,7 +12,7 @@ import {
 	WidgetState,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Stack, Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
 /**
  * Internal dependencies
@@ -99,20 +99,12 @@ export const MostPopularDayHighlight = ( { date, views, share }: MostPopularDayH
 	return (
 		<Stack className={ styles.highlight } direction="column" gap="xl" justify="center">
 			<MostPopularDayField
-				label={ _x(
-					'Day',
-					'label for the calendar date a site drew the most views',
-					'jetpack-premium-analytics-pkg'
-				) }
+				label={ __( 'Day', 'jetpack-premium-analytics-pkg' ) }
 				value={ formatDate( date, 'short' ) }
 				caption={ formatDate( date, 'year' ) }
 			/>
 			<MostPopularDayField
-				label={ _x(
-					'Views',
-					'label for how many views the best day drew',
-					'jetpack-premium-analytics-pkg'
-				) }
+				label={ __( 'Views', 'jetpack-premium-analytics-pkg' ) }
 				// An abbreviated headline is read aloud as "102.6 K", so the exact
 				// count is what reaches a screen reader.
 				value={
@@ -158,7 +150,9 @@ function MostPopularDayReport() {
 	const date = readBestDay( summary );
 	const views = summaryCount( summary, 'views_best_day_total' );
 	const totalViews = summaryCount( summary, 'views' );
-	const isEmpty = date === undefined || views === undefined;
+	// A best day that drew no views is the empty state the copy describes, not a
+	// measurement of zero — `summaryCount` reports a present `0` as a number.
+	const isEmpty = date === undefined || ! views;
 
 	return (
 		<Stack className={ styles.root } direction="column">

--- a/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
@@ -6,6 +6,7 @@ import { parseSiteDateTime } from '@jetpack-premium-analytics/datetime';
 import { formatDate, formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { calendar } from '@jetpack-premium-analytics/icons';
 import {
+	describeError,
 	summaryCount,
 	WidgetRoot,
 	WidgetState,
@@ -37,7 +38,8 @@ type MostPopularDayHighlightProps = {
 	 */
 	views: number;
 	/**
-	 * The share of all-time views that fall on `date`, as a fraction (0–1).
+	 * The share of all-time views that fall on `date`, as a fraction (0–1), or
+	 * `undefined` when the summary carries no all-time total to divide by.
 	 */
 	share?: number;
 };
@@ -45,7 +47,7 @@ type MostPopularDayHighlightProps = {
 type MostPopularDayFieldProps = {
 	label: string;
 	value: string;
-	caption: string;
+	caption?: string;
 };
 
 /**
@@ -56,9 +58,11 @@ const MostPopularDayField = ( { label, value, caption }: MostPopularDayFieldProp
 	<Stack direction="column" gap="xs">
 		<Text variant="body-md">{ label }</Text>
 		<Text variant="heading-2xl">{ value }</Text>
-		<Text variant="body-md" className={ styles.caption }>
-			{ caption }
-		</Text>
+		{ caption !== undefined && (
+			<Text variant="body-md" className={ styles.caption }>
+				{ caption }
+			</Text>
+		) }
 	</Stack>
 );
 
@@ -68,11 +72,7 @@ const MostPopularDayField = ( { label, value, caption }: MostPopularDayFieldProp
  * `<WidgetState>` in the report component, so this only renders the populated
  * highlight.
  */
-export const MostPopularDayHighlight = ( {
-	date,
-	views,
-	share = 0,
-}: MostPopularDayHighlightProps ) => (
+export const MostPopularDayHighlight = ( { date, views, share }: MostPopularDayHighlightProps ) => (
 	<Stack className={ styles.highlight } direction="column" gap="xl" justify="center">
 		<MostPopularDayField
 			label={ __( 'Day', 'jetpack-premium-analytics-pkg' ) }
@@ -82,11 +82,17 @@ export const MostPopularDayHighlight = ( {
 		<MostPopularDayField
 			label={ __( 'Views', 'jetpack-premium-analytics-pkg' ) }
 			value={ formatMetricValue( views, 'number', { useMultipliers: true, decimals: 1 } ) }
-			caption={ sprintf(
-				/* translators: %s is a percentage, e.g. "0.32%". */
-				__( '%s of views', 'jetpack-premium-analytics-pkg' ),
-				formatMetricValue( share, 'percentage', { decimals: 2, signDisplay: 'never' } )
-			) }
+			// A summary without an all-time total gives no share to state; "0% of
+			// views" would read as a measurement rather than a missing one.
+			caption={
+				share === undefined
+					? undefined
+					: sprintf(
+							/* translators: %s is a percentage, e.g. "0.32%". */
+							__( '%s of views', 'jetpack-premium-analytics-pkg' ),
+							formatMetricValue( share, 'percentage', { decimals: 2, signDisplay: 'never' } )
+					  )
+			}
 		/>
 	</Stack>
 );
@@ -101,7 +107,7 @@ function readBestDay( summary: Record< string, unknown > | undefined ) {
  * summary is site-wide, so it does not read the dashboard date range.
  */
 function MostPopularDayReport() {
-	const { data, isLoading, isFetching, isError, refetch } = useStatsSite();
+	const { data, isLoading, isFetching, isError, error, refetch } = useStatsSite();
 
 	const summary = data?.stats;
 	const date = readBestDay( summary );
@@ -119,18 +125,13 @@ function MostPopularDayReport() {
 					// surface the error when there is nothing to show.
 					isError={ isError && isEmpty }
 					isEmpty={ isEmpty }
-					error={ {
-						description: __(
+					error={ describeError( error, {
+						retryDescription: __(
 							"We couldn't load your most popular day. Please try again in a moment.",
 							'jetpack-premium-analytics-pkg'
 						),
-						actions: [
-							{
-								label: __( 'Retry', 'jetpack-premium-analytics-pkg' ),
-								onClick: () => void refetch(),
-							},
-						],
-					} }
+						onRetry: () => void refetch(),
+					} ) }
 					empty={ {
 						icon: calendar,
 						description: __(
@@ -143,7 +144,7 @@ function MostPopularDayReport() {
 						<MostPopularDayHighlight
 							date={ date }
 							views={ views }
-							share={ totalViews ? views / totalViews : 0 }
+							share={ totalViews ? views / totalViews : undefined }
 						/>
 					) }
 				</WidgetState>

--- a/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
@@ -49,7 +49,7 @@ const SITE_SUMMARY_PATH_FRAGMENT = 'proxy/v1.1/stats';
  * drop it again on cleanup so a forced empty/error result doesn't leak into the
  * other stories' shared cache entry.
  */
-function forceSiteSummaryState( state: 'loading' | 'error' | 'empty' ) {
+function forceSiteSummaryState( state: 'loading' | 'error' | 'error-retryable' | 'empty' ) {
 	queryClient.removeQueries( { queryKey: [ 'stats', 'site' ] } );
 	setReportMockState( SITE_SUMMARY_PATH_FRAGMENT, state );
 	return () => {
@@ -101,14 +101,26 @@ export const Loading: Story = {
 };
 
 /**
- * The fetch failed: the widget shows its error state with a Retry action (which
- * re-runs the query — still mocked as failing while this story is active).
+ * The reader cannot see this site's stats — a permission-gated 403. The widget
+ * states that neutrally and offers no Retry, which could not help.
  */
 export const Error: Story = {
 	render: renderMostPopularDay,
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceSiteSummaryState( 'error' ),
+};
+
+/**
+ * The fetch failed in a way that can heal — the proxy's `no_connection` 403: the
+ * widget shows its retryable copy with a Retry action, which re-runs the query
+ * (still mocked as failing while this story is active).
+ */
+export const ErrorRetryable: Story = {
+	render: renderMostPopularDay,
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceSiteSummaryState( 'error-retryable' ),
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
@@ -22,6 +22,7 @@ import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
+	type ReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import MostPopularDayRender from '../render';
 import widgetDefinition from '../widget';
@@ -49,7 +50,7 @@ const SITE_SUMMARY_PATH_FRAGMENT = 'proxy/v1.1/stats';
  * drop it again on cleanup so a forced empty/error result doesn't leak into the
  * other stories' shared cache entry.
  */
-function forceSiteSummaryState( state: 'loading' | 'error' | 'error-retryable' | 'empty' ) {
+function forceSiteSummaryState( state: ReportMockState ) {
 	queryClient.removeQueries( { queryKey: [ 'stats', 'site' ] } );
 	setReportMockState( SITE_SUMMARY_PATH_FRAGMENT, state );
 	return () => {

--- a/projects/packages/premium-analytics/widgets/most-popular-day/style.module.css
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/style.module.css
@@ -19,7 +19,7 @@
  * rather than `height`: on a tile too short for both fields the box grows to
  * them instead, so `justify: center` has no free space to distribute and the
  * overflow falls below the fold, where `.root` can scroll to it. A fixed height
- * would centre the overflow and push the first field past the top edge. */
+ * would center the overflow and push the first field past the top edge. */
 .highlight {
 	min-height: 100%;
 }

--- a/projects/packages/premium-analytics/widgets/most-popular-day/style.module.css
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/style.module.css
@@ -1,7 +1,10 @@
+/* The default tile is two rows tall, where both fields fit. Resized down to one
+ * row the display figures outgrow the body, so scroll rather than clip. */
 .root {
 	container-type: inline-size;
 	height: 100%;
-	overflow: hidden;
+	overflow-x: hidden;
+	overflow-y: auto;
 }
 
 .content {
@@ -12,9 +15,13 @@
 	min-height: 0;
 }
 
-/* Fill the WidgetState ready area so the highlight stays centered. */
+/* Fill the WidgetState ready area so the highlight stays centered. `min-height`
+ * rather than `height`: on a tile too short for both fields the box grows to
+ * them instead, so `justify: center` has no free space to distribute and the
+ * overflow falls below the fold, where `.root` can scroll to it. A fixed height
+ * would centre the overflow and push the first field past the top edge. */
 .highlight {
-	height: 100%;
+	min-height: 100%;
 }
 
 .caption {

--- a/projects/packages/premium-analytics/widgets/most-popular-day/style.module.css
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/style.module.css
@@ -2,7 +2,7 @@
  * row the display figures outgrow the body, so scroll rather than clip. */
 .root {
 	container-type: inline-size;
-	height: 100%;
+	block-size: 100%;
 	overflow-x: hidden;
 	overflow-y: auto;
 }
@@ -12,16 +12,20 @@
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;
-	min-height: 0;
+	min-block-size: 0;
 }
 
-/* Fill the WidgetState ready area so the highlight stays centered. `min-height`
- * rather than `height`: on a tile too short for both fields the box grows to
- * them instead, so `justify: center` has no free space to distribute and the
- * overflow falls below the fold, where `.root` can scroll to it. A fixed height
- * would center the overflow and push the first field past the top edge. */
+/* Fill the WidgetState ready area so the highlight stays centered. A minimum
+ * rather than a fixed size: on a tile too short for both fields the box grows
+ * to them, so `justify: center` has no free space to distribute and the
+ * overflow falls below the fold, where `.root` can scroll to it. A fixed size
+ * would center the overflow and push the first field past the top edge.
+ *
+ * `widget-state.module.scss` solves the same problem with auto margins because
+ * it cannot beat the Stack's inline `justify-content`; here the Stack is ours,
+ * so growing the box keeps that prop meaningful on a tile that has room. */
 .highlight {
-	min-height: 100%;
+	min-block-size: 100%;
 }
 
 .caption {

--- a/projects/packages/premium-analytics/widgets/most-popular-day/widget.json
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/widget.json
@@ -3,7 +3,13 @@
 	"title": "Most popular day",
 	"description": "The day your site received the most views.",
 	"help": {
-		"content": "The day your site received the most views."
+		"content": "The single day your site received the most views, and that day's share of every view your site has recorded. These figures are all-time and don't change with the period you select.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://wordpress.com/support/stats/learn-insights-about-your-website/"
+			}
+		]
 	},
 	"category": "stats",
 	"presentation": "framed"

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-2011-most-popular-day-clipping
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-2011-most-popular-day-clipping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: show the whole Most popular day card on a short tile instead of clipping it.

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-2011-most-popular-day-insights
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-2011-most-popular-day-insights
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: add the Most popular day widget to the default Insights layout.

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-2011-most-popular-day-insights
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-2011-most-popular-day-insights
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Premium Analytics: add the Most popular day widget to the default Insights layout.
+Premium Analytics: add the Most popular day widget to the default Insights layout, and say in its help note that its figures are all-time.

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-2011-most-popular-day-states
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-2011-most-popular-day-states
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Most popular day states a share of views only when there is an all-time total to take it from, and drops the Retry a reader without stats access cannot use.

--- a/projects/plugins/jetpack/changelog/echo-wooa7s-2011-most-popular-day-states
+++ b/projects/plugins/jetpack/changelog/echo-wooa7s-2011-most-popular-day-states
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Premium Analytics: Most popular day states a share of views only when there is an all-time total to take it from, and drops the Retry a reader without stats access cannot use.
+Premium Analytics: Most popular day gives its Day and Views labels the weight the design has them at and the heading structure a screen reader can navigate, states a share of views only when there is an all-time total to take it from, and drops the Retry a reader without stats access cannot use.

--- a/projects/plugins/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-clipping
+++ b/projects/plugins/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-clipping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Most popular day: show the whole card on a short tile instead of clipping it.

--- a/projects/plugins/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-insights
+++ b/projects/plugins/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-insights
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Insights: add the Most popular day widget to the default layout.
+Insights: add the Most popular day widget to the default layout, and say in its help note that its figures are all-time.

--- a/projects/plugins/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-insights
+++ b/projects/plugins/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-insights
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Insights: add the Most popular day widget to the default layout.

--- a/projects/plugins/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-states
+++ b/projects/plugins/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-states
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Most popular day: state a share of views only when there is an all-time total to take it from, and drop the Retry a reader without stats access cannot use.
+Most popular day: give the Day and Views labels the weight the design has them at and the heading structure a screen reader can navigate, state a share of views only when there is an all-time total to take it from, and drop the Retry a reader without stats access cannot use.

--- a/projects/plugins/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-states
+++ b/projects/plugins/premium-analytics/changelog/echo-wooa7s-2011-most-popular-day-states
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Most popular day: state a share of views only when there is an all-time total to take it from, and drop the Retry a reader without stats access cannot use.


### PR DESCRIPTION
Fixes WOOA7S-2011

## Why

The Insights design has a "Most popular day" card — the single day a site drew the most views, with that day's share of every view it has recorded — but the widget has been picker-only, so nobody sees it unless they go and add it themselves. This puts it on the page by default.

Making it a default surfaced a few things it got wrong. They were tolerable while it was opt-in, less so when everyone gets it, so they're fixed here too.

## Proposed changes

* Add `jpa/most-popular-day` to the default Insights layout, in the spot the design gives it (right after Highlights), sized 1x2 so both fields fit at the 200px row height.
* Scroll instead of clipping. `.root` was `overflow: hidden` with no scroll fallback, and `.highlight` was pinned to `height: 100%` under a `justify: center`, so a tile resized down to one row sliced the day in half at the top *and* the view count in half at the bottom, with neither reachable. `overflow-y: auto` plus `min-height: 100%` lets the body grow to its content and top-anchor, so the rest scrolls into view.
* Render the view count as a count. `decimals: 1` with multipliers is what keeps the digit the design wants in "102.6K", but below the first multiplier that digit is only ever ".0" — a 110-view best day read "110.0". Split the two the way Total views already does, and hand the exact figure to assistive tech, which would otherwise hear the abbreviated "102.6 K".
* Say nothing rather than "0.00% of views". When the summary carries no all-time total to divide by, the share was coerced to zero and captioned anyway, which reads like a measurement instead of a missing one. The caption is dropped now.
* Route the error state through `describeError`, as the Stats widget rules require. Before this, a reader without stats access was told to try again in a moment, behind a Retry that could never work.
* Say what period the card reflects in the help text, and add a Learn more link like Popular days and Popular hours have.
* Give the "Day" and "Views" labels the weight the design has them at, as headings rather than body text — matching the Most popular time card they are meant to sit beside, so the labels reach a screen reader as the structure they are. Both are one-word strings a translator cannot place from the string alone, so both carry context now.
* Add `__tests__/` — the widget had none — and an `ErrorRetryable` story, now that the two 403 shapes render differently.

### One thing worth a reviewer's eye

**The row is mostly empty until its companions land, and that is visible.** The design pairs this card with All-time stats and Most popular time, which land in WOOA7S-2021 (#51635) and WOOA7S-2019 (#51636); WOOA7S-2009 does the final arrangement last. The grid is plain auto-flow with no dense packing, so a 1-wide card between two full-width rows strands columns 2-4 of both its rows — roughly 600x416px of whitespace directly under Highlights, on the default tab of every site that has not customized its Insights layout. It is not subtle, and it lasts until those two PRs merge.

I still put the card where the design has it rather than somewhere tidier that WOOA7S-2009 would only have to undo, and rather than pulling two other in-flight PRs into this one. #51636 makes the identical call for the same row, and this will conflict textually with it — the resolution is both cards in that row, in the design's order. Say the word if you would rather this waited behind WOOA7S-2009 instead.

## Related product discussion/links

* WOOA7S-2011
* p1787126958522969-slack-C06FSDTSN82

## Does this pull request change what data or activity we track or use?

No. Same `stats` site-summary request as before — the widget just renders what already comes back, and the request itself is unchanged.

## Testing instructions

* Open **Jetpack → Stats → Insights** on a site that has some traffic, with no saved Insights layout (a fresh user, or hit Reset in Customize).
* Ensure a "Most popular day" card shows up right below Highlights, one column wide and two rows tall, with Day and Views both fully visible and nothing cut off.
* Ensure the view count reads as a count — `110`, not `110.0`. On a site whose best day drew four figures or more, ensure it keeps one digit (`102.6K`) and that hovering it shows the exact number.
* In Customize, drag the card down to one row tall. Ensure the body top-anchors and scrolls to the Views field instead of slicing the day in half at the top and the count in half at the bottom.
* Click the (i) next to the card title. Ensure the help text says the figures are all-time and don't follow the selected period, and that Learn more opens the Insights support page.
* On a site where the current user can't view stats (or with the proxy returning a plain 403), ensure the card says you don't have access and shows **no** Retry button. With a `no_connection` 403, ensure Retry appears and recovers.
* Change the section's year filter. Ensure the card does not change — it is all-time by design.
* Ensure the rest of the Insights page is unchanged — same widgets, same order, nothing else moved.

## Known, not fixed here

* The card's scroll region has no focusable descendant, so on a one-row tile a keyboard-only reader may not be able to scroll to the second field. Same in `all-time-stats`, `email-top-row`, and `post-detail-highlights` — a package-wide question rather than a regression from this change, but worth someone picking up.
