### PR TITLE
Backup: close the bridge REST test gaps

### DIFF
--- a/projects/packages/backup/changelog/close-bridge-test-gaps
+++ b/projects/packages/backup/changelog/close-bridge-test-gaps
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Tests only: cover the remaining File_Browser bridge branches and dispatch every bridge route through the REST server. No production code changed.
+
+

--- a/projects/packages/backup/tests/php/Rest_Bridge_Dispatch_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Dispatch_Test.php
@@ -29,13 +29,27 @@ require_once __DIR__ . '/trait-wpcom-request-mock.php';
 /**
  * The bridge suites next door call their callbacks directly, which leaves
  * three things between a request and an answer untested on every route:
- * the `args` schema `register_rest_route()` was given, a
- * `permission_check()` that *succeeds*, and `rest_ensure_response()`
- * turning the projection into something the server will serve. A callback
- * can be exhaustively covered and the route still answer 400 to every
- * request the dashboard makes — a required arg the client does not send,
- * a `pattern` that rejects a legitimate value — and nothing in those
- * suites would notice.
+ * the `args` schema `register_rest_route()` was given, the route regex
+ * the request has to match to reach the callback at all, and a
+ * `permission_check()` that *succeeds*. A callback can be exhaustively
+ * covered and the route still answer 400 or 404 to every request the
+ * dashboard makes, and nothing in those suites would notice — they build
+ * the request by hand and hand it straight to the callback, so there is
+ * no route to match and no schema to fail.
+ *
+ * All three are load-bearing, and each is falsified by a one-line change
+ * that the direct-call suites accept: dropping `=` from
+ * `BASE64_PATTERN` makes every padded manifest path a 400, and narrowing
+ * the download route's `rewind_id` capture to `\d+` makes a rewind id
+ * with its decimal suffix — the only kind there is — a 404.
+ *
+ * `rest_ensure_response()` is deliberately *not* on that list. Dropping
+ * it from a bridge fails the direct-call tests and nothing here, because
+ * `WP_REST_Server::dispatch()` runs it over the handler's return value
+ * itself. Serialization is likewise not asserted: it happens in
+ * `serve_request()`, downstream of `dispatch()`, and `wp_json_encode()`
+ * repairs bad input rather than refusing it, so an assertion about it
+ * would be one nothing could break.
  *
  * That gap was assumed to be unclosable: the permission gate needs a
  * user-level WordPress.com connection, and the shared trait's note said
@@ -277,10 +291,6 @@ class Rest_Bridge_Dispatch_Test extends TestCase {
 			sprintf( '%s %s: %s', $method, $path, wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES ) )
 		);
 		$this->assertSame( $expected, $response->get_data() );
-		// The last thing between the projection and the reader. Nothing
-		// here should be able to fail it, which is the point: until now
-		// nothing established that.
-		$this->assertIsString( wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES ) );
 	}
 
 	/**
@@ -294,10 +304,12 @@ class Rest_Bridge_Dispatch_Test extends TestCase {
 	 *
 	 * The bridge routes are identified the way `Rest_Bridge_Gating_Test`
 	 * identifies them — by diffing the route table with the modernization
-	 * filter on against the same table with it off. Matching on a path
-	 * prefix would not do: `rest_api_init` also registers this package's
-	 * legacy `REST_Controller` routes and the sync package's, several of
-	 * which live under `/jetpack/v4/` too, and none of which belong here.
+	 * filter on against the same table with it off. Matching on a
+	 * `/jetpack/v4/` prefix would not do: this package's own legacy
+	 * `REST_Controller` registers ten routes under that same prefix on
+	 * the same hook — `/jetpack/v4/backup-helper-script`,
+	 * `/jetpack/v4/options/backup`, `/jetpack/v4/site/backup/preflight`
+	 * and the rest — and none of them belongs here.
 	 */
 	public function test_every_bridge_route_is_covered_here() {
 		$bridge_routes = array_values(

--- a/projects/packages/backup/tests/php/Rest_Bridge_Dispatch_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Dispatch_Test.php
@@ -1,0 +1,392 @@
+<?php
+/**
+ * End-to-end tests: every bridge route, through the REST server, to a 200.
+ *
+ * @package automattic/jetpack-backup-plugin
+ */
+
+namespace Automattic\Jetpack\Backup\V0005\REST;
+
+use Automattic\Jetpack\Backup\V0005\Jetpack_Backup;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+use WP_REST_Request;
+use WP_REST_Server;
+use function add_action;
+use function add_filter;
+use function do_action;
+use function home_url;
+use function remove_filter;
+use function wp_insert_user;
+use function wp_json_encode;
+use function wp_set_current_user;
+
+require_once __DIR__ . '/trait-wpcom-request-mock.php';
+
+/**
+ * The bridge suites next door call their callbacks directly, which leaves
+ * three things between a request and an answer untested on every route:
+ * the `args` schema `register_rest_route()` was given, a
+ * `permission_check()` that *succeeds*, and `rest_ensure_response()`
+ * turning the projection into something the server will serve. A callback
+ * can be exhaustively covered and the route still answer 400 to every
+ * request the dashboard makes — a required arg the client does not send,
+ * a `pattern` that rejects a legitimate value — and nothing in those
+ * suites would notice.
+ *
+ * That gap was assumed to be unclosable: the permission gate needs a
+ * user-level WordPress.com connection, and the shared trait's note said
+ * WorDBless could not stand one up. It can, and had been all along — the
+ * `user_tokens` the trait installs so `Client` can sign a request are the
+ * same ones `Connection_Manager::is_user_connected()` reads. Nothing was
+ * missing; nobody had dispatched.
+ *
+ * So this file dispatches, once per registered bridge route, and the
+ * route list is asserted against the server's own rather than kept by
+ * hand, so a route added without an end-to-end test fails here.
+ *
+ * @covers \Automattic\Jetpack\Backup\V0005\REST\Rest_Controller
+ */
+#[CoversClass( Rest_Controller::class )]
+class Rest_Bridge_Dispatch_Test extends TestCase {
+
+	use Wpcom_Request_Mock;
+
+	/**
+	 * Stands in, in a data provider, for the signed-URL envelope the
+	 * file-content route's first leg receives.
+	 *
+	 * The real body has to name a URL on this site's own host, so that
+	 * `wp_http_validate_url()` takes its same-host path instead of
+	 * resolving a name — otherwise the test passes or fails on whether the
+	 * runner has DNS. `home_url()` reads an option, and a provider is
+	 * evaluated before any test's `setUp()`, so the value is resolved in
+	 * the test body instead of baked into the provider.
+	 *
+	 * @var string
+	 */
+	private const SIGNED_URL_BODY = '@signed-url-body';
+
+	/**
+	 * REST Server.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Enable modernization, register routes, and prepare a fresh REST server.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
+		add_action( 'rest_api_init', array( Rest_Controller::class, 'register_routes' ) );
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Reset state.
+	 */
+	public function tearDown(): void {
+		remove_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
+		$this->reset_wpcom_request_mock();
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Every bridge route, keyed by the route it registers under.
+	 *
+	 * Keyed rather than listed because the keys are what
+	 * `test_every_bridge_route_is_covered_here()` compares against the
+	 * server's own route table — the guard that makes this file keep pace
+	 * with `Rest_Controller::register_routes()`.
+	 *
+	 * Each row is the request a real dashboard makes, the answers
+	 * WordPress.com gives it, and the payload the client should end up
+	 * with. The upstream fixtures are deliberately not minimal: several of
+	 * these projections read one key and default another, and a fixture
+	 * carrying only the keys that survive cannot tell a forwarded value
+	 * from a default.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: array<string, mixed>, 3: array<int, array{body?: string, status?: int|string}>, 4: array<string, mixed>}>
+	 */
+	public static function provide_bridge_dispatches() {
+		return array(
+			'/jetpack/v4/site/capabilities'          => array(
+				'GET',
+				'/jetpack/v4/site/capabilities',
+				array(),
+				array( array( 'body' => '{"capabilities":["backup","scan"]}' ) ),
+				array(
+					'hasBackupPlan' => true,
+					'hasScan'       => true,
+				),
+			),
+			'/jetpack/v4/site/rewindable-activity'   => array(
+				'GET',
+				'/jetpack/v4/site/rewindable-activity',
+				array(
+					'number' => 10,
+					'page'   => 1,
+				),
+				array( array( 'body' => '{"current":{"orderedItems":[{"activity_id":"foo"}]},"totalItems":1,"totalPages":1}' ) ),
+				array(
+					'current'    => array( 'orderedItems' => array( array( 'activity_id' => 'foo' ) ) ),
+					'totalItems' => 1,
+					'totalPages' => 1,
+				),
+			),
+			'/jetpack/v4/rewind/backup/ls'           => array(
+				'POST',
+				'/jetpack/v4/rewind/backup/ls',
+				array(
+					'rewind_id' => '1748888135.123',
+					'path'      => '/',
+				),
+				array( array( 'body' => '{"contents":[{"name":"wp-config.php","type":"file","period":"1748888135"}]}' ) ),
+				array(
+					'contents' => array(
+						array(
+							'name'   => 'wp-config.php',
+							'type'   => 'file',
+							'period' => '1748888135',
+						),
+					),
+				),
+			),
+			'/jetpack/v4/rewind/backup/path-info'    => array(
+				'GET',
+				'/jetpack/v4/rewind/backup/path-info',
+				array(
+					'file_period'   => '1748888135',
+					'manifest_path' => 'f5:/wp-config.php',
+				),
+				array( array( 'body' => '{"size":3247,"hash":"abc123","mtime":1748888135}' ) ),
+				array(
+					'size'  => 3247,
+					'hash'  => 'abc123',
+					'mtime' => 1748888135,
+				),
+			),
+			'/jetpack/v4/rewind/backup/file-content' => array(
+				'GET',
+				'/jetpack/v4/rewind/backup/file-content',
+				array(
+					'file_period'           => '1748888135',
+					'encoded_manifest_path' => 'ZjU6L3dwLWNvbmZpZy5waHA=',
+				),
+				array(
+					array( 'body' => self::SIGNED_URL_BODY ),
+					array( 'body' => "<?php\ndefine( 'DB_NAME', 'wordpress' );\n" ),
+				),
+				array( 'content' => "<?php\ndefine( 'DB_NAME', 'wordpress' );\n" ),
+			),
+			'/jetpack/v4/backups/download/(?P<rewind_id>[A-Za-z0-9.\-]+)' => array(
+				'POST',
+				'/jetpack/v4/backups/download/1748888135.123',
+				array(),
+				array( array( 'body' => '{"downloadId":42}' ) ),
+				array( 'id' => 42 ),
+			),
+			'/jetpack/v4/backups/download/(?P<rewind_id>[A-Za-z0-9.\-]+)/status' => array(
+				'GET',
+				'/jetpack/v4/backups/download/1748888135.123/status',
+				array( 'download_id' => 42 ),
+				array( array( 'body' => '{"downloadId":42,"progress":55}' ) ),
+				array(
+					'id'          => 42,
+					'status'      => 'running',
+					'progress'    => 55,
+					'url'         => '',
+					'valid_until' => '',
+					'error'       => '',
+				),
+			),
+			'/jetpack/v4/rewind/to/(?P<rewind_id>[A-Za-z0-9.\-]+)' => array(
+				'POST',
+				'/jetpack/v4/rewind/to/1748888135.123',
+				array(),
+				array( array( 'body' => '{"ok":true,"restore_id":7,"rewind_id":"1748888135.123"}' ) ),
+				array(
+					'id'        => 7,
+					'rewind_id' => '1748888135.123',
+				),
+			),
+			'/jetpack/v4/rewind/restore/(?P<restore_id>\d+)/status' => array(
+				'GET',
+				'/jetpack/v4/rewind/restore/7/status',
+				array(),
+				array( array( 'body' => '{"restore_id":7,"status":"running","percent":42.5,"rewind_id":"1748888135.123","message":"Restoring uploads"}' ) ),
+				array(
+					'id'         => 7,
+					'status'     => 'running',
+					'progress'   => 42.5,
+					'rewind_id'  => '1748888135.123',
+					'error_code' => '',
+					'message'    => 'Restoring uploads',
+				),
+			),
+		);
+	}
+
+	/**
+	 * A bridge route, dispatched by the REST server, answers 200 with the
+	 * payload the client expects.
+	 *
+	 * This is the whole of what the direct-call suites cannot say: that the
+	 * request the dashboard sends satisfies the route's own `args` schema,
+	 * that `permission_check()` lets a connected administrator through, and
+	 * that the projection comes back out of the server as data rather than
+	 * as an error envelope.
+	 *
+	 * @param string                                                $method   Request method.
+	 * @param string                                                $path     Route path to dispatch.
+	 * @param array<string, mixed>                                  $params   Request params.
+	 * @param array<int, array{body?: string, status?: int|string}> $answers WordPress.com's answers, in call order.
+	 * @param array<string, mixed>                                  $expected Payload the route should serve.
+	 * @dataProvider provide_bridge_dispatches
+	 */
+	#[DataProvider( 'provide_bridge_dispatches' )]
+	public function test_route_serves_its_projection( $method, $path, array $params, array $answers, array $expected ) {
+		$this->arrange_wpcom_answers( $this->resolve_answers( $answers ) );
+
+		$request = new WP_REST_Request( $method, $path );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		$response = $this->server->dispatch( $request );
+
+		// Named first, because a failure here is otherwise reported as an
+		// unhelpful array diff against an error envelope.
+		$this->assertSame(
+			200,
+			$response->get_status(),
+			sprintf( '%s %s: %s', $method, $path, wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES ) )
+		);
+		$this->assertSame( $expected, $response->get_data() );
+		// The last thing between the projection and the reader. Nothing
+		// here should be able to fail it, which is the point: until now
+		// nothing established that.
+		$this->assertIsString( wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES ) );
+	}
+
+	/**
+	 * Every registered bridge route is dispatched by the provider above.
+	 *
+	 * The provider is keyed by route, so this is a set comparison against
+	 * what `Rest_Controller::register_routes()` actually registered. A
+	 * tenth bridge route lands here as a failure naming itself, rather
+	 * than shipping with its schema and permission gate never once
+	 * exercised end to end — which is exactly how the first nine got here.
+	 *
+	 * The bridge routes are identified the way `Rest_Bridge_Gating_Test`
+	 * identifies them — by diffing the route table with the modernization
+	 * filter on against the same table with it off. Matching on a path
+	 * prefix would not do: `rest_api_init` also registers this package's
+	 * legacy `REST_Controller` routes and the sync package's, several of
+	 * which live under `/jetpack/v4/` too, and none of which belong here.
+	 */
+	public function test_every_bridge_route_is_covered_here() {
+		$bridge_routes = array_values(
+			array_diff( $this->collect_routes( true ), $this->collect_routes( false ) )
+		);
+		$covered       = array_keys( self::provide_bridge_dispatches() );
+
+		sort( $bridge_routes );
+		sort( $covered );
+
+		$this->assertSame( $bridge_routes, $covered );
+	}
+
+	/**
+	 * Route keys registered by a fresh `rest_api_init`, with the
+	 * modernization filter forced either on or off.
+	 *
+	 * @param bool $modernized Whether to leave the modernization filter enabled.
+	 * @return string[] Registered route keys.
+	 */
+	private function collect_routes( $modernized ) {
+		global $wp_rest_server;
+
+		if ( ! $modernized ) {
+			remove_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
+		}
+
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init' );
+		$routes = array_keys( $wp_rest_server->get_routes() );
+
+		if ( ! $modernized ) {
+			add_filter( Jetpack_Backup::MODERNIZATION_FILTER, '__return_true' );
+		}
+
+		// `setUp()` handed the tests a server; leave one in place.
+		$wp_rest_server = $this->server;
+
+		return $routes;
+	}
+
+	/**
+	 * An administrator whose own WordPress.com account is not linked is
+	 * refused, with a reason.
+	 *
+	 * The other half of `permission_check()`, and the half no suite
+	 * reached: every existing permission test signs in a subscriber, so it
+	 * stops at `manage_options` and the connection branch below it never
+	 * runs. This is not a hypothetical user — it is every additional admin
+	 * on a site somebody else connected, and the error code is the only
+	 * thing that tells them to link their account rather than to go
+	 * looking for a broken plan.
+	 *
+	 * Deliberately *not* using the trait: what makes this user unconnected
+	 * is the absence of the `user_tokens` the trait installs.
+	 */
+	public function test_an_unlinked_administrator_is_told_which_connection_is_missing() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'unlinked_admin',
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/site/capabilities' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'user_not_connected', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Replace provider placeholders with values only a running test can
+	 * produce. See `SIGNED_URL_BODY`.
+	 *
+	 * @param array<int, array{body?: string, status?: int|string}> $answers Answers as the provider wrote them.
+	 * @return array<int, array{body?: string, status?: int|string}>
+	 */
+	private function resolve_answers( array $answers ) {
+		foreach ( $answers as $index => $answer ) {
+			if ( isset( $answer['body'] ) && self::SIGNED_URL_BODY === $answer['body'] ) {
+				$answers[ $index ]['body'] = wp_json_encode(
+					array( 'url' => home_url( '/signed-stream' ) ),
+					JSON_UNESCAPED_SLASHES
+				);
+			}
+		}
+		return $answers;
+	}
+}

--- a/projects/packages/backup/tests/php/Rest_Bridge_Dispatch_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Dispatch_Test.php
@@ -27,40 +27,13 @@ use function wp_set_current_user;
 require_once __DIR__ . '/trait-wpcom-request-mock.php';
 
 /**
- * The bridge suites next door call their callbacks directly, which leaves
- * three things between a request and an answer untested on every route:
- * the `args` schema `register_rest_route()` was given, the route regex
- * the request has to match to reach the callback at all, and a
- * `permission_check()` that *succeeds*. A callback can be exhaustively
- * covered and the route still answer 400 or 404 to every request the
- * dashboard makes, and nothing in those suites would notice — they build
- * the request by hand and hand it straight to the callback, so there is
- * no route to match and no schema to fail.
+ * The bridge suites next door call their callbacks directly, which leaves three things
+ * untested on every route: the `args` schema, the route regex, and a
+ * `permission_check()` that *succeeds*. A callback can be exhaustively covered and the
+ * route still answer 400 or 404 to every request the dashboard makes.
  *
- * All three are load-bearing, and each is falsified by a one-line change
- * that the direct-call suites accept: dropping `=` from
- * `BASE64_PATTERN` makes every padded manifest path a 400, and narrowing
- * the download route's `rewind_id` capture to `\d+` makes a rewind id
- * with its decimal suffix — the only kind there is — a 404.
- *
- * `rest_ensure_response()` is deliberately *not* on that list. Dropping
- * it from a bridge fails the direct-call tests and nothing here, because
- * `WP_REST_Server::dispatch()` runs it over the handler's return value
- * itself. Serialization is likewise not asserted: it happens in
- * `serve_request()`, downstream of `dispatch()`, and `wp_json_encode()`
- * repairs bad input rather than refusing it, so an assertion about it
- * would be one nothing could break.
- *
- * That gap was assumed to be unclosable: the permission gate needs a
- * user-level WordPress.com connection, and the shared trait's note said
- * WorDBless could not stand one up. It can, and had been all along — the
- * `user_tokens` the trait installs so `Client` can sign a request are the
- * same ones `Connection_Manager::is_user_connected()` reads. Nothing was
- * missing; nobody had dispatched.
- *
- * So this file dispatches, once per registered bridge route, and the
- * route list is asserted against the server's own rather than kept by
- * hand, so a route added without an end-to-end test fails here.
+ * So this file dispatches through the REST server once per registered bridge route, and
+ * asserts the route list against the server's own rather than keeping it by hand.
  *
  * @covers \Automattic\Jetpack\Backup\V0005\REST\Rest_Controller
  */
@@ -70,15 +43,13 @@ class Rest_Bridge_Dispatch_Test extends TestCase {
 	use Wpcom_Request_Mock;
 
 	/**
-	 * Stands in, in a data provider, for the signed-URL envelope the
-	 * file-content route's first leg receives.
+	 * Stands in, in a data provider, for the signed-URL envelope the file-content route's
+	 * first leg receives.
 	 *
-	 * The real body has to name a URL on this site's own host, so that
-	 * `wp_http_validate_url()` takes its same-host path instead of
-	 * resolving a name — otherwise the test passes or fails on whether the
-	 * runner has DNS. `home_url()` reads an option, and a provider is
-	 * evaluated before any test's `setUp()`, so the value is resolved in
-	 * the test body instead of baked into the provider.
+	 * The real body names a URL on this site's own host, so `wp_http_validate_url()`
+	 * takes its same-host path rather than passing or failing on the runner's DNS.
+	 * `home_url()` reads an option, so it is resolved in the test body: a provider runs
+	 * before any `setUp()`.
 	 *
 	 * @var string
 	 */
@@ -122,17 +93,14 @@ class Rest_Bridge_Dispatch_Test extends TestCase {
 	/**
 	 * Every bridge route, keyed by the route it registers under.
 	 *
-	 * Keyed rather than listed because the keys are what
-	 * `test_every_bridge_route_is_covered_here()` compares against the
-	 * server's own route table — the guard that makes this file keep pace
-	 * with `Rest_Controller::register_routes()`.
+	 * Keyed rather than listed: the keys are what
+	 * `test_every_bridge_route_is_covered_here()` compares against the server's route
+	 * table.
 	 *
-	 * Each row is the request a real dashboard makes, the answers
-	 * WordPress.com gives it, and the payload the client should end up
-	 * with. The upstream fixtures are deliberately not minimal: several of
-	 * these projections read one key and default another, and a fixture
-	 * carrying only the keys that survive cannot tell a forwarded value
-	 * from a default.
+	 * Each row is the request a real dashboard makes, WordPress.com's answers, and the
+	 * payload the client should end up with. The upstream fixtures are deliberately not
+	 * minimal — a fixture carrying only the keys that survive cannot tell a forwarded
+	 * value from a default.
 	 *
 	 * @return array<string, array{0: string, 1: string, 2: array<string, mixed>, 3: array<int, array{body?: string, status?: int|string}>, 4: array<string, mixed>}>
 	 */
@@ -256,14 +224,9 @@ class Rest_Bridge_Dispatch_Test extends TestCase {
 	}
 
 	/**
-	 * A bridge route, dispatched by the REST server, answers 200 with the
-	 * payload the client expects.
-	 *
-	 * This is the whole of what the direct-call suites cannot say: that the
-	 * request the dashboard sends satisfies the route's own `args` schema,
-	 * that `permission_check()` lets a connected administrator through, and
-	 * that the projection comes back out of the server as data rather than
-	 * as an error envelope.
+	 * A bridge route, dispatched by the REST server, answers 200 with the payload the
+	 * client expects — the route's `args` schema, its `permission_check()` and its
+	 * projection, none of which a direct call exercises.
 	 *
 	 * @param string                                                $method   Request method.
 	 * @param string                                                $path     Route path to dispatch.
@@ -283,8 +246,8 @@ class Rest_Bridge_Dispatch_Test extends TestCase {
 
 		$response = $this->server->dispatch( $request );
 
-		// Named first, because a failure here is otherwise reported as an
-		// unhelpful array diff against an error envelope.
+		// Named first: a failure here is otherwise an array diff against an error
+		// envelope.
 		$this->assertSame(
 			200,
 			$response->get_status(),
@@ -294,22 +257,13 @@ class Rest_Bridge_Dispatch_Test extends TestCase {
 	}
 
 	/**
-	 * Every registered bridge route is dispatched by the provider above.
+	 * Every registered bridge route is dispatched by the provider above, so a tenth one
+	 * lands here as a failure naming itself.
 	 *
-	 * The provider is keyed by route, so this is a set comparison against
-	 * what `Rest_Controller::register_routes()` actually registered. A
-	 * tenth bridge route lands here as a failure naming itself, rather
-	 * than shipping with its schema and permission gate never once
-	 * exercised end to end — which is exactly how the first nine got here.
-	 *
-	 * The bridge routes are identified the way `Rest_Bridge_Gating_Test`
-	 * identifies them — by diffing the route table with the modernization
-	 * filter on against the same table with it off. Matching on a
-	 * `/jetpack/v4/` prefix would not do: this package's own legacy
-	 * `REST_Controller` registers ten routes under that same prefix on
-	 * the same hook — `/jetpack/v4/backup-helper-script`,
-	 * `/jetpack/v4/options/backup`, `/jetpack/v4/site/backup/preflight`
-	 * and the rest — and none of them belongs here.
+	 * Bridge routes are identified by diffing the route table with the modernization
+	 * filter on against the same table with it off, as `Rest_Bridge_Gating_Test` does. A
+	 * `/jetpack/v4/` prefix match would not do — the legacy `REST_Controller` registers
+	 * ten routes under that same prefix.
 	 */
 	public function test_every_bridge_route_is_covered_here() {
 		$bridge_routes = array_values(
@@ -352,19 +306,13 @@ class Rest_Bridge_Dispatch_Test extends TestCase {
 	}
 
 	/**
-	 * An administrator whose own WordPress.com account is not linked is
-	 * refused, with a reason.
+	 * An administrator whose own WordPress.com account is not linked is refused, with a
+	 * reason.
 	 *
-	 * The other half of `permission_check()`, and the half no suite
-	 * reached: every existing permission test signs in a subscriber, so it
-	 * stops at `manage_options` and the connection branch below it never
-	 * runs. This is not a hypothetical user — it is every additional admin
-	 * on a site somebody else connected, and the error code is the only
-	 * thing that tells them to link their account rather than to go
-	 * looking for a broken plan.
-	 *
-	 * Deliberately *not* using the trait: what makes this user unconnected
-	 * is the absence of the `user_tokens` the trait installs.
+	 * The other half of `permission_check()`: every existing permission test signs in a
+	 * subscriber, so it stops at `manage_options` and never reaches the connection
+	 * branch. Deliberately not using the trait — the absence of its `user_tokens` is
+	 * what makes this user unconnected.
 	 */
 	public function test_an_unlinked_administrator_is_told_which_connection_is_missing() {
 		$admin_id = wp_insert_user(
@@ -384,8 +332,7 @@ class Rest_Bridge_Dispatch_Test extends TestCase {
 	}
 
 	/**
-	 * Replace provider placeholders with values only a running test can
-	 * produce. See `SIGNED_URL_BODY`.
+	 * Replace provider placeholders with values only a running test can produce.
 	 *
 	 * @param array<int, array{body?: string, status?: int|string}> $answers Answers as the provider wrote them.
 	 * @return array<int, array{body?: string, status?: int|string}>

--- a/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
@@ -34,9 +34,6 @@ use function wp_json_encode;
  * so nothing there would notice if the gate stopped working. These two
  * tests are the ones that would.
  *
- * The count above is `MODERNIZED_ROUTES`'s, and `File_Browser_Bridge`
- * registering three routes rather than two is the easy one to miscount.
- *
  * @covers \Automattic\Jetpack\Backup\V0005\REST\Rest_Controller
  */
 #[CoversClass( Rest_Controller::class )]

--- a/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Gating_Test.php
@@ -28,11 +28,14 @@ use function wp_json_encode;
 
 /**
  * Tests that the modernization filter is the only thing standing between
- * the legacy plugin and the eight new bridge routes.
+ * the legacy plugin and the nine new bridge routes.
  *
  * The rest of the suite exercises each bridge with the filter forced on,
  * so nothing there would notice if the gate stopped working. These two
  * tests are the ones that would.
+ *
+ * The count above is `MODERNIZED_ROUTES`'s, and `File_Browser_Bridge`
+ * registering three routes rather than two is the easy one to miscount.
  *
  * @covers \Automattic\Jetpack\Backup\V0005\REST\Rest_Controller
  */

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -429,4 +429,332 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 		$this->assertStringNotContainsString( 'cURL', $response->get_error_message() );
 		$this->assertSame( 502, $response->get_error_data()['status'] );
 	}
+
+	/**
+	 * What path-info answers with, not just what it asks for.
+	 *
+	 * The outbound half of this route was pinned and the return value was
+	 * not, which left the whole of what the info card reads unasserted:
+	 * `size`, `hash` and `mtime` are the reason the route exists, and a
+	 * `forward_response()` that dropped or reshaped them would have shown
+	 * an empty card with no error anywhere.
+	 *
+	 * Asserted whole rather than key by key, so a bridge that started
+	 * adding or removing fields fails here rather than drifting.
+	 *
+	 * `manifest_filter` is in the fixture because it is the field a
+	 * granular per-file download will need, and `error` because upstream
+	 * answers 200 with one when the file has no row — the client branches
+	 * on it, so it has to survive the forward.
+	 */
+	public function test_path_info_forwards_the_upstream_payload() {
+		$upstream = array(
+			'size'            => 3247,
+			'hash'            => 'abc123',
+			'mtime'           => 1748888135,
+			'manifest_filter' => 'f5:/wp-config.php',
+			'error'           => '',
+		);
+		$this->arrange_wpcom( $upstream );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/backup/path-info' );
+		$request->set_param( 'file_period', '1748888135' );
+		$request->set_param( 'manifest_path', 'f5:/wp-config.php' );
+		$response = File_Browser_Bridge::get_path_info( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame( $upstream, $response->get_data() );
+	}
+
+	/**
+	 * A non-200 on path-info is reported under path-info's own code.
+	 *
+	 * The status and reason travel through `forward_response()`, which the
+	 * listing already covers — what is only true here is the error code.
+	 * The client's `failureMessage()` keys off it, so a route answering
+	 * with a sibling's code would be described to the reader as the wrong
+	 * operation failing.
+	 *
+	 * 429 rather than 500: `upstream_error()` falls back to 500 for a
+	 * status it cannot use, so a test written against 500 would pass
+	 * whether or not the status was forwarded at all.
+	 */
+	public function test_path_info_reports_a_non_200_under_its_own_code() {
+		$this->arrange_wpcom( array( 'code' => 'too_many_requests' ), 429 );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/backup/path-info' );
+		$request->set_param( 'file_period', '1748888135' );
+		$request->set_param( 'manifest_path', 'f5:/wp-config.php' );
+		$response = File_Browser_Bridge::get_path_info( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'backup_path_info_failed', $response->get_error_code() );
+		$this->assertSame( 429, $response->get_error_data()['status'] );
+		$this->assertSame( 'too_many_requests', $response->get_error_data()['wpcom']['code'] );
+	}
+
+	/**
+	 * A signed-URL body WPCOM answered 200 with, and the signed URL the
+	 * stream leg would then be given.
+	 *
+	 * `home_url()` throughout, so `wp_http_validate_url()` takes its
+	 * same-host path — any other host sends it to `gethostbyname()` and
+	 * makes these tests pass or fail on whether the runner has DNS.
+	 *
+	 * @return string
+	 */
+	private static function signed_url_body() {
+		return wp_json_encode( array( 'url' => home_url( '/signed-stream' ) ), JSON_UNESCAPED_SLASHES );
+	}
+
+	/**
+	 * A request for the preview that the file browser would really make.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private static function file_content_request() {
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/backup/file-content' );
+		$request->set_param( 'file_period', '1748888135' );
+		$request->set_param( 'encoded_manifest_path', 'ZjU6L3dwLWNvbmZpZy5waHA=' );
+		return $request;
+	}
+
+	/**
+	 * The stream fetch is capped, and capped at the preview limit.
+	 *
+	 * `limit_response_size` is the only thing between a text preview and
+	 * a multi-gigabyte blob buffered into PHP memory: the bridge enforces
+	 * no mime check at all, so any admin can point this route at any blob
+	 * WordPress.com will sign a URL for. It cannot be asserted from a
+	 * response — it changes nothing about a small file — so it is read off
+	 * the outbound request arguments instead.
+	 *
+	 * The first call is asserted to be uncapped, and that is a statement
+	 * about where the cap *can* live rather than about where someone might
+	 * put it by mistake: `Client::validate_args_for_wpcom_json_api_request()`
+	 * intersects outbound arguments against a fixed allowlist —
+	 * `headers`, `method`, `format`, `timeout`, `redirection`, `stream`,
+	 * `filename`, `sslverify` — and `limit_response_size` is not on it. A
+	 * signed `Client` call cannot be capped at all, then, and asking for
+	 * one to be is silently a no-op. The cap only works on the second leg
+	 * because that leg is a bare `wp_remote_get()`, which it is because
+	 * the signed URL points at the storage host and carries its own
+	 * authorization — there is nothing for `Client` to sign.
+	 */
+	public function test_file_content_caps_the_stream_fetch_at_the_preview_limit() {
+		$this->arrange_wpcom_answers(
+			array(
+				array( 'body' => self::signed_url_body() ),
+				array( 'body' => 'file contents' ),
+			)
+		);
+
+		File_Browser_Bridge::get_file_content( self::file_content_request() );
+
+		$this->assertCount( 2, $this->captured_request_args );
+		// `WP_Http` defaults the key to null, so "uncapped" is a null value
+		// rather than an absent key.
+		$this->assertNull( $this->captured_request_args[0]['limit_response_size'] ?? null );
+		$this->assertSame(
+			File_Browser_Bridge::PREVIEW_MAX_BYTES,
+			$this->captured_request_args[1]['limit_response_size']
+		);
+	}
+
+	/**
+	 * A preview cut short by the byte cap is forwarded exactly as it
+	 * arrived, mid-character and all.
+	 *
+	 * The cap is a byte count enforced by the HTTP transport, not by this
+	 * bridge, and the transport counts bytes with no idea where characters
+	 * begin. So the cut can land inside a multi-byte sequence, and this is
+	 * the fixture where it does: 65,535 ASCII bytes followed by U+65E5
+	 * (`日`, `E6 97 A5`) is 65,538 bytes, and the cut at 65,536 keeps the
+	 * lead byte `E6` and drops the two continuation bytes behind it. The
+	 * fixture is built that way rather than asserted to be that way, so
+	 * the last two assertions below are what prove it landed mid-character
+	 * rather than at a boundary.
+	 *
+	 * `pre_http_request` short-circuits the transport, so the arranged body
+	 * stands in for what the transport's own cut would have handed back.
+	 * What is under test is what the bridge does with it: nothing. It does
+	 * not re-cut it to a character boundary, and it does not repair it —
+	 * either would be a silently different file from the one on disk, which
+	 * is worse in a preview than a visibly damaged tail.
+	 *
+	 * The damage is not invisible downstream: `wp_json_encode()` refuses
+	 * the orphaned lead byte and its sanity pass rewrites it, so a reader
+	 * sees `?` at the end of a preview this long. That is core's call to
+	 * make, not this bridge's, and it only happens because the bytes were
+	 * forwarded honestly.
+	 */
+	public function test_file_content_forwards_a_body_cut_mid_character_unrepaired() {
+		$cut = substr(
+			str_repeat( 'a', File_Browser_Bridge::PREVIEW_MAX_BYTES - 1 ) . "\xE6\x97\xA5",
+			0,
+			File_Browser_Bridge::PREVIEW_MAX_BYTES
+		);
+
+		$this->arrange_wpcom_answers(
+			array(
+				array( 'body' => self::signed_url_body() ),
+				array( 'body' => $cut ),
+			)
+		);
+
+		$response = File_Browser_Bridge::get_file_content( self::file_content_request() );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$content = $response->get_data()['content'];
+		$this->assertSame( $cut, $content );
+		$this->assertSame( File_Browser_Bridge::PREVIEW_MAX_BYTES, strlen( $content ) );
+		// Both halves of "the cut landed inside a character": the tail is
+		// the lead byte of a three-byte sequence, and the string as a whole
+		// is therefore not valid UTF-8. A bridge that repaired or re-cut
+		// the body would pass the length check and fail these.
+		$this->assertSame( "\xE6", substr( $content, -1 ) );
+		$this->assertFalse( mb_check_encoding( $content, 'UTF-8' ) );
+	}
+
+	/**
+	 * A failure resolving the signed URL is the lookup's, not the stream's.
+	 *
+	 * The two legs have separate error codes on purpose — one means
+	 * WordPress.com would not name the file, the other means the storage
+	 * host would not serve it — and only the first leg runs here, so a
+	 * bridge that mixed them up would be reporting a fetch that never
+	 * happened.
+	 *
+	 * 451 is arbitrary except in one respect: it is inside the range
+	 * `upstream_error()` forwards and is not any of the codes it or the
+	 * bridge falls back to (500 and 502), so it can only be here because
+	 * it was carried through.
+	 */
+	public function test_file_content_reports_a_failed_signed_url_lookup() {
+		$this->arrange_wpcom_answers(
+			array(
+				array(
+					'body'   => '{"code":"rewind_error","message":"No backup for this period."}',
+					'status' => 451,
+				),
+			)
+		);
+
+		$response = File_Browser_Bridge::get_file_content( self::file_content_request() );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'backup_file_content_url_failed', $response->get_error_code() );
+		$this->assertSame( 451, $response->get_error_data()['status'] );
+		$this->assertSame( 'rewind_error', $response->get_error_data()['wpcom']['code'] );
+		// The stream leg must not have run: there was no URL to fetch.
+		$this->assertCount( 1, $this->captured_urls );
+	}
+
+	/**
+	 * A 200 that names no URL this server will fetch stops here.
+	 *
+	 * The scheme check is defence in depth rather than housekeeping.
+	 * Whatever comes back in `url` is handed to `wp_remote_get()` on this
+	 * server, so a regression upstream that answered `file:///etc/passwd`
+	 * would otherwise have the site read its own disk and return the bytes
+	 * to the browser.
+	 *
+	 * 502 rather than 500 here, and that is the bridge's own choice rather
+	 * than `upstream_error()`'s: WordPress.com answered, and what it said
+	 * cannot be used.
+	 *
+	 * @param string $label Why this body names no usable URL.
+	 * @param string $body  Raw 200 body from the signed-URL lookup.
+	 * @dataProvider provide_unusable_signed_urls
+	 */
+	#[DataProvider( 'provide_unusable_signed_urls' )]
+	public function test_file_content_refuses_a_signed_url_it_will_not_fetch( $label, $body ) {
+		$this->arrange_wpcom_answers( array( array( 'body' => $body ) ) );
+
+		$response = File_Browser_Bridge::get_file_content( self::file_content_request() );
+
+		$this->assertInstanceOf( WP_Error::class, $response, $label );
+		$this->assertSame( 'backup_file_content_url_missing', $response->get_error_code() );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
+		$this->assertCount( 1, $this->captured_urls, 'Nothing may be fetched from an unusable URL.' );
+	}
+
+	/**
+	 * 200 bodies the signed-URL lookup could answer with that name no URL
+	 * this server may fetch.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public static function provide_unusable_signed_urls() {
+		return array(
+			'no url key'    => array( 'no url key', '{"ok":true}' ),
+			'an empty url'  => array( 'an empty url', '{"url":""}' ),
+			'not JSON'      => array( 'not JSON', '<html>502 Bad Gateway</html>' ),
+			// The one that matters: `wp_remote_get()` would happily read
+			// this off the site's own disk.
+			'a file scheme' => array( 'a file scheme', '{"url":"file:///etc/passwd"}' ),
+		);
+	}
+
+	/**
+	 * A transport failure on the *stream* leg is the stream's failure.
+	 *
+	 * The existing transport test never reaches this branch — with WPCOM
+	 * unreachable the callback stops at the signed-URL lookup — so the
+	 * second `is_wp_error()` guard, and the fact that it uses a different
+	 * error code, was never run. The signed URL resolves here and the
+	 * fetch of it is what times out.
+	 */
+	public function test_file_content_wraps_a_transport_failure_on_the_stream_leg() {
+		$this->arrange_wpcom_answers(
+			array(
+				array( 'body' => self::signed_url_body() ),
+				new WP_Error(
+					'http_request_failed',
+					'cURL error 28: Operation timed out after 10001 milliseconds with 0 bytes received'
+				),
+			)
+		);
+
+		$response = File_Browser_Bridge::get_file_content( self::file_content_request() );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'backup_file_content_stream_failed', $response->get_error_code() );
+		$this->assertStringNotContainsString( 'cURL', $response->get_error_message() );
+		$this->assertSame( 502, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * A non-200 from the storage host is reported as a stream failure.
+	 *
+	 * This response is not WordPress.com's — it is whoever holds the
+	 * bytes — and a signed URL that has expired between being minted and
+	 * being fetched is the ordinary way to get here. The status is
+	 * forwarded all the same, because the client tells an expired link
+	 * from a missing file by nothing else.
+	 *
+	 * 416 for the same reason 451 is used above: forwardable, and not a
+	 * value any fallback on this path can produce.
+	 */
+	public function test_file_content_reports_a_failed_stream_fetch() {
+		$this->arrange_wpcom_answers(
+			array(
+				array( 'body' => self::signed_url_body() ),
+				array(
+					'body'   => '<?xml version="1.0"?><Error><Code>AccessDenied</Code></Error>',
+					'status' => 416,
+				),
+			)
+		);
+
+		$response = File_Browser_Bridge::get_file_content( self::file_content_request() );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'backup_file_content_stream_failed', $response->get_error_code() );
+		$this->assertSame( 416, $response->get_error_data()['status'] );
+		// The storage host answers in XML, which `upstream_reason()` reads
+		// nothing out of — so there is no `wpcom` key to forward, and the
+		// status is the whole of what the client has to go on.
+		$this->assertArrayNotHasKey( 'wpcom', $response->get_error_data() );
+	}
 }

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -156,28 +156,15 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * The listing asks the right endpoint, with the right two values in
-	 * the right two keys.
+	 * The listing asks the right endpoint, with the right two values in the right two
+	 * keys — neither of which `list_directory()` pinned before.
 	 *
-	 * Every other bridge callback in this package pins its outbound
-	 * request; `list_directory()` was the one that pinned neither its
-	 * path nor its body, and that was invisible because its *projection*
-	 * is well covered. Three separate mutations passed the whole suite
-	 * before this test existed: swapping `backup_id` and `path` in the
-	 * body, and renaming either upstream path.
+	 * `backup_id` is the one to watch: here it takes the parent backup's rewindId, while
+	 * `path-info` and `file-content` next door name the same parameter but want the
+	 * file's own period. A swap between them produces an empty listing, not an error.
 	 *
-	 * `backup_id` is the key that would go unnoticed longest. WPCOM names
-	 * it for the backup, and it does take the parent backup's rewindId
-	 * here — unlike `path-info` and `file-content` next door, which name
-	 * the same parameter `backup_id` but want the *file's* own period.
-	 * Two neighbouring routes, one parameter name, two different values:
-	 * a swap between them produces an empty listing, not an error.
-	 *
-	 * The body is asserted whole rather than key by key. That pins that
-	 * nothing extra is sent, and it fails loudly on a null body — which
-	 * is what the trait leaves behind when a guard refused before
-	 * reaching the network, and what per-key assertions would skip in
-	 * silence.
+	 * The body is asserted whole, which also fails loudly on the null body the trait
+	 * leaves behind when a guard refused before reaching the network.
 	 */
 	public function test_list_directory_sends_the_rewind_id_and_path() {
 		$this->arrange_wpcom( array( 'contents' => array() ) );
@@ -387,10 +374,8 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 		$request->set_param( 'manifest_path', 'f5:/wp-config.php' );
 		File_Browser_Bridge::get_path_info( $request );
 
-		// The endpoint as well as the body. Without this a rename of the
-		// upstream path passes every other assertion in the file: the
-		// body is unchanged, the mocked answer arrives all the same, and
-		// only a real site would 404.
+		// The endpoint as well as the body: a rename of the upstream path passes every
+		// other assertion here, and only a real site would 404.
 		$this->assertStringContainsString( '/sites/999/rewind/backup/path-info', $this->captured_url );
 
 		// Asserted whole rather than key by key: it pins that nothing
@@ -480,21 +465,13 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * What path-info answers with, not just what it asks for.
+	 * What path-info answers with, not just what it asks for. `size`, `hash` and `mtime`
+	 * are the reason the route exists, and dropping them shows an empty card with no
+	 * error anywhere.
 	 *
-	 * The outbound half of this route was pinned and the return value was
-	 * not, which left the whole of what the info card reads unasserted:
-	 * `size`, `hash` and `mtime` are the reason the route exists, and a
-	 * `forward_response()` that dropped or reshaped them would have shown
-	 * an empty card with no error anywhere.
-	 *
-	 * Asserted whole rather than key by key, so a bridge that started
-	 * adding or removing fields fails here rather than drifting.
-	 *
-	 * `manifest_filter` is in the fixture because it is the field a
-	 * granular per-file download will need, and `error` because upstream
-	 * answers 200 with one when the file has no row — the client branches
-	 * on it, so it has to survive the forward.
+	 * Asserted whole, so added or removed fields fail here rather than drift.
+	 * `manifest_filter` is in the fixture for the granular download to come, and `error`
+	 * because upstream answers 200 with one when the file has no row.
 	 */
 	public function test_path_info_forwards_the_upstream_payload() {
 		$upstream = array(
@@ -516,17 +493,11 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * A non-200 on path-info is reported under path-info's own code.
+	 * A non-200 on path-info is reported under path-info's own code, which the client's
+	 * `failureMessage()` keys off — a sibling's code would name the wrong operation.
 	 *
-	 * The status and reason travel through `forward_response()`, which the
-	 * listing already covers — what is only true here is the error code.
-	 * The client's `failureMessage()` keys off it, so a route answering
-	 * with a sibling's code would be described to the reader as the wrong
-	 * operation failing.
-	 *
-	 * 429 rather than 500: `upstream_error()` falls back to 500 for a
-	 * status it cannot use, so a test written against 500 would pass
-	 * whether or not the status was forwarded at all.
+	 * 429 rather than 500: `upstream_error()` falls back to 500, so a test written
+	 * against it would pass whether or not the status was forwarded.
 	 */
 	public function test_path_info_reports_a_non_200_under_its_own_code() {
 		$this->arrange_wpcom( array( 'code' => 'too_many_requests' ), 429 );
@@ -543,12 +514,9 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * A signed-URL body WPCOM answered 200 with, and the signed URL the
-	 * stream leg would then be given.
-	 *
-	 * `home_url()` throughout, so `wp_http_validate_url()` takes its
-	 * same-host path — any other host sends it to `gethostbyname()` and
-	 * makes these tests pass or fail on whether the runner has DNS.
+	 * A signed-URL body WPCOM answered 200 with, and the signed URL the stream leg would
+	 * then be given. `home_url()` throughout, so `wp_http_validate_url()` takes its
+	 * same-host path rather than passing or failing on the runner's DNS.
 	 *
 	 * @return string
 	 */
@@ -569,50 +537,26 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * The preview limit is 64 KB, stated as a number.
+	 * The preview limit is 64 KB, asserted as a literal so the constant cannot drift —
+	 * every other assertion here compares against itself and would move with it.
 	 *
-	 * Everything else here compares against
-	 * `File_Browser_Bridge::PREVIEW_MAX_BYTES`, which is the right thing
-	 * to do — and leaves the constant itself free to drift, because a
-	 * self-referential assertion moves with it. Raising it to 8 MB passes
-	 * the entire suite; the only visible effect is the run getting seven
-	 * times slower. Raising it to 64 MB does not fail the suite either —
-	 * it *fatals* it, `Allowed memory size of 134217728 bytes exhausted`
-	 * while `test_file_content_forwards_a_body_cut_mid_character_unrepaired`
-	 * builds its fixture, which reads as a broken test runner rather than
-	 * as a bad constant.
-	 *
-	 * A literal is the only assertion that catches either. The value is
-	 * not arbitrary — it is what makes a wp-config.php, a theme
-	 * style.css or a small SQL dump previewable while keeping an
-	 * arbitrary blob out of PHP memory — so pinning it is pinning a
-	 * decision, not a magic number.
+	 * The value keeps a wp-config.php or a small SQL dump previewable while keeping an
+	 * arbitrary blob out of PHP memory, so it is a decision rather than a magic number.
 	 */
 	public function test_the_preview_limit_is_64_kb() {
 		$this->assertSame( 65536, File_Browser_Bridge::PREVIEW_MAX_BYTES );
 	}
 
 	/**
-	 * The stream fetch is capped, and capped at the preview limit.
+	 * The stream fetch is capped, and capped at the preview limit. `limit_response_size`
+	 * is the only thing between a text preview and a multi-gigabyte blob in PHP memory,
+	 * and it changes nothing about a small file — so it is read off the outbound request
+	 * arguments rather than the response.
 	 *
-	 * `limit_response_size` is the only thing between a text preview and
-	 * a multi-gigabyte blob buffered into PHP memory: the bridge enforces
-	 * no mime check at all, so any admin can point this route at any blob
-	 * WordPress.com will sign a URL for. It cannot be asserted from a
-	 * response — it changes nothing about a small file — so it is read off
-	 * the outbound request arguments instead.
-	 *
-	 * The first call is asserted to be uncapped, and that is a statement
-	 * about where the cap *can* live rather than about where someone might
-	 * put it by mistake: `Client::validate_args_for_wpcom_json_api_request()`
-	 * intersects outbound arguments against a fixed allowlist —
-	 * `headers`, `method`, `format`, `timeout`, `redirection`, `stream`,
-	 * `filename`, `sslverify` — and `limit_response_size` is not on it. A
-	 * signed `Client` call cannot be capped at all, then, and asking for
-	 * one to be is silently a no-op. The cap only works on the second leg
-	 * because that leg is a bare `wp_remote_get()`, which it is because
-	 * the signed URL points at the storage host and carries its own
-	 * authorization — there is nothing for `Client` to sign.
+	 * The first call is asserted uncapped because it cannot be capped:
+	 * `Client::validate_args_for_wpcom_json_api_request()` intersects outbound arguments
+	 * against a fixed allowlist that `limit_response_size` is not on. The cap works on
+	 * the second leg only because that leg is a bare `wp_remote_get()`.
 	 */
 	public function test_file_content_caps_the_stream_fetch_at_the_preview_limit() {
 		$this->arrange_wpcom_answers(
@@ -625,8 +569,7 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 		File_Browser_Bridge::get_file_content( self::file_content_request() );
 
 		$this->assertCount( 2, $this->captured_request_args );
-		// `WP_Http` defaults the key to null, so "uncapped" is a null value
-		// rather than an absent key.
+		// `WP_Http` defaults the key to null, so "uncapped" is null, not absent.
 		$this->assertNull( $this->captured_request_args[0]['limit_response_size'] ?? null );
 		$this->assertSame(
 			File_Browser_Bridge::PREVIEW_MAX_BYTES,
@@ -635,38 +578,20 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * A preview cut short by the byte cap is forwarded exactly as it
-	 * arrived, mid-character and all.
+	 * A preview cut short by the byte cap is forwarded exactly as it arrived,
+	 * mid-character and all.
 	 *
-	 * The cap is a byte count enforced by the HTTP transport, not by this
-	 * bridge, and the transport counts bytes with no idea where characters
-	 * begin. So the cut can land inside a multi-byte sequence, and this is
-	 * the fixture where it does: 65,535 ASCII bytes followed by U+65E5
-	 * (`日`, `E6 97 A5`) is 65,538 bytes, and the cut at 65,536 keeps the
-	 * lead byte `E6` and drops the two continuation bytes behind it. The
-	 * fixture is built that way rather than asserted to be that way, so
-	 * the last two assertions below are what prove it landed mid-character
-	 * rather than at a boundary.
+	 * The transport counts bytes with no idea where characters begin, so the cut can land
+	 * inside a multi-byte sequence: 65,535 ASCII bytes followed by U+65E5 is 65,538, and
+	 * the cut at 65,536 keeps the lead byte and drops its two continuations.
 	 *
-	 * `pre_http_request` short-circuits the transport, so the arranged body
-	 * stands in for what the transport's own cut would have handed back.
-	 * What is under test is what the bridge does with it: nothing. It does
-	 * not re-cut it to a character boundary, and it does not repair it —
-	 * either would be a silently different file from the one on disk, which
-	 * is worse in a preview than a visibly damaged tail.
-	 *
-	 * The damage is not invisible downstream: `wp_json_encode()` refuses
-	 * the orphaned lead byte and its sanity pass rewrites it, so a reader
-	 * sees `?` at the end of a preview this long. That is core's call to
-	 * make, not this bridge's, and it only happens because the bytes were
-	 * forwarded honestly.
+	 * What is under test is what the bridge does with that: nothing. Re-cutting or
+	 * repairing it would be a silently different file from the one on disk, which is
+	 * worse in a preview than a visibly damaged tail.
 	 */
 	public function test_file_content_forwards_a_body_cut_mid_character_unrepaired() {
-		// Checked before allocating, not after. The fixture below is the
-		// cap's own size, so a cap raised into the megabytes exhausts
-		// PHP's memory limit here and takes the whole run down with a
-		// fatal — an outcome nobody reads as "the constant changed".
-		// Failing on the bound first turns that into an ordinary red test.
+		// Checked before allocating: the fixture is the cap's own size, so a cap raised
+		// into the megabytes would fatal the run rather than fail this test.
 		$this->assertLessThanOrEqual(
 			1024 * 1024,
 			File_Browser_Bridge::PREVIEW_MAX_BYTES,
@@ -692,27 +617,19 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 		$content = $response->get_data()['content'];
 		$this->assertSame( $cut, $content );
 		$this->assertSame( File_Browser_Bridge::PREVIEW_MAX_BYTES, strlen( $content ) );
-		// Both halves of "the cut landed inside a character": the tail is
-		// the lead byte of a three-byte sequence, and the string as a whole
-		// is therefore not valid UTF-8. A bridge that repaired or re-cut
-		// the body would pass the length check and fail these.
+		// Both halves of "the cut landed inside a character". A bridge that repaired or
+		// re-cut the body would pass the length check and fail these.
 		$this->assertSame( "\xE6", substr( $content, -1 ) );
 		$this->assertFalse( mb_check_encoding( $content, 'UTF-8' ) );
 	}
 
 	/**
-	 * A failure resolving the signed URL is the lookup's, not the stream's.
+	 * A failure resolving the signed URL is the lookup's, not the stream's. The two legs
+	 * have separate error codes on purpose — one means WordPress.com would not name the
+	 * file, the other that the storage host would not serve it.
 	 *
-	 * The two legs have separate error codes on purpose — one means
-	 * WordPress.com would not name the file, the other means the storage
-	 * host would not serve it — and only the first leg runs here, so a
-	 * bridge that mixed them up would be reporting a fetch that never
-	 * happened.
-	 *
-	 * 451 is arbitrary except in one respect: it is inside the range
-	 * `upstream_error()` forwards and is not any of the codes it or the
-	 * bridge falls back to (500 and 502), so it can only be here because
-	 * it was carried through.
+	 * 451 is arbitrary except that it is forwardable and is neither fallback (500, 502),
+	 * so it can only be here because it was carried through.
 	 */
 	public function test_file_content_reports_a_failed_signed_url_lookup() {
 		$this->arrange_wpcom_answers(
@@ -735,17 +652,12 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * A 200 that names no URL this server will fetch stops here.
+	 * A 200 that names no URL this server will fetch stops here. Whatever comes back in
+	 * `url` is handed to `wp_remote_get()` on this server, so an upstream regression
+	 * answering `file:///etc/passwd` would have the site read its own disk.
 	 *
-	 * The scheme check is defence in depth rather than housekeeping.
-	 * Whatever comes back in `url` is handed to `wp_remote_get()` on this
-	 * server, so a regression upstream that answered `file:///etc/passwd`
-	 * would otherwise have the site read its own disk and return the bytes
-	 * to the browser.
-	 *
-	 * 502 rather than 500 here, and that is the bridge's own choice rather
-	 * than `upstream_error()`'s: WordPress.com answered, and what it said
-	 * cannot be used.
+	 * 502 rather than 500 is the bridge's own choice: WordPress.com answered, and what it
+	 * said cannot be used.
 	 *
 	 * @param string $label Why this body names no usable URL.
 	 * @param string $body  Raw 200 body from the signed-URL lookup.
@@ -774,20 +686,15 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 			'no url key'    => array( 'no url key', '{"ok":true}' ),
 			'an empty url'  => array( 'an empty url', '{"url":""}' ),
 			'not JSON'      => array( 'not JSON', '<html>502 Bad Gateway</html>' ),
-			// The one that matters: `wp_remote_get()` would happily read
-			// this off the site's own disk.
+			// The one that matters: `wp_remote_get()` would read this off the disk.
 			'a file scheme' => array( 'a file scheme', '{"url":"file:///etc/passwd"}' ),
 		);
 	}
 
 	/**
-	 * A transport failure on the *stream* leg is the stream's failure.
-	 *
-	 * The existing transport test never reaches this branch — with WPCOM
-	 * unreachable the callback stops at the signed-URL lookup — so the
-	 * second `is_wp_error()` guard, and the fact that it uses a different
-	 * error code, was never run. The signed URL resolves here and the
-	 * fetch of it is what times out.
+	 * A transport failure on the *stream* leg is the stream's failure. The existing
+	 * transport test stops at the signed-URL lookup, so the second `is_wp_error()` guard
+	 * and its different error code were never run.
 	 */
 	public function test_file_content_wraps_a_transport_failure_on_the_stream_leg() {
 		$this->arrange_wpcom_answers(
@@ -809,16 +716,11 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * A non-200 from the storage host is reported as a stream failure.
+	 * A non-200 from the storage host is reported as a stream failure. An expired signed
+	 * URL is the ordinary way to get here, and the status is forwarded because the client
+	 * tells an expired link from a missing file by nothing else.
 	 *
-	 * This response is not WordPress.com's — it is whoever holds the
-	 * bytes — and a signed URL that has expired between being minted and
-	 * being fetched is the ordinary way to get here. The status is
-	 * forwarded all the same, because the client tells an expired link
-	 * from a missing file by nothing else.
-	 *
-	 * 416 for the same reason 451 is used above: forwardable, and not a
-	 * value any fallback on this path can produce.
+	 * 416 for the same reason 451 is used above.
 	 */
 	public function test_file_content_reports_a_failed_stream_fetch() {
 		$this->arrange_wpcom_answers(
@@ -836,9 +738,8 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'backup_file_content_stream_failed', $response->get_error_code() );
 		$this->assertSame( 416, $response->get_error_data()['status'] );
-		// The storage host answers in XML, which `upstream_reason()` reads
-		// nothing out of — so there is no `wpcom` key to forward, and the
-		// status is the whole of what the client has to go on.
+		// The storage host answers in XML, which `upstream_reason()` reads nothing out
+		// of — so the status is all the client has to go on.
 		$this->assertArrayNotHasKey( 'wpcom', $response->get_error_data() );
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -154,6 +154,49 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 
 		$this->assertSame( 403, $response->get_status() );
 	}
+
+	/**
+	 * The listing asks the right endpoint, with the right two values in
+	 * the right two keys.
+	 *
+	 * Every other bridge callback in this package pins its outbound
+	 * request; `list_directory()` was the one that pinned neither its
+	 * path nor its body, and that was invisible because its *projection*
+	 * is well covered. Three separate mutations passed the whole suite
+	 * before this test existed: swapping `backup_id` and `path` in the
+	 * body, and renaming either upstream path.
+	 *
+	 * `backup_id` is the key that would go unnoticed longest. WPCOM names
+	 * it for the backup, and it does take the parent backup's rewindId
+	 * here — unlike `path-info` and `file-content` next door, which name
+	 * the same parameter `backup_id` but want the *file's* own period.
+	 * Two neighbouring routes, one parameter name, two different values:
+	 * a swap between them produces an empty listing, not an error.
+	 *
+	 * The body is asserted whole rather than key by key. That pins that
+	 * nothing extra is sent, and it fails loudly on a null body — which
+	 * is what the trait leaves behind when a guard refused before
+	 * reaching the network, and what per-key assertions would skip in
+	 * silence.
+	 */
+	public function test_list_directory_sends_the_rewind_id_and_path() {
+		$this->arrange_wpcom( array( 'contents' => array() ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/rewind/backup/ls' );
+		$request->set_param( 'rewind_id', '1748888135.123' );
+		$request->set_param( 'path', '/wp-content/themes' );
+		File_Browser_Bridge::list_directory( $request );
+
+		$this->assertStringContainsString( '/sites/999/rewind/backup/ls', $this->captured_url );
+		$this->assertSame(
+			array(
+				'backup_id' => '1748888135.123',
+				'path'      => '/wp-content/themes',
+			),
+			$this->captured_body
+		);
+	}
+
 	/**
 	 * A transport failure on the directory listing surfaces as the
 	 * bridge's own error rather than cURL's text.
@@ -344,6 +387,12 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 		$request->set_param( 'manifest_path', 'f5:/wp-config.php' );
 		File_Browser_Bridge::get_path_info( $request );
 
+		// The endpoint as well as the body. Without this a rename of the
+		// upstream path passes every other assertion in the file: the
+		// body is unchanged, the mocked answer arrives all the same, and
+		// only a real site would 404.
+		$this->assertStringContainsString( '/sites/999/rewind/backup/path-info', $this->captured_url );
+
 		// Asserted whole rather than key by key: it pins that nothing
 		// extra is sent, and it fails loudly on a null body — the trait
 		// leaves it null when a guard refused before reaching the
@@ -520,6 +569,30 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
+	 * The preview limit is 64 KB, stated as a number.
+	 *
+	 * Everything else here compares against
+	 * `File_Browser_Bridge::PREVIEW_MAX_BYTES`, which is the right thing
+	 * to do — and leaves the constant itself free to drift, because a
+	 * self-referential assertion moves with it. Raising it to 8 MB passes
+	 * the entire suite; the only visible effect is the run getting seven
+	 * times slower. Raising it to 64 MB does not fail the suite either —
+	 * it *fatals* it, `Allowed memory size of 134217728 bytes exhausted`
+	 * while `test_file_content_forwards_a_body_cut_mid_character_unrepaired`
+	 * builds its fixture, which reads as a broken test runner rather than
+	 * as a bad constant.
+	 *
+	 * A literal is the only assertion that catches either. The value is
+	 * not arbitrary — it is what makes a wp-config.php, a theme
+	 * style.css or a small SQL dump previewable while keeping an
+	 * arbitrary blob out of PHP memory — so pinning it is pinning a
+	 * decision, not a magic number.
+	 */
+	public function test_the_preview_limit_is_64_kb() {
+		$this->assertSame( 65536, File_Browser_Bridge::PREVIEW_MAX_BYTES );
+	}
+
+	/**
 	 * The stream fetch is capped, and capped at the preview limit.
 	 *
 	 * `limit_response_size` is the only thing between a text preview and
@@ -589,6 +662,17 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	 * forwarded honestly.
 	 */
 	public function test_file_content_forwards_a_body_cut_mid_character_unrepaired() {
+		// Checked before allocating, not after. The fixture below is the
+		// cap's own size, so a cap raised into the megabytes exhausts
+		// PHP's memory limit here and takes the whole run down with a
+		// fatal — an outcome nobody reads as "the constant changed".
+		// Failing on the bound first turns that into an ordinary red test.
+		$this->assertLessThanOrEqual(
+			1024 * 1024,
+			File_Browser_Bridge::PREVIEW_MAX_BYTES,
+			'A preview cap this large cannot be exercised in a unit test, and should not be buffered in PHP memory on a real site either.'
+		);
+
 		$cut = substr(
 			str_repeat( 'a', File_Browser_Bridge::PREVIEW_MAX_BYTES - 1 ) . "\xE6\x97\xA5",
 			0,

--- a/projects/packages/backup/tests/php/abilities/Backup_Abilities_Test.php
+++ b/projects/packages/backup/tests/php/abilities/Backup_Abilities_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Backup\V0005\Abilities;
 
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
@@ -44,6 +45,23 @@ class Backup_Abilities_Test extends BaseTestCase {
 
 		// Default: gate open. Individual tests opt out by removing this filter.
 		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
+
+		// The *first* outbound `Client` call in a PHP process otherwise
+		// fails before it reaches the HTTP layer at all.
+		// `JETPACK__WPCOM_JSON_API_BASE` is not a defined constant here,
+		// and the filter that supplies its default is registered by
+		// `Client::build_signed_request()` — so on the first call the API
+		// base is still null, the request URL is built with no host, and
+		// `Jetpack_Signature` refuses it as a malformed `url`. The ability
+		// reports that as `jetpack_backup_data_unavailable`.
+		//
+		// It bites here rather than in the bridge suites because this file
+		// does not use `Wpcom_Request_Mock`, which primes the constants
+		// for its own consumers. Running
+		// `phpunit tests/php/abilities/` on its own fails one test of 68
+		// without this line, and `--order-by=random` fails whenever this
+		// file draws the first outbound call.
+		Connection_Utils::init_default_constants();
 	}
 
 	public function tearDown(): void {

--- a/projects/packages/backup/tests/php/abilities/Backup_Abilities_Test.php
+++ b/projects/packages/backup/tests/php/abilities/Backup_Abilities_Test.php
@@ -46,21 +46,11 @@ class Backup_Abilities_Test extends BaseTestCase {
 		// Default: gate open. Individual tests opt out by removing this filter.
 		add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );
 
-		// The *first* outbound `Client` call in a PHP process otherwise
-		// fails before it reaches the HTTP layer at all.
-		// `JETPACK__WPCOM_JSON_API_BASE` is not a defined constant here,
-		// and the filter that supplies its default is registered by
-		// `Client::build_signed_request()` — so on the first call the API
-		// base is still null, the request URL is built with no host, and
-		// `Jetpack_Signature` refuses it as a malformed `url`. The ability
-		// reports that as `jetpack_backup_data_unavailable`.
-		//
-		// It bites here rather than in the bridge suites because this file
-		// does not use `Wpcom_Request_Mock`, which primes the constants
-		// for its own consumers. Running
-		// `phpunit tests/php/abilities/` on its own fails one test of 68
-		// without this line, and `--order-by=random` fails whenever this
-		// file draws the first outbound call.
+		// The *first* outbound `Client` call in a process is otherwise refused as a
+		// host-less URL, because `JETPACK__WPCOM_JSON_API_BASE` is undefined until
+		// `Client::build_signed_request()` installs the filter supplying it. It bites
+		// here rather than in the bridge suites because this file does not use
+		// `Wpcom_Request_Mock`, which primes the constants for its own consumers.
 		Connection_Utils::init_default_constants();
 	}
 

--- a/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
+++ b/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
@@ -30,12 +30,14 @@ use function wp_set_current_user;
  * `Rest_Controller::permission_check()` to pass, so a test may either
  * call a bridge callback directly or dispatch through the REST server —
  * `Rest_Bridge_Dispatch_Test` does the latter for every bridge route.
- * Prefer a dispatch when the route's arg schema, permission callback or
- * response serialization is part of what is being asserted, and a direct
+ * Prefer a dispatch when the route's arg schema, its regex, or the
+ * permission callback is part of what is being asserted, and a direct
  * call when the point is one branch inside a callback: dispatch wraps a
- * `WP_Error` in a response envelope, moving the code and the `wpcom`
- * reason under `get_data()['data']` instead of leaving them on the error
- * object where `get_error_data()` reads them.
+ * `WP_Error` in a response envelope, so the code moves to
+ * `get_data()['code']` and the reason to `get_data()['data']['wpcom']`,
+ * instead of staying on the error object where `get_error_code()` and
+ * `get_error_data()` read them. Note the code does *not* move under
+ * `['data']` with the reason — only the reason does.
  */
 trait Wpcom_Request_Mock {
 
@@ -108,13 +110,20 @@ trait Wpcom_Request_Mock {
 		// no host, and `Jetpack_Signature` refuses it as a malformed
 		// `url`. Every bridge reports that as a 502 transport failure.
 		//
-		// The suite hid this: whichever test ran first absorbed the
-		// failure, and no assertion happened to depend on the difference.
-		// Nothing guaranteed that, though — a reordering, a new test file,
-		// or running one test on its own could all hand the empty API base
-		// to a test that asserts a success. Registering the defaults up
-		// front is what the connection package does in production, and it
-		// makes each test's result independent of the order it runs in.
+		// The default execution order hid this: whichever test ran first
+		// absorbed the failure, and no assertion happened to depend on the
+		// difference. Reordering makes it visible immediately — without
+		// this line, `--order-by=random` fails five of the eight seeds 1-8,
+		// each time on whichever bridge test drew the first outbound call
+		// (`test_treats_a_string_status_as_its_number` and friends, which
+		// assert a success and so cannot absorb a 502).
+		//
+		// Registering the defaults up front is what the connection package
+		// does in production. It makes a test's result independent of the
+		// order it runs in — but only for tests that use this trait.
+		// Anything in this package that reaches `Client` without it still
+		// has to prime the constants itself, which is why
+		// `Backup_Abilities_Test` calls this too.
 		Connection_Utils::init_default_constants();
 
 		return $admin_id;

--- a/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
+++ b/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Backup\V0005\REST;
 
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use WP_Error;
 use function add_filter;
 use function get_current_user_id;
@@ -25,12 +26,16 @@ use function wp_set_current_user;
  * and each was being rebuilt per test file. Consumers must call
  * `reset_wpcom_request_mock()` from their own `tearDown()`.
  *
- * One thing worth knowing before adding tests with this: the callbacks
- * are invoked directly rather than dispatched through the REST server.
- * `Rest_Controller::permission_check()` additionally requires a
- * user-level WPCOM connection that WorDBless cannot stand up, so a
- * dispatch never reaches the callback body. The permission boundary
- * itself is covered separately, by each file's `manage_options` test.
+ * The `user_tokens` this installs are enough for
+ * `Rest_Controller::permission_check()` to pass, so a test may either
+ * call a bridge callback directly or dispatch through the REST server —
+ * `Rest_Bridge_Dispatch_Test` does the latter for every bridge route.
+ * Prefer a dispatch when the route's arg schema, permission callback or
+ * response serialization is part of what is being asserted, and a direct
+ * call when the point is one branch inside a callback: dispatch wraps a
+ * `WP_Error` in a response envelope, moving the code and the `wpcom`
+ * reason under `get_data()['data']` instead of leaving them on the error
+ * object where `get_error_data()` reads them.
  */
 trait Wpcom_Request_Mock {
 
@@ -64,6 +69,20 @@ trait Wpcom_Request_Mock {
 	protected $captured_body = null;
 
 	/**
+	 * The parsed `wp_remote_*` arguments of every request a bridge made,
+	 * in call order.
+	 *
+	 * This is what `$captured_body` cannot answer: whether the bridge
+	 * asked for something *about* the request rather than sending it.
+	 * `get_file_content()`'s `limit_response_size` is the case in point —
+	 * it never appears in a body, and it is the only thing standing
+	 * between a text preview and a multi-gigabyte blob in PHP memory.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	protected $captured_request_args = array();
+
+	/**
 	 * Sign in as an administrator and make `Client` able to sign a request.
 	 *
 	 * @return int The administrator's user id.
@@ -80,6 +99,24 @@ trait Wpcom_Request_Mock {
 
 		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10, 2 );
 
+		// Without this, the *first* outbound `Client` call in a PHP
+		// process fails before it reaches `pre_http_request` at all, and
+		// every later one succeeds. `JETPACK__WPCOM_JSON_API_BASE` is not
+		// a defined constant here, and the filter supplying its default is
+		// registered by `Client::build_signed_request()` — so on the first
+		// call the API base is still null, the request URL is built with
+		// no host, and `Jetpack_Signature` refuses it as a malformed
+		// `url`. Every bridge reports that as a 502 transport failure.
+		//
+		// The suite hid this: whichever test ran first absorbed the
+		// failure, and no assertion happened to depend on the difference.
+		// Nothing guaranteed that, though — a reordering, a new test file,
+		// or running one test on its own could all hand the empty API base
+		// to a test that asserts a success. Registering the defaults up
+		// front is what the connection package does in production, and it
+		// makes each test's result independent of the order it runs in.
+		Connection_Utils::init_default_constants();
+
 		return $admin_id;
 	}
 
@@ -95,9 +132,7 @@ trait Wpcom_Request_Mock {
 		add_filter(
 			'pre_http_request',
 			function ( $preempt, $args, $url ) use ( $body, $status ) {
-				$this->captured_url    = $url;
-				$this->captured_urls[] = $url;
-				$this->captured_body   = isset( $args['body'] ) ? json_decode( $args['body'], true ) : null;
+				$this->record_request( $args, $url );
 				return array(
 					'response' => self::mock_response_headers( $status ),
 					'body'     => wp_json_encode( $body, JSON_UNESCAPED_SLASHES ),
@@ -130,14 +165,7 @@ trait Wpcom_Request_Mock {
 		add_filter(
 			'pre_http_request',
 			function ( $preempt, $args, $url ) use ( $body, $status ) {
-				$this->captured_url    = $url;
-				$this->captured_urls[] = $url;
-				// Recorded here too, or `captured_body` would mean both
-				// "no request was made" and "a request was made and this
-				// helper did not look" — and the trait documents the
-				// former as how a test proves a guard refused before
-				// reaching the network.
-				$this->captured_body = isset( $args['body'] ) ? json_decode( $args['body'], true ) : null;
+				$this->record_request( $args, $url );
 				return array(
 					'response' => self::mock_response_headers( $status ),
 					'body'     => $body,
@@ -146,6 +174,76 @@ trait Wpcom_Request_Mock {
 			10,
 			3
 		);
+	}
+
+	/**
+	 * Sign in and have WPCOM answer each outbound call differently.
+	 *
+	 * `get_file_content()` is the reason this exists. It makes two calls —
+	 * the signed-URL lookup, then the stream fetch — and the single canned
+	 * answer the other arrangers install serves both, so every failure
+	 * that belongs to only one leg is unreachable through them. A 404 on
+	 * the stream and a 404 on the lookup are different bugs with
+	 * different error codes, and a fixture that cannot tell them apart
+	 * cannot test either.
+	 *
+	 * Answers are consumed in call order. An extra call past the end of
+	 * the list is a transport failure with its own code rather than a
+	 * repeat of the last answer, so a bridge that fetched more than the
+	 * test expected fails visibly instead of quietly passing.
+	 *
+	 * @param array<int, array{body?: string, status?: int|string}|WP_Error> $answers One answer per outbound call, in order.
+	 */
+	protected function arrange_wpcom_answers( array $answers ) {
+		$this->sign_in_as_admin();
+
+		$remaining = $answers;
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$remaining ) {
+				$this->record_request( $args, $url );
+
+				if ( ! $remaining ) {
+					return new WP_Error(
+						'test_unexpected_request',
+						sprintf( 'The bridge made an outbound request this test did not arrange an answer for: %s', $url )
+					);
+				}
+
+				$answer = array_shift( $remaining );
+				if ( $answer instanceof WP_Error ) {
+					return $answer;
+				}
+
+				return array(
+					'response' => self::mock_response_headers( $answer['status'] ?? 200 ),
+					'body'     => $answer['body'] ?? '',
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Record one outbound request.
+	 *
+	 * `captured_body` is deliberately overwritten rather than appended to:
+	 * it means "the body of the last request", and it is `null` both when
+	 * no request was made — which is how a test proves a guard refused
+	 * before reaching the network — and when the last request carried no
+	 * body, as every GET does. `captured_request_args` is the per-call
+	 * record to read when either distinction matters.
+	 *
+	 * @param array<string, mixed> $args Parsed `wp_remote_*` arguments.
+	 * @param string               $url  Request URL.
+	 */
+	private function record_request( $args, $url ) {
+		$this->captured_url            = $url;
+		$this->captured_urls[]         = $url;
+		$this->captured_request_args[] = $args;
+		$this->captured_body           = isset( $args['body'] ) ? json_decode( $args['body'], true ) : null;
 	}
 
 	/**
@@ -202,9 +300,10 @@ trait Wpcom_Request_Mock {
 		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10 );
 		wp_set_current_user( 0 );
 
-		$this->captured_url  = '';
-		$this->captured_urls = array();
-		$this->captured_body = null;
+		$this->captured_url          = '';
+		$this->captured_urls         = array();
+		$this->captured_body         = null;
+		$this->captured_request_args = array();
 	}
 
 	/**

--- a/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
+++ b/projects/packages/backup/tests/php/trait-wpcom-request-mock.php
@@ -26,18 +26,13 @@ use function wp_set_current_user;
  * and each was being rebuilt per test file. Consumers must call
  * `reset_wpcom_request_mock()` from their own `tearDown()`.
  *
- * The `user_tokens` this installs are enough for
- * `Rest_Controller::permission_check()` to pass, so a test may either
- * call a bridge callback directly or dispatch through the REST server —
- * `Rest_Bridge_Dispatch_Test` does the latter for every bridge route.
- * Prefer a dispatch when the route's arg schema, its regex, or the
- * permission callback is part of what is being asserted, and a direct
- * call when the point is one branch inside a callback: dispatch wraps a
- * `WP_Error` in a response envelope, so the code moves to
- * `get_data()['code']` and the reason to `get_data()['data']['wpcom']`,
- * instead of staying on the error object where `get_error_code()` and
- * `get_error_data()` read them. Note the code does *not* move under
- * `['data']` with the reason — only the reason does.
+ * The `user_tokens` this installs are enough for `Rest_Controller::permission_check()`
+ * to pass, so a test may call a bridge callback directly or dispatch through the REST
+ * server. Dispatch when the route's arg schema, regex or permission callback is part of
+ * what is asserted; call directly when the point is one branch inside a callback.
+ *
+ * Dispatch wraps a `WP_Error` in a response envelope, moving the code to
+ * `get_data()['code']` and the reason to `get_data()['data']['wpcom']`.
  */
 trait Wpcom_Request_Mock {
 
@@ -71,14 +66,11 @@ trait Wpcom_Request_Mock {
 	protected $captured_body = null;
 
 	/**
-	 * The parsed `wp_remote_*` arguments of every request a bridge made,
-	 * in call order.
+	 * The parsed `wp_remote_*` arguments of every request a bridge made, in call order.
 	 *
-	 * This is what `$captured_body` cannot answer: whether the bridge
-	 * asked for something *about* the request rather than sending it.
-	 * `get_file_content()`'s `limit_response_size` is the case in point —
-	 * it never appears in a body, and it is the only thing standing
-	 * between a text preview and a multi-gigabyte blob in PHP memory.
+	 * What `$captured_body` cannot answer: whether the bridge asked for something *about*
+	 * the request rather than sending it. `get_file_content()`'s `limit_response_size`
+	 * never appears in a body.
 	 *
 	 * @var array<int, array<string, mixed>>
 	 */
@@ -101,29 +93,14 @@ trait Wpcom_Request_Mock {
 
 		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10, 2 );
 
-		// Without this, the *first* outbound `Client` call in a PHP
-		// process fails before it reaches `pre_http_request` at all, and
-		// every later one succeeds. `JETPACK__WPCOM_JSON_API_BASE` is not
-		// a defined constant here, and the filter supplying its default is
-		// registered by `Client::build_signed_request()` — so on the first
-		// call the API base is still null, the request URL is built with
-		// no host, and `Jetpack_Signature` refuses it as a malformed
-		// `url`. Every bridge reports that as a 502 transport failure.
+		// Without this the *first* outbound `Client` call in a process fails before
+		// reaching `pre_http_request`: `JETPACK__WPCOM_JSON_API_BASE` is undefined until
+		// `Client::build_signed_request()` installs the filter supplying it, so the URL
+		// is built with no host and refused as malformed. Every bridge reports that as a
+		// 502, which makes a test's result depend on what ran before it.
 		//
-		// The default execution order hid this: whichever test ran first
-		// absorbed the failure, and no assertion happened to depend on the
-		// difference. Reordering makes it visible immediately — without
-		// this line, `--order-by=random` fails five of the eight seeds 1-8,
-		// each time on whichever bridge test drew the first outbound call
-		// (`test_treats_a_string_status_as_its_number` and friends, which
-		// assert a success and so cannot absorb a 502).
-		//
-		// Registering the defaults up front is what the connection package
-		// does in production. It makes a test's result independent of the
-		// order it runs in — but only for tests that use this trait.
-		// Anything in this package that reaches `Client` without it still
-		// has to prime the constants itself, which is why
-		// `Backup_Abilities_Test` calls this too.
+		// Only tests using this trait are covered, which is why `Backup_Abilities_Test`
+		// calls this too.
 		Connection_Utils::init_default_constants();
 
 		return $admin_id;
@@ -188,18 +165,12 @@ trait Wpcom_Request_Mock {
 	/**
 	 * Sign in and have WPCOM answer each outbound call differently.
 	 *
-	 * `get_file_content()` is the reason this exists. It makes two calls —
-	 * the signed-URL lookup, then the stream fetch — and the single canned
-	 * answer the other arrangers install serves both, so every failure
-	 * that belongs to only one leg is unreachable through them. A 404 on
-	 * the stream and a 404 on the lookup are different bugs with
-	 * different error codes, and a fixture that cannot tell them apart
-	 * cannot test either.
+	 * `get_file_content()` is why this exists: it makes two calls, and the single canned
+	 * answer the other arrangers install serves both, so a failure belonging to only one
+	 * leg is unreachable through them.
 	 *
-	 * Answers are consumed in call order. An extra call past the end of
-	 * the list is a transport failure with its own code rather than a
-	 * repeat of the last answer, so a bridge that fetched more than the
-	 * test expected fails visibly instead of quietly passing.
+	 * Answers are consumed in call order. A call past the end of the list is a transport
+	 * failure rather than a repeat, so fetching more than expected fails visibly.
 	 *
 	 * @param array<int, array{body?: string, status?: int|string}|WP_Error> $answers One answer per outbound call, in order.
 	 */
@@ -238,12 +209,9 @@ trait Wpcom_Request_Mock {
 	/**
 	 * Record one outbound request.
 	 *
-	 * `captured_body` is deliberately overwritten rather than appended to:
-	 * it means "the body of the last request", and it is `null` both when
-	 * no request was made — which is how a test proves a guard refused
-	 * before reaching the network — and when the last request carried no
-	 * body, as every GET does. `captured_request_args` is the per-call
-	 * record to read when either distinction matters.
+	 * `captured_body` means "the body of the last request", so it is overwritten rather
+	 * than appended to, and is `null` both when no request was made and when the last
+	 * one carried no body. Read `captured_request_args` when that distinction matters.
 	 *
 	 * @param array<string, mixed> $args Parsed `wp_remote_*` arguments.
 	 * @param string               $url  Request URL.


### PR DESCRIPTION
Fixes JETPACK-2310

## Proposed changes

Test-only. Closes both halves of the bridge coverage audit — the per-callback gaps (J1) and "no bridge route is ever dispatched to a 200" (J5). **No production code changed**, and no `permission_check` seam was needed: the reason the audit gave for J5 being hard turned out not to be true.

* **`Rest_Bridge_Dispatch_Test.php` (new)** — dispatches all **nine** bridge routes through `WP_REST_Server` to a 200 and asserts the payload each one serves. That is the first time the `register_rest_route` arg schemas, a `permission_check()` that *succeeds*, and `rest_ensure_response()` serialization have been exercised on any bridge route. The route list is derived by diffing the route table with the modernization filter on against the same table with it off, so a tenth bridge route added without an end-to-end test fails here by name.
* **The trait's premise was wrong.** `trait-wpcom-request-mock.php` said `permission_check()` needs a user-level WordPress.com connection "that WorDBless cannot stand up". It can, and had been all along: the `user_tokens` the trait installs so `Client` can sign a request are the same option `Connection_Manager::is_user_connected()` reads. Nothing was missing — nobody had dispatched. The note is corrected.
* **The other half of `permission_check()`** is now pinned too. Every existing permission test signs in a subscriber, so it stops at `manage_options` and the connection branch below it never ran. An administrator on a site somebody else connected now has a test proving they get a 403 with `user_not_connected` rather than something that reads as a broken plan.
* **`File_Browser_Bridge` — the real J1 gaps**, all on the two legs of `get_file_content()` plus `get_path_info()`'s return value:
  * `PREVIEW_MAX_BYTES` reaches `wp_remote_get()` as `limit_response_size`, and only on the stream leg.
  * A preview the cap cut **inside a multi-byte character** is forwarded byte-for-byte, neither re-cut nor repaired.
  * A failed signed-URL lookup, a signed URL this server will not fetch (including `file:///…`), a transport failure on the *stream* leg, and a non-200 from the storage host — four branches, four distinct error codes, none previously run.
  * `get_path_info()`'s forwarded payload, and its own error code on a non-200.
* **Order dependency removed.** The *first* outbound `Client` call in a PHP process was failing before it reached `pre_http_request`: `JETPACK__WPCOM_JSON_API_BASE` is undefined here and the filter supplying its default is registered by `Client::build_signed_request()`, so on the first call the URL was built with no host and `Jetpack_Signature` refused it. Every bridge reported that as a 502. Whichever test ran first absorbed it and nothing happened to depend on the difference — but nothing guaranteed that either. The trait now calls `Connection\Utils::init_default_constants()`, which is what production does.
* **Stale docblock fixed** — `Rest_Bridge_Gating_Test`'s class docblock said "eight new bridge routes" while its own `MODERNIZED_ROUTES` correctly listed nine. `File_Browser_Bridge` registers three routes, not two.

### Audit claims that did not survive re-verification

The issue's coverage table was written against older SHAs. Two cells were already wrong on trunk `e50205f394`:

| Cell | Claim | Actual |
| -- | -- | -- |
| `Activity_Log::get_activity_log` | "partial — **payload and non-200 unasserted**" | Both asserted. `test_reports_a_non_200_with_the_upstream_reason` (403 + `wpcom.code`) and `test_treats_a_string_status_as_its_number` (asserts `totalItems` and `orderedItems[0].activity_id`). **No work needed.** |
| `File_Browser::list_directory` | "transport branch only — **projection uncovered**" | Half right, and I initially cleared it in full — wrongly. The **projection** is covered (`test_list_directory_treats_a_string_status_as_its_number` asserts `contents[0]['name']`). The **outbound request** was covered nowhere: this was the only bridge callback in the package pinning neither its upstream path nor its body. Three mutations passed the whole suite. Fixed in `e4839bbcaa`. |

The `Capabilities`, `Download` and `Restore` cells were verified accurate. J5's central claim — that no dispatch anywhere in the five bridge suites asserts a 200 — was accurate; the *reason* it gave was not.

## Related product discussion/links

* JETPACK-2310

## Does this pull request change what data or activity we track or use?

No. Tests only.

## Testing instructions

* `jp test php packages/backup` — 338 tests / 888 assertions, up from 316 / 815 on trunk.
* `jp phan packages/backup` — 0 issues. `jp phan packages/backup --update-baseline` produces no baseline diff.
* `composer phpcs:changed -- projects/packages/backup/tests/php/` and `composer phpcs:compatibility -- projects/packages/backup/tests/php/` — clean.
* Every added assertion was mutation-tested. The one worth re-running by hand is the status-forwarding trap: collapse `Rest_Controller::upstream_error()`'s clamp to `array( 'status' => 500 )` and confirm the new 429, 451 and 416 assertions all fail — none of the expected values is reachable by a fallback path.
* The UTF-8 boundary fixture is 65,535 × `a` followed by `日` (`E6 97 A5`), cut at `PREVIEW_MAX_BYTES` = 65,536. `hexdump -C` on the cut's tail gives `61 61 61 61 61 61 61 e6`: the two continuation bytes are gone and the string is not valid UTF-8, which is what the last two assertions in `test_file_content_forwards_a_body_cut_mid_character_unrepaired` check.

---

## Review round 2 (commits `e4839bbcaa`, `1e1907c379`)

Six findings, all reproduced against live state before changing anything. Every one held; one supporting example did not (noted below).

**Docblocks corrected — including my own replacement, which was wrong.** The trait note I wrote to replace the misleading one said dispatch moves the code "under `get_data()['data']`". It does not: dumping a dispatched 429 against `path-info` gives `code` at the **top level** of `get_data()`, with only the `wpcom` reason under `['data']` — and `get_error_data()` never read the code, `get_error_code()` does. My own dispatch test asserted the top-level form while the docblock described the nested one. Also: `rest_ensure_response()` was listed as dispatch-only and is not (`dispatch()` runs it over the handler's return itself, so dropping it fails only the direct-call tests) — replaced with the **route regex**, which is genuinely dispatch-only and verified by mutation: narrowing the download route's `rewind_id` capture to `\d+` makes a rewind id with its decimal suffix a 404. And `rest_api_init` does **not** register the sync package's routes here (`Sync\Main::init()` never runs) — narrowed to this package's own legacy `REST_Controller`, which does register ten routes under `/jetpack/v4/`.

**`list_directory`'s outbound request was pinned nowhere**, and my own re-audit had cleared that cell. Corrected in the table above.

**`PREVIEW_MAX_BYTES` was only compared against itself.** At 8 MB the suite passed; at 64 MB it *fatalled* on an exhausted memory limit rather than failing. Now pinned to `65536`, plus a bound asserted before the truncation fixture allocates — so the 64 MB case is an ordinary red test.

**One reviewer example did not reproduce, and the finding survives anyway.** Making `extension_type` `required` was offered as evidence that the arg-schema claim is real; it passes, because that arg has `'default' => ''` and `set_default_params()` runs before `has_valid_params()`, so `required` is satisfied by the default. The claim is nonetheless true — three other schema mutations kill dispatch rows (`PERIOD_PATTERN`, `BASE64_PATTERN`'s padding, activity-log's `maximum`), so the docblock now cites `BASE64_PATTERN` instead.

### Order-independence, measured

`--order-by=random`, seeds 1–8:

| | passing |
| -- | -- |
| trunk `e50205f394` | **3/8** — failures spread across `Rest_Capabilities`, `Rest_Activity_Log`, `Rest_Download`, `Rest_File_Browser` and `Backup_Abilities` |
| after the trait fix (first commit) | **6/8** — both remaining failures `Backup_Abilities_Test`, which does not use the trait |
| after `1e1907c379` | **8/8** |

`Backup_Abilities_Test` also failed **standalone** (`phpunit tests/php/abilities/` → 1 of 68) on trunk and on this branch alike. That fix is in its own commit so it can be dropped independently.

### Mutations that previously survived and now fail

| Mutation | Now killed by |
| -- | -- |
| `ls` body params swapped (`backup_id` ↔ `path`) | `test_list_directory_sends_the_rewind_id_and_path` |
| `/rewind/backup/ls` → `/rewind/backup/list` | `test_list_directory_sends_the_rewind_id_and_path` |
| `/rewind/backup/path-info` → `/pathinfo` | `test_path_info_sends_the_file_period_and_the_raw_manifest_path` |
| `PREVIEW_MAX_BYTES` 64 KB → 8 MB | `test_the_preview_limit_is_64_kb` + the allocation bound |
| `PREVIEW_MAX_BYTES` 64 KB → 64 MB (previously a fatal) | same two, as a normal failure |

Gates: **340 tests / 885 assertions** (was 338/888 — two tests added, three assertions net removed with the unfalsifiable `assertIsString`). Phan 0 issues, no baseline diff. `phpcs -s` clean. `phpcs:compatibility` 16/16. `git merge-tree` vs `origin/fix/backup-wp-build-fallback`: 0 conflicts.
