### PR TITLE
Backup: drop the dead isComplete field and an orphaned CSS rule

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-remove-dead-iscomplete-and-orphan-css
+++ b/projects/packages/backup/changelog/fix-backup-remove-dead-iscomplete-and-orphan-css
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Removes an unread field and an orphaned CSS rule from the modernized dashboard, which is behind a feature flag and not reachable with it off.
+
+

--- a/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
@@ -55,9 +55,4 @@
 			color: var(--wp-components-color-foreground, #1e1e1e);
 		}
 	}
-
-	&__actions {
-		padding-top: 8px;
-		border-top: 1px solid var(--wp-components-color-gray-200, #e0e0e0);
-	}
 }

--- a/projects/packages/backup/src/dashboard/data/normalize/activity-log.ts
+++ b/projects/packages/backup/src/dashboard/data/normalize/activity-log.ts
@@ -56,8 +56,6 @@ export function normalizeEntry( entry: WpcomActivityEntry ): ActivityItem {
 			// stringified JSON blob, not a friendly string — rendering
 			// it verbatim dumps raw JSON into the UI.
 			stats: entry.content?.text ?? '',
-			isComplete:
-				entry.name === 'rewind__backup_complete_full' || entry.name === 'rewind__backup_complete',
 		};
 	}
 

--- a/projects/packages/backup/src/dashboard/data/normalize/test/activity-log.test.ts
+++ b/projects/packages/backup/src/dashboard/data/normalize/test/activity-log.test.ts
@@ -73,7 +73,6 @@ describe( 'normalizeEntry', () => {
 			// `object.backup_stats`. Rendering backup_stats verbatim
 			// would dump JSON into the UI.
 			stats: '4 plugins, 1 theme, 20 uploads, 4 posts, 1 page',
-			isComplete: true,
 		} );
 	} );
 

--- a/projects/packages/backup/src/dashboard/types/activity.ts
+++ b/projects/packages/backup/src/dashboard/types/activity.ts
@@ -31,7 +31,6 @@ export type BackupActivityItem = ActivityItemBase & {
 	kind: 'backup';
 	rewindId: string;
 	stats: string;
-	isComplete: boolean;
 };
 
 export type NonBackupActivityItem = ActivityItemBase & {

--- a/projects/packages/backup/tests/backup-detail-title.test.tsx
+++ b/projects/packages/backup/tests/backup-detail-title.test.tsx
@@ -35,7 +35,6 @@ function backupItem( title: string ): BackupActivityItem {
 		actor: { type: 'Application', name: 'Jetpack' },
 		rewindId: '1786644531.123',
 		stats: '46 plugins, 23 themes',
-		isComplete: true,
 	};
 }
 


### PR DESCRIPTION
Part of JETPACK-2315.

Deliberately **not** a closing keyword — this lands two of that issue's three items. Item 3 is left open, see below.

## Proposed changes

Two unrelated deletions in the modernized Backup dashboard. Both are pure removals of code nothing reads; there is no behavior change with the modernization flag on or off.

* **Remove the dead `isComplete` field.** It was computed in `normalizeEntry`, declared on `BackupActivityItem`, and asserted in two test fixtures — and read by nothing. Deleted from all four sites.
* **Remove the orphaned `.jpb-file-info-card__actions` CSS rule.** It styled the per-file Download and Restore buttons that `52228c8732` deleted; that commit dropped the last `className="jpb-file-info-card__actions"` from the component and left the rule behind.

### Item 3 is deferred, not done

JETPACK-2315's third item is the progress-bar `aria-label`s in `src/dashboard/screens/restore.tsx` and `src/dashboard/screens/download.tsx`. Both files are held by open PR #51666, so touching them here would guarantee a conflict.

**JETPACK-2315 must stay open when this merges** — item 3 still needs a follow-up once #51666 lands.

## Evidence that each deleted thing is unread

This is deletion work, so the claim needing proof is a negative. Both searches were re-derived against trunk rather than taken from the issue.

**`isComplete` — whole monorepo, all JS/TS extensions:**

```
grep -rn --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' \
  --exclude-dir=node_modules --exclude-dir=build --exclude-dir=.git -w 'isComplete' .
```

Hits land only in unrelated packages — premium-analytics, forms, podcast, scan, publicize, jetpack-mu-wpcom, and the tiled-gallery / image-compare blocks — each an independent local binding. Within `packages/backup` an unrestricted `grep -rn 'isComplete'` (no extension filter, so `.scss`, `.php` and `.json` included) returned exactly four lines, all of them the definition sites removed here.

Ruling out non-literal reads:
* No bracket access — `grep -rn '\(item\|activity\|backup\|entry\)\s*\['` over `src/dashboard/` returns nothing.
* No key walk — the `Object.keys`/`entries`/`values` calls in the dashboard operate on file trees, restore-type maps, storage thresholds, query args and `backup_stats`, never on an activity item.
* The one spread of a backup entry, `{ ...backupEntry, rewind_id: undefined }` in the normalize test, rebuilds a *wire* entry, not a normalized item.
* `packages/backup` has no `__snapshots__` directory, so no snapshot pins the field.

**`.jpb-file-info-card__actions` — whole monorepo, every file type, build dirs included:**

```
grep -rn 'jpb-file-info-card__actions' . --exclude-dir=node_modules --exclude-dir=.git
```

Exit 1, zero matches. `git log -S` confirms the string's whole life cycle: added in `7f2679ddd5`, removed from the component in `52228c8732`, never re-added.

The converse also holds — `__actions` is the *only* dead rule in that file. The five remaining selectors (root, `__header`, `__meta`, `__hash`, `__preview`) were each matched against rendered markup in `index.tsx`, including the nested `&__meta div/dt/dd` and `&__preview pre`.

### What was deliberately *not* removed

Removing `isComplete` leaves `WpcomActivityEntry.name` with no reader in `src/`. It is kept on purpose: it is a required field of the WPCOM wire payload, not something we derive, and three test fixtures set it. An unread field on a type that models an external payload is documentation, not dead code — and making it optional would be actively worse, since it would weaken a field WPCOM always sends. Trimming the response type is a separate judgment call from deleting our own dead output, and `data/api/activity-log.ts` is outside this PR's scope.

Worth a one-line comment on that field as a follow-up, so the next dead-code sweep does not re-litigate it.

### Test-suite sensitivity

The normalize suite asserts with `toMatchObject`, which is a *superset* match — dropping an expectation line alone can never fail. So I checked the suite actually detects this class of change. Both directions, on the pre-change code:

* Production emits `isComplete`, test omits it → **17 passed** (superset match, as expected).
* Test expects a field, production omits it → **1 failed, 16 passed** (removing the live sibling `stats` from `normalizeEntry`).

So the remaining expectations are load-bearing, and the deletion here is safe because production and assertion were removed together. Package-wide the ratio is 38 `toMatchObject` to 19 `toEqual` — a generic weakness, pre-existing and out of scope for this PR.

### Corrections to the issue body

* JETPACK-2315 says PR #51412 "cleaned up the docblock and the orphaned `&__hash` rule". **It did neither.** `git show --stat b8cad2cd60` lists 11 files and `style.scss` is not among them; `git log --oneline -- .../file-info-card/style.scss` shows the SCSS has exactly one commit in its entire history (`7f2679ddd5`, the original). What #51412 actually did was re-add `<dd className="jpb-file-info-card__hash">` to `index.tsx` — `git log -S 'jpb-file-info-card__hash'` names it as the commit that reintroduced the string, and its own diff says it "gives the orphaned `&__hash` style a consumer again". **`&__hash` is live and stays.** Acting on the issue's wording would have deleted a rule that is in use.
* The issue's note that "#51404 adds a test fixture that sets it" resolves to `projects/packages/backup/tests/backup-detail-title.test.tsx:38`, merged as `bf54749033`. Its `backupItem()` helper set `isComplete: true` as hygiene — the field existed on the type, so the fixture mirrored it. No gate required it: `tsconfig.json` has `include: [ "./src/js", "./routes/**/*", "types.d.ts" ]`, so neither `tests/**` nor `src/dashboard/**/test/**` is in a root set, and jest strips types via Babel. That line is removed here because the field no longer exists, not because anything would have failed.
* All four cited line numbers were accurate against trunk `e50205f394` — `activity-log.ts:59-60`, `types/activity.ts:34`, `activity-log.test.ts:76`, `style.scss:59-62`.

## Related product discussion/links

* JETPACK-2315

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a pure deletion with no runtime behavior change, so the check is that nothing regressed.

From `projects/packages/backup`:

* `jp build packages/backup --deps` — completes.
* `pnpm test` — 55 suites, 512 tests, all passing.
* `pnpm run typecheck` — clean. This is the meaningful gate for the *production* deletion: `src/dashboard/**` is not in the tsconfig root set directly but is pulled in transitively through `routes/**/*`, so any real read of `isComplete` in a component or hook would fail here. Verified with a control — planting `const __probe: number = "not a number";` in `src/dashboard/types/activity.ts` produces `TS2322`, while the same line in either test file is not caught.
* `pnpm exec stylelint src/dashboard/components/file-info-card/style.scss` — clean.
* `jp phan packages/backup` — `FOUND 0 ISSUES TOTAL`.

For a visual check, open the modernized dashboard's file browser and select a file: the info card should look exactly as it does on trunk — the removed rule styled a button row that no longer exists.
