### PR TITLE
Backup: give the gate decision one owner

### DIFF
--- a/projects/packages/backup/changelog/backup-gate-state-hook
+++ b/projects/packages/backup/changelog/backup-gate-state-hook
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Modernized dashboard only, behind the flag: the connection/capabilities gate decision moves into a shared useGateState hook that <Gates> and the Back up now button both read. No behaviour change.
+
+

--- a/projects/packages/backup/src/dashboard/components/backup-now-button/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-now-button/index.tsx
@@ -18,11 +18,9 @@ import { useSiteSize } from '../../hooks/use-site-size';
  * handler and discards the response body, so every outcome — including a
  * WPCOM refusal and a permissions error — shows "Backup enqueued".
  *
- * The button gates itself, on the same `useGateState` verdict `<Gates>`
- * renders from. `DashboardLayout` passes header actions to `<Page>`,
- * which renders them above `<Gates>` rather than inside it, so an
- * unconnected or unlicensed site would otherwise be offered a control
- * that cannot work.
+ * The button gates itself, on the same `useGateState` verdict `<Gates>` renders from: it
+ * sits in `<Page>`'s header actions, above the gate, so an unconnected or unlicensed site
+ * would otherwise be offered a control that cannot work.
  *
  * @return The rendered button, or null when the site can't use it.
  */

--- a/projects/packages/backup/src/dashboard/components/backup-now-button/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-now-button/index.tsx
@@ -3,9 +3,8 @@ import { __ } from '@wordpress/i18n';
 import { Button, Tooltip } from '@wordpress/ui';
 import { useAnalytics } from '../../hooks/use-analytics';
 import { useBackups } from '../../hooks/use-backups';
-import { useCapabilities } from '../../hooks/use-capabilities';
-import { useCanQueryWpcom } from '../../hooks/use-connection';
 import { useEnqueueBackup } from '../../hooks/use-enqueue-backup';
+import { useGateState } from '../../hooks/use-gate-state';
 import { useSiteSize } from '../../hooks/use-site-size';
 
 /**
@@ -19,17 +18,17 @@ import { useSiteSize } from '../../hooks/use-site-size';
  * handler and discards the response body, so every outcome — including a
  * WPCOM refusal and a permissions error — shows "Backup enqueued".
  *
- * The button gates itself. `DashboardLayout` passes header actions to
- * `<Page>`, which renders them above `<Gates>` rather than inside it, so
- * an unconnected or unlicensed site would otherwise be offered a control
+ * The button gates itself, on the same `useGateState` verdict `<Gates>`
+ * renders from. `DashboardLayout` passes header actions to `<Page>`,
+ * which renders them above `<Gates>` rather than inside it, so an
+ * unconnected or unlicensed site would otherwise be offered a control
  * that cannot work.
  *
  * @return The rendered button, or null when the site can't use it.
  */
 export default function BackupNowButton() {
 	const { tracks } = useAnalytics();
-	const canQuery = useCanQueryWpcom();
-	const capabilities = useCapabilities( { enabled: canQuery } );
+	const gate = useGateState();
 	const { backupsStopped } = useSiteSize();
 	const { state: enqueueState, errorMessage, enqueue, reset } = useEnqueueBackup();
 
@@ -59,9 +58,7 @@ export default function BackupNowButton() {
 		enqueue();
 	}, [ tracks, enqueue ] );
 
-	const hasPlan =
-		! capabilities.isLoading && ! capabilities.error && capabilities.data?.hasBackupPlan;
-	if ( ! canQuery || ! hasPlan ) {
+	if ( gate.status !== 'ready' ) {
 		return null;
 	}
 

--- a/projects/packages/backup/src/dashboard/components/gates/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/index.tsx
@@ -14,9 +14,7 @@ type Props = {
 /**
  * Capability + connection gate that wraps the modernized dashboard body.
  *
- * One screen per non-ready verdict from `useGateState`, which owns the
- * decision itself — and which `<BackupNowButton>` also reads, because it
- * renders above this gate rather than inside it.
+ * One screen per non-ready verdict from `useGateState`, which owns the decision itself.
  *
  * @param props          - Component props.
  * @param props.children - The dashboard body to render when all gates pass.
@@ -55,12 +53,8 @@ export default function Gates( { children }: Props ) {
 		return <NoBackupPlanScreen />;
 	}
 
-	// Fail closed at compile time. `<BackupNowButton>` withholds itself on
-	// anything that is not `ready`, but this branch renders the dashboard
-	// body for any verdict no branch above claimed — so adding a verdict to
-	// `GateState` and forgetting a branch here would show the body to a site
-	// that should be blocked, while the button correctly stayed away. This
-	// makes that a type error instead.
+	// Fail closed at compile time: this branch renders the body for any verdict no branch
+	// above claimed, so a new `GateState` without a branch here is a type error.
 	gate.status satisfies 'ready';
 
 	return <>{ children }</>;

--- a/projects/packages/backup/src/dashboard/components/gates/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/index.tsx
@@ -1,6 +1,5 @@
 import { Spinner } from '@wordpress/components';
-import { useCapabilities } from '../../hooks/use-capabilities';
-import { useCanQueryWpcom, useConnection } from '../../hooks/use-connection';
+import { useGateState } from '../../hooks/use-gate-state';
 import CapabilitiesErrorScreen from './capabilities-error';
 import NoBackupPlanScreen from './no-backup-plan';
 import NotConnectedScreen from './not-connected';
@@ -15,40 +14,26 @@ type Props = {
 /**
  * Capability + connection gate that wraps the modernized dashboard body.
  *
- * Top-to-bottom decision tree, first match wins:
- * not-connected → secondary-admin → loading → capabilities-error → no-plan → children
- *
- * The loading branch is deliberately first-load-only. It sits above the
- * error branch, so a retry that made the query "loading" again would
- * replace the error screen — reason, explanation and the only control
- * that can ask again — with a bare spinner, for the whole round trip.
- * See `useCapabilities`.
- *
- * The connection checks come first because they're synchronous — they
- * read a global PHP emitted into the page. Gating them behind the
- * capabilities spinner would make a disconnected site sit through a
- * request (and its retry) that was never going to succeed.
+ * One screen per non-ready verdict from `useGateState`, which owns the
+ * decision itself — and which `<BackupNowButton>` also reads, because it
+ * renders above this gate rather than inside it.
  *
  * @param props          - Component props.
  * @param props.children - The dashboard body to render when all gates pass.
  * @return The matching fallback screen, or `children`.
  */
 export default function Gates( { children }: Props ) {
-	const connection = useConnection();
-	// Hooks can't be called conditionally, so the connection state gates
-	// the request itself rather than the call: without a user-level WPCOM
-	// connection the bridge can only answer 403.
-	const capabilities = useCapabilities( { enabled: useCanQueryWpcom() } );
+	const gate = useGateState();
 
-	if ( ! connection.isFullyConnected ) {
+	if ( gate.status === 'not-connected' ) {
 		return <NotConnectedScreen />;
 	}
 
-	if ( connection.isSecondaryAdminNotConnected ) {
+	if ( gate.status === 'secondary-admin' ) {
 		return <SecondaryAdminScreen />;
 	}
 
-	if ( capabilities.isLoading ) {
+	if ( gate.status === 'loading' ) {
 		return (
 			<div className="jpb-gates__skeleton">
 				<Spinner />
@@ -56,20 +41,17 @@ export default function Gates( { children }: Props ) {
 		);
 	}
 
-	// Must precede the plan check: a failed request also leaves `data`
-	// undefined, and "we couldn't ask" must not be reported as "you
-	// don't have a plan".
-	if ( capabilities.error ) {
+	if ( gate.status === 'error' ) {
 		return (
 			<CapabilitiesErrorScreen
-				error={ capabilities.error }
-				onRetry={ capabilities.refetch }
-				isRetrying={ capabilities.isRetrying }
+				error={ gate.error }
+				onRetry={ gate.onRetry }
+				isRetrying={ gate.isRetrying }
 			/>
 		);
 	}
 
-	if ( ! capabilities.data?.hasBackupPlan ) {
+	if ( gate.status === 'no-plan' ) {
 		return <NoBackupPlanScreen />;
 	}
 

--- a/projects/packages/backup/src/dashboard/components/gates/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/index.tsx
@@ -55,5 +55,13 @@ export default function Gates( { children }: Props ) {
 		return <NoBackupPlanScreen />;
 	}
 
+	// Fail closed at compile time. `<BackupNowButton>` withholds itself on
+	// anything that is not `ready`, but this branch renders the dashboard
+	// body for any verdict no branch above claimed — so adding a verdict to
+	// `GateState` and forgetting a branch here would show the body to a site
+	// that should be blocked, while the button correctly stayed away. This
+	// makes that a type error instead.
+	gate.status satisfies 'ready';
+
 	return <>{ children }</>;
 }

--- a/projects/packages/backup/src/dashboard/hooks/use-gate-state.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-gate-state.ts
@@ -35,16 +35,28 @@ export type GateState =
  * read the same React Query key, so the second caller costs a cache read
  * and not a request.
  *
- * The loading branch is deliberately first-load-only. It sits above the
- * error branch, so a retry that made the query "loading" again would
- * replace the error screen — reason, explanation and the only control
- * that can ask again — with a bare spinner, for the whole round trip.
- * See `useCapabilities`.
+ * Only one step of that order is load-bearing: the plan check has to
+ * come last. A pending or failed read leaves `data` undefined too, which
+ * is indistinguishable here from an honest "no plan" — so hoisting it
+ * above either one sells the upsell to a site that may well be entitled.
  *
- * The connection checks come first because they're synchronous — they
- * read a global PHP emitted into the page. Gating them behind the
- * capabilities spinner would make a disconnected site sit through a
- * request (and its retry) that was never going to succeed.
+ * The rest of the chain is mutually exclusive rather than prioritised,
+ * and what makes each pair safe lives in the hooks below rather than in
+ * the order these branches happen to be written in.
+ *
+ * The two connection branches can never both match, because
+ * `isSecondaryAdminNotConnected` is derived as `isFullyConnected &&
+ * ! isUserConnected` (`use-connection.ts`). Nor is listing them first
+ * what spares a disconnected site a doomed request: `enabled` does that,
+ * and a disabled query reports `isLoading` false, so the loading branch
+ * could not match there even if it were hoisted above them.
+ *
+ * Loading and error are likewise exclusive, because `useCapabilities`
+ * computes `isLoading` as `query.isLoading && error === null`. That is
+ * what stops a retry — which rewinds an errored query back to pending —
+ * from re-entering the loading branch and replacing the error screen,
+ * reason and explanation and the only control that can ask again, with a
+ * bare spinner for the whole round trip.
  *
  * @return The gate verdict.
  */

--- a/projects/packages/backup/src/dashboard/hooks/use-gate-state.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-gate-state.ts
@@ -4,9 +4,8 @@ import { useCanQueryWpcom, useConnection } from './use-connection';
 /**
  * Whether the dashboard is usable, and if not, why not.
  *
- * `error` carries what the error screen needs, so a consumer that wants
- * to render it doesn't have to read `useCapabilities` a second time to
- * find the reason and the way to ask again.
+ * `error` carries what the error screen needs, so a consumer doesn't have to read
+ * `useCapabilities` a second time for the reason and the retry.
  */
 export type GateState =
 	| { status: 'not-connected' | 'secondary-admin' | 'loading' | 'no-plan' | 'ready' }
@@ -26,45 +25,21 @@ export type GateState =
  * Top-to-bottom, first match wins:
  * not-connected → secondary-admin → loading → error → no-plan → ready
  *
- * Two consumers need this answer and they cannot share it through the
- * tree: `<Gates>` wraps the dashboard body, but `DashboardLayout` passes
- * header actions to `<Page>`, which renders them *above* `<Gates>`
- * rather than inside it — so `<BackupNowButton>` has to reach the same
- * verdict on its own or it would offer an unconnected or unlicensed site
- * a control that cannot work. Hence a hook rather than context: both
- * read the same React Query key, so the second caller costs a cache read
- * and not a request.
+ * A hook rather than context: `<BackupNowButton>` renders in `<Page>`'s header actions,
+ * above this gate, so it cannot read the verdict through the tree. Both callers hit the
+ * same React Query key, so the second costs a cache read and not a request.
  *
- * Only one step of that order is load-bearing: the plan check has to
- * come last. A pending or failed read leaves `data` undefined too, which
- * is indistinguishable here from an honest "no plan" — so hoisting it
- * above either one sells the upsell to a site that may well be entitled.
- *
- * The rest of the chain is mutually exclusive rather than prioritised,
- * and what makes each pair safe lives in the hooks below rather than in
- * the order these branches happen to be written in.
- *
- * The two connection branches can never both match, because
- * `isSecondaryAdminNotConnected` is derived as `isFullyConnected &&
- * ! isUserConnected` (`use-connection.ts`). Nor is listing them first
- * what spares a disconnected site a doomed request: `enabled` does that,
- * and a disabled query reports `isLoading` false, so the loading branch
- * could not match there even if it were hoisted above them.
- *
- * Loading and error are likewise exclusive, because `useCapabilities`
- * computes `isLoading` as `query.isLoading && error === null`. That is
- * what stops a retry — which rewinds an errored query back to pending —
- * from re-entering the loading branch and replacing the error screen,
- * reason and explanation and the only control that can ask again, with a
- * bare spinner for the whole round trip.
+ * Only the last step is load-bearing. A pending or failed read leaves `data` undefined
+ * too, so the plan check has to follow both or it sells the upsell to a site that may
+ * well be entitled. The rest of the chain is mutually exclusive, enforced in the hooks
+ * below rather than by this ordering.
  *
  * @return The gate verdict.
  */
 export function useGateState(): GateState {
 	const connection = useConnection();
-	// Hooks can't be called conditionally, so the connection state gates
-	// the request itself rather than the call: without a user-level WPCOM
-	// connection the bridge can only answer 403.
+	// Hooks can't be called conditionally, so the connection state gates the request
+	// rather than the call: without a user connection the bridge can only answer 403.
 	const capabilities = useCapabilities( { enabled: useCanQueryWpcom() } );
 
 	if ( ! connection.isFullyConnected ) {
@@ -79,9 +54,8 @@ export function useGateState(): GateState {
 		return { status: 'loading' };
 	}
 
-	// Must precede the plan check: a failed request also leaves `data`
-	// undefined, and "we couldn't ask" must not be reported as "you
-	// don't have a plan".
+	// Must precede the plan check: a failed request also leaves `data` undefined, and
+	// "we couldn't ask" is not "you don't have a plan".
 	if ( capabilities.error ) {
 		return {
 			status: 'error',

--- a/projects/packages/backup/src/dashboard/hooks/use-gate-state.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-gate-state.ts
@@ -1,0 +1,87 @@
+import { useCapabilities } from './use-capabilities';
+import { useCanQueryWpcom, useConnection } from './use-connection';
+
+/**
+ * Whether the dashboard is usable, and if not, why not.
+ *
+ * `error` carries what the error screen needs, so a consumer that wants
+ * to render it doesn't have to read `useCapabilities` a second time to
+ * find the reason and the way to ask again.
+ */
+export type GateState =
+	| { status: 'not-connected' | 'secondary-admin' | 'loading' | 'no-plan' | 'ready' }
+	| {
+			status: 'error';
+			/** The capabilities read's error, held across a retry. */
+			error: Error;
+			/** Ask again. */
+			onRetry: () => void;
+			/** A retry is in flight and there is already something on screen. */
+			isRetrying: boolean;
+	  };
+
+/**
+ * The single decision about whether this site can use the dashboard.
+ *
+ * Top-to-bottom, first match wins:
+ * not-connected → secondary-admin → loading → error → no-plan → ready
+ *
+ * Two consumers need this answer and they cannot share it through the
+ * tree: `<Gates>` wraps the dashboard body, but `DashboardLayout` passes
+ * header actions to `<Page>`, which renders them *above* `<Gates>`
+ * rather than inside it — so `<BackupNowButton>` has to reach the same
+ * verdict on its own or it would offer an unconnected or unlicensed site
+ * a control that cannot work. Hence a hook rather than context: both
+ * read the same React Query key, so the second caller costs a cache read
+ * and not a request.
+ *
+ * The loading branch is deliberately first-load-only. It sits above the
+ * error branch, so a retry that made the query "loading" again would
+ * replace the error screen — reason, explanation and the only control
+ * that can ask again — with a bare spinner, for the whole round trip.
+ * See `useCapabilities`.
+ *
+ * The connection checks come first because they're synchronous — they
+ * read a global PHP emitted into the page. Gating them behind the
+ * capabilities spinner would make a disconnected site sit through a
+ * request (and its retry) that was never going to succeed.
+ *
+ * @return The gate verdict.
+ */
+export function useGateState(): GateState {
+	const connection = useConnection();
+	// Hooks can't be called conditionally, so the connection state gates
+	// the request itself rather than the call: without a user-level WPCOM
+	// connection the bridge can only answer 403.
+	const capabilities = useCapabilities( { enabled: useCanQueryWpcom() } );
+
+	if ( ! connection.isFullyConnected ) {
+		return { status: 'not-connected' };
+	}
+
+	if ( connection.isSecondaryAdminNotConnected ) {
+		return { status: 'secondary-admin' };
+	}
+
+	if ( capabilities.isLoading ) {
+		return { status: 'loading' };
+	}
+
+	// Must precede the plan check: a failed request also leaves `data`
+	// undefined, and "we couldn't ask" must not be reported as "you
+	// don't have a plan".
+	if ( capabilities.error ) {
+		return {
+			status: 'error',
+			error: capabilities.error,
+			onRetry: capabilities.refetch,
+			isRetrying: capabilities.isRetrying,
+		};
+	}
+
+	if ( ! capabilities.data?.hasBackupPlan ) {
+		return { status: 'no-plan' };
+	}
+
+	return { status: 'ready' };
+}

--- a/projects/packages/backup/tests/first-run-state.test.tsx
+++ b/projects/packages/backup/tests/first-run-state.test.tsx
@@ -19,6 +19,7 @@ import userEvent from '@testing-library/user-event';
 import BackupNowButton from '../src/dashboard/components/backup-now-button';
 import BackupStatusPanel, { replacesOverview } from '../src/dashboard/components/backup-status';
 import BackupStatusBanner from '../src/dashboard/components/backup-status/banner';
+import { keys } from '../src/dashboard/data/query-client';
 import type { ReactNode } from 'react';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
@@ -211,14 +212,15 @@ describe( 'BackupNowButton', () => {
 	it( 'renders nothing on a site with no plan', async () => {
 		mockEndpoints( { hasBackupPlan: false } );
 
-		const { container } = renderWithClient( <BackupNowButton /> );
+		const { container, client } = renderWithClient( <BackupNowButton /> );
 
-		// Settle on the capabilities answer having arrived, rather than on
-		// a timer — then confirm the button stayed away.
+		// Settle on the capabilities answer reaching the cache, not on the
+		// request having been issued — then confirm the button stayed away.
+		// Waiting on the call returns while the query is still pending, and
+		// the button is empty then for the loading reason, so the no-plan
+		// state this test is named for would never be reached.
 		await waitFor( () =>
-			expect( mockApiFetch ).toHaveBeenCalledWith(
-				expect.objectContaining( { path: '/jetpack/v4/site/capabilities' } )
-			)
+			expect( client.getQueryState( keys.capabilities() )?.status ).toBe( 'success' )
 		);
 		expect( container ).toBeEmptyDOMElement();
 	} );

--- a/projects/packages/backup/tests/gate-decision.test.tsx
+++ b/projects/packages/backup/tests/gate-decision.test.tsx
@@ -1,19 +1,9 @@
-// JETPACK-2313 F1 — the gate decision was written twice.
+// JETPACK-2313 F1 — the gate decision was written twice: `<Gates>` walked it, and
+// `<BackupNowButton>` re-derived the same walk because it renders above the gate.
 //
-// `<Gates>` walked connection → secondary admin → capabilities loading →
-// capabilities error → plan, and `<BackupNowButton>` re-derived the same
-// walk from the same two hooks to decide whether to render at all. It has
-// to decide for itself: `DashboardLayout` passes header actions to
-// `<Page>`, which renders them *above* `<Gates>` rather than inside it, so
-// the button cannot rely on the gate having run.
-//
-// The two agreed — both withhold in every state short of "ready", so no
-// contradictory UI was ever possible — which is what makes consolidating
-// them a pure refactor and this file its safety net. It renders the real
-// arrangement, button above gate in one tree, and pins what *both* show in
-// each of the six states. Written against the duplicated code and passing
-// there before `useGateState` existed; anything it catches afterwards is a
-// behaviour change, not a cleanup.
+// The two already agreed, so consolidating them is a pure refactor and this file is its
+// safety net: button and gate in one tree, pinning what both show in each of the six
+// states. Written against the duplicated code and passing there first.
 
 const mockApiFetch = jest.fn();
 
@@ -61,9 +51,8 @@ function deferred< T >() {
  * Answer every endpoint this tree reads, with the capabilities route
  * under the caller's control.
  *
- * The other three are answered plainly and identically in every state:
- * whatever withholds the button here has to be the gate decision, not a
- * fixture that never resolved.
+ * The other three answer plainly in every state, so whatever withholds the button has to
+ * be the gate decision and not an unresolved fixture.
  *
  * @param capabilities - Produces the capabilities response; called per fetch.
  */
@@ -79,9 +68,8 @@ function answerWith( capabilities: () => Promise< unknown > ) {
 		if ( path.includes( '/backups' ) ) {
 			return Promise.resolve( [] );
 		}
-		// The promoted-product catalogue, read by the no-plan screen.
-		// `null` is the "no offer to show" answer, which that screen
-		// renders without a price rather than failing.
+		// The promoted-product catalogue. `null` means "no offer", which the no-plan
+		// screen renders without a price rather than failing.
 		return Promise.resolve( null );
 	} );
 }
@@ -91,16 +79,9 @@ function answerWith( capabilities: () => Promise< unknown > ) {
  * `DashboardLayout` arranges them: the header action outside the gate,
  * the dashboard body inside it.
  *
- * A fresh `QueryClient` per render rather than the module singleton, so
- * one state's capabilities answer cannot be served from cache to the
- * next — the capabilities query is held for five minutes.
- *
- * Returns the container for the caller to wrap in `within()` itself,
- * which is what lets `testing-library/prefer-screen-queries` see the
- * scoping it allows. Scoped rather than `screen` because `Notice` and
- * `Button` announce through `@wordpress/a11y`'s speak region — a node
- * appended to `document.body` once per process that keeps its text
- * between tests.
+ * A fresh `QueryClient` per render, so one state's capabilities answer is not served
+ * from cache to the next. Scoped queries rather than `screen`, because `@wordpress/a11y`
+ * keeps its speak region on `document.body` between tests.
  *
  * @return The render container.
  */
@@ -145,11 +126,8 @@ function skeleton(): HTMLElement | null {
  * the client so a test can settle on the capabilities answer reaching
  * the cache rather than on anything that got rendered.
  *
- * The distinction is the point of this half of the file. "No button" is
- * also true of a button that has not decided yet, so an absence
- * assertion means nothing until the answer it decides on has landed —
- * and settling on the *gate's* output instead would quietly turn a test
- * of the button into a second test of the gate.
+ * "No button" is also true of a button that has not decided yet, so the absence
+ * assertions mean nothing until the answer has landed.
  *
  * @return The client and the render container.
  */
@@ -195,9 +173,8 @@ describe( 'Gate decision — what the gate and the header button each show', () 
 
 		const view = within( renderShell() );
 
-		// Nothing to await: the connection state is read synchronously
-		// from a global and every query it gates is disabled, so no
-		// request exists that could change this later.
+		// Nothing to await: the connection state is synchronous and every query it
+		// gates is disabled, so no request could change this later.
 		expect( view.getByText( NOT_CONNECTED ) ).toBeInTheDocument();
 		expect( view.queryByText( BODY ) ).not.toBeInTheDocument();
 		expect( headerSlot() ).toBeEmptyDOMElement();
@@ -224,8 +201,8 @@ describe( 'Gate decision — what the gate and the header button each show', () 
 
 		const view = within( renderShell() );
 
-		// The other two queries are answered, so their settling is what
-		// separates "still starting up" from "held by capabilities".
+		// The other two queries are answered, so this separates "still starting up"
+		// from "held by capabilities".
 		await waitFor( () =>
 			expect( mockApiFetch ).toHaveBeenCalledWith(
 				expect.objectContaining( { path: '/jetpack/v4/backups' } )
@@ -238,9 +215,8 @@ describe( 'Gate decision — what the gate and the header button each show', () 
 		expect( view.queryByText( NO_PLAN ) ).not.toBeInTheDocument();
 		expect( headerSlot() ).toBeEmptyDOMElement();
 
-		// Releasing the read is what proves the withholding above was the
-		// loading state and not a fixture that never arrived: both the
-		// body and the button turn up the moment it lands.
+		// Releasing the read proves the withholding above was the loading state and
+		// not a fixture that never arrived.
 		pending.resolve( { hasBackupPlan: true, hasScan: false } );
 		await expect( view.findByText( BODY ) ).resolves.toBeInTheDocument();
 		await expect(
@@ -256,8 +232,8 @@ describe( 'Gate decision — what the gate and the header button each show', () 
 
 		await expect( view.findByText( CAPABILITIES_ERROR ) ).resolves.toBeInTheDocument();
 
-		// "We couldn't ask" must not be reported as "you don't have a
-		// plan": a failed read leaves `data` undefined too.
+		// "We couldn't ask" is not "you don't have a plan": a failed read also leaves
+		// `data` undefined.
 		expect( view.queryByText( NO_PLAN ) ).not.toBeInTheDocument();
 		expect( view.queryByText( BODY ) ).not.toBeInTheDocument();
 		expect( headerSlot() ).toBeEmptyDOMElement();
@@ -296,9 +272,8 @@ describe( 'The header button on its own, with no gate above it', () => {
 	} );
 
 	it( 'stays away when capabilities cannot be read', async () => {
-		// A failed read leaves `data` undefined, exactly as no plan does.
-		// Both must withhold the button, and for the same reason: nothing
-		// here can say the site is entitled to press it.
+		// A failed read leaves `data` undefined exactly as no plan does, and neither
+		// can say the site is entitled to press this.
 		answerWith( () => Promise.reject( new Error( 'capabilities unavailable' ) ) );
 
 		const { client, container } = renderButtonAlone();
@@ -313,8 +288,7 @@ describe( 'The header button on its own, with no gate above it', () => {
 
 		const { client, container } = renderButtonAlone();
 
-		// The button's other read is answered, so the capabilities read is
-		// the only thing left that could be withholding it.
+		// The button's other read is answered, so capabilities is all that is left.
 		await waitFor( () =>
 			expect( mockApiFetch ).toHaveBeenCalledWith(
 				expect.objectContaining( { path: '/jetpack/v4/backups' } )
@@ -323,8 +297,7 @@ describe( 'The header button on its own, with no gate above it', () => {
 		expect( client.getQueryState( keys.capabilities() )?.fetchStatus ).toBe( 'fetching' );
 		expect( container ).toBeEmptyDOMElement();
 
-		// And it is only that: releasing the read brings the button back,
-		// with nothing else about the fixture changed.
+		// And only that: releasing the read brings the button back, unchanged.
 		pending.resolve( { hasBackupPlan: true, hasScan: false } );
 		await waitFor( () => expect( container ).not.toBeEmptyDOMElement() );
 		expect( container ).toHaveTextContent( 'Back up now' );

--- a/projects/packages/backup/tests/gate-decision.test.tsx
+++ b/projects/packages/backup/tests/gate-decision.test.tsx
@@ -307,10 +307,45 @@ describe( 'The header button on its own, with no gate above it', () => {
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
+	it( 'stays away while the first capabilities read is in flight', async () => {
+		const pending = deferred< unknown >();
+		answerWith( () => pending.promise );
+
+		const { client, container } = renderButtonAlone();
+
+		// The button's other read is answered, so the capabilities read is
+		// the only thing left that could be withholding it.
+		await waitFor( () =>
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( { path: '/jetpack/v4/backups' } )
+			)
+		);
+		expect( client.getQueryState( keys.capabilities() )?.fetchStatus ).toBe( 'fetching' );
+		expect( container ).toBeEmptyDOMElement();
+
+		// And it is only that: releasing the read brings the button back,
+		// with nothing else about the fixture changed.
+		pending.resolve( { hasBackupPlan: true, hasScan: false } );
+		await waitFor( () => expect( container ).not.toBeEmptyDOMElement() );
+		expect( container ).toHaveTextContent( 'Back up now' );
+	} );
+
 	it( 'stays away for an unconnected secondary admin', () => {
 		window.JP_CONNECTION_INITIAL_STATE = {
 			...window.JP_CONNECTION_INITIAL_STATE,
 			connectionStatus: SECONDARY_ADMIN,
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
+
+		const { container } = renderButtonAlone();
+
+		expect( container ).toBeEmptyDOMElement();
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'stays away on a site that is not connected at all', () => {
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			connectionStatus: DISCONNECTED,
 		} as typeof window.JP_CONNECTION_INITIAL_STATE;
 
 		const { container } = renderButtonAlone();

--- a/projects/packages/backup/tests/gate-decision.test.tsx
+++ b/projects/packages/backup/tests/gate-decision.test.tsx
@@ -1,0 +1,335 @@
+// JETPACK-2313 F1 — the gate decision was written twice.
+//
+// `<Gates>` walked connection → secondary admin → capabilities loading →
+// capabilities error → plan, and `<BackupNowButton>` re-derived the same
+// walk from the same two hooks to decide whether to render at all. It has
+// to decide for itself: `DashboardLayout` passes header actions to
+// `<Page>`, which renders them *above* `<Gates>` rather than inside it, so
+// the button cannot rely on the gate having run.
+//
+// The two agreed — both withhold in every state short of "ready", so no
+// contradictory UI was ever possible — which is what makes consolidating
+// them a pure refactor and this file its safety net. It renders the real
+// arrangement, button above gate in one tree, and pins what *both* show in
+// each of the six states. Written against the duplicated code and passing
+// there before `useGateState` existed; anything it catches afterwards is a
+// behaviour change, not a cleanup.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factory above.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor, within } from '@testing-library/react';
+import BackupNowButton from '../src/dashboard/components/backup-now-button';
+import Gates from '../src/dashboard/components/gates';
+import { keys } from '../src/dashboard/data/query-client';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const SECONDARY_ADMIN = { isRegistered: true, hasConnectedOwner: true, isUserConnected: false };
+const DISCONNECTED = { isRegistered: false, hasConnectedOwner: false, isUserConnected: false };
+
+const CAPABILITIES_PATH = '/jetpack/v4/site/capabilities';
+
+// One marker per branch of the gate's decision tree, so a test that
+// expects one screen cannot be satisfied by another.
+const NOT_CONNECTED = 'Connect Jetpack to get started';
+const SECONDARY_ADMIN_SCREEN = 'Link your account to view backups';
+const NO_PLAN = "This site doesn't have an active Backup plan";
+const CAPABILITIES_ERROR = "We couldn't load your backup details";
+const BODY = 'dashboard body';
+
+/**
+ * A promise whose settlement the test controls, so the capabilities read
+ * can be held in flight while assertions run against the rendered output.
+ *
+ * @return The promise and its resolver.
+ */
+function deferred< T >() {
+	let resolve!: ( value: T ) => void;
+	const promise = new Promise< T >( res => {
+		resolve = res;
+	} );
+	return { promise, resolve };
+}
+
+/**
+ * Answer every endpoint this tree reads, with the capabilities route
+ * under the caller's control.
+ *
+ * The other three are answered plainly and identically in every state:
+ * whatever withholds the button here has to be the gate decision, not a
+ * fixture that never resolved.
+ *
+ * @param capabilities - Produces the capabilities response; called per fetch.
+ */
+function answerWith( capabilities: () => Promise< unknown > ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return capabilities();
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: false } );
+		}
+		if ( path.includes( '/backups' ) ) {
+			return Promise.resolve( [] );
+		}
+		// The promoted-product catalogue, read by the no-plan screen.
+		// `null` is the "no offer to show" answer, which that screen
+		// renders without a price rather than failing.
+		return Promise.resolve( null );
+	} );
+}
+
+/**
+ * Render the button and the gate in one tree, arranged as
+ * `DashboardLayout` arranges them: the header action outside the gate,
+ * the dashboard body inside it.
+ *
+ * A fresh `QueryClient` per render rather than the module singleton, so
+ * one state's capabilities answer cannot be served from cache to the
+ * next — the capabilities query is held for five minutes.
+ *
+ * Returns the container for the caller to wrap in `within()` itself,
+ * which is what lets `testing-library/prefer-screen-queries` see the
+ * scoping it allows. Scoped rather than `screen` because `Notice` and
+ * `Button` announce through `@wordpress/a11y`'s speak region — a node
+ * appended to `document.body` once per process that keeps its text
+ * between tests.
+ *
+ * @return The render container.
+ */
+function renderShell(): HTMLElement {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	const { container } = render(
+		<QueryClientProvider client={ client }>
+			<div className="jpb-test-header-actions">
+				<BackupNowButton />
+			</div>
+			<Gates>
+				<div>{ BODY }</div>
+			</Gates>
+		</QueryClientProvider>
+	);
+	return container;
+}
+
+/**
+ * The header slot `renderShell` puts the button in, standing in for the
+ * `actions` prop `DashboardLayout` hands to `<Page>`.
+ *
+ * @return The slot element.
+ */
+function headerSlot(): HTMLElement {
+	return document.querySelector( '.jpb-test-header-actions' ) as HTMLElement;
+}
+
+/**
+ * The gate's first-load spinner, if it is on screen.
+ *
+ * @return The skeleton element, or null.
+ */
+function skeleton(): HTMLElement | null {
+	return document.querySelector( '.jpb-gates__skeleton' );
+}
+
+/**
+ * Render the header button with no gate anywhere above it, and hand back
+ * the client so a test can settle on the capabilities answer reaching
+ * the cache rather than on anything that got rendered.
+ *
+ * The distinction is the point of this half of the file. "No button" is
+ * also true of a button that has not decided yet, so an absence
+ * assertion means nothing until the answer it decides on has landed —
+ * and settling on the *gate's* output instead would quietly turn a test
+ * of the button into a second test of the gate.
+ *
+ * @return The client and the render container.
+ */
+function renderButtonAlone() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	const { container } = render(
+		<QueryClientProvider client={ client }>
+			<BackupNowButton />
+		</QueryClientProvider>
+	);
+	return { client, container };
+}
+
+/**
+ * Wait until the capabilities query has settled.
+ *
+ * @param client - The client the tree is rendering against.
+ * @param status - The settled status to wait for.
+ */
+async function capabilitiesSettled( client: QueryClient, status: 'success' | 'error' ) {
+	await waitFor( () =>
+		expect( client.getQueryState( keys.capabilities() )?.status ).toBe( status )
+	);
+}
+
+beforeEach( () => {
+	mockApiFetch.mockReset();
+	answerWith( () => Promise.resolve( { hasBackupPlan: true, hasScan: false } ) );
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'Gate decision — what the gate and the header button each show', () => {
+	it( 'shows the connect screen and no button when the site is not connected', () => {
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			connectionStatus: DISCONNECTED,
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
+
+		const view = within( renderShell() );
+
+		// Nothing to await: the connection state is read synchronously
+		// from a global and every query it gates is disabled, so no
+		// request exists that could change this later.
+		expect( view.getByText( NOT_CONNECTED ) ).toBeInTheDocument();
+		expect( view.queryByText( BODY ) ).not.toBeInTheDocument();
+		expect( headerSlot() ).toBeEmptyDOMElement();
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows the link-account screen and no button for an unconnected secondary admin', () => {
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			connectionStatus: SECONDARY_ADMIN,
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
+
+		const view = within( renderShell() );
+
+		expect( view.getByText( SECONDARY_ADMIN_SCREEN ) ).toBeInTheDocument();
+		expect( view.queryByText( BODY ) ).not.toBeInTheDocument();
+		expect( headerSlot() ).toBeEmptyDOMElement();
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'spins, and withholds the button, while the first capabilities read is in flight', async () => {
+		const pending = deferred< unknown >();
+		answerWith( () => pending.promise );
+
+		const view = within( renderShell() );
+
+		// The other two queries are answered, so their settling is what
+		// separates "still starting up" from "held by capabilities".
+		await waitFor( () =>
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( { path: '/jetpack/v4/backups' } )
+			)
+		);
+
+		expect( skeleton() ).not.toBeNull();
+		expect( view.queryByText( BODY ) ).not.toBeInTheDocument();
+		expect( view.queryByText( CAPABILITIES_ERROR ) ).not.toBeInTheDocument();
+		expect( view.queryByText( NO_PLAN ) ).not.toBeInTheDocument();
+		expect( headerSlot() ).toBeEmptyDOMElement();
+
+		// Releasing the read is what proves the withholding above was the
+		// loading state and not a fixture that never arrived: both the
+		// body and the button turn up the moment it lands.
+		pending.resolve( { hasBackupPlan: true, hasScan: false } );
+		await expect( view.findByText( BODY ) ).resolves.toBeInTheDocument();
+		await expect(
+			within( headerSlot() ).findByRole( 'button', { name: 'Back up now' } )
+		).resolves.toBeInTheDocument();
+		expect( skeleton() ).toBeNull();
+	} );
+
+	it( 'shows the error screen and no button when capabilities cannot be read', async () => {
+		answerWith( () => Promise.reject( new Error( 'capabilities unavailable' ) ) );
+
+		const view = within( renderShell() );
+
+		await expect( view.findByText( CAPABILITIES_ERROR ) ).resolves.toBeInTheDocument();
+
+		// "We couldn't ask" must not be reported as "you don't have a
+		// plan": a failed read leaves `data` undefined too.
+		expect( view.queryByText( NO_PLAN ) ).not.toBeInTheDocument();
+		expect( view.queryByText( BODY ) ).not.toBeInTheDocument();
+		expect( headerSlot() ).toBeEmptyDOMElement();
+	} );
+
+	it( 'shows the upgrade screen and no button when the site has no plan', async () => {
+		answerWith( () => Promise.resolve( { hasBackupPlan: false, hasScan: false } ) );
+
+		const view = within( renderShell() );
+
+		await expect( view.findByText( NO_PLAN ) ).resolves.toBeInTheDocument();
+		expect( view.queryByText( BODY ) ).not.toBeInTheDocument();
+		expect( headerSlot() ).toBeEmptyDOMElement();
+	} );
+
+	it( 'shows the dashboard body and the button when everything passes', async () => {
+		const view = within( renderShell() );
+
+		await expect( view.findByText( BODY ) ).resolves.toBeInTheDocument();
+		await expect(
+			within( headerSlot() ).findByRole( 'button', { name: 'Back up now' } )
+		).resolves.toBeInTheDocument();
+		expect( view.queryByText( NO_PLAN ) ).not.toBeInTheDocument();
+		expect( view.queryByText( CAPABILITIES_ERROR ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'The header button on its own, with no gate above it', () => {
+	it( 'stays away on a site with no plan', async () => {
+		answerWith( () => Promise.resolve( { hasBackupPlan: false, hasScan: false } ) );
+
+		const { client, container } = renderButtonAlone();
+		await capabilitiesSettled( client, 'success' );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'stays away when capabilities cannot be read', async () => {
+		// A failed read leaves `data` undefined, exactly as no plan does.
+		// Both must withhold the button, and for the same reason: nothing
+		// here can say the site is entitled to press it.
+		answerWith( () => Promise.reject( new Error( 'capabilities unavailable' ) ) );
+
+		const { client, container } = renderButtonAlone();
+		await capabilitiesSettled( client, 'error' );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'stays away for an unconnected secondary admin', () => {
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			connectionStatus: SECONDARY_ADMIN,
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
+
+		const { container } = renderButtonAlone();
+
+		expect( container ).toBeEmptyDOMElement();
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'Shared capabilities read', () => {
+	it( 'is issued once for the two of them', async () => {
+		// Both read the same query key, so mounting the button above the
+		// gate must not cost a second round trip to WPCOM.
+		const view = within( renderShell() );
+		await expect( view.findByText( BODY ) ).resolves.toBeInTheDocument();
+
+		const capabilityReads = mockApiFetch.mock.calls.filter(
+			( [ options ] ) => options?.path === CAPABILITIES_PATH
+		);
+		expect( capabilityReads ).toHaveLength( 1 );
+	} );
+} );


### PR DESCRIPTION
Fixes JETPACK-2313

## Proposed changes

The modernized Backup dashboard decides twice whether a site can use it.

`<Gates>` walks connection → secondary admin → capabilities loading → capabilities error → plan, and picks a screen. `<BackupNowButton>` re-derives the same walk from the same two hooks to decide whether to render at all. It has to decide for itself — `DashboardLayout` passes header actions to `<Page>`, which renders them *above* `<Gates>` rather than inside it — but it was doing so by copying the decision rather than sharing it.

**This is a reuse change, not a correctness one.** The two already agreed: the gate renders a spinner where the button renders `null`, but both withhold in every state short of "ready", so no contradictory UI was ever possible. The only observable effect of the old arrangement is that the header button pops in once capabilities resolve, and that is unchanged here.

* Add `useGateState`, which owns the walk and returns one verdict — `not-connected` | `secondary-admin` | `loading` | `error` | `no-plan` | `ready` — carrying the error screen's `error`, `onRetry` and `isRetrying` with the `error` verdict so a consumer that renders it doesn't read `useCapabilities` a second time.
* `<Gates>` renders one screen per verdict.
* `<BackupNowButton>` renders only on `ready`.
* Both callers read the same React Query key, so the second costs a cache read and not a request. There is a test for that.
* Guard the gate's fall-through with `gate.status satisfies 'ready'`. The button is fail-closed (`!== 'ready' → null`); the gate's bare `return <>{ children }</>` was fail-open, so a verdict added to `GateState` without a branch here would have shown the dashboard body to a site that should be blocked. Now a compile error. Only expressible because the verdict is a discriminated union — trunk's boolean chain had nothing to be exhaustive over.

No production behaviour change, and nothing here is reachable with the modernization flag off.

### Also fixed here: an existing test that passed for the wrong reason

`tests/first-run-state.test.tsx` › *"renders nothing on a site with no plan"* waited on `mockApiFetch` having been **called** with the capabilities path. That returns while the query is still pending, so the button was empty for the *loading* reason and the no-plan state never arrived — a "renders nothing while capabilities are in flight" test wearing the wrong name. Deleting the hook's no-plan branch left it passing **17/17**.

It now waits on the answer reaching the query cache. The same mutation fails it, **1 of 17**. The comment claimed to do this already; it now does.

### What the branch order actually guarantees

The ordering docblock inherited from trunk credited branch order for work the `enabled` flag does. Mutations run against this branch:

| Mutation | Result |
|---|---|
| Hoist `loading` above both connection checks | **522/522 — inert.** `enabled` prevents the request, and a disabled query reports `isLoading` false |
| Swap the two connection branches | **inert.** `isSecondaryAdminNotConnected` is derived as `isFullyConnected && ! isUserConnected` |
| Swap `loading` and `error` | **inert.** `useCapabilities` computes `isLoading` as `query.isLoading && error === null` |
| Hoist the plan check above `loading` and `error` | **5 failed across 3 files** |

So exactly one step is load-bearing — the plan check comes last — and the docblock now says that, pointing each remaining guarantee at the hook that provides it rather than at the line order.

## Related product discussion/links

* JETPACK-2313
* Builds on #51455, which widened the `useCapabilities` result with `isRetrying`; that shape is part of what is consolidated here.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a pure refactor, so the useful test is that nothing moved.

**Automated** — from `projects/packages/backup`:

* `pnpm test` → 56 suites, **524** tests passing.
* `pnpm run typecheck`, `npx eslint --max-warnings=0 …` on the touched files (and the same from the repo root), `jp phan packages/backup` (0 issues), `vendor/bin/phpcs -s` from the repo root (**0 errors**; 8 pre-existing warnings in `class-rest-controller.php`, which this PR does not touch — phpcs exits non-zero on warnings alone).

The equivalence argument is in the commit order. `tests/gate-decision.test.tsx` was written **first**, against the duplicated code, and passes there — 10/10 with the refactor reverted and the test file in place, since grown to 12. It renders the real arrangement (button outside the gate, body inside it) and pins what both consumers show in each of the six states, so anything it catches after the extraction is a behaviour change rather than a cleanup.

A second suite in that file renders the button with no gate anywhere above it and settles on the capabilities answer reaching the query cache. "No button" is also true of a button that has not decided yet, so an absence assertion proves nothing until the answer it decides on has landed — and settling on the gate's output instead would quietly turn a test of the button into a second test of the gate. All five withholding states are covered there.

**Manual**, on a site with the modernized dashboard flag on — each state should look exactly as it does on trunk:

* Connected, licensed site → dashboard body renders, "Back up now" in the header.
* While capabilities are in flight → gate shows its spinner, no header button.
* Site with no Backup plan → upgrade screen, no header button.
* Capabilities request failing (block `/jetpack/v4/site/capabilities`) → the error card with a working "Try again", no header button. Clicking retry must keep the reason on screen rather than blanking to a spinner.
* Disconnected site, and a secondary admin who has not linked their account → the respective connect screens, no header button, and no requests issued.
