### PR TITLE
Premium Analytics: match Tags & categories numbers with old Stats

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -773,7 +773,10 @@ wire a handler in `routeStatsReport()` inside `register-report-mocks.ts`. See
 - Widget title: use the framed widget host header via the widget definition/title/icon. Do not
   add a second in-widget `<Text variant="heading-md" render={ <h3 /> }>` title for framed Stats
   widgets.
-- View count format: `dataFormat={ { type: 'number', options: { useMultipliers: true, decimals: 0 } } }`
+- View count format: `dataFormat={ { type: 'number', options: { useMultipliers: true, decimals: 0 } } }`.
+  The one exception is `widgets/tags`, which sets `useMultipliers: false` so its counts read the
+  same as the Jetpack Stats module it is compared against — compacting rounds to whole thousands
+  ("1,240" → "1K") and was reported as a data mismatch (WOOA7S-2018).
 - Leaderboard rows: spread `buildLeaderboardRow()` into the chart entry — it carries the
   drill-down `onClick`/`ariaLabel` that a bare `<LeaderboardRow>` label silently drops. Use
   `<LeaderboardRow>` directly only outside a chart, as `widgets/tags` does for its drilled-in

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -774,13 +774,10 @@ wire a handler in `routeStatsReport()` inside `register-report-mocks.ts`. See
   add a second in-widget `<Text variant="heading-md" render={ <h3 /> }>` title for framed Stats
   widgets.
 - View count format: `dataFormat={ { type: 'number', options: { useMultipliers: true, decimals: 0 } } }`.
-  A new leaderboard uses that. The single exception is `widgets/tags`, which passes
-  `useMultipliers: false` because compacting rounds to the nearest magnitude ("1,240" → "1K") and
-  that was reported as a data mismatch against the Jetpack Stats module it is compared with
-  (WOOA7S-2018). Note the tension rather than resolving it yourself: every report table under
-  `routes/reports/` already prints in full, so a compact widget disagrees with its own "View all"
-  page. Whether the remaining leaderboards follow tags is a product decision, not a refactor —
-  raise it rather than flipping them.
+  `widgets/tags` is the one exception — it passes `useMultipliers: false` because compacting
+  ("1,240" → "1K") was reported as a data mismatch against the Jetpack Stats module it is read
+  beside (WOOA7S-2018). Report tables already print in full, so the widgets are the outliers;
+  whether the rest follow is a product call to raise, not a refactor to do.
 - Leaderboard rows: spread `buildLeaderboardRow()` into the chart entry — it carries the
   drill-down `onClick`/`ariaLabel` that a bare `<LeaderboardRow>` label silently drops. Use
   `<LeaderboardRow>` directly only outside a chart, as `widgets/tags` does for its drilled-in

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -777,7 +777,9 @@ wire a handler in `routeStatsReport()` inside `register-report-mocks.ts`. See
   `widgets/tags` is the one exception — it passes `useMultipliers: false` because compacting
   ("1,240" → "1K") was reported as a data mismatch against the Jetpack Stats module it is read
   beside (WOOA7S-2018). Report tables already print in full, so the widgets are the outliers;
-  whether the rest follow is a product call to raise, not a refactor to do.
+  whether the rest follow is a product call to raise, not a refactor to do. It is not free: the
+  leaderboard grid is `minmax(0, 1fr) auto`, so the wider value permanently takes width from the
+  label — at the 370px tile a long name ellipsizes where the compact form left it room.
 - Leaderboard rows: spread `buildLeaderboardRow()` into the chart entry — it carries the
   drill-down `onClick`/`ariaLabel` that a bare `<LeaderboardRow>` label silently drops. Use
   `<LeaderboardRow>` directly only outside a chart, as `widgets/tags` does for its drilled-in

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -773,10 +773,12 @@ wire a handler in `routeStatsReport()` inside `register-report-mocks.ts`. See
 - Widget title: use the framed widget host header via the widget definition/title/icon. Do not
   add a second in-widget `<Text variant="heading-md" render={ <h3 /> }>` title for framed Stats
   widgets.
-- View count format: `dataFormat={ { type: 'number', options: { useMultipliers: true, decimals: 0 } } }`.
-  The one exception is `widgets/tags`, which sets `useMultipliers: false` so its counts read the
-  same as the Jetpack Stats module it is compared against — compacting rounds to whole thousands
-  ("1,240" → "1K") and was reported as a data mismatch (WOOA7S-2018).
+- View count format: `dataFormat={ { type: 'number', options: { useMultipliers: true, decimals: 0 } } }`,
+  except in `widgets/tags`, which passes `useMultipliers: false`. Compacting rounds to whole
+  thousands ("1,240" → "1K"), which was reported as a data mismatch against Jetpack Stats
+  (WOOA7S-2018). Every report table under `routes/reports/` already prints in full, so a widget on
+  the compact form disagrees with its own "View all" page; expect the rest of the leaderboards to
+  follow `widgets/tags` rather than the other way round.
 - Leaderboard rows: spread `buildLeaderboardRow()` into the chart entry — it carries the
   drill-down `onClick`/`ariaLabel` that a bare `<LeaderboardRow>` label silently drops. Use
   `<LeaderboardRow>` directly only outside a chart, as `widgets/tags` does for its drilled-in

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -773,12 +773,14 @@ wire a handler in `routeStatsReport()` inside `register-report-mocks.ts`. See
 - Widget title: use the framed widget host header via the widget definition/title/icon. Do not
   add a second in-widget `<Text variant="heading-md" render={ <h3 /> }>` title for framed Stats
   widgets.
-- View count format: `dataFormat={ { type: 'number', options: { useMultipliers: true, decimals: 0 } } }`,
-  except in `widgets/tags`, which passes `useMultipliers: false`. Compacting rounds to whole
-  thousands ("1,240" → "1K"), which was reported as a data mismatch against Jetpack Stats
-  (WOOA7S-2018). Every report table under `routes/reports/` already prints in full, so a widget on
-  the compact form disagrees with its own "View all" page; expect the rest of the leaderboards to
-  follow `widgets/tags` rather than the other way round.
+- View count format: `dataFormat={ { type: 'number', options: { useMultipliers: true, decimals: 0 } } }`.
+  A new leaderboard uses that. The single exception is `widgets/tags`, which passes
+  `useMultipliers: false` because compacting rounds to the nearest magnitude ("1,240" → "1K") and
+  that was reported as a data mismatch against the Jetpack Stats module it is compared with
+  (WOOA7S-2018). Note the tension rather than resolving it yourself: every report table under
+  `routes/reports/` already prints in full, so a compact widget disagrees with its own "View all"
+  page. Whether the remaining leaderboards follow tags is a product decision, not a refactor —
+  raise it rather than flipping them.
 - Leaderboard rows: spread `buildLeaderboardRow()` into the chart entry — it carries the
   drill-down `onClick`/`ariaLabel` that a bare `<LeaderboardRow>` label silently drops. Use
   `<LeaderboardRow>` directly only outside a chart, as `widgets/tags` does for its drilled-in

--- a/projects/packages/premium-analytics/changelog/wooa7s-2018-tags-numbers-match-old-stats
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2018-tags-numbers-match-old-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tags & categories: print view counts in full and list every row in the report.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2018-tags-numbers-match-old-stats
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2018-tags-numbers-match-old-stats
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Tags & categories: print view counts in full and list every row in the report.
+Tags & categories: print view counts in full, and list far more rows in the report.

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -586,6 +586,22 @@ describe( 'Stats query factories', () => {
 		] );
 	} );
 
+	// `stats/tags` is the one stats endpoint that rewrites `max < 1` back to its
+	// default of 10, so a `0` is left off the request rather than sent as a value
+	// the server would silently change.
+	it( 'leaves a non-positive tags max off the request', () => {
+		expect( statsTagsQuery( { max: 0 } ).queryKey ).toEqual( [
+			'stats',
+			'tags',
+			'1.1',
+			'stats/tags',
+			'GET',
+			{},
+			undefined,
+			'tags',
+		] );
+	} );
+
 	it( 'passes max through tags query keys', () => {
 		const query = statsTagsQuery( { max: 10 } );
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -586,9 +586,8 @@ describe( 'Stats query factories', () => {
 		] );
 	} );
 
-	// `stats/tags` is the one stats endpoint that rewrites `max < 1` back to its
-	// default of 10, so a `0` is left off the request rather than sent as a value
-	// the server would silently change.
+	// The endpoint rewrites `max < 1` back to its default of 10 rather than reading
+	// it as "all rows", so a `0` must not reach it.
 	it( 'leaves a non-positive tags max off the request', () => {
 		expect( statsTagsQuery( { max: 0 } ).queryKey ).toEqual( [
 			'stats',
@@ -618,10 +617,8 @@ describe( 'Stats query factories', () => {
 		] );
 	} );
 
-	// WPCOM declares `max` as the endpoint's only query parameter and strips the
-	// rest before the handler runs, so a date would change the cache key without
-	// changing a single row. `StatsTagsParams` already rejects one; spreading a
-	// wider object past that check is how this covers the untyped caller.
+	// A date would change the cache key without changing a row. `StatsTagsParams`
+	// already rejects one, so this spreads past the type to cover untyped callers.
 	it( 'never sends a date on the tags query, whatever the selected period', () => {
 		const tagsQueryKey = ( period: Record< string, unknown > ) =>
 			statsTagsQuery( { max: 10, ...period } ).queryKey;

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -586,11 +586,8 @@ describe( 'Stats query factories', () => {
 		] );
 	} );
 
-	it( 'passes supported tags params through query keys', () => {
-		const query = statsTagsQuery( {
-			to: '2026-06-07',
-			max: 10,
-		} );
+	it( 'passes max through tags query keys', () => {
+		const query = statsTagsQuery( { max: 10 } );
 
 		expect( query.enabled ).toBe( true );
 		expect( query.queryKey ).toEqual( [
@@ -599,13 +596,23 @@ describe( 'Stats query factories', () => {
 			'1.1',
 			'stats/tags',
 			'GET',
-			{
-				date: '2026-06-07',
-				max: 10,
-			},
+			{ max: 10 },
 			undefined,
 			'tags',
 		] );
+	} );
+
+	// WPCOM declares `max` as the endpoint's only query parameter and strips the
+	// rest before the handler runs, so a date would change the cache key without
+	// changing a single row. `StatsTagsParams` already rejects one; spreading a
+	// wider object past that check is how this covers the untyped caller.
+	it( 'never sends a date on the tags query, whatever the selected period', () => {
+		const tagsQueryKey = ( period: Record< string, unknown > ) =>
+			statsTagsQuery( { max: 10, ...period } ).queryKey;
+		const maxOnly = [ 'stats', 'tags', '1.1', 'stats/tags', 'GET', { max: 10 }, undefined, 'tags' ];
+
+		expect( tagsQueryKey( { to: '2026-01-31T23:59:59.999-08:00' } ) ).toEqual( maxOnly );
+		expect( tagsQueryKey( { date: '2026-06-30', period: 'year', days: 365 } ) ).toEqual( maxOnly );
 	} );
 
 	it( 'builds devices query keys from the selected device property', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
@@ -4,20 +4,16 @@
 import { statsProxyQuery, type StatsReportQueryOptions } from './stats-query';
 
 /**
- * `stats/tags` declares `max` as its only query parameter, so WPCOM's
- * `query_args()` strips everything else — including `date` — before the handler
- * runs. The window is hardcoded to the seven days ending yesterday in site time:
- * today never counts, and no parameter can move it. Sending a date would only
- * split the query cache per selected period while returning the same rows.
+ * `stats/tags` declares `max` as its only query parameter, so WPCOM strips
+ * everything else — `date` included — before the handler runs: the window is a
+ * hardcoded seven days ending yesterday in site time, and nothing can move it.
  */
 export type StatsTagsParams = {
 	/**
-	 * Rows to request. The server groups and ranks every tag first, over its own
-	 * fixed scan of the site's 50 most-viewed posts, and truncates last — so a
-	 * larger `max` adds rows but never changes a row's views. `0` does not mean
-	 * "all rows": anything below 1 is floored back to the endpoint's default of
-	 * 10, so it is left off the request rather than sent as a value the server
-	 * would silently rewrite.
+	 * Rows to request. `max` only truncates an already-ranked list, so a larger one
+	 * adds rows without moving a row's views. `0` is not "all rows" here — anything
+	 * below 1 is floored back to the endpoint's default of 10, so it is left off the
+	 * request rather than sent to be silently rewritten.
 	 */
 	max?: number;
 };

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
@@ -1,33 +1,29 @@
 /**
  * Internal dependencies
  */
-import { reportParamsToStatsQueryParams } from '../utils/stats-params';
-import {
-	statsProxyQuery,
-	type StatsReportParams,
-	type StatsReportQueryOptions,
-} from './stats-query';
-import type { StatsProxyParams } from '../api';
+import { statsProxyQuery, type StatsReportQueryOptions } from './stats-query';
 
-export type StatsTagsParams = Partial< StatsReportParams > & {
+/**
+ * `stats/tags` declares `max` as its only query parameter, so WPCOM's
+ * `query_args()` strips everything else — including `date` — before the handler
+ * runs. The window is a hardcoded last-7-days anchored on the request instant,
+ * which no parameter can move. Sending a date would only split the query cache
+ * per selected period while returning the same rows.
+ */
+export type StatsTagsParams = {
+	/**
+	 * Rows to request. `0` does not mean "all rows" here: the endpoint floors
+	 * anything below 1 back to its own default of 10, so it is left off the
+	 * request rather than sent as a value the server would silently rewrite.
+	 */
 	max?: number;
 };
-
-function statsTagsParamsToApiParams( params: StatsTagsParams = {} ): StatsProxyParams {
-	const statsParams = reportParamsToStatsQueryParams( params );
-	const date = statsParams.date ?? statsParams.end_date;
-
-	return {
-		...( date ? { date } : {} ),
-		...( statsParams.max !== undefined ? { max: statsParams.max } : {} ),
-	};
-}
 
 export const statsTagsQuery = ( params: StatsTagsParams = {} ): StatsReportQueryOptions< 'tags' > =>
 	statsProxyQuery( {
 		name: 'tags',
 		version: '1.1',
 		endpoint: 'stats/tags',
-		params: statsTagsParamsToApiParams( params ),
+		params: ( params.max ?? 0 ) > 0 ? { max: params.max } : {},
 		sanitizer: 'tags',
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
@@ -6,15 +6,18 @@ import { statsProxyQuery, type StatsReportQueryOptions } from './stats-query';
 /**
  * `stats/tags` declares `max` as its only query parameter, so WPCOM's
  * `query_args()` strips everything else — including `date` — before the handler
- * runs. The window is a hardcoded last-7-days anchored on the request instant,
- * which no parameter can move. Sending a date would only split the query cache
- * per selected period while returning the same rows.
+ * runs. The window is hardcoded to the seven days ending yesterday in site time:
+ * today never counts, and no parameter can move it. Sending a date would only
+ * split the query cache per selected period while returning the same rows.
  */
 export type StatsTagsParams = {
 	/**
-	 * Rows to request. `0` does not mean "all rows" here: the endpoint floors
-	 * anything below 1 back to its own default of 10, so it is left off the
-	 * request rather than sent as a value the server would silently rewrite.
+	 * Rows to request. The server groups and ranks every tag first, over its own
+	 * fixed scan of the site's 50 most-viewed posts, and truncates last — so a
+	 * larger `max` adds rows but never changes a row's views. `0` does not mean
+	 * "all rows": anything below 1 is floored back to the endpoint's default of
+	 * 10, so it is left off the request rather than sent as a value the server
+	 * would silently rewrite.
 	 */
 	max?: number;
 };

--- a/projects/packages/premium-analytics/packages/fields/src/field-select/__tests__/select-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/field-select/__tests__/select-field.test.tsx
@@ -104,9 +104,11 @@ describe( 'SelectField', () => {
 		const control = sizeControl( { data: { size: 10 }, onChange } );
 
 		// `hidden: true` because in jsdom, with no layout to position the popup
-		// against, the mounted options stay hidden even once opened.
+		// against, the mounted options stay hidden even once opened. The options
+		// mount a tick after the click, so this has to wait for them rather than
+		// query once — a synchronous read passes alone and fails under load.
 		await userEvent.click( control );
-		await userEvent.click( screen.getByRole( 'option', { name: 'Twenty', hidden: true } ) );
+		await userEvent.click( await screen.findByRole( 'option', { name: 'Twenty', hidden: true } ) );
 
 		expect( onChange ).toHaveBeenCalledWith( { size: 20 } );
 	} );

--- a/projects/packages/premium-analytics/packages/fields/src/field-select/__tests__/select-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/field-select/__tests__/select-field.test.tsx
@@ -104,9 +104,9 @@ describe( 'SelectField', () => {
 		const control = sizeControl( { data: { size: 10 }, onChange } );
 
 		// `hidden: true` because in jsdom, with no layout to position the popup
-		// against, the mounted options stay hidden even once opened. The options
-		// mount a tick after the click, so this has to wait for them rather than
-		// query once — a synchronous read passes alone and fails under load.
+		// against, the mounted options stay hidden even once opened. They also mount
+		// a tick after the click, so a synchronous read passes alone but fails under
+		// load — wait for them.
 		await userEvent.click( control );
 		await userEvent.click( await screen.findByRole( 'option', { name: 'Twenty', hidden: true } ) );
 

--- a/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.test.ts
@@ -1,7 +1,13 @@
+/**
+ * External dependencies
+ */
 import { useStatsTags } from '@jetpack-premium-analytics/data';
 import { renderHook } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
 import { useTagsReportRecords } from './use-report-records';
-import type { StatsTagsResponse } from '@jetpack-premium-analytics/data';
+import type { StatsNormalizedReport, StatsTagsItem } from '@jetpack-premium-analytics/data';
 
 jest.mock( '@jetpack-premium-analytics/data', () => ( {
 	...jest.requireActual( '@jetpack-premium-analytics/data' ),
@@ -10,10 +16,13 @@ jest.mock( '@jetpack-premium-analytics/data', () => ( {
 
 const mockUseStatsTags = useStatsTags as jest.MockedFunction< typeof useStatsTags >;
 
-const report = {
+const report: StatsNormalizedReport< StatsTagsItem > = {
 	summary: {},
 	data: [
 		{
+			time_interval: '',
+			date_start: '',
+			date_end: '',
 			items: [
 				{
 					label: [
@@ -26,7 +35,7 @@ const report = {
 			],
 		},
 	],
-} as unknown as StatsTagsResponse;
+};
 
 describe( 'useTagsReportRecords', () => {
 	beforeEach( () => {

--- a/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.test.ts
@@ -52,9 +52,6 @@ describe( 'useTagsReportRecords', () => {
 		jest.clearAllMocks();
 	} );
 
-	// `max` is the endpoint's only query parameter and anything below 1 is floored
-	// back to its default of 10, so the report has to name a number to list more
-	// rows than the widget does.
 	it( 'requests more rows than the endpoint would return by default', () => {
 		renderHook( () => useTagsReportRecords() );
 

--- a/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.test.ts
@@ -1,0 +1,62 @@
+import { useStatsTags } from '@jetpack-premium-analytics/data';
+import { renderHook } from '@testing-library/react';
+import { useTagsReportRecords } from './use-report-records';
+import type { StatsTagsResponse } from '@jetpack-premium-analytics/data';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	useStatsTags: jest.fn(),
+} ) );
+
+const mockUseStatsTags = useStatsTags as jest.MockedFunction< typeof useStatsTags >;
+
+const report = {
+	summary: {},
+	data: [
+		{
+			items: [
+				{
+					label: [
+						{ label: 'Recipes', labelIcon: 'folder', link: 'https://example.com/recipes/' },
+					],
+					labelText: 'Recipes',
+					value: 1240,
+					link: 'https://example.com/recipes/',
+				},
+			],
+		},
+	],
+} as unknown as StatsTagsResponse;
+
+describe( 'useTagsReportRecords', () => {
+	beforeEach( () => {
+		mockUseStatsTags.mockReturnValue( {
+			data: report,
+			isLoading: false,
+			isFetching: false,
+			isError: false,
+			refetch: jest.fn(),
+		} as unknown as ReturnType< typeof useStatsTags > );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	// `max` is the endpoint's only query parameter and anything below 1 is floored
+	// back to its default of 10, so the report has to name a number to list more
+	// rows than the widget does.
+	it( 'requests more rows than the endpoint would return by default', () => {
+		renderHook( () => useTagsReportRecords() );
+
+		expect( mockUseStatsTags ).toHaveBeenCalledWith( { max: 100 } );
+	} );
+
+	it( 'returns the normalized rows', () => {
+		const { result } = renderHook( () => useTagsReportRecords() );
+
+		expect( result.current.rows ).toEqual( [
+			expect.objectContaining( { labelText: 'Recipes', value: 1240 } ),
+		] );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.test.ts
@@ -55,7 +55,7 @@ describe( 'useTagsReportRecords', () => {
 	it( 'requests more rows than the endpoint would return by default', () => {
 		renderHook( () => useTagsReportRecords() );
 
-		expect( mockUseStatsTags ).toHaveBeenCalledWith( { max: 100 } );
+		expect( mockUseStatsTags ).toHaveBeenCalledWith( { max: 1000 } );
 	} );
 
 	it( 'returns the normalized rows', () => {

--- a/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
@@ -15,18 +15,25 @@ export function getTagRowId( item: StatsTagsItem ): string {
 }
 
 /**
- * Fetch the all-time Tags & categories rows.
+ * Rows to request for the report table. The endpoint declares `max` as its only
+ * query parameter and floors anything below 1 back to its default of 10, so a
+ * report that wants every row has to name a number. Its own ranking is drawn
+ * from at most 50 posts, which this comfortably clears.
+ */
+const TAGS_REPORT_ROW_LIMIT = 100;
+
+/**
+ * Fetch the Tags & categories rows.
  *
- * The endpoint ignores date-window parameters (`period`, `start_date`,
- * `days`, `summarize`) and always reports one flat all-time list — verified
- * against WPCOM directly, and matching Calypso, which never sends date
- * params here — so the report requests only `max: 0` (all rows) and renders
- * no chart or date filters.
+ * The endpoint reports one flat list over a fixed last-seven-days window and
+ * takes no date parameters — WPCOM strips everything but `max` before the
+ * handler runs, and Calypso never sends any — so the report renders no chart
+ * and no date filters.
  *
  * @return Table rows and fetch state.
  */
 export function useTagsReportRecords() {
-	const tags = useStatsTags( { max: 0 } );
+	const tags = useStatsTags( { max: TAGS_REPORT_ROW_LIMIT } );
 	const rows = useMemo< StatsTagsItem[] >(
 		() => tags.data?.data?.[ 0 ]?.items ?? [],
 		[ tags.data ]

--- a/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
@@ -15,10 +15,12 @@ export function getTagRowId( item: StatsTagsItem ): string {
 }
 
 /**
- * Rows to request for the report table. The endpoint declares `max` as its only
- * query parameter and floors anything below 1 back to its default of 10, so a
- * report that wants every row has to name a number. Its own ranking is drawn
- * from at most 50 posts, which this comfortably clears.
+ * Rows to request for the report table. `stats/tags` declares `max` as its only
+ * query parameter and is the one stats endpoint that floors anything below 1
+ * back to its default of 10 (`if ( $max < 1 ) $max = 10;`), rather than reading
+ * it as "all rows" the way its siblings do — so a report that wants more than
+ * the widget's ten has to name a number. Its ranking is drawn from at most 50
+ * posts, which this comfortably clears.
  */
 const TAGS_REPORT_ROW_LIMIT = 100;
 

--- a/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
@@ -15,10 +15,13 @@ export function getTagRowId( item: StatsTagsItem ): string {
 }
 
 /**
- * `stats/tags` has no "all rows" value (see `StatsTagsParams`), so a report that
- * wants more than the widget's ten has to name a number.
+ * `stats/tags` has no "all rows" value (see `StatsTagsParams`), so unlike the
+ * sibling reports that send `max: 0` this one has to name a ceiling. The endpoint
+ * ranks over at most ~51 posts per day across its seven days, so a thousand groups
+ * is past what a real site produces — but it is a ceiling all the same, and the
+ * table reports whatever arrives as the total.
  */
-const TAGS_REPORT_ROW_LIMIT = 100;
+const TAGS_REPORT_ROW_LIMIT = 1000;
 
 /**
  * Fetch the Tags & categories rows.

--- a/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
@@ -27,10 +27,8 @@ const TAGS_REPORT_ROW_LIMIT = 100;
 /**
  * Fetch the Tags & categories rows.
  *
- * The endpoint reports one flat list over a fixed last-seven-days window and
- * takes no date parameters — WPCOM strips everything but `max` before the
- * handler runs, and Calypso never sends any — so the report renders no chart
- * and no date filters.
+ * One flat list, no chart and no date filters, because the endpoint takes no
+ * date parameters — see `TAGS_REPORT_ROW_LIMIT` above.
  *
  * @return Table rows and fetch state.
  */

--- a/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
@@ -15,20 +15,13 @@ export function getTagRowId( item: StatsTagsItem ): string {
 }
 
 /**
- * Rows to request for the report table. `stats/tags` has no "all rows" value —
- * anything below 1 is floored back to its default of 10 — so a report that wants
- * more than the widget's ten has to name a number. Truncation is the only thing
- * `max` does (see `StatsTagsParams`), so asking for more rows here cannot put a
- * row's views out of step with the same row in the widget, or in the Jetpack
- * Stats module both are read beside.
+ * `stats/tags` has no "all rows" value (see `StatsTagsParams`), so a report that
+ * wants more than the widget's ten has to name a number.
  */
 const TAGS_REPORT_ROW_LIMIT = 100;
 
 /**
  * Fetch the Tags & categories rows.
- *
- * One flat list, no chart and no date filters, because the endpoint takes no
- * date parameters — see `TAGS_REPORT_ROW_LIMIT` above.
  *
  * @return Table rows and fetch state.
  */

--- a/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
@@ -15,12 +15,12 @@ export function getTagRowId( item: StatsTagsItem ): string {
 }
 
 /**
- * Rows to request for the report table. `stats/tags` declares `max` as its only
- * query parameter and is the one stats endpoint that floors anything below 1
- * back to its default of 10 (`if ( $max < 1 ) $max = 10;`), rather than reading
- * it as "all rows" the way its siblings do — so a report that wants more than
- * the widget's ten has to name a number. Its ranking is drawn from at most 50
- * posts, which this comfortably clears.
+ * Rows to request for the report table. `stats/tags` has no "all rows" value —
+ * anything below 1 is floored back to its default of 10 — so a report that wants
+ * more than the widget's ten has to name a number. Truncation is the only thing
+ * `max` does (see `StatsTagsParams`), so asking for more rows here cannot put a
+ * row's views out of step with the same row in the widget, or in the Jetpack
+ * Stats module both are read beside.
  */
 const TAGS_REPORT_ROW_LIMIT = 100;
 

--- a/projects/packages/premium-analytics/routes/reports/tags/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/tags/page.tsx
@@ -40,8 +40,9 @@ const sortTagCsvRows = ( a: StatsTagsItem, b: StatsTagsItem ) => b.value - a.val
 /**
  * Premium Analytics Tags & categories report page component.
  *
- * `stats/tags` returns one flat all-time list and ignores date-window params, so this page
- * has no date filters, tabs, or performance chart — just the header and records table.
+ * `stats/tags` returns one flat list over the seven days ending yesterday and ignores
+ * date-window params, so this page has no date filters, tabs, or performance chart —
+ * just the header and records table.
  *
  * @return The Tags & categories report page.
  */

--- a/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
@@ -35,10 +35,6 @@ const TAGS_RESPONSE = {
 			views: 980,
 		},
 		{
-			tags: [ { type: 'tag', name: 'viral', link: 'https://example.com/tag/viral/' } ],
-			views: 1234567,
-		},
-		{
 			tags: [
 				{ type: 'category', name: 'Desserts', link: 'https://example.com/category/desserts/' },
 				{ type: 'tag', name: 'chocolate', link: 'https://example.com/tag/chocolate/' },
@@ -134,14 +130,30 @@ describe( 'TagsWidget', () => {
 	// The same module in Jetpack Stats prints the count in full, and the two are
 	// read side by side. Compacting rounds to whole thousands, so 1,240 would show
 	// as "1K" and read as different data rather than as rounding (WOOA7S-2018).
-	// The seven-digit row covers the widest count the row has to hold once the
-	// compact form is gone.
 	it( 'prints view counts in full rather than compacting them', async () => {
 		render( <TagsWidget attributes={ { reportParams: getDefaultQueryParams() } } /> );
 
 		await expect( screen.findByText( '1,240' ) ).resolves.toBeInTheDocument();
-		expect( screen.getByText( '1,234,567' ) ).toBeInTheDocument();
 		expect( screen.queryByText( '1K' ) ).not.toBeInTheDocument();
+	} );
+
+	// The widest count a row has to hold once the compact form is gone. Its own
+	// response, because the top row sets the denominator every other row's bar
+	// width is drawn from.
+	it( 'prints a seven-digit count in full', async () => {
+		mockApiFetch.mockResolvedValue( {
+			...TAGS_RESPONSE,
+			tags: [
+				{
+					tags: [ { type: 'tag', name: 'viral', link: 'https://example.com/tag/viral/' } ],
+					views: 1234567,
+				},
+			],
+		} );
+
+		render( <TagsWidget attributes={ { reportParams: getDefaultQueryParams() } } /> );
+
+		await expect( screen.findByText( '1,234,567' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( '1M' ) ).not.toBeInTheDocument();
 	} );
 

--- a/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
+import { WIDGET_ROW_LIMIT } from '@jetpack-premium-analytics/widgets-toolkit';
 import { fireEvent, render, screen } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import { category, tag } from '@wordpress/icons';
@@ -32,6 +33,10 @@ const TAGS_RESPONSE = {
 		{
 			tags: [ { type: 'tag', name: 'vegan', link: 'https://example.com/tag/vegan/' } ],
 			views: 980,
+		},
+		{
+			tags: [ { type: 'tag', name: 'viral', link: 'https://example.com/tag/viral/' } ],
+			views: 1234567,
 		},
 		{
 			tags: [
@@ -124,5 +129,37 @@ describe( 'TagsWidget', () => {
 
 		await expect( screen.findByText( 'Recipes' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'chocolate' ) ).not.toBeInTheDocument();
+	} );
+
+	// The same module in Jetpack Stats prints the count in full, and the two are
+	// read side by side. Compacting rounds to whole thousands, so 1,240 would show
+	// as "1K" and read as different data rather than as rounding (WOOA7S-2018).
+	// The seven-digit row covers the widest count the row has to hold once the
+	// compact form is gone.
+	it( 'prints view counts in full rather than compacting them', async () => {
+		render( <TagsWidget attributes={ { reportParams: getDefaultQueryParams() } } /> );
+
+		await expect( screen.findByText( '1,240' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( '1,234,567' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '1K' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( '1M' ) ).not.toBeInTheDocument();
+	} );
+
+	// WPCOM declares `max` as the only query parameter `stats/tags` accepts and
+	// strips the rest, so a date would only split the cache per selected period.
+	it( 'requests the endpoint with max alone', async () => {
+		render( <TagsWidget attributes={ { reportParams: getDefaultQueryParams() } } /> );
+
+		await expect( screen.findByText( 'Recipes' ) ).resolves.toBeInTheDocument();
+
+		const requestedPaths = mockApiFetch.mock.calls
+			.map( ( [ options ] ) => String( options?.path ?? '' ) )
+			.filter( path => path.includes( 'stats/tags' ) );
+
+		expect( requestedPaths ).not.toHaveLength( 0 );
+		requestedPaths.forEach( path => {
+			expect( path ).toContain( `max=${ WIDGET_ROW_LIMIT }` );
+			expect( path ).not.toContain( 'date=' );
+		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
@@ -171,8 +171,9 @@ describe( 'TagsWidget', () => {
 
 		expect( requestedPaths ).not.toHaveLength( 0 );
 		requestedPaths.forEach( path => {
-			expect( path ).toContain( `max=${ WIDGET_ROW_LIMIT }` );
-			expect( path ).not.toContain( 'date=' );
+			const params = new URLSearchParams( path.split( '?' )[ 1 ] );
+			expect( params.get( 'max' ) ).toBe( String( WIDGET_ROW_LIMIT ) );
+			expect( params.has( 'date' ) ).toBe( false );
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
@@ -175,4 +175,13 @@ describe( 'TagsWidget', () => {
 			expect( path ).not.toContain( 'date=' );
 		} );
 	} );
+
+	// Calypso's Tags & categories module sends no query at all, so Jetpack Stats
+	// gets the endpoint's own `(int=10)` default. Asking for the same ten is what
+	// makes the two surfaces list the same rows; if the shared row limit is ever
+	// retuned, this widget stops matching the module it is read beside, so make
+	// that a deliberate change rather than a side effect.
+	it( 'asks for the row count Jetpack Stats gets by default', () => {
+		expect( WIDGET_ROW_LIMIT ).toBe( 10 );
+	} );
 } );

--- a/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
@@ -176,11 +176,8 @@ describe( 'TagsWidget', () => {
 		} );
 	} );
 
-	// Calypso's Tags & categories module sends no query at all, so Jetpack Stats
-	// gets the endpoint's own `(int=10)` default. Asking for the same ten is what
-	// makes the two surfaces list the same rows; if the shared row limit is ever
-	// retuned, this widget stops matching the module it is read beside, so make
-	// that a deliberate change rather than a side effect.
+	// Calypso sends no query at all, so Jetpack Stats gets the endpoint's own
+	// default of 10. Retuning the shared limit silently stops the two matching.
 	it( 'asks for the row count Jetpack Stats gets by default', () => {
 		expect( WIDGET_ROW_LIMIT ).toBe( 10 );
 	} );

--- a/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
@@ -137,9 +137,10 @@ describe( 'TagsWidget', () => {
 		expect( screen.queryByText( '1K' ) ).not.toBeInTheDocument();
 	} );
 
-	// The widest count a row has to hold once the compact form is gone. Its own
-	// response, because the top row sets the denominator every other row's bar
-	// width is drawn from.
+	// The widest count a row has to hold once the compact form is gone. It gets its
+	// own response because the top row is the denominator every other row's bar
+	// width is drawn from, so putting it in the shared fixture would quietly
+	// re-tune every other test in this file.
 	it( 'prints a seven-digit count in full', async () => {
 		mockApiFetch.mockResolvedValue( {
 			...TAGS_RESPONSE,

--- a/projects/packages/premium-analytics/widgets/tags/render.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/render.tsx
@@ -189,7 +189,7 @@ function TagsInner() {
 }
 
 /**
-* Ported from the Jetpack Stats "Tags & categories" module. Grouped rows
+ * Ported from the Jetpack Stats "Tags & categories" module. Grouped rows
  * (several tags/categories sharing a post) drill down to their individual members.
  */
 export default function Tags( { attributes = {} }: TagsWidgetProps ) {

--- a/projects/packages/premium-analytics/widgets/tags/render.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/render.tsx
@@ -16,7 +16,6 @@ import {
 	safeHttpUrl,
 	sharePercentage,
 	useWidgetDrillDown,
-	useWidgetRootContext,
 	type LeaderboardChartData,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
@@ -71,9 +70,7 @@ function TagGroupMembers( { members }: TagGroupMembersProps ) {
 }
 
 function TagsInner() {
-	const { reportParams } = useWidgetRootContext();
 	const { data, isLoading, isFetching, isError, refetch } = useTagViews( {
-		reportParams,
 		max: WIDGET_ROW_LIMIT,
 	} );
 
@@ -171,9 +168,14 @@ function TagsInner() {
 							data={ leaderboardData }
 							withOverlayLabel
 							showLegend={ false }
+							// Exact counts rather than the leaderboards' usual compact form:
+							// this widget is read side by side with the same module in
+							// Jetpack Stats, where a tag with 1,240 views reads "1,240".
+							// Compacting to whole thousands would show it as "1K" and read
+							// as a data mismatch rather than as rounding.
 							dataFormat={ {
 								type: 'number',
-								options: { useMultipliers: true, decimals: 0 },
+								options: { useMultipliers: false, decimals: 0 },
 							} }
 						/>
 					) }
@@ -187,7 +189,7 @@ function TagsInner() {
 }
 
 /**
- * Ported from the Jetpack Stats "Tags & categories" module. Grouped rows
+* Ported from the Jetpack Stats "Tags & categories" module. Grouped rows
  * (several tags/categories sharing a post) drill down to their individual members.
  */
 export default function Tags( { attributes = {} }: TagsWidgetProps ) {

--- a/projects/packages/premium-analytics/widgets/tags/render.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/render.tsx
@@ -168,11 +168,10 @@ function TagsInner() {
 							data={ leaderboardData }
 							withOverlayLabel
 							showLegend={ false }
-							// Exact counts rather than the leaderboards' usual compact form:
-							// this widget is read side by side with the same module in
-							// Jetpack Stats, where a tag with 1,240 views reads "1,240".
-							// Compacting to whole thousands would show it as "1K" and read
-							// as a data mismatch rather than as rounding.
+							// Exact counts, not the leaderboards' usual compact form: this
+							// widget is read beside the same module in Jetpack Stats, where
+							// 1,240 views reads "1,240". Compacted to "1K" it looks like a
+							// data mismatch rather than like rounding.
 							dataFormat={ {
 								type: 'number',
 								options: { useMultipliers: false, decimals: 0 },

--- a/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
@@ -43,7 +43,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Tags & categories" widget. Displays the site\'s most visited tags and categories for the selected period, ranked by views. Single tags/categories link to their archive; grouped rows (several tags/categories sharing posts) drill down to their members. Ported from the Jetpack Stats Tags & categories module.',
+					'The "Tags & categories" widget. Displays the site\'s most visited tags and categories over the last seven days, ranked by views — the endpoint takes no date parameters, so the section\'s date filter does not reach it. Single tags/categories link to their archive; grouped rows (several tags/categories sharing posts) drill down to their members. Ported from the Jetpack Stats Tags & categories module.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
@@ -43,7 +43,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Tags & categories" widget. Displays the site\'s most visited tags and categories over the last seven days, ranked by views — the endpoint takes no date parameters, so the section\'s date filter does not reach it. Single tags/categories link to their archive; grouped rows (several tags/categories sharing posts) drill down to their members. Ported from the Jetpack Stats Tags & categories module.',
+					'The "Tags & categories" widget. Displays the site\'s most visited tags and categories over the seven days ending yesterday, ranked by views — the endpoint takes no date parameters, so the section\'s date filter does not reach it. Single tags/categories link to their archive; grouped rows (several tags/categories sharing posts) drill down to their members. Ported from the Jetpack Stats Tags & categories module.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
+++ b/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
@@ -84,11 +84,9 @@ interface TagViewsState {
  * Fetch the most visited tags and categories for the Tags & categories widget
  * via the shared Stats data layer.
  *
- * Delegates fetching, caching, and normalization to `useStatsTags` from
- * `@jetpack-premium-analytics/data`, then maps the normalized rows onto the
- * leaderboard shape and trims to `max`. The `stats/tags` endpoint reports the
- * seven days ending yesterday, with no comparison and no date parameters, so
- * rows carry current-period views only and the report params never reach it.
+ * Delegates to `useStatsTags`, then maps the normalized rows onto the leaderboard
+ * shape and trims to `max`. Single period, no comparison: `stats/tags` takes no
+ * date parameters, so the dashboard's date filter never reaches this widget.
  */
 export default function useTagViews( { max }: UseTagViewsArgs ): TagViewsState {
 	const { data, isLoading, isFetching, isError, refetch } = useStatsTags( { max } );

--- a/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
+++ b/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
@@ -6,11 +6,7 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import { useStatsTags } from '@jetpack-premium-analytics/data';
-import type {
-	ReportParams,
-	StatsNormalizedReport,
-	StatsTagsItem,
-} from '@jetpack-premium-analytics/data';
+import type { StatsNormalizedReport, StatsTagsItem } from '@jetpack-premium-analytics/data';
 
 /**
  * A single tag or category grouped under a parent row. Grouped rows have no
@@ -71,11 +67,8 @@ export interface TagView {
 
 interface UseTagViewsArgs {
 	/**
-	 * PA ReportParams from WidgetRoot context.
-	 */
-	reportParams: ReportParams;
-	/**
-	 * Maximum rows to display; `0` means all.
+	 * Rows to request and display; `0` requests the endpoint's own default and
+	 * displays every row it returns.
 	 */
 	max: number;
 }
@@ -94,14 +87,12 @@ interface TagViewsState {
  *
  * Delegates fetching, caching, and normalization to `useStatsTags` from
  * `@jetpack-premium-analytics/data`, then maps the normalized rows onto the
- * leaderboard shape and trims to `max`. The `stats/tags` endpoint is a single
- * period query with no comparison, so rows carry current-period views only.
+ * leaderboard shape and trims to `max`. The `stats/tags` endpoint reports a
+ * fixed last-seven-days window with no comparison and no date parameters, so
+ * rows carry current-period views only and the report params never reach it.
  */
-export default function useTagViews( { reportParams, max }: UseTagViewsArgs ): TagViewsState {
-	const { data, isLoading, isFetching, isError, refetch } = useStatsTags( {
-		...reportParams,
-		max,
-	} );
+export default function useTagViews( { max }: UseTagViewsArgs ): TagViewsState {
+	const { data, isLoading, isFetching, isError, refetch } = useStatsTags( { max } );
 
 	// Memoize on the query's stable `data` reference so the row array keeps a
 	// stable identity across unrelated re-renders; otherwise every render hands a

--- a/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
+++ b/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
@@ -86,8 +86,8 @@ interface TagViewsState {
  *
  * Delegates fetching, caching, and normalization to `useStatsTags` from
  * `@jetpack-premium-analytics/data`, then maps the normalized rows onto the
- * leaderboard shape and trims to `max`. The `stats/tags` endpoint reports a
- * fixed last-seven-days window with no comparison and no date parameters, so
+ * leaderboard shape and trims to `max`. The `stats/tags` endpoint reports the
+ * seven days ending yesterday, with no comparison and no date parameters, so
  * rows carry current-period views only and the report params never reach it.
  */
 export default function useTagViews( { max }: UseTagViewsArgs ): TagViewsState {

--- a/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
+++ b/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
@@ -67,8 +67,7 @@ export interface TagView {
 
 interface UseTagViewsArgs {
 	/**
-	 * Rows to request and display; `0` requests the endpoint's own default and
-	 * displays every row it returns.
+	 * Rows to request and display.
 	 */
 	max: number;
 }

--- a/projects/packages/premium-analytics/widgets/tags/widget.ts
+++ b/projects/packages/premium-analytics/widgets/tags/widget.ts
@@ -8,7 +8,7 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 export type TagsAttributes = Record< never, never >;
 
 /**
- * Ported from the Jetpack Stats "Tags & categories" module: most-visited tags
+* Ported from the Jetpack Stats "Tags & categories" module: most-visited tags
  * and categories, ranked by views. Grouped rows (multiple tags on one post)
  * have no single archive URL and drill down to their members instead.
  */

--- a/projects/packages/premium-analytics/widgets/tags/widget.ts
+++ b/projects/packages/premium-analytics/widgets/tags/widget.ts
@@ -8,7 +8,7 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 export type TagsAttributes = Record< never, never >;
 
 /**
-* Ported from the Jetpack Stats "Tags & categories" module: most-visited tags
+ * Ported from the Jetpack Stats "Tags & categories" module: most-visited tags
  * and categories, ranked by views. Grouped rows (multiple tags on one post)
  * have no single archive URL and drill down to their members instead.
  */

--- a/projects/plugins/jetpack/changelog/wooa7s-2018-tags-numbers-match-old-stats
+++ b/projects/plugins/jetpack/changelog/wooa7s-2018-tags-numbers-match-old-stats
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Premium Analytics: print Tags & categories view counts in full and show every row in its report.
+Premium Analytics: print Tags & categories view counts in full, and list far more rows in its report.

--- a/projects/plugins/jetpack/changelog/wooa7s-2018-tags-numbers-match-old-stats
+++ b/projects/plugins/jetpack/changelog/wooa7s-2018-tags-numbers-match-old-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: print Tags & categories view counts in full and show every row in its report.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2018-tags-numbers-match-old-stats
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2018-tags-numbers-match-old-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: print Tags & categories view counts in full and show every row in its report.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2018-tags-numbers-match-old-stats
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2018-tags-numbers-match-old-stats
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: print Tags & categories view counts in full and show every row in its report.
+Premium Analytics: print Tags & categories view counts in full, and list far more rows in its report.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2018-tags-numbers-match-old-stats
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2018-tags-numbers-match-old-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Tags & categories: print view counts in full and list every row in the report.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2018-tags-numbers-match-old-stats
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2018-tags-numbers-match-old-stats
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Tags & categories: print view counts in full and list every row in the report.
+Tags & categories: print view counts in full, and list far more rows in the report.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2018-tags-numbers-match-old-stats
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2018-tags-numbers-match-old-stats
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: print Tags & categories view counts in full and show every row in its report.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2018-tags-numbers-match-old-stats
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2018-tags-numbers-match-old-stats
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: print Tags & categories view counts in full and show every row in its report.
+Premium Analytics: print Tags & categories view counts in full, and list far more rows in its report.


### PR DESCRIPTION
Fixes WOOA7S-2018

## What was actually wrong

Gary spotted that the Tags & categories numbers in the new Insights tab don't match the same module in Stats. The issue guessed at parameter differences, but that turned out not to be it — the two surfaces read exactly the same data.

`stats/tags` declares `max` as its only query parameter, so WPCOM's `query_args()` strips everything else before the handler ever runs. The window is a hardcoded last-seven-days anchored on the request instant, and `max` only slices rows — a tag present in both a `max=6` and a `max=10` response carries the identical `views`, because the per-row sum is computed over a post set fixed at 50 posts before `max` is applied.

Two comments in this repo previously claimed the opposite (an all-time list, "verified against WPCOM directly"), so here is the evidence rather than a third "verified". The endpoint's whole callback is one line, `stats_show_tagviews( $site_id, stats_yesterday(), 7, $max, true, true )` — `7` is a literal and `stats_yesterday()` takes no argument from the request. And the live endpoint echoes today's date back whatever `date` you send it:

<details>
<summary>Live endpoint probe (via the site's Jetpack connection)</summary>

```
== no params            [200] rows=0 meta={"date":"2026-08-27"}
== max=10               [200] rows=0 meta={"date":"2026-08-27"}
== date=2026-05-28      [200] rows=0 meta={"date":"2026-08-27"}
== date=2025-06-15      [200] rows=0 meta={"date":"2026-08-27"}
== date ISO with offset [200] rows=0 meta={"date":"2026-08-27"}
== date=not-a-date      [200] rows=0 meta={"date":"2026-08-27"}
```

</details>

So the mismatch is on our side, and it's display rounding. The widget formatted its counts with `useMultipliers: true, decimals: 0`, which rounds anything at or above a thousand to whole thousands — 1,240 shows as "1K", 9,800 as "10K". Anything under 1,000 is untouched, which is why only *some* of the numbers looked wrong.

## Proposed changes

* Tags & categories prints view counts in full (`1,240`), the same as the Stats module it gets compared against. This is deliberately an exception to the leaderboard convention in `AGENTS.md`, and the exception is documented there.
* `statsTagsQuery` no longer sends `date`. The endpoint drops it anyway, and sending it split the query cache per selected period and made the year pills look like they filter the widget when they can't. It now matches `stats/comments` and `stats/insights`, which are already parameter-less.
* The Tags report page had two comments claiming the endpoint returns an all-time list — it doesn't, it's the same fixed seven days. Corrected. It also requested `max: 0`, so "View all" was showing the same ten rows as the widget. It now asks for a real number.

  `stats/tags` turns out to be the **only** stats endpoint that reads `max: 0` that way — its callback does `if ( $max < 1 ) $max = 10;`, where `clicks`, `referrers`, `file-downloads`, `video-plays`, `search-terms` and `archives` all use `$max < 0` and treat `0` as "all rows". So the dozen sibling report pages still sending `max: 0` are fine; only this one was capped. (Source read of wpcom trunk — I couldn't get a runtime row count, my sandbox login is currently refusing to sign. The `date` finding above *is* measured.)

* Unrelated, but it kept failing under me: the `SelectField` test read the popup options synchronously right after the click, which passes alone and fails under full-suite load. It waits for them now.

### Not fixed here

The same `decimals: 0` compaction applies to every other PA leaderboard — top posts, referrers, most-commented, shares, and so on — so they will read the same way against Stats. Only Tags was changed, which is the scope this ticket was given. Happy to widen it if we want the whole set to match.

Nothing on screen still says the widget is a rolling seven days regardless of the year pill. That's WOOA7S-2017's job, so I left it alone here.

## Related product discussion/links

* p1787126958522969-slack-premium-analytics

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to **Jetpack → Stats v2 → Insights** on a Jetpack-connected site with some tag/category traffic in the last 7 days.
* Ensure the Tags & categories widget prints full counts (`1,240`, not `1K`).
* Open the same site's Jetpack Stats → Insights and compare the two lists side by side. Ensure the numbers match row for row.
* Open devtools' network tab and reload. Ensure the request is `…/proxy/v1.1/stats/tags?max=10` with no `date` param.
* Switch the year pills (All time / 2026 / 2025 …). Ensure no second `stats/tags` request fires — one cache entry serves them all, since the endpoint can't scope by date anyway.
* Click **View all** into the Tags & categories report. Ensure it lists more than ten rows on a site that has more than ten tags/categories.
