### PR TITLE
Backup: four follow-ups — response-code casts across the package, a malformed msgid, a stale test fixture, and a test-suite fatal

### DIFF
--- a/projects/packages/backup/.phan/baseline.php
+++ b/projects/packages/backup/.phan/baseline.php
@@ -9,13 +9,13 @@
  */
 return [
     // # Issue statistics:
-    // PhanTypeMismatchReturnProbablyReal : 9 occurrences
-    // PhanTypeMismatchReturn : 2 occurrences
+    // PhanTypeMismatchReturnProbablyReal : 7 occurrences
+    // PhanTypeMismatchReturn : 1 occurrence
 
     // Currently, file_suppressions and directory_suppressions are the only supported suppressions
     'file_suppressions' => [
         'src/class-jetpack-backup.php' => ['PhanTypeMismatchReturn'],
-        'src/class-rest-controller.php' => ['PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal'],
+        'src/class-rest-controller.php' => ['PhanTypeMismatchReturnProbablyReal'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.
     // (directory_suppressions will currently be ignored by subsequent calls to --save-baseline, but may be preserved in future Phan releases)

--- a/projects/packages/backup/changelog/fix-backup-storage-reading-placeholders
+++ b/projects/packages/backup/changelog/fix-backup-storage-reading-placeholders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show storage usage and the plan limit the right way round in translated languages.

--- a/projects/packages/backup/changelog/fix-backup-storage-reading-placeholders
+++ b/projects/packages/backup/changelog/fix-backup-storage-reading-placeholders
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Show storage usage and the plan limit the right way round in translated languages.
+Show storage usage and the plan limit the right way round when the interface is translated.

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -544,7 +544,14 @@ class Jetpack_Backup {
 
 		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/rewind', $site_id ) . '?force=wpcom', '2', array( 'timeout' => 2 ), null, 'wpcom' );
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		// Cast: `wp_remote_retrieve_response_code()` hands back whatever the
+		// transport put there, and a numeric-string `'200'` fails this
+		// strict comparison. The result is memoized in `$status` and read by
+		// `has_backup_plan()`, which answers false for a `WP_Error` — so a
+		// site that does have Backup is told, for the rest of the request,
+		// that it does not. That answer is acted on: it backs the
+		// `/has-backup-plan` route and the standalone-license upsell.
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'rewind_state_fetch_failed' );
 		}
 
@@ -682,7 +689,12 @@ class Jetpack_Backup {
 			'wpcom'
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		// Cast, as everywhere else this package reads a status. Uncast, a
+		// numeric-string `'200'` discards a good activity page and the
+		// `jetpack-backup/list-backup-events` ability reports that the site
+		// has completed no backups — `unwrap_response()` flattens this
+		// `null` into an empty list, which is a claim rather than an error.
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
 			return null;
 		}
 

--- a/projects/packages/backup/src/class-rest-controller.php
+++ b/projects/packages/backup/src/class-rest-controller.php
@@ -583,7 +583,11 @@ class REST_Controller {
 			'wpcom'
 		);
 
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		// Cast: `wp_remote_retrieve_response_code()` hands back whatever the
+		// transport put there, and a numeric-string `'200'` fails this
+		// strict comparison — so a perfectly good answer is discarded and
+		// the route reports that the site has no rewindable event to undo.
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
 			return null;
 		}
 
@@ -701,7 +705,12 @@ class REST_Controller {
 	/**
 	 * Fetch backup preflight status
 	 *
-	 * @return array
+	 * The `array` this used to advertise was never a shape it could return;
+	 * both branches below hand back an object. Corrected because Phan reads
+	 * it, and a caller that believed it would be calling array offsets on a
+	 * `WP_REST_Response`.
+	 *
+	 * @return \WP_REST_Response|WP_Error The preflight payload, or a WP_Error if WordPress.com refused or could not be reached.
 	 */
 	public static function get_site_backup_preflight() {
 		$blog_id = Jetpack_Options::get_option( 'id' );
@@ -722,12 +731,29 @@ class REST_Controller {
 			);
 		}
 
-		$response_code = wp_remote_retrieve_response_code( $response );
+		// Cast and then clamp, and this route needs both more than any
+		// other in the package. `wp_remote_retrieve_response_code()` hands
+		// back whatever the transport put there, so an uncast `'200'` fails
+		// the comparison below — and this is the one place that then
+		// forwards the status it just read straight into `data.status`.
+		// WordPress runs that through `absint()`, so the error envelope is
+		// served as HTTP 200: `apiFetch` resolves, nothing throws, and a
+		// failure arrives at the caller looking like a successful preflight.
+		//
+		// The clamp covers what the cast cannot. `(int)` is total, so an
+		// absent or unparseable code becomes `0` and `'2 Bad'` becomes `2`,
+		// and neither is a status `status_header()` can emit. The same
+		// reasoning, written out at length, is on
+		// `REST\Rest_Controller::upstream_error()`; it is open-coded here
+		// rather than borrowed because that helper also attaches
+		// WordPress.com's own reason under a `wpcom` key, which would change
+		// this route's response shape for callers we do not control.
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $response_code ) {
 			return new WP_Error(
 				'http_error_fetch_preflight',
 				wp_remote_retrieve_response_message( $response ),
-				array( 'status' => $response_code )
+				array( 'status' => $response_code >= 400 && $response_code <= 599 ? $response_code : 500 )
 			);
 		}
 

--- a/projects/packages/backup/src/dashboard/components/storage-space/usage-details.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/usage-details.tsx
@@ -20,35 +20,23 @@ const TERABYTE = 2 ** 40;
  * that has filled whole terabytes is vanishingly rare, and "0.01TB used"
  * would answer a question nobody asked.
  *
- * Both msgids are legacy's, character for character, so the strings
- * arrive already translated rather than waiting a GlotPress cycle. That
- * carries a known defect across with them, and it is worth being precise
- * about which one.
+ * Both msgids are shared with legacy's copy in
+ * `js/components/backup-storage-space/storage-usage-details/use-storage-usage-text.tsx`,
+ * character for character. Change one and the other has to change in the
+ * same breath, or the two dashboards become separate GlotPress entries
+ * saying the same thing.
  *
- * The gigabyte msgid's `%1.1f` and `%2f` are *not* argument references,
- * despite reading as though they were. They parse as a width and a
- * precision, and `@tannin/sprintf` — which is what `@wordpress/i18n` uses —
- * annotates the width group "Min width (unsupported)" and discards it. So
- * both are plain sequential placeholders, consumed in the order they
- * appear, and the English source renders correctly at every limit:
- * `sprintf( 'Using <strong>%1.1fGB</strong> of %2fGB', 3, 5 )` gives
- * `Using <strong>3.0GB</strong> of 5GB`, with no padding and no stray
- * space.
- *
- * The hazard is not the rendering, it is the reordering. Being sequential,
- * the two values swap places if a translation fronts the total — which is
- * natural in plenty of languages: `sprintf( 'Of %2fGB, using
- * <strong>%1.1fGB</strong>', 12.4, 20 )` gives `Of 12.4GB, using 20.0GB`,
- * used and total transposed. On the one screen whose job is to say whether
- * backups are at risk, that tells the reader they are over quota when they
- * are not. Truly positional placeholders survive the same reorder, which is
- * why the terabyte msgid below — spelled `%1$d`/`%2$d` — is immune.
- *
- * Fixing the gigabyte string means changing legacy and this copy together
- * so the msgid stays shared, and that is queued as its own change rather
- * than done here. Until it lands, the translator comment on the string
- * must not describe these as numbered arguments, or it invites exactly the
- * reorder that breaks them.
+ * Both are spelled positionally — `%1$.1f`/`%2$f` here, `%1$d`/`%2$d` for
+ * terabytes — and that spelling is the whole of what keeps them correct
+ * once translated. `@tannin/sprintf`, which is what `@wordpress/i18n`
+ * uses, reads a digit that is *not* followed by `$` as a min-width
+ * specifier, annotates it "Min width (unsupported)", discards it, and then
+ * fills what is left in the order the placeholders appear. The gigabyte
+ * msgid used to be spelled that way, `%1.1f` and `%2f`, which rendered
+ * correctly in English at every value and transposed the two figures the
+ * moment a translation fronted the total — natural in plenty of languages.
+ * On the one screen whose job is to say whether backups are at risk, that
+ * told the reader they were over quota when they were not.
  *
  * @param storageUsed  - Bytes of backup storage in use.
  * @param storageLimit - The plan's storage limit in bytes.
@@ -58,24 +46,20 @@ function usageText( storageUsed: number, storageLimit: number ): ReactNode {
 	const usedGigabytes = storageUsed / GIGABYTE;
 
 	if ( storageLimit < TERABYTE ) {
-		// translators: Must use unit abbreviation; describes used vs available storage amounts (e.g. 20.0GB of 30GB used, 0.5GB of 20GB used). %1.1f and %2f are NOT numbered arguments — they are filled in the order they appear, %1.1f first with the amount of disk space used, then %2f with the amount available. Please keep them in that order.
-		const inGigabytes = __( 'Using <strong>%1.1fGB</strong> of %2fGB', 'jetpack-backup-pkg' );
+		// translators: Must use unit abbreviation; describes used vs available storage amounts (e.g. 20.0GB of 30GB used, 0.5GB of 20GB used). %1$.1f: numeric amount of disk space used, %2$f: numeric amount of disk space available.
+		const inGigabytes = __( 'Using <strong>%1$.1fGB</strong> of %2$fGB', 'jetpack-backup-pkg' );
 
-		// Legacy carries `eslint-disable-next-line @wordpress/valid-sprintf`
-		// on its copy of this call, and its absence here is not a clean
-		// bill of health: the rule only inspects a format string it can
-		// resolve, and hoisting the msgid into a `const` — which the
-		// minifier reasoning above requires — puts it out of reach. The
-		// string is exactly as malformed as it was; nothing is checking it
-		// any more. See the note on this function about what that costs.
+		// Not machine-checked here: `@wordpress/valid-sprintf` only inspects
+		// a format string it can resolve at the call, and hoisting the msgid
+		// into a `const` — the spelling this file uses throughout — puts it
+		// out of reach. Legacy's copy is the one the rule reads. What guards
+		// the placeholders on this side is `storage-usage-details.test.tsx`,
+		// which renders the line under a reordering translation.
 		return createInterpolateElement(
-			sprintf(
-				inGigabytes,
-				// @ts-expect-error The format string is parsed at the type level, and this spelling defeats that parser — it infers a single argument.
-				usedGigabytes,
-				storageLimit / GIGABYTE
-			),
-			{ strong: <strong /> }
+			sprintf( inGigabytes, usedGigabytes, storageLimit / GIGABYTE ),
+			{
+				strong: <strong />,
+			}
 		);
 	}
 

--- a/projects/packages/backup/src/js/components/backup-storage-space/storage-usage-details/use-storage-usage-text.tsx
+++ b/projects/packages/backup/src/js/components/backup-storage-space/storage-usage-details/use-storage-usage-text.tsx
@@ -33,12 +33,20 @@ export const useStorageUsageText = ( bytesUsed, bytesAvailable ) => {
 		const availableUnitAmount = bytesToUnit( bytesAvailable, availableUnit );
 
 		if ( availableUnit === StorageUnits.Gigabyte ) {
+			// Positional, and it has to stay that way. `@tannin/sprintf`
+			// reads a digit that is not followed by `$` as a min-width
+			// specifier, discards it, and then fills the placeholders in
+			// the order they appear — so the earlier `%1.1f`/`%2f` spelling
+			// rendered correctly in English and transposed the two figures
+			// under any translation that fronts the total, which reads as
+			// "over quota" to someone who is not. The modernized copy in
+			// `dashboard/components/storage-space/usage-details.tsx` shares
+			// this msgid; change the two together or they become separate
+			// GlotPress entries saying the same thing.
 			return createInterpolateElement(
-				// eslint-disable-next-line @wordpress/valid-sprintf
 				sprintf(
-					// translators: Must use unit abbreviation; describes used vs available storage amounts (e.g. 20.0GB of 30GB used, 0.5GB of 20GB used). %1.1f: numeric amount of disk space used, %2f: numeric amount of disk space available.
-					__( 'Using <strong>%1.1fGB</strong> of %2fGB', 'jetpack-backup-pkg' ),
-					// @ts-expect-error sprintf types seem to be wrong to expect only 1 argument here.
+					// translators: Must use unit abbreviation; describes used vs available storage amounts (e.g. 20.0GB of 30GB used, 0.5GB of 20GB used). %1$.1f: numeric amount of disk space used, %2$f: numeric amount of disk space available.
+					__( 'Using <strong>%1$.1fGB</strong> of %2$fGB', 'jetpack-backup-pkg' ),
 					usedGigabytes,
 					availableUnitAmount
 				),

--- a/projects/packages/backup/src/rest/class-activity-log-bridge.php
+++ b/projects/packages/backup/src/rest/class-activity-log-bridge.php
@@ -113,7 +113,13 @@ class Activity_Log_Bridge {
 			return Rest_Controller::transport_error( $response, 'activity_log_fetch_failed' );
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
+		// Cast because `wp_remote_retrieve_response_code()` hands back
+		// whatever the transport put there, and a numeric string fails the
+		// strict comparison below — routing a perfectly good response into
+		// the failure branch, where `upstream_error()`'s clamp then reports
+		// it as a 500. Same reasoning at every bridge; the long version is
+		// on `Rest_Controller::upstream_error()`.
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
 			return Rest_Controller::upstream_error(
 				$response,

--- a/projects/packages/backup/src/rest/class-download-bridge.php
+++ b/projects/packages/backup/src/rest/class-download-bridge.php
@@ -138,7 +138,13 @@ class Download_Bridge {
 			return Rest_Controller::transport_error( $response, 'download_initiate_failed' );
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
+		// Cast because `wp_remote_retrieve_response_code()` hands back
+		// whatever the transport put there, and a numeric string fails the
+		// strict comparison below — routing a perfectly good response into
+		// the failure branch, where `upstream_error()`'s clamp then reports
+		// it as a 500. Same reasoning at every bridge; the long version is
+		// on `Rest_Controller::upstream_error()`.
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
 			return Rest_Controller::upstream_error(
 				$response,
@@ -199,7 +205,8 @@ class Download_Bridge {
 			return Rest_Controller::transport_error( $response, 'download_status_fetch_failed' );
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
+		// Cast, as in `initiate_download()`.
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
 			return Rest_Controller::upstream_error(
 				$response,

--- a/projects/packages/backup/src/rest/class-file-browser-bridge.php
+++ b/projects/packages/backup/src/rest/class-file-browser-bridge.php
@@ -280,7 +280,13 @@ class File_Browser_Bridge {
 			return Rest_Controller::transport_error( $url_response, 'backup_file_content_url_failed' );
 		}
 
-		$url_status = wp_remote_retrieve_response_code( $url_response );
+		// Cast because `wp_remote_retrieve_response_code()` hands back
+		// whatever the transport put there, and a numeric string fails the
+		// strict comparison below — routing a perfectly good response into
+		// the failure branch, where `upstream_error()`'s clamp then reports
+		// it as a 500. Same reasoning at every bridge; the long version is
+		// on `Rest_Controller::upstream_error()`.
+		$url_status = (int) wp_remote_retrieve_response_code( $url_response );
 		if ( 200 !== $url_status ) {
 			return Rest_Controller::upstream_error(
 				$url_response,
@@ -322,7 +328,13 @@ class File_Browser_Bridge {
 			return Rest_Controller::transport_error( $stream_response, 'backup_file_content_stream_failed' );
 		}
 
-		$stream_status = wp_remote_retrieve_response_code( $stream_response );
+		// Cast, as at the signed-URL lookup above — and this is the call
+		// where it bites hardest, because the response body on the success
+		// side is the previewed file itself. Uncast, a `'200'` from a
+		// transport that reports statuses as strings took the branch below
+		// with the file's own bytes in hand: the preview the reader asked
+		// for was discarded and reported as a 500.
+		$stream_status = (int) wp_remote_retrieve_response_code( $stream_response );
 		if ( 200 !== $stream_status ) {
 			// The one failure here whose reason does not come from the JSON
 			// API. This response is the storage host's, not WordPress.com's,
@@ -334,16 +346,6 @@ class File_Browser_Bridge {
 			// sometimes answer in JSON. When it does, the reason is filed
 			// under a key named `wpcom`, which misnames its origin — worth
 			// knowing before anyone reads that field as WordPress.com's.
-			//
-			// And the body it reads is not guaranteed to be an error body.
-			// `200 !== $stream_status` is not type-safe, so a `'200'` from
-			// a transport that reports statuses as strings arrives here
-			// with the previewed file's own bytes in hand. Harmless — the
-			// caller is the admin who asked for that file, and the clamp in
-			// `upstream_error()` reports the status as 500 rather than
-			// forwarding a success code — but it is not the same claim as
-			// "a 200 never reaches this branch", which is what this comment
-			// used to say and is not true.
 			return Rest_Controller::upstream_error(
 				$stream_response,
 				'backup_file_content_stream_failed',
@@ -375,7 +377,8 @@ class File_Browser_Bridge {
 		if ( is_wp_error( $response ) ) {
 			return Rest_Controller::transport_error( $response, $code );
 		}
-		$status_code = wp_remote_retrieve_response_code( $response );
+		// Cast, as at every other bridge — see `get_file_content()` above.
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
 			return Rest_Controller::upstream_error( $response, $code, $message );
 		}

--- a/projects/packages/backup/src/rest/class-rest-controller.php
+++ b/projects/packages/backup/src/rest/class-rest-controller.php
@@ -286,10 +286,13 @@ class Rest_Controller {
 	 *
 	 * The status is clamped to the failure range rather than merely tested
 	 * for truthiness, and that is load-bearing. The retrieval helper hands
-	 * back whatever the transport put there, so a *success* code can reach
-	 * this function: four of the callers compare `200 !== $status_code`
-	 * without casting, which a numeric-string `'200'` fails, routing a
-	 * perfectly good response into the failure branch. Forwarding it would then set `data.status` to 200, WordPress
+	 * back whatever the transport put there, and its callers must cast
+	 * before comparing — a numeric-string `'200'` fails `200 !==
+	 * $status_code`, which routed a perfectly good response into the
+	 * failure branch. Every bridge casts now, so this function should no
+	 * longer be reachable with a success code; the clamp stays because
+	 * "should not" is not "cannot", and the cost of being wrong is
+	 * one-sided. Forwarding a 200 would set `data.status` to 200, WordPress
 	 * would serve the error envelope as HTTP 200, `apiFetch` would resolve
 	 * instead of rejecting, and `apiCall()` would never throw — so a
 	 * failed restore would run the mutation's `onSuccess` and report a

--- a/projects/packages/backup/src/rest/class-rest-controller.php
+++ b/projects/packages/backup/src/rest/class-rest-controller.php
@@ -289,16 +289,17 @@ class Rest_Controller {
 	 * back whatever the transport put there, and its callers must cast
 	 * before comparing — a numeric-string `'200'` fails `200 !==
 	 * $status_code`, which routed a perfectly good response into the
-	 * failure branch. Every bridge casts now, so this function should no
-	 * longer be reachable with a success code; the clamp stays because
-	 * "should not" is not "cannot", and the cost of being wrong is
-	 * one-sided. Forwarding a 200 would set `data.status` to 200, WordPress
-	 * would serve the error envelope as HTTP 200, `apiFetch` would resolve
-	 * instead of rejecting, and `apiCall()` would never throw — so a
-	 * failed restore would run the mutation's `onSuccess` and report a
-	 * restore that never started. A visible failure becoming an invisible
-	 * false success is the worst outcome available on a destructive
-	 * operation, so anything outside 4xx/5xx becomes a 500.
+	 * failure branch. Every status comparison in this package casts now —
+	 * bridges and legacy routes alike — so this function should no longer
+	 * be reachable with a success code; the clamp stays because "should
+	 * not" is not "cannot", and the cost of being wrong is one-sided.
+	 * Forwarding a 200 would set `data.status` to 200, WordPress would
+	 * serve the error envelope as HTTP 200, `apiFetch` would resolve
+	 * instead of rejecting, and `apiCall()` would never throw — so a failed
+	 * restore would run the mutation's `onSuccess` and report a restore
+	 * that never started. A visible failure becoming an invisible false
+	 * success is the worst outcome available on a destructive operation, so
+	 * anything outside 4xx/5xx becomes a 500.
 	 *
 	 * The same clamp is what keeps junk out. `(int)` is a total function:
 	 * `'2 Bad'` is 2, `3.7` is 3, `true` is 1, and a zero must never reach

--- a/projects/packages/backup/src/rest/class-restore-bridge.php
+++ b/projects/packages/backup/src/rest/class-restore-bridge.php
@@ -148,7 +148,13 @@ class Restore_Bridge {
 			return Rest_Controller::transport_error( $response, 'restore_initiate_failed' );
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
+		// Cast because `wp_remote_retrieve_response_code()` hands back
+		// whatever the transport put there, and a numeric string fails the
+		// strict comparison below. On this route that is the worst place to
+		// get it wrong: a restore WordPress.com accepted would be reported
+		// as a failure, and the reader would start a second one. The long
+		// version is on `Rest_Controller::upstream_error()`.
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
 			return Rest_Controller::upstream_error(
 				$response,
@@ -277,7 +283,11 @@ class Restore_Bridge {
 			return Rest_Controller::transport_error( $response, 'restore_status_fetch_failed' );
 		}
 
-		$status_code = wp_remote_retrieve_response_code( $response );
+		// Cast, as in `initiate_restore()`. Both branches below depend on
+		// it: an uncast `'404'` would miss the queued-restore carve-out as
+		// well as the success test, so the ordinary opening seconds of a
+		// restore would surface as an error.
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
 
 		// A 404 is the normal first answer, not a failure. A restore that
 		// has just been queued is not visible to this route yet, and the

--- a/projects/packages/backup/tests/legacy-storage-usage-text.test.tsx
+++ b/projects/packages/backup/tests/legacy-storage-usage-text.test.tsx
@@ -1,0 +1,88 @@
+// Tests for the flag-off dashboard's storage reading.
+//
+// This hook, not the modernized `dashboard/components/storage-space/
+// usage-details.tsx`, is what ships to readers today — so the msgid it
+// carries is the one a mis-spelled placeholder actually reaches people
+// through. The two copies share both msgids character for character;
+// `storage-usage-details.test.tsx` covers the other side.
+//
+// Here rather than beside the hook, as `src/js`'s own `test/` folders
+// would suggest: `tsconfig.json` includes `./src/js`, and a `.tsx` test
+// under it is typechecked without the test runner's globals declared.
+// Every other suite in this package lives here anyway.
+
+import { render, screen } from '@testing-library/react';
+import { resetLocaleData, setLocaleData } from '@wordpress/i18n';
+import { useStorageUsageText } from '../src/js/components/backup-storage-space/storage-usage-details/use-storage-usage-text';
+
+const GB = 2 ** 30;
+const TB = 2 ** 40;
+
+/**
+ * Render the hook's output on its own.
+ *
+ * A `<p>` rather than a bare fragment so the line has an element of its
+ * own to match against. The copy wraps the used figure in `<strong>`, so
+ * this element holds only the fragments either side of it — which is all
+ * Testing Library's text matcher reads — hence the search for the opening
+ * word and the anchored regexes at the call sites.
+ *
+ * @param props           - Component props.
+ * @param props.used      - Bytes of backup storage in use.
+ * @param props.available - The plan's storage limit in bytes.
+ * @return The reading.
+ */
+function Reading( { used, available }: { used: number; available?: number } ) {
+	return <p>{ useStorageUsageText( used, available ) }</p>;
+}
+
+afterEach( () => {
+	// Wipes every domain, which is what this function does — nothing here
+	// depends on loaded translations otherwise.
+	resetLocaleData();
+} );
+
+describe( 'the untranslated reading', () => {
+	it( 'states both figures in gigabytes on a plan sold in them', () => {
+		render( <Reading used={ 12.4 * GB } available={ 20 * GB } /> );
+		expect( screen.getByText( /^Using/ ) ).toHaveTextContent( /^Using 12\.4GB of 20GB$/ );
+	} );
+
+	it( 'switches the limit to terabytes once the plan is sold in them', () => {
+		render( <Reading used={ 12.4 * GB } available={ TB } /> );
+		expect( screen.getByText( /^Using/ ) ).toHaveTextContent( /^Using 12GB of 1TB$/ );
+	} );
+} );
+
+describe( 'the translated reading', () => {
+	// English cannot tell you whether the placeholders are positional:
+	// nothing moves, so `%1.1f`/`%2f` — which `@tannin/sprintf` reads as
+	// widths and then fills in the order they appear — renders exactly
+	// like `%1$.1f`/`%2$f` at every value. The two part company only under
+	// a translation that reorders them, which is the natural phrasing in
+	// plenty of languages.
+	it( 'keeps used and total the right way round when a translation fronts the total', () => {
+		setLocaleData(
+			{
+				'Using <strong>%1$.1fGB</strong> of %2$fGB': [
+					'Of %2$fGB, using <strong>%1$.1fGB</strong>',
+				],
+				// The pre-fix spelling, carried here on purpose: without it,
+				// reverting the msgid fails this test with a translation
+				// that matches no key, which reads as a stale fixture and
+				// invites someone to update the key and bless the bug back
+				// in. With it, the failure is the transposed figures.
+				'Using <strong>%1.1fGB</strong> of %2fGB': [ 'Of %2fGB, using <strong>%1.1fGB</strong>' ],
+			},
+			'jetpack-backup-pkg'
+		);
+
+		render( <Reading used={ 12.4 * GB } available={ 20 * GB } /> );
+
+		// Sequential placeholders give "Of 12.4GB, using 20.0GB" here — the
+		// plan reported as the usage and the usage as the plan. On the
+		// screen whose job is to say whether backups are at risk, that
+		// tells a reader with room to spare that they are over quota.
+		expect( screen.getByText( /^Of/ ) ).toHaveTextContent( /^Of 20GB, using 12\.4GB$/ );
+	} );
+} );

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -46,6 +46,17 @@ class Jetpack_Backup_Test extends TestCase {
 	private $wpcom_status = 200;
 
 	/**
+	 * Raw body for the next mocked WordPress.com response.
+	 *
+	 * An empty object by default, which is all the route tests above need —
+	 * they assert on the status, not on what came back. A test that has to
+	 * reach past the status guard and read the payload sets its own.
+	 *
+	 * @var string
+	 */
+	private $wpcom_body = '{}';
+
+	/**
 	 * How many times a route reached the mocked transport.
 	 *
 	 * @var int
@@ -63,6 +74,7 @@ class Jetpack_Backup_Test extends TestCase {
 		wp_set_current_user( 0 );
 
 		$this->wpcom_status  = 200;
+		$this->wpcom_body    = '{}';
 		$this->http_requests = 0;
 
 		parent::tearDown();
@@ -234,6 +246,56 @@ class Jetpack_Backup_Test extends TestCase {
 		$this->assertNull( $result );
 
 		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_server_error' ) );
+	}
+
+	/**
+	 * A success code reported as a string still lists the events.
+	 *
+	 * `list_backup_events()` is not one of the seven routes covered by the
+	 * providers above — it answers no route of its own and is read by the
+	 * `jetpack-backup/list-backup-events` ability, which flattens this
+	 * `null` into an empty list through `unwrap_response()`. So an uncast
+	 * `'200'` did not surface as an error anywhere: it told the caller the
+	 * site has completed no backups, which is a claim rather than a failure.
+	 */
+	public function test_list_backup_events_reads_a_string_status_200() {
+		$this->sign_in_as_connected_admin();
+		$this->wpcom_status = '200';
+		$this->wpcom_body   = '{"type":"OrderedCollection","totalItems":1}';
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
+
+		$result = Jetpack_Backup::list_backup_events();
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( 1, $result->get_data()['totalItems'] );
+	}
+
+	/**
+	 * A success code reported as a string does not cost the site its plan.
+	 *
+	 * `get_rewind_state_from_wpcom()` is private; `has_backup_plan()` is the
+	 * door, and it answers false for the `WP_Error` an uncast `'200'`
+	 * produced — so a site that does have Backup was told it does not. That
+	 * answer is acted on: it backs `GET /jetpack/v4/has-backup-plan` and the
+	 * standalone-license upsell in `jetpack_check_user_licenses()`.
+	 *
+	 * The request count is asserted because that helper memoizes a
+	 * *successful* fetch in a function static, which no test can reset. This
+	 * is the only test in the suite that drives it to a success, so the
+	 * static should still be empty when it runs — and if some later test
+	 * changes that, this assertion says so rather than passing on a cached
+	 * answer that never touched the code under test.
+	 */
+	public function test_has_backup_plan_reads_a_string_status_200() {
+		$this->sign_in_as_connected_admin();
+		$this->wpcom_status = '200';
+		$this->wpcom_body   = '{"state":"active"}';
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
+
+		$result = Jetpack_Backup::has_backup_plan();
+
+		$this->assertSame( 1, $this->http_requests );
+		$this->assertTrue( $result );
 	}
 
 	public function test_list_backup_events_returns_response_and_pins_backup_actions_on_success() {
@@ -468,7 +530,7 @@ class Jetpack_Backup_Test extends TestCase {
 
 		return array(
 			'response' => array( 'code' => $this->wpcom_status ),
-			'body'     => '{}',
+			'body'     => $this->wpcom_body,
 		);
 	}
 

--- a/projects/packages/backup/tests/php/REST_Controller_Test.php
+++ b/projects/packages/backup/tests/php/REST_Controller_Test.php
@@ -11,11 +11,15 @@
 // are installed, or in some other cases).
 namespace Automattic\Jetpack\Backup\V0005;
 
+use Automattic\Jetpack\Backup\V0005\REST\Wpcom_Request_Mock;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Posts as WorDBless_Posts;
 use WorDBless\Users as WorDBless_Users;
+use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -29,7 +33,11 @@ use function wp_insert_user;
 use function wp_json_encode;
 use function wp_set_current_user;
 
+require_once __DIR__ . '/trait-wpcom-request-mock.php';
+
 class REST_Controller_Test extends TestCase {
+
+	use Wpcom_Request_Mock;
 
 	/**
 	 * REST Server object.
@@ -74,6 +82,7 @@ class REST_Controller_Test extends TestCase {
 	 */
 	public function tearDown(): void {
 		parent::tearDown();
+		$this->reset_wpcom_request_mock();
 		wp_set_current_user( 0 );
 
 		unset(
@@ -538,5 +547,129 @@ class REST_Controller_Test extends TestCase {
 		$response = $this->dispatch_request_signed_with_blog_token( $request );
 
 		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * Sign in and have WordPress.com answer, with the constants a signed
+	 * request needs already in place.
+	 *
+	 * `Client::validate_args_for_wpcom_json_api_request()` reads
+	 * `JETPACK__WPCOM_JSON_API_BASE` before `build_signed_request()` installs
+	 * the filter that supplies its default, so without this the first signed
+	 * request of the process is built against a host-less URL and refused
+	 * before the wire — which would make these tests pass or fail on where
+	 * they land in the run order. Plugins prime the constants at bootstrap;
+	 * tests have to do it themselves.
+	 *
+	 * @param string     $body   Raw body WordPress.com should answer with.
+	 * @param int|string $status HTTP status WordPress.com should answer with.
+	 */
+	private function arrange_signed_wpcom( $body, $status ) {
+		Connection_Utils::init_default_constants();
+		$this->arrange_wpcom_raw( $body, $status );
+	}
+
+	/**
+	 * Preflight reads a success code reported as a string.
+	 *
+	 * `wp_remote_retrieve_response_code()` hands back whatever the transport
+	 * put there, and this route was the one place in the package that then
+	 * forwarded the status it had just read straight into `data.status`.
+	 * Uncast, `'200'` failed the comparison and the error envelope was served
+	 * as HTTP 200 — `WP_HTTP_Response::set_status()` runs the value through
+	 * `absint()` — so `apiFetch` resolves, nothing throws, and a failure
+	 * arrives at the caller looking like a successful preflight.
+	 *
+	 * The decoded payload is asserted rather than the absence of an error,
+	 * and that is the point: the bug served a *success* status, so a test
+	 * that only checked for "not a failure status" would have passed on it.
+	 */
+	public function test_preflight_treats_a_string_status_as_its_number() {
+		$this->arrange_signed_wpcom( '{"ok":true,"score":42}', '200' );
+
+		$response = REST_Controller::get_site_backup_preflight();
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 42, $response->get_data()['score'] );
+	}
+
+	/**
+	 * A real failure status still travels, which is what the route is for.
+	 *
+	 * Guards the clamp below from being "fixed" into a flat 500: the reason
+	 * this route forwards the status at all is that 403 and 503 mean
+	 * different things to whoever is reading. 403 rather than 500, because
+	 * 500 is also what the clamp falls back to.
+	 */
+	public function test_preflight_forwards_a_genuine_failure_status() {
+		$this->arrange_signed_wpcom( '{}', 403 );
+
+		$data = REST_Controller::get_site_backup_preflight()->get_error_data();
+
+		$this->assertSame( 403, $data['status'] );
+	}
+
+	/**
+	 * A status outside the failure range never reaches `data.status`.
+	 *
+	 * The cast alone does not make the forward safe. `(int)` is total, so an
+	 * absent code becomes `0` and `'2 Bad'` becomes `2`; `status_header()`
+	 * emits an invalid status line for either. A 3xx is servable and still
+	 * wrong — an error envelope under a redirect code, with no `Location`.
+	 *
+	 * @param string $label    What this response carries.
+	 * @param mixed  $upstream The status code the transport reports.
+	 * @dataProvider provide_preflight_statuses_that_are_not_failures
+	 */
+	#[DataProvider( 'provide_preflight_statuses_that_are_not_failures' )]
+	public function test_preflight_never_forwards_a_status_it_cannot_serve( $label, $upstream ) {
+		$this->arrange_signed_wpcom( '{}', $upstream );
+
+		$data = REST_Controller::get_site_backup_preflight()->get_error_data();
+
+		$this->assertSame( 500, $data['status'], $label );
+	}
+
+	/**
+	 * Statuses the preflight route must not forward as its own.
+	 *
+	 * @return array
+	 */
+	public static function provide_preflight_statuses_that_are_not_failures() {
+		return array(
+			'a 3xx'                    => array( 'a 3xx', 302 ),
+			'a status with a suffix'   => array( 'a status with a suffix', '2 Bad' ),
+			'no status at all'         => array( 'no status at all', '' ),
+			'a status above the range' => array( 'a status above the range', 600 ),
+		);
+	}
+
+	/**
+	 * The undo-event route reads a success code reported as a string.
+	 *
+	 * Uncast, a `'200'` discarded a perfectly good activity page and the
+	 * route answered `null` — which it also answers when the site genuinely
+	 * has nothing to undo, so the caller cannot tell the two apart.
+	 *
+	 * The fixture needs two rewindable events: the first that is not itself a
+	 * backup becomes `last_rewindable_event`, and the next one after it
+	 * supplies the `rewind_id` to undo to. With only one, the route returns
+	 * `null` for a reason that has nothing to do with the status.
+	 */
+	public function test_undo_event_treats_a_string_status_as_its_number() {
+		$this->arrange_signed_wpcom(
+			'{"current":{"orderedItems":['
+				. '{"name":"plugin__updated","is_rewindable":true,"rewind_id":"1786663613.94"},'
+				. '{"name":"rewind__backup_complete_full","is_rewindable":true,"rewind_id":"1786600000.11"}'
+				. ']}}',
+			'200'
+		);
+
+		$response = REST_Controller::get_site_backup_undo_event();
+
+		$this->assertNotNull( $response );
+		$data = $response->get_data();
+		$this->assertSame( 'plugin__updated', $data['last_rewindable_event']['name'] );
+		$this->assertSame( '1786600000.11', $data['undo_backup_id'] );
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
@@ -140,11 +140,6 @@ class Rest_Activity_Log_Bridge_Test extends TestCase {
 	 * A non-200 becomes the bridge's error, carrying the status and the
 	 * reason WordPress.com gave.
 	 *
-	 * This route had no non-200 coverage at all, which mattered more than
-	 * it looks: it is one of the four callers that compares
-	 * `200 !== $status_code` without casting, so it is a route where a
-	 * mis-clamped status would reach the client unnoticed.
-	 *
 	 * 403 rather than 500, because 500 is also the fallback for a status
 	 * outside the failure range — a test written against it would pass
 	 * whether or not the status was forwarded.
@@ -168,22 +163,30 @@ class Rest_Activity_Log_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * A success code reported as a string is never served as one.
+	 * A success code reported as a string is a success.
 	 *
-	 * This route compares `200 !== $status_code` uncast, so a transport
-	 * that reports statuses as strings sends a perfectly good response
-	 * down the failure branch. What must not then happen is the 200
-	 * travelling on as the error's own status: WordPress would serve the
-	 * error envelope as HTTP 200 and the client would read a failure as a
-	 * success.
+	 * `wp_remote_retrieve_response_code()` hands back whatever the
+	 * transport put there, so an uncast `200 !== $status_code` sent a
+	 * perfectly good activity log down the failure branch — and the reader
+	 * got "We couldn't load your site's activity." over a response that had
+	 * arrived intact.
+	 *
+	 * The forwarded payload is what is asserted, not the absence of an
+	 * error. The uncast behaviour reported these as a 500 rather than as a
+	 * 200, so a test that only checked the status would have been satisfied
+	 * by the bug it exists to catch.
 	 */
-	public function test_never_serves_a_string_200_as_a_success() {
-		$this->arrange_wpcom_raw( '{"current":{"orderedItems":[]}}', '200' );
+	public function test_treats_a_string_status_as_its_number() {
+		$this->arrange_wpcom_raw(
+			'{"current":{"orderedItems":[{"activity_id":"foo"}]},"totalItems":1}',
+			'200'
+		);
 
 		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/site/rewindable-activity' );
 		$response = Activity_Log_Bridge::get_activity_log( $request );
 
-		$this->assertInstanceOf( WP_Error::class, $response );
-		$this->assertSame( 500, $response->get_error_data()['status'] );
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 1, $response->get_data()['totalItems'] );
+		$this->assertSame( 'foo', $response->get_data()['current']['orderedItems'][0]['activity_id'] );
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
@@ -566,8 +566,10 @@ class Rest_Bridge_Gating_Test extends TestCase {
 	public static function provide_statuses_that_are_not_failures() {
 		return array(
 			// The one that matters: what an un-cast caller would route
-			// into the failure branch on a perfectly good response. Each
-			// bridge has its own test that it does not.
+			// into the failure branch on a perfectly good response. Every
+			// status comparison in the package has its own test that it
+			// does not — the bridges here, the legacy routes in
+			// `Jetpack_Backup_Test` and `REST_Controller_Test`.
 			'a 200 reported as a string' => array( 'a 200 reported as a string', '200' ),
 			'a 204 reported as a string' => array( 'a 204 reported as a string', '204' ),
 			'a real 200'                 => array( 'a real 200', 200 ),

--- a/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
@@ -531,13 +531,13 @@ class Rest_Bridge_Gating_Test extends TestCase {
 	 *
 	 * The most dangerous input this function takes, and the reason the
 	 * status is clamped to the failure range rather than tested for
-	 * truthiness. Four of the callers compare `200 !== $status_code`
-	 * without casting, so a numeric-string `'200'` fails that comparison
-	 * and lands here — carrying a success code into a failure. Forwarded,
-	 * it would make WordPress serve the error envelope as HTTP 200:
-	 * `apiFetch` resolves, `apiCall()` never throws, `isAmbiguousFailure()`
-	 * never runs, and the restore mutation's `onSuccess` reports a restore
-	 * that never started.
+	 * truthiness. Every bridge now casts before comparing, so nothing
+	 * should reach here with a success code — this pins what happens if
+	 * one ever stops, which is the cheap half of a bargain whose expensive
+	 * half is silent. Forwarded, a 200 would make WordPress serve the error
+	 * envelope as HTTP 200: `apiFetch` resolves, `apiCall()` never throws,
+	 * `isAmbiguousFailure()` never runs, and the restore mutation's
+	 * `onSuccess` reports a restore that never started.
 	 *
 	 * The junk cases ride along because `(int)` is total — `'2 Bad'` is 2
 	 * and `true` is 1 — and a low status is no more servable than a zero.
@@ -565,8 +565,9 @@ class Rest_Bridge_Gating_Test extends TestCase {
 	 */
 	public static function provide_statuses_that_are_not_failures() {
 		return array(
-			// The one that matters: this is what an un-cast caller routes
-			// into the failure branch on a perfectly good response.
+			// The one that matters: what an un-cast caller would route
+			// into the failure branch on a perfectly good response. Each
+			// bridge has its own test that it does not.
 			'a 200 reported as a string' => array( 'a 200 reported as a string', '200' ),
 			'a 204 reported as a string' => array( 'a 204 reported as a string', '204' ),
 			'a real 200'                 => array( 'a real 200', 200 ),

--- a/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
@@ -318,6 +318,49 @@ class Rest_Download_Bridge_Test extends TestCase {
 	}
 
 	/**
+	 * A success code reported as a string still queues the archive.
+	 *
+	 * `wp_remote_retrieve_response_code()` hands back whatever the
+	 * transport put there, so an uncast `200 !== $status_code` sent an
+	 * accepted download into the failure branch — and the reader was told
+	 * their archive could not be started while WordPress.com was building
+	 * it.
+	 *
+	 * The download id is what is asserted, not the absence of an error:
+	 * uncast, this came back as a 500, so a status-only test would have
+	 * passed on the bug.
+	 */
+	public function test_initiate_treats_a_string_status_as_its_number() {
+		$this->arrange_wpcom_raw( '{"downloadId":4321}', '200' );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$response = Download_Bridge::initiate_download( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame( array( 'id' => 4321 ), $response->get_data() );
+	}
+
+	/**
+	 * The same on the poll: a string 200 reports the finished archive.
+	 */
+	public function test_status_treats_a_string_status_as_its_number() {
+		$this->arrange_wpcom_raw(
+			'{"downloadId":55,"url":"https://example.com/archive.zip","validUntil":"2026-08-20T00:00:00+00:00"}',
+			'200'
+		);
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/backups/download/123/status' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'download_id', 55 );
+		$response = Download_Bridge::get_download_status( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'finished', $response->get_data()['status'] );
+		$this->assertSame( 'https://example.com/archive.zip', $response->get_data()['url'] );
+	}
+
+	/**
 	 * A 200 with no `downloadId` is a failure, not a queued download.
 	 */
 	public function test_initiate_reports_a_missing_download_id() {

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -19,8 +19,10 @@ use WP_REST_Server;
 use function add_action;
 use function add_filter;
 use function do_action;
+use function home_url;
 use function remove_filter;
 use function wp_insert_user;
+use function wp_json_encode;
 use function wp_set_current_user;
 
 require_once __DIR__ . '/trait-wpcom-request-mock.php';
@@ -199,6 +201,61 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 		$this->assertSame( 412, $data['status'] );
 		$this->assertSame( 'no_connected_jetpack', $data['wpcom']['code'] );
 		$this->assertSame( 'This site is not connected.', $data['wpcom']['message'] );
+	}
+
+	/**
+	 * A success code reported as a string lists the directory.
+	 *
+	 * `wp_remote_retrieve_response_code()` hands back whatever the
+	 * transport put there, so an uncast `200 !== $status_code` sent a
+	 * perfectly good listing down the failure branch and left the file
+	 * tree empty with an error over it.
+	 *
+	 * Through `forward_response()`, which `get_path_info()` shares — so
+	 * this covers the cast on both pass-through routes. The listing itself
+	 * is what is asserted, not the absence of an error: uncast, this came
+	 * back as a 500, so a status-only test would have passed on the bug.
+	 */
+	public function test_list_directory_treats_a_string_status_as_its_number() {
+		$this->arrange_wpcom_raw( '{"contents":[{"name":"wp-config.php","type":"file"}]}', '200' );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/backups/123/ls' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'path', '/' );
+		$response = File_Browser_Bridge::list_directory( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'wp-config.php', $response->get_data()['contents'][0]['name'] );
+	}
+
+	/**
+	 * A string 200 on either leg of the preview still returns the file.
+	 *
+	 * This callback reads a status twice — once for the signed-URL lookup
+	 * and once for the stream fetch — and the single canned answer here
+	 * serves both, so one test covers both casts. The stream leg is the
+	 * one where getting this wrong cost most: the branch it wrongly took
+	 * already had the previewed file's bytes in hand and threw them away
+	 * to report a 500.
+	 *
+	 * The signed URL is built from `home_url()` so that
+	 * `wp_http_validate_url()` takes its same-host path. Any other host
+	 * would send it to `gethostbyname()`, and this test would then pass or
+	 * fail on whether the runner has DNS.
+	 */
+	public function test_file_content_treats_a_string_status_as_its_number() {
+		$body = wp_json_encode( array( 'url' => home_url( '/signed-stream' ) ), JSON_UNESCAPED_SLASHES );
+		$this->arrange_wpcom_raw( $body, '200' );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/backup/file-content' );
+		$request->set_param( 'file_period', '1748888135' );
+		$request->set_param( 'encoded_manifest_path', 'ZjU6L3dwLWNvbmZpZy5waHA=' );
+		$response = File_Browser_Bridge::get_file_content( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		// The stream leg is answered by the same filter, so the "file"
+		// here is that canned body, forwarded verbatim.
+		$this->assertSame( $body, $response->get_data()['content'] );
 	}
 
 	/**

--- a/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
@@ -480,6 +480,75 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	}
 
 	/**
+	 * A success code reported as a string starts the restore.
+	 *
+	 * `wp_remote_retrieve_response_code()` hands back whatever the
+	 * transport put there, so an uncast `200 !== $status_code` routed an
+	 * accepted restore into the failure branch. This is the worst route in
+	 * the package to get that wrong on: the restore is running, the reader
+	 * is told it failed, and the obvious next move is to start a second
+	 * one.
+	 *
+	 * The queued restore's own id is what is asserted, not the absence of
+	 * an error — uncast, this response came back as a 500, so a test that
+	 * only read the status would have passed on the bug.
+	 */
+	public function test_initiate_treats_a_string_status_as_its_number() {
+		$this->arrange_wpcom_raw(
+			'{"ok":true,"restore_id":42,"rewind_id":"1786663613.9425"}',
+			'200'
+		);
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/to/1786663613.9425' );
+		$request->set_param( 'rewind_id', '1786663613.9425' );
+		$request->set_param( 'types', array( 'themes' => true ) );
+		$response = Restore_Bridge::initiate_restore( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 42, $response->get_data()['id'] );
+		$this->assertSame( '1786663613.9425', $response->get_data()['rewind_id'] );
+	}
+
+	/**
+	 * The same on the poll: a string 200 reports the restore's progress.
+	 */
+	public function test_status_treats_a_string_status_as_its_number() {
+		$this->arrange_wpcom_raw(
+			'{"restore_id":7,"status":"running","percent":42}',
+			'200'
+		);
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/7/status' );
+		$request->set_param( 'restore_id', 7 );
+		$response = Restore_Bridge::get_restore_status( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'running', $response->get_data()['status'] );
+		$this->assertSame( 42.0, $response->get_data()['progress'] );
+	}
+
+	/**
+	 * A 404 reported as a string is still the queued carve-out.
+	 *
+	 * Both branches of this callback read the same variable, so the cast
+	 * buys more here than the success test above shows: uncast, `'404'`
+	 * missed the carve-out *and* the success test, and the ordinary
+	 * opening seconds of every restore — before the id is visible to this
+	 * route — surfaced as a failure.
+	 */
+	public function test_status_treats_a_string_404_as_queued() {
+		$this->arrange_wpcom_raw( '{"error":"not_found"}', '404' );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/7/status' );
+		$request->set_param( 'restore_id', 7 );
+		$response = Restore_Bridge::get_restore_status( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'queued', $response->get_data()['status'] );
+		$this->assertSame( 7, $response->get_data()['id'] );
+	}
+
+	/**
 	 * A 5xx is still a hard error — that is the half of the old behaviour
 	 * worth keeping.
 	 */

--- a/projects/packages/backup/tests/php/mock-wp-build-render-page.php
+++ b/projects/packages/backup/tests/php/mock-wp-build-render-page.php
@@ -1,12 +1,40 @@
 <?php
 /**
- * Stand-in for the render callback the wp-build dashboard generates. `build/build.php`
- * is never generated in a unit test run, so the menu tests could not otherwise reach
- * the modernized branch of `Jetpack_Backup::add_wp_admin_submenu()`.
+ * Makes `jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page()` exist
+ * before the menu tests run, so they can reach the modernized branch of
+ * `Jetpack_Backup::add_wp_admin_submenu()` — which picks that callback only if
+ * `function_exists()` says so.
+ *
+ * Two ways to get there, because the package has two states and the tests have
+ * to pass in both.
+ *
+ * On a checkout that has never been built there is no generated file, so a
+ * stub is declared here and `Jetpack_Backup::load_wp_build()` finds no
+ * `build/build.php` to load.
+ *
+ * On a checkout that *has* been built — every developer's normal state after
+ * `jp build packages/backup`, and the reason this file used to make the suite
+ * fatal — the generated page is loaded instead of being faked. A stub cannot
+ * coexist with it: `Admin_Modernization_Gating_Test` exercises
+ * `maybe_load_wp_build()`, which requires `build/build.php`, whose `pages.php`
+ * requires this same generated file, which declares the function unguarded.
+ * Mock first, real file second, "Cannot redeclare" fatal. Loading it here
+ * under the path `pages.php` will use means `require_once` treats the two as
+ * one file and the second load is a no-op.
+ *
+ * Reaching into `build/` from a test is not lovely, but the alternative is a
+ * suite that only passes on a clean checkout. `wp-build` is an external
+ * binary, so the generated file is not ours to add a guard to.
  *
  * @package automattic/jetpack-backup-plugin
  */
 
-if ( ! function_exists( 'jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page' ) ) {
+$jetpack_backup_generated_page = dirname( __DIR__, 2 ) . '/build/pages/jetpack-backup-dashboard/page-wp-admin.php';
+
+if ( file_exists( $jetpack_backup_generated_page ) ) {
+	require_once $jetpack_backup_generated_page;
+} elseif ( ! function_exists( 'jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page' ) ) {
 	function jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page() {}
 }
+
+unset( $jetpack_backup_generated_page );

--- a/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
+++ b/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Backup\V0005\REST;
 use WP_Error;
 use function add_filter;
 use function get_current_user_id;
+use function get_status_header_desc;
 use function remove_all_filters;
 use function remove_filter;
 use function wp_insert_user;
@@ -98,7 +99,7 @@ trait Wpcom_Request_Mock {
 				$this->captured_urls[] = $url;
 				$this->captured_body   = isset( $args['body'] ) ? json_decode( $args['body'], true ) : null;
 				return array(
-					'response' => array( 'code' => $status ),
+					'response' => self::mock_response_headers( $status ),
 					'body'     => wp_json_encode( $body, JSON_UNESCAPED_SLASHES ),
 				);
 			},
@@ -138,7 +139,7 @@ trait Wpcom_Request_Mock {
 				// reaching the network.
 				$this->captured_body = isset( $args['body'] ) ? json_decode( $args['body'], true ) : null;
 				return array(
-					'response' => array( 'code' => $status ),
+					'response' => self::mock_response_headers( $status ),
 					'body'     => $body,
 				);
 			},
@@ -168,6 +169,28 @@ trait Wpcom_Request_Mock {
 					'cURL error 28: Operation timed out after 10001 milliseconds with 0 bytes received'
 				);
 			}
+		);
+	}
+
+	/**
+	 * The `response` half of a faked `wp_remote_*` return value.
+	 *
+	 * The reason phrase is here because a real response always carries one,
+	 * and `wp_remote_retrieve_response_message()` reads it without checking:
+	 * a fixture that omits it makes any code path calling that helper emit
+	 * an "Undefined array key" warning that belongs to the fixture rather
+	 * than to the code under test. `get_status_header_desc()` is what core
+	 * itself would have put there, and answers `''` for a status it does not
+	 * recognise — including the deliberately malformed ones these tests
+	 * feed in.
+	 *
+	 * @param int|string $status HTTP status WordPress.com should answer with.
+	 * @return array<string, mixed>
+	 */
+	private static function mock_response_headers( $status ) {
+		return array(
+			'code'    => $status,
+			'message' => get_status_header_desc( (int) $status ),
 		);
 	}
 

--- a/projects/packages/backup/tests/storage-meter.test.tsx
+++ b/projects/packages/backup/tests/storage-meter.test.tsx
@@ -36,11 +36,45 @@ function renderWithClient( ui: ReactNode ) {
 }
 
 /**
+ * A 200 whose body `/size` or `/policies` could not read.
+ *
+ * One of two failure shapes these routes have, and the quiet one:
+ * `json_decode` gives `null`, the route forwards that bare `null`, and
+ * WordPress serves it as HTTP 200 — so `apiFetch` resolves, React Query
+ * records a success, and the only evidence anything went wrong is the
+ * shape of the data.
+ *
+ * The other shape is a non-200 from WordPress.com, which #51625 turned
+ * into a `WP_Error`; the REST layer serves that with a real status, so
+ * `apiFetch` rejects and `apiCall()` throws. Before that PR both failures
+ * arrived as this one, which is why the tests below used to model only
+ * this half. `mockFailedRead()` arranges the other.
+ */
+const Undecodable = null;
+
+/**
+ * The rejection a failed read now produces.
+ *
+ * A plain object rather than an `Error`, because that is what `apiFetch`
+ * itself rejects with — the parsed error envelope — and `apiCall()` reads
+ * `code`, `message` and `data` off it.
+ *
+ * @return A rejected promise shaped like `apiFetch`'s.
+ */
+function bridgeFailure(): Promise< never > {
+	return Promise.reject( {
+		code: 'failed_to_fetch_data',
+		message: 'Unable to fetch the requested data.',
+		data: { status: 500 },
+	} );
+}
+
+/**
  * Answer the two routes the meter reads.
  *
- * Both default to a healthy site well under its limit. `null` for either
- * response stands for the bridges' failure shape — a bare `null` body
- * served as HTTP 200.
+ * Both default to a healthy site well under its limit. `Undecodable` for
+ * either response stands for the 200-with-an-unreadable-body case above;
+ * `mockFailedRead()` is how the rejecting one is arranged.
  *
  * @param options          - Overrides.
  * @param options.size     - What `/site/backup/size` returns.
@@ -71,6 +105,48 @@ function mockEndpoints( {
 		}
 		return Promise.resolve( {} );
 	} );
+}
+
+/**
+ * Answer one of the two routes with a bridge failure, the other normally.
+ *
+ * @param failing - Path fragment of the route that should reject.
+ */
+function mockFailedRead( failing: '/site/backup/size' | '/site/backup/policies' ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( failing ) ) {
+			return bridgeFailure();
+		}
+		if ( path.includes( '/site/backup/policies' ) ) {
+			return Promise.resolve( { policies: { storage_limit_bytes: 100 * GB } } );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, size: 10 * GB } );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+/**
+ * Wait until neither read is in flight any more.
+ *
+ * Every "stays silent" test below is a claim about what the section does
+ * once it has both answers, and `waitFor( mockApiFetch ).toHaveBeenCalled()`
+ * does not get there: it is already true on the first render, before either
+ * promise has resolved, while the `aria-hidden` skeleton is still up. An
+ * assertion of absence made at that point passes against the skeleton, and
+ * would pass against a broken gate just as happily.
+ *
+ * The skeleton's own class is the handle because it is `aria-hidden` by
+ * design — there is nothing worth announcing yet — so no role or label
+ * reaches it. Same escape hatch as `barModifiers()`.
+ */
+async function settled() {
+	await waitFor( () =>
+		// eslint-disable-next-line testing-library/no-node-access -- see above.
+		expect( document.querySelector( '.jpb-storage-meter__placeholder' ) ).toBeNull()
+	);
 }
 
 /**
@@ -131,21 +207,58 @@ describe( 'the render gate', () => {
 		release( { ok: true, size: 10 * GB, policies: { storage_limit_bytes: 100 * GB } } );
 	} );
 
-	it( 'stays silent when the policies read fails, rather than drawing an empty bar', async () => {
-		// The dangerous case. `/policies` answering a non-200 arrives as a
-		// bare `null` with HTTP 200, so nothing rejects and nothing here
-		// gets to see an error — only the missing limit says so.
-		mockEndpoints( { policies: null } );
+	it( 'stays silent when the policies body cannot be read, rather than drawing an empty bar', async () => {
+		// The quiet case. `/policies` answering 200 with something it
+		// cannot decode forwards a bare `null`, so nothing rejects and
+		// nothing here gets to see an error — only the missing limit says
+		// so, and a bar drawn against a missing limit would read as an
+		// empty one over a site that may be full.
+		mockEndpoints( { policies: Undecodable } );
 		renderWithClient( <StorageSpace /> );
-		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
+		await settled();
+		expect( screen.queryByText( 'Cloud storage space' ) ).not.toBeInTheDocument();
+		expect( meterValue() ).toBeNull();
+	} );
+
+	it( 'stays silent when the size body cannot be read', async () => {
+		// The other half of the same shape. `/size` carries the numerator,
+		// so an unreadable body there has to collapse to null rather than
+		// to a zero — which would draw an empty bar and say the site has
+		// used none of its storage.
+		mockEndpoints( { size: Undecodable } );
+		renderWithClient( <StorageSpace /> );
+		await settled();
+		expect( screen.queryByText( 'Cloud storage space' ) ).not.toBeInTheDocument();
+		expect( meterValue() ).toBeNull();
+	} );
+
+	it( 'stays silent when the policies read fails outright', async () => {
+		// The shape #51625 introduced: a non-200 from WordPress.com is a
+		// `WP_Error` now, so this one rejects rather than resolving `null`.
+		// The section has to reach the same silence down a path where
+		// React Query records an error and hands back no data at all —
+		// including staying out of the loading placeholder, which would
+		// otherwise reserve height for a bar that is never coming.
+		mockFailedRead( '/site/backup/policies' );
+		renderWithClient( <StorageSpace /> );
+		await settled();
+		expect( screen.queryByText( 'Cloud storage space' ) ).not.toBeInTheDocument();
+		expect( meterValue() ).toBeNull();
+	} );
+
+	it( 'stays silent when the size read fails outright', async () => {
+		mockFailedRead( '/site/backup/size' );
+		renderWithClient( <StorageSpace /> );
+		await settled();
 		expect( screen.queryByText( 'Cloud storage space' ) ).not.toBeInTheDocument();
 		expect( meterValue() ).toBeNull();
 	} );
 
 	it( 'stays silent for a site whose plan carries no retention policy', async () => {
-		// `{ policies: null }` inside a 200 is a different thing from a
-		// failed read, and produces the same silence for a different
-		// reason: there is no limit to measure against.
+		// `{ policies: null }` inside a 200 is a different thing again from
+		// either failure above — the read worked, and this is the answer —
+		// and it produces the same silence for a third reason: there is no
+		// limit to measure against.
 		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
 			const path = options?.path ?? '';
 			if ( path.includes( '/site/backup/policies' ) ) {
@@ -154,14 +267,14 @@ describe( 'the render gate', () => {
 			return Promise.resolve( { ok: true, size: 10 * GB } );
 		} );
 		renderWithClient( <StorageSpace /> );
-		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
+		await settled();
 		expect( screen.queryByText( 'Cloud storage space' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'stays silent on a zero limit rather than reading it as 100% full', async () => {
 		mockEndpoints( { policies: { storage_limit_bytes: 0 } } );
 		renderWithClient( <StorageSpace /> );
-		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
+		await settled();
 		expect( screen.queryByText( 'Cloud storage full' ) ).not.toBeInTheDocument();
 		expect( meterValue() ).toBeNull();
 	} );
@@ -171,7 +284,7 @@ describe( 'the render gate', () => {
 		// zero must not be read as "you have used none of your storage".
 		mockEndpoints( { size: { ok: false, size: 0 } } );
 		renderWithClient( <StorageSpace /> );
-		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
+		await settled();
 		expect( meterValue() ).toBeNull();
 	} );
 } );

--- a/projects/packages/backup/tests/storage-usage-details.test.tsx
+++ b/projects/packages/backup/tests/storage-usage-details.test.tsx
@@ -16,6 +16,7 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 // Imports must come after the jest.mock factory above.
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
+import { resetLocaleData, setLocaleData } from '@wordpress/i18n';
 import StorageSpace from '../src/dashboard/components/storage-space';
 import type { ReactNode } from 'react';
 
@@ -138,6 +139,53 @@ describe( 'the usage reading', () => {
 		mockEndpoints( { size: { size: 5 * GB }, policies: { storage_limit_bytes: 10 * GB } } );
 		renderWithClient( <StorageSpace /> );
 		await expect( usageLine() ).resolves.toHaveTextContent( /^Using 5\.0GB of 10GB$/ );
+	} );
+} );
+
+describe( 'the usage reading, translated', () => {
+	// The English source cannot tell you whether the msgid's placeholders
+	// are positional. Nothing moves, so `%1.1f`/`%2f` — which
+	// `@tannin/sprintf` reads as widths and fills in the order they appear
+	// — renders exactly like `%1$.1f`/`%2$f` at every value. The two only
+	// part company under a translation that reorders them, which is the
+	// natural phrasing in plenty of languages and is what this covers: it
+	// is the only assertion in the suite that fails if the `$` are ever
+	// dropped again.
+	afterEach( () => {
+		// Wipes every domain, which is what this function does — nothing
+		// in this file depends on loaded translations, so that is the
+		// cheapest way back to a clean slate.
+		resetLocaleData();
+	} );
+
+	it( 'keeps used and total the right way round when a translation fronts the total', async () => {
+		setLocaleData(
+			{
+				'Using <strong>%1$.1fGB</strong> of %2$fGB': [
+					'Of %2$fGB, using <strong>%1$.1fGB</strong>',
+				],
+				// The pre-fix spelling, carried here on purpose. Without
+				// it, reverting the msgid fails this test with "unable to
+				// find /^Of/" — a translation that no longer matches any
+				// key — which reads as a stale fixture and invites someone
+				// to update the key and bless the bug back in. With it, the
+				// failure is the transposed figures themselves, which is
+				// the thing actually worth seeing.
+				'Using <strong>%1.1fGB</strong> of %2fGB': [ 'Of %2fGB, using <strong>%1.1fGB</strong>' ],
+			},
+			'jetpack-backup-pkg'
+		);
+		mockEndpoints( { size: { size: 12.4 * GB }, policies: { storage_limit_bytes: 20 * GB } } );
+		renderWithClient( <StorageSpace /> );
+
+		// Sequential placeholders would read this as "Of 12.4GB, using
+		// 20.0GB" — the site's 20GB plan reported as its usage, and 12.4GB
+		// of usage reported as the plan. On the screen whose job is to say
+		// whether backups are at risk, that tells a reader with room to
+		// spare that they are over quota.
+		await expect( screen.findByText( /^Of/ ) ).resolves.toHaveTextContent(
+			/^Of 20GB, using 12\.4GB$/
+		);
 	} );
 } );
 

--- a/projects/plugins/backup/changelog/fix-backup-storage-reading-placeholders
+++ b/projects/plugins/backup/changelog/fix-backup-storage-reading-placeholders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show storage usage and the plan limit the right way round in translated languages.

--- a/projects/plugins/backup/changelog/fix-backup-storage-reading-placeholders
+++ b/projects/plugins/backup/changelog/fix-backup-storage-reading-placeholders
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Show storage usage and the plan limit the right way round in translated languages.
+Show storage usage and the plan limit the right way round when the interface is translated.

--- a/projects/plugins/jetpack/changelog/fix-backup-storage-reading-placeholders
+++ b/projects/plugins/jetpack/changelog/fix-backup-storage-reading-placeholders
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Backup: show storage usage and the plan limit the right way round in translated languages.
+Backup: show storage usage and the plan limit the right way round when the interface is translated.

--- a/projects/plugins/jetpack/changelog/fix-backup-storage-reading-placeholders
+++ b/projects/plugins/jetpack/changelog/fix-backup-storage-reading-placeholders
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Backup: show storage usage and the plan limit the right way round in translated languages.


### PR DESCRIPTION
## Proposed changes

Three review follow-ups in `projects/packages/backup`, plus one test-infrastructure fix, one commit each. The first three came out of review of #51625, #51626 and #51627 after those had merged — each was a correct observation about code the PR touched but not about the change it was making, so splitting them out kept those reviews on the change under discussion. Nothing connects them beyond the package they live in; they can be read commit by commit.

### 1. Every status comparison in the package now casts

`wp_remote_retrieve_response_code()` returns whatever the transport put in the response. Core's own transports cast it (`class-wp-http.php:786`), but a `pre_http_request` filter — which caching, mocking and proxy plugins install — returns whatever it likes, and core itself returns `'code' => false` for a non-blocking request. So a numeric-string `'200'` fails `200 !== $status_code` and sends a perfectly good response down the failure branch.

`Capabilities_Bridge` already cast and carried a comment saying why. Twelve other comparisons did not: eight in the four modernized bridges, and four on the package's always-registered legacy surface.

**The bridges** (flag-gated, so not reachable today). `Rest_Controller::upstream_error()` clamps anything outside 4xx/5xx to 500, so the failure was wrong but at least *visible*. What the missing cast cost was the outcomes: an accepted restore reported as a failure — and the obvious next move for the reader is to start a second one; a queued download reported as unstartable; a file preview whose bytes were already in hand thrown away to report a 500. The restore poll gains most, because its status feeds a 404 carve-out as well as the success test, so an uncast `'404'` missed the "queued, not visible yet" branch and turned the opening seconds of every restore into a user-visible error.

**The legacy surface** (unconditionally registered — this half ships today):

* `get_site_backup_preflight()` is the important one, and the only site anywhere that both compared uncast **and forwarded the status it read into `data.status`**. `WP_HTTP_Response::set_status()` runs that through `absint()`, so a `'200'` had WordPress serve the *error envelope* as HTTP 200 — `apiFetch` resolves, nothing throws. That is exactly what `upstream_error()`'s clamp exists to prevent, and this route had no clamp behind it, so it gains one. The clamp covers what the cast cannot: `(int)` is total, so an absent code becomes `0` and `'2 Bad'` becomes `2`, and `status_header()` can emit neither. Open-coded rather than borrowed from `upstream_error()`, which would also attach a `wpcom` key and change this route's response shape for callers we do not control.
* `get_rewind_state_from_wpcom()` memoizes into `has_backup_plan()`, which answers false for a `WP_Error`. A site that *does* have Backup is told for the rest of the request that it does not — and that answer backs `GET /jetpack/v4/has-backup-plan` and the standalone-license upsell.
* `list_backup_events()` returns `null`, which the abilities layer flattens into an empty list — the site reports no completed backups, which is a claim rather than an error.
* `get_site_backup_undo_event()` returns `null`, which it also returns when there is genuinely nothing to undo, so the caller cannot tell the two apart.

Coverage: one test per cast site, each pinning the **success** rather than the absence of a 500 — the uncast behaviour *was* a 500 (or a `null`, or a `false`), so a status-only assertion would have been satisfied by the bug it exists to catch. `Rest_Activity_Log_Bridge_Test::test_never_serves_a_string_200_as_a_success` was exactly that shape and is rewritten. The clamp gets three more: a genuine 403 still travels, and four statuses that are not failures all become 500.

Prose describing the uncast state as current is updated with it — the comment on the stream fetch in `get_file_content()` (which said in so many words that `200 !== $stream_status` is not type-safe), the `upstream_error()` docblock, and the test docblocks that counted the un-casting callers.

Two fixture repairs ride along: the shared `Wpcom_Request_Mock` omitted the reason phrase a real response always carries, so `wp_remote_retrieve_response_message()` emitted an "Undefined array key" warning belonging to the fixture rather than the code under test; and `get_site_backup_preflight()`'s `@return array` was never a shape it could return — both branches hand back an object — which Phan reads.

### 2. A malformed sprintf msgid, in two copies

`'Using <strong>%1.1fGB</strong> of %2fGB'` reads as though it carried argument references, but `%2f` is a *width* specifier. `@tannin/sprintf`, which is what `@wordpress/i18n` uses, annotates the width group "Min width (unsupported)", discards it, and fills what is left in the order the placeholders appear. So the English source renders correctly at every value, and the two figures transpose the moment a translation fronts the total:

```
sprintf( 'Of %2fGB, using <strong>%1.1fGB</strong>', 12.4, 20 )    → "Of 12.4GB, using 20.0GB"   ← wrong way round
sprintf( 'Of %2$fGB, using <strong>%1$.1fGB</strong>', 12.4, 20 )  → "Of 20GB, using 12.4GB"     ← positional survives
```

Fronting the total is natural phrasing in plenty of languages, and on the one screen whose job is to say whether backups are at risk it tells a reader with room to spare that they are **over quota**. The sibling terabyte msgid two lines away was already positional and already immune.

`%1$.1f`/`%2$f` renders byte-identically to the old spelling at every value checked, including a fractional limit — which `%2$d` would have truncated, so `f` rather than `d` on the second placeholder is deliberate.

Both copies change in the same commit so the msgid stays shared: `src/js/…/use-storage-usage-text.tsx` (the dashboard that ships today) and `src/dashboard/…/usage-details.tsx` (behind the modernization flag).

**This changes the msgid, so the existing translations for it are discarded and it starts a fresh GlotPress cycle.** That is the point of the change rather than a side effect: the translations being discarded are exactly the ones that could transpose the figures. Until the new msgid is translated, non-English locales see this one line in English.

Two suppressions go with it:

* legacy's `// eslint-disable-next-line @wordpress/valid-sprintf` was load-bearing — the rule reports "Mix of ordered and non-ordered placeholders" on the old string (verified by putting the old string back) — and is obsolete now that the string is ordered;
* both `@ts-expect-error`s were load-bearing too, and are now *errors* rather than merely unnecessary: the type-level format parser infers `[number, number]` from a well-formed positional string, so leaving them raises `TS2578: Unused '@ts-expect-error' directive`.

Translator comments on both copies now read `%1$.1f: numeric amount of disk space used, %2$f: numeric amount of disk space available.` — the description legacy already had, which was misleading before and is true now. The modernized copy's comment warning translators that these were *not* numbered arguments is gone.

### 3. A test fixture that simulated a path #51625 removed

`tests/storage-meter.test.tsx` built every failure as `Promise.resolve( null )` and described it as "the bridges' failure shape — a bare `null` body". #51625 made these legacy routes answer a non-200 with a `WP_Error`, so a non-200 now rejects. The resolved `null` is still reachable, but only for a 200 whose body the route could not decode — much narrower than the comments claimed.

Both shapes are real, so the file covers both now: `Undecodable` names the resolved-`null` case, `mockFailedRead()` arranges the rejecting one. The `{ policies: null }` case is left alone — a plan carrying no retention policy is a third thing again, the read having worked, and that distinction survived #51625 untouched.

**Not asked for, but found while doing it:** the "stays silent" tests were not asserting much. They waited on `mockApiFetch` having been called, which is already true on the first render while the `aria-hidden` skeleton is still up — so an assertion of *absence* made there passed against the skeleton and would have passed against a broken gate just as happily. A `settled()` helper waits for the skeleton to go instead. With it in place, defaulting the two byte figures to numbers rather than `null` fails five of these tests and relaxing the zero-limit gate fails a sixth; before it, none of them noticed either.

### 4. `jp test php packages/backup` fatals on any built checkout

Not from this branch — it fails the same way on `trunk`, and has since the wp-build dashboard landed. But it is the difference between "run the tests" and "run the tests, but delete your build first", and every developer's checkout is in the failing state after `jp build`.

`tests/php/mock-wp-build-render-page.php` declares `jetpack_backup_jetpack_backup_dashboard_wp_admin_render_page()` so the menu tests can reach the modernized branch of `add_wp_admin_submenu()`, which picks that callback only if `function_exists()` says so. But `Admin_Modernization_Gating_Test` also exercises `maybe_load_wp_build()`, which requires `build/build.php`, whose `pages.php` requires the generated `page-wp-admin.php`, which declares the same function *unguarded*. Mock first, real file second, "Cannot redeclare".

Only the mock's guard is ours to change — `wp-build` is an external npm binary, so the generated file is not in this repo. So the mock stops faking a file that is already there: when the generated page exists it is loaded, under the same path `pages.php` will use, so `require_once` treats the two as one file and the later load is a no-op. The stub is declared only when the generated file is absent. Both states now run the same 316 tests with the same 815 assertions.

### Changelog

Judgement call worth stating, because the four items land on different sides of it and the obvious shorthand ("it's all flag-gated") is not true.

**Items 3 and 4 are test-only.** Nothing to say.

**Item 1 is *not* all flag-gated** — the four legacy sites back routes and an ability that ship today, unconditionally. So it needs deciding on observability rather than on the flag, and the answer is that it is a hardening fix rather than an observed bug: core's own transports cast the response code before we ever see it, so the string-status path needs a third-party `pre_http_request` filter to arise. Real, worth fixing, but not something a site owner has seen or could self-diagnose — "Fix Backup telling you that you have no plan" would be alarming and unactionable in a plugin changelog. No entry.

**Item 2 is the user-facing one.** It touches `src/js/`, the dashboard that ships today, and is observable twice over: a translated locale that fronts the total currently shows used and total the wrong way round, and every translated locale sees this line in English until GlotPress catches up. That is a user-facing bug fix in a package, so it gets the same treatment #51625 gave its own: a real entry in `packages/backup`, plus entries in `plugins/jetpack` (prefixed `Backup:`, type `bugfix`) and `plugins/backup` (unprefixed, since the prefix would only repeat the plugin's name).

One changelog file per project, written from the user's side and about item 2 alone. The project fanout is unchanged from the first round — items 1 and 4 stay inside `packages/backup`.

## Related product discussion/links

* No Linear issue — these are review follow-ups from #51625, #51626 and #51627.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Gates, from the repo root unless noted:

```
jp build packages/backup --deps
pnpm test                        # from projects/packages/backup — 54 suites, 503 tests
pnpm run typecheck               # from projects/packages/backup
npx eslint --max-warnings=0 <changed JS/TS>   # from projects/packages/backup
jp test php packages/backup      # 316 tests, 815 assertions — and now passes with build/ present
jp phan packages/backup          # 0 issues
vendor/bin/phpcs -s <changed PHP>
```

`vendor/bin/phpcs` reports 8 pre-existing `WordPress.DB.DirectDatabaseQuery` warnings in `src/class-rest-controller.php`, on four lines this branch does not touch; they are identical on `trunk`, and CI's changed-lines filter does not report them.

Behaviour, if you would rather see it than read it:

* **Item 1, the casts:** drop the `(int)` from any of the twelve sites and exactly that site's test fails. The two casts in `get_file_content()` are covered by one test that fails if either is reverted.
* **Item 1, the clamp:** delete the `>= 400 && <= 599` ternary in `get_site_backup_preflight()` and the four out-of-range provider cases fail; flatten it to a bare `500` and the genuine-403 test fails instead.
* **Item 2, English:** the reading under the storage meter is unchanged — `Using 12.4GB of 20GB` before and after, at every value. `tests/storage-usage-details.test.tsx` and `tests/legacy-storage-usage-text.test.tsx` both assert that.
* **Item 2, translated:** each of those files renders the line under a translation that fronts the total and asserts the figures do **not** swap. Put the old msgid back in either source file and that file's test fails with `Received: Of 12.4GB, using 20.0GB` — the transposition itself. (Each fixture carries the pre-fix msgid as a second key on purpose, so the failure is the wrong numbers rather than a translation matching no key, which would read as a stale fixture and invite someone to update it and bless the bug back in.)
* **Item 3:** in `src/dashboard/hooks/use-storage-usage.ts`, change `?? null` to `?? 0` / `?? 1` on the two byte figures and five render-gate tests fail; change `storageLimit > 0` to `>= 0` and a sixth does.
* **Item 4:** restore the previous `mock-wp-build-render-page.php` with `build/` present and `jp test php packages/backup` fatals in `Admin_Modernization_Gating_Test::test_maybe_load_wp_build_hooks_the_page_when_modernized`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
