### PR TITLE
Agents Manager: expose the deployed build version to the frontend

### DIFF
--- a/projects/packages/agents-manager/changelog/ai-1115-expose-agents-manager-version-to-frontend
+++ b/projects/packages/agents-manager/changelog/ai-1115-expose-agents-manager-version-to-frontend
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Expose the deployed build version to the frontend as `agentsManagerData.version`.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -376,7 +376,7 @@ class Agents_Manager {
 		 */
 		$agent_id = apply_filters( 'agents_manager_agent_id', null );
 
-		$this->enqueue_script( $variant );
+		$script_version = $this->enqueue_script( $variant );
 
 		$inline_data = array(
 			'agentProviders'       => $agent_providers,
@@ -389,6 +389,10 @@ class Agents_Manager {
 			'site'                 => $this->get_current_site(),
 			'helpCenterUrl'        => self::HELP_CENTER_URL,
 		);
+
+		if ( null !== $script_version ) {
+			$inline_data['version'] = $variant . ':' . $script_version;
+		}
 
 		if ( $agent_id ) {
 			$inline_data['agentId'] = $agent_id;
@@ -589,6 +593,7 @@ class Agents_Manager {
 	 * Enqueue Agents Manager script based on context.
 	 *
 	 * @param string $variant The variant of the asset file to get.
+	 * @return string|null The deployed build version from the asset file, or null when unavailable.
 	 */
 	private function enqueue_script( $variant ) {
 		$cache_key  = 'agents-manager-asset-' . $variant . '.asset.json';
@@ -597,7 +602,7 @@ class Agents_Manager {
 		if ( ! $asset_file ) {
 			$asset_file = self::get_assets_json( 'widgets.wp.com/agents-manager/agents-manager-' . $variant . '.asset.json' );
 			if ( ! $asset_file ) {
-				return;
+				return null;
 			}
 			set_transient( $cache_key, $asset_file, HOUR_IN_SECONDS );
 		}
@@ -648,6 +653,8 @@ class Agents_Manager {
 				$version
 			);
 		}
+
+		return (string) $asset_file['version'];
 	}
 
 	/**

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -233,17 +233,27 @@ class Agents_Manager {
 	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
 	 */
 	public function add_ai_chat_button( $wp_admin_bar ) {
+		$meta = array(
+			'menu_title' => __( 'Ask AI', 'jetpack-agents-manager' ),
+			'icon'       => $this->get_icon( 'ask-ai' ),
+			// The wp-admin bundle mounts the chat into this div.
+			'html'       => '<div id="agents-manager-masterbar"></div>',
+		);
+
+		// The deployed build version, so REST consumers can report the same
+		// `agent_manager_version` as the app itself.
+		$variant = self::get_active_variant();
+		$version = null !== $variant ? self::get_deployed_version( $variant ) : null;
+		if ( null !== $version ) {
+			$meta['version'] = $version;
+		}
+
 		$wp_admin_bar->add_menu(
 			array(
 				'id'     => 'agents-manager-ai-chat',
 				'parent' => 'top-secondary',
 				'title'  => '<span title="' . esc_attr__( 'Ask AI', 'jetpack-agents-manager' ) . '">' . $this->get_icon( 'ask-ai' ) . '</span>',
-				'meta'   => array(
-					'menu_title' => __( 'Ask AI', 'jetpack-agents-manager' ),
-					'icon'       => $this->get_icon( 'ask-ai' ),
-					// The wp-admin bundle mounts the chat into this div.
-					'html'       => '<div id="agents-manager-masterbar"></div>',
-				),
+				'meta'   => $meta,
 			)
 		);
 	}
@@ -376,7 +386,9 @@ class Agents_Manager {
 		 */
 		$agent_id = apply_filters( 'agents_manager_agent_id', null );
 
-		$script_version = $this->enqueue_script( $variant );
+		$this->enqueue_script( $variant );
+
+		$version = self::get_deployed_version( $variant );
 
 		$inline_data = array(
 			'agentProviders'       => $agent_providers,
@@ -390,8 +402,8 @@ class Agents_Manager {
 			'helpCenterUrl'        => self::HELP_CENTER_URL,
 		);
 
-		if ( null !== $script_version ) {
-			$inline_data['version'] = $variant . ':' . $script_version;
+		if ( null !== $version ) {
+			$inline_data['version'] = $version;
 		}
 
 		if ( $agent_id ) {
@@ -590,12 +602,12 @@ class Agents_Manager {
 	}
 
 	/**
-	 * Enqueue Agents Manager script based on context.
+	 * The cached asset metadata for a variant, or null when unavailable.
 	 *
 	 * @param string $variant The variant of the asset file to get.
-	 * @return string|null The deployed build version from the asset file, or null when unavailable.
+	 * @return array|null
 	 */
-	private function enqueue_script( $variant ) {
+	private static function get_asset_file( $variant ) {
 		$cache_key  = 'agents-manager-asset-' . $variant . '.asset.json';
 		$asset_file = get_transient( $cache_key );
 
@@ -605,6 +617,32 @@ class Agents_Manager {
 				return null;
 			}
 			set_transient( $cache_key, $asset_file, HOUR_IN_SECONDS );
+		}
+
+		return $asset_file;
+	}
+
+	/**
+	 * The deployed build version for a variant, as `{variant}:{version}`, or null when unavailable.
+	 *
+	 * @param string $variant The variant of the asset file to get.
+	 * @return string|null
+	 */
+	private static function get_deployed_version( $variant ) {
+		$asset_file = self::get_asset_file( $variant );
+
+		return $asset_file ? $variant . ':' . (string) $asset_file['version'] : null;
+	}
+
+	/**
+	 * Enqueue Agents Manager script based on context.
+	 *
+	 * @param string $variant The variant of the asset file to get.
+	 */
+	private function enqueue_script( $variant ) {
+		$asset_file = self::get_asset_file( $variant );
+		if ( ! $asset_file ) {
+			return;
 		}
 
 		// When the request is dev mode, use a random cache buster as the version for easier debugging.
@@ -653,8 +691,6 @@ class Agents_Manager {
 				$version
 			);
 		}
-
-		return (string) $asset_file['version'];
 	}
 
 	/**

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -233,27 +233,17 @@ class Agents_Manager {
 	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
 	 */
 	public function add_ai_chat_button( $wp_admin_bar ) {
-		$meta = array(
-			'menu_title' => __( 'Ask AI', 'jetpack-agents-manager' ),
-			'icon'       => $this->get_icon( 'ask-ai' ),
-			// The wp-admin bundle mounts the chat into this div.
-			'html'       => '<div id="agents-manager-masterbar"></div>',
-		);
-
-		// The deployed build version, so REST consumers can report the same
-		// `agent_manager_version` as the app itself.
-		$variant = self::get_active_variant();
-		$version = null !== $variant ? self::get_deployed_version( $variant ) : null;
-		if ( null !== $version ) {
-			$meta['version'] = $version;
-		}
-
 		$wp_admin_bar->add_menu(
 			array(
 				'id'     => 'agents-manager-ai-chat',
 				'parent' => 'top-secondary',
 				'title'  => '<span title="' . esc_attr__( 'Ask AI', 'jetpack-agents-manager' ) . '">' . $this->get_icon( 'ask-ai' ) . '</span>',
-				'meta'   => $meta,
+				'meta'   => array(
+					'menu_title' => __( 'Ask AI', 'jetpack-agents-manager' ),
+					'icon'       => $this->get_icon( 'ask-ai' ),
+					// The wp-admin bundle mounts the chat into this div.
+					'html'       => '<div id="agents-manager-masterbar"></div>',
+				),
 			)
 		);
 	}
@@ -386,9 +376,7 @@ class Agents_Manager {
 		 */
 		$agent_id = apply_filters( 'agents_manager_agent_id', null );
 
-		$this->enqueue_script( $variant );
-
-		$version = self::get_deployed_version( $variant );
+		$script_version = $this->enqueue_script( $variant );
 
 		$inline_data = array(
 			'agentProviders'       => $agent_providers,
@@ -402,8 +390,8 @@ class Agents_Manager {
 			'helpCenterUrl'        => self::HELP_CENTER_URL,
 		);
 
-		if ( null !== $version ) {
-			$inline_data['version'] = $version;
+		if ( null !== $script_version ) {
+			$inline_data['version'] = $variant . ':' . $script_version;
 		}
 
 		if ( $agent_id ) {
@@ -602,12 +590,12 @@ class Agents_Manager {
 	}
 
 	/**
-	 * The cached asset metadata for a variant, or null when unavailable.
+	 * Enqueue Agents Manager script based on context.
 	 *
 	 * @param string $variant The variant of the asset file to get.
-	 * @return array|null
+	 * @return string|null The deployed build version from the asset file, or null when unavailable.
 	 */
-	private static function get_asset_file( $variant ) {
+	private function enqueue_script( $variant ) {
 		$cache_key  = 'agents-manager-asset-' . $variant . '.asset.json';
 		$asset_file = get_transient( $cache_key );
 
@@ -617,32 +605,6 @@ class Agents_Manager {
 				return null;
 			}
 			set_transient( $cache_key, $asset_file, HOUR_IN_SECONDS );
-		}
-
-		return $asset_file;
-	}
-
-	/**
-	 * The deployed build version for a variant, as `{variant}:{version}`, or null when unavailable.
-	 *
-	 * @param string $variant The variant of the asset file to get.
-	 * @return string|null
-	 */
-	private static function get_deployed_version( $variant ) {
-		$asset_file = self::get_asset_file( $variant );
-
-		return $asset_file ? $variant . ':' . (string) $asset_file['version'] : null;
-	}
-
-	/**
-	 * Enqueue Agents Manager script based on context.
-	 *
-	 * @param string $variant The variant of the asset file to get.
-	 */
-	private function enqueue_script( $variant ) {
-		$asset_file = self::get_asset_file( $variant );
-		if ( ! $asset_file ) {
-			return;
 		}
 
 		// When the request is dev mode, use a random cache buster as the version for easier debugging.
@@ -691,6 +653,8 @@ class Agents_Manager {
 				$version
 			);
 		}
+
+		return (string) $asset_file['version'];
 	}
 
 	/**

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -918,6 +918,36 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that the Ask AI node meta carries the deployed build version for REST consumers.
+	 */
+	public function test_ai_chat_button_meta_includes_deployed_version() {
+		require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+
+		$force_variant = static function () {
+			return 'wp-admin';
+		};
+		add_filter( 'agents_manager_variant', $force_variant );
+		// Seed the cached asset metadata so no fetch is attempted.
+		set_transient(
+			'agents-manager-asset-wp-admin.asset.json',
+			array(
+				'version'      => 'abc123',
+				'dependencies' => array(),
+			)
+		);
+
+		$wp_admin_bar = new \WP_Admin_Bar();
+		$wp_admin_bar->initialize();
+		$this->agents_manager->add_ai_chat_button( $wp_admin_bar );
+
+		$node = $wp_admin_bar->get_node( 'agents-manager-ai-chat' );
+		$this->assertSame( 'wp-admin:abc123', $node->meta['version'] ?? null );
+
+		remove_filter( 'agents_manager_variant', $force_variant );
+		delete_transient( 'agents-manager-asset-wp-admin.asset.json' );
+	}
+
+	/**
 	 * Tests that the full UI mount target belongs to Ask AI rather than Help.
 	 */
 	public function test_ai_chat_button_owns_full_ui_mount_target() {

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -918,36 +918,6 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the Ask AI node meta carries the deployed build version for REST consumers.
-	 */
-	public function test_ai_chat_button_meta_includes_deployed_version() {
-		require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
-
-		$force_variant = static function () {
-			return 'wp-admin';
-		};
-		add_filter( 'agents_manager_variant', $force_variant );
-		// Seed the cached asset metadata so no fetch is attempted.
-		set_transient(
-			'agents-manager-asset-wp-admin.asset.json',
-			array(
-				'version'      => 'abc123',
-				'dependencies' => array(),
-			)
-		);
-
-		$wp_admin_bar = new \WP_Admin_Bar();
-		$wp_admin_bar->initialize();
-		$this->agents_manager->add_ai_chat_button( $wp_admin_bar );
-
-		$node = $wp_admin_bar->get_node( 'agents-manager-ai-chat' );
-		$this->assertSame( 'wp-admin:abc123', $node->meta['version'] ?? null );
-
-		remove_filter( 'agents_manager_variant', $force_variant );
-		delete_transient( 'agents-manager-asset-wp-admin.asset.json' );
-	}
-
-	/**
 	 * Tests that the full UI mount target belongs to Ask AI rather than Help.
 	 */
 	public function test_ai_chat_button_owns_full_ui_mount_target() {

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -458,10 +458,11 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that enqueue_scripts exposes the deployed build version as `{variant}:{version}`.
+	 * Tests that enqueue_scripts exposes the deployed build version as `{variant}:{version}`,
+	 * even in dev mode, where the enqueue cache buster is a random number.
 	 */
 	public function test_enqueue_scripts_exposes_deployed_version() {
-		Functions\when( 'wpcom_is_proxied_request' )->justReturn( false );
+		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
 
 		// Set admin context - scripts only enqueue in admin.
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
@@ -490,6 +491,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$inline_scripts = $wp_scripts->registered['agents-manager']->extra['before'] ?? array();
 		$inline_script  = implode( "\n", array_filter( $inline_scripts ) );
 
+		$this->assertStringContainsString( '"isDevMode":true', $inline_script );
 		$this->assertStringContainsString( '"version":"wp-admin:abc123"', $inline_script );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -458,6 +458,46 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that enqueue_scripts exposes the deployed build version as `{variant}:{version}`.
+	 */
+	public function test_enqueue_scripts_exposes_deployed_version() {
+		Functions\when( 'wpcom_is_proxied_request' )->justReturn( false );
+
+		// Set admin context - scripts only enqueue in admin.
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+
+		// Register the agents-manager script so we can attach inline script to it.
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		$force_variant = static function () {
+			return 'wp-admin';
+		};
+		add_filter( 'agents_manager_variant', $force_variant );
+		// Seed the cached asset metadata so no fetch is attempted.
+		set_transient(
+			'agents-manager-asset-wp-admin.asset.json',
+			array(
+				'version'      => 'abc123',
+				'dependencies' => array(),
+			)
+		);
+
+		$this->agents_manager->enqueue_scripts();
+
+		global $wp_scripts;
+		$inline_scripts = $wp_scripts->registered['agents-manager']->extra['before'] ?? array();
+		$inline_script  = implode( "\n", array_filter( $inline_scripts ) );
+
+		$this->assertStringContainsString( '"version":"wp-admin:abc123"', $inline_script );
+
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'agents_manager_variant', $force_variant );
+		delete_transient( 'agents-manager-asset-wp-admin.asset.json' );
+	}
+
+	/**
 	 * Tests that enqueue_scripts includes providers added via the filter.
 	 */
 	public function test_enqueue_scripts_includes_filtered_providers() {


### PR DESCRIPTION
## Proposed changes

* Expose the deployed Agents Manager build version to the frontend as `agentsManagerData.version`, in the form `{variant}:{version}` (e.g. `gutenberg:5d3eb843a48`).
* The value comes from the `.asset.json` metadata the package already fetches (and caches) when enqueuing the bundle from widgets.wp.com — no extra request. The key is omitted when the asset metadata is unavailable.
* The dev-mode `wp_rand()` cache buster is untouched; it only ever applied to the enqueue `?ver=` query string. The exposed value is always the deployed build's version.
* An earlier revision also exposed the value as `meta.version` on the Ask AI admin bar node, for REST consumers on Calypso surfaces; that was removed after discussion — the admin-bar endpoints belong to the Dashboard and are not the right home for AM-specific data. Calypso-rendered surfaces report `none` until a dedicated sync mechanism exists.

## Related product discussion/links

* AI-1115 (part of AI-1108)

## Does this pull request change what data or activity we track or use?

Not by itself — this only exposes the version to the frontend. A follow-up in the Calypso repo will send it as the `agent_manager_version` property on Agents Manager Tracks events (AI-1115).

## Testing instructions

* Run the package tests: `jp test php packages/agents-manager` — includes a new test asserting the inline data carries `"version":"{variant}:{version}"`.
* From your sandbox `public_html` folder run:
  ```
  bin/jetpack-downloader test jetpack-mu-wpcom-plugin ai-1115-expose-agents-manager-version-to-frontend
  ```
* Sandbox a site with the Agents Manager active, open wp-admin, and run `agentsManagerData.version` in the browser console — expect `{variant}:{hash}` matching the loaded variant, e.g. `wp-admin:<hash>`.
* When done: `bin/jetpack-downloader reset jetpack-mu-wpcom-plugin`.
