### PR TITLE
Backup: offer more storage when usage leaves Normal, and explain the archive size

### DIFF
--- a/projects/packages/backup/changelog/add-backup-storage-addon-upsell-and-help-popover
+++ b/projects/packages/backup/changelog/add-backup-storage-addon-upsell-and-help-popover
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Backup: add the storage add-on upsell and the storage help popover to the modernized dashboard. Both render only behind the dashboard modernization filter and are unreachable from the legacy dashboard, so nothing changes for users today.
+
+

--- a/projects/packages/backup/src/dashboard/components/storage-space/addon-upsell.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/addon-upsell.tsx
@@ -1,0 +1,208 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { createInterpolateElement, useCallback } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { LinkButton, Stack, Text } from '@wordpress/ui';
+import { StorageUsageLevels } from '../../data/storage-usage-levels';
+import { useAnalytics } from '../../hooks/use-analytics';
+import { useSiteSuffix } from '../../hooks/use-connection';
+import { useStorageAddonOffer } from '../../hooks/use-storage-addon-offer';
+import { storageAddonCheckoutUrl } from './checkout-url';
+import type { StorageUsageLevelName } from '../../data/storage-usage-levels';
+import type { ReactNode } from 'react';
+
+/**
+ * What has gone wrong, in the reader's terms.
+ *
+ * All four msgids are legacy's, character for character
+ * (`storage-addon-upsell-prompt/use-storage-status-text.js`), so they
+ * arrive already translated. The "day(s)" and "backup(s)" spellings are
+ * legacy's too — worse English than `_n()` would give, but changing them
+ * starts a fresh GlotPress cycle for a line the flag-off dashboard is
+ * still rendering today.
+ *
+ * `Normal` has no line, which is what makes it the level at which this
+ * whole component is absent rather than silent.
+ *
+ * Both figures are typed nullable and both are checked, though neither
+ * can be null where it is read: `getUsageLevel` only returns `Full` and
+ * `BackupsDiscarded` from a branch guarded by `!! daysOfBackupsSaved`
+ * and `!! minDaysOfBackupsAllowed` together. The checks cost nothing and
+ * keep the alternative from being legacy's, which renders its selector's
+ * `null` into the sentence and says "null day(s) of backups saved".
+ *
+ * @param usageLevel              - Derived level, or null when it could not be computed.
+ * @param daysOfBackupsSaved      - Days of history actually held.
+ * @param minDaysOfBackupsAllowed - Fewest days the plan will ever keep.
+ * @return The line, or null when this level has nothing to say.
+ */
+function statusText(
+	usageLevel: StorageUsageLevelName | null,
+	daysOfBackupsSaved: number | null,
+	minDaysOfBackupsAllowed: number | null
+): string | null {
+	if ( usageLevel === StorageUsageLevels.Warning ) {
+		return __(
+			'You are close to reaching your storage limit. Once you do, we will delete your oldest backups to make space for new ones.',
+			'jetpack-backup-pkg'
+		);
+	}
+
+	if ( usageLevel === StorageUsageLevels.Critical ) {
+		return __(
+			'You are very close to reaching your storage limit. Once you do, we will delete your oldest backups to make space for new ones.',
+			'jetpack-backup-pkg'
+		);
+	}
+
+	if ( usageLevel === StorageUsageLevels.Full && daysOfBackupsSaved !== null ) {
+		return sprintf(
+			/* translators: %s is a number greather than 0 that means a number of days. */
+			__(
+				'You have reached your storage limit with %s day(s) of backups saved. Backups have been stopped. Please upgrade your storage to resume backups.',
+				'jetpack-backup-pkg'
+			),
+			String( daysOfBackupsSaved )
+		);
+	}
+
+	if ( usageLevel === StorageUsageLevels.BackupsDiscarded && minDaysOfBackupsAllowed !== null ) {
+		return sprintf(
+			/* translators: %s is a number greather than 0 that means a number of days. */
+			__(
+				'We removed your oldest backup(s) to make space for new ones. We will continue to remove old backups as needed, up to the last %s days.',
+				'jetpack-backup-pkg'
+			),
+			String( minDaysOfBackupsAllowed )
+		);
+	}
+
+	return null;
+}
+
+/**
+ * The button's label: how much storage, at what price, on what terms.
+ *
+ * Legacy's msgid, reused rather than rewritten, so it arrives
+ * translated. Its `<Price />` token used to carry a component that split
+ * the amount into symbol, integer and fraction for `PricingCard`'s
+ * layout; nothing here wants that shape, so the token now carries the
+ * finished string `formatCurrency` returns. `createInterpolateElement`
+ * keeps the mapped element's own children for a self-closing token —
+ * verified by rendering `Add 100GB additional storage for <Price
+ * />/month, billed monthly` against `<span>R$44.95</span>` — so the
+ * amount survives the substitution.
+ *
+ * Never a written currency symbol. `formatCurrency` places the right one
+ * for `currencyCode`, which WordPress.com chooses from where the site
+ * appears to be: `R$44.95` for a Brazilian site, `¥1,000` for a Japanese
+ * one, both verified against the installed formatter.
+ *
+ * @param sizeText     - The add-on's size as WordPress.com words it, e.g. `100GB`.
+ * @param monthlyPrice - One month of the add-on.
+ * @param currencyCode - The currency WordPress.com priced it in.
+ * @return The label.
+ */
+function offerLabel( sizeText: string, monthlyPrice: number, currencyCode: string ): ReactNode {
+	// translators: %1$s: Storage unit, <Price>: Additional charge.
+	const offer = __(
+		'Add %1$s additional storage for <Price />/month, billed monthly',
+		'jetpack-backup-pkg'
+	);
+
+	return createInterpolateElement( sprintf( offer, sizeText ), {
+		Price: <span>{ formatCurrency( monthlyPrice, currencyCode ) }</span>,
+	} );
+}
+
+type Props = {
+	usageLevel: StorageUsageLevelName | null;
+	storageUsed: number;
+	storageLimit: number;
+	daysOfBackupsSaved: number | null;
+	minDaysOfBackupsAllowed: number | null;
+};
+
+/**
+ * The offer of more storage, shown once usage leaves `Normal`.
+ *
+ * Two halves that fail independently, which is the one structural change
+ * from legacy. Legacy nests the warning *inside* the checkout button, so
+ * a site whose `/addon-offer` request fails is told nothing at all —
+ * neither what is wrong nor what to do — on the one screen whose job is
+ * to say whether backups are at risk. Here the warning is its own line
+ * and renders on the level alone; the priced link renders only when the
+ * offer arrives complete.
+ *
+ * Nothing is rendered at `Normal`. That gate lives in the section rather
+ * than here, matching legacy's own `usageLevel !==
+ * StorageUsageLevels.Normal` and keeping this component from issuing the
+ * offer request on a site that has no reason to see it.
+ *
+ * @param props                         - Component props.
+ * @param props.usageLevel              - Derived level driving the warning's wording.
+ * @param props.storageUsed             - Bytes of backup storage in use.
+ * @param props.storageLimit            - The plan's storage limit in bytes.
+ * @param props.daysOfBackupsSaved      - Days of history held, or null when unreported.
+ * @param props.minDaysOfBackupsAllowed - Fewest days the plan will ever keep, or null.
+ * @return The upsell, or null when there is neither a warning nor an offer.
+ */
+export default function StorageAddonUpsell( {
+	usageLevel,
+	storageUsed,
+	storageLimit,
+	daysOfBackupsSaved,
+	minDaysOfBackupsAllowed,
+}: Props ) {
+	const site = useSiteSuffix();
+	const analytics = useAnalytics();
+	const { slug, sizeText, monthlyPrice, currencyCode } = useStorageAddonOffer(
+		storageUsed,
+		storageLimit
+	);
+
+	const recordClick = useCallback( () => {
+		// Recorded on the click, not on arrival at checkout — the event
+		// measures the reader deciding to buy, and there is no later
+		// moment this page ever sees.
+		//
+		// The `undefined` arm cannot be reached today: the link this fires
+		// from is only drawn when the site slug is known. It is spelled
+		// anyway because the alternative — `{ site }` with `site`
+		// undefined — is a payload reporting the site as the string
+		// `undefined`, and that is the failure mode worth making
+		// impossible rather than merely unlikely. `recordEvent` reads a
+		// missing properties argument as `{}`.
+		analytics.tracks.recordEvent(
+			'jetpack_backup_upgrade_storage_prompt_cta',
+			site ? { site } : undefined
+		);
+	}, [ analytics, site ] );
+
+	const status = statusText( usageLevel, daysOfBackupsSaved, minDaysOfBackupsAllowed );
+
+	// Every part or no link. The slug names the product, the site slug is
+	// half the checkout path, and the two price fields are the whole of
+	// what the label promises — a link missing any of them is either
+	// malformed or dishonest. Spelled as two nullable values rather than
+	// one boolean so the checks are also what narrows the types.
+	const href = slug !== null && site !== undefined ? storageAddonCheckoutUrl( slug, site ) : null;
+	const label =
+		sizeText !== null && monthlyPrice !== null && currencyCode !== null
+			? offerLabel( sizeText, monthlyPrice, currencyCode )
+			: null;
+
+	if ( ! status && ! ( href && label ) ) {
+		return null;
+	}
+
+	return (
+		<Stack className="jpb-storage-space__upsell" direction="column" gap="xs" align="start">
+			{ status && <Text variant="body-sm">{ status }</Text> }
+			{ href && label && (
+				<LinkButton variant="solid" size="compact" href={ href } onClick={ recordClick }>
+					{ label }
+				</LinkButton>
+			) }
+		</Stack>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/storage-space/addon-upsell.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/addon-upsell.tsx
@@ -23,12 +23,28 @@ import type { ReactNode } from 'react';
  * `Normal` has no line, which is what makes it the level at which this
  * whole component is absent rather than silent.
  *
- * Both figures are typed nullable and both are checked, though neither
- * can be null where it is read: `getUsageLevel` only returns `Full` and
- * `BackupsDiscarded` from a branch guarded by `!! daysOfBackupsSaved`
- * and `!! minDaysOfBackupsAllowed` together. The checks cost nothing and
- * keep the alternative from being legacy's, which renders its selector's
- * `null` into the sentence and says "null day(s) of backups saved".
+ * The two day counts are not equally trustworthy, and an earlier version
+ * of this file wrongly said they were.
+ *
+ * `BackupsDiscarded` really does imply a count: it is returned from one
+ * place only, inside `getUsageLevel`'s branch guarded on
+ * `!! minDaysOfBackupsAllowed && !! daysOfBackupsAllowed &&
+ * !! retentionDays && !! daysOfBackupsSaved`, and it is absent from the
+ * threshold table that produces every other level. So its `!== null`
+ * check below is unreachable, kept only because it is also what narrows
+ * the type.
+ *
+ * `Full` implies nothing of the sort. It appears in that guarded branch
+ * and *also* as `100:` in the threshold table, so any site at or over
+ * its limit reaches it with no day counts at all —
+ * `getUsageLevel( 100GB, 100GB, null, null, null, null )` returns
+ * `'Full'`, verified. Every field of `/site/backup/size` is optional, so
+ * a response carrying `size` and nothing else is enough. Hence two
+ * sentences for that level rather than one: without the countless
+ * fallback, a site whose backups have stopped is shown the "add more
+ * storage" button with no sentence saying why, and is shown nothing at
+ * all if the offer request also fails. Legacy renders this same case as
+ * "null day(s) of backups saved".
  *
  * @param usageLevel              - Derived level, or null when it could not be computed.
  * @param daysOfBackupsSaved      - Days of history actually held.
@@ -54,9 +70,23 @@ function statusText(
 		);
 	}
 
-	if ( usageLevel === StorageUsageLevels.Full && daysOfBackupsSaved !== null ) {
+	if ( usageLevel === StorageUsageLevels.Full ) {
+		// Two separate `__()` calls in two `return` statements, rather
+		// than one call with the msgid chosen by a ternary: the minifier
+		// factors a shared call out and leaves the msgid a variable, which
+		// the text-domain scanner then drops without saying so.
+		if ( daysOfBackupsSaved === null ) {
+			// The one string here that is not legacy's, so the one that
+			// waits a GlotPress cycle. It earns that: the alternative on
+			// this path is silence about stopped backups.
+			return __(
+				'You have reached your storage limit. Backups have been stopped. Please upgrade your storage to resume backups.',
+				'jetpack-backup-pkg'
+			);
+		}
+
 		return sprintf(
-			/* translators: %s is a number greather than 0 that means a number of days. */
+			/* translators: %s is a number greater than 0 that means a number of days. */
 			__(
 				'You have reached your storage limit with %s day(s) of backups saved. Backups have been stopped. Please upgrade your storage to resume backups.',
 				'jetpack-backup-pkg'
@@ -67,7 +97,7 @@ function statusText(
 
 	if ( usageLevel === StorageUsageLevels.BackupsDiscarded && minDaysOfBackupsAllowed !== null ) {
 		return sprintf(
-			/* translators: %s is a number greather than 0 that means a number of days. */
+			/* translators: %s is a number greater than 0 that means a number of days. */
 			__(
 				'We removed your oldest backup(s) to make space for new ones. We will continue to remove old backups as needed, up to the last %s days.',
 				'jetpack-backup-pkg'
@@ -103,7 +133,7 @@ function statusText(
  * @return The label.
  */
 function offerLabel( sizeText: string, monthlyPrice: number, currencyCode: string ): ReactNode {
-	// translators: %1$s: Storage unit, <Price>: Additional charge.
+	/* translators: %1$s: Storage unit, <Price>: Additional charge. */
 	const offer = __(
 		'Add %1$s additional storage for <Price />/month, billed monthly',
 		'jetpack-backup-pkg'

--- a/projects/packages/backup/src/dashboard/components/storage-space/addon-upsell.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/addon-upsell.tsx
@@ -13,38 +13,14 @@ import type { ReactNode } from 'react';
 /**
  * What has gone wrong, in the reader's terms.
  *
- * All four msgids are legacy's, character for character
- * (`storage-addon-upsell-prompt/use-storage-status-text.js`), so they
- * arrive already translated. The "day(s)" and "backup(s)" spellings are
- * legacy's too — worse English than `_n()` would give, but changing them
- * starts a fresh GlotPress cycle for a line the flag-off dashboard is
- * still rendering today.
+ * All four msgids are legacy's character for character, so they arrive translated —
+ * including the "day(s)" spellings, which changing would start a fresh GlotPress cycle
+ * for a line the flag-off dashboard still renders.
  *
- * `Normal` has no line, which is what makes it the level at which this
- * whole component is absent rather than silent.
- *
- * The two day counts are not equally trustworthy, and an earlier version
- * of this file wrongly said they were.
- *
- * `BackupsDiscarded` really does imply a count: it is returned from one
- * place only, inside `getUsageLevel`'s branch guarded on
- * `!! minDaysOfBackupsAllowed && !! daysOfBackupsAllowed &&
- * !! retentionDays && !! daysOfBackupsSaved`, and it is absent from the
- * threshold table that produces every other level. So its `!== null`
- * check below is unreachable, kept only because it is also what narrows
- * the type.
- *
- * `Full` implies nothing of the sort. It appears in that guarded branch
- * and *also* as `100:` in the threshold table, so any site at or over
- * its limit reaches it with no day counts at all —
- * `getUsageLevel( 100GB, 100GB, null, null, null, null )` returns
- * `'Full'`, verified. Every field of `/site/backup/size` is optional, so
- * a response carrying `size` and nothing else is enough. Hence two
- * sentences for that level rather than one: without the countless
- * fallback, a site whose backups have stopped is shown the "add more
- * storage" button with no sentence saying why, and is shown nothing at
- * all if the offer request also fails. Legacy renders this same case as
- * "null day(s) of backups saved".
+ * The two day counts are not equally trustworthy. `BackupsDiscarded` is only ever
+ * returned from a branch that guarantees one. `Full` also appears in the threshold
+ * table, so a site at its limit reaches it with no day counts at all — hence two
+ * sentences for that level. Legacy renders that case as "null day(s) of backups saved".
  *
  * @param usageLevel              - Derived level, or null when it could not be computed.
  * @param daysOfBackupsSaved      - Days of history actually held.
@@ -71,14 +47,12 @@ function statusText(
 	}
 
 	if ( usageLevel === StorageUsageLevels.Full ) {
-		// Two separate `__()` calls in two `return` statements, rather
-		// than one call with the msgid chosen by a ternary: the minifier
-		// factors a shared call out and leaves the msgid a variable, which
-		// the text-domain scanner then drops without saying so.
+		// Two separate `__()` calls rather than one with a ternary msgid: the minifier
+		// factors a shared call out and leaves the msgid a variable, which the
+		// text-domain scanner then drops silently.
 		if ( daysOfBackupsSaved === null ) {
-			// The one string here that is not legacy's, so the one that
-			// waits a GlotPress cycle. It earns that: the alternative on
-			// this path is silence about stopped backups.
+			// The one string here that is not legacy's. It earns its GlotPress cycle:
+			// the alternative on this path is silence about stopped backups.
 			return __(
 				'You have reached your storage limit. Backups have been stopped. Please upgrade your storage to resume backups.',
 				'jetpack-backup-pkg'
@@ -112,20 +86,12 @@ function statusText(
 /**
  * The button's label: how much storage, at what price, on what terms.
  *
- * Legacy's msgid, reused rather than rewritten, so it arrives
- * translated. Its `<Price />` token used to carry a component that split
- * the amount into symbol, integer and fraction for `PricingCard`'s
- * layout; nothing here wants that shape, so the token now carries the
- * finished string `formatCurrency` returns. `createInterpolateElement`
- * keeps the mapped element's own children for a self-closing token —
- * verified by rendering `Add 100GB additional storage for <Price
- * />/month, billed monthly` against `<span>R$44.95</span>` — so the
- * amount survives the substitution.
+ * Legacy's msgid, reused so it arrives translated. Its `<Price />` token now carries
+ * the finished string `formatCurrency` returns rather than the split-out symbol,
+ * integer and fraction `PricingCard` wanted.
  *
- * Never a written currency symbol. `formatCurrency` places the right one
- * for `currencyCode`, which WordPress.com chooses from where the site
- * appears to be: `R$44.95` for a Brazilian site, `¥1,000` for a Japanese
- * one, both verified against the installed formatter.
+ * Never a written currency symbol: `formatCurrency` places the right one for
+ * `currencyCode`, which WordPress.com chooses from where the site appears to be.
  *
  * @param sizeText     - The add-on's size as WordPress.com words it, e.g. `100GB`.
  * @param monthlyPrice - One month of the add-on.
@@ -155,18 +121,12 @@ type Props = {
 /**
  * The offer of more storage, shown once usage leaves `Normal`.
  *
- * Two halves that fail independently, which is the one structural change
- * from legacy. Legacy nests the warning *inside* the checkout button, so
- * a site whose `/addon-offer` request fails is told nothing at all —
- * neither what is wrong nor what to do — on the one screen whose job is
- * to say whether backups are at risk. Here the warning is its own line
- * and renders on the level alone; the priced link renders only when the
- * offer arrives complete.
+ * Two halves that fail independently, which is the one structural change from legacy:
+ * legacy nests the warning inside the checkout button, so a site whose `/addon-offer`
+ * request fails is told nothing at all. Here the warning renders on the level alone.
  *
- * Nothing is rendered at `Normal`. That gate lives in the section rather
- * than here, matching legacy's own `usageLevel !==
- * StorageUsageLevels.Normal` and keeping this component from issuing the
- * offer request on a site that has no reason to see it.
+ * The `Normal` gate lives in the section rather than here, so this component never
+ * issues the offer request on a site with no reason to see it.
  *
  * @param props                         - Component props.
  * @param props.usageLevel              - Derived level driving the warning's wording.
@@ -191,17 +151,11 @@ export default function StorageAddonUpsell( {
 	);
 
 	const recordClick = useCallback( () => {
-		// Recorded on the click, not on arrival at checkout — the event
-		// measures the reader deciding to buy, and there is no later
-		// moment this page ever sees.
+		// On the click rather than on arrival at checkout: the event measures the
+		// reader deciding to buy, and there is no later moment this page sees.
 		//
-		// The `undefined` arm cannot be reached today: the link this fires
-		// from is only drawn when the site slug is known. It is spelled
-		// anyway because the alternative — `{ site }` with `site`
-		// undefined — is a payload reporting the site as the string
-		// `undefined`, and that is the failure mode worth making
-		// impossible rather than merely unlikely. `recordEvent` reads a
-		// missing properties argument as `{}`.
+		// The `undefined` arm is unreachable today, and spelled anyway because the
+		// alternative is a payload reporting the site as the string `undefined`.
 		analytics.tracks.recordEvent(
 			'jetpack_backup_upgrade_storage_prompt_cta',
 			site ? { site } : undefined
@@ -210,11 +164,8 @@ export default function StorageAddonUpsell( {
 
 	const status = statusText( usageLevel, daysOfBackupsSaved, minDaysOfBackupsAllowed );
 
-	// Every part or no link. The slug names the product, the site slug is
-	// half the checkout path, and the two price fields are the whole of
-	// what the label promises — a link missing any of them is either
-	// malformed or dishonest. Spelled as two nullable values rather than
-	// one boolean so the checks are also what narrows the types.
+	// Every part or no link: a link missing any of them is malformed or dishonest.
+	// Two nullable values rather than one boolean, so the checks also narrow the types.
 	const href = slug !== null && site !== undefined ? storageAddonCheckoutUrl( slug, site ) : null;
 	const label =
 		sizeText !== null && monthlyPrice !== null && currencyCode !== null

--- a/projects/packages/backup/src/dashboard/components/storage-space/checkout-url.ts
+++ b/projects/packages/backup/src/dashboard/components/storage-space/checkout-url.ts
@@ -1,0 +1,45 @@
+/**
+ * Where the reader lands to buy a storage add-on for this site.
+ *
+ * A local seven-line rewrite of `@automattic/jetpack-components`'
+ * `getProductCheckoutUrl`, which legacy imports. That package exposes
+ * only two deep entry points — `./tools/jp-redirect` and a handful of
+ * components — and `getProductCheckoutUrl` is not among them, so the
+ * only way to reach it is the barrel. `use-connection.ts` records why
+ * this dashboard cannot import that barrel at all: it pulls in SCSS that
+ * wp-build's bundler will not resolve. Adding an export there is the
+ * better long-term fix and belongs in that package with its own
+ * changelog entry.
+ *
+ * Two deliberate differences from the helper it replaces.
+ *
+ * The site slug is a parameter with no fallback, and callers must not
+ * render a link without one. The helper interpolates whatever it is
+ * given, so an unknown slug produces `…/checkout/undefined/<product>`;
+ * the same class of bug as passing `getRedirectUrl` an undefined `site`,
+ * and `usage-details.tsx` documents that one.
+ *
+ * `redirect_to` is the page the reader is standing on rather than a
+ * rebuilt `admin.php?page=jetpack-backup`. Legacy builds that string
+ * from `JPBACKUP_INITIAL_STATE.adminUrl`, which the modernized page
+ * deliberately does not emit (see `gates/license-key-link.tsx`), and
+ * `JP_CONNECTION_INITIAL_STATE` carries no admin URL either. The current
+ * URL is the same destination by construction — this section only
+ * renders on the Backup dashboard — and it is absolute, which
+ * `redirect_to` requires and a relative path could not give.
+ *
+ * Legacy passes `isUserConnected: true` unconditionally, so the helper's
+ * `unlinked=1` branch is dead there; it is simply absent here.
+ *
+ * @param productSlug - The WordPress.com product slug to buy.
+ * @param siteSuffix  - The site's Calypso slug, e.g. `example.wordpress.com`.
+ * @return The Calypso checkout URL.
+ */
+export function storageAddonCheckoutUrl( productSlug: string, siteSuffix: string ): string {
+	const url = new URL( `https://wordpress.com/checkout/${ siteSuffix }/${ productSlug }` );
+
+	url.searchParams.set( 'redirect_to', window.location.href );
+	url.searchParams.set( 'site', siteSuffix );
+
+	return url.toString();
+}

--- a/projects/packages/backup/src/dashboard/components/storage-space/checkout-url.ts
+++ b/projects/packages/backup/src/dashboard/components/storage-space/checkout-url.ts
@@ -3,47 +3,16 @@ import { getProductCheckoutUrl } from '@automattic/jetpack-components';
 /**
  * Where the reader lands to buy a storage add-on for this site.
  *
- * A wrapper, not a reimplementation. The URL itself comes from
- * `@automattic/jetpack-components`, which is where legacy gets it and
- * where any future change to Calypso's checkout path will land. This
- * file exists only to hold the two decisions that are ours rather than
- * that helper's, and to keep them in one place instead of at both call
- * sites.
+ * A wrapper around `@automattic/jetpack-components`, holding only the two decisions
+ * that are ours rather than that helper's.
  *
- * The import is the package's barrel, unlike `usage-details.tsx`, which
- * reaches `getRedirectUrl` through the `./tools/jp-redirect` deep entry
- * point. There is no deep entry for this one — `exports` in that
- * package's `package.json` lists ten paths and no
- * `./tools/get-product-checkout-url` — and adding one is the tidier fix,
- * belonging in that package with its own changelog entry. The barrel is
- * safe in the meantime: `index.ts` is 84 lines of re-exports with no
- * top-level stylesheet import, and esbuild tree-shakes it to the one
- * function. Measured on the dashboard route, importing it this way
- * rather than writing the seven lines locally costs about a hundred
- * bytes. Note this package's own `use-connection.ts` warns off a barrel
- * — that warning is about `@automattic/jetpack-connection`, a different
- * package, whose barrel does pull in SCSS.
+ * The site slug has no fallback, and callers must not render a link without one: the
+ * helper interpolates whatever it is given, so an unknown slug produces
+ * `…/checkout/undefined/<product>`. Requiring a `string` here makes the caller decide.
  *
- * **The site slug has no fallback, and callers must not render a link
- * without one.** The helper interpolates whatever it is given, so an
- * unknown slug produces `…/checkout/undefined/<product>` — the same
- * class of bug as passing `getRedirectUrl` an undefined `site`, which
- * `usage-details.tsx` documents. Requiring a `string` here is what makes
- * the caller decide.
- *
- * **`redirect_to` is the page the reader is standing on**, rather than a
- * rebuilt `admin.php?page=jetpack-backup`. Legacy builds that string
- * from `JPBACKUP_INITIAL_STATE.adminUrl`, which the modernized page
- * deliberately does not emit (see `gates/license-key-link.tsx`), and
- * `JP_CONNECTION_INITIAL_STATE` carries no admin URL either. The current
- * URL is the same destination by construction — this section only
- * renders on the Backup dashboard — and it is absolute, which
- * `redirect_to` requires and a relative path could not give.
- *
- * The final argument is `isUserConnected`, passed `true` as legacy
- * passes it. Its only effect is to suppress an `unlinked=1` query arg,
- * and this section renders only inside `<Gates>`, which has already
- * established a user connection by the time anything here is on screen.
+ * `redirect_to` is the page the reader is standing on rather than a rebuilt
+ * `admin.php?page=jetpack-backup`, which the modernized page emits no URL for. It is the
+ * same destination by construction, and absolute, which `redirect_to` requires.
  *
  * @param productSlug - The WordPress.com product slug to buy.
  * @param siteSuffix  - The site's Calypso slug, e.g. `example.wordpress.com`.

--- a/projects/packages/backup/src/dashboard/components/storage-space/checkout-url.ts
+++ b/projects/packages/backup/src/dashboard/components/storage-space/checkout-url.ts
@@ -1,25 +1,37 @@
+import { getProductCheckoutUrl } from '@automattic/jetpack-components';
+
 /**
  * Where the reader lands to buy a storage add-on for this site.
  *
- * A local seven-line rewrite of `@automattic/jetpack-components`'
- * `getProductCheckoutUrl`, which legacy imports. That package exposes
- * only two deep entry points — `./tools/jp-redirect` and a handful of
- * components — and `getProductCheckoutUrl` is not among them, so the
- * only way to reach it is the barrel. `use-connection.ts` records why
- * this dashboard cannot import that barrel at all: it pulls in SCSS that
- * wp-build's bundler will not resolve. Adding an export there is the
- * better long-term fix and belongs in that package with its own
- * changelog entry.
+ * A wrapper, not a reimplementation. The URL itself comes from
+ * `@automattic/jetpack-components`, which is where legacy gets it and
+ * where any future change to Calypso's checkout path will land. This
+ * file exists only to hold the two decisions that are ours rather than
+ * that helper's, and to keep them in one place instead of at both call
+ * sites.
  *
- * Two deliberate differences from the helper it replaces.
+ * The import is the package's barrel, unlike `usage-details.tsx`, which
+ * reaches `getRedirectUrl` through the `./tools/jp-redirect` deep entry
+ * point. There is no deep entry for this one — `exports` in that
+ * package's `package.json` lists ten paths and no
+ * `./tools/get-product-checkout-url` — and adding one is the tidier fix,
+ * belonging in that package with its own changelog entry. The barrel is
+ * safe in the meantime: `index.ts` is 84 lines of re-exports with no
+ * top-level stylesheet import, and esbuild tree-shakes it to the one
+ * function. Measured on the dashboard route, importing it this way
+ * rather than writing the seven lines locally costs about a hundred
+ * bytes. Note this package's own `use-connection.ts` warns off a barrel
+ * — that warning is about `@automattic/jetpack-connection`, a different
+ * package, whose barrel does pull in SCSS.
  *
- * The site slug is a parameter with no fallback, and callers must not
- * render a link without one. The helper interpolates whatever it is
- * given, so an unknown slug produces `…/checkout/undefined/<product>`;
- * the same class of bug as passing `getRedirectUrl` an undefined `site`,
- * and `usage-details.tsx` documents that one.
+ * **The site slug has no fallback, and callers must not render a link
+ * without one.** The helper interpolates whatever it is given, so an
+ * unknown slug produces `…/checkout/undefined/<product>` — the same
+ * class of bug as passing `getRedirectUrl` an undefined `site`, which
+ * `usage-details.tsx` documents. Requiring a `string` here is what makes
+ * the caller decide.
  *
- * `redirect_to` is the page the reader is standing on rather than a
+ * **`redirect_to` is the page the reader is standing on**, rather than a
  * rebuilt `admin.php?page=jetpack-backup`. Legacy builds that string
  * from `JPBACKUP_INITIAL_STATE.adminUrl`, which the modernized page
  * deliberately does not emit (see `gates/license-key-link.tsx`), and
@@ -28,18 +40,15 @@
  * renders on the Backup dashboard — and it is absolute, which
  * `redirect_to` requires and a relative path could not give.
  *
- * Legacy passes `isUserConnected: true` unconditionally, so the helper's
- * `unlinked=1` branch is dead there; it is simply absent here.
+ * The final argument is `isUserConnected`, passed `true` as legacy
+ * passes it. Its only effect is to suppress an `unlinked=1` query arg,
+ * and this section renders only inside `<Gates>`, which has already
+ * established a user connection by the time anything here is on screen.
  *
  * @param productSlug - The WordPress.com product slug to buy.
  * @param siteSuffix  - The site's Calypso slug, e.g. `example.wordpress.com`.
  * @return The Calypso checkout URL.
  */
 export function storageAddonCheckoutUrl( productSlug: string, siteSuffix: string ): string {
-	const url = new URL( `https://wordpress.com/checkout/${ siteSuffix }/${ productSlug }` );
-
-	url.searchParams.set( 'redirect_to', window.location.href );
-	url.searchParams.set( 'site', siteSuffix );
-
-	return url.toString();
+	return getProductCheckoutUrl( productSlug, siteSuffix, window.location.href, true );
 }

--- a/projects/packages/backup/src/dashboard/components/storage-space/help-popover.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/help-popover.tsx
@@ -10,10 +10,8 @@ import { storageAddonCheckoutUrl } from './checkout-url';
 /**
  * Where "reducing the backup size" goes.
  *
- * A jetpack.com support anchor rather than a redirect slug, which is
- * what legacy links to. Left as the literal URL for that reason: the
- * redirect service has no slug pointing at this fragment, and inventing
- * one here would point somewhere else.
+ * A literal URL rather than a redirect slug: the redirect service has no slug pointing
+ * at this fragment.
  */
 const REDUCE_SIZE_URL =
 	'https://jetpack.com/support/backup/jetpack-vaultpress-backup-storage-and-retention/#reduce-storage-size';
@@ -27,31 +25,16 @@ type Props = {
 /**
  * The info button beside the usage reading, and what it says.
  *
- * Answers the question the meter raises but cannot itself answer: at the
- * size this site's backups actually are, how many days of them fit in
- * the plan's storage. Shown only where that number is lower than the
- * retention the plan promises — the section decides that, and passes a
- * forecast only when it is worth reading.
+ * Answers the question the meter raises but cannot: at the size this site's backups
+ * actually are, how many days of them fit in the plan's storage.
  *
- * Two departures from legacy, both deliberate.
+ * Two deliberate departures from legacy. The checkout link is built from an offer this
+ * component asks for itself — legacy reads the slug from a store slot only its upsell
+ * fills, and the two never coexist, so legacy's link carries a literal `null` where the
+ * product should be.
  *
- * The checkout link is built from an offer this component asks for
- * itself. Legacy reads the slug from a store slot that only its *upsell*
- * ever fills, and the upsell renders only above `Normal` while this
- * renders only at `Normal` — so the two never coexist and the slot holds
- * its `null` default every time this link is drawn, producing a checkout
- * path with the literal string `null` where the product should be.
- * Sharing `useStorageAddonOffer` makes the dependency real; React Query
- * keys the answer on the same two figures, so the upsell and this cost
- * one request between them rather than two.
- *
- * It opens closed. Legacy opens it automatically the first time a
- * browser ever loads the dashboard and remembers the dismissal in
- * `localStorage`. Under `@wordpress/ui` that would move keyboard focus
- * into a popup nobody asked for, on page load — `Popover.Popup` takes
- * focus when it opens — and the latch is per-browser rather than per
- * reader, so a shared machine shows it to exactly one person. The button
- * is the affordance; it does not need to open itself.
+ * And it opens closed. Legacy auto-opens on first load, which under `@wordpress/ui`
+ * would move keyboard focus into a popup nobody asked for.
  *
  * @param props                - Component props.
  * @param props.forecastInDays - Days of full backups the limit would hold.
@@ -65,19 +48,16 @@ export default function StorageHelpPopover( { forecastInDays, storageUsed, stora
 	const { slug } = useStorageAddonOffer( storageUsed, storageLimit );
 
 	const recordClick = useCallback( () => {
-		// On the click, like the section's own upsell, and under its own
-		// event name: the two CTAs answer different questions and legacy
-		// counts them separately. The `undefined` arm is unreachable for
-		// the same reason it is there — see `addon-upsell.tsx`.
+		// Its own event name: the two CTAs answer different questions and legacy counts
+		// them separately. The `undefined` arm is as in `addon-upsell.tsx`.
 		analytics.tracks.recordEvent(
 			'jetpack_backup_upgrade_storage_prompt_from_popover_cta',
 			site ? { site } : undefined
 		);
 	}, [ analytics, site ] );
 
-	// No slug or no site slug, no link. Both are half of a checkout URL,
-	// and the bug this replaces is exactly the one where a missing half
-	// was interpolated anyway.
+	// No slug or no site slug, no link — the bug this replaces is exactly the one where
+	// a missing half was interpolated anyway.
 	const href = slug !== null && site !== undefined ? storageAddonCheckoutUrl( slug, site ) : null;
 
 	const forecast = sprintf(
@@ -96,40 +76,19 @@ export default function StorageHelpPopover( { forecastInDays, storageUsed, stora
 		'jetpack-backup-pkg'
 	);
 
-	// The same string labels the trigger and titles the popup. That is
-	// legacy's arrangement and the right one twice over: what a screen
-	// reader announces before the popup opens matches what it announces
-	// after, and — now that the trigger carries the string visibly — the
-	// accessible name contains the visible label, which is the whole of
-	// WCAG 2.5.3 and the reason the visible text could not be some
-	// third, friendlier sentence.
+	// The same string labels the trigger and titles the popup, so the accessible name
+	// contains the visible label (WCAG 2.5.3) and the announcement is the same before
+	// and after opening.
 	const heading = __( 'Backup archive size', 'jetpack-backup-pkg' );
 
 	return (
 		<Popover.Root>
 			{ /*
-			 * A labelled button rather than a bare `ⓘ`. The icon alone had
-			 * an accessible name and no visible one, which is the worst
-			 * combination here: this renders at the one usage level where
-			 * nothing else on the screen suggests storage is worth a
-			 * thought, so a glyph with no words beside it reads as
-			 * decoration and goes unopened. `Button` with `Button.Icon`
-			 * rather than `IconButton`, because `IconButton` puts its
-			 * `label` in `aria-label` and a tooltip and renders no text.
-			 *
-			 * The name is unchanged by the swap. It used to come from
-			 * `IconButton`'s `aria-label` and now comes from the button's
-			 * own text content, and `Button.Icon` renders through
-			 * `@wordpress/primitives`' `SVG`, which is `aria-hidden` and
-			 * `focusable="false"` — so it contributes nothing to the name.
-			 *
-			 * The alternative considered was folding the forecast into the
-			 * reading beside it. It was rejected: that row already ends in
-			 * "30 days of backups saved", and putting "20 days of full
-			 * backups fit" next to it gives two different day counts, both
-			 * about backups, with nothing explaining why they disagree —
-			 * which is the question this popover exists to answer, asked
-			 * more confusingly.
+			 * A labelled button rather than a bare `ⓘ`. This renders at the one usage
+			 * level where nothing else on screen suggests storage is worth a thought,
+			 * so a glyph with no words beside it reads as decoration and goes
+			 * unopened. `Button` with `Button.Icon` rather than `IconButton`, which
+			 * renders no text and puts its `label` in `aria-label`.
 			 */ }
 			<Popover.Trigger render={ <Button variant="minimal" tone="neutral" size="small" /> }>
 				<Button.Icon icon={ info } />
@@ -138,14 +97,10 @@ export default function StorageHelpPopover( { forecastInDays, storageUsed, stora
 			<Popover.Popup className="jpb-storage-space__help-popup">
 				<Stack direction="column" gap="sm" align="start">
 					{ /*
-					 * Required by the primitive, not optional decoration:
-					 * `Popover.Popup` is `aria-labelledby` this, so without
-					 * it the popup opens with no accessible name. Left at
-					 * the design system's own element and variant — an `h2`
-					 * in `heading-xl`, the same as `Dialog` — rather than
-					 * matched to the section's heading scale. It is not part
-					 * of the page outline to match: the popup is portalled
-					 * out of this section and announced as a dialog.
+					 * Required, not decoration: `Popover.Popup` is `aria-labelledby`
+					 * this. Left at the design system's own element and variant
+					 * rather than the section's heading scale — the popup is
+					 * portalled out and announced as a dialog.
 					 */ }
 					<Popover.Title>{ heading }</Popover.Title>
 					<Popover.Description>

--- a/projects/packages/backup/src/dashboard/components/storage-space/help-popover.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/help-popover.tsx
@@ -1,7 +1,7 @@
 import { createInterpolateElement, useCallback } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
-import { IconButton, Link, LinkButton, Popover, Stack, Text } from '@wordpress/ui';
+import { Button, Link, LinkButton, Popover, Stack, Text } from '@wordpress/ui';
 import { useAnalytics } from '../../hooks/use-analytics';
 import { useSiteSuffix } from '../../hooks/use-connection';
 import { useStorageAddonOffer } from '../../hooks/use-storage-addon-offer';
@@ -96,25 +96,45 @@ export default function StorageHelpPopover( { forecastInDays, storageUsed, stora
 		'jetpack-backup-pkg'
 	);
 
-	// The same string labels the trigger and titles the popup, which is
-	// legacy's arrangement and the right one: the button's accessible
-	// name is what a screen reader announces before the popup opens, and
-	// the title is what it announces after.
+	// The same string labels the trigger and titles the popup. That is
+	// legacy's arrangement and the right one twice over: what a screen
+	// reader announces before the popup opens matches what it announces
+	// after, and — now that the trigger carries the string visibly — the
+	// accessible name contains the visible label, which is the whole of
+	// WCAG 2.5.3 and the reason the visible text could not be some
+	// third, friendlier sentence.
 	const heading = __( 'Backup archive size', 'jetpack-backup-pkg' );
 
 	return (
 		<Popover.Root>
-			<Popover.Trigger
-				render={
-					<IconButton
-						icon={ info }
-						label={ heading }
-						variant="minimal"
-						tone="neutral"
-						size="small"
-					/>
-				}
-			/>
+			{ /*
+			 * A labelled button rather than a bare `ⓘ`. The icon alone had
+			 * an accessible name and no visible one, which is the worst
+			 * combination here: this renders at the one usage level where
+			 * nothing else on the screen suggests storage is worth a
+			 * thought, so a glyph with no words beside it reads as
+			 * decoration and goes unopened. `Button` with `Button.Icon`
+			 * rather than `IconButton`, because `IconButton` puts its
+			 * `label` in `aria-label` and a tooltip and renders no text.
+			 *
+			 * The name is unchanged by the swap. It used to come from
+			 * `IconButton`'s `aria-label` and now comes from the button's
+			 * own text content, and `Button.Icon` renders through
+			 * `@wordpress/primitives`' `SVG`, which is `aria-hidden` and
+			 * `focusable="false"` — so it contributes nothing to the name.
+			 *
+			 * The alternative considered was folding the forecast into the
+			 * reading beside it. It was rejected: that row already ends in
+			 * "30 days of backups saved", and putting "20 days of full
+			 * backups fit" next to it gives two different day counts, both
+			 * about backups, with nothing explaining why they disagree —
+			 * which is the question this popover exists to answer, asked
+			 * more confusingly.
+			 */ }
+			<Popover.Trigger render={ <Button variant="minimal" tone="neutral" size="small" /> }>
+				<Button.Icon icon={ info } />
+				{ heading }
+			</Popover.Trigger>
 			<Popover.Popup className="jpb-storage-space__help-popup">
 				<Stack direction="column" gap="sm" align="start">
 					{ /*

--- a/projects/packages/backup/src/dashboard/components/storage-space/help-popover.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/help-popover.tsx
@@ -1,0 +1,148 @@
+import { createInterpolateElement, useCallback } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { info } from '@wordpress/icons';
+import { IconButton, Link, LinkButton, Popover, Stack, Text } from '@wordpress/ui';
+import { useAnalytics } from '../../hooks/use-analytics';
+import { useSiteSuffix } from '../../hooks/use-connection';
+import { useStorageAddonOffer } from '../../hooks/use-storage-addon-offer';
+import { storageAddonCheckoutUrl } from './checkout-url';
+
+/**
+ * Where "reducing the backup size" goes.
+ *
+ * A jetpack.com support anchor rather than a redirect slug, which is
+ * what legacy links to. Left as the literal URL for that reason: the
+ * redirect service has no slug pointing at this fragment, and inventing
+ * one here would point somewhere else.
+ */
+const REDUCE_SIZE_URL =
+	'https://jetpack.com/support/backup/jetpack-vaultpress-backup-storage-and-retention/#reduce-storage-size';
+
+type Props = {
+	forecastInDays: number;
+	storageUsed: number;
+	storageLimit: number;
+};
+
+/**
+ * The info button beside the usage reading, and what it says.
+ *
+ * Answers the question the meter raises but cannot itself answer: at the
+ * size this site's backups actually are, how many days of them fit in
+ * the plan's storage. Shown only where that number is lower than the
+ * retention the plan promises — the section decides that, and passes a
+ * forecast only when it is worth reading.
+ *
+ * Two departures from legacy, both deliberate.
+ *
+ * The checkout link is built from an offer this component asks for
+ * itself. Legacy reads the slug from a store slot that only its *upsell*
+ * ever fills, and the upsell renders only above `Normal` while this
+ * renders only at `Normal` — so the two never coexist and the slot holds
+ * its `null` default every time this link is drawn, producing a checkout
+ * path with the literal string `null` where the product should be.
+ * Sharing `useStorageAddonOffer` makes the dependency real; React Query
+ * keys the answer on the same two figures, so the upsell and this cost
+ * one request between them rather than two.
+ *
+ * It opens closed. Legacy opens it automatically the first time a
+ * browser ever loads the dashboard and remembers the dismissal in
+ * `localStorage`. Under `@wordpress/ui` that would move keyboard focus
+ * into a popup nobody asked for, on page load — `Popover.Popup` takes
+ * focus when it opens — and the latch is per-browser rather than per
+ * reader, so a shared machine shows it to exactly one person. The button
+ * is the affordance; it does not need to open itself.
+ *
+ * @param props                - Component props.
+ * @param props.forecastInDays - Days of full backups the limit would hold.
+ * @param props.storageUsed    - Bytes of backup storage in use.
+ * @param props.storageLimit   - The plan's storage limit in bytes.
+ * @return The trigger and its popup.
+ */
+export default function StorageHelpPopover( { forecastInDays, storageUsed, storageLimit }: Props ) {
+	const site = useSiteSuffix();
+	const analytics = useAnalytics();
+	const { slug } = useStorageAddonOffer( storageUsed, storageLimit );
+
+	const recordClick = useCallback( () => {
+		// On the click, like the section's own upsell, and under its own
+		// event name: the two CTAs answer different questions and legacy
+		// counts them separately. The `undefined` arm is unreachable for
+		// the same reason it is there — see `addon-upsell.tsx`.
+		analytics.tracks.recordEvent(
+			'jetpack_backup_upgrade_storage_prompt_from_popover_cta',
+			site ? { site } : undefined
+		);
+	}, [ analytics, site ] );
+
+	// No slug or no site slug, no link. Both are half of a checkout URL,
+	// and the bug this replaces is exactly the one where a missing half
+	// was interpolated anyway.
+	const href = slug !== null && site !== undefined ? storageAddonCheckoutUrl( slug, site ) : null;
+
+	const forecast = sprintf(
+		/* translators: %d: is number of days of the forecast */
+		_n(
+			'Based on the current size of your site, Jetpack will save <strong>%d day of full backup</strong>.',
+			'Based on the current size of your site, Jetpack will save <strong>%d days of full backups</strong>.',
+			forecastInDays,
+			'jetpack-backup-pkg'
+		),
+		forecastInDays
+	);
+
+	const advice = __(
+		'If you need more backup days, try <link>reducing the backup size</link> or adding more storage.',
+		'jetpack-backup-pkg'
+	);
+
+	// The same string labels the trigger and titles the popup, which is
+	// legacy's arrangement and the right one: the button's accessible
+	// name is what a screen reader announces before the popup opens, and
+	// the title is what it announces after.
+	const heading = __( 'Backup archive size', 'jetpack-backup-pkg' );
+
+	return (
+		<Popover.Root>
+			<Popover.Trigger
+				render={
+					<IconButton
+						icon={ info }
+						label={ heading }
+						variant="minimal"
+						tone="neutral"
+						size="small"
+					/>
+				}
+			/>
+			<Popover.Popup className="jpb-storage-space__help-popup">
+				<Stack direction="column" gap="sm" align="start">
+					{ /*
+					 * Required by the primitive, not optional decoration:
+					 * `Popover.Popup` is `aria-labelledby` this, so without
+					 * it the popup opens with no accessible name. Left at
+					 * the design system's own element and variant — an `h2`
+					 * in `heading-xl`, the same as `Dialog` — rather than
+					 * matched to the section's heading scale. It is not part
+					 * of the page outline to match: the popup is portalled
+					 * out of this section and announced as a dialog.
+					 */ }
+					<Popover.Title>{ heading }</Popover.Title>
+					<Popover.Description>
+						{ createInterpolateElement( forecast, { strong: <strong /> } ) }
+					</Popover.Description>
+					<Text variant="body-sm">
+						{ createInterpolateElement( advice, {
+							link: <Link openInNewTab href={ REDUCE_SIZE_URL } />,
+						} ) }
+					</Text>
+					{ href && (
+						<LinkButton variant="solid" size="compact" href={ href } onClick={ recordClick }>
+							{ __( 'Add more storage', 'jetpack-backup-pkg' ) }
+						</LinkButton>
+					) }
+				</Stack>
+			</Popover.Popup>
+		</Popover.Root>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
@@ -34,20 +34,13 @@ function sectionHeading( usageLevel: StorageUsageLevelName | null ): string {
 /**
  * The forecast worth putting behind an info button, or null for none.
  *
- * Legacy's gate, in one place instead of two: it splits the same
- * decision between the parent (`forecastInDays < planRetentionDays &&
- * usageLevel === Normal`) and the popover's own early return on a falsy
- * forecast. Both halves are here.
+ * Legacy's gate, in one place instead of split between the parent and the popover's own
+ * early return.
  *
- * `Normal` is the whole of the reason this and the upsell never appear
- * together. Above `Normal` the section is already saying storage is
- * running out and offering more of it, and a second, calmer explanation
- * of how many days fit would be arguing with it.
- *
- * The comparison is against what the *plan* promises, not the retention
- * in force. If the site is already holding fewer days than the plan
- * offers, the limit — not the plan — is what is deciding, and that is
- * the only case worth explaining.
+ * The `Normal` check is why this and the upsell never appear together: above `Normal`
+ * the section is already saying storage is running out. The comparison is against what
+ * the *plan* promises rather than the retention in force — if the site holds fewer days
+ * than the plan offers, the limit is what is deciding.
  *
  * @param usageLevel        - Derived level, or null when it could not be computed.
  * @param forecastInDays    - Days of full backups the limit would hold, or null.
@@ -67,12 +60,8 @@ function helpForecast(
 		return null;
 	}
 
-	// A forecast of zero is a real answer — it is what a site whose last
-	// backup is larger than its entire limit looks like — but "we will
-	// keep zero days of backups" is not something an info button beside a
-	// calm meter can usefully explain, so it counts as nothing to say.
-	// Legacy arrives at the same place from the other end: its popover
-	// returns early on any falsy forecast.
+	// A forecast of zero is a real answer — a site whose last backup exceeds its whole
+	// limit — but not one an info button beside a calm meter can usefully explain.
 	return forecastInDays > 0 && forecastInDays < planRetentionDays ? forecastInDays : null;
 }
 
@@ -85,12 +74,9 @@ function helpForecast(
  * meter that means nothing. That silence is deliberate and matches the
  * legacy dashboard's own `storageSize !== null && storageLimit > 0` gate.
  *
- * The two things that hang off the readings are mutually exclusive by
- * construction: the add-on upsell renders above `Normal`, and the help
- * popover only at it. A site therefore sees one explanation of its
- * storage or the other, never both — and only one of them asks
- * `/site/backup/addon-offer`, which is what keeps that request to one
- * per page even though two components can make it.
+ * The upsell renders above `Normal` and the help popover only at it, so a site sees one
+ * explanation or the other — which is what keeps `/site/backup/addon-offer` to one
+ * request per page even though two components can make it.
  *
  * @return The storage section, or null when there is nothing to show.
  */

--- a/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/index.tsx
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { Skeleton, Text } from '@wordpress/ui';
 import { StorageUsageLevels } from '../../data/storage-usage-levels';
 import { useStorageUsage } from '../../hooks/use-storage-usage';
+import StorageAddonUpsell from './addon-upsell';
 import StorageMeter from './meter';
 import StorageUsageDetails from './usage-details';
 import './style.scss';
@@ -31,6 +32,51 @@ function sectionHeading( usageLevel: StorageUsageLevelName | null ): string {
 }
 
 /**
+ * The forecast worth putting behind an info button, or null for none.
+ *
+ * Legacy's gate, in one place instead of two: it splits the same
+ * decision between the parent (`forecastInDays < planRetentionDays &&
+ * usageLevel === Normal`) and the popover's own early return on a falsy
+ * forecast. Both halves are here.
+ *
+ * `Normal` is the whole of the reason this and the upsell never appear
+ * together. Above `Normal` the section is already saying storage is
+ * running out and offering more of it, and a second, calmer explanation
+ * of how many days fit would be arguing with it.
+ *
+ * The comparison is against what the *plan* promises, not the retention
+ * in force. If the site is already holding fewer days than the plan
+ * offers, the limit — not the plan — is what is deciding, and that is
+ * the only case worth explaining.
+ *
+ * @param usageLevel        - Derived level, or null when it could not be computed.
+ * @param forecastInDays    - Days of full backups the limit would hold, or null.
+ * @param planRetentionDays - Days the plan promises, or null when unreported.
+ * @return The forecast to show, or null.
+ */
+function helpForecast(
+	usageLevel: StorageUsageLevelName | null,
+	forecastInDays: number | null,
+	planRetentionDays: number | null
+): number | null {
+	if ( usageLevel !== StorageUsageLevels.Normal ) {
+		return null;
+	}
+
+	if ( forecastInDays === null || planRetentionDays === null ) {
+		return null;
+	}
+
+	// A forecast of zero is a real answer — it is what a site whose last
+	// backup is larger than its entire limit looks like — but "we will
+	// keep zero days of backups" is not something an info button beside a
+	// calm meter can usefully explain, so it counts as nothing to say.
+	// Legacy arrives at the same place from the other end: its popover
+	// returns early on any falsy forecast.
+	return forecastInDays > 0 && forecastInDays < planRetentionDays ? forecastInDays : null;
+}
+
+/**
  * The Overview screen's storage section.
  *
  * Renders nothing at all until both halves of the answer have arrived and
@@ -39,8 +85,12 @@ function sectionHeading( usageLevel: StorageUsageLevelName | null ): string {
  * meter that means nothing. That silence is deliberate and matches the
  * legacy dashboard's own `storageSize !== null && storageLimit > 0` gate.
  *
- * Sibling issues add the upsell and the help popover inside this same
- * section.
+ * The two things that hang off the readings are mutually exclusive by
+ * construction: the add-on upsell renders above `Normal`, and the help
+ * popover only at it. A site therefore sees one explanation of its
+ * storage or the other, never both — and only one of them asks
+ * `/site/backup/addon-offer`, which is what keeps that request to one
+ * per page even though two components can make it.
  *
  * @return The storage section, or null when there is nothing to show.
  */
@@ -100,7 +150,21 @@ export default function StorageSpace() {
 				storageUsed={ usage.storageUsed }
 				storageLimit={ usage.storageLimit }
 				daysOfBackupsSaved={ usage.daysOfBackupsSaved }
+				helpForecastInDays={ helpForecast(
+					usage.usageLevel,
+					usage.forecastInDays,
+					usage.planRetentionDays
+				) }
 			/>
+			{ usage.usageLevel !== StorageUsageLevels.Normal && (
+				<StorageAddonUpsell
+					usageLevel={ usage.usageLevel }
+					storageUsed={ usage.storageUsed }
+					storageLimit={ usage.storageLimit }
+					daysOfBackupsSaved={ usage.daysOfBackupsSaved }
+					minDaysOfBackupsAllowed={ usage.minDaysOfBackupsAllowed }
+				/>
+			) }
 		</section>
 	);
 }

--- a/projects/packages/backup/src/dashboard/components/storage-space/style.scss
+++ b/projects/packages/backup/src/dashboard/components/storage-space/style.scss
@@ -41,23 +41,19 @@
 		margin-block-start: 8px;
 	}
 
-	// The warning and the add-on offer, below the readings. `Stack` owns
-	// the column and its gap, so all that is left is how far the pair sits
-	// from the row above — the same 8px the readings sit from the meter,
-	// which keeps the three bands evenly spaced.
+	// `Stack` owns the column and its gap, so all that is left is how far
+	// the pair sits from the row above — the same 8px the readings sit
+	// from the meter.
 	&__upsell {
 		margin-block-start: 8px;
 	}
 }
 
-// Deliberately not nested inside `.jpb-storage-space`. `Popover.Popup`
-// portals its content out of this subtree by default, so the section is
-// no longer an ancestor by the time the popup exists and a nested
-// selector would never match it.
+// Deliberately not nested inside `.jpb-storage-space`: `Popover.Popup`
+// portals its content out, so a nested selector would never match.
 .jpb-storage-space__help-popup {
-	// Two sentences and a button want a column narrow enough to read.
-	// Without a cap the popup is as wide as its longest sentence, which
-	// on a wide screen is a single line running most of the viewport.
+	// Without a cap the popup is as wide as its longest sentence, which on
+	// a wide screen is a single line running most of the viewport.
 	max-inline-size: 320px;
 }
 

--- a/projects/packages/backup/src/dashboard/components/storage-space/style.scss
+++ b/projects/packages/backup/src/dashboard/components/storage-space/style.scss
@@ -40,6 +40,25 @@
 		inline-size: 240px;
 		margin-block-start: 8px;
 	}
+
+	// The warning and the add-on offer, below the readings. `Stack` owns
+	// the column and its gap, so all that is left is how far the pair sits
+	// from the row above — the same 8px the readings sit from the meter,
+	// which keeps the three bands evenly spaced.
+	&__upsell {
+		margin-block-start: 8px;
+	}
+}
+
+// Deliberately not nested inside `.jpb-storage-space`. `Popover.Popup`
+// portals its content out of this subtree by default, so the section is
+// no longer an ancestor by the time the popup exists and a nested
+// selector would never match it.
+.jpb-storage-space__help-popup {
+	// Two sentences and a button want a column narrow enough to read.
+	// Without a cap the popup is as wide as its longest sentence, which
+	// on a wide screen is a single line running most of the viewport.
+	max-inline-size: 320px;
 }
 
 .jpb-storage-meter {

--- a/projects/packages/backup/src/dashboard/components/storage-space/usage-details.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/usage-details.tsx
@@ -107,10 +107,8 @@ type Props = {
 	storageLimit: number;
 	daysOfBackupsSaved: number | null;
 	/**
-	 * Days of full backups the limit would hold, when that is worth
-	 * explaining; null when it is not. The section decides — see
-	 * `helpForecast` in `index.tsx` — so this component only has to
-	 * render or not render.
+	 * Days of full backups the limit would hold, or null when that is not worth
+	 * explaining. The section decides — see `helpForecast` in `index.tsx`.
 	 */
 	helpForecastInDays: number | null;
 };
@@ -127,10 +125,9 @@ type Props = {
  * section's `hasUsableFigures` branch, so both byte figures are known
  * numbers by the time they get here and neither needs re-testing.
  *
- * The one exception to "presentational" is the help popover, which sits
- * beside the usage reading as it does in legacy — that is where the
- * question it answers is raised. It brings its own data and its own
- * Tracks event; what arrives as a prop is only whether to show it.
+ * The one exception to "presentational" is the help popover, which sits beside the
+ * usage reading because that is where the question it answers is raised. It brings its
+ * own data; the prop only says whether to show it.
  *
  * @param props                    - Component props.
  * @param props.storageUsed        - Bytes of backup storage in use.
@@ -172,11 +169,9 @@ export default function StorageUsageDetails( {
 			gap="xs"
 		>
 			{ /*
-			 * The reading and its info button travel together — the button
-			 * explains that reading and nothing else — so they share a row
-			 * of their own rather than becoming two children of the
-			 * space-between row above, where the button would be flung to
-			 * the far end.
+			 * The reading and its info button share a row of their own rather than
+			 * becoming two children of the space-between row above, where the button
+			 * would be flung to the far end.
 			 */ }
 			<Stack direction="row" gap="xs" align="center">
 				<Text variant="body-md">{ usageText( storageUsed, storageLimit ) }</Text>

--- a/projects/packages/backup/src/dashboard/components/storage-space/usage-details.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/usage-details.tsx
@@ -3,6 +3,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Link, Stack, Text } from '@wordpress/ui';
 import { useSiteSuffix } from '../../hooks/use-connection';
+import StorageHelpPopover from './help-popover';
 import type { ReactNode } from 'react';
 
 // Binary multiples, as legacy spells them. WordPress.com reports these
@@ -105,6 +106,13 @@ type Props = {
 	storageUsed: number;
 	storageLimit: number;
 	daysOfBackupsSaved: number | null;
+	/**
+	 * Days of full backups the limit would hold, when that is worth
+	 * explaining; null when it is not. The section decides — see
+	 * `helpForecast` in `index.tsx` — so this component only has to
+	 * render or not render.
+	 */
+	helpForecastInDays: number | null;
 };
 
 /**
@@ -119,22 +127,23 @@ type Props = {
  * section's `hasUsableFigures` branch, so both byte figures are known
  * numbers by the time they get here and neither needs re-testing.
  *
- * Legacy's copy of this also hosts the storage help popover. That is
- * JETPACK-2332 and deliberately absent, along with the Tracks event its
- * purchase link fires — there is no Tracks client on the modernized page
- * yet (JETPACK-2301). Legacy's own orchestrator never passes the
- * `onClickedPurchase` prop either, so nothing is lost in the meantime.
+ * The one exception to "presentational" is the help popover, which sits
+ * beside the usage reading as it does in legacy — that is where the
+ * question it answers is raised. It brings its own data and its own
+ * Tracks event; what arrives as a prop is only whether to show it.
  *
  * @param props                    - Component props.
  * @param props.storageUsed        - Bytes of backup storage in use.
  * @param props.storageLimit       - The plan's storage limit in bytes.
  * @param props.daysOfBackupsSaved - Days of history held, or null when unreported.
+ * @param props.helpForecastInDays - Days of backups the limit holds, or null for no popover.
  * @return The rendered readings.
  */
 export default function StorageUsageDetails( {
 	storageUsed,
 	storageLimit,
 	daysOfBackupsSaved,
+	helpForecastInDays,
 }: Props ) {
 	const site = useSiteSuffix();
 
@@ -162,7 +171,23 @@ export default function StorageUsageDetails( {
 			wrap="wrap"
 			gap="xs"
 		>
-			<Text variant="body-md">{ usageText( storageUsed, storageLimit ) }</Text>
+			{ /*
+			 * The reading and its info button travel together — the button
+			 * explains that reading and nothing else — so they share a row
+			 * of their own rather than becoming two children of the
+			 * space-between row above, where the button would be flung to
+			 * the far end.
+			 */ }
+			<Stack direction="row" gap="xs" align="center">
+				<Text variant="body-md">{ usageText( storageUsed, storageLimit ) }</Text>
+				{ helpForecastInDays !== null && (
+					<StorageHelpPopover
+						forecastInDays={ helpForecastInDays }
+						storageUsed={ storageUsed }
+						storageLimit={ storageLimit }
+					/>
+				) }
+			</Stack>
 			{ /*
 			 * Omitted rather than shown as "0 days" when the count is
 			 * missing. Legacy renders the plural label over its selector's

--- a/projects/packages/backup/src/dashboard/data/api/storage-addon-offer.ts
+++ b/projects/packages/backup/src/dashboard/data/api/storage-addon-offer.ts
@@ -3,29 +3,18 @@ import { apiCall, apiPath } from './_helpers';
 /**
  * The pricing block `Wpcom_Products::get_product_pricing()` builds.
  *
- * Only the three fields this dashboard reads are declared. The helper
- * returns several more — `is_introductory_offer`, `introductory_offer`,
- * `product_term`, and a `coupon_discount` when a sale coupon is live —
- * none of which are needed to render one monthly figure.
+ * Only the three fields this dashboard reads are declared.
  *
- * `currency_code` is snake_case, and that matters more than it looks.
- * Legacy's upsell reads `addonPricing.currencyCode` off this same
- * object, gets `undefined`, and hands it to `getCurrencyObject`, which
- * falls back to a `$` symbol: verified against the installed
- * `@automattic/number-formatters`, where `getCurrencyObject( 9.95,
- * undefined )` returns `symbol: '$'`. WordPress.com prices this
- * catalogue from where the *site* appears to be, so a Brazilian site is
- * quoted in BRL and shown a dollar sign. Nothing here may assume a
- * currency.
+ * `currency_code` is snake_case, and that matters: legacy reads `currencyCode` off this
+ * same object, gets `undefined`, and `getCurrencyObject` falls back to a `$`. This
+ * catalogue is priced from where the *site* appears to be, so nothing may assume USD.
  */
 type RawAddonPricing = {
 	currency_code?: string;
 	/** One month of the add-on, in `currency_code`. See `fetchStorageAddonOffer`. */
 	full_price?: number;
 	/**
-	 * The introductory price, when one is running. Equal to `full_price`
-	 * otherwise — the helper seeds it with the full cost and only
-	 * overwrites it from `introductory_offer.cost_per_interval`.
+	 * The introductory price when one is running, and `full_price` otherwise.
 	 */
 	discount_price?: number;
 };
@@ -33,17 +22,10 @@ type RawAddonPricing = {
 /**
  * Response of `GET /jetpack/v4/site/backup/addon-offer`.
  *
- * `Jetpack_Backup::get_storage_addon_upsell_slug()` picks the add-on
- * that would cover this site's overage, and `size_text` is that slug's
- * entry in a three-key map — so the two arrive together or not at all.
- *
- * Every field is optional because a 200 does not promise a priced
- * answer. `pricing` in particular is `array()` on the PHP side when the
- * slug is missing from the catalogue, which serializes as a JSON `[]`
- * rather than an object; reads below go through optional chaining, so
- * that case yields `undefined` for each field instead of throwing.
- * Legacy's `res.slug && res.pricing && res.size_text` guard does *not*
- * catch it — `[]` is truthy in JavaScript.
+ * Every field is optional because a 200 does not promise a priced answer. `pricing` in
+ * particular is `array()` on the PHP side when the slug is missing from the catalogue,
+ * which serializes as a JSON `[]` — truthy in JavaScript, which is why legacy's
+ * `res.slug && res.pricing && res.size_text` guard does not catch it.
  */
 export type RawStorageAddonOffer = {
 	slug?: string;
@@ -54,31 +36,15 @@ export type RawStorageAddonOffer = {
 /**
  * Fetch the storage add-on WordPress.com would sell this site next.
  *
- * Both figures are query args and both are `'required' => true` on the
- * route (`class-jetpack-backup.php`, the `/site/backup/addon-offer`
- * registration), which is why the caller must know both before asking.
+ * Both figures are `required` query args, and the caller must know both before asking.
+ * Omitting one earns a 400; sending one *empty* earns something worse — `required` is
+ * satisfied by a param that is merely set, and the route's declared `'type' => 'numeric'`
+ * is not a WordPress schema type, so it validates nothing and the route answers with the
+ * smallest add-on. `apiPath` drops an `undefined` arg and forwards a `null` one empty,
+ * so the two mistakes land on opposite sides of that.
  *
- * The two ways of getting that wrong fail differently, and the quieter
- * one is the reason the caller gates rather than trusting the route.
- * Omit an arg and `WP_REST_Request::has_valid_params()` refuses the
- * request with a 400 `rest_missing_callback_param`. Send it *empty* and
- * nothing objects: `required` is satisfied by a param that is merely
- * set, and the declared `'type' => 'numeric'` checks nothing at all —
- * it is not one of WordPress's seven schema types, so
- * `rest_validate_value_from_schema` warns via `_doing_it_wrong` and
- * falls through its switch to `default: $is_valid = true`. The route
- * then compares `''` against the limit and answers with the smallest
- * add-on, which looks exactly like a real offer. Verified against
- * WordPress core, `wp-includes/rest-api.php` and
- * `wp-includes/rest-api/class-wp-rest-request.php`.
- *
- * `apiPath` drops an `undefined` arg and forwards a `null` one as an
- * empty value, so those two mistakes land on opposite sides of that.
- *
- * The three slugs this can return are all `…_monthly`, so the `cost`
- * behind `full_price` is already a monthly figure and needs no term
- * conversion — unlike `/backup-promoted-product-info`, whose product is
- * yearly and whose hook divides by twelve.
+ * The three slugs this can return are all `…_monthly`, so `full_price` is already a
+ * monthly figure and needs no term conversion.
  *
  * @param storageUsed  - Bytes of backup storage in use.
  * @param storageLimit - The plan's storage limit in bytes.

--- a/projects/packages/backup/src/dashboard/data/api/storage-addon-offer.ts
+++ b/projects/packages/backup/src/dashboard/data/api/storage-addon-offer.ts
@@ -1,0 +1,97 @@
+import { apiCall, apiPath } from './_helpers';
+
+/**
+ * The pricing block `Wpcom_Products::get_product_pricing()` builds.
+ *
+ * Only the three fields this dashboard reads are declared. The helper
+ * returns several more — `is_introductory_offer`, `introductory_offer`,
+ * `product_term`, and a `coupon_discount` when a sale coupon is live —
+ * none of which are needed to render one monthly figure.
+ *
+ * `currency_code` is snake_case, and that matters more than it looks.
+ * Legacy's upsell reads `addonPricing.currencyCode` off this same
+ * object, gets `undefined`, and hands it to `getCurrencyObject`, which
+ * falls back to a `$` symbol: verified against the installed
+ * `@automattic/number-formatters`, where `getCurrencyObject( 9.95,
+ * undefined )` returns `symbol: '$'`. WordPress.com prices this
+ * catalogue from where the *site* appears to be, so a Brazilian site is
+ * quoted in BRL and shown a dollar sign. Nothing here may assume a
+ * currency.
+ */
+type RawAddonPricing = {
+	currency_code?: string;
+	/** One month of the add-on, in `currency_code`. See `fetchStorageAddonOffer`. */
+	full_price?: number;
+	/**
+	 * The introductory price, when one is running. Equal to `full_price`
+	 * otherwise — the helper seeds it with the full cost and only
+	 * overwrites it from `introductory_offer.cost_per_interval`.
+	 */
+	discount_price?: number;
+};
+
+/**
+ * Response of `GET /jetpack/v4/site/backup/addon-offer`.
+ *
+ * `Jetpack_Backup::get_storage_addon_upsell_slug()` picks the add-on
+ * that would cover this site's overage, and `size_text` is that slug's
+ * entry in a three-key map — so the two arrive together or not at all.
+ *
+ * Every field is optional because a 200 does not promise a priced
+ * answer. `pricing` in particular is `array()` on the PHP side when the
+ * slug is missing from the catalogue, which serializes as a JSON `[]`
+ * rather than an object; reads below go through optional chaining, so
+ * that case yields `undefined` for each field instead of throwing.
+ * Legacy's `res.slug && res.pricing && res.size_text` guard does *not*
+ * catch it — `[]` is truthy in JavaScript.
+ */
+export type RawStorageAddonOffer = {
+	slug?: string;
+	size_text?: string;
+	pricing?: RawAddonPricing | null;
+} | null;
+
+/**
+ * Fetch the storage add-on WordPress.com would sell this site next.
+ *
+ * Both figures are query args and both are `'required' => true` on the
+ * route (`class-jetpack-backup.php`, the `/site/backup/addon-offer`
+ * registration), which is why the caller must know both before asking.
+ *
+ * The two ways of getting that wrong fail differently, and the quieter
+ * one is the reason the caller gates rather than trusting the route.
+ * Omit an arg and `WP_REST_Request::has_valid_params()` refuses the
+ * request with a 400 `rest_missing_callback_param`. Send it *empty* and
+ * nothing objects: `required` is satisfied by a param that is merely
+ * set, and the declared `'type' => 'numeric'` checks nothing at all —
+ * it is not one of WordPress's seven schema types, so
+ * `rest_validate_value_from_schema` warns via `_doing_it_wrong` and
+ * falls through its switch to `default: $is_valid = true`. The route
+ * then compares `''` against the limit and answers with the smallest
+ * add-on, which looks exactly like a real offer. Verified against
+ * WordPress core, `wp-includes/rest-api.php` and
+ * `wp-includes/rest-api/class-wp-rest-request.php`.
+ *
+ * `apiPath` drops an `undefined` arg and forwards a `null` one as an
+ * empty value, so those two mistakes land on opposite sides of that.
+ *
+ * The three slugs this can return are all `…_monthly`, so the `cost`
+ * behind `full_price` is already a monthly figure and needs no term
+ * conversion — unlike `/backup-promoted-product-info`, whose product is
+ * yearly and whose hook divides by twelve.
+ *
+ * @param storageUsed  - Bytes of backup storage in use.
+ * @param storageLimit - The plan's storage limit in bytes.
+ * @return WordPress.com's payload, or `null` when it could not be read.
+ */
+export async function fetchStorageAddonOffer(
+	storageUsed: number,
+	storageLimit: number
+): Promise< RawStorageAddonOffer > {
+	return apiCall< RawStorageAddonOffer >( {
+		path: apiPath( '/site/backup/addon-offer', {
+			storage_size: storageUsed,
+			storage_limit: storageLimit,
+		} ),
+	} );
+}

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -46,6 +46,13 @@ export const keys = {
 	// Not keyed on anything: WordPress.com picks the currency from the
 	// site, so one site only ever sees one answer.
 	promotedProduct: () => [ 'backup', 'promoted-product' ] as const,
+	// The storage add-on being offered, for the storage section's upsell
+	// and its help popover. Keyed on both byte figures because the route
+	// derives its answer from both and requires both — the same pair that
+	// gates the query being enabled at all. Nulls appear in the key only
+	// while the query is disabled, so no request is ever made under one.
+	storageAddonOffer: ( storageUsed: number | null, storageLimit: number | null ) =>
+		[ 'backup', 'storage-addon-offer', storageUsed, storageLimit ] as const,
 	// Family prefix for any rewindable-activity-log page. Use as a
 	// query-filter root to scan all cached pages (e.g. when looking up
 	// a row by id across pages).

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -46,11 +46,9 @@ export const keys = {
 	// Not keyed on anything: WordPress.com picks the currency from the
 	// site, so one site only ever sees one answer.
 	promotedProduct: () => [ 'backup', 'promoted-product' ] as const,
-	// The storage add-on being offered, for the storage section's upsell
-	// and its help popover. Keyed on both byte figures because the route
-	// derives its answer from both and requires both — the same pair that
-	// gates the query being enabled at all. Nulls appear in the key only
-	// while the query is disabled, so no request is ever made under one.
+	// The storage add-on being offered. Keyed on both byte figures because the route
+	// derives its answer from both — the same pair that gates the query. Nulls appear
+	// in the key only while it is disabled, so no request is made under one.
 	storageAddonOffer: ( storageUsed: number | null, storageLimit: number | null ) =>
 		[ 'backup', 'storage-addon-offer', storageUsed, storageLimit ] as const,
 	// Family prefix for any rewindable-activity-log page. Use as a

--- a/projects/packages/backup/src/dashboard/hooks/use-storage-addon-offer.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-storage-addon-offer.ts
@@ -72,13 +72,27 @@ export function useStorageAddonOffer(
 	const query = useQuery( {
 		queryKey: keys.storageAddonOffer( storageUsed, storageLimit ),
 		// The two assertions are exactly what `enabled` guarantees: React
-		// Query does not call this while the flag is false.
+		// Query does not call this while the flag is false. Today nothing
+		// can race that — both components receive the two figures already
+		// narrowed to numbers by `hasUsableFigures`, and the nullable
+		// signature exists for the tests and for future callers.
 		//
-		// Deliberately not a second runtime check. One would answer `null`
-		// for a request that should never have been attempted, which turns
-		// a gate that has drifted into silence — and silence is the one
-		// outcome from which nobody learns the gate is wrong. The route's
-		// refusal is the signal, so let it happen.
+		// There is deliberately no second runtime check here, and it is
+		// worth being plain that this leaves `enabled` as the *only*
+		// protection. A drifted gate would not be caught downstream:
+		// `storageUsed` is typed `number | null`, so it would arrive as
+		// `null`, and `apiPath` forwards `null` as an empty value —
+		// `?storage_size=&storage_limit=…`, verified — which is the shape
+		// `storage-addon-offer.ts` documents as the *worse* of the two,
+		// answered with a confidently wrong add-on rather than refused.
+		//
+		// A guard here would trade that silent-wrong for a silent-nothing,
+		// which is no better, and it would cost the one test that can show
+		// the gate works at all: "asks for nothing until both figures are
+		// known" proves its point by counting requests, and a guard that
+		// short-circuits before `apiFetch` makes that count zero however
+		// the gate is written. So the gate is asserted directly instead of
+		// being backstopped.
 		queryFn: () => fetchStorageAddonOffer( storageUsed as number, storageLimit as number ),
 		enabled,
 		staleTime: STORAGE_ADDON_OFFER_STALE_MS,

--- a/projects/packages/backup/src/dashboard/hooks/use-storage-addon-offer.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-storage-addon-offer.ts
@@ -3,32 +3,24 @@ import { fetchStorageAddonOffer } from '../data/api/storage-addon-offer';
 import { keys } from '../data/query-client';
 
 /**
- * Add-on prices move on a catalogue's schedule, not a session's. An hour
- * matches `use-promoted-product.ts`, for the same reason: opening the
- * screen twice costs one request, and a price change still reaches a tab
- * left open all day.
+ * Add-on prices move on a catalogue's schedule, not a session's. Matches
+ * `use-promoted-product.ts`.
  */
 const STORAGE_ADDON_OFFER_STALE_MS = 60 * 60_000;
 
 type Result = {
 	/**
-	 * The WordPress.com product slug to send to checkout, or null when no
-	 * offer could be read. Callers must not build a checkout URL without
-	 * it — legacy does, and the resulting path carries the literal string
-	 * `null` where the product should be.
+	 * The product slug to send to checkout, or null. Callers must not build a checkout
+	 * URL without it — legacy does, and the path carries a literal `null`.
 	 */
 	slug: string | null;
 	/** The add-on's size as WordPress.com words it, e.g. `100GB`. */
 	sizeText: string | null;
-	/**
-	 * One month of the add-on, in `currencyCode`. The introductory price
-	 * when one is running, the full price otherwise.
-	 */
+	/** One month of the add-on: the introductory price if one is running, else full. */
 	monthlyPrice: number | null;
 	/**
-	 * The currency WordPress.com priced this in. Null whenever
-	 * `monthlyPrice` is null; there is no default, and assuming one would
-	 * mislabel every non-USD site.
+	 * The currency WordPress.com priced this in. No default — assuming one mislabels
+	 * every non-USD site.
 	 */
 	currencyCode: string | null;
 };
@@ -38,21 +30,13 @@ const EMPTY: Result = { slug: null, sizeText: null, monthlyPrice: null, currency
 /**
  * React Query hook exposing the storage add-on being offered.
  *
- * Both consumers live inside the storage section, and neither can render
- * anything useful before it: the upsell needs the size and the price for
- * its copy, and the help popover needs the slug for its checkout link.
- * Sharing one hook is what makes that dependency explicit. Legacy leaves
- * it to chance — only its upsell fetches, only at a usage level where its
- * popover does not render, so the popover's link is built from the
- * store's `null` default on every site.
+ * Shared by both consumers in the storage section — the upsell needs the size and
+ * price, the popover needs the slug. Legacy leaves that to chance: only its upsell
+ * fetches, so its popover's link is built from a `null` default on every site.
  *
- * Deliberately not gated on `useCanQueryWpcom()`, like
- * `use-promoted-product.ts` and unlike the rest of this dashboard. The
- * route's permission callback is `current_user_can( 'manage_options' )`
- * and nothing more, so the site's WordPress.com user connection is not a
- * precondition. What keeps this from firing behind the connection gate is
- * the `enabled` flag below: both byte figures come from routes that *are*
- * gated, so neither is known until the connection is.
+ * Deliberately not gated on `useCanQueryWpcom()`: the route only checks
+ * `manage_options`. The `enabled` flag below is what keeps it from firing early, since
+ * both byte figures come from routes that *are* gated.
  *
  * @param storageUsed  - Bytes of backup storage in use, or null if unknown.
  * @param storageLimit - The plan's storage limit in bytes, or null if unknown.
@@ -62,46 +46,22 @@ export function useStorageAddonOffer(
 	storageUsed: number | null,
 	storageLimit: number | null
 ): Result {
-	// Both, not either. A request carrying one figure is not a partial
-	// answer: dropped, the missing arg earns a 400; sent empty, it earns
-	// something worse — a confidently wrong add-on, because the route's
-	// `'type' => 'numeric'` validates nothing. `storage-addon-offer.ts`
-	// has the details.
+	// Both, not either: a request carrying one figure earns a 400 or, worse, a
+	// confidently wrong add-on. See `storage-addon-offer.ts`.
 	const enabled = storageUsed !== null && storageLimit !== null;
 
 	const query = useQuery( {
 		queryKey: keys.storageAddonOffer( storageUsed, storageLimit ),
-		// The two assertions are exactly what `enabled` guarantees: React
-		// Query does not call this while the flag is false. Today nothing
-		// can race that — both components receive the two figures already
-		// narrowed to numbers by `hasUsableFigures`, and the nullable
-		// signature exists for the tests and for future callers.
-		//
-		// There is deliberately no second runtime check here, and it is
-		// worth being plain that this leaves `enabled` as the *only*
-		// protection. A drifted gate would not be caught downstream:
-		// `storageUsed` is typed `number | null`, so it would arrive as
-		// `null`, and `apiPath` forwards `null` as an empty value —
-		// `?storage_size=&storage_limit=…`, verified — which is the shape
-		// `storage-addon-offer.ts` documents as the *worse* of the two,
-		// answered with a confidently wrong add-on rather than refused.
-		//
-		// A guard here would trade that silent-wrong for a silent-nothing,
-		// which is no better, and it would cost the one test that can show
-		// the gate works at all: "asks for nothing until both figures are
-		// known" proves its point by counting requests, and a guard that
-		// short-circuits before `apiFetch` makes that count zero however
-		// the gate is written. So the gate is asserted directly instead of
-		// being backstopped.
+		// The assertions are what `enabled` guarantees, and deliberately not
+		// backstopped by a runtime check: a guard here would trade a silent-wrong for
+		// a silent-nothing, and would make "asks for nothing until both figures are
+		// known" pass however the gate is written, since it counts requests.
 		queryFn: () => fetchStorageAddonOffer( storageUsed as number, storageLimit as number ),
 		enabled,
 		staleTime: STORAGE_ADDON_OFFER_STALE_MS,
-		// Overrides the client's `retry: 1`, for the reason
-		// `use-promoted-product.ts` spells out: the route's own work is an
-		// uncached, blocking request from the *site* to WordPress.com's
-		// product catalogue, so a retry doubles the expensive hop rather
-		// than the cheap one, to buy a figure both consumers are built to
-		// render without.
+		// Overrides the client's `retry: 1`: the route's own work is an uncached,
+		// blocking hop from the site to WordPress.com's catalogue, and both consumers
+		// render without the figure anyway.
 		retry: false,
 	} );
 
@@ -114,26 +74,16 @@ export function useStorageAddonOffer(
 	const discountPrice = typeof pricing?.discount_price === 'number' ? pricing.discount_price : null;
 	const currencyCode = typeof pricing?.currency_code === 'string' ? pricing.currency_code : null;
 
-	// Both halves or neither: an amount cannot be formatted without a
-	// currency, and this catalogue's currency varies by site rather than
-	// being implicitly USD.
+	// Both halves or neither: an amount cannot be formatted without a currency, and
+	// this catalogue's varies by site rather than being implicitly USD.
 	if ( ! slug || ! sizeText || fullPrice === null || ! currencyCode ) {
 		return { ...EMPTY, slug, sizeText };
 	}
 
-	// The lower of the two, and only one of them is ever rendered. The
-	// helper seeds `discount_price` with the full cost and overwrites it
-	// only from a live introductory offer, so the two are usually equal;
-	// the comparison is what stops a catalogue quirk from quoting the
-	// higher figure.
-	//
-	// No struck-through original accompanies it, which is why this
-	// compares numbers where `gates/promoted-price.tsx` compares rendered
-	// strings. That rule exists to stop a strikethrough showing the same
-	// amount twice — two prices differing below the currency's precision
-	// format identically. With a single figure on screen there is nothing
-	// to strike through and nothing to contradict; anyone adding one here
-	// must switch this comparison to the rendered form.
+	// The lower of the two, and only one is ever rendered. Compared as numbers rather
+	// than rendered strings, unlike `gates/promoted-price.tsx` — that rule exists to
+	// stop a strikethrough showing the same amount twice, and there is no strikethrough
+	// here. Anyone adding one must switch this to the rendered form.
 	const monthlyPrice =
 		discountPrice !== null && discountPrice > 0 && discountPrice < fullPrice
 			? discountPrice

--- a/projects/packages/backup/src/dashboard/hooks/use-storage-addon-offer.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-storage-addon-offer.ts
@@ -1,0 +1,129 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchStorageAddonOffer } from '../data/api/storage-addon-offer';
+import { keys } from '../data/query-client';
+
+/**
+ * Add-on prices move on a catalogue's schedule, not a session's. An hour
+ * matches `use-promoted-product.ts`, for the same reason: opening the
+ * screen twice costs one request, and a price change still reaches a tab
+ * left open all day.
+ */
+const STORAGE_ADDON_OFFER_STALE_MS = 60 * 60_000;
+
+type Result = {
+	/**
+	 * The WordPress.com product slug to send to checkout, or null when no
+	 * offer could be read. Callers must not build a checkout URL without
+	 * it — legacy does, and the resulting path carries the literal string
+	 * `null` where the product should be.
+	 */
+	slug: string | null;
+	/** The add-on's size as WordPress.com words it, e.g. `100GB`. */
+	sizeText: string | null;
+	/**
+	 * One month of the add-on, in `currencyCode`. The introductory price
+	 * when one is running, the full price otherwise.
+	 */
+	monthlyPrice: number | null;
+	/**
+	 * The currency WordPress.com priced this in. Null whenever
+	 * `monthlyPrice` is null; there is no default, and assuming one would
+	 * mislabel every non-USD site.
+	 */
+	currencyCode: string | null;
+};
+
+const EMPTY: Result = { slug: null, sizeText: null, monthlyPrice: null, currencyCode: null };
+
+/**
+ * React Query hook exposing the storage add-on being offered.
+ *
+ * Both consumers live inside the storage section, and neither can render
+ * anything useful before it: the upsell needs the size and the price for
+ * its copy, and the help popover needs the slug for its checkout link.
+ * Sharing one hook is what makes that dependency explicit. Legacy leaves
+ * it to chance — only its upsell fetches, only at a usage level where its
+ * popover does not render, so the popover's link is built from the
+ * store's `null` default on every site.
+ *
+ * Deliberately not gated on `useCanQueryWpcom()`, like
+ * `use-promoted-product.ts` and unlike the rest of this dashboard. The
+ * route's permission callback is `current_user_can( 'manage_options' )`
+ * and nothing more, so the site's WordPress.com user connection is not a
+ * precondition. What keeps this from firing behind the connection gate is
+ * the `enabled` flag below: both byte figures come from routes that *are*
+ * gated, so neither is known until the connection is.
+ *
+ * @param storageUsed  - Bytes of backup storage in use, or null if unknown.
+ * @param storageLimit - The plan's storage limit in bytes, or null if unknown.
+ * @return The offer, or nulls throughout.
+ */
+export function useStorageAddonOffer(
+	storageUsed: number | null,
+	storageLimit: number | null
+): Result {
+	// Both, not either. A request carrying one figure is not a partial
+	// answer: dropped, the missing arg earns a 400; sent empty, it earns
+	// something worse — a confidently wrong add-on, because the route's
+	// `'type' => 'numeric'` validates nothing. `storage-addon-offer.ts`
+	// has the details.
+	const enabled = storageUsed !== null && storageLimit !== null;
+
+	const query = useQuery( {
+		queryKey: keys.storageAddonOffer( storageUsed, storageLimit ),
+		// The two assertions are exactly what `enabled` guarantees: React
+		// Query does not call this while the flag is false.
+		//
+		// Deliberately not a second runtime check. One would answer `null`
+		// for a request that should never have been attempted, which turns
+		// a gate that has drifted into silence — and silence is the one
+		// outcome from which nobody learns the gate is wrong. The route's
+		// refusal is the signal, so let it happen.
+		queryFn: () => fetchStorageAddonOffer( storageUsed as number, storageLimit as number ),
+		enabled,
+		staleTime: STORAGE_ADDON_OFFER_STALE_MS,
+		// Overrides the client's `retry: 1`, for the reason
+		// `use-promoted-product.ts` spells out: the route's own work is an
+		// uncached, blocking request from the *site* to WordPress.com's
+		// product catalogue, so a retry doubles the expensive hop rather
+		// than the cheap one, to buy a figure both consumers are built to
+		// render without.
+		retry: false,
+	} );
+
+	const offer = query.data;
+	const slug = typeof offer?.slug === 'string' ? offer.slug : null;
+	const sizeText = typeof offer?.size_text === 'string' ? offer.size_text : null;
+
+	const pricing = offer?.pricing;
+	const fullPrice = typeof pricing?.full_price === 'number' ? pricing.full_price : null;
+	const discountPrice = typeof pricing?.discount_price === 'number' ? pricing.discount_price : null;
+	const currencyCode = typeof pricing?.currency_code === 'string' ? pricing.currency_code : null;
+
+	// Both halves or neither: an amount cannot be formatted without a
+	// currency, and this catalogue's currency varies by site rather than
+	// being implicitly USD.
+	if ( ! slug || ! sizeText || fullPrice === null || ! currencyCode ) {
+		return { ...EMPTY, slug, sizeText };
+	}
+
+	// The lower of the two, and only one of them is ever rendered. The
+	// helper seeds `discount_price` with the full cost and overwrites it
+	// only from a live introductory offer, so the two are usually equal;
+	// the comparison is what stops a catalogue quirk from quoting the
+	// higher figure.
+	//
+	// No struck-through original accompanies it, which is why this
+	// compares numbers where `gates/promoted-price.tsx` compares rendered
+	// strings. That rule exists to stop a strikethrough showing the same
+	// amount twice — two prices differing below the currency's precision
+	// format identically. With a single figure on screen there is nothing
+	// to strike through and nothing to contradict; anyone adding one here
+	// must switch this comparison to the rendered form.
+	const monthlyPrice =
+		discountPrice !== null && discountPrice > 0 && discountPrice < fullPrice
+			? discountPrice
+			: fullPrice;
+
+	return { slug, sizeText, monthlyPrice, currencyCode };
+}

--- a/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
@@ -30,11 +30,32 @@ type Figures = {
 	 * response can describe storage perfectly well and omit this.
 	 */
 	daysOfBackupsSaved: number | null;
+	/**
+	 * Fewest days of backups the plan will ever keep. Only the
+	 * `BackupsDiscarded` warning reads it, and `getUsageLevel` reaches
+	 * that level only from a branch guarded on this being truthy — so it
+	 * is never null where it is rendered.
+	 */
+	minDaysOfBackupsAllowed: number | null;
+	/**
+	 * Days of full backups the storage limit would hold at the size of
+	 * the last one, or null when the last backup's size is unknown.
+	 *
+	 * Legacy spells this `Math.floor( storageLimit / lastBackupSize )`
+	 * guarded by both being above zero, and collapses "cannot compute"
+	 * and "not even one fits" into the same `0`. Separating them is what
+	 * lets the help popover say nothing in the first case and be shown a
+	 * real zero in the second.
+	 */
+	forecastInDays: number | null;
+	/**
+	 * The retention the *plan* promises, which is not the same as the
+	 * retention in force: `retentionDays` above falls back to this, but
+	 * the help popover's gate compares the forecast against the promise
+	 * rather than the fallback, as legacy's does.
+	 */
+	planRetentionDays: number | null;
 };
-
-// `last_backup_size` and the plan's own retention are read off these same
-// responses but deliberately not returned: nothing consumes them yet.
-// Adding each back is one line when there is a caller.
 
 /**
  * `hasUsableFigures` is a discriminant, not a convenience flag: it is the
@@ -94,14 +115,29 @@ export function useStorageUsage(): Result {
 	// planRetentionDays` at `backup-storage-space/index.jsx:33`, and the
 	// `||` is load-bearing: `retention_days` is `0` on a site with no
 	// retention policy, not absent.
-	const retentionDays = size?.retention_days || ( policies?.activity_log_limit_days ?? null );
+	const planRetentionDays = policies?.activity_log_limit_days ?? null;
+	const retentionDays = size?.retention_days || planRetentionDays;
 
 	const daysOfBackupsSaved = size?.days_of_backups_saved ?? null;
+	const minDaysOfBackupsAllowed = size?.min_days_of_backups_allowed ?? null;
+
+	// Both above zero or no forecast. `last_backup_size` is one of the
+	// fields a `/size` response may simply omit, and a site with nothing
+	// to measure can report it as zero — either way there is no divisor,
+	// and `Math.floor( limit / 0 )` is `Infinity`, which would go on to
+	// be rendered as a day count. A limit of zero is separately not a
+	// limit anyone can be measured against, the same judgement
+	// `hasUsableFigures` makes below.
+	const lastBackupSize = size?.last_backup_size ?? null;
+	const forecastInDays =
+		storageLimit !== null && storageLimit > 0 && lastBackupSize !== null && lastBackupSize > 0
+			? Math.floor( storageLimit / lastBackupSize )
+			: null;
 
 	const usageLevel = getUsageLevel(
 		storageUsed,
 		storageLimit,
-		size?.min_days_of_backups_allowed ?? null,
+		minDaysOfBackupsAllowed,
 		size?.days_of_backups_allowed ?? null,
 		retentionDays,
 		daysOfBackupsSaved
@@ -111,6 +147,9 @@ export function useStorageUsage(): Result {
 		usageLevel,
 		isLoading: sizeQuery.isLoading || policiesQuery.isLoading,
 		daysOfBackupsSaved,
+		minDaysOfBackupsAllowed,
+		forecastInDays,
+		planRetentionDays,
 	};
 
 	// A limit of zero is not a limit anyone can be measured against, and a

--- a/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-storage-usage.ts
@@ -31,28 +31,22 @@ type Figures = {
 	 */
 	daysOfBackupsSaved: number | null;
 	/**
-	 * Fewest days of backups the plan will ever keep. Only the
-	 * `BackupsDiscarded` warning reads it, and `getUsageLevel` reaches
-	 * that level only from a branch guarded on this being truthy — so it
-	 * is never null where it is rendered.
+	 * Fewest days of backups the plan will ever keep. Never null where it is rendered:
+	 * only the `BackupsDiscarded` warning reads it, and that level is reached only from
+	 * a branch guarded on this being truthy.
 	 */
 	minDaysOfBackupsAllowed: number | null;
 	/**
 	 * Days of full backups the storage limit would hold at the size of
 	 * the last one, or null when the last backup's size is unknown.
 	 *
-	 * Legacy spells this `Math.floor( storageLimit / lastBackupSize )`
-	 * guarded by both being above zero, and collapses "cannot compute"
-	 * and "not even one fits" into the same `0`. Separating them is what
-	 * lets the help popover say nothing in the first case and be shown a
-	 * real zero in the second.
+	 * Legacy collapses "cannot compute" and "not even one fits" into the same `0`.
+	 * Separating them lets the help popover say nothing in the first case.
 	 */
 	forecastInDays: number | null;
 	/**
-	 * The retention the *plan* promises, which is not the same as the
-	 * retention in force: `retentionDays` above falls back to this, but
-	 * the help popover's gate compares the forecast against the promise
-	 * rather than the fallback, as legacy's does.
+	 * The retention the *plan* promises, which is not the retention in force. The help
+	 * popover's gate compares against the promise, as legacy's does.
 	 */
 	planRetentionDays: number | null;
 };
@@ -121,13 +115,9 @@ export function useStorageUsage(): Result {
 	const daysOfBackupsSaved = size?.days_of_backups_saved ?? null;
 	const minDaysOfBackupsAllowed = size?.min_days_of_backups_allowed ?? null;
 
-	// Both above zero or no forecast. `last_backup_size` is one of the
-	// fields a `/size` response may simply omit, and a site with nothing
-	// to measure can report it as zero — either way there is no divisor,
-	// and `Math.floor( limit / 0 )` is `Infinity`, which would go on to
-	// be rendered as a day count. A limit of zero is separately not a
-	// limit anyone can be measured against, the same judgement
-	// `hasUsableFigures` makes below.
+	// Both above zero or no forecast: `last_backup_size` may be omitted or reported as
+	// zero, and `Math.floor( limit / 0 )` is `Infinity`, which would render as a day
+	// count.
 	const lastBackupSize = size?.last_backup_size ?? null;
 	const forecastInDays =
 		storageLimit !== null && storageLimit > 0 && lastBackupSize !== null && lastBackupSize > 0

--- a/projects/packages/backup/tests/storage-addon-upsell.test.tsx
+++ b/projects/packages/backup/tests/storage-addon-upsell.test.tsx
@@ -1,0 +1,485 @@
+// Tests for the "add more storage" offer under the Overview's storage
+// meter (JETPACK-2331 / H3c), and for the query that prices it.
+//
+// The meter itself and the readings beside it are covered in
+// `storage-meter.test.tsx` and `storage-usage-details.test.tsx`. This
+// file is about the four things the offer can get wrong in ways nobody
+// would notice: asking the route for a price before it can answer,
+// quoting an amount in the wrong currency, building half a checkout URL,
+// and recording the Tracks event somewhere other than the click.
+
+const mockRecordEvent = jest.fn();
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		initialize: jest.fn(),
+		tracks: { recordEvent: ( ...args: unknown[] ) => mockRecordEvent( ...args ) },
+	},
+} ) );
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import StorageSpace from '../src/dashboard/components/storage-space';
+import { useStorageAddonOffer } from '../src/dashboard/hooks/use-storage-addon-offer';
+import type { ReactNode } from 'react';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const GB = 1024 * 1024 * 1024;
+const SITE = 'example.wordpress.com';
+
+/** Figures that put the site above `Normal` without reaching `Full`. */
+const CRITICAL = { size: 90 * GB, limit: 100 * GB };
+
+/**
+ * A provider wrapping each render in its own QueryClient.
+ *
+ * @param props          - Props.
+ * @param props.children - The tree to wrap.
+ * @return The wrapped tree.
+ */
+function Wrapper( { children }: { children: ReactNode } ) {
+	// Held in state rather than rebuilt each render: a fresh client on
+	// every render throws away the cache mid-test, which would make every
+	// "how many requests went out" assertion here meaningless.
+	const [ client ] = useState(
+		() =>
+			new QueryClient( {
+				defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+			} )
+	);
+	return <QueryClientProvider client={ client }>{ children }</QueryClientProvider>;
+}
+
+/**
+ * Render inside an isolated QueryClient.
+ *
+ * @param ui - The tree to render.
+ * @return The testing-library render result.
+ */
+function renderWithClient( ui: ReactNode ) {
+	return render( <Wrapper>{ ui }</Wrapper> );
+}
+
+/**
+ * Answer the three routes the section reads.
+ *
+ * @param options          - Overrides.
+ * @param options.size     - What `/site/backup/size` returns.
+ * @param options.policies - What `/site/backup/policies` returns.
+ * @param options.offer    - What `/site/backup/addon-offer` returns.
+ */
+function mockEndpoints( {
+	size = {} as Record< string, unknown >,
+	policies = {} as Record< string, unknown >,
+	offer = {} as Record< string, unknown >,
+} = {} ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/site/backup/addon-offer' ) ) {
+			return Promise.resolve( {
+				slug: 'jetpack_backup_addon_storage_100gb_monthly',
+				size_text: '100GB',
+				pricing: { currency_code: 'USD', full_price: 9.95, discount_price: 9.95 },
+				...offer,
+			} );
+		}
+		if ( path.includes( '/site/backup/policies' ) ) {
+			return Promise.resolve( {
+				policies: { storage_limit_bytes: CRITICAL.limit, activity_log_limit_days: 30, ...policies },
+			} );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( {
+				ok: true,
+				size: CRITICAL.size,
+				days_of_backups_saved: 14,
+				...size,
+			} );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+/**
+ * Every `/site/backup/addon-offer` path that was asked for.
+ *
+ * @return The paths, in call order.
+ */
+function offerRequests(): string[] {
+	return mockApiFetch.mock.calls
+		.map( ( [ options ] ) => String( options?.path ?? '' ) )
+		.filter( path => path.includes( '/site/backup/addon-offer' ) );
+}
+
+/**
+ * The offer's checkout link, once it has arrived.
+ *
+ * @return The anchor.
+ */
+function offerLink(): Promise< HTMLElement > {
+	return screen.findByRole( 'link', { name: /additional storage/ } );
+}
+
+/**
+ * The warning line, once it has arrived.
+ *
+ * @param pattern - What the line should say.
+ * @return The element carrying it.
+ */
+function warning( pattern: RegExp ): Promise< HTMLElement > {
+	return screen.findByText( pattern );
+}
+
+/**
+ * Let whatever the section started finish before asserting an absence.
+ *
+ * Every "there is no offer link" assertion here is otherwise racing the
+ * offer request rather than testing the thing it names. The warning line
+ * and the usage reading both render from figures already in hand, so
+ * awaiting either returns while `/addon-offer` is still in flight — and
+ * "no link yet" is then true for a reason that has nothing to do with
+ * the gate. Three separate mutations that wrongly drew a link survived
+ * this suite before it was added, including one that quoted `$0.00`.
+ *
+ * Two macrotask turns inside `act`: the first lets the mocked response's
+ * microtask chain run and React Query commit, the second lets the render
+ * it schedules flush.
+ */
+async function settle(): Promise< void > {
+	await act( async () => {
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+	} );
+}
+
+beforeEach( () => {
+	mockApiFetch.mockReset();
+	mockRecordEvent.mockReset();
+	mockEndpoints();
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+		siteSuffix: SITE,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'the offer query', () => {
+	// Asserted on the hook rather than through the section, because the
+	// section renders nothing until *both* figures are known — so the
+	// partial case this is about cannot be staged from up there at all.
+
+	it( 'asks for nothing until both figures are known', async () => {
+		// Each of the three ways a caller can be partly informed. Under a
+		// gate that fired on either figure this sends two requests —
+		// `…?storage_size=96636764160&storage_limit=` and
+		// `…?storage_size=&storage_limit=107374182400`, both observed —
+		// and neither is a partial answer. The dropped-arg form is a 400;
+		// the empty-value form is worse, because the route's `'type' =>
+		// 'numeric'` is not a WordPress schema type and validates nothing,
+		// so an empty figure is compared against the limit and answered
+		// with the smallest add-on.
+		renderHook( () => useStorageAddonOffer( null, null ), { wrapper: Wrapper } );
+		renderHook( () => useStorageAddonOffer( CRITICAL.size, null ), { wrapper: Wrapper } );
+		renderHook( () => useStorageAddonOffer( null, CRITICAL.limit ), { wrapper: Wrapper } );
+
+		// Settled rather than asserted immediately, and deliberately not
+		// `waitFor`: React Query starts a fetch in an effect, and a
+		// `waitFor` on an assertion that already holds returns on its first
+		// pass — so it would report "no request" before an enabled query
+		// had even tried.
+		await settle();
+		expect( offerRequests() ).toHaveLength( 0 );
+	} );
+
+	it( 'asks once both are known, and sends both', async () => {
+		// The other half of the test above. Without this, disabling the
+		// query permanently would satisfy it just as well.
+		renderHook( () => useStorageAddonOffer( CRITICAL.size, CRITICAL.limit ), {
+			wrapper: Wrapper,
+		} );
+
+		await waitFor( () => expect( offerRequests() ).toHaveLength( 1 ) );
+		expect( offerRequests()[ 0 ] ).toContain( `storage_size=${ CRITICAL.size }` );
+		expect( offerRequests()[ 0 ] ).toContain( `storage_limit=${ CRITICAL.limit }` );
+	} );
+
+	it( 'sends a zero usage figure rather than dropping it', async () => {
+		// `apiPath` filters out `undefined` and `''`, and zero is neither.
+		// A freshly connected site reports `size: 0`, and dropping the arg
+		// there would turn a legitimate question into a 400 —
+		// `rest_missing_callback_param`, which is what a `required` arg
+		// gets when it is absent rather than empty.
+		renderHook( () => useStorageAddonOffer( 0, CRITICAL.limit ), { wrapper: Wrapper } );
+
+		await waitFor( () => expect( offerRequests() ).toHaveLength( 1 ) );
+		expect( offerRequests()[ 0 ] ).toContain( 'storage_size=0' );
+	} );
+} );
+
+describe( 'when the upsell appears', () => {
+	it( 'says nothing at all while usage is Normal', async () => {
+		mockEndpoints( { size: { size: 10 * GB } } );
+		renderWithClient( <StorageSpace /> );
+
+		// Awaited on the reading first, so this is a real absence rather
+		// than an assertion that ran before anything had rendered.
+		await expect( screen.findByText( /^Using/ ) ).resolves.toBeInTheDocument();
+		await settle();
+		expect( screen.queryByRole( 'link', { name: /additional storage/ } ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /storage limit/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'does not even ask for a price while usage is Normal', async () => {
+		// The gate is in the section rather than in the component, so a
+		// site with room to spare never pays for the round trip to
+		// WordPress.com's product catalogue that pricing this costs.
+		mockEndpoints( { size: { size: 10 * GB } } );
+		renderWithClient( <StorageSpace /> );
+
+		await expect( screen.findByText( /^Using/ ) ).resolves.toBeInTheDocument();
+		await settle();
+		expect( offerRequests() ).toHaveLength( 0 );
+	} );
+
+	it( 'warns and offers once usage leaves Normal', async () => {
+		renderWithClient( <StorageSpace /> );
+
+		await expect(
+			warning( /You are very close to reaching your storage limit/ )
+		).resolves.toBeInTheDocument();
+		await expect( offerLink() ).resolves.toHaveTextContent(
+			/^Add 100GB additional storage for \$9\.95\/month, billed monthly$/
+		);
+	} );
+
+	it( 'still warns when the offer never arrives', async () => {
+		// Legacy nests the warning inside the checkout button, so a failed
+		// `/addon-offer` leaves a site that is nearly out of storage with
+		// nothing on screen saying so. The two fail separately here.
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( '/site/backup/addon-offer' ) ) {
+				return Promise.reject( new Error( 'catalogue unavailable' ) );
+			}
+			if ( path.includes( '/site/backup/policies' ) ) {
+				return Promise.resolve( { policies: { storage_limit_bytes: CRITICAL.limit } } );
+			}
+			if ( path.includes( '/site/backup/size' ) ) {
+				return Promise.resolve( { ok: true, size: CRITICAL.size, days_of_backups_saved: 14 } );
+			}
+			return Promise.resolve( {} );
+		} );
+
+		renderWithClient( <StorageSpace /> );
+
+		await expect(
+			warning( /You are very close to reaching your storage limit/ )
+		).resolves.toBeInTheDocument();
+		await settle();
+		expect( screen.queryByRole( 'link', { name: /additional storage/ } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'offers no link when the pricing block came back empty', async () => {
+		// `Wpcom_Products::get_product_pricing()` returns `array()` when
+		// the slug is missing from the catalogue, which arrives as a JSON
+		// `[]`. Legacy's `res.pricing &&` guard passes on it — `[]` is
+		// truthy in JavaScript — and it then formats `undefined` as a
+		// price, which the installed formatter renders as `$0.00`.
+		mockEndpoints( { offer: { pricing: [] } } );
+		renderWithClient( <StorageSpace /> );
+
+		await expect(
+			warning( /You are very close to reaching your storage limit/ )
+		).resolves.toBeInTheDocument();
+		await settle();
+		expect( screen.queryByRole( 'link', { name: /additional storage/ } ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'what the offer says', () => {
+	it( 'quotes a Brazilian site in reais, with no dollar sign anywhere', async () => {
+		// The reason `price.jsx` was not ported. It reads `currencyCode`
+		// off a pricing block whose key is `currency_code`, gets undefined,
+		// and `getCurrencyObject` then falls back to `$` — verified against
+		// the installed formatter. WordPress.com prices this catalogue from
+		// where the *site* appears to be, so that is wrong for every
+		// non-USD site on earth.
+		mockEndpoints( {
+			offer: { pricing: { currency_code: 'BRL', full_price: 44.95, discount_price: 44.95 } },
+		} );
+		renderWithClient( <StorageSpace /> );
+
+		await expect( offerLink() ).resolves.toHaveTextContent(
+			/^Add 100GB additional storage for R\$44\.95\/month, billed monthly$/
+		);
+	} );
+
+	it( 'quotes a currency with no minor unit without inventing one', async () => {
+		mockEndpoints( {
+			offer: { pricing: { currency_code: 'JPY', full_price: 1000, discount_price: 1000 } },
+		} );
+		renderWithClient( <StorageSpace /> );
+
+		await expect( offerLink() ).resolves.toHaveTextContent(
+			/^Add 100GB additional storage for ¥1,000\/month, billed monthly$/
+		);
+	} );
+
+	it( 'quotes the introductory price when one is running', async () => {
+		mockEndpoints( {
+			offer: { pricing: { currency_code: 'USD', full_price: 9.95, discount_price: 4.95 } },
+		} );
+		renderWithClient( <StorageSpace /> );
+
+		await expect( offerLink() ).resolves.toHaveTextContent( /\$4\.95\/month/ );
+	} );
+
+	it( 'ignores a discount that is not one', async () => {
+		// The pricing helper seeds `discount_price` with the full cost, so
+		// the two are equal far more often than not — and a catalogue that
+		// ever sent a higher one must not be allowed to quote it.
+		mockEndpoints( {
+			offer: { pricing: { currency_code: 'USD', full_price: 9.95, discount_price: 19.95 } },
+		} );
+		renderWithClient( <StorageSpace /> );
+
+		await expect( offerLink() ).resolves.toHaveTextContent( /\$9\.95\/month/ );
+	} );
+
+	it( 'names the level in the warning it leads with', async () => {
+		// Four levels, four sentences, and the wording is the whole of what
+		// tells "getting close" apart from "backups have stopped".
+		mockEndpoints( { size: { size: 70 * GB } } );
+		renderWithClient( <StorageSpace /> );
+
+		await expect(
+			warning( /^You are close to reaching your storage limit/ )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'reports the days saved when storage is full', async () => {
+		mockEndpoints( {
+			size: {
+				size: 100 * GB,
+				days_of_backups_saved: 3,
+				days_of_backups_allowed: 3,
+				min_days_of_backups_allowed: 5,
+			},
+		} );
+		renderWithClient( <StorageSpace /> );
+
+		await expect(
+			warning( /^You have reached your storage limit with 3 day\(s\) of backups saved/ )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'reports the floor the plan keeps once backups start being discarded', async () => {
+		// The one level whose sentence is built from
+		// `min_days_of_backups_allowed` rather than the days actually
+		// saved, and the only thing that reads that figure at all.
+		mockEndpoints( {
+			size: {
+				size: 70 * GB,
+				days_of_backups_saved: 10,
+				days_of_backups_allowed: 10,
+				min_days_of_backups_allowed: 5,
+			},
+		} );
+		renderWithClient( <StorageSpace /> );
+
+		await expect( warning( /up to the last 5 days\.$/ ) ).resolves.toBeInTheDocument();
+	} );
+} );
+
+describe( 'the checkout link', () => {
+	it( 'names the product and the site, and comes back here afterwards', async () => {
+		renderWithClient( <StorageSpace /> );
+		const link = await offerLink();
+		const href = new URL( link.getAttribute( 'href' ) as string );
+
+		expect( href.origin + href.pathname ).toBe(
+			`https://wordpress.com/checkout/${ SITE }/jetpack_backup_addon_storage_100gb_monthly`
+		);
+		expect( href.searchParams.get( 'site' ) ).toBe( SITE );
+		// The page the reader is standing on. The modernized dashboard
+		// emits no admin URL, and legacy's rebuilt
+		// `admin.php?page=jetpack-backup` resolves to this same place.
+		expect( href.searchParams.get( 'redirect_to' ) ).toBe( window.location.href );
+	} );
+
+	it( 'shows no link at all when the connection global carries no site slug', async () => {
+		// Legacy interpolates whatever it has, producing
+		// `…/checkout/undefined/<product>`. Half a checkout URL is worse
+		// than none: it still looks like a working button.
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			siteSuffix: undefined,
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
+		renderWithClient( <StorageSpace /> );
+
+		await expect(
+			warning( /You are very close to reaching your storage limit/ )
+		).resolves.toBeInTheDocument();
+		await settle();
+		expect( screen.queryByRole( 'link', { name: /additional storage/ } ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'the Tracks event', () => {
+	it( 'records nothing until the reader actually clicks', async () => {
+		renderWithClient( <StorageSpace /> );
+
+		await expect( offerLink() ).resolves.toBeInTheDocument();
+		expect( mockRecordEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'records the click itself, not the arrival at checkout', async () => {
+		renderWithClient( <StorageSpace /> );
+		const link = await offerLink();
+
+		// A plain anchor, so there is no follow-up request to order the
+		// event against — which is how `tracks-events.test.tsx` tells "on
+		// click" from "on success" for the Back up now button. What
+		// distinguishes it here is the window the count is read in: still
+		// inside the click's own propagation, before the browser has been
+		// allowed to leave and before anything asynchronous could have
+		// run. An event moved to a `then`, to a `useEffect`, or to the
+		// offer query's own success path all land outside it.
+		//
+		// The probe goes on `document`, not on the link. React 18
+		// dispatches synthetic events from the root container, which sits
+		// below `document` in the propagation path — a listener on the
+		// link itself would run *before* the component's `onClick` and
+		// read zero however the handler was written. `preventDefault` here
+		// still cancels the navigation, which happens only after the event
+		// has finished propagating.
+		const countAtClick = new Promise< number >( resolve => {
+			document.addEventListener(
+				'click',
+				event => {
+					event.preventDefault();
+					resolve( mockRecordEvent.mock.calls.length );
+				},
+				{ once: true }
+			);
+		} );
+
+		await userEvent.click( link );
+
+		await expect( countAtClick ).resolves.toBe( 1 );
+		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_backup_upgrade_storage_prompt_cta', {
+			site: SITE,
+		} );
+	} );
+} );

--- a/projects/packages/backup/tests/storage-addon-upsell.test.tsx
+++ b/projects/packages/backup/tests/storage-addon-upsell.test.tsx
@@ -1,12 +1,10 @@
 // Tests for the "add more storage" offer under the Overview's storage
 // meter (JETPACK-2331 / H3c), and for the query that prices it.
 //
-// The meter itself and the readings beside it are covered in
-// `storage-meter.test.tsx` and `storage-usage-details.test.tsx`. This
-// file is about the four things the offer can get wrong in ways nobody
-// would notice: asking the route for a price before it can answer,
-// quoting an amount in the wrong currency, building half a checkout URL,
-// and recording the Tracks event somewhere other than the click.
+// The meter and the readings are covered elsewhere. This file is about the four things
+// the offer can get wrong silently: asking the route for a price before it can answer,
+// quoting the wrong currency, building half a checkout URL, and recording the Tracks
+// event somewhere other than the click.
 
 const mockRecordEvent = jest.fn();
 
@@ -49,9 +47,8 @@ const CRITICAL = { size: 90 * GB, limit: 100 * GB };
  * @return The wrapped tree.
  */
 function Wrapper( { children }: { children: ReactNode } ) {
-	// Held in state rather than rebuilt each render: a fresh client on
-	// every render throws away the cache mid-test, which would make every
-	// "how many requests went out" assertion here meaningless.
+	// Held in state: a fresh client each render throws away the cache mid-test, which
+	// would make every "how many requests went out" assertion meaningless.
 	const [ client ] = useState(
 		() =>
 			new QueryClient( {
@@ -144,17 +141,12 @@ function warning( pattern: RegExp ): Promise< HTMLElement > {
 /**
  * Let whatever the section started finish before asserting an absence.
  *
- * Every "there is no offer link" assertion here is otherwise racing the
- * offer request rather than testing the thing it names. The warning line
- * and the usage reading both render from figures already in hand, so
- * awaiting either returns while `/addon-offer` is still in flight — and
- * "no link yet" is then true for a reason that has nothing to do with
- * the gate. Three separate mutations that wrongly drew a link survived
- * this suite before it was added, including one that quoted `$0.00`.
+ * Every "there is no offer link" assertion is otherwise racing the offer request: the
+ * warning and the reading render from figures already in hand, so awaiting either
+ * returns while `/addon-offer` is still in flight.
  *
- * Two macrotask turns inside `act`: the first lets the mocked response's
- * microtask chain run and React Query commit, the second lets the render
- * it schedules flush.
+ * Two macrotask turns inside `act`: the first lets the mocked response commit, the
+ * second lets the render it schedules flush.
  */
 async function settle(): Promise< void > {
 	await act( async () => {
@@ -175,29 +167,20 @@ beforeEach( () => {
 } );
 
 describe( 'the offer query', () => {
-	// Asserted on the hook rather than through the section, because the
-	// section renders nothing until *both* figures are known — so the
-	// partial case this is about cannot be staged from up there at all.
+	// Asserted on the hook, because the section renders nothing until both figures are
+	// known — so the partial case cannot be staged from up there.
 
 	it( 'asks for nothing until both figures are known', async () => {
-		// Each of the three ways a caller can be partly informed. Under a
-		// gate that fired on either figure this sends two requests —
-		// `…?storage_size=96636764160&storage_limit=` and
-		// `…?storage_size=&storage_limit=107374182400`, both observed —
-		// and neither is a partial answer. The dropped-arg form is a 400;
-		// the empty-value form is worse, because the route's `'type' =>
-		// 'numeric'` is not a WordPress schema type and validates nothing,
-		// so an empty figure is compared against the limit and answered
-		// with the smallest add-on.
+		// The three ways a caller can be partly informed. A gate that fired on either
+		// figure would send a request with one arg empty, and the route's
+		// `'type' => 'numeric'` validates nothing — so it answers with the smallest
+		// add-on rather than refusing.
 		renderHook( () => useStorageAddonOffer( null, null ), { wrapper: Wrapper } );
 		renderHook( () => useStorageAddonOffer( CRITICAL.size, null ), { wrapper: Wrapper } );
 		renderHook( () => useStorageAddonOffer( null, CRITICAL.limit ), { wrapper: Wrapper } );
 
-		// Settled rather than asserted immediately, and deliberately not
-		// `waitFor`: React Query starts a fetch in an effect, and a
-		// `waitFor` on an assertion that already holds returns on its first
-		// pass — so it would report "no request" before an enabled query
-		// had even tried.
+		// Not `waitFor`: React Query starts its fetch in an effect, and a `waitFor` on
+		// an assertion that already holds returns on its first pass.
 		await settle();
 		expect( offerRequests() ).toHaveLength( 0 );
 	} );
@@ -215,11 +198,8 @@ describe( 'the offer query', () => {
 	} );
 
 	it( 'sends a zero usage figure rather than dropping it', async () => {
-		// `apiPath` filters out `undefined` and `''`, and zero is neither.
-		// A freshly connected site reports `size: 0`, and dropping the arg
-		// there would turn a legitimate question into a 400 —
-		// `rest_missing_callback_param`, which is what a `required` arg
-		// gets when it is absent rather than empty.
+		// `apiPath` filters out `undefined` and `''`, and zero is neither. A freshly
+		// connected site reports `size: 0`, where a dropped arg would be a 400.
 		renderHook( () => useStorageAddonOffer( 0, CRITICAL.limit ), { wrapper: Wrapper } );
 
 		await waitFor( () => expect( offerRequests() ).toHaveLength( 1 ) );
@@ -232,8 +212,7 @@ describe( 'when the upsell appears', () => {
 		mockEndpoints( { size: { size: 10 * GB } } );
 		renderWithClient( <StorageSpace /> );
 
-		// Awaited on the reading first, so this is a real absence rather
-		// than an assertion that ran before anything had rendered.
+		// Awaited on the reading first, so this is a real absence.
 		await expect( screen.findByText( /^Using/ ) ).resolves.toBeInTheDocument();
 		await settle();
 		expect( screen.queryByRole( 'link', { name: /additional storage/ } ) ).not.toBeInTheDocument();
@@ -241,9 +220,8 @@ describe( 'when the upsell appears', () => {
 	} );
 
 	it( 'does not even ask for a price while usage is Normal', async () => {
-		// The gate is in the section rather than in the component, so a
-		// site with room to spare never pays for the round trip to
-		// WordPress.com's product catalogue that pricing this costs.
+		// The gate is in the section, so a site with room to spare never pays for the
+		// round trip to WordPress.com's product catalogue.
 		mockEndpoints( { size: { size: 10 * GB } } );
 		renderWithClient( <StorageSpace /> );
 
@@ -265,8 +243,7 @@ describe( 'when the upsell appears', () => {
 
 	it( 'still warns when the offer never arrives', async () => {
 		// Legacy nests the warning inside the checkout button, so a failed
-		// `/addon-offer` leaves a site that is nearly out of storage with
-		// nothing on screen saying so. The two fail separately here.
+		// `/addon-offer` says nothing at all. The two fail separately here.
 		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
 			const path = options?.path ?? '';
 			if ( path.includes( '/site/backup/addon-offer' ) ) {
@@ -291,11 +268,8 @@ describe( 'when the upsell appears', () => {
 	} );
 
 	it( 'offers no link when the pricing block came back empty', async () => {
-		// `Wpcom_Products::get_product_pricing()` returns `array()` when
-		// the slug is missing from the catalogue, which arrives as a JSON
-		// `[]`. Legacy's `res.pricing &&` guard passes on it — `[]` is
-		// truthy in JavaScript — and it then formats `undefined` as a
-		// price, which the installed formatter renders as `$0.00`.
+		// A slug missing from the catalogue arrives as a JSON `[]`, which legacy's
+		// `res.pricing &&` guard passes — it then formats `undefined` as `$0.00`.
 		mockEndpoints( { offer: { pricing: [] } } );
 		renderWithClient( <StorageSpace /> );
 
@@ -309,12 +283,9 @@ describe( 'when the upsell appears', () => {
 
 describe( 'what the offer says', () => {
 	it( 'quotes a Brazilian site in reais, with no dollar sign anywhere', async () => {
-		// The reason `price.jsx` was not ported. It reads `currencyCode`
-		// off a pricing block whose key is `currency_code`, gets undefined,
-		// and `getCurrencyObject` then falls back to `$` — verified against
-		// the installed formatter. WordPress.com prices this catalogue from
-		// where the *site* appears to be, so that is wrong for every
-		// non-USD site on earth.
+		// Why `price.jsx` was not ported: it reads `currencyCode` off a block keyed
+		// `currency_code` and `getCurrencyObject` falls back to `$`. This catalogue is
+		// priced from where the site appears to be.
 		mockEndpoints( {
 			offer: { pricing: { currency_code: 'BRL', full_price: 44.95, discount_price: 44.95 } },
 		} );
@@ -346,9 +317,8 @@ describe( 'what the offer says', () => {
 	} );
 
 	it( 'ignores a discount that is not one', async () => {
-		// The pricing helper seeds `discount_price` with the full cost, so
-		// the two are equal far more often than not — and a catalogue that
-		// ever sent a higher one must not be allowed to quote it.
+		// The helper seeds `discount_price` with the full cost, so the two are usually
+		// equal — and a catalogue sending a higher one must not quote it.
 		mockEndpoints( {
 			offer: { pricing: { currency_code: 'USD', full_price: 9.95, discount_price: 19.95 } },
 		} );
@@ -358,11 +328,8 @@ describe( 'what the offer says', () => {
 	} );
 
 	it( 'ignores a discount of zero rather than quoting the add-on as free', async () => {
-		// A separate guard from the one above, and a separate failure: a
-		// zero is *lower* than the full price, so the "is this really a
-		// discount" comparison waves it through. What stops it is the
-		// `> 0` test beside it, and without that this button reads
-		// "$0.00/month" for something that costs $9.95.
+		// A separate failure: zero is *lower* than the full price, so the discount
+		// comparison waves it through. Only the `> 0` test stops "$0.00/month".
 		mockEndpoints( {
 			offer: { pricing: { currency_code: 'USD', full_price: 9.95, discount_price: 0 } },
 		} );
@@ -373,8 +340,8 @@ describe( 'what the offer says', () => {
 	} );
 
 	it( 'names the level in the warning it leads with', async () => {
-		// Four levels, four sentences, and the wording is the whole of what
-		// tells "getting close" apart from "backups have stopped".
+		// The wording is the whole of what tells "getting close" apart from "backups
+		// have stopped".
 		mockEndpoints( { size: { size: 70 * GB } } );
 		renderWithClient( <StorageSpace /> );
 
@@ -400,9 +367,8 @@ describe( 'what the offer says', () => {
 	} );
 
 	it( 'reports the floor the plan keeps once backups start being discarded', async () => {
-		// The one level whose sentence is built from
-		// `min_days_of_backups_allowed` rather than the days actually
-		// saved, and the only thing that reads that figure at all.
+		// The one level whose sentence is built from `min_days_of_backups_allowed`
+		// rather than the days actually saved.
 		mockEndpoints( {
 			size: {
 				size: 70 * GB,
@@ -427,16 +393,14 @@ describe( 'the checkout link', () => {
 			`https://wordpress.com/checkout/${ SITE }/jetpack_backup_addon_storage_100gb_monthly`
 		);
 		expect( href.searchParams.get( 'site' ) ).toBe( SITE );
-		// The page the reader is standing on. The modernized dashboard
-		// emits no admin URL, and legacy's rebuilt
-		// `admin.php?page=jetpack-backup` resolves to this same place.
+		// The page the reader is standing on: the modernized dashboard emits no admin
+		// URL, and legacy's rebuilt one resolves to the same place.
 		expect( href.searchParams.get( 'redirect_to' ) ).toBe( window.location.href );
 	} );
 
 	it( 'shows no link at all when the connection global carries no site slug', async () => {
-		// Legacy interpolates whatever it has, producing
-		// `…/checkout/undefined/<product>`. Half a checkout URL is worse
-		// than none: it still looks like a working button.
+		// Legacy interpolates whatever it has, producing `…/checkout/undefined/…`.
+		// Half a checkout URL is worse than none: it still looks like a button.
 		window.JP_CONNECTION_INITIAL_STATE = {
 			...window.JP_CONNECTION_INITIAL_STATE,
 			siteSuffix: undefined,
@@ -463,22 +427,14 @@ describe( 'the Tracks event', () => {
 		renderWithClient( <StorageSpace /> );
 		const link = await offerLink();
 
-		// A plain anchor, so there is no follow-up request to order the
-		// event against — which is how `tracks-events.test.tsx` tells "on
-		// click" from "on success" for the Back up now button. What
-		// distinguishes it here is the window the count is read in: still
-		// inside the click's own propagation, before the browser has been
-		// allowed to leave and before anything asynchronous could have
-		// run. An event moved to a `then`, to a `useEffect`, or to the
-		// offer query's own success path all land outside it.
+		// A plain anchor, so there is no follow-up request to order the event against.
+		// What distinguishes it is the window the count is read in: still inside the
+		// click's own propagation, which an event moved to a `then`, a `useEffect` or
+		// the query's success path all land outside of.
 		//
-		// The probe goes on `document`, not on the link. React 18
-		// dispatches synthetic events from the root container, which sits
-		// below `document` in the propagation path — a listener on the
-		// link itself would run *before* the component's `onClick` and
-		// read zero however the handler was written. `preventDefault` here
-		// still cancels the navigation, which happens only after the event
-		// has finished propagating.
+		// The probe goes on `document`, not the link: React 18 dispatches synthetic
+		// events from the root container, so a listener on the link would run before
+		// the component's `onClick` and read zero however it was written.
 		const countAtClick = new Promise< number >( resolve => {
 			document.addEventListener(
 				'click',
@@ -500,16 +456,9 @@ describe( 'the Tracks event', () => {
 } );
 
 describe( 'a full site that reported no day count', () => {
-	// `getUsageLevel` reaches `Full` two ways: from the branch guarded on
-	// four truthy day counts, and from `100:` in the threshold table,
-	// which needs none of them. Only the second is exercised here, and it
-	// is not exotic — every field of `/site/backup/size` is optional, so
-	// a response carrying `size` and nothing else lands on it.
-	//
-	// Verified before this was written:
-	// `getUsageLevel( 100GB, 100GB, null, null, null, null )` → `'Full'`,
-	// and the section then rendered the heading "Cloud storage full" and
-	// the priced button with no warning line at all.
+	// `getUsageLevel` reaches `Full` two ways, and only the countless one — `100:` in
+	// the threshold table — is exercised here. It is not exotic: every field of
+	// `/site/backup/size` is optional, so a response carrying `size` alone lands on it.
 
 	beforeEach( () => {
 		mockEndpoints( {
@@ -521,10 +470,8 @@ describe( 'a full site that reported no day count', () => {
 	it( 'still says backups have stopped, without inventing a day count', async () => {
 		renderWithClient( <StorageSpace /> );
 
-		// Deliberately anchored: the counted sentence starts the same way
-		// and would satisfy a loose match, so an assertion that did not
-		// pin the ending would pass on "…with null day(s) of backups
-		// saved", which is what legacy prints here.
+		// Deliberately anchored: the counted sentence starts the same way, so a loose
+		// match would pass on legacy's "…with null day(s) of backups saved".
 		await expect(
 			warning(
 				/^You have reached your storage limit\. Backups have been stopped\. Please upgrade your storage to resume backups\.$/
@@ -540,11 +487,9 @@ describe( 'a full site that reported no day count', () => {
 	} );
 
 	it( 'says it even when the offer never arrives', async () => {
-		// The half of this that legacy gets wrong twice over. Its warning
-		// lives inside the checkout button, so no offer means no warning;
-		// and on this path it has no count to put in the warning either.
-		// A site whose backups have stopped would be shown an empty
-		// section.
+		// What legacy gets wrong twice over: its warning lives inside the checkout
+		// button, and on this path it has no count to put in it either — so a site
+		// whose backups have stopped is shown an empty section.
 		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
 			const path = options?.path ?? '';
 			if ( path.includes( '/site/backup/addon-offer' ) ) {

--- a/projects/packages/backup/tests/storage-addon-upsell.test.tsx
+++ b/projects/packages/backup/tests/storage-addon-upsell.test.tsx
@@ -357,6 +357,21 @@ describe( 'what the offer says', () => {
 		await expect( offerLink() ).resolves.toHaveTextContent( /\$9\.95\/month/ );
 	} );
 
+	it( 'ignores a discount of zero rather than quoting the add-on as free', async () => {
+		// A separate guard from the one above, and a separate failure: a
+		// zero is *lower* than the full price, so the "is this really a
+		// discount" comparison waves it through. What stops it is the
+		// `> 0` test beside it, and without that this button reads
+		// "$0.00/month" for something that costs $9.95.
+		mockEndpoints( {
+			offer: { pricing: { currency_code: 'USD', full_price: 9.95, discount_price: 0 } },
+		} );
+		renderWithClient( <StorageSpace /> );
+
+		await expect( offerLink() ).resolves.toHaveTextContent( /\$9\.95\/month/ );
+		expect( screen.queryByText( /\$0\.00/ ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'names the level in the warning it leads with', async () => {
 		// Four levels, four sentences, and the wording is the whole of what
 		// tells "getting close" apart from "backups have stopped".
@@ -481,5 +496,75 @@ describe( 'the Tracks event', () => {
 		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_backup_upgrade_storage_prompt_cta', {
 			site: SITE,
 		} );
+	} );
+} );
+
+describe( 'a full site that reported no day count', () => {
+	// `getUsageLevel` reaches `Full` two ways: from the branch guarded on
+	// four truthy day counts, and from `100:` in the threshold table,
+	// which needs none of them. Only the second is exercised here, and it
+	// is not exotic — every field of `/site/backup/size` is optional, so
+	// a response carrying `size` and nothing else lands on it.
+	//
+	// Verified before this was written:
+	// `getUsageLevel( 100GB, 100GB, null, null, null, null )` → `'Full'`,
+	// and the section then rendered the heading "Cloud storage full" and
+	// the priced button with no warning line at all.
+
+	beforeEach( () => {
+		mockEndpoints( {
+			size: { size: 100 * GB, days_of_backups_saved: undefined },
+			policies: { storage_limit_bytes: 100 * GB },
+		} );
+	} );
+
+	it( 'still says backups have stopped, without inventing a day count', async () => {
+		renderWithClient( <StorageSpace /> );
+
+		// Deliberately anchored: the counted sentence starts the same way
+		// and would satisfy a loose match, so an assertion that did not
+		// pin the ending would pass on "…with null day(s) of backups
+		// saved", which is what legacy prints here.
+		await expect(
+			warning(
+				/^You have reached your storage limit\. Backups have been stopped\. Please upgrade your storage to resume backups\.$/
+			)
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'never renders the counted sentence with a missing count in it', async () => {
+		renderWithClient( <StorageSpace /> );
+
+		await expect( offerLink() ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( /day\(s\) of backups saved/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'says it even when the offer never arrives', async () => {
+		// The half of this that legacy gets wrong twice over. Its warning
+		// lives inside the checkout button, so no offer means no warning;
+		// and on this path it has no count to put in the warning either.
+		// A site whose backups have stopped would be shown an empty
+		// section.
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( '/site/backup/addon-offer' ) ) {
+				return Promise.reject( new Error( 'catalogue unavailable' ) );
+			}
+			if ( path.includes( '/site/backup/policies' ) ) {
+				return Promise.resolve( { policies: { storage_limit_bytes: 100 * GB } } );
+			}
+			if ( path.includes( '/site/backup/size' ) ) {
+				return Promise.resolve( { ok: true, size: 100 * GB } );
+			}
+			return Promise.resolve( {} );
+		} );
+
+		renderWithClient( <StorageSpace /> );
+
+		await expect(
+			warning( /^You have reached your storage limit\. Backups have been stopped/ )
+		).resolves.toBeInTheDocument();
+		await settle();
+		expect( screen.queryByRole( 'link', { name: /additional storage/ } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/storage-help-popover.test.tsx
+++ b/projects/packages/backup/tests/storage-help-popover.test.tsx
@@ -1,0 +1,350 @@
+// Tests for the storage help popover beside the Overview's usage reading
+// (JETPACK-2332 / H3d).
+//
+// Two things are worth pinning here beyond "it opens". The first is when
+// it appears at all: only where the storage limit, not the plan, is what
+// decides how much history the site keeps. The second is its checkout
+// link, which is where legacy's copy is broken — the slug it interpolates
+// is written only by the `/addon-offer` response, and legacy's only
+// caller of that route renders at usage levels where this popover does
+// not, so the link is built from the store's `null` default every time.
+
+const mockRecordEvent = jest.fn();
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		initialize: jest.fn(),
+		tracks: { recordEvent: ( ...args: unknown[] ) => mockRecordEvent( ...args ) },
+	},
+} ) );
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StorageSpace from '../src/dashboard/components/storage-space';
+import type { ReactNode } from 'react';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const GB = 1024 * 1024 * 1024;
+const SITE = 'example.wordpress.com';
+
+// 100GB of limit at 5GB a backup is 20 days, against a plan promising 30
+// — the storage is deciding, so there is something to explain.
+const LIMIT = 100 * GB;
+const LAST_BACKUP = 5 * GB;
+const PLAN_RETENTION = 30;
+
+const TRIGGER = { name: 'Backup archive size' };
+
+/**
+ * Render inside an isolated QueryClient.
+ *
+ * @param ui - The tree to render.
+ * @return The testing-library render result.
+ */
+function renderWithClient( ui: ReactNode ) {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	return render( <QueryClientProvider client={ client }>{ ui }</QueryClientProvider> );
+}
+
+/**
+ * Answer the three routes the section reads.
+ *
+ * Defaults describe a site well inside its limit, whose backups are big
+ * enough that the limit — not the plan — caps its history.
+ *
+ * @param options          - Overrides.
+ * @param options.size     - What `/site/backup/size` returns.
+ * @param options.policies - What `/site/backup/policies` returns.
+ * @param options.offer    - What `/site/backup/addon-offer` returns.
+ */
+function mockEndpoints( {
+	size = {} as Record< string, unknown >,
+	policies = {} as Record< string, unknown >,
+	offer = {} as Record< string, unknown >,
+} = {} ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/site/backup/addon-offer' ) ) {
+			return Promise.resolve( {
+				slug: 'jetpack_backup_addon_storage_10gb_monthly',
+				size_text: '10GB',
+				pricing: { currency_code: 'USD', full_price: 4.95, discount_price: 4.95 },
+				...offer,
+			} );
+		}
+		if ( path.includes( '/site/backup/policies' ) ) {
+			return Promise.resolve( {
+				policies: {
+					storage_limit_bytes: LIMIT,
+					activity_log_limit_days: PLAN_RETENTION,
+					...policies,
+				},
+			} );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( {
+				ok: true,
+				size: 10 * GB,
+				days_of_backups_saved: 14,
+				last_backup_size: LAST_BACKUP,
+				...size,
+			} );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+/**
+ * Open the popover and hand back its "Add more storage" link.
+ *
+ * @return The anchor.
+ */
+async function openAndFindCta(): Promise< HTMLElement > {
+	await userEvent.click( await screen.findByRole( 'button', TRIGGER ) );
+	return screen.findByRole( 'link', { name: /Add more storage/ } );
+}
+
+/**
+ * The forecast sentence, once the popover is open.
+ *
+ * Found on its opening words rather than on the whole line: the copy
+ * wraps the day count in `<strong>`, and Testing Library's text matcher
+ * reads only an element's own text nodes — so the sentence is never a
+ * single match. Assert the rest with `toHaveTextContent`, which reads
+ * the subtree.
+ *
+ * @return The element carrying the sentence.
+ */
+function forecastLine(): Promise< HTMLElement > {
+	return screen.findByText( /^Based on the current size of your site/ );
+}
+
+/**
+ * Let whatever the popover started finish before asserting an absence.
+ *
+ * The two paragraphs render from figures already in hand, so awaiting
+ * them returns while `/addon-offer` is still in flight — and "there is no
+ * checkout link" would then be true for a reason that has nothing to do
+ * with the offer. See the same helper in `storage-addon-upsell.test.tsx`.
+ */
+async function settle(): Promise< void > {
+	await act( async () => {
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+	} );
+}
+
+beforeEach( () => {
+	mockApiFetch.mockReset();
+	mockRecordEvent.mockReset();
+	mockEndpoints();
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+		siteSuffix: SITE,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'when the popover appears', () => {
+	it( 'offers the explanation when storage is what caps the history', async () => {
+		renderWithClient( <StorageSpace /> );
+
+		await expect( screen.findByRole( 'button', TRIGGER ) ).resolves.toBeInTheDocument();
+	} );
+
+	it( 'says nothing when the plan, not the storage, is what caps it', async () => {
+		// 100GB at 1GB a backup is 100 days against a 30-day plan: the
+		// limit is not the constraint, so there is nothing to explain and
+		// an info button would only invite a question that has no answer.
+		mockEndpoints( { size: { last_backup_size: 1 * GB } } );
+		renderWithClient( <StorageSpace /> );
+
+		await expect( screen.findByText( /^Using/ ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', TRIGGER ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'says nothing when the last backup size is unreported', async () => {
+		// No divisor, so no forecast. Legacy folds this into the same zero
+		// it uses for "not even one backup fits", and then hides on the
+		// zero — right answer, but only by accident.
+		mockEndpoints( { size: { last_backup_size: undefined } } );
+		renderWithClient( <StorageSpace /> );
+
+		await expect( screen.findByText( /^Using/ ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', TRIGGER ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'says nothing once the section is already warning about storage', async () => {
+		// Above `Normal` the section is telling the reader storage is
+		// running out and offering more; a second, calmer explanation of
+		// how many days fit would be arguing with it.
+		mockEndpoints( { size: { size: 90 * GB } } );
+		renderWithClient( <StorageSpace /> );
+
+		await expect( screen.findByText( /^Using/ ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', TRIGGER ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'starts closed', async () => {
+		// Legacy opens itself the first time any browser loads the
+		// dashboard. `Popover.Popup` takes focus when it opens, so doing
+		// that here would move the keyboard into a panel nobody asked for
+		// during page load.
+		renderWithClient( <StorageSpace /> );
+
+		await expect( screen.findByRole( 'button', TRIGGER ) ).resolves.toBeInTheDocument();
+		expect(
+			screen.queryByText( /Based on the current size of your site/ )
+		).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'what the popover says', () => {
+	it( 'states the forecast in days, pluralized', async () => {
+		renderWithClient( <StorageSpace /> );
+		await userEvent.click( await screen.findByRole( 'button', TRIGGER ) );
+
+		await expect( forecastLine() ).resolves.toHaveTextContent(
+			/^Based on the current size of your site, Jetpack will save 20 days of full backups\.$/
+		);
+	} );
+
+	it( 'says "1 day of full backup" rather than "1 days"', async () => {
+		// 100GB of limit at 60GB a backup is one whole day and a
+		// remainder, floored to one. The singular is a separate msgid
+		// rather than a substitution, so nothing else covers it.
+		mockEndpoints( { size: { last_backup_size: 60 * GB } } );
+		renderWithClient( <StorageSpace /> );
+		await userEvent.click( await screen.findByRole( 'button', TRIGGER ) );
+
+		await expect( forecastLine() ).resolves.toHaveTextContent(
+			/^Based on the current size of your site, Jetpack will save 1 day of full backup\.$/
+		);
+	} );
+
+	it( 'links out to the guidance on shrinking a backup', async () => {
+		renderWithClient( <StorageSpace /> );
+		await userEvent.click( await screen.findByRole( 'button', TRIGGER ) );
+
+		const link = await screen.findByRole( 'link', { name: /reducing the backup size/ } );
+		expect( link ).toHaveAttribute(
+			'href',
+			'https://jetpack.com/support/backup/jetpack-vaultpress-backup-storage-and-retention/#reduce-storage-size'
+		);
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+	} );
+} );
+
+describe( 'the popover checkout link', () => {
+	it( 'carries a real product slug rather than an empty one', async () => {
+		// The legacy bug this replaces. Its slug comes from a store slot
+		// only the upsell fills, and the upsell never renders at the level
+		// this popover does — so legacy builds `…/checkout/<site>/null`.
+		renderWithClient( <StorageSpace /> );
+		const href = ( await openAndFindCta() ).getAttribute( 'href' ) as string;
+
+		expect( href ).toContain( '/jetpack_backup_addon_storage_10gb_monthly' );
+		expect( href ).not.toMatch( /\/(null|undefined)\b/ );
+	} );
+
+	it( 'fetches the offer itself rather than waiting for a sibling to', async () => {
+		// The dependency made explicit. Nothing else on this screen asks
+		// for the offer at `Normal`, so if this component did not, the
+		// slug above could only ever arrive by accident.
+		renderWithClient( <StorageSpace /> );
+		await expect( screen.findByRole( 'button', TRIGGER ) ).resolves.toBeInTheDocument();
+
+		await waitFor( () =>
+			expect(
+				mockApiFetch.mock.calls.filter( ( [ options ] ) =>
+					String( options?.path ?? '' ).includes( '/site/backup/addon-offer' )
+				)
+			).toHaveLength( 1 )
+		);
+	} );
+
+	it( 'shows no link at all when the offer never arrives', async () => {
+		// The explanation is still worth reading without it, so the
+		// popover keeps its two paragraphs and drops only the button.
+		mockEndpoints( { offer: { slug: undefined } } );
+		renderWithClient( <StorageSpace /> );
+		await userEvent.click( await screen.findByRole( 'button', TRIGGER ) );
+
+		await expect( forecastLine() ).resolves.toHaveTextContent(
+			/^Based on the current size of your site, Jetpack will save 20 days of full backups\.$/
+		);
+		await settle();
+		expect( screen.queryByRole( 'link', { name: /Add more storage/ } ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'the popover Tracks event', () => {
+	it( 'records nothing for opening the popover', async () => {
+		// Legacy records only the purchase click, and so does this. An
+		// event on the toggle would be a different, unregistered one.
+		renderWithClient( <StorageSpace /> );
+		await openAndFindCta();
+
+		expect( mockRecordEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'records the click itself under its own event name', async () => {
+		// Its own name, not the section upsell's: the two CTAs answer
+		// different questions and legacy counts them separately.
+		renderWithClient( <StorageSpace /> );
+		const cta = await openAndFindCta();
+
+		// Read from inside the click's own propagation, before the browser
+		// is allowed to leave — see `storage-addon-upsell.test.tsx` for
+		// why the probe goes on `document` rather than on the link.
+		const countAtClick = new Promise< number >( resolve => {
+			document.addEventListener(
+				'click',
+				event => {
+					event.preventDefault();
+					resolve( mockRecordEvent.mock.calls.length );
+				},
+				{ once: true }
+			);
+		} );
+
+		await userEvent.click( cta );
+
+		await expect( countAtClick ).resolves.toBe( 1 );
+		expect( mockRecordEvent ).toHaveBeenCalledWith(
+			'jetpack_backup_upgrade_storage_prompt_from_popover_cta',
+			{ site: SITE }
+		);
+	} );
+
+	it( 'omits the site rather than reporting it as the string "undefined"', async () => {
+		// No site slug means no checkout link, so the event is reached
+		// through the same absence the link is — which is the point: there
+		// is no path on which a payload could carry `site: undefined`.
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			siteSuffix: undefined,
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
+		renderWithClient( <StorageSpace /> );
+		await userEvent.click( await screen.findByRole( 'button', TRIGGER ) );
+
+		await expect( forecastLine() ).resolves.toHaveTextContent(
+			/^Based on the current size of your site, Jetpack will save 20 days of full backups\.$/
+		);
+		await settle();
+		expect( screen.queryByRole( 'link', { name: /Add more storage/ } ) ).not.toBeInTheDocument();
+		expect( mockRecordEvent ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/backup/tests/storage-help-popover.test.tsx
+++ b/projects/packages/backup/tests/storage-help-popover.test.tsx
@@ -1,13 +1,10 @@
 // Tests for the storage help popover beside the Overview's usage reading
 // (JETPACK-2332 / H3d).
 //
-// Two things are worth pinning here beyond "it opens". The first is when
-// it appears at all: only where the storage limit, not the plan, is what
-// decides how much history the site keeps. The second is its checkout
-// link, which is where legacy's copy is broken — the slug it interpolates
-// is written only by the `/addon-offer` response, and legacy's only
-// caller of that route renders at usage levels where this popover does
-// not, so the link is built from the store's `null` default every time.
+// Two things are pinned beyond "it opens": when it appears at all — only where the
+// storage limit, not the plan, decides how much history the site keeps — and its
+// checkout link, which legacy builds from a `null` default because its only caller of
+// `/addon-offer` renders at usage levels this popover does not.
 
 const mockRecordEvent = jest.fn();
 
@@ -119,11 +116,9 @@ async function openAndFindCta(): Promise< HTMLElement > {
 /**
  * The forecast sentence, once the popover is open.
  *
- * Found on its opening words rather than on the whole line: the copy
- * wraps the day count in `<strong>`, and Testing Library's text matcher
- * reads only an element's own text nodes — so the sentence is never a
- * single match. Assert the rest with `toHaveTextContent`, which reads
- * the subtree.
+ * Found on its opening words: the copy wraps the day count in `<strong>`, and Testing
+ * Library's matcher reads only an element's own text nodes. Assert the rest with
+ * `toHaveTextContent`.
  *
  * @return The element carrying the sentence.
  */
@@ -134,10 +129,8 @@ function forecastLine(): Promise< HTMLElement > {
 /**
  * Let whatever the popover started finish before asserting an absence.
  *
- * The two paragraphs render from figures already in hand, so awaiting
- * them returns while `/addon-offer` is still in flight — and "there is no
- * checkout link" would then be true for a reason that has nothing to do
- * with the offer. See the same helper in `storage-addon-upsell.test.tsx`.
+ * The two paragraphs render from figures already in hand, so awaiting them returns
+ * while `/addon-offer` is still in flight. See `storage-addon-upsell.test.tsx`.
  */
 async function settle(): Promise< void > {
 	await act( async () => {
@@ -165,29 +158,23 @@ describe( 'when the popover appears', () => {
 	} );
 
 	it( 'says what it is in words, not only to a screen reader', async () => {
-		// The trigger was a bare `ⓘ` carrying its name in `aria-label`,
-		// and every accessible-name assertion in this file passed on that
-		// — which is exactly why this one reads `textContent` instead.
-		// That is the only thing separating a labelled button from a glyph
-		// with a tooltip, and the distinction matters here more than
-		// anywhere else in the section: this renders at the one usage
-		// level where nothing else on screen suggests storage is worth a
-		// thought, so an unlabelled glyph is a feature nobody opens.
+		// Reads `textContent`, because every accessible-name assertion in this file
+		// also passed on the bare `ⓘ` this replaces. Visible words are the only thing
+		// separating a labelled button from a glyph with a tooltip — and this renders
+		// at the one level where nothing else suggests storage is worth a thought.
 		renderWithClient( <StorageSpace /> );
 		const trigger = await screen.findByRole( 'button', TRIGGER );
 
 		expect( trigger ).toHaveTextContent( /^Backup archive size$/ );
 
-		// The visible words *are* the accessible name rather than a second
-		// string beside it, which is WCAG 2.5.3 and the reason the visible
-		// text is this phrase and not a friendlier one of its own.
+		// The visible words *are* the accessible name rather than a second string
+		// beside it, which is WCAG 2.5.3.
 		expect( trigger ).toHaveAccessibleName( 'Backup archive size' );
 	} );
 
 	it( 'says nothing when the plan, not the storage, is what caps it', async () => {
-		// 100GB at 1GB a backup is 100 days against a 30-day plan: the
-		// limit is not the constraint, so there is nothing to explain and
-		// an info button would only invite a question that has no answer.
+		// 100GB at 1GB a backup is 100 days against a 30-day plan: the limit is not
+		// the constraint, so there is nothing to explain.
 		mockEndpoints( { size: { last_backup_size: 1 * GB } } );
 		renderWithClient( <StorageSpace /> );
 
@@ -196,9 +183,8 @@ describe( 'when the popover appears', () => {
 	} );
 
 	it( 'says nothing when the last backup size is unreported', async () => {
-		// No divisor, so no forecast. Legacy folds this into the same zero
-		// it uses for "not even one backup fits", and then hides on the
-		// zero — right answer, but only by accident.
+		// No divisor, so no forecast. Legacy folds this into the same zero it uses for
+		// "not even one backup fits" and hides on it — right answer, by accident.
 		mockEndpoints( { size: { last_backup_size: undefined } } );
 		renderWithClient( <StorageSpace /> );
 
@@ -207,11 +193,8 @@ describe( 'when the popover appears', () => {
 	} );
 
 	it( 'says nothing when not even one backup fits in the limit', async () => {
-		// 100GB of limit at a 200GB backup floors to zero. That is a real
-		// answer rather than a missing one, which is why the forecast is
-		// nullable separately — but "we will keep zero days of backups" is
-		// not something a small info button beside a calm meter can
-		// usefully explain, so it counts as nothing to say.
+		// 100GB of limit at a 200GB backup floors to zero — a real answer rather than
+		// a missing one, but not one a small info button can usefully explain.
 		mockEndpoints( { size: { last_backup_size: 200 * GB } } );
 		renderWithClient( <StorageSpace /> );
 
@@ -220,12 +203,8 @@ describe( 'when the popover appears', () => {
 	} );
 
 	it( 'says nothing when the forecast exactly matches what the plan promises', async () => {
-		// 90GB at 3GB a backup is 30 days against a 30-day plan. The
-		// comparison is strict on purpose: at parity the limit is not
-		// costing the reader anything, so there is no shortfall to
-		// explain. Chosen as round numbers because the boundary is the
-		// whole point — a limit divided by a retention would land on
-		// either side of it depending on floating-point luck.
+		// 90GB at 3GB a backup is 30 days against a 30-day plan. Strict on purpose: at
+		// parity the limit costs the reader nothing, so there is no shortfall.
 		mockEndpoints( {
 			size: { last_backup_size: 3 * GB },
 			policies: { storage_limit_bytes: 90 * GB },
@@ -237,9 +216,8 @@ describe( 'when the popover appears', () => {
 	} );
 
 	it( 'says nothing once the section is already warning about storage', async () => {
-		// Above `Normal` the section is telling the reader storage is
-		// running out and offering more; a second, calmer explanation of
-		// how many days fit would be arguing with it.
+		// Above `Normal` the section is already saying storage is running out; a
+		// calmer explanation of how many days fit would be arguing with it.
 		mockEndpoints( { size: { size: 90 * GB } } );
 		renderWithClient( <StorageSpace /> );
 
@@ -248,10 +226,8 @@ describe( 'when the popover appears', () => {
 	} );
 
 	it( 'starts closed', async () => {
-		// Legacy opens itself the first time any browser loads the
-		// dashboard. `Popover.Popup` takes focus when it opens, so doing
-		// that here would move the keyboard into a panel nobody asked for
-		// during page load.
+		// Legacy auto-opens on first load. `Popover.Popup` takes focus when it opens,
+		// so that would move the keyboard into a panel nobody asked for.
 		renderWithClient( <StorageSpace /> );
 
 		await expect( screen.findByRole( 'button', TRIGGER ) ).resolves.toBeInTheDocument();
@@ -272,9 +248,8 @@ describe( 'what the popover says', () => {
 	} );
 
 	it( 'says "1 day of full backup" rather than "1 days"', async () => {
-		// 100GB of limit at 60GB a backup is one whole day and a
-		// remainder, floored to one. The singular is a separate msgid
-		// rather than a substitution, so nothing else covers it.
+		// Floors to one. The singular is a separate msgid rather than a substitution,
+		// so nothing else covers it.
 		mockEndpoints( { size: { last_backup_size: 60 * GB } } );
 		renderWithClient( <StorageSpace /> );
 		await userEvent.click( await screen.findByRole( 'button', TRIGGER ) );
@@ -299,9 +274,8 @@ describe( 'what the popover says', () => {
 
 describe( 'the popover checkout link', () => {
 	it( 'carries a real product slug rather than an empty one', async () => {
-		// The legacy bug this replaces. Its slug comes from a store slot
-		// only the upsell fills, and the upsell never renders at the level
-		// this popover does — so legacy builds `…/checkout/<site>/null`.
+		// The legacy bug this replaces: its slug comes from a store slot only the
+		// upsell fills, so legacy builds `…/checkout/<site>/null`.
 		renderWithClient( <StorageSpace /> );
 		const href = ( await openAndFindCta() ).getAttribute( 'href' ) as string;
 
@@ -310,9 +284,8 @@ describe( 'the popover checkout link', () => {
 	} );
 
 	it( 'fetches the offer itself rather than waiting for a sibling to', async () => {
-		// The dependency made explicit. Nothing else on this screen asks
-		// for the offer at `Normal`, so if this component did not, the
-		// slug above could only ever arrive by accident.
+		// Nothing else on this screen asks for the offer at `Normal`, so without this
+		// the slug above could only arrive by accident.
 		renderWithClient( <StorageSpace /> );
 		await expect( screen.findByRole( 'button', TRIGGER ) ).resolves.toBeInTheDocument();
 
@@ -326,14 +299,10 @@ describe( 'the popover checkout link', () => {
 	} );
 
 	it( 'keeps its link on a response the upsell would reject', async () => {
-		// The one place the two consumers of `useStorageAddonOffer`
-		// deliberately differ. The upsell needs a size, a price and a
-		// currency for its label, so a priced-slug-without-pricing
-		// response leaves it with no button; this popover's button says
-		// only "Add more storage" and needs nothing but the slug. The hook
-		// carries `slug` and `sizeText` out past its own price check for
-		// exactly this, and dropping them would silently take the button
-		// away here while every other test went on passing.
+		// Where the two consumers of `useStorageAddonOffer` deliberately differ: the
+		// upsell needs a size, a price and a currency for its label, while this button
+		// says only "Add more storage" and needs the slug. The hook carries `slug` and
+		// `sizeText` past its own price check for exactly this.
 		mockEndpoints( { offer: { pricing: [] } } );
 		renderWithClient( <StorageSpace /> );
 
@@ -358,8 +327,7 @@ describe( 'the popover checkout link', () => {
 
 describe( 'the popover Tracks event', () => {
 	it( 'records nothing for opening the popover', async () => {
-		// Legacy records only the purchase click, and so does this. An
-		// event on the toggle would be a different, unregistered one.
+		// Legacy records only the purchase click, and so does this.
 		renderWithClient( <StorageSpace /> );
 		await openAndFindCta();
 
@@ -367,14 +335,12 @@ describe( 'the popover Tracks event', () => {
 	} );
 
 	it( 'records the click itself under its own event name', async () => {
-		// Its own name, not the section upsell's: the two CTAs answer
-		// different questions and legacy counts them separately.
+		// Its own name, not the section upsell's: legacy counts them separately.
 		renderWithClient( <StorageSpace /> );
 		const cta = await openAndFindCta();
 
-		// Read from inside the click's own propagation, before the browser
-		// is allowed to leave — see `storage-addon-upsell.test.tsx` for
-		// why the probe goes on `document` rather than on the link.
+		// Read from inside the click's own propagation — see
+		// `storage-addon-upsell.test.tsx` for why the probe goes on `document`.
 		const countAtClick = new Promise< number >( resolve => {
 			document.addEventListener(
 				'click',
@@ -396,9 +362,8 @@ describe( 'the popover Tracks event', () => {
 	} );
 
 	it( 'omits the site rather than reporting it as the string "undefined"', async () => {
-		// No site slug means no checkout link, so the event is reached
-		// through the same absence the link is — which is the point: there
-		// is no path on which a payload could carry `site: undefined`.
+		// No site slug means no checkout link, so there is no path on which a payload
+		// could carry `site: undefined`.
 		window.JP_CONNECTION_INITIAL_STATE = {
 			...window.JP_CONNECTION_INITIAL_STATE,
 			siteSuffix: undefined,
@@ -416,11 +381,9 @@ describe( 'the popover Tracks event', () => {
 } );
 
 describe( 'the panel a11y contract', () => {
-	// Everything asserted here is behaviour `@wordpress/ui`'s `Popover`
-	// brings on its own — none of it is wired up in this file. It is
-	// pinned because it is the whole of what that primitive is being paid
-	// for in bundle size, and because a later change to the trigger or the
-	// panel could take any of it away silently.
+	// Everything here is behaviour `@wordpress/ui`'s `Popover` brings on its own. Pinned
+	// because it is what that primitive is being paid for, and a later change to the
+	// trigger or panel could take it away silently.
 
 	/**
 	 * Open the popover and hand back the trigger and the panel.

--- a/projects/packages/backup/tests/storage-help-popover.test.tsx
+++ b/projects/packages/backup/tests/storage-help-popover.test.tsx
@@ -186,6 +186,36 @@ describe( 'when the popover appears', () => {
 		expect( screen.queryByRole( 'button', TRIGGER ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'says nothing when not even one backup fits in the limit', async () => {
+		// 100GB of limit at a 200GB backup floors to zero. That is a real
+		// answer rather than a missing one, which is why the forecast is
+		// nullable separately — but "we will keep zero days of backups" is
+		// not something a small info button beside a calm meter can
+		// usefully explain, so it counts as nothing to say.
+		mockEndpoints( { size: { last_backup_size: 200 * GB } } );
+		renderWithClient( <StorageSpace /> );
+
+		await expect( screen.findByText( /^Using/ ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', TRIGGER ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'says nothing when the forecast exactly matches what the plan promises', async () => {
+		// 90GB at 3GB a backup is 30 days against a 30-day plan. The
+		// comparison is strict on purpose: at parity the limit is not
+		// costing the reader anything, so there is no shortfall to
+		// explain. Chosen as round numbers because the boundary is the
+		// whole point — a limit divided by a retention would land on
+		// either side of it depending on floating-point luck.
+		mockEndpoints( {
+			size: { last_backup_size: 3 * GB },
+			policies: { storage_limit_bytes: 90 * GB },
+		} );
+		renderWithClient( <StorageSpace /> );
+
+		await expect( screen.findByText( /^Using/ ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', TRIGGER ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'says nothing once the section is already warning about storage', async () => {
 		// Above `Normal` the section is telling the reader storage is
 		// running out and offering more; a second, calmer explanation of
@@ -273,6 +303,22 @@ describe( 'the popover checkout link', () => {
 				)
 			).toHaveLength( 1 )
 		);
+	} );
+
+	it( 'keeps its link on a response the upsell would reject', async () => {
+		// The one place the two consumers of `useStorageAddonOffer`
+		// deliberately differ. The upsell needs a size, a price and a
+		// currency for its label, so a priced-slug-without-pricing
+		// response leaves it with no button; this popover's button says
+		// only "Add more storage" and needs nothing but the slug. The hook
+		// carries `slug` and `sizeText` out past its own price check for
+		// exactly this, and dropping them would silently take the button
+		// away here while every other test went on passing.
+		mockEndpoints( { offer: { pricing: [] } } );
+		renderWithClient( <StorageSpace /> );
+
+		const href = ( await openAndFindCta() ).getAttribute( 'href' ) as string;
+		expect( href ).toContain( '/jetpack_backup_addon_storage_10gb_monthly' );
 	} );
 
 	it( 'shows no link at all when the offer never arrives', async () => {

--- a/projects/packages/backup/tests/storage-help-popover.test.tsx
+++ b/projects/packages/backup/tests/storage-help-popover.test.tsx
@@ -164,6 +164,26 @@ describe( 'when the popover appears', () => {
 		await expect( screen.findByRole( 'button', TRIGGER ) ).resolves.toBeInTheDocument();
 	} );
 
+	it( 'says what it is in words, not only to a screen reader', async () => {
+		// The trigger was a bare `ⓘ` carrying its name in `aria-label`,
+		// and every accessible-name assertion in this file passed on that
+		// — which is exactly why this one reads `textContent` instead.
+		// That is the only thing separating a labelled button from a glyph
+		// with a tooltip, and the distinction matters here more than
+		// anywhere else in the section: this renders at the one usage
+		// level where nothing else on screen suggests storage is worth a
+		// thought, so an unlabelled glyph is a feature nobody opens.
+		renderWithClient( <StorageSpace /> );
+		const trigger = await screen.findByRole( 'button', TRIGGER );
+
+		expect( trigger ).toHaveTextContent( /^Backup archive size$/ );
+
+		// The visible words *are* the accessible name rather than a second
+		// string beside it, which is WCAG 2.5.3 and the reason the visible
+		// text is this phrase and not a friendlier one of its own.
+		expect( trigger ).toHaveAccessibleName( 'Backup archive size' );
+	} );
+
 	it( 'says nothing when the plan, not the storage, is what caps it', async () => {
 		// 100GB at 1GB a backup is 100 days against a 30-day plan: the
 		// limit is not the constraint, so there is nothing to explain and
@@ -392,5 +412,67 @@ describe( 'the popover Tracks event', () => {
 		await settle();
 		expect( screen.queryByRole( 'link', { name: /Add more storage/ } ) ).not.toBeInTheDocument();
 		expect( mockRecordEvent ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'the panel a11y contract', () => {
+	// Everything asserted here is behaviour `@wordpress/ui`'s `Popover`
+	// brings on its own — none of it is wired up in this file. It is
+	// pinned because it is the whole of what that primitive is being paid
+	// for in bundle size, and because a later change to the trigger or the
+	// panel could take any of it away silently.
+
+	/**
+	 * Open the popover and hand back the trigger and the panel.
+	 *
+	 * @return Both elements.
+	 */
+	async function openPanel(): Promise< { trigger: HTMLElement; panel: HTMLElement } > {
+		const trigger = await screen.findByRole( 'button', TRIGGER );
+		await userEvent.click( trigger );
+		return { trigger, panel: await screen.findByRole( 'dialog' ) };
+	}
+
+	it( 'exposes the panel as a dialog named by its title', async () => {
+		renderWithClient( <StorageSpace /> );
+		const { panel } = await openPanel();
+
+		expect( panel ).toHaveAccessibleName( 'Backup archive size' );
+
+		// Named by pointing at the title element rather than by copying the
+		// string into an attribute, which is what `Popover.Title` is for.
+		const titleId = panel.getAttribute( 'aria-labelledby' );
+		expect( titleId ).toBeTruthy();
+		/* eslint-disable-next-line testing-library/no-node-access -- the wiring is the assertion. */
+		expect( document.getElementById( titleId as string ) ).toHaveTextContent(
+			'Backup archive size'
+		);
+	} );
+
+	it( 'closes on Escape', async () => {
+		renderWithClient( <StorageSpace /> );
+		await openPanel();
+
+		await userEvent.keyboard( '{Escape}' );
+
+		await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument() );
+	} );
+
+	it( 'closes on a press outside it', async () => {
+		renderWithClient( <StorageSpace /> );
+		await openPanel();
+
+		await userEvent.click( document.body );
+
+		await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument() );
+	} );
+
+	it( 'returns focus to the trigger when it closes', async () => {
+		renderWithClient( <StorageSpace /> );
+		const { trigger } = await openPanel();
+
+		await userEvent.keyboard( '{Escape}' );
+
+		await waitFor( () => expect( trigger ).toHaveFocus() );
 	} );
 } );


### PR DESCRIPTION
Fixes JETPACK-2331
Fixes JETPACK-2332

Two H3 issues in one PR, deliberately: both add children to the modernized dashboard's storage section, and both need the same `/site/backup/addon-offer` response, so separate PRs would conflict with each other and would reproduce a legacy ordering bug between them.

## Proposed changes

* **JETPACK-2331 (H3c) — offer more storage when usage leaves Normal.** Once the storage meter leaves `Normal`, the section states what is wrong ("You are very close to reaching your storage limit…") and offers a priced "Add 100GB additional storage for $9.95/month, billed monthly" link into WordPress.com checkout. New `data/api/storage-addon-offer.ts` and `hooks/use-storage-addon-offer.ts` back it, following the `promoted-product` pattern H2 established — including its deliberate `retry: false`, because each attempt costs the *site* an uncached round trip to the product catalogue.
* **JETPACK-2332 (H3d) — the storage help popover.** At `Normal`, a labelled "Backup archive size" button beside the usage reading opens a panel explaining how many days of full backups the storage limit would hold, links to the guidance on shrinking a backup, and offers the same add-on.
* Extends `useStorageUsage()` with the three figures the two need — `minDaysOfBackupsAllowed`, `forecastInDays` and `planRetentionDays` — which that hook's own comment already anticipated ("Adding each back is one line when there is a caller").

Both are behind the dashboard modernization filter and unreachable from the legacy `src/js/` dashboard, which is why the changelog entry is the empty `Comment:` form and no plugin entries accompany it.

### Four legacy behaviours deliberately not carried over

* **`price.jsx` is not ported.** It splits an amount into symbol/integer/fraction for `PricingCard`'s layout, which nothing here wants, and it reads `currencyCode` off a pricing block whose key is `currency_code`. It therefore always gets `undefined`, and `getCurrencyObject` falls back to a `$` symbol — verified against the installed `@automattic/number-formatters`, where `getCurrencyObject( 9.95, undefined )` returns `symbol: '$'`. WordPress.com prices this catalogue from where the *site* appears to be, so legacy quotes a Brazilian site `$44.95` for a `R$44.95` add-on. `formatCurrency` returns the finished string with the right symbol. Legacy's msgid is reused verbatim, with its `<Price />` token now carrying that string, so the line arrives already translated.
* **The popover fetches the offer itself.** Legacy reads the add-on slug from a store slot that only its *upsell* fills, and the upsell renders only above `Normal` while the popover renders only at it — so the two never coexist and the slot holds its `null` default every time the popover draws its link, producing `…/checkout/<site>/null`. Sharing one React Query hook makes the dependency explicit; the two components cost one request between them, not two.
* **The warning is no longer inside the checkout button.** Legacy nests it there, so a site that is nearly out of storage and whose `/addon-offer` request fails is told nothing at all. The warning and the link now fail separately.
* **The popover starts closed, and its trigger is labelled.** See D2 below.

### Two gaps the issues flagged

* **`adminUrl`** has no source on the modernized page — `JPBACKUP_INITIAL_STATE` is deliberately not emitted there, and `JP_CONNECTION_INITIAL_STATE` carries no admin URL. `redirect_to` is `window.location.href` instead, which is the same destination by construction (this section only renders on the Backup dashboard) and is absolute, which `redirect_to` requires.
* **The Tracks hook** now exists — `hooks/use-analytics.ts`, from #51669 — so both CTAs record: `jetpack_backup_upgrade_storage_prompt_cta` and `jetpack_backup_upgrade_storage_prompt_from_popover_cta`, on the click, with `{ site }`.

## Three decisions taken deliberately — please don't re-litigate without reading these

### D1 — the popover uses `@wordpress/ui`'s `Popover`, and the size cost is accepted

This PR grows the dashboard route by ~10%, and **the WPDS popover is 94% of that**: +64,536 bytes raw, isolated by rebuilding with only the `Popover.*` primitives swapped for plain `div`s. A variant built on `@wordpress/components`' `Popover` would have brought the entire PR down to +19,527 raw / +3,948 gzipped.

We are taking the larger one on purpose. This package is moving to `@wordpress/ui`, so where both libraries offer the same primitive, WPDS wins and bundle size is not the argument that decides it. Recording the numbers here so the next reader sees the trade was measured rather than missed.

Nothing can be externalized to shrink it: `@wordpress/ui` declares `"wpScript": false`, so no `wp-ui` script handle exists to depend on, and the route's `content.min.asset.php` dependency array is byte-identical before and after.

What the ~15.8KB gzipped difference buys, each verified against `@wordpress/ui` 0.20.0 rather than assumed — all five are now pinned by `tests/storage-help-popover.test.tsx` § "the panel a11y contract":

* the panel is exposed as `role="dialog"`;
* it is named by `aria-labelledby` pointing at the `Popover.Title` element, rather than by a copied string;
* Escape closes it;
* a press outside closes it;
* focus returns to the trigger on close.

Focus management on the way *in* is `Popover.Popup`'s `initialFocus`/`finalFocus` plus `useDeprioritizedInitialFocus`, which skips close buttons when choosing what to focus first. None of this is wired up by this PR — it all comes from the primitive, which is what the bytes are paying for.

### D2 — the panel opens on click only, and the trigger says what it is

Legacy opens this panel automatically the first time any browser loads the dashboard, latching the dismissal in `localStorage`. Not carried over, for two reasons that were checked: `Popover.Popup` takes focus when it opens, so a self-open moves the keyboard into an unrequested panel during page load; and a `localStorage` latch is per-browser, so on a shared machine exactly one person ever sees it.

But dropping the self-open without replacing it would have left a small unlabelled `ⓘ` at the one usage level where nothing else on the page suggests storage is worth thinking about — a feature nobody opens. So the trigger now carries visible text: **"Backup archive size"**, with the info icon beside it, rendered as `Button` + `Button.Icon` instead of `IconButton`.

The visible string is the same msgid that titles the panel and that legacy already ships as this control's `aria-label`, so it arrives translated. That is not only convenience: the accessible name has to *contain* the visible label (WCAG 2.5.3), so a friendlier third sentence in the button was not available without either breaking that or changing the name.

The alternative — folding the forecast into the reading beside it — was rejected. That row already ends in "30 days of backups saved"; putting "20 days of full backups fit" next to it gives two different day counts, both about backups, with nothing explaining the disagreement, which is exactly the question this panel exists to answer.

The accessible name is unchanged by the swap: it used to come from `IconButton`'s `aria-label` and now comes from the button's own text, and `Button.Icon` renders through `@wordpress/primitives`' `SVG`, which is `aria-hidden` and `focusable="false"`. Every existing popover test locates the trigger by that name and all of them still pass untouched.

It also made the bundle **smaller**: −2,705 raw / −592 gzipped. `IconButton` pulls `utils/keyboard-shortcut` (three exports) that nothing else in the route uses; `Tooltip` itself was already present via `backup-now-button`.

### D3 — during an introductory promotion, flag-on and flag-off quote different prices

`use-storage-addon-offer.ts` shows the lower of `discount_price` and `full_price`. Legacy always shows `full_price`, because it renders `<Price discountPrice={…} />` into a component that destructures `discountedPrice` — `src/js/components/backup-storage-space/storage-addon-upsell-prompt/index.jsx:52` against `price.jsx:3`. The prop name never matches, so `discountedPrice` is always `undefined`, `discountedPrice > 0` is always false, and the discount branch is dead.

So the two dashboards will disagree during a promotion. That is deliberate: matching legacy would mean knowingly quoting the non-promotional figure to someone being offered the promotional one. The legacy bug has been logged separately for its owners; `src/js/` is out of scope here.

### Bundle cost, all in

`routes/dashboard/content.min.js` grows **815,851 → 897,723 bytes** (+81,872 raw, +10.0%) and **208,019 → 227,335 gzipped** (+19,316, +9.3%), measured by building trunk and this branch from the same checkout.

The split, isolated by rebuilding with one piece removed at a time: the upsell is **+15,125**, the popover **+69,210**, of which the WPDS `Popover` primitive alone is **+64,536** (see D1). `@automattic/number-formatters` adds **0** new bytes — `components/gates/promoted-price.tsx` already imports it on trunk. Importing `getProductCheckoutUrl` from the `@automattic/jetpack-components` barrel rather than keeping a local copy costs **+98**.

## Related product discussion/links

* JETPACK-2331, JETPACK-2332
* Builds on #51669 (JETPACK-2301), which put the Tracks client on the modernized page, and on JETPACK-2330, which added the usage readings this popover sits beside.
* Overlaps #51666 (`fix/backup-heading-outline`) in three files. Verified conflict-free: `git merge-tree` against that branch reports 0 conflicts, a trial three-way merge auto-merges cleanly, and the full suite passes on the merged tree — including that PR's new `heading-outline.test.tsx`, which the new components do not trip.
* **Separate bug, not fixed here.** The `/site/backup/addon-offer` route declares `'type' => 'numeric'` for both args (`src/class-jetpack-backup.php`). That is not one of WordPress's seven schema types, so `rest_validate_value_from_schema` emits `_doing_it_wrong` and falls through to `default: $is_valid = true` — neither arg is validated. `required` catches only absence, so an *empty* value passes both checks and the route answers 200 with the smallest add-on. Should be `'number'`. Left alone because that file has an open PR (#51436); logged separately.

## Does this pull request change what data or activity we track or use?

Yes, in the sense that two Tracks events the legacy dashboard already sends now also fire from the modernized one: `jetpack_backup_upgrade_storage_prompt_cta` and `jetpack_backup_upgrade_storage_prompt_from_popover_cta`, both carrying `{ site }`. No new event names, no new properties, and nothing fires until the reader clicks the link.

## Testing instructions

The whole change is behind the dashboard modernization filter, so nothing below is visible without it.

* Turn the modernized dashboard on, connect a site with a Backup plan, and go to **Jetpack → VaultPress Backup**.
* **The popover (`Normal` usage).** On a site using well under 65% of its storage whose last backup is large enough that the limit caps its history, a **"Backup archive size"** button with an info icon appears next to the "Using 12.4GB of 100GB" reading. It should be closed on load, including the very first load in a fresh browser profile. Open it: it should say how many days of full backups fit, link out to the guidance on reducing backup size, and offer "Add more storage". Check the "Add more storage" URL — it must name a real product (`jetpack_backup_addon_storage_*`), never `null`, which is what legacy produces here.
* **The panel's keyboard behaviour.** Tab to the button and press Enter. Focus should land inside the panel, Escape should close it, and focus should return to the button. A click anywhere outside should also close it.
* **The upsell (above `Normal`).** Push usage past 65% and the button is replaced by a warning line and a priced link below the readings. Past 80% the wording escalates, and at the limit it names the days of backups saved — or, if WordPress.com reported no day count, says "You have reached your storage limit. Backups have been stopped." without one.
* **The price.** The amount must carry the symbol WordPress.com priced it in. The quickest check is the network tab: `/jetpack/v4/site/backup/addon-offer` returns `pricing.currency_code`, and the rendered figure must agree with it. Legacy renders `$` here whatever that field says.
* **The request.** `/site/backup/addon-offer` should be requested exactly once per page, only after both `/site/backup/size` and `/site/backup/policies` have answered, and always with both `storage_size` and `storage_limit`. At `Normal` with no button showing, it should not be requested at all.
* `pnpm test` in `projects/packages/backup` — 57 suites, 557 tests. The two new files are `tests/storage-addon-upsell.test.tsx` (23) and `tests/storage-help-popover.test.tsx` (22).
