### PR TITLE
Premium Analytics: label the Insights leaderboard widgets with their data periods

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -771,3 +771,10 @@ wire a handler in `routeStatsReport()` inside `register-report-mocks.ts`. See
 - Loading / error / empty state: render through `<WidgetState>` (see "Loading / error / empty
   state" above), not `LeaderboardChart`'s `emptyStateText` or a hand-rolled `data.length === 0`
   branch. Empty uses a neutral glyph distinct from the error icon.
+- Fixed data periods: a widget whose endpoint serves a window the dashboard date range cannot
+  move must say so, with `WidgetPeriodLabel` from `widgets-toolkit` as the first element of the
+  widget body ("Last 7 days", "All time"). It does not go in the title — the host renders the
+  title on one line and truncates it, so at a one-column tile the period is the first thing cut
+  off. State the same thing in `help.content` in `widget.json`, and keep the widget's data hook
+  honest: do not thread `reportParams` into a request that discards them. `widgets/tags` (fixed
+  window) and `widgets/most-commented-posts` (all-time) are the references.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: changed
 
-Insights: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.
+Insights: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments reports.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Insights: State the data period on the Tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.
+Insights: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Insights: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments reports.
+Insights: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments report pages.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Insights: State the data period on the Tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -45,7 +45,7 @@ import {
 	statsSubscribersQuery,
 	statsSubscribersReportQuery,
 } from '../stats-subscribers-query';
-import { statsTagsQuery } from '../stats-tags-query';
+import { statsTagsQuery, type StatsTagsParams } from '../stats-tags-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
 import { statsUtmQuery } from '../stats-utm-query';
 import { statsVideoPlaysSummaryQuery } from '../stats-video-plays-summary-query';
@@ -600,16 +600,16 @@ describe( 'Stats query factories', () => {
 	} );
 
 	// `stats/tags` hardcodes a 7-day window and discards date parameters, so the
-	// query must send only `max`. Sending a date cannot change the response, but
-	// it would re-key this cache per date selection and refetch identical rows —
-	// and it would contradict the widget, which tells the user its figures do not
-	// follow the dashboard date range.
+	// query must send only `max`. `StatsTagsParams` no longer accepts a window, so
+	// these cast past the type to cover a caller reaching the builder from
+	// untyped JS — the runtime must drop the dates either way, or the cache
+	// re-keys per date selection and refetches identical rows, contradicting the
+	// widget's own "not affected by the dashboard date range" copy.
+	const withDates = ( params: Record< string, unknown > ) =>
+		statsTagsQuery( params as StatsTagsParams );
+
 	it( 'drops the date window from tags query keys, keeping only max', () => {
-		const query = statsTagsQuery( {
-			to: '2026-06-07',
-			from: '2026-06-01',
-			max: 10,
-		} );
+		const query = withDates( { to: '2026-06-07', from: '2026-06-01', max: 10 } );
 
 		expect( query.enabled ).toBe( true );
 		expect( query.queryKey ).toEqual( [
@@ -625,10 +625,16 @@ describe( 'Stats query factories', () => {
 	} );
 
 	it( 'keys two different date selections identically for tags', () => {
-		const june = statsTagsQuery( { from: '2026-06-01', to: '2026-06-07', max: 10 } );
-		const december = statsTagsQuery( { from: '2024-01-01', to: '2024-12-31', max: 10 } );
+		const oneWeek = withDates( { from: '2026-06-01', to: '2026-06-07', max: 10 } );
+		const oneYear = withDates( { from: '2024-01-01', to: '2024-12-31', max: 10 } );
 
-		expect( june.queryKey ).toEqual( december.queryKey );
+		expect( oneWeek.queryKey ).toEqual( oneYear.queryKey );
+	} );
+
+	// `max: 0` means "all rows" for the Tags report; a truthiness check in the
+	// builder would silently drop it back to the endpoint's default of 10.
+	it( 'keeps an explicit max of zero for the tags report', () => {
+		expect( statsTagsQuery( { max: 0 } ).queryKey ).toContainEqual( { max: 0 } );
 	} );
 
 	it( 'builds devices query keys from the selected device property', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -599,9 +599,15 @@ describe( 'Stats query factories', () => {
 		] );
 	} );
 
-	it( 'passes supported tags params through query keys', () => {
+	// `stats/tags` hardcodes a 7-day window and discards date parameters, so the
+	// query must send only `max`. Sending a date cannot change the response, but
+	// it would re-key this cache per date selection and refetch identical rows —
+	// and it would contradict the widget, which tells the user its figures do not
+	// follow the dashboard date range.
+	it( 'drops the date window from tags query keys, keeping only max', () => {
 		const query = statsTagsQuery( {
 			to: '2026-06-07',
+			from: '2026-06-01',
 			max: 10,
 		} );
 
@@ -612,13 +618,17 @@ describe( 'Stats query factories', () => {
 			'1.1',
 			'stats/tags',
 			'GET',
-			{
-				date: '2026-06-07',
-				max: 10,
-			},
+			{ max: 10 },
 			undefined,
 			'tags',
 		] );
+	} );
+
+	it( 'keys two different date selections identically for tags', () => {
+		const june = statsTagsQuery( { from: '2026-06-01', to: '2026-06-07', max: 10 } );
+		const december = statsTagsQuery( { from: '2024-01-01', to: '2024-12-31', max: 10 } );
+
+		expect( june.queryKey ).toEqual( december.queryKey );
 	} );
 
 	it( 'builds devices query keys from the selected device property', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-comments-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-comments-query.ts
@@ -3,6 +3,13 @@
  */
 import { statsProxyQuery, type StatsReportQueryOptions } from './stats-query';
 
+// The endpoint accepts no parameters at all — its public API reference lists no
+// endpoint-specific query parameters, and reports `total_comments` as the
+// "number of total comments":
+// https://developer.wordpress.com/docs/api/1.1/get/sites/$site/stats/comments/
+//
+// So both comment leaderboards are all-time and cannot follow a date range,
+// which is what they tell the user. Adding date support is WOOA7S-1965.
 export type StatsCommentsParams = Record< string, never >;
 
 export type { StatsCommentsResponse } from '../processing/stats';

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
@@ -13,14 +13,18 @@ export type StatsTagsParams = Partial< StatsReportParams > & {
 	max?: number;
 };
 
+// `max` is the only parameter the endpoint reads. `stats/tags` hardcodes a
+// 7-day window server-side and discards every date parameter, so sending one
+// cannot change the response — it only re-keys the React Query cache and the
+// proxy's response cache per date selection, refetching identical rows.
+// Verified against WPCOM through the proxy on 2026-08-27: `stats/tags` with
+// `date=2024-12-31` and `date=2026-12-31` returned byte-identical bodies, both
+// echoing `date` as the current day and carrying no `period` key, while
+// `stats/top-posts` on the same proxy echoed each date back and bucketed by it.
 function statsTagsParamsToApiParams( params: StatsTagsParams = {} ): StatsProxyParams {
 	const statsParams = reportParamsToStatsQueryParams( params );
-	const date = statsParams.date ?? statsParams.end_date;
 
-	return {
-		...( date ? { date } : {} ),
-		...( statsParams.max !== undefined ? { max: statsParams.max } : {} ),
-	};
+	return statsParams.max !== undefined ? { max: statsParams.max } : {};
 }
 
 export const statsTagsQuery = ( params: StatsTagsParams = {} ): StatsReportQueryOptions< 'tags' > =>

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { reportParamsToStatsQueryParams } from '../utils/stats-params';
 import {
 	statsProxyQuery,
 	type StatsReportParams,
@@ -13,18 +12,28 @@ export type StatsTagsParams = Partial< StatsReportParams > & {
 	max?: number;
 };
 
-// `max` is the only parameter the endpoint reads. `stats/tags` hardcodes a
-// 7-day window server-side and discards every date parameter, so sending one
-// cannot change the response — it only re-keys the React Query cache and the
-// proxy's response cache per date selection, refetching identical rows.
-// Verified against WPCOM through the proxy on 2026-08-27: `stats/tags` with
-// `date=2024-12-31` and `date=2026-12-31` returned byte-identical bodies, both
-// echoing `date` as the current day and carrying no `period` key, while
+// `max` is the only parameter the endpoint reads.
+//
+// The window is fixed at the 7 days ending yesterday, hardcoded in the wpcom
+// endpoint rather than derived from the request:
+//
+//   // class.wpcom-json-api-stats-tags-and-categories-v1-1-endpoint.php
+//   $data = stats_show_tagviews( $site_id, stats_yesterday(), 7, $max, true, true );
+//
+// and its registration in class.wpcom-stats-api-endpoints.php declares `max` as
+// its only query parameter, so `date`, `period`, `num`, `start_date` and
+// `end_date` are all discarded (source quoted in WOOA7S-1962).
+//
+// Confirmed from the client side through the proxy on 2026-08-27: `stats/tags`
+// with `date=2024-12-31` and `date=2026-12-31` returned byte-identical bodies,
+// both echoing `date` as the current day and carrying no `period` key, while
 // `stats/top-posts` on the same proxy echoed each date back and bucketed by it.
+//
+// So forwarding a date cannot change the response — it only re-keys the React
+// Query cache and the proxy's response cache per date selection, refetching
+// identical rows.
 function statsTagsParamsToApiParams( params: StatsTagsParams = {} ): StatsProxyParams {
-	const statsParams = reportParamsToStatsQueryParams( params );
-
-	return statsParams.max !== undefined ? { max: statsParams.max } : {};
+	return params.max !== undefined && params.max !== null ? { max: params.max } : {};
 }
 
 export const statsTagsQuery = ( params: StatsTagsParams = {} ): StatsReportQueryOptions< 'tags' > =>

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-tags-query.ts
@@ -1,39 +1,47 @@
 /**
  * Internal dependencies
  */
-import {
-	statsProxyQuery,
-	type StatsReportParams,
-	type StatsReportQueryOptions,
-} from './stats-query';
+import { statsProxyQuery, type StatsReportQueryOptions } from './stats-query';
 import type { StatsProxyParams } from '../api';
 
-export type StatsTagsParams = Partial< StatsReportParams > & {
+// Deliberately narrow: the endpoint takes no date window (see below), so the
+// type must not let a caller pass one and assume it applies.
+export type StatsTagsParams = {
+	/**
+	 * Maximum rows to return; `0` means all. The only parameter the endpoint reads.
+	 */
 	max?: number;
 };
 
-// `max` is the only parameter the endpoint reads.
+// `max` is the only parameter this endpoint accepts. Its public API reference
+// lists exactly one endpoint-specific query parameter:
 //
-// The window is fixed at the 7 days ending yesterday, hardcoded in the wpcom
-// endpoint rather than derived from the request:
+//   max (int) — the maximum number of tags to include in result. Default: 10.
+//   https://developer.wordpress.com/docs/api/1.1/get/sites/$site/stats/tags/
 //
-//   // class.wpcom-json-api-stats-tags-and-categories-v1-1-endpoint.php
+// where the neighbouring `stats/top-posts` declares `num`, `period`, `date`,
+// `start_date`, `offset` and `summarize`. So `stats/tags` takes no date window;
+// the response's `date` field is documented as "the most-recent day for which
+// stats are returned", not a range anchor.
+//
+// The window it does serve is the 7 days ending yesterday, hardcoded in the
+// wpcom endpoint rather than derived from the request (source quoted in
+// WOOA7S-1962):
+//
 //   $data = stats_show_tagviews( $site_id, stats_yesterday(), 7, $max, true, true );
-//
-// and its registration in class.wpcom-stats-api-endpoints.php declares `max` as
-// its only query parameter, so `date`, `period`, `num`, `start_date` and
-// `end_date` are all discarded (source quoted in WOOA7S-1962).
 //
 // Confirmed from the client side through the proxy on 2026-08-27: `stats/tags`
 // with `date=2024-12-31` and `date=2026-12-31` returned byte-identical bodies,
-// both echoing `date` as the current day and carrying no `period` key, while
-// `stats/top-posts` on the same proxy echoed each date back and bucketed by it.
+// both echoing `date` as the current day, while `stats/top-posts` on the same
+// proxy echoed each date back and bucketed by it.
 //
 // So forwarding a date cannot change the response — it only re-keys the React
 // Query cache and the proxy's response cache per date selection, refetching
 // identical rows.
 function statsTagsParamsToApiParams( params: StatsTagsParams = {} ): StatsProxyParams {
-	return params.max !== undefined && params.max !== null ? { max: params.max } : {};
+	// `!== undefined`, not truthiness: the Tags report passes `max: 0` for "all
+	// rows", which a truthy check would drop back to the endpoint's default of 10.
+	return params.max !== undefined ? { max: params.max } : {};
 }
 
 export const statsTagsQuery = ( params: StatsTagsParams = {} ): StatsReportQueryOptions< 'tags' > =>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
@@ -82,6 +82,7 @@ export {
 } from './widget-state';
 export { WidgetBackLink, type WidgetBackLinkProps } from './widget-back-link';
 export { WidgetFooter, type WidgetFooterProps } from './widget-footer';
+export { WidgetPeriodLabel, type WidgetPeriodLabelProps } from './widget-period-label';
 export { ReportLink, type ReportLinkProps } from './report-link';
 export { PostTitleLink, POST_URL_SEARCH_PARAM, type PostTitleLinkProps } from './post-title-link';
 export { PostDetailLink, type PostDetailLinkProps } from './post-detail-link';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-period-label/__tests__/widget-period-label.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-period-label/__tests__/widget-period-label.test.tsx
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { WidgetPeriodLabel } from '../widget-period-label';
+
+jest.mock( '../widget-period-label.module.scss', () => ( { periodLabel: 'periodLabel' } ) );
+
+describe( 'WidgetPeriodLabel', () => {
+	it( 'renders the period as text and merges a class name', () => {
+		render( <WidgetPeriodLabel label="Last 7 days" className="custom-period" /> );
+
+		expect( screen.getByText( 'Last 7 days' ) ).toHaveClass( 'periodLabel', 'custom-period' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-period-label/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-period-label/index.ts
@@ -1,0 +1,1 @@
+export { WidgetPeriodLabel, type WidgetPeriodLabelProps } from './widget-period-label';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-period-label/widget-period-label.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-period-label/widget-period-label.module.scss
@@ -1,13 +1,13 @@
 // Sits directly under the widget title, so it reads as a caption on that title
-// rather than as part of the body content below it.
+// rather than as part of the body content below it. It wraps rather than
+// truncating: the whole point of the line is to be read, and a longer
+// translation of a short English period must not be cut off.
 .periodLabel {
 	flex: 0 0 auto;
-	margin: 0 0 var(--wpds-dimension-gap-md);
+	margin-block: 0 var(--wpds-dimension-gap-md);
+	margin-inline: 0;
 	color: var(--wpds-color-foreground-content-neutral-weak);
 	font-size: 13px;
 	font-weight: 500;
 	line-height: 20px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-period-label/widget-period-label.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-period-label/widget-period-label.module.scss
@@ -1,0 +1,13 @@
+// Sits directly under the widget title, so it reads as a caption on that title
+// rather than as part of the body content below it.
+.periodLabel {
+	flex: 0 0 auto;
+	margin: 0 0 var(--wpds-dimension-gap-md);
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	font-size: 13px;
+	font-weight: 500;
+	line-height: 20px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-period-label/widget-period-label.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-period-label/widget-period-label.tsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+/**
+ * Internal dependencies
+ */
+import styles from './widget-period-label.module.scss';
+
+export type WidgetPeriodLabelProps = {
+	/**
+	 * The period the widget's data covers, e.g. "Last 7 days" or "All time".
+	 */
+	label: string;
+
+	/**
+	 * Optional class for widget-specific layout tweaks.
+	 */
+	className?: string;
+};
+
+/**
+ * States the period a widget's data covers, for widgets whose endpoint serves a
+ * fixed window and so cannot follow the dashboard date range.
+ *
+ * The host header renders the title on a single line and truncates it, so the
+ * period cannot live there: at the one-column tile these widgets ship at, it
+ * would be the first thing cut off.
+ *
+ * @return The rendered period label.
+ */
+export function WidgetPeriodLabel( { label, className }: WidgetPeriodLabelProps ) {
+	return <p className={ clsx( styles.periodLabel, className ) }>{ label }</p>;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-period-label/widget-period-label.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-period-label/widget-period-label.tsx
@@ -27,6 +27,11 @@ export type WidgetPeriodLabelProps = {
  * period cannot live there: at the one-column tile these widgets ship at, it
  * would be the first thing cut off.
  *
+ * Widgets render this above `<WidgetState>`, so it shows through the loading,
+ * error and empty states too. That is deliberate: the period describes the
+ * widget, not the response, and on an empty result it is the thing that tells
+ * the reader they are looking at a fixed window rather than a filtered one.
+ *
  * @return The rendered period label.
  */
 export function WidgetPeriodLabel( { label, className }: WidgetPeriodLabelProps ) {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -75,6 +75,8 @@ export {
 	type WidgetBackLinkProps,
 	WidgetFooter,
 	type WidgetFooterProps,
+	WidgetPeriodLabel,
+	type WidgetPeriodLabelProps,
 	ReportLink,
 	type ReportLinkProps,
 	PostTitleLink,

--- a/projects/packages/premium-analytics/routes/reports/comments/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comments/page.tsx
@@ -92,7 +92,7 @@ function CommentsReport(): JSX.Element {
 			visual={ <StatsPageIcon /> }
 			breadcrumbs={ <StatsBreadcrumbs items={ [ { label: getLabel() } ] } /> }
 			subTitle={ __(
-				'All comments your site has received, by author, post, and page.',
+				'All-time comments on your site, by author, post, and page.',
 				'jetpack-premium-analytics-pkg'
 			) }
 			actions={

--- a/projects/packages/premium-analytics/routes/reports/comments/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comments/page.tsx
@@ -92,7 +92,7 @@ function CommentsReport(): JSX.Element {
 			visual={ <StatsPageIcon /> }
 			breadcrumbs={ <StatsBreadcrumbs items={ [ { label: getLabel() } ] } /> }
 			subTitle={ __(
-				'Learn about the all-time comments your site receives by authors, posts, and pages.',
+				'All comments your site has received, by author, post, and page.',
 				'jetpack-premium-analytics-pkg'
 			) }
 			actions={

--- a/projects/packages/premium-analytics/routes/reports/comments/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comments/page.tsx
@@ -92,7 +92,7 @@ function CommentsReport(): JSX.Element {
 			visual={ <StatsPageIcon /> }
 			breadcrumbs={ <StatsBreadcrumbs items={ [ { label: getLabel() } ] } /> }
 			subTitle={ __(
-				'Learn about the comments your site receives by authors, posts, and pages.',
+				'Learn about the all-time comments your site receives by authors, posts, and pages.',
 				'jetpack-premium-analytics-pkg'
 			) }
 			actions={

--- a/projects/packages/premium-analytics/routes/reports/registry.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.ts
@@ -120,7 +120,7 @@ export const REPORTS: Record< string, ReportDefinition > = {
 		getTitle: () => __( 'All comments report', 'jetpack-premium-analytics-pkg' ),
 		getDescription: () =>
 			__(
-				'Learn about the comments your site receives by authors, posts, and pages.',
+				'All comments your site has received, by author, post, and page.',
 				'jetpack-premium-analytics-pkg'
 			),
 		resolveSection: resolveCommentsTabId,
@@ -174,7 +174,10 @@ export const REPORTS: Record< string, ReportDefinition > = {
 		getLabel: () => __( 'Tags & categories', 'jetpack-premium-analytics-pkg' ),
 		getTitle: () => __( 'Tags & categories report', 'jetpack-premium-analytics-pkg' ),
 		getDescription: () =>
-			__( 'Your most visited tags and categories.', 'jetpack-premium-analytics-pkg' ),
+			__(
+				'Your most visited tags and categories over the last 7 days.',
+				'jetpack-premium-analytics-pkg'
+			),
 		load: () => import( './tags/page' ),
 	},
 	videos: {

--- a/projects/packages/premium-analytics/routes/reports/registry.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.ts
@@ -120,7 +120,7 @@ export const REPORTS: Record< string, ReportDefinition > = {
 		getTitle: () => __( 'All comments report', 'jetpack-premium-analytics-pkg' ),
 		getDescription: () =>
 			__(
-				'All comments your site has received, by author, post, and page.',
+				'All-time comments on your site, by author, post, and page.',
 				'jetpack-premium-analytics-pkg'
 			),
 		resolveSection: resolveCommentsTabId,

--- a/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
@@ -15,7 +15,7 @@ export function getTagRowId( item: StatsTagsItem ): string {
 }
 
 /**
- * Fetch the all-time Tags & categories rows.
+ * Fetch the Tags & categories rows.
  *
  * The endpoint ignores every date-window parameter and always reports a
  * rolling 7-day window — verified against WPCOM through the proxy on

--- a/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/use-report-records.ts
@@ -17,11 +17,11 @@ export function getTagRowId( item: StatsTagsItem ): string {
 /**
  * Fetch the all-time Tags & categories rows.
  *
- * The endpoint ignores date-window parameters (`period`, `start_date`,
- * `days`, `summarize`) and always reports one flat all-time list — verified
- * against WPCOM directly, and matching Calypso, which never sends date
- * params here — so the report requests only `max: 0` (all rows) and renders
- * no chart or date filters.
+ * The endpoint ignores every date-window parameter and always reports a
+ * rolling 7-day window — verified against WPCOM through the proxy on
+ * 2026-08-27, and matching Calypso, which never sends date params here — so
+ * the report requests only `max: 0` (all rows) and renders no chart or date
+ * filters.
  *
  * @return Table rows and fetch state.
  */

--- a/projects/packages/premium-analytics/routes/reports/tags/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/tags/page.tsx
@@ -41,9 +41,10 @@ const sortTagCsvRows = ( a: StatsTagsItem, b: StatsTagsItem ) => b.value - a.val
  * Premium Analytics Tags & categories report page component.
  *
  * The `stats/tags` endpoint hardcodes a rolling 7-day window and ignores
- * date-window parameters (verified against WPCOM; Calypso never sends date
- * params here either), so the page composes only the breadcrumb header and
- * records table: no date filters, tabs, or performance chart.
+ * date-window parameters (verified against WPCOM through the proxy on
+ * 2026-08-27; Calypso never sends date params here either), so the page
+ * composes only the breadcrumb header and records table: no date filters,
+ * tabs, or performance chart.
  *
  * @return The Tags & categories report page.
  */

--- a/projects/packages/premium-analytics/routes/reports/tags/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/tags/page.tsx
@@ -40,7 +40,7 @@ const sortTagCsvRows = ( a: StatsTagsItem, b: StatsTagsItem ) => b.value - a.val
 /**
  * Premium Analytics Tags & categories report page component.
  *
- * The `stats/tags` endpoint reports one flat all-time list and ignores
+ * The `stats/tags` endpoint hardcodes a rolling 7-day window and ignores
  * date-window parameters (verified against WPCOM; Calypso never sends date
  * params here either), so the page composes only the breadcrumb header and
  * records table: no date filters, tabs, or performance chart.
@@ -79,7 +79,10 @@ function TagsReport(): JSX.Element {
 		<ReportPageShell
 			visual={ <StatsPageIcon /> }
 			breadcrumbs={ <StatsBreadcrumbs items={ [ { label: getLabel() } ] } /> }
-			subTitle={ __( 'Your most visited tags and categories.', 'jetpack-premium-analytics-pkg' ) }
+			subTitle={ __(
+				'Your most visited tags and categories over the last 7 days.',
+				'jetpack-premium-analytics-pkg'
+			) }
 			actions={
 				canExport ? (
 					<ReportCsvAction columns={ csvColumns } rows={ csvRows } filename={ csvFilename } />

--- a/projects/packages/premium-analytics/tests/groups/widgets-shared-route-mock-part2.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/widgets-shared-route-mock-part2.test.tsx
@@ -1,5 +1,6 @@
 // See README.md before adding a suite to this group.
 
+import '../../widgets/shares/__tests__/shares.test';
 import '../../widgets/site-overview/__tests__/site-overview.test';
 import '../../widgets/subscriber-highlights/__tests__/subscriber-highlights.test';
 import '../../widgets/tags/__tests__/tags.test';

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/__tests__/most-commented-authors.test.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/__tests__/most-commented-authors.test.tsx
@@ -71,9 +71,10 @@ describe( 'MostCommentedAuthorsWidget', () => {
 
 	// The `stats/comments` endpoint takes no date parameters, so the widget states
 	// its own period rather than letting a dashboard date range imply one.
-	it( 'states that the counts are all-time', () => {
+	it( 'states that the counts are all-time', async () => {
 		renderWidget();
 
+		await expect( screen.findByText( 'Guest Author' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'All time' ) ).toBeInTheDocument();
 	} );
 

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/__tests__/most-commented-authors.test.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/__tests__/most-commented-authors.test.tsx
@@ -69,6 +69,14 @@ describe( 'MostCommentedAuthorsWidget', () => {
 		expect( screen.getByAltText( 'Avatar of Member Author' ) ).toBeInTheDocument();
 	} );
 
+	// The `stats/comments` endpoint takes no date parameters, so the widget states
+	// its own period rather than letting a dashboard date range imply one.
+	it( 'states that the counts are all-time', () => {
+		renderWidget();
+
+		expect( screen.getByText( 'All time' ) ).toBeInTheDocument();
+	} );
+
 	// Both comment widgets read the same response; this one must show only the
 	// authors group, never the posts rows the sibling widget renders.
 	it( 'shows only the authors group from the shared report', async () => {

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/render.tsx
@@ -8,6 +8,7 @@ import {
 	ReportLink,
 	WIDGET_ROW_LIMIT,
 	WidgetFooter,
+	WidgetPeriodLabel,
 	WidgetRoot,
 	WidgetState,
 	buildLeaderboardRow,
@@ -64,6 +65,7 @@ function MostCommentedAuthorsInner() {
 
 	return (
 		<Stack className={ styles.root }>
+			<WidgetPeriodLabel label={ __( 'All time', 'jetpack-premium-analytics-pkg' ) } />
 			<div className={ styles.content }>
 				<WidgetState
 					isLoading={ isLoading }

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/widget.json
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/widget.json
@@ -3,7 +3,7 @@
 	"title": "Top commented authors",
 	"description": "The people who comment the most on your site.",
 	"help": {
-		"content": "Your most active commenters, ranked by the number of comments they have left.",
+		"content": "Your most active commenters, ranked by the number of comments they have left. Figures are all-time and are not affected by the dashboard date range.",
 		"links": [
 			{
 				"label": "Learn more",

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/__tests__/most-commented-posts.test.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/__tests__/most-commented-posts.test.tsx
@@ -84,6 +84,14 @@ describe( 'MostCommentedPostsWidget', () => {
 		expect( screen.queryByRole( 'link', { name: /Unsafe permalink/ } ) ).not.toBeInTheDocument();
 	} );
 
+	// The `stats/comments` endpoint takes no date parameters, so the widget states
+	// its own period rather than letting a dashboard date range imply one.
+	it( 'states that the counts are all-time', () => {
+		renderWidget();
+
+		expect( screen.getByText( 'All time' ) ).toBeInTheDocument();
+	} );
+
 	// Both comment widgets read the same response; this one must show only the
 	// posts group, never the author rows the sibling widget renders.
 	it( 'shows only the posts group from the shared report', async () => {

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/__tests__/most-commented-posts.test.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/__tests__/most-commented-posts.test.tsx
@@ -86,9 +86,10 @@ describe( 'MostCommentedPostsWidget', () => {
 
 	// The `stats/comments` endpoint takes no date parameters, so the widget states
 	// its own period rather than letting a dashboard date range imply one.
-	it( 'states that the counts are all-time', () => {
+	it( 'states that the counts are all-time', async () => {
 		renderWidget();
 
+		await expect( screen.findByText( 'Hello world' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'All time' ) ).toBeInTheDocument();
 	} );
 

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/render.tsx
@@ -9,6 +9,7 @@ import {
 	ReportLink,
 	WIDGET_ROW_LIMIT,
 	WidgetFooter,
+	WidgetPeriodLabel,
 	WidgetRoot,
 	WidgetState,
 	describeError,
@@ -57,6 +58,7 @@ function MostCommentedPostsInner() {
 
 	return (
 		<Stack className={ styles.root }>
+			<WidgetPeriodLabel label={ __( 'All time', 'jetpack-premium-analytics-pkg' ) } />
 			<div className={ styles.content }>
 				<WidgetState
 					isLoading={ isLoading }

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/widget.json
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/widget.json
@@ -3,7 +3,7 @@
 	"title": "Top commented posts",
 	"description": "The posts and pages that receive the most comments.",
 	"help": {
-		"content": "Your posts and pages, ranked by the number of comments they have received.",
+		"content": "Your posts and pages, ranked by the number of comments they have received. Figures are all-time and are not affected by the dashboard date range.",
 		"links": [
 			{
 				"label": "Learn more",

--- a/projects/packages/premium-analytics/widgets/shares/__tests__/shares.test.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/__tests__/shares.test.tsx
@@ -43,9 +43,10 @@ describe( 'SharesWidget', () => {
 
 	// Share counts are a running total per post and no share date is ever
 	// recorded, so this widget can never follow a date range and says so.
-	it( 'states that the counts are all-time', () => {
+	it( 'states that the counts are all-time', async () => {
 		renderWidget();
 
+		await expect( screen.findByText( 'Facebook' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'All time' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/shares/__tests__/shares.test.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/__tests__/shares.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import SharesWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+describe( 'SharesWidget', () => {
+	beforeEach( () => {
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( {
+			stats: {
+				shares: 15,
+				shares_facebook: 10,
+				shares_twitter: 5,
+			},
+		} );
+	} );
+
+	function renderWidget() {
+		return render(
+			<SharesWidget attributes={ { reportParams: getDefaultQueryParams( false ) } } />
+		);
+	}
+
+	it( 'ranks the sharing networks by share count', async () => {
+		renderWidget();
+
+		await expect( screen.findByText( 'Facebook' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Twitter' ) ).toBeInTheDocument();
+	} );
+
+	// Share counts are a running total per post and no share date is ever
+	// recorded, so this widget can never follow a date range and says so.
+	it( 'states that the counts are all-time', () => {
+		renderWidget();
+
+		expect( screen.getByText( 'All time' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/shares/render.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/render.tsx
@@ -5,6 +5,7 @@ import {
 	LeaderboardChart,
 	LeaderboardSkeleton,
 	WIDGET_ROW_LIMIT,
+	WidgetPeriodLabel,
 	WidgetRoot,
 	WidgetState,
 	buildLeaderboardRow,
@@ -53,6 +54,7 @@ function SharesInner() {
 
 	return (
 		<Stack className={ styles.root }>
+			<WidgetPeriodLabel label={ __( 'All time', 'jetpack-premium-analytics-pkg' ) } />
 			<div className={ styles.content }>
 				<WidgetState
 					isLoading={ isLoading }

--- a/projects/packages/premium-analytics/widgets/shares/widget.json
+++ b/projects/packages/premium-analytics/widgets/shares/widget.json
@@ -3,7 +3,7 @@
 	"title": "Top social media shares",
 	"description": "The number of times your content was shared to social networks.",
 	"help": {
-		"content": "The platforms where your content was shared most often, sorted by number of shares."
+		"content": "The platforms where your content was shared most often, sorted by number of shares. Share dates are never recorded, so figures are all-time and are not affected by the dashboard date range."
 	},
 	"category": "stats",
 	"presentation": "framed"

--- a/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
@@ -132,6 +132,7 @@ describe( 'TagsWidget', () => {
 	it( 'states that the report covers the last 7 days, drilled in or not', async () => {
 		render( <TagsWidget attributes={ { reportParams: getDefaultQueryParams() } } /> );
 
+		await expect( screen.findByText( 'Recipes' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Last 7 days' ) ).toBeInTheDocument();
 
 		// Group members come from the same report, so the period still holds.

--- a/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/__tests__/tags.test.tsx
@@ -125,4 +125,23 @@ describe( 'TagsWidget', () => {
 		await expect( screen.findByText( 'Recipes' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'chocolate' ) ).not.toBeInTheDocument();
 	} );
+
+	// `stats/tags` hardcodes a 7-day window server-side and ignores date
+	// parameters, so the widget states that period instead of implying it follows
+	// the dashboard date range.
+	it( 'states that the report covers the last 7 days, drilled in or not', async () => {
+		render( <TagsWidget attributes={ { reportParams: getDefaultQueryParams() } } /> );
+
+		expect( screen.getByText( 'Last 7 days' ) ).toBeInTheDocument();
+
+		// Group members come from the same report, so the period still holds.
+		const groupButton = await screen.findByRole( 'button', {
+			name: /view the tags and categories in desserts, chocolate/i,
+		} );
+
+		fireEvent.click( groupButton ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		await expect( screen.findByText( 'Desserts' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Last 7 days' ) ).toBeInTheDocument();
+	} );
 } );

--- a/projects/packages/premium-analytics/widgets/tags/render.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/render.tsx
@@ -17,7 +17,6 @@ import {
 	safeHttpUrl,
 	sharePercentage,
 	useWidgetDrillDown,
-	useWidgetRootContext,
 	type LeaderboardChartData,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
@@ -72,9 +71,7 @@ function TagGroupMembers( { members }: TagGroupMembersProps ) {
 }
 
 function TagsInner() {
-	const { reportParams } = useWidgetRootContext();
 	const { data, isLoading, isFetching, isError, refetch } = useTagViews( {
-		reportParams,
 		max: WIDGET_ROW_LIMIT,
 	} );
 

--- a/projects/packages/premium-analytics/widgets/tags/render.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/render.tsx
@@ -9,6 +9,7 @@ import {
 	WIDGET_ROW_LIMIT,
 	WidgetBackLink,
 	WidgetFooter,
+	WidgetPeriodLabel,
 	WidgetRoot,
 	WidgetState,
 	buildLeaderboardRow,
@@ -131,6 +132,7 @@ function TagsInner() {
 
 	return (
 		<Stack className={ styles.root }>
+			<WidgetPeriodLabel label={ __( 'Last 7 days', 'jetpack-premium-analytics-pkg' ) } />
 			<div className={ styles.content }>
 				{ selectedGroup && (
 					<WidgetBackLink
@@ -188,10 +190,14 @@ function TagsInner() {
 }
 
 /**
- * Tags & categories widget: the site's most visited tags and categories for the
- * selected period, ranked by views. Ported from the Jetpack Stats "Tags &
+ * Tags & categories widget: the site's most visited tags and categories over the
+ * last 7 days, ranked by views. Ported from the Jetpack Stats "Tags &
  * categories" module. Grouped rows (several tags/categories sharing a post) drill
  * down to their individual members.
+ *
+ * `stats/tags` hardcodes that 7-day window server-side and accepts no date
+ * parameters, so the widget states the period itself rather than implying it
+ * follows the dashboard date range.
  */
 export default function Tags( { attributes = {} }: TagsWidgetProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
@@ -43,7 +43,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Tags & categories" widget. Displays the site\'s most visited tags and categories for the selected period, ranked by views. Single tags/categories link to their archive; grouped rows (several tags/categories sharing posts) drill down to their members. Ported from the Jetpack Stats Tags & categories module.',
+					'The "Tags & categories" widget. Displays the site\'s most visited tags and categories over the last 7 days, ranked by views. Single tags/categories link to their archive; grouped rows (several tags/categories sharing posts) drill down to their members. Ported from the Jetpack Stats Tags & categories module.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
+++ b/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
@@ -6,11 +6,7 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import { useStatsTags } from '@jetpack-premium-analytics/data';
-import type {
-	ReportParams,
-	StatsNormalizedReport,
-	StatsTagsItem,
-} from '@jetpack-premium-analytics/data';
+import type { StatsNormalizedReport, StatsTagsItem } from '@jetpack-premium-analytics/data';
 
 /**
  * A single tag or category grouped under a parent row. Grouped rows have no
@@ -71,10 +67,6 @@ export interface TagView {
 
 interface UseTagViewsArgs {
 	/**
-	 * PA ReportParams from WidgetRoot context.
-	 */
-	reportParams: ReportParams;
-	/**
 	 * Maximum rows to display; `0` means all.
 	 */
 	max: number;
@@ -94,14 +86,12 @@ interface TagViewsState {
  *
  * Delegates fetching, caching, and normalization to `useStatsTags` from
  * `@jetpack-premium-analytics/data`, then maps the normalized rows onto the
- * leaderboard shape and trims to `max`. The `stats/tags` endpoint is a single
- * period query with no comparison, so rows carry current-period views only.
+ * leaderboard shape and trims to `max`. No report params are passed: the
+ * endpoint serves a fixed 7-day window and has no comparison period, so rows
+ * carry that window's views only and the dashboard date range cannot move them.
  */
-export default function useTagViews( { reportParams, max }: UseTagViewsArgs ): TagViewsState {
-	const { data, isLoading, isFetching, isError, refetch } = useStatsTags( {
-		...reportParams,
-		max,
-	} );
+export default function useTagViews( { max }: UseTagViewsArgs ): TagViewsState {
+	const { data, isLoading, isFetching, isError, refetch } = useStatsTags( { max } );
 
 	// Memoize on the query's stable `data` reference so the row array keeps a
 	// stable identity across unrelated re-renders; otherwise every render hands a

--- a/projects/packages/premium-analytics/widgets/tags/widget.json
+++ b/projects/packages/premium-analytics/widgets/tags/widget.json
@@ -3,7 +3,7 @@
 	"title": "Top tags & categories",
 	"description": "Your most visited tags and categories, ranked by views.",
 	"help": {
-		"content": "The tags and categories associated with your most-viewed content, sorted by views.",
+		"content": "The tags and categories associated with your most-viewed content, sorted by views. Figures always cover the last 7 days and are not affected by the dashboard date range.",
 		"links": [
 			{
 				"label": "Learn more",

--- a/projects/packages/premium-analytics/widgets/tags/widget.ts
+++ b/projects/packages/premium-analytics/widgets/tags/widget.ts
@@ -11,11 +11,13 @@ export type TagsAttributes = Record< never, never >;
  * Widget type definition for the Tags & categories widget.
  *
  * Ported from the Jetpack Stats "Tags & categories" module. Lists the site's
- * most visited tags and categories for the selected period, ranked by views.
+ * most visited tags and categories over the last 7 days, ranked by views.
  *
- * Data: read from the `stats/tags` endpoint via `useStatsTags`. A row can group
- * several tags/categories that share a post; those grouped rows have no single
- * archive URL and drill down to their individual members instead.
+ * Data: read from the `stats/tags` endpoint via `useStatsTags`. The endpoint
+ * hardcodes a 7-day window and accepts no date parameters, so the widget cannot
+ * follow the dashboard date range and labels its own period instead. A row can
+ * group several tags/categories that share a post; those grouped rows have no
+ * single archive URL and drill down to their individual members instead.
  */
 export default {
 	icon: category,

--- a/projects/packages/premium-analytics/widgets/tags/widget.ts
+++ b/projects/packages/premium-analytics/widgets/tags/widget.ts
@@ -15,7 +15,10 @@ export type TagsAttributes = Record< never, never >;
  *
  * Data: read from the `stats/tags` endpoint via `useStatsTags`. The endpoint
  * hardcodes a 7-day window and accepts no date parameters, so the widget cannot
- * follow the dashboard date range and labels its own period instead. A row can
+ * follow the dashboard date range and labels its own period instead. That window
+ * is cited in `packages/data/src/queries/stats-tags-query.ts`; the same 7 is
+ * repeated in this widget's title label, `widget.json` help, story description,
+ * and the Tags report page and registry entry, so change them together. A row can
  * group several tags/categories that share a post; those grouped rows have no
  * single archive URL and drill down to their individual members instead.
  */

--- a/projects/plugins/jetpack/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/jetpack/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments reports.
+Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments report pages.

--- a/projects/plugins/jetpack/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/jetpack/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: State the data period on the Tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.

--- a/projects/plugins/jetpack/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/jetpack/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Premium Analytics: State the data period on the Tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.
+Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.

--- a/projects/plugins/jetpack/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/jetpack/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.
+Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments reports.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: State the data period on the Tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.
+Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Premium Analytics: State the data period on the Tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.
+Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments reports.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments reports.
+Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments report pages.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
-Type: added
+Type: changed
 
-Insights: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.
+Insights: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments reports.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Insights: State the data period on the Tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.
+Insights: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Insights: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments reports.
+Insights: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments report pages.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Insights: State the data period on the Tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: State the data period on the Tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.
+Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Premium Analytics: State the data period on the Tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets.
+Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments reports.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2017-label-leaderboard-periods
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2017-label-leaderboard-periods
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments reports.
+Premium Analytics: State the data period on the Top tags & categories, Top commented posts, Top commented authors, and Top social media shares widgets, and on the Tags and Comments report pages.


### PR DESCRIPTION
Fixes WOOA7S-2017

## Why

Site owners looking at the Insights tab had no way to tell what period the bottom-row widgets covered. Pick 2025 in the year filter and Top commented posts, Top commented authors and Top tags & categories just don't move - the comment ones are all-time and tags is always the last 7 days, but nothing on screen said so, so the numbers read as if they were 2025 numbers. Now each of those widgets states its own period, so people can trust what they're looking at instead of quietly getting the wrong idea.

## Proposed changes

* Adds a shared `WidgetPeriodLabel` to the widgets toolkit - a muted caption line under the widget title, for widgets whose endpoint serves a fixed window and so can't follow the dashboard date range.
* Labels the four leaderboard widgets with it: `jpa/tags` "Last 7 days", `jpa/most-commented-posts` / `jpa/most-commented-authors` / `jpa/shares` "All time".
* Updates the `help` tooltip copy on all four to say the same thing, reusing the phrasing already used by `jpa/email-top-row` ("Figures are all-time and are not affected by the dashboard date range.").
* Fixes the stale docblocks and report page subtitles that claimed Tags followed the selected period, or that `stats/tags` "reports one flat all-time list" - it's a rolling 7-day window server side.
* Stops `statsTagsParamsToApiParams` forwarding a `date` the endpoint throws away. It could never change the response, but it re-keyed the React Query cache and the proxy's 5-min cache per year selection, so every year change refetched identical rows - and it contradicted the caption the widget now shows.
* With that gone the Tags widget's `reportParams` plumbing was inert, so it's removed too. The widget now reads no dashboard context at all, same as the other three all-time leaderboards.

### Where the period claims come from

These are now asserted to users in a fair few strings, so the evidence, from the public API reference:

| Endpoint | Endpoint-specific query parameters it declares |
|---|---|
| [`stats/tags`](https://developer.wordpress.com/docs/api/1.1/get/sites/$site/stats/tags/) | `max` only |
| [`stats/comments`](https://developer.wordpress.com/docs/api/1.1/get/sites/$site/stats/comments/) | none at all |
| [`stats/top-posts`](https://developer.wordpress.com/docs/api/1.1/get/sites/$site/stats/top-posts/) (for contrast) | `num`, `period`, `date`, `start_date`, `max`, `offset`, `summarize` |

So neither Tags nor the comment leaderboards can take a date window - there's no parameter to send. The `date` in their responses is documented as "the most-recent day for which stats are returned", which is what makes them look date-aware when they aren't. `stats/comments` also reports `total_comments` as the "number of total comments", so "All time" is right for those two.

The 7-day *length* isn't in the docs; it's hardcoded in the wpcom endpoint (quoted in WOOA7S-1962):

```php
$data = stats_show_tagviews( $site_id, stats_yesterday(), 7, $max, true, true );
```

And I confirmed the behaviour from the client side through the proxy, with `stats/top-posts` as a control to prove params really reach WPCOM:

| Endpoint | `date=2024-12-31` | `date=2026-12-31` |
|---|---|---|
| `stats/top-posts` (control) | echoes `2024-12-31`, buckets `2024-01-01` | echoes `2026-12-31`, buckets `2026-01-01` |
| `stats/tags` (subject) | returns today's date, no `period` key | returns today's date, no `period` key |

The two `stats/tags` bodies were byte-identical. `packages/data/src/queries/__tests__/stats-queries.test.ts` now pins this - two different date selections must produce the same query key.

### Why a caption and not the title

The obvious option was a title suffix ("Top tags & categories (last 7 days)"), but these four all ship 1 column wide in the Insights layout, and the host renders the title on one line with `text-overflow: ellipsis` (`widget-header.module.css`). Measured in the live env at that tile width, the period is exactly what gets cut off:

| Widget | Title space available | Needed with the period appended |
|---|---|---|
| Top commented posts | 159px | 227px |
| Top commented authors | 174px | 242px |
| Top tags & categories | 156px | 247px |

So it goes in the body, where the widget owns the space. Trade-off worth calling out: the caption costs one visible row of the leaderboard list. That list already scrolls at `WIDGET_ROW_LIMIT` = 10 rows, so it doesn't introduce a scrollbar, it just moves the cut one row up.

`jpa/shares` is included even though "keep or drop Shares" (WOOA7S-2022) is still open - share dates are never recorded, so "All time" is correct however that lands.

One thing I deliberately left out of scope: `jpa/latest-post` sits in the same section and has the same problem (its tiles are all-time under a year picker). Its help copy is at least honest about it, and WOOA7S-2013 is already touching `jpa/popular-post` nearby, so I'd rather not widen this one. Happy to raise a follow-up if folks think it should be in.

## Related product discussion/links

* WOOA7S-2017, parent WOOA7S-2008
* Slack thread: p1787126958522969-slack-premium-analytics

## Does this pull request change what data or activity we track or use?

No. Nothing new is tracked or stored. The only request change is subtractive - `stats/tags` no longer receives a `date` it was discarding anyway, so the Insights tab makes strictly fewer requests than before.

## Testing instructions

The four widgets are on the **Stats v2 → Insights** tab (`admin.php?page=jetpack-premium-analytics-wp-admin`, Insights section). Note `jpa/shares` is WordPress.com Simple only (`get_unsupported_widget_types()`), so on a Jetpack site it won't be there.

* Go to Insights and scroll to the bottom row of widgets.
* Ensure **Top tags & categories** shows "Last 7 days" under the title.
* Ensure **Top commented posts** and **Top commented authors** both show "All time".
* On a Simple site, ensure **Top social media shares** shows "All time".
* Switch the year filter between All time and 2025 and ensure those labels don't change, and neither do the numbers - that's the point, the widgets never followed the filter.
* With devtools open, switch the year a couple of times and ensure no `stats/tags` request goes out at all (before this PR each switch fired one).
* Ensure the caption still shows when a widget is empty or loading, and on Tags after drilling into a grouped row.
* Open each widget's ⓘ tooltip and ensure the help text mentions the period and that it isn't affected by the dashboard date range.
* Click "View all" from Tags and ensure the report page subtitle reads "Your most visited tags and categories over the last 7 days."; from either comments widget, ensure it reads "All comments your site has received, by author, post, and page.".
