### PR TITLE
Jetpack AI: open the Search dashboard on its AI tab from the AI Search row

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -110,7 +110,8 @@ const SECTIONS = [
 				),
 				enabledAction: {
 					label: __( 'Open Search Settings', 'jetpack' ),
-					href: 'admin.php?page=jetpack-search',
+					// The toggle lives on the Search dashboard's AI tab, not Overview.
+					href: 'admin.php?page=jetpack-search#/ai-answers',
 				},
 				disabledAction: {
 					label: __( 'Learn more', 'jetpack' ),

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -422,6 +422,7 @@ describe( 'AiFeatures rendering', () => {
 					features: {
 						writing_assistant: { enabled: true },
 						image_editor: { enabled: true },
+						ai_search: { enabled: true },
 					},
 				} }
 				savingKeys={ new Set() }
@@ -441,6 +442,12 @@ describe( 'AiFeatures rendering', () => {
 		expect( screen.getByRole( 'link', { name: 'Try it out' } ) ).toHaveAttribute(
 			'href',
 			'upload.php?ai-assistant'
+		);
+
+		// AI Search opens the Search dashboard on its AI tab, not Overview.
+		expect( screen.getByRole( 'link', { name: 'Open Search Settings' } ) ).toHaveAttribute(
+			'href',
+			'admin.php?page=jetpack-search#/ai-answers'
 		);
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/update-ai-features-search-link
+++ b/projects/plugins/jetpack/changelog/update-ai-features-search-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Features: Point the AI Search "Open Search Settings" link at the AI tab of the Search dashboard.


### PR DESCRIPTION
Fixes #

## Proposed changes

* The "Open Search Settings" link on the AI Search row pointed at `admin.php?page=jetpack-search`, which lands on the Search dashboard's Overview tab. It now points at `#/ai-answers`, the tab that holds the "Enable AI Answers" toggle.
* Adds a test asserting the href.

## Related product discussion/links

* JETPACK-2384

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a site with a paid Jetpack Search plan, go to `https://<your-site>/wp-admin/admin.php?page=jetpack#/ai/features`.
2. In the Search section, turn on AI Search.
3. Click "Open Search Settings".
4. You land on the Search dashboard with the "AI Answers (Preview)" tab selected, showing the "Enable AI Answers" toggle. Before this change it opened the Overview tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
