### PR TITLE
Connection: widen the ambient wpcomUser type to the fields it actually carries

### DIFF
--- a/projects/js-packages/connection/changelog/jetpack-2412-wpcom-user-type
+++ b/projects/js-packages/connection/changelog/jetpack-2412-wpcom-user-type
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: changed
 
 Type the connection script data's `wpcomUser` with the fields WordPress.com actually returns, including `ID` and `login`.

--- a/projects/js-packages/connection/changelog/jetpack-2412-wpcom-user-type
+++ b/projects/js-packages/connection/changelog/jetpack-2412-wpcom-user-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Type the connection script data's `wpcomUser` with the fields WordPress.com actually returns, including `ID` and `login`.

--- a/projects/js-packages/connection/components/use-connection/types.ts
+++ b/projects/js-packages/connection/components/use-connection/types.ts
@@ -1,8 +1,8 @@
 import type { ConnectionErrorMap } from '../../hooks/use-connection-error-notice/types.ts';
-import type { ConnectionOwner } from '../../types.ts';
+import type { ConnectionOwner, WpcomUser } from '../../types.ts';
 import type { SyntheticEvent } from 'react';
 
-export type { ConnectionOwner };
+export type { ConnectionOwner, WpcomUser };
 
 export interface UseConnectionProps {
 	/**
@@ -37,15 +37,6 @@ export interface UseConnectionProps {
 	 * Whether to skip the pricing page.
 	 */
 	skipPricingPage?: boolean;
-}
-
-export interface WpcomUser {
-	display_name?: string;
-	email?: string;
-	login?: string;
-	avatar?: string;
-	ID?: number;
-	[ key: string ]: unknown;
 }
 
 export interface UserConnectionData {

--- a/projects/js-packages/connection/test/wpcom-user-types.test.ts
+++ b/projects/js-packages/connection/test/wpcom-user-types.test.ts
@@ -10,6 +10,7 @@
  * index signature and the directive goes unused. The `expect()` calls only keep
  * this a valid test file.
  */
+import type { UserConnectionData } from '../components/use-connection/types.ts';
 import type { WpcomUser } from '../types.ts';
 
 /**
@@ -20,6 +21,15 @@ import type { WpcomUser } from '../types.ts';
 type GlobalWpcomUser =
 	Window[ 'JP_CONNECTION_INITIAL_STATE' ][ 'userConnectionData' ][ 'currentUser' ][ 'wpcomUser' ];
 
+/**
+ * The type `useConnection()` hands its consumers. Once the package's two
+ * `WpcomUser` declarations were collapsed onto one, this and `GlobalWpcomUser`
+ * became the same interface, and nothing but an assertion keeps them that way.
+ */
+type UseConnectionWpcomUser = NonNullable<
+	NonNullable< UserConnectionData[ 'currentUser' ] >[ 'wpcomUser' ]
+>;
+
 /** `true` only when two types are mutually assignable. */
 type Same< A, B > = [ A ] extends [ B ] ? ( [ B ] extends [ A ] ? true : false ) : false;
 
@@ -29,6 +39,14 @@ describe( 'JP_CONNECTION_INITIAL_STATE wpcomUser', () => {
 		const wired: Same< GlobalWpcomUser, WpcomUser > = true;
 
 		expect( wired ).toBe( true );
+	} );
+
+	test( 'useConnection() resolves to that same declaration', () => {
+		// The two used to be separate interfaces, one of them open. If they are
+		// split again this fails to compile as `const unified: false = true`.
+		const unified: Same< UseConnectionWpcomUser, WpcomUser > = true;
+
+		expect( unified ).toBe( true );
 	} );
 
 	test( 'exposes the identity jetpackAnalytics.initialize() needs, uncast', () => {

--- a/projects/js-packages/connection/test/wpcom-user-types.test.ts
+++ b/projects/js-packages/connection/test/wpcom-user-types.test.ts
@@ -2,30 +2,18 @@
  * Type-level tests for the `wpcomUser` object on the ambient
  * `JP_CONNECTION_INITIAL_STATE` global.
  *
- * The assertions that matter are the `@ts-expect-error` directives and the
- * `Same<>` check, which `tsgo --noEmit` enforces — Jest cannot see any of it,
- * because Babel strips the types before it runs. An unused `@ts-expect-error` is
- * itself a compile error, so each one fails in both directions: delete the
- * directive and the misspelling has to error on its own; give `WpcomUser` an
- * index signature and the directive goes unused. The `expect()` calls only keep
- * this a valid test file.
+ * `tsgo --noEmit` enforces these, not Jest — Babel strips the types before the run. An
+ * unused `@ts-expect-error` is itself a compile error, so each directive below fails in
+ * both directions.
  */
 import type { UserConnectionData } from '../components/use-connection/types.ts';
 import type { WpcomUser } from '../types.ts';
 
-/**
- * The type the ambient declaration actually puts on the global — resolved
- * through `declarations.d.ts`, not imported directly, so this breaks if the
- * wiring is changed rather than only if `WpcomUser` is.
- */
+/** Resolved through `declarations.d.ts` rather than imported, so a rewiring breaks it too. */
 type GlobalWpcomUser =
 	Window[ 'JP_CONNECTION_INITIAL_STATE' ][ 'userConnectionData' ][ 'currentUser' ][ 'wpcomUser' ];
 
-/**
- * The type `useConnection()` hands its consumers. Once the package's two
- * `WpcomUser` declarations were collapsed onto one, this and `GlobalWpcomUser`
- * became the same interface, and nothing but an assertion keeps them that way.
- */
+/** The type `useConnection()` hands its consumers. */
 type UseConnectionWpcomUser = NonNullable<
 	NonNullable< UserConnectionData[ 'currentUser' ] >[ 'wpcomUser' ]
 >;
@@ -42,8 +30,7 @@ describe( 'JP_CONNECTION_INITIAL_STATE wpcomUser', () => {
 	} );
 
 	test( 'useConnection() resolves to that same declaration', () => {
-		// The two used to be separate interfaces, one of them open. If they are
-		// split again this fails to compile as `const unified: false = true`.
+		// Fails to compile as `const unified: false = true` if the two are split again.
 		const unified: Same< UseConnectionWpcomUser, WpcomUser > = true;
 
 		expect( unified ).toBe( true );
@@ -61,8 +48,7 @@ describe( 'JP_CONNECTION_INITIAL_STATE wpcomUser', () => {
 	test( 'rejects the `Id` misspelling instead of resolving it to unknown', () => {
 		const user: GlobalWpcomUser = { ID: 99999, avatar: false };
 
-		// @ts-expect-error WordPress.com spells it `ID`. This has to stay a compile
-		// error: an index signature typed `unknown` would resolve `Id` and hide it.
+		// @ts-expect-error WordPress.com spells it `ID`; an index signature would hide this.
 		const misspelled = user.Id;
 
 		expect( misspelled ).toBeUndefined();
@@ -71,8 +57,7 @@ describe( 'JP_CONNECTION_INITIAL_STATE wpcomUser', () => {
 	test( 'rejects any other undeclared field, so the shape stays closed', () => {
 		const user: GlobalWpcomUser = { avatar: false };
 
-		// @ts-expect-error `userEmail` is not a field WordPress.com returns, and
-		// there is no index signature to absorb it.
+		// @ts-expect-error Not a field WordPress.com returns, and nothing absorbs it.
 		const undeclared = user.userEmail;
 
 		expect( undeclared ).toBeUndefined();
@@ -83,27 +68,23 @@ describe( 'JP_CONNECTION_INITIAL_STATE wpcomUser', () => {
 
 		const avatar: string | false = user.avatar;
 
-		// @ts-expect-error `avatar` is `string | false`. The superseded `boolean`
-		// declaration accepted this assignment, so the directive going unused is
-		// what would tell us the widening had been reverted.
+		// @ts-expect-error `avatar` is `string | false`; the superseded `boolean`
+		// declaration accepted this, so an unused directive means the widening was reverted.
 		const asBoolean: boolean = user.avatar;
 
 		expect( asBoolean ).toBe( avatar );
 	} );
 
 	test( 'requires avatar, the one field the PHP always sets', () => {
-		// @ts-expect-error `avatar` is required: `get_user_connection_data()` sets it
-		// unconditionally, so even with no connected WordPress.com user the object is
-		// `{ avatar: false }` rather than empty. Every other field is optional, which
-		// leaves this the only assertion pinning that asymmetry.
+		// @ts-expect-error `avatar` is required — the PHP sets it unconditionally, so the
+		// emptiest this object gets is `{ avatar: false }`. Every other field is optional.
 		const user: GlobalWpcomUser = {};
 
 		expect( user ).toEqual( {} );
 	} );
 
 	test( 'no longer accepts the `true` that the boolean declaration allowed', () => {
-		// @ts-expect-error `avatar` is a URL or `false`; `get_avatar_url()` never
-		// returns `true`, which the superseded `boolean` declaration permitted.
+		// @ts-expect-error `avatar` is a URL or `false`; `get_avatar_url()` never returns `true`.
 		const user: GlobalWpcomUser = { avatar: true };
 
 		expect( user.avatar ).toBe( true );

--- a/projects/js-packages/connection/test/wpcom-user-types.test.ts
+++ b/projects/js-packages/connection/test/wpcom-user-types.test.ts
@@ -73,6 +73,16 @@ describe( 'JP_CONNECTION_INITIAL_STATE wpcomUser', () => {
 		expect( asBoolean ).toBe( avatar );
 	} );
 
+	test( 'requires avatar, the one field the PHP always sets', () => {
+		// @ts-expect-error `avatar` is required: `get_user_connection_data()` sets it
+		// unconditionally, so even with no connected WordPress.com user the object is
+		// `{ avatar: false }` rather than empty. Every other field is optional, which
+		// leaves this the only assertion pinning that asymmetry.
+		const user: GlobalWpcomUser = {};
+
+		expect( user ).toEqual( {} );
+	} );
+
 	test( 'no longer accepts the `true` that the boolean declaration allowed', () => {
 		// @ts-expect-error `avatar` is a URL or `false`; `get_avatar_url()` never
 		// returns `true`, which the superseded `boolean` declaration permitted.

--- a/projects/js-packages/connection/test/wpcom-user-types.test.ts
+++ b/projects/js-packages/connection/test/wpcom-user-types.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Type-level tests for the `wpcomUser` object on the ambient
+ * `JP_CONNECTION_INITIAL_STATE` global.
+ *
+ * The assertions that matter are the `@ts-expect-error` directives and the
+ * `Same<>` check, which `tsgo --noEmit` enforces — Jest cannot see any of it,
+ * because Babel strips the types before it runs. An unused `@ts-expect-error` is
+ * itself a compile error, so each one fails in both directions: delete the
+ * directive and the misspelling has to error on its own; give `WpcomUser` an
+ * index signature and the directive goes unused. The `expect()` calls only keep
+ * this a valid test file.
+ */
+import type { WpcomUser } from '../types.ts';
+
+/**
+ * The type the ambient declaration actually puts on the global — resolved
+ * through `declarations.d.ts`, not imported directly, so this breaks if the
+ * wiring is changed rather than only if `WpcomUser` is.
+ */
+type GlobalWpcomUser =
+	Window[ 'JP_CONNECTION_INITIAL_STATE' ][ 'userConnectionData' ][ 'currentUser' ][ 'wpcomUser' ];
+
+/** `true` only when two types are mutually assignable. */
+type Same< A, B > = [ A ] extends [ B ] ? ( [ B ] extends [ A ] ? true : false ) : false;
+
+describe( 'JP_CONNECTION_INITIAL_STATE wpcomUser', () => {
+	test( 'the global is wired to WpcomUser', () => {
+		// Fails to compile as `const wired: false = true` if the two drift apart.
+		const wired: Same< GlobalWpcomUser, WpcomUser > = true;
+
+		expect( wired ).toBe( true );
+	} );
+
+	test( 'exposes the identity jetpackAnalytics.initialize() needs, uncast', () => {
+		const user: GlobalWpcomUser = { ID: 99999, login: 'bobsacramento', avatar: false };
+
+		const id: number | undefined = user.ID;
+		const login: string | undefined = user.login;
+
+		expect( { id, login } ).toEqual( { id: 99999, login: 'bobsacramento' } );
+	} );
+
+	test( 'rejects the `Id` misspelling instead of resolving it to unknown', () => {
+		const user: GlobalWpcomUser = { ID: 99999, avatar: false };
+
+		// @ts-expect-error WordPress.com spells it `ID`. This has to stay a compile
+		// error: an index signature typed `unknown` would resolve `Id` and hide it.
+		const misspelled = user.Id;
+
+		expect( misspelled ).toBeUndefined();
+	} );
+
+	test( 'rejects any other undeclared field, so the shape stays closed', () => {
+		const user: GlobalWpcomUser = { avatar: false };
+
+		// @ts-expect-error `userEmail` is not a field WordPress.com returns, and
+		// there is no index signature to absorb it.
+		const undeclared = user.userEmail;
+
+		expect( undeclared ).toBeUndefined();
+	} );
+
+	test( 'types avatar as a URL or false, never as a boolean', () => {
+		const user: GlobalWpcomUser = { avatar: 'https://example.com/avatar.png' };
+
+		const avatar: string | false = user.avatar;
+
+		// @ts-expect-error `avatar` is `string | false`. The superseded `boolean`
+		// declaration accepted this assignment, so the directive going unused is
+		// what would tell us the widening had been reverted.
+		const asBoolean: boolean = user.avatar;
+
+		expect( asBoolean ).toBe( avatar );
+	} );
+
+	test( 'no longer accepts the `true` that the boolean declaration allowed', () => {
+		// @ts-expect-error `avatar` is a URL or `false`; `get_avatar_url()` never
+		// returns `true`, which the superseded `boolean` declaration permitted.
+		const user: GlobalWpcomUser = { avatar: true };
+
+		expect( user.avatar ).toBe( true );
+	} );
+} );

--- a/projects/js-packages/connection/tsconfig.json
+++ b/projects/js-packages/connection/tsconfig.json
@@ -7,6 +7,7 @@
 		"hooks",
 		"helpers",
 		"state",
+		"test",
 		"types.ts",
 		"declarations.d.ts"
 	]

--- a/projects/js-packages/connection/types.ts
+++ b/projects/js-packages/connection/types.ts
@@ -31,9 +31,19 @@ export interface ConnectionOwner {
  * field absent from this list is a compile error instead, so adding one is a
  * deliberate edit here.
  *
- * `components/use-connection/types.ts` declares a second, open `WpcomUser` for
- * the `useConnection()` return value. Collapsing the two onto this declaration
- * is a follow-up; it reaches beyond the ambient global this change is about.
+ * This is the package's only `WpcomUser`. `components/use-connection/types.ts`
+ * re-exports it, so the ambient global and the `useConnection()` return value
+ * resolve to one declaration; `test/wpcom-user-types.test.ts` asserts they still
+ * do. That direction costs consumers something real: reading a `wpcomUser` field
+ * that is not listed here used to be absorbed by the open declaration's index
+ * signature and is now a compile error. No consumer relies on that today — every
+ * typed read in the monorepo is `ID`, `login`, `display_name`, `email` or
+ * `avatar` — but a new field has to be added here first rather than just used.
+ *
+ * One caveat on the unification: `tsconfig.base.json` sets `strict: false`, so
+ * `strictNullChecks` is off and optionality differences between the two former
+ * declarations cannot surface. A clean typecheck today is therefore not evidence
+ * that a future strict migration stays clean.
  */
 export interface WpcomUser {
 	/**

--- a/projects/js-packages/connection/types.ts
+++ b/projects/js-packages/connection/types.ts
@@ -12,57 +12,23 @@ export interface ConnectionOwner {
  * The WordPress.com account behind the current user's connection, as served at
  * `window.JP_CONNECTION_INITIAL_STATE.userConnectionData.currentUser.wpcomUser`.
  *
- * Server-side this is the decoded body of WordPress.com's
- * `/sites/<blog_id>/jetpack-wpcom-user-data` endpoint, fetched by
- * `Connection\Manager::get_connected_user_data()`, with `avatar` added on top by
- * `REST_Connector::get_user_connection_data()`. The field list mirrors the
- * payload that `ManagerIntegrationTest::test_get_connected_user_data_fetches_from_rest_endpoint()`
- * exercises, which is the response shape that endpoint call was written against.
+ * Only `avatar` is guaranteed: with no connected WordPress.com user the PHP still sets
+ * it, so the whole object is `{ avatar: false }`.
  *
- * Only `avatar` is guaranteed. With no connected WordPress.com user
- * `get_connected_user_data()` returns `false`, `get_user_connection_data()`
- * substitutes an empty array for it and then sets `avatar` unconditionally, so
- * the whole object is `{ avatar: false }`.
- *
- * Deliberately closed: there is no `[ key: string ]: unknown` index signature.
- * Listing `ID` is only half of what makes the `Id` misspelling (JETPACK-2411)
- * catchable — an index signature typed `unknown` resolves `Id` to `unknown`
- * rather than erroring, so the misspelling would go on typechecking. Reading a
- * field absent from this list is a compile error instead, so adding one is a
- * deliberate edit here.
- *
- * This is the package's only `WpcomUser`. `components/use-connection/types.ts`
- * re-exports it, so the ambient global and the `useConnection()` return value
- * resolve to one declaration; `test/wpcom-user-types.test.ts` asserts they still
- * do. That direction costs consumers something real: reading a `wpcomUser` field
- * that is not listed here used to be absorbed by the open declaration's index
- * signature and is now a compile error. No consumer relies on that today — every
- * typed read in the monorepo is `ID`, `login`, `display_name`, `email` or
- * `avatar` — but a new field has to be added here first rather than just used.
- *
- * One caveat on the unification: `tsconfig.base.json` sets `strict: false`, so
- * `strictNullChecks` is off and optionality differences between the two former
- * declarations cannot surface. A clean typecheck today is therefore not evidence
- * that a future strict migration stays clean.
+ * Deliberately closed — an index signature typed `unknown` would resolve the `Id`
+ * misspelling (JETPACK-2411) rather than erroring on it, so a new field has to be added
+ * here before it can be read.
  */
 export interface WpcomUser {
 	/**
-	 * The WordPress.com user ID, the first argument to `jetpackAnalytics.initialize()`.
-	 * Note the capitalisation: WordPress.com spells it `ID`. Every caller skips
-	 * `initialize()` when it is missing, so a misspelling costs the identity on
-	 * every Tracks event the page sends without failing anywhere visible.
+	 * Note the capitalisation. Callers skip `jetpackAnalytics.initialize()` when this is
+	 * missing, so a misspelling costs the identity on every Tracks event, silently.
 	 */
 	ID?: number;
-	/** The WordPress.com username, the second argument to `jetpackAnalytics.initialize()`. */
 	login?: string;
 	email?: string;
 	display_name?: string;
-	/**
-	 * Gravatar URL for `email`, or `false`. The PHP passes `false` straight
-	 * through when `email` is empty, and `get_avatar_url()` is itself declared
-	 * `string|false` in WordPress core — it returns `false` when it cannot
-	 * resolve an avatar. Neither `boolean` nor `string` alone describes it.
-	 */
+	/** Gravatar URL for `email`, or `false` when core cannot resolve one. */
 	avatar: string | false;
 	text_direction?: string;
 	site_count?: number;

--- a/projects/js-packages/connection/types.ts
+++ b/projects/js-packages/connection/types.ts
@@ -8,6 +8,61 @@ export interface ConnectionOwner {
 	displayName: string;
 }
 
+/**
+ * The WordPress.com account behind the current user's connection, as served at
+ * `window.JP_CONNECTION_INITIAL_STATE.userConnectionData.currentUser.wpcomUser`.
+ *
+ * Server-side this is the decoded body of WordPress.com's
+ * `/sites/<blog_id>/jetpack-wpcom-user-data` endpoint, fetched by
+ * `Connection\Manager::get_connected_user_data()`, with `avatar` added on top by
+ * `REST_Connector::get_user_connection_data()`. The field list mirrors the
+ * payload that `ManagerIntegrationTest::test_get_connected_user_data_fetches_from_rest_endpoint()`
+ * exercises, which is the response shape that endpoint call was written against.
+ *
+ * Only `avatar` is guaranteed. With no connected WordPress.com user
+ * `get_connected_user_data()` returns `false`, `get_user_connection_data()`
+ * substitutes an empty array for it and then sets `avatar` unconditionally, so
+ * the whole object is `{ avatar: false }`.
+ *
+ * Deliberately closed: there is no `[ key: string ]: unknown` index signature.
+ * Listing `ID` is only half of what makes the `Id` misspelling (JETPACK-2411)
+ * catchable — an index signature typed `unknown` resolves `Id` to `unknown`
+ * rather than erroring, so the misspelling would go on typechecking. Reading a
+ * field absent from this list is a compile error instead, so adding one is a
+ * deliberate edit here.
+ *
+ * `components/use-connection/types.ts` declares a second, open `WpcomUser` for
+ * the `useConnection()` return value. Collapsing the two onto this declaration
+ * is a follow-up; it reaches beyond the ambient global this change is about.
+ */
+export interface WpcomUser {
+	/**
+	 * The WordPress.com user ID, the first argument to `jetpackAnalytics.initialize()`.
+	 * Note the capitalisation: WordPress.com spells it `ID`. Every caller skips
+	 * `initialize()` when it is missing, so a misspelling costs the identity on
+	 * every Tracks event the page sends without failing anywhere visible.
+	 */
+	ID?: number;
+	/** The WordPress.com username, the second argument to `jetpackAnalytics.initialize()`. */
+	login?: string;
+	email?: string;
+	display_name?: string;
+	/**
+	 * Gravatar URL for `email`, or `false`. The PHP passes `false` straight
+	 * through when `email` is empty, and `get_avatar_url()` is itself declared
+	 * `string|false` in WordPress core — it returns `false` when it cannot
+	 * resolve an avatar. Neither `boolean` nor `string` alone describes it.
+	 */
+	avatar: string | false;
+	text_direction?: string;
+	site_count?: number;
+	jetpack_connect?: string;
+	color_scheme?: string;
+	sidebar_collapsed?: boolean;
+	user_locale?: string;
+	user_currency?: string;
+}
+
 export type ConnectionScriptData = {
 	apiRoot: string;
 	apiNonce: string;
@@ -35,11 +90,7 @@ export type ConnectionScriptData = {
 			username: string;
 			id: number;
 			blogId: number;
-			wpcomUser: {
-				avatar: boolean;
-				display_name: string;
-				email: string;
-			};
+			wpcomUser: WpcomUser;
 			gravatar: string;
 			permissions: {
 				admin_page?: boolean;


### PR DESCRIPTION
Fixes JETPACK-2412

## Proposed changes

`js-packages/connection/declarations.d.ts` wires `window.JP_CONNECTION_INITIAL_STATE` to `ConnectionScriptData`, whose `wpcomUser` declared exactly three fields — `avatar`, `display_name`, `email`. The runtime object carries twelve, including the `ID` and `login` that every `jetpackAnalytics.initialize()` call site reads. Reading them therefore needed a cast, and neither `ID` nor `Id` typechecked against a three-field declaration, so the compiler could not tell the two apart.

* Extract an exported `WpcomUser` interface in `types.ts` and point `ConnectionScriptData.userConnectionData.currentUser.wpcomUser` at it. Fields come from the payload `Connection\Manager::get_connected_user_data()` fetches from WordPress.com's `/sites/<blog_id>/jetpack-wpcom-user-data`, plus the `avatar` that `REST_Connector::get_user_connection_data()` adds on top.
* `avatar` becomes `string | false`, not `boolean`. The PHP sets it to `get_avatar_url( $email, … )` — declared `string|false` in WordPress core — or to `false` outright when `email` is empty. Neither the old `boolean` nor the `string` on the sibling `WpcomUser` was right.
* Every field but `avatar` is optional: with no connected WordPress.com user, `get_connected_user_data()` returns `false`, the REST connector substitutes an empty array and then sets `avatar` unconditionally, so the whole object is `{ avatar: false }`.
* Adds a type-level test, following the existing pattern in `js-packages/charts/src/components/legend/test/legend-config-types.test.tsx`. Its `test/` directory is added to the package `tsconfig.json` `include` so `tsgo` checks it.

### Why not just reuse the existing `WpcomUser`

The issue suggested pointing the ambient declaration at the `WpcomUser` already in `components/use-connection/types.ts`. Reused verbatim that only satisfies half the goal: its `[ key: string ]: unknown` index signature resolves `wpcomUser.Id` to `unknown` rather than erroring, so the misspelling keeps typechecking. Verified by mutation — adding the index signature back turns both closed-shape assertions into `TS2578: Unused '@ts-expect-error' directive`.

The new interface is therefore deliberately closed, and `components/use-connection/types.ts` now imports and re-exports it instead of declaring its own. The package has one `WpcomUser`, and a `Same<>` assertion keeps the ambient global and the `useConnection()` return value resolving to it.

### What collapsing the declarations costs

Removing the open declaration's `[ key: string ]: unknown` means reading a `wpcomUser` field that is not declared is now a compile error inside consumers, rather than silently `unknown`. That is the intent, but it is a real ergonomic change: a new field has to be added to `WpcomUser` before it can be used.

Nothing relies on the old behaviour. Every typed `wpcomUser` field read in the monorepo is one of `login` (7), `ID` (6), `display_name` (2), `email` (1), `avatar` (1) — all five declared. The nearby `currentUser.blogId` read in `videopress/src/client/admin/hooks/use-analytics-tracks/index.ts` is absorbed by `UserConnectionData['currentUser']`'s own index signature, which this PR does not touch.

One caveat worth recording: `tsconfig.base.json` sets `strict: false`, so `strictNullChecks` is off and the optionality differences between the two former declarations cannot surface. A clean typecheck today is not evidence that a future strict migration stays clean.

### Follow-up this unblocks

One consumer can drop a local type and a cast: `packages/backup/src/dashboard/hooks/use-analytics.ts`, which declares its own `WpcomUserIdentity` and casts through it, with a comment pointing at this issue. A repo-wide grep for `WpcomUserIdentity|wpcomUser as|as WpcomUser` returns that file and nothing else.

Every other reader — `activity-log`, `my-jetpack`, `videopress`, `plugins/protect`, and `shared-extension-utils`' `use-analytics.js` — reaches `ID`/`login` through `useConnection()`, and now resolves to this same declaration. They have no cast and no local type, so there is nothing there to clean up. (`shared-extension-utils/src/libs/connection/index.ts` reads the global directly but never touches `wpcomUser` at all.)

## Related product discussion/links

* JETPACK-2412
* JETPACK-2411 — the `ID`/`Id` fixture confusion this makes catchable

## Does this pull request change what data or activity we track or use?

No. This is a type declaration only; there is no runtime code in the change, and no Tracks event or property is added, removed or altered.

## Testing instructions

This is a compile-time change, so the gates are the test:

* `pnpm run typecheck` from the monorepo root — 46 projects, exit 0, zero errors, identical to trunk.
* `jp test js js-packages/connection` — 24 suites, 205 tests (203 passed, 2 todo). The new `test/wpcom-user-types.test.ts` contributes 8.

To see the assertions bite, in `projects/js-packages/connection`:

* Add `[ key: string ]: unknown;` to `WpcomUser` in `types.ts` and run `pnpm run typecheck`. Two `TS2578: Unused '@ts-expect-error' directive` — `.Id` and `.userEmail` stopped erroring.
* Change `avatar: string | false` back to `avatar: boolean`. Four errors: two assignments break, two directives go unused.
* Make `avatar` optional (`avatar?: string | false`). One `TS2578` — the assertion that `avatar` is the single required field.
* Delete the five `@ts-expect-error` lines. Each masks a real error, including `TS2551: Property 'Id' does not exist on type 'WpcomUser'. Did you mean 'ID'?` and `TS2741: Property 'avatar' is missing in type '{}' but required in type 'WpcomUser'`.
* Replace `wpcomUser: WpcomUser` with the old inline three-field shape. The `Same<>` wiring assertion fails as `Type 'true' is not assignable to type 'false'`.
* Give `components/use-connection/types.ts` its own `WpcomUser` again instead of re-exporting. The unification assertion fails the same way.

### On the "JS tests" check having gone red once

It was a pre-existing flake: a re-run of the identical SHA passed. Nothing in this PR can reach a jest run — `tools/js-tools/jest/config.base.js` and `config.node.js` contain no reference to `tsconfig` at all (the transform is `babel-jest` with `@babel/preset-typescript` configured inline), so jest never reads `tsconfig.json` and the `"test"` entry added to its `include` cannot affect any test run. That `include` feeds only `tsgo --noEmit`, whose separate "Type checking" job was green throughout. `types.ts` is type-only, so Babel erases it to an empty module and no build output changes either.

