### PR TITLE
repo-gardening: Replace deprecated `@octokit/webhook-types` dep

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,9 +64,9 @@ importers:
       '@babel/core':
         specifier: ^7.29.0
         version: 7.29.7
-      '@octokit/webhooks-types':
-        specifier: 7.6.1
-        version: 7.6.1
+      '@octokit/openapi-webhooks-types':
+        specifier: 12.1.0
+        version: 12.1.0
       '@types/node':
         specifier: ^24.12.0
         version: 24.13.3
@@ -9108,6 +9108,9 @@ packages:
   '@octokit/openapi-types@27.0.0':
     resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
 
+  '@octokit/openapi-webhooks-types@12.1.0':
+    resolution: {integrity: sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA==}
+
   '@octokit/plugin-paginate-rest@14.0.0':
     resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
     engines: {node: '>= 20'}
@@ -9140,10 +9143,6 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
-
-  '@octokit/webhooks-types@7.6.1':
-    resolution: {integrity: sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
     resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
@@ -21574,6 +21573,8 @@ snapshots:
 
   '@octokit/openapi-types@27.0.0': {}
 
+  '@octokit/openapi-webhooks-types@12.1.0': {}
+
   '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
     dependencies:
       '@octokit/core': 7.0.6
@@ -21611,8 +21612,6 @@ snapshots:
   '@octokit/types@16.0.0':
     dependencies:
       '@octokit/openapi-types': 27.0.0
-
-  '@octokit/webhooks-types@7.6.1': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.127.0':
     optional: true

--- a/projects/github-actions/repo-gardening/changelog/remove-deprecated-octokit-webhook-types-dep
+++ b/projects/github-actions/repo-gardening/changelog/remove-deprecated-octokit-webhook-types-dep
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Replace deprecated `@octokit/webhooks-types` with `@octokit/openapi-webhooks-types`.
+
+

--- a/projects/github-actions/repo-gardening/package.json
+++ b/projects/github-actions/repo-gardening/package.json
@@ -31,7 +31,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.29.0",
-		"@octokit/webhooks-types": "7.6.1",
+		"@octokit/openapi-webhooks-types": "12.1.0",
 		"@types/node": "^24.12.0",
 		"@typescript/native-preview": "7.0.0-dev.20260707.2",
 		"babel-jest": "30.4.1",

--- a/projects/github-actions/repo-gardening/src/tasks/add-milestone/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/add-milestone/index.ts
@@ -13,7 +13,6 @@ import type { OctokitClient, PushEvent } from '../../types.ts';
 async function addMilestone( payload: PushEvent, octokit: OctokitClient ): Promise< void > {
 	const { commits, ref, repository } = payload;
 	const { name: repo, owner } = repository;
-	const ownerLogin = owner.login;
 
 	// We should not get to that point as the action is triggered on pushes to trunk, but...
 	if ( ref !== 'refs/heads/trunk' ) {
@@ -26,6 +25,12 @@ async function addMilestone( payload: PushEvent, octokit: OctokitClient ): Promi
 		debug( 'add-milestone: Commit is not a squashed PR. Aborting' );
 		return;
 	}
+
+	if ( ! owner ) {
+		debug( 'add-milestone: No owner supplied in push event. Aborting' );
+		return;
+	}
+	const ownerLogin = owner.login;
 
 	const {
 		data: { milestone: pullMilestone },

--- a/projects/github-actions/repo-gardening/src/tasks/assign-issues/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/assign-issues/index.ts
@@ -8,6 +8,11 @@ import type { OctokitClient, PullRequestEvent } from '../../types.ts';
  * @param octokit - Initialized Octokit REST client.
  */
 async function assignIssues( payload: PullRequestEvent, octokit: OctokitClient ): Promise< void > {
+	if ( ! payload.pull_request.user ) {
+		debug( 'assignIssues: No user supplied in pull_request event. Aborting.' );
+		return;
+	}
+
 	const regex =
 		/(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):? +(?:#{1}|https?:\/\/github\.com\/automattic\/jetpack\/issues\/)(\d+)/gi;
 

--- a/projects/github-actions/repo-gardening/src/tasks/check-description/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/check-description/index.ts
@@ -193,7 +193,7 @@ async function getCheckComment(
 	const comments = await getComments( octokit, owner, repo, number );
 	for ( const comment of comments ) {
 		if (
-			comment.user.login === 'github-actions[bot]' &&
+			comment.user?.login === 'github-actions[bot]' &&
 			comment.body.includes( '**Thank you for your PR!**' )
 		) {
 			commentID = comment.id;
@@ -508,6 +508,11 @@ async function checkDescription(
 	payload: PullRequestEvent,
 	octokit: OctokitClient
 ): Promise< void > {
+	if ( ! payload.pull_request.user ) {
+		debug( `check-description: No user supplied in pull_request event. Aborting.` );
+		return;
+	}
+
 	const {
 		number,
 		user: { login: author },

--- a/projects/github-actions/repo-gardening/src/tasks/flag-oss/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/flag-oss/index.ts
@@ -19,6 +19,11 @@ async function flagOss( payload: PullRequestEvent, octokit: OctokitClient ): Pro
 		return;
 	}
 
+	if ( ! head.user ) {
+		debug( `flag-oss: No head.user supplied in pull_request event. Aborting.` );
+		return;
+	}
+
 	// Check if PR author is org member
 	// Result is communicated by status code, and non-successful status codes throw.
 	// https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-organization-membership-for-a-user

--- a/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/gather-support-references/index.ts
@@ -3,8 +3,7 @@ import debug from '../../utils/debug.ts';
 import getComments from '../../utils/get-comments.ts';
 import getLabels from '../../utils/labels/get-labels.ts';
 import sendSlackMessage from '../../utils/slack/send-slack-message.ts';
-import type { OctokitClient, IssuesEvent, IssueCommentEvent } from '../../types.ts';
-import type { IssueComment } from '@octokit/webhooks-types';
+import type { OctokitClient, IssuesEvent, IssueComment, IssueCommentEvent } from '../../types.ts';
 
 /**
  * Represents the info extracted from a previous bot comment.
@@ -27,7 +26,7 @@ async function getListComment( issueComments: IssueComment[] ): Promise< ListCom
 
 	for ( const comment of issueComments ) {
 		if (
-			comment.user.login === 'github-actions[bot]' &&
+			comment.user?.login === 'github-actions[bot]' &&
 			comment.body.includes( '**Support References**' )
 		) {
 			commentInfo = {
@@ -87,7 +86,7 @@ async function getIssueReferences(
 	debug( `gather-support-references: Getting references from comments.` );
 	for ( const comment of issueComments ) {
 		if (
-			comment.user.login !== 'github-actions[bot]' ||
+			comment.user?.login !== 'github-actions[bot]' ||
 			! comment.body.includes( '**Support References**' )
 		) {
 			ticketReferences.push( ...comment.body.matchAll( referencesRegexP ) );

--- a/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.ts
+++ b/projects/github-actions/repo-gardening/src/tasks/triage-issues/index.ts
@@ -74,6 +74,12 @@ async function addCommentAskLabels(
  */
 async function triageIssues( payload: IssuesEvent, octokit: OctokitClient ): Promise< void > {
 	const { action, issue, repository } = payload;
+
+	if ( ! issue.user ) {
+		debug( `triage-issues: No user supplied in issues event. Aborting.` );
+		return;
+	}
+
 	const {
 		user: { login: authorLogin },
 		number,

--- a/projects/github-actions/repo-gardening/src/types.ts
+++ b/projects/github-actions/repo-gardening/src/types.ts
@@ -1,13 +1,40 @@
 import { GitHub } from '@actions/github/lib/utils';
-import type {
-	PullRequestEvent,
-	PushEvent,
-	IssuesEvent,
-	IssueCommentEvent,
-} from '@octokit/webhooks-types';
+import type { components } from '@octokit/openapi-webhooks-types';
 
 // Re-export webhook payload types from the canonical source.
-export type { PullRequestEvent, PushEvent, IssuesEvent, IssueCommentEvent };
+export type IssueComment = components[ 'schemas' ][ 'webhooks_issue_comment' ];
+
+export type PushEvent = components[ 'schemas' ][ 'webhook-push' ];
+
+export type PullRequestClosedEvent = components[ 'schemas' ][ 'webhook-pull-request-closed' ];
+export type PullRequestEditedEvent = components[ 'schemas' ][ 'webhook-pull-request-edited' ];
+export type PullRequestLabeledEvent = components[ 'schemas' ][ 'webhook-pull-request-labeled' ];
+export type PullRequestOpenedEvent = components[ 'schemas' ][ 'webhook-pull-request-opened' ];
+export type PullRequestReopenedEvent = components[ 'schemas' ][ 'webhook-pull-request-reopened' ];
+export type PullRequestSynchronizeEvent =
+	components[ 'schemas' ][ 'webhook-pull-request-synchronize' ];
+export type PullRequestEvent =
+	| PullRequestClosedEvent
+	| PullRequestEditedEvent
+	| PullRequestLabeledEvent
+	| PullRequestOpenedEvent
+	| PullRequestReopenedEvent
+	| PullRequestSynchronizeEvent;
+
+export type IssuesClosedEvent = components[ 'schemas' ][ 'webhook-issues-closed' ];
+export type IssuesEditedEvent = components[ 'schemas' ][ 'webhook-issues-edited' ];
+export type IssuesLabeledEvent = components[ 'schemas' ][ 'webhook-issues-labeled' ];
+export type IssuesOpenedEvent = components[ 'schemas' ][ 'webhook-issues-opened' ];
+export type IssuesReopenedEvent = components[ 'schemas' ][ 'webhook-issues-reopened' ];
+export type IssuesEvent =
+	| IssuesClosedEvent
+	| IssuesEditedEvent
+	| IssuesLabeledEvent
+	| IssuesOpenedEvent
+	| IssuesReopenedEvent;
+
+export type IssueCommentCreatedEvent = components[ 'schemas' ][ 'webhook-issue-comment-created' ];
+export type IssueCommentEvent = IssueCommentCreatedEvent;
 
 /**
  * The Octokit instance type returned by getOctokit().

--- a/projects/github-actions/repo-gardening/src/utils/get-comments.ts
+++ b/projects/github-actions/repo-gardening/src/utils/get-comments.ts
@@ -1,6 +1,5 @@
 import debug from './debug.ts';
-import type { OctokitClient } from '../types.ts';
-import type { IssueComment } from '@octokit/webhooks-types';
+import type { OctokitClient, IssueComment } from '../types.ts';
 
 // Cache for getComments.
 const cache: Record< string, IssueComment[] > = {};

--- a/projects/github-actions/repo-gardening/src/utils/parse-content/has-many-support-references.ts
+++ b/projects/github-actions/repo-gardening/src/utils/parse-content/has-many-support-references.ts
@@ -1,5 +1,5 @@
 import { getInput } from '@actions/core';
-import type { IssueComment } from '@octokit/webhooks-types';
+import type { IssueComment } from '../../types.ts';
 
 /**
  * Check if the issue has a comment with a list of support references,
@@ -15,7 +15,7 @@ async function hasManySupportReferences( issueComments: IssueComment[] ): Promis
 
 	for ( const comment of issueComments ) {
 		if (
-			comment.user.login === 'github-actions[bot]' &&
+			comment.user?.login === 'github-actions[bot]' &&
 			comment.body.includes( '**Support References**' )
 		) {
 			// Count the number of to-do items in the comment.

--- a/projects/github-actions/repo-gardening/src/utils/slack/send-slack-message.ts
+++ b/projects/github-actions/repo-gardening/src/utils/slack/send-slack-message.ts
@@ -55,7 +55,9 @@ async function sendSlackMessage(
 					type: 'section',
 					text: {
 						type: 'mrkdwn',
-						text: `PR created by ${ user.login } in the <${ repository.html_url }|${ repository.full_name }> repo.`,
+						text: `PR created by ${ user?.login ?? '<unknown>' } in the <${ repository.html_url }|${
+							repository.full_name
+						}> repo.`,
 					},
 				},
 				{

--- a/projects/github-actions/repo-gardening/tests/has-many-support-references.test.ts
+++ b/projects/github-actions/repo-gardening/tests/has-many-support-references.test.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import type { IssueComment } from '@octokit/webhooks-types';
+import type { IssueComment } from '../src/types.d.ts';
 
 // Mock @actions/core before importing the module under test.
 jest.unstable_mockModule( '@actions/core', () => ( {


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Apparently the replacement is `@octokit/openapi-webhooks-types`, which has a very different structure. That part isn't too bad, but the fact that it marks a lot of owner/user properties as nullable is annoying.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Still works?