### PR TITLE
Tests: give the wpcom user fixtures the ID key WordPress.com sends

### DIFF
--- a/projects/js-packages/connection/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/js-packages/connection/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test fixture only: correct the wpcom user id key to ID.
+
+

--- a/projects/js-packages/connection/jest.setup.js
+++ b/projects/js-packages/connection/jest.setup.js
@@ -1,7 +1,12 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/js-packages/connection/jest.setup.js
+++ b/projects/js-packages/connection/jest.setup.js
@@ -1,7 +1,7 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/js-packages/licensing/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/js-packages/licensing/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test fixture only: correct the wpcom user id key to ID.
+
+

--- a/projects/js-packages/licensing/jest-globals.js
+++ b/projects/js-packages/licensing/jest-globals.js
@@ -1,7 +1,12 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/js-packages/licensing/jest-globals.js
+++ b/projects/js-packages/licensing/jest-globals.js
@@ -1,7 +1,7 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/js-packages/partner-coupon/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/js-packages/partner-coupon/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test fixture only: correct the wpcom user id key to ID.
+
+

--- a/projects/js-packages/partner-coupon/jest.setup.js
+++ b/projects/js-packages/partner-coupon/jest.setup.js
@@ -5,7 +5,12 @@ expect.extend( { toHaveBeenCalledAfter } );
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/js-packages/partner-coupon/jest.setup.js
+++ b/projects/js-packages/partner-coupon/jest.setup.js
@@ -5,7 +5,7 @@ expect.extend( { toHaveBeenCalledAfter } );
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/js-packages/storybook/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/js-packages/storybook/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Storybook preview global only: correct the wpcom user id key to ID.
+
+

--- a/projects/js-packages/storybook/storybook/preview.jsx
+++ b/projects/js-packages/storybook/storybook/preview.jsx
@@ -13,7 +13,12 @@ window.wp = {
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/js-packages/storybook/storybook/preview.jsx
+++ b/projects/js-packages/storybook/storybook/preview.jsx
@@ -13,7 +13,7 @@ window.wp = {
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/packages/forms/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/packages/forms/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test fixture only: correct the wpcom user id key to ID.
+
+

--- a/projects/packages/forms/tests/jest.setup.js
+++ b/projects/packages/forms/tests/jest.setup.js
@@ -1,7 +1,12 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/packages/forms/tests/jest.setup.js
+++ b/projects/packages/forms/tests/jest.setup.js
@@ -1,7 +1,7 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts
@@ -1,33 +1,10 @@
 /**
- * My Jetpack reports its Tracks events under the reader's WordPress.com
- * identity, and that identity is keyed `ID` — capital I, capital D.
- * `Connection\Manager::get_connected_user_data()` returns the WordPress.com
- * response verbatim, and `REST_Connector::get_user_connection_data()` serves it
- * as `wpcomUser` after adding `avatar` and changing nothing else. So every
- * other key is whichever one WordPress.com sent, and the PHP Tracks path reads
- * that same array as `$wpcom_user_data['ID']`
- * (`packages/connection/src/class-tracking.php`).
+ * My Jetpack reports Tracks events under the reader's WordPress.com identity, which is
+ * keyed `ID` — capital I, capital D. The failure is silent: `initialize()` is skipped
+ * when the id is falsy, and every later `recordEvent` then reports nothing.
  *
- * The failure is silent by construction: `jetpackAnalytics.initialize()` is
- * simply skipped when the id is falsy, after which every `recordEvent` reports
- * nothing — no error, no warning, no failed build. In Tracks that is
- * indistinguishable from a screen nobody opened.
- *
- * A type cannot close this on its own, whatever the declaration happens to
- * allow. What reaches `initialize()` is server-provided JSON crossing an
- * untyped `@wordpress/data` store, so the value is only ever checked at
- * runtime; and even a declaration that rejects `Id` outright says nothing about
- * whether this hook passes the id on or drops it. These tests assert what
- * `initialize()` actually receives, which is the part no declaration reaches.
- *
- * So both directions of the spelling are pinned here: the first test fails if
- * the shared fixture stops carrying the key WordPress.com actually sends, the
- * second fails if this hook starts accepting one it does not.
- *
- * The rest guard the conditions around it — that an identity is not enough on
- * its own, that a half-formed one is refused, and that the effect keeps
- * tracking its inputs instead of firing once at mount. Each of those was a
- * mutation that survived the two spelling tests.
+ * A type cannot close this on its own — the value crosses an untyped `@wordpress/data`
+ * store — so these assert what `initialize()` actually receives.
  */
 
 const mockInitialize = jest.fn();
@@ -48,12 +25,10 @@ import { dispatch, select } from '@wordpress/data';
 import useAnalytics from '../index';
 
 /**
- * The connection store's bound selectors, the object `useConnection` reads through.
+ * The connection store's bound selectors.
  *
- * `userConnectionData` has no reducer case, so the store takes it from the
- * initial state and never updates it. Spying on the selector is the only way to
- * hand the hook a different identity, and it is the pattern this package's
- * other connection tests already use.
+ * `userConnectionData` has no reducer case, so spying on the selector is the only way to
+ * hand the hook a different identity.
  *
  * @return The bound selector object for the connection store.
  */
@@ -80,9 +55,8 @@ beforeEach( () => {
 	mockInitialize.mockClear();
 	mockRecordEvent.mockClear();
 
-	// The shared fixture declares no `connectionStatus`, so `isUserConnected`
-	// defaults to false and the hook would skip `initialize()` for a reason
-	// that has nothing to do with the key under test.
+	// The shared fixture declares no `connectionStatus`, so the hook would otherwise skip
+	// `initialize()` for a reason unrelated to the key under test.
 	connectionActions().setConnectionStatus( {
 		isRegistered: true,
 		isUserConnected: true,
@@ -96,18 +70,16 @@ afterEach( () => {
 
 describe( 'useAnalytics', () => {
 	it( 'identifies the reader with the id WordPress.com actually sends', () => {
-		// No spy: this reads the identity straight out of the package's shared
-		// jest fixture, through the real connection store, so the assertion
-		// fails the moment that fixture stops spelling the key `ID`.
+		// No spy: reads the shared jest fixture through the real store, so this fails the
+		// moment that fixture stops spelling the key `ID`.
 		renderHook( () => useAnalytics() );
 
 		expect( mockInitialize ).toHaveBeenCalledWith( 99999, 'bobsacramento' );
 	} );
 
 	it( 'refuses a lowercase id rather than reporting a phantom reader', () => {
-		// `Id` is the shape this package's own fixture used to assert.
-		// WordPress.com never sends it, so accepting it would mean identifying
-		// the reader as `undefined` and silently losing every later event.
+		// The shape this package's fixture used to assert. WordPress.com never sends it, so
+		// accepting it would identify the reader as `undefined` and lose every later event.
 		jest.spyOn( connectionSelectors(), 'getUserConnectionData' ).mockReturnValue( {
 			currentUser: { wpcomUser: { Id: 99999, login: 'bobsacramento' } },
 		} );
@@ -118,9 +90,8 @@ describe( 'useAnalytics', () => {
 	} );
 
 	it( 'refuses an identity that is missing the login', () => {
-		// `initialize( ID, login )` takes both. Dropping `login` from the guard
-		// would report the reader under an `undefined` username rather than not
-		// reporting them at all, which is the worse of the two failures.
+		// `initialize( ID, login )` takes both, and reporting the reader under an
+		// `undefined` username is worse than not reporting them at all.
 		jest.spyOn( connectionSelectors(), 'getUserConnectionData' ).mockReturnValue( {
 			currentUser: { wpcomUser: { ID: 99999 } },
 		} );
@@ -131,9 +102,8 @@ describe( 'useAnalytics', () => {
 	} );
 
 	it( 'does not identify anyone while the viewer is not a connected user', () => {
-		// The identity is present and correctly spelled here — only the
-		// connection is missing. Without this case the connection half of the
-		// guard is never exercised, because every other test arrives connected.
+		// A correctly spelled identity with no connection — the half of the guard every
+		// other test arrives past.
 		connectionActions().setConnectionStatus( { isUserConnected: false } );
 
 		renderHook( () => useAnalytics() );
@@ -142,16 +112,9 @@ describe( 'useAnalytics', () => {
 	} );
 
 	it( 'identifies the reader when the connection is confirmed after mount', () => {
-		// `connectionStatus` is the part of this store that changes while the
-		// page is mounted: `registerSite` yields one (`state/actions.jsx`), and
-		// My Jetpack's own connection status card dispatches two more when the
-		// reader unlinks or disconnects (`connection-status-card/index.tsx`).
-		// `userConnectionData`, by contrast, has no reducer case at all, so the
-		// identity itself cannot arrive late — the connection can.
-		//
-		// An effect that does not list its inputs fires once at mount, before
-		// the guard can pass, and never runs again. The reader is then never
-		// identified for the rest of the visit.
+		// `connectionStatus` is the part of this store that changes while mounted, so an
+		// effect that does not list its inputs fires once before the guard can pass and
+		// never identifies the reader again.
 		connectionActions().setConnectionStatus( { isUserConnected: false } );
 
 		renderHook( () => useAnalytics() );

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts
@@ -2,9 +2,10 @@
  * My Jetpack reports its Tracks events under the reader's WordPress.com
  * identity, and that identity is keyed `ID` — capital I, capital D.
  * `Connection\Manager::get_connected_user_data()` returns the WordPress.com
- * response verbatim and `REST_Connector::get_user_connection_data()` passes it
- * through untouched as `wpcomUser`, so the key is whichever one WordPress.com
- * sent; the PHP Tracks path reads that same array as `$wpcom_user_data['ID']`
+ * response verbatim, and `REST_Connector::get_user_connection_data()` serves it
+ * as `wpcomUser` after adding `avatar` and changing nothing else. So every
+ * other key is whichever one WordPress.com sent, and the PHP Tracks path reads
+ * that same array as `$wpcom_user_data['ID']`
  * (`packages/connection/src/class-tracking.php`).
  *
  * The failure is silent by construction: `jetpackAnalytics.initialize()` is

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts
@@ -1,0 +1,107 @@
+/**
+ * My Jetpack reports its Tracks events under the reader's WordPress.com
+ * identity, and that identity is keyed `ID` — capital I, capital D.
+ * `Connection\Manager::get_connected_user_data()` returns the WordPress.com
+ * response verbatim and `REST_Connector::get_user_connection_data()` passes it
+ * through untouched as `wpcomUser`, so the key is whichever one WordPress.com
+ * sent; the PHP Tracks path reads that same array as `$wpcom_user_data['ID']`
+ * (`packages/connection/src/class-tracking.php`).
+ *
+ * Nothing else guards the spelling. `WpcomUser` carries an index signature, so
+ * a misspelled key still typechecks, and `jetpackAnalytics.initialize()` is
+ * simply skipped when the id is falsy — every later `recordEvent` then reports
+ * nothing, with no error, no warning and no failed build. In Tracks that is
+ * indistinguishable from a screen nobody opened.
+ *
+ * So both directions are pinned here: the first test fails if the shared
+ * fixture stops carrying the key WordPress.com actually sends, the second
+ * fails if this hook starts accepting one it does not.
+ */
+
+const mockInitialize = jest.fn();
+const mockRecordEvent = jest.fn();
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		initialize: ( ...args: unknown[] ) => mockInitialize( ...args ),
+		tracks: { recordEvent: ( ...args: unknown[] ) => mockRecordEvent( ...args ) },
+	},
+} ) );
+
+// Imports must come after the jest.mock factory above.
+import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
+import { renderHook } from '@testing-library/react';
+import { dispatch, select } from '@wordpress/data';
+import useAnalytics from '../index';
+
+/**
+ * The connection store's bound selectors, the object `useConnection` reads through.
+ *
+ * `userConnectionData` has no reducer case, so the store takes it from the
+ * initial state and never updates it. Spying on the selector is the only way to
+ * hand the hook a different identity, and it is the pattern this package's
+ * other connection tests already use.
+ *
+ * @return The bound selector object for the connection store.
+ */
+function connectionSelectors() {
+	return select( CONNECTION_STORE_ID ) as unknown as {
+		getUserConnectionData: () => unknown;
+	};
+}
+
+/**
+ * The connection store's bound actions.
+ *
+ * `dispatch()` is untyped for this store, so the one action used here is narrowed by hand.
+ *
+ * @return The bound action object for the connection store.
+ */
+function connectionActions() {
+	return dispatch( CONNECTION_STORE_ID ) as unknown as {
+		setConnectionStatus: ( status: Record< string, boolean > ) => void;
+	};
+}
+
+beforeEach( () => {
+	mockInitialize.mockClear();
+	mockRecordEvent.mockClear();
+
+	// The shared fixture declares no `connectionStatus`, so `isUserConnected`
+	// defaults to false and the hook would skip `initialize()` for a reason
+	// that has nothing to do with the key under test.
+	connectionActions().setConnectionStatus( {
+		isRegistered: true,
+		isUserConnected: true,
+		hasConnectedOwner: true,
+	} );
+} );
+
+afterEach( () => {
+	jest.restoreAllMocks();
+} );
+
+describe( 'useAnalytics', () => {
+	it( 'identifies the reader with the id WordPress.com actually sends', () => {
+		// No spy: this reads the identity straight out of the package's shared
+		// jest fixture, through the real connection store, so the assertion
+		// fails the moment that fixture stops spelling the key `ID`.
+		renderHook( () => useAnalytics() );
+
+		expect( mockInitialize ).toHaveBeenCalledWith( 99999, 'bobsacramento' );
+	} );
+
+	it( 'refuses a lowercase id rather than reporting a phantom reader', () => {
+		// `Id` is the shape this package's own fixture used to assert.
+		// WordPress.com never sends it, so accepting it would mean identifying
+		// the reader as `undefined` and silently losing every later event.
+		jest.spyOn( connectionSelectors(), 'getUserConnectionData' ).mockReturnValue( {
+			currentUser: { wpcomUser: { Id: 99999, login: 'bobsacramento' } },
+		} );
+
+		renderHook( () => useAnalytics() );
+
+		expect( mockInitialize ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts
@@ -7,14 +7,17 @@
  * sent; the PHP Tracks path reads that same array as `$wpcom_user_data['ID']`
  * (`packages/connection/src/class-tracking.php`).
  *
- * Nothing else guards the spelling. The `WpcomUser` this hook reads through —
- * the one in `js-packages/connection/components/use-connection/types.ts`, not
- * the closed ambient type of the same name in that package's `types.ts` —
- * carries an index signature, so a misspelled key still typechecks. And
- * `jetpackAnalytics.initialize()` is simply skipped when the id is falsy, after
- * which every `recordEvent` reports nothing, with no error, no warning and no
- * failed build. In Tracks that is indistinguishable from a screen nobody
- * opened.
+ * The failure is silent by construction: `jetpackAnalytics.initialize()` is
+ * simply skipped when the id is falsy, after which every `recordEvent` reports
+ * nothing — no error, no warning, no failed build. In Tracks that is
+ * indistinguishable from a screen nobody opened.
+ *
+ * A type cannot close this on its own, whatever the declaration happens to
+ * allow. What reaches `initialize()` is server-provided JSON crossing an
+ * untyped `@wordpress/data` store, so the value is only ever checked at
+ * runtime; and even a declaration that rejects `Id` outright says nothing about
+ * whether this hook passes the id on or drops it. These tests assert what
+ * `initialize()` actually receives, which is the part no declaration reaches.
  *
  * So both directions of the spelling are pinned here: the first test fails if
  * the shared fixture stops carrying the key WordPress.com actually sends, the

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts
@@ -7,15 +7,23 @@
  * sent; the PHP Tracks path reads that same array as `$wpcom_user_data['ID']`
  * (`packages/connection/src/class-tracking.php`).
  *
- * Nothing else guards the spelling. `WpcomUser` carries an index signature, so
- * a misspelled key still typechecks, and `jetpackAnalytics.initialize()` is
- * simply skipped when the id is falsy — every later `recordEvent` then reports
- * nothing, with no error, no warning and no failed build. In Tracks that is
- * indistinguishable from a screen nobody opened.
+ * Nothing else guards the spelling. The `WpcomUser` this hook reads through —
+ * the one in `js-packages/connection/components/use-connection/types.ts`, not
+ * the closed ambient type of the same name in that package's `types.ts` —
+ * carries an index signature, so a misspelled key still typechecks. And
+ * `jetpackAnalytics.initialize()` is simply skipped when the id is falsy, after
+ * which every `recordEvent` reports nothing, with no error, no warning and no
+ * failed build. In Tracks that is indistinguishable from a screen nobody
+ * opened.
  *
- * So both directions are pinned here: the first test fails if the shared
- * fixture stops carrying the key WordPress.com actually sends, the second
- * fails if this hook starts accepting one it does not.
+ * So both directions of the spelling are pinned here: the first test fails if
+ * the shared fixture stops carrying the key WordPress.com actually sends, the
+ * second fails if this hook starts accepting one it does not.
+ *
+ * The rest guard the conditions around it — that an identity is not enough on
+ * its own, that a half-formed one is refused, and that the effect keeps
+ * tracking its inputs instead of firing once at mount. Each of those was a
+ * mutation that survived the two spelling tests.
  */
 
 const mockInitialize = jest.fn();
@@ -31,7 +39,7 @@ jest.mock( '@automattic/jetpack-analytics', () => ( {
 
 // Imports must come after the jest.mock factory above.
 import { CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { dispatch, select } from '@wordpress/data';
 import useAnalytics from '../index';
 
@@ -103,5 +111,52 @@ describe( 'useAnalytics', () => {
 		renderHook( () => useAnalytics() );
 
 		expect( mockInitialize ).not.toHaveBeenCalled();
+	} );
+
+	it( 'refuses an identity that is missing the login', () => {
+		// `initialize( ID, login )` takes both. Dropping `login` from the guard
+		// would report the reader under an `undefined` username rather than not
+		// reporting them at all, which is the worse of the two failures.
+		jest.spyOn( connectionSelectors(), 'getUserConnectionData' ).mockReturnValue( {
+			currentUser: { wpcomUser: { ID: 99999 } },
+		} );
+
+		renderHook( () => useAnalytics() );
+
+		expect( mockInitialize ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not identify anyone while the viewer is not a connected user', () => {
+		// The identity is present and correctly spelled here — only the
+		// connection is missing. Without this case the connection half of the
+		// guard is never exercised, because every other test arrives connected.
+		connectionActions().setConnectionStatus( { isUserConnected: false } );
+
+		renderHook( () => useAnalytics() );
+
+		expect( mockInitialize ).not.toHaveBeenCalled();
+	} );
+
+	it( 'identifies the reader when the connection is confirmed after mount', () => {
+		// `connectionStatus` is the part of this store that changes while the
+		// page is mounted: `registerSite` yields one (`state/actions.jsx`), and
+		// My Jetpack's own connection status card dispatches two more when the
+		// reader unlinks or disconnects (`connection-status-card/index.tsx`).
+		// `userConnectionData`, by contrast, has no reducer case at all, so the
+		// identity itself cannot arrive late — the connection can.
+		//
+		// An effect that does not list its inputs fires once at mount, before
+		// the guard can pass, and never runs again. The reader is then never
+		// identified for the rest of the visit.
+		connectionActions().setConnectionStatus( { isUserConnected: false } );
+
+		renderHook( () => useAnalytics() );
+		expect( mockInitialize ).not.toHaveBeenCalled();
+
+		act( () => {
+			connectionActions().setConnectionStatus( { isUserConnected: true } );
+		} );
+
+		expect( mockInitialize ).toHaveBeenCalledWith( 99999, 'bobsacramento' );
 	} );
 } );

--- a/projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts
+++ b/projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts
@@ -1,10 +1,8 @@
 /**
- * My Jetpack reports Tracks events under the reader's WordPress.com identity, which is
- * keyed `ID` — capital I, capital D. The failure is silent: `initialize()` is skipped
- * when the id is falsy, and every later `recordEvent` then reports nothing.
- *
- * A type cannot close this on its own — the value crosses an untyped `@wordpress/data`
- * store — so these assert what `initialize()` actually receives.
+ * My Jetpack reports Tracks events under the reader's WordPress.com identity, keyed `ID`.
+ * A misspelling is silent: `initialize()` is skipped on a falsy id and every later
+ * `recordEvent` reports nothing. A type cannot close it either — the value crosses an
+ * untyped `@wordpress/data` store — so these assert what `initialize()` receives.
  */
 
 const mockInitialize = jest.fn();
@@ -70,16 +68,17 @@ afterEach( () => {
 
 describe( 'useAnalytics', () => {
 	it( 'identifies the reader with the id WordPress.com actually sends', () => {
-		// No spy: reads the shared jest fixture through the real store, so this fails the
-		// moment that fixture stops spelling the key `ID`.
+		// The already-connected-at-mount path: the "confirmed after mount" test below
+		// starts disconnected, so nothing else here covers it. No spy, so the identity
+		// arrives through the real store rather than a stub.
 		renderHook( () => useAnalytics() );
 
 		expect( mockInitialize ).toHaveBeenCalledWith( 99999, 'bobsacramento' );
 	} );
 
 	it( 'refuses a lowercase id rather than reporting a phantom reader', () => {
-		// The shape this package's fixture used to assert. WordPress.com never sends it, so
-		// accepting it would identify the reader as `undefined` and lose every later event.
+		// The only test that catches a production fallback like `ID ?? Id`, which someone
+		// could add to paper over a fixture mismatch. WordPress.com never sends `Id`.
 		jest.spyOn( connectionSelectors(), 'getUserConnectionData' ).mockReturnValue( {
 			currentUser: { wpcomUser: { Id: 99999, login: 'bobsacramento' } },
 		} );

--- a/projects/packages/my-jetpack/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/packages/my-jetpack/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Tests only: correct the wpcom user id key to ID and pin that the lowercase spelling is refused.
+
+

--- a/projects/packages/my-jetpack/tests/jest.setup.js
+++ b/projects/packages/my-jetpack/tests/jest.setup.js
@@ -2,7 +2,7 @@ const globalScope = typeof window !== 'undefined' ? window : globalThis;
 globalScope.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/packages/my-jetpack/tests/jest.setup.js
+++ b/projects/packages/my-jetpack/tests/jest.setup.js
@@ -2,7 +2,12 @@ const globalScope = typeof window !== 'undefined' ? window : globalThis;
 globalScope.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/packages/newsletter/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/packages/newsletter/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test fixture only: correct the wpcom user id key to ID.
+
+

--- a/projects/packages/newsletter/tests/jest.setup.js
+++ b/projects/packages/newsletter/tests/jest.setup.js
@@ -6,7 +6,12 @@ window.JP_CONNECTION_INITIAL_STATE = {
 	},
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/packages/newsletter/tests/jest.setup.js
+++ b/projects/packages/newsletter/tests/jest.setup.js
@@ -6,7 +6,7 @@ window.JP_CONNECTION_INITIAL_STATE = {
 	},
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/packages/publicize/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/packages/publicize/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test fixture only: correct the wpcom user id key to ID.
+
+

--- a/projects/packages/publicize/jest-globals.js
+++ b/projects/packages/publicize/jest-globals.js
@@ -1,7 +1,12 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/packages/publicize/jest-globals.js
+++ b/projects/packages/publicize/jest-globals.js
@@ -1,7 +1,7 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/packages/search/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/packages/search/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test fixture only: correct the wpcom user id key to ID.
+
+

--- a/projects/packages/search/tests/jest-globals.gui.js
+++ b/projects/packages/search/tests/jest-globals.gui.js
@@ -7,7 +7,7 @@ window.wp.i18n = require( '@wordpress/i18n' );
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/packages/search/tests/jest-globals.gui.js
+++ b/projects/packages/search/tests/jest-globals.gui.js
@@ -7,7 +7,12 @@ window.wp.i18n = require( '@wordpress/i18n' );
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test fixture only: correct the wpcom user id key to ID.
+
+

--- a/projects/plugins/automattic-for-agencies-client/jest.setup.js
+++ b/projects/plugins/automattic-for-agencies-client/jest.setup.js
@@ -1,7 +1,12 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/plugins/automattic-for-agencies-client/jest.setup.js
+++ b/projects/plugins/automattic-for-agencies-client/jest.setup.js
@@ -1,7 +1,7 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/plugins/classic-theme-helper-plugin/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test fixture only: correct the wpcom user id key to ID.
+
+

--- a/projects/plugins/classic-theme-helper-plugin/jest.setup.js
+++ b/projects/plugins/classic-theme-helper-plugin/jest.setup.js
@@ -1,7 +1,12 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/plugins/classic-theme-helper-plugin/jest.setup.js
+++ b/projects/plugins/classic-theme-helper-plugin/jest.setup.js
@@ -1,7 +1,7 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/plugins/jetpack/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/plugins/jetpack/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Test fixture only: correct the wpcom user id key to ID.
+
+

--- a/projects/plugins/jetpack/tests/jest-globals.extensions.js
+++ b/projects/plugins/jetpack/tests/jest-globals.extensions.js
@@ -2,7 +2,7 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/plugins/jetpack/tests/jest-globals.extensions.js
+++ b/projects/plugins/jetpack/tests/jest-globals.extensions.js
@@ -2,7 +2,12 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/plugins/jetpack/tests/jest-globals.gui.js
+++ b/projects/plugins/jetpack/tests/jest-globals.gui.js
@@ -10,7 +10,12 @@ window.Initial_State = {
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/plugins/jetpack/tests/jest-globals.gui.js
+++ b/projects/plugins/jetpack/tests/jest-globals.gui.js
@@ -10,7 +10,7 @@ window.Initial_State = {
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test fixture only: correct the wpcom user id key to ID.
+
+

--- a/projects/plugins/paypal-payment-buttons/jest.setup.js
+++ b/projects/plugins/paypal-payment-buttons/jest.setup.js
@@ -1,7 +1,12 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/plugins/paypal-payment-buttons/jest.setup.js
+++ b/projects/plugins/paypal-payment-buttons/jest.setup.js
@@ -1,7 +1,7 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };

--- a/projects/plugins/starter-plugin/changelog/fix-wpcom-user-id-jest-fixtures
+++ b/projects/plugins/starter-plugin/changelog/fix-wpcom-user-id-jest-fixtures
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test fixture only: correct the wpcom user id key to ID.
+
+

--- a/projects/plugins/starter-plugin/jest.setup.js
+++ b/projects/plugins/starter-plugin/jest.setup.js
@@ -1,7 +1,12 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: {
+				ID: 99999,
+				login: 'bobsacramento',
+				display_name: 'Bob Sacramento',
+				avatar: false,
+			},
 		},
 	},
 };

--- a/projects/plugins/starter-plugin/jest.setup.js
+++ b/projects/plugins/starter-plugin/jest.setup.js
@@ -1,7 +1,7 @@
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {
-			wpcomUser: { Id: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
+			wpcomUser: { ID: 99999, login: 'bobsacramento', display_name: 'Bob Sacramento' },
 		},
 	},
 };


### PR DESCRIPTION
Fixes JETPACK-2411

## Proposed changes

`window.JP_CONNECTION_INITIAL_STATE.userConnectionData.currentUser.wpcomUser` carries **`ID`** — capital I, capital D. `Connection\Manager::get_connected_user_data()` returns the WordPress.com response verbatim, `REST_Connector::get_user_connection_data()` passes it through untouched, and the PHP Tracks path reads that same array as `$wpcom_user_data['ID']` (`packages/connection/src/class-tracking.php`).

Fifteen jest fixtures asserted `Id`, a key that has never existed. (The issue counted sixteen; `packages/backup/tests/jest.setup.js` was already fixed by #51669.)

* Flip `wpcomUser: { Id: … }` to `wpcomUser: { ID: … }` in all fifteen.
* Add `avatar: false` to the same fifteen — see below.
* Add `projects/packages/my-jetpack/_inc/hooks/use-analytics/test/index.test.ts`, which pins the spelling in both directions and the conditions around it.

**Why the spelling matters.** Four live consumers read the real `ID` and feed it to `jetpackAnalytics.initialize( ID, login )`:

* `js-packages/shared-extension-utils/src/hooks/use-analytics.js:16`
* `packages/activity-log/src/js/hooks/use-analytics.ts:34`
* `packages/my-jetpack/_inc/hooks/use-analytics/index.ts:18`
* `packages/videopress/src/client/admin/hooks/use-analytics-tracks/index.ts:18`

`initialize()` is skipped when the id is falsy, and every later `recordEvent` then reports nothing — no error, no warning, no failed build. In Tracks that is indistinguishable from a screen nobody opened. A fixture saying `Id` therefore described a shape production never produces, and passed whether the code read `ID` or `Id` — precisely the case it existed to catch. `packages/my-jetpack` had both halves: its fixture said `Id`, its hook reads `ID`.

**Why `avatar` too.** `REST_Connector::get_user_connection_data()` sets `avatar` unconditionally: when `get_connected_user_data()` returns `false` — no connected WordPress.com user at all — it substitutes an empty array and then writes `avatar` anyway. So `{ avatar: false }` is the genuine floor rather than `{}`, and the PHP test fixture is literally `array( 'avatar' => false )`. This PR's thesis is that the fixtures should carry the shape WordPress.com sends; fixing the spelling while omitting the one field that is always present would fix one infidelity and leave another.

Nothing enforces that in CI — the fixtures are `.js` and `tsconfig.base.json` sets `allowJs` without `checkJs` — so it was checked with a throwaway `.ts` probe compiled against the `WpcomUser` from sibling #51673, which declares `avatar` as its one required field. Before: `TS2741: Property 'avatar' is missing in type '{ ID: number; login: string; display_name: string; }' but required in type 'WpcomUser'`. After: clean. `avatar: true` still errors (`TS2322: Type 'true' is not assignable to type 'string | false'`), so the probe was reacting to the field rather than passing vacuously. The probe was deleted; it is not part of this PR.

### Scope of what is actually pinned

Only `packages/my-jetpack` gains a regression test. Reverting any of the other fourteen fixture lines still breaks nothing — those suites never reach an identity-dependent assertion, so their fixtures are documentation of the payload shape rather than something enforced. That is a deliberate proportionality call: one test in the package that had both halves wrong, rather than fourteen near-copies. Anyone editing the other fixtures should know they are on their honour.

`currentUser` is still missing `blogId`, `id`, `username` and `isConnected` in all fifteen. Those are deliberately out of scope here — see the note on `blogId` below, which is load-bearing rather than cosmetic.

### The new test

It lives in `packages/my-jetpack` because that is the package the issue names as having had both halves wrong, and it is a live `initialize()` consumer. It reads the identity out of the package's shared jest fixture, through the real connection store — no mock of the hook or its wrapper — and asserts what `initialize()` actually receives. A test that only asserted "the fixture now says `ID`" would merely restate the fixture, so every claim below was checked by breaking the implementation and watching it fail:

| Mutation | Result |
| --- | --- |
| Fixture back to `Id` | 2 failed, 3 passed |
| Hook reads `Id` instead of `ID` | 3 failed, 2 passed — the refusal test reports `Received number of calls: 1` |
| Guard loses `isUserConnected` | 2 failed, 3 passed |
| Guard loses `login` | 1 failed, 4 passed |
| Effect deps narrowed to `[]` | 1 failed, 4 passed |
| Drop the `setConnectionStatus` dispatch from `beforeEach` | 1 failed — confirms the harness comment's claim that the shared fixture declares no `connectionStatus` |
| `jest --randomize`, three runs | 5 passed each time — no order dependence |

The last three cases exist because review found those mutations surviving the two spelling tests. Worth noting for the deps one: `connectionStatus` is the part of this store that changes while the page is mounted — `registerSite` yields one (`js-packages/connection/state/actions.jsx:144`) and My Jetpack's own connection status card dispatches two more on unlink and disconnect (`connection-status-card/index.tsx:96,105`) — whereas `userConnectionData` has no reducer case and no action at all, so the identity itself cannot arrive late in this store. The connection can, and an effect that does not list its inputs never sees it.

The test deliberately asserts nothing about the type declarations, which are in flux in #51673. Its value does not depend on them: what reaches `initialize()` is server-provided JSON crossing an untyped `@wordpress/data` store, and no declaration says whether this hook passes the id on or drops it.

No production code changes. No PHP files are touched, so no Phan baseline can move.

## Related product discussion/links

* JETPACK-2411
* Follows #51669, which fixed the sixteenth fixture (`packages/backup/tests/jest.setup.js`) and added the equivalent refusal test for that package.
* Sibling #51673 tightens the ambient `wpcomUser` type. The two merge cleanly in either order.

## Does this pull request change what data or activity we track or use?

No. Nothing in production changes. The fixtures now describe the payload WordPress.com already sends, so the tests exercise the same identity the four `initialize()` consumers already read at runtime.

## Testing instructions

This is a test-only change; CI is the test. To reproduce locally:

* Confirm no fixture asserts the lowercase key any more. Exactly **one** hit is expected — the deliberate refusal case inside the new test:
  ```
  grep -rn "wpcomUser: { Id" projects --include='*.js' --include='*.jsx' --include='*.ts' --include='*.tsx'
  ```
  Adding `--exclude-dir=test` returns nothing.
* Confirm no code reads it either — this one does come back empty:
  ```
  grep -rn "\.Id\b" projects --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx'
  ```
* Run the new test: `jp test js packages/my-jetpack` (24 suites, 201 tests).
* Prove it can fail. In `projects/packages/my-jetpack/tests/jest.setup.js` change `ID: 99999` back to `Id: 99999` and re-run — `identifies the reader with the id WordPress.com actually sends` fails with `Number of calls: 0`. Restore it.
* Prove the other direction. In `projects/packages/my-jetpack/_inc/hooks/use-analytics/index.ts` change `const { login, ID } = …` to `const { login, Id: ID } = …` and re-run — `refuses a lowercase id rather than reporting a phantom reader` reports `Received number of calls: 1`. Restore it.
* Or break the guard: drop `isUserConnected`, or `login`, or narrow the `useEffect` deps to `[]`. Each fails a different case.
* The other suites consuming a changed fixture, all green locally: `js-packages/connection` (23 suites / 197 tests), `js-packages/licensing` (5 / 19), `js-packages/partner-coupon` (4 / 22), `packages/forms` (97 / 1221), `packages/newsletter` (25 / 194), `packages/publicize` (78 / 558), `packages/search` (89 / 1197 scripts plus 34 / 731 url-tests — both configs load the changed globals file), `plugins/automattic-for-agencies-client` (1 / 2), `plugins/jetpack` (15 / 161 adminpage plus 128 / 794 extensions), `plugins/starter-plugin` (1 / 1). `plugins/classic-theme-helper-plugin` and `plugins/paypal-payment-buttons` have no jest tests yet, and `js-packages/storybook` has no `test-js` — its file is the Storybook preview global, not a jest fixture.

### Why the `plugins/jetpack` extensions suite is unaffected

Not because the consumer chain is absent — it is present. `js-packages/shared-extension-utils/src/hooks/use-analytics.js:16` destructures `wpcomUser: { login, ID }`, 44 files under `projects/plugins/jetpack/extensions` import that hook, and four of them are test files that run in this suite (`ai-assistant-plugin-sidebar/test/index.test.tsx`, `seo-enhancer/test/seo-enhancer.test.tsx`, `subscriptions/test/panel-test.jsx`, `subscriptions/test/email-preview.test.tsx`).

The suite is blind to the spelling because that hook's guards never open, for two independent reasons — and **`currentUser.blogId` is the load-bearing one**:

1. **`blogId` is absent from the fixture.** `initialize()` requires `isUserConnected && ID && login && blogId`, and `blogId` sits on `currentUser`, not on `wpcomUser`. No fixture in this PR supplies it, so this guard cannot open no matter how the id is spelled.
2. **`connectionStatus` is absent too.** The store's reducer defaults it to `{}` (`js-packages/connection/state/reducers.jsx:17`) and there is no resolver for it — `resolvers.jsx` defines only `getAuthorizationUrl` — so `useConnection` coerces the missing key and hands the hook `isUserConnected: false`. No extensions test dispatches `setConnectionStatus`. This also closes `recordEventAsync()`, which needs `isUserConnected && ID && login`.

So the fixtures are *not* otherwise faithful; two further gaps are keeping this path dark. Adding `blogId` would make the extensions analytics path live for the first time and is deliberately left to a follow-up.

Verified empirically rather than by reading: those four suites run 45 tests, and they pass 45/45 with `ID` and 45/45 with `Id`.
