### PR TITLE
Stats: only show the admin bar link when the Stats module is active

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-stats-admin-bar-link-module-check
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-stats-admin-bar-link-module-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Only show the site-name admin bar link when the Stats module is active.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -10,6 +10,7 @@
 use Automattic\Jetpack\Connection\Urls;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status;
 
 // The $icon-color variable for admin color schemes.
@@ -521,10 +522,21 @@ add_action( 'admin_bar_menu', 'wpcom_add_site_badges_and_plan', 35 );
  * (priority 30) has added the `site-name` node and either `dashboard` (front end)
  * or `view-site` (wp-admin), so this shows in both contexts.
  *
+ * `view_stats` is not a proxy for the module being on: the Stats package registers
+ * its `map_meta_cap` handler on any wp-admin request, so an administrator keeps the
+ * capability after the module is switched off, while `admin.php?page=stats` stops
+ * being registered. Linking there then renders "Sorry, you are not allowed to access
+ * this page", so check the module too. `is_active()` short-circuits to true on Simple,
+ * where the module can't be switched off; it only narrows anything on Atomic.
+ *
  * @param WP_Admin_Bar $wp_admin_bar Admin bar instance.
  */
 function wpcom_add_stats_to_site_menu( $wp_admin_bar ) {
-	if ( ( ! $wp_admin_bar->get_node( 'dashboard' ) && ! $wp_admin_bar->get_node( 'view-site' ) ) || ! current_user_can( 'view_stats' ) ) {
+	if (
+		( ! $wp_admin_bar->get_node( 'dashboard' ) && ! $wp_admin_bar->get_node( 'view-site' ) )
+		|| ! current_user_can( 'view_stats' )
+		|| ! ( new Modules() )->is_active( 'stats' )
+	) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-admin-bar/WPCOM_Admin_Bar_Test.php
@@ -149,9 +149,14 @@ class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
 	 * adds in wp-admin), then fires `admin_bar_menu`, the hook our Stats node
 	 * listens on.
 	 *
-	 * @param string|null $site_name_child Child node id to add under 'site-name', or null for none.
+	 * This environment has no Jetpack module files, so `Modules::get_active()` would
+	 * report nothing active. Filter the active module list in explicitly instead, and
+	 * let each test say which state it is exercising.
+	 *
+	 * @param string|null $site_name_child     Child node id to add under 'site-name', or null for none.
+	 * @param bool        $stats_module_active Whether the Stats module is switched on.
 	 */
-	private static function make_test_admin_bar_with_site_name( $site_name_child = null ) {
+	private static function make_test_admin_bar_with_site_name( $site_name_child = null, $stats_module_active = true ) {
 		$admin_bar = new \WP_Admin_Bar();
 		$admin_bar->add_node(
 			array(
@@ -171,7 +176,13 @@ class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
 			);
 		}
 
+		$active_modules = static function () use ( $stats_module_active ) {
+			return $stats_module_active ? array( 'stats' ) : array();
+		};
+
+		add_filter( 'jetpack_active_modules', $active_modules );
 		do_action( 'admin_bar_menu', $admin_bar );
+		remove_filter( 'jetpack_active_modules', $active_modules );
 
 		return $admin_bar;
 	}
@@ -236,6 +247,20 @@ class WPCOM_Admin_Bar_Test extends \WorDBless\BaseTestCase {
 		$stats_node = $admin_bar->get_node( 'wpcom-stats' );
 
 		$this->assertNull( $stats_node );
+	}
+
+	/**
+	 * Switching the Stats module off unregisters `admin.php?page=stats`, but the Stats
+	 * package still maps `view_stats` on any wp-admin request, so the capability check
+	 * alone keeps passing. Linking there would render "Sorry, you are not allowed to
+	 * access this page" (JETPACK-2366).
+	 */
+	public function test_stats_link_hidden_when_stats_module_inactive() {
+		add_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
+		$admin_bar = self::make_test_admin_bar_with_site_name( 'dashboard', false );
+		remove_filter( 'user_has_cap', array( $this, 'grant_view_stats' ) );
+
+		$this->assertNull( $admin_bar->get_node( 'wpcom-stats' ) );
 	}
 
 	public function test_stats_link_hidden_when_dashboard_and_view_site_nodes_absent() {

--- a/projects/plugins/wpcomsh/changelog/fix-stats-admin-bar-link-module-check
+++ b/projects/plugins/wpcomsh/changelog/fix-stats-admin-bar-link-module-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Only show the admin bar link when the Stats module is active.


### PR DESCRIPTION
On an Atomic site with the Jetpack Stats module switched off, the Stats link still shows up in the admin bar site-name menu, and clicking it lands on "Sorry, you are not allowed to access this page". This makes the link go away when the page isn't there, so folks don't get sent to a dead end.

Fixes #51590

## Proposed changes
* `wpcom_add_stats_to_site_menu()` now checks `Modules::is_active( 'stats' )` on top of the existing `view_stats` check.
* The cap alone isn't enough - the Stats package registers its `map_meta_cap` handler on any wp-admin request (the `is_admin()` branch in `class.jetpack.php`), so an admin keeps `view_stats` after the module is switched off, while `admin.php?page=stats` stops being registered. So the cap check passes and the link 404s.
* `is_active()` short-circuits to true on Simple (`IS_WPCOM`), so this only narrows anything on Atomic, where the module can actually be switched off.
* Added a test for the module-off case, and the existing "link shows" tests now state the module state explicitly (this env has no Jetpack module files, so `Modules::get_active()` would report nothing active).

## Related product discussion/links
* https://linear.app/a8c/issue/JETPACK-2366/disabled-stats-module-breaks-mywordpresscomsites-primary-link
* https://linear.app/a8c/issue/STATS-287/add-stats-to-omnibar - where the link was added

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* On an Atomic site, make sure Jetpack Stats is active (Jetpack → Settings → Traffic, or `wp jetpack module activate stats`).
* Open the site-name menu in the admin bar, both in wp-admin and on the front end.
* Ensure the Stats link shows up in both, and goes to `admin.php?page=stats`.
* Now switch the Stats module off (`wp jetpack module deactivate stats`).
* Ensure the Stats link is gone from the site-name menu in both places.
* Ensure you can't land on the "Sorry, you are not allowed to access this page" screen from the admin bar anymore.
* `jp test php packages/jetpack-mu-wpcom` covers both directions too.

This is only half of it - the my.wordpress.com/sites link from the issue comes from Calypso, which had the same gap. That side is Automattic/wp-calypso#113890.
