### PR TITLE
Enhanced Ownership: retire the site-level legacy contact field

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/retire-site-level-legacy-contact
+++ b/projects/packages/jetpack-mu-wpcom/changelog/retire-site-level-legacy-contact
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Enhanced Ownership: Retire the site-level legacy contact field in favour of the account-level legacy contact setting on WordPress.com.

--- a/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/enhanced-ownership.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/100-year-plan/enhanced-ownership.php
@@ -2,66 +2,14 @@
 /**
  * Enhanced Ownership
  *
+ * The site-level legacy contact setting is retired in favour of the account-level
+ * feature on WordPress.com, which covers every site a user owns.
+ *
  * @package automattic/jetpack-mu-wpcom
  */
 
 /**
- * Registers Enhanced Ownership settings.
- */
-function wpcom_eo_register_settings() {
-	if ( ! wpcom_site_has_feature( WPCOM_Features::LEGACY_CONTACT ) ) {
-		return;
-	}
-
-	register_setting(
-		'general',
-		'wpcom_legacy_contact',
-		array(
-			'type'         => 'string',
-			'description'  => 'The legacy contact for this site.',
-			'show_in_rest' => true,
-			'default'      => '',
-		)
-	);
-}
-add_action( 'admin_init', 'wpcom_eo_register_settings' );
-add_action( 'rest_api_init', 'wpcom_eo_register_settings' );
-
-/**
- * Adds settings to the v1 API site settings endpoint.
- *
- * @param array $settings A single site's settings.
- * @return array
- */
-function wpcom_eo_get_options_v1_api( $settings ) {
-	if ( wpcom_site_has_feature( WPCOM_Features::LEGACY_CONTACT ) ) {
-		$settings['wpcom_legacy_contact'] = get_option( 'wpcom_legacy_contact' );
-	}
-
-	return $settings;
-}
-add_filter( 'site_settings_endpoint_get', 'wpcom_eo_get_options_v1_api' );
-
-/**
- * Updates settings via public-api.wordpress.com.
- *
- * @param array $input             Associative array of site settings to be updated.
- *                                 Cast and filtered based on documentation.
- * @param array $unfiltered_input  Associative array of site settings to be updated.
- *                                 Neither cast nor filtered. Contains raw input.
- * @return array
- */
-function wpcom_eo_update_options_v1_api( $input, $unfiltered_input ) {
-	if ( isset( $unfiltered_input['wpcom_legacy_contact'] ) ) {
-		$input['wpcom_legacy_contact'] = sanitize_text_field( $unfiltered_input['wpcom_legacy_contact'] );
-	}
-
-	return $input;
-}
-add_filter( 'rest_api_update_site_settings', 'wpcom_eo_update_options_v1_api', 10, 2 );
-
-/**
- * Registers the settings section and fields.
+ * Registers the settings section.
  */
 function wpcom_eo_settings_page_init() {
 	if ( ! wpcom_site_has_feature( WPCOM_Features::LEGACY_CONTACT ) ) {
@@ -71,36 +19,24 @@ function wpcom_eo_settings_page_init() {
 	add_settings_section(
 		'wpcom_enhanced_ownership_section',
 		__( 'Enhanced Ownership', 'jetpack-mu-wpcom' ),
-		'', // No callback needed.
-		'general'
-	);
-
-	add_settings_field(
-		'wpcom_legacy_contact',
-		__( 'Legacy Contact', 'jetpack-mu-wpcom' ),
 		'wpcom_legacy_contact_render',
-		'general',
-		'wpcom_enhanced_ownership_section',
-		array(
-			'label_for' => 'wpcom_legacy_contact',
-		)
+		'general'
 	);
 }
 add_action( 'admin_init', 'wpcom_eo_settings_page_init' );
 
 /**
- * Renders the Legacy Contact settings markup.
+ * Renders a pointer to the account-level legacy contact setting.
  */
 function wpcom_legacy_contact_render() {
 	?>
-	<input type="text" id="wpcom_legacy_contact" class="regular-text" name="wpcom_legacy_contact" value="<?php echo esc_attr( get_option( 'wpcom_legacy_contact' ) ); ?>">
-	<p class="description"><?php esc_html_e( 'Choose someone to look after your site when you pass away.', 'jetpack-mu-wpcom' ); ?></p>
+	<p class="description"><?php esc_html_e( 'Choose someone to look after your sites when you pass away.', 'jetpack-mu-wpcom' ); ?></p>
 	<p class="description">
 		<?php
 		printf(
-			/* translators: link to the help page: https://wordpress.com/help */
-			esc_html__( 'To take ownership of the site, we ask that the person you designate contacts us at %s with a copy of the death certificate.', 'jetpack-mu-wpcom' ),
-			'<a href="https://wordpress.com/help">wordpress.com/help</a>'
+			/* translators: %s: link to the account-level legacy contact settings on WordPress.com. */
+			esc_html__( 'Legacy contact is now set on your WordPress.com account and applies to all of your sites. %s', 'jetpack-mu-wpcom' ),
+			'<a href="https://my.wordpress.com/me/security/legacy-contact">' . esc_html__( 'Manage your legacy contact ↗', 'jetpack-mu-wpcom' ) . '</a>'
 		);
 		?>
 	</p>

--- a/projects/packages/sync/changelog/retire-site-level-legacy-contact
+++ b/projects/packages/sync/changelog/retire-site-level-legacy-contact
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Stop syncing the retired wpcom_legacy_contact option.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -197,7 +197,6 @@ class Defaults {
 		'jetpack_post_date_in_email',
 		'wpcom_gifting_subscription',
 		'wpcom_is_fse_activated',
-		'wpcom_legacy_contact',
 		'wpcom_locked_mode',
 		'wpcom_newsletter_categories',
 		'wpcom_newsletter_categories_enabled',

--- a/projects/plugins/jetpack/changelog/retire-site-level-legacy-contact
+++ b/projects/plugins/jetpack/changelog/retire-site-level-legacy-contact
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sync: Stop syncing the retired wpcom_legacy_contact option.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
@@ -266,7 +266,6 @@ class Jetpack_Sync_Options_Test extends Jetpack_Sync_TestBase {
 			'wpcom_subscription_emails_use_excerpt'        => false,
 			'launchpad_checklist_tasks_statuses'           => array(),
 			'launchpad_screen'                             => 'full',
-			'wpcom_legacy_contact'                         => '',
 			'wpcom_locked_mode'                            => false,
 			'wpcom_reader_views_enabled'                   => true,
 			'wpcom_site_setup'                             => '',

--- a/projects/plugins/mu-wpcom-plugin/changelog/retire-site-level-legacy-contact
+++ b/projects/plugins/mu-wpcom-plugin/changelog/retire-site-level-legacy-contact
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Enhanced Ownership: Retire the site-level legacy contact field in favour of the account-level legacy contact setting on WordPress.com.

--- a/projects/plugins/wpcomsh/changelog/retire-site-level-legacy-contact
+++ b/projects/plugins/wpcomsh/changelog/retire-site-level-legacy-contact
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Enhanced Ownership: Retire the site-level legacy contact field in favour of the account-level legacy contact setting on WordPress.com.


### PR DESCRIPTION
## Proposed changes
* Remove the site-level Legacy Contact field from Settings > General. The Enhanced Ownership section now renders only explanatory text linking to the account-level legacy contact setting, which applies to every site a user owns.
* Remove the `wpcom_legacy_contact` option: its `register_setting()` registration and the `site_settings_endpoint_get` / `rest_api_update_site_settings` v1 API filters.
* Drop `wpcom_legacy_contact` from Sync's `Defaults` option allowlist, and the matching assertion in `Jetpack_Sync_Options_Test`.
* The `WPCOM_Features::LEGACY_CONTACT` gate is unchanged, so the section is still only shown to sites with the feature.

No sites currently have a value stored in `wpcom_legacy_contact`, so no migration to the account-level feature is needed. This will be re-checked before merge — dropping the option from Sync defaults stops the value reaching WP.com.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
Yes, in that it stops tracking something: `wpcom_legacy_contact` is no longer registered, exposed via the v1 site settings endpoint, or synced to WP.com. No new data is collected. Existing option rows in site databases are left untouched — they are simply no longer read or synced.

## Testing instructions
* Set up a site with the Legacy Contact feature enabled (a 100-year plan site, or force `wpcom_site_has_feature( WPCOM_Features::LEGACY_CONTACT )` to return true).
* Go to **Settings > General** and scroll to the **Enhanced Ownership** section.
* Confirm the text input is gone, and that the section shows the explanatory copy with a "Manage your legacy contact" link.
* Confirm the link points to `https://my.wordpress.com/me/security/legacy-contact` and loads the account-level setting.
* Confirm the section is still hidden on a site without the feature.
* Confirm `GET /rest/v1.1/sites/$site/settings` no longer returns a `wpcom_legacy_contact` key, and that `POST`ing that key no longer stores anything.
