### PR TITLE
Jetpack AI: show the Overview connection notices without a wrapping card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -289,21 +289,17 @@ export default function AiOverview( {
 			{ !! blogId && ! hostBlocked && userUnlinked && (
 				// The usage endpoint proxies as the current user, so without a
 				// linked account the fetch can only fail — say so instead.
-				<Card.Root>
-					<Card.Content>
-						<Notice.Root intent="warning">
-							<Notice.Title>
-								{ __( 'Your WordPress.com account isn’t connected.', 'jetpack' ) }
-							</Notice.Title>
-							<Notice.Description>
-								{ __( 'Connect your account to see your AI usage.', 'jetpack' ) }{ ' ' }
-								<Link href="admin.php?page=my-jetpack#/connection">
-									{ __( 'Connect account', 'jetpack' ) }
-								</Link>
-							</Notice.Description>
-						</Notice.Root>
-					</Card.Content>
-				</Card.Root>
+				<Notice.Root intent="warning">
+					<Notice.Title>
+						{ __( 'Your WordPress.com account isn’t connected.', 'jetpack' ) }
+					</Notice.Title>
+					<Notice.Description>
+						{ __( 'Connect your account to see your AI usage.', 'jetpack' ) }{ ' ' }
+						<Link href="admin.php?page=my-jetpack#/connection">
+							{ __( 'Connect account', 'jetpack' ) }
+						</Link>
+					</Notice.Description>
+				</Notice.Root>
 			) }
 			{ !! blogId && ! hostBlocked && ! userUnlinked && (
 				<UsageCard
@@ -316,21 +312,17 @@ export default function AiOverview( {
 			{ ! blogId && (
 				// Disconnected: skip the fetch (it can only fail) and explain
 				// the actual problem instead of a fetch error.
-				<Card.Root>
-					<Card.Content>
-						<Notice.Root intent="warning">
-							<Notice.Title>
-								{ __( 'Jetpack is not connected to WordPress.com.', 'jetpack' ) }
-							</Notice.Title>
-							<Notice.Description>
-								{ __( 'Connect the site to see your AI usage.', 'jetpack' ) }{ ' ' }
-								<Link href="admin.php?page=my-jetpack#/connection">
-									{ __( 'Connect Jetpack', 'jetpack' ) }
-								</Link>
-							</Notice.Description>
-						</Notice.Root>
-					</Card.Content>
-				</Card.Root>
+				<Notice.Root intent="warning">
+					<Notice.Title>
+						{ __( 'Jetpack is not connected to WordPress.com.', 'jetpack' ) }
+					</Notice.Title>
+					<Notice.Description>
+						{ __( 'Connect the site to see your AI usage.', 'jetpack' ) }{ ' ' }
+						<Link href="admin.php?page=my-jetpack#/connection">
+							{ __( 'Connect Jetpack', 'jetpack' ) }
+						</Link>
+					</Notice.Description>
+				</Notice.Root>
 			) }
 
 			{ showActivityLog && activityLogUrl && (

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-overview-notice-layout
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-overview-notice-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Hub: Show the Overview connection notices without a surrounding card, matching the WordPress Agent tab.


### PR DESCRIPTION
## Proposed changes

* AI Hub Overview: the "Jetpack is not connected" and "your account isn't connected" notices sat inside a card, so they rendered as a box in a box. They now sit directly on the page, the way the WordPress Agent tab (and Podcast settings) show theirs.

No behaviour change; the notice text and links are the same.

## Screenshots

| Before | After |
|---|---|
| ![Notice inside a card](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/update/jetpack-ai-overview-notice-layout/1-before.png) | ![Notice directly on the page](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/update/jetpack-ai-overview-notice-layout/2-after.png) |

## Related product discussion/links

* Follow-up to #51109.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a site with this branch that is **not** connected to WordPress.com (a fresh Docker site works), as admin:

1. Go to `/wp-admin/admin.php?page=jetpack-ai`.
2. The yellow "Jetpack is not connected to WordPress.com." notice sits on the page with no white card around it — compare with the notice on the WordPress Agent tab, which looks the same.
3. Connect the site, then disconnect your own WordPress.com account (My Jetpack → Connection): the "Your WordPress.com account isn't connected." notice renders the same way.
