### PR TITLE
CODEOWNERS: stop requesting Stats review for changelog-only changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,8 +59,11 @@
 
 # Packages
 /projects/packages/premium-analytics @Automattic/jetpack-stats 
+/projects/packages/premium-analytics/changelog # No owner - too noisy on cross-project PRs
 /projects/packages/stats @Automattic/jetpack-stats
+/projects/packages/stats/changelog # No owner - too noisy on cross-project PRs
 /projects/packages/stats-admin @Automattic/jetpack-stats
+/projects/packages/stats-admin/changelog # No owner - too noisy on cross-project PRs
 /projects/packages/search/src/wpes @Automattic/prometheus
 /projects/packages/connection/src @Automattic/jetpack-connection
 /projects/packages/connection/legacy @Automattic/jetpack-connection
@@ -73,7 +76,9 @@
 # Plugins
 
 /projects/plugins/premium-analytics @Automattic/jetpack-stats 
+/projects/plugins/premium-analytics/changelog # No owner - too noisy on cross-project PRs
 /projects/plugins/stats @Automattic/jetpack-stats
+/projects/plugins/stats/changelog # No owner - too noisy on cross-project PRs
 /projects/plugins/boost @Automattic/jetpack-boost
 
 # Functionality that is important to our partners


### PR DESCRIPTION
Fixes #

## Proposed changes
* Any cross-project PR that adds a changelog entry to a Stats-owned project auto-requests review from `@Automattic/jetpack-stats`, even when the PR changes nothing else in Stats. [#51605](https://github.com/Automattic/jetpack/pull/51605) is a Boost change that pinged the Stats team purely because it dropped one file in `projects/plugins/stats/changelog/`. Multiply that by every plugin that bundles a shared package and it is a lot of noise.
* This marks the `changelog/` directory of each Stats-owned project as unowned, using the same "pattern with no owner" form already used for `beta`, `starter-plugin`, and the `class-package-version.php` files.
* Real Stats work still touches Stats source, so the team is still requested on anything that needs their eyes. The only PRs that stop notifying them are ones whose sole Stats-owned file is a changelog entry.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

There is nothing to run locally — CODEOWNERS only takes effect once it is on `trunk`.

* Read the diff and confirm each new line sits *after* the line that grants ownership. CODEOWNERS uses last-match-wins, so the order matters.
* After merge, the next PR that only adds a changelog entry to a Stats project should no longer list `Jetpack Stats` under reviewers. A PR that changes Stats source should still request them.
