### PR TITLE
Backup: show the next scheduled backup on the modernized Overview

### DIFF
--- a/projects/packages/backup/changelog/add-backup-next-scheduled-backup
+++ b/projects/packages/backup/changelog/add-backup-next-scheduled-backup
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Adds the next-scheduled-backup line to the modernized Backup dashboard, which is only reachable behind the rsm_jetpack_ui_modernization_backup filter and so is not user-facing yet.
+
+

--- a/projects/packages/backup/changelog/add-backup-next-scheduled-backup
+++ b/projects/packages/backup/changelog/add-backup-next-scheduled-backup
@@ -1,5 +1,3 @@
 Significance: patch
 Type: added
-Comment: Adds the next-scheduled-backup line to the modernized Backup dashboard, which is only reachable behind the rsm_jetpack_ui_modernization_backup filter and so is not user-facing yet.
-
-
+Comment: Backup: show when the next full backup runs on the modernized dashboard, above the storage section. Reads /site/backup/schedule and stays silent when the site has no schedule or WordPress.com has stopped backing it up. Legacy's Calypso "Modify" link is deliberately not ported, pending JETPACK-2329. No-op when the modernization filter is off.

--- a/projects/packages/backup/src/dashboard/components/next-scheduled-backup/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/next-scheduled-backup/index.tsx
@@ -10,6 +10,12 @@ import './style.scss';
  * Ported from legacy's `js/components/next-scheduled-backup.tsx`, which
  * the modernized Overview had no equivalent of.
  *
+ * Legacy's gate came in two halves and both are kept, in two places.
+ * `overview.tsx` holds the backup-state half — the line mounts only for
+ * `complete` and `in-progress`, and that comment explains why
+ * `replacesOverview()` does not arrange it on its own. This file holds
+ * the other half, `! backupsStopped`, below.
+ *
  * **The msgid is legacy's, character for character**, so the two
  * dashboards share one GlotPress entry rather than asking translators
  * for the same sentence twice. Change one and the other has to change in

--- a/projects/packages/backup/src/dashboard/components/next-scheduled-backup/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/next-scheduled-backup/index.tsx
@@ -7,84 +7,47 @@ import './style.scss';
 /**
  * The one line that answers "when does the next one run?".
  *
- * Ported from legacy's `js/components/next-scheduled-backup.tsx`, which
- * the modernized Overview had no equivalent of.
+ * Ported from legacy's `js/components/next-scheduled-backup.tsx`. Legacy's gate came in
+ * two halves: `overview.tsx` holds the backup-state half, this file holds
+ * `! backupsStopped` below.
  *
- * Legacy's gate came in two halves and both are kept, in two places.
- * `overview.tsx` holds the backup-state half — the line mounts only for
- * `complete` and `in-progress`, and that comment explains why
- * `replacesOverview()` does not arrange it on its own. This file holds
- * the other half, `! backupsStopped`, below.
+ * The msgid is legacy's character for character, so the two dashboards share one
+ * GlotPress entry. Its positional `%1$s` / `%2$s` spelling is load-bearing —
+ * `@tannin/sprintf` reads a digit not followed by `$` as a min-width specifier and fills
+ * the rest in source order, so dropping the `$` swaps date and time under any
+ * translation that reorders them.
  *
- * **The msgid is legacy's, character for character**, so the two
- * dashboards share one GlotPress entry rather than asking translators
- * for the same sentence twice. Change one and the other has to change in
- * the same breath. Its placeholders are spelled positionally — `%1$s`
- * and `%2$s` — and that spelling is load-bearing: `@tannin/sprintf`,
- * which is what `@wordpress/i18n` uses, reads a digit *not* followed by
- * `$` as a min-width specifier, discards it, and fills what is left in
- * the order the placeholders appear. Drop the `$` and a translation that
- * puts the time first renders the date as the time and the time as the
- * date, in English-looking output that nobody reviewing English would
- * catch. `next-scheduled-backup.test.tsx` renders the line under exactly
- * such a translation.
+ * Legacy's "Modify" link is deliberately absent: it points at Calypso, and whether this
+ * dashboard links out there at all is open (JETPACK-2329). Its Tracks event goes with it.
  *
- * **Legacy's "Modify" link is deliberately absent.** It points at
- * `backup-plugin-schedule-time-setting`, which resolves to
- * `cloud.jetpack.com/settings` — so porting it would be this dashboard's
- * first outbound link to Calypso, and whether it links out to Calypso at
- * all is an open product question (JETPACK-2329). The
- * `jetpack_backup_schedule_modify_click` Tracks event legacy fires from
- * that link is absent for the same reason: no link, nothing to record.
- * Both come back together, here, once 2329 is decided.
- *
- * **On a half-hour timezone this reads differently from legacy, on
- * purpose.** At UTC+5:30 with a 10:00 UTC schedule, this says
- * "3:30-4:29 PM" and legacy says "3:00-3:59 PM". Legacy throws the
- * minutes away — it takes the integer local *hour* off its date and
- * rebuilds the range from that — so it reports a window the site does
- * not have. 15:30–16:29 is where the run actually falls, so the figure
- * here is the correct one; it just stops matching legacy for India,
- * Iran, Nepal, Newfoundland and parts of Australia. Whether the two
- * should be reconciled, and in which direction, is a product call.
+ * On a half-hour timezone this deliberately disagrees with legacy, which throws the
+ * minutes away and reports a window the site does not have.
  *
  * @return The rendered line, a placeholder, or nothing.
  */
 export default function NextScheduledBackup() {
 	const schedule = useNextBackupSchedule();
-	// The same `/site/backup/size` query the storage section and the
-	// "Back up now" button already read, shared through `useSiteSizeQuery`
-	// rather than issued again — see that hook for why the definition is
-	// shared rather than merely the key.
+	// The same `/site/backup/size` query the storage section and "Back up now" already
+	// read, shared through `useSiteSizeQuery` rather than issued again.
 	const { backupsStopped, isLoading: stoppedIsLoading } = useSiteSize();
 
-	// Both reads, because the line must not appear and then retract: a
-	// site whose backups have stopped would otherwise promise a run at
-	// 10:00 for as long as `/size` takes to say otherwise.
+	// Both reads, or the line appears and then retracts: a site whose backups have
+	// stopped would promise a run for as long as `/size` takes to say otherwise.
 	if ( schedule.isLoading || stoppedIsLoading ) {
 		return <Skeleton className="jpb-next-scheduled-backup__placeholder" />;
 	}
 
-	// Legacy gates this line on `! backupsStopped` too, but derives that
-	// flag client-side from `StorageUsageLevels.Full`. This dashboard has
-	// already settled on WordPress.com's server-side `backups_stopped`
-	// instead (JETPACK-2300, `use-site-size.ts`), and the same answer has
-	// to serve both readings: "Back up now" is disabled from the server
-	// flag, so deriving this one differently would let the page disable
-	// the button and promise a 10:00 backup in the same breath. The
-	// server flag is also the one WordPress.com actually acts on, and it
-	// needs only `/size` where the derivation needs `/policies` as well —
-	// on a site with no retention policy there is no derivation to make.
+	// Legacy derives this flag client-side from `StorageUsageLevels.Full`; this dashboard
+	// uses WordPress.com's server-side `backups_stopped` (JETPACK-2300). "Back up now" is
+	// already disabled from the server flag, so deriving this one differently would let
+	// the page disable the button and promise a backup in the same breath.
 	if ( backupsStopped || ! schedule.hasSchedule ) {
 		return null;
 	}
 
 	return (
-		// Left as `Text`'s default `<span>`, which every other muted line
-		// on this dashboard also is. Rendering it as a `<p>` puts it in
-		// reach of `@wordpress/ui`'s unlayered `p.p` global-CSS defense,
-		// whose `margin: var( --_gcd-p-margin, 0 )` outranks a plain class
-		// selector — see `style.scss`.
+		// Left as `Text`'s default `<span>`: a `<p>` would come into reach of
+		// `@wordpress/ui`'s unlayered global-CSS defense — see `style.scss`.
 		<Text variant="body-sm" className="jpb-text-muted jpb-next-scheduled-backup">
 			{ sprintf(
 				/* translators: %1$s is the formatted date (e.g. "Oct 22"); %2$s is a time range (e.g. "10:00-10:59 AM"). */

--- a/projects/packages/backup/src/dashboard/components/next-scheduled-backup/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/next-scheduled-backup/index.tsx
@@ -1,0 +1,76 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { Skeleton, Text } from '@wordpress/ui';
+import { useNextBackupSchedule } from '../../hooks/use-backup-schedule';
+import { useSiteSize } from '../../hooks/use-site-size';
+import './style.scss';
+
+/**
+ * The one line that answers "when does the next one run?".
+ *
+ * Ported from legacy's `js/components/next-scheduled-backup.tsx`, which
+ * the modernized Overview had no equivalent of.
+ *
+ * **The msgid is legacy's, character for character**, so the two
+ * dashboards share one GlotPress entry rather than asking translators
+ * for the same sentence twice. Change one and the other has to change in
+ * the same breath. Its placeholders are spelled positionally — `%1$s`
+ * and `%2$s` — and that spelling is load-bearing: `@tannin/sprintf`,
+ * which is what `@wordpress/i18n` uses, reads a digit *not* followed by
+ * `$` as a min-width specifier, discards it, and fills what is left in
+ * the order the placeholders appear. Drop the `$` and a translation that
+ * puts the time first renders the date as the time and the time as the
+ * date, in English-looking output that nobody reviewing English would
+ * catch. `next-scheduled-backup.test.tsx` renders the line under exactly
+ * such a translation.
+ *
+ * **Legacy's "Modify" link is deliberately absent.** It points at
+ * `backup-plugin-schedule-time-setting`, which resolves to
+ * `cloud.jetpack.com/settings` — so porting it would be this dashboard's
+ * first outbound link to Calypso, and whether it links out to Calypso at
+ * all is an open product question (JETPACK-2329). The
+ * `jetpack_backup_schedule_modify_click` Tracks event legacy fires from
+ * that link is absent for the same reason: no link, nothing to record.
+ * Both come back together, here, once 2329 is decided.
+ *
+ * @return The rendered line, a placeholder, or nothing.
+ */
+export default function NextScheduledBackup() {
+	const schedule = useNextBackupSchedule();
+	// The same `/site/backup/size` query the storage section and the
+	// "Back up now" button already read, shared through `useSiteSizeQuery`
+	// rather than issued again — see that hook for why the definition is
+	// shared rather than merely the key.
+	const { backupsStopped, isLoading: stoppedIsLoading } = useSiteSize();
+
+	// Both reads, because the line must not appear and then retract: a
+	// site whose backups have stopped would otherwise promise a run at
+	// 10:00 for as long as `/size` takes to say otherwise.
+	if ( schedule.isLoading || stoppedIsLoading ) {
+		return <Skeleton className="jpb-next-scheduled-backup__placeholder" />;
+	}
+
+	// Legacy gates this line on `! backupsStopped` too, but derives that
+	// flag client-side from `StorageUsageLevels.Full`. This dashboard has
+	// already settled on WordPress.com's server-side `backups_stopped`
+	// instead (JETPACK-2300, `use-site-size.ts`), and the same answer has
+	// to serve both readings: "Back up now" is disabled from the server
+	// flag, so deriving this one differently would let the page disable
+	// the button and promise a 10:00 backup in the same breath. The
+	// server flag is also the one WordPress.com actually acts on, and it
+	// needs only `/size` where the derivation needs `/policies` as well —
+	// on a site with no retention policy there is no derivation to make.
+	if ( backupsStopped || ! schedule.hasSchedule ) {
+		return null;
+	}
+
+	return (
+		<Text variant="body-sm" className="jpb-text-muted jpb-next-scheduled-backup" render={ <p /> }>
+			{ sprintf(
+				/* translators: %1$s is the formatted date (e.g. "Oct 22"); %2$s is a time range (e.g. "10:00-10:59 AM"). */
+				__( 'Next full backup: %1$s, %2$s.', 'jetpack-backup-pkg' ),
+				schedule.nextBackupDate,
+				schedule.timeRange
+			) }
+		</Text>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/next-scheduled-backup/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/next-scheduled-backup/index.tsx
@@ -32,6 +32,16 @@ import './style.scss';
  * that link is absent for the same reason: no link, nothing to record.
  * Both come back together, here, once 2329 is decided.
  *
+ * **On a half-hour timezone this reads differently from legacy, on
+ * purpose.** At UTC+5:30 with a 10:00 UTC schedule, this says
+ * "3:30-4:29 PM" and legacy says "3:00-3:59 PM". Legacy throws the
+ * minutes away — it takes the integer local *hour* off its date and
+ * rebuilds the range from that — so it reports a window the site does
+ * not have. 15:30–16:29 is where the run actually falls, so the figure
+ * here is the correct one; it just stops matching legacy for India,
+ * Iran, Nepal, Newfoundland and parts of Australia. Whether the two
+ * should be reconciled, and in which direction, is a product call.
+ *
  * @return The rendered line, a placeholder, or nothing.
  */
 export default function NextScheduledBackup() {
@@ -64,7 +74,12 @@ export default function NextScheduledBackup() {
 	}
 
 	return (
-		<Text variant="body-sm" className="jpb-text-muted jpb-next-scheduled-backup" render={ <p /> }>
+		// Left as `Text`'s default `<span>`, which every other muted line
+		// on this dashboard also is. Rendering it as a `<p>` puts it in
+		// reach of `@wordpress/ui`'s unlayered `p.p` global-CSS defense,
+		// whose `margin: var( --_gcd-p-margin, 0 )` outranks a plain class
+		// selector — see `style.scss`.
+		<Text variant="body-sm" className="jpb-text-muted jpb-next-scheduled-backup">
 			{ sprintf(
 				/* translators: %1$s is the formatted date (e.g. "Oct 22"); %2$s is a time range (e.g. "10:00-10:59 AM"). */
 				__( 'Next full backup: %1$s, %2$s.', 'jetpack-backup-pkg' ),

--- a/projects/packages/backup/src/dashboard/components/next-scheduled-backup/style.scss
+++ b/projects/packages/backup/src/dashboard/components/next-scheduled-backup/style.scss
@@ -1,42 +1,21 @@
-// The next-backup line sits above the Overview's two-pane grid, a
-// sibling of `.jpb-overview` rather than a child: that element is a
-// two-column grid at >= 961px, so a third child would be auto-placed
-// into the layout. Same reason the storage section and the status
-// banners are siblings.
+// A sibling of `.jpb-overview` rather than a child: that element is a
+// two-column grid at >= 961px, so a third child would be auto-placed.
 .jpb-next-scheduled-backup {
-	// `Text` renders a `<span>`, so this has to be told to take a line of
-	// its own before a block margin means anything. Measured in Chromium:
-	// with the margin but without this, the rendered gap to the next
-	// element is 1px, because vertical margins do not apply to an inline
-	// box — `margin-bottom` still *computes* to 16px, so reading the
+	// `Text` renders a `<span>`, and vertical margins do not apply to an
+	// inline box. `margin-block-end` still computes to 16px, so reading the
 	// computed style alone would say this was working.
 	display: block;
 
-	// And the reason the element is left as a `<span>`. `Text` also
-	// applies `@wordpress/ui`'s global-CSS defense, which is deliberately
-	// unlayered and includes `p.<hash> { margin: var(--_gcd-p-margin, 0) }`
-	// at specificity (0,1,1). Rendered as a `<p>`, that rule outranks a
-	// plain class selector at (0,1,0) and this margin is silently dropped:
-	// measured at 0px computed and a 0px rendered gap, identical to having
-	// no rule here at all. On a `<span>` the defense does not match — its
-	// selector requires a `p` element — and the only competitor left is
-	// `@wordpress/ui`'s own `.text { margin: 0 }`, which sits inside
-	// `@layer wp-ui` and loses to any unlayered rule whatever its
-	// specificity. So this wins outright rather than by a source-order
-	// tiebreak that runtime-injected CSS could flip.
-	// The 16px, rather than legacy's 24px, is because legacy's copy is the
-	// last thing in its column, where this one has the storage section
-	// immediately under it carrying its own 24px.
+	// And why the element stays a `<span>`: `@wordpress/ui`'s global-CSS
+	// defense is unlayered and matches `p` at (0,1,1), outranking a plain
+	// class selector and dropping this margin silently. 16px rather than
+	// legacy's 24px because the storage section below carries its own.
 	margin-block-end: 16px;
 
-	// Stands in for the line while the schedule and storage reads are in
-	// flight, so the storage section below is not pushed down when they
-	// land. Matches the rendered line exactly — `body-sm` is
-	// `--wpds-typography-line-height-xs`, 16px — plus the same 16px gap,
-	// and is deliberately narrower than the column so the pair does not
-	// read as a block of content that failed to load.
-	// A sibling class rather than a descendant: the skeleton *replaces*
-	// this element, so the two are never in the DOM together.
+	// Stands in for the line while the reads are in flight, so the storage
+	// section is not pushed down when they land. A sibling class rather than
+	// a descendant: the skeleton replaces this element, so the two are never
+	// in the DOM together.
 	&__placeholder {
 		block-size: 16px;
 		inline-size: 260px;

--- a/projects/packages/backup/src/dashboard/components/next-scheduled-backup/style.scss
+++ b/projects/packages/backup/src/dashboard/components/next-scheduled-backup/style.scss
@@ -1,0 +1,28 @@
+// The next-backup line sits above the Overview's two-pane grid, a
+// sibling of `.jpb-overview` rather than a child: that element is a
+// two-column grid at >= 961px, so a third child would be auto-placed
+// into the layout. Same reason the storage section and the status
+// banners are siblings.
+.jpb-next-scheduled-backup {
+	// Stated rather than inherited. `Text` renders a `<span>` and this one
+	// renders a real `<p>`, so without a rule here the gap below would be
+	// wp-admin's paragraph margin — `@wordpress/ui`'s own `margin: 0` is
+	// declared inside `@layer wp-ui`, and every layered rule loses to an
+	// unlayered one whatever its specificity.
+	// 16px rather than legacy's 24px because legacy's copy is the last
+	// thing in its column, where this one has the storage section
+	// immediately under it carrying its own 24px.
+	margin-block: 0 16px;
+}
+
+// Stands in for the line while the schedule and storage reads are in
+// flight, so the storage section below is not pushed down when they
+// land. Matches the rendered line exactly — `body-sm` is
+// `--wpds-typography-line-height-xs`, 16px — plus the same 16px gap, and
+// is deliberately narrower than the column so the pair does not read as
+// a block of content that failed to load.
+.jpb-next-scheduled-backup__placeholder {
+	block-size: 16px;
+	inline-size: 260px;
+	margin-block-end: 16px;
+}

--- a/projects/packages/backup/src/dashboard/components/next-scheduled-backup/style.scss
+++ b/projects/packages/backup/src/dashboard/components/next-scheduled-backup/style.scss
@@ -4,25 +4,42 @@
 // into the layout. Same reason the storage section and the status
 // banners are siblings.
 .jpb-next-scheduled-backup {
-	// Stated rather than inherited. `Text` renders a `<span>` and this one
-	// renders a real `<p>`, so without a rule here the gap below would be
-	// wp-admin's paragraph margin — `@wordpress/ui`'s own `margin: 0` is
-	// declared inside `@layer wp-ui`, and every layered rule loses to an
-	// unlayered one whatever its specificity.
-	// 16px rather than legacy's 24px because legacy's copy is the last
-	// thing in its column, where this one has the storage section
-	// immediately under it carrying its own 24px.
-	margin-block: 0 16px;
-}
+	// `Text` renders a `<span>`, so this has to be told to take a line of
+	// its own before a block margin means anything. Measured in Chromium:
+	// with the margin but without this, the rendered gap to the next
+	// element is 1px, because vertical margins do not apply to an inline
+	// box — `margin-bottom` still *computes* to 16px, so reading the
+	// computed style alone would say this was working.
+	display: block;
 
-// Stands in for the line while the schedule and storage reads are in
-// flight, so the storage section below is not pushed down when they
-// land. Matches the rendered line exactly — `body-sm` is
-// `--wpds-typography-line-height-xs`, 16px — plus the same 16px gap, and
-// is deliberately narrower than the column so the pair does not read as
-// a block of content that failed to load.
-.jpb-next-scheduled-backup__placeholder {
-	block-size: 16px;
-	inline-size: 260px;
+	// And the reason the element is left as a `<span>`. `Text` also
+	// applies `@wordpress/ui`'s global-CSS defense, which is deliberately
+	// unlayered and includes `p.<hash> { margin: var(--_gcd-p-margin, 0) }`
+	// at specificity (0,1,1). Rendered as a `<p>`, that rule outranks a
+	// plain class selector at (0,1,0) and this margin is silently dropped:
+	// measured at 0px computed and a 0px rendered gap, identical to having
+	// no rule here at all. On a `<span>` the defense does not match — its
+	// selector requires a `p` element — and the only competitor left is
+	// `@wordpress/ui`'s own `.text { margin: 0 }`, which sits inside
+	// `@layer wp-ui` and loses to any unlayered rule whatever its
+	// specificity. So this wins outright rather than by a source-order
+	// tiebreak that runtime-injected CSS could flip.
+	// The 16px, rather than legacy's 24px, is because legacy's copy is the
+	// last thing in its column, where this one has the storage section
+	// immediately under it carrying its own 24px.
 	margin-block-end: 16px;
+
+	// Stands in for the line while the schedule and storage reads are in
+	// flight, so the storage section below is not pushed down when they
+	// land. Matches the rendered line exactly — `body-sm` is
+	// `--wpds-typography-line-height-xs`, 16px — plus the same 16px gap,
+	// and is deliberately narrower than the column so the pair does not
+	// read as a block of content that failed to load.
+	// A sibling class rather than a descendant: the skeleton *replaces*
+	// this element, so the two are never in the DOM together.
+	&__placeholder {
+		block-size: 16px;
+		inline-size: 260px;
+		margin-block-end: 16px;
+	}
 }

--- a/projects/packages/backup/src/dashboard/data/api/backup-schedule.ts
+++ b/projects/packages/backup/src/dashboard/data/api/backup-schedule.ts
@@ -3,33 +3,17 @@ import { apiCall, apiPath } from './_helpers';
 /**
  * Response of `GET /jetpack/v4/site/backup/schedule`.
  *
- * The route proxies WordPress.com's `/sites/%d/rewind/scheduled` and
- * forwards the decoded body verbatim. Every field is optional here
- * because the route hands back whatever it managed to decode: a reply it
- * cannot read at all collapses to a bare `null` body served with HTTP
- * 200, the same shape the other legacy `/site/backup/*` routes take.
- * A non-200 from WordPress.com is the one case that does *not* look like
- * that — `get_site_backup_schedule_time()` returns a `WP_Error`, so the
- * request rejects and `apiCall` throws.
+ * The route proxies WordPress.com's `/sites/%d/rewind/scheduled` and forwards the
+ * decoded body verbatim. Every field is optional because a reply the route cannot read
+ * collapses to a bare `null` body served with HTTP 200, as the other legacy
+ * `/site/backup/*` routes do.
  *
- * `scheduled_hour` is the hour of the day **in UTC**, 0–23, at which
- * WordPress.com starts the site's daily full backup. Nothing in the
- * payload says so; it is how the legacy dashboard has always read it
- * (`js/hooks/scheduled-backups/use-next-backup-schedule.ts` builds the
- * instant with `moment.utc()`), and reading it as local time would move
- * every reported backup by the site's own offset.
+ * `scheduled_hour` is the hour **in UTC**. Nothing in the payload says so, but it is how
+ * legacy has always read it, and reading it as local time would move every reported
+ * backup by the site's own offset.
  *
- * The field names are legacy's, which is the only description of this
- * payload written against a live response — `js/hooks/scheduled-backups/
- * use-scheduled-time-query.ts` declares `{ ok, scheduled_hour,
- * scheduled_by }`. Note that `src/abilities/class-backup-abilities.php`
- * reads `hour` and `minute` off the same route instead; the two cannot
- * both be right, and the one that renders on screen today is this one.
- *
- * `ok` is declared because legacy declares it, and deliberately not read
- * — see `useNextBackupSchedule()` for why the hour is the better gate.
- * `scheduled_by` is the account that last changed the schedule; nothing
- * here shows it.
+ * `ok` is declared because legacy declares it, and deliberately not read — see
+ * `useNextBackupSchedule()` for why the hour is the better gate.
  */
 export type RawBackupSchedule = {
 	ok?: boolean;

--- a/projects/packages/backup/src/dashboard/data/api/backup-schedule.ts
+++ b/projects/packages/backup/src/dashboard/data/api/backup-schedule.ts
@@ -12,8 +12,8 @@ import { apiCall, apiPath } from './_helpers';
  * legacy has always read it, and reading it as local time would move every reported
  * backup by the site's own offset.
  *
- * `ok` is declared because legacy declares it, and deliberately not read — see
- * `useNextBackupSchedule()` for why the hour is the better gate.
+ * `ok` is WordPress.com's own success flag inside the 200 body; a payload that does not
+ * set it carries no usable hour.
  */
 export type RawBackupSchedule = {
 	ok?: boolean;

--- a/projects/packages/backup/src/dashboard/data/api/backup-schedule.ts
+++ b/projects/packages/backup/src/dashboard/data/api/backup-schedule.ts
@@ -1,0 +1,47 @@
+import { apiCall, apiPath } from './_helpers';
+
+/**
+ * Response of `GET /jetpack/v4/site/backup/schedule`.
+ *
+ * The route proxies WordPress.com's `/sites/%d/rewind/scheduled` and
+ * forwards the decoded body verbatim. Every field is optional here
+ * because the route hands back whatever it managed to decode: a reply it
+ * cannot read at all collapses to a bare `null` body served with HTTP
+ * 200, the same shape the other legacy `/site/backup/*` routes take.
+ * A non-200 from WordPress.com is the one case that does *not* look like
+ * that — `get_site_backup_schedule_time()` returns a `WP_Error`, so the
+ * request rejects and `apiCall` throws.
+ *
+ * `scheduled_hour` is the hour of the day **in UTC**, 0–23, at which
+ * WordPress.com starts the site's daily full backup. Nothing in the
+ * payload says so; it is how the legacy dashboard has always read it
+ * (`js/hooks/scheduled-backups/use-next-backup-schedule.ts` builds the
+ * instant with `moment.utc()`), and reading it as local time would move
+ * every reported backup by the site's own offset.
+ *
+ * The field names are legacy's, which is the only description of this
+ * payload written against a live response — `js/hooks/scheduled-backups/
+ * use-scheduled-time-query.ts` declares `{ ok, scheduled_hour,
+ * scheduled_by }`. Note that `src/abilities/class-backup-abilities.php`
+ * reads `hour` and `minute` off the same route instead; the two cannot
+ * both be right, and the one that renders on screen today is this one.
+ *
+ * `ok` is declared because legacy declares it, and deliberately not read
+ * — see `useNextBackupSchedule()` for why the hour is the better gate.
+ * `scheduled_by` is the account that last changed the schedule; nothing
+ * here shows it.
+ */
+export type RawBackupSchedule = {
+	ok?: boolean;
+	scheduled_hour?: number | null;
+	scheduled_by?: string | null;
+} | null;
+
+/**
+ * Fetch the hour of the day WordPress.com backs this site up.
+ *
+ * @return WordPress.com's payload, or `null` when it could not be read.
+ */
+export async function fetchBackupSchedule(): Promise< RawBackupSchedule > {
+	return apiCall< RawBackupSchedule >( { path: apiPath( '/site/backup/schedule' ) } );
+}

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -42,9 +42,8 @@ export const keys = {
 	// change rate — but the storage meter needs both, so the two are
 	// always read together.
 	sitePolicies: () => [ 'backup', 'site-policies' ] as const,
-	// The hour of the day WordPress.com runs the site's daily backup.
-	// Its own key rather than a slice of `siteSize`: a different route,
-	// and a setting that only changes when somebody changes it.
+	// The hour WordPress.com runs the site's daily backup. Its own key rather than a
+	// slice of `siteSize`: a different route, and a far longer stale time.
 	backupSchedule: () => [ 'backup', 'schedule' ] as const,
 	// The Backup product being promoted, for the no-plan screen's price.
 	// Not keyed on anything: WordPress.com picks the currency from the

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -42,6 +42,10 @@ export const keys = {
 	// change rate — but the storage meter needs both, so the two are
 	// always read together.
 	sitePolicies: () => [ 'backup', 'site-policies' ] as const,
+	// The hour of the day WordPress.com runs the site's daily backup.
+	// Its own key rather than a slice of `siteSize`: a different route,
+	// and a setting that only changes when somebody changes it.
+	backupSchedule: () => [ 'backup', 'schedule' ] as const,
 	// The Backup product being promoted, for the no-plan screen's price.
 	// Not keyed on anything: WordPress.com picks the currency from the
 	// site, so one site only ever sees one answer.

--- a/projects/packages/backup/src/dashboard/hooks/use-backup-schedule.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backup-schedule.ts
@@ -1,0 +1,170 @@
+import { useQuery } from '@tanstack/react-query';
+import { dateI18n } from '@wordpress/date';
+import { fetchBackupSchedule, type RawBackupSchedule } from '../data/api/backup-schedule';
+import { keys } from '../data/query-client';
+import { useCanQueryWpcom } from './use-connection';
+
+// The schedule only changes when somebody changes it, and the setting
+// that does so does not live on this page — so an hour is a generous
+// floor rather than a risk. Well past the 30s default the query client
+// hands out, which would re-read this on every list interaction.
+const BACKUP_SCHEDULE_STALE_MS = 60 * 60_000;
+
+// The last minute the reported window covers. WordPress.com starts the
+// run at the top of the scheduled hour, so a window opening at 10:00 is
+// shown as ending at 10:59 — legacy's `convertHourToRange` spells the
+// same figure as `.add( 59, 'minutes' )`.
+const WINDOW_LAST_MINUTE_MS = 59 * 60_000;
+
+// And the instant the window is actually over, which is 59 seconds later
+// than the minute it last displays. The distinction only shows up in the
+// roll-forward below: without those seconds, the line would jump to
+// tomorrow at 10:59:00 while the clock still reads 10:59.
+const WINDOW_END_MS = WINDOW_LAST_MINUTE_MS + 59_000;
+
+type Result = { isLoading: boolean } & (
+	| {
+			hasSchedule: true;
+			/** The next run's date, formatted for the site, e.g. `Oct 22`. */
+			nextBackupDate: string;
+			/** The window it runs in, e.g. `10:00-10:59 AM`. */
+			timeRange: string;
+	  }
+	| { hasSchedule: false; nextBackupDate: null; timeRange: null }
+);
+
+/**
+ * The scheduled hour, if the payload carried a usable one.
+ *
+ * The whole of the render gate, and deliberately narrow: this is the one
+ * field the line needs, and every way of not having it — a site with no
+ * schedule, which answers `scheduled_hour: null`; a response the route
+ * could not decode, which is a bare `null` body served as HTTP 200 —
+ * arrives here as "not a number in 0–23" and is answered with silence.
+ *
+ * `ok` is not consulted, even though the payload declares it. Requiring
+ * it would blank the line on any response that simply omits the flag,
+ * and that failure is silent and indistinguishable from "this site has
+ * no schedule". A response carrying a usable hour has already answered
+ * the only question asked of it.
+ *
+ * The range check is not ceremony. `Date.UTC( …, 24, … )` is not an
+ * error, it is the following midnight, so an out-of-range hour would
+ * quietly report a backup at the wrong time rather than reporting
+ * nothing.
+ *
+ * @param raw - Whatever the route returned.
+ * @return The hour in UTC, or null when there is nothing to show.
+ */
+function scheduledHourOf( raw: RawBackupSchedule ): number | null {
+	const hour = raw?.scheduled_hour;
+
+	if ( typeof hour !== 'number' || ! Number.isInteger( hour ) || hour < 0 || hour > 23 ) {
+		return null;
+	}
+
+	return hour;
+}
+
+/**
+ * The instant WordPress.com next opens this site's backup window.
+ *
+ * Today's window if it has not closed yet, tomorrow's otherwise —
+ * "otherwise" being generous on purpose: a reader looking at the page at
+ * 10:30 on a 10:00 schedule is told about the run happening now, not the
+ * one tomorrow.
+ *
+ * All arithmetic is in UTC, which is both where the hour is expressed
+ * and the only calendar with no daylight-saving discontinuity to fall
+ * into — `setUTCDate( +1 )` is exactly 24 hours here, where the same
+ * step taken on a local-time date is 23 or 25 hours twice a year.
+ *
+ * @param scheduledHourUtc - Hour of the day, 0–23, in UTC.
+ * @param now              - The current instant.
+ * @return The start of the next window.
+ */
+function nextWindowStart( scheduledHourUtc: number, now: Date ): Date {
+	const start = new Date(
+		Date.UTC( now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), scheduledHourUtc, 0, 0, 0 )
+	);
+
+	if ( now.getTime() > start.getTime() + WINDOW_END_MS ) {
+		start.setUTCDate( start.getUTCDate() + 1 );
+	}
+
+	return start;
+}
+
+/**
+ * When the site's next full backup runs, ready to render.
+ *
+ * A port of legacy's `useNextBackupSchedule`
+ * (`js/hooks/scheduled-backups/use-next-backup-schedule.ts`) with two
+ * deliberate differences.
+ *
+ * **It formats here rather than handing back a date.** Legacy returns a
+ * moment and lets the component call `.format()` on it. Returning the
+ * two finished strings keeps every date decision — the calendar the
+ * arithmetic runs in, the timezone it is presented in, the format
+ * characters — inside this file, and leaves the component with nothing
+ * to get wrong.
+ *
+ * **It formats with `@wordpress/date`, not moment.** That is what every
+ * other date on this dashboard uses, and on this page it is free: each
+ * route's `package.json` declares `@wordpress/date`, so wp-build
+ * externalizes it to WordPress core's own `wp-date` script, while a bare
+ * `moment` import is not declared, not externalized, and would bundle a
+ * second copy of moment into the route.
+ *
+ * It also gets the timezone right in a case legacy does not. `dateI18n`
+ * resolves the site's zone itself — the IANA string when WordPress has
+ * one, the numeric offset when it does not. Legacy reads
+ * `getSettings().timezone.offset` by hand and branches on whether that
+ * value is truthy, and the offset is typed `number`: a site set to UTC
+ * reports `0`, takes the else branch, and is rendered in the reader's
+ * browser timezone instead of its own.
+ *
+ * @return The formatted next-run date and window, or nulls.
+ */
+export function useNextBackupSchedule(): Result {
+	const query = useQuery( {
+		queryKey: keys.backupSchedule(),
+		queryFn: fetchBackupSchedule,
+		staleTime: BACKUP_SCHEDULE_STALE_MS,
+		enabled: useCanQueryWpcom(),
+	} );
+
+	const scheduledHour = scheduledHourOf( query.data ?? null );
+
+	if ( scheduledHour === null ) {
+		return {
+			isLoading: query.isLoading,
+			hasSchedule: false,
+			nextBackupDate: null,
+			timeRange: null,
+		};
+	}
+
+	const start = nextWindowStart( scheduledHour, new Date() );
+	const lastMinute = new Date( start.getTime() + WINDOW_LAST_MINUTE_MS );
+
+	// The explicit `undefined` third argument is this dashboard's spelling
+	// throughout, and it means the site's timezone rather than the
+	// browser's: with no zone passed, `dateI18n` falls back to the
+	// `settings.timezone` that `wp.date.setSettings()` populates from the
+	// site's own options.
+	//
+	// The range is assembled here rather than as a third msgid because
+	// neither half is translatable prose — both are `dateI18n` output —
+	// and the separator is the hyphen legacy already renders between them.
+	return {
+		isLoading: query.isLoading,
+		hasSchedule: true,
+		nextBackupDate: dateI18n( 'M j', start, undefined ),
+		timeRange: `${ dateI18n( 'g:i', start, undefined ) }-${ dateI18n(
+			'g:i A',
+			lastMinute,
+			undefined
+		) }`,
+	};
+}

--- a/projects/packages/backup/src/dashboard/hooks/use-backup-schedule.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backup-schedule.ts
@@ -109,12 +109,18 @@ function nextWindowStart( scheduledHourUtc: number, now: Date ): Date {
  * characters — inside this file, and leaves the component with nothing
  * to get wrong.
  *
- * **It formats with `@wordpress/date`, not moment.** That is what every
- * other date on this dashboard uses, and on this page it is free: each
- * route's `package.json` declares `@wordpress/date`, so wp-build
- * externalizes it to WordPress core's own `wp-date` script, while a bare
- * `moment` import is not declared, not externalized, and would bundle a
- * second copy of moment into the route.
+ * **It formats with `@wordpress/date`, not moment.** For consistency —
+ * six other files on this dashboard already format dates with `dateI18n`
+ * — and for the timezone fix below. Not for bundle size: wp-build
+ * externalizes `moment` unconditionally, from the `vendorExternals` table
+ * in `@wordpress/build/lib/wordpress-externals-plugin.mjs`, rewriting the
+ * import to `window.moment` and adding a `moment` script handle. Measured:
+ * importing moment here grew the route bundle by 111 bytes, all of it the
+ * shim and the probe that used it. Core's `wp-date` declares `moment` as
+ * a dependency anyway (`wp-includes/assets/script-loader-packages.php`,
+ * `date.js`), so depending on `@wordpress/date` already puts moment on
+ * the page. An earlier revision of this comment claimed a second copy of
+ * moment would be bundled; that was wrong.
  *
  * It also gets the timezone right in a case legacy does not. `dateI18n`
  * resolves the site's zone itself — the IANA string when WordPress has

--- a/projects/packages/backup/src/dashboard/hooks/use-backup-schedule.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backup-schedule.ts
@@ -4,22 +4,16 @@ import { fetchBackupSchedule, type RawBackupSchedule } from '../data/api/backup-
 import { keys } from '../data/query-client';
 import { useCanQueryWpcom } from './use-connection';
 
-// The schedule only changes when somebody changes it, and the setting
-// that does so does not live on this page — so an hour is a generous
-// floor rather than a risk. Well past the 30s default the query client
-// hands out, which would re-read this on every list interaction.
+// The schedule only changes when somebody changes it, and not from this page, so an
+// hour is a generous floor rather than a risk.
 const BACKUP_SCHEDULE_STALE_MS = 60 * 60_000;
 
-// The last minute the reported window covers. WordPress.com starts the
-// run at the top of the scheduled hour, so a window opening at 10:00 is
-// shown as ending at 10:59 — legacy's `convertHourToRange` spells the
-// same figure as `.add( 59, 'minutes' )`.
+// The last minute the reported window covers: WordPress.com starts the run at the top
+// of the scheduled hour, so a window opening at 10:00 is shown as ending at 10:59.
 const WINDOW_LAST_MINUTE_MS = 59 * 60_000;
 
-// And the instant the window is actually over, which is 59 seconds later
-// than the minute it last displays. The distinction only shows up in the
-// roll-forward below: without those seconds, the line would jump to
-// tomorrow at 10:59:00 while the clock still reads 10:59.
+// And the instant the window is actually over. Without those extra seconds the
+// roll-forward below jumps to tomorrow while the clock still reads 10:59.
 const WINDOW_END_MS = WINDOW_LAST_MINUTE_MS + 59_000;
 
 type Result = { isLoading: boolean } & (
@@ -36,22 +30,12 @@ type Result = { isLoading: boolean } & (
 /**
  * The scheduled hour, if the payload carried a usable one.
  *
- * The whole of the render gate, and deliberately narrow: this is the one
- * field the line needs, and every way of not having it — a site with no
- * schedule, which answers `scheduled_hour: null`; a response the route
- * could not decode, which is a bare `null` body served as HTTP 200 —
- * arrives here as "not a number in 0–23" and is answered with silence.
+ * The whole of the render gate: every way of not having an hour arrives here as "not a
+ * number in 0–23" and is answered with silence. `ok` is deliberately not consulted —
+ * requiring it would blank the line on a response that merely omits the flag.
  *
- * `ok` is not consulted, even though the payload declares it. Requiring
- * it would blank the line on any response that simply omits the flag,
- * and that failure is silent and indistinguishable from "this site has
- * no schedule". A response carrying a usable hour has already answered
- * the only question asked of it.
- *
- * The range check is not ceremony. `Date.UTC( …, 24, … )` is not an
- * error, it is the following midnight, so an out-of-range hour would
- * quietly report a backup at the wrong time rather than reporting
- * nothing.
+ * The range check is not ceremony: `Date.UTC( …, 24, … )` is the following midnight, so
+ * an out-of-range hour would report a backup at the wrong time rather than none.
  *
  * @param raw - Whatever the route returned.
  * @return The hour in UTC, or null when there is nothing to show.
@@ -69,15 +53,9 @@ function scheduledHourOf( raw: RawBackupSchedule ): number | null {
 /**
  * The instant WordPress.com next opens this site's backup window.
  *
- * Today's window if it has not closed yet, tomorrow's otherwise —
- * "otherwise" being generous on purpose: a reader looking at the page at
- * 10:30 on a 10:00 schedule is told about the run happening now, not the
- * one tomorrow.
- *
- * All arithmetic is in UTC, which is both where the hour is expressed
- * and the only calendar with no daylight-saving discontinuity to fall
- * into — `setUTCDate( +1 )` is exactly 24 hours here, where the same
- * step taken on a local-time date is 23 or 25 hours twice a year.
+ * Today's window if it has not closed yet, tomorrow's otherwise — so a reader at 10:30
+ * on a 10:00 schedule is told about the run happening now. All arithmetic is in UTC,
+ * where `setUTCDate( +1 )` is exactly 24 hours rather than 23 or 25 twice a year.
  *
  * @param scheduledHourUtc - Hour of the day, 0–23, in UTC.
  * @param now              - The current instant.
@@ -98,37 +76,12 @@ function nextWindowStart( scheduledHourUtc: number, now: Date ): Date {
 /**
  * When the site's next full backup runs, ready to render.
  *
- * A port of legacy's `useNextBackupSchedule`
- * (`js/hooks/scheduled-backups/use-next-backup-schedule.ts`) with two
- * deliberate differences.
+ * A port of legacy's `useNextBackupSchedule` that formats here rather than handing back
+ * a date, so the calendar, the timezone and the format characters all stay in this file.
  *
- * **It formats here rather than handing back a date.** Legacy returns a
- * moment and lets the component call `.format()` on it. Returning the
- * two finished strings keeps every date decision — the calendar the
- * arithmetic runs in, the timezone it is presented in, the format
- * characters — inside this file, and leaves the component with nothing
- * to get wrong.
- *
- * **It formats with `@wordpress/date`, not moment.** For consistency —
- * six other files on this dashboard already format dates with `dateI18n`
- * — and for the timezone fix below. Not for bundle size: wp-build
- * externalizes `moment` unconditionally, from the `vendorExternals` table
- * in `@wordpress/build/lib/wordpress-externals-plugin.mjs`, rewriting the
- * import to `window.moment` and adding a `moment` script handle. Measured:
- * importing moment here grew the route bundle by 111 bytes, all of it the
- * shim and the probe that used it. Core's `wp-date` declares `moment` as
- * a dependency anyway (`wp-includes/assets/script-loader-packages.php`,
- * `date.js`), so depending on `@wordpress/date` already puts moment on
- * the page. An earlier revision of this comment claimed a second copy of
- * moment would be bundled; that was wrong.
- *
- * It also gets the timezone right in a case legacy does not. `dateI18n`
- * resolves the site's zone itself — the IANA string when WordPress has
- * one, the numeric offset when it does not. Legacy reads
- * `getSettings().timezone.offset` by hand and branches on whether that
- * value is truthy, and the offset is typed `number`: a site set to UTC
- * reports `0`, takes the else branch, and is rendered in the reader's
- * browser timezone instead of its own.
+ * Formatting with `@wordpress/date` also fixes a timezone bug legacy has: it branches on
+ * a truthy `getSettings().timezone.offset`, so a site set to UTC reports `0` and renders
+ * in the reader's browser timezone instead of its own.
  *
  * @return The formatted next-run date and window, or nulls.
  */
@@ -154,15 +107,9 @@ export function useNextBackupSchedule(): Result {
 	const start = nextWindowStart( scheduledHour, new Date() );
 	const lastMinute = new Date( start.getTime() + WINDOW_LAST_MINUTE_MS );
 
-	// The explicit `undefined` third argument is this dashboard's spelling
-	// throughout, and it means the site's timezone rather than the
-	// browser's: with no zone passed, `dateI18n` falls back to the
-	// `settings.timezone` that `wp.date.setSettings()` populates from the
-	// site's own options.
-	//
-	// The range is assembled here rather than as a third msgid because
-	// neither half is translatable prose — both are `dateI18n` output —
-	// and the separator is the hyphen legacy already renders between them.
+	// The explicit `undefined` third argument means the site's timezone rather than the
+	// browser's. The range is assembled here rather than as a third msgid: neither half
+	// is translatable prose.
 	return {
 		isLoading: query.isLoading,
 		hasSchedule: true,

--- a/projects/packages/backup/src/dashboard/hooks/use-backup-schedule.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backup-schedule.ts
@@ -30,9 +30,9 @@ type Result = { isLoading: boolean } & (
 /**
  * The scheduled hour, if the payload carried a usable one.
  *
- * The whole of the render gate: every way of not having an hour arrives here as "not a
- * number in 0–23" and is answered with silence. `ok` is deliberately not consulted —
- * requiring it would blank the line on a response that merely omits the flag.
+ * The whole of the render gate. `ok` is WordPress.com's own success flag inside a 200
+ * body, so a payload without it carries no usable hour — the reading `useSiteSize()`
+ * already takes of the same envelope, and the one the backup ability publishes.
  *
  * The range check is not ceremony: `Date.UTC( …, 24, … )` is the following midnight, so
  * an out-of-range hour would report a backup at the wrong time rather than none.
@@ -41,7 +41,11 @@ type Result = { isLoading: boolean } & (
  * @return The hour in UTC, or null when there is nothing to show.
  */
 function scheduledHourOf( raw: RawBackupSchedule ): number | null {
-	const hour = raw?.scheduled_hour;
+	if ( ! raw?.ok ) {
+		return null;
+	}
+
+	const hour = raw.scheduled_hour;
 
 	if ( typeof hour !== 'number' || ! Number.isInteger( hour ) || hour < 0 || hour > 23 ) {
 		return null;

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -234,22 +234,48 @@ export default function OverviewScreen() {
 			 * because that is the order legacy reads in: the schedule, then
 			 * what it is filling up.
 			 *
-			 * Deliberately not gated on `backupsState` here. Legacy mounts
-			 * its copy inside the component that only renders in
-			 * `BACKUP_STATE.COMPLETE`, but `replacesOverview` above has
-			 * already taken the body over for every state that gate was
-			 * excluding — no backups, a first backup running, a first
-			 * attempt that will retry, and nothing usable at all. What is
-			 * left is the case legacy has no view for: a site that *does*
-			 * have restore points while its latest attempt is running or
-			 * failing. There the schedule is still the true answer to "when
-			 * is the next one", and the banner directly above it has
-			 * already said what is going wrong.
+			 * This is legacy's `BACKUP_STATE.COMPLETE` gate, carried over
+			 * and widened by one state. The line shows when the site has a
+			 * usable restore point, and while a backup is running — which
+			 * legacy does not do, because its `IN_PROGRESS` branch replaces
+			 * `COMPLETE` and takes the line down for the length of every
+			 * run. Reporting both facts side by side is the same call
+			 * `summarizeBackups` already made when it stopped letting a
+			 * running backup erase a finished one.
+			 *
+			 * It shows in no other state, and `replacesOverview` above is
+			 * *not* enough to arrange that — which is the correction this
+			 * gate exists to make. That helper returns true only for
+			 * `no-backups | will-retry | no-good-backups | (in-progress &&
+			 * isInitialBackup)`, and only when its third argument is false.
+			 * That argument is `restorePointsLoading || restorePointsError
+			 * || hasRestorePoints`, so the veto is up in three situations
+			 * and only one of them means "this site has restore points";
+			 * `backup-status/banner.tsx` spells out the second, "the
+			 * activity request failed so we cannot know either way". And
+			 * for `error` and `loading` the helper has no branch at all —
+			 * it can never take the body over for either.
+			 *
+			 * So without this gate, a site whose `/jetpack/v4/backups` read
+			 * came back undecodable rendered "We couldn't check your site's
+			 * backup status." directly above "Next full backup: Oct 22,
+			 * 10:00-10:59 AM.", and a site whose last attempt failed while
+			 * the activity log was also unreachable promised a next run
+			 * under a banner saying the last one had not completed. Legacy
+			 * produced neither pairing.
+			 *
+			 * `in-progress` is deliberately not narrowed by
+			 * `isInitialBackup`. The one case that would exclude is a first
+			 * ever backup running while the activity read is failing, where
+			 * the schedule is still true and still the answer to the
+			 * question the line asks.
 			 *
 			 * The component self-hides on the other half of legacy's gate —
 			 * see it for which "backups stopped" this dashboard means.
 			 */ }
-			<NextScheduledBackup />
+			{ ( backupsState === 'complete' || backupsState === 'in-progress' ) && (
+				<NextScheduledBackup />
+			) }
 			{ /*
 			 * Above the list, and a sibling of the grid for the same
 			 * reason the banners are. It answers a question the list

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -9,6 +9,7 @@ import BackupNowButton from '../components/backup-now-button';
 import BackupStatusPanel, { replacesOverview } from '../components/backup-status';
 import BackupStatusBanner, { BackupTroubleBanner } from '../components/backup-status/banner';
 import DashboardLayout from '../components/dashboard-layout';
+import NextScheduledBackup from '../components/next-scheduled-backup';
 import QueryError from '../components/query-error';
 import StorageSpace from '../components/storage-space';
 import {
@@ -227,6 +228,28 @@ export default function OverviewScreen() {
 			 * loading, so the terminal case still reports immediately.
 			 */ }
 			{ ! restorePointsLoading && <BackupTroubleBanner state={ backupsState } /> }
+			{ /*
+			 * When the next one runs. A sibling of the grid for the same
+			 * reason everything above it is, and above the storage section
+			 * because that is the order legacy reads in: the schedule, then
+			 * what it is filling up.
+			 *
+			 * Deliberately not gated on `backupsState` here. Legacy mounts
+			 * its copy inside the component that only renders in
+			 * `BACKUP_STATE.COMPLETE`, but `replacesOverview` above has
+			 * already taken the body over for every state that gate was
+			 * excluding — no backups, a first backup running, a first
+			 * attempt that will retry, and nothing usable at all. What is
+			 * left is the case legacy has no view for: a site that *does*
+			 * have restore points while its latest attempt is running or
+			 * failing. There the schedule is still the true answer to "when
+			 * is the next one", and the banner directly above it has
+			 * already said what is going wrong.
+			 *
+			 * The component self-hides on the other half of legacy's gate —
+			 * see it for which "backups stopped" this dashboard means.
+			 */ }
+			<NextScheduledBackup />
 			{ /*
 			 * Above the list, and a sibling of the grid for the same
 			 * reason the banners are. It answers a question the list

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -229,49 +229,20 @@ export default function OverviewScreen() {
 			 */ }
 			{ ! restorePointsLoading && <BackupTroubleBanner state={ backupsState } /> }
 			{ /*
-			 * When the next one runs. A sibling of the grid for the same
-			 * reason everything above it is, and above the storage section
-			 * because that is the order legacy reads in: the schedule, then
-			 * what it is filling up.
+			 * When the next one runs, above the storage section because that is the
+			 * order legacy reads in.
 			 *
-			 * This is legacy's `BACKUP_STATE.COMPLETE` gate, carried over
-			 * and widened by one state. The line shows when the site has a
-			 * usable restore point, and while a backup is running — which
-			 * legacy does not do, because its `IN_PROGRESS` branch replaces
-			 * `COMPLETE` and takes the line down for the length of every
-			 * run. Reporting both facts side by side is the same call
-			 * `summarizeBackups` already made when it stopped letting a
-			 * running backup erase a finished one.
+			 * Legacy's `COMPLETE` gate, widened to include `in-progress`: legacy takes
+			 * the line down for the length of every run, where reporting both facts
+			 * side by side is the call `summarizeBackups` already made.
 			 *
-			 * It shows in no other state, and `replacesOverview` above is
-			 * *not* enough to arrange that — which is the correction this
-			 * gate exists to make. That helper returns true only for
-			 * `no-backups | will-retry | no-good-backups | (in-progress &&
-			 * isInitialBackup)`, and only when its third argument is false.
-			 * That argument is `restorePointsLoading || restorePointsError
-			 * || hasRestorePoints`, so the veto is up in three situations
-			 * and only one of them means "this site has restore points";
-			 * `backup-status/banner.tsx` spells out the second, "the
-			 * activity request failed so we cannot know either way". And
-			 * for `error` and `loading` the helper has no branch at all —
-			 * it can never take the body over for either.
+			 * `replacesOverview` above is not enough to arrange this. Its veto is up
+			 * whenever restore points are loading or errored, not only when the site
+			 * has them, and it has no branch at all for `error` or `loading` — so
+			 * without this gate a site with an undecodable backups read promised a next
+			 * run directly under "We couldn't check your site's backup status."
 			 *
-			 * So without this gate, a site whose `/jetpack/v4/backups` read
-			 * came back undecodable rendered "We couldn't check your site's
-			 * backup status." directly above "Next full backup: Oct 22,
-			 * 10:00-10:59 AM.", and a site whose last attempt failed while
-			 * the activity log was also unreachable promised a next run
-			 * under a banner saying the last one had not completed. Legacy
-			 * produced neither pairing.
-			 *
-			 * `in-progress` is deliberately not narrowed by
-			 * `isInitialBackup`. The one case that would exclude is a first
-			 * ever backup running while the activity read is failing, where
-			 * the schedule is still true and still the answer to the
-			 * question the line asks.
-			 *
-			 * The component self-hides on the other half of legacy's gate —
-			 * see it for which "backups stopped" this dashboard means.
+			 * The component self-hides on the other half of legacy's gate.
 			 */ }
 			{ ( backupsState === 'complete' || backupsState === 'in-progress' ) && (
 				<NextScheduledBackup />

--- a/projects/packages/backup/tests/next-scheduled-backup.test.tsx
+++ b/projects/packages/backup/tests/next-scheduled-backup.test.tsx
@@ -1,15 +1,12 @@
 // The Overview's "Next full backup: …" line (JETPACK-2328 / K2).
 //
-// Four things are worth pinning here and nothing else asserts any of
-// them: that the line is silent when there is no schedule to report,
-// that it stays silent when WordPress.com has stopped backing the site
-// up, that the date and window are read in the *site's* timezone rather
-// than UTC or the reader's, and that the msgid's positional placeholders
-// survive a translation that reorders them.
+// Four things are pinned here and nothing else asserts any of them: silence when there
+// is no schedule, silence when WordPress.com has stopped backing the site up, the date
+// and window read in the *site's* timezone, and the msgid's positional placeholders
+// surviving a translation that reorders them.
 //
-// Every date assertion runs against a frozen clock. Computing the
-// expectation the way the implementation computes it would pass no
-// matter what either of them did.
+// Every date assertion runs against a frozen clock, with the expectation written out
+// rather than computed the way the implementation computes it.
 
 const mockApiFetch = jest.fn();
 const mockSearch = jest.fn< Record< string, unknown >, [] >();
@@ -44,22 +41,17 @@ const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected
 // taken well over Testing Library's 1s default on a loaded runner.
 const SETTLE = { timeout: 10000 };
 
-// jsdom implements no scrolling, and DataViews' list layout calls
-// `scrollIntoView` on the selected row. Defined rather than spied on:
-// `jest.spyOn` requires the property to already exist, and in jsdom it
-// does not.
+// jsdom implements no scrolling, and DataViews calls `scrollIntoView`. Defined rather
+// than spied on: `jest.spyOn` needs the property to already exist.
 Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
 	value: () => {},
 	writable: true,
 } );
 
-// Everything Jest's fake timers can replace *except* `Date`.
-//
-// The clock is the only thing these tests need frozen. Faking the timer
-// functions as well would take React Query's retries and Testing
-// Library's own polling with it — `waitFor` switches to a
-// timer-advancing implementation the moment it sees a mocked
-// `setTimeout` — and the suite would hang on the first `findBy*`.
+// Everything Jest's fake timers can replace *except* `Date`. Faking the timer functions
+// too would take Testing Library's polling with it — `waitFor` switches implementation
+// the moment it sees a mocked `setTimeout` — and the suite would hang on the first
+// `findBy*`.
 const DO_NOT_FAKE = [
 	'cancelAnimationFrame',
 	'cancelIdleCallback',
@@ -92,8 +84,8 @@ function freezeClock( iso: string ) {
 /**
  * A fresh client with retries off.
  *
- * Built separately from the render below so a test that needs to wait on
- * the queries themselves can hold on to one — see `readsSettled`.
+ * Built separately from the render below so a test can hold on to one — see
+ * `readsSettled`.
  *
  * @return The client.
  */
@@ -117,12 +109,9 @@ function renderWithClient( ui: ReactNode, client: QueryClient = newQueryClient()
 /**
  * Wait until both reads behind the line have actually landed.
  *
- * Every "says nothing" assertion below needs this, and needs it to
- * synchronize on the *queries* rather than on anything the component
- * renders. Waiting for the placeholder to clear would look equivalent
- * and is not: a component that stopped rendering a placeholder at all
- * would satisfy that wait on the very first tick, and each of those
- * tests would then assert an absence that had never had a chance to
+ * Every "says nothing" assertion below synchronizes on the *queries*, not on what the
+ * component renders: a component that stopped rendering a placeholder would satisfy a
+ * wait on the placeholder immediately, and the absence would never have had a chance to
  * become a presence.
  *
  * @param client - The client the tree was rendered with.
@@ -130,17 +119,10 @@ function renderWithClient( ui: ReactNode, client: QueryClient = newQueryClient()
 /**
  * A second, deliberately unconditional reader of the schedule.
  *
- * Every stage-level absence assertion needs to know that the schedule was
- * there to be shown and the Overview declined to show it — otherwise it
- * passes just as well against a broken fixture, or against an assertion
- * that ran too early. Waiting on what the takeover or a banner
- * renders is not that: those come from `/jetpack/v4/backups`, which
- * resolves independently of `/site/backup/schedule`. And waiting on the
- * schedule query itself does not work either, because when the line is
- * correctly hidden nothing mounts the hook and the query is never issued.
- *
- * So this mounts the hook regardless, on the same client, and says what
- * the line would have said. It is a test instrument, not a fixture.
+ * Every stage-level absence assertion needs to know the schedule was there to be shown
+ * and the Overview declined to show it. Waiting on the schedule query itself cannot do
+ * that — when the line is correctly hidden nothing mounts the hook and no query is
+ * issued — so this mounts the hook regardless and says what the line would have said.
  *
  * @return The date the line would have carried, or nothing.
  */
@@ -157,9 +139,8 @@ function ScheduleProbe() {
 /**
  * Render the Overview with that probe beside it.
  *
- * The probe needs its own provider: `<OverviewStage>` mounts one
- * internally, so a sibling is outside it. Both point at the module-scope
- * client, so the two share a cache and issue one request between them.
+ * The probe needs its own provider, since `<OverviewStage>` mounts one internally. Both
+ * point at the module-scope client, so they share a cache and issue one request.
  */
 function renderStageWithProbe() {
 	render(
@@ -184,12 +165,8 @@ function scheduleIsAvailable(): Promise< HTMLElement > {
 /**
  * Wait until both reads behind the line have actually landed.
  *
- * Every component-level "says nothing" assertion needs this, and needs it
- * to synchronize on the *queries* rather than on anything the component
- * renders. Waiting for the placeholder to clear would look equivalent and
- * is not: a component that stopped rendering a placeholder would satisfy
- * that wait on the very first tick, and each of those tests would then
- * assert an absence that had never had a chance to become a presence.
+ * Synchronizes on the *queries*, not on what the component renders: a component that
+ * stopped rendering a placeholder would satisfy a wait on the placeholder immediately.
  *
  * @param client - The client the tree was rendered with.
  */
@@ -270,9 +247,8 @@ const USABLE_BACKUP = {
  * @param options.schedule      - What `/site/backup/schedule` resolves with.
  * @param options.size          - Extra fields for `/site/backup/size`.
  * @param options.backups       - What `/jetpack/v4/backups` resolves with. `null` is the
- *                              shape a non-200 from WordPress.com actually takes: the
- *                              legacy route answers a body it cannot decode with a bare
- *                              `null`, which WordPress serves as HTTP 200.
+ *                              shape a non-200 takes: the legacy route serves an
+ *                              undecodable body as a bare `null` with HTTP 200.
  * @param options.activity      - Rewindable-activity entries.
  * @param options.activityFails - Make `/site/rewindable-activity` reject.
  */
@@ -334,10 +310,8 @@ function overviewGrid(): HTMLElement | null {
 /**
  * Where the schedule line sits relative to that grid.
  *
- * All the direct node access lives here rather than in the test body,
- * which is both what `testing-library/no-node-access` wants and the only
- * way to ask this question at all — neither "is a sibling of" nor "comes
- * before" has a Testing Library query.
+ * The direct node access lives here rather than in the test body: neither "is a sibling
+ * of" nor "comes before" has a Testing Library query.
  *
  * @param line - The rendered schedule line.
  * @return Whether it is a sibling of the grid, and whether it precedes it.
@@ -359,10 +333,8 @@ function placementRelativeToGrid( line: HTMLElement ) {
 }
 
 /**
- * The skeleton that holds the line's space while the reads are in
- * flight. A placeholder carries no role and no accessible name, so its
- * class is the only handle — the same escape hatch the storage suites
- * use.
+ * The skeleton that holds the line's space while the reads are in flight. No role and
+ * no accessible name, so the class is the only handle.
  *
  * @return The placeholder, or null before it has rendered.
  */
@@ -392,9 +364,8 @@ afterEach( () => {
 
 describe( 'the next-backup line', () => {
 	it( "reports today's window while it is still ahead", async () => {
-		// 05:00 UTC, on a site backed up at 10:00 UTC. The site's own
-		// timezone is `@wordpress/date`'s default here, which is UTC — the
-		// zone is varied deliberately further down.
+		// 05:00 UTC, on a site backed up at 10:00 UTC. The site's zone is UTC here;
+		// it is varied further down.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 } } );
 
@@ -419,11 +390,8 @@ describe( 'the next-backup line', () => {
 	} );
 
 	it( 'still reports today while the window is open', async () => {
-		// 10:59:30 is inside the window and must not roll forward: a reader
-		// looking at the page during the run wants the run that is
-		// happening, not the one tomorrow. Half a minute past 10:59 is the
-		// case that separates "the window ends at 10:59:59" from "the
-		// window ends at 10:59:00".
+		// Inside the window, so it must not roll forward. Half a minute past 10:59 is
+		// what separates a window ending at 10:59:59 from one ending at 10:59:00.
 		freezeClock( '2026-10-22T10:59:30Z' );
 		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 } } );
 
@@ -435,11 +403,8 @@ describe( 'the next-backup line', () => {
 	} );
 
 	it( 'reads midnight UTC as an hour like any other', async () => {
-		// `scheduled_hour: 0` is a real answer and the one a truthiness
-		// check would drop. Distinct from every other fixture here: the
-		// window opens at midnight and reads back as 12:00 AM, which is
-		// also the only case where the 12-hour clock and the 24-hour hour
-		// disagree.
+		// `scheduled_hour: 0` is a real answer and the one a truthiness check drops. It
+		// is also the only hour where the 12- and 24-hour clocks disagree.
 		freezeClock( '2026-10-21T23:30:00Z' );
 		mockEndpoints( { schedule: { ok: true, scheduled_hour: 0 } } );
 
@@ -459,19 +424,14 @@ describe( 'the site timezone', () => {
 	} );
 
 	it( 'states the date and window where the site is, not where the reader is', async () => {
-		// A five-hour western offset, spelled as a number with no IANA
-		// string: `@wordpress/date` bundles moment-timezone without its
-		// zone data, so a named zone here would resolve to nothing and the
-		// assertion would silently be about UTC again.
+		// A numeric offset, not an IANA string: `@wordpress/date` bundles
+		// moment-timezone without zone data, so a named zone resolves to nothing.
 		setSettings( {
 			...original,
 			timezone: { offset: -5, offsetFormatted: '-5', string: '', abbr: 'EST' },
 		} );
-		// 02:00 UTC on the 22nd is 21:00 on the 21st for this site, and the
-		// backup window opens at 02:00 UTC — so the site is told about a
-		// backup that runs on its *previous* calendar day. Read as UTC this
-		// would say "Oct 22, 2:00-2:59 AM"; read in the browser's zone it
-		// would say whatever the runner happens to be set to.
+		// The site is told about a backup running on its *previous* calendar day. Read
+		// as UTC this would say "Oct 22, 2:00-2:59 AM" instead.
 		freezeClock( '2026-10-22T01:00:00Z' );
 		mockEndpoints( { schedule: { ok: true, scheduled_hour: 2 } } );
 
@@ -485,11 +445,8 @@ describe( 'the site timezone', () => {
 
 describe( 'when there is nothing to report', () => {
 	it( 'says nothing when the site has no schedule', async () => {
-		// What WordPress.com answers for a site it is not scheduling.
-		// Silence is the whole behaviour: there is no "unknown" copy to
-		// fall back to, so a guard that let this through would render
-		// "Next full backup: Jan 1, 12:00-12:59 AM." — a date nobody
-		// promised.
+		// What WordPress.com answers for a site it is not scheduling. There is no
+		// "unknown" copy, so a guard that let this through would promise Jan 1.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		mockEndpoints( { schedule: { ok: true, scheduled_hour: null } } );
 
@@ -502,9 +459,8 @@ describe( 'when there is nothing to report', () => {
 	} );
 
 	it( 'says nothing when the route could not read WordPress.com', async () => {
-		// A reply the route cannot decode collapses to a bare `null` body
-		// served as HTTP 200, so the request resolves and React Query
-		// records a success. The shape of the data is the only evidence.
+		// An undecodable reply is a bare `null` body served as HTTP 200, so React Query
+		// records a success and the shape of the data is the only evidence.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		mockEndpoints( { schedule: null } );
 
@@ -517,11 +473,8 @@ describe( 'when there is nothing to report', () => {
 	} );
 
 	it( 'says nothing when the hour is not a whole number', async () => {
-		// `Date.UTC` truncates rather than rejecting — hour 10.5 is
-		// 10:00:00Z — so without `Number.isInteger` this renders a
-		// confident "10:00-10:59 AM" for a payload we could not actually
-		// read. Verified: `new Date( Date.UTC( 2026, 9, 22, 10.5, 0, 0, 0 ) )`
-		// is `2026-10-22T10:00:00.000Z`.
+		// `Date.UTC` truncates rather than rejecting, so without `Number.isInteger`
+		// this renders a confident "10:00-10:59 AM" for an unreadable payload.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10.5 } } );
 
@@ -534,9 +487,8 @@ describe( 'when there is nothing to report', () => {
 	} );
 
 	it( 'says nothing when the hour is negative', async () => {
-		// The other end of the range, and it fails the same silent way:
-		// `Date.UTC( …, -1, … )` is 23:00 on the *previous* day, so this
-		// would report a backup at 11:00 PM that nobody scheduled.
+		// The other end, failing the same silent way: `Date.UTC( …, -1, … )` is 23:00
+		// on the previous day.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		mockEndpoints( { schedule: { ok: true, scheduled_hour: -1 } } );
 
@@ -549,9 +501,7 @@ describe( 'when there is nothing to report', () => {
 	} );
 
 	it( 'says nothing when the hour is out of range', async () => {
-		// `Date.UTC( …, 24, … )` is not an error, it is the following
-		// midnight — so without the range check this would report a backup
-		// at 12:00 AM on the 23rd, which is a time nobody scheduled.
+		// `Date.UTC( …, 24, … )` is the following midnight, not an error.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		mockEndpoints( { schedule: { ok: true, scheduled_hour: 24 } } );
 
@@ -564,12 +514,9 @@ describe( 'when there is nothing to report', () => {
 	} );
 
 	it( 'says nothing once WordPress.com has stopped backing the site up', async () => {
-		// The half of legacy's gate this port keeps. The schedule is still
-		// there and still readable — WordPress.com just is not acting on
-		// it — so the request below succeeds and only `backups_stopped`
-		// separates this from the first test in the file. Promising a
-		// 10:00 backup here would also contradict the "Back up now" button,
-		// which reads the same flag and disables itself on it.
+		// The half of legacy's gate this port keeps. The schedule is still readable, so
+		// only `backups_stopped` separates this from the first test — and promising a
+		// backup here would contradict "Back up now", which reads the same flag.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		mockEndpoints( {
 			schedule: { ok: true, scheduled_hour: 10 },
@@ -587,13 +534,9 @@ describe( 'when there is nothing to report', () => {
 
 describe( 'when the site cannot reach WordPress.com', () => {
 	it( 'does not issue the request at all', async () => {
-		// `enabled: useCanQueryWpcom()` on the query. A site that is
-		// registered but has no connected owner cannot answer this route,
-		// and asking anyway spends a round trip to be told so. `<Gates>`
-		// keeps most readers away from here, but nothing else pins the
-		// line itself, and a disabled query is also what keeps
-		// `isLoading` false — so dropping it would leave the placeholder
-		// up forever rather than merely wasting a request.
+		// `enabled: useCanQueryWpcom()` on the query. A registered site with no
+		// connected owner cannot answer this route, and a disabled query is also what
+		// keeps `isLoading` false — so dropping it leaves the placeholder up forever.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		window.JP_CONNECTION_INITIAL_STATE = {
 			...window.JP_CONNECTION_INITIAL_STATE,
@@ -613,11 +556,9 @@ describe( 'when the site cannot reach WordPress.com', () => {
 
 describe( 'while the reads are in flight', () => {
 	it( "holds the line's height so the storage section is not pushed down", async () => {
-		// Only `/site/backup/size` is left pending, and that is the whole
-		// point of the test. Holding *both* requests open would be
-		// satisfied by `schedule.isLoading` alone, so the second half of
-		// the guard could be deleted with every test still green — which
-		// is exactly what happened before this was narrowed.
+		// Only `/site/backup/size` is left pending. Holding both open would be
+		// satisfied by `schedule.isLoading` alone, leaving the second half of the
+		// guard deletable with every test still green.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		let releaseSize: ( v: unknown ) => void = () => {};
 		const pendingSize = new Promise( resolve => {
@@ -641,10 +582,8 @@ describe( 'while the reads are in flight', () => {
 		await waitFor( () =>
 			expect( client.getQueryState( keys.backupSchedule() )?.status ).toBe( 'success' )
 		);
-		// …and is deliberately still held back, because `/size` has not yet
-		// said whether WordPress.com is even running these backups. Showing
-		// the line now means retracting it a moment later on a site that is
-		// out of storage.
+		// …and is held back, because `/size` has not yet said whether WordPress.com is
+		// running these backups at all.
 		expect( placeholder() ).not.toBeNull();
 		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
 
@@ -656,13 +595,9 @@ describe( 'while the reads are in flight', () => {
 } );
 
 describe( 'the line, translated', () => {
-	// The English source cannot tell you whether the msgid's placeholders
-	// are positional: nothing moves, so `%1s`/`%2s` — which
-	// `@tannin/sprintf` reads as min-widths, discards, and then fills in
-	// the order they appear — renders exactly like `%1$s`/`%2$s`. The two
-	// only part company under a translation that reorders them, which is
-	// natural phrasing in plenty of languages. This is the only assertion
-	// in the suite that fails if the `$` are ever dropped.
+	// The English source cannot tell you whether the placeholders are positional:
+	// `%1s`/`%2s` renders identically until a translation reorders them. This is the
+	// only assertion in the suite that fails if the `$` are dropped.
 	afterEach( () => {
 		resetLocaleData();
 	} );
@@ -671,13 +606,9 @@ describe( 'the line, translated', () => {
 		setLocaleData(
 			{
 				'Next full backup: %1$s, %2$s.': [ 'At %2$s on %1$s, the next full backup runs.' ],
-				// The broken spelling, carried here on purpose. Without it,
-				// reverting the msgid fails this test with "unable to find
-				// /^At/" — a translation that no longer matches any key —
-				// which reads as a stale fixture and invites someone to
-				// update the key and bless the bug back in. With it, the
-				// failure is the transposition itself, which is the thing
-				// worth seeing.
+				// The broken spelling, on purpose: without it, reverting the msgid
+				// fails as an unmatched translation key, which reads as a stale
+				// fixture and invites someone to bless the bug back in.
 				'Next full backup: %1s, %2s.': [ 'At %2s on %1s, the next full backup runs.' ],
 			},
 			'jetpack-backup-pkg'
@@ -687,9 +618,7 @@ describe( 'the line, translated', () => {
 
 		renderWithClient( <NextScheduledBackup /> );
 
-		// Sequential placeholders would read this as "At Oct 22 on
-		// 10:00-10:59 AM" — the date announced as the time and the time as
-		// the date.
+		// Sequential placeholders would read this as "At Oct 22 on 10:00-10:59 AM".
 		await expect( screen.findByText( /^At/ ) ).resolves.toHaveTextContent(
 			/^At 10:00-10:59 AM on Oct 22, the next full backup runs\.$/
 		);
@@ -706,23 +635,16 @@ describe( 'on the Overview', () => {
 		const line = await screen.findByText( /^Next full backup/, undefined, SETTLE );
 		expect( line ).toHaveTextContent( /^Next full backup: Oct 22, 10:00-10:59 AM\.$/ );
 
-		// Placement, not just presence. `.jpb-overview` is a two-column
-		// grid above 960px, so this element has to be its *sibling* and
-		// has to come before it — as a child it would be auto-placed into
-		// a grid cell, and after it the schedule would sit below the fold
-		// under a full-height activity list. Asserting the text alone let
-		// both of those through: moving the mount below the grid changed
-		// nothing any test could see.
+		// Placement, not just presence: `.jpb-overview` is a two-column grid above
+		// 960px, so a child would be auto-placed into a cell and a following sibling
+		// would sit below the fold. Asserting the text alone let both through.
 		expect( overviewGrid() ).not.toBeNull();
 		expect( placementRelativeToGrid( line ) ).toEqual( { isSibling: true, comesFirst: true } );
 	} );
 
 	it( 'still reports the schedule while a backup is running', async () => {
-		// The one state this port deliberately keeps that legacy does not.
-		// Legacy's `IN_PROGRESS` replaces `COMPLETE`, so its line vanishes
-		// for the length of every run; here the two facts are reported
-		// side by side, which is the same decision `summarizeBackups` made
-		// when it stopped letting a running backup erase a finished one.
+		// The state this port keeps that legacy does not: legacy's `IN_PROGRESS`
+		// replaces `COMPLETE`, so its line vanishes for the length of every run.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		mockEndpoints( {
 			schedule: { ok: true, scheduled_hour: 10 },
@@ -742,23 +664,17 @@ describe( 'on the Overview', () => {
 	} );
 
 	it( 'says nothing when the backup state could not be read', async () => {
-		// `/jetpack/v4/backups` answers a WordPress.com reply it cannot
-		// decode with a bare `null` body served as HTTP 200, so the request
-		// resolves and only the derived state says otherwise. Note
-		// `replacesOverview()` has no branch for `'error'` at all — it can
-		// never take the body over here — so without the state gate the
-		// page renders its own "we couldn't check" notice directly above a
-		// confident "the next one runs at 10:00", which reads as the page
-		// contradicting itself. Legacy never produced that pairing.
+		// An undecodable reply is a bare `null` body served as HTTP 200, so only the
+		// derived state says otherwise — and `replacesOverview()` has no `'error'`
+		// branch, so without the state gate the page renders "we couldn't check"
+		// directly above a confident next-run time.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 }, backups: null } );
 
 		renderStageWithProbe();
 
-		// Synchronized on the failure being reported *and* on the schedule
-		// being available — both evidence from outside the thing under
-		// test, and neither removed by the mutation this test exists to
-		// catch.
+		// Synchronized on the failure being reported *and* the schedule being
+		// available, neither of which the mutation under test removes.
 		await expect(
 			screen.findByText( "We couldn't check your site's backup status.", undefined, SETTLE )
 		).resolves.toBeInTheDocument();
@@ -767,14 +683,11 @@ describe( 'on the Overview', () => {
 	} );
 
 	it( 'says nothing when the last attempt failed and the activity log did too', async () => {
-		// The second way the takeover stands down, and the one this
-		// package already documents in `backup-status/banner.tsx`: not
-		// "the site has restore points" but "the activity request failed
-		// so we cannot know either way". The veto at `overview.tsx` is
-		// `restorePointsLoading || restorePointsError || hasRestorePoints`,
-		// so a failed activity read is enough to keep the first-run panel
-		// away — and the line was rendering underneath a banner saying the
-		// last backup did not complete.
+		// The second way the takeover stands down: not "the site has restore points"
+		// but "the activity request failed, so we cannot know". The veto is
+		// `restorePointsLoading || restorePointsError || hasRestorePoints`, so a failed
+		// read keeps the first-run panel away and the line rendered under a banner
+		// saying the last backup did not complete.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		mockEndpoints( {
 			schedule: { ok: true, scheduled_hour: 10 },
@@ -796,16 +709,9 @@ describe( 'on the Overview', () => {
 	} );
 
 	it( 'stays away while the first-run panel has the body', async () => {
-		// The other half of legacy's gate, and the reason this port does
-		// not re-impose `BACKUP_STATE.COMPLETE` on the line itself:
-		// `replacesOverview` has already taken the body over for every
-		// state that gate excluded. A site with nothing recorded and
-		// nothing in its activity log is the plainest of them.
-		//
-		// Only half a test on its own — an absence assertion passes just as
-		// well against a screen that never mounts the line at all. The test
-		// directly above is the other half, and the two have to be read and
-		// kept together.
+		// Why this port does not re-impose `BACKUP_STATE.COMPLETE` on the line itself:
+		// `replacesOverview` has already taken the body over for every state that gate
+		// excluded. Half a test on its own — the one above is the other half.
 		freezeClock( '2026-10-22T05:00:00Z' );
 		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 }, backups: [], activity: [] } );
 

--- a/projects/packages/backup/tests/next-scheduled-backup.test.tsx
+++ b/projects/packages/backup/tests/next-scheduled-backup.test.tsx
@@ -218,6 +218,45 @@ function scheduleLine(): Promise< HTMLElement > {
 }
 
 /**
+ * The Overview's two-pane grid.
+ *
+ * A layout container with no role and no accessible name, so its class is
+ * the only handle — the same escape hatch the storage suites use.
+ *
+ * @return The grid, or null when the Overview body is not rendered.
+ */
+function overviewGrid(): HTMLElement | null {
+	return document.querySelector( '.jpb-overview' );
+}
+
+/**
+ * Where the schedule line sits relative to that grid.
+ *
+ * All the direct node access lives here rather than in the test body,
+ * which is both what `testing-library/no-node-access` wants and the only
+ * way to ask this question at all — neither "is a sibling of" nor "comes
+ * before" has a Testing Library query.
+ *
+ * @param line - The rendered schedule line.
+ * @return Whether it is a sibling of the grid, and whether it precedes it.
+ */
+function placementRelativeToGrid( line: HTMLElement ) {
+	/* eslint-disable testing-library/no-node-access -- the question *is* about node relationships; see above. */
+	const grid = overviewGrid();
+	const gridParent = grid?.parentElement ?? null;
+
+	return {
+		isSibling: gridParent !== null && line.parentElement === gridParent,
+		comesFirst: Boolean(
+			grid &&
+				// eslint-disable-next-line no-bitwise -- compareDocumentPosition returns a bitmask.
+				line.compareDocumentPosition( grid ) & Node.DOCUMENT_POSITION_FOLLOWING
+		),
+	};
+	/* eslint-enable testing-library/no-node-access */
+}
+
+/**
  * The skeleton that holds the line's space while the reads are in
  * flight. A placeholder carries no role and no accessible name, so its
  * class is the only handle — the same escape hatch the storage suites
@@ -375,6 +414,38 @@ describe( 'when there is nothing to report', () => {
 		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'says nothing when the hour is not a whole number', async () => {
+		// `Date.UTC` truncates rather than rejecting — hour 10.5 is
+		// 10:00:00Z — so without `Number.isInteger` this renders a
+		// confident "10:00-10:59 AM" for a payload we could not actually
+		// read. Verified: `new Date( Date.UTC( 2026, 9, 22, 10.5, 0, 0, 0 ) )`
+		// is `2026-10-22T10:00:00.000Z`.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10.5 } } );
+
+		const client = newQueryClient();
+		renderWithClient( <NextScheduledBackup />, client );
+
+		await readsSettled( client );
+		expect( placeholder() ).toBeNull();
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'says nothing when the hour is negative', async () => {
+		// The other end of the range, and it fails the same silent way:
+		// `Date.UTC( …, -1, … )` is 23:00 on the *previous* day, so this
+		// would report a backup at 11:00 PM that nobody scheduled.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: -1 } } );
+
+		const client = newQueryClient();
+		renderWithClient( <NextScheduledBackup />, client );
+
+		await readsSettled( client );
+		expect( placeholder() ).toBeNull();
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'says nothing when the hour is out of range', async () => {
 		// `Date.UTC( …, 24, … )` is not an error, it is the following
 		// midnight — so without the range check this would report a backup
@@ -412,23 +483,73 @@ describe( 'when there is nothing to report', () => {
 	} );
 } );
 
-describe( 'while the reads are in flight', () => {
-	it( "holds the line's height so the storage section is not pushed down", async () => {
+describe( 'when the site cannot reach WordPress.com', () => {
+	it( 'does not issue the request at all', async () => {
+		// `enabled: useCanQueryWpcom()` on the query. A site that is
+		// registered but has no connected owner cannot answer this route,
+		// and asking anyway spends a round trip to be told so. `<Gates>`
+		// keeps most readers away from here, but nothing else pins the
+		// line itself, and a disabled query is also what keeps
+		// `isLoading` false — so dropping it would leave the placeholder
+		// up forever rather than merely wasting a request.
 		freezeClock( '2026-10-22T05:00:00Z' );
-		let release: ( v: unknown ) => void = () => {};
-		const pending = new Promise( resolve => {
-			release = resolve;
-		} );
-		mockApiFetch.mockImplementation( ( options: { path?: string } ) =>
-			( options?.path ?? '' ).includes( '/site/backup/' ) ? pending : Promise.resolve( {} )
-		);
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			connectionStatus: { isRegistered: true, hasConnectedOwner: false, isUserConnected: false },
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
 
 		renderWithClient( <NextScheduledBackup /> );
 
-		await waitFor( () => expect( placeholder() ).not.toBeNull() );
+		// Nothing rendered, and — the part that matters — nothing asked.
+		await waitFor( () => expect( placeholder() ).toBeNull() );
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+		expect( mockApiFetch ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { path: expect.stringContaining( '/site/backup/schedule' ) } )
+		);
+	} );
+} );
+
+describe( 'while the reads are in flight', () => {
+	it( "holds the line's height so the storage section is not pushed down", async () => {
+		// Only `/site/backup/size` is left pending, and that is the whole
+		// point of the test. Holding *both* requests open would be
+		// satisfied by `schedule.isLoading` alone, so the second half of
+		// the guard could be deleted with every test still green — which
+		// is exactly what happened before this was narrowed.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		let releaseSize: ( v: unknown ) => void = () => {};
+		const pendingSize = new Promise( resolve => {
+			releaseSize = resolve;
+		} );
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( '/site/backup/schedule' ) ) {
+				return Promise.resolve( { ok: true, scheduled_hour: 10 } );
+			}
+			if ( path.includes( '/site/backup/size' ) ) {
+				return pendingSize;
+			}
+			return Promise.resolve( {} );
+		} );
+
+		const client = newQueryClient();
+		renderWithClient( <NextScheduledBackup />, client );
+
+		// The schedule has landed and could be rendered…
+		await waitFor( () =>
+			expect( client.getQueryState( keys.backupSchedule() )?.status ).toBe( 'success' )
+		);
+		// …and is deliberately still held back, because `/size` has not yet
+		// said whether WordPress.com is even running these backups. Showing
+		// the line now means retracting it a moment later on a site that is
+		// out of storage.
+		expect( placeholder() ).not.toBeNull();
 		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
 
-		release( { ok: true, scheduled_hour: 10, backups_stopped: false } );
+		releaseSize( { ok: true, backups_stopped: false } );
+		await expect( scheduleLine() ).resolves.toHaveTextContent(
+			/^Next full backup: Oct 22, 10:00-10:59 AM\.$/
+		);
 	} );
 } );
 
@@ -480,9 +601,18 @@ describe( 'on the Overview', () => {
 
 		render( <OverviewStage /> );
 
-		await expect(
-			screen.findByText( /^Next full backup/, undefined, SETTLE )
-		).resolves.toHaveTextContent( /^Next full backup: Oct 22, 10:00-10:59 AM\.$/ );
+		const line = await screen.findByText( /^Next full backup/, undefined, SETTLE );
+		expect( line ).toHaveTextContent( /^Next full backup: Oct 22, 10:00-10:59 AM\.$/ );
+
+		// Placement, not just presence. `.jpb-overview` is a two-column
+		// grid above 960px, so this element has to be its *sibling* and
+		// has to come before it — as a child it would be auto-placed into
+		// a grid cell, and after it the schedule would sit below the fold
+		// under a full-height activity list. Asserting the text alone let
+		// both of those through: moving the mount below the grid changed
+		// nothing any test could see.
+		expect( overviewGrid() ).not.toBeNull();
+		expect( placementRelativeToGrid( line ) ).toEqual( { isSibling: true, comesFirst: true } );
 	} );
 
 	it( 'stays away while the first-run panel has the body', async () => {

--- a/projects/packages/backup/tests/next-scheduled-backup.test.tsx
+++ b/projects/packages/backup/tests/next-scheduled-backup.test.tsx
@@ -35,6 +35,7 @@ import { resetLocaleData, setLocaleData } from '@wordpress/i18n';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
 import NextScheduledBackup from '../src/dashboard/components/next-scheduled-backup';
 import { keys, queryClient } from '../src/dashboard/data/query-client';
+import { useNextBackupSchedule } from '../src/dashboard/hooks/use-backup-schedule';
 import type { ReactNode } from 'react';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
@@ -126,6 +127,72 @@ function renderWithClient( ui: ReactNode, client: QueryClient = newQueryClient()
  *
  * @param client - The client the tree was rendered with.
  */
+/**
+ * A second, deliberately unconditional reader of the schedule.
+ *
+ * Every stage-level absence assertion needs to know that the schedule was
+ * there to be shown and the Overview declined to show it — otherwise it
+ * passes just as well against a broken fixture, or against an assertion
+ * that ran too early. Waiting on what the takeover or a banner
+ * renders is not that: those come from `/jetpack/v4/backups`, which
+ * resolves independently of `/site/backup/schedule`. And waiting on the
+ * schedule query itself does not work either, because when the line is
+ * correctly hidden nothing mounts the hook and the query is never issued.
+ *
+ * So this mounts the hook regardless, on the same client, and says what
+ * the line would have said. It is a test instrument, not a fixture.
+ *
+ * @return The date the line would have carried, or nothing.
+ */
+function ScheduleProbe() {
+	const schedule = useNextBackupSchedule();
+
+	if ( ! schedule.hasSchedule ) {
+		return null;
+	}
+
+	return <span data-testid="schedule-probe">{ schedule.nextBackupDate }</span>;
+}
+
+/**
+ * Render the Overview with that probe beside it.
+ *
+ * The probe needs its own provider: `<OverviewStage>` mounts one
+ * internally, so a sibling is outside it. Both point at the module-scope
+ * client, so the two share a cache and issue one request between them.
+ */
+function renderStageWithProbe() {
+	render(
+		<>
+			<OverviewStage />
+			<QueryClientProvider client={ queryClient }>
+				<ScheduleProbe />
+			</QueryClientProvider>
+		</>
+	);
+}
+
+/**
+ * Wait until the schedule is known to be renderable.
+ *
+ * @return The probe element, once it has something to show.
+ */
+function scheduleIsAvailable(): Promise< HTMLElement > {
+	return screen.findByTestId( 'schedule-probe', undefined, SETTLE );
+}
+
+/**
+ * Wait until both reads behind the line have actually landed.
+ *
+ * Every component-level "says nothing" assertion needs this, and needs it
+ * to synchronize on the *queries* rather than on anything the component
+ * renders. Waiting for the placeholder to clear would look equivalent and
+ * is not: a component that stopped rendering a placeholder would satisfy
+ * that wait on the very first tick, and each of those tests would then
+ * assert an absence that had never had a chance to become a presence.
+ *
+ * @param client - The client the tree was rendered with.
+ */
 async function readsSettled( client: QueryClient ) {
 	await waitFor( () => {
 		expect( client.getQueryState( keys.backupSchedule() )?.status ).toBe( 'success' );
@@ -151,6 +218,34 @@ function backupActivityEntry() {
 	};
 }
 
+/** A backup currently running. */
+const RUNNING_BACKUP = {
+	id: '2',
+	started: '2026-08-14 09:00:00',
+	last_updated: '2026-08-14 09:04:00',
+	status: 'started',
+	period: '1786730931',
+	percent: '42',
+	is_backup: '1',
+	is_scan: '0',
+	discarded: '0',
+	stats: {},
+};
+
+/** An attempt that failed and that WordPress.com will retry on its own. */
+const WILL_RETRY_BACKUP = {
+	id: '3',
+	started: '2026-08-14 09:00:00',
+	last_updated: '2026-08-14 09:04:00',
+	status: 'error-will-retry',
+	period: '1786730931',
+	percent: '0',
+	is_backup: '1',
+	is_scan: '0',
+	discarded: '0',
+	stats: {},
+};
+
 /** A finished, usable restore point. */
 const USABLE_BACKUP = {
 	id: '1',
@@ -171,17 +266,22 @@ const USABLE_BACKUP = {
  *
  * Defaults to a site backed up at 10:00 UTC with storage to spare.
  *
- * @param options          - Overrides.
- * @param options.schedule - What `/site/backup/schedule` resolves with.
- * @param options.size     - Extra fields for `/site/backup/size`.
- * @param options.backups  - What `/jetpack/v4/backups` resolves with.
- * @param options.activity - Rewindable-activity entries.
+ * @param options               - Overrides.
+ * @param options.schedule      - What `/site/backup/schedule` resolves with.
+ * @param options.size          - Extra fields for `/site/backup/size`.
+ * @param options.backups       - What `/jetpack/v4/backups` resolves with. `null` is the
+ *                              shape a non-200 from WordPress.com actually takes: the
+ *                              legacy route answers a body it cannot decode with a bare
+ *                              `null`, which WordPress serves as HTTP 200.
+ * @param options.activity      - Rewindable-activity entries.
+ * @param options.activityFails - Make `/site/rewindable-activity` reject.
  */
 function mockEndpoints( {
 	schedule = { ok: true, scheduled_hour: 10, scheduled_by: null } as unknown,
 	size = {} as Record< string, unknown >,
-	backups = [ USABLE_BACKUP ] as unknown[],
+	backups = [ USABLE_BACKUP ] as unknown[] | null,
 	activity = [ backupActivityEntry() ] as unknown[],
+	activityFails = false,
 } = {} ) {
 	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
 		const path = options?.path ?? '';
@@ -195,11 +295,13 @@ function mockEndpoints( {
 			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
 		}
 		if ( path.includes( '/site/rewindable-activity' ) ) {
-			return Promise.resolve( {
-				current: { orderedItems: activity },
-				totalItems: activity.length,
-				totalPages: 1,
-			} );
+			return activityFails
+				? Promise.reject( new Error( 'Could not fetch the activity log.' ) )
+				: Promise.resolve( {
+						current: { orderedItems: activity },
+						totalItems: activity.length,
+						totalPages: 1,
+				  } );
 		}
 		if ( path === '/jetpack/v4/backups' ) {
 			return Promise.resolve( backups );
@@ -615,6 +717,84 @@ describe( 'on the Overview', () => {
 		expect( placementRelativeToGrid( line ) ).toEqual( { isSibling: true, comesFirst: true } );
 	} );
 
+	it( 'still reports the schedule while a backup is running', async () => {
+		// The one state this port deliberately keeps that legacy does not.
+		// Legacy's `IN_PROGRESS` replaces `COMPLETE`, so its line vanishes
+		// for the length of every run; here the two facts are reported
+		// side by side, which is the same decision `summarizeBackups` made
+		// when it stopped letting a running backup erase a finished one.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( {
+			schedule: { ok: true, scheduled_hour: 10 },
+			backups: [ RUNNING_BACKUP, USABLE_BACKUP ],
+		} );
+
+		render( <OverviewStage /> );
+
+		// The running backup is reported…
+		await expect(
+			screen.findByText( 'Your backup will be ready soon', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+		// …and so is the next one.
+		await expect(
+			screen.findByText( /^Next full backup/, undefined, SETTLE )
+		).resolves.toHaveTextContent( /^Next full backup: Oct 22, 10:00-10:59 AM\.$/ );
+	} );
+
+	it( 'says nothing when the backup state could not be read', async () => {
+		// `/jetpack/v4/backups` answers a WordPress.com reply it cannot
+		// decode with a bare `null` body served as HTTP 200, so the request
+		// resolves and only the derived state says otherwise. Note
+		// `replacesOverview()` has no branch for `'error'` at all — it can
+		// never take the body over here — so without the state gate the
+		// page renders its own "we couldn't check" notice directly above a
+		// confident "the next one runs at 10:00", which reads as the page
+		// contradicting itself. Legacy never produced that pairing.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 }, backups: null } );
+
+		renderStageWithProbe();
+
+		// Synchronized on the failure being reported *and* on the schedule
+		// being available — both evidence from outside the thing under
+		// test, and neither removed by the mutation this test exists to
+		// catch.
+		await expect(
+			screen.findByText( "We couldn't check your site's backup status.", undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+		await expect( scheduleIsAvailable() ).resolves.toHaveTextContent( 'Oct 22' );
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'says nothing when the last attempt failed and the activity log did too', async () => {
+		// The second way the takeover stands down, and the one this
+		// package already documents in `backup-status/banner.tsx`: not
+		// "the site has restore points" but "the activity request failed
+		// so we cannot know either way". The veto at `overview.tsx` is
+		// `restorePointsLoading || restorePointsError || hasRestorePoints`,
+		// so a failed activity read is enough to keep the first-run panel
+		// away — and the line was rendering underneath a banner saying the
+		// last backup did not complete.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( {
+			schedule: { ok: true, scheduled_hour: 10 },
+			backups: [ WILL_RETRY_BACKUP ],
+			activityFails: true,
+		} );
+
+		renderStageWithProbe();
+
+		await expect(
+			screen.findByText(
+				"Your latest backup didn't complete. We'll try again shortly.",
+				undefined,
+				SETTLE
+			)
+		).resolves.toBeInTheDocument();
+		await expect( scheduleIsAvailable() ).resolves.toHaveTextContent( 'Oct 22' );
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'stays away while the first-run panel has the body', async () => {
 		// The other half of legacy's gate, and the reason this port does
 		// not re-impose `BACKUP_STATE.COMPLETE` on the line itself:
@@ -629,11 +809,12 @@ describe( 'on the Overview', () => {
 		freezeClock( '2026-10-22T05:00:00Z' );
 		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 }, backups: [], activity: [] } );
 
-		render( <OverviewStage /> );
+		renderStageWithProbe();
 
 		await expect(
 			screen.findByText( 'Your first cloud backup will be ready soon', undefined, SETTLE )
 		).resolves.toBeInTheDocument();
+		await expect( scheduleIsAvailable() ).resolves.toHaveTextContent( 'Oct 22' );
 		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/next-scheduled-backup.test.tsx
+++ b/projects/packages/backup/tests/next-scheduled-backup.test.tsx
@@ -1,0 +1,509 @@
+// The Overview's "Next full backup: …" line (JETPACK-2328 / K2).
+//
+// Four things are worth pinning here and nothing else asserts any of
+// them: that the line is silent when there is no schedule to report,
+// that it stays silent when WordPress.com has stopped backing the site
+// up, that the date and window are read in the *site's* timezone rather
+// than UTC or the reader's, and that the msgid's positional placeholders
+// survive a translation that reorders them.
+//
+// Every date assertion runs against a frozen clock. Computing the
+// expectation the way the implementation computes it would pass no
+// matter what either of them did.
+
+const mockApiFetch = jest.fn();
+const mockSearch = jest.fn< Record< string, unknown >, [] >();
+const mockNavigate = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => mockSearch(),
+	useNavigate: () => mockNavigate,
+	useParams: () => ( { rewindId: '1777035492' } ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { getSettings, setSettings } from '@wordpress/date';
+import { resetLocaleData, setLocaleData } from '@wordpress/i18n';
+import { stage as OverviewStage } from '../routes/dashboard/stage';
+import NextScheduledBackup from '../src/dashboard/components/next-scheduled-backup';
+import { keys, queryClient } from '../src/dashboard/data/query-client';
+import type { ReactNode } from 'react';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+// The route stages render behind several sequential requests and have
+// taken well over Testing Library's 1s default on a loaded runner.
+const SETTLE = { timeout: 10000 };
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row. Defined rather than spied on:
+// `jest.spyOn` requires the property to already exist, and in jsdom it
+// does not.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );
+
+// Everything Jest's fake timers can replace *except* `Date`.
+//
+// The clock is the only thing these tests need frozen. Faking the timer
+// functions as well would take React Query's retries and Testing
+// Library's own polling with it — `waitFor` switches to a
+// timer-advancing implementation the moment it sees a mocked
+// `setTimeout` — and the suite would hang on the first `findBy*`.
+const DO_NOT_FAKE = [
+	'cancelAnimationFrame',
+	'cancelIdleCallback',
+	'clearImmediate',
+	'clearInterval',
+	'clearTimeout',
+	'hrtime',
+	'nextTick',
+	'performance',
+	'queueMicrotask',
+	'requestAnimationFrame',
+	'requestIdleCallback',
+	'setImmediate',
+	'setInterval',
+	'setTimeout',
+];
+
+/**
+ * Freeze `Date` at an instant, leaving every timer real.
+ *
+ * @param iso - The instant, as an ISO 8601 string with an explicit zone.
+ */
+function freezeClock( iso: string ) {
+	jest.useFakeTimers( {
+		doNotFake: DO_NOT_FAKE as Parameters< typeof jest.useFakeTimers >[ 0 ][ 'doNotFake' ],
+		now: new Date( iso ),
+	} );
+}
+
+/**
+ * A fresh client with retries off.
+ *
+ * Built separately from the render below so a test that needs to wait on
+ * the queries themselves can hold on to one — see `readsSettled`.
+ *
+ * @return The client.
+ */
+function newQueryClient(): QueryClient {
+	return new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+}
+
+/**
+ * Render inside an isolated QueryClient.
+ *
+ * @param ui     - The tree to render.
+ * @param client - The client to render under. Defaults to a fresh one.
+ * @return The testing-library render result.
+ */
+function renderWithClient( ui: ReactNode, client: QueryClient = newQueryClient() ) {
+	return render( <QueryClientProvider client={ client }>{ ui }</QueryClientProvider> );
+}
+
+/**
+ * Wait until both reads behind the line have actually landed.
+ *
+ * Every "says nothing" assertion below needs this, and needs it to
+ * synchronize on the *queries* rather than on anything the component
+ * renders. Waiting for the placeholder to clear would look equivalent
+ * and is not: a component that stopped rendering a placeholder at all
+ * would satisfy that wait on the very first tick, and each of those
+ * tests would then assert an absence that had never had a chance to
+ * become a presence.
+ *
+ * @param client - The client the tree was rendered with.
+ */
+async function readsSettled( client: QueryClient ) {
+	await waitFor( () => {
+		expect( client.getQueryState( keys.backupSchedule() )?.status ).toBe( 'success' );
+		expect( client.getQueryState( keys.siteSize() )?.status ).toBe( 'success' );
+	} );
+}
+
+/**
+ * One rewindable-activity entry, in WordPress.com's shape.
+ *
+ * @return A raw activity entry describing a completed backup.
+ */
+function backupActivityEntry() {
+	return {
+		activity_id: 'act-cloud',
+		gridicon: 'cloud',
+		summary: 'Backup complete',
+		published: '2026-08-13T18:08:56+00:00',
+		rewind_id: '1786644531.123',
+		actor: { type: 'Application', name: 'Jetpack' },
+		content: { text: '46 plugins, 23 themes' },
+		name: 'rewind__backup_complete_full',
+	};
+}
+
+/** A finished, usable restore point. */
+const USABLE_BACKUP = {
+	id: '1',
+	started: '2026-08-13 18:08:56',
+	last_updated: '2026-08-13 18:54:14',
+	status: 'finished',
+	period: '1786644531',
+	percent: '100',
+	is_backup: '1',
+	is_scan: '0',
+	discarded: '0',
+	stats: { prefix: 'wp_' },
+};
+
+/**
+ * Answer every route the line — and, for the wiring tests, the whole
+ * Overview — reads.
+ *
+ * Defaults to a site backed up at 10:00 UTC with storage to spare.
+ *
+ * @param options          - Overrides.
+ * @param options.schedule - What `/site/backup/schedule` resolves with.
+ * @param options.size     - Extra fields for `/site/backup/size`.
+ * @param options.backups  - What `/jetpack/v4/backups` resolves with.
+ * @param options.activity - Rewindable-activity entries.
+ */
+function mockEndpoints( {
+	schedule = { ok: true, scheduled_hour: 10, scheduled_by: null } as unknown,
+	size = {} as Record< string, unknown >,
+	backups = [ USABLE_BACKUP ] as unknown[],
+	activity = [ backupActivityEntry() ] as unknown[],
+} = {} ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/site/backup/schedule' ) ) {
+			return Promise.resolve( schedule );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: false, ...size } );
+		}
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		if ( path.includes( '/site/rewindable-activity' ) ) {
+			return Promise.resolve( {
+				current: { orderedItems: activity },
+				totalItems: activity.length,
+				totalPages: 1,
+			} );
+		}
+		if ( path === '/jetpack/v4/backups' ) {
+			return Promise.resolve( backups );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+/**
+ * The line, once it has arrived.
+ *
+ * @return The element carrying it.
+ */
+function scheduleLine(): Promise< HTMLElement > {
+	return screen.findByText( /^Next full backup/ );
+}
+
+/**
+ * The skeleton that holds the line's space while the reads are in
+ * flight. A placeholder carries no role and no accessible name, so its
+ * class is the only handle — the same escape hatch the storage suites
+ * use.
+ *
+ * @return The placeholder, or null before it has rendered.
+ */
+function placeholder(): HTMLElement | null {
+	return document.querySelector( '.jpb-next-scheduled-backup__placeholder' );
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockEndpoints();
+	mockSearch.mockReset();
+	mockSearch.mockReturnValue( {} );
+	mockNavigate.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+afterEach( () => {
+	jest.useRealTimers();
+} );
+
+describe( 'the next-backup line', () => {
+	it( "reports today's window while it is still ahead", async () => {
+		// 05:00 UTC, on a site backed up at 10:00 UTC. The site's own
+		// timezone is `@wordpress/date`'s default here, which is UTC — the
+		// zone is varied deliberately further down.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 } } );
+
+		renderWithClient( <NextScheduledBackup /> );
+
+		await expect( scheduleLine() ).resolves.toHaveTextContent(
+			/^Next full backup: Oct 22, 10:00-10:59 AM\.$/
+		);
+	} );
+
+	it( "moves to tomorrow once today's window has closed", async () => {
+		// One second after 10:59:59, which is the last instant the window
+		// covers.
+		freezeClock( '2026-10-22T11:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 } } );
+
+		renderWithClient( <NextScheduledBackup /> );
+
+		await expect( scheduleLine() ).resolves.toHaveTextContent(
+			/^Next full backup: Oct 23, 10:00-10:59 AM\.$/
+		);
+	} );
+
+	it( 'still reports today while the window is open', async () => {
+		// 10:59:30 is inside the window and must not roll forward: a reader
+		// looking at the page during the run wants the run that is
+		// happening, not the one tomorrow. Half a minute past 10:59 is the
+		// case that separates "the window ends at 10:59:59" from "the
+		// window ends at 10:59:00".
+		freezeClock( '2026-10-22T10:59:30Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 } } );
+
+		renderWithClient( <NextScheduledBackup /> );
+
+		await expect( scheduleLine() ).resolves.toHaveTextContent(
+			/^Next full backup: Oct 22, 10:00-10:59 AM\.$/
+		);
+	} );
+
+	it( 'reads midnight UTC as an hour like any other', async () => {
+		// `scheduled_hour: 0` is a real answer and the one a truthiness
+		// check would drop. Distinct from every other fixture here: the
+		// window opens at midnight and reads back as 12:00 AM, which is
+		// also the only case where the 12-hour clock and the 24-hour hour
+		// disagree.
+		freezeClock( '2026-10-21T23:30:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 0 } } );
+
+		renderWithClient( <NextScheduledBackup /> );
+
+		await expect( scheduleLine() ).resolves.toHaveTextContent(
+			/^Next full backup: Oct 22, 12:00-12:59 AM\.$/
+		);
+	} );
+} );
+
+describe( 'the site timezone', () => {
+	const original = getSettings();
+
+	afterEach( () => {
+		setSettings( original );
+	} );
+
+	it( 'states the date and window where the site is, not where the reader is', async () => {
+		// A five-hour western offset, spelled as a number with no IANA
+		// string: `@wordpress/date` bundles moment-timezone without its
+		// zone data, so a named zone here would resolve to nothing and the
+		// assertion would silently be about UTC again.
+		setSettings( {
+			...original,
+			timezone: { offset: -5, offsetFormatted: '-5', string: '', abbr: 'EST' },
+		} );
+		// 02:00 UTC on the 22nd is 21:00 on the 21st for this site, and the
+		// backup window opens at 02:00 UTC — so the site is told about a
+		// backup that runs on its *previous* calendar day. Read as UTC this
+		// would say "Oct 22, 2:00-2:59 AM"; read in the browser's zone it
+		// would say whatever the runner happens to be set to.
+		freezeClock( '2026-10-22T01:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 2 } } );
+
+		renderWithClient( <NextScheduledBackup /> );
+
+		await expect( scheduleLine() ).resolves.toHaveTextContent(
+			/^Next full backup: Oct 21, 9:00-9:59 PM\.$/
+		);
+	} );
+} );
+
+describe( 'when there is nothing to report', () => {
+	it( 'says nothing when the site has no schedule', async () => {
+		// What WordPress.com answers for a site it is not scheduling.
+		// Silence is the whole behaviour: there is no "unknown" copy to
+		// fall back to, so a guard that let this through would render
+		// "Next full backup: Jan 1, 12:00-12:59 AM." — a date nobody
+		// promised.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: null } } );
+
+		const client = newQueryClient();
+		renderWithClient( <NextScheduledBackup />, client );
+
+		await readsSettled( client );
+		expect( placeholder() ).toBeNull();
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'says nothing when the route could not read WordPress.com', async () => {
+		// A reply the route cannot decode collapses to a bare `null` body
+		// served as HTTP 200, so the request resolves and React Query
+		// records a success. The shape of the data is the only evidence.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: null } );
+
+		const client = newQueryClient();
+		renderWithClient( <NextScheduledBackup />, client );
+
+		await readsSettled( client );
+		expect( placeholder() ).toBeNull();
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'says nothing when the hour is out of range', async () => {
+		// `Date.UTC( …, 24, … )` is not an error, it is the following
+		// midnight — so without the range check this would report a backup
+		// at 12:00 AM on the 23rd, which is a time nobody scheduled.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 24 } } );
+
+		const client = newQueryClient();
+		renderWithClient( <NextScheduledBackup />, client );
+
+		await readsSettled( client );
+		expect( placeholder() ).toBeNull();
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'says nothing once WordPress.com has stopped backing the site up', async () => {
+		// The half of legacy's gate this port keeps. The schedule is still
+		// there and still readable — WordPress.com just is not acting on
+		// it — so the request below succeeds and only `backups_stopped`
+		// separates this from the first test in the file. Promising a
+		// 10:00 backup here would also contradict the "Back up now" button,
+		// which reads the same flag and disables itself on it.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( {
+			schedule: { ok: true, scheduled_hour: 10 },
+			size: { backups_stopped: true },
+		} );
+
+		const client = newQueryClient();
+		renderWithClient( <NextScheduledBackup />, client );
+
+		await readsSettled( client );
+		expect( placeholder() ).toBeNull();
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'while the reads are in flight', () => {
+	it( "holds the line's height so the storage section is not pushed down", async () => {
+		freezeClock( '2026-10-22T05:00:00Z' );
+		let release: ( v: unknown ) => void = () => {};
+		const pending = new Promise( resolve => {
+			release = resolve;
+		} );
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) =>
+			( options?.path ?? '' ).includes( '/site/backup/' ) ? pending : Promise.resolve( {} )
+		);
+
+		renderWithClient( <NextScheduledBackup /> );
+
+		await waitFor( () => expect( placeholder() ).not.toBeNull() );
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+
+		release( { ok: true, scheduled_hour: 10, backups_stopped: false } );
+	} );
+} );
+
+describe( 'the line, translated', () => {
+	// The English source cannot tell you whether the msgid's placeholders
+	// are positional: nothing moves, so `%1s`/`%2s` — which
+	// `@tannin/sprintf` reads as min-widths, discards, and then fills in
+	// the order they appear — renders exactly like `%1$s`/`%2$s`. The two
+	// only part company under a translation that reorders them, which is
+	// natural phrasing in plenty of languages. This is the only assertion
+	// in the suite that fails if the `$` are ever dropped.
+	afterEach( () => {
+		resetLocaleData();
+	} );
+
+	it( 'keeps the date and the window the right way round when a translation swaps them', async () => {
+		setLocaleData(
+			{
+				'Next full backup: %1$s, %2$s.': [ 'At %2$s on %1$s, the next full backup runs.' ],
+				// The broken spelling, carried here on purpose. Without it,
+				// reverting the msgid fails this test with "unable to find
+				// /^At/" — a translation that no longer matches any key —
+				// which reads as a stale fixture and invites someone to
+				// update the key and bless the bug back in. With it, the
+				// failure is the transposition itself, which is the thing
+				// worth seeing.
+				'Next full backup: %1s, %2s.': [ 'At %2s on %1s, the next full backup runs.' ],
+			},
+			'jetpack-backup-pkg'
+		);
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 } } );
+
+		renderWithClient( <NextScheduledBackup /> );
+
+		// Sequential placeholders would read this as "At Oct 22 on
+		// 10:00-10:59 AM" — the date announced as the time and the time as
+		// the date.
+		await expect( screen.findByText( /^At/ ) ).resolves.toHaveTextContent(
+			/^At 10:00-10:59 AM on Oct 22, the next full backup runs\.$/
+		);
+	} );
+} );
+
+describe( 'on the Overview', () => {
+	it( 'renders above the activity list', async () => {
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 } } );
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByText( /^Next full backup/, undefined, SETTLE )
+		).resolves.toHaveTextContent( /^Next full backup: Oct 22, 10:00-10:59 AM\.$/ );
+	} );
+
+	it( 'stays away while the first-run panel has the body', async () => {
+		// The other half of legacy's gate, and the reason this port does
+		// not re-impose `BACKUP_STATE.COMPLETE` on the line itself:
+		// `replacesOverview` has already taken the body over for every
+		// state that gate excluded. A site with nothing recorded and
+		// nothing in its activity log is the plainest of them.
+		//
+		// Only half a test on its own — an absence assertion passes just as
+		// well against a screen that never mounts the line at all. The test
+		// directly above is the other half, and the two have to be read and
+		// kept together.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 }, backups: [], activity: [] } );
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByText( 'Your first cloud backup will be ready soon', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/next-scheduled-backup.test.tsx
+++ b/projects/packages/backup/tests/next-scheduled-backup.test.tsx
@@ -472,6 +472,35 @@ describe( 'when there is nothing to report', () => {
 		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'says nothing when the payload does not set ok', async () => {
+		// `ok` is WordPress.com's own success flag inside a 200 body, so a payload
+		// without it carries no usable hour. The fixture keeps a plausible one, so this
+		// cannot pass merely because the payload was empty.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { scheduled_hour: 10 } } );
+
+		const client = newQueryClient();
+		renderWithClient( <NextScheduledBackup />, client );
+
+		await readsSettled( client );
+		expect( placeholder() ).toBeNull();
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'says nothing when ok is false', async () => {
+		// The reading `useSiteSize()` already takes of this same envelope, and the one
+		// `summarize_schedule()` publishes from the backup ability.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: false, scheduled_hour: 10 } } );
+
+		const client = newQueryClient();
+		renderWithClient( <NextScheduledBackup />, client );
+
+		await readsSettled( client );
+		expect( placeholder() ).toBeNull();
+		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'says nothing when the hour is not a whole number', async () => {
 		// `Date.UTC` truncates rather than rejecting, so without `Number.isInteger`
 		// this renders a confident "10:00-10:59 AM" for an unreadable payload.


### PR DESCRIPTION
Fixes JETPACK-2328

## Proposed changes

The legacy Backup dashboard tells a reader when the next full backup will run. The modernized Overview said nothing at all — there was no next-backup time anywhere in `src/dashboard/`. This ports that line.

`GET /jetpack/v4/site/backup/schedule` is registered unconditionally in `Jetpack_Backup::register_rest_routes()` — no modernization gate anywhere in that method — so this is a pure client-side port with no backend work:

* `src/dashboard/data/api/backup-schedule.ts` — the fetcher, on the shared `apiCall`/`apiPath` helpers.
* `src/dashboard/hooks/use-backup-schedule.ts` — turns WordPress.com's UTC `scheduled_hour` into the next window and returns it formatted.
* `src/dashboard/components/next-scheduled-backup/` — the line itself, rendered above the storage section on the Overview.
* `tests/next-scheduled-backup.test.tsx` — 13 tests, each of them mutation-checked.

**The msgid is legacy's, character for character** (`'Next full backup: %1$s, %2$s.'`), so the two dashboards share one GlotPress entry instead of asking translators for the same sentence twice.

### Two omissions, both deliberate

**Legacy's "Modify" link is not ported.** It points at `getRedirectUrl( 'backup-plugin-schedule-time-setting' )`, which resolves to `https://cloud.jetpack.com/settings` — so porting it would make this the modernized dashboard's first outbound link to Calypso, and whether it links out to Calypso at all is an open product question tracked as **JETPACK-2329**. That is not a decision this PR should settle. The component is structured so the link is a one-element addition once 2329 is decided, and says so in its docblock.

**The `jetpack_backup_schedule_modify_click` Tracks event goes with it.** Legacy fires it from that link's `onClick`. No link, nothing to record. Same docblock, same reason; both come back together.

### The gating decisions

Legacy mounts its copy inside `CompleteBackup`, so it requires `BACKUP_STATE.COMPLETE` **and** `! backupsStopped`. Both halves were considered explicitly:

* **`! backupsStopped` is kept**, sourced from WordPress.com's server-side `backups_stopped` flag via `useSiteSize()` — *not* the client-side `StorageUsageLevels.Full` derivation legacy computes. This dashboard already settled on the server flag (JETPACK-2300), and the same answer has to serve both readings: "Back up now" disables itself on that flag, so deriving this line differently would let the page disable the button and promise a 10:00 backup in the same breath. The server flag is also what WordPress.com actually acts on, and it needs only `/site/backup/size` where the derivation additionally needs `/site/backup/policies` — a site with no retention policy has no derivation to make.
* **`BACKUP_STATE.COMPLETE` is re-imposed and widened by one state**: the line shows for `complete` and `in-progress`, and in no other state. `in-progress` is the one case this port deliberately adds — legacy's `IN_PROGRESS` branch replaces `COMPLETE` and takes the line down for the length of every run, whereas reporting both facts side by side is the same call `summarizeBackups` already made when it stopped letting a running backup erase a finished one. It is not narrowed by `isInitialBackup`; the only case that would exclude is a first-ever backup running while the activity read fails, where the schedule is still true.

  An earlier revision of this PR argued the gate was redundant because `replacesOverview()` already covered it. **That was wrong.** The helper returns true only for `no-backups | will-retry | no-good-backups | (in-progress && isInitialBackup)`, and only when its third argument is false — and that argument is `restorePointsLoading || restorePointsError || hasRestorePoints`, so the veto is up in three situations, of which only one means "this site has restore points". `backup-status/banner.tsx` already documents the second: *"the activity request failed so we cannot know either way"*. For `error` and `loading` the helper has no branch at all and can never take the body over.

  Two contradictory pairings were shipping as a result, each now covered by a test written before the fix and confirmed failing against the old code: a site whose `/jetpack/v4/backups` read came back undecodable rendered *"We couldn't check your site's backup status."* directly above *"Next full backup: Oct 22, 10:00-10:59 AM."*; and a site whose last attempt failed while the activity log was also unreachable promised a next run under a banner saying the last one had not completed. Legacy produced neither.

### Dates: `@wordpress/date`, not moment

Legacy formats with moment. This uses `dateI18n`, for two reasons — **neither of them bundle size.**

An earlier revision of this PR claimed a bare `moment` import would add a second copy of moment (~59 KB) to the route. **That was wrong, and has been corrected in the code comment too.** wp-build externalizes `moment` unconditionally, from the `vendorExternals` table in `@wordpress/build/lib/wordpress-externals-plugin.mjs`: the `onResolve` hook routes it to a `vendor-external` namespace whose `onLoad` emits `module.exports = window.moment`, and adds a `moment` script handle. Measured by actually importing it — the route bundle grew **111 bytes** (817,559 → 817,670), all of it the shim plus the probe that used it, with exactly one `window.moment` in the output and `'moment'` added to the asset `dependencies`. Core's `wp-date` declares `moment` as a dependency anyway (`wp-includes/assets/script-loader-packages.php`, `date.js`), so depending on `@wordpress/date` already puts moment on the page.

The two real reasons: **consistency** — six other files on this dashboard already format with `dateI18n` — and **the timezone fix** below.

Measured cost of this PR: `build/routes/dashboard/content.min.js` grows **815,851 → 817,648 bytes**, a **1,797-byte** minified delta.

### Half-hour timezones read differently from legacy, deliberately

At UTC+5:30 with `scheduled_hour: 10`, this renders **"3:30-4:29 PM"** where legacy renders **"3:00-3:59 PM"**. Legacy takes the integer local *hour* off its date and rebuilds the range from that, throwing the minutes away, so it reports a window the site does not have; 15:30–16:29 is where the run actually falls. The figure here is the correct one — it just stops matching legacy for India, Iran, Nepal, Newfoundland and parts of Australia. Documented in the component rather than changed: whether the two should be reconciled, and in which direction, is a product call.

### Timezone

It also fixes a timezone case legacy gets wrong. `dateI18n` resolves the site's zone itself; legacy reads `getSettings().timezone.offset` by hand and branches on whether the value is truthy, and that offset is typed `number` — so a site set to UTC reports `0`, falls into the `else`, and is rendered in the *reader's browser* timezone rather than its own.

## Related product discussion/links

* JETPACK-2328 (this issue), split out of JETPACK-2302
* JETPACK-2329 — the open "does the modernized dashboard link out to Calypso?" question that blocks the "Modify" link
* JETPACK-2300 — where the `backups_stopped` source was decided

## Does this pull request change what data or activity we track or use?

No. It reads one existing REST route and records nothing. Legacy's `jetpack_backup_schedule_modify_click` event is deliberately *not* ported, because the link that fires it is not ported — see above.

## Testing instructions

The modernized dashboard is behind a feature flag, so the whole change is unreachable without it. That is also why the changelog entry is a `Comment:` entry rather than a user-facing one, and why no `plugins/jetpack` or `plugins/backup` entries are needed.

1. On a site with a working Backup plan, turn the modernization filter on:
   ```php
   add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
   ```
2. Build: `jp build packages/backup --deps`.
3. Go to **Jetpack → VaultPress Backup**. Above the storage meter you should now see a line reading e.g. *"Next full backup: Oct 22, 10:00-10:59 AM."*, in the site's timezone (Settings → General → Timezone), with no "Modify" link beside it.
4. Compare with the flag off: legacy's line under "Latest Backup" should read the same date and window, and should still carry its "Modify" link.
5. Change the site's timezone and reload — both the date and the window should move with it.
6. Two silent cases, if you can reach them: a site WordPress.com reports `backups_stopped` for (the "Back up now" button is disabled and reads "Backups stopped") shows no line at all; and a site with nothing recorded yet gets the first-run takeover panel, also with no line.

Automated coverage, all green locally:

* `pnpm test` — 56 suites, 531 tests (was 55 / 512; +1 suite, +19 tests).
* `pnpm run typecheck` — clean.
* `npx eslint --max-warnings=0` on the touched files, from both the package dir and the repo root — 0 problems.
* `pnpm exec stylelint` on the new SCSS — 0 problems.
* `jp phan packages/backup` — `FOUND 0 ISSUES TOTAL`; `jp phan --all --update-baseline` leaves `packages/backup/.phan/baseline.php` untouched.
* `vendor/bin/phpcs -s projects/packages/backup` — 0 errors, 8 warnings, all pre-existing in `src/class-rest-controller.php` and byte-identical on trunk. No PHP is touched by this PR.

Every assertion in the new suite is mutation-checked — weakening the `scheduled_hour` guard (four ways: non-number, non-integer, negative, out of range), dropping the 59-second window tail, forcing UTC instead of the site timezone, dropping either half of the loading guard, dropping the `backupsStopped` gate, dropping the positional `$` from the msgid, dropping the loading skeleton, dropping the `enabled` gate, unmounting the line, moving it below or inside the activity grid, and letting it into the takeover panel each fail exactly one test and nothing else.

### Review follow-ups

Three findings from review are fixed in the commits after the first, and two of them were factual errors in my own comments:

* **The margin never worked.** `Text` applies `@wordpress/ui`'s global-CSS defense, which is unlayered and includes `p.<hash> { margin: var(--_gcd-p-margin, 0) }` at specificity (0,1,1). Rendered as a `<p>`, that outranked `.jpb-next-scheduled-backup` at (0,1,0) and the margin was dropped — measured in Chromium at 0px computed and a 0px rendered gap, identical to having no rule at all. Fixed by leaving `Text` as its default `<span>`, which the defense cannot match, plus an explicit `display: block` (vertical margins do not apply to an inline box, and `margin-bottom` still *computes* to 16px there — so reading the computed style alone would have said it was fine). Measured after: 16px computed, 16px rendered.
* **The moment claim**, above.
* **Five surviving mutations** in the test suite, now closed.
* **The `BACKUP_STATE.COMPLETE` gate is re-imposed**, per the section above, and a stage-level test that had gone vacuous is fixed: "stays away while the first-run panel has the body" synchronized on the takeover panel, which comes from `/jetpack/v4/backups` and resolves independently of `/site/backup/schedule`, so the absence assertion could land before the line had any chance to render. All three stage-level absence assertions now wait on a `ScheduleProbe` that mounts the hook unconditionally on the same client — proving the schedule was there to be shown and the Overview declined to show it. (Waiting on the schedule *query* does not work here: when the line is correctly hidden, nothing mounts the hook and the request is never issued.)

The suite grew from 13 tests to 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


