### PR TITLE
Jetpack AI: add Quick start links for Claude and ChatGPT to the Overview

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/components/nav-row/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/components/nav-row/index.jsx
@@ -18,7 +18,7 @@ import './style.scss';
  * @param {string}   props.title         - Row title.
  * @param {string}   [props.description] - Row description.
  * @param {string}   [props.href]        - Link target; renders an anchor when set.
- * @param {Function} [props.onClick]     - Click handler; renders a button when no href.
+ * @param {Function} [props.onClick]     - Click handler; without an href the row is a button.
  * @param {boolean}  [props.external]    - Open `href` in a new tab and announce that.
  * @param {string}   [props.tone]        - Icon and chevron treatment. Defaults to the
  *                                       colours the MCP rows already use; 'neutral'
@@ -27,10 +27,10 @@ import './style.scss';
  */
 export default function NavRow( { icon, title, description, href, onClick, external, tone } ) {
 	// Only the element and its props differ between the two forms: an anchor
-	// when there is a destination, a button when there is a handler.
+	// when there is a destination, a button otherwise.
 	const Tag = href ? 'a' : 'button';
 	const tagProps = href
-		? { href, ...( external && { target: '_blank', rel: 'noopener noreferrer' } ) }
+		? { href, onClick, ...( external && { target: '_blank', rel: 'noopener noreferrer' } ) }
 		: { onClick, type: 'button' };
 	const className = tone
 		? `jetpack-ai-nav-row jetpack-ai-nav-row--${ tone }`

--- a/projects/plugins/jetpack/_inc/client/ai/components/nav-row/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/components/nav-row/index.jsx
@@ -3,7 +3,8 @@
  * Renders a link when `href` is given, a button otherwise.
  */
 
-import { Icon } from '@wordpress/components';
+import { Icon, VisuallyHidden } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { chevronRight } from '@wordpress/icons';
 import { Text } from '@wordpress/ui';
 
@@ -18,16 +19,19 @@ import './style.scss';
  * @param {string}   [props.description] - Row description.
  * @param {string}   [props.href]        - Link target; renders an anchor when set.
  * @param {Function} [props.onClick]     - Click handler; renders a button when no href.
+ * @param {boolean}  [props.external]    - Open `href` in a new tab and announce that.
  * @param {string}   [props.tone]        - Icon and chevron treatment. Defaults to the
  *                                       colours the MCP rows already use; 'neutral'
  *                                       takes the design system token.
  * @return {object} Component markup.
  */
-export default function NavRow( { icon, title, description, href, onClick, tone } ) {
+export default function NavRow( { icon, title, description, href, onClick, external, tone } ) {
 	// Only the element and its props differ between the two forms: an anchor
 	// when there is a destination, a button when there is a handler.
 	const Tag = href ? 'a' : 'button';
-	const tagProps = href ? { href } : { onClick, type: 'button' };
+	const tagProps = href
+		? { href, ...( external && { target: '_blank', rel: 'noopener noreferrer' } ) }
+		: { onClick, type: 'button' };
 	const className = tone
 		? `jetpack-ai-nav-row jetpack-ai-nav-row--${ tone }`
 		: 'jetpack-ai-nav-row';
@@ -50,6 +54,9 @@ export default function NavRow( { icon, title, description, href, onClick, tone 
 			<span className="jetpack-ai-nav-row__chevron">
 				<Icon icon={ chevronRight } size={ 24 } />
 			</span>
+			{ href && external && (
+				<VisuallyHidden>{ __( '(opens in a new tab)', 'jetpack' ) }</VisuallyHidden>
+			) }
 		</Tag>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -9,7 +9,7 @@ import { ExternalLink, ProgressBar, Spinner, VisuallyHidden } from '@wordpress/c
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
-import { list } from '@wordpress/icons';
+import { connection, list } from '@wordpress/icons';
 import { Card, Link, LinkButton, Notice, Stack, Text } from '@wordpress/ui';
 import NavRow from '../components/nav-row';
 import { EVENTS, recordAiHubEvent, useRecordOnce } from '../tracks';
@@ -20,6 +20,21 @@ import optimizeSiteThumb from './images/optimize-site.webp';
 import { normalizeUsage, useAiUsage } from './use-ai-usage';
 
 import './style.scss';
+
+// Quick start cards from the i4 Overview frame: each is a nav row to the
+// connector's install page, through the redirect service.
+const QUICK_START = [
+	{
+		slug: 'jetpack-ai-hub-overview-quick-start-claude',
+		title: __( 'Connect Claude', 'jetpack' ),
+		description: __( 'Give Claude access to your site by installing the connector.', 'jetpack' ),
+	},
+	{
+		slug: 'jetpack-ai-hub-overview-quick-start-chatgpt',
+		title: __( 'Connect ChatGPT', 'jetpack' ),
+		description: __( 'Give ChatGPT access to your site by installing the connector.', 'jetpack' ),
+	},
+];
 
 // Lessons from the "Use AI agents with WordPress.com" course; each card links
 // to its lesson page (no inline player). Durations are the live lesson
@@ -341,6 +356,26 @@ export default function AiOverview( {
 					/>
 				</Card.Root>
 			) }
+
+			<div className="jetpack-ai-overview__quick-start">
+				<Text render={ <h2 /> } variant="heading-lg">
+					{ __( 'Quick start', 'jetpack' ) }
+				</Text>
+				<div className="jetpack-ai-overview__quick-start-grid">
+					{ QUICK_START.map( ( { slug, title, description } ) => (
+						<Card.Root key={ slug } className="jetpack-ai-overview__row-card">
+							<NavRow
+								icon={ connection }
+								title={ title }
+								description={ description }
+								href={ getRedirectUrl( slug ) }
+								tone="neutral"
+								external
+							/>
+						</Card.Root>
+					) ) }
+				</div>
+			</div>
 
 			<div className="jetpack-ai-overview__videos">
 				<Text render={ <h2 /> } variant="heading-lg">

--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -290,8 +290,8 @@ export default function AiOverview( {
 	const hostBlocked = hostAllowsAi === false;
 	const userUnlinked = isUserConnected === false;
 	useRecordOnce( EVENTS.VIEWED, { tab: 'overview' } );
-	const recordVideoClick = slug => () =>
-		recordAiHubEvent( EVENTS.LINK_CLICK, { link_type: 'video', link: slug } );
+	const recordLinkClick = ( linkType, slug ) => () =>
+		recordAiHubEvent( EVENTS.LINK_CLICK, { link_type: linkType, link: slug } );
 	return (
 		<Stack direction="column" gap="xl">
 			{ !! blogId && hostBlocked && (
@@ -369,6 +369,7 @@ export default function AiOverview( {
 								title={ title }
 								description={ description }
 								href={ getRedirectUrl( slug ) }
+								onClick={ recordLinkClick( 'quick_start', slug ) }
 								tone="neutral"
 								external
 							/>
@@ -389,7 +390,7 @@ export default function AiOverview( {
 							key={ slug }
 							target="_blank"
 							rel="noopener noreferrer"
-							onClick={ recordVideoClick( slug ) }
+							onClick={ recordLinkClick( 'video', slug ) }
 						>
 							{ /* Decorative: the card's title carries the meaning. */ }
 							<img

--- a/projects/plugins/jetpack/_inc/client/ai/overview/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/style.scss
@@ -88,6 +88,7 @@
 
 	// The titled sections sit 48px under the preceding card: the outer
 	// stack's 24px gap plus this margin.
+	&__quick-start,
 	&__videos,
 	&__docs {
 		display: flex;
@@ -96,6 +97,7 @@
 		margin-block-start: var(--wpds-dimension-gap-xl, 24px);
 	}
 
+	&__quick-start-grid,
 	&__video-grid {
 		display: grid;
 		grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -442,6 +442,24 @@ describe( 'AiOverview', () => {
 		] );
 	} );
 
+	test( 'tracks: a quick start card click records the connector slug', async () => {
+		apiFetch.mockResolvedValueOnce( freePayload() );
+
+		render( <AiOverview { ...PROPS } /> );
+		await expect( screen.findByText( 'Available requests' ) ).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'link', { name: /Connect ChatGPT/ } ) );
+		expect( callsFor( 'jetpack_ai_hub_link_click' ) ).toEqual( [
+			{
+				site_type: 'jetpack',
+				is_a11n: 'false',
+				is_test: 'false',
+				link_type: 'quick_start',
+				link: 'jetpack-ai-hub-overview-quick-start-chatgpt',
+			},
+		] );
+	} );
+
 	test( 'quick start: renders the two connector cards through the redirect service', async () => {
 		apiFetch.mockResolvedValueOnce( freePayload() );
 

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -240,6 +240,8 @@ describe( 'AiOverview', () => {
 		render( <AiOverview { ...PROPS } /> );
 
 		const row = await screen.findByRole( 'link', { name: /Activity log/ } );
+		// Same-site row: no new tab, unlike the external Quick start cards.
+		expect( row ).not.toHaveAttribute( 'target' );
 		expect( row ).toHaveAttribute( 'href', 'https://example.com/activity' );
 	} );
 
@@ -438,5 +440,48 @@ describe( 'AiOverview', () => {
 				link: 'jetpack-ai-hub-overview-video-connect-claude',
 			},
 		] );
+	} );
+
+	test( 'quick start: renders the two connector cards through the redirect service', async () => {
+		apiFetch.mockResolvedValueOnce( freePayload() );
+
+		render( <AiOverview { ...PROPS } /> );
+
+		// Settle the usage fetch so it cannot update state after the test body.
+		await expect( screen.findByText( 'Available requests' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { level: 2, name: 'Quick start' } ) ).toBeInTheDocument();
+
+		// The frame's Quick start row: Connect Claude / Connect ChatGPT, each a
+		// nav row whose destination lives in the redirect service.
+		const slugByName = {
+			'Connect Claude': 'jetpack-ai-hub-overview-quick-start-claude',
+			'Connect ChatGPT': 'jetpack-ai-hub-overview-quick-start-chatgpt',
+		};
+		for ( const [ name, slug ] of Object.entries( slugByName ) ) {
+			const card = screen.getByRole( 'link', { name: new RegExp( name ) } );
+			expect( card ).toHaveAttribute( 'href', expect.stringContaining( slug ) );
+		}
+		expect(
+			screen.getByText( 'Give Claude access to your site by installing the connector.' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Give ChatGPT access to your site by installing the connector.' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'quick start: each card opens in a new tab and says so', async () => {
+		apiFetch.mockResolvedValueOnce( freePayload() );
+
+		render( <AiOverview { ...PROPS } /> );
+
+		await expect( screen.findByText( 'Available requests' ) ).resolves.toBeInTheDocument();
+
+		for ( const title of [ 'Connect Claude', 'Connect ChatGPT' ] ) {
+			const card = screen.getByRole( 'link', {
+				name: new RegExp( `${ title }.*\\(opens in a new tab\\)` ),
+			} );
+			expect( card ).toHaveAttribute( 'target', '_blank' );
+			expect( card ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+		}
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-hub-quick-start
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-hub-quick-start
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI: Add Quick start links for connecting Claude and ChatGPT to the AI Hub Overview.


### PR DESCRIPTION
## Proposed changes

* AI Hub Overview: add the Quick start row from the i4 frame — two cards, Connect Claude and Connect ChatGPT, linking to the connector install pages through the redirect service. Same `NavRow` as the Activity log row, in the same 2-column grid as the videos.
* `NavRow` gets an `external` prop (new tab + hidden "opens in a new tab") and passes `onClick` through on its link form.
* Clicks record `jetpack_ai_hub_link_click` with `link_type: quick_start`, the same event the video cards use.
* Card copy drops the Figma's WordPress.com wording (p1HpG7-ym2-p2#comment-78366).

The Figma also shows two more cards (SEO Agent, Create posts) — not in this PR.

## Screenshots

![Overview tab with the Quick start row](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/add/jetpack-ai-hub-quick-start/1-overview.png)

| Quick start row | Under 600px |
|---|---|
| ![Connect Claude and Connect ChatGPT cards](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/add/jetpack-ai-hub-quick-start/2-quick-start-row.png) | ![Cards stacked in one column](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/add/jetpack-ai-hub-quick-start/4-quick-start-narrow-560.png) |

## Related product discussion/links

* Figma: GmGBrmF9qcNuwOveO7cRdu-fi-6021_4045

## Does this pull request change what data or activity we track or use?

Adds a `quick_start` value for `link_type` on the existing `jetpack_ai_hub_link_click` Tracks event; no new event, no new properties.

## Testing instructions

On a connected site with this branch (Jetpack Beta or Docker), as admin:

1. Go to `/wp-admin/admin.php?page=jetpack-ai`.
2. Between the usage card and the videos you see **Quick start** with two cards.
3. Connect Claude opens `claude.ai/directory/wordpress-com` in a new tab. Connect ChatGPT opens the ChatGPT plugin page.
4. Tab to a card: focus ring is visible; Enter opens it.
5. Narrow the window under 600px: the cards stack.

Note: the card icon is `connection` from `@wordpress/icons`, as the Figma names it. The Figma library renders it half-filled because it lost the icon's `fill-rule="evenodd"`; the package version (outline) is the intended one, so this follows the package.
