### PR TITLE
Profile Settings: add a "Manage on WP.com" link to the username row on profile.php

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-590-username-manage-on-wpcom-link
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-590-username-manage-on-wpcom-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Profile Settings: add a "Manage on WP.com" link to the username row on wp-admin/profile.php.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
@@ -37,6 +37,10 @@ function wpcom_profile_settings_add_links_to_wpcom() {
 				'text'  => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
 				'title' => __( 'Name', 'jetpack-mu-wpcom' ),
 			),
+			'username'      => array(
+				'link' => esc_url( 'https://wordpress.com/me/account' ),
+				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+			),
 			'website'       => array(
 				'link' => esc_url( 'https://wordpress.com/me' ),
 				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -40,7 +40,6 @@ const wpcom_profile_settings_modify_name_section = () => {
 	}
 
 	[
-		'.user-user-login-wrap',
 		'.user-first-name-wrap',
 		'.user-last-name-wrap',
 		'.user-nickname-wrap',
@@ -51,6 +50,18 @@ const wpcom_profile_settings_modify_name_section = () => {
 			field.classList.add( 'hidden' );
 		}
 	} );
+};
+
+const wpcom_profile_settings_modify_username_section = () => {
+	const section = document.querySelector( '.user-user-login-wrap' )?.querySelector( 'td' );
+	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.username?.link;
+	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.username?.text;
+	if ( section && settingsLink && settingsLinkText ) {
+		const notice = document.createElement( 'p' );
+		notice.className = 'description';
+		notice.innerHTML = `<a href="${ settingsLink }">${ settingsLinkText }</a>`;
+		section.appendChild( notice );
+	}
 };
 
 const wpcom_profile_settings_modify_email_section = () => {
@@ -134,6 +145,7 @@ const wpcom_profile_settings_modify_password_section = () => {
 document.addEventListener( 'DOMContentLoaded', () => {
 	wpcom_profile_settings_modify_language_section();
 	wpcom_profile_settings_modify_name_section();
+	wpcom_profile_settings_modify_username_section();
 	wpcom_profile_settings_modify_email_section();
 	wpcom_profile_settings_modify_website_section();
 	wpcom_profile_settings_modify_bio_section();


### PR DESCRIPTION
## Proposed changes

The username row on `wp-admin/profile.php` is currently hidden entirely, bundled in with the Name/first/last/nickname/display-name fields, which are replaced by a single "Manage on WP.com" link under a "Name" heading. This leaves no discoverable path for someone specifically looking to change their WordPress.com username.

This gives the username row its own "Manage on WP.com ↗" link pointing to `https://wordpress.com/me/account` (where Calypso's username-change form lives) — following the exact same pattern already used for Email, Website, Bio, and Password in this same file.

## Why are these changes being made?

Reported in [DOTOBRD-590](https://linear.app/a8c/issue/DOTOBRD-590/add-link-to-change-wordpresscom-username-from-wp-adminprofilephp) (Team Polaris CfT testing) — customers navigating `wp-admin/profile.php` with the specific goal of changing their username find no path forward. Zendesk 11251797 shows this caused a real support escalation. Usernames are intentionally managed at the WordPress.com account level, not the site level, so the fix is a clear link rather than inline editing.

## Testing instructions

**Note:** I'm a Happiness Engineer submitting this via Automattic's Bug Blitz program, not a jetpack-mu-wpcom developer, and don't have this package wired into my WP.com sandbox yet — this has been verified via code review only (the new function is a direct copy of the existing website/bio/email link pattern in the same file). Reviewer verification on a live site would be appreciated:

* Navigate to `wp-admin/profile.php` on a WordPress.com site
* Confirm the Username row is now visible (previously hidden)
* Confirm a "Manage on WP.com ↗" link appears below it, pointing to `https://wordpress.com/me/account`
* Confirm Name, Email, Website, Bio, Password sections are unaffected


## Does this pull request change what data or activity we track or use?

No. This adds a static link (same as the existing Email, Website, Bio, and Password links in this file) — it does not add, remove, or change any data collection, tracking, or telemetry.
---
**Linear:** [DOTOBRD-590](https://linear.app/a8c/issue/DOTOBRD-590/add-link-to-change-wordpresscom-username-from-wp-adminprofilephp)

Note: opening this PR will auto-flip the linked Linear issue to "In Progress" — this is review-ready, not actively being worked by an engineer.