### PR TITLE
WP Build Polyfills: keep boot single-page apps sized to the viewport

### DIFF
--- a/projects/packages/wp-build-polyfills/changelog/fix-boot-single-page-scroll
+++ b/projects/packages/wp-build-polyfills/changelog/fix-boot-single-page-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the page header and content in view when the wp-admin menu is taller than the window.

--- a/projects/packages/wp-build-polyfills/src/class-wp-build-admin-frame.php
+++ b/projects/packages/wp-build-polyfills/src/class-wp-build-admin-frame.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Backdrop for the `@wordpress/boot` single-page layout in wp-admin.
+ * Frame fixes for the `@wordpress/boot` single-page layout in wp-admin.
  *
  * @package automattic/jetpack-wp-build-polyfills
  */
@@ -8,7 +8,9 @@
 namespace Automattic\Jetpack\WP_Build_Polyfills;
 
 /**
- * Makes the boot single-page backdrop continue the wp-admin menu color.
+ * Reconciles the boot single-page layout with the wp-admin frame: the backdrop
+ * continues the admin menu color, and the app keeps its own scroller when the
+ * admin menu is taller than the viewport.
  *
  * `@wordpress/admin-ui` derives the backdrop from a fixed map of Core color
  * schemes and falls back to a near-black `modern` seed for any other scheme,
@@ -33,9 +35,9 @@ class WP_Build_Admin_Frame {
 	}
 
 	/**
-	 * Print the backdrop override.
+	 * Print the backdrop and scroll-containment overrides.
 	 *
-	 * Both selectors are (1,1,0), so they outrank the layout rule boot injects
+	 * The backdrop selectors are (1,1,0), so they outrank the layout rule boot injects
 	 * at runtime. The fallbacks keep boot's own colors when the sampling script
 	 * did not run.
 	 *
@@ -55,6 +57,23 @@ class WP_Build_Admin_Frame {
 			body:has(.boot-layout--single-page),
 			body:has([class*="__layout-single-page"]) {
 				background: var(--wp-build-admin-menu-background, #fff);
+			}
+
+			/*
+			 * TODO (upstream): drop once WordPress/gutenberg#82114 lands. Boot's
+			 * layout is absolutely positioned against `#wpbody`, which grows with
+			 * the admin menu — a menu taller than the viewport stretches the app
+			 * and scrolls its sticky header away. Capping `#wpbody` to the
+			 * viewport gives the app back its own scroller.
+			 */
+			/* Below 783px the menu is off-canvas and the template scrolls `#wpwrap` instead. */
+			@media (min-width: 783px) {
+				body:has(.boot-layout--single-page) #wpbody,
+				body:has([class*="__layout-single-page"]) #wpbody {
+					position: sticky;
+					top: var(--wp-admin--admin-bar--height, 32px);
+					height: calc(100vh - var(--wp-admin--admin-bar--height, 32px));
+				}
 			}
 		</style>
 		<?php

--- a/projects/packages/wp-build-polyfills/src/class-wp-build-admin-frame.php
+++ b/projects/packages/wp-build-polyfills/src/class-wp-build-admin-frame.php
@@ -60,13 +60,15 @@ class WP_Build_Admin_Frame {
 			}
 
 			/*
-			 * TODO (upstream): drop once WordPress/gutenberg#82114 lands. Boot's
-			 * layout is absolutely positioned against `#wpbody`, which grows with
-			 * the admin menu — a menu taller than the viewport stretches the app
-			 * and scrolls its sticky header away. Capping `#wpbody` to the
-			 * viewport gives the app back its own scroller.
+			 * Boot's layout is absolutely positioned against `#wpbody`, which grows
+			 * with the admin menu: a menu taller than the viewport stretches the app
+			 * and scrolls its sticky header away, so cap `#wpbody` to the viewport to
+			 * give the app back its own scroller. Below 783px the menu is off-canvas
+			 * and the template scrolls `#wpwrap` instead. Drop this once every boot
+			 * this package can run against pins its own layout: Core's bundled copy
+			 * from WordPress 7.0, and the polyfilled one below that
+			 * (WordPress/gutenberg#82114).
 			 */
-			/* Below 783px the menu is off-canvas and the template scrolls `#wpwrap` instead. */
 			@media (min-width: 783px) {
 				body:has(.boot-layout--single-page) #wpbody,
 				body:has([class*="__layout-single-page"]) #wpbody {

--- a/projects/packages/wp-build-polyfills/tests/php/WP_Build_Admin_Frame_Test.php
+++ b/projects/packages/wp-build-polyfills/tests/php/WP_Build_Admin_Frame_Test.php
@@ -115,6 +115,26 @@ class WP_Build_Admin_Frame_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The stylesheet caps the wp-admin body box to the viewport on desktop, so a
+	 * tall admin menu cannot stretch the boot layout past it.
+	 */
+	public function test_styles_cap_the_admin_body_to_the_viewport() {
+		ob_start();
+		WP_Build_Admin_Frame::print_styles();
+		$css = ob_get_clean();
+
+		$this->assertStringContainsString( '@media (min-width: 783px) {', $css );
+		$this->assertStringContainsString( 'body:has(.boot-layout--single-page) #wpbody,', $css );
+		$this->assertStringContainsString( 'body:has([class*="__layout-single-page"]) #wpbody {', $css );
+		$this->assertStringContainsString( 'position: sticky;', $css );
+		$this->assertStringContainsString( 'top: var(--wp-admin--admin-bar--height, 32px);', $css );
+		$this->assertStringContainsString(
+			'height: calc(100vh - var(--wp-admin--admin-bar--height, 32px));',
+			$css
+		);
+	}
+
+	/**
 	 * The script samples #adminmenuback into the custom property on the root element.
 	 */
 	public function test_script_samples_the_admin_menu_into_the_custom_property() {

--- a/projects/plugins/backup/changelog/fix-boot-single-page-scroll
+++ b/projects/plugins/backup/changelog/fix-boot-single-page-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin dashboards: Keep the page header and content in view when the wp-admin menu is taller than the window.

--- a/projects/plugins/boost/changelog/fix-boot-single-page-scroll
+++ b/projects/plugins/boost/changelog/fix-boot-single-page-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin dashboards: Keep the page header and content in view when the wp-admin menu is taller than the window.

--- a/projects/plugins/jetpack/changelog/fix-boot-single-page-scroll
+++ b/projects/plugins/jetpack/changelog/fix-boot-single-page-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Admin dashboards: Keep the page header and content in view when the wp-admin menu is taller than the window.

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-boot-single-page-scroll
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-boot-single-page-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin dashboards: Keep the page header and content in view when the wp-admin menu is taller than the window.

--- a/projects/plugins/premium-analytics/changelog/fix-boot-single-page-scroll
+++ b/projects/plugins/premium-analytics/changelog/fix-boot-single-page-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Keep the page header and content in view when the wp-admin menu is taller than the window.

--- a/projects/plugins/protect/changelog/fix-boot-single-page-scroll
+++ b/projects/plugins/protect/changelog/fix-boot-single-page-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin dashboards: Keep the page header and content in view when the wp-admin menu is taller than the window.

--- a/projects/plugins/search/changelog/fix-boot-single-page-scroll
+++ b/projects/plugins/search/changelog/fix-boot-single-page-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin dashboards: Keep the page header and content in view when the wp-admin menu is taller than the window.

--- a/projects/plugins/social/changelog/fix-boot-single-page-scroll
+++ b/projects/plugins/social/changelog/fix-boot-single-page-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin dashboards: Keep the page header and content in view when the wp-admin menu is taller than the window.

--- a/projects/plugins/videopress/changelog/fix-boot-single-page-scroll
+++ b/projects/plugins/videopress/changelog/fix-boot-single-page-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin dashboards: Keep the page header and content in view when the wp-admin menu is taller than the window.

--- a/projects/plugins/wpcomsh/changelog/fix-boot-single-page-scroll
+++ b/projects/plugins/wpcomsh/changelog/fix-boot-single-page-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin dashboards: Keep the page header and content in view when the wp-admin menu is taller than the window.


### PR DESCRIPTION
## Proposed changes

`@wordpress/boot` single-page screens should use the space below the wp-admin bar and scroll within that space. On desktop sites with an admin menu taller than the viewport, they instead inherit the menu's height. This causes three related problems:

* The screen header scrolls out of view.
* Content at the bottom of the screen cannot be reached.
* The browser alternates between the page and app scroll areas, making the mouse wheel appear to stall.

This happens because Boot absolutely positions its layout inside `#wpbody`; when the menu is taller than the window, `#wpbody` grows to match it.

This PR adds a temporary, narrowly scoped frame override for Boot single-page layouts on desktop:

* Pins `#wpbody` below the admin bar and caps its height to the viewport, restoring Boot's own scroll container.
* Applies only at widths of 783px and above, where the admin menu is visible. Mobile continues to use WordPress's existing `#wpwrap` scrolling behavior.
* Targets both the legacy Boot class and the CSS Modules class pattern, and has no effect on non-Boot admin pages.
* Covers the generated CSS with a PHP test.

The override can be removed when the upstream fix in WordPress/gutenberg#82114 is available.

### Two scroll areas

This PR does not reduce the page to a single scroll area: the app scrolls in its own container, and the page still scrolls to reveal the rest of a tall admin menu.

Removing the second one means capping the admin menu so it scrolls within its own column. That part works, and WordPress's `pinMenu()` steps aside cleanly because it measures `#adminmenuwrap`, the element being capped. The blocker is that `overflow-y: auto` also forces `overflow-x`, which clips the fly-out submenus that open beside the menu and makes them unclickable — `overflow-x: clip` with `overflow-clip-margin` computes to `hidden` when paired with a scrolling axis, so it does not help either. Keeping those submenus usable means moving them out of the scroll container, which is markup or JS on wp-admin's own chrome rather than anything this stylesheet can reach. It belongs with WordPress/gutenberg#82114, where the layout and the admin frame can change together.

## Related product discussion/links

* WOOA7S-1991
* p1787803956825729-slack-C06FSDTSN82
* Reported upstream as WordPress/gutenberg#82114.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Make the wp-admin menu taller than the browser window. Dropping this in a mu-plugin is the quickest way — 25 items makes the menu about 1350px tall; raise the count if your window is taller:

```php
add_action(
	'admin_menu',
	function () {
		for ( $i = 1; $i <= 25; $i++ ) {
			add_menu_page( "Filler $i", "Filler $i", 'read', "filler-$i", '__return_empty_string', 'dashicons-marker' );
		}
	}
);
```

* Open a Boot single-page screen — **Jetpack → Stats** (`admin.php?page=jetpack-premium-analytics-wp-admin`) or **My Jetpack**.
* On `trunk`, scroll the screen: its header moves out of view, the bottom content cannot be reached, and scrolling over the app may stall.
* With this PR, the header remains visible, the app fills the space below the admin bar, and its content scrolls to the end normally. Scrolling over the menu still reveals all menu items.
* Verify that a menu that fits in the window behaves as before.
* At widths below 783px, the override does not apply. On a non-Boot page such as **Posts**, `#wpbody` remains `position: relative`.

Before:

https://github.com/user-attachments/assets/ba5bf2af-c04a-4286-9641-e228f409f713

After:

https://github.com/user-attachments/assets/17ddae35-0312-47ed-8406-2ef96d98aa94

