### PR TITLE
Forms: record welcome guide views, slides and dismissals

### DIFF
--- a/projects/packages/forms/changelog/add-forms-welcome-guide-tracks
+++ b/projects/packages/forms/changelog/add-forms-welcome-guide-tracks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Form editor: record when the welcome guide is shown, stepped through, and dismissed.

--- a/projects/packages/forms/src/form-editor/welcome-guide/analytics.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/analytics.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 
 /** Fired once each time the guide opens. */
 export const VIEW_EVENT = 'jetpack_forms_welcome_guide_view';
@@ -75,14 +75,35 @@ interface SlideTrackerProps {
  * @return Nothing; this renders no markup.
  */
 export const SlideTracker = ( { index, slideCount, origin, record }: SlideTrackerProps ) => {
+	/*
+	 * Only the slide is a reason to report. `origin` and `slideCount` are fixed
+	 * for an opening, and `record`'s identity is not something this component
+	 * should depend on — including them would re-report the same slide the
+	 * moment any of them changed, which is a duplicate event rather than a
+	 * navigation. Refs keep the values current without making them triggers.
+	 */
+	const latest = useRef( { slideCount, origin, record } );
+	latest.current = { slideCount, origin, record };
+
+	// The opening reports its own first slide, after the view event and after
+	// the analytics hook has identified the user. This reports the moves.
+	const hasSeenFirstSlide = useRef( false );
+
 	useEffect( () => {
-		record( SLIDE_VIEW_EVENT, {
+		if ( ! hasSeenFirstSlide.current ) {
+			hasSeenFirstSlide.current = true;
+			return;
+		}
+
+		const current = latest.current;
+
+		current.record( SLIDE_VIEW_EVENT, {
 			// One-based, to read naturally against `slide_count` in a report.
 			slide: index + 1,
-			slide_count: slideCount,
-			origin,
+			slide_count: current.slideCount,
+			origin: current.origin,
 		} );
-	}, [ index, origin, record, slideCount ] );
+	}, [ index ] );
 
 	return null;
 };

--- a/projects/packages/forms/src/form-editor/welcome-guide/analytics.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/analytics.tsx
@@ -1,0 +1,88 @@
+/**
+ * Welcome guide analytics
+ *
+ * The guide is onboarding, so what matters is whether the people who see it are
+ * the people it was aimed at, and how far they get before leaving. Every event
+ * carries `origin`, because "opened by itself for a newcomer" and "reopened
+ * deliberately from the Options menu" are different questions wearing the same
+ * modal.
+ */
+
+import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
+import { useCallback, useEffect } from '@wordpress/element';
+
+/** Fired once each time the guide opens. */
+export const VIEW_EVENT = 'jetpack_forms_welcome_guide_view';
+
+/** Fired for each slide the user actually lands on, including the first. */
+export const SLIDE_VIEW_EVENT = 'jetpack_forms_welcome_guide_slide_view';
+
+/** Fired when the guide closes, whichever way it was closed. */
+export const DISMISS_EVENT = 'jetpack_forms_welcome_guide_dismiss';
+
+/** Why the guide is open. */
+export type GuideOrigin = 'auto' | 'menu' | 'forced';
+
+interface TracksProps {
+	[ key: string ]: string | number | boolean;
+}
+
+interface Tracks {
+	recordEvent: ( event: string, props?: TracksProps ) => void;
+}
+
+/**
+ * Records a guide event with the properties every one of them carries.
+ *
+ * @return A recorder taking an event name and any extra properties.
+ */
+export function useGuideTracks() {
+	const { tracks } = useAnalytics() as { tracks: Tracks };
+
+	return useCallback(
+		( event: string, props: TracksProps = {} ) => {
+			tracks.recordEvent( event, props );
+		},
+		[ tracks ]
+	);
+}
+
+interface SlideTrackerProps {
+	/** Zero-based index of the slide being shown. */
+	index: number;
+	/** Total number of slides, so a drop-off can be read without knowing the guide. */
+	slideCount: number;
+	/** Why the guide is open. */
+	origin: GuideOrigin;
+	/** Records the event. */
+	record: ( event: string, props?: TracksProps ) => void;
+}
+
+/**
+ * Reports the slide currently on screen.
+ *
+ * `Guide` keeps its page number in internal state and exposes no change
+ * callback, but it renders only the current page — so a component sitting
+ * inside that page reports the slide simply by being the one that is mounted.
+ * The effect keys on `index` rather than on mount, because React reuses this
+ * element across page changes instead of remounting it.
+ *
+ * @param props            - Component props
+ * @param props.index      - Zero-based index of the slide being shown
+ * @param props.slideCount - Total number of slides
+ * @param props.origin     - Why the guide is open
+ * @param props.record     - Records the event
+ * @return Nothing; this renders no markup.
+ */
+export const SlideTracker = ( { index, slideCount, origin, record }: SlideTrackerProps ) => {
+	useEffect( () => {
+		record( SLIDE_VIEW_EVENT, {
+			// One-based, to read naturally against `slide_count` in a report.
+			slide: index + 1,
+			slide_count: slideCount,
+			origin,
+		} );
+	}, [ index, origin, record, slideCount ] );
+
+	return null;
+};

--- a/projects/packages/forms/src/form-editor/welcome-guide/index.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/index.tsx
@@ -18,6 +18,13 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { FORM_POST_TYPE } from '../../blocks/shared/util/constants.js';
+import {
+	DISMISS_EVENT,
+	SlideTracker,
+	useGuideTracks,
+	VIEW_EVENT,
+	type GuideOrigin,
+} from './analytics';
 import { getWelcomeGuidePages, WELCOME_GUIDE_IMAGES } from './pages';
 import {
 	isCoreWelcomeGuidePending,
@@ -97,7 +104,44 @@ export const FormWelcomeGuide = () => {
 	// a request is already stored; see the effect that clears it below.
 	const [ isReopened, setIsReopened ] = useState( isCoreWelcomeGuidePending );
 
+	const pages = getWelcomeGuidePages();
+
+	const record = useGuideTracks();
+
+	/*
+	 * Reopening covers both the Options menu and a request stored from a load
+	 * this bundle never saw, which are the same thing from the user's side: they
+	 * asked for it. The query argument is checked first because a forced guide
+	 * is a developer re-testing the first run, not a real audience.
+	 */
+	const origin: GuideOrigin = isForced ? 'forced' : ( isReopened && 'menu' ) || 'auto';
+
+	// The slide the user is on, so a dismissal says how far they got. Held in a
+	// ref because only the dismissal reads it, and re-rendering on every slide
+	// change would rebuild the whole guide.
+	const currentSlide = useRef( 1 );
+
+	const recordSlideView = useCallback(
+		( event: string, props: Record< string, string | number | boolean > = {} ) => {
+			if ( typeof props.slide === 'number' ) {
+				currentSlide.current = props.slide;
+			}
+
+			record( event, props );
+		},
+		[ record ]
+	);
+
+	const recordDismiss = useCallback( () => {
+		record( DISMISS_EVENT, {
+			origin,
+			slide: currentSlide.current,
+			slide_count: pages.length,
+		} );
+	}, [ origin, pages.length, record ] );
+
 	const handleFinish = useCallback( () => {
+		recordDismiss();
 		setIsReopened( false );
 		setIsClosed( true );
 
@@ -110,7 +154,7 @@ export const FormWelcomeGuide = () => {
 		if ( ! isForced && shouldPersistDismissal( preference ) ) {
 			set( PREFERENCE_SCOPE, PREFERENCE_NAME, false );
 		}
-	}, [ isForced, preference, set ] );
+	}, [ isForced, preference, recordDismiss, set ] );
 
 	const handleReopen = useCallback( () => {
 		setIsClosed( false );
@@ -120,6 +164,17 @@ export const FormWelcomeGuide = () => {
 	const isOpen =
 		isFormEditor &&
 		isWelcomeGuideOpen( { preference, isForced, isEligible, isClosed, isReopened } );
+
+	// One view per opening, not per render.
+	useEffect( () => {
+		if ( ! isOpen ) {
+			return;
+		}
+
+		currentSlide.current = 1;
+		record( VIEW_EVENT, { origin, slide_count: pages.length } );
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- Only a change in `isOpen` is a new viewing; `origin` is fixed for one.
+	}, [ isOpen ] );
 
 	/*
 	 * `Guide` mounts only the slide you are looking at, so each illustration
@@ -190,13 +245,32 @@ export const FormWelcomeGuide = () => {
 		return null;
 	}
 
+	/*
+	 * The tracker rides inside each slide's content because `Guide` renders only
+	 * the page you are on, which makes "mounted" and "on screen" the same thing.
+	 */
+	const trackedPages = pages.map( ( page, index ) => ( {
+		...page,
+		content: (
+			<>
+				<SlideTracker
+					index={ index }
+					origin={ origin }
+					record={ recordSlideView }
+					slideCount={ pages.length }
+				/>
+				{ page.content }
+			</>
+		),
+	} ) );
+
 	return (
 		<Guide
 			className="jetpack-forms-welcome-guide"
 			contentLabel={ __( 'Welcome to the form editor', 'jetpack-forms' ) }
 			finishButtonText={ __( 'Start building', 'jetpack-forms' ) }
 			onFinish={ handleFinish }
-			pages={ getWelcomeGuidePages() }
+			pages={ trackedPages }
 		/>
 	);
 };

--- a/projects/packages/forms/src/form-editor/welcome-guide/index.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/index.tsx
@@ -20,12 +20,13 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { FORM_POST_TYPE } from '../../blocks/shared/util/constants.js';
 import {
 	DISMISS_EVENT,
+	SLIDE_VIEW_EVENT,
 	SlideTracker,
 	useGuideTracks,
 	VIEW_EVENT,
 	type GuideOrigin,
 } from './analytics';
-import { getWelcomeGuidePages, WELCOME_GUIDE_IMAGES } from './pages';
+import { getWelcomeGuidePages, SLIDE_COUNT, WELCOME_GUIDE_IMAGES } from './pages';
 import {
 	isCoreWelcomeGuidePending,
 	isWelcomeGuideEligible,
@@ -104,8 +105,6 @@ export const FormWelcomeGuide = () => {
 	// a request is already stored; see the effect that clears it below.
 	const [ isReopened, setIsReopened ] = useState( isCoreWelcomeGuidePending );
 
-	const pages = getWelcomeGuidePages();
-
 	const record = useGuideTracks();
 
 	/*
@@ -136,9 +135,9 @@ export const FormWelcomeGuide = () => {
 		record( DISMISS_EVENT, {
 			origin,
 			slide: currentSlide.current,
-			slide_count: pages.length,
+			slide_count: SLIDE_COUNT,
 		} );
-	}, [ origin, pages.length, record ] );
+	}, [ origin, record ] );
 
 	const handleFinish = useCallback( () => {
 		recordDismiss();
@@ -172,7 +171,8 @@ export const FormWelcomeGuide = () => {
 		}
 
 		currentSlide.current = 1;
-		record( VIEW_EVENT, { origin, slide_count: pages.length } );
+		record( VIEW_EVENT, { origin, slide_count: SLIDE_COUNT } );
+		record( SLIDE_VIEW_EVENT, { slide: 1, slide_count: SLIDE_COUNT, origin } );
 		// eslint-disable-next-line react-hooks/exhaustive-deps -- Only a change in `isOpen` is a new viewing; `origin` is fixed for one.
 	}, [ isOpen ] );
 
@@ -249,7 +249,7 @@ export const FormWelcomeGuide = () => {
 	 * The tracker rides inside each slide's content because `Guide` renders only
 	 * the page you are on, which makes "mounted" and "on screen" the same thing.
 	 */
-	const trackedPages = pages.map( ( page, index ) => ( {
+	const trackedPages = getWelcomeGuidePages().map( ( page, index ) => ( {
 		...page,
 		content: (
 			<>
@@ -257,7 +257,7 @@ export const FormWelcomeGuide = () => {
 					index={ index }
 					origin={ origin }
 					record={ recordSlideView }
-					slideCount={ pages.length }
+					slideCount={ SLIDE_COUNT }
 				/>
 				{ page.content }
 			</>

--- a/projects/packages/forms/src/form-editor/welcome-guide/pages.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/pages.tsx
@@ -81,6 +81,9 @@ const SLIDES = [
  */
 export const WELCOME_GUIDE_IMAGES = SLIDES.map( slide => slide.image );
 
+/** How many slides the guide has, without building them. */
+export const SLIDE_COUNT = SLIDES.length;
+
 /**
  * Builds the welcome guide pages.
  *

--- a/projects/packages/forms/tests/js/form-editor/welcome-guide/index.test.jsx
+++ b/projects/packages/forms/tests/js/form-editor/welcome-guide/index.test.jsx
@@ -12,9 +12,11 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useCallback, useState } from 'react';
 
 // Mocks must be registered before importing the component under test.
 const set = jest.fn();
+const recordEvent = jest.fn();
 const preferences = new Map();
 let currentPostType = 'jetpack_form';
 
@@ -24,6 +26,10 @@ await jest.unstable_mockModule( '@wordpress/preferences', () => ( {
 
 await jest.unstable_mockModule( '@wordpress/editor', () => ( {
 	store: 'core/editor',
+} ) );
+
+await jest.unstable_mockModule( '@automattic/jetpack-shared-extension-utils', () => ( {
+	useAnalytics: () => ( { tracks: { recordEvent } } ),
 } ) );
 
 await jest.unstable_mockModule( '@wordpress/data', () => ( {
@@ -39,19 +45,32 @@ await jest.unstable_mockModule( '@wordpress/data', () => ( {
 
 /*
  * `Guide` renders into a portal and pulls in a large slice of
- * @wordpress/components. These tests only care whether it rendered and what
- * happens when it is finished, so the mock exposes the finish handler as a
- * button and nothing else.
+ * @wordpress/components. The mock keeps the two behaviours the tests depend
+ * on: it renders only the page you are on, and it owns the page number — which
+ * is why the slide tracker has to live inside the page content.
  */
 await jest.unstable_mockModule( '@wordpress/components', () => ( {
-	Guide: ( { contentLabel, onFinish } ) => (
-		<div data-testid="guide">
-			{ contentLabel }
-			<button type="button" onClick={ onFinish }>
-				Finish
-			</button>
-		</div>
-	),
+	Guide: ( { contentLabel, onFinish, pages = [] } ) => {
+		const [ current, setCurrent ] = useState( 0 );
+		const goForward = useCallback( () => setCurrent( page => page + 1 ), [] );
+		const goBack = useCallback( () => setCurrent( page => page - 1 ), [] );
+
+		return (
+			<div data-testid="guide">
+				{ contentLabel }
+				{ pages[ current ]?.content }
+				<button type="button" onClick={ goForward }>
+					Next
+				</button>
+				<button type="button" onClick={ goBack }>
+					Previous
+				</button>
+				<button type="button" onClick={ onFinish }>
+					Finish
+				</button>
+			</div>
+		);
+	},
 } ) );
 
 /**
@@ -282,6 +301,80 @@ describe( 'FormWelcomeGuide', () => {
 			render( <FormWelcomeGuide /> );
 
 			expect( set ).not.toHaveBeenCalledWith( CORE_SCOPE, PREFERENCE_NAME, false );
+		} );
+	} );
+
+	describe( 'analytics', () => {
+		/**
+		 * The properties of the first matching event.
+		 *
+		 * @param {string} event - Event name.
+		 * @return {object|undefined} The recorded properties.
+		 */
+		const propsFor = event => recordEvent.mock.calls.find( ( [ name ] ) => name === event )?.[ 1 ];
+
+		it( 'records one view when the guide opens, with why it opened', () => {
+			render( <FormWelcomeGuide /> );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'jetpack_forms_welcome_guide_view',
+				expect.objectContaining( { origin: 'auto', slide_count: 5 } )
+			);
+		} );
+
+		it( 'records nothing at all when the guide does not open', () => {
+			seedPreferences( { jetpackForms: false } );
+
+			render( <FormWelcomeGuide /> );
+
+			expect( recordEvent ).not.toHaveBeenCalled();
+		} );
+
+		it( 'attributes a forced guide to the query argument, not to a real audience', () => {
+			setSearch( '?jetpack_forms_welcome_guide=1' );
+			seedPreferences( { jetpackForms: false } );
+
+			render( <FormWelcomeGuide /> );
+
+			expect( propsFor( 'jetpack_forms_welcome_guide_view' ) ).toEqual(
+				expect.objectContaining( { origin: 'forced' } )
+			);
+		} );
+
+		it( 'records the first slide without any navigation', () => {
+			render( <FormWelcomeGuide /> );
+
+			expect( propsFor( 'jetpack_forms_welcome_guide_slide_view' ) ).toEqual(
+				expect.objectContaining( { slide: 1, slide_count: 5, origin: 'auto' } )
+			);
+		} );
+
+		it( 'records each slide the user moves to, forwards and back', async () => {
+			const user = userEvent.setup();
+			render( <FormWelcomeGuide /> );
+
+			await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+			await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+			await user.click( screen.getByRole( 'button', { name: 'Previous' } ) );
+
+			const slides = recordEvent.mock.calls
+				.filter( ( [ name ] ) => name === 'jetpack_forms_welcome_guide_slide_view' )
+				.map( ( [ , props ] ) => props.slide );
+
+			expect( slides ).toEqual( [ 1, 2, 3, 2 ] );
+		} );
+
+		it( 'reports how far the user got when they leave', async () => {
+			const user = userEvent.setup();
+			render( <FormWelcomeGuide /> );
+
+			await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+			await user.click( screen.getByRole( 'button', { name: 'Finish' } ) );
+
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'jetpack_forms_welcome_guide_dismiss',
+				expect.objectContaining( { slide: 2, slide_count: 5, origin: 'auto' } )
+			);
 		} );
 	} );
 } );

--- a/projects/packages/forms/tests/js/form-editor/welcome-guide/index.test.jsx
+++ b/projects/packages/forms/tests/js/form-editor/welcome-guide/index.test.jsx
@@ -313,13 +313,59 @@ describe( 'FormWelcomeGuide', () => {
 		 */
 		const propsFor = event => recordEvent.mock.calls.find( ( [ name ] ) => name === event )?.[ 1 ];
 
-		it( 'records one view when the guide opens, with why it opened', () => {
+		/**
+		 * Every recorded event of one name.
+		 *
+		 * @param {string} event - Event name.
+		 * @return {Array} The recorded property objects, in order.
+		 */
+		const allOf = event =>
+			recordEvent.mock.calls
+				.filter( ( [ name ] ) => name === event )
+				.map( ( [ , props ] ) => props );
+
+		it( 'records exactly one view per opening, however often it re-renders', () => {
+			const { rerender } = render( <FormWelcomeGuide /> );
+			rerender( <FormWelcomeGuide /> );
+			rerender( <FormWelcomeGuide /> );
+
+			expect( allOf( 'jetpack_forms_welcome_guide_view' ) ).toEqual( [
+				expect.objectContaining( { origin: 'auto', slide_count: 5 } ),
+			] );
+		} );
+
+		it( 'records the view before the slide it opened on', () => {
 			render( <FormWelcomeGuide /> );
 
-			expect( recordEvent ).toHaveBeenCalledWith(
+			const names = recordEvent.mock.calls
+				.map( ( [ name ] ) => name )
+				.filter( name => name.startsWith( 'jetpack_forms_welcome_guide_' ) );
+
+			expect( names.slice( 0, 2 ) ).toEqual( [
 				'jetpack_forms_welcome_guide_view',
-				expect.objectContaining( { origin: 'auto', slide_count: 5 } )
-			);
+				'jetpack_forms_welcome_guide_slide_view',
+			] );
+		} );
+
+		it( 'records only one slide view for the slide it opened on', () => {
+			const { rerender } = render( <FormWelcomeGuide /> );
+			rerender( <FormWelcomeGuide /> );
+
+			expect( allOf( 'jetpack_forms_welcome_guide_slide_view' ) ).toEqual( [
+				expect.objectContaining( { slide: 1 } ),
+			] );
+		} );
+
+		it( 'attributes a guide reopened from the Options menu to the menu', () => {
+			// Dismissed, so it can only be open because it was asked for.
+			window.jetpackFormsWelcomeGuide = { isEligible: false, isCoreGuidePending: true };
+			seedPreferences( { jetpackForms: false, coreWelcomeGuide: true } );
+
+			render( <FormWelcomeGuide /> );
+
+			expect( allOf( 'jetpack_forms_welcome_guide_view' ) ).toEqual( [
+				expect.objectContaining( { origin: 'menu' } ),
+			] );
 		} );
 
 		it( 'records nothing at all when the guide does not open', () => {


### PR DESCRIPTION
Follow-up to #51039.

## Proposed changes

#51039 added the form editor welcome guide but shipped no instrumentation, so there is currently no way to tell whether the people seeing it are the people it was aimed at, or how far they get before leaving. This adds three Tracks events.

| Event | When | Properties |
| --- | --- | --- |
| `jetpack_forms_welcome_guide_view` | Once each time the guide opens | `origin`, `slide_count` |
| `jetpack_forms_welcome_guide_slide_view` | Each slide the user lands on, including the first | `slide`, `slide_count`, `origin` |
| `jetpack_forms_welcome_guide_dismiss` | When the guide closes, however it was closed | `slide`, `slide_count`, `origin` |

`origin` is the property worth having. The guide opens for three different reasons and they answer different questions:

* `auto` — it opened by itself, for someone the eligibility rules picked out. This is the population that tells you whether those rules are landing on the right people.
* `menu` — reopened deliberately from **Options → Welcome Guide**, or from a request stored on an earlier load. Someone asking for it a second time is not the same signal as someone meeting it for the first time.
* `forced` — the `jetpack_forms_welcome_guide` query argument, which exists so the first run can be re-tested. This is a developer, and lumping them in with real users would quietly inflate the view count.

`slide` is one-based, so it reads naturally against `slide_count` — a dismissal at `slide: 2` of `slide_count: 5` is a drop-off, not an offset.

### Why moving between slides is not its own event

`Guide` renders its Next/Previous buttons itself and routes both them **and** the Left/Right arrow keys through a single internal handler, exposing neither. Anything named for a click would therefore have counted keyboard navigation too, which is not what the name promises. The sequence of `slide_view` events already carries the journey — `1, 2, 3, 2` is unambiguously a step back — so the information is there without a label that misleads. Reading direction costs a window function rather than a `COUNT(*)`; that seemed the better trade.

### Implementation notes

* Follows the package convention: `useAnalytics()` from `@automattic/jetpack-shared-extension-utils`, `jetpack_forms_*` event names, alongside the 25 events already in Forms.
* **The slide tracker has to live inside the slide.** `Guide` keeps its page number in internal state with no change callback, but it renders only the current page — so a component sitting in that page reports the slide by being the one that is mounted. Its effect keys on `index` rather than on mount, because React updates that element across page changes instead of remounting it. Getting this wrong is silent: the first slide still reports and nothing else ever does, which is exactly what the tests below pin.
* Event names live in `analytics.tsx` as exported constants, so they are greppable from one place.
* Nothing about the form or its content is recorded, and nothing fires at all for a user the guide never opens for — the effect is gated on the guide being open.

## Other information

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked for TypeScript, React or other console errors?

## Does this pull request change what data or activity we track or use?

Yes — it adds the three Tracks events above. No form content, no response data, and nothing for a user who never sees the guide.

## Testing instructions

Requires a site with Jetpack Forms and a Tracks-capable environment (an Automattician on a connected site).

* Open the browser network tab and filter for `pixel.wp.com`.
* Go to **Jetpack → Forms → Add new form**, or `/wp-admin/post-new.php?post_type=jetpack_form&jetpack_forms_welcome_guide=1` to force it.
* Confirm one `jetpack_forms_welcome_guide_view` fires as the guide opens, and a `jetpack_forms_welcome_guide_slide_view` with `slide=1` alongside it.
* Step forward and back through the slides. Confirm a `slide_view` fires for each slide you land on, with `slide` matching the dot you are on — including when you go back.
* Close with **Start building** or the ✕. Confirm one `jetpack_forms_welcome_guide_dismiss` fires carrying the slide you were on.
* Check `origin`: it should be `forced` when you used the query argument, `auto` on a plain first-run load, and `menu` when you reopen from **Options (⋮) → Welcome Guide**.
* Reload as a user who has dismissed the guide and confirm no events fire at all.
