### PR TITLE
Premium Analytics: drop the quarter bucket the interval list no longer has

### DIFF
--- a/projects/packages/premium-analytics/changelog/echo-fix-drill-quarter
+++ b/projects/packages/premium-analytics/changelog/echo-fix-drill-quarter
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Drop a chart bucket boundary for an interval the picker no longer offers; nothing user-facing changed.
+
+

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/drill-date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/drill-date-range.test.ts
@@ -43,13 +43,6 @@ describe( 'drillDateRange', () => {
 		expect( range?.to?.getTime() ).toBe( Date.parse( '2026-02-28T23:59:59.999Z' ) );
 	} );
 
-	it( 'opens the calendar quarter', () => {
-		const range = drillDateRange( utc( '2026-05-09T00:00:00.000Z' ), 'quarter', NOW );
-
-		expect( range?.from?.getTime() ).toBe( Date.parse( '2026-04-01T00:00:00.000Z' ) );
-		expect( range?.to?.getTime() ).toBe( Date.parse( '2026-06-30T23:59:59.999Z' ) );
-	} );
-
 	it( 'opens the calendar year', () => {
 		const range = drillDateRange( utc( '2026-05-09T00:00:00.000Z' ), 'year', NOW );
 

--- a/projects/packages/premium-analytics/packages/datetime/src/drill-date-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/drill-date-range.ts
@@ -5,12 +5,10 @@ import {
 	endOfDay,
 	endOfISOWeek,
 	endOfMonth,
-	endOfQuarter,
 	endOfYear,
 	startOfDay,
 	startOfISOWeek,
 	startOfMonth,
-	startOfQuarter,
 	startOfYear,
 } from 'date-fns';
 /**
@@ -32,7 +30,6 @@ const BUCKET_BOUNDS: Partial<
 	// ISO weeks, matching how the report's own week buckets are cut.
 	week: { start: startOfISOWeek, end: endOfISOWeek },
 	month: { start: startOfMonth, end: endOfMonth },
-	quarter: { start: startOfQuarter, end: endOfQuarter },
 	year: { start: startOfYear, end: endOfYear },
 };
 

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/render.test.tsx
@@ -126,10 +126,10 @@ describe( 'TrafficChart bucket size', () => {
 } );
 
 describe( 'TrafficChart drill-down', () => {
-	// A quarterly page draws in months here, so the click must name the month:
-	// left to the page interval, a click on March would open the whole quarter.
+	// A yearly page draws in months here, so the click must name the month: left
+	// to the page interval, a click on March would open the whole year.
 	it( 'names the bucket size it drew, not the page interval', () => {
-		render( <TrafficChartRender attributes={ { reportParams: reportParams( 'quarter' ) } } /> );
+		render( <TrafficChartRender attributes={ { reportParams: reportParams( 'year' ) } } /> );
 
 		const clicked = new Date( '2026-02-14T00:00:00.000Z' );
 		chartClickHandler()( clicked );

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -60,8 +60,8 @@ function TrafficChartInner( { chartType }: TrafficChartInnerProps ) {
 	// Bound to whichever route hosts the widget, the same way `reportParams` are.
 	const { drillDown } = useReportDateFilters();
 
-	// Names the bucket size drawn, not the page interval: a quarter or year page
-	// interval clamps to months here, and the click must open the bar it hit.
+	// Names the bucket size drawn, not the page interval: a year page interval
+	// clamps to months here, and the click must open the bar it hit.
 	const openBucket = useCallback(
 		( date: Date ) => drillDown( date, period ),
 		[ drillDown, period ]


### PR DESCRIPTION
## Why

Trunk is red. Two PRs that each passed on their own branch landed close together and disagree:

* #51544 gave the chart drill-down a `quarter` bucket boundary.
* #51631 dropped `quarter` from `INTERVAL_TYPES` — the API never served it.

`BUCKET_BOUNDS` keys a `Record` on `IntervalType`, so with `quarter` gone from the union, `drill-date-range.ts` no longer type-checks. Its own test passes `'quarter'` too, and the traffic chart's drill-down test drove its clamping through a quarterly page, so **Type checking** and **JS tests** both fail on current trunk and on every PR branched after #51631.

Neither PR could have caught this: the conflict is semantic, not textual, so nothing flagged it and neither branch had the other's change.

## Proposed changes

* Drop the `quarter` entry from `BUCKET_BOUNDS` and the two `date-fns` imports it needed. Quarter is not an interval the picker offers any more, so the boundary was unreachable.
* Drop the `drill-date-range` test case for it.
* Move the traffic chart's "names the bucket size it drew, not the page interval" test from a quarterly page to a yearly one. `defaultPeriodForInterval` clamps `year` to `month` exactly as it clamped `quarter`, so the assertion is unchanged — only the page interval it starts from.

## Related product discussion/links

* #51544
* #51631

## Does this pull request change what data or activity we track or use?

No. Dead-code removal behind an interval the picker no longer offers.

## Testing instructions

This one is verified by CI going green rather than by clicking, but to confirm locally:

* `cd projects/packages/premium-analytics && pnpm run typecheck` — passes. On trunk it reports two `quarter` errors in `packages/datetime`.
* `pnpm run test` in the same directory — 2777 pass. On trunk, `TrafficChart drill-down › names the bucket size it drew, not the page interval` fails.
* In the dashboard, open **Jetpack → Stats** on a range long enough that the chart draws monthly bars, and click one. Ensure it still opens that month rather than a wider window — that is the clamping the moved test covers.

## Verification

<details>
<summary>Before, on <code>origin/trunk</code></summary>

```text
$ pnpm run typecheck
packages/datetime/src/__tests__/drill-date-range.test.ts(47,68): error TS2345: Argument of type '"quarter"' is not assignable to parameter of type '"day" | "hour" | "month" | "week" | "year"'.
packages/datetime/src/drill-date-range.ts(35,2): error TS2353: Object literal may only specify known properties, and 'quarter' does not exist in type 'Partial<Record<"day" | "hour" | "month" | "week" | "year", { start: (date: Date) => Date; end: (date: Date) => Date; }>>'.
```

</details>

<details>
<summary>After, on this branch</summary>

```text
$ pnpm run typecheck
$ tsgo --noEmit

$ pnpm run test
Test Suites: 141 passed, 141 total
Tests:       2777 passed, 2777 total
```

</details>
