### PR TITLE
Renovate: allow @wordpress/theme 2.x for wp-build's peer range

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -351,6 +351,16 @@ function fixPeerDeps( pkg ) {
 		}
 	}
 
+	// @wordpress/build's optional peer on @wordpress/theme stops below 2.0.0, blocking the theme 2.x
+	// that @wordpress/ui and @wordpress/boot require. Widened upstream, drop once a release carries it.
+	// @see https://github.com/WordPress/gutenberg/pull/82139
+	if (
+		pkg.name === '@wordpress/build' &&
+		pkg.peerDependencies?.[ '@wordpress/theme' ] === '>=0.8.0 <2.0.0'
+	) {
+		pkg.peerDependencies[ '@wordpress/theme' ] = '>=0.8.0 <3.0.0';
+	}
+
 	// We use this under tsdown (Rolldown), not Rollup. The `rollup` peer is only used for one TypeScript type, and it being missing apparently makes no difference in our usage.
 	// @see https://github.com/mjeanroy/rollup-plugin-license/issues/2110
 	if ( pkg.name === 'rollup-plugin-license' ) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-vYOntO+/i1MF3Vga6/F/uFipfd9dwgWLzcm+29b/J5E=
+pnpmfileChecksum: sha256-Koac67WaJpuLyJalTUuFaNmp0WUcSQVOu5ejcFHnxKQ=
 
 patchedDependencies:
   '@wordpress/build': 151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022
@@ -11262,7 +11262,7 @@ packages:
       '@wordpress/boot': '>=0.3.0 <1.0.0'
       '@wordpress/private-apis': ^1.0.0
       '@wordpress/route': '>=0.2.0 <1.0.0'
-      '@wordpress/theme': '>=0.8.0 <2.0.0'
+      '@wordpress/theme': '>=0.8.0 <3.0.0'
     peerDependenciesMeta:
       '@wordpress/boot':
         optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,14 @@ autoInstallPeers: false
 dedupePeerDependents: false
 strictPeerDependencies: true
 
+# @wordpress/build's optional peer on @wordpress/theme stops below 2.0.0, which blocks
+# the theme 2.x releases that @wordpress/ui and @wordpress/boot require. 2.0.0 only changed
+# TypeScript declaration resolution; the fallback plugins wp-build loads are unchanged.
+# Widened upstream in WordPress/gutenberg (wp-build); drop this once a release carries it.
+peerDependencyRules:
+  allowedVersions:
+    '@wordpress/build>@wordpress/theme': '>=0.8.0 <3.0.0'
+
 # No hoisting by default.
 hoistPattern: []
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,14 +21,6 @@ autoInstallPeers: false
 dedupePeerDependents: false
 strictPeerDependencies: true
 
-# @wordpress/build's optional peer on @wordpress/theme stops below 2.0.0, which blocks
-# the theme 2.x releases that @wordpress/ui and @wordpress/boot require. 2.0.0 only changed
-# TypeScript declaration resolution; the fallback plugins wp-build loads are unchanged.
-# Widened upstream in WordPress/gutenberg (wp-build); drop this once a release carries it.
-peerDependencyRules:
-  allowedVersions:
-    '@wordpress/build>@wordpress/theme': '>=0.8.0 <3.0.0'
-
 # No hoisting by default.
 hoistPattern: []
 


### PR DESCRIPTION
## Proposed changes

`@wordpress/build` 0.22.0 keeps its optional peer dependency on `@wordpress/theme` at `>=0.8.0 <2.0.0`, while the rest of the August 26 release train (`@wordpress/ui` 0.21, `@wordpress/boot` 0.21) requires `@wordpress/theme` `^2.0.0`. With `strictPeerDependencies: true`.

The next bundled `@wordpress/*` Renovate round cannot install: every wp-build project (12 of them, all pinning `build` + `theme`) fails with `ERR_PNPM_PEER_DEP_ISSUES`, the bot's lockfile step dies, and the PR arrives with a stale lock, the same failure mode as the August 17 round.

This adds a `peerDependencyRules.allowedVersions` entry in `pnpm-workspace.yaml` for `@wordpress/build>@wordpress/theme` (`>=0.8.0 <3.0.0`).

The range is safe: wp-build only loads two optional plugins from theme (`postcss-plugins/postcss-ds-token-fallbacks`, `esbuild-plugins/esbuild-ds-token-fallbacks`) and theme 2.0.0 still exports both; its only breaking change is TypeScript declaration resolution (TypeScript 5+, we are on 6). Same shape as WordPress/gutenberg#80089, which widened the range for theme 1.x; the 2.x widening is being proposed upstream, and this rule can go once a wp-build release carries it.

## Related product discussion/links

* #51303 (previous bundled round) and the Renovate Dependency Dashboard #23363, where the next round is waiting.
* WordPress/gutenberg#80089 (precedent for theme 1.x).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm install --frozen-lockfile` on this branch: the rule alone changes nothing in the lockfile.
* Simulate the round: in `projects/packages/scan/package.json` set `@wordpress/theme` to `2.0.0` and `@wordpress/build` to `0.22.0`, then run `pnpm install --lockfile-only`.
On trunk, it fails with `ERR_PNPM_PEER_DEP_ISSUES: unmet peer @wordpress/theme`; on this branch, it resolves. Revert the two files afterward.
