### PR TITLE
Backup: read the field names WordPress.com actually sends in get-backup-overview

### DIFF
--- a/projects/packages/backup/changelog/backup-overview-storage-and-schedule-mapping
+++ b/projects/packages/backup/changelog/backup-overview-storage-and-schedule-mapping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Abilities: Fix the backup overview reporting no storage usage, storage limit or backup time.

--- a/projects/packages/backup/src/abilities/class-backup-abilities.php
+++ b/projects/packages/backup/src/abilities/class-backup-abilities.php
@@ -191,11 +191,14 @@ class Backup_Abilities extends Registrar {
 								'has_warnings'  => array( 'type' => array( 'boolean', 'null' ) ),
 							),
 						),
+						// Hour only, and deliberately so: WordPress.com schedules
+						// daily backups to the hour (`scheduled_hour`), and no
+						// endpoint carries a minute. A `minute` field here could
+						// only ever be null, which is worse than absent.
 						'schedule'            => array(
 							'type'       => array( 'object', 'null' ),
 							'properties' => array(
-								'hour'   => array( 'type' => array( 'integer', 'null' ) ),
-								'minute' => array( 'type' => array( 'integer', 'null' ) ),
+								'hour' => array( 'type' => array( 'integer', 'null' ) ),
 							),
 						),
 						'storage'             => array(
@@ -432,12 +435,18 @@ class Backup_Abilities extends Registrar {
 		$backups       = self::unwrap_response( Jetpack_Backup::get_recent_backups() );
 		$schedule_data = self::unwrap_response( Jetpack_Backup::get_site_backup_schedule_time() );
 		$size_data     = self::unwrap_response( Jetpack_Backup::get_site_backup_size() );
+		// Storage takes two round-trips because neither route describes it
+		// alone: `/rewind/size` reports usage and `/rewind/policies` reports
+		// the plan's limit. Fetched unconditionally rather than only when the
+		// size read succeeded, so a usable limit still reaches the caller when
+		// WordPress.com cannot report usage.
+		$policies_data = self::unwrap_response( Jetpack_Backup::get_site_backup_policies() );
 
 		return array(
 			'recent_backup_count' => is_array( $backups ) ? count( $backups ) : null,
 			'last_backup'         => self::summarize_last_backup( is_array( $backups ) ? ( $backups[0] ?? null ) : null ),
 			'schedule'            => self::summarize_schedule( $schedule_data ),
-			'storage'             => self::summarize_storage( $size_data ),
+			'storage'             => self::summarize_storage( $size_data, $policies_data ),
 		);
 	}
 
@@ -861,7 +870,14 @@ class Backup_Abilities extends Registrar {
 	}
 
 	/**
-	 * Summarize the wpcom schedule payload to `{ hour, minute }`.
+	 * Summarize the `/site/backup/schedule` payload to `{ hour }`.
+	 *
+	 * WordPress.com answers `{ ok, scheduled_hour, scheduled_by }` — the hour
+	 * of the day, in UTC, that the daily backup is scheduled for. `ok` is its
+	 * own success flag *inside* a 200 body, so a payload that does not set it
+	 * carries no usable hour, and there is no minute anywhere on the response
+	 * (the legacy dashboard renders the hour as a `HH:00`-`HH:59` window for
+	 * exactly this reason).
 	 *
 	 * @param mixed $raw Upstream schedule payload.
 	 * @return array|null
@@ -871,30 +887,57 @@ class Backup_Abilities extends Registrar {
 			return null;
 		}
 		$raw = (array) $raw;
+		if ( empty( $raw['ok'] ) ) {
+			return null;
+		}
 		return array(
-			'hour'   => isset( $raw['hour'] ) ? (int) $raw['hour'] : null,
-			'minute' => isset( $raw['minute'] ) ? (int) $raw['minute'] : null,
+			'hour' => isset( $raw['scheduled_hour'] ) ? (int) $raw['scheduled_hour'] : null,
 		);
 	}
 
 	/**
-	 * Maps both the production wpcom field names (`size_in_bytes`, `storage_limit_bytes`)
-	 * and shorter aliases (`used_bytes`, `limit_bytes`) so the ability stays stable
-	 * if the upstream payload is renamed.
+	 * Summarize storage from the two payloads that between them describe it.
 	 *
-	 * @param mixed $raw Upstream storage payload.
+	 * Usage is `size` on `/site/backup/size`, whose response carries no
+	 * storage limit at all despite the route's name; the limit is
+	 * `policies.storage_limit_bytes` on `/site/backup/policies`. The same
+	 * fan-out the dashboard's storage meter performs — see
+	 * `src/dashboard/hooks/use-storage-usage.ts`.
+	 *
+	 * `/size` additionally carries WordPress.com's own `ok` flag inside a 200
+	 * body; without it the sibling fields carry no meaning, so usage is
+	 * discarded rather than half-read. The limit is read independently, so a
+	 * site whose usage could not be measured still reports what it is allowed.
+	 *
+	 * @param mixed $size_raw     Upstream `/site/backup/size` payload.
+	 * @param mixed $policies_raw Upstream `/site/backup/policies` payload.
 	 * @return array|null
 	 */
-	private static function summarize_storage( $raw ): ?array {
-		if ( ! is_array( $raw ) && ! is_object( $raw ) ) {
+	private static function summarize_storage( $size_raw, $policies_raw ): ?array {
+		$size     = ( is_array( $size_raw ) || is_object( $size_raw ) ) ? (array) $size_raw : null;
+		$policies = ( is_array( $policies_raw ) || is_object( $policies_raw ) ) ? (array) $policies_raw : null;
+
+		if ( null === $size && null === $policies ) {
 			return null;
 		}
-		$raw         = (array) $raw;
-		$used_bytes  = $raw['size_in_bytes'] ?? ( $raw['used_bytes'] ?? null );
-		$limit_bytes = $raw['storage_limit_bytes'] ?? ( $raw['limit_bytes'] ?? null );
+
+		$used_bytes = ( null !== $size && ! empty( $size['ok'] ) && isset( $size['size'] ) )
+			? (int) $size['size']
+			: null;
+
+		// The limit is nested one level down, and `policies` is itself nullable
+		// inside a 200: a plan with no retention policy answers
+		// `{ "policies": null }`.
+		$policy = $policies['policies'] ?? null;
+		$policy = ( is_array( $policy ) || is_object( $policy ) ) ? (array) $policy : null;
+
+		$limit_bytes = ( null !== $policy && isset( $policy['storage_limit_bytes'] ) )
+			? (int) $policy['storage_limit_bytes']
+			: null;
+
 		return array(
-			'used_bytes'  => null === $used_bytes ? null : (int) $used_bytes,
-			'limit_bytes' => null === $limit_bytes ? null : (int) $limit_bytes,
+			'used_bytes'  => $used_bytes,
+			'limit_bytes' => $limit_bytes,
 		);
 	}
 }

--- a/projects/packages/backup/src/abilities/class-backup-abilities.php
+++ b/projects/packages/backup/src/abilities/class-backup-abilities.php
@@ -191,10 +191,8 @@ class Backup_Abilities extends Registrar {
 								'has_warnings'  => array( 'type' => array( 'boolean', 'null' ) ),
 							),
 						),
-						// Hour only, and deliberately so: WordPress.com schedules
-						// daily backups to the hour (`scheduled_hour`), and no
-						// endpoint carries a minute. A `minute` field here could
-						// only ever be null, which is worse than absent.
+						// Hour only: no WordPress.com endpoint carries a minute,
+						// so a `minute` field could only ever be null.
 						'schedule'            => array(
 							'type'       => array( 'object', 'null' ),
 							'properties' => array(
@@ -435,11 +433,9 @@ class Backup_Abilities extends Registrar {
 		$backups       = self::unwrap_response( Jetpack_Backup::get_recent_backups() );
 		$schedule_data = self::unwrap_response( Jetpack_Backup::get_site_backup_schedule_time() );
 		$size_data     = self::unwrap_response( Jetpack_Backup::get_site_backup_size() );
-		// Storage takes two round-trips because neither route describes it
-		// alone: `/rewind/size` reports usage and `/rewind/policies` reports
-		// the plan's limit. Fetched unconditionally rather than only when the
-		// size read succeeded, so a usable limit still reaches the caller when
-		// WordPress.com cannot report usage.
+		// Two round-trips because neither route describes storage alone: `/rewind/size`
+		// reports usage, `/rewind/policies` the limit. Fetched unconditionally so a
+		// usable limit still arrives when usage cannot be measured.
 		$policies_data = self::unwrap_response( Jetpack_Backup::get_site_backup_policies() );
 
 		return array(
@@ -872,12 +868,9 @@ class Backup_Abilities extends Registrar {
 	/**
 	 * Summarize the `/site/backup/schedule` payload to `{ hour }`.
 	 *
-	 * WordPress.com answers `{ ok, scheduled_hour, scheduled_by }` — the hour
-	 * of the day, in UTC, that the daily backup is scheduled for. `ok` is its
-	 * own success flag *inside* a 200 body, so a payload that does not set it
-	 * carries no usable hour, and there is no minute anywhere on the response
-	 * (the legacy dashboard renders the hour as a `HH:00`-`HH:59` window for
-	 * exactly this reason).
+	 * WordPress.com answers `{ ok, scheduled_hour, scheduled_by }` — the UTC hour of the
+	 * daily backup, and no minute anywhere. `ok` is its own success flag inside a 200
+	 * body, so a payload without it carries no usable hour.
 	 *
 	 * @param mixed $raw Upstream schedule payload.
 	 * @return array|null
@@ -898,21 +891,12 @@ class Backup_Abilities extends Registrar {
 	/**
 	 * Summarize storage from the two payloads that between them describe it.
 	 *
-	 * Usage is `size` on `/site/backup/size`, whose response carries no
-	 * storage limit at all despite the route's name; the limit is
-	 * `policies.storage_limit_bytes` on `/site/backup/policies`. The same
-	 * fan-out the dashboard's storage meter performs — see
-	 * `src/dashboard/hooks/use-storage-usage.ts`.
+	 * Usage is `size` on `/site/backup/size`, which despite its name carries no limit;
+	 * the limit is `policies.storage_limit_bytes` on `/site/backup/policies`.
 	 *
-	 * `/size` additionally carries WordPress.com's own `ok` flag inside a 200
-	 * body; without it the sibling fields carry no meaning, so usage is
-	 * discarded rather than half-read. The limit is read independently, so a
-	 * site whose usage could not be measured still reports what it is allowed.
-	 *
-	 * That is a deliberate asymmetry with `summarize_schedule()`, which drops
-	 * its whole object on a payload that is not `ok`: there, nothing is left
-	 * to report once the hour is gone. Here, the limit comes from a different
-	 * route and is unaffected by whatever went wrong with `/size`.
+	 * The two are read independently, so a site whose usage could not be measured still
+	 * reports what it is allowed. That is deliberately unlike `summarize_schedule()`,
+	 * which has nothing left to report once its hour is gone.
 	 *
 	 * @param mixed $size_raw     Upstream `/site/backup/size` payload.
 	 * @param mixed $policies_raw Upstream `/site/backup/policies` payload.
@@ -930,9 +914,8 @@ class Backup_Abilities extends Registrar {
 			? (int) $size['size']
 			: null;
 
-		// The limit is nested one level down, and `policies` is itself nullable
-		// inside a 200: a plan with no retention policy answers
-		// `{ "policies": null }`.
+		// `policies` is itself nullable inside a 200: a plan with no retention policy
+		// answers `{ "policies": null }`.
 		$policy = $policies['policies'] ?? null;
 		$policy = ( is_array( $policy ) || is_object( $policy ) ) ? (array) $policy : null;
 

--- a/projects/packages/backup/src/abilities/class-backup-abilities.php
+++ b/projects/packages/backup/src/abilities/class-backup-abilities.php
@@ -909,6 +909,11 @@ class Backup_Abilities extends Registrar {
 	 * discarded rather than half-read. The limit is read independently, so a
 	 * site whose usage could not be measured still reports what it is allowed.
 	 *
+	 * That is a deliberate asymmetry with `summarize_schedule()`, which drops
+	 * its whole object on a payload that is not `ok`: there, nothing is left
+	 * to report once the hour is gone. Here, the limit comes from a different
+	 * route and is unaffected by whatever went wrong with `/size`.
+	 *
 	 * @param mixed $size_raw     Upstream `/site/backup/size` payload.
 	 * @param mixed $policies_raw Upstream `/site/backup/policies` payload.
 	 * @return array|null

--- a/projects/packages/backup/tests/php/abilities/Backup_Abilities_Test.php
+++ b/projects/packages/backup/tests/php/abilities/Backup_Abilities_Test.php
@@ -421,11 +421,13 @@ class Backup_Abilities_Test extends BaseTestCase {
 								'has_warnings'  => array( 'type' => array( 'boolean', 'null' ) ),
 							),
 						),
+						// No `minute`: WordPress.com schedules to the hour and
+						// nothing upstream supplies a minute, so publishing the
+						// field would advertise a permanently-null value.
 						'schedule'            => array(
 							'type'       => array( 'object', 'null' ),
 							'properties' => array(
-								'hour'   => array( 'type' => array( 'integer', 'null' ) ),
-								'minute' => array( 'type' => array( 'integer', 'null' ) ),
+								'hour' => array( 'type' => array( 'integer', 'null' ) ),
 							),
 						),
 						'storage'             => array(
@@ -787,6 +789,86 @@ class Backup_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
+	 * End-to-end for JETPACK-2372 and its schedule twin: every upstream route
+	 * answers with the body WordPress.com actually sends (see the
+	 * `recorded_*_payload()` helpers for where each shape is sourced), and the
+	 * overview is asserted whole.
+	 *
+	 * Before the fix this produced `storage => { used_bytes: null, limit_bytes:
+	 * null }` and `schedule => { hour: null, minute: null }` against exactly
+	 * these payloads, because the mapping read four field names — `size_in_bytes`,
+	 * `storage_limit_bytes`, `hour`, `minute` — that appear on none of them.
+	 */
+	public function test_get_backup_overview_maps_recorded_wpcom_payloads(): void {
+		// The first signed `Client` call of the process is built before
+		// `Client::build_signed_request()` has installed the filter supplying
+		// `JETPACK__WPCOM_JSON_API_BASE`, so it is refused as a host-less URL.
+		// Four calls are made here and the first would otherwise be lost,
+		// making the assertion depend on what ran earlier in the suite. Same
+		// reasoning as `Jetpack_Backup_Test::sign_in_as_connected_admin()`.
+		\Automattic\Jetpack\Connection\Utils::init_default_constants();
+
+		wp_set_current_user( $this->admin_id );
+
+		$bodies = array(
+			'rewind/size'      => $this->recorded_size_payload(),
+			'rewind/policies'  => $this->recorded_policies_payload(),
+			'rewind/scheduled' => $this->recorded_schedule_payload(),
+			'rewind/backups'   => array(
+				array(
+					'id'            => 875405461,
+					'rewind_id'     => '1774526400.481',
+					'started'       => '2026-03-26T12:00:00+00:00',
+					'last_updated'  => '2026-03-26T12:04:00+00:00',
+					'status'        => 'finished',
+					'period'        => 'daily',
+					'is_rewindable' => true,
+					'has_warnings'  => false,
+				),
+			),
+		);
+
+		$mock = function ( $preempt, $args, $url ) use ( $bodies ) {
+			foreach ( $bodies as $fragment => $body ) {
+				if ( false !== strpos( $url, $fragment ) ) {
+					return array(
+						'response' => array( 'code' => 200 ),
+						'body'     => wp_json_encode( $body, JSON_UNESCAPED_SLASHES ),
+					);
+				}
+			}
+			return $preempt;
+		};
+
+		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10, 2 );
+		add_filter( 'pre_http_request', $mock, 10, 3 );
+
+		$result = Backup_Abilities::execute_get_backup_overview( array() );
+
+		remove_filter( 'pre_http_request', $mock, 10 );
+		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10 );
+
+		$this->assertSame(
+			array(
+				'recent_backup_count' => 1,
+				'last_backup'         => array(
+					'id'            => '1774526400.481',
+					'last_updated'  => '2026-03-26T12:04:00+00:00',
+					'status'        => 'finished',
+					'is_rewindable' => true,
+					'has_warnings'  => false,
+				),
+				'schedule'            => array( 'hour' => 17 ),
+				'storage'             => array(
+					'used_bytes'  => 3221225472,
+					'limit_bytes' => 10737418240,
+				),
+			),
+			$result
+		);
+	}
+
+	/**
 	 * Mock a Jetpack user connection so wpcom-as-user requests are signed.
 	 *
 	 * @param mixed  $value The current option value.
@@ -1110,51 +1192,226 @@ class Backup_Abilities_Test extends BaseTestCase {
 		$this->assertArrayNotHasKey( 'noise_field', $result );
 	}
 
+	/**
+	 * Body of a successful `GET /jetpack/v4/site/backup/schedule`.
+	 *
+	 * The route forwards WordPress.com's body verbatim. Its three keys, and
+	 * only those three, are built at
+	 * `wp-content/rest-api-plugins/endpoints/sites-rewind-scheduled-backup.php`
+	 * lines 76-78 (cache hit) and 95-97 (VaultPress round-trip) — there is no
+	 * `hour`, no `minute` and no `scheduled_minute` on either branch.
+	 *
+	 * @param array $overrides Fields to replace.
+	 * @return array
+	 */
+	private function recorded_schedule_payload( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'ok'             => true,
+				'scheduled_hour' => 17,
+				'scheduled_by'   => 'Backup Owner',
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Body of a successful `GET /jetpack/v4/site/backup/size`.
+	 *
+	 * These ten keys, in this order, are what
+	 * `wp-content/rest-api-plugins/endpoints/sites-rewind-size.php` builds at
+	 * lines 54-63, and they match the live 200 captured on JETPACK-2372 key
+	 * for key. Note what is absent: usage is `size` (not `size_in_bytes`),
+	 * and the response carries no storage limit at all despite the route's
+	 * name — that lives on `/site/backup/policies`.
+	 *
+	 * @param array $overrides Fields to replace.
+	 * @return array
+	 */
+	private function recorded_size_payload( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'ok'                          => true,
+				'error'                       => '',
+				'size'                        => 3221225472,
+				'days_of_backups_saved'       => 14,
+				'days_of_backups_allowed'     => 30,
+				'min_days_of_backups_allowed' => 2,
+				'last_backup_size'            => 1073741824,
+				'last_backup_failed'          => false,
+				'retention_days'              => 30,
+				'backups_stopped'             => 0,
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Body of a successful `GET /jetpack/v4/site/backup/policies`.
+	 *
+	 * `wp-content/rest-api-plugins/endpoints/sites-rewind-policies.php:47`
+	 * nests everything under a single `policies` key, whose contents come
+	 * from the plan tier table in
+	 * `wp-content/lib/activity-log/rewind-permissions.php` (lines 31/39/47
+	 * carry `storage_limit_bytes`). `policies` is itself nullable inside a
+	 * 200 when the plan carries no policy.
+	 *
+	 * @param bool $with_policy False to model the `{ "policies": null }` body a
+	 *                          plan with no policy answers with.
+	 * @return array
+	 */
+	private function recorded_policies_payload( bool $with_policy = true ): array {
+		return array(
+			'policies' => $with_policy
+				? array(
+					'storage_limit_bytes'     => 10737418240,
+					'activity_log_limit_days' => 30,
+				)
+				: null,
+		);
+	}
+
 	public function test_summarize_schedule_returns_null_for_invalid_input(): void {
 		$this->assertNull( $this->call_private( 'summarize_schedule', array( null ) ) );
 		$this->assertNull( $this->call_private( 'summarize_schedule', array( 'string' ) ) );
 	}
 
-	public function test_summarize_schedule_extracts_hour_minute(): void {
+	public function test_summarize_schedule_reads_scheduled_hour_and_publishes_no_minute(): void {
+		$result = $this->call_private( 'summarize_schedule', array( $this->recorded_schedule_payload() ) );
+
+		$this->assertSame( array( 'hour' => 17 ), $result, 'Schedule must map scheduled_hour to hour and expose nothing else.' );
+		$this->assertArrayNotHasKey( 'minute', $result, 'Nothing upstream supplies a minute, so the field must not be published.' );
+	}
+
+	/**
+	 * Regression for JETPACK-2372's twin: the ability used to read `hour` and
+	 * `minute`, names WordPress.com has never sent. The `ok`/`scheduled_hour`
+	 * pair below is real; `hour`/`minute` are the invented names, present only
+	 * to prove they are ignored. A reader that fell back to them would report
+	 * 3, not 17.
+	 */
+	public function test_summarize_schedule_ignores_the_hour_minute_names_wpcom_never_sends(): void {
 		$result = $this->call_private(
 			'summarize_schedule',
 			array(
 				array(
-					'hour'   => 3,
-					'minute' => 30,
+					'ok'             => true,
+					'scheduled_hour' => 17,
+					'hour'           => 3,
+					'minute'         => 30,
 				),
 			)
 		);
-		$this->assertSame( 3, $result['hour'] );
-		$this->assertSame( 30, $result['minute'] );
+
+		$this->assertSame( array( 'hour' => 17 ), $result );
 	}
 
-	public function test_summarize_storage_handles_both_field_aliases(): void {
-		// Production WPCOM payload uses size_in_bytes/storage_limit_bytes.
+	/**
+	 * `ok` is WordPress.com's own success flag *inside* a 200 body; without it
+	 * the sibling fields carry no meaning. The fixture keeps a plausible
+	 * `scheduled_hour` so the assertion cannot pass merely because the payload
+	 * was empty.
+	 */
+	public function test_summarize_schedule_discards_payload_that_is_not_ok(): void {
 		$result = $this->call_private(
-			'summarize_storage',
-			array(
-				array(
-					'size_in_bytes'       => 1024,
-					'storage_limit_bytes' => 10240,
-				),
-			)
+			'summarize_schedule',
+			array( $this->recorded_schedule_payload( array( 'ok' => false ) ) )
 		);
-		$this->assertSame( 1024, $result['used_bytes'] );
-		$this->assertSame( 10240, $result['limit_bytes'] );
 
-		// Defensive shape: bare *_bytes keys also accepted.
+		$this->assertNull( $result );
+	}
+
+	public function test_summarize_storage_maps_size_and_policy_limit(): void {
+		$result = $this->call_private(
+			'summarize_storage',
+			array( $this->recorded_size_payload(), $this->recorded_policies_payload() )
+		);
+
+		$this->assertSame(
+			array(
+				'used_bytes'  => 3221225472,
+				'limit_bytes' => 10737418240,
+			),
+			$result
+		);
+	}
+
+	/**
+	 * Regression for JETPACK-2372: `size_in_bytes` and a top-level
+	 * `storage_limit_bytes` were the names the ability used to read, and
+	 * neither exists on any WordPress.com response. They are planted here
+	 * with values no correct mapping can produce.
+	 *
+	 * `limit_bytes` is asserted to be the *policies* figure rather than null,
+	 * so the test cannot pass just because everything collapsed to null.
+	 */
+	public function test_summarize_storage_ignores_the_field_names_wpcom_never_sends(): void {
+		$size = $this->recorded_size_payload();
+		unset( $size['size'] );
+		$size['size_in_bytes']       = 4294967296;
+		$size['storage_limit_bytes'] = 999;
+
+		$result = $this->call_private(
+			'summarize_storage',
+			array( $size, $this->recorded_policies_payload() )
+		);
+
+		$this->assertNull( $result['used_bytes'], 'size_in_bytes is not a WordPress.com field and must not be read.' );
+		$this->assertSame( 10737418240, $result['limit_bytes'], 'The limit must come from policies.storage_limit_bytes, not from the size payload.' );
+	}
+
+	/**
+	 * A 200 with `ok: false` carries no usable usage figure, but the limit
+	 * comes from a different route and is unaffected — so this asserts the
+	 * limit still arrives, which a wholesale "everything is null" failure
+	 * could not satisfy.
+	 */
+	public function test_summarize_storage_drops_usage_when_size_response_is_not_ok(): void {
 		$result = $this->call_private(
 			'summarize_storage',
 			array(
-				array(
-					'used_bytes'  => 5,
-					'limit_bytes' => 50,
-				),
+				$this->recorded_size_payload( array( 'ok' => false ) ),
+				$this->recorded_policies_payload(),
 			)
 		);
-		$this->assertSame( 5, $result['used_bytes'] );
-		$this->assertSame( 50, $result['limit_bytes'] );
+
+		$this->assertNull( $result['used_bytes'] );
+		$this->assertSame( 10737418240, $result['limit_bytes'] );
+	}
+
+	/**
+	 * `{ "policies": null }` is a real 200 body — a plan with no policy. Usage
+	 * must survive it, which is what distinguishes this from a failed read.
+	 */
+	public function test_summarize_storage_keeps_usage_when_policies_are_absent(): void {
+		$result = $this->call_private(
+			'summarize_storage',
+			array( $this->recorded_size_payload(), $this->recorded_policies_payload( false ) )
+		);
+
+		$this->assertSame( 3221225472, $result['used_bytes'] );
+		$this->assertNull( $result['limit_bytes'] );
+	}
+
+	/**
+	 * The two routes fail independently — either can return a `WP_Error` that
+	 * unwraps to null while the other answers. Whichever figure did arrive has
+	 * to survive, so each half is asserted to be the real number rather than
+	 * null.
+	 */
+	public function test_summarize_storage_reports_whichever_route_answered(): void {
+		$size_failed = $this->call_private( 'summarize_storage', array( null, $this->recorded_policies_payload() ) );
+		$this->assertNull( $size_failed['used_bytes'] );
+		$this->assertSame( 10737418240, $size_failed['limit_bytes'] );
+
+		$policies_failed = $this->call_private( 'summarize_storage', array( $this->recorded_size_payload(), null ) );
+		$this->assertSame( 3221225472, $policies_failed['used_bytes'] );
+		$this->assertNull( $policies_failed['limit_bytes'] );
+	}
+
+	public function test_summarize_storage_returns_null_when_neither_route_answered(): void {
+		$this->assertNull( $this->call_private( 'summarize_storage', array( null, null ) ) );
+		$this->assertNull( $this->call_private( 'summarize_storage', array( 'string', 'string' ) ) );
 	}
 
 	public function test_apply_id_or_pagination_filters_by_id(): void {

--- a/projects/packages/backup/tests/php/abilities/Backup_Abilities_Test.php
+++ b/projects/packages/backup/tests/php/abilities/Backup_Abilities_Test.php
@@ -421,9 +421,8 @@ class Backup_Abilities_Test extends BaseTestCase {
 								'has_warnings'  => array( 'type' => array( 'boolean', 'null' ) ),
 							),
 						),
-						// No `minute`: WordPress.com schedules to the hour and
-						// nothing upstream supplies a minute, so publishing the
-						// field would advertise a permanently-null value.
+						// No `minute`: nothing upstream supplies one, so the
+						// field could only advertise a permanent null.
 						'schedule'            => array(
 							'type'       => array( 'object', 'null' ),
 							'properties' => array(
@@ -789,33 +788,16 @@ class Backup_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * End-to-end for JETPACK-2372 and its schedule twin. The three routes this
-	 * PR is about — `/size`, `/policies` and `/scheduled` — answer with the
-	 * bodies WordPress.com actually sends; each `recorded_*_payload()` helper
-	 * cites where its shape came from.
+	 * End-to-end for JETPACK-2372 and its schedule twin: `/size`, `/policies` and
+	 * `/scheduled` answer with the bodies WordPress.com actually sends.
 	 *
-	 * The fourth body, for `/rewind/backups`, is **illustrative and not
-	 * sourced**. It is here only so `recent_backup_count` and `last_backup`
-	 * have something to summarize while the storage and schedule blocks are
-	 * asserted; `summarize_backup()` is pre-existing and not under audit here.
-	 * Do not read it as a record of that endpoint: the wpcom v2 endpoint
-	 * (`sites-rewind-backup.php`) proxies VaultPress rather than building the
-	 * item itself, and the one place these field names are constructed —
-	 * `sites-rewind-backup-v3.php` — belongs to v3, while this code path calls
-	 * v2. Pinning that shape needs its own issue.
-	 *
-	 * Before the fix this produced `storage => { used_bytes: null, limit_bytes:
-	 * null }` and `schedule => { hour: null, minute: null }` against exactly
-	 * these payloads, because the mapping read four field names — `size_in_bytes`,
-	 * `storage_limit_bytes`, `hour`, `minute` — that appear on none of them.
+	 * The fourth body, for `/rewind/backups`, is illustrative and not sourced — it only
+	 * gives `summarize_backup()` something to chew on while storage and schedule are
+	 * asserted. Pinning that shape needs its own issue.
 	 */
 	public function test_get_backup_overview_maps_recorded_wpcom_payloads(): void {
-		// The first signed `Client` call of the process is built before
-		// `Client::build_signed_request()` has installed the filter supplying
-		// `JETPACK__WPCOM_JSON_API_BASE`, so it is refused as a host-less URL.
-		// Four calls are made here and the first would otherwise be lost,
-		// making the assertion depend on what ran earlier in the suite. Same
-		// reasoning as `Jetpack_Backup_Test::sign_in_as_connected_admin()`.
+		// The first signed `Client` call of the process is refused as a host-less URL,
+		// so without this the assertion depends on what ran earlier in the suite.
 		\Automattic\Jetpack\Connection\Utils::init_default_constants();
 
 		wp_set_current_user( $this->admin_id );
@@ -1205,11 +1187,9 @@ class Backup_Abilities_Test extends BaseTestCase {
 	/**
 	 * Body of a successful `GET /jetpack/v4/site/backup/schedule`.
 	 *
-	 * The route forwards WordPress.com's body verbatim. Its three keys, and
-	 * only those three, are built at
-	 * `wp-content/rest-api-plugins/endpoints/sites-rewind-scheduled-backup.php`
-	 * lines 76-78 (cache hit) and 95-97 (VaultPress round-trip) — there is no
-	 * `hour`, no `minute` and no `scheduled_minute` on either branch.
+	 * The route forwards WordPress.com's body verbatim, and these three keys are all it
+	 * ever sets: no `hour`, no `minute`, no `scheduled_minute` on either branch of
+	 * `sites-rewind-scheduled-backup.php`.
 	 *
 	 * @param array $overrides Fields to replace.
 	 * @return array
@@ -1228,12 +1208,9 @@ class Backup_Abilities_Test extends BaseTestCase {
 	/**
 	 * Body of a successful `GET /jetpack/v4/site/backup/size`.
 	 *
-	 * These ten keys, in this order, are what
-	 * `wp-content/rest-api-plugins/endpoints/sites-rewind-size.php` builds at
-	 * lines 54-63, and they match the live 200 captured on JETPACK-2372 key
-	 * for key. Note what is absent: usage is `size` (not `size_in_bytes`),
-	 * and the response carries no storage limit at all despite the route's
-	 * name — that lives on `/site/backup/policies`.
+	 * These ten keys are what `sites-rewind-size.php` builds, matching the live 200
+	 * captured on JETPACK-2372. Note what is absent: usage is `size`, not
+	 * `size_in_bytes`, and there is no storage limit here at all.
 	 *
 	 * @param array $overrides Fields to replace.
 	 * @return array
@@ -1259,12 +1236,8 @@ class Backup_Abilities_Test extends BaseTestCase {
 	/**
 	 * Body of a successful `GET /jetpack/v4/site/backup/policies`.
 	 *
-	 * `wp-content/rest-api-plugins/endpoints/sites-rewind-policies.php:47`
-	 * nests everything under a single `policies` key, whose contents come
-	 * from the plan tier table in
-	 * `wp-content/lib/activity-log/rewind-permissions.php` (lines 31/39/47
-	 * carry `storage_limit_bytes`). `policies` is itself nullable inside a
-	 * 200 when the plan carries no policy.
+	 * `sites-rewind-policies.php` nests everything under a single `policies` key, which
+	 * is itself nullable inside a 200 when the plan carries no policy.
 	 *
 	 * @param bool $with_policy False to model the `{ "policies": null }` body a
 	 *                          plan with no policy answers with.
@@ -1294,15 +1267,11 @@ class Backup_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Regression for JETPACK-2372's twin: the ability used to read `hour` and
-	 * `minute`, names WordPress.com has never sent.
+	 * Regression for JETPACK-2372's twin: the ability used to read `hour` and `minute`,
+	 * names WordPress.com has never sent.
 	 *
-	 * Two payloads, because a wrong reader fails two different ways and only
-	 * the second catches both. A reader that *prefers* `hour` — trunk's bug —
-	 * reports 3 for the first. A reader that merely *falls back* to `hour`
-	 * passes the first, because `scheduled_hour` is still there to be found;
-	 * it is caught only by the second, where the real name is absent exactly
-	 * as it would be if the alias were reintroduced as a safety net.
+	 * Two payloads, because a reader that merely *falls back* to `hour` passes the
+	 * first — only the second, where `scheduled_hour` is absent, catches it.
 	 */
 	public function test_summarize_schedule_ignores_the_hour_minute_names_wpcom_never_sends(): void {
 		$alias_preferred = $this->call_private(
@@ -1332,10 +1301,9 @@ class Backup_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * `ok` is WordPress.com's own success flag *inside* a 200 body; without it
-	 * the sibling fields carry no meaning. The fixture keeps a plausible
-	 * `scheduled_hour` so the assertion cannot pass merely because the payload
-	 * was empty.
+	 * `ok` is WordPress.com's own success flag inside a 200 body. The fixture keeps a
+	 * plausible `scheduled_hour` so this cannot pass merely because the payload was
+	 * empty.
 	 */
 	public function test_summarize_schedule_discards_payload_that_is_not_ok(): void {
 		$result = $this->call_private(
@@ -1366,14 +1334,10 @@ class Backup_Abilities_Test extends BaseTestCase {
 	 * `storage_limit_bytes` were the names the ability used to read, and
 	 * neither exists on any WordPress.com response.
 	 *
-	 * The two aliases need different setups. `size_in_bytes` is checked
-	 * against a full policies payload, so `limit_bytes` can be asserted to be
-	 * the real figure and the test cannot pass by collapsing everything to
-	 * null. The planted `storage_limit_bytes` needs the opposite: with a real
-	 * policy present the policy wins whatever the code does, so the plant is
-	 * unreachable and proves nothing. It is only meaningful against
-	 * `{ "policies": null }`, where a reader that fell back to the size
-	 * payload would surface 999.
+	 * The two aliases need opposite setups: `size_in_bytes` against a full policies
+	 * payload, so the test cannot pass by collapsing to null; the planted
+	 * `storage_limit_bytes` against `{ "policies": null }`, where a policy would
+	 * otherwise win whatever the code does.
 	 */
 	public function test_summarize_storage_ignores_the_field_names_wpcom_never_sends(): void {
 		$size = $this->recorded_size_payload();
@@ -1405,10 +1369,8 @@ class Backup_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A 200 with `ok: false` carries no usable usage figure, but the limit
-	 * comes from a different route and is unaffected — so this asserts the
-	 * limit still arrives, which a wholesale "everything is null" failure
-	 * could not satisfy.
+	 * A 200 with `ok: false` carries no usable usage figure, but the limit comes from a
+	 * different route — so it still has to arrive.
 	 */
 	public function test_summarize_storage_drops_usage_when_size_response_is_not_ok(): void {
 		$result = $this->call_private(
@@ -1438,10 +1400,8 @@ class Backup_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The two routes fail independently — either can return a `WP_Error` that
-	 * unwraps to null while the other answers. Whichever figure did arrive has
-	 * to survive, so each half is asserted to be the real number rather than
-	 * null.
+	 * The two routes fail independently, so whichever figure did arrive has to survive.
+	 * Each half is asserted to be the real number rather than null.
 	 */
 	public function test_summarize_storage_reports_whichever_route_answered(): void {
 		$size_failed = $this->call_private( 'summarize_storage', array( null, $this->recorded_policies_payload() ) );
@@ -1454,10 +1414,8 @@ class Backup_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * `ok` absent is not the same as `ok: true`. WordPress.com sets it on
-	 * every success branch of both routes, so a payload missing it is not a
-	 * success payload and its siblings are not trustworthy — relaxing either
-	 * guard to "present and false" would start trusting them.
+	 * `ok` absent is not `ok: true`. WordPress.com sets it on every success branch, so a
+	 * payload missing it is not a success payload and its siblings cannot be trusted.
 	 *
 	 * The two routes then diverge deliberately, which is the asymmetry
 	 * documented on `summarize_storage()`: schedule has nothing left to report
@@ -1479,12 +1437,9 @@ class Backup_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * `{ "policies": { "storage_limit_bytes": null } }` is a real body — the
-	 * dashboard's own types declare it at
-	 * `src/dashboard/data/api/policies.ts`. It has to read as "no limit", not
-	 * as a limit of zero: `array_key_exists()` where the code uses `isset()`
-	 * would publish `limit_bytes: 0`, which reads as "no storage allowed" and
-	 * divides by zero in any consumer drawing a percentage.
+	 * `{ "policies": { "storage_limit_bytes": null } }` is a real body, and has to read
+	 * as "no limit" rather than a limit of zero — `array_key_exists()` in place of
+	 * `isset()` would publish `limit_bytes: 0` and divide by zero downstream.
 	 */
 	public function test_summarize_storage_treats_a_null_limit_as_absent_not_zero(): void {
 		$result = $this->call_private(
@@ -1500,12 +1455,9 @@ class Backup_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The output schema declares `hour`, `used_bytes` and `limit_bytes` as
-	 * `integer`. These payloads are whatever `json_decode()` made of
-	 * WordPress.com's answer, so a numeric string or a float would otherwise
-	 * be republished verbatim and break that declaration. The three casts are
-	 * what keep it true; each value below is chosen so `assertSame` fails on
-	 * the uncast type while still comparing equal loosely.
+	 * The output schema declares these three as `integer`, but the payloads are whatever
+	 * `json_decode()` made of WordPress.com's answer. Each value below is chosen so
+	 * `assertSame` fails on the uncast type while still comparing equal loosely.
 	 */
 	public function test_summarize_helpers_cast_numeric_figures_to_integers(): void {
 		$schedule = $this->call_private(

--- a/projects/packages/backup/tests/php/abilities/Backup_Abilities_Test.php
+++ b/projects/packages/backup/tests/php/abilities/Backup_Abilities_Test.php
@@ -789,10 +789,20 @@ class Backup_Abilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * End-to-end for JETPACK-2372 and its schedule twin: every upstream route
-	 * answers with the body WordPress.com actually sends (see the
-	 * `recorded_*_payload()` helpers for where each shape is sourced), and the
-	 * overview is asserted whole.
+	 * End-to-end for JETPACK-2372 and its schedule twin. The three routes this
+	 * PR is about — `/size`, `/policies` and `/scheduled` — answer with the
+	 * bodies WordPress.com actually sends; each `recorded_*_payload()` helper
+	 * cites where its shape came from.
+	 *
+	 * The fourth body, for `/rewind/backups`, is **illustrative and not
+	 * sourced**. It is here only so `recent_backup_count` and `last_backup`
+	 * have something to summarize while the storage and schedule blocks are
+	 * asserted; `summarize_backup()` is pre-existing and not under audit here.
+	 * Do not read it as a record of that endpoint: the wpcom v2 endpoint
+	 * (`sites-rewind-backup.php`) proxies VaultPress rather than building the
+	 * item itself, and the one place these field names are constructed —
+	 * `sites-rewind-backup-v3.php` — belongs to v3, while this code path calls
+	 * v2. Pinning that shape needs its own issue.
 	 *
 	 * Before the fix this produced `storage => { used_bytes: null, limit_bytes:
 	 * null }` and `schedule => { hour: null, minute: null }` against exactly
@@ -1285,13 +1295,17 @@ class Backup_Abilities_Test extends BaseTestCase {
 
 	/**
 	 * Regression for JETPACK-2372's twin: the ability used to read `hour` and
-	 * `minute`, names WordPress.com has never sent. The `ok`/`scheduled_hour`
-	 * pair below is real; `hour`/`minute` are the invented names, present only
-	 * to prove they are ignored. A reader that fell back to them would report
-	 * 3, not 17.
+	 * `minute`, names WordPress.com has never sent.
+	 *
+	 * Two payloads, because a wrong reader fails two different ways and only
+	 * the second catches both. A reader that *prefers* `hour` — trunk's bug —
+	 * reports 3 for the first. A reader that merely *falls back* to `hour`
+	 * passes the first, because `scheduled_hour` is still there to be found;
+	 * it is caught only by the second, where the real name is absent exactly
+	 * as it would be if the alias were reintroduced as a safety net.
 	 */
 	public function test_summarize_schedule_ignores_the_hour_minute_names_wpcom_never_sends(): void {
-		$result = $this->call_private(
+		$alias_preferred = $this->call_private(
 			'summarize_schedule',
 			array(
 				array(
@@ -1302,8 +1316,19 @@ class Backup_Abilities_Test extends BaseTestCase {
 				),
 			)
 		);
+		$this->assertSame( array( 'hour' => 17 ), $alias_preferred );
 
-		$this->assertSame( array( 'hour' => 17 ), $result );
+		$alias_as_fallback = $this->call_private(
+			'summarize_schedule',
+			array(
+				array(
+					'ok'     => true,
+					'hour'   => 3,
+					'minute' => 30,
+				),
+			)
+		);
+		$this->assertSame( array( 'hour' => null ), $alias_as_fallback );
 	}
 
 	/**
@@ -1339,17 +1364,21 @@ class Backup_Abilities_Test extends BaseTestCase {
 	/**
 	 * Regression for JETPACK-2372: `size_in_bytes` and a top-level
 	 * `storage_limit_bytes` were the names the ability used to read, and
-	 * neither exists on any WordPress.com response. They are planted here
-	 * with values no correct mapping can produce.
+	 * neither exists on any WordPress.com response.
 	 *
-	 * `limit_bytes` is asserted to be the *policies* figure rather than null,
-	 * so the test cannot pass just because everything collapsed to null.
+	 * The two aliases need different setups. `size_in_bytes` is checked
+	 * against a full policies payload, so `limit_bytes` can be asserted to be
+	 * the real figure and the test cannot pass by collapsing everything to
+	 * null. The planted `storage_limit_bytes` needs the opposite: with a real
+	 * policy present the policy wins whatever the code does, so the plant is
+	 * unreachable and proves nothing. It is only meaningful against
+	 * `{ "policies": null }`, where a reader that fell back to the size
+	 * payload would surface 999.
 	 */
 	public function test_summarize_storage_ignores_the_field_names_wpcom_never_sends(): void {
 		$size = $this->recorded_size_payload();
 		unset( $size['size'] );
-		$size['size_in_bytes']       = 4294967296;
-		$size['storage_limit_bytes'] = 999;
+		$size['size_in_bytes'] = 4294967296;
 
 		$result = $this->call_private(
 			'summarize_storage',
@@ -1358,6 +1387,21 @@ class Backup_Abilities_Test extends BaseTestCase {
 
 		$this->assertNull( $result['used_bytes'], 'size_in_bytes is not a WordPress.com field and must not be read.' );
 		$this->assertSame( 10737418240, $result['limit_bytes'], 'The limit must come from policies.storage_limit_bytes, not from the size payload.' );
+
+		$no_policy = $this->call_private(
+			'summarize_storage',
+			array(
+				array(
+					'ok'                  => true,
+					'size'                => 3221225472,
+					'storage_limit_bytes' => 999,
+				),
+				array( 'policies' => null ),
+			)
+		);
+
+		$this->assertSame( 3221225472, $no_policy['used_bytes'] );
+		$this->assertNull( $no_policy['limit_bytes'], 'A storage limit on the size payload is not a WordPress.com field and must not be read.' );
 	}
 
 	/**
@@ -1407,6 +1451,79 @@ class Backup_Abilities_Test extends BaseTestCase {
 		$policies_failed = $this->call_private( 'summarize_storage', array( $this->recorded_size_payload(), null ) );
 		$this->assertSame( 3221225472, $policies_failed['used_bytes'] );
 		$this->assertNull( $policies_failed['limit_bytes'] );
+	}
+
+	/**
+	 * `ok` absent is not the same as `ok: true`. WordPress.com sets it on
+	 * every success branch of both routes, so a payload missing it is not a
+	 * success payload and its siblings are not trustworthy — relaxing either
+	 * guard to "present and false" would start trusting them.
+	 *
+	 * The two routes then diverge deliberately, which is the asymmetry
+	 * documented on `summarize_storage()`: schedule has nothing left to report
+	 * so the whole object goes, while storage keeps the limit the other route
+	 * supplied. Each half asserts a figure only a working path produces, so
+	 * neither can pass by collapsing to null.
+	 */
+	public function test_summarize_helpers_require_ok_to_be_present(): void {
+		$schedule = $this->recorded_schedule_payload();
+		unset( $schedule['ok'] );
+		$this->assertNull( $this->call_private( 'summarize_schedule', array( $schedule ) ) );
+
+		$size = $this->recorded_size_payload();
+		unset( $size['ok'] );
+		$storage = $this->call_private( 'summarize_storage', array( $size, $this->recorded_policies_payload() ) );
+
+		$this->assertNull( $storage['used_bytes'] );
+		$this->assertSame( 10737418240, $storage['limit_bytes'] );
+	}
+
+	/**
+	 * `{ "policies": { "storage_limit_bytes": null } }` is a real body — the
+	 * dashboard's own types declare it at
+	 * `src/dashboard/data/api/policies.ts`. It has to read as "no limit", not
+	 * as a limit of zero: `array_key_exists()` where the code uses `isset()`
+	 * would publish `limit_bytes: 0`, which reads as "no storage allowed" and
+	 * divides by zero in any consumer drawing a percentage.
+	 */
+	public function test_summarize_storage_treats_a_null_limit_as_absent_not_zero(): void {
+		$result = $this->call_private(
+			'summarize_storage',
+			array(
+				$this->recorded_size_payload(),
+				array( 'policies' => array( 'storage_limit_bytes' => null ) ),
+			)
+		);
+
+		$this->assertSame( 3221225472, $result['used_bytes'] );
+		$this->assertNull( $result['limit_bytes'] );
+	}
+
+	/**
+	 * The output schema declares `hour`, `used_bytes` and `limit_bytes` as
+	 * `integer`. These payloads are whatever `json_decode()` made of
+	 * WordPress.com's answer, so a numeric string or a float would otherwise
+	 * be republished verbatim and break that declaration. The three casts are
+	 * what keep it true; each value below is chosen so `assertSame` fails on
+	 * the uncast type while still comparing equal loosely.
+	 */
+	public function test_summarize_helpers_cast_numeric_figures_to_integers(): void {
+		$schedule = $this->call_private(
+			'summarize_schedule',
+			array( $this->recorded_schedule_payload( array( 'scheduled_hour' => '17' ) ) )
+		);
+		$this->assertSame( 17, $schedule['hour'] );
+
+		$storage = $this->call_private(
+			'summarize_storage',
+			array(
+				$this->recorded_size_payload( array( 'size' => '3221225472' ) ),
+				array( 'policies' => array( 'storage_limit_bytes' => 10737418240.0 ) ),
+			)
+		);
+
+		$this->assertSame( 3221225472, $storage['used_bytes'] );
+		$this->assertSame( 10737418240, $storage['limit_bytes'] );
 	}
 
 	public function test_summarize_storage_returns_null_when_neither_route_answered(): void {

--- a/projects/plugins/backup/changelog/backup-overview-storage-and-schedule-mapping
+++ b/projects/plugins/backup/changelog/backup-overview-storage-and-schedule-mapping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the backup overview ability reporting no storage usage, storage limit or backup time.

--- a/projects/plugins/jetpack/changelog/backup-overview-storage-and-schedule-mapping
+++ b/projects/plugins/jetpack/changelog/backup-overview-storage-and-schedule-mapping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Backup: Fix the backup overview ability reporting no storage usage, storage limit or backup time.


### PR DESCRIPTION
Fixes JETPACK-2372

## Proposed changes

`jetpack-backup/get-backup-overview` filled its `storage` and `schedule` blocks from four field names that appear on none of the responses it reads, so both came back entirely null on every site. Two independent bugs, one root cause, one file.

### Storage — JETPACK-2372

`summarize_storage()` read `size_in_bytes` / `storage_limit_bytes` (falling back to `used_bytes` / `limit_bytes`). None of the four exist.

* **Usage is `size`**, on `/site/backup/size`.
* **That response carries no storage limit at all**, despite the route's name. The limit is `policies.storage_limit_bytes` on `/site/backup/policies`, so the ability now fans out to both routes — the same fan-out `src/dashboard/hooks/use-storage-usage.ts` already performs for the dashboard's storage meter.

### Fixture provenance

The three payloads this PR is about are sourced, and each helper says where from: `/rewind/size`'s ten keys are built at `sites-rewind-size.php:54-63` (matching the live 200 on JETPACK-2372 key for key and in order), `policies.storage_limit_bytes` at `sites-rewind-policies.php:47` plus `rewind-permissions.php:31/39/47`, and `ok`/`scheduled_hour`/`scheduled_by` at `sites-rewind-scheduled-backup.php:76-78` and `95-97`.

The end-to-end test needs a fourth body, for `/rewind/backups`, and that one is **illustrative and explicitly labelled as such** — the wpcom v2 endpoint proxies VaultPress rather than building the item, and the only place these field names are constructed (`sites-rewind-backup-v3.php:95/100`) belongs to v3 while this code path calls v2. It is there only so `recent_backup_count` and `last_backup` have something to summarize; `summarize_backup()` is pre-existing and not under audit here. Pinning that shape wants its own issue. The policies call is unconditional, so a usable limit still reaches the caller when WordPress.com cannot report usage.
* `/size` carries WordPress.com's own **`ok` flag inside a 200 body**; without it the sibling figures are discarded rather than half-read.

### Schedule — found during the 2026-08-27 review round, not yet filed

Same defect, same file, no issue of its own yet — please file or link one.

`summarize_schedule()` read `$raw['hour']` and `$raw['minute']`. The payload carries neither: `Jetpack_Backup::get_site_backup_schedule_time()` forwards WordPress.com's body verbatim from `/rewind/scheduled`, and both branches of that endpoint build `ok`, **`scheduled_hour`** and `scheduled_by` — there is no `hour`, no `minute`, no `scheduled_minute`.

Corroboration in this repo: the legacy dashboard renders this today from `scheduled_hour` (`src/js/hooks/scheduled-backups/use-scheduled-time-query.ts`) and would hard-crash otherwise, since `moment.utc().startOf('day').hour(undefined)` is a *getter*.

**`minute` is removed from the output schema** rather than published as a permanently-null field. WordPress.com schedules daily backups to the hour — which is why the legacy dashboard renders the value as an `HH:00`-`HH:59` window — so nothing upstream can ever supply a minute. A declared field that can only be null is the same class of defect this PR is fixing, and since the value has never been anything but null in production, no consumer can have depended on it.

### Why the tests missed both

`Backup_Abilities_Test.php` invented the payloads it asserted against, and a comment recorded the invented names as the production ones (*"Production WPCOM payload uses size_in_bytes/storage_limit_bytes"*). The tests passed precisely because they never used a real response shape, so they pinned the wrong contract instead of catching the mismatch.

The fixtures are now built from the shapes WordPress.com's endpoints actually construct, and the adversarial cases plant the old names alongside a real figure from the *other* route — so a regression that collapses everything to null cannot pass. Net: **316 → 327 tests, 815 → 838 assertions.**

Each new assertion was mutation-tested: sixteen separate breakages of the implementation were each confirmed to fail the suite before being reverted — wrong size key, limit read from the wrong payload, both `ok` guards dropped, wrong schedule key, `minute` reintroduced in the output and in the schema, policies not fetched, nesting ignored, over-eager bail-out, each alias reintroduced *as a fallback* rather than as a preference, `isset()` relaxed to `array_key_exists()`, and each of the three integer casts dropped.

A review round caught two anti-regression tests that did not catch what their docblocks promised, and both are fixed here. The schedule fixture set `scheduled_hour` **and** `hour`, so it only caught a reader that *prefers* the alias — one that merely falls back to it still found `17` and survived; a second payload with the real name absent now covers that direction. The planted `storage_limit_bytes` was unreachable because the same call supplied a full policies body that wins regardless, so it now runs against `{ "policies": null }`. Three correct-but-unpinned behaviours also gained tests: `ok` must be *present* rather than merely not false; `policies.storage_limit_bytes: null` must read as "no limit" rather than a limit of zero (which would divide by zero in any consumer drawing a percentage); and the three integer casts that keep the declared `integer` schema honest.

### Note for reviewers

One bullet in JETPACK-2372 is now stale: it asks to guard a bare `null` body served as HTTP 200 on a non-200 upstream. #51625 already fixed that — `get_site_backup_size()`, `get_site_backup_policies()` and `get_site_backup_schedule_time()` all return a `WP_Error` on non-200, which `unwrap_response()` maps to null. The type guards here remain, because a 200 whose body does not decode still yields a null payload.

## Related product discussion/links

* JETPACK-2372
* Found while reviewing #51580
* Touches the same test file as #51675 (which adds an `init_default_constants()` call to `setUp()`); verified conflict-free — `git merge-tree` reports 0 conflicts against `add/backup-bridge-test-coverage`.

## Does this pull request change what data or activity we track or use?

No. The same WordPress.com endpoints are read as before, plus `/site/backup/policies`, which this package already calls from its own REST route and dashboard. No new data is collected, stored or sent.

## Testing instructions

This is server-side only; the fastest check is the test suite, then a live call if you have a connected site with a Backup plan.

**Automated**

```
jp test php packages/backup
```
Expect `OK (327 tests, 838 assertions)`.

To see the bug the tests now catch, revert just the implementation and re-run:
```
git checkout origin/trunk -- projects/packages/backup/src/abilities/class-backup-abilities.php
jp test php packages/backup
```
`test_get_backup_overview_maps_recorded_wpcom_payloads` fails with `schedule => { hour: null, minute: null }` and `storage => { used_bytes: null, limit_bytes: null }` against payloads that are the real response shapes.

**On a live site** (connected, with a Backup plan)

1. Enable the abilities gate — `add_filter( 'jetpack_wp_abilities_enabled', '__return_true' );` in an mu-plugin. (WordPress.com's own loader already does this, so no step is needed there.)
2. As an administrator, run `jetpack-backup/get-backup-overview` through whichever surface you normally use — the `wp-abilities/v1` REST namespace or an MCP client. (The ability declares `show_in_rest` and `mcp.public`, so both reach it.)
3. **Before:** `storage` is `{ used_bytes: null, limit_bytes: null }` and `schedule` is `{ hour: null, minute: null }`.
   **After:** `used_bytes` matches the usage shown on the Backup dashboard's storage meter, `limit_bytes` matches the plan's storage limit, and `schedule.hour` matches the UTC hour behind "Next full backup" on the Backup page.
4. Confirm `schedule` no longer carries a `minute` key, and that the ability's published `output_schema` no longer declares one.

