### PR TITLE
jetpack-mu-wpcom: stop launch celebration modal reappearing after saving Reading settings

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-celebrate-launch-modal-reappears
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-celebrate-launch-modal-reappears
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site visibility: Stop the site launch celebration modal from reappearing after saving Reading settings.

--- a/projects/packages/jetpack-mu-wpcom/src/common/celebrate-launch/celebrate-launch-url.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/celebrate-launch/celebrate-launch-url.test.mts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { CELEBRATE_LAUNCH_PARAM, withoutCelebrateLaunchParam } from './celebrate-launch-url.ts';
+
+describe( 'withoutCelebrateLaunchParam', () => {
+	it( 'removes the param from an absolute URL', () => {
+		assert.equal(
+			withoutCelebrateLaunchParam(
+				'https://example.com/wp-admin/options-reading.php?celebrate-launch'
+			),
+			'https://example.com/wp-admin/options-reading.php'
+		);
+	} );
+
+	it( 'removes the param but keeps other query args on an absolute URL', () => {
+		assert.equal(
+			withoutCelebrateLaunchParam(
+				'https://example.com/wp-admin/options-reading.php?celebrate-launch&settings-updated=true'
+			),
+			'https://example.com/wp-admin/options-reading.php?settings-updated=true'
+		);
+	} );
+
+	it( 'removes the param from a relative referer path, preserving its relative shape', () => {
+		assert.equal(
+			withoutCelebrateLaunchParam(
+				'/wp-admin/options-reading.php?celebrate-launch&settings-updated=true'
+			),
+			'/wp-admin/options-reading.php?settings-updated=true'
+		);
+	} );
+
+	it( 'returns the value unchanged when the param is absent', () => {
+		assert.equal(
+			withoutCelebrateLaunchParam( '/wp-admin/options-reading.php?settings-updated=true' ),
+			'/wp-admin/options-reading.php?settings-updated=true'
+		);
+	} );
+
+	it( 'exposes the param name it strips', () => {
+		assert.equal( CELEBRATE_LAUNCH_PARAM, 'celebrate-launch' );
+	} );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/common/celebrate-launch/celebrate-launch-url.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/celebrate-launch/celebrate-launch-url.ts
@@ -1,0 +1,27 @@
+/**
+ * The query parameter that signals the post-launch celebration modal should show.
+ */
+export const CELEBRATE_LAUNCH_PARAM = 'celebrate-launch';
+
+/**
+ * Remove the celebrate-launch query parameter from a URL string.
+ *
+ * Accepts both absolute URLs (e.g. `window.location.href`) and relative paths
+ * (e.g. a `_wp_http_referer` field value), and returns the same shape it was
+ * given. When the parameter is absent the input string is returned untouched.
+ *
+ * @param {string} value - An absolute URL or a relative path, possibly carrying the param.
+ * @return {string} The value with the celebrate-launch parameter removed.
+ */
+export function withoutCelebrateLaunchParam( value: string ): string {
+	const isAbsolute = /^[a-z][a-z0-9+.-]*:\/\//i.test( value );
+	const url = new URL( value, isAbsolute ? undefined : 'http://placeholder.invalid' );
+
+	if ( ! url.searchParams.has( CELEBRATE_LAUNCH_PARAM ) ) {
+		return value;
+	}
+
+	url.searchParams.delete( CELEBRATE_LAUNCH_PARAM );
+
+	return isAbsolute ? url.toString() : url.pathname + url.search + url.hash;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/launch-celebration-modal.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/launch-celebration-modal.tsx
@@ -1,5 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import CelebrateLaunchModal from '../../common/celebrate-launch/celebrate-launch-modal';
+import {
+	CELEBRATE_LAUNCH_PARAM,
+	withoutCelebrateLaunchParam,
+} from '../../common/celebrate-launch/celebrate-launch-url';
 
 interface Props {
 	siteDomain: string;
@@ -9,10 +13,26 @@ interface Props {
 }
 
 const LaunchCelebrationModal = ( { siteDomain, homeUrl, sitePlan, hasCustomDomain }: Props ) => {
-	const [ showCelebrateLaunchModal, setShowCelebrateLaunchModal ] = useState( () => {
-		const url = new URL( window.location.href );
-		return url.searchParams.has( 'celebrate-launch' );
-	} );
+	const [ showCelebrateLaunchModal, setShowCelebrateLaunchModal ] = useState( () =>
+		new URL( window.location.href ).searchParams.has( CELEBRATE_LAUNCH_PARAM )
+	);
+
+	// Strip the param on mount so the celebration shows exactly once. This lives on
+	// the Reading settings page, whose form redirects back to its _wp_http_referer
+	// after every save; that hidden field captured the param on page load, so unless
+	// we clean it too each save would re-open this modal.
+	useEffect( () => {
+		const cleanedHref = withoutCelebrateLaunchParam( window.location.href );
+		if ( cleanedHref !== window.location.href ) {
+			window.history.replaceState( null, '', cleanedHref );
+		}
+
+		document
+			.querySelectorAll< HTMLInputElement >( 'input[name="_wp_http_referer"]' )
+			.forEach( field => {
+				field.value = withoutCelebrateLaunchParam( field.value );
+			} );
+	}, [] );
 
 	if ( ! showCelebrateLaunchModal ) {
 		return null;
@@ -24,12 +44,7 @@ const LaunchCelebrationModal = ( { siteDomain, homeUrl, sitePlan, hasCustomDomai
 			siteUrl={ homeUrl }
 			sitePlan={ sitePlan }
 			hasCustomDomain={ hasCustomDomain }
-			onRequestClose={ () => {
-				setShowCelebrateLaunchModal( false );
-				const url = new URL( window.location.href );
-				url.searchParams.delete( 'celebrate-launch' );
-				window.history.replaceState( null, '', url.toString() );
-			} }
+			onRequestClose={ () => setShowCelebrateLaunchModal( false ) }
 		/>
 	);
 };

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-celebrate-launch-modal-reappears
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-celebrate-launch-modal-reappears
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site visibility: Stop the site launch celebration modal from reappearing after saving Reading settings.

--- a/projects/plugins/wpcomsh/changelog/fix-celebrate-launch-modal-reappears
+++ b/projects/plugins/wpcomsh/changelog/fix-celebrate-launch-modal-reappears
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site visibility: Stop the site launch celebration modal from reappearing after saving Reading settings.


### PR DESCRIPTION
## Proposed changes

Fixes a bug on **Settings → Reading** where the "Congrats, your site is live!" launch celebration modal reappears every time you save after launching a site.

**Bug:**
https://github.com/user-attachments/assets/77f707ee-fbf3-4511-bd2c-a89c2598cb83

**Root cause:** The modal is triggered by the `celebrate-launch` query param. The Reading settings form carries a hidden `_wp_http_referer` field that WordPress renders from the current page URL. When you arrive from the launch flow that URL is `options-reading.php?celebrate-launch`, so the field captures the param. After each **Save Changes**, `options.php` redirects back to that referer — re-adding `?celebrate-launch` and re-triggering the modal. The previous code only stripped the param from the address bar on modal *close*, never from the referer field.

**Fix:**
* On mount, strip `celebrate-launch` from both the address bar (`history.replaceState`) and every `_wp_http_referer` field, so the celebration shows exactly once. Closing the modal is now just a state flip.
* Extract the URL-cleaning logic into a pure, unit-tested helper (`common/celebrate-launch/celebrate-launch-url.ts`), following the repo's existing "extract predicate + `node:test`" pattern.

The dashboard-widget consumer of the same modal isn't affected — there's no settings form there — so it's left unchanged.

## Related product discussion/links

* The bug was found while working on: DOTPROD-77

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Set up — Simple site

1. On your sandbox, run:
   * `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/celebrate-launch-modal-reappears`
2. Sandbox your simple site (eg., premium plan site).
3. Go to **wp-admin** and confirm the **"sandboxed"** badge appears in the bottom-left corner.


* On a Simple **launched** site, go to **Settings → Reading**. (check the video uploaded above)
* Add a query param `?celebrate-launch=true` and press enter
* You will see the Celebration modal"
* Close the modal, then switch the **Site visibility** option (e.g. Public → Private) and click **Save Changes**.
* **Expected:** the page saves and the celebration modal does **not** reappear. Repeat with other visibility options — it should never come back.
* Reload the page manually — the modal should not reappear either.
* Unit test: `pnpm --filter @automattic/jetpack-mu-wpcom test` (covers the new `withoutCelebrateLaunchParam` helper).
