### PR TITLE
Backup: add an e2e suite covering the modernized dashboard's gates

### DIFF
--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -132,8 +132,6 @@ const projects = [
 		project: 'Backup',
 		path: 'projects/plugins/backup/tests/e2e',
 		testArgs: [ 'specs' ],
-		// Expanded with `dependencies list --add-dependencies` below, which pulls in
-		// packages/backup — where the dashboard this suite drives actually lives.
 		targets: [ 'plugins/backup' ],
 		buildGroup: 'jetpack-backup',
 	},

--- a/.github/files/e2e-tests/e2e-matrix.js
+++ b/.github/files/e2e-tests/e2e-matrix.js
@@ -128,6 +128,15 @@ const projects = [
 		targets: [ 'plugins/protect' ],
 		buildGroup: 'jetpack-protect',
 	},
+	{
+		project: 'Backup',
+		path: 'projects/plugins/backup/tests/e2e',
+		testArgs: [ 'specs' ],
+		// Expanded with `dependencies list --add-dependencies` below, which pulls in
+		// packages/backup — where the dashboard this suite drives actually lives.
+		targets: [ 'plugins/backup' ],
+		buildGroup: 'jetpack-backup',
+	},
 ];
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5454,6 +5454,30 @@ importers:
         specifier: ^0.0.26
         version: 0.0.26
 
+  projects/plugins/backup/tests/e2e:
+    devDependencies:
+      '@automattic/_jetpack-e2e-commons':
+        specifier: workspace:*
+        version: link:../../../../../tools/e2e-commons
+      '@playwright/test':
+        specifier: 1.60.0
+        version: 1.60.0
+      '@types/node':
+        specifier: ^24.12.0
+        version: 24.13.3
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260707.2
+        version: 7.0.0-dev.20260707.2
+      allure-playwright:
+        specifier: 2.15.1
+        version: 2.15.1
+      config:
+        specifier: 4.4.1
+        version: 4.4.1
+      playwright-ctrf-json-reporter:
+        specifier: ^0.0.26
+        version: 0.0.26
+
   projects/plugins/boost:
     dependencies:
       '@automattic/jetpack-base-styles':

--- a/projects/plugins/backup/changelog/add-backup-e2e-gates
+++ b/projects/plugins/backup/changelog/add-backup-e2e-gates
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Adds an end-to-end test suite; no user-facing change.
+
+

--- a/projects/plugins/backup/tests/e2e/.gitignore
+++ b/projects/plugins/backup/tests/e2e/.gitignore
@@ -1,0 +1,10 @@
+/node_modules
+/config/local*
+/config/tmp/*
+/output
+plan-data.txt
+e2e_tunnels.txt
+jetpack-private-options.txt
+/allure-results
+storage.json
+/tmp

--- a/projects/plugins/backup/tests/e2e/config/default.cjs
+++ b/projects/plugins/backup/tests/e2e/config/default.cjs
@@ -1,0 +1,1 @@
+module.exports = require( '@automattic/_jetpack-e2e-commons/config/default.cjs' );

--- a/projects/plugins/backup/tests/e2e/eslint.config.mjs
+++ b/projects/plugins/backup/tests/e2e/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { makeE2eConfig } from '@automattic/_jetpack-e2e-commons/eslint.config.mjs';
+
+export default makeE2eConfig( import.meta.url );

--- a/projects/plugins/backup/tests/e2e/package.json
+++ b/projects/plugins/backup/tests/e2e/package.json
@@ -1,0 +1,32 @@
+{
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"allure-report": "allure generate --clean --output ./output/allure-report ./output/allure-results && allure open ./output/allure-report",
+		"build": "pnpm jetpack build js-packages/social-logos js-packages/boost-score-api js-packages/components js-packages/number-formatters js-packages/charts packages/wp-build-polyfills packages/assets packages/connection packages/backup plugins/backup plugins/jetpack -v --no-pnpm-install --production",
+		"clean": "rm -rf output",
+		"config:decrypt": "openssl enc -md sha1 -aes-256-cbc -pbkdf2 -iter 100000 -d -pass env:CONFIG_KEY -in ./node_modules/@automattic/_jetpack-e2e-commons/config/encrypted.enc -out ./config/local.cjs",
+		"distclean": "rm -rf node_modules",
+		"env:clean": "e2e-env clean",
+		"env:down": "e2e-env stop",
+		"env:new": "e2e-env new --activate-plugins jetpack-backup e2e-backup-test-helper",
+		"env:reset": "e2e-env reset --activate-plugins jetpack-backup e2e-backup-test-helper",
+		"env:up": "e2e-env start --activate-plugins jetpack-backup e2e-backup-test-helper",
+		"pretest:run": "pnpm run clean",
+		"test:run": "playwright install chromium && NODE_CONFIG_DIR='./config' ALLURE_RESULTS_DIR=./output/allure-results NODE_PATH=\"$PWD/node_modules\" playwright test",
+		"tunnel:down": "tunnel down",
+		"tunnel:reset": "tunnel reset",
+		"tunnel:up": "tunnel up",
+		"typecheck": "tsgo --noEmit"
+	},
+	"browserslist": [],
+	"devDependencies": {
+		"@automattic/_jetpack-e2e-commons": "workspace:*",
+		"@playwright/test": "1.60.0",
+		"@types/node": "^24.12.0",
+		"@typescript/native-preview": "7.0.0-dev.20260707.2",
+		"allure-playwright": "2.15.1",
+		"config": "4.4.1",
+		"playwright-ctrf-json-reporter": "^0.0.26"
+	}
+}

--- a/projects/plugins/backup/tests/e2e/package.json
+++ b/projects/plugins/backup/tests/e2e/package.json
@@ -28,5 +28,9 @@
 		"allure-playwright": "2.15.1",
 		"config": "4.4.1",
 		"playwright-ctrf-json-reporter": "^0.0.26"
+	},
+	"ci": {
+		"pluginSlug": "jetpack-backup",
+		"mirrorName": "jetpack-backup-plugin"
 	}
 }

--- a/projects/plugins/backup/tests/e2e/playwright.config.ts
+++ b/projects/plugins/backup/tests/e2e/playwright.config.ts
@@ -1,0 +1,19 @@
+import baseConfig, {
+	setupProjects,
+} from '@automattic/_jetpack-e2e-commons/playwright.config.default';
+
+export default {
+	...baseConfig,
+	projects: [
+		// The 'connection setup' project is dropped on purpose: one of these specs
+		// needs a disconnected site, and each spec establishes the connection state
+		// it wants for itself. Leaving the shared setup in would connect the site
+		// once up front and then be undone by the first spec that runs.
+		...setupProjects.filter( project => project.name !== 'connection setup' ),
+		{
+			name: 'jetpack backup e2e',
+			testMatch: '**/specs/**',
+			dependencies: [ 'global authentication' ],
+		},
+	],
+};

--- a/projects/plugins/backup/tests/e2e/playwright.config.ts
+++ b/projects/plugins/backup/tests/e2e/playwright.config.ts
@@ -4,17 +4,11 @@ import baseConfig, {
 
 export default {
 	...baseConfig,
-	// Pinned rather than inherited from `PLAYWRIGHT_WORKERS`. Every spec here
-	// mutates global site state — `disconnect()` / `connect()` in `beforeEach`
-	// — and the three share two WordPress options, so they cannot run
-	// concurrently. Making that a property of the suite keeps it true whatever
-	// the environment says.
+	// Every spec mutates global site state, so they cannot run concurrently.
 	workers: 1,
 	projects: [
-		// The 'connection setup' project is dropped on purpose: one of these specs
-		// needs a disconnected site, and each spec establishes the connection state
-		// it wants for itself. Leaving the shared setup in would connect the site
-		// once up front and then be undone by the first spec that runs.
+		// Each spec establishes its own connection state, and one needs the site
+		// disconnected — so the shared 'connection setup' project is dropped.
 		...setupProjects.filter( project => project.name !== 'connection setup' ),
 		{
 			name: 'jetpack backup e2e',

--- a/projects/plugins/backup/tests/e2e/playwright.config.ts
+++ b/projects/plugins/backup/tests/e2e/playwright.config.ts
@@ -4,6 +4,12 @@ import baseConfig, {
 
 export default {
 	...baseConfig,
+	// Pinned rather than inherited from `PLAYWRIGHT_WORKERS`. Every spec here
+	// mutates global site state — `disconnect()` / `connect()` in `beforeEach`
+	// — and the three share two WordPress options, so they cannot run
+	// concurrently. Making that a property of the suite keeps it true whatever
+	// the environment says.
+	workers: 1,
 	projects: [
 		// The 'connection setup' project is dropped on purpose: one of these specs
 		// needs a disconnected site, and each spec establishes the connection state

--- a/projects/plugins/backup/tests/e2e/specs/gates.test.ts
+++ b/projects/plugins/backup/tests/e2e/specs/gates.test.ts
@@ -1,20 +1,12 @@
 import { expect, test } from '@automattic/_jetpack-e2e-commons/fixtures/base-test';
 import type { TestUtils } from '@automattic/_jetpack-e2e-commons/utils/index';
 
-/**
- * Comma-separated rewind capabilities `e2e-backup-test-helper.php` answers
- * `/sites/{id}/rewind/capabilities` with. Nothing else fakes this endpoint:
- * `e2e-plan-helper.php`, which `setMockPlanData()` drives, intercepts
- * `/sites/{id}` and `/sites/{id}/wordads/status` and nothing else — and
- * `<Gates>` never reads the site's Jetpack plan anyway.
- */
+/** Comma-separated rewind capabilities the e2e helper answers `/rewind/capabilities` with. */
 const CAPABILITIES_OPTION = 'e2e_backup_capabilities';
 
 /**
- * How many capabilities requests the helper has answered. Asserted on so a
- * green run can't come from the helper silently doing nothing: the e2e site
- * is partner-provisioned on the free plan, so WordPress.com's own answer is
- * also "no Backup" and the no-plan gate would look identical either way.
+ * How many capabilities requests the helper has answered. Asserted on because the e2e
+ * site's real plan also lacks Backup, so a mock that stopped working would still pass.
  */
 const INTERCEPT_COUNT_OPTION = 'e2e_backup_capabilities_intercepts';
 
@@ -35,9 +27,7 @@ test.describe( 'Jetpack Backup modernized dashboard gates', () => {
 		await testUtils.executeWpCommand( [ 'plugin', 'activate', 'e2e-backup-test-helper' ] );
 		await testUtils.executeWpCommand( [ 'option', 'update', INTERCEPT_COUNT_OPTION, '0' ] );
 
-		// Every spec establishes the connection state it needs, so start from a
-		// known one. The playwright project deliberately omits the shared
-		// 'connection setup' dependency for the same reason.
+		// Every spec establishes the connection state it needs, so start from a known one.
 		await testUtils.disconnect();
 	} );
 
@@ -50,29 +40,16 @@ test.describe( 'Jetpack Backup modernized dashboard gates', () => {
 
 		await admin.visitAdminPage( 'admin.php', 'page=jetpack-backup' );
 
-		// `.jpb-dashboard-layout` is the modernized `<DashboardLayout>`'s own
-		// class, passed through `<Page>` from @wordpress/admin-ui. The legacy
-		// Backup admin page does not render it, so this is what separates
-		// "the wp-build dashboard booted" from "the flag was off and we are
-		// asserting against the old React app".
+		// The modernized `<DashboardLayout>`'s own class. The legacy admin page renders no
+		// such element, so this separates "the dashboard booted" from "the flag was off".
 		await expect( page.locator( '.jpb-dashboard-layout' ) ).toBeVisible();
 
 		await expect(
 			page.getByRole( 'heading', { name: 'Connect Jetpack to get started' } )
 		).toBeVisible();
 
-		// The capability list above says this site *does* have Backup, so a
-		// request that had gone out would have come back with a plan. Zero
-		// means none went out: `<Gates>` passes `enabled: useCanQueryWpcom()`
-		// to `useCapabilities` (`gates/index.tsx:41`), and that is false
-		// without a user-level connection (`use-connection.ts:90-93`).
-		//
-		// It is the heading above, not this count, that pins the branch order.
-		// Both hooks are called at the top of `<Gates>` (lines 37 and 41, above
-		// the first `if` on 43), so no reordering can change whether the
-		// request happens: move the plan check first and this is still 0 —
-		// a disabled query reports `isLoading === false` — while
-		// `NoBackupPlanScreen` renders and the heading assertion fails.
+		// The list above grants Backup, so zero means no request went out: `<Gates>` disables
+		// the capabilities query without a user-level connection.
 		expect( await getInterceptCount( testUtils ) ).toBe( 0 );
 	} );
 
@@ -81,9 +58,8 @@ test.describe( 'Jetpack Backup modernized dashboard gates', () => {
 		admin,
 		testUtils,
 	} ) => {
-		// A non-empty list that lacks `backup`, rather than an empty one: the
-		// gate must key on the capability itself, not merely on "we got
-		// nothing back".
+		// Non-empty but without `backup`, so the gate has to key on the capability itself
+		// rather than on an empty response.
 		await testUtils.executeWpCommand( [ 'option', 'update', CAPABILITIES_OPTION, 'scan' ] );
 		await testUtils.connect();
 
@@ -109,18 +85,11 @@ test.describe( 'Jetpack Backup modernized dashboard gates', () => {
 
 		await expect( page.locator( '.jpb-dashboard-layout' ) ).toBeVisible();
 
-		// What `<Gates>` renders when it passes is the Overview screen's body,
-		// and that body has two shapes: the two-pane activity view, or the
-		// first-run/no-restore-point takeover panel. Which one appears depends
-		// on the activity log and `/jetpack/v4/backups`, and this helper fakes
-		// neither — those go to the real WordPress.com. So the assertion is
-		// "one of the two bodies rendered", which is exactly the gate decision
-		// and nothing more. Pinning down which body appears needs the canned
-		// activity data a later slice adds.
+		// The Overview body has two shapes, and which one renders turns on activity data this
+		// helper does not fake — so the union is exactly the gate decision and nothing more.
 		await expect( page.locator( '.jpb-overview, .jpb-backup-status' ).first() ).toBeVisible();
 
-		// And no gate fallback anywhere: not-connected, secondary-admin,
-		// capabilities-error and no-plan all render inside `.jpb-gates__card`.
+		// And no gate fallback: every gate screen renders inside `.jpb-gates__card`.
 		await expect( page.locator( '.jpb-gates__card' ) ).toHaveCount( 0 );
 
 		expect( await getInterceptCount( testUtils ) ).toBeGreaterThan( 0 );

--- a/projects/plugins/backup/tests/e2e/specs/gates.test.ts
+++ b/projects/plugins/backup/tests/e2e/specs/gates.test.ts
@@ -3,8 +3,9 @@ import { expect, test } from '@automattic/_jetpack-e2e-commons/fixtures/base-tes
 /**
  * Comma-separated rewind capabilities `e2e-backup-test-helper.php` answers
  * `/sites/{id}/rewind/capabilities` with. Nothing else fakes this endpoint:
- * `setMockPlanData()` intercepts `/sites/{id}` and `/sites/{id}/wordads/status`
- * only, and `<Gates>` never reads the site's Jetpack plan.
+ * `e2e-plan-helper.php`, which `setMockPlanData()` drives, intercepts
+ * `/sites/{id}` and `/sites/{id}/wordads/status` and nothing else — and
+ * `<Gates>` never reads the site's Jetpack plan anyway.
  */
 const CAPABILITIES_OPTION = 'e2e_backup_capabilities';
 

--- a/projects/plugins/backup/tests/e2e/specs/gates.test.ts
+++ b/projects/plugins/backup/tests/e2e/specs/gates.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@automattic/_jetpack-e2e-commons/fixtures/base-test';
+import type { TestUtils } from '@automattic/_jetpack-e2e-commons/utils/index';
 
 /**
  * Comma-separated rewind capabilities `e2e-backup-test-helper.php` answers
@@ -20,23 +21,18 @@ const INTERCEPT_COUNT_OPTION = 'e2e_backup_capabilities_intercepts';
 /**
  * Read the helper's interception counter.
  *
- * Takes `testUtils.executeWpCommand` rather than the whole `testUtils`: it is a plain
- * function reference on that class, not a bound method, so it travels on its own.
- *
- * @param executeWpCommand - wp-cli runner from the e2e-commons test utilities.
+ * @param testUtils - e2e-commons test utilities.
  * @return The number of capabilities requests answered locally.
  */
-async function getInterceptCount(
-	executeWpCommand: ( cmd: string[] ) => Promise< string >
-): Promise< number > {
-	const raw = await executeWpCommand( [ 'option', 'get', INTERCEPT_COUNT_OPTION ] );
+async function getInterceptCount( testUtils: TestUtils ): Promise< number > {
+	const raw = await testUtils.executeWpCommand( [ 'option', 'get', INTERCEPT_COUNT_OPTION ] );
 	return parseInt( raw.trim(), 10 );
 }
 
 test.describe( 'Jetpack Backup modernized dashboard gates', () => {
 	test.beforeEach( async ( { testUtils } ) => {
-		await testUtils.executeWpCommand( 'plugin activate jetpack-backup' );
-		await testUtils.executeWpCommand( 'plugin activate e2e-backup-test-helper' );
+		await testUtils.executeWpCommand( [ 'plugin', 'activate', 'jetpack-backup' ] );
+		await testUtils.executeWpCommand( [ 'plugin', 'activate', 'e2e-backup-test-helper' ] );
 		await testUtils.executeWpCommand( [ 'option', 'update', INTERCEPT_COUNT_OPTION, '0' ] );
 
 		// Every spec establishes the connection state it needs, so start from a
@@ -65,11 +61,19 @@ test.describe( 'Jetpack Backup modernized dashboard gates', () => {
 			page.getByRole( 'heading', { name: 'Connect Jetpack to get started' } )
 		).toBeVisible();
 
-		// The capabilities option says this site *does* have Backup. It is the
-		// connection check that has to answer first — `<Gates>` returns the
-		// not-connected screen before it looks at capabilities — so this also
-		// pins the order of the two branches, not just their outcomes.
-		expect( await getInterceptCount( testUtils.executeWpCommand ) ).toBe( 0 );
+		// The capability list above says this site *does* have Backup, so a
+		// request that had gone out would have come back with a plan. Zero
+		// means none went out: `<Gates>` passes `enabled: useCanQueryWpcom()`
+		// to `useCapabilities` (`gates/index.tsx:41`), and that is false
+		// without a user-level connection (`use-connection.ts:90-93`).
+		//
+		// It is the heading above, not this count, that pins the branch order.
+		// Both hooks are called at the top of `<Gates>` (lines 37 and 41, above
+		// the first `if` on 43), so no reordering can change whether the
+		// request happens: move the plan check first and this is still 0 —
+		// a disabled query reports `isLoading === false` — while
+		// `NoBackupPlanScreen` renders and the heading assertion fails.
+		expect( await getInterceptCount( testUtils ) ).toBe( 0 );
 	} );
 
 	test( 'a connected site without the backup capability gets the no-plan screen', async ( {
@@ -90,7 +94,7 @@ test.describe( 'Jetpack Backup modernized dashboard gates', () => {
 			page.getByRole( 'heading', { name: "This site doesn't have an active Backup plan" } )
 		).toBeVisible();
 
-		expect( await getInterceptCount( testUtils.executeWpCommand ) ).toBeGreaterThan( 0 );
+		expect( await getInterceptCount( testUtils ) ).toBeGreaterThan( 0 );
 	} );
 
 	test( 'a connected site with the backup capability gets the dashboard', async ( {
@@ -119,6 +123,6 @@ test.describe( 'Jetpack Backup modernized dashboard gates', () => {
 		// capabilities-error and no-plan all render inside `.jpb-gates__card`.
 		await expect( page.locator( '.jpb-gates__card' ) ).toHaveCount( 0 );
 
-		expect( await getInterceptCount( testUtils.executeWpCommand ) ).toBeGreaterThan( 0 );
+		expect( await getInterceptCount( testUtils ) ).toBeGreaterThan( 0 );
 	} );
 } );

--- a/projects/plugins/backup/tests/e2e/specs/gates.test.ts
+++ b/projects/plugins/backup/tests/e2e/specs/gates.test.ts
@@ -1,0 +1,123 @@
+import { expect, test } from '@automattic/_jetpack-e2e-commons/fixtures/base-test';
+
+/**
+ * Comma-separated rewind capabilities `e2e-backup-test-helper.php` answers
+ * `/sites/{id}/rewind/capabilities` with. Nothing else fakes this endpoint:
+ * `setMockPlanData()` intercepts `/sites/{id}` and `/sites/{id}/wordads/status`
+ * only, and `<Gates>` never reads the site's Jetpack plan.
+ */
+const CAPABILITIES_OPTION = 'e2e_backup_capabilities';
+
+/**
+ * How many capabilities requests the helper has answered. Asserted on so a
+ * green run can't come from the helper silently doing nothing: the e2e site
+ * is partner-provisioned on the free plan, so WordPress.com's own answer is
+ * also "no Backup" and the no-plan gate would look identical either way.
+ */
+const INTERCEPT_COUNT_OPTION = 'e2e_backup_capabilities_intercepts';
+
+/**
+ * Read the helper's interception counter.
+ *
+ * Takes `testUtils.executeWpCommand` rather than the whole `testUtils`: it is a plain
+ * function reference on that class, not a bound method, so it travels on its own.
+ *
+ * @param executeWpCommand - wp-cli runner from the e2e-commons test utilities.
+ * @return The number of capabilities requests answered locally.
+ */
+async function getInterceptCount(
+	executeWpCommand: ( cmd: string[] ) => Promise< string >
+): Promise< number > {
+	const raw = await executeWpCommand( [ 'option', 'get', INTERCEPT_COUNT_OPTION ] );
+	return parseInt( raw.trim(), 10 );
+}
+
+test.describe( 'Jetpack Backup modernized dashboard gates', () => {
+	test.beforeEach( async ( { testUtils } ) => {
+		await testUtils.executeWpCommand( 'plugin activate jetpack-backup' );
+		await testUtils.executeWpCommand( 'plugin activate e2e-backup-test-helper' );
+		await testUtils.executeWpCommand( [ 'option', 'update', INTERCEPT_COUNT_OPTION, '0' ] );
+
+		// Every spec establishes the connection state it needs, so start from a
+		// known one. The playwright project deliberately omits the shared
+		// 'connection setup' dependency for the same reason.
+		await testUtils.disconnect();
+	} );
+
+	test( 'a disconnected site gets the not-connected screen', async ( {
+		page,
+		admin,
+		testUtils,
+	} ) => {
+		await testUtils.executeWpCommand( [ 'option', 'update', CAPABILITIES_OPTION, 'backup' ] );
+
+		await admin.visitAdminPage( 'admin.php', 'page=jetpack-backup' );
+
+		// `.jpb-dashboard-layout` is the modernized `<DashboardLayout>`'s own
+		// class, passed through `<Page>` from @wordpress/admin-ui. The legacy
+		// Backup admin page does not render it, so this is what separates
+		// "the wp-build dashboard booted" from "the flag was off and we are
+		// asserting against the old React app".
+		await expect( page.locator( '.jpb-dashboard-layout' ) ).toBeVisible();
+
+		await expect(
+			page.getByRole( 'heading', { name: 'Connect Jetpack to get started' } )
+		).toBeVisible();
+
+		// The capabilities option says this site *does* have Backup. It is the
+		// connection check that has to answer first — `<Gates>` returns the
+		// not-connected screen before it looks at capabilities — so this also
+		// pins the order of the two branches, not just their outcomes.
+		expect( await getInterceptCount( testUtils.executeWpCommand ) ).toBe( 0 );
+	} );
+
+	test( 'a connected site without the backup capability gets the no-plan screen', async ( {
+		page,
+		admin,
+		testUtils,
+	} ) => {
+		// A non-empty list that lacks `backup`, rather than an empty one: the
+		// gate must key on the capability itself, not merely on "we got
+		// nothing back".
+		await testUtils.executeWpCommand( [ 'option', 'update', CAPABILITIES_OPTION, 'scan' ] );
+		await testUtils.connect();
+
+		await admin.visitAdminPage( 'admin.php', 'page=jetpack-backup' );
+
+		await expect( page.locator( '.jpb-dashboard-layout' ) ).toBeVisible();
+		await expect(
+			page.getByRole( 'heading', { name: "This site doesn't have an active Backup plan" } )
+		).toBeVisible();
+
+		expect( await getInterceptCount( testUtils.executeWpCommand ) ).toBeGreaterThan( 0 );
+	} );
+
+	test( 'a connected site with the backup capability gets the dashboard', async ( {
+		page,
+		admin,
+		testUtils,
+	} ) => {
+		await testUtils.executeWpCommand( [ 'option', 'update', CAPABILITIES_OPTION, 'backup,scan' ] );
+		await testUtils.connect();
+
+		await admin.visitAdminPage( 'admin.php', 'page=jetpack-backup' );
+
+		await expect( page.locator( '.jpb-dashboard-layout' ) ).toBeVisible();
+
+		// What `<Gates>` renders when it passes is the Overview screen's body,
+		// and that body has two shapes: the two-pane activity view, or the
+		// first-run/no-restore-point takeover panel. Which one appears depends
+		// on the activity log and `/jetpack/v4/backups`, and this helper fakes
+		// neither — those go to the real WordPress.com. So the assertion is
+		// "one of the two bodies rendered", which is exactly the gate decision
+		// and nothing more. Pinning down which body appears needs the canned
+		// activity data a later slice adds.
+		await expect( page.locator( '.jpb-overview, .jpb-backup-status' ).first() ).toBeVisible();
+
+		// And no gate fallback anywhere: not-connected, secondary-admin,
+		// capabilities-error and no-plan all render inside `.jpb-gates__card`.
+		await expect( page.locator( '.jpb-gates__card' ) ).toHaveCount( 0 );
+
+		expect( await getInterceptCount( testUtils.executeWpCommand ) ).toBeGreaterThan( 0 );
+	} );
+} );

--- a/projects/plugins/backup/tests/e2e/tsconfig.json
+++ b/projects/plugins/backup/tests/e2e/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "@automattic/_jetpack-e2e-commons/tsconfig.json"
+}

--- a/tools/docker/jetpack-docker-config-default.yml
+++ b/tools/docker/jetpack-docker-config-default.yml
@@ -74,3 +74,4 @@ e2e:
     tools/e2e-commons/plugins/e2e-search-test-helper.php: /var/www/html/wp-content/plugins/e2e-search-test-helper.php
     tools/e2e-commons/plugins/e2e-wpcom-request-interceptor.php: /var/www/html/wp-content/plugins/e2e-wpcom-request-interceptor.php
     tools/e2e-commons/plugins/e2e-plan-helper.php: /var/www/html/wp-content/plugins/e2e-plan-helper.php
+    tools/e2e-commons/plugins/e2e-backup-test-helper.php: /var/www/html/wp-content/plugins/e2e-backup-test-helper.php

--- a/tools/e2e-commons/plugins/e2e-backup-test-helper.php
+++ b/tools/e2e-commons/plugins/e2e-backup-test-helper.php
@@ -6,42 +6,24 @@
  * Version: 1.0.0
  * Text Domain: jetpack
  *
- * Two jobs, both needed before the modernized Backup dashboard can be
- * driven from an e2e test:
- *
- * 1. Turn on the modernization filter. `Jetpack_Backup::is_modernized()`
- *    reads `rsm_jetpack_ui_modernization_backup`, which defaults to false,
- *    so without this the suite would exercise the legacy React admin page
- *    and every assertion in the Backup specs would be meaningless.
- * 2. Answer `/sites/{id}/rewind/capabilities` locally. That endpoint is
- *    the only thing `<Gates>` consults to decide whether the site has a
- *    Backup plan — it does not read the site's Jetpack plan, so
- *    `setMockPlanData()` / `e2e-plan-helper.php` (which intercept
- *    `/sites/{id}` and `/sites/{id}/wordads/status`) cannot fake it.
- *
- * Only activated by the Backup e2e suite; it is inert in every other
- * environment because nothing else turns it on.
+ * Turns on the Backup modernization filter and answers
+ * `/sites/{id}/rewind/capabilities` locally. That endpoint is the only thing `<Gates>`
+ * reads to decide whether the site has a Backup plan, so `e2e-plan-helper.php` — which
+ * intercepts `/sites/{id}` — cannot fake it.
  *
  * @package automattic/jetpack
  */
 
 /**
- * Comma-separated rewind capabilities to answer with, e.g. `backup,scan`.
- * Absent or empty means "this site has no rewind capabilities at all",
- * which is a legitimate WPCOM answer and the one that drives the no-plan
- * gate. Interception is therefore unconditional: a spec that forgets to
- * set the option gets a deterministic no-plan answer rather than
- * whatever WordPress.com happens to say about the test site.
+ * Comma-separated rewind capabilities to answer with, e.g. `backup,scan`. Absent or empty
+ * is a legitimate WPCOM answer and the one that drives the no-plan gate, so interception
+ * is unconditional.
  */
 const E2E_BACKUP_CAPABILITIES_OPTION = 'e2e_backup_capabilities';
 
 /**
- * Number of `/rewind/capabilities` requests this helper has answered.
- *
- * Read by the specs. Without it the no-plan assertion would pass just as
- * happily against a real WordPress.com reply for a site with no Backup
- * plan — which is exactly what the e2e site is — so a mock that had
- * quietly stopped working would still look like a passing test.
+ * Number of `/rewind/capabilities` requests this helper has answered. Read by the specs,
+ * because the e2e site's real plan also lacks Backup and a dead mock would still pass.
  */
 const E2E_BACKUP_INTERCEPT_COUNT_OPTION = 'e2e_backup_capabilities_intercepts';
 
@@ -67,8 +49,7 @@ function e2e_jetpack_backup_intercept_capabilities( $return, $_parsed_args, $url
 		return $return;
 	}
 
-	// Anchored at the end (or at a query string) so this can never also
-	// swallow a longer path that starts with the same segments.
+	// Anchored so a longer path sharing these segments is not also swallowed.
 	if ( 1 !== preg_match( sprintf( '#/sites/%d/rewind/capabilities($|\?)#', $site_id ), $url ) ) {
 		return $return;
 	}
@@ -91,10 +72,8 @@ function e2e_jetpack_backup_intercept_capabilities( $return, $_parsed_args, $url
 /**
  * The capability list to answer with, parsed out of the option.
  *
- * `array_values()` matters: `Capabilities_Bridge` refuses a body whose
- * `capabilities` key is not a numeric array, so a list with gaps in its
- * keys would reach the dashboard as an unreadable response rather than
- * as the capabilities it names.
+ * `array_values()` matters: `Capabilities_Bridge` refuses a `capabilities` key that is
+ * not a numeric array.
  *
  * @return string[] Capability slugs, possibly empty.
  */

--- a/tools/e2e-commons/plugins/e2e-backup-test-helper.php
+++ b/tools/e2e-commons/plugins/e2e-backup-test-helper.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Plugin Name: Jetpack Backup E2E Helper
+ * Plugin URI: https://github.com/automattic/jetpack
+ * Author: Jetpack Team
+ * Version: 1.0.0
+ * Text Domain: jetpack
+ *
+ * Two jobs, both needed before the modernized Backup dashboard can be
+ * driven from an e2e test:
+ *
+ * 1. Turn on the modernization filter. `Jetpack_Backup::is_modernized()`
+ *    reads `rsm_jetpack_ui_modernization_backup`, which defaults to false,
+ *    so without this the suite would exercise the legacy React admin page
+ *    and every assertion in the Backup specs would be meaningless.
+ * 2. Answer `/sites/{id}/rewind/capabilities` locally. That endpoint is
+ *    the only thing `<Gates>` consults to decide whether the site has a
+ *    Backup plan — it does not read the site's Jetpack plan, so
+ *    `setMockPlanData()` / `e2e-plan-helper.php` (which intercept
+ *    `/sites/{id}` and `/sites/{id}/wordads/status`) cannot fake it.
+ *
+ * Only activated by the Backup e2e suite; it is inert in every other
+ * environment because nothing else turns it on.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Comma-separated rewind capabilities to answer with, e.g. `backup,scan`.
+ * Absent or empty means "this site has no rewind capabilities at all",
+ * which is a legitimate WPCOM answer and the one that drives the no-plan
+ * gate. Interception is therefore unconditional: a spec that forgets to
+ * set the option gets a deterministic no-plan answer rather than
+ * whatever WordPress.com happens to say about the test site.
+ */
+const E2E_BACKUP_CAPABILITIES_OPTION = 'e2e_backup_capabilities';
+
+/**
+ * Number of `/rewind/capabilities` requests this helper has answered.
+ *
+ * Read by the specs. Without it the no-plan assertion would pass just as
+ * happily against a real WordPress.com reply for a site with no Backup
+ * plan — which is exactly what the e2e site is — so a mock that had
+ * quietly stopped working would still look like a passing test.
+ */
+const E2E_BACKUP_INTERCEPT_COUNT_OPTION = 'e2e_backup_capabilities_intercepts';
+
+add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
+add_filter( 'pre_http_request', 'e2e_jetpack_backup_intercept_capabilities', 3, 3 );
+
+/**
+ * Intercept the WPCOM rewind capabilities request and answer it locally.
+ *
+ * @param false|array|WP_Error $return result.
+ * @param array                $_parsed_args not used.
+ * @param string               $url request URL.
+ * @return false|array|WP_Error The canned response, or $return when the URL isn't ours.
+ */
+function e2e_jetpack_backup_intercept_capabilities( $return, $_parsed_args, $url ) {
+	if ( ! class_exists( 'Jetpack_Options' ) ) {
+		return $return;
+	}
+
+	$site_id = Jetpack_Options::get_option( 'id' );
+
+	if ( empty( $site_id ) ) {
+		return $return;
+	}
+
+	// Anchored at the end (or at a query string) so this can never also
+	// swallow a longer path that starts with the same segments.
+	if ( 1 !== preg_match( sprintf( '#/sites/%d/rewind/capabilities($|\?)#', $site_id ), $url ) ) {
+		return $return;
+	}
+
+	update_option(
+		E2E_BACKUP_INTERCEPT_COUNT_OPTION,
+		(int) get_option( E2E_BACKUP_INTERCEPT_COUNT_OPTION, 0 ) + 1,
+		false
+	);
+
+	return array(
+		'response' => array( 'code' => 200 ),
+		'body'     => wp_json_encode(
+			array( 'capabilities' => e2e_jetpack_backup_capabilities() ),
+			JSON_UNESCAPED_SLASHES
+		),
+	);
+}
+
+/**
+ * The capability list to answer with, parsed out of the option.
+ *
+ * `array_values()` matters: `Capabilities_Bridge` refuses a body whose
+ * `capabilities` key is not a numeric array, so a list with gaps in its
+ * keys would reach the dashboard as an unreadable response rather than
+ * as the capabilities it names.
+ *
+ * @return string[] Capability slugs, possibly empty.
+ */
+function e2e_jetpack_backup_capabilities() {
+	$raw = get_option( E2E_BACKUP_CAPABILITIES_OPTION, '' );
+
+	if ( ! is_string( $raw ) ) {
+		return array();
+	}
+
+	return array_values( array_filter( array_map( 'trim', explode( ',', $raw ) ) ) );
+}


### PR DESCRIPTION
Part of JETPACK-2333

## Proposed changes

Backup has had no end-to-end coverage anywhere. This is the first slice of one: the harness, end to end, plus the three assertions that prove it is wired up.

* **`projects/plugins/backup/tests/e2e/`** — a suite cloned from `projects/plugins/protect/tests/e2e/` (same `playwright.config.ts` shape, same `config/default.cjs` re-export, same `tsconfig.json`/`eslint.config.mjs`/`.gitignore`). It filters the `connection setup` project out — as Protect's config already does (`protect/tests/e2e/playwright.config.ts:8`), though here the reason is Backup-specific: one of the three specs needs a *disconnected* site, so each spec establishes the connection state it wants. The real departures from Protect are the `build` script, the `env:*` scripts, and the omitted `ci` block.
* **`tools/e2e-commons/plugins/e2e-backup-test-helper.php`** — the only genuinely new piece. It does two things:
  1. Returns true from `rsm_jetpack_ui_modernization_backup`. The filter defaults to false, and the only thing enabling it before this PR was a **gitignored** local mu-plugin (`tools/docker/mu-plugins/0-sandbox.php`, `.gitignore:25`). Without this the suite would be driving the *legacy* Backup admin page in CI and every assertion would be meaningless.
  2. Answers `/sites/{id}/rewind/capabilities` from `pre_http_request`, with a capability list read out of the `e2e_backup_capabilities` option. `<Gates>` never reads the site's Jetpack plan — it reads that endpoint — so `setMockPlanData()` / `e2e-plan-helper.php` (which intercept `/sites/{id}` and `/sites/{id}/wordads/status`, `e2e-plan-helper.php:628,642`) cannot fake it. The `vaultpress-*` entries in that helper are inert legacy feature lists nothing in Backup reads.

  It also counts the requests it answers into `e2e_backup_capabilities_intercepts`, which the specs assert on. Without that counter the no-plan spec would pass just as happily against WordPress.com's real answer — the e2e site is partner-provisioned on the free plan, so the real answer is *also* "no Backup" and a mock that had quietly stopped working would look like a passing test.
* **`tools/docker/jetpack-docker-config-default.yml`** — mounts the helper into the e2e environment. It is mapped into every e2e environment but activated only by this suite's `env:up`; `tools/e2e-commons/bin/e2e-env.sh` activates a fixed list that does not include it.
* **`.github/files/e2e-tests/e2e-matrix.js`** — one entry, `targets: [ 'plugins/backup' ]`, `buildGroup: 'jetpack-backup'`.

Three specs, one per branch of the `<Gates>` decision tree in `projects/packages/backup/src/dashboard/components/gates/index.tsx`: disconnected → not-connected screen; connected without the `backup` capability → no-plan screen; connected with it → the dashboard body.

## What this is worth, and what it is not

The issue says this plainly and it should not be oversold. **This is UI + bridge + polling integration, not a real WordPress.com round trip** — no e2e suite in this monorepo does one. And `projects/packages/backup/tests/` already covers these state machines in jest (`restore-lost-track.test.tsx`, `stages.test.tsx`, `error-surfacing.test.tsx`, `first-run-state.test.tsx`, `empty-selection.test.tsx`, `overview-takeover.test.tsx`).

The marginal value here is *"the page boots in real WordPress, with real enqueues, a real wp-build import map, real routes and a real Jetpack connection"* — not *"the flows behave"*. JETPACK-2319 lists the e2e gap as an accepted risk; this narrows that risk to the boot path and the gate, and no further.

## What remains

This is the first slice only. The issue's remaining scope stays open, and every piece of it needs the same thing: more canned JSON in `e2e-backup-test-helper.php`, on the same `pre_http_request` hook.

**The three flows.** Each is one or two more intercepted endpoints (all verified present in `projects/packages/backup/src/rest/` on this trunk):

| Flow | WordPress.com endpoints to fake |
| --- | --- |
| Download | `/sites/%d/rewind/downloads` (`class-download-bridge.php:130`), `/sites/%d/rewind/downloads/%d` (`:197`) |
| Restore | `/sites/%d/rewind/restores` (`class-restore-bridge.php:140`), `/sites/%d/rewind/restores/%d` (`:275`) |
| File browser / preview | `/sites/%d/rewind/backup/ls` (`class-file-browser-bridge.php:159`), and for the full flow `/rewind/backup/path-info` (`:201`) and `/rewind/backup/%s/file/%s/url` (`:268`) |

Under interception restore is **not** destructive: the POST never leaves the site.

**Pinning which dashboard body renders.** Spec 3 currently asserts a `.jpb-overview, .jpb-backup-status` union — the two shapes the Overview screen can take — and a later slice should narrow it to one. Note this is *not* unblocked by the endpoints above: the union exists because the two queries that decide the shape still go to the real WordPress.com, and those are `/sites/%d/activity/rewindable` (`class-activity-log-bridge.php:99`) and `/sites/%d/rewind/backups` (`class-jetpack-backup.php:513`). Faking that pair is what turns the union into a single assertion.

**`ci.pluginSlug` / `ci.mirrorName`** in the suite's `package.json`, deliberately omitted here. Adding `mirrorName` would make the suite run on `jetpack-backup-plugin` mirror dispatches too, against a *released* plugin that does not yet have the wp-build dashboard — so it would fail. Add it after the flag flips.

## Related product discussion/links

* JETPACK-2333
* JETPACK-2319 (which lists the missing e2e coverage as an accepted risk)

## Does this pull request change what data or activity we track or use?

No. Test-only scaffolding plus one e2e helper plugin that is never shipped to users.

## CI cost

The matrix is change-gated and I confirmed the gating is real by running `e2e-matrix.js` against three synthetic `pull_request` events:

| Simulated PR | Suites queued | Backup queued? |
| --- | --- | --- |
| A Forms-only commit (`e787b20357`) | 8 | no |
| A `packages/backup`-only commit (`e50205f394`) | 10 | **yes, 2** |
| This PR | 38 | yes — but see below; *every* suite runs |

This PR's own 38 is not the new entry's doing, and not `tools/e2e-commons`'s either — that path maps to no project at all. `list-changed-projects.sh` reports the two real causes: *"Diff touches .github/files/e2e-tests/e2e-matrix.js, marking monorepo as changed"* and *"Diff touches infrastructure file pnpm-lock.yaml, considering all projects as changed"*. The lockfile is what widens it.

So the steady-state cost of the new entry is **2 test jobs** (latest + min WP, which is currently 7.0) **plus 1 `E2E: Build jetpack-backup` job**. The build job is worth calling out because the issue's estimate of "2 extra jobs" missed it: `buildGroup` produces its own row in the workflow's `build-matrix`. Locally the three specs plus the two setup projects run in **4.6 minutes**, inside the 3–10 minute band `e2e-tests.yml` documents for a test job.

## Testing instructions

Run it locally (`CONFIG_KEY` is the "E2E Jetpack CONFIG_KEY" secret):

```bash
cd projects/plugins/backup/tests/e2e
pnpm run build            # builds packages/backup's wp-build output, plugins/backup and plugins/jetpack
CONFIG_KEY=… pnpm run config:decrypt
pnpm run env:up
pnpm run tunnel:up
pnpm run test:run specs
```

Expect `5 passed` (2 setup projects + 3 specs).

**Then break it, and confirm it goes red.** All four of these were run against this branch:

1. Flip the helper's filter to `__return_false`. All three specs must fail on `locator('.jpb-dashboard-layout')` — that class is the modernized `<DashboardLayout>`'s own, so its absence is the suite telling you it is looking at the legacy page.
2. Add `await testUtils.connect()` to the first spec. It must fail on the `Connect Jetpack to get started` heading.
3. Change the second spec's capability list to `backup`. It must fail on the `This site doesn't have an active Backup plan` heading.
4. Change the third spec's list to `scan`. It must fail on `locator('.jpb-overview, .jpb-backup-status')`.

**One trap if you try (1), and it is the reason this warning exists.** My first flag-off run passed 5/5 — which looks exactly like the suite being worthless theatre, and was not. The helper is mounted into the container as a **single-file bind mount**, and Docker binds the *inode*, not the path. Any edit that writes by rename — `sed -i`, and most editors' atomic saves — replaces the inode, so the container goes on serving the *old* file indefinitely. `git diff` shows your change; PHP never sees it, and the negative test then passes for the worst possible reason.

The diagnostic is to compare the two inodes, which must match:

```bash
ls -i tools/e2e-commons/plugins/e2e-backup-test-helper.php
docker exec jetpack_t1-wordpress-1 stat -c '%i' \
  /var/www/html/wp-content/plugins/e2e-backup-test-helper.php
```

Mine read `8023622` on the host against `8027708` in the container — the edit had never arrived. Either write in place (`python3 -c "open(p,'w').write(s)"` and `cat > file` both truncate, preserving the inode) or `docker restart jetpack_t1-wordpress-1` afterwards, which re-resolves the mount. Then confirm the container has the new bytes:

```bash
docker exec jetpack_t1-wordpress-1 grep -n "modernization_backup" \
  /var/www/html/wp-content/plugins/e2e-backup-test-helper.php
```

With the edit actually landed, that run goes **3 failed, 2 passed** — the two passes being the setup projects.

**Worktree note.** You do **not** need `tools/docker/bin/seed-worktree-env.sh` for this suite, and it does no harm if you have already run it. `--type e2e --name t1` pins the environment to `jetpack_t1` on port 8889 (`tools/cli/commands/docker.js:119,137`), and the e2e environment starts only `wordpress` and `db` — phpMyAdmin, mailpit and sftp are defined under the `dev:` overrides alone in `jetpack-docker-config-default.yml` — so 8889 is the only host port it binds and it cannot collide with `jetpack_dev`. The `.env` port keys a seeded worktree writes are read only when `type === 'dev'` (`shouldManageParallelEnv`, `docker.js:359`, gating the call at `:831`), so they never reach the e2e flow: every run reported here was made from a seeded worktree whose `.env` says `PORT_WORDPRESS=8080`, and the container bound 8889 each time while `jetpack_dev` stayed up on 80/8181/1080/25/1022.

Known, pre-existing console noise on the connected page loads: three `SyntaxError: Unexpected token '<'`, one 403, and one `atob` failure. They appear identically with the modernization flag **off**, on the legacy page, so they are not from this dashboard and they do not affect any assertion.



