### PR TITLE
Jetpack AI: support AI Hub on WordPress.com Simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/BSKY-2033
+++ b/projects/packages/jetpack-mu-wpcom/changelog/BSKY-2033
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Jetpack AI Hub to WordPress.com Simple sites.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -87,6 +87,7 @@ class Jetpack_Mu_Wpcom {
 
 		// These features run only on simple sites.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_simple_jetpack_ai' ) );
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_comments' ) );
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_moderate' ) );
 			add_action( 'wp_loaded', array( __CLASS__, 'load_verbum_comments_admin' ) );
@@ -133,6 +134,24 @@ class Jetpack_Mu_Wpcom {
 		 * @since 0.1.2
 		 */
 		do_action( 'jetpack_mu_wpcom_initialized' );
+	}
+
+	/**
+	 * Load the Jetpack AI Hub integration on WordPress.com Simple sites.
+	 */
+	public static function load_wpcom_simple_jetpack_ai() {
+		/**
+		 * Filters whether WordPress.com Simple should register the Jetpack AI Hub.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $load Whether to load the AI Hub integration.
+		 */
+		if ( ! apply_filters( 'jetpack_mu_wpcom_load_jetpack_ai_hub', false ) ) {
+			return;
+		}
+
+		require_once __DIR__ . '/features/jetpack-ai-hub/jetpack-ai-hub.php';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-hub/jetpack-ai-hub.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-hub/jetpack-ai-hub.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * WordPress.com Simple integration for the Jetpack AI Hub.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Hub;
+
+/**
+ * Point the upstream Hub at WordPress.com's native site-scoped MCP API.
+ *
+ * @param array $config Upstream AI Hub host configuration.
+ * @return array WordPress.com Simple configuration.
+ */
+function configure( $config ) {
+	$blog_id = get_current_blog_id();
+
+	$config['showGatedViews']  = false;
+	$config['isUserConnected'] = true;
+	$config['mcpSettingsApi']  = array(
+		'path'   => '/wpcom/v2/sites/' . $blog_id . '/mcp-abilities',
+		'format' => 'wpcom',
+	);
+
+	return $config;
+}
+
+// Scheduled tasks are a WordPress.com-backed experience and should be visible
+// whenever the AI Hub integration is loaded on Simple sites.
+add_filter( 'jetpack_feature_flag_enabled_ai-hub-scheduled-tasks', '__return_true' );
+
+/**
+ * Register the upstream AI Hub page on WordPress.com Simple.
+ */
+function register() {
+	if ( ! defined( 'JETPACK__PLUGIN_DIR' ) ) {
+		return;
+	}
+
+	$page_path = JETPACK__PLUGIN_DIR . '_inc/lib/admin-pages/class-jetpack-ai-page.php';
+	if ( ! file_exists( $page_path ) ) {
+		return;
+	}
+
+	require_once $page_path;
+	// @phan-suppress-next-line PhanUndeclaredClassReference -- loaded from the sibling Jetpack plugin above and guarded at runtime.
+	if ( ! class_exists( '\Jetpack_AI_Page' ) || ! method_exists( '\Jetpack_AI_Page', 'add_actions' ) ) {
+		return;
+	}
+
+	add_filter( 'jetpack_ai_admin_config', __NAMESPACE__ . '\\configure' );
+
+	// @phan-suppress-next-line PhanUndeclaredClassMethod -- loaded from the sibling Jetpack plugin above and guarded at runtime.
+	$page = new \Jetpack_AI_Page();
+	// @phan-suppress-next-line PhanUndeclaredClassInCallable -- loaded from the sibling Jetpack plugin above and guarded at runtime.
+	add_action( 'admin_menu', array( $page, 'add_actions' ), 998 );
+}
+
+register();

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/Jetpack_AI_Hub_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/Jetpack_AI_Hub_Test.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Tests for the WordPress.com Simple Jetpack AI Hub integration.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Hub;
+
+use WorDBless\BaseTestCase;
+
+require_once __DIR__ . '/../../../../src/features/jetpack-ai-hub/jetpack-ai-hub.php';
+
+/**
+ * Tests the Simple-specific Hub settings.
+ */
+class Jetpack_AI_Hub_Test extends BaseTestCase {
+	/**
+	 * Scheduled tasks are enabled with the Hub on WordPress.com Simple.
+	 */
+	public function test_enables_scheduled_tasks() {
+		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- the hook suffix is the registered feature flag name.
+		$this->assertTrue( apply_filters( 'jetpack_feature_flag_enabled_ai-hub-scheduled-tasks', false ) );
+	}
+
+	/**
+	 * The integration uses the native site-scoped WordPress.com MCP endpoint.
+	 */
+	public function test_configures_native_wpcom_mcp_api() {
+		$config = configure(
+			array(
+				'showGatedViews'  => true,
+				'isUserConnected' => false,
+				'mcpSettingsApi'  => array(),
+			)
+		);
+
+		$this->assertFalse( $config['showGatedViews'] );
+		$this->assertTrue( $config['isUserConnected'] );
+		$this->assertSame(
+			array(
+				'path'   => '/wpcom/v2/sites/' . get_current_blog_id() . '/mcp-abilities',
+				'format' => 'wpcom',
+			),
+			$config['mcpSettingsApi']
+		);
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/Jetpack_AI_Hub_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/Jetpack_AI_Hub_Test.php
@@ -117,7 +117,7 @@ class Jetpack_AI_Hub_Test extends BaseTestCase {
 		$registered = false;
 		foreach ( $GLOBALS['wp_filter']['admin_menu']->callbacks[998] ?? array() as $callback ) {
 			$function = $callback['function'] ?? null;
-			if ( is_array( $function ) && $function[0] instanceof \Jetpack_AI_Page && 'add_actions' === $function[1] ) {
+			if ( is_array( $function ) && is_a( $function[0], 'Jetpack_AI_Page' ) && 'add_actions' === $function[1] ) {
 				$registered = true;
 				break;
 			}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/Jetpack_AI_Hub_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/Jetpack_AI_Hub_Test.php
@@ -7,18 +7,51 @@
 
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Hub;
 
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
-
-require_once __DIR__ . '/../../../../src/features/jetpack-ai-hub/jetpack-ai-hub.php';
 
 /**
  * Tests the Simple-specific Hub settings.
  */
 class Jetpack_AI_Hub_Test extends BaseTestCase {
 	/**
+	 * Load the integration through its production gate.
+	 */
+	private function load_integration() {
+		add_filter( 'jetpack_mu_wpcom_load_jetpack_ai_hub', '__return_true' );
+		Jetpack_Mu_Wpcom::load_wpcom_simple_jetpack_ai();
+	}
+
+	/**
+	 * Reset feature filters changed by the integration.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'jetpack_mu_wpcom_load_jetpack_ai_hub' );
+		remove_all_filters( 'jetpack_feature_flag_enabled_ai-hub-scheduled-tasks' );
+		remove_all_filters( 'jetpack_ai_admin_config' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The package does not load the integration without an explicit host opt-in.
+	 */
+	public function test_loader_is_disabled_by_default() {
+		$filters_before = did_filter( 'jetpack_mu_wpcom_load_jetpack_ai_hub' );
+
+		Jetpack_Mu_Wpcom::load_wpcom_simple_jetpack_ai();
+
+		$this->assertSame( $filters_before + 1, did_filter( 'jetpack_mu_wpcom_load_jetpack_ai_hub' ) );
+	}
+
+	/**
 	 * Scheduled tasks are enabled with the Hub on WordPress.com Simple.
 	 */
 	public function test_enables_scheduled_tasks() {
+		$this->load_integration();
+
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- the hook suffix is the registered feature flag name.
 		$this->assertTrue( apply_filters( 'jetpack_feature_flag_enabled_ai-hub-scheduled-tasks', false ) );
 	}
@@ -27,6 +60,8 @@ class Jetpack_AI_Hub_Test extends BaseTestCase {
 	 * The integration uses the native site-scoped WordPress.com MCP endpoint.
 	 */
 	public function test_configures_native_wpcom_mcp_api() {
+		$this->load_integration();
+
 		$config = configure(
 			array(
 				'showGatedViews'  => true,
@@ -44,5 +79,50 @@ class Jetpack_AI_Hub_Test extends BaseTestCase {
 			),
 			$config['mcpSettingsApi']
 		);
+	}
+
+	/**
+	 * A packaged integration safely stops when the sibling Jetpack page is absent.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_registration_stops_when_jetpack_page_is_absent() {
+		define( 'JETPACK__PLUGIN_DIR', '/jetpack-ai-hub-test/missing/' );
+
+		$this->load_integration();
+
+		$this->assertTrue( function_exists( __NAMESPACE__ . '\\configure' ) );
+		$this->assertFalse( has_filter( 'jetpack_ai_admin_config', __NAMESPACE__ . '\\configure' ) );
+	}
+
+	/**
+	 * The packaged integration registers the upstream Jetpack page when present.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_registration_uses_packaged_jetpack_page() {
+		define( 'JETPACK__PLUGIN_DIR', Jetpack_Mu_Wpcom::PKG_DIR . '../../plugins/jetpack/' );
+
+		$this->load_integration();
+
+		$this->assertTrue( class_exists( '\\Jetpack_AI_Page', false ) );
+		$this->assertNotFalse( has_filter( 'jetpack_ai_admin_config', __NAMESPACE__ . '\\configure' ) );
+
+		$registered = false;
+		foreach ( $GLOBALS['wp_filter']['admin_menu']->callbacks[998] ?? array() as $callback ) {
+			$function = $callback['function'] ?? null;
+			if ( is_array( $function ) && $function[0] instanceof \Jetpack_AI_Page && 'add_actions' === $function[1] ) {
+				$registered = true;
+				break;
+			}
+		}
+
+		$this->assertTrue( $registered );
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.js
@@ -33,6 +33,15 @@ describe( 'useFeatureSettings', () => {
 		expect( result.current.error ).toBeNull();
 	} );
 
+	test( 'does not load settings when the gated views are hidden', async () => {
+		const { result } = renderHook( () => useFeatureSettings( false ) );
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( result.current.settings ).toBeNull();
+		expect( result.current.error ).toBeNull();
+	} );
+
 	test( 'surfaces a load failure as an error message', async () => {
 		apiFetch.mockRejectedValueOnce( new Error( 'no route' ) );
 

--- a/projects/plugins/jetpack/_inc/client/ai/features/use-feature-settings.js
+++ b/projects/plugins/jetpack/_inc/client/ai/features/use-feature-settings.js
@@ -17,9 +17,10 @@ const ENDPOINT = '/wpcom/v2/jetpack-ai/feature-settings';
 /**
  * Hook that loads and exposes the Jetpack AI feature settings for the current site.
  *
+ * @param {boolean} enabled Whether the gated AI views can use these settings.
  * @return {{ isLoading: boolean, savingKeys: Set, settings: Object|null, error: string|null, updateSettings: Function }} Feature settings state and updater. `error` reports a load failure only.
  */
-export function useFeatureSettings() {
+export function useFeatureSettings( enabled = true ) {
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ savingKeys, setSavingKeys ] = useState( () => new Set() );
 	const [ settings, setSettings ] = useState( null );
@@ -31,6 +32,11 @@ export function useFeatureSettings() {
 	const pendingKeyCounts = useRef( new Map() );
 
 	useEffect( () => {
+		if ( ! enabled ) {
+			setIsLoading( false );
+			return;
+		}
+
 		let cancelled = false;
 		setIsLoading( true );
 		apiFetch( { path: ENDPOINT } )
@@ -53,7 +59,7 @@ export function useFeatureSettings() {
 		return () => {
 			cancelled = true;
 		};
-	}, [] );
+	}, [ enabled ] );
 
 	/**
 	 * Send a partial settings update.

--- a/projects/plugins/jetpack/_inc/client/ai/features/use-feature-settings.js
+++ b/projects/plugins/jetpack/_inc/client/ai/features/use-feature-settings.js
@@ -17,7 +17,7 @@ const ENDPOINT = '/wpcom/v2/jetpack-ai/feature-settings';
 /**
  * Hook that loads and exposes the Jetpack AI feature settings for the current site.
  *
- * @param {boolean} enabled Whether the gated AI views can use these settings.
+ * @param {boolean} enabled - Whether the gated AI views can use these settings.
  * @return {{ isLoading: boolean, savingKeys: Set, settings: Object|null, error: string|null, updateSettings: Function }} Feature settings state and updater. `error` reports a load failure only.
  */
 export function useFeatureSettings( enabled = true ) {

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -141,6 +141,7 @@ export default function App() {
 		planRenewsOn,
 		planAutoRenew,
 		isUserConnected,
+		showFeaturesView = false,
 	} = window?.jetpackAiSettings ?? {};
 	const [ view, setView ] = useState( getViewFromHash );
 	// Save feedback goes through the shared GlobalNotices snackbars (the
@@ -156,7 +157,7 @@ export default function App() {
 		settings: aiSettings,
 		error: aiSettingsError,
 		updateSettings: updateAiSettings,
-	} = useFeatureSettings();
+	} = useFeatureSettings( showFeaturesView );
 
 	// The hash is the single source of truth for the current view: popstate
 	// covers back/forward, hashchange covers direct hash edits and links.

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/test/use-mcp-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/test/use-mcp-settings.jsx
@@ -1,0 +1,95 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { useMcpSettings } from '../use-mcp-settings';
+
+jest.mock( '@wordpress/api-fetch' );
+
+const wpcomResponse = {
+	has_mcp_plan: true,
+	site_level_enabled: true,
+	abilities: [
+		{ name: 'wpcom/get-site', site_context: true, enabled: true },
+		{ name: 'wpcom/get-account', site_context: false, enabled: true },
+	],
+	groups: [ { name: 'content' } ],
+	user_overrides: {
+		abilities: { 'wpcom/get-site': false },
+		group_intents: { read: true },
+	},
+};
+
+describe( 'useMcpSettings with the native WordPress.com API', () => {
+	beforeEach( () => {
+		window.jetpackAiSettings = {
+			blogId: 123,
+			mcpSettingsApi: {
+				path: '/wpcom/v2/sites/123/mcp-abilities',
+				format: 'wpcom',
+			},
+		};
+	} );
+
+	afterEach( () => {
+		delete window.jetpackAiSettings;
+		jest.resetAllMocks();
+	} );
+
+	test( 'loads and normalizes native abilities', async () => {
+		apiFetch.mockResolvedValueOnce( wpcomResponse );
+
+		const { result } = renderHook( () => useMcpSettings() );
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wpcom/v2/sites/123/mcp-abilities',
+		} );
+		expect( result.current.hasMcpAccess ).toBe( true );
+		expect( result.current.mcpAbilities.account ).toHaveProperty( 'wpcom/get-site' );
+		expect( result.current.mcpAbilities.account ).toHaveProperty( 'wpcom/get-account' );
+		expect( result.current.mcpAbilities.site ).toHaveProperty( 'wpcom/get-site' );
+		expect( result.current.mcpAbilities.site ).not.toHaveProperty( 'wpcom/get-account' );
+		expect( result.current.mcpAbilities.sites[ 0 ] ).toEqual( {
+			blog_id: 123,
+			site_level_enabled: true,
+			abilities: { 'wpcom/get-site': false },
+			group_intents: { read: true },
+		} );
+	} );
+
+	test( 'sends Hub updates in the native endpoint shape', async () => {
+		apiFetch.mockResolvedValueOnce( wpcomResponse ).mockResolvedValueOnce( wpcomResponse );
+		const { result } = renderHook( () => useMcpSettings() );
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+
+		await act( async () => {
+			await result.current.updateMcpAbilities( {
+				sites: [
+					{
+						blog_id: 123,
+						site_level_enabled: true,
+						abilities: { 'wpcom/get-site': false },
+					},
+				],
+			} );
+		} );
+
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/wpcom/v2/sites/123/mcp-abilities',
+			method: 'POST',
+			data: {
+				site_level_enabled: true,
+				abilities: { 'wpcom/get-site': false },
+			},
+		} );
+	} );
+
+	test( 'maps a missing plan to the Hub access-denied state', async () => {
+		apiFetch.mockResolvedValueOnce( { has_mcp_plan: false } );
+
+		const { result } = renderHook( () => useMcpSettings() );
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+		expect( result.current.hasMcpAccess ).toBe( false );
+		expect( result.current.mcpAbilities ).toEqual( {} );
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/use-mcp-settings.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/use-mcp-settings.js
@@ -10,7 +10,76 @@ import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-const ENDPOINT = '/wpcom/v2/jetpack-ai/mcp-settings';
+const DEFAULT_API = {
+	path: '/wpcom/v2/jetpack-ai/mcp-settings',
+	format: 'jetpack',
+};
+
+/**
+ * Convert the native WordPress.com MCP response to the Hub's settings shape.
+ *
+ * @param {object} data   Native endpoint response.
+ * @param {number} blogId Current site ID.
+ * @return {object} AI Hub MCP settings response.
+ */
+export function normalizeWpcomMcpSettings( data, blogId ) {
+	if ( ! data?.has_mcp_plan ) {
+		return { has_mcp_access: false, mcp_abilities: {} };
+	}
+
+	const account = {};
+	const site = {};
+	for ( const ability of data?.abilities ?? [] ) {
+		if ( ! ability?.name ) {
+			continue;
+		}
+
+		account[ ability.name ] = ability;
+		if ( ability.site_context ) {
+			site[ ability.name ] = ability;
+		}
+	}
+
+	const siteLevelEnabled = data?.site_level_enabled === true;
+	const userOverrides = data?.user_overrides ?? {};
+
+	return {
+		has_mcp_access: true,
+		mcp_abilities: {
+			account,
+			site,
+			sites: [
+				{
+					blog_id: Number( blogId ),
+					site_level_enabled: siteLevelEnabled,
+					abilities: userOverrides.abilities ?? {},
+					group_intents: userOverrides.group_intents ?? {},
+				},
+			],
+			site_level_enabled_default: siteLevelEnabled,
+			groups: data?.groups ?? [],
+		},
+	};
+}
+
+/**
+ * Convert a partial Hub update to the native WordPress.com endpoint shape.
+ *
+ * @param {object} update Partial Hub MCP settings update.
+ * @return {object} Native WordPress.com update body.
+ */
+export function prepareWpcomMcpUpdate( update ) {
+	const site = update?.sites?.[ 0 ] ?? {};
+	const data = {};
+
+	for ( const key of [ 'site_level_enabled', 'abilities', 'group_intents' ] ) {
+		if ( Object.hasOwn( site, key ) ) {
+			data[ key ] = site[ key ];
+		}
+	}
+
+	return data;
+}
 
 /**
  * Hook that loads and exposes MCP settings for the current site.
@@ -18,6 +87,9 @@ const ENDPOINT = '/wpcom/v2/jetpack-ai/mcp-settings';
  * @return {{ isLoading: boolean, isSaving: boolean, mcpAbilities: Object|null, error: string|null, updateMcpAbilities: Function }} MCP settings state and updater.
  */
 export function useMcpSettings() {
+	const { blogId = 0, mcpSettingsApi = DEFAULT_API } = window?.jetpackAiSettings ?? {};
+	const endpoint = mcpSettingsApi.path ?? DEFAULT_API.path;
+	const usesWpcomApi = mcpSettingsApi.format === 'wpcom';
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ savingToolIds, setSavingToolIds ] = useState( () => new Set() );
 	const [ mcpAbilities, setMcpAbilities ] = useState( null );
@@ -27,15 +99,16 @@ export function useMcpSettings() {
 	useEffect( () => {
 		let cancelled = false;
 		setIsLoading( true );
-		apiFetch( { path: ENDPOINT } )
+		apiFetch( { path: endpoint } )
 			.then( data => {
 				if ( ! cancelled ) {
-					setMcpAbilities( data?.mcp_abilities ?? {} );
+					const response = usesWpcomApi ? normalizeWpcomMcpSettings( data, blogId ) : data;
+					setMcpAbilities( response?.mcp_abilities ?? {} );
 					// has_mcp_access is explicitly set by the PHP proxy.
 					// Fall back to checking whether any account tools were returned.
 					setHasMcpAccess(
-						data?.has_mcp_access !== false &&
-							Object.keys( data?.mcp_abilities?.account ?? {} ).length > 0
+						response?.has_mcp_access !== false &&
+							Object.keys( response?.mcp_abilities?.account ?? {} ).length > 0
 					);
 					setError( null );
 				}
@@ -53,7 +126,7 @@ export function useMcpSettings() {
 		return () => {
 			cancelled = true;
 		};
-	}, [] );
+	}, [ blogId, endpoint, usesWpcomApi ] );
 
 	/**
 	 * Send a partial mcp_abilities update.
@@ -79,12 +152,13 @@ export function useMcpSettings() {
 			} );
 
 			return apiFetch( {
-				path: ENDPOINT,
+				path: endpoint,
 				method: 'POST',
-				data: { mcp_abilities: update },
+				data: usesWpcomApi ? prepareWpcomMcpUpdate( update ) : { mcp_abilities: update },
 			} )
 				.then( data => {
-					setMcpAbilities( data?.mcp_abilities ?? mcpAbilities );
+					const response = usesWpcomApi ? normalizeWpcomMcpSettings( data, blogId ) : data;
+					setMcpAbilities( response?.mcp_abilities ?? mcpAbilities );
 					setError( null );
 				} )
 				.catch( err => {
@@ -99,7 +173,7 @@ export function useMcpSettings() {
 					} );
 				} );
 		},
-		[ mcpAbilities ]
+		[ blogId, endpoint, mcpAbilities, usesWpcomApi ]
 	);
 
 	return { isLoading, savingToolIds, mcpAbilities, hasMcpAccess, error, updateMcpAbilities };

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/use-mcp-settings.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/use-mcp-settings.js
@@ -18,8 +18,8 @@ const DEFAULT_API = {
 /**
  * Convert the native WordPress.com MCP response to the Hub's settings shape.
  *
- * @param {object} data   Native endpoint response.
- * @param {number} blogId Current site ID.
+ * @param {object} data   - Native endpoint response.
+ * @param {number} blogId - Current site ID.
  * @return {object} AI Hub MCP settings response.
  */
 export function normalizeWpcomMcpSettings( data, blogId ) {
@@ -65,7 +65,7 @@ export function normalizeWpcomMcpSettings( data, blogId ) {
 /**
  * Convert a partial Hub update to the native WordPress.com endpoint shape.
  *
- * @param {object} update Partial Hub MCP settings update.
+ * @param {object} update - Partial Hub MCP settings update.
  * @return {object} Native WordPress.com update body.
  */
 export function prepareWpcomMcpUpdate( update ) {

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -21,21 +21,47 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
-require_once __DIR__ . '/class.jetpack-admin-page.php';
 require_once dirname( __DIR__ ) . '/class-jetpack-ai-feature-flags.php';
 
 /**
  * Builds the Jetpack AI admin page and its sidebar menu entry.
  */
-class Jetpack_AI_Page extends Jetpack_Admin_Page {
+class Jetpack_AI_Page {
 
 	/**
-	 * Hide the "AI" sidebar entry when Jetpack is not yet connected.
-	 * Other Jetpack products follow the same convention.
+	 * Register the page and its page-specific hooks.
 	 *
-	 * @var bool
+	 * The AI Hub owns its full React layout, so it does not need the legacy
+	 * Jetpack_Admin_Page lifecycle. Keeping this controller independent also
+	 * lets WordPress.com Simple load the same page without replacing its
+	 * request-wide Jetpack_Admin_Page compatibility stub.
 	 */
-	protected $dont_show_if_not_active = true;
+	public function add_actions() {
+		$is_offline_mode = ( new Status() )->is_offline_mode();
+
+		if ( ! current_user_can( 'manage_options' ) && ( $is_offline_mode || ! Jetpack::is_connection_ready() ) ) {
+			return;
+		}
+
+		if ( ! Jetpack::is_connection_ready() && ! $is_offline_mode ) {
+			return;
+		}
+
+		$hook = $this->get_page_hook();
+		if ( ! $hook ) {
+			return;
+		}
+
+		add_action( 'admin_print_scripts-' . $hook, array( $this, 'page_admin_scripts' ) );
+
+		// Preserve the standalone Jetpack page's existing base stylesheet. Simple
+		// never loaded it for the Hub because it conflicts with wpcom admin pages.
+		if ( ! ( new Host() )->is_wpcom_simple() ) {
+			add_action( 'admin_print_styles-' . $hook, array( $this, 'admin_styles' ) );
+		}
+
+		$this->add_page_actions( $hook );
+	}
 
 	/**
 	 * Register the "AI" submenu under the Jetpack top-level menu.
@@ -61,6 +87,17 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 	 */
 	public function add_page_actions( $hook ) {
 		add_action( 'load-' . $hook, array( $this, 'load_agents_manager' ) );
+	}
+
+	/**
+	 * Enqueue the stylesheet historically supplied by Jetpack_Admin_Page.
+	 */
+	public function admin_styles() {
+		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+
+		wp_enqueue_style( 'jetpack-admin', plugins_url( "css/jetpack-admin{$min}.css", JETPACK__PLUGIN_FILE ), array( 'genericons', 'jetpack-connection' ), JETPACK__VERSION . '-20121016' );
+		wp_style_add_data( 'jetpack-admin', 'rtl', 'replace' );
+		wp_style_add_data( 'jetpack-admin', 'suffix', $min );
 	}
 
 	/**
@@ -155,14 +192,6 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 	}
 
 	/**
-	 * No additional styles needed: AdminPage from @automattic/jetpack-components
-	 * owns the full layout and does not need the wrap_ui admin.css / style.min.css
-	 * bundle (which zeroes out #wpcontent padding and conflicts with AdminPage's
-	 * margin-left compensation).
-	 */
-	public function additional_styles() {}
-
-	/**
 	 * Enqueue scripts and styles for the AI admin page.
 	 */
 	public function page_admin_scripts() {
@@ -223,10 +252,29 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 			Connection_Initial_State::render_script( 'jetpack-ai-admin' );
 		}
 
-		// Pre-release gate for the Overview and Features views. When opening
-		// them to everyone, also drop the matching gate in My Jetpack's
-		// Jetpack_Ai::get_manage_url() so its links land here too.
-		$show_gated_views = $is_internal_test;
+		/**
+		 * Filters the host-specific AI Hub configuration.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $config AI Hub host configuration.
+		 */
+		$config = apply_filters(
+			'jetpack_ai_admin_config',
+			array(
+				// Pre-release gate for the Overview and Features views. When opening
+				// them to everyone, also drop the matching gate in My Jetpack's
+				// Jetpack_Ai::get_manage_url() so its links land here too.
+				'showGatedViews'  => $is_internal_test,
+				'isUserConnected' => ( new Connection_Manager() )->is_user_connected(),
+				'mcpSettingsApi'  => array(
+					'path'   => '/wpcom/v2/jetpack-ai/mcp-settings',
+					'format' => 'jetpack',
+				),
+			)
+		);
+
+		$show_gated_views = ! empty( $config['showGatedViews'] );
 
 		$plan_info = $show_gated_views ? self::get_ai_plan_info() : array(
 			'name'       => '',
@@ -234,45 +282,48 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 			'auto_renew' => true,
 		);
 
+		$settings = array(
+			'blogId'           => $blog_id ? (int) $blog_id : 0,
+			'activityLogUrl'   => $activity_log_url,
+			'seoSettingsUrl'   => $seo_settings_url,
+			'siteAdminUrl'     => admin_url(),
+			'apiRoot'          => esc_url_raw( rest_url() ),
+			'apiNonce'         => wp_create_nonce( 'wp_rest' ),
+			'pluginUrl'        => plugins_url( '', JETPACK__PLUGIN_FILE ),
+			// The redirect entry bakes in the jetpack_ai_yearly product and
+			// a post-checkout return to this page, so both can be
+			// retargeted without shipping a code change.
+			'upgradeUrl'       => Redirect::get_url( 'jetpack-ai-hub-upgrade' ),
+			// The purchase granting AI, for the Overview usage card — the
+			// usage endpoint cannot name it. Only looked up when a gated
+			// view can render it.
+			'planName'         => $plan_info['name'],
+			// The plan's own renewal date, matching My Jetpack — the
+			// usage-period rollover is a different, monthly date.
+			'planRenewsOn'     => $plan_info['renews_on'],
+			// The same date reads "Renews on" or "Expires on" depending on
+			// auto-renew, matching My Jetpack and the wpcom subscriptions page.
+			'planAutoRenew'    => $plan_info['auto_renew'],
+			'showFeaturesView' => $show_gated_views,
+			// The tab and its Agents Manager sidebar ship disabled by default.
+			'featureFlags'     => array(
+				Jetpack_AI_Feature_Flags::SCHEDULED_TASKS => $show_scheduled_tasks_view,
+			),
+			// The usage endpoint proxies as the current user, which needs
+			// their own WordPress.com account linked — not just the site.
+			'isUserConnected'  => ! empty( $config['isUserConnected'] ),
+			// Tracks audience properties for the jetpack_mcp_* events, per the
+			// Tracks standards for AI product events (AIINT-586). The client
+			// sends them as the strings 'true'/'false' (AIINT-576).
+			'isA11n'           => self::is_current_user_automattician(),
+			'isTest'           => $is_internal_test,
+			'mcpSettingsApi'   => $config['mcpSettingsApi'],
+		);
+
 		wp_add_inline_script(
 			'jetpack-ai-admin',
 			'var jetpackAiSettings = ' . wp_json_encode(
-				array(
-					'blogId'           => $blog_id ? (int) $blog_id : 0,
-					'activityLogUrl'   => $activity_log_url,
-					'seoSettingsUrl'   => $seo_settings_url,
-					'siteAdminUrl'     => admin_url(),
-					'apiRoot'          => esc_url_raw( rest_url() ),
-					'apiNonce'         => wp_create_nonce( 'wp_rest' ),
-					'pluginUrl'        => plugins_url( '', JETPACK__PLUGIN_FILE ),
-					// The redirect entry bakes in the jetpack_ai_yearly product and
-					// a post-checkout return to this page, so both can be
-					// retargeted without shipping a code change.
-					'upgradeUrl'       => Redirect::get_url( 'jetpack-ai-hub-upgrade' ),
-					// The purchase granting AI, for the Overview usage card — the
-					// usage endpoint cannot name it. Only looked up when a gated
-					// view can render it.
-					'planName'         => $plan_info['name'],
-					// The plan's own renewal date, matching My Jetpack — the
-					// usage-period rollover is a different, monthly date.
-					'planRenewsOn'     => $plan_info['renews_on'],
-					// The same date reads "Renews on" or "Expires on" depending on
-					// auto-renew, matching My Jetpack and the wpcom subscriptions page.
-					'planAutoRenew'    => $plan_info['auto_renew'],
-					'showFeaturesView' => $show_gated_views,
-					// The tab and its Agents Manager sidebar ship disabled by default.
-					'featureFlags'     => array(
-						Jetpack_AI_Feature_Flags::SCHEDULED_TASKS => $show_scheduled_tasks_view,
-					),
-					// The usage endpoint proxies as the current user, which needs
-					// their own WordPress.com account linked — not just the site.
-					'isUserConnected'  => ( new Connection_Manager() )->is_user_connected(),
-					// Tracks audience properties for the jetpack_mcp_* events, per the
-					// Tracks standards for AI product events (AIINT-586). The client
-					// sends them as the strings 'true'/'false' (AIINT-576).
-					'isA11n'           => self::is_current_user_automattician(),
-					'isTest'           => $is_internal_test,
-				),
+				$settings,
 				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 			) . ';',
 			'before'

--- a/projects/plugins/jetpack/changelog/BSKY-2033
+++ b/projects/plugins/jetpack/changelog/BSKY-2033
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack AI: Support the AI Hub on WordPress.com Simple sites.

--- a/projects/plugins/jetpack/tests/jest.config.gui.js
+++ b/projects/plugins/jetpack/tests/jest.config.gui.js
@@ -12,6 +12,7 @@ module.exports = {
 		'<rootDir>/_inc/client/ai/test/ai-admin.jsx',
 		'<rootDir>/_inc/client/ai/features/test/component.jsx',
 		'<rootDir>/_inc/client/ai/mcp/test/allowlist-updated.jsx',
+		'<rootDir>/_inc/client/ai/mcp/test/use-mcp-settings.jsx',
 		'<rootDir>/_inc/client/ai/overview/test/component.jsx',
 		'<rootDir>/_inc/client/ai/scheduled-tasks/test/index.jsx',
 		'<rootDir>/_inc/client/ai/scheduled-tasks/test/use-scheduled-tasks.js',

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -173,7 +173,7 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	 */
 	public function test_add_actions_registers_standalone_page_hooks() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-		add_filter( 'jetpack_is_connection_ready', '__return_true' );
+		add_filter( 'jetpack_is_connection_ready', '__return_true', PHP_INT_MAX );
 
 		$page = $this->get_page_with_registered_hook();
 		$page->add_actions();
@@ -189,7 +189,7 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	public function test_add_actions_skips_standalone_styles_on_simple() {
 		Constants::set_constant( 'IS_WPCOM', true );
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-		add_filter( 'jetpack_is_connection_ready', '__return_true' );
+		add_filter( 'jetpack_is_connection_ready', '__return_true', PHP_INT_MAX );
 
 		$page = $this->get_page_with_registered_hook();
 		$page->add_actions();
@@ -203,7 +203,7 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	 */
 	public function test_add_actions_skips_disconnected_site() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-		add_filter( 'jetpack_is_connection_ready', '__return_false' );
+		add_filter( 'jetpack_is_connection_ready', '__return_false', PHP_INT_MAX );
 		add_filter( 'jetpack_offline_mode', '__return_false' );
 
 		$page = new Jetpack_AI_Page();
@@ -230,7 +230,7 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	 */
 	public function test_add_actions_stops_when_menu_registration_fails() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-		add_filter( 'jetpack_is_connection_ready', '__return_true' );
+		add_filter( 'jetpack_is_connection_ready', '__return_true', PHP_INT_MAX );
 
 		$page = new class() extends Jetpack_AI_Page {
 			/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -139,18 +139,43 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The standalone controller registers the menu, scripts, styles, and page loader.
+	 * Create a page whose menu registration has already returned its hook.
+	 *
+	 * @return Jetpack_AI_Page
+	 */
+	private function get_page_with_registered_hook() {
+		return new class() extends Jetpack_AI_Page {
+			/**
+			 * Return the hook assigned to the Jetpack AI menu page.
+			 *
+			 * @return string
+			 */
+			public function get_page_hook() {
+				return 'jetpack_page_jetpack-ai';
+			}
+		};
+	}
+
+	/**
+	 * The standalone page registers through the shared Jetpack admin menu.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
+	public function test_get_page_hook_registers_jetpack_ai_menu() {
+		$this->assertSame( 'jetpack_page_jetpack-ai', ( new Jetpack_AI_Page() )->get_page_hook() );
+	}
+
+	/**
+	 * The standalone controller registers scripts, styles, and the page loader.
+	 */
 	public function test_add_actions_registers_standalone_page_hooks() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		add_filter( 'jetpack_is_connection_ready', '__return_true' );
 
-		$page = new Jetpack_AI_Page();
+		$page = $this->get_page_with_registered_hook();
 		$page->add_actions();
 
 		$this->assertNotFalse( has_action( 'admin_print_scripts-jetpack_page_jetpack-ai', array( $page, 'page_admin_scripts' ) ) );
@@ -160,18 +185,13 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Simple sites keep the Hub's own layout without the standalone base stylesheet.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
 	public function test_add_actions_skips_standalone_styles_on_simple() {
 		Constants::set_constant( 'IS_WPCOM', true );
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		add_filter( 'jetpack_is_connection_ready', '__return_true' );
 
-		$page = new Jetpack_AI_Page();
+		$page = $this->get_page_with_registered_hook();
 		$page->add_actions();
 
 		$this->assertNotFalse( has_action( 'admin_print_scripts-jetpack_page_jetpack-ai', array( $page, 'page_admin_scripts' ) ) );

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -38,6 +38,7 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 		remove_all_filters( 'agents_manager_agent_id' );
 		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
+		remove_all_filters( 'jetpack_ai_admin_config' );
 		remove_all_filters( 'jetpack_feature_flag_enabled_ai-hub-scheduled-tasks' );
 
 		parent::tear_down();
@@ -150,6 +151,53 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 
 		$this->assertTrue( $settings['showFeaturesView'] );
 		$this->assertFalse( $settings['featureFlags'][ Jetpack_AI_Feature_Flags::SCHEDULED_TASKS ] );
+	}
+
+	/**
+	 * Hosts can hide pre-release views even in an internal testing environment.
+	 */
+	public function test_features_view_flag_can_be_filtered_by_the_host() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter(
+			'jetpack_ai_admin_config',
+			function ( $config ) {
+				$config['showGatedViews'] = false;
+
+				return $config;
+			}
+		);
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertFalse( $settings['showFeaturesView'] );
+		$this->assertSame( '', $settings['planName'] );
+	}
+
+	/**
+	 * Hosts can replace the MCP endpoint contract without copying the page.
+	 */
+	public function test_admin_settings_can_be_filtered_by_the_host() {
+		add_filter(
+			'jetpack_ai_admin_config',
+			function ( $config ) {
+				$config['mcpSettingsApi'] = array(
+					'path'   => '/wpcom/v2/sites/123/mcp-abilities',
+					'format' => 'wpcom',
+				);
+
+				return $config;
+			}
+		);
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertSame(
+			array(
+				'path'   => '/wpcom/v2/sites/123/mcp-abilities',
+				'format' => 'wpcom',
+			),
+			$settings['mcpSettingsApi']
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -10,6 +10,7 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Cache as Status_Cache;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -40,6 +41,13 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
 		remove_all_filters( 'jetpack_ai_admin_config' );
 		remove_all_filters( 'jetpack_feature_flag_enabled_ai-hub-scheduled-tasks' );
+		remove_all_filters( 'jetpack_is_connection_ready' );
+		remove_all_filters( 'jetpack_offline_mode' );
+		remove_all_actions( 'admin_print_scripts-jetpack_page_jetpack-ai' );
+		remove_all_actions( 'admin_print_styles-jetpack_page_jetpack-ai' );
+		remove_all_actions( 'load-jetpack_page_jetpack-ai' );
+		unset( $GLOBALS['wp_styles'] );
+		Constants::clear_constants();
 
 		parent::tear_down();
 	}
@@ -126,6 +134,100 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 		$this->assertIsArray( $settings );
 
 		return $settings;
+	}
+
+	/**
+	 * The standalone controller registers the menu, scripts, styles, and page loader.
+	 */
+	public function test_add_actions_registers_standalone_page_hooks() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		add_filter( 'jetpack_is_connection_ready', '__return_true' );
+
+		$page = new Jetpack_AI_Page();
+		$page->add_actions();
+
+		$this->assertNotFalse( has_action( 'admin_print_scripts-jetpack_page_jetpack-ai', array( $page, 'page_admin_scripts' ) ) );
+		$this->assertNotFalse( has_action( 'admin_print_styles-jetpack_page_jetpack-ai', array( $page, 'admin_styles' ) ) );
+		$this->assertNotFalse( has_action( 'load-jetpack_page_jetpack-ai', array( $page, 'load_agents_manager' ) ) );
+	}
+
+	/**
+	 * Simple sites keep the Hub's own layout without the standalone base stylesheet.
+	 */
+	public function test_add_actions_skips_standalone_styles_on_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		add_filter( 'jetpack_is_connection_ready', '__return_true' );
+
+		$page = new Jetpack_AI_Page();
+		$page->add_actions();
+
+		$this->assertNotFalse( has_action( 'admin_print_scripts-jetpack_page_jetpack-ai', array( $page, 'page_admin_scripts' ) ) );
+		$this->assertFalse( has_action( 'admin_print_styles-jetpack_page_jetpack-ai', array( $page, 'admin_styles' ) ) );
+	}
+
+	/**
+	 * A disconnected site does not expose the page outside offline mode.
+	 */
+	public function test_add_actions_skips_disconnected_site() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		add_filter( 'jetpack_is_connection_ready', '__return_false' );
+		add_filter( 'jetpack_offline_mode', '__return_false' );
+
+		$page = new Jetpack_AI_Page();
+		$page->add_actions();
+
+		$this->assertFalse( has_action( 'admin_print_scripts-jetpack_page_jetpack-ai', array( $page, 'page_admin_scripts' ) ) );
+	}
+
+	/**
+	 * Offline mode does not expose the page to users without admin access.
+	 */
+	public function test_add_actions_skips_non_admin_in_offline_mode() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+		add_filter( 'jetpack_offline_mode', '__return_true' );
+
+		$page = new Jetpack_AI_Page();
+		$page->add_actions();
+
+		$this->assertFalse( has_action( 'admin_print_scripts-jetpack_page_jetpack-ai', array( $page, 'page_admin_scripts' ) ) );
+	}
+
+	/**
+	 * A host that cannot register the menu does not attach page-specific hooks.
+	 */
+	public function test_add_actions_stops_when_menu_registration_fails() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		add_filter( 'jetpack_is_connection_ready', '__return_true' );
+
+		$page = new class() extends Jetpack_AI_Page {
+			/**
+			 * Simulate a host declining to register the menu.
+			 *
+			 * @return false
+			 */
+			public function get_page_hook() {
+				return false;
+			}
+		};
+		$page->add_actions();
+
+		$this->assertFalse( has_action( 'admin_print_scripts-jetpack_page_jetpack-ai', array( $page, 'page_admin_scripts' ) ) );
+	}
+
+	/**
+	 * The standalone stylesheet keeps the legacy Jetpack style metadata.
+	 */
+	public function test_admin_styles_enqueues_legacy_jetpack_stylesheet() {
+		( new Jetpack_AI_Page() )->admin_styles();
+
+		$style = wp_styles()->registered['jetpack-admin'];
+		$min   = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+
+		$this->assertTrue( wp_style_is( 'jetpack-admin', 'enqueued' ) );
+		$this->assertStringEndsWith( "css/jetpack-admin{$min}.css", $style->src );
+		$this->assertSame( 'replace', $style->extra['rtl'] );
+		$this->assertSame( $min, $style->extra['suffix'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -13,6 +13,8 @@
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Cache as Status_Cache;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 require_once JETPACK__PLUGIN_DIR . '_inc/lib/admin-pages/class-jetpack-ai-page.php';
 
@@ -138,7 +140,12 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 
 	/**
 	 * The standalone controller registers the menu, scripts, styles, and page loader.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_add_actions_registers_standalone_page_hooks() {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		add_filter( 'jetpack_is_connection_ready', '__return_true' );
@@ -153,7 +160,12 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Simple sites keep the Hub's own layout without the standalone base stylesheet.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_add_actions_skips_standalone_styles_on_simple() {
 		Constants::set_constant( 'IS_WPCOM', true );
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );


### PR DESCRIPTION
## Proposed changes

This is refactoring Jetpack AI Hub page so it can run on dotcom simple

<img width="1482" height="1200" alt="Zrzut ekranu 2026-08-27 o 18 30 40" src="https://github.com/user-attachments/assets/1effe298-ee4e-444b-a728-a2a8729ea782" />


* Make the Jetpack AI Hub page independent of the legacy Jetpack_Admin_Page lifecycle so the same controller can run safely on WordPress.com Simple.
* Add one host-configuration filter and support the native site-scoped WordPress.com MCP settings response alongside Jetpack's existing proxy response.
* Register the upstream Hub from jetpack-mu-wpcom when the host opts in, including the Scheduled Tasks experience, while leaving the experimental Overview and Features views gated.

## Related product discussion/links

* BSKY-2033

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run jp build plugins/jetpack and jp build plugins/mu-wpcom-plugin.
* On a WordPress.com Simple test site add this to your `0-sandbox.php` : `add_filter( 'jetpack_mu_wpcom_load_jetpack_ai_hub', '__return_true' );`
* open **Jetpack → Jetpack AI**.
* Confirm **Scheduled tasks** and **MCP Settings** are available, Scheduled Tasks can load its list, and MCP Settings loads through the native site-scoped API.
* Confirm **Settings → Sharing** still renders normally.
