### PR TITLE
Search: rename AI Answers to AI Search

### DIFF
--- a/projects/packages/search/changelog/update-search-ai-search-naming
+++ b/projects/packages/search/changelog/update-search-ai-search-naming
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Rename "AI Answers" to "AI Search" to match the AI Features page.

--- a/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/sidebar-options.jsx
@@ -224,7 +224,7 @@ export default function SidebarOptions() {
 						className="jp-search-configure-ai-answers-toggle"
 						checked={ aiAnswersEnabled }
 						disabled={ isDisabled || ! aiMasterEnabled }
-						label={ __( 'Enable AI Answers', 'jetpack-search-pkg' ) }
+						label={ __( 'Enable AI Search', 'jetpack-search-pkg' ) }
 						help={ aiAnswersHelp }
 						onChange={ setAiAnswersEnabled }
 						__nextHasNoMarginBottom={ true }

--- a/projects/packages/search/src/customberg/components/sidebar/test/sidebar-options-ai-off.test.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/test/sidebar-options-ai-off.test.jsx
@@ -55,7 +55,7 @@ describe( 'SidebarOptions with the site-wide AI switch off', () => {
 	it( 'locks the AI Answers toggle', () => {
 		renderSidebar();
 
-		expect( screen.getByLabelText( 'Enable AI Answers' ) ).toBeDisabled();
+		expect( screen.getByLabelText( 'Enable AI Search' ) ).toBeDisabled();
 	} );
 
 	it( 'explains why the toggle is locked', () => {
@@ -67,6 +67,6 @@ describe( 'SidebarOptions with the site-wide AI switch off', () => {
 	it( 'keeps showing the saved choice', () => {
 		renderSidebar();
 
-		expect( screen.getByLabelText( 'Enable AI Answers' ) ).toBeChecked();
+		expect( screen.getByLabelText( 'Enable AI Search' ) ).toBeChecked();
 	} );
 } );

--- a/projects/packages/search/src/customberg/components/sidebar/test/sidebar-options-ai-on.test.jsx
+++ b/projects/packages/search/src/customberg/components/sidebar/test/sidebar-options-ai-on.test.jsx
@@ -56,7 +56,7 @@ describe( 'SidebarOptions with the site-wide AI switch on', () => {
 	it( 'leaves the AI Answers toggle usable', () => {
 		renderSidebar();
 
-		expect( screen.getByLabelText( 'Enable AI Answers' ) ).toBeEnabled();
+		expect( screen.getByLabelText( 'Enable AI Search' ) ).toBeEnabled();
 	} );
 
 	it( 'shows the normal help text', () => {

--- a/projects/packages/search/src/dashboard/components/ai-answers-tab/index.jsx
+++ b/projects/packages/search/src/dashboard/components/ai-answers-tab/index.jsx
@@ -74,7 +74,7 @@ export default function AiAnswersTab() {
 						<div className="jp-search-dashboard-row">
 							<div className="jp-search-ai-answers-tab__upsell-inner lg-col-span-8 md-col-span-6 sm-col-span-4">
 								<h2 className="jp-search-ai-answers-tab__upsell-heading">
-									{ __( 'Upgrade to use AI Answers', 'jetpack-search-pkg' ) }
+									{ __( 'Upgrade to use AI Search', 'jetpack-search-pkg' ) }
 								</h2>
 								<ul className="jp-search-ai-answers-tab__upsell-bullets">
 									<li>
@@ -118,7 +118,7 @@ export default function AiAnswersTab() {
 									</Notice.Title>
 									<Notice.Description>
 										{ __(
-											'Your AI Answers setting is saved and will apply again when AI is turned back on.',
+											'Your AI Search setting is saved and will apply again when AI is turned back on.',
 											'jetpack-search-pkg'
 										) }
 									</Notice.Description>
@@ -128,7 +128,7 @@ export default function AiAnswersTab() {
 								<Notice.Root intent="warning">
 									<Notice.Title>
 										{ __(
-											'Instant Search must be enabled for AI Answers to work.',
+											'Instant Search must be enabled for AI Search to work.',
 											'jetpack-search-pkg'
 										) }
 									</Notice.Title>
@@ -138,7 +138,7 @@ export default function AiAnswersTab() {
 								</Notice.Root>
 							) }
 							<ToggleControl
-								label={ __( 'Enable AI Answers', 'jetpack-search-pkg' ) }
+								label={ __( 'Enable AI Search', 'jetpack-search-pkg' ) }
 								checked={ isToggleChecked }
 								onChange={ setAiAnswersEnabled }
 								className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -23,14 +23,14 @@ import './dashboard-page.scss';
 
 const DEFAULT_TAB = 'overview';
 // Keep this allowlist in sync with the <Tabs.Tab value="..."> definitions below.
-const VALID_TABS = [ DEFAULT_TAB, 'settings', 'ai-answers' ];
+const VALID_TABS = [ DEFAULT_TAB, 'settings', 'ai-search' ];
 // Tabs are now routed via the URL hash (#/<slug>) to match the my-jetpack
 // admin's HashRouter convention. The pre-hash `?tab=<slug>` query param is
 // still honored on mount so existing bookmarks resolve correctly; mount-time
 // normalization rewrites the URL to the canonical hash form.
 const LEGACY_TAB_QUERY_PARAM = 'tab';
 // Maps removed slugs to their current equivalents so existing bookmarks/links keep working.
-const LEGACY_TAB_ALIASES = { 'plan-usage': 'overview' };
+const LEGACY_TAB_ALIASES = { 'plan-usage': 'overview', 'ai-answers': 'ai-search' };
 // Experiences whose product search reads `override_woocommerce_search_template`:
 // Embedded/Inline swap WooCommerce's product-search page for the Jetpack
 // product-results template; overlay_blocks paints the product overlay. The
@@ -327,8 +327,8 @@ export default function DashboardPage( { isLoading = false } ) {
 						<Tabs.List variant="minimal">
 							<Tabs.Tab value="overview">{ __( 'Overview', 'jetpack-search-pkg' ) }</Tabs.Tab>
 							<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-search-pkg' ) }</Tabs.Tab>
-							<Tabs.Tab value="ai-answers">
-								{ __( 'AI Answers', 'jetpack-search-pkg' ) }
+							<Tabs.Tab value="ai-search">
+								{ __( 'AI Search', 'jetpack-search-pkg' ) }
 								<span className="jp-search-dashboard-tabs__tab-preview-label">
 									&nbsp;{ __( '(Preview)', 'jetpack-search-pkg' ) }
 								</span>
@@ -475,7 +475,7 @@ export default function DashboardPage( { isLoading = false } ) {
 							</>
 						) }
 					</Tabs.Panel>
-					<Tabs.Panel value="ai-answers">
+					<Tabs.Panel value="ai-search">
 						<AiAnswersTab />
 					</Tabs.Panel>
 				</Tabs.Root>

--- a/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/test/dashboard-page.test.jsx
@@ -416,11 +416,11 @@ describe( 'DashboardPage', () => {
 	} );
 
 	test( 'hydrates active tab from the URL hash', () => {
-		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }#/ai-answers` );
+		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }#/ai-search` );
 
 		render( <DashboardPage /> );
 
-		expect( screen.getByRole( 'tab', { name: /ai answers/i } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'tab', { name: /ai search/i } ) ).toHaveAttribute(
 			'aria-selected',
 			'true'
 		);
@@ -457,16 +457,23 @@ describe( 'DashboardPage', () => {
 		expect( window.location.hash ).toBe( '#/overview' );
 	} );
 
+	test( 'resolves the legacy ai-answers slug in the hash to the AI Search tab', () => {
+		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }#/ai-answers` );
+		render( <DashboardPage /> );
+		expect( screen.getByTestId( 'ai-answers-tab' ) ).toBeInTheDocument();
+		expect( window.location.hash ).toBe( '#/ai-search' );
+	} );
+
 	test( 'normalizes legacy ?tab= query strings to the equivalent hash on mount', () => {
 		window.history.replaceState( {}, '', `${ DEFAULT_TEST_URL }&tab=ai-answers` );
 
 		render( <DashboardPage /> );
 
-		expect( screen.getByRole( 'tab', { name: /ai answers/i } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'tab', { name: /ai search/i } ) ).toHaveAttribute(
 			'aria-selected',
 			'true'
 		);
-		expect( window.location.hash ).toBe( '#/ai-answers' );
+		expect( window.location.hash ).toBe( '#/ai-search' );
 		expect( window.location.search ).not.toContain( 'tab=' );
 	} );
 
@@ -487,9 +494,9 @@ describe( 'DashboardPage', () => {
 		const user = userEvent.setup();
 
 		render( <DashboardPage /> );
-		await user.click( screen.getByRole( 'tab', { name: /ai answers/i } ) );
+		await user.click( screen.getByRole( 'tab', { name: /ai search/i } ) );
 
-		await waitFor( () => expect( window.location.hash ).toBe( '#/ai-answers' ) );
+		await waitFor( () => expect( window.location.hash ).toBe( '#/ai-search' ) );
 	} );
 
 	test( 'syncs active tab when the hash changes externally (back/forward)', () => {

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -564,7 +564,7 @@ const searchBlocksPricingItems = [
 const aiAnswersPricingItems = [
 	{
 		id: 'ai-answers',
-		name: __( 'AI Answers (Preview)', 'jetpack-search-pkg' ),
+		name: __( 'AI Search (Preview)', 'jetpack-search-pkg' ),
 		tooltipInfo: __(
 			'Let visitors ask a question and get an instant, AI-generated answer drawn from your own content — right at the top of the search results.',
 			'jetpack-search-pkg'

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/test/index.test.jsx
@@ -139,12 +139,12 @@ describe( 'UpsellPage pricing grid — AI Answers (paid-only)', () => {
 	test( 'always shows the AI Answers row regardless of the Search blocks gate', () => {
 		mockSelectMethods = createSelectMethods( { isSearchBlocksEnabled: false } );
 		const { unmount } = render( <UpsellPage /> );
-		expect( screen.getByText( 'AI Answers (Preview)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'AI Search (Preview)' ) ).toBeInTheDocument();
 		unmount();
 
 		mockSelectMethods = createSelectMethods( { isSearchBlocksEnabled: true } );
 		render( <UpsellPage /> );
-		expect( screen.getByText( 'AI Answers (Preview)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'AI Search (Preview)' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Jetpack Search blocks' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/search/src/dashboard/components/test/ai-answers-tab.test.jsx
+++ b/projects/packages/search/src/dashboard/components/test/ai-answers-tab.test.jsx
@@ -118,7 +118,7 @@ describe( 'AiAnswersTab', () => {
 		setupStore( { isFreePlan: true } );
 		render( <AiAnswersTab /> );
 		await waitFor( () => {
-			expect( screen.getByText( 'Upgrade to use AI Answers' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Upgrade to use AI Search' ) ).toBeInTheDocument();
 		} );
 		expect(
 			screen.getByText( 'Give visitors real answers, not just search results.' )
@@ -130,7 +130,7 @@ describe( 'AiAnswersTab', () => {
 		setupStore( { supportsInstantSearch: false } );
 		render( <AiAnswersTab /> );
 		await waitFor( () => {
-			expect( screen.getByText( 'Upgrade to use AI Answers' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Upgrade to use AI Search' ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -138,20 +138,20 @@ describe( 'AiAnswersTab', () => {
 		setupStore( { supportsInstantSearch: true, isFreePlan: false } );
 		render( <AiAnswersTab /> );
 		await waitFor( () => {
-			expect( screen.queryByText( 'Upgrade to use AI Answers' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Upgrade to use AI Search' ) ).not.toBeInTheDocument();
 		} );
 	} );
 
 	it( 'settings section is present for paid plan users', async () => {
 		setupStore( { supportsInstantSearch: true, isAiAnswersEnabled: true } );
 		render( <AiAnswersTab /> );
-		await expect( screen.findByText( 'Enable AI Answers' ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Enable AI Search' ) ).resolves.toBeInTheDocument();
 	} );
 
 	it( 'settings section is present but visually gated for free plan users', async () => {
 		setupStore( { isFreePlan: true } );
 		render( <AiAnswersTab /> );
-		await expect( screen.findByText( 'Enable AI Answers' ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Enable AI Search' ) ).resolves.toBeInTheDocument();
 		const gated = screen.getByTestId( 'ai-answers-settings' );
 		expect( gated ).toHaveClass( 'jp-search-ai-answers-tab__settings--gated' );
 	} );
@@ -160,7 +160,7 @@ describe( 'AiAnswersTab', () => {
 		setupStore( { supportsInstantSearch: true, isInstantSearchEnabled: false } );
 		render( <AiAnswersTab /> );
 		await expect(
-			screen.findByText( 'Instant Search must be enabled for AI Answers to work.' )
+			screen.findByText( 'Instant Search must be enabled for AI Search to work.' )
 		).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Enable Instant Search on the Settings tab.' ) ).toBeInTheDocument();
 	} );

--- a/projects/packages/search/tests/js/dashboard/pages/dashboard-page.test.jsx
+++ b/projects/packages/search/tests/js/dashboard/pages/dashboard-page.test.jsx
@@ -141,10 +141,10 @@ const settings = {
 };
 
 describe( '<DashboardPage> branch', () => {
-	test( 'renders Overview and AI Answers tabs', () => {
+	test( 'renders Overview and AI Search tabs', () => {
 		renderWith( { searchBlocksEnabled: false, jetpackSettings: settings } );
 		expect( screen.getByRole( 'tab', { name: /overview/i } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'tab', { name: /ai answers/i } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'tab', { name: /ai search/i } ) ).toBeInTheDocument();
 	} );
 
 	test( 'renders ExperienceSelector when searchBlocksEnabled is true', () => {

--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -110,7 +110,8 @@ const SECTIONS = [
 				),
 				enabledAction: {
 					label: __( 'Open Search Settings', 'jetpack' ),
-					href: 'admin.php?page=jetpack-search',
+					// The toggle lives on the Search dashboard's AI tab, not Overview.
+					href: 'admin.php?page=jetpack-search#/ai-answers',
 				},
 				disabledAction: {
 					label: __( 'Learn more', 'jetpack' ),

--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -111,7 +111,7 @@ const SECTIONS = [
 				enabledAction: {
 					label: __( 'Open Search Settings', 'jetpack' ),
 					// The toggle lives on the Search dashboard's AI tab, not Overview.
-					href: 'admin.php?page=jetpack-search#/ai-answers',
+					href: 'admin.php?page=jetpack-search#/ai-search',
 				},
 				disabledAction: {
 					label: __( 'Learn more', 'jetpack' ),

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -447,7 +447,7 @@ describe( 'AiFeatures rendering', () => {
 		// AI Search opens the Search dashboard on its AI tab, not Overview.
 		expect( screen.getByRole( 'link', { name: 'Open Search Settings' } ) ).toHaveAttribute(
 			'href',
-			'admin.php?page=jetpack-search#/ai-answers'
+			'admin.php?page=jetpack-search#/ai-search'
 		);
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -422,6 +422,7 @@ describe( 'AiFeatures rendering', () => {
 					features: {
 						writing_assistant: { enabled: true },
 						image_editor: { enabled: true },
+						ai_search: { enabled: true },
 					},
 				} }
 				savingKeys={ new Set() }
@@ -441,6 +442,12 @@ describe( 'AiFeatures rendering', () => {
 		expect( screen.getByRole( 'link', { name: 'Try it out' } ) ).toHaveAttribute(
 			'href',
 			'upload.php?ai-assistant'
+		);
+
+		// AI Search opens the Search dashboard on its AI tab, not Overview.
+		expect( screen.getByRole( 'link', { name: 'Open Search Settings' } ) ).toHaveAttribute(
+			'href',
+			'admin.php?page=jetpack-search#/ai-answers'
 		);
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/update-ai-features-search-link
+++ b/projects/plugins/jetpack/changelog/update-ai-features-search-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Features: Point the AI Search "Open Search Settings" link at the AI tab of the Search dashboard.

--- a/projects/plugins/jetpack/changelog/update-search-ai-search-naming
+++ b/projects/plugins/jetpack/changelog/update-search-ai-search-naming
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Features: Point the AI Search link at the renamed AI Search tab of the Search dashboard.


### PR DESCRIPTION
Fixes #

## Proposed changes

Stacked on #51689.

* Rename "AI Answers" to "AI Search" everywhere a visitor to the Search dashboard sees it: the tab (still with the "(Preview)" badge), the "Enable AI Search" toggle, the Instant Search notice, the upgrade heading, the pricing-grid row, and the Customberg sidebar toggle. This matches the name on the AI Features page.
* Rename the tab's URL slug from `#/ai-answers` to `#/ai-search`. The old slug is kept as an alias, so existing links and bookmarks still open the tab.
* Point the AI Features "Open Search Settings" link at `#/ai-search`.

Internal names (`ai-answers` component, hook, CSS classes, option keys) are unchanged.

## Related product discussion/links

* JETPACK-2384

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Go to `https://<your-site>/wp-admin/admin.php?page=jetpack-search`.
2. The third tab reads "AI Search (Preview)". Click it: the toggle reads "Enable AI Search" and the URL ends in `#/ai-search`.
3. Change the URL to end in `#/ai-answers` and press Enter. The same tab opens and the URL rewrites to `#/ai-search`.
4. Go to `https://<your-site>/wp-admin/admin.php?page=jetpack#/ai/features`, turn on AI Search, click "Open Search Settings". It opens the "AI Search (Preview)" tab.
5. Go to `https://<your-site>/wp-admin/admin.php?page=jetpack-search-configure`. The sidebar toggle reads "Enable AI Search".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
