### PR TITLE
Correct the asset location for the Forms welcome guide

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-welcome-guide-images-wpcom
+++ b/projects/packages/forms/changelog/fix-forms-welcome-guide-images-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form editor: fix the welcome guide artwork not loading on WordPress.com Simple sites.

--- a/projects/packages/forms/src/form-editor/class-form-editor.php
+++ b/projects/packages/forms/src/form-editor/class-form-editor.php
@@ -302,6 +302,17 @@ class Form_Editor {
 				array(
 					'isEligible'         => $is_eligible,
 					'isCoreGuidePending' => self::is_core_welcome_guide_pending( $preferences ),
+
+					/*
+					 * Build-dir URL for the guide's artwork. The bundle sets
+					 * webpack's publicPath from this because `'auto'` misresolves
+					 * the images on WordPress.com Simple, where JS concatenation
+					 * rewrites the script URL auto-detection reads. Derived the
+					 * same way register_script() resolves the script URL above.
+					 */
+					'assetsUrl'          => trailingslashit(
+						Assets::normalize_path( plugins_url( '../../dist/form-editor', __FILE__ ) )
+					),
 				),
 				JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
 			) . ';',

--- a/projects/packages/forms/src/form-editor/welcome-guide/bootstrap.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/bootstrap.tsx
@@ -13,6 +13,8 @@
  * here; see Form_Editor::enqueue_admin_scripts().
  */
 
+// Must run before any image module evaluates its URL. See public-path.ts.
+import './public-path';
 import { registerPlugin } from '@wordpress/plugins';
 import { FormWelcomeGuide, JETPACK_FORM_WELCOME_GUIDE } from './index';
 

--- a/projects/packages/forms/src/form-editor/welcome-guide/public-path.ts
+++ b/projects/packages/forms/src/form-editor/welcome-guide/public-path.ts
@@ -1,0 +1,18 @@
+/* exported __webpack_public_path__ */
+/* global __webpack_public_path__ */
+
+/**
+ * Set Webpack's publicPath from the localized global so the guide's artwork
+ * resolves against the package build dir. The `'auto'` fallback is unreliable
+ * on WordPress.com Simple, where JS concatenation rewrites the script URL that
+ * auto-detection reads, leaving every emitted image 404ing.
+ *
+ * Imported first from bootstrap.tsx so this runs before any image module
+ * evaluates its URL.
+ * @see https://webpack.js.org/guides/public-path/#on-the-fly
+ */
+if ( typeof window === 'object' && window.jetpackFormsWelcomeGuide?.assetsUrl ) {
+	// @ts-expect-error: __webpack_public_path__ is set globally by webpack, ignore TS2304
+	// eslint-disable-next-line no-global-assign
+	__webpack_public_path__ = window.jetpackFormsWelcomeGuide.assetsUrl;
+}

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -252,7 +252,12 @@ declare global {
 			setCount: ( menuSlug: string, count: number ) => void;
 		};
 		/** Set by Form_Editor::enqueue_welcome_guide(); absent off the form editor. */
-		jetpackFormsWelcomeGuide?: { isEligible: boolean; isCoreGuidePending: boolean };
+		jetpackFormsWelcomeGuide?: {
+			isEligible: boolean;
+			isCoreGuidePending: boolean;
+			/** Build-dir URL webpack prepends to the guide's artwork; see welcome-guide/public-path.ts. */
+			assetsUrl?: string;
+		};
 	}
 }
 

--- a/projects/packages/forms/tests/js/form-editor/welcome-guide/public-path.test.js
+++ b/projects/packages/forms/tests/js/form-editor/welcome-guide/public-path.test.js
@@ -1,0 +1,52 @@
+/**
+ * Tests for the welcome guide's Webpack public-path override, which runs as an
+ * import-time side effect — each case arranges globals then re-requires it.
+ */
+
+describe( 'welcome-guide public-path', () => {
+	beforeEach( () => {
+		/*
+		 * Webpack supplies this free variable in real builds; define it here so
+		 * the module's strict-mode assignment resolves instead of throwing.
+		 */
+		global.__webpack_public_path__ = 'initial/';
+		jest.resetModules();
+	} );
+
+	afterEach( () => {
+		delete window.jetpackFormsWelcomeGuide;
+		delete global.__webpack_public_path__;
+	} );
+
+	test( 'sets the public path from the localized global when present', () => {
+		window.jetpackFormsWelcomeGuide = {
+			isEligible: true,
+			isCoreGuidePending: false,
+			assetsUrl: 'https://example.com/dist/form-editor/',
+		};
+
+		require( '../../../../src/form-editor/welcome-guide/public-path' );
+
+		expect( global.__webpack_public_path__ ).toBe( 'https://example.com/dist/form-editor/' );
+	} );
+
+	test( 'leaves the public path unchanged when the localized global is absent', () => {
+		delete window.jetpackFormsWelcomeGuide;
+
+		require( '../../../../src/form-editor/welcome-guide/public-path' );
+
+		expect( global.__webpack_public_path__ ).toBe( 'initial/' );
+	} );
+
+	test( 'leaves the public path unchanged when assetsUrl is empty', () => {
+		window.jetpackFormsWelcomeGuide = {
+			isEligible: true,
+			isCoreGuidePending: false,
+			assetsUrl: '',
+		};
+
+		require( '../../../../src/form-editor/welcome-guide/public-path' );
+
+		expect( global.__webpack_public_path__ ).toBe( 'initial/' );
+	} );
+} );

--- a/projects/packages/forms/tests/js/form-editor/welcome-guide/public-path.test.js
+++ b/projects/packages/forms/tests/js/form-editor/welcome-guide/public-path.test.js
@@ -1,7 +1,11 @@
 /**
  * Tests for the welcome guide's Webpack public-path override, which runs as an
- * import-time side effect — each case arranges globals then re-requires it.
+ * import-time side effect — each case arranges globals then re-imports it.
  */
+
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+const MODULE = '../../../../src/form-editor/welcome-guide/public-path';
 
 describe( 'welcome-guide public-path', () => {
 	beforeEach( () => {
@@ -18,34 +22,34 @@ describe( 'welcome-guide public-path', () => {
 		delete global.__webpack_public_path__;
 	} );
 
-	test( 'sets the public path from the localized global when present', () => {
+	test( 'sets the public path from the localized global when present', async () => {
 		window.jetpackFormsWelcomeGuide = {
 			isEligible: true,
 			isCoreGuidePending: false,
 			assetsUrl: 'https://example.com/dist/form-editor/',
 		};
 
-		require( '../../../../src/form-editor/welcome-guide/public-path' );
+		await import( MODULE );
 
 		expect( global.__webpack_public_path__ ).toBe( 'https://example.com/dist/form-editor/' );
 	} );
 
-	test( 'leaves the public path unchanged when the localized global is absent', () => {
+	test( 'leaves the public path unchanged when the localized global is absent', async () => {
 		delete window.jetpackFormsWelcomeGuide;
 
-		require( '../../../../src/form-editor/welcome-guide/public-path' );
+		await import( MODULE );
 
 		expect( global.__webpack_public_path__ ).toBe( 'initial/' );
 	} );
 
-	test( 'leaves the public path unchanged when assetsUrl is empty', () => {
+	test( 'leaves the public path unchanged when assetsUrl is empty', async () => {
 		window.jetpackFormsWelcomeGuide = {
 			isEligible: true,
 			isCoreGuidePending: false,
 			assetsUrl: '',
 		};
 
-		require( '../../../../src/form-editor/welcome-guide/public-path' );
+		await import( MODULE );
 
 		expect( global.__webpack_public_path__ ).toBe( 'initial/' );
 	} );

--- a/projects/plugins/jetpack/changelog/fix-forms-welcome-guide-images-wpcom
+++ b/projects/plugins/jetpack/changelog/fix-forms-welcome-guide-images-wpcom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: fix the form editor welcome guide artwork not loading on WordPress.com Simple sites.


### PR DESCRIPTION
## Proposed changes

* Correct the asset location for the Forms welcome guide so its illustrations load on WordPress.com Simple sites. The bundle now sets webpack's `publicPath` from a localized build-dir URL instead of relying on `publicPath: 'auto'`, which JS concatenation breaks on Simple sites.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a WordPress.com Simple site, create a new form (`post-new.php?post_type=jetpack_form`).
* Confirm the welcome guide modal opens with all five slide illustrations rendered (previously they 404'd).
* Also verify on a self-hosted/Atomic site that the images still render, to confirm no regression where concatenation is absent.
