### PR TITLE
Backup: send the first Tracks events from the modernized dashboard

### DIFF
--- a/projects/packages/backup/changelog/add-backup-modernized-tracks-events
+++ b/projects/packages/backup/changelog/add-backup-modernized-tracks-events
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Backup: send the modernized dashboard's first two Tracks events — the admin page view and "Back up now" — and correct the connected-user fixture the analytics client reads. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/backup-now-button/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-now-button/index.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Tooltip } from '@wordpress/ui';
+import { useAnalytics } from '../../hooks/use-analytics';
 import { useBackups } from '../../hooks/use-backups';
 import { useCapabilities } from '../../hooks/use-capabilities';
 import { useCanQueryWpcom } from '../../hooks/use-connection';
@@ -26,6 +27,7 @@ import { useSiteSize } from '../../hooks/use-site-size';
  * @return The rendered button, or null when the site can't use it.
  */
 export default function BackupNowButton() {
+	const { tracks } = useAnalytics();
 	const canQuery = useCanQueryWpcom();
 	const capabilities = useCapabilities( { enabled: canQuery } );
 	const { backupsStopped } = useSiteSize();
@@ -45,6 +47,17 @@ export default function BackupNowButton() {
 			reset();
 		}
 	}, [ isBackupRunning, enqueueState, reset ] );
+
+	// Recorded on the click rather than on a successful enqueue, which is
+	// where legacy records it (`back-up-now/index.jsx:25-26`, before the
+	// request resolves). The event measures the reader asking for a
+	// backup, so a WPCOM refusal should still count as an ask — and
+	// moving it onto success would silently drop exactly the failures
+	// worth knowing about.
+	const handleClick = useCallback( () => {
+		tracks.recordEvent( 'jetpack_backup_plugin_backup_now' );
+		enqueue();
+	}, [ tracks, enqueue ] );
 
 	const hasPlan =
 		! capabilities.isLoading && ! capabilities.error && capabilities.data?.hasBackupPlan;
@@ -92,7 +105,7 @@ export default function BackupNowButton() {
 			// and "Backup in progress" is the whole point of that state.
 			loading={ isEnqueuing }
 			loadingAnnouncement={ label }
-			onClick={ enqueue }
+			onClick={ handleClick }
 		>
 			{ label }
 		</Button>

--- a/projects/packages/backup/src/dashboard/hooks/use-analytics.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-analytics.ts
@@ -1,18 +1,21 @@
 import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { useEffect } from 'react';
+import { useEffect } from '@wordpress/element';
 
 /**
  * The two fields `jetpackAnalytics.initialize()` needs, which the
  * ambient type for `wpcomUser` does not declare.
  *
- * `@automattic/jetpack-connection`'s `types.ts` types that object as
- * `{ avatar, display_name, email }`. The runtime object has twelve keys
- * — verified against a connected site, where it carries `ID`, `login`,
- * `email`, `display_name`, `text_direction`, `site_count`,
- * `jetpack_connect`, `color_scheme`, `sidebar_collapsed`, `user_locale`,
- * `user_currency` and `avatar`. So the declaration is incomplete rather
- * than wrong, and the two fields read here are the ones the legacy
- * dashboard has always used.
+ * `@automattic/jetpack-connection`'s ambient `ConnectionScriptData` —
+ * the one `declarations.d.ts` wires to `window.JP_CONNECTION_INITIAL_STATE`
+ * — types that object as `{ avatar, display_name, email }`. The runtime
+ * object has twelve keys, verified against a connected site, including
+ * `ID` and `login`.
+ *
+ * The same package already declares the correct shape as `WpcomUser` in
+ * `components/use-connection/types.ts`, so the real fix is to point the
+ * ambient declaration at it. That belongs in `js-packages/connection`
+ * with its own changelog entry, and it would delete this type and the
+ * cast below along with every other reader's copy of them.
  *
  * Note the capitalisation: WordPress.com's `/me` returns `ID`, not `Id`.
  * Getting it wrong is silent — `initialize()` would be skipped and every
@@ -23,6 +26,29 @@ type WpcomUserIdentity = {
 	ID?: number;
 	login?: string;
 };
+
+/**
+ * Whether the reader has already been identified on this page load.
+ *
+ * Module scope rather than a ref, because "once" means once per page
+ * load and this hook has several consumers: `OverviewScreen` and its
+ * descendant `BackupNowButton` both call it, so a per-component guard
+ * would identify twice per mount and four times under StrictMode,
+ * pushing a duplicate `identifyUser` onto `_tkq` each time. Matches
+ * `packages/podcast/src/dashboard/analytics.ts`.
+ */
+let hasIdentified = false;
+
+/**
+ * Reset the identify latch. Test-only.
+ *
+ * Module state outlives a `render()`/`unmount()` cycle by design, which
+ * is the whole point of the latch — but it also means one test's first
+ * render would otherwise silence every later one in the same file.
+ */
+export function resetAnalyticsForTesting(): void {
+	hasIdentified = false;
+}
 
 /**
  * The Tracks client for the modernized dashboard.
@@ -43,7 +69,7 @@ type WpcomUserIdentity = {
  * `JP_CONNECTION_INITIAL_STATE` global `useConnection()` uses, so this
  * costs no request where legacy costs one.
  *
- * Initialization is skipped when the site has no connected WordPress.com
+ * Identification is skipped when the site has no connected WordPress.com
  * user. Recording still works — the events simply carry no identity —
  * which is the legacy behaviour and the reason the page view fires on
  * an unconnected site too.
@@ -64,10 +90,11 @@ export function useAnalytics() {
 	const login = wpcomUser?.login;
 
 	useEffect( () => {
-		if ( ! userId || ! login ) {
+		if ( hasIdentified || ! userId || ! login ) {
 			return;
 		}
 
+		hasIdentified = true;
 		jetpackAnalytics.initialize( userId, login );
 	}, [ userId, login ] );
 

--- a/projects/packages/backup/src/dashboard/hooks/use-analytics.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-analytics.ts
@@ -1,0 +1,75 @@
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { useEffect } from 'react';
+
+/**
+ * The two fields `jetpackAnalytics.initialize()` needs, which the
+ * ambient type for `wpcomUser` does not declare.
+ *
+ * `@automattic/jetpack-connection`'s `types.ts` types that object as
+ * `{ avatar, display_name, email }`. The runtime object has twelve keys
+ * — verified against a connected site, where it carries `ID`, `login`,
+ * `email`, `display_name`, `text_direction`, `site_count`,
+ * `jetpack_connect`, `color_scheme`, `sidebar_collapsed`, `user_locale`,
+ * `user_currency` and `avatar`. So the declaration is incomplete rather
+ * than wrong, and the two fields read here are the ones the legacy
+ * dashboard has always used.
+ *
+ * Note the capitalisation: WordPress.com's `/me` returns `ID`, not `Id`.
+ * Getting it wrong is silent — `initialize()` would be skipped and every
+ * event would then do nothing, which looks exactly like a dashboard
+ * nobody opened.
+ */
+type WpcomUserIdentity = {
+	ID?: number;
+	login?: string;
+};
+
+/**
+ * The Tracks client for the modernized dashboard.
+ *
+ * Deliberately not a port of `src/js/hooks/useAnalytics.js`. That one
+ * reads the API root and nonce out of the legacy Redux store and hands
+ * them to `@automattic/jetpack-connection`'s `useConnection()`, which
+ * fetches the connected user over REST. Neither is available here: there
+ * is no store, and `use-connection.ts` documents why this package cannot
+ * import that package's hooks at all — its barrel pulls in SCSS that
+ * wp-build's bundler will not resolve.
+ *
+ * `@automattic/jetpack-analytics` itself is safe to import: a single
+ * `.` export pointing at one JSX file, with no stylesheet anywhere in
+ * the package.
+ *
+ * The identity is read synchronously from the same
+ * `JP_CONNECTION_INITIAL_STATE` global `useConnection()` uses, so this
+ * costs no request where legacy costs one.
+ *
+ * Initialization is skipped when the site has no connected WordPress.com
+ * user. Recording still works — the events simply carry no identity —
+ * which is the legacy behaviour and the reason the page view fires on
+ * an unconnected site too.
+ *
+ * The Tracks *script* is enqueued by PHP, in `Jetpack_Backup`'s
+ * `enqueue_admin_scripts()`. Without that this client has nothing to
+ * post to, and it fails silently rather than throwing.
+ *
+ * @return The analytics client, whose `tracks.recordEvent()` sends events.
+ */
+export function useAnalytics() {
+	const state = typeof window !== 'undefined' ? window.JP_CONNECTION_INITIAL_STATE : undefined;
+	const wpcomUser = state?.userConnectionData?.currentUser?.wpcomUser as
+		| WpcomUserIdentity
+		| undefined;
+
+	const userId = wpcomUser?.ID;
+	const login = wpcomUser?.login;
+
+	useEffect( () => {
+		if ( ! userId || ! login ) {
+			return;
+		}
+
+		jetpackAnalytics.initialize( userId, login );
+	}, [ userId, login ] );
+
+	return jetpackAnalytics;
+}

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
 import { Text } from '@wordpress/ui';
@@ -17,6 +17,7 @@ import {
 	useDefaultBackupRewindId,
 	useHasRestorePoints,
 } from '../hooks/use-activity-log';
+import { useAnalytics } from '../hooks/use-analytics';
 import { useBackups } from '../hooks/use-backups';
 import { useRefreshActivityOnBackupComplete } from '../hooks/use-refresh-activity-on-backup-complete';
 import { isBackupItem } from '../types/activity';
@@ -52,6 +53,33 @@ const INITIAL_VIEW: View = {
  * @return The rendered Overview screen.
  */
 export default function OverviewScreen() {
+	// Called before any other hook here so its initialization effect runs
+	// before the page-view effect below: React runs a component's effects
+	// in the order the hooks were called, and an event recorded before
+	// `initialize()` carries no identity.
+	const { tracks } = useAnalytics();
+	// Overview only, deliberately. The legacy dashboard is one page whose
+	// Download and Restore views are client-side, so it fires this once
+	// per visit. Here each route is its own wp-build page, so firing it
+	// from all three would report three views for one reader moving
+	// between them — a step change at flag-flip that reads as growth and
+	// is not. Landing straight on Download or Restore therefore goes
+	// uncounted, which is the accepted cost of keeping the metric
+	// comparable across the flip.
+	const hasRecordedPageView = useRef( false );
+	useEffect( () => {
+		// A ref rather than a bare `[]`, which is what legacy uses. React
+		// StrictMode invokes effects twice, and nothing here controls
+		// whether wp-build's boot enables it — so the bare form would
+		// double-count on a whim of the host.
+		if ( hasRecordedPageView.current ) {
+			return;
+		}
+
+		hasRecordedPageView.current = true;
+		tracks.recordEvent( 'jetpack_backup_admin_page_view' );
+	}, [ tracks ] );
+
 	const search = useSearch( {
 		from: '/' as unknown as never,
 		strict: false,

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
 import { Text } from '@wordpress/ui';
@@ -42,6 +42,24 @@ const INITIAL_VIEW: View = {
 };
 
 /**
+ * Whether this page load has already recorded its view.
+ *
+ * See the effect below for why this is module state rather than a ref.
+ */
+let hasRecordedPageView = false;
+
+/**
+ * Reset the page-view latch. Test-only.
+ *
+ * The latch is module state precisely so it outlives an unmount, which
+ * also means one test's render would otherwise silence every later one
+ * in the same file.
+ */
+export function resetPageViewForTesting(): void {
+	hasRecordedPageView = false;
+}
+
+/**
  * Overview screen for the modernized Backup dashboard.
  *
  * Renders the shared `<DashboardLayout>` chrome around a two-pane body: the
@@ -58,25 +76,27 @@ export default function OverviewScreen() {
 	// in the order the hooks were called, and an event recorded before
 	// `initialize()` carries no identity.
 	const { tracks } = useAnalytics();
-	// Overview only, deliberately. The legacy dashboard is one page whose
-	// Download and Restore views are client-side, so it fires this once
-	// per visit. Here each route is its own wp-build page, so firing it
-	// from all three would report three views for one reader moving
-	// between them — a step change at flag-flip that reads as growth and
-	// is not. Landing straight on Download or Restore therefore goes
-	// uncounted, which is the accepted cost of keeping the metric
-	// comparable across the flip.
-	const hasRecordedPageView = useRef( false );
+	// Overview only, deliberately. All three routes declare
+	// `"page": "jetpack-backup-dashboard"` in their `package.json`, so
+	// this is one admin page whose Download and Restore views are
+	// client-side transitions through `@wordpress/route` — the same shape
+	// as legacy, which records one view per visit. Recording from all
+	// three routes would report three views for one reader moving between
+	// them, a step change at flag-flip that reads as growth and is not.
+	// Landing straight on Download or Restore therefore goes uncounted,
+	// which is the accepted cost of keeping the metric comparable.
 	useEffect( () => {
-		// A ref rather than a bare `[]`, which is what legacy uses. React
-		// StrictMode invokes effects twice, and nothing here controls
-		// whether wp-build's boot enables it — so the bare form would
-		// double-count on a whim of the host.
-		if ( hasRecordedPageView.current ) {
+		// The latch is module scope, not a ref. A client-side transition
+		// to Download and back unmounts and remounts this screen, and a
+		// per-instance guard resets with it — so a ref would record a
+		// second view for the same visit, which is the over-counting this
+		// whole decision exists to avoid. Module scope also subsumes the
+		// StrictMode double-invocation a ref was reaching for.
+		if ( hasRecordedPageView ) {
 			return;
 		}
 
-		hasRecordedPageView.current = true;
+		hasRecordedPageView = true;
 		tracks.recordEvent( 'jetpack_backup_admin_page_view' );
 	}, [ tracks ] );
 

--- a/projects/packages/backup/tests/jest.setup.js
+++ b/projects/packages/backup/tests/jest.setup.js
@@ -1,7 +1,7 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/packages/backup/tests/tracks-events.test.tsx
+++ b/projects/packages/backup/tests/tracks-events.test.tsx
@@ -39,7 +39,7 @@ jest.mock( '@wordpress/route', () => ( {
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { queryClient } from '../src/dashboard/data/query-client';
-import { useAnalytics } from '../src/dashboard/hooks/use-analytics';
+import { resetAnalyticsForTesting, useAnalytics } from '../src/dashboard/hooks/use-analytics';
 import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
 
 /**
@@ -87,6 +87,7 @@ beforeEach( () => {
 	mockApiFetch.mockReset();
 	mockApiFetch.mockResolvedValue( null );
 	queryClient.clear();
+	resetAnalyticsForTesting();
 	window.JP_CONNECTION_INITIAL_STATE = {
 		...ORIGINAL_STATE,
 		connectionStatus: CONNECTED,
@@ -104,6 +105,18 @@ describe( 'useAnalytics', () => {
 		await waitFor( () => expect( mockInitialize ).toHaveBeenCalledWith( 99999, 'bobsacramento' ) );
 	} );
 
+	it( 'identifies the reader once per page load, not once per consumer', async () => {
+		// `OverviewScreen` and its descendant `BackupNowButton` both call
+		// this hook, so an unlatched effect would push a duplicate
+		// `identifyUser` onto `_tkq` for every consumer — twice per mount,
+		// four times under StrictMode.
+		renderHook( () => useAnalytics() );
+		renderHook( () => useAnalytics() );
+
+		await waitFor( () => expect( mockInitialize ).toHaveBeenCalled() );
+		expect( mockInitialize ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'does not identify anyone when the site has no connected WordPress.com user', async () => {
 		// Recording still has to work — the events just carry no identity,
 		// which is what legacy does and why the page view fires on an
@@ -112,7 +125,7 @@ describe( 'useAnalytics', () => {
 
 		renderHook( () => useAnalytics() );
 
-		await waitFor( () => expect( mockInitialize ).not.toHaveBeenCalled() );
+		expect( mockInitialize ).not.toHaveBeenCalled();
 	} );
 
 	it( 'refuses the lowercase id rather than reporting a phantom reader', async () => {
@@ -124,23 +137,31 @@ describe( 'useAnalytics', () => {
 
 		renderHook( () => useAnalytics() );
 
-		await waitFor( () => expect( mockInitialize ).not.toHaveBeenCalled() );
+		expect( mockInitialize ).not.toHaveBeenCalled();
 	} );
 } );
 
 describe( 'Overview page view', () => {
 	/**
 	 * Render the Overview screen inside the dashboard's query client.
+	 *
+	 * @return The Testing Library render result, whose `unmount` stands in
+	 * for a client-side transition away from this route.
 	 */
 	async function renderOverview() {
-		const OverviewScreen = ( await import( '../src/dashboard/screens/overview' ) ).default;
+		const mod = await import( '../src/dashboard/screens/overview' );
+		const OverviewScreen = mod.default;
 
-		render(
+		return render(
 			<QueryClientProvider>
 				<OverviewScreen />
 			</QueryClientProvider>
 		);
 	}
+
+	beforeEach( async () => {
+		( await import( '../src/dashboard/screens/overview' ) ).resetPageViewForTesting();
+	} );
 
 	it( 'records one page view per visit', async () => {
 		await renderOverview();
@@ -148,6 +169,26 @@ describe( 'Overview page view', () => {
 		await waitFor( () =>
 			expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_backup_admin_page_view' )
 		);
+		expect(
+			mockRecordEvent.mock.calls.filter( c => c[ 0 ] === 'jetpack_backup_admin_page_view' )
+		).toHaveLength( 1 );
+	} );
+
+	it( 'records once across a client-side round trip to another route', async () => {
+		// The three routes share one admin page — each `package.json`
+		// declares `"page": "jetpack-backup-dashboard"` — so Overview →
+		// Download → back is a client-side transition that unmounts and
+		// remounts this screen. A per-component latch resets with it and
+		// records a second view for the same visit, which is exactly the
+		// over-counting the Overview-only decision exists to prevent.
+		const { unmount } = await renderOverview();
+		await waitFor( () =>
+			expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_backup_admin_page_view' )
+		);
+
+		unmount();
+		await renderOverview();
+
 		expect(
 			mockRecordEvent.mock.calls.filter( c => c[ 0 ] === 'jetpack_backup_admin_page_view' )
 		).toHaveLength( 1 );
@@ -191,10 +232,16 @@ describe( 'Back up now', () => {
 			expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_backup_plugin_backup_now' )
 		);
 
+		// Asserting both happened is not enough — it passes just as well
+		// when the event is recorded on a successful enqueue, because the
+		// mocked enqueue resolves. Only the ordering distinguishes them.
 		const enqueueCall = mockApiFetch.mock.calls.findIndex( ( [ opts ] ) =>
 			String( opts?.path ?? '' ).includes( '/site/backup/enqueue' )
 		);
 		expect( enqueueCall ).toBeGreaterThanOrEqual( 0 );
+		expect( mockRecordEvent.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			mockApiFetch.mock.invocationCallOrder[ enqueueCall ]
+		);
 	} );
 
 	it( 'records nothing until the reader actually clicks', async () => {

--- a/projects/packages/backup/tests/tracks-events.test.tsx
+++ b/projects/packages/backup/tests/tracks-events.test.tsx
@@ -1,0 +1,216 @@
+// JETPACK-2301 (H1b) — the modernized dashboard fired none of the legacy
+// dashboard's 12 Tracks events. #51403 put the Tracks *script* on the page
+// by moving `Tracking::register_tracks_functions_scripts()` above an early
+// return; it recorded nothing. These are the two events that are portable
+// without a host surface that does not exist yet.
+//
+// The identity assertions are the point of the file as much as the events
+// are. `jetpackAnalytics.initialize()` is skipped when the user id is
+// missing, and every later `recordEvent` then reports nothing — a failure
+// indistinguishable, in Tracks, from a dashboard nobody opened. The key is
+// `ID`; WordPress.com's `/me` does not return `Id`.
+
+const mockRecordEvent = jest.fn();
+const mockInitialize = jest.fn();
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		initialize: ( ...args: unknown[] ) => mockInitialize( ...args ),
+		tracks: { recordEvent: ( ...args: unknown[] ) => mockRecordEvent( ...args ) },
+	},
+} ) );
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+	useNavigate: () => () => {},
+	useParams: () => ( {} ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { queryClient } from '../src/dashboard/data/query-client';
+import { useAnalytics } from '../src/dashboard/hooks/use-analytics';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+
+/**
+ * Replace the connection global's wpcom user for one test.
+ *
+ * @param wpcomUser - The identity object, or undefined to remove it.
+ */
+function setWpcomUser( wpcomUser: unknown ) {
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+		userConnectionData: { currentUser: { wpcomUser } },
+	} as unknown as typeof window.JP_CONNECTION_INITIAL_STATE;
+}
+
+/**
+ * Answer the endpoints `<BackupNowButton>` gates itself on.
+ *
+ * It returns null without a plan, so a bare mock renders nothing and a
+ * click test would pass by never finding the button.
+ */
+function mockEndpointsForButton() {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: false } );
+		}
+		if ( path.includes( '/backups' ) ) {
+			return Promise.resolve( [] );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+const ORIGINAL_STATE = window.JP_CONNECTION_INITIAL_STATE;
+
+beforeEach( () => {
+	mockRecordEvent.mockReset();
+	mockInitialize.mockReset();
+	mockApiFetch.mockReset();
+	mockApiFetch.mockResolvedValue( null );
+	queryClient.clear();
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...ORIGINAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'useAnalytics', () => {
+	it( 'identifies the reader with the id WordPress.com actually sends', async () => {
+		// Verified against a live connected site: the object carries `ID`,
+		// `login`, `email`, `display_name` and eight more. The ambient type
+		// declares only three of them, so this is the assertion standing in
+		// for a type that cannot check it.
+		renderHook( () => useAnalytics() );
+
+		await waitFor( () => expect( mockInitialize ).toHaveBeenCalledWith( 99999, 'bobsacramento' ) );
+	} );
+
+	it( 'does not identify anyone when the site has no connected WordPress.com user', async () => {
+		// Recording still has to work — the events just carry no identity,
+		// which is what legacy does and why the page view fires on an
+		// unconnected site at all.
+		setWpcomUser( undefined );
+
+		renderHook( () => useAnalytics() );
+
+		await waitFor( () => expect( mockInitialize ).not.toHaveBeenCalled() );
+	} );
+
+	it( 'refuses the lowercase id rather than reporting a phantom reader', async () => {
+		// `Id` is the shape this package's own test fixture used to assert.
+		// WordPress.com never sends it, so treating it as an identity would
+		// mean initializing with `undefined` and silently losing every
+		// event.
+		setWpcomUser( { Id: 99999, login: 'bobsacramento' } );
+
+		renderHook( () => useAnalytics() );
+
+		await waitFor( () => expect( mockInitialize ).not.toHaveBeenCalled() );
+	} );
+} );
+
+describe( 'Overview page view', () => {
+	/**
+	 * Render the Overview screen inside the dashboard's query client.
+	 */
+	async function renderOverview() {
+		const OverviewScreen = ( await import( '../src/dashboard/screens/overview' ) ).default;
+
+		render(
+			<QueryClientProvider>
+				<OverviewScreen />
+			</QueryClientProvider>
+		);
+	}
+
+	it( 'records one page view per visit', async () => {
+		await renderOverview();
+
+		await waitFor( () =>
+			expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_backup_admin_page_view' )
+		);
+		expect(
+			mockRecordEvent.mock.calls.filter( c => c[ 0 ] === 'jetpack_backup_admin_page_view' )
+		).toHaveLength( 1 );
+	} );
+
+	it( 'identifies the reader before recording the view', async () => {
+		// Ordering, not coincidence: an event recorded before
+		// `initialize()` carries no identity, so the hook is called ahead
+		// of the page-view effect on purpose.
+		await renderOverview();
+
+		await waitFor( () => expect( mockRecordEvent ).toHaveBeenCalled() );
+		expect( mockInitialize.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			mockRecordEvent.mock.invocationCallOrder[ 0 ]
+		);
+	} );
+} );
+
+describe( 'Back up now', () => {
+	it( 'records the ask, and records it before the request goes out', async () => {
+		// Legacy records on the click, not on a successful enqueue
+		// (`back-up-now/index.jsx:25-26`). The event measures the reader
+		// asking for a backup, so a WordPress.com refusal still counts as
+		// an ask — recording on success would drop exactly the failures
+		// worth knowing about.
+		mockEndpointsForButton();
+		const BackupNowButton = ( await import( '../src/dashboard/components/backup-now-button' ) )
+			.default;
+
+		render(
+			<QueryClientProvider>
+				<BackupNowButton />
+			</QueryClientProvider>
+		);
+
+		const button = await screen.findByRole( 'button', { name: /back up now/i } );
+		mockApiFetch.mockClear();
+		await userEvent.click( button );
+
+		await waitFor( () =>
+			expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_backup_plugin_backup_now' )
+		);
+
+		const enqueueCall = mockApiFetch.mock.calls.findIndex( ( [ opts ] ) =>
+			String( opts?.path ?? '' ).includes( '/site/backup/enqueue' )
+		);
+		expect( enqueueCall ).toBeGreaterThanOrEqual( 0 );
+	} );
+
+	it( 'records nothing until the reader actually clicks', async () => {
+		mockEndpointsForButton();
+		const BackupNowButton = ( await import( '../src/dashboard/components/backup-now-button' ) )
+			.default;
+
+		render(
+			<QueryClientProvider>
+				<BackupNowButton />
+			</QueryClientProvider>
+		);
+
+		await expect(
+			screen.findByRole( 'button', { name: /back up now/i } )
+		).resolves.toBeInTheDocument();
+		expect( mockRecordEvent ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Fixes JETPACK-2301

## Proposed changes

The modernized Backup dashboard fired **none** of the legacy dashboard's 12 Tracks events. #51403 moved `Tracking::register_tracks_functions_scripts()` above an early return so the Tracks *script* reaches the page — but nothing ever called it, so the dashboard still reported nothing. This adds the two events that are portable today; the other ten wait on host surfaces that do not exist yet (the review card, the schedule row, the Calypso CTAs).

* **`jetpack_backup_admin_page_view`** — recorded once per visit, from the Overview route only.
* **`jetpack_backup_plugin_backup_now`** — recorded on the click, before the request resolves.

### Not a port of `useAnalytics`

Legacy's hook reads the API root and nonce out of its Redux store and hands them to `@automattic/jetpack-connection`'s `useConnection()`, which fetches the connected user over REST. Neither is available here: there is no store, and `use-connection.ts` already documents why this package cannot import that package's hooks at all — its barrel pulls in SCSS the wp-build bundler will not resolve.

`@automattic/jetpack-analytics` itself is safe to import: a single `.` export pointing at one JSX file, with no stylesheet anywhere in the package. The identity comes from the `JP_CONNECTION_INITIAL_STATE` global `useConnection()` already reads, so this costs **no request** where legacy costs one.

### The user id key is `ID`, and getting it wrong is silent

The ambient type for `wpcomUser` declares `{ avatar, display_name, email }`. The runtime object has twelve keys — verified against a connected site — including `ID` and `login`, which is what `initialize()` needs.

Read `Id` instead and initialization is skipped, every later `recordEvent` reports nothing, and Tracks shows a dashboard nobody opened. No error, no warning, no failed build.

**This package's own jest fixture asserted `Id`**, a shape WordPress.com has never sent. It is corrected here, and a test pins that `Id` is *refused* rather than silently accepted — so a future edit cannot quietly reintroduce the phantom.

### Why the page view fires from Overview only

All three routes declare `"page": "jetpack-backup-dashboard"` in their manifests, so this is **one** admin page whose Download and Restore views are client-side transitions through `@wordpress/route` — the same shape as legacy, which records one view per visit. Recording from all three routes would report three views for one reader moving between them: a step change at flag-flip that reads as growth and is not.

Landing straight on Download or Restore therefore goes uncounted. That is the accepted cost of a metric that stays comparable across the flip.

The latch is **module scope, not a ref**, which is what "once per page load" means here. A client-side transition to Download and back unmounts and remounts the screen, so a per-instance guard would reset with it and record a second view for the same visit. Module scope also subsumes the StrictMode double-invocation a ref would be reaching for. Matches `packages/podcast/src/dashboard/analytics.ts`.

`initialize()` is latched the same way: `OverviewScreen` and its descendant `BackupNowButton` both call the hook, so an unlatched effect identifies twice per mount and four times under StrictMode.

### Why "Back up now" records the ask, not the outcome

On the click, before the request resolves, as legacy does. A WordPress.com refusal is still a reader asking for a backup — moving the event onto success would silently drop exactly the failures worth knowing about.

## Related product discussion/links

* [JETPACK-2301](https://linear.app/a8c/issue/JETPACK-2301/h1b-send-tracks-events-from-the-modernized-dashboard) — H1b, which this closes
* [Backup: modernized dashboard](https://linear.app/a8c/project/backup-modernized-dashboard-736b571c0f4b) — the project
* #51403 — put the Tracks client on the page; this is what calls it

This unblocks the Tracks events on [JETPACK-2331](https://linear.app/a8c/issue/JETPACK-2331/h3c-offer-more-storage-when-usage-leaves-normal) (H3c), [JETPACK-2332](https://linear.app/a8c/issue/JETPACK-2332/h3d-add-the-storage-help-popover) (H3d), [JETPACK-2328](https://linear.app/a8c/issue/JETPACK-2328/k2-show-the-next-scheduled-backup-on-the-modernized-overview) (K2) and [JETPACK-2371](https://linear.app/a8c/issue/JETPACK-2371/k4-the-file-browsers-learn-more-cta-was-never-ported) (K4), each of which was waiting for a `recordEvent` call site to exist.

## Does this pull request change what data or activity we track or use?

**Yes — that is the point of the change**, and it restores telemetry the legacy dashboard already sends rather than adding anything new.

Both event names already exist and are already recorded by the legacy dashboard (`Admin/index.jsx:57`, `back-up-now/index.jsx:25-26`). No new event name, no new property. The identity passed to `initialize()` is the connected WordPress.com user id and login, which is what legacy passes. `window.jpTracksContext.blog_id` is already emitted on the modernized page and is attached as a super prop by the analytics client, unchanged.

Nothing is recorded while `rsm_jetpack_ui_modernization_backup` is off, because the dashboard does not render.

## Testing instructions

Requires a Jetpack-connected site with the modernization filter on:

```php
add_filter( 'jetpack_feature_flag_enabled_rsm_jetpack_ui_modernization_backup', '__return_true' );
```

1. In the browser console, turn on the analytics client's own logging, then reload **Jetpack → VaultPress Backup**:
   ```js
   localStorage.setItem( 'debug', '*' );
   ```
2. The console should show the page view, with the site's blog id attached as a super prop:
   ```
   dops:analytics Record event "jetpack_backup_admin_page_view" called with props {"blog_id":<your blog id>}
   ```
3. Click **Back up now** and confirm a second line for `jetpack_backup_plugin_backup_now`. It should appear on the click, *before* the enqueue request settles — a failed enqueue must still record.
4. Navigate to Download or Restore and back. **No further page-view events** should appear — the routes share one page, so this is a client-side transition and the view is already recorded for this visit.
5. Turn the filter off and confirm the legacy dashboard still records its own events as before — nothing in `src/js/` changed except the corrected test fixture.

Automated:

```
jp test js packages/backup     # 505 passed (9 new)
pnpm run typecheck             # in the package
```

## Verification

**Confirmed live** on a connected site with the flag on — the console reported:

```
dops:analytics Record event "jetpack_backup_admin_page_view" called with props {"blog_id":209013209} +0ms
```

So the event reaches the client, and the blog id is attached as a super prop.

**Seven mutations, all caught**: reading `Id` instead of `ID`; dropping the no-connected-user guard; dropping the identify latch; dropping the page-view latch; removing either event; and moving the backup-now event onto a successful enqueue rather than the click.

The last two are the ones review caught me on. An earlier revision reported five mutations, but the one described as "records on success" had deleted the call rather than moving it, so it duplicated another and the ordering was never tested — the backup-now test passed either way, because the mocked enqueue resolves. It now asserts the event's invocation order against the enqueue request, which is the only thing that separates the two.

**Bundle cost: +3,917 bytes** minified on the dashboard route (806,231 → 810,148, +0.49%) — the whole analytics client. Both event names and the client's own machinery were verified present in the built output, not tree-shaken away.

505 jest, tsgo, ESLint zero warnings, Prettier, and a clean `wp-build`.
