### PR TITLE
Forms: persist the dashboard view with @wordpress/views

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2748,6 +2748,9 @@ importers:
       '@wordpress/url':
         specifier: 4.51.0
         version: 4.51.0
+      '@wordpress/views':
+        specifier: ~1.20.0
+        version: 1.20.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: 2.1.1
         version: 2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2759,6 +2759,9 @@ importers:
       '@wordpress/url':
         specifier: 4.54.0
         version: 4.54.0
+      '@wordpress/views':
+        specifier: ~1.21.0
+        version: 1.21.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: 2.1.1
         version: 2.1.1

--- a/projects/packages/forms/changelog/forms-dashboard-views-persistence
+++ b/projects/packages/forms/changelog/forms-dashboard-views-persistence
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Remember the responses dashboard's columns, sorting and page size between visits.

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -81,6 +81,7 @@
 		"@wordpress/theme": "1.2.0",
 		"@wordpress/ui": "0.20.0",
 		"@wordpress/url": "4.51.0",
+		"@wordpress/views": "~1.20.0",
 		"clsx": "2.1.1",
 		"copy-webpack-plugin": "14.0.0",
 		"debug": "4.4.3",

--- a/projects/packages/forms/package.json
+++ b/projects/packages/forms/package.json
@@ -81,6 +81,7 @@
 		"@wordpress/theme": "2.0.0",
 		"@wordpress/ui": "0.21.0",
 		"@wordpress/url": "4.54.0",
+		"@wordpress/views": "~1.21.0",
 		"clsx": "2.1.1",
 		"copy-webpack-plugin": "14.0.0",
 		"debug": "4.4.3",

--- a/projects/packages/forms/routes/forms/package.json
+++ b/projects/packages/forms/routes/forms/package.json
@@ -17,8 +17,10 @@
 		"@wordpress/i18n": "6.24.0",
 		"@wordpress/icons": "15.4.0",
 		"@wordpress/notices": "5.51.0",
+		"@wordpress/preferences": "4.51.0",
 		"@wordpress/route": "0.19.0",
 		"@wordpress/ui": "0.20.0",
+		"@wordpress/views": "~1.20.0",
 		"clsx": "2.1.1"
 	},
 	"route": {

--- a/projects/packages/forms/routes/forms/package.json
+++ b/projects/packages/forms/routes/forms/package.json
@@ -17,8 +17,10 @@
 		"@wordpress/i18n": "6.27.0",
 		"@wordpress/icons": "15.5.0",
 		"@wordpress/notices": "5.54.0",
+		"@wordpress/preferences": "4.54.0",
 		"@wordpress/route": "0.20.0",
 		"@wordpress/ui": "0.21.0",
+		"@wordpress/views": "~1.21.0",
 		"clsx": "2.1.1"
 	},
 	"route": {

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -13,8 +13,10 @@ import { DataViews } from '@wordpress/dataviews';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as preferencesStore } from '@wordpress/preferences';
 import { useSearch, useNavigate } from '@wordpress/route';
 import { Badge, EmptyState, Stack, Tooltip } from '@wordpress/ui';
+import { useView } from '@wordpress/views';
 /**
  * Internal dependencies
  */
@@ -31,6 +33,7 @@ import {
 import useDeleteForm from '../../src/dashboard/hooks/use-delete-form.ts';
 import useFormStatusCounts from '../../src/dashboard/hooks/use-form-status-counts.ts';
 import useFormsData, { getFormsListQuery } from '../../src/dashboard/hooks/use-forms-data.ts';
+import { ensurePreferencesPersistence } from '../../src/dashboard/preferences-persistence.ts';
 import WpRouteDashboardSearchParamsProvider from '../../src/dashboard/router/wp-route-dashboard-search-params-provider.tsx';
 import { getFormEditUrl } from '../../src/dashboard/utils.ts';
 import DataViewsHeaderRow from '../../src/dashboard/wp-build/components/dataviews-header-row';
@@ -91,18 +94,39 @@ function StageInner() {
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
 	const hasClassicForms = useConfigValue( 'hasClassicForms' );
 
-	const [ view, setView ] = useState< View >( () => ( {
-		...DEFAULT_VIEW,
-		search: searchParams?.search || '',
-	} ) );
+	// Nothing else gives the preferences store `useView` writes to somewhere to persist.
+	const { setPersistenceLayer } = useDispatch( preferencesStore );
+	ensurePreferencesPersistence( setPersistenceLayer );
 
-	// Keep DataViews search in sync with the URL.
-	useEffect( () => {
-		const urlSearch = searchParams?.search || '';
-		if ( urlSearch !== view.search ) {
-			setView( previous => ( { ...previous, search: urlSearch } ) );
-		}
-	}, [ searchParams?.search ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	// `page` has never been in the URL on this screen, so it is held here and handed to
+	// the view as a query param, the way the search term in the URL is.
+	const [ page, setPage ] = useState( 1 );
+
+	const onChangeQueryParams = useCallback(
+		( next: { page: number; search: string } ) => {
+			setPage( next.page );
+
+			if ( next.search !== ( searchParams?.search || '' ) ) {
+				navigate( {
+					search: {
+						...searchParams,
+						search: next.search || undefined,
+					},
+				} );
+			}
+		},
+		[ navigate, searchParams ]
+	);
+
+	const { view, updateView } = useView( {
+		kind: 'postType',
+		name: 'jetpack_form',
+		slug: 'all',
+		defaultView: DEFAULT_VIEW,
+		defaultLayouts,
+		queryParams: { page, search: searchParams?.search || '' },
+		onChangeQueryParams,
+	} );
 
 	const statusQuery = useMemo( () => {
 		const statusFilterValue = view.filters?.find( filter => filter.field === 'status' )?.value;
@@ -161,7 +185,7 @@ function StageInner() {
 		confirmPermanentDelete,
 	} = useDeleteForm( {
 		view,
-		setView,
+		setView: updateView,
 		recordsLength: records?.length ?? 0,
 		statusQuery,
 	} );
@@ -562,19 +586,11 @@ function StageInner() {
 
 	const onChangeView = useCallback(
 		( newView: View ) => {
-			setView( newView );
-
-			// Sync DataViews search to the URL.
-			if ( newView.search !== view.search ) {
-				navigate( {
-					search: {
-						...searchParams,
-						search: newView.search || undefined,
-					},
-				} );
-			}
+			// The search term reaches the URL through `onChangeQueryParams`, which
+			// `updateView` calls whenever it changes.
+			updateView( newView );
 		},
-		[ navigate, searchParams, view.search ]
+		[ updateView ]
 	);
 
 	const openIntegrationsModal = useCallback( () => {

--- a/projects/packages/forms/routes/forms/stage.tsx
+++ b/projects/packages/forms/routes/forms/stage.tsx
@@ -94,12 +94,11 @@ function StageInner() {
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
 	const hasClassicForms = useConfigValue( 'hasClassicForms' );
 
-	// Nothing else gives the preferences store `useView` writes to somewhere to persist.
 	const { setPersistenceLayer } = useDispatch( preferencesStore );
 	ensurePreferencesPersistence( setPersistenceLayer );
 
-	// `page` has never been in the URL on this screen, so it is held here and handed to
-	// the view as a query param, the way the search term in the URL is.
+	// `page` has never been in the URL here; it reaches the view as a query param anyway,
+	// because `useView` sources both `page` and `search` from there and nowhere else.
 	const [ page, setPage ] = useState( 1 );
 
 	const onChangeQueryParams = useCallback(

--- a/projects/packages/forms/routes/responses/package.json
+++ b/projects/packages/forms/routes/responses/package.json
@@ -23,9 +23,11 @@
 		"@wordpress/i18n": "6.24.0",
 		"@wordpress/icons": "15.4.0",
 		"@wordpress/notices": "5.51.0",
+		"@wordpress/preferences": "4.51.0",
 		"@wordpress/route": "0.19.0",
 		"@wordpress/theme": "1.2.0",
-		"@wordpress/ui": "0.20.0"
+		"@wordpress/ui": "0.20.0",
+		"@wordpress/views": "~1.20.0"
 	},
 	"route": {
 		"path": "/responses/$view",

--- a/projects/packages/forms/routes/responses/package.json
+++ b/projects/packages/forms/routes/responses/package.json
@@ -23,9 +23,11 @@
 		"@wordpress/i18n": "6.27.0",
 		"@wordpress/icons": "15.5.0",
 		"@wordpress/notices": "5.54.0",
+		"@wordpress/preferences": "4.54.0",
 		"@wordpress/route": "0.20.0",
 		"@wordpress/theme": "2.0.0",
-		"@wordpress/ui": "0.21.0"
+		"@wordpress/ui": "0.21.0",
+		"@wordpress/views": "~1.21.0"
 	},
 	"route": {
 		"path": "/responses/$view",

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -16,8 +16,10 @@ import { useMemo, useState, useCallback, useEffect, useRef } from '@wordpress/el
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { caution } from '@wordpress/icons';
+import { store as preferencesStore } from '@wordpress/preferences';
 import { useParams, useSearch, useNavigate } from '@wordpress/route';
 import { Badge, Link, Notice, Stack } from '@wordpress/ui';
+import { useView } from '@wordpress/views';
 import * as React from 'react';
 /**
  * Internal dependencies
@@ -28,7 +30,8 @@ import TextWithFlag from '../../src/dashboard/components/text-with-flag/index.ts
 import { RESPONSES_PER_PAGE, getResponseStatusFilter } from '../../src/dashboard/constants.ts';
 import useInboxData from '../../src/dashboard/hooks/use-inbox-data.ts';
 import useResponseFieldColumns from '../../src/dashboard/hooks/use-response-field-columns.ts';
-import { writeColumnPreference } from '../../src/dashboard/response-column-preferences.ts';
+import { ensurePreferencesPersistence } from '../../src/dashboard/preferences-persistence.ts';
+import { writeKnownAnswerIds } from '../../src/dashboard/response-column-preferences.ts';
 import {
 	buildResponseFieldColumns,
 	getFrozenColumnsClassName,
@@ -176,10 +179,76 @@ function StageInner() {
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
 	const adminUrl = ( useConfigValue( 'adminUrl' ) as string ) || '';
 
-	const [ view, setView ] = useState< View >( () => ( {
-		...DEFAULT_VIEW,
-		search: searchParams?.search || '',
-	} ) );
+	// `useView` keeps the view in the preferences store, which only holds it in memory
+	// until something gives it somewhere to write to. A wp-build dashboard is not booted
+	// by Core, so nothing else will.
+	const { setPersistenceLayer } = useDispatch( preferencesStore );
+	ensurePreferencesPersistence( setPersistenceLayer );
+
+	// The Folder filter is the route, not a preference: it comes from the URL and must
+	// never be persisted, or reloading /responses/inbox could resolve a stored `spam`.
+	// `isLocked` is how `useView` is told to apply a filter but keep it out of what it
+	// saves. A single form's responses have no Folder filter at all.
+	const activeViewOverrides = useMemo(
+		() =>
+			isSingleFormView
+				? undefined
+				: {
+						filters: [
+							{ field: 'folder', operator: 'is' as const, value: statusView, isLocked: true },
+						],
+				  },
+		[ isSingleFormView, statusView ]
+	);
+
+	// `page` is deliberately not in the URL — it never has been here — so it lives
+	// alongside the search term that is, and both reach the view as query params.
+	const [ page, setPage ] = useState( 1 );
+
+	const onChangeQueryParams = useCallback(
+		( next: { page: number; search: string } ) => {
+			setPage( next.page );
+
+			if ( next.search !== ( searchParams?.search || '' ) ) {
+				navigate( {
+					search: {
+						...searchParams,
+						search: next.search || undefined,
+					},
+				} );
+			}
+		},
+		[ navigate, searchParams ]
+	);
+
+	const { view, updateView } = useView( {
+		kind: 'postType',
+		name: 'feedback',
+		// One remembered view per form, plus one for the view spanning every form. A
+		// form's answer columns name its own fields, so sharing a view across forms
+		// would strand one form's columns on another.
+		slug: isSingleFormView ? `form-${ sourceIdNumber }` : 'all',
+		defaultView: DEFAULT_VIEW,
+		activeViewOverrides,
+		queryParams: { page, search: searchParams?.search || '' },
+		onChangeQueryParams,
+	} );
+
+	// `useView` takes a whole view, while the columns hook and the effects below think in
+	// updates to the previous one. The ref is what makes a second update in the same tick
+	// build on the first instead of clobbering it — the columns effect does exactly that
+	// when it drops the outgoing form's columns and adds the incoming form's.
+	const pendingViewRef = useRef< View >( view );
+	pendingViewRef.current = view;
+
+	const setView = useCallback(
+		( updater: ( previousView: View ) => View ) => {
+			const next = updater( pendingViewRef.current );
+			pendingViewRef.current = next;
+			updateView( next );
+		},
+		[ updateView ]
+	);
 
 	// The form whose column choice is being read and written, or null on the view
 	// spanning every form.
@@ -205,13 +274,6 @@ function StageInner() {
 		currentQuery,
 	} = useInboxData( { status: statusView } );
 
-	useEffect( () => {
-		const urlSearch = searchParams?.search || '';
-		if ( urlSearch !== view.search ) {
-			setView( prev => ( { ...prev, search: urlSearch } ) );
-		}
-	}, [ searchParams?.search ] ); // eslint-disable-line react-hooks/exhaustive-deps
-
 	const onChangeView = useCallback(
 		( incomingView: View ) => {
 			const newView = keepColumnChoice(
@@ -228,10 +290,7 @@ function StageInner() {
 			// constantly and, while a form's responses are still loading, record an empty
 			// set of known answer columns over a choice that names several.
 			if ( ! isSameColumnChoice( newView.fields, view.fields ) ) {
-				writeColumnPreference( columnPreferenceFormId, {
-					fields: newView.fields ?? [],
-					knownAnswerIds: knownAnswerIdsRef.current,
-				} );
+				writeKnownAnswerIds( columnPreferenceFormId, knownAnswerIdsRef.current );
 			}
 
 			if ( ! isSingleFormView ) {
@@ -248,21 +307,14 @@ function StageInner() {
 							responseIds: undefined,
 						},
 					} );
-					setView( { ...newView, page: 1 } );
+					updateView( { ...newView, page: 1 } );
 					return;
 				}
 			}
 
-			setView( newView );
-
-			if ( newView.search !== view.search ) {
-				navigate( {
-					search: {
-						...searchParams,
-						search: newView.search || undefined,
-					},
-				} );
-			}
+			// The search term reaches the URL through `onChangeQueryParams`, which
+			// `updateView` calls whenever it changes.
+			updateView( newView );
 		},
 		[
 			columnPreferenceFormId,
@@ -271,6 +323,7 @@ function StageInner() {
 			navigate,
 			searchParams,
 			statusView,
+			updateView,
 			view,
 		]
 	);
@@ -305,27 +358,6 @@ function StageInner() {
 		},
 		[ isSingleFormView, navigate, searchParams, sourceIdNumber ]
 	);
-
-	// Keep the Folder filter in sync with the route param (CFM-on behavior).
-	useEffect( () => {
-		if ( isSingleFormView ) {
-			return;
-		}
-		setView( previousView => {
-			const previousFilters = previousView.filters || [];
-			const existing = previousFilters.find( filter => filter.field === 'folder' );
-			if ( existing?.value === statusView ) {
-				return previousView;
-			}
-			return {
-				...previousView,
-				filters: [
-					{ field: 'folder', operator: 'is', value: statusView },
-					...previousFilters.filter( filter => filter.field !== 'folder' ),
-				],
-			};
-		} );
-	}, [ isSingleFormView, setView, statusView ] );
 
 	// A form's own fields become columns, so a single form's responses can be read
 	// across at a glance. The "All responses" view spans every form and has no

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -185,22 +185,6 @@ function StageInner() {
 	const { setPersistenceLayer } = useDispatch( preferencesStore );
 	ensurePreferencesPersistence( setPersistenceLayer );
 
-	// The Folder filter is the route, not a preference: it comes from the URL and must
-	// never be persisted, or reloading /responses/inbox could resolve a stored `spam`.
-	// `isLocked` is how `useView` is told to apply a filter but keep it out of what it
-	// saves. A single form's responses have no Folder filter at all.
-	const activeViewOverrides = useMemo(
-		() =>
-			isSingleFormView
-				? undefined
-				: {
-						filters: [
-							{ field: 'folder', operator: 'is' as const, value: statusView, isLocked: true },
-						],
-				  },
-		[ isSingleFormView, statusView ]
-	);
-
 	// `page` is deliberately not in the URL — it never has been here — so it lives
 	// alongside the search term that is, and both reach the view as query params.
 	const [ page, setPage ] = useState( 1 );
@@ -229,7 +213,6 @@ function StageInner() {
 		// would strand one form's columns on another.
 		slug: isSingleFormView ? `form-${ sourceIdNumber }` : 'all',
 		defaultView: DEFAULT_VIEW,
-		activeViewOverrides,
 		queryParams: { page, search: searchParams?.search || '' },
 		onChangeQueryParams,
 	} );
@@ -358,6 +341,31 @@ function StageInner() {
 		},
 		[ isSingleFormView, navigate, searchParams, sourceIdNumber ]
 	);
+
+	// Keep the Folder filter in sync with the route param (CFM-on behavior). The filter is
+	// a real control here, so it cannot be locked out of what `useView` persists; a stored
+	// folder that disagrees with the route is corrected here instead. The responses
+	// themselves are queried from the route, never from this filter, so only the chip is
+	// ever briefly out of step.
+	useEffect( () => {
+		if ( isSingleFormView ) {
+			return;
+		}
+		setView( previousView => {
+			const previousFilters = previousView.filters || [];
+			const existing = previousFilters.find( filter => filter.field === 'folder' );
+			if ( existing?.value === statusView ) {
+				return previousView;
+			}
+			return {
+				...previousView,
+				filters: [
+					{ field: 'folder', operator: 'is' as const, value: statusView },
+					...previousFilters.filter( filter => filter.field !== 'folder' ),
+				],
+			};
+		} );
+	}, [ isSingleFormView, setView, statusView ] );
 
 	// A form's own fields become columns, so a single form's responses can be read
 	// across at a glance. The "All responses" view spans every form and has no

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -179,14 +179,11 @@ function StageInner() {
 	const showDashboardIntegrations = useConfigValue( 'showDashboardIntegrations' );
 	const adminUrl = ( useConfigValue( 'adminUrl' ) as string ) || '';
 
-	// `useView` keeps the view in the preferences store, which only holds it in memory
-	// until something gives it somewhere to write to. A wp-build dashboard is not booted
-	// by Core, so nothing else will.
 	const { setPersistenceLayer } = useDispatch( preferencesStore );
 	ensurePreferencesPersistence( setPersistenceLayer );
 
-	// `page` is deliberately not in the URL — it never has been here — so it lives
-	// alongside the search term that is, and both reach the view as query params.
+	// `page` has never been in the URL here; it reaches the view as a query param anyway,
+	// because `useView` sources both `page` and `search` from there and nowhere else.
 	const [ page, setPage ] = useState( 1 );
 
 	const onChangeQueryParams = useCallback(
@@ -208,8 +205,7 @@ function StageInner() {
 	const { view, updateView } = useView( {
 		kind: 'postType',
 		name: 'feedback',
-		// One remembered view per form, plus one for the view spanning every form. A
-		// form's answer columns name its own fields, so sharing a view across forms
+		// One view per form: answer columns name that form's own fields, so a shared view
 		// would strand one form's columns on another.
 		slug: isSingleFormView ? `form-${ sourceIdNumber }` : 'all',
 		defaultView: DEFAULT_VIEW,
@@ -217,10 +213,8 @@ function StageInner() {
 		onChangeQueryParams,
 	} );
 
-	// `useView` takes a whole view, while the columns hook and the effects below think in
-	// updates to the previous one. The ref is what makes a second update in the same tick
-	// build on the first instead of clobbering it — the columns effect does exactly that
-	// when it drops the outgoing form's columns and adds the incoming form's.
+	// `useView` takes a whole view, while the callers below pass an updater. The ref is what
+	// lets two updates in the same tick build on each other, as the columns effect does.
 	const pendingViewRef = useRef< View >( view );
 	pendingViewRef.current = view;
 
@@ -342,11 +336,9 @@ function StageInner() {
 		[ isSingleFormView, navigate, searchParams, sourceIdNumber ]
 	);
 
-	// Keep the Folder filter in sync with the route param (CFM-on behavior). The filter is
-	// a real control here, so it cannot be locked out of what `useView` persists; a stored
-	// folder that disagrees with the route is corrected here instead. The responses
-	// themselves are queried from the route, never from this filter, so only the chip is
-	// ever briefly out of step.
+	// Keep the Folder filter in sync with the route param (CFM-on behavior). `useView`'s only
+	// way to exclude a filter, `isLocked`, would also make this one unclickable, so a stored
+	// folder disagreeing with the route is corrected here instead.
 	useEffect( () => {
 		if ( isSingleFormView ) {
 			return;

--- a/projects/packages/forms/src/dashboard/hooks/test/use-response-field-columns.test.js
+++ b/projects/packages/forms/src/dashboard/hooks/test/use-response-field-columns.test.js
@@ -1,11 +1,33 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { renderHook } from '@testing-library/react';
-import { writeColumnPreference } from '../../response-column-preferences.ts';
-import useResponseFieldColumns from '../use-response-field-columns.ts';
 
-afterEach( () => window.localStorage.clear() );
+/**
+ * The answer columns each form has already offered, standing in for what the preferences
+ * store holds. The hook only ever reads this, so driving it directly keeps these tests
+ * about which columns get offered rather than about how the record is stored.
+ */
+const knownAnswerIdsByForm = new Map();
+
+await jest.unstable_mockModule( '../../response-column-preferences.ts', () => ( {
+	getColumnPreferenceKey: formId => `response-columns/${ formId ?? 'all' }`,
+	readKnownAnswerIds: formId => knownAnswerIdsByForm.get( formId ) ?? null,
+	writeKnownAnswerIds: ( formId, ids ) => knownAnswerIdsByForm.set( formId, ids ),
+} ) );
+
+const { default: useResponseFieldColumns } = await import( '../use-response-field-columns.ts' );
+
+afterEach( () => knownAnswerIdsByForm.clear() );
 
 const DEFAULT_FIELDS = [ 'date', 'source', 'ip' ];
+
+/**
+ * Records the answer columns a form had already offered when its view was last changed.
+ *
+ * @param {number|null} formId - The form the record belongs to.
+ * @param {string[]}    ids    - The columns already offered.
+ * @return {Map} The updated record map.
+ */
+const alreadyOffered = ( formId, ids ) => knownAnswerIdsByForm.set( formId, ids );
 
 /**
  * Builds a response carrying the given fields, tied to a form.
@@ -26,14 +48,15 @@ const response = ( formId, labels ) => ( {
 } );
 
 /**
- * Renders the hook with a view whose state persists across rerenders, the way a
- * real `useState` view does.
+ * Renders the hook with a view whose state persists across rerenders, the way the view
+ * `useView` hands back does.
  *
- * @param {object} initial - Initial props (`formId`, `records`).
+ * @param {object}   initial - Initial props (`formId`, `records`).
+ * @param {string[]} fields  - The visible columns to start from, as `useView` resolved them.
  * @return {object} The hook result plus `view()` and `rerender()` helpers.
  */
-const setup = initial => {
-	let view = { titleField: 'from', fields: [ ...DEFAULT_FIELDS ] };
+const setup = ( initial, fields = DEFAULT_FIELDS ) => {
+	let view = { titleField: 'from', fields: [ ...fields ] };
 	const setView = jest.fn( updater => {
 		view = typeof updater === 'function' ? updater( view ) : updater;
 	} );
@@ -140,112 +163,75 @@ describe( 'useResponseFieldColumns', () => {
 	} );
 
 	it( 'shows answers first when Date is not among the visible columns', () => {
-		let view = { titleField: 'from', fields: [ 'ip' ] };
-		const setView = jest.fn( updater => {
-			view = typeof updater === 'function' ? updater( view ) : updater;
-		} );
+		const { view } = setup( { formId: 5, records: [ response( 5, [ 'Name' ] ) ] }, [ 'ip' ] );
 
-		renderHook( () =>
-			useResponseFieldColumns( {
-				formId: 5,
-				records: [ response( 5, [ 'Name' ] ) ],
-				setView,
-			} )
-		);
-
-		expect( view.fields ).toEqual( [ 'field:1_Name', 'ip' ] );
+		expect( view().fields ).toEqual( [ 'field:1_Name', 'ip' ] );
 	} );
 } );
 
-describe( 'useResponseFieldColumns, restoring a saved choice', () => {
-	it( 'starts from the columns the user last chose on this form', () => {
-		writeColumnPreference( 5, {
-			fields: [ 'date', 'field:2_Email', 'ip' ],
-			knownAnswerIds: [ 'field:1_Name', 'field:2_Email' ],
-		} );
+describe( 'useResponseFieldColumns, against a view that was restored', () => {
+	it( 'leaves the restored columns alone rather than re-offering them', () => {
+		// `useView` restores which columns are shown; the record says both answer columns
+		// were already offered when that choice was made, so neither may be added back.
+		alreadyOffered( 5, [ 'field:1_Name', 'field:2_Email' ] );
 
-		const { view } = setup( { formId: 5, records: [ response( 5, [ 'Name', 'Email' ] ) ] } );
+		const { view } = setup( { formId: 5, records: [ response( 5, [ 'Name', 'Email' ] ) ] }, [
+			'date',
+			'field:2_Email',
+			'ip',
+		] );
 
-		// Name was hidden and Source removed; both stay that way, and neither column is
-		// re-offered just because the responses carrying them loaded again.
+		// Name stays hidden and Source stays removed.
 		expect( view().fields ).toEqual( [ 'date', 'field:2_Email', 'ip' ] );
 	} );
 
-	it( 'still shows a field added to the form since the choice was saved', () => {
-		writeColumnPreference( 5, {
-			fields: [ 'date', 'ip' ],
-			knownAnswerIds: [ 'field:1_Name' ],
-		} );
+	it( 'still shows a field added to the form since the choice was made', () => {
+		alreadyOffered( 5, [ 'field:1_Name' ] );
 
-		const { view } = setup( { formId: 5, records: [ response( 5, [ 'Name', 'Phone' ] ) ] } );
+		const { view } = setup( { formId: 5, records: [ response( 5, [ 'Name', 'Phone' ] ) ] }, [
+			'date',
+			'ip',
+		] );
 
-		// Name was on offer when the choice was saved and stays hidden. Phone was not, so
-		// it is genuinely new and appears after Date.
+		// Name was on offer at the time and stays hidden. Phone was not, so it is
+		// genuinely new and appears after Date.
 		expect( view().fields ).toEqual( [ 'date', 'field:2_Phone', 'ip' ] );
 	} );
 
-	it( 'restores each form its own choice when switching between them', () => {
-		writeColumnPreference( 5, { fields: [ 'date', 'ip' ], knownAnswerIds: [ 'field:1_Name' ] } );
-		writeColumnPreference( 30, {
-			fields: [ 'field:1_Reporter', 'date' ],
-			knownAnswerIds: [ 'field:1_Reporter' ],
-		} );
+	it( 'reads each form’s own record when switching between them', () => {
+		alreadyOffered( 5, [ 'field:1_Name' ] );
+		alreadyOffered( 30, [] );
 
-		const { rerender, view } = setup( { formId: 5, records: [ response( 5, [ 'Name' ] ) ] } );
+		const { rerender, view } = setup( { formId: 5, records: [ response( 5, [ 'Name' ] ) ] }, [
+			'date',
+			'ip',
+		] );
 
+		// Form 5 had already offered Name, so it is not added back.
 		expect( view().fields ).toEqual( [ 'date', 'ip' ] );
 
+		// Form 30 has offered nothing, so its own field is new and appears.
 		rerender( { formId: 30, records: [ response( 30, [ 'Reporter' ] ) ] } );
 
-		expect( view().fields ).toEqual( [ 'field:1_Reporter', 'date' ] );
+		expect( view().fields ).toEqual( [ 'date', 'field:1_Reporter', 'ip' ] );
 	} );
 
-	it( 'restores the every-form view too, which has no answer columns of its own', () => {
-		writeColumnPreference( null, { fields: [ 'date', 'read_status' ], knownAnswerIds: [] } );
-
-		const { result, view } = setup( { formId: null, records: [ response( 5, [ 'Name' ] ) ] } );
-
-		expect( result.current ).toEqual( [] );
-		expect( view().fields ).toEqual( [ 'date', 'read_status' ] );
-	} );
-
-	it( 'falls back to the default columns when nothing was ever saved', () => {
+	it( 'offers every column when the form has no record at all', () => {
 		const { view } = setup( { formId: 5, records: [ response( 5, [ 'Name' ] ) ] } );
 
 		expect( view().fields ).toEqual( [ 'date', 'field:1_Name', 'source', 'ip' ] );
 	} );
-} );
 
-/**
- * A response whose fields carry form field ids, as everything stored since they shipped does.
- *
- * @param {number}   formId - The jetpack_form post the response belongs to.
- * @param {string[]} labels - One field per label.
- * @return {object} A form response.
- */
-const identifiedResponse = ( formId, labels ) => ( {
-	id: `${ formId }-id-${ labels.join( '-' ) }`,
-	form_id: formId,
-	fields: labels.map( ( label, index ) => ( {
-		id: `g${ formId }-${ label.toLowerCase() }`,
-		key: `${ index + 1 }_${ label }`,
-		label,
-		value: 'x',
-		type: 'text',
-	} ) ),
-} );
-
-describe( 'useResponseFieldColumns, reconciling a restored choice', () => {
-	it( 'does not add a column the restored choice already names', () => {
-		// A choice can name a column the hook is only now discovering — when it was saved
-		// before the answer columns had loaded, so `knownAnswerIds` never recorded them.
-		// Adding it again would render the column twice.
-		writeColumnPreference( 5, {
-			fields: [ 'date', 'field:1_Name', 'source', 'ip' ],
-			knownAnswerIds: [],
-		} );
-
-		const { view } = setup( { formId: 5, records: [ response( 5, [ 'Name' ] ) ] } );
+	it( 'does not add a column the restored view already names', () => {
+		// A view can already name a column the hook is only now discovering — when it was
+		// saved before the answer columns had loaded, so nothing was ever recorded as
+		// offered. Adding it again would render the column twice.
+		const { view } = setup( { formId: 5, records: [ response( 5, [ 'Name' ] ) ] }, [
+			'date',
+			'field:1_Name',
+			'source',
+			'ip',
+		] );
 
 		expect( view().fields ).toEqual( [ 'date', 'field:1_Name', 'source', 'ip' ] );
 	} );
@@ -253,29 +239,39 @@ describe( 'useResponseFieldColumns, reconciling a restored choice', () => {
 	it( 'leaves a column for a field the form no longer has, for the view to withhold', () => {
 		// The hook cannot tell a deleted field from one whose responses are still loading,
 		// so it keeps the id and `getResponseTableView` declines to render it.
-		writeColumnPreference( 5, {
-			fields: [ 'date', 'field:1_Deleted', 'source' ],
-			knownAnswerIds: [ 'field:1_Deleted' ],
-		} );
+		alreadyOffered( 5, [ 'field:1_Deleted' ] );
 
-		const { result, view } = setup( { formId: 5, records: [ response( 5, [ 'Name' ] ) ] } );
+		const { result, view } = setup( { formId: 5, records: [ response( 5, [ 'Name' ] ) ] }, [
+			'date',
+			'field:1_Deleted',
+			'source',
+		] );
 
-		// Name was never on offer when the choice was saved, so it is new and appears;
-		// the deleted field's id is kept, and only the rendered view drops it.
+		// Name was never offered before, so it is new and appears; the deleted field's id
+		// is kept, and only the rendered view drops it.
 		expect( view().fields ).toEqual( [ 'date', 'field:1_Name', 'field:1_Deleted', 'source' ] );
 		expect( result.current.map( column => column.id ) ).toEqual( [ 'field:1_Name' ] );
 	} );
 
-	it( 'restores a choice made on responses that carry form field ids', () => {
-		writeColumnPreference( 5, {
-			fields: [ 'date', 'field:g5-email', 'ip' ],
-			knownAnswerIds: [ 'field:g5-name', 'field:g5-email' ],
+	it( 'works the same for responses that carry form field ids', () => {
+		alreadyOffered( 5, [ 'field:g5-name', 'field:g5-email' ] );
+
+		const identifiedResponse = ( formId, labels ) => ( {
+			id: `${ formId }-id-${ labels.join( '-' ) }`,
+			form_id: formId,
+			fields: labels.map( ( label, index ) => ( {
+				id: `g${ formId }-${ label.toLowerCase() }`,
+				key: `${ index + 1 }_${ label }`,
+				label,
+				value: 'x',
+				type: 'text',
+			} ) ),
 		} );
 
-		const { result, view } = setup( {
-			formId: 5,
-			records: [ identifiedResponse( 5, [ 'Name', 'Email' ] ) ],
-		} );
+		const { result, view } = setup(
+			{ formId: 5, records: [ identifiedResponse( 5, [ 'Name', 'Email' ] ) ] },
+			[ 'date', 'field:g5-email', 'ip' ]
+		);
 
 		expect( result.current.map( column => column.id ) ).toEqual( [
 			'field:g5-name',

--- a/projects/packages/forms/src/dashboard/hooks/test/use-response-field-columns.test.js
+++ b/projects/packages/forms/src/dashboard/hooks/test/use-response-field-columns.test.js
@@ -1,11 +1,8 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { renderHook } from '@testing-library/react';
 
-/**
- * The answer columns each form has already offered, standing in for what the preferences
- * store holds. The hook only ever reads this, so driving it directly keeps these tests
- * about which columns get offered rather than about how the record is stored.
- */
+// Stands in for the stored record. The hook only reads it, so driving it directly keeps
+// these tests about which columns get offered, not about how the record is stored.
 const knownAnswerIdsByForm = new Map();
 
 await jest.unstable_mockModule( '../../response-column-preferences.ts', () => ( {

--- a/projects/packages/forms/src/dashboard/hooks/use-response-field-columns.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-response-field-columns.ts
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { readColumnPreference } from '../response-column-preferences.ts';
+import { readKnownAnswerIds } from '../response-column-preferences.ts';
 import {
 	getResponseFieldColumns,
 	mergeResponseFieldColumns,
@@ -115,24 +115,24 @@ export default function useResponseFieldColumns( {
 
 		if ( previous.formId !== formId ) {
 			const staleIds = new Set( previous.columns.map( column => column.id ) );
-			const restored = readColumnPreference( formId );
 
 			seen.current = {
 				formId,
 				columns: EMPTY_COLUMNS,
-				// The answer columns that were on offer when this form's choice was saved.
-				// Anything in here has already been offered to the user once, so it must
-				// not be re-added — that is what keeps a hidden column hidden.
-				restoredIds: new Set( restored?.knownAnswerIds ?? [] ),
+				// The answer columns that were on offer when this form's view was last
+				// changed. Anything in here has already been offered to the user once, so
+				// it must not be re-added — that is what keeps a hidden column hidden.
+				restoredIds: new Set( readKnownAnswerIds( formId ) ?? [] ),
 			};
 			setColumns( EMPTY_COLUMNS );
 
-			if ( restored || staleIds.size > 0 ) {
+			// Which columns are shown is restored by `useView` before this runs, so the
+			// only thing left to fix up is the outgoing form's answer columns: they name
+			// fields the incoming form does not have.
+			if ( staleIds.size > 0 ) {
 				setView( previousView => ( {
 					...previousView,
-					fields: restored
-						? restored.fields
-						: ( previousView.fields || [] ).filter( id => ! staleIds.has( id ) ),
+					fields: ( previousView.fields || [] ).filter( id => ! staleIds.has( id ) ),
 				} ) );
 			}
 		}

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.jsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.jsx
@@ -35,7 +35,7 @@ import Page from '../../components/page/index.tsx';
 import TextWithFlag from '../../components/text-with-flag/index.tsx';
 import useInboxData from '../../hooks/use-inbox-data.ts';
 import useResponseFieldColumns from '../../hooks/use-response-field-columns.ts';
-import { writeColumnPreference } from '../../response-column-preferences.ts';
+import { writeKnownAnswerIds } from '../../response-column-preferences.ts';
 import {
 	buildResponseFieldColumns,
 	getFrozenColumnsClassName,
@@ -103,7 +103,7 @@ const setupSidebarWidthObserver = () => {
  * @return {import('react').JSX.Element} The DataViews component.
  */
 export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) {
-	const [ view, setView ] = useView();
+	const [ view, setView ] = useView( parentId );
 	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
 	const parent = useMemo( () => {
 		const id = Number( parentId );
@@ -323,10 +323,7 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 			// constantly and, while a form's responses are still loading, record an empty
 			// set of known answer columns over a choice that names several.
 			if ( ! isSameColumnChoice( newView.fields, view.fields ) ) {
-				writeColumnPreference( parent, {
-					fields: newView.fields ?? [],
-					knownAnswerIds: knownAnswerIdsRef.current,
-				} );
+				writeKnownAnswerIds( parent, knownAnswerIdsRef.current );
 			}
 
 			if ( ! isInboxStatusToggleView ) {

--- a/projects/packages/forms/src/dashboard/inbox/stage/views.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/views.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { useEvent } from '@wordpress/compose';
-import { useEffect, useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { useRef, useState } from '@wordpress/element';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { useView as useCoreView } from '@wordpress/views';
+import { ensurePreferencesPersistence } from '../../preferences-persistence.ts';
 import { useDashboardSearchParams } from '../../router/dashboard-search-params-context.tsx';
 
 const LAYOUT_TABLE = 'table';
@@ -26,60 +30,74 @@ export const defaultLayouts = {
 };
 
 /**
- * This hook provides a [ state, setState ] tuple based on the URL parameters
- * and handles the syncing between the URL and the state.
+ * Provides the responses view as a [ state, setState ] tuple.
  *
- * Currently we do that for the `status` and `search` URL params.
+ * The view itself is `useView` from `@wordpress/views`: it resolves the stored view over
+ * the defaults and writes back whatever the user changed, so a column choice, a sort or a
+ * page size survives a reload. `search` stays in the URL, where it was already, and
+ * reaches the view as a query param rather than as something remembered.
  *
+ * @param {number|string} [parentId] - The form whose responses are on screen, if one.
  * @return {Array} The [ state, setState ] tuple.
  */
-export function useView() {
+export function useView( parentId ) {
 	const [ searchParams, setSearchParams ] = useDashboardSearchParams();
 	// Normalize missing query param to empty string so we don't treat
 	// `null` (missing) and `''` (empty) as different values.
 	const urlSearch = searchParams.get( 'search' ) ?? '';
-	const [ view, setView ] = useState( () => ( {
-		...defaultView,
-		search: urlSearch,
-	} ) );
-	// When view changes, update the URL params if needed.
+
+	// Nothing else gives the preferences store somewhere to write to here.
+	const { setPersistenceLayer } = useDispatch( preferencesStore );
+	ensurePreferencesPersistence( setPersistenceLayer );
+
+	// `page` has never been in the URL on this screen, so it is held here and handed to
+	// the view as a query param, the way `search` is.
+	const [ page, setPage ] = useState( 1 );
+
+	const onChangeQueryParams = useEvent( next => {
+		setPage( next.page );
+
+		if ( next.search === urlSearch ) {
+			return;
+		}
+
+		setSearchParams( previousSearchParams => {
+			const _searchParams = new URLSearchParams( previousSearchParams );
+			if ( next.search ) {
+				_searchParams.set( 'search', next.search );
+			} else {
+				_searchParams.delete( 'search' );
+			}
+			return _searchParams;
+		} );
+	} );
+
+	const formId = Number( parentId );
+	const { view, updateView } = useCoreView( {
+		kind: 'postType',
+		name: 'feedback',
+		// One remembered view per form, plus one for the view spanning every form: a
+		// form's answer columns name its own fields and mean nothing on another.
+		slug: Number.isFinite( formId ) && formId > 0 ? `form-${ formId }` : 'all',
+		defaultView,
+		queryParams: { page, search: urlSearch },
+		onChangeQueryParams,
+	} );
+
+	// Callers treat this like a normal React setState setter, and some of them pass an
+	// updater. `useView` takes a whole view, so the previous one is read from a ref —
+	// which is also what lets two updates in the same tick build on each other rather
+	// than the second discarding the first.
+	const pendingViewRef = useRef( view );
+	pendingViewRef.current = view;
+
 	const setViewWithUrlUpdate = useEvent( nextView => {
-		// Support both "setView(newView)" and "setView(prev => next)" call styles,
-		// since callers treat this like a normal React setState setter.
-		setView( previousView => {
-			const resolvedView = typeof nextView === 'function' ? nextView( previousView ) : nextView;
+		const resolvedView =
+			typeof nextView === 'function' ? nextView( pendingViewRef.current ) : nextView;
 
-			if ( resolvedView.search !== urlSearch ) {
-				setSearchParams( previousSearchParams => {
-					const _searchParams = new URLSearchParams( previousSearchParams );
-					if ( resolvedView.search ) {
-						_searchParams.set( 'search', resolvedView.search );
-					} else {
-						_searchParams.delete( 'search' );
-					}
-					return _searchParams;
-				} );
-			}
+		pendingViewRef.current = resolvedView;
+		updateView( resolvedView );
+	} );
 
-			return resolvedView;
-		} );
-	} );
-	// When search URL param changes, update the view's search filter
-	// without affecting any other config.
-	const onUrlSearchChange = useEvent( () => {
-		setView( previousView => {
-			const newValue = urlSearch;
-			if ( newValue === previousView.search ) {
-				return previousView;
-			}
-			return {
-				...previousView,
-				search: newValue,
-			};
-		} );
-	} );
-	useEffect( () => {
-		onUrlSearchChange();
-	}, [ onUrlSearchChange, urlSearch ] );
 	return [ view, setViewWithUrlUpdate ];
 }

--- a/projects/packages/forms/src/dashboard/inbox/stage/views.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/views.js
@@ -30,12 +30,10 @@ export const defaultLayouts = {
 };
 
 /**
- * Provides the responses view as a [ state, setState ] tuple.
+ * Provides the responses view as a [ state, setState ] tuple, persisted by `useView`.
  *
- * The view itself is `useView` from `@wordpress/views`: it resolves the stored view over
- * the defaults and writes back whatever the user changed, so a column choice, a sort or a
- * page size survives a reload. `search` stays in the URL, where it was already, and
- * reaches the view as a query param rather than as something remembered.
+ * `search` stays in the URL where it already was, reaching the view as a query param
+ * rather than as something remembered.
  *
  * @param {number|string} [parentId] - The form whose responses are on screen, if one.
  * @return {Array} The [ state, setState ] tuple.
@@ -46,12 +44,11 @@ export function useView( parentId ) {
 	// `null` (missing) and `''` (empty) as different values.
 	const urlSearch = searchParams.get( 'search' ) ?? '';
 
-	// Nothing else gives the preferences store somewhere to write to here.
 	const { setPersistenceLayer } = useDispatch( preferencesStore );
 	ensurePreferencesPersistence( setPersistenceLayer );
 
-	// `page` has never been in the URL on this screen, so it is held here and handed to
-	// the view as a query param, the way `search` is.
+	// `page` has never been in the URL here; it reaches the view as a query param anyway,
+	// because `useView` sources both `page` and `search` from there and nowhere else.
 	const [ page, setPage ] = useState( 1 );
 
 	const onChangeQueryParams = useEvent( next => {
@@ -76,18 +73,16 @@ export function useView( parentId ) {
 	const { view, updateView } = useCoreView( {
 		kind: 'postType',
 		name: 'feedback',
-		// One remembered view per form, plus one for the view spanning every form: a
-		// form's answer columns name its own fields and mean nothing on another.
+		// One view per form: answer columns name that form's own fields, so a shared view
+		// would strand one form's columns on another.
 		slug: Number.isFinite( formId ) && formId > 0 ? `form-${ formId }` : 'all',
 		defaultView,
 		queryParams: { page, search: urlSearch },
 		onChangeQueryParams,
 	} );
 
-	// Callers treat this like a normal React setState setter, and some of them pass an
-	// updater. `useView` takes a whole view, so the previous one is read from a ref —
-	// which is also what lets two updates in the same tick build on each other rather
-	// than the second discarding the first.
+	// Callers pass an updater, while `useView` takes a whole view. The ref supplies the
+	// previous one, and lets two updates in the same tick build on each other.
 	const pendingViewRef = useRef( view );
 	pendingViewRef.current = view;
 

--- a/projects/packages/forms/src/dashboard/preferences-persistence.ts
+++ b/projects/packages/forms/src/dashboard/preferences-persistence.ts
@@ -1,0 +1,92 @@
+/**
+ * Gives the Forms dashboard's `@wordpress/preferences` store somewhere to persist to.
+ *
+ * `useView` from `@wordpress/views` keeps a DataViews view in the preferences store, but
+ * the store only holds it in memory: persisting is the host's job, and the host wires a
+ * layer up during boot. wp-admin does that for the block editor; a wp-build dashboard is
+ * not booted by Core and `@wordpress/boot` registers nothing, so without this the view
+ * resolves from the defaults again on every reload and no preference ever survives.
+ *
+ * `localStorage` rather than user meta: a view is a per-browser convenience, and writing
+ * it to user meta would mean a REST round trip on every column drag. The layer is the
+ * only thing that would have to change to move it server-side later.
+ */
+import { getScriptData } from '@automattic/jetpack-script-data';
+
+/** The shape the preferences store hands us: its entire payload, scopes and all. */
+type PersistenceData = Record< string, unknown >;
+
+/**
+ * Builds a storage key scoped to the current site and user, so two accounts sharing a
+ * browser — or one account across two sites — don't inherit each other's views.
+ *
+ * @return The per-site, per-user storage key.
+ */
+const getStorageKey = (): string => {
+	const data = getScriptData();
+	// `blog_id` is 0 on a disconnected site, so `??` would read that 0 as a real id and
+	// collapse every disconnected site in this browser onto one key. Only a positive id
+	// is an id; otherwise fall back to the host so sites stay apart.
+	const blogId = data?.site?.wpcom?.blog_id;
+	const scope = typeof blogId === 'number' && blogId > 0 ? blogId : data?.site?.host ?? 'site';
+	const userId = data?.user?.current_user?.id ?? 'user';
+
+	return `jetpack-forms-preferences-${ scope }-${ userId }`;
+};
+
+/**
+ * Reads the stored payload.
+ *
+ * Every access is wrapped: reading `localStorage` is not merely unreliable but throwing —
+ * a private window, a browser set to block site data, or a full quota all raise rather
+ * than return empty. A remembered column layout must never take the dashboard down.
+ *
+ * @return The stored payload, or an empty one when there is nothing to restore.
+ */
+const readStoredData = (): PersistenceData => {
+	try {
+		const raw = window.localStorage.getItem( getStorageKey() );
+
+		return raw ? JSON.parse( raw ) : {};
+	} catch {
+		return {};
+	}
+};
+
+let persistenceLayerRegistered = false;
+
+/**
+ * Registers the persistence layer on the preferences store.
+ *
+ * The store calls `get()` once on registration to hydrate itself, then `set()` with its
+ * whole payload on every change. Idempotent, because both dashboard implementations mount
+ * this and a second registration would re-hydrate over unsaved state.
+ *
+ * @param registerLayer - The preferences store's `setPersistenceLayer` action.
+ */
+export const ensurePreferencesPersistence = (
+	registerLayer: ( layer: {
+		get: () => Promise< PersistenceData >;
+		set: ( value: PersistenceData ) => void;
+	} ) => void
+): void => {
+	if ( persistenceLayerRegistered ) {
+		return;
+	}
+
+	persistenceLayerRegistered = true;
+
+	const storageKey = getStorageKey();
+
+	registerLayer( {
+		get: async () => readStoredData(),
+		set: ( value: PersistenceData ) => {
+			try {
+				window.localStorage.setItem( storageKey, JSON.stringify( value ) );
+			} catch {
+				// Storage may be unavailable or full. The view still works for this
+				// session; it simply starts from the defaults next time.
+			}
+		},
+	} );
+};

--- a/projects/packages/forms/src/dashboard/preferences-persistence.ts
+++ b/projects/packages/forms/src/dashboard/preferences-persistence.ts
@@ -1,15 +1,8 @@
 /**
  * Gives the Forms dashboard's `@wordpress/preferences` store somewhere to persist to.
  *
- * `useView` from `@wordpress/views` keeps a DataViews view in the preferences store, but
- * the store only holds it in memory: persisting is the host's job, and the host wires a
- * layer up during boot. wp-admin does that for the block editor; a wp-build dashboard is
- * not booted by Core and `@wordpress/boot` registers nothing, so without this the view
- * resolves from the defaults again on every reload and no preference ever survives.
- *
- * `localStorage` rather than user meta: a view is a per-browser convenience, and writing
- * it to user meta would mean a REST round trip on every column drag. The layer is the
- * only thing that would have to change to move it server-side later.
+ * Without this the store keeps the view in memory only: a wp-build dashboard is not booted
+ * by Core, and `@wordpress/boot` registers no layer, so nothing survives a reload.
  */
 import { getScriptData } from '@automattic/jetpack-script-data';
 
@@ -37,9 +30,8 @@ const getStorageKey = (): string => {
 /**
  * Reads the stored payload.
  *
- * Every access is wrapped: reading `localStorage` is not merely unreliable but throwing —
- * a private window, a browser set to block site data, or a full quota all raise rather
- * than return empty. A remembered column layout must never take the dashboard down.
+ * Wrapped because `localStorage` throws rather than returning empty in a private window or
+ * when site data is blocked, and a remembered view must never take the dashboard down.
  *
  * @return The stored payload, or an empty one when there is nothing to restore.
  */
@@ -58,9 +50,8 @@ let persistenceLayerRegistered = false;
 /**
  * Registers the persistence layer on the preferences store.
  *
- * The store calls `get()` once on registration to hydrate itself, then `set()` with its
- * whole payload on every change. Idempotent, because both dashboard implementations mount
- * this and a second registration would re-hydrate over unsaved state.
+ * Idempotent: both dashboard implementations mount this, and a second registration would
+ * re-hydrate over unsaved state.
  *
  * @param registerLayer - The preferences store's `setPersistenceLayer` action.
  */

--- a/projects/packages/forms/src/dashboard/response-column-preferences.ts
+++ b/projects/packages/forms/src/dashboard/response-column-preferences.ts
@@ -1,107 +1,77 @@
 /**
- * Remembers which columns a user chose on the responses table.
+ * Remembers which answer columns a form has already offered the user.
  *
- * DataViews reports a column being shown, hidden or moved, but has nowhere to keep that:
- * the view is component state, so a refresh puts every column back where it started and
- * silently discards the choice.
+ * `useView` persists the view itself, `fields` included, so which columns are shown is no
+ * longer this file's business. What it cannot record is which columns were *on offer*
+ * when the user made that choice, and without that a hidden column comes straight back:
+ * the columns hook adds any answer column it has not seen before, and after a reload it
+ * has seen none of them. Recording what was on offer lets it tell a column the user hid
+ * from a field genuinely added to the form since.
  *
- * The choice is stored per form. Answer columns are the form's own fields, so they mean
- * nothing on another form, and one shared list would either strand a form's columns on
- * its neighbour or fight the per-form reset the columns hook already does.
+ * The record is kept per form. Answer columns are the form's own fields, so they mean
+ * nothing on another form.
  *
- * `localStorage` rather than user meta: this is a per-browser convenience, and the
- * dashboard has no preferences store to hang it on. Every access is wrapped, because
- * reading it is not merely unreliable but throwing — a private window, a browser set to
- * block site data, or a full quota all raise rather than return empty. A forgotten column
- * layout must never take the dashboard down with it.
+ * It lives in the `@wordpress/preferences` store, next to the view it belongs to, so both
+ * are written through the one persistence layer and cannot end up in different places.
  */
+import { select, dispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
 
-/** Namespaced so the key cannot collide with anything else on the admin origin. */
-const STORAGE_PREFIX = 'jetpack-forms/response-columns/';
+/** Namespaced so the key cannot collide with another feature's preferences. */
+const PREFERENCES_SCOPE = 'jetpack/forms';
 
 /*
- * Shape of the stored payload. A stored choice replaces the default columns wholesale, so
- * a later change to what those defaults are — a new built-in column, say — would never
- * reach anyone holding an older choice. Bumping this discards them and starts over, which
- * costs the user one re-hidden column and is the only way to make such a change land.
+ * Shape of the stored payload. Bumping this discards what is stored and starts over,
+ * which costs the user one re-shown column — the only way a change to the shape can land
+ * without stranding anyone holding an older record.
  */
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 
-export type ResponseColumnPreference = {
-	/** The view's `fields`: which columns are shown, in the order the user put them. */
-	fields: string[];
-	/**
-	 * Every answer column that existed when the choice was saved.
-	 *
-	 * Without this, a hidden column would come straight back: the columns hook adds any
-	 * answer column it has not seen before, and after a refresh it has seen none of them.
-	 * Recording what was on offer at the time lets it tell a column the user hid from a
-	 * field that has genuinely been added to the form since.
-	 */
+type StoredKnownAnswerIds = {
+	v: number;
 	knownAnswerIds: string[];
 };
 
 /**
- * The storage key for a form's column choice.
+ * The preference key for a form's record.
  *
  * @param formId - The form on screen, or null on the view spanning every form.
- * @return         The storage key.
+ * @return         The preference key.
  */
 export const getColumnPreferenceKey = ( formId: number | null ): string =>
-	`${ STORAGE_PREFIX }${ formId ?? 'all' }`;
+	`response-columns/${ formId ?? 'all' }`;
 
 /**
- * Reads a form's stored column choice.
+ * Reads the answer columns a form had already offered when its view was last changed.
  *
- * Anything unreadable, malformed or of the wrong shape is treated as no choice at all, so
- * a stale or hand-edited entry falls back to the defaults rather than rendering a broken
- * table.
+ * Anything malformed or of an older shape is treated as no record at all, so a stale
+ * entry re-offers every column rather than wedging the table.
  *
  * @param formId - The form on screen, or null on the view spanning every form.
- * @return         The stored choice, or null when there is none to restore.
+ * @return         The columns already offered, or null when there is no record.
  */
-export const readColumnPreference = ( formId: number | null ): ResponseColumnPreference | null => {
-	try {
-		const raw = window.localStorage.getItem( getColumnPreferenceKey( formId ) );
+export const readKnownAnswerIds = ( formId: number | null ): string[] | null => {
+	const stored = select( preferencesStore ).get(
+		PREFERENCES_SCOPE,
+		getColumnPreferenceKey( formId )
+	) as StoredKnownAnswerIds | undefined;
 
-		if ( ! raw ) {
-			return null;
-		}
-
-		const parsed = JSON.parse( raw );
-
-		if ( ! parsed || ! Array.isArray( parsed.fields ) || parsed.v !== SCHEMA_VERSION ) {
-			return null;
-		}
-
-		const fields = parsed.fields.filter( ( id: unknown ) => typeof id === 'string' );
-		const knownAnswerIds = Array.isArray( parsed.knownAnswerIds )
-			? parsed.knownAnswerIds.filter( ( id: unknown ) => typeof id === 'string' )
-			: [];
-
-		return { fields, knownAnswerIds };
-	} catch {
+	if ( ! stored || stored.v !== SCHEMA_VERSION || ! Array.isArray( stored.knownAnswerIds ) ) {
 		return null;
 	}
+
+	return stored.knownAnswerIds.filter( ( id: unknown ) => typeof id === 'string' );
 };
 
 /**
- * Stores a form's column choice.
+ * Records the answer columns a form has offered.
  *
- * @param formId     - The form on screen, or null on the view spanning every form.
- * @param preference - The choice to store.
+ * @param formId         - The form on screen, or null on the view spanning every form.
+ * @param knownAnswerIds - Every answer column on offer at the time.
  */
-export const writeColumnPreference = (
-	formId: number | null,
-	preference: ResponseColumnPreference
-): void => {
-	try {
-		window.localStorage.setItem(
-			getColumnPreferenceKey( formId ),
-			JSON.stringify( { ...preference, v: SCHEMA_VERSION } )
-		);
-	} catch {
-		// A choice of columns is not worth an error path. If it cannot be stored the
-		// table still works; it simply starts from the defaults next time.
-	}
+export const writeKnownAnswerIds = ( formId: number | null, knownAnswerIds: string[] ): void => {
+	dispatch( preferencesStore ).set( PREFERENCES_SCOPE, getColumnPreferenceKey( formId ), {
+		v: SCHEMA_VERSION,
+		knownAnswerIds,
+	} );
 };

--- a/projects/packages/forms/src/dashboard/response-column-preferences.ts
+++ b/projects/packages/forms/src/dashboard/response-column-preferences.ts
@@ -1,18 +1,8 @@
 /**
  * Remembers which answer columns a form has already offered the user.
  *
- * `useView` persists the view itself, `fields` included, so which columns are shown is no
- * longer this file's business. What it cannot record is which columns were *on offer*
- * when the user made that choice, and without that a hidden column comes straight back:
- * the columns hook adds any answer column it has not seen before, and after a reload it
- * has seen none of them. Recording what was on offer lets it tell a column the user hid
- * from a field genuinely added to the form since.
- *
- * The record is kept per form. Answer columns are the form's own fields, so they mean
- * nothing on another form.
- *
- * It lives in the `@wordpress/preferences` store, next to the view it belongs to, so both
- * are written through the one persistence layer and cannot end up in different places.
+ * `useView` persists which columns are shown; this records which were on offer at the time,
+ * without which the columns hook re-adds — and so un-hides — every one of them on reload.
  */
 import { select, dispatch } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -20,11 +10,8 @@ import { store as preferencesStore } from '@wordpress/preferences';
 /** Namespaced so the key cannot collide with another feature's preferences. */
 const PREFERENCES_SCOPE = 'jetpack/forms';
 
-/*
- * Shape of the stored payload. Bumping this discards what is stored and starts over,
- * which costs the user one re-shown column — the only way a change to the shape can land
- * without stranding anyone holding an older record.
- */
+// Bumping this discards what is stored, costing one re-shown column. It is the only way a
+// change to the shape lands without stranding anyone holding an older record.
 const SCHEMA_VERSION = 2;
 
 type StoredKnownAnswerIds = {
@@ -44,8 +31,8 @@ export const getColumnPreferenceKey = ( formId: number | null ): string =>
 /**
  * Reads the answer columns a form had already offered when its view was last changed.
  *
- * Anything malformed or of an older shape is treated as no record at all, so a stale
- * entry re-offers every column rather than wedging the table.
+ * A malformed or older-shaped record reads as none at all, so a stale entry re-offers every
+ * column rather than wedging the table.
  *
  * @param formId - The form on screen, or null on the view spanning every form.
  * @return         The columns already offered, or null when there is no record.

--- a/projects/packages/forms/src/dashboard/test/preferences-persistence.test.js
+++ b/projects/packages/forms/src/dashboard/test/preferences-persistence.test.js
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+await jest.unstable_mockModule( '@automattic/jetpack-script-data', () => ( {
+	getScriptData: () => ( {
+		site: { wpcom: { blog_id: 123 }, host: 'example.com' },
+		user: { current_user: { id: 7 } },
+	} ),
+} ) );
+
+const { ensurePreferencesPersistence } = await import( '../preferences-persistence.ts' );
+
+const KEY = 'jetpack-forms-preferences-123-7';
+
+let layer;
+
+beforeEach( () => {
+	window.localStorage.clear();
+} );
+
+afterEach( () => {
+	jest.restoreAllMocks();
+	window.localStorage.clear();
+} );
+
+describe( 'ensurePreferencesPersistence', () => {
+	it( 'registers a layer keyed to the site and user', () => {
+		const registerLayer = jest.fn( registered => {
+			layer = registered;
+		} );
+
+		ensurePreferencesPersistence( registerLayer );
+
+		expect( registerLayer ).toHaveBeenCalledTimes( 1 );
+
+		layer.set( { 'core/views': { 'dataviews-postType-feedback-all': { perPage: 50 } } } );
+
+		expect( JSON.parse( window.localStorage.getItem( KEY ) ) ).toEqual( {
+			'core/views': { 'dataviews-postType-feedback-all': { perPage: 50 } },
+		} );
+	} );
+
+	it( 'registers only once, so a second dashboard mount cannot re-hydrate over live state', () => {
+		const registerLayer = jest.fn();
+
+		ensurePreferencesPersistence( registerLayer );
+
+		expect( registerLayer ).not.toHaveBeenCalled();
+	} );
+
+	it( 'hydrates from what was stored', async () => {
+		window.localStorage.setItem( KEY, JSON.stringify( { 'core/views': { a: 1 } } ) );
+
+		await expect( layer.get() ).resolves.toEqual( { 'core/views': { a: 1 } } );
+	} );
+
+	it( 'hydrates empty when nothing is stored', async () => {
+		await expect( layer.get() ).resolves.toEqual( {} );
+	} );
+
+	it( 'hydrates empty rather than throwing on a damaged entry', async () => {
+		window.localStorage.setItem( KEY, '{ not json' );
+
+		await expect( layer.get() ).resolves.toEqual( {} );
+	} );
+
+	it( 'hydrates empty when storage itself throws', async () => {
+		// A private window or a browser set to block site data raises here rather than
+		// returning empty, and the dashboard has to keep working.
+		jest.spyOn( window.localStorage.__proto__, 'getItem' ).mockImplementation( () => {
+			throw new Error( 'SecurityError' );
+		} );
+
+		await expect( layer.get() ).resolves.toEqual( {} );
+	} );
+
+	it( 'swallows a write failure, because a remembered view is not worth an error', () => {
+		jest.spyOn( window.localStorage.__proto__, 'setItem' ).mockImplementation( () => {
+			throw new Error( 'QuotaExceededError' );
+		} );
+
+		expect( () => layer.set( { 'core/views': {} } ) ).not.toThrow();
+	} );
+} );

--- a/projects/packages/forms/src/dashboard/test/response-column-preferences.test.js
+++ b/projects/packages/forms/src/dashboard/test/response-column-preferences.test.js
@@ -1,102 +1,103 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
-import {
-	getColumnPreferenceKey,
-	readColumnPreference,
-	writeColumnPreference,
-} from '../response-column-preferences.ts';
 
-const PREFERENCE = {
-	fields: [ 'date', 'field:g5-name', 'source' ],
-	knownAnswerIds: [ 'field:g5-name', 'field:g5-email' ],
-};
+/**
+ * Stands in for the preferences store's own state. Importing the real store pulls the
+ * whole `@wordpress/components` tree in behind it, and what matters here is the payload
+ * the module reads and writes, not how the store keeps it.
+ */
+const stored = new Map();
+
+const keyFor = ( scope, key ) => `${ scope }::${ key }`;
+
+await jest.unstable_mockModule( '@wordpress/preferences', () => ( {
+	store: { name: 'core/preferences' },
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	select: () => ( {
+		get: ( scope, key ) => stored.get( keyFor( scope, key ) ),
+	} ),
+	dispatch: () => ( {
+		set: ( scope, key, value ) => stored.set( keyFor( scope, key ), value ),
+	} ),
+} ) );
+
+const { getColumnPreferenceKey, readKnownAnswerIds, writeKnownAnswerIds } = await import(
+	'../response-column-preferences.ts'
+);
+
+const SCOPE = 'jetpack/forms';
+const KNOWN_IDS = [ 'field:g5-name', 'field:g5-email' ];
+
+/**
+ * Writes a raw payload, standing in for a record left by an older release.
+ *
+ * @param {number|null} formId  - The form the record belongs to.
+ * @param {unknown}     payload - What to store.
+ * @return {Map} The updated store map.
+ */
+const storeRaw = ( formId, payload ) =>
+	stored.set( keyFor( SCOPE, getColumnPreferenceKey( formId ) ), payload );
 
 afterEach( () => {
-	window.localStorage.clear();
-	jest.restoreAllMocks();
+	stored.clear();
 } );
 
 describe( 'getColumnPreferenceKey', () => {
 	it( 'keys a form by its id and the every-form view by name', () => {
-		expect( getColumnPreferenceKey( 5 ) ).toBe( 'jetpack-forms/response-columns/5' );
-		expect( getColumnPreferenceKey( null ) ).toBe( 'jetpack-forms/response-columns/all' );
+		expect( getColumnPreferenceKey( 5 ) ).toBe( 'response-columns/5' );
+		expect( getColumnPreferenceKey( null ) ).toBe( 'response-columns/all' );
 	} );
 } );
 
-describe( 'readColumnPreference', () => {
+describe( 'readKnownAnswerIds', () => {
 	it( 'reads back what was written, for that form only', () => {
-		writeColumnPreference( 5, PREFERENCE );
+		writeKnownAnswerIds( 5, KNOWN_IDS );
 
-		expect( readColumnPreference( 5 ) ).toEqual( PREFERENCE );
-		// Another form's columns are its own; nothing leaks across.
-		expect( readColumnPreference( 6 ) ).toBeNull();
-		expect( readColumnPreference( null ) ).toBeNull();
+		expect( readKnownAnswerIds( 5 ) ).toEqual( KNOWN_IDS );
+		// Another form's answer columns are its own; nothing leaks across.
+		expect( readKnownAnswerIds( 6 ) ).toBeNull();
+		expect( readKnownAnswerIds( null ) ).toBeNull();
 	} );
 
-	it( 'reports no choice when none was ever made', () => {
-		expect( readColumnPreference( 5 ) ).toBeNull();
-	} );
+	it( 'writes into the preferences scope, where the view is kept too', () => {
+		writeKnownAnswerIds( 5, KNOWN_IDS );
 
-	it( 'falls back to the defaults rather than trusting a damaged entry', () => {
-		// A hand-edited or half-written entry must not render a broken table.
-		window.localStorage.setItem( getColumnPreferenceKey( 5 ), '{ not json' );
-		expect( readColumnPreference( 5 ) ).toBeNull();
-
-		window.localStorage.setItem(
-			getColumnPreferenceKey( 5 ),
-			JSON.stringify( { fields: 'date' } )
-		);
-		expect( readColumnPreference( 5 ) ).toBeNull();
-
-		window.localStorage.setItem( getColumnPreferenceKey( 5 ), 'null' );
-		expect( readColumnPreference( 5 ) ).toBeNull();
-	} );
-
-	it( 'drops entries that are not column ids, and tolerates a missing known list', () => {
-		window.localStorage.setItem(
-			getColumnPreferenceKey( 5 ),
-			JSON.stringify( { v: 1, fields: [ 'date', 7, null, 'ip' ] } )
-		);
-
-		expect( readColumnPreference( 5 ) ).toEqual( {
-			fields: [ 'date', 'ip' ],
-			knownAnswerIds: [],
+		expect( stored.get( keyFor( SCOPE, 'response-columns/5' ) ) ).toEqual( {
+			v: 2,
+			knownAnswerIds: KNOWN_IDS,
 		} );
 	} );
 
-	it( 'discards a choice written under a different schema', () => {
-		// A stored choice replaces the default columns wholesale, so a later change to
-		// what those defaults are would never reach anyone holding an older one. Refusing
-		// to read it is what lets such a change land.
-		window.localStorage.setItem(
-			getColumnPreferenceKey( 5 ),
-			JSON.stringify( { fields: [ 'date' ], knownAnswerIds: [] } )
-		);
-		expect( readColumnPreference( 5 ) ).toBeNull();
-
-		window.localStorage.setItem(
-			getColumnPreferenceKey( 5 ),
-			JSON.stringify( { v: 99, fields: [ 'date' ], knownAnswerIds: [] } )
-		);
-		expect( readColumnPreference( 5 ) ).toBeNull();
+	it( 'reports no record when none was ever written', () => {
+		expect( readKnownAnswerIds( 5 ) ).toBeNull();
 	} );
 
-	it( 'reports no choice when storage itself throws', () => {
-		// A private window or a browser set to block site data raises here rather than
-		// returning empty, and the dashboard has to keep working.
-		jest.spyOn( window.localStorage.__proto__, 'getItem' ).mockImplementation( () => {
-			throw new Error( 'SecurityError' );
-		} );
+	it( 're-offers every column rather than trusting a damaged record', () => {
+		storeRaw( 5, null );
+		expect( readKnownAnswerIds( 5 ) ).toBeNull();
 
-		expect( readColumnPreference( 5 ) ).toBeNull();
+		storeRaw( 5, { v: 2, knownAnswerIds: 'field:g5-name' } );
+		expect( readKnownAnswerIds( 5 ) ).toBeNull();
 	} );
-} );
 
-describe( 'writeColumnPreference', () => {
-	it( 'swallows a storage failure, because a column layout is not worth an error', () => {
-		jest.spyOn( window.localStorage.__proto__, 'setItem' ).mockImplementation( () => {
-			throw new Error( 'QuotaExceededError' );
-		} );
+	it( 'discards a record written under a different schema', () => {
+		// The record is what keeps a hidden column hidden, so a change to its shape must
+		// not be read through older eyes. Refusing it costs one re-shown column.
+		storeRaw( 5, { knownAnswerIds: KNOWN_IDS } );
+		expect( readKnownAnswerIds( 5 ) ).toBeNull();
 
-		expect( () => writeColumnPreference( 5, PREFERENCE ) ).not.toThrow();
+		// The localStorage shape this replaced, which carried `fields` as well.
+		storeRaw( 5, { v: 1, fields: [ 'date' ], knownAnswerIds: KNOWN_IDS } );
+		expect( readKnownAnswerIds( 5 ) ).toBeNull();
+
+		storeRaw( 5, { v: 99, knownAnswerIds: KNOWN_IDS } );
+		expect( readKnownAnswerIds( 5 ) ).toBeNull();
+	} );
+
+	it( 'drops entries that are not column ids', () => {
+		storeRaw( 5, { v: 2, knownAnswerIds: [ 'field:g5-name', 7, null, 'field:g5-email' ] } );
+
+		expect( readKnownAnswerIds( 5 ) ).toEqual( KNOWN_IDS );
 	} );
 } );

--- a/projects/packages/forms/src/dashboard/test/response-column-preferences.test.js
+++ b/projects/packages/forms/src/dashboard/test/response-column-preferences.test.js
@@ -1,10 +1,7 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
-/**
- * Stands in for the preferences store's own state. Importing the real store pulls the
- * whole `@wordpress/components` tree in behind it, and what matters here is the payload
- * the module reads and writes, not how the store keeps it.
- */
+// Stands in for the preferences store: importing the real one pulls the whole
+// `@wordpress/components` tree in behind it.
 const stored = new Map();
 
 const keyFor = ( scope, key ) => `${ scope }::${ key }`;

--- a/projects/plugins/jetpack/changelog/forms-dashboard-views-persistence
+++ b/projects/plugins/jetpack/changelog/forms-dashboard-views-persistence
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: remember the responses dashboard's columns, sorting and page size between visits.


### PR DESCRIPTION
Fixes #

## Proposed changes

The Forms dashboard forgot how you liked it. The view — which columns are shown, sorting, page size — lived in component state, so every reload put it back to defaults. The one exception was the column choice, kept in `localStorage` by `response-column-preferences.ts`, whose own comment explained the compromise: *"`localStorage` rather than user meta: this is a per-browser convenience, and the dashboard has no preferences store to hang it on."*

That premise no longer holds. `@wordpress/views` is the package Core uses for exactly this (`@wordpress/media-utils` drives the media modal's DataViews with it), and `wp-build-polyfills` already ships it — pinned, built as `wp-views`, with its private-apis dependency wired up. Nothing consumed it yet.

* Both wp-build routes (`routes/responses`, `routes/forms`) and the legacy inbox SPA now hold their view through `useView`, keyed `postType` / `feedback` (or `jetpack_form`) with a per-form slug.
* New `src/dashboard/preferences-persistence.ts` gives the preferences store somewhere to write. `useView` persists through `@wordpress/preferences`, which only holds values in memory until a host registers a persistence layer — wp-admin does this for the block editor, but a wp-build dashboard is not booted by Core and `@wordpress/boot` registers nothing. Without it nothing survives a reload. The layer is localStorage-backed and keyed per site + user; moving persistence server-side later means changing only this file.
* `response-column-preferences.ts` shrinks to the one thing `useView` cannot model: which answer columns a form had already *offered* when the choice was made. Without it a hidden column returns on reload, because the columns hook re-adds any answer column it has not seen. It now lives in the preferences store alongside the view rather than in its own `localStorage` key.

Only what the user actually changed is stored, as a diff over the defaults — so a later change to the default columns still reaches people who have customised theirs.

### Notes for review

* **The Folder filter is deliberately not locked.** `useView`'s only mechanism for keeping a filter out of what it persists is `isLocked`, and in `dataviews@18.0.0` that also sets `aria-disabled`, `tabIndex: -1` and guards the click handler — which would have disabled folder switching, since Folder is a real control here. It is instead synced from the route, as before. A stored folder can therefore briefly disagree with the route on load; responses are queried from the route, never from the filter, so only the chip is affected.
* **`useView` has no session-only view state.** The persisted preference and the URL query params are the only places state lives, so anything not persisted cannot be held at all. That is why filters are persisted-and-corrected rather than simply excluded.
* `@wordpress/views` is bundled rather than externalised (it is on `dependency-extraction-webpack-plugin`'s bundled list, like `@wordpress/dataviews`), so the bundled copy opts into private APIs against whatever `wp-private-apis` resolves to. WP 7.1's Core allowlist includes `@wordpress/views`; below that `wp-build-polyfills` force-replaces the handle. This is the same mechanism `@wordpress/theme` — already used by this dashboard — depends on.
* Activity Log still has its own localStorage `usePersistentView`. Converging it is separate work; nothing is shared between the two.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No. View preferences stay in the browser, as they did before; the storage key moves from `jetpack-forms/response-columns/<form>` to a single per-site, per-user entry.

## Testing instructions

* Open **Jetpack → Forms** and pick a form with responses (or the All responses view).
* Open a column's header menu and choose **Hide column**. Reload the page — the column should stay hidden. Change sorting or items-per-page and reload; those should stick too.
* Check `localStorage` for `jetpack-forms-preferences-<blog_id>-<user_id>`: it should hold a `core/views` entry keyed `dataviews-postType-feedback-<form>` containing **only** what you changed.
* Switch between **Inbox / Spam / Trash** using the Folder filter. The filter must stay clickable and the route must follow it.
* Hide an answer column on a form, then add a new field to that form and submit a response. The hidden column stays hidden; the new field's column appears.
* Confirm the same on the Forms list screen, and that a column choice on one form does not follow you to another.
