### PR TITLE
Backup: stop the dashboard's heading outline skipping h2

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-heading-outline
+++ b/projects/packages/backup/changelog/fix-backup-heading-outline
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: fix the modernized dashboard's heading outline, which jumped from the page title straight to level 3 and skipped a level on every screen. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/activity-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-detail/index.tsx
@@ -20,7 +20,7 @@ export default function ActivityDetail( { item }: Props ) {
 		<Card.Root className="jpb-activity-detail">
 			<Card.Content>
 				<Stack direction="column" gap="sm">
-					<Text variant="heading-md" render={ <h3 /> }>
+					<Text variant="heading-md" render={ <h2 /> }>
 						{ item.title }
 					</Text>
 					<Text variant="body-sm" className="jpb-text-muted">

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -78,7 +78,7 @@ export default function BackupDetail( { item }: Props ) {
 						align="center"
 					>
 						<Icon icon={ cloud } />
-						<Text variant="heading-md" render={ <h3 /> }>
+						<Text variant="heading-md" render={ <h2 /> }>
 							{ item.title }
 						</Text>
 					</Stack>

--- a/projects/packages/backup/src/dashboard/components/error-boundary/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/error-boundary/index.tsx
@@ -90,9 +90,9 @@ export default class ErrorBoundary extends Component< Props, State > {
 					 * `<Page title>` inside `<DashboardLayout>`, and this
 					 * fallback renders *instead of* that whole subtree. When
 					 * it is on screen there is no other heading on the page,
-					 * so this is the document's first one. (The gate screens
-					 * use lower levels because they render inside the layout,
-					 * with that `h1` still above them.)
+					 * so this is the document's first one. (Every other first
+					 * in-body heading is an `h2`, because they all render
+					 * inside the layout with that `h1` still above them.)
 					 */ }
 					<Text variant="heading-md" render={ <h1 /> }>
 						{ __( 'Something went wrong', 'jetpack-backup-pkg' ) }

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -204,7 +204,7 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 				justify="space-between"
 				className="jpb-file-info-card__header"
 			>
-				<Text variant="heading-sm" render={ <h4 /> }>
+				<Text variant="heading-sm" render={ <h3 /> }>
 					{ file.name }
 				</Text>
 				<Button

--- a/projects/packages/backup/src/dashboard/components/gates/capabilities-error.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/capabilities-error.tsx
@@ -28,7 +28,7 @@ export default function CapabilitiesErrorScreen( { error, onRetry, isRetrying = 
 	return (
 		<Card className="jpb-gates__card">
 			<Stack direction="column" gap="md" align="center">
-				<Text variant="heading-md" render={ <h3 /> }>
+				<Text variant="heading-md" render={ <h2 /> }>
 					{ __( "We couldn't load your backup details", 'jetpack-backup-pkg' ) }
 				</Text>
 				<Notice status="error" isDismissible={ false }>

--- a/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
@@ -37,7 +37,7 @@ export default function NoBackupPlanScreen() {
 	return (
 		<Card className="jpb-gates__card">
 			<Stack direction="column" gap="md" align="center">
-				<Text variant="heading-md" render={ <h3 /> }>
+				<Text variant="heading-md" render={ <h2 /> }>
 					{ __( "This site doesn't have an active Backup plan", 'jetpack-backup-pkg' ) }
 				</Text>
 				<Notice status="info" isDismissible={ false }>

--- a/projects/packages/backup/src/dashboard/components/gates/not-connected.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/not-connected.tsx
@@ -33,7 +33,7 @@ export default function NotConnectedScreen() {
 	return (
 		<Card className="jpb-gates__card">
 			<Stack direction="column" gap="md" align="center">
-				<Text variant="heading-md" render={ <h3 /> }>
+				<Text variant="heading-md" render={ <h2 /> }>
 					{ __( 'Connect Jetpack to get started', 'jetpack-backup-pkg' ) }
 				</Text>
 				<Text>

--- a/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
@@ -16,7 +16,7 @@ export default function SecondaryAdminScreen() {
 	return (
 		<Card className="jpb-gates__card">
 			<Stack direction="column" gap="md" align="center">
-				<Text variant="heading-md" render={ <h3 /> }>
+				<Text variant="heading-md" render={ <h2 /> }>
 					{ __( 'Link your account to view backups', 'jetpack-backup-pkg' ) }
 				</Text>
 				<Text>

--- a/projects/packages/backup/src/dashboard/components/invalid-rewind-id/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/invalid-rewind-id/index.tsx
@@ -43,7 +43,7 @@ export default function InvalidRewindId( { prefix, title, body }: Props ) {
 				</Link>
 				<Card.Root className={ `${ prefix }__card` }>
 					<Stack direction="column" gap="xs">
-						<Text variant="heading-md" render={ <h3 /> }>
+						<Text variant="heading-md" render={ <h2 /> }>
 							{ title }
 						</Text>
 						<Text variant="body-sm" className="jpb-text-muted">

--- a/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
@@ -89,7 +89,10 @@ export default function StorageSpace() {
 			 * under it — no longer applies: those cards are `h2` too, so the
 			 * three are siblings in the outline as well as on screen.
 			 */ }
-			<Text variant="heading-md" render={ <h2 id={ headingId } /> }>
+			<Text
+				variant="heading-md"
+				render={ <h2 id={ headingId } className="jpb-storage-space__heading" /> }
+			>
 				{ sectionHeading( usage.usageLevel ) }
 			</Text>
 			<StorageMeter

--- a/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
@@ -83,12 +83,13 @@ export default function StorageSpace() {
 	return (
 		<section className="jpb-storage-space" aria-labelledby={ headingId }>
 			{ /*
-			 * `h3` rather than the `h2` legacy uses, to match every other
-			 * heading in this dashboard — the backup and activity detail
-			 * cards are visual siblings of this section, not children of
-			 * it, and an `h2` here would put them under it in the outline.
+			 * `h2`, like every other first in-body heading here. The concern
+			 * that made this an `h3` — that the backup and activity detail
+			 * cards are visual siblings of this section and would end up
+			 * under it — no longer applies: those cards are `h2` too, so the
+			 * three are siblings in the outline as well as on screen.
 			 */ }
-			<Text variant="heading-md" render={ <h3 id={ headingId } /> }>
+			<Text variant="heading-md" render={ <h2 id={ headingId } /> }>
 				{ sectionHeading( usage.usageLevel ) }
 			</Text>
 			<StorageMeter

--- a/projects/packages/backup/src/dashboard/components/storage-space/style.scss
+++ b/projects/packages/backup/src/dashboard/components/storage-space/style.scss
@@ -13,8 +13,12 @@
 	// happened when the outline went `h3` to `h2` — the rule died,
 	// `@wordpress/ui`'s `:is(h1,…,h6).heading` default supplied `margin: 0`,
 	// and the 12px gap to the meter vanished while the placeholder below
-	// went on reserving it.
-	&__heading {
+	// went on reserving it. Doubled the same way `& &__bar` is below:
+	// `&__heading` alone is a single class (0,1,0) and loses to that
+	// `@wordpress/ui` rule (0,1,1); the tag selector it replaced happened to
+	// tie at 0,1,1 and win on source order. Repeating the block restores the
+	// tie without reaching for `!important`.
+	& &__heading {
 		margin-block: 0 12px;
 	}
 

--- a/projects/packages/backup/src/dashboard/components/storage-space/style.scss
+++ b/projects/packages/backup/src/dashboard/components/storage-space/style.scss
@@ -13,11 +13,15 @@
 	// happened when the outline went `h3` to `h2` — the rule died,
 	// `@wordpress/ui`'s `:is(h1,…,h6).heading` default supplied `margin: 0`,
 	// and the 12px gap to the meter vanished while the placeholder below
-	// went on reserving it. Doubled the same way `& &__bar` is below:
-	// `&__heading` alone is a single class (0,1,0) and loses to that
-	// `@wordpress/ui` rule (0,1,1); the tag selector it replaced happened to
-	// tie at 0,1,1 and win on source order. Repeating the block restores the
-	// tie without reaching for `!important`.
+	// went on reserving it. `&__heading` alone is a single class (0,1,0) and
+	// loses to that `@wordpress/ui` rule, which is (0,1,1) — `:is()` takes
+	// the specificity of its most specific argument, all type selectors here.
+	// Doubling it to `.jpb-storage-space .jpb-storage-space__heading` is
+	// (0,2,0) and wins outright: no source-order dependency, no
+	// `!important`. Same trick as `& &__bar` below. The tag selector this
+	// replaced was itself (0,1,1) — it tied and won on
+	// source order, which is why it worked and why nothing recorded that it
+	// was load-bearing.
 	& &__heading {
 		margin-block: 0 12px;
 	}

--- a/projects/packages/backup/src/dashboard/components/storage-space/style.scss
+++ b/projects/packages/backup/src/dashboard/components/storage-space/style.scss
@@ -6,10 +6,15 @@
 	inline-size: 100%;
 	margin-block-end: 24px;
 
-	// `<Text render={ <h3 /> }>` renders a real heading, which inherits
-	// wp-admin's own `h3` margins. Reset both so the gap to the bar is
-	// this file's decision.
-	h3 {
+	// `<Text render={ <hN /> }>` renders a real heading, which inherits
+	// wp-admin's own heading margins. Reset both so the gap to the bar is
+	// this file's decision. Matched by class, not by tag: a tag selector
+	// stops matching the moment the heading's level changes, which is what
+	// happened when the outline went `h3` to `h2` — the rule died,
+	// `@wordpress/ui`'s `:is(h1,…,h6).heading` default supplied `margin: 0`,
+	// and the 12px gap to the meter vanished while the placeholder below
+	// went on reserving it.
+	&__heading {
 		margin-block: 0 12px;
 	}
 

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -62,7 +62,7 @@ export default function DownloadScreen() {
 					<Stack direction="row" gap="sm" align="center">
 						<Icon icon={ cloud } />
 						<Stack direction="column" gap="xs">
-							<Text variant="heading-md" render={ <h3 /> }>
+							<Text variant="heading-md" render={ <h2 /> }>
 								{ __( 'Download backup', 'jetpack-backup-pkg' ) }
 							</Text>
 							<Text variant="body-sm" className="jpb-text-muted">

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -70,7 +70,7 @@ export default function RestoreScreen() {
 					<Stack direction="row" gap="sm" align="center">
 						<Icon icon={ backupIcon } />
 						<Stack direction="column" gap="xs">
-							<Text variant="heading-md" render={ <h3 /> }>
+							<Text variant="heading-md" render={ <h2 /> }>
 								{ __( 'Restore backup', 'jetpack-backup-pkg' ) }
 							</Text>
 							<Text variant="body-sm" className="jpb-text-muted">

--- a/projects/packages/backup/tests/file-preview-types.test.tsx
+++ b/projects/packages/backup/tests/file-preview-types.test.tsx
@@ -61,7 +61,7 @@ async function openFile( name: string ): Promise< void > {
 	);
 
 	await userEvent.click( await screen.findByRole( 'button', { name: `File: ${ name }` } ) );
-	await expect( screen.findByRole( 'heading', { name, level: 4 } ) ).resolves.toBeInTheDocument();
+	await expect( screen.findByRole( 'heading', { name, level: 3 } ) ).resolves.toBeInTheDocument();
 }
 
 beforeEach( () => {

--- a/projects/packages/backup/tests/heading-outline.test.tsx
+++ b/projects/packages/backup/tests/heading-outline.test.tsx
@@ -1,0 +1,113 @@
+// The page's `h1` comes from the `<Page>` chassis in `<DashboardLayout>`.
+// Every screen and card renders inside that, so every first in-body heading
+// is an `h2` — the outline used to jump h1 → h3, skipping a level on every
+// screen. The one exception is the error boundary, which replaces the whole
+// layout including the chassis, so its heading really is the document's
+// first.
+//
+// Asserted from the source rather than by rendering: eleven components
+// across four route bundles, each with its own mocking requirements, and
+// what is being pinned is a property of the tree as a whole rather than of
+// any one screen.
+
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+const DASHBOARD = join( __dirname, '..', 'src', 'dashboard' );
+
+/** The one component that renders instead of the chassis, not inside it. */
+const REPLACES_THE_CHASSIS = 'components/error-boundary/index.tsx';
+
+/**
+ * Components that render inside another card rather than directly under the
+ * chassis, and so legitimately start deeper than `h2`.
+ *
+ * Keyed to the parent they nest under, which is what makes "one level down"
+ * checkable rather than asserted.
+ */
+const NESTED_UNDER: Record< string, string > = {
+	'components/file-info-card/index.tsx': 'components/backup-detail/index.tsx',
+};
+
+/**
+ * Every `.tsx` under `src/dashboard`, relative to that directory.
+ *
+ * @param dir - Directory to walk.
+ * @return Relative paths, POSIX-separated.
+ */
+function tsxFiles( dir: string ): string[] {
+	return readdirSync( dir ).flatMap( entry => {
+		const full = join( dir, entry );
+		if ( statSync( full ).isDirectory() ) {
+			return tsxFiles( full );
+		}
+		return entry.endsWith( '.tsx' )
+			? [
+					full
+						.slice( DASHBOARD.length + 1 )
+						.split( '\\' )
+						.join( '/' ),
+			  ]
+			: [];
+	} );
+}
+
+/**
+ * The heading levels a file renders, in source order.
+ *
+ * Matches the `render={ <hN … /> }` form this package uses to give a
+ * `<Text>` its semantics.
+ *
+ * @param relative - Path relative to `src/dashboard`.
+ * @return The levels found, as numbers.
+ */
+function headingLevels( relative: string ): number[] {
+	const source = readFileSync( join( DASHBOARD, relative ), 'utf8' );
+	return Array.from( source.matchAll( /render=\{ <h([1-6])/g ) ).map( m => Number( m[ 1 ] ) );
+}
+
+describe( 'the dashboard heading outline', () => {
+	// The premise. If this ever finds nothing the rest passes vacuously.
+	it( 'finds headings to check', () => {
+		const withHeadings = tsxFiles( DASHBOARD ).filter( f => headingLevels( f ).length > 0 );
+
+		expect( withHeadings.length ).toBeGreaterThanOrEqual( 11 );
+	} );
+
+	it( 'starts every top-level in-layout component at h2, never h3', () => {
+		const offenders = tsxFiles( DASHBOARD )
+			.filter( f => f !== REPLACES_THE_CHASSIS && ! NESTED_UNDER[ f ] )
+			.map( f => ( { file: f, first: headingLevels( f )[ 0 ] } ) )
+			.filter( ( { first } ) => first !== undefined && first !== 2 );
+
+		expect( offenders ).toEqual( [] );
+	} );
+
+	// The error boundary is `h1` on purpose: when it renders, the chassis
+	// `h1` is gone and this is the document's only heading.
+	it( 'keeps the error boundary at h1', () => {
+		expect( headingLevels( REPLACES_THE_CHASSIS ) ).toEqual( [ 1 ] );
+	} );
+
+	// A nested card goes exactly one level deeper than the card it sits in —
+	// deeper is allowed, skipping is not.
+	it( 'puts each nested card one level under its parent', () => {
+		const wrong = Object.entries( NESTED_UNDER )
+			.map( ( [ child, parent ] ) => ( {
+				child,
+				childLevel: headingLevels( child )[ 0 ],
+				parentLevel: headingLevels( parent )[ 0 ],
+			} ) )
+			.filter( ( { childLevel, parentLevel } ) => childLevel !== parentLevel + 1 );
+
+		expect( wrong ).toEqual( [] );
+	} );
+
+	it( 'never skips a level within a single component', () => {
+		const skips = tsxFiles( DASHBOARD )
+			.map( f => ( { file: f, levels: headingLevels( f ) } ) )
+			.filter( ( { levels } ) => levels.some( ( l, i ) => i > 0 && l - levels[ i - 1 ] > 1 ) );
+
+		expect( skips ).toEqual( [] );
+	} );
+} );

--- a/projects/packages/backup/tests/heading-outline.test.tsx
+++ b/projects/packages/backup/tests/heading-outline.test.tsx
@@ -30,41 +30,20 @@ const NESTED_UNDER: Record< string, string > = {
 };
 
 /**
- * Every `.tsx` under `src/dashboard`, relative to that directory.
+ * Every file with the given extension under `src/dashboard`, relative to that
+ * directory.
  *
+ * @param ext - Extension to match, including the dot.
  * @param dir - Directory to walk.
  * @return Relative paths, POSIX-separated.
  */
-function tsxFiles( dir: string ): string[] {
+function filesWithExt( ext: string, dir: string = DASHBOARD ): string[] {
 	return readdirSync( dir ).flatMap( entry => {
 		const full = join( dir, entry );
 		if ( statSync( full ).isDirectory() ) {
-			return tsxFiles( full );
+			return filesWithExt( ext, full );
 		}
-		return entry.endsWith( '.tsx' )
-			? [
-					full
-						.slice( DASHBOARD.length + 1 )
-						.split( '\\' )
-						.join( '/' ),
-			  ]
-			: [];
-	} );
-}
-
-/**
- * Every `.scss` under `src/dashboard`, relative to that directory.
- *
- * @param dir - Directory to walk.
- * @return Relative paths, POSIX-separated.
- */
-function scssFiles( dir: string ): string[] {
-	return readdirSync( dir ).flatMap( entry => {
-		const full = join( dir, entry );
-		if ( statSync( full ).isDirectory() ) {
-			return scssFiles( full );
-		}
-		return entry.endsWith( '.scss' )
+		return entry.endsWith( ext )
 			? [
 					full
 						.slice( DASHBOARD.length + 1 )
@@ -86,19 +65,25 @@ function scssFiles( dir: string ): string[] {
  */
 function headingLevels( relative: string ): number[] {
 	const source = readFileSync( join( DASHBOARD, relative ), 'utf8' );
-	return Array.from( source.matchAll( /render=\{ <h([1-6])/g ) ).map( m => Number( m[ 1 ] ) );
+	// Both spellings. `render={ <hN /> }` is the `@wordpress/ui` idiom this
+	// package uses, but a bare `<hN>` is the obvious thing for someone
+	// unfamiliar with it to write, and matching only the first would let a
+	// thirteenth component opt out of every rule below by accident.
+	return Array.from( source.matchAll( /(?:render=\{ <|<)h([1-6])[\s/>]/g ) ).map( m =>
+		Number( m[ 1 ] )
+	);
 }
 
 describe( 'the dashboard heading outline', () => {
 	// The premise. If this ever finds nothing the rest passes vacuously.
 	it( 'finds headings to check', () => {
-		const withHeadings = tsxFiles( DASHBOARD ).filter( f => headingLevels( f ).length > 0 );
+		const withHeadings = filesWithExt( '.tsx' ).filter( f => headingLevels( f ).length > 0 );
 
 		expect( withHeadings.length ).toBeGreaterThanOrEqual( 11 );
 	} );
 
 	it( 'starts every top-level in-layout component at h2, never h3', () => {
-		const offenders = tsxFiles( DASHBOARD )
+		const offenders = filesWithExt( '.tsx' )
 			.filter( f => f !== REPLACES_THE_CHASSIS && ! NESTED_UNDER[ f ] )
 			.map( f => ( { file: f, first: headingLevels( f )[ 0 ] } ) )
 			.filter( ( { first } ) => first !== undefined && first !== 2 );
@@ -135,18 +120,18 @@ describe( 'the dashboard heading outline', () => {
 	// the built stylesheet, so no render test can catch it; reading the SCSS
 	// can.
 	it( 'never selects a heading by tag name in SCSS', () => {
-		const offenders = scssFiles( DASHBOARD ).flatMap( file =>
+		const offenders = filesWithExt( '.scss' ).flatMap( file =>
 			readFileSync( join( DASHBOARD, file ), 'utf8' )
 				.split( '\n' )
 				.map( ( line, i ) => ( { file, line: i + 1, text: line.trim() } ) )
-				.filter( ( { text } ) => /^&?\s*h[1-6]\s*(,|\{)/.test( text ) )
+				.filter( ( { text } ) => /(^|[\s>+~,])h[1-6]\s*(,|\{|$)/.test( text ) )
 		);
 
 		expect( offenders ).toEqual( [] );
 	} );
 
 	it( 'never skips a level within a single component', () => {
-		const skips = tsxFiles( DASHBOARD )
+		const skips = filesWithExt( '.tsx' )
 			.map( f => ( { file: f, levels: headingLevels( f ) } ) )
 			.filter( ( { levels } ) => levels.some( ( l, i ) => i > 0 && l - levels[ i - 1 ] > 1 ) );
 

--- a/projects/packages/backup/tests/heading-outline.test.tsx
+++ b/projects/packages/backup/tests/heading-outline.test.tsx
@@ -53,6 +53,29 @@ function tsxFiles( dir: string ): string[] {
 }
 
 /**
+ * Every `.scss` under `src/dashboard`, relative to that directory.
+ *
+ * @param dir - Directory to walk.
+ * @return Relative paths, POSIX-separated.
+ */
+function scssFiles( dir: string ): string[] {
+	return readdirSync( dir ).flatMap( entry => {
+		const full = join( dir, entry );
+		if ( statSync( full ).isDirectory() ) {
+			return scssFiles( full );
+		}
+		return entry.endsWith( '.scss' )
+			? [
+					full
+						.slice( DASHBOARD.length + 1 )
+						.split( '\\' )
+						.join( '/' ),
+			  ]
+			: [];
+	} );
+}
+
+/**
  * The heading levels a file renders, in source order.
  *
  * Matches the `render={ <hN … /> }` form this package uses to give a
@@ -101,6 +124,25 @@ describe( 'the dashboard heading outline', () => {
 			.filter( ( { childLevel, parentLevel } ) => childLevel !== parentLevel + 1 );
 
 		expect( wrong ).toEqual( [] );
+	} );
+
+	// Changing a level silently orphans any CSS that selected the old tag.
+	// That is not hypothetical: `.jpb-storage-space h3 { margin-block: 0 12px }`
+	// stopped matching when this outline was corrected, `@wordpress/ui`'s
+	// `:is(h1,…,h6).heading` default supplied `margin: 0`, and the section
+	// lost 12px of its height — while the loading placeholder went on
+	// reserving the gap, so it started jumping on load. jsdom does not apply
+	// the built stylesheet, so no render test can catch it; reading the SCSS
+	// can.
+	it( 'never selects a heading by tag name in SCSS', () => {
+		const offenders = scssFiles( DASHBOARD ).flatMap( file =>
+			readFileSync( join( DASHBOARD, file ), 'utf8' )
+				.split( '\n' )
+				.map( ( line, i ) => ( { file, line: i + 1, text: line.trim() } ) )
+				.filter( ( { text } ) => /^&?\s*h[1-6]\s*(,|\{)/.test( text ) )
+		);
+
+		expect( offenders ).toEqual( [] );
 	} );
 
 	it( 'never skips a level within a single component', () => {

--- a/projects/packages/backup/tests/storage-meter.test.tsx
+++ b/projects/packages/backup/tests/storage-meter.test.tsx
@@ -387,14 +387,15 @@ describe( 'landmarks', () => {
 		).resolves.toBeInTheDocument();
 	} );
 
-	it( 'puts the heading at level 3, level with its siblings', async () => {
-		// Deliberately not legacy's `h2`. The backup and activity detail
-		// cards are `h3` and are visual siblings of this section, so an
-		// `h2` here would read as though they were nested inside cloud
-		// storage.
+	it( 'puts the heading at level 2, level with its siblings', async () => {
+		// The page's `h1` comes from the `<Page>` chassis and this section
+		// renders inside it, so `h2` is the first in-body level. The backup
+		// and activity detail cards are `h2` as well, so the three read as
+		// siblings rather than as cards nested inside cloud storage — which
+		// is what kept this at `h3` until the outline was fixed.
 		renderWithClient( <StorageSpace /> );
 		await expect(
-			screen.findByRole( 'heading', { level: 3, name: 'Cloud storage space' } )
+			screen.findByRole( 'heading', { level: 2, name: 'Cloud storage space' } )
 		).resolves.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Fixes JETPACK-2369

## Proposed changes

* Fix the modernized dashboard's heading outline, which skipped `h2` on every screen.

`<DashboardLayout>` wraps `<Page title={ PRODUCT_NAME }>` from `@wordpress/admin-ui`, which renders the page title as `h1`. Every first in-body heading in the package was an `h3`, so the outline read **h1 → h3** everywhere and no `h2` existed anywhere in `src/dashboard/`.

### The outline this settles

Everything except the error boundary renders *inside* that layout with the chassis `h1` still above it, so all of it is a top-level section under that `h1`:

| Level | What |
| -- | -- |
| `h1` | the `<Page>` title — unchanged |
| `h2` | both route screens (`restore`, `download`), `invalid-rewind-id`, the four `gates/*`, `storage-space`, and the `backup-detail` / `activity-detail` cards — **10 files, h3 → h2** |
| `h3` | `file-info-card`, which nests inside the detail pane's file browser — **h4 → h3** |

The **error boundary stays `h1`**, and its own comment already explained why: it renders instead of the layout rather than inside it, so when it is on screen the chassis heading is gone and its heading really is the document's first.

### Two comments argued for the old levels

Both corrected rather than left to contradict the code:

* `storage-space/index.tsx` reasoned that an `h2` there would put the backup and activity detail cards *under* cloud storage in the outline. That was true when those cards were `h3`. They are `h2` now, so the three are siblings in the outline as well as on screen.
* `error-boundary/index.tsx` said the gates "use lower levels". Now specifically `h2`, so it says that.

### Nothing changes visually — but getting there took two attempts

`Text variant` sets the size; `render={ <hN /> }` sets the semantics, so every heading keeps its existing size. **That is true of the current head and was not true of either earlier one.** Both failures were caught by live before/after capture, not by the test suite, and both were the same trap.

**`storage-space/style.scss` styled the heading by tag:**

```scss
.jpb-storage-space { h3 { margin-block: 0 12px; } }   /* 0,1,1 */
```

`@wordpress/ui` ships an unlayered `:is(h1,…,h6).<hash>__heading { margin: var(--_gcd-heading-margin, 0) }`, also **0,1,1**. The two tied, and the local rule won on source order. Nothing recorded that this was load-bearing.

**Attempt 1 (`h3` → `h2`)** orphaned the selector outright. The wp-ui rule supplied `margin: 0`, the gap to the meter went 12px → 0, and the section lost 12px. `&__heading-placeholder` kept reserving the 12px, so the loading skeleton no longer matched the real heading and the section jumped on load — precisely what that placeholder exists to prevent.

**Attempt 2 swapped the tag for a class and did not fix it.** `&__heading` concatenates to a *single* class, `.jpb-storage-space__heading` — **0,1,0**. That is one class *lower* than the tag selector it replaced, so it lost to wp-ui outright rather than tying. The measurements were unchanged from attempt 1.

**The fix is `& &__heading`**, compiling to `.jpb-storage-space .jpb-storage-space__heading` — two classes, **0,2,0**, which beats wp-ui's 0,1,1 outright rather than tying. No source-order dependency and no `!important`. This is the idiom the same file already uses a few lines down, where `& &__bar` beats an emotion class with the comment *"One extra class wins it without reaching for `!important`."*

Measured on the built bundle against trunk:

| | trunk | attempts 1 & 2 | current head |
|---|---|---|---|
| `margin-block-end` | 12px | **0px** | 12px |
| gap heading → meter | 12px | **0px** | 12px |
| section height | 84px | **72px** | 84px |

Verified two independent ways on the PR build: raising the selector to 0,1,1 restores the margin, and so does deleting the wp-ui rule from the CSSOM. Full-Overview pixel diff against trunk is **1 differing pixel in 1,440,000**. The gate, restore and download screens — the gate using entirely real data, no stubs — are **0-pixel identical**.

### Why the tests did not catch this

jsdom does not apply the built stylesheet, so no render test can see a margin. The suite now carries the next best thing: **no SCSS under `src/dashboard` may select a heading by tag name**, which is the trap that started this. It would not have caught attempt 2's specificity error — that needs a real browser, which is how it was found.

## Related product discussion/links

* JETPACK-2369, split from JETPACK-2299 (F6). The other two pieces: JETPACK-2299 shipped in #51616, and JETPACK-2370 was decided — no ARIA tree.

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

Captured on a real wp-admin page at 1440x1000, DPR 1. Only the dashboard bundle differs between columns — same server, page, viewport and data.

**Every pair below should look the same.** That is the claim being evidenced, not a failed capture.

| | Before (trunk) | After (this PR) |
| --- | --- | --- |
| **Storage section**<br>the one at risk — `84px` in both | <img width="440" alt="storage section, trunk" src="https://github.com/user-attachments/assets/4b14eef4-5ac3-46eb-9e96-198210905e71" /> | <img width="440" alt="storage section, this PR" src="https://github.com/user-attachments/assets/74276679-3221-43f7-b1fc-df5683a14d93" /> |
| **Overview**<br>1 differing pixel in 1,440,000 | <img width="440" alt="Overview, trunk" src="https://github.com/user-attachments/assets/610af2d9-ca97-4d8b-bb62-f22d4389f385" /> | <img width="440" alt="Overview, this PR" src="https://github.com/user-attachments/assets/860a3d0a-537e-4cad-a6d0-b7a46f386023" /> |
| **Gate screen**<br>real data, no stubs — 0 pixels differ | <img width="440" alt="gate screen, trunk" src="https://github.com/user-attachments/assets/5cda424d-c7a9-4b84-8cf1-d156462b65b0" /> | <img width="440" alt="gate screen, this PR" src="https://github.com/user-attachments/assets/ba467616-33bb-4ac5-a894-c2f50765a714" /> |

The storage crop is the row worth looking at: it is the only surface the heading change could affect, and it is where both earlier attempts regressed to `72px`. Restore and Download were also captured and are 0-pixel identical; they are omitted here only to keep the table short.

The change these prove is invisible to a screenshot by design — it is in the accessibility tree:

```
Overview                   h1 h1 h3 h3     ->  h1 h1 h2 h2
Overview + file info card  h1 h1 h3 h3 h4  ->  h1 h1 h2 h2 h3
Gate / Restore / Download  h1 h1 h3        ->  h1 h1 h2
```

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, off by default:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

Build (`jp build packages/backup --deps`) and open **Jetpack → VaultPress Backup**.

1. Run an outline checker over the page — browser devtools' accessibility pane, or the WAVE / axe extensions. Before: `h1` followed by `h3`, flagged as a skipped level. After: `h1 → h2`, no skip.
2. Confirm nothing moved or resized — the change is semantic only.
3. Open a file in the **Files** browser: its card heading is `h3`, one level under the `h2` detail pane it sits in.
4. Visit the Restore and Download screens, and a gate screen (disconnect the site, or filter capabilities to no plan) — each starts at `h2`.

**Automated:** `jetpack test js packages/backup` — 501 tests / 54 suites.

New suite `tests/heading-outline.test.tsx` pins the rule itself rather than one screen: it walks every `.tsx` under `src/dashboard/` and asserts each top-level component starts at `h2`, the error boundary stays `h1`, each nested card sits exactly one level under its parent, and no component skips a level internally. It reads the source rather than rendering, because eleven components across four route bundles each carry their own mocking requirements and what is being pinned is a property of the tree as a whole.

It also carries a premise test — *finds headings to check* — so the suite cannot pass vacuously if the matcher ever stops matching, plus the SCSS tag-selector guard described above. Reinstating the `h3` selector fails it.

Mutation-checked:

| mutation | fails |
|---|---|
| storage heading back to `h3` | the outline rule **and** `storage-meter`'s own level assertion |
| file info card back to `h4` | the nesting rule only |

`storage-meter.test.tsx`'s `puts the heading at level 3` assertion is updated to level 2, with its comment rewritten — it was asserting the old convention deliberately, so it had to move with it.

