### PR TITLE
Agents Manager: register the admin bar nodes on admin_bar_menu

### DIFF
--- a/projects/packages/agents-manager/AGENTS.md
+++ b/projects/packages/agents-manager/AGENTS.md
@@ -33,5 +33,7 @@ These filters control behavior and are used by other plugins (like Big Sky) to i
 ## Pitfalls
 
 - **Enqueue priority matters**: Scripts enqueue at priority 101 (after Help Center at 100) so the Agents Manager can dequeue Help Center. Changing priority breaks this. Note the dequeue only runs in the unified experience (see Concepts) — block-editor-only mode leaves Help Center alone.
+- **Admin bar nodes are independent of the enqueue hooks**: they are hooked on `admin_bar_menu` from the constructor, so the admin-bar REST endpoints get them too. Eligibility belongs in `add_admin_bar_nodes()`, never in the registration, and the priority must stay above Help Center's `admin_bar_menu` callback so `add_help_menu()` can replace its node.
+- **Node `meta` is a client contract**: REST consumers read `menu_title` for the label, because `title` is wp-admin markup. Keep it unescaped — core escapes it again for the group `aria-label`. `icon` is the same SVG markup wp-admin renders, built from `get_icon()` so the two cannot drift. `route` is the in-app destination for the panel items that have no `href`, and `html` is the wp-admin mount point only.
 - **Feature gating is multi-layered**: `is_enabled()` checks CIAB, unified experience, and block editor filters in order. The first match wins. This is not a simple on/off.
 - **Router history cleanup**: The `calypso_preferences_update` filter silently limits history to 50 entries. If debugging missing history state, check this.

--- a/projects/packages/agents-manager/changelog/2026-08-27-14-22-57-956094
+++ b/projects/packages/agents-manager/changelog/2026-08-27-14-22-57-956094
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make the help and Ask AI admin bar nodes available from the admin-bar REST endpoints, with the label, icon and destination a client needs.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -46,6 +46,10 @@ class Agents_Manager {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ), 101 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ), 101 );
 		add_action( 'next_admin_init', array( $this, 'enqueue_scripts' ), 1001 );
+
+		// Runs after Help Center's own admin_bar_menu callback, so add_help_menu() can replace its node.
+		add_action( 'admin_bar_menu', array( $this, 'add_admin_bar_nodes' ), 100 );
+
 		add_filter( 'agents_manager_use_unified_experience', array( $this, 'should_use_unified_experience' ) );
 
 		Sidebar_Open_Preservation::init();
@@ -67,12 +71,19 @@ class Agents_Manager {
 	 * @return string The SVG markup.
 	 */
 	private function get_icon( $icon_name ) {
+		// Not cached: the Ask AI label is translated, and the locale can switch mid-request.
 		$icons = array(
 			'comment' => '<svg class="help-center-menu-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M18 4H6c-1.1 0-2 .9-2 2v12.9c0 .6.5 1.1 1.1 1.1.3 0 .5-.1.8-.3L8.5 17H18c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 11c0 .3-.2.5-.5.5H7.9l-2.4 2.4V6c0-.3.2-.5.5-.5h12c.3 0 .5.2.5.5v9z" /></svg>',
 			'backup'  => '<svg class="help-center-menu-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5.5 12h1.75l-2.5 3-2.5-3H4a8 8 0 113.134 6.35l.907-1.194A6.5 6.5 0 105.5 12zm9.53 1.97l-2.28-2.28V8.5a.75.75 0 00-1.5 0V12a.747.747 0 00.218.529l1.282-.84-1.28.842 2.5 2.5a.75.75 0 101.06-1.061z" /></svg>',
 			'page'    => '<svg class="help-center-menu-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15.5 7.5h-7V9h7V7.5Zm-7 3.5h7v1.5h-7V11Zm7 3.5h-7V16h7v-1.5Z" /><path d="M17 4H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2ZM7 5.5h10a.5.5 0 0 1 .5.5v12a.5.5 0 0 1-.5.5H7a.5.5 0 0 1-.5-.5V6a.5.5 0 0 1 .5-.5Z" /></svg>',
 			'video'   => '<svg class="help-center-menu-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M18.7 3H5.3C4 3 3 4 3 5.3v13.4C3 20 4 21 5.3 21h13.4c1.3 0 2.3-1 2.3-2.3V5.3C21 4 20 3 18.7 3zm.8 15.7c0 .4-.4.8-.8.8H5.3c-.4 0-.8-.4-.8-.8V5.3c0-.4.4-.8.8-.8h13.4c.4 0 .8.4.8.8v13.4zM10 15l5-3-5-3v6z" /></svg>',
 			'rss'     => '<svg class="help-center-menu-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5 10.2h-.8v1.5H5c1.9 0 3.8.8 5.1 2.1 1.4 1.4 2.1 3.2 2.1 5.1v.8h1.5V19c0-2.3-.9-4.5-2.6-6.2-1.6-1.6-3.8-2.6-6.1-2.6zm10.4-1.6C12.6 5.8 8.9 4.2 5 4.2h-.8v1.5H5c3.5 0 6.9 1.4 9.4 3.9s3.9 5.8 3.9 9.4v.8h1.5V19c0-3.9-1.6-7.6-4.4-10.4zM4 20h3v-3H4v3z" /></svg>',
+			'help'    => '<svg id="agents-manager-icon" class="ab-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+							<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
+						</svg>',
+			'ask-ai'  => '<svg class="ab-icon" role="img" aria-label="' . esc_attr__( 'Ask AI', 'jetpack-agents-manager' ) . '" width="24" height="24" viewBox="-45 -45 490 490" xmlns="http://www.w3.org/2000/svg">
+								<path fill="currentColor" d="M391.528 188.061L309.455 159.75C276.997 148.597 251.403 123.003 240.25 90.5451L211.939 8.47185C208.079 -2.82395 191.921 -2.82395 188.061 8.47185L159.75 90.5451C148.597 123.003 123.003 148.597 90.5451 159.75L8.47185 188.061C-2.82395 191.921 -2.82395 208.079 8.47185 211.939L90.5451 240.25C123.003 251.403 148.597 276.997 159.75 309.455L188.061 391.528C191.921 402.824 208.079 402.824 211.939 391.528L240.25 309.455C251.403 276.997 276.997 251.403 309.455 240.25L391.528 211.939C402.824 208.079 402.824 191.921 391.528 188.061ZM295.728 206.077L254.692 220.232C238.391 225.809 225.666 238.677 220.089 254.835L205.934 295.871C203.932 301.591 195.925 301.591 193.923 295.871L179.768 254.835C174.191 238.534 161.323 225.809 145.165 220.232L104.129 206.077C98.4093 204.075 98.4093 196.068 104.129 194.066L145.165 179.911C161.466 174.334 174.191 161.466 179.768 145.308L193.923 104.272C195.925 98.5523 203.932 98.5523 205.934 104.272L220.089 145.308C225.666 161.609 238.534 174.334 254.692 179.911L295.728 194.066C301.448 196.068 301.448 204.075 295.728 206.077Z" />
+							</svg>',
 		);
 
 		return $icons[ $icon_name ] ?? '';
@@ -90,23 +101,23 @@ class Agents_Manager {
 
 		$menu_args = array(
 			'id'     => 'agents-manager',
-			'title'  => '<span title="' . esc_attr__( 'Help Center', 'jetpack-agents-manager' ) . '"><svg id="agents-manager-icon" class="ab-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-							<path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z" />
-						</svg></span>',
+			'title'  => '<span title="' . esc_attr__( 'Help Center', 'jetpack-agents-manager' ) . '">' . $this->get_icon( 'help' ) . '</span>',
 			'parent' => 'top-secondary',
 		);
 
 		if ( $use_disconnected ) {
 			$menu_args['href'] = self::HELP_CENTER_URL;
 			$menu_args['meta'] = array(
-				'target' => '_blank',
-				'rel'    => 'noopener noreferrer',
+				'menu_title' => __( 'Help Center', 'jetpack-agents-manager' ),
+				'icon'       => $this->get_icon( 'help' ),
+				'target'     => '_blank',
+				'rel'        => 'noopener noreferrer',
 			);
 		} else {
 			$menu_args['meta'] = array(
-				'class'  => 'menupop',
-				'target' => '_blank',
-				'rel'    => 'noopener noreferrer',
+				'menu_title' => __( 'Help Center', 'jetpack-agents-manager' ),
+				'icon'       => $this->get_icon( 'help' ),
+				'class'      => 'menupop',
 			);
 		}
 
@@ -136,6 +147,11 @@ class Agents_Manager {
 				'parent' => 'agents-manager-menu-panel-chat',
 				'id'     => 'agents-manager-chat-support',
 				'title'  => $this->get_icon( 'comment' ) . '<span>' . __( 'Chat support', 'jetpack-agents-manager' ) . '</span>',
+				'meta'   => array(
+					'menu_title' => __( 'Chat support', 'jetpack-agents-manager' ),
+					'icon'       => $this->get_icon( 'comment' ),
+					'route'      => '/chat',
+				),
 			)
 		);
 
@@ -145,6 +161,11 @@ class Agents_Manager {
 				'parent' => 'agents-manager-menu-panel-chat',
 				'id'     => 'agents-manager-chat-history',
 				'title'  => $this->get_icon( 'backup' ) . '<span>' . __( 'Chat history', 'jetpack-agents-manager' ) . '</span>',
+				'meta'   => array(
+					'menu_title' => __( 'Chat history', 'jetpack-agents-manager' ),
+					'icon'       => $this->get_icon( 'backup' ),
+					'route'      => '/history',
+				),
 			)
 		);
 
@@ -165,6 +186,11 @@ class Agents_Manager {
 				'parent' => 'agents-manager-menu-panel-links',
 				'id'     => 'agents-manager-support-guides',
 				'title'  => $this->get_icon( 'page' ) . '<span>' . __( 'Support guides', 'jetpack-agents-manager' ) . '</span>',
+				'meta'   => array(
+					'menu_title' => __( 'Support guides', 'jetpack-agents-manager' ),
+					'icon'       => $this->get_icon( 'page' ),
+					'route'      => '/support-guides',
+				),
 			)
 		);
 
@@ -176,8 +202,10 @@ class Agents_Manager {
 				'title'  => $this->get_icon( 'video' ) . '<span>' . __( 'Courses', 'jetpack-agents-manager' ) . '</span>',
 				'href'   => 'https://wordpress.com/support/courses/',
 				'meta'   => array(
-					'target' => '_blank',
-					'rel'    => 'noopener noreferrer',
+					'menu_title' => __( 'Courses', 'jetpack-agents-manager' ),
+					'icon'       => $this->get_icon( 'video' ),
+					'target'     => '_blank',
+					'rel'        => 'noopener noreferrer',
 				),
 			)
 		);
@@ -190,8 +218,10 @@ class Agents_Manager {
 				'title'  => $this->get_icon( 'rss' ) . '<span>' . __( 'Product updates', 'jetpack-agents-manager' ) . '</span>',
 				'href'   => 'https://wordpress.com/blog/category/product-features/',
 				'meta'   => array(
-					'target' => '_blank',
-					'rel'    => 'noopener noreferrer',
+					'menu_title' => __( 'Product updates', 'jetpack-agents-manager' ),
+					'icon'       => $this->get_icon( 'rss' ),
+					'target'     => '_blank',
+					'rel'        => 'noopener noreferrer',
 				),
 			)
 		);
@@ -207,73 +237,82 @@ class Agents_Manager {
 			array(
 				'id'     => 'agents-manager-ai-chat',
 				'parent' => 'top-secondary',
-				'title'  => '<span title="' . esc_attr__( 'Ask AI', 'jetpack-agents-manager' ) . '"><svg class="ab-icon" role="img" aria-label="' . esc_attr__( 'Ask AI', 'jetpack-agents-manager' ) . '" width="24" height="24" viewBox="-45 -45 490 490" xmlns="http://www.w3.org/2000/svg">
-								<path fill="currentColor" d="M391.528 188.061L309.455 159.75C276.997 148.597 251.403 123.003 240.25 90.5451L211.939 8.47185C208.079 -2.82395 191.921 -2.82395 188.061 8.47185L159.75 90.5451C148.597 123.003 123.003 148.597 90.5451 159.75L8.47185 188.061C-2.82395 191.921 -2.82395 208.079 8.47185 211.939L90.5451 240.25C123.003 251.403 148.597 276.997 159.75 309.455L188.061 391.528C191.921 402.824 208.079 402.824 211.939 391.528L240.25 309.455C251.403 276.997 276.997 251.403 309.455 240.25L391.528 211.939C402.824 208.079 402.824 191.921 391.528 188.061ZM295.728 206.077L254.692 220.232C238.391 225.809 225.666 238.677 220.089 254.835L205.934 295.871C203.932 301.591 195.925 301.591 193.923 295.871L179.768 254.835C174.191 238.534 161.323 225.809 145.165 220.232L104.129 206.077C98.4093 204.075 98.4093 196.068 104.129 194.066L145.165 179.911C161.466 174.334 174.191 161.466 179.768 145.308L193.923 104.272C195.925 98.5523 203.932 98.5523 205.934 104.272L220.089 145.308C225.666 161.609 238.534 174.334 254.692 179.911L295.728 194.066C301.448 196.068 301.448 204.075 295.728 206.077Z" />
-							</svg></span>',
+				'title'  => '<span title="' . esc_attr__( 'Ask AI', 'jetpack-agents-manager' ) . '">' . $this->get_icon( 'ask-ai' ) . '</span>',
 				'meta'   => array(
-					'html' => '<div id="agents-manager-masterbar"></div>',
+					'menu_title' => __( 'Ask AI', 'jetpack-agents-manager' ),
+					'icon'       => $this->get_icon( 'ask-ai' ),
+					// The wp-admin bundle mounts the chat into this div.
+					'html'       => '<div id="agents-manager-masterbar"></div>',
 				),
 			)
 		);
 	}
 
 	/**
-	 * Enqueue Agents Manager scripts and add inline script data.
+	 * The Agents Manager context for this request, or null when it should not load.
+	 *
+	 * Shared by `add_admin_bar_nodes()` and `enqueue_scripts()`.
+	 *
+	 * @return array{variant: string, disconnected: bool, gutenberg: bool, unified: bool, ciab: bool, enabled: bool}|null
 	 */
-	public function enqueue_scripts() {
-		// Early return for P2 frontend - don't add admin bar or enqueue scripts.
+	private function get_active_context() {
+		// P2 frontends get neither the admin bar entry points nor the app.
 		$stylesheet = get_stylesheet();
 		$is_p2      = str_contains( $stylesheet, 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && \WPForTeams\is_wpforteams_site( get_current_blog_id() );
 
 		if ( ! is_admin() && $is_p2 ) {
-			return;
+			return null;
 		}
 
 		// Determine which variant to load (null = don't load).
 		$variant = self::get_active_variant();
 		if ( null === $variant ) {
-			return;
+			return null;
 		}
-		$use_disconnected       = str_contains( $variant, 'disconnected' );
-		$is_gutenberg           = $this->is_block_editor();
-		$use_unified_experience = self::is_unified_experience();
 
-		// In Gutenberg, dequeue Help Center so we don't end up with two buttons — but only
-		// in the full unified experience, where Agents Manager takes over the Help Center.
-		// In block-editor-only mode (e.g. ?flags=unified-big-sky) Agents Manager replaces
-		// Big Sky's native UI and Help Center should remain available.
-		// Agents Manager fires at priority 101, after Help Center at 100, so HC is already enqueued.
-		if ( $is_gutenberg && $use_unified_experience ) {
-			wp_dequeue_script( 'help-center' );
-			wp_dequeue_style( 'help-center-style' );
+		return array(
+			'variant'      => $variant,
+			'disconnected' => str_contains( $variant, 'disconnected' ),
+			'gutenberg'    => $this->is_block_editor(),
+			'unified'      => self::is_unified_experience(),
+			'ciab'         => $this->is_ciab_environment(),
+			'enabled'      => self::is_enabled(),
+		);
+	}
+
+	/**
+	 * Add the Agents Manager entry points to the admin bar.
+	 *
+	 * Hooked unconditionally, with eligibility resolved here rather than at registration, so the
+	 * admin-bar REST endpoints — which fire `admin_bar_menu` with no enqueue hook — get the same
+	 * nodes as a page load.
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+	 */
+	public function add_admin_bar_nodes( $wp_admin_bar ) {
+		$context = $this->get_active_context();
+		if ( null === $context ) {
+			return;
 		}
 
 		// For non-Gutenberg, non-CIAB environments, add to the admin bar. Gutenberg uses JS when
 		// no admin bar is visible and the server-side branch below when one is available. CIAB
 		// hides the admin bar and uses its own Site Hub.
-		$is_ciab = $this->is_ciab_environment();
-		if ( ! $is_gutenberg && ! $is_ciab ) {
+		if ( ! $context['gutenberg'] && ! $context['ciab'] ) {
 			// Disconnected variants are Help-only. Full variants take over Help
 			// only when the unified experience is active.
-			if ( $use_disconnected || $use_unified_experience ) {
-				add_action(
-					'admin_bar_menu',
-					function ( $wp_admin_bar ) use ( $use_disconnected ) {
-						$this->add_help_menu( $wp_admin_bar, $use_disconnected );
-					},
-					// Add the agents manager icon after Help Center so it can replace that node.
-					100
-				);
+			if ( $context['disconnected'] || $context['unified'] ) {
+				$this->add_help_menu( $wp_admin_bar, $context['disconnected'] );
 			}
 
 			// Initialize the Help menu panel only for the full unified experience.
-			if ( ! $use_disconnected && $use_unified_experience ) {
-				add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
+			if ( ! $context['disconnected'] && $context['unified'] ) {
+				$this->add_menu_panel( $wp_admin_bar );
 			}
 
 			// Standalone AI chat button, shown whenever the full Agents Manager app is enabled.
-			if ( ! $use_disconnected && self::is_enabled() ) {
-				add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
+			if ( ! $context['disconnected'] && $context['enabled'] ) {
+				$this->add_ai_chat_button( $wp_admin_bar );
 			}
 		}
 
@@ -281,22 +320,38 @@ class Agents_Manager {
 		// CIAB is excluded — it has its own Site Hub UI.
 		// Mirroring wp-admin: the Help "?" dropdown shows only in the full unified experience;
 		// the Ask AI button shows whenever Agents Manager is enabled in this editor.
-		if ( ! $is_ciab && ! $use_disconnected && self::is_admin_bar_in_editor() ) {
+		if ( ! $context['ciab'] && ! $context['disconnected'] && self::is_admin_bar_in_editor() ) {
 			// Help "?" node + dropdown panel first, matching the wp-admin admin bar order.
-			if ( $use_unified_experience ) {
-				add_action(
-					'admin_bar_menu',
-					function ( $wp_admin_bar ) {
-						$this->add_help_menu( $wp_admin_bar, false );
-					},
-					100
-				);
-				add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
+			if ( $context['unified'] ) {
+				$this->add_help_menu( $wp_admin_bar, false );
+				$this->add_menu_panel( $wp_admin_bar );
 			}
 
-			if ( self::is_enabled() ) {
-				add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
+			if ( $context['enabled'] ) {
+				$this->add_ai_chat_button( $wp_admin_bar );
 			}
+		}
+	}
+
+	/**
+	 * Enqueue Agents Manager scripts and add inline script data.
+	 */
+	public function enqueue_scripts() {
+		$context = $this->get_active_context();
+		if ( null === $context ) {
+			return;
+		}
+
+		$variant = $context['variant'];
+
+		// In Gutenberg, dequeue Help Center so we don't end up with two buttons — but only
+		// in the full unified experience, where Agents Manager takes over the Help Center.
+		// In block-editor-only mode (e.g. ?flags=unified-big-sky) Agents Manager replaces
+		// Big Sky's native UI and Help Center should remain available.
+		// Agents Manager fires at priority 101, after Help Center at 100, so HC is already enqueued.
+		if ( $context['gutenberg'] && $context['unified'] ) {
+			wp_dequeue_script( 'help-center' );
+			wp_dequeue_style( 'help-center-style' );
 		}
 
 		/**
@@ -325,7 +380,7 @@ class Agents_Manager {
 
 		$inline_data = array(
 			'agentProviders'       => $agent_providers,
-			'useUnifiedExperience' => $use_unified_experience,
+			'useUnifiedExperience' => $context['unified'],
 			'isDevMode'            => self::is_dev_mode(),
 			'isA11n'               => self::is_tracking_automattician(),
 			'isWpcomPlatform'      => ( new \Automattic\Jetpack\Status\Host() )->is_wpcom_platform(),

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -134,6 +134,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		remove_action( 'next_admin_init', array( $this->agents_manager, 'enqueue_scripts' ), 1001 );
 		remove_filter( 'agents_manager_use_unified_experience', array( $this->agents_manager, 'should_use_unified_experience' ) );
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
+		remove_action( 'admin_bar_menu', array( $this->agents_manager, 'add_admin_bar_nodes' ), 100 );
+		remove_all_filters( 'agents_manager_use_unified_experience' );
+		remove_all_filters( 'agents_manager_enabled_in_block_editor' );
+		remove_all_filters( 'agents_manager_should_load' );
 
 		// Restore original superglobal values.
 		if ( $this->original_get_preview === null ) {
@@ -677,55 +681,198 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the standalone AI chat button is added to the admin bar when the
-	 * unified experience is enabled.
+	 * Tests that each panel item carries the label and route the client renders from.
+	 *
+	 * @param string      $id         Node ID.
+	 * @param string      $menu_title Expected label.
+	 * @param string|null $route      Expected in-app route, or null for external links.
+	 * @dataProvider provide_panel_node_data
 	 */
-	public function test_ai_chat_button_registered_in_unified_experience() {
-		// Set admin context so the admin bar nodes are registered.
-		require_once ABSPATH . 'wp-admin/includes/screen.php';
-		set_current_screen( 'dashboard' );
+	#[DataProvider( 'provide_panel_node_data' )]
+	public function test_panel_nodes_carry_their_label_and_route( $id, $menu_title, $route ) {
+		$this->apply_admin_bar_context( array( 'unified' => true ) );
 
-		// Register the script so enqueue_scripts can attach its inline data.
-		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+		$node = $this->render_admin_bar()->get_node( $id );
 
-		// Enable the unified experience (priority 20 runs after the class's own filter).
-		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertNotFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
-		);
-
-		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		$this->assertNotNull( $node );
+		$this->assertSame( $menu_title, $node->meta['menu_title'] ?? null );
+		$this->assertSame( $route, $node->meta['route'] ?? null );
 	}
 
 	/**
-	 * Tests that the standalone AI chat button is added when an integration requests
-	 * Agents Manager without enabling the unified experience.
+	 * Data provider for the panel item label and route pairs.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: string|null}>
 	 */
-	public function test_ai_chat_button_registered_for_requested_shell_without_unified_experience() {
-		// Same admin context as the enabled case, so only the unified flag differs.
-		require_once ABSPATH . 'wp-admin/includes/screen.php';
-		set_current_screen( 'dashboard' );
-		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
-
-		// Disable the unified experience (priority 20 runs after the class's own filter).
-		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		add_filter( 'agents_manager_should_load', '__return_true' );
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertNotFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
+	public static function provide_panel_node_data() {
+		return array(
+			'chat support'    => array( 'agents-manager-chat-support', 'Chat support', '/chat' ),
+			'chat history'    => array( 'agents-manager-chat-history', 'Chat history', '/history' ),
+			'support guides'  => array( 'agents-manager-support-guides', 'Support guides', '/support-guides' ),
+			'courses'         => array( 'agents-manager-courses', 'Courses', null ),
+			'product updates' => array( 'agents-manager-product-updates', 'Product updates', null ),
 		);
-		$this->assertFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_menu_panel' ) ),
-			'Requesting the shell must not take over the Help Center.'
+	}
+
+	/**
+	 * Tests that the Help node replaces the legacy Help Center node rather than sitting beside it.
+	 */
+	public function test_help_node_replaces_the_legacy_help_center_node() {
+		$this->apply_admin_bar_context( array( 'unified' => true ) );
+
+		// Help Center registers its own node at the default priority, below ours.
+		$help_center = static function ( $wp_admin_bar ) {
+			$wp_admin_bar->add_menu(
+				array(
+					'id'     => 'help-center',
+					'parent' => 'top-secondary',
+				)
+			);
+		};
+		add_action( 'admin_bar_menu', $help_center );
+
+		$ids = array_keys( $this->render_admin_bar()->get_nodes() ?? array() );
+
+		remove_action( 'admin_bar_menu', $help_center );
+
+		$this->assertContains( 'agents-manager', $ids );
+		$this->assertNotContains( 'help-center', $ids );
+	}
+
+	/**
+	 * Tests that the Ask AI icon label follows a locale switch within the request.
+	 *
+	 * The admin-bar endpoint switches locale for `_locale=user`, so the icon markup cannot
+	 * be built once and reused.
+	 */
+	public function test_ask_ai_icon_label_follows_a_locale_switch() {
+		require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+
+		$label  = 'Ask AI';
+		$filter = static function ( $translation, $text ) use ( &$label ) {
+			return 'Ask AI' === $text ? $label : $translation;
+		};
+		add_filter( 'gettext', $filter, 10, 2 );
+
+		$first = new \WP_Admin_Bar();
+		$first->initialize();
+		$this->agents_manager->add_ai_chat_button( $first );
+
+		$label  = 'Demander a l IA';
+		$second = new \WP_Admin_Bar();
+		$second->initialize();
+		$this->agents_manager->add_ai_chat_button( $second );
+
+		remove_filter( 'gettext', $filter, 10 );
+
+		$this->assertStringContainsString( 'aria-label="Ask AI"', $first->get_node( 'agents-manager-ai-chat' )->title );
+		$this->assertStringContainsString( 'aria-label="Demander a l IA"', $second->get_node( 'agents-manager-ai-chat' )->title );
+	}
+
+	/**
+	 * Tests that `meta.icon` is the same markup wp-admin renders, so the two cannot drift.
+	 *
+	 * @param string $id Node ID.
+	 * @dataProvider provide_icon_bearing_node_ids
+	 */
+	#[DataProvider( 'provide_icon_bearing_node_ids' )]
+	public function test_meta_icon_matches_the_rendered_icon( $id ) {
+		$this->apply_admin_bar_context( array( 'unified' => true ) );
+
+		$node = $this->render_admin_bar()->get_node( $id );
+
+		$this->assertNotNull( $node );
+		$this->assertNotEmpty( $node->meta['icon'] ?? '' );
+		$this->assertStringContainsString( $node->meta['icon'], $node->title );
+	}
+
+	/**
+	 * Data provider for the nodes that carry an icon.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function provide_icon_bearing_node_ids() {
+		return array(
+			'help'            => array( 'agents-manager' ),
+			'ask ai'          => array( 'agents-manager-ai-chat' ),
+			'chat support'    => array( 'agents-manager-chat-support' ),
+			'chat history'    => array( 'agents-manager-chat-history' ),
+			'support guides'  => array( 'agents-manager-support-guides' ),
+			'courses'         => array( 'agents-manager-courses' ),
+			'product updates' => array( 'agents-manager-product-updates' ),
+		);
+	}
+
+	/**
+	 * Tests that `menu_title` is not HTML-escaped.
+	 *
+	 * It is API data, and core escapes it again when rendering the group's aria-label.
+	 */
+	public function test_menu_title_is_not_html_escaped() {
+		$filter = static fn( $translation, $text ) => 'Ask AI' === $text ? "L'IA" : $translation;
+		add_filter( 'gettext', $filter, 10, 2 );
+
+		global $wp_admin_bar;
+		require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+		$wp_admin_bar = new \WP_Admin_Bar();
+		$wp_admin_bar->initialize();
+		$this->agents_manager->add_ai_chat_button( $wp_admin_bar );
+
+		remove_filter( 'gettext', $filter, 10 );
+
+		$this->assertSame( "L'IA", $wp_admin_bar->get_node( 'agents-manager-ai-chat' )->meta['menu_title'] );
+	}
+
+	/**
+	 * Tests that Help is registered before Ask AI, matching the wp-admin admin bar order.
+	 */
+	public function test_help_node_is_registered_before_ask_ai() {
+		$this->apply_admin_bar_context( array( 'unified' => true ) );
+
+		$ids = array_keys( $this->render_admin_bar()->get_nodes() ?? array() );
+
+		$this->assertContains( 'agents-manager', $ids );
+		$this->assertContains( 'agents-manager-ai-chat', $ids );
+		$this->assertLessThan(
+			array_search( 'agents-manager-ai-chat', $ids, true ),
+			array_search( 'agents-manager', $ids, true )
+		);
+	}
+
+	/**
+	 * Tests that the Help node links straight out only for disconnected variants.
+	 *
+	 * Drives `admin_bar_menu` so the caller's choice of argument is covered, not just the method.
+	 *
+	 * @param string|null $variant     Forced variant, or null for the connected default.
+	 * @param bool        $expect_href Whether the node should carry the Help Center URL.
+	 * @dataProvider provide_help_menu_connection_states
+	 */
+	#[DataProvider( 'provide_help_menu_connection_states' )]
+	public function test_help_menu_links_out_only_when_disconnected( $variant, $expect_href ) {
+		$this->apply_admin_bar_context(
+			array(
+				'unified' => true,
+				'variant' => $variant,
+			)
 		);
 
-		remove_filter( 'agents_manager_should_load', '__return_true' );
-		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		$node = $this->render_admin_bar()->get_node( 'agents-manager' );
+
+		$this->assertNotNull( $node );
+		$this->assertSame( $expect_href, ! empty( $node->href ) );
+	}
+
+	/**
+	 * Data provider for the Help node connection states.
+	 *
+	 * @return array<string, array{0: string|null, 1: bool}>
+	 */
+	public static function provide_help_menu_connection_states() {
+		return array(
+			'disconnected links to the Help Center' => array( 'wp-admin-disconnected', true ),
+			'connected opens the dropdown'          => array( null, false ),
+		);
 	}
 
 	/**
@@ -748,183 +895,6 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->assertNotNull( $ai_node );
 		$this->assertStringNotContainsString( 'agents-manager-masterbar', $help_node->meta['html'] ?? '' );
 		$this->assertStringContainsString( 'agents-manager-masterbar', $ai_node->meta['html'] ?? '' );
-	}
-
-	/**
-	 * Tests that the standalone AI chat button is not added for a disconnected
-	 * Help-only variant.
-	 */
-	public function test_ai_chat_button_not_registered_for_disconnected_variant() {
-		require_once ABSPATH . 'wp-admin/includes/screen.php';
-		set_current_screen( 'dashboard' );
-		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
-
-		$variant_filter = static function () {
-			return 'wp-admin-disconnected';
-		};
-		add_filter( 'agents_manager_variant', $variant_filter );
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
-		);
-
-		remove_filter( 'agents_manager_variant', $variant_filter );
-	}
-
-	/**
-	 * Puts the current request into a block-editor screen so the editor admin-bar branch is reachable.
-	 *
-	 * @param bool $enable Whether to enable Agents Manager in the block editor (block-editor-only,
-	 *                     no unified experience). Pass false to exercise the not-enabled path.
-	 */
-	private function set_up_block_editor_request( $enable = true ) {
-		require_once ABSPATH . 'wp-admin/includes/screen.php';
-		set_current_screen( 'post' );
-		$screen     = get_current_screen();
-		$reflection = new \ReflectionClass( $screen );
-		$property   = $reflection->getProperty( 'is_block_editor' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$property->setAccessible( true );
-		}
-		$property->setValue( $screen, true );
-
-		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
-
-		if ( $enable ) {
-			add_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
-		}
-	}
-
-	/**
-	 * Tests that the Ask AI button is added when the editor admin bar is showing and Agents Manager
-	 * is enabled — independent of dev mode (here, a non-proxied request).
-	 */
-	public function test_ai_chat_button_registered_in_editor_admin_bar() {
-		$this->set_up_block_editor_request();
-
-		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertNotFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
-		);
-
-		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
-	}
-
-	/**
-	 * Tests that an integration-requested Gutenberg shell adds Ask AI to the editor
-	 * admin bar without taking over the Help Center.
-	 */
-	public function test_ai_chat_button_registered_in_editor_admin_bar_for_requested_shell() {
-		$this->set_up_block_editor_request( false );
-
-		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-
-		add_filter( 'agents_manager_should_load', '__return_true' );
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertNotFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
-		);
-
-		remove_filter( 'agents_manager_should_load', '__return_true' );
-	}
-
-	/**
-	 * Tests that a classic editor admin bar receives Ask AI without the Gutenberg
-	 * omnibar experiment.
-	 */
-	public function test_ai_chat_button_registered_in_classic_editor_admin_bar() {
-		$this->set_up_block_editor_request();
-
-		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertNotFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
-		);
-
-		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
-	}
-
-	/**
-	 * Tests that the Ask AI button is not added to the editor admin bar when the admin
-	 * bar is hidden, even though Agents Manager is enabled.
-	 */
-	public function test_ai_chat_button_not_registered_in_editor_without_admin_bar() {
-		$this->set_up_block_editor_request();
-
-		Functions\when( 'is_admin_bar_showing' )->justReturn( false );
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
-		);
-
-		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
-	}
-
-	/**
-	 * Tests that the Ask AI button is not added to the editor admin bar when Agents Manager is
-	 * not enabled, even while the admin bar is showing.
-	 */
-	public function test_ai_chat_button_not_registered_in_editor_when_not_enabled() {
-		$this->set_up_block_editor_request( false );
-
-		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
-		);
-	}
-
-	/**
-	 * Tests that the Help "?" dropdown (its menu panel) is added to the editor admin bar in the
-	 * unified experience.
-	 */
-	public function test_help_menu_registered_in_editor_admin_bar_when_unified() {
-		$this->set_up_block_editor_request();
-
-		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
-		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertNotFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_menu_panel' ) )
-		);
-
-		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
-		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
-	}
-
-	/**
-	 * Tests that the Help "?" dropdown is not added to the editor admin bar when the unified
-	 * experience is disabled (Ask AI only).
-	 */
-	public function test_help_menu_not_registered_in_editor_admin_bar_without_unified() {
-		$this->set_up_block_editor_request();
-
-		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_menu_panel' ) )
-		);
-
-		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
 	}
 
 	/**
@@ -2891,6 +2861,277 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 			'Simplified Chinese kept'       => array( 'zh_CN', 'zh-cn' ),
 			'English strips region'         => array( 'en_US', 'en' ),
 			'Empty locale falls back to en' => array( '', 'en' ),
+		);
+	}
+
+	/**
+	 * Puts the request into the context described by $ctx.
+	 *
+	 * @param array<string, mixed> $ctx Context flags from provide_admin_bar_contexts().
+	 */
+	private function apply_admin_bar_context( array $ctx = array() ) {
+		$ctx = array_merge(
+			array(
+				'screen'         => 'dashboard',
+				'block_editor'   => false,
+				'admin_bar'      => true,
+				'unified'        => false,
+				'variant'        => null,
+				'editor_enabled' => false,
+				'should_load'    => false,
+				'ciab'           => false,
+				'p2'             => false,
+				'iframe_tab'     => false,
+				'editor_user'    => false,
+			),
+			$ctx
+		);
+
+		if ( $ctx['editor_user'] ) {
+			// `WP_Admin_Bar::initialize()` indexes this by blog ID for logged-in users.
+			Functions\when( 'get_blogs_of_user' )->justReturn(
+				array( get_current_blog_id() => (object) array( 'userblog_id' => get_current_blog_id() ) )
+			);
+
+			wp_set_current_user(
+				wp_insert_user(
+					array(
+						'user_login' => 'am-editor',
+						'user_pass'  => 'password',
+						'role'       => 'editor',
+					)
+				)
+			);
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+
+		// Always stubbed: Patchwork keeps a stubbed function defined for the rest of the
+		// process, so a conditional stub would leak into later tests.
+		Functions\when( 'get_stylesheet' )->justReturn( $ctx['p2'] ? 'pub/p2-breathe' : 'twentytwentyfour' );
+
+		if ( null !== $ctx['screen'] ) {
+			set_current_screen( $ctx['screen'] );
+
+			if ( $ctx['block_editor'] ) {
+				$screen     = get_current_screen();
+				$reflection = new \ReflectionClass( $screen );
+				$property   = $reflection->getProperty( 'is_block_editor' );
+				if ( PHP_VERSION_ID < 80100 ) {
+					$property->setAccessible( true );
+				}
+				$property->setValue( $screen, true );
+			}
+		} else {
+			unset( $GLOBALS['current_screen'] );
+		}
+
+		if ( $ctx['iframe_tab'] ) {
+			$_GET['tab'] = 'plugin-information';
+		}
+
+		if ( $ctx['ciab'] ) {
+			global $wp_actions;
+			$wp_actions['next_admin_init'] = 1;
+		}
+
+		Functions\when( 'is_admin_bar_showing' )->justReturn( $ctx['admin_bar'] );
+
+		// Priority 20 runs after the class's own filter.
+		add_filter( 'agents_manager_use_unified_experience', $ctx['unified'] ? '__return_true' : '__return_false', 20 );
+
+		if ( null !== $ctx['variant'] ) {
+			$variant = $ctx['variant'];
+			add_filter( 'agents_manager_variant', static fn() => $variant );
+		}
+
+		if ( $ctx['editor_enabled'] ) {
+			add_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+		}
+
+		if ( $ctx['should_load'] ) {
+			add_filter( 'agents_manager_should_load', '__return_true' );
+		}
+	}
+
+	/**
+	 * Renders the admin bar, firing `admin_bar_menu` with no enqueue hook first — the same
+	 * conditions as the admin-bar REST endpoints.
+	 *
+	 * @return \WP_Admin_Bar The rendered admin bar.
+	 */
+	private function render_admin_bar() {
+		global $wp_admin_bar;
+
+		require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+		$wp_admin_bar = new \WP_Admin_Bar();
+		$wp_admin_bar->initialize();
+
+		do_action_ref_array( 'admin_bar_menu', array( &$wp_admin_bar ) );
+
+		return $wp_admin_bar;
+	}
+
+	/**
+	 * Renders the admin bar and returns the Agents Manager node IDs on it.
+	 *
+	 * @return string[] Sorted Agents Manager node IDs.
+	 */
+	private function render_agents_manager_nodes() {
+		$wp_admin_bar = $this->render_admin_bar();
+
+		$ids = array_values(
+			array_filter(
+				array_keys( $wp_admin_bar->get_nodes() ?? array() ),
+				static fn( $id ) => str_starts_with( (string) $id, 'agents-manager' )
+			)
+		);
+		sort( $ids );
+
+		return $ids;
+	}
+
+	/**
+	 * Locks the node set each surface renders, so a change to how the nodes are registered
+	 * cannot silently alter which of them appear.
+	 *
+	 * @param array<string, mixed> $ctx      Request context.
+	 * @param string[]             $expected Expected node IDs.
+	 * @dataProvider provide_admin_bar_contexts
+	 */
+	#[DataProvider( 'provide_admin_bar_contexts' )]
+	public function test_admin_bar_nodes_match_context( array $ctx, array $expected ) {
+		$this->apply_admin_bar_context( $ctx );
+
+		$this->assertSame( $expected, $this->render_agents_manager_nodes() );
+	}
+
+	/**
+	 * Data provider for the admin-bar node matrix.
+	 *
+	 * @return array<string, array{0: array<string, mixed>, 1: string[]}>
+	 */
+	public static function provide_admin_bar_contexts() {
+		$help    = 'agents-manager';
+		$ai_chat = 'agents-manager-ai-chat';
+		$panel   = array(
+			'agents-manager-chat-history',
+			'agents-manager-chat-support',
+			'agents-manager-courses',
+			'agents-manager-menu-panel-chat',
+			'agents-manager-menu-panel-links',
+			'agents-manager-product-updates',
+			'agents-manager-support-guides',
+		);
+
+		$unified_nodes = array_merge( array( $help, $ai_chat ), $panel );
+		sort( $unified_nodes );
+
+		return array(
+			'wp-admin, unified experience'           => array(
+				array( 'unified' => true ),
+				$unified_nodes,
+			),
+			'wp-admin, requested shell only'         => array(
+				array( 'should_load' => true ),
+				array( $ai_chat ),
+			),
+			'wp-admin, disconnected is help-only'    => array(
+				array( 'variant' => 'wp-admin-disconnected' ),
+				array( $help ),
+			),
+			'wp-admin, disconnected and unified'     => array(
+				array(
+					'variant' => 'wp-admin-disconnected',
+					'unified' => true,
+				),
+				array( $help ),
+			),
+			'front end, disconnected is help-only'   => array(
+				array(
+					'screen'      => null,
+					'editor_user' => true,
+					'should_load' => true,
+				),
+				array( $help ),
+			),
+			'editor with admin bar, unified'         => array(
+				array(
+					'screen'       => 'post',
+					'block_editor' => true,
+					'unified'      => true,
+				),
+				$unified_nodes,
+			),
+			'editor with admin bar, editor-only'     => array(
+				array(
+					'screen'         => 'post',
+					'block_editor'   => true,
+					'editor_enabled' => true,
+				),
+				array( $ai_chat ),
+			),
+			'editor with admin bar, requested shell' => array(
+				array(
+					'screen'       => 'post',
+					'block_editor' => true,
+					'should_load'  => true,
+				),
+				array( $ai_chat ),
+			),
+			'editor with admin bar, not enabled'     => array(
+				array(
+					'screen'       => 'post',
+					'block_editor' => true,
+				),
+				array(),
+			),
+			'editor without admin bar'               => array(
+				array(
+					'screen'         => 'post',
+					'block_editor'   => true,
+					'editor_enabled' => true,
+					'admin_bar'      => false,
+				),
+				array(),
+			),
+			'wp-admin, not enabled'                  => array(
+				array(),
+				array(),
+			),
+			'editor with admin bar, disconnected'    => array(
+				array(
+					'screen'       => 'post',
+					'block_editor' => true,
+					'unified'      => true,
+					'variant'      => 'gutenberg-disconnected',
+				),
+				array(),
+			),
+			'CIAB has its own Site Hub'              => array(
+				array(
+					'ciab'    => true,
+					'unified' => true,
+				),
+				array(),
+			),
+			'P2 frontend is excluded'                => array(
+				array(
+					'screen'  => null,
+					'p2'      => true,
+					'unified' => true,
+					'variant' => 'wp-admin',
+				),
+				array(),
+			),
+			'plugin information iframe is excluded'  => array(
+				array(
+					'screen'     => 'plugin-install',
+					'iframe_tab' => true,
+					'unified'    => true,
+				),
+				array(),
+			),
 		);
 	}
 }

--- a/projects/plugins/agents-manager/changelog/2026-08-27-14-23-05-959815
+++ b/projects/plugins/agents-manager/changelog/2026-08-27-14-23-05-959815
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make the help and Ask AI admin bar nodes available from the admin-bar REST endpoints, with the label, icon and destination a client needs.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
@@ -33,7 +33,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Bar extends WP_REST_Controller {
 	 *
 	 * @var string[]
 	 */
-	const ALLOWED_TOP_LEVEL_NODES = array( 'wp-logo', 'site-name', 'updates', 'command-palette', 'comments', 'new-content', 'my-account' );
+	const ALLOWED_TOP_LEVEL_NODES = array( 'wp-logo', 'site-name', 'updates', 'command-palette', 'comments', 'new-content', 'my-account', 'agents-manager', 'agents-manager-ai-chat' );
 
 	/**
 	 * WPCOM_REST_API_V2_Endpoint_Admin_Bar constructor.

--- a/projects/plugins/jetpack/changelog/2026-08-27-14-23-06-585647
+++ b/projects/plugins/jetpack/changelog/2026-08-27-14-23-06-585647
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin Bar endpoint: Expose the Agents Manager help and Ask AI nodes.

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-agents-manager-admin-bar-nodes-in-rest
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-agents-manager-admin-bar-nodes-in-rest
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make the help and Ask AI admin bar nodes available from the admin-bar REST endpoints, with the label, icon and destination a client needs.

--- a/projects/plugins/wpcomsh/changelog/update-agents-manager-admin-bar-nodes-in-rest
+++ b/projects/plugins/wpcomsh/changelog/update-agents-manager-admin-bar-nodes-in-rest
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Make the help and Ask AI admin bar nodes available from the admin-bar REST endpoints, with the label, icon and destination a client needs.


### PR DESCRIPTION
Part of AM-34

## Proposed changes

* Register the Agents Manager admin bar nodes once on `admin_bar_menu` from the constructor, instead of six `add_action()` calls inside `enqueue_scripts()`.
* Resolve eligibility in the callback via a shared `get_active_context()`, used by both the nodes and the script enqueue.
* Allowlist `agents-manager` and `agents-manager-ai-chat` in the site admin-bar endpoint.
* Add the data a client needs: `menu_title` (translated label), `icon` (the same SVG wp-admin renders), and `route` for the in-app panel items.

## Other information

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and confirmed that your changes do not break them?
- [x] Have you tested your changes on WordPress.com, if applicable (P9HQHe-k8-p2)?

## Jetpack product discussion

The admin-bar endpoints fire `admin_bar_menu` during a REST request. Our nodes were registered inside `enqueue_scripts()`, which only runs on the enqueue hooks — none of which fire in REST. So the endpoints returned no Agents Manager nodes, whatever the allowlist said.

Registering on `admin_bar_menu` fixes that. Eligibility moves into the callback, where the screen, the admin bar and host filters have all settled. `get_active_context()` carries the guards that previously sat at the top of `enqueue_scripts()`, including the P2 front-end early return.

`menu_title` matters because the omnibar reads `node.meta?.menu_title || node.title`, and our `title` is wp-admin markup — without it a client renders an SVG blob as the label.

`meta.icon` is built from the same `get_icon()` call that renders the wp-admin `title`, so the two cannot drift. It carries wp-admin styling hooks (`ab-icon`, `help-center-menu-icon`), which a client will want to strip or ignore.

Click behaviour, Tracks context and `localizeUrl()` stay in Calypso.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Sandbox the site for `/wp-admin`, and `public-api.wordpress.com` for the endpoint. Then, on your WordPress.com sandbox:

```bash
bin/jetpack-downloader test jetpack 51657
# bin/jetpack-downloader reset jetpack   # when done
```

The nodes need the unified experience, which is proxied-Automattician-only: enable **"Enable the unified AI chat experience in Help Center"** in your profile settings, or force it in `0-sandbox.php`:

```php
add_filter( 'agents_manager_use_unified_experience', '__return_true', 9999 );
```

### Node data

The `admin-bar` API response now includes the Agents Manager nodes (`title` truncated — it is the wp-admin icon markup):

```jsonc
[
  // Help "?" — top level. `menupop` opens the dropdown; no href.
  {
    "id":     "agents-manager",
    "parent": "top-secondary",
    "href":   false,
    "title":  "<span title=\"Help Center\"><svg class=\"ab-icon\" …></svg></span>",
    "meta":   {
      "menu_title": "Help Center",
      "icon":       "<svg id=\"agents-manager-icon\" class=\"ab-icon\" …></svg>",
      "class":      "menupop"
    }
  },

  // Chat group, and its two items. No href — the client routes via `meta.route`.
  {
    "id":     "agents-manager-menu-panel-chat",
    "parent": "agents-manager",
    "group":  true,
    "meta":   { "class": "ab-sub-secondary" }
  },
  {
    "id":     "agents-manager-chat-support",
    "parent": "agents-manager-menu-panel-chat",
    "title":  "<svg class=\"help-center-menu-icon\" …></svg><span>Chat support</span>",
    "meta":   {
      "menu_title": "Chat support",
      "icon":       "<svg class=\"help-center-menu-icon\" …></svg>",
      "route":      "/chat"
    }
  },
  {
    "id":     "agents-manager-chat-history",
    "parent": "agents-manager-menu-panel-chat",
    "title":  "<svg class=\"help-center-menu-icon\" …></svg><span>Chat history</span>",
    "meta":   {
      "menu_title": "Chat history",
      "icon":       "<svg class=\"help-center-menu-icon\" …></svg>",
      "route":      "/history"
    }
  },

  // Resources group. Support guides routes in-app; the other two are external links.
  {
    "id":     "agents-manager-menu-panel-links",
    "parent": "agents-manager",
    "group":  true,
    "meta":   { "class": "ab-sub-secondary" }
  },
  {
    "id":     "agents-manager-support-guides",
    "parent": "agents-manager-menu-panel-links",
    "title":  "<svg class=\"help-center-menu-icon\" …></svg><span>Support guides</span>",
    "meta":   {
      "menu_title": "Support guides",
      "icon":       "<svg class=\"help-center-menu-icon\" …></svg>",
      "route":      "/support-guides"
    }
  },
  {
    "id":     "agents-manager-courses",
    "parent": "agents-manager-menu-panel-links",
    "href":   "https://wordpress.com/support/courses/",
    "title":  "<svg class=\"help-center-menu-icon\" …></svg><span>Courses</span>",
    "meta":   {
      "menu_title": "Courses",
      "icon":       "<svg class=\"help-center-menu-icon\" …></svg>",
      "target":     "_blank",
      "rel":        "noopener noreferrer"
    }
  },
  {
    "id":     "agents-manager-product-updates",
    "parent": "agents-manager-menu-panel-links",
    "href":   "https://wordpress.com/blog/category/product-features/",
    "title":  "<svg class=\"help-center-menu-icon\" …></svg><span>Product updates</span>",
    "meta":   {
      "menu_title": "Product updates",
      "icon":       "<svg class=\"help-center-menu-icon\" …></svg>",
      "target":     "_blank",
      "rel":        "noopener noreferrer"
    }
  },

  // Ask AI — top level.
  {
    "id":     "agents-manager-ai-chat",
    "parent": "top-secondary",
    "href":   false,
    "title":  "<span title=\"Ask AI\"><svg class=\"ab-icon\" …></svg></span>",
    "meta":   {
      "menu_title": "Ask AI",
      "icon":       "<svg class=\"ab-icon\" role=\"img\" aria-label=\"Ask AI\" …></svg>",
      // wp-admin only: core prints this inside the node's <li>, and the
      // wp-admin bundle mounts the chat into it. Other clients ignore it.
      "html": "<div id=\"agents-manager-masterbar\"></div>"
    }
  }
]
```

Two shapes a consumer has to handle:

* **Disconnected sites** get `agents-manager` with an `href` to the Help Center and **no menu panel** — `add_menu_panel()` runs only for the full unified experience. Rendering a dropdown unconditionally gives a dead button.
* **`meta.icon` is markup from the site**, so a consumer rendering it outside wp-admin should rebuild it rather than inject it as HTML.

Nothing renders these yet — the omnibar drops unclaimed `top-secondary` nodes. This PR only provides the data.

### No regressions

Everything below should look and behave exactly as it does on trunk — this change moves when the nodes are registered, not what they do.

| Surface | With unified disabled | With unified enabled |
|---|---|---|
| Simple `/wp-admin` | legacy HC panel, no Ask AI | new HC menu + Ask AI |
| WoA `/wp-admin` | legacy HC panel + Ask AI | new HC menu + Ask AI |
| Editors | legacy HC panel + Ask AI | new HC menu + Ask AI |
| P2 front end | no Agents Manager nodes | no Agents Manager nodes |

Note: `/wp-admin/admin.php?page=wc-*` has no HC panel.

Opening and closing the chat should collapse it back into the button, not leave a floating bubble.






