### PR TITLE
Forms: fix trunk phan failure from a semantic merge of two test PRs

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-jwt-id-tests-isolation
+++ b/projects/packages/forms/changelog/fix-forms-jwt-id-tests-isolation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Realign the JWT form-id tests with the shared setUp/tearDown isolation helpers.
+
+

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Test.php
@@ -720,7 +720,7 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 	}
 
 	public function test_process_form_rejects_zero_form_id_with_jwt() {
-		$previous_post = $this->setup_token_test( null, 'Test User' );
+		$this->setup_token_test( null, 'Test User' );
 
 		// A valid signed token, but the posted id does not identify the signed form.
 		$_POST['contact-form-id'] = '0';
@@ -731,12 +731,10 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertInstanceOf( Form_Submission_Error::class, $result, 'Expected a Form_Submission_Error when the posted id does not match the signed source.' );
 		$this->assertEquals( 'form_id_mismatch_post', $result->get_error_code(), 'Expected the error code to be "form_id_mismatch_post".' );
 		$this->assertTrue( $result->is_system_type(), 'Expected this to be a system error.' );
-
-		$this->teardown_post_for_test( $previous_post );
 	}
 
 	public function test_process_form_rejects_foreign_form_id_with_jwt() {
-		$previous_post = $this->setup_token_test( null, 'Test User' );
+		$this->setup_token_test( null, 'Test User' );
 
 		// Another real post is still not the source the token was signed for.
 		$other_post_id = wp_insert_post(
@@ -756,19 +754,19 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		$this->assertEquals( 'form_id_mismatch_post', $result->get_error_code(), 'Expected the error code to be "form_id_mismatch_post".' );
 
 		wp_delete_post( $other_post_id, true );
-		$this->teardown_post_for_test( $previous_post );
 	}
 
 	public function test_process_form_accepts_no_post_context_with_jwt() {
-		// A form rendered with no post in scope signs a ('single', 0) source and
-		// posts a non-numeric id ('jp-form'). The id gate must not treat that as a
-		// mismatch -- there is no post to bind to. Mirrors validate_parent_post().
-		global $post;
-		$this->get_current_user = wp_get_current_user();
+		/*
+		 * A form rendered with no post in scope signs a ('single', 0) source and
+		 * posts a non-numeric id ('jp-form'). The id gate must not treat that as a
+		 * mismatch -- there is no post to bind to. Mirrors validate_parent_post().
+		 *
+		 * setUp() has already nulled the $post global, and tearDown() restores the
+		 * $post global, $_POST and the current user, so there is nothing to save or
+		 * clean up here. Submit as a logged-out visitor, the way the JWT path runs.
+		 */
 		wp_set_current_user( 0 );
-
-		$previous_post = $post;
-		$post          = null;
 
 		$form                              = new Contact_Form( array( 'to' => 'test@example.com' ), "[contact-field label='Name' type='name' required='1'/]" );
 		$_POST['jetpack_contact_form_jwt'] = $form->get_jwt();
@@ -782,21 +780,18 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 		// not be rejected by the id gate.
 		$this->assertInstanceOf( Form_Submission_Error::class, $result );
 		$this->assertNotEquals( 'form_id_mismatch_post', $result->get_error_code(), 'A form with no post in scope must not be rejected by the id gate.' );
-
-		unset( $_POST['jetpack_contact_form_jwt'], $_POST['contact-form-hash'], $_POST['contact-form-id'] );
-		$post = $previous_post;
-		wp_set_current_user( $this->get_current_user->ID );
 	}
 
 	public function test_process_form_accepts_non_post_source_mismatch_with_jwt() {
-		// A widget (non-post) source is never bound to a post id, whatever the
-		// posted contact-form-id is.
-		global $post;
-		$this->get_current_user = wp_get_current_user();
+		/*
+		 * A widget (non-post) source is never bound to a post id, whatever the
+		 * posted contact-form-id is.
+		 *
+		 * setUp() has already nulled the $post global, and tearDown() restores the
+		 * $post global, $_POST and the current user, so there is nothing to save or
+		 * clean up here. Submit as a logged-out visitor, the way the JWT path runs.
+		 */
 		wp_set_current_user( 0 );
-
-		$previous_post = $post;
-		$post          = null;
 
 		$form                              = new Contact_Form(
 			array(
@@ -814,10 +809,6 @@ class Contact_Form_Plugin_Test extends BaseTestCase {
 
 		$this->assertInstanceOf( Form_Submission_Error::class, $result );
 		$this->assertNotEquals( 'form_id_mismatch_post', $result->get_error_code(), 'A non-post source must not be bound to a post id.' );
-
-		unset( $_POST['jetpack_contact_form_jwt'], $_POST['contact-form-hash'], $_POST['contact-form-id'] );
-		$post = $previous_post;
-		wp_set_current_user( $this->get_current_user->ID );
 	}
 
 	public function test_process_form_with_deleted_parent_post() {


### PR DESCRIPTION
## Proposed changes

Trunk's Static analysis (phan) job is currently red because two Forms test PRs that each passed CI on their own conflict semantically when landed together:

- **#51576** ("Forms: make the PHP test suite independent of test ordering") removed the `$get_current_user` property and the `teardown_post_for_test()` helper from `Contact_Form_Plugin_Test`, moving `$post`/`$_POST`/current-user cleanup into `setUp()`/`tearDown()`.
- **#51510** ("Contact Form: bind the posted form ID to the signed source on JWT submissions"), written against the pre-#51576 file, added four JWT tests that still captured `$previous_post`, called `$this->teardown_post_for_test()`, and referenced `$this->get_current_user`.

There was no textual conflict, so both merged clean and phan on trunk began failing with `PhanUndeclaredProperty` / `PhanUndeclaredMethod`. (This is what surfaced as the "Linting failed on trunk" alert — it's the Static analysis job, not PHPUnit.)

This PR reworks those four tests to the post-#51576 conventions: it drops the `$previous_post` capture and the `teardown_post_for_test()` calls, and lets `setUp()`/`tearDown()` handle the globals instead of the tests juggling `$post`, `$_POST`, and the current user by hand.

Test-only change; nothing user-facing.

## Related product discussion/links

* Reported in the jetpack-alerts channel: p1787864487459839-slack-C034JEXD1RD
* Failing run: https://github.com/Automattic/jetpack/actions/runs/33115584987/job/98669298220

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `jp phan packages/forms` — passes with `FOUND 0 ISSUES TOTAL` (fails on trunk without this change).
* `jp test php packages/forms` — the four `test_process_form_{rejects,accepts}_*_with_jwt` tests pass. (The only failures in a local run are the unrelated `Form_Webhooks_Test` localhost-SSRF tests, which fail in local Docker regardless of this change and pass in CI.)
