### PR TITLE
Premium Analytics: correct the Subscribers summary help text

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1854-subscribers-help-copy
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1854-subscribers-help-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers summary: Fix the help text to describe the cumulative subscriber total the chart plots, not new subscribers.

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/widget.json
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/widget.json
@@ -3,7 +3,7 @@
 	"title": "Subscribers summary",
 	"description": "Track subscriber growth over time, with paid subscribers and the previous period overlaid for comparison.",
 	"help": {
-		"content": "A summary of the new subscribers you gained over time."
+		"content": "A summary of your subscriber growth over time."
 	},
 	"category": "subscribers",
 	"presentation": "framed"

--- a/projects/plugins/jetpack/changelog/wooa7s-1854-subscribers-help-copy
+++ b/projects/plugins/jetpack/changelog/wooa7s-1854-subscribers-help-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Fix the Subscribers summary help text to describe the cumulative subscriber total the chart plots, not new subscribers.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-1854-subscribers-help-copy
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-1854-subscribers-help-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Fix the Subscribers summary help text to describe the cumulative subscriber total the chart plots, not new subscribers.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-1854-subscribers-help-copy
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-1854-subscribers-help-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers summary: Fix the help text to describe the cumulative subscriber total the chart plots, not new subscribers.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-1854-subscribers-help-copy
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-1854-subscribers-help-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Fix the Subscribers summary help text to describe the cumulative subscriber total the chart plots, not new subscribers.


### PR DESCRIPTION
## Proposed changes

* Restore the Subscribers summary help text to describe subscriber growth, not "the new subscribers you gained".
* The chart plots the cumulative subscriber count as of each period, and the headline is the last point rather than a sum, so the previous wording was off by orders of magnitude on any established site.
* The widget's own `description` field never changed and still says "Track subscriber growth over time", so the two strings currently disagree with each other.
* Copy only. No behavior, data, or layout changes.

The wording regressed in #50900, which applied the Widgets mapping sheet to the Traffic, Insights, and Subscribers widgets. Every other widget in that PR was a title-only rename; this was the one help string whose meaning changed. The sheet row needs the same correction, otherwise the next sync will bring it back.

## Related product discussion/links

* WOOA7S-1854
* Regressed in #50900

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Premium Analytics dashboard and go to the Subscribers tab.
* Hover (or focus) the help icon on the **Subscribers summary** widget.
* The tooltip reads "A summary of your subscriber growth over time."
* Confirm the chart itself is unchanged: the line is the running subscriber total, and the headline number matches the last point.
