### PR TITLE
Premium Analytics: audit and trim code comments again

### DIFF
--- a/projects/packages/premium-analytics/.phan/config.php
+++ b/projects/packages/premium-analytics/.phan/config.php
@@ -13,11 +13,8 @@ require __DIR__ . '/../../../../.phan/config.base.php';
 return make_phan_config(
 	dirname( __DIR__ ),
 	array(
-		// WooCommerce stubs for the TEMPORARY interim sync module port (WOOA7S-1550).
-		// WooCommerce is a runtime, not composer, dependency; these let Phan resolve WC symbols.
-		// 'wpcom' also pulls in wpcomsh's wpcom-features files (.phan/config.base.php),
-		// which is where wpcom_site_has_feature() is defined — it is not in the
-		// generated wpcom stubs.
+		// WC stubs resolve WooCommerce symbols for this TEMPORARY interim sync port (WOOA7S-1550);
+		// 'wpcom' also pulls in wpcom_site_has_feature(), defined in wpcomsh's wpcom-features files.
 		'+stubs'             => array( 'woocommerce', 'woocommerce-internal', 'wpcom' ),
 		'exclude_file_regex' => array(
 			'build/',

--- a/projects/packages/premium-analytics/changelog/comment-audit-2
+++ b/projects/packages/premium-analytics/changelog/comment-audit-2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Comments-only cleanup: trim over-budget comments added since the last audit. No user-facing change.
+
+

--- a/projects/packages/premium-analytics/packages/data/src/defaults/reports.ts
+++ b/projects/packages/premium-analytics/packages/data/src/defaults/reports.ts
@@ -19,13 +19,7 @@ import { getStoreInfo } from './store-info';
 const DEFAULT_PRESET: PresetType = 'last-30-days';
 
 /**
- * Pick the default date-range preset based on how long
- * the store has been live.
- *
- * - Not launched / unknown → last-30-days (safe default)
- * - Launched today         → today
- * - Launched ≤ 7 days ago  → last-7-days
- * - Launched > 7 days ago  → last-30-days
+ * Pick the default date-range preset based on how long the store has been live.
  */
 export function getDefaultPreset( launchedDate?: string ): PresetType {
 	if ( ! launchedDate ) {
@@ -58,11 +52,8 @@ export function getDefaultReportParams(): { preset: PresetType } {
 }
 
 /**
- * Build report query parameters (from, to, interval, preset) for the given date-range
- * preset, optionally including the previous-period comparison range.
- *
- * Callers that need a dynamic default (e.g. based on store
- * age) should resolve the preset externally and pass it in.
+ * Build report query parameters for the given preset, optionally with the
+ * previous-period comparison range.
  */
 export const getDefaultQueryParams = (
 	withComparison: boolean = false,

--- a/projects/packages/premium-analytics/packages/data/src/defaults/store-info.ts
+++ b/projects/packages/premium-analytics/packages/data/src/defaults/store-info.ts
@@ -6,9 +6,7 @@ export type StoreInfo = {
 };
 
 /**
- * Stand-in for real store info. `launchedDate` is the only field consumed, and
- * it feeds `getDefaultPreset( launchedDate )`, which falls back to its default
- * preset when the date is undefined — so an empty object stays correct.
+ * Stand-in for real store info; every consumer tolerates the empty object.
  *
  * TODO: Source store info from the analytics boot/localized settings once the
  * host exposes it.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/awaiting-data.test.tsx
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/awaiting-data.test.tsx
@@ -73,12 +73,7 @@ describe( 'isAwaitingData', () => {
 		return <QueryClientProvider client={ client }>{ children }</QueryClientProvider>;
 	}
 
-	/**
-	 * Wait for a range's rows to land. Polled, not slept through — a fixed delay
-	 * races the query on a loaded runner.
-	 *
-	 * @param range - The range whose rows should be on screen.
-	 */
+	// Polled, not slept through — a fixed delay races the query on a loaded runner.
 	async function settleOn( range: string ) {
 		await waitFor( () => expect( read( 'shown' ) ).toBe( range ) );
 		await waitFor( () => expect( read( 'awaiting' ) ).toBe( 'false' ) );
@@ -125,9 +120,8 @@ describe( 'isAwaitingData', () => {
 		} );
 		await waitFor( () => expect( read( 'fetching' ) ).toBe( 'true' ) );
 
-		// What a window refocus past `staleTime` does. `isFetching` is true here
-		// exactly as it is through the range change above; what separates them is
-		// that January still answers what was asked, so it is not placeholder data.
+		// `isFetching` is true exactly as in the range change above; what separates
+		// them is that January still answers what was asked.
 		expect( read( 'shown' ) ).toBe( 'january' );
 		expect( read( 'awaiting' ) ).toBe( 'false' );
 
@@ -157,12 +151,9 @@ describe( 'isAwaitingData', () => {
 		await settleOn( 'january' );
 	} );
 
-	// The whole flag rests on React Query reporting the new key's fetch on the
-	// very first render after the params change. Were there a frame where the
-	// placeholder is on screen with nothing yet in flight, the widget would
-	// flash the previous range as though it were the answer. React Query's
-	// optimistic result covers that frame — asserted here because the flag is
-	// only exact for as long as it does.
+	// The flag rests on React Query's optimistic result reporting the new key's
+	// fetch on the first render after a param change; a frame without it would
+	// flash the previous range as though it were the answer.
 	it( 'never calls the placeholder the answer mid-transition', async () => {
 		render( wrap( <Host /> ) );
 		await settleOn( 'january' );
@@ -177,12 +168,8 @@ describe( 'isAwaitingData', () => {
 		expect( renders.filter( frame => frame.isPlaceholderData && ! frame.awaiting ) ).toEqual( [] );
 	} );
 
-	// The stuck-skeleton bug: a widget that switches a query off (a metric the
-	// current bucket cannot serve, a view that is no longer selected) changes
-	// that query's params in the same render. `placeholderData` fills it from
-	// the previous params and React Query calls it placeholder — but nothing
-	// will ever fetch to replace it, so treating that as "awaiting" pins the
-	// widget in its skeleton forever.
+	// The stuck-skeleton bug: switching a query off changes its params in the same
+	// render, leaving placeholder data no fetch will ever replace.
 	it( 'stays false for a disabled query left holding placeholder data', async () => {
 		render( wrap( <SwitchableHost /> ) );
 		await waitFor( () => expect( read( 'shown' ) ).toBe( 'january' ) );
@@ -195,11 +182,8 @@ describe( 'isAwaitingData', () => {
 		expect( read( 'awaiting' ) ).toBe( 'false' );
 	} );
 
-	// `refetch()` deliberately ignores `enabled`, so a switched-off query can
-	// still have a real request in flight — and a query that is fetching is
-	// awaiting however it was configured. Reading `enabled` instead would report
-	// "not awaiting" over a genuine load and leave the widget showing its empty
-	// state until the request landed.
+	// `refetch()` deliberately ignores `enabled`, so a switched-off query can still
+	// have a real request in flight.
 	it( 'is true while a switched-off query is refetching by hand', async () => {
 		render( wrap( <Probe range="january" enabled={ false } /> ) );
 

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-refresh-failure.test.tsx
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-refresh-failure.test.tsx
@@ -119,7 +119,6 @@ describe( 'useRefreshFailure', () => {
 		} );
 		expect( result.current.failure.hasStaleData ).toBe( true );
 
-		// The reader switches a control off: the observer stays, `enabled` does not.
 		// `refetchQueries` skips disabled queries, so counting this one would leave
 		// a notice no Retry can clear.
 		rerender( { enabled: false } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-report.test.tsx
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-report.test.tsx
@@ -87,12 +87,9 @@ describe( 'useReport', () => {
 	} );
 
 	it( 'awaits data when only the comparison window moves, leaving primary untouched', async () => {
-		// Deliberate: `isLoading` is the union of both queries, so moving the
-		// comparison window alone (previous period → previous year, or switching
-		// comparison on) takes the whole widget to a skeleton even though the
-		// primary numbers never went stale. The deltas on screen did, and a widget
-		// showing one comparison's deltas under another's label is the bug this
-		// flag exists to prevent.
+		// Deliberate: the whole widget skeletons even though the primary numbers
+		// never went stale, because the deltas on screen did — showing one
+		// comparison's deltas under another's label is the bug this prevents.
 		const queryFactory = (
 			params: ReportParams,
 			queryType: string
@@ -125,21 +122,17 @@ describe( 'useReport', () => {
 
 		rerender( { compare: [ '2025-06-01', '2025-06-07' ] } );
 
-		// The primary query key never changed, so its own numbers are still on
-		// screen — `hasData` proves the old `&& ! hasData` guard would have
-		// cancelled this skeleton.
+		// `hasData` proves the old `&& ! hasData` guard would have cancelled this
+		// skeleton.
 		expect( result.current.hasData ).toBe( true );
 		expect( result.current.isLoading ).toBe( true );
 
 		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
 	} );
 
-	// The stuck-skeleton bug (WOOA7S-1902): the Traffic chart switches its
-	// likes/comments request off at the hourly grain, and the same change moves
-	// that request's `period` — so `placeholderData` hands it the daily rows and
-	// React Query reports placeholder data forever, because a disabled query
-	// never fetches to replace them. Folded into the widget's own `isLoading`,
-	// that pinned the whole chart in its skeleton.
+	// The stuck-skeleton bug (WOOA7S-1902): the Traffic chart switches a request
+	// off and moves its `period` in the same change, so it is left on placeholder
+	// rows a disabled query never fetches to replace.
 	it( 'stops awaiting once a query is switched off mid-flight', async () => {
 		type Report = { summary: Record< string, unknown >; data: unknown[] };
 		const queryFactory = ( p: ReportParams, queryType: string ): UseQueryOptions< Report > => ( {
@@ -179,9 +172,7 @@ describe( 'useReport', () => {
 	} );
 
 	// React Query's own `refetch()` deliberately ignores `enabled`, so the
-	// combined refetch applies the gate itself. Without it, a widget's Retry
-	// would issue the one request it switched off — and widgets would each need
-	// their own guard around the retry action.
+	// combined refetch applies the gate itself.
 	it( 'leaves a switched-off query alone when the combined refetch runs', async () => {
 		const fetches: string[] = [];
 		const queryFactory = (

--- a/projects/packages/premium-analytics/packages/data/src/hooks/awaiting-data.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/awaiting-data.ts
@@ -8,23 +8,12 @@ type PlaceholderAwareQuery = {
  * Whether nothing on screen answers the current params — what widgets gate
  * their skeleton on.
  *
- * Broader than React Query's `isLoading`, which a range change leaves false:
- * `placeholderData` keeps the previous params' response mounted, and React
- * Query calls that a success. Neither remaining flag says it alone — a
- * revalidation of unchanged params is equally `isFetching`, and there the
- * numbers on screen are still the right answer (WOOA7S-1934). Together they
- * are exact: stale data on screen *and* a request in flight to replace it.
- *
- * The conjunction is also what unpins a query a widget switches off. Switching
- * a query off usually changes its params in the same render — a metric the
- * bucket cannot serve, a view no longer selected — so it is left holding
- * placeholder data that no fetch will ever replace, since a disabled query does
- * not fetch. Reading that as a load still in flight pinned the widget in its
- * skeleton for good. Not fetching, so not awaiting. `refetch()` deliberately
- * ignores `enabled`, so a switched-off query genuinely reloading still awaits.
- *
- * @param query - A React Query result.
- * @return Whether the result has nothing valid for the current params.
+ * Neither React Query flag says this alone: `placeholderData` leaves
+ * `isLoading` false across a range change, and `isFetching` is equally true
+ * while revalidating unchanged params, whose numbers on screen are still right
+ * (WOOA7S-1934). The conjunction also releases a query the widget switched off,
+ * which holds placeholder data no fetch will replace and used to pin the
+ * skeleton for good.
  */
 export function isAwaitingData( query: PlaceholderAwareQuery ): boolean {
 	return query.isLoading || ( query.isPlaceholderData && query.isFetching );
@@ -32,16 +21,11 @@ export function isAwaitingData( query: PlaceholderAwareQuery ): boolean {
 
 /**
  * `isAwaitingData` folded into a result's own `isLoading`, so hooks hand widgets
- * one flag. `isPlaceholderData` stays on the result for callers that need the
- * two apart.
+ * one flag.
  *
- * Spreading costs React Query's tracked-property optimization: reading every key
- * marks every key as tracked, so the caller also re-renders on fields it never
- * uses (`isStale` flipping at `staleTime`, for one). Cheap next to a fetch, and
- * the alternative is handing widgets a flag whose name lies.
- *
- * @param query - A React Query result.
- * @return The same result with `isLoading` widened.
+ * Spreading forfeits React Query's tracked-property optimization — every key
+ * reads as tracked, so callers re-render on fields they never use. Cheap next
+ * to a fetch.
  */
 export function withAwaitedDataLoading< TQuery extends PlaceholderAwareQuery >(
 	query: TQuery

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
@@ -24,18 +24,6 @@ type QueryFactory< TData > = (
  * Generic hook for fetching report data with comparison support. The comparison
  * query is driven by the comparison dates in `params`; when it is disabled the
  * query still mounts, parked on `options.disabledComparisonKey`.
- *
- * @example
- * ```typescript
- * const { primary, comparison, hasComparison, isLoading, hasData } = useReport(
- *   (params) => reportOrdersQuery(params, hasProductFilters),
- *   reportParams,
- *   {
- *     enabled: true,
- *     disabledComparisonKey: ['reports', 'orders', '__comparison__', 'disabled'],
- *   }
- * );
- * ```
  */
 export function useReport< TData, TParams extends ReportParams = ReportParams >(
 	queryFactory: QueryFactory< TData >,
@@ -86,12 +74,8 @@ export function useReport< TData, TParams extends ReportParams = ReportParams >(
 	const isLoading = isAwaitingData( primary ) || isAwaitingData( comparison );
 	const isFetching = primary.isFetching || comparison.isFetching;
 
-	/**
-	 * Sanitized report responses always carry `summary` and `data`; only the
-	 * conversion funnel adds `steps`, so all three are checked. The `as any`
-	 * escapes the generic `TData`, which cannot be constrained without breaking
-	 * existing callers.
-	 */
+	// Only the conversion funnel adds `steps`, so all three shapes are checked.
+	// `as any` escapes `TData`, unconstrainable without breaking callers.
 	const hasData =
 		Boolean( ( primary.data as any )?.summary ) ||
 		Boolean( ( primary.data as any )?.data?.length ) ||
@@ -100,11 +84,8 @@ export function useReport< TData, TParams extends ReportParams = ReportParams >(
 		Boolean( ( comparison.data as any )?.data?.length ) ||
 		Boolean( ( comparison.data as any )?.steps?.length );
 
-	// Combined refetch: memoized and awaiting both queries, so one "Retry" can
-	// re-run everything the widget asked for. React Query's own `refetch()`
-	// deliberately ignores `enabled`, so the gate is applied here instead — a
-	// switched-off query is left alone, and widgets passing `enabled` need no
-	// guard of their own around the retry action.
+	// React Query's `refetch()` deliberately ignores `enabled`, so the gate is
+	// re-applied here to leave a switched-off query alone.
 	const primaryRefetch = primary.refetch;
 	const comparisonRefetch = comparison.refetch;
 	const refetch = useCallback( async () => {

--- a/projects/packages/premium-analytics/packages/data/src/processing/latest-post/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/latest-post/index.ts
@@ -54,11 +54,9 @@ function pickFeaturedImageUrl( media: StatsRecord ): string {
 }
 
 /**
- * Reduce a core `/wp/v2/posts` response (an array of posts) to the first post's
- * headline fields and its embedded featured image. Content is read locally so it
- * resolves regardless of site privacy; the post's views, likes, and comments
- * come from the Stats post endpoint. Returns null when the site has no published
- * post.
+ * Reduce a core `/wp/v2/posts` response to the first post's headline fields and
+ * its embedded featured image. Read locally so it resolves regardless of site
+ * privacy; views, likes, and comments come from the Stats post endpoint.
  */
 export function sanitizeLatestPostResponse( response: unknown ): LatestPostResponse {
 	const [ first ] = coerceStatsArray( response );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts
@@ -365,9 +365,8 @@ describe( 'Stats clicks normalizer', () => {
 	} );
 
 	it( 'matches rows whose URL cannot be parsed by falling back to the raw value', () => {
-		// Not every `url` the endpoint returns is absolute — a root-relative one
-		// makes `new URL()` throw. Both periods have to key off the same raw
-		// string, or such rows would never match and would lose their delta.
+		// A root-relative `url` makes `new URL()` throw, so both periods must key
+		// off the same raw string or the row loses its delta.
 		const buildReport = ( views: number, date: string ) =>
 			sanitizeStatsClicksResponse(
 				{

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/comments.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/comments.test.ts
@@ -73,10 +73,8 @@ describe( 'Stats comments normalizer', () => {
 				children: [
 					expect.objectContaining( {
 						label: 'Aggie',
-						// The raw `?s=<email>` fragment is not a URL; it maps to the
-						// comment management screen filtered to that author. WPCOM-user
-						// rows (`?user_id=<id>`) have no wp-admin equivalent and stay
-						// unlinked (covered above).
+						// Not a URL: the comment screen filtered to that author. WPCOM-user
+						// rows have no wp-admin equivalent and stay unlinked (covered above).
 						link: 'edit-comments.php?s=aggie%40example.com',
 					} ),
 				],
@@ -188,8 +186,7 @@ describe( 'selectStatsCommentsRows', () => {
 	} );
 
 	// Consumers guard the permalink themselves, so the raw link has to survive
-	// here: a post with no id keys its row on it. Guards the second step of the
-	// posts id fallback chain, and that `postId` stays unset without a post id.
+	// here — a post with no id keys its row on it.
 	it( 'keeps the raw link as the row id when a post has no id', () => {
 		const report = sanitizeStatsCommentsResponse( {
 			posts: [ { name: 'Hello world', comments: 3, link: 'javascript:alert(1)' } ],

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -237,9 +237,8 @@ describe( 'Stats time-series normalizer', () => {
 	} );
 
 	it( 'trims buckets outside a window_start/window_end window and sums only the rest', () => {
-		// The last-24-hours shape: the endpoint anchors hourly buckets on the
-		// start day's midnight, so the payload carries leading buckets before
-		// the window's 09:00 start that must not be plotted or summed.
+		// The last-24-hours shape: hourly buckets are anchored on the start day's
+		// midnight, so leading pre-09:00 buckets arrive and must not be summed.
 		const result = sanitizeStatsEmailTimeSeriesResponse(
 			{
 				timeline: {
@@ -299,9 +298,8 @@ describe( 'Stats time-series normalizer', () => {
 			'2026-06-15 08:00',
 		] );
 
-		// Space-separated datetimes degrade upstream (getDatePart splits on T
-		// only, so the day count is already wrong before the request is sized);
-		// the trim must stay disabled for them rather than half-apply.
+		// Space-separated datetimes already degrade upstream (getDatePart splits on
+		// T only), so the trim must stay off for them rather than half-apply.
 		const spaceSeparated = sanitizeStatsEmailTimeSeriesResponse( timeline, {
 			period: 'hour',
 			window_start: '2026-06-14 09:00:00-04:00',
@@ -351,9 +349,8 @@ describe( 'Stats time-series normalizer', () => {
 		expect( windowed.data ).toHaveLength( 2 );
 		expect( windowed.summary ).toEqual( expect.objectContaining( { opens_count: 8 } ) );
 
-		// A lone bound must not trim, and neither must the generic
-		// start_date/end_date request params — range-bounded endpoints (e.g.
-		// visits) reach this sanitizer with those and must keep every bucket.
+		// Neither a lone bound nor the generic start_date/end_date may trim —
+		// range-bounded endpoints reach this sanitizer carrying those.
 		const oneBound = sanitizeStatsEmailTimeSeriesResponse( timeline, {
 			period: 'day',
 			window_start: '2026-06-16',

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-posts.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/top-posts.test.ts
@@ -213,9 +213,8 @@ describe( 'Stats top posts normalizer', () => {
 		} );
 	} );
 	it( 'keeps URL-less rows and matches them by label', () => {
-		// With skip_archives=1 the API returns the homepage-as-latest-posts
-		// entry without a link; it must survive the merge and match across
-		// periods by its label.
+		// With skip_archives=1 the homepage-as-latest-posts entry comes back with
+		// no link, so it can only match across periods by its label.
 		const homepage: StatsTopPostsItem = {
 			id: 0,
 			label: 'Homepage (Latest posts)',

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/archives.ts
@@ -146,9 +146,8 @@ export function sanitizeStatsArchivesResponse(
 	};
 }
 
-// Archive nodes match across periods by label within the same parent —
-// merging children against the matched parent's children means same-named
-// terms under different parents cannot cross-match.
+// Labels are only unique within a parent; children merge against the matched
+// parent's children, so same-named terms elsewhere cannot cross-match.
 function getStatsArchiveKey( item: StatsArchivesItem ): string | null {
 	const label = getStatsLabel( item.label );
 	return label === '' ? null : label;

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/bucket-window.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/bucket-window.ts
@@ -1,15 +1,12 @@
 /**
  * The trim window for quantity-based time-series endpoints — the email
- * timeline's special case, owned end to end by this module. That endpoint
- * resolves its `date` param to a calendar day and returns `quantity` buckets
- * forward from that day's midnight regardless of the time of day the window
- * starts (verified against production), so a mid-day window comes back with
- * leading out-of-window buckets. The query side sizes the request with
- * `windowEndHour` and sends the window through `toStatsBucketWindowParams`;
- * only `sanitizeStatsEmailTimeSeriesResponse` turns those params back into a
- * bucket filter (`createStatsBucketWindowFilter`) and passes it to the shared
- * sanitizer — for every other sanitizer the pair is inert, so range-bounded
- * endpoints (visits, subscribers, wordads) can never be trimmed.
+ * timeline's special case, owned end to end by this module.
+ *
+ * That endpoint returns `quantity` buckets forward from the resolved day's
+ * midnight whatever time of day the window starts (verified against
+ * production), so a mid-day window comes back with leading out-of-window
+ * buckets. Only `sanitizeStatsEmailTimeSeriesResponse` turns these params back
+ * into a filter, so range-bounded endpoints can never be trimmed.
  */
 
 /**
@@ -21,11 +18,8 @@ import { formatDatePartWithTime, readSiteTimestamp } from '@jetpack-premium-anal
  */
 import type { StatsQueryParams } from '../../utils/stats-params';
 
-// One reader decides which timestamp shapes the window supports: bare dates
-// and T-separated datetimes, exactly what the stats-params pipeline itself
-// carries — getDatePart, which derives day counts upstream, splits on T
-// alone, so a space-separated datetime already degrades there and must not
-// size or trim a window here either.
+// Bare dates and T-separated datetimes only — getDatePart splits on T alone
+// upstream, so a space-separated datetime must degrade here too.
 function readWindowTimestamp( value: unknown ) {
 	const timestamp = typeof value === 'string' ? readSiteTimestamp( value ) : null;
 
@@ -52,10 +46,8 @@ const EDGE_FALLBACKS = {
 	end: { time: '23:59:59', seconds: '59' },
 } as const;
 
-// A window bound in the same timezone-naive wall-clock shape the bucket
-// labels carry: the value's own date and time parts as written, any offset
-// ignored. A bare date widens to its edge's whole-day time; a seconds-less
-// time takes the edge's seconds.
+// A window bound in the same timezone-naive wall-clock shape the bucket labels
+// carry: date and time parts as written, any offset ignored.
 function toWindowBound( value: unknown, edge: keyof typeof EDGE_FALLBACKS ) {
 	const timestamp = readWindowTimestamp( value );
 
@@ -67,8 +59,7 @@ function toWindowBound( value: unknown, edge: keyof typeof EDGE_FALLBACKS ) {
 	const datePart = `${ String( year ).padStart( 4, '0' ) }-${ padTimePart(
 		month + 1
 	) }-${ padTimePart( day ) }`;
-	// The reader guarantees these shapes, so the probes only ask what was
-	// written: a time at all, and seconds within it.
+	// The reader already constrained the shape, so these only ask what was written.
 	const hasTime = timestamp.value.includes( 'T' );
 	const hasSeconds = /T\d{2}:\d{2}:\d{2}/.test( timestamp.value );
 	const time = hasTime
@@ -80,18 +71,15 @@ function toWindowBound( value: unknown, edge: keyof typeof EDGE_FALLBACKS ) {
 	return formatDatePartWithTime( datePart, time );
 }
 
-// Bucket bounds are comparable against a window bound only in this shape; a
-// row whose bounds fall outside it (an unparseable period label echoed back
-// verbatim) is kept rather than silently discarded.
+// Bucket bounds compare against a window bound only in this shape; a row that
+// fails it is kept rather than silently discarded.
 const isWallClockStamp = ( value: string ) => /^\d{4}-\d{2}-\d{2}T/.test( value );
 
 export type StatsBucketFilter = ( range: { date_start: string; date_end: string } ) => boolean;
 
 /**
- * The sanitizer-side half of the window contract: turns the
- * `window_start`/`window_end` sanitizer params back into a bucket filter, or
- * `undefined` when the query names no usable window — a missing or invalid
- * bound, and an inverted window (a hand-edited deep link), all mean "keep
+ * The sanitizer-side half of the window contract: the `window_start`/`window_end`
+ * params as a bucket filter. A missing, invalid, or inverted window means "keep
  * every bucket" rather than a silently emptied chart.
  *
  * @param query - The sanitizer's merged query params.
@@ -107,9 +95,8 @@ export function createStatsBucketWindowFilter(
 		return undefined;
 	}
 
-	// Raw lexicographic comparison — the same rule as the shared sanitizer's
-	// compareBucketBounds, never localeCompare (a collation may ignore the
-	// separators these bounds carry).
+	// Raw lexicographic comparison, as in compareBucketBounds — never
+	// localeCompare, whose collation may ignore these bounds' separators.
 	return range =>
 		! isWallClockStamp( range.date_start ) ||
 		! isWallClockStamp( range.date_end ) ||
@@ -117,11 +104,9 @@ export function createStatsBucketWindowFilter(
 }
 
 /**
- * The query-side half of the window contract: the sanitizer params a
- * windowed query opts into trimming with. Dedicated names, never the generic
- * `start_date`/`end_date` — those reach the shared sanitizer from
- * range-bounded endpoints that must not be trimmed — and stripped from the
- * HTTP request by `statsQueryParamsToApiParams`.
+ * The query-side half of the window contract: the sanitizer params a windowed
+ * query opts into trimming with. Dedicated names, never the generic
+ * `start_date`/`end_date`, which range-bounded endpoints also send.
  *
  * @param params            - The query's stats params.
  * @param params.start_date - The window's start timestamp.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/chart-buckets.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/chart-buckets.ts
@@ -49,9 +49,8 @@ export function getStatsChartBucketKey( date: string, period: StatsChartBucketPe
 /**
  * Collapse a normalized daily Stats report into chart buckets.
  *
- * The caller maps each data point to its chart metrics, including the required
- * headline `value`. Metrics are summed when daily points share a chart bucket.
- * Each bucket preserves the first daily point's time suffix.
+ * Metrics are summed when daily points share a bucket, and each bucket keeps the
+ * first daily point's time suffix.
  *
  * @param report          - The normalized daily Stats report.
  * @param period          - The chart bucket period.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/comments.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/comments.ts
@@ -81,11 +81,9 @@ function normalizeCommentAvatar( avatar?: string | null ) {
 }
 
 /**
- * Build the author row's link from the raw payload's `link`, which is not a
- * URL but a `?s=<email>` search fragment (legacy Calypso used it to open the
- * comment management screen filtered to that author). The dashboard runs
- * inside wp-admin, so a relative `edit-comments.php` href resolves to the
- * same screen.
+ * Build the author row's link from the raw payload's `link`, which is not a URL
+ * but a `?s=<email>` search fragment. The dashboard runs inside wp-admin, so a
+ * relative `edit-comments.php` href resolves to the comment management screen.
  *
  * @param link - The raw author `link` fragment.
  * @return The comments-admin search URL, or null when there is no email.
@@ -159,9 +157,7 @@ export function sanitizeStatsCommentsResponse(
 export type StatsCommentsGroup = 'authors' | 'posts';
 
 /**
- * A flat Comments report row, shared by every consumer of the report: the
- * "Top commented authors" and "Top commented posts" widgets and the Comments
- * report page.
+ * A flat Comments report row, shared by every consumer of the report.
  *
  * `link` is the value the report carries: a locally built, root-relative
  * `edit-comments.php` search for authors, and a remote permalink for posts.
@@ -172,7 +168,7 @@ export type StatsCommentsGroup = 'authors' | 'posts';
 export type StatsCommentsRow = {
 	/**
 	 * Stable row key, derived from the item's own identity rather than its
-	 * position so it survives a refetch and cannot collide on a repeated label.
+	 * position so it survives a refetch.
 	 */
 	id: string;
 	/**
@@ -187,9 +183,6 @@ export type StatsCommentsRow = {
 	 * Author avatar URL. Set for the `authors` group only.
 	 */
 	avatarUrl?: string;
-	/**
-	 * The link the report carries for this row, when it has one.
-	 */
 	link?: string;
 	/**
 	 * Numeric post id as a string. Set for the `posts` group only.
@@ -205,10 +198,6 @@ function toCommentsRowLabel( value: unknown ): string {
 
 /**
  * Map one group child to a flat row.
- *
- * `label`, `value` and `link` are derived identically for both groups; only the
- * row key and the group-specific extras (`avatarUrl`, `postId`) differ, so the
- * group discriminator selects just those.
  *
  * @param item  - The group child to map.
  * @param group - The group the child belongs to.
@@ -238,9 +227,8 @@ function toCommentsRow(
 
 	return {
 		...shared,
-		// Posts key on their post id, falling back to the raw link so row
-		// identity holds even when a consumer rejects that URL, and finally on
-		// the label.
+		// Falls back to the raw link so row identity holds even when a consumer
+		// rejects that URL, and finally to the label.
 		id: postId ?? shared.link ?? `post-${ label }`,
 		postId,
 	};
@@ -250,9 +238,8 @@ function toCommentsRow(
  * Select one group's rows from a normalized Comments report.
  *
  * The endpoint returns a single all-time report whose `data[0].items` are two
- * group rows — one keyed `authors`, one keyed `posts`. This picks the requested
- * group, flattens its children to `StatsCommentsRow`, sorts them by comment
- * count and trims the result to `maxRows` (`0` or omitted means all rows).
+ * group rows — one keyed `authors`, one keyed `posts`. Sorted by comment count
+ * and trimmed to `maxRows` (`0` or omitted means all rows).
  *
  * @param report  - The normalized Comments report, if it has resolved.
  * @param group   - The group to select.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/hour-of-day.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/hour-of-day.ts
@@ -68,9 +68,8 @@ export function sanitizeStatsHourOfDayResponse(
 		throw new StatsResponseShapeError( 'Expected hour-of-day data to be an array' );
 	}
 
-	// The endpoint always reports the range it actually read, so take its count
-	// rather than re-deriving one from the echoed dates. Without it the buckets
-	// cannot be averaged, which is all the widget shows.
+	// The endpoint reports the range it actually read, so take its count rather
+	// than re-deriving one from the echoed dates.
 	const days = safeParseInt( payload.days );
 
 	if ( days < 1 ) {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/post.ts
@@ -54,10 +54,8 @@ type StatsPostRawWeek = {
 };
 
 /**
- * The `post` field of the Stats post response is the site's raw post row, so it
- * uses WordPress column names (`post_title`, `post_type`, `post_date_gmt`) — not
- * the WP REST `title`/`type` shape. Only the fields the dashboard consumes are
- * modeled; the endpoint returns more.
+ * The `post` field is the site's raw post row, so it uses WordPress column names
+ * (`post_title`, `post_type`) — not the WP REST `title`/`type` shape.
  */
 export type StatsPostMeta = {
 	ID?: number;

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/single-video.ts
@@ -66,9 +66,8 @@ function sanitizeSingleVideoPost( value: unknown ): StatsSingleVideoPost | null 
 
 export function sanitizeStatsSingleVideoResponse( response: unknown ): StatsSingleVideoReport {
 	const payload = coerceStatsRecord( response );
-	// When the requested window has no rows at all, the endpoint returns a
-	// single `{ date, p }` object instead of the usual tuples; `coerceStatsArray`
-	// and the per-row tuple filter both guard against that.
+	// An empty window comes back as a single `{ date, p }` object rather than the
+	// usual tuples, which both guards below reject.
 	const tuples = coerceStatsArray< unknown >( payload.data ).filter(
 		( row ): row is [ string, ...unknown[] ] =>
 			Array.isArray( row ) && row.length >= 2 && typeof row[ 0 ] === 'string'
@@ -99,10 +98,8 @@ export function sanitizeStatsSingleVideoResponse( response: unknown ): StatsSing
 		  )
 		: null;
 
-	// Range queries also return canonical totals over the window, keyed by
-	// metric name. A non-numeric cell is unknown, not a measured zero — drop it
-	// (same guard as `normalizeStatsSummary`) so consumers see the metric as
-	// missing instead of a fabricated 0.
+	// A non-numeric cell is unknown, not a measured zero — drop it (same guard as
+	// `normalizeStatsSummary`) so the metric reads as missing, not a fabricated 0.
 	const total = isStatsRecord( payload.total )
 		? Object.fromEntries(
 				Object.entries( payload.total )

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -245,10 +245,8 @@ function getRowIntervalFields( row: StatsRecord, rawPeriod: unknown, unit: strin
 }
 
 // Rebuild a summary bound from a query date when no rows came back. Rows stamp
-// `date_start`/`date_end` as timezone-naive wall times (see
-// getStatsIntervalFields), so the query's own site-local offset can't be passed
-// through verbatim — a real offset would get converted rather than read as the
-// bucket's label. Mirrors getStatsSummaryIntervalFields.
+// their bounds as timezone-naive wall times, so the query's own offset cannot be
+// passed through verbatim — it would be converted, not read as a label.
 function toSummaryBound( value: string | undefined, time: string ) {
 	const datePart = getDatePart( value );
 
@@ -293,9 +291,8 @@ export function sanitizeStatsTimeSeriesResponse(
 
 		return { row, range: getRowIntervalFields( row, rawPeriod, unit ) };
 	} );
-	// Filter before the summary, so dropped buckets inflate neither the totals
-	// nor the chart. Only an endpoint-specific sanitizer supplies a filter (see
-	// bucket-window.ts); the shared path keeps every bucket.
+	// Filter before the summary, so dropped buckets inflate neither the totals nor
+	// the chart. Only an endpoint-specific sanitizer supplies a filter.
 	const kept = keepBucket ? buckets.filter( ( { range } ) => keepBucket( range ) ) : buckets;
 	const summary = kept.reduce< Record< string, number > >( ( totals, { row } ) => {
 		Object.entries( row ).forEach( ( [ key, value ] ) => {
@@ -319,8 +316,7 @@ export function sanitizeStatsTimeSeriesResponse(
 			};
 		} )
 		// `stats/visits` returns buckets oldest first, `stats/subscribers` newest
-		// first, but everything downstream reads `data[0]` as the oldest bucket —
-		// starting with the summary bounds below.
+		// first, but everything downstream reads `data[0]` as the oldest.
 		.sort( ( a, b ) => compareBucketBounds( a.date_start, b.date_start ) );
 	const firstRow = data[ 0 ];
 	const lastRow = data[ data.length - 1 ];
@@ -360,10 +356,8 @@ export function sanitizeStatsEmailTimeSeriesResponse(
 	const timeline = coerceStatsRecord( coerceStatsRecord( payload ).timeline );
 	const fields = coerceStatsArray< string >( timeline.fields );
 
-	// The real hourly timeline labels its hour column ([ 'date', 'hour', '<metric>_count' ]), which
-	// the normalizer resolves into per-hour buckets. As a fallback, an unlabeled trailing hour
-	// column is named here so older/alternate payloads still resolve (matching Calypso's
-	// parseEmailChartData).
+	// Names an unlabeled trailing hour column so older/alternate payloads still
+	// resolve into per-hour buckets (matching Calypso's parseEmailChartData).
 	const normalizedTimeline =
 		timeline.unit === 'hour' && fields.length && ! fields.includes( 'hour' )
 			? { ...timeline, fields: [ ...fields, 'hour' ] }

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/top-authors.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/top-authors.ts
@@ -36,10 +36,8 @@ export type StatsTopAuthorsComparisonItem = Omit< StatsTopAuthorsItem, 'children
 	children?: StatsTopAuthorsPostComparisonItem[] | null;
 };
 
-// Prefer the stable author id for comparison matching. Without one, build a
-// period-independent key so the same author aligns across the primary and
-// comparison periods even when their rank (and thus array position) differs;
-// the avatar keeps same-named authors distinct where one is available.
+// Period-independent by design: the same author must align across periods even
+// when their rank differs. The avatar keeps same-named authors distinct.
 function getAuthorKey( author: StatsTopAuthorsItem ): string {
 	if ( author.id != null ) {
 		return String( author.id );
@@ -88,9 +86,8 @@ function mergeStatsTopAuthorsPostRows(
 		} ),
 	} );
 
-	// Posts that only existed in the comparison period still matter for the
-	// drill-down view: surface them with zero current views so their previous
-	// value is not silently dropped.
+	// Posts that only existed in the comparison period surface with zero current
+	// views, so their previous value is not silently dropped.
 	const primaryKeys = new Set(
 		primaryPosts.map( getAuthorPostKey ).filter( ( key ): key is string => key != null )
 	);

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/wordads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/wordads.ts
@@ -48,8 +48,7 @@ export type StatsWordAdsEarningsPeriod = {
 	/**
 	 * The payment status code, or `undefined` when the payload omits it. `0` is
 	 * itself a meaningful status ("Unpaid"), so a missing status must not
-	 * collapse into it — consumers would state a payment claim the API never
-	 * made.
+	 * collapse into it.
 	 */
 	status: number | undefined;
 };
@@ -93,9 +92,8 @@ function summarizeWordAdsStats(
 }
 
 function normalizeEarningsPeriod( value: StatsRecord ): StatsWordAdsEarningsPeriod {
-	// Not `safeParseFloat`: its `fallback = 0` default fires on an explicit
-	// `undefined`, and `0` is itself a status ("Unpaid"), so an absent or
-	// unparseable status has to stay absent rather than collapse into it.
+	// Not `safeParseFloat`: its `fallback = 0` fires on an explicit `undefined`,
+	// and `0` is itself a status ("Unpaid"), so an absent status must stay absent.
 	const status = parseFloat( String( value.status ) );
 
 	return {

--- a/projects/packages/premium-analytics/packages/data/src/providers/query-client-provider.tsx
+++ b/projects/packages/premium-analytics/packages/data/src/providers/query-client-provider.tsx
@@ -9,13 +9,10 @@ import { ReactNode } from 'react';
 import { getApiErrorStatus, shouldRetryApiError, StatsResponseShapeError } from '../utils';
 import { globalErrorManager } from './global-error-manager';
 
-// Both the retry policy and the global error detection below read the HTTP
-// status, which apiFetch drops on its way to throwing the parsed body.
-// `fetchPreservingStatus()` restores it for every request that goes through the
-// stats transport or the notices route by parsing at its own call site — nothing
-// needs registering here, so neither depends on the app's boot path. The few
-// queries still on bare apiFetch (latest post, product images, site sync) hit
-// local WP REST routes, whose `WP_Error` bodies already carry `data.status`.
+// Everything below reads the HTTP status, which apiFetch drops on its way to
+// throwing the parsed body. `fetchPreservingStatus()` restores it at its own
+// call site; the queries still on bare apiFetch hit local WP REST routes, whose
+// `WP_Error` bodies already carry `data.status`.
 
 const DEFAULT_STALE_TIME = 5 * 60 * 1000;
 const DEFAULT_GC_TIME = 10 * 60 * 1000;
@@ -23,16 +20,8 @@ const DEFAULT_GC_TIME = 10 * 60 * 1000;
 /**
  * QueryCache with global error detection for auth and server errors.
  *
- * Error codes handled:
- * - 401: Authentication failure (session expired, invalid token)
- * - 502: Bad gateway (proxy/load balancer can't reach upstream)
- * - 503: Service unavailable (server overloaded or under maintenance)
- * - 504: Gateway timeout (request took too long)
- *
- * Module level is safe: this is QueryClient configuration rather than a side-effect
- * subscription, and QueryClient must be instantiated once. The error state itself is
- * consumed via useSyncExternalStore in GlobalErrorProvider, which also handles
- * network errors via onlineManager.
+ * Module level is safe: configuration rather than a side-effect subscription,
+ * and QueryClient must be instantiated once.
  */
 const queryCache = new QueryCache( {
 	onError: error => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -56,8 +56,7 @@ import type { StatsReportParams } from '../stats-query';
 jest.mock( '@wordpress/api-fetch' );
 
 // `localTZDate()` defaults to the site zone, so pin it rather than letting the
-// machine timezone decide the WordAds "yesterday" clamp in
-// stats-wordads-query.ts.
+// machine timezone decide the WordAds "yesterday" clamp.
 setSettings( {
 	...getSettings(),
 	timezone: { string: 'UTC', offset: 0, offsetFormatted: '0', abbr: 'UTC' },
@@ -264,18 +263,11 @@ describe( 'Stats query factories', () => {
 	} );
 
 	it( 'sizes an offset-bearing hourly window from its start day midnight through its end hour', () => {
-		// The shape the last-24-hours preset produces: hour-aligned, mid-day, and
-		// spanning two calendar days. `date` is the window START for this
-		// endpoint and carries the time, but the endpoint resolves it to the
-		// calendar day and buckets from midnight regardless — verified against
-		// production, where a bare `2026-08-06` and `2026-08-06T09:00:00.000-04:00`
-		// return byte-identical hour-0..23 windows. So `quantity` must span from
-		// that midnight through the window's end hour (hours 00:00 June 14 →
-		// 08:xx June 15 = 33 buckets, not 24 from 09:00, and not 24 per calendar
-		// day touched — the 48-bucket over-fetch was WOOA7S-1840). The leading
-		// out-of-window buckets the midnight anchor forces are trimmed by the
-		// sanitizer via the window_start/window_end pair passed in
-		// sanitizerParams (query key slot 8).
+		// The last-24-hours shape. The endpoint resolves the window START to its
+		// calendar day and buckets from midnight regardless of the time it carries
+		// (verified against production), so `quantity` must span that midnight
+		// through the end hour — 33 buckets, not 24 from 09:00, and not 24 per
+		// calendar day touched (the 48-bucket over-fetch was WOOA7S-1840).
 		const { queryKey } = statsEmailClicksTimeSeriesQuery( 41, {
 			from: '2026-06-14T09:00:00.000-04:00',
 			to: '2026-06-15T08:59:59.999-04:00',
@@ -306,10 +298,8 @@ describe( 'Stats query factories', () => {
 		// so quantity and the sanitizer trim stay agreed.
 		expect( quantityFor( '2026-06-14T09:00-04:00', '2026-06-15T08:59-04:00' ) ).toBe( 33 );
 
-		// Space-separated datetimes degrade upstream (getDatePart, which
-		// derives `days`, splits on T only), so the end hour falls back to 23
-		// there too — one whole degraded day, matching pre-fix behavior, with
-		// the sanitizer trim disabled by the same narrowing.
+		// Space-separated datetimes degrade upstream (getDatePart splits on T only),
+		// so the end hour falls back to 23 and the sanitizer trim stays off.
 		expect( quantityFor( '2026-06-14 09:00:00-04:00', '2026-06-15 08:59:59-04:00' ) ).toBe( 24 );
 
 		// An end the reader rejects falls back to hour 23 — the old full-day
@@ -401,10 +391,8 @@ describe( 'Stats query factories', () => {
 	} );
 
 	it( 'sends offset-bearing top-posts date params through untrimmed', () => {
-		// This endpoint used to resolve its date params in UTC rather than the
-		// site's timezone, so the client trimmed them to a bare day. The server
-		// now resolves the embedded offset, so the full datetime goes through
-		// like every other Stats request.
+		// The server resolves the embedded offset, so no client-side trim to a bare
+		// day is needed any more.
 		const query = statsTopPostsQuery( {
 			from: '2026-06-01T00:00:00.000-07:00',
 			to: '2026-06-07T23:59:59.999-07:00',
@@ -452,10 +440,9 @@ describe( 'Stats query factories', () => {
 	} );
 
 	it( 'keeps file-downloads day-bucketed and summarized when the caller only passes a range', () => {
-		// The File downloads widget passes the dashboard params through untouched,
-		// so a long range arrives with a coarse chart interval and no summarize.
-		// The interval must not become the period, or the endpoint would count
-		// the range in weeks and stop returning one row per file.
+		// A long range arrives with a coarse chart interval, which must not become
+		// the period — the endpoint would count the range in weeks and stop
+		// returning one row per file.
 		const query = statsFileDownloadsQuery( {
 			from: '2026-04-01',
 			to: '2026-06-29',
@@ -1109,9 +1096,8 @@ describe( 'Stats query factories', () => {
 	} );
 
 	it( 'maps an offset-bearing daily dashboard range onto subscribers unit/quantity/date', () => {
-		// start_date/end_date now carry the full offset-bearing ISO datetime
-		// (reportParamsToStatsQueryParams no longer trims it); the day-based
-		// quantity math must still resolve from the calendar day.
+		// start_date/end_date carry a full offset-bearing ISO datetime, but the
+		// day-based quantity math must still resolve from the calendar day.
 		const query = statsSubscribersReportQuery( {
 			from: '2026-06-01T00:00:00.000-07:00',
 			to: '2026-06-30T23:59:59.000-07:00',
@@ -1207,10 +1193,8 @@ describe( 'Stats query factories', () => {
 	} );
 
 	it( 'clamps the WordAds window end to yesterday, keeping it anchored to the range start', () => {
-		// WordAds stats are computed nightly, so a range ending today ends at
-		// yesterday instead. The window stays anchored to the range start: the
-		// unavailable trailing bucket is dropped (quantity 7 → 6) rather than the
-		// whole window shifting a bucket earlier.
+		// The window stays anchored to the range start: the unavailable trailing
+		// bucket is dropped rather than the whole window shifting earlier.
 		jest.useFakeTimers().setSystemTime( new Date( '2026-06-15T12:00:00Z' ) );
 
 		try {
@@ -1239,10 +1223,8 @@ describe( 'Stats query factories', () => {
 	} );
 
 	it( 'sends an unclamped WordAds window end through untrimmed', () => {
-		// This endpoint used to resolve the window end in UTC and decide whether
-		// to honor it via a raw string comparison, so the client stripped the
-		// offset. Both halves are fixed server-side, so the full datetime goes
-		// through like every other Stats request.
+		// Both halves of the old UTC/raw-string problem are fixed server-side, so
+		// the client no longer strips the offset.
 		jest.useFakeTimers().setSystemTime( new Date( '2026-07-15T12:00:00Z' ) );
 
 		try {
@@ -1267,11 +1249,9 @@ describe( 'Stats query factories', () => {
 	} );
 
 	it( 'leaves a WordAds window ending exactly yesterday unclamped', () => {
-		// The last-7-days / last-30-days shape: the range already ends on
-		// yesterday's calendar day, so the clamp must not fire. This is why the
-		// clamp compares calendar days — the raw offset-bearing string sorts
-		// after the bare `yesterday` it starts with, which would clamp the window
-		// and silently shorten it by a bucket.
+		// Why the clamp compares calendar days: the raw offset-bearing string sorts
+		// after the bare `yesterday` it starts with, so a range already ending on
+		// yesterday would clamp and silently lose a bucket.
 		jest.useFakeTimers().setSystemTime( new Date( '2026-06-15T12:00:00Z' ) );
 
 		try {
@@ -1296,9 +1276,8 @@ describe( 'Stats query factories', () => {
 	} );
 
 	it( 'clamps an offset-bearing WordAds window end to yesterday, keyed off its calendar day', () => {
-		// The clamp fires, so `date` becomes the locally built bare `yesterday`
-		// rather than the request's own offset-bearing end. Both the comparison
-		// and the bucket count key off the calendar day.
+		// The clamp fires, so `date` becomes the locally built bare `yesterday`;
+		// both the comparison and the bucket count key off the calendar day.
 		jest.useFakeTimers().setSystemTime( new Date( '2026-06-15T12:00:00Z' ) );
 
 		try {
@@ -1335,9 +1314,8 @@ describe( 'Stats query factories', () => {
 		] );
 	} );
 
-	// The range is the only thing that bounds a visits request: the endpoint
-	// recounts the buckets from start_date/date and ignores a bucket count sent
-	// alongside them, so neither `quantity` nor `days` belongs in the request.
+	// The endpoint recounts the buckets from start_date/date and ignores a bucket
+	// count sent alongside them, so neither `quantity` nor `days` belongs here.
 	it( 'bounds visits with the range alone', () => {
 		const query = statsVisitsQuery( {
 			from: '2026-06-01',
@@ -1356,8 +1334,7 @@ describe( 'Stats query factories', () => {
 	} );
 
 	// Hourly is the one unit whose window needs finer precision than a calendar
-	// day, and the endpoint reads these two straight off the request — so they
-	// have to reach it with their time of day intact.
+	// day, so these must reach the endpoint with their time of day intact.
 	it( 'carries the hourly range at full precision', () => {
 		const query = statsVisitsQuery( {
 			from: '2026-06-15T00:00:00-07:00',

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-email-time-series-query.ts
@@ -32,17 +32,14 @@ const hasValidPostId = ( postId: number ) => Number.isInteger( postId ) && postI
 const toEmailPeriod = ( period?: string ): StatsEmailTimeSeriesPeriod =>
 	period === 'hour' ? 'hour' : 'day';
 
-// The endpoint anchors hourly buckets on the start day's midnight regardless
-// of the time of day `date` carries (see bucket-window.ts), so an hourly
-// request must span that midnight through the window's end hour; the
-// sanitizer trims the leading out-of-window buckets.
+// Hourly buckets are anchored on the start day's midnight whatever time `date`
+// carries, so the request must span it; the sanitizer trims the leading ones.
 const hourlyQuantity = ( days: number, endDate?: string ) =>
 	Math.max( 1, 24 * ( days - 1 ) + windowEndHour( endDate ) + 1 );
 
-// Mirror Calypso's requestEmailStats: the timeline is period-scoped and always sends period,
-// quantity, date, and stats_fields=timeline. Unlike the other stats endpoints (where `date`
-// is the window's END), the email timeline reads `date` as the window's START and returns
-// `quantity` buckets going forward — one per day, or 24 per day for hourly.
+// Mirrors Calypso's requestEmailStats. Unlike the other stats endpoints (where
+// `date` is the window's END), this one reads `date` as the window's START and
+// returns `quantity` buckets going forward.
 function emailTimeSeriesQuery(
 	statType: 'opens' | 'clicks',
 	postId: number,

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-hour-of-day-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-hour-of-day-query.ts
@@ -33,9 +33,8 @@ export const statsHourOfDayQuery = (
 	const range: StatsQueryParams = date ? { date } : {};
 
 	if ( date && startDate && getDaysBetweenInclusive( startDate, date ) > HOUR_OF_DAY_MAX_DAYS ) {
-		// The endpoint counts `days` back from `date` exactly as it would derive the
-		// range from `start_date`, so ask it for the cap rather than shortening the
-		// start ourselves.
+		// The endpoint counts `days` back from `date` exactly as it derives the range
+		// from `start_date`, so ask it for the cap rather than shortening the start.
 		range.days = HOUR_OF_DAY_MAX_DAYS;
 	} else if ( startDate ) {
 		range.start_date = startDate;

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -50,9 +50,8 @@ import {
 import type { ReportParams } from '../utils/search';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
-// Including `StatsProxyParams` confuses TypeScript because it brings in a string index signature,
-// which conflicts with `ReportParams.filters`. Endpoint-specific extras reach the proxy through
-// `statsReportQuery`'s `extraParams`, not this index signature.
+// `StatsProxyParams` is deliberately left out: its string index signature conflicts
+// with `ReportParams.filters`. Extras reach the proxy through `extraParams` instead.
 export type StatsReportParams = ReportParams & StatsQueryParamFields;
 type StatsSanitizer< TData = unknown > = ( response: unknown, params?: StatsQueryParams ) => TData;
 
@@ -182,11 +181,9 @@ export function statsReportQuery< TSanitizer extends StatsSanitizerKey >(
 	const statsParams = reportParamsToStatsQueryParams( params );
 	const reportParams = {
 		...statsParams,
-		// List reports are day-bucketed: `days` counts calendar days and the
-		// summarized window is `period` × `days`, so the dashboard's chart
-		// interval must not leak in as the period (e.g. `period=week` with
-		// `days=189` would cover 189 weeks). Callers can still force a period
-		// explicitly via `params.period`.
+		// The summarized window is `period` × `days`, so the dashboard's chart
+		// interval must not leak in as the period — `period=week` with `days=189`
+		// would cover 189 weeks.
 		...( params.period === undefined ? { period: 'day' as const } : {} ),
 		...extraParams,
 		...( statsParams.summarize === undefined &&

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-subscribers-query.ts
@@ -49,12 +49,8 @@ export const statsSubscribersQuery = (
 /**
  * Build the subscribers time-series query from dashboard report params.
  *
- * The `stats/subscribers` endpoint is quantity-based (`unit` + `quantity` ending
- * at `date`), not `from`/`to`-based, so the dashboard range is translated here:
- * the interval picks the `unit`, the range end becomes `date`, and the number of
- * buckets spanning the range becomes `quantity`. Wrapped in `useStatsReport`,
- * the comparison window is fetched automatically from the dashboard's compare
- * range.
+ * The endpoint is quantity-based (`unit` + `quantity` ending at `date`), not
+ * `from`/`to`-based, so the dashboard range is translated here.
  */
 export const statsSubscribersReportQuery = (
 	params: StatsReportParams

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
@@ -30,9 +30,8 @@ export const statsVisitsQuery = (
 ): StatsReportQueryOptions< 'visits' > => {
 	const statsParams = reportParamsToStatsQueryParams( params );
 	const apiParams = statsQueryParamsToApiParams( statsParams );
-	// `start_date` + `date` bound the window at every unit, hourly included, and
-	// the endpoint recounts the buckets from them — a `quantity` alongside is
-	// ignored. So the range alone describes the request.
+	// `start_date` + `date` bound the window at every unit, and the endpoint
+	// recounts the buckets from them — a `quantity` alongside is ignored.
 	const visitsParams: StatsProxyParams = {
 		unit: apiParams.period,
 		date: apiParams.date,

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
@@ -44,7 +44,6 @@ export const statsWordAdsStatsQuery = (
 	const date = clampToYesterday ? yesterday : rangeEnd;
 	// The endpoint takes a bucket count and end date, not a range: derive the count
 	// from the clamped end so dropping today's bucket does not shift the start.
-	// Calypso's own defaults stand in when no range is supplied.
 	const defaultQuantity = unit === 'year' ? 10 : 30;
 	const quantity =
 		params.quantity ??

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/api-error.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/api-error.test.ts
@@ -5,9 +5,8 @@ import {
 	StatsResponseShapeError,
 } from '../api-error';
 
-// Two envelopes reach the client: our own `WP_Error` responses
-// (`{ code, message, data: { status } }`) and WPCOM pass-through errors
-// (`{ error, message }`, with the status attached separately by the fetch layer).
+// Two error envelopes reach the client: our own `WP_Error` shape
+// (`{ code, data: { status } }`) and WPCOM pass-through (`{ error, message }`).
 
 describe( 'getApiErrorStatus', () => {
 	it( 'returns status from a top-level status property', () => {
@@ -83,10 +82,8 @@ describe( 'shouldRetryApiError', () => {
 	} );
 
 	it( 'does not auto-retry a sanitizer parse failure', () => {
-		// The request itself succeeded; retrying it verbatim reproduces the same
-		// unparsable response instead of a different one. A manual Retry (e.g. a
-		// still-undeployed endpoint) is the mechanism that actually changes the
-		// outcome, so this must not eat the automatic-retry budget.
+		// Retrying verbatim reproduces the same unparsable response; only a
+		// manual Retry (e.g. after a redeploy) can actually change the outcome.
 		expect( shouldRetryApiError( 0, new StatsResponseShapeError( 'bad shape' ) ) ).toBe( false );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/compute-date-range-from-preset.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/compute-date-range-from-preset.test.ts
@@ -37,13 +37,7 @@ setSettings( {
 	timezone: { string: 'UTC', offset: 0, offsetFormatted: '0', abbr: 'UTC' },
 } );
 
-/*
- * Pin "now" to 2026-02-19 12:00:00 UTC for deterministic results.
- *
- * Expected dates are computed in UTC. Since TZ is mocked to +00:00,
- * computePrimaryRange runs in UTC and dateToISOStringWithLocalTZ
- * normalizes to Z-format via the mock.
- */
+// Pin "now" to 2026-02-19 12:00:00 UTC for deterministic, timezone-independent results.
 const NOW = new Date( '2026-02-19T12:00:00.000Z' );
 const UTC = tz( '+00:00' );
 

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/interval.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/interval.test.ts
@@ -16,19 +16,16 @@ describe( 'getDaysBetweenInclusive', () => {
 	} );
 
 	it( 'counts an offset-bearing range exactly as its bare equivalent', () => {
-		// Request params are no longer trimmed to a bare day before reaching
-		// here. Left unextracted, the ISO datetime concatenates into an invalid
-		// date, the NaN guard returns 1, and every range silently collapses to a
-		// single day.
+		// Offset-bearing params reach here untrimmed; without the NaN guard the
+		// ISO datetime would parse invalid and every range would collapse to 1 day.
 		expect(
 			getDaysBetweenInclusive( '2026-06-01T00:00:00.000-07:00', '2026-06-07T23:59:59.999-07:00' )
 		).toBe( 7 );
 	} );
 
 	it( 'reads the site-local calendar day at either offset extreme', () => {
-		// 23:00 on 2026-06-30 at -07:00 is already 2026-07-01 in UTC, and 00:30
-		// on 2026-06-01 at +13:00 is still 2026-05-31 there. Counting off the UTC
-		// day would add a bucket at one end and drop one at the other.
+		// -07:00 at 23:00 is already the next UTC day; +13:00 at 00:30 is still
+		// the previous one. Counting off the UTC day would misplace a bucket either way.
 		expect(
 			getDaysBetweenInclusive( '2026-06-01T00:00:00.000-07:00', '2026-06-30T23:00:00.000-07:00' )
 		).toBe( 30 );

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/normalize-report-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/normalize-report-params.test.ts
@@ -65,12 +65,6 @@ beforeEach( () => {
 } );
 
 describe( 'normalizeReportParams', () => {
-	/*
-	 * Scenario 1 – Fresh load (no params in URL)
-	 * The user visits /dashboard with no query string.
-	 * Expected: defaults kick in, preset "last-30-days" is used,
-	 * and default comparison is applied.
-	 */
 	it( 'applies defaults with preset and comparison on fresh load', () => {
 		const result = normalizeReportParams();
 
@@ -86,11 +80,6 @@ describe( 'normalizeReportParams', () => {
 		expect( result.compare_to ).toBe( DEFAULTS_WITH_COMPARISON.compare_to );
 	} );
 
-	/*
-	 * Scenario 2 – Same-day reload with preset
-	 * The URL has preset=last-30-days and from/to that match today's
-	 * computation. The dates are still fresh → no redirect needed.
-	 */
 	it( 'returns same dates when preset range is still fresh', () => {
 		const result = normalizeReportParams( {
 			from: FRESH_FROM,
@@ -133,11 +122,6 @@ describe( 'normalizeReportParams', () => {
 		expect( result.interval ).toBe( 'week' );
 	} );
 
-	/*
-	 * Scenario 3 – Next-day reload with stale dates
-	 * The URL has yesterday's dates but the same preset.
-	 * computeDateRangeFromPreset returns fresh dates → redirect.
-	 */
 	it( 'recalculates dates when preset range is stale', () => {
 		const result = normalizeReportParams( {
 			from: STALE_FROM,
@@ -152,11 +136,6 @@ describe( 'normalizeReportParams', () => {
 		expect( mockComputeRange ).toHaveBeenCalledWith( 'last-30-days' );
 	} );
 
-	/*
-	 * Scenario 4 – Custom range (no preset)
-	 * The user picked explicit from/to dates without a preset.
-	 * The dates should be used as-is, no recalculation.
-	 */
 	it( 'uses explicit dates as-is when no preset is set', () => {
 		const customFrom = '2026-01-01T00:00:00.000-05:00';
 		const customTo = '2026-01-31T23:59:59.999-05:00';
@@ -188,11 +167,6 @@ describe( 'normalizeReportParams', () => {
 		expect( mockComputeRange ).not.toHaveBeenCalled();
 	} );
 
-	/*
-	 * Scenario 5 – Preset with stale comparison enabled
-	 * The URL has a stale preset and comparison params.
-	 * Primary range is recalculated; comparison is preserved from URL.
-	 */
 	it( 'recalculates primary but preserves comparison from URL', () => {
 		const compFrom = '2025-12-20T00:00:00.000-05:00';
 		const compTo = '2026-01-18T23:59:59.999-05:00';
@@ -217,12 +191,9 @@ describe( 'normalizeReportParams', () => {
 		expect( result.compare_preset ).toBe( 'previous-period' );
 	} );
 
-	/*
-	 * Scenario 5b – Comparison flag arrives as a number
-	 * The router JSON-parses search values, so a URL written without JSON
-	 * quoting (hand-edited or from an older link builder) delivers comp as the
-	 * number 1. It must still enable comparison, normalized back to '1'.
-	 */
+	// The router JSON-parses search values, so an unquoted URL (hand-edited or
+	// from an older link builder) can deliver comp as the number 1, which must
+	// still enable comparison, normalized back to '1'.
 	it( 'accepts a numeric comp flag from an unquoted URL', () => {
 		const compFrom = '2025-12-20T00:00:00.000-05:00';
 		const compTo = '2026-01-18T23:59:59.999-05:00';
@@ -243,11 +214,6 @@ describe( 'normalizeReportParams', () => {
 		expect( result.compare_to ).toBe( compTo );
 	} );
 
-	/*
-	 * Scenario 6 – Preset without comparison
-	 * The URL has a stale preset but comparison is disabled.
-	 * Primary is recalculated; comparison params are absent.
-	 */
 	it( 'recalculates primary with no comparison when comp is absent', () => {
 		const result = normalizeReportParams( {
 			from: STALE_FROM,

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/stats-params.test.ts
@@ -44,10 +44,8 @@ describe( 'getPeriodsBetweenInclusive', () => {
 		}
 	);
 
-	// Hourly is the one granularity finer than a calendar day, so it counts the
-	// instants rather than the days they fall on. A range ending on the hour is
-	// not a bucket longer than one ending a millisecond before it, so the span
-	// rounds up rather than gaining a fixed `+ 1`.
+	// Hourly buckets count instants, not calendar days, so a range ending on
+	// the hour rounds up rather than always adding a fixed +1.
 	it.each( [
 		[ '2026-06-01T00:00:00.000-07:00', '2026-06-01T23:59:59.999-07:00', 24 ],
 		[ '2026-06-01T09:00:00.000-07:00', '2026-06-02T08:59:59.999-07:00', 24 ],
@@ -61,9 +59,8 @@ describe( 'getPeriodsBetweenInclusive', () => {
 	} );
 
 	it( 'reads the site-local calendar day, not the UTC day, at a day boundary', () => {
-		// 23:00 on 2026-06-30 at -07:00 is already 2026-07-01 in UTC. Counting
-		// off the UTC day would report an extra bucket on every negative-offset
-		// site whose range ends late in the evening.
+		// 23:00 on 2026-06-30 at -07:00 is already 2026-07-01 in UTC; counting off
+		// the UTC day would add an extra bucket on negative-offset sites.
 		expect(
 			getPeriodsBetweenInclusive(
 				'day',
@@ -121,9 +118,8 @@ describe( 'reportParamsToStatsQueryParams', () => {
 	} );
 
 	it( 'keeps the time of day on an hourly range, still counting whole days', () => {
-		// The `last-24-hours` shape: an hourly range whose ends are mid-day, not
-		// midnight. The time survives to the wire (the endpoint resolves it),
-		// while `days` stays a calendar-day count for the bucket math.
+		// The `last-24-hours` shape: ends are mid-day, not midnight. Time survives
+		// to the wire for the endpoint to resolve, while `days` stays a day count.
 		expect(
 			reportParamsToStatsQueryParams( {
 				from: '2026-06-14T09:00:00.000-04:00',
@@ -156,9 +152,8 @@ describe( 'reportParamsToStatsQueryParams', () => {
 				days: 7,
 			} )
 		);
-		// The semantic end_date must not survive alongside the API's date param
-		// — endpoints read `date`, and a stray end_date would leak into query
-		// keys and request URLs.
+		// end_date must not survive alongside the API's `date` param — endpoints
+		// read `date`, and a stray end_date would leak into query keys and URLs.
 		expect( apiParams ).not.toHaveProperty( 'end_date' );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/utils/api-error.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/api-error.ts
@@ -79,11 +79,9 @@ export function isAccessDenied( error: unknown ): boolean {
 }
 
 /**
- * Whether offering the reader a Retry can plausibly help.
- *
- * Distinct from `shouldRetryApiError`, the query client's automatic policy: a
- * 401 or 404 is worth a deliberate retry from the reader even though retrying it
- * three times unprompted is not.
+ * Whether offering the reader a Retry can plausibly help — distinct from
+ * `shouldRetryApiError`'s automatic policy: a 401/404 is worth a manual retry
+ * even though auto-retrying it three times unprompted is not.
  */
 export function isUserRetryableError( error: unknown ): boolean {
 	return ! ( error instanceof StatsResponseShapeError ) && ! isAccessDenied( error );

--- a/projects/packages/premium-analytics/packages/data/src/utils/interval.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/interval.ts
@@ -26,17 +26,14 @@ import { localTZDate } from './date';
 export type { IntervalType };
 
 export function getDaysBetweenInclusive( from: string, to: string ): number {
-	// Extract the calendar day first: callers may now pass a full offset-bearing
-	// ISO datetime (Stats endpoints resolve those correctly, so request params
-	// aren't pre-trimmed anymore) rather than a bare `yyyy-MM-dd`.
+	// Callers may pass a full offset-bearing ISO datetime rather than a bare
+	// `yyyy-MM-dd`, so take the calendar day first.
 	const fromDay = getDatePart( from );
 	const toDay = getDatePart( to );
 
 	// Anchor both dates in UTC before diffing: `differenceInCalendarDays` reads
-	// its arguments' local calendar getters, and a plain UTC-tagged `Date`'s
-	// getters reflect the machine's local timezone, not UTC. Left unanchored,
-	// a negative-offset machine can read a UTC midnight instant as the
-	// previous local calendar day, shifting the day count.
+	// local calendar getters, so on a negative-offset machine a UTC midnight
+	// instant reads as the previous day and shifts the count.
 	const fromDate = localTZDate( `${ fromDay }T00:00:00Z`, '+00:00' );
 	const toDate = localTZDate( `${ toDay }T00:00:00Z`, '+00:00' );
 	const days = differenceInCalendarDays( toDate, fromDate );
@@ -50,9 +47,8 @@ export function getDaysBetweenInclusive( from: string, to: string ): number {
 }
 
 function getAllowedIntervalsByRange( from: string, to: string ): IntervalType[] {
-	// Use hours instead of days to handle ranges that are 1 second short of a full day.
-	// E.g., '2024-11-01 00:00:00' to '2025-10-31 23:59:59' is 8759 hours (364.958 days),
-	// which rounds to 365 days, correctly categorizing it as a yearly interval.
+	// Hours, not days, so a range one second short of a full year (8759 hours)
+	// still rounds to 365 and categorizes as yearly.
 	const daysDiff = Math.round(
 		Math.abs( differenceInHours( localTZDate( to ), localTZDate( from ) ) / 24 )
 	);
@@ -81,9 +77,6 @@ function getAllowedIntervalsByRange( from: string, to: string ): IntervalType[] 
 
 /**
  * Allowed intervals for a preset, default first.
- *
- * Unknown / custom / year-surface presets derive the list from `from`–`to`
- * length.
  *
  * Also what the interval control lists, so the menu can never offer a bucket
  * the range would coerce away.

--- a/projects/packages/premium-analytics/packages/data/src/utils/search.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/search.ts
@@ -61,13 +61,9 @@ type PartialComparisonFields = Partial<
 	Pick< ReportParams, 'comp' | 'compare_from' | 'compare_to' >
 >;
 
-/*
- * Checks if the comparison is present in the search params.
- *
- * `comp` is compared loosely: the router JSON-parses search values, so a URL
- * written without JSON quoting (hand-edited, or by an older link builder)
- * delivers the number 1 instead of the string '1'.
- */
+// Whether comparison is enabled. `comp` is compared loosely because the
+// router JSON-parses search values, so an unquoted URL (hand-edited, or an
+// older link builder) can deliver the number 1 instead of the string '1'.
 export function hasComparisonEnabled< T extends PartialComparisonFields >( p: T ) {
 	return String( p.comp ) === '1' && !! p.compare_from?.trim() && !! p.compare_to?.trim();
 }
@@ -96,12 +92,6 @@ export function normalizeReportParams(
 		? getDefaultQueryParams( true, defaultPreset )
 		: getDefaultQueryParams( true );
 
-	// Preset handling:
-	// - Use search.preset only if valid
-	// - Recompute a year preset from its ID; carry all time only with its URL range
-	// - On fresh load (no from/to), fallback to defaults.preset
-	// - If user has explicit dates but no/invalid preset,
-	//   keep undefined (custom range)
 	let preset: ReportPresetId | undefined;
 	if (
 		search?.preset &&
@@ -109,22 +99,15 @@ export function normalizeReportParams(
 	) {
 		preset = search.preset;
 	} else if ( search?.preset === PRESET_ALL_TIME && search?.from && search?.to ) {
-		/*
-		 * The all-time start belongs to the year surface and may eventually be
-		 * site-specific, so only honour it next to the range the section wrote.
-		 * Keeping the marker lets widgets distinguish it from a single year when
-		 * both ranges happen to cover the same dates.
-		 */
+		// Only honour the URL's all-time start next to the range the section
+		// wrote — it lets widgets tell all-time apart from a same-dated single year.
 		preset = search.preset;
 	} else if ( ! search?.from && ! search?.to ) {
 		preset = defaults.preset;
 	}
 
-	// Recalculate presets so their moving end stays fresh on every page load.
-	// For all time, preserve the URL-authored start because the year surface owns
-	// it and may eventually resolve it from the site's first year.
-	// If the preset is valid but has no range implementation,
-	// clear it to avoid silently falling back to stale dates.
+	// All-time preserves the URL's start (the year surface may later resolve it
+	// site-specific); an unresolvable preset is cleared instead of going stale.
 	let presetRange: ReturnType< typeof computeDateRangeFromPreset >;
 	if ( preset ) {
 		const computedRange = computeDateRangeFromPreset( preset );
@@ -152,9 +135,8 @@ export function normalizeReportParams(
 		preset,
 		...( typeof search?.period === 'string' ? { period: search.period } : {} ),
 		date_type: search?.date_type ?? 'created',
-		// Preserve the single-resource scope so detail-page widgets stay bound to
-		// their post/page, dropping an invalid one so a hand-edited deep link can't
-		// push a malformed post_id into downstream Stats requests.
+		// Preserve the post_id scope so detail-page widgets stay bound to their
+		// post; drop an invalid one so a hand-edited deep link can't reach Stats.
 		...( postId > 0 ? { post_id: postId } : {} ),
 	};
 

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -31,10 +31,8 @@ export type StatsQueryParamFields = {
 	summarize?: number | boolean;
 	complete_stats?: number | boolean;
 	skip_archives?: number | boolean;
-	// Sanitizer-only: the trim window owned by processing/stats/bucket-window.ts,
-	// sent via `sanitizerParams` and honored only by the email time-series
-	// sanitizer — inert for every other sanitizer. Deliberately absent from
-	// statsParamKeys so report params can never carry them into a request.
+	// Sanitizer-only trim window (bucket-window.ts), sent via `sanitizerParams`
+	// — deliberately absent from statsParamKeys so it can never reach a request.
 	window_start?: string;
 	window_end?: string;
 };
@@ -77,17 +75,13 @@ export function getStatsPeriodFromInterval( interval?: string ): StatsPeriod {
 /**
  * Count the hour buckets a range covers, from the span between its ends.
  *
- * Hour is the only unit whose ends carry precision finer than the unit itself,
- * so it is the only one that can land mid-bucket. Rounding the span up counts
- * the bucket a partial hour falls in, without adding one to a range that already
- * ends on the hour — the presets end at `23:59:59.999`, but a hand-edited or
- * deep-linked range need not.
+ * Hour is the only unit that can land mid-bucket, so the span is rounded up
+ * rather than always adding a fixed +1 — a range already ending on the hour
+ * (as the presets do) must not count an extra bucket.
  *
- * Unlike the calendar counters, this one reads the ends as instants rather than
- * as calendar days, so both must carry a time of day. Bare `yyyy-MM-dd` ends
- * both parse as midnight and undercount by a bucket-day — `2026-08-01` to
- * `2026-08-07` counts 144 hours, not 168. Callers that can reach `hour` pass
- * datetimes; see `getPeriodsBetweenInclusive`.
+ * Ends must carry a time of day: unlike the calendar counters, this reads
+ * them as instants, so a bare `yyyy-MM-dd` parses as midnight and undercounts
+ * by a bucket-day (`2026-08-01` to `2026-08-07` reads as 144 hours, not 168).
  *
  * @param from - Range start, as a datetime.
  * @param to   - Range end, as a datetime.
@@ -104,12 +98,9 @@ function countHourBuckets( from: string, to: string ): number {
  * included.
  *
  * Both dates are anchored in UTC before diffing: the calendar-diff functions
- * read their arguments' local getters, and a plain UTC-tagged `Date`'s getters
- * reflect the machine's local timezone, not UTC. Left unanchored, a
- * negative-offset machine can read a UTC midnight instant that lands exactly on
- * a week/month/year boundary as the previous local period, shifting only one
- * side of the range and skewing the bucket count (e.g. a 4-week range reading
- * as 5 weeks).
+ * read local getters, and an unanchored UTC-tagged `Date` reflects the
+ * machine's local timezone — a negative-offset machine can misread a UTC
+ * midnight boundary and skew the count (e.g. 4 weeks reading as 5).
  *
  * @param difference - The calendar diff for the unit.
  * @return A counter for that unit.
@@ -138,14 +129,13 @@ const BUCKET_COUNTERS: Record< StatsPeriod, ( from: string, to: string ) => numb
 };
 
 /**
- * Count the buckets a range covers at a given unit. Used to translate a
- * dashboard date range into the `quantity` param that quantity-based Stats
- * endpoints (e.g. `stats/subscribers`) expect, mirroring how `days` is derived
- * for day-based requests.
+ * Count the buckets a range covers at a given unit — the `quantity` param
+ * that quantity-based Stats endpoints (e.g. `stats/subscribers`) expect,
+ * mirroring how `days` is derived for day-based requests.
  *
  * @param period - The bucket granularity.
- * @param from   - Range start (`yyyy-MM-dd`, or a full ISO datetime; `hour`
- *               needs the datetime — see `countHourBuckets`).
+ * @param from   - Range start (date or datetime; `hour` requires a datetime,
+ *               see `countHourBuckets`).
  * @param to     - Range end, same shapes and the same `hour` caveat.
  * @return The bucket count, at least 1.
  */
@@ -167,9 +157,8 @@ export function reportParamsToStatsQueryParams(
 	) as StatsQueryParams;
 
 	const period = params.period ?? getStatsPeriodFromInterval( params.interval );
-	// Stats v1.1 endpoints now resolve an offset-bearing ISO datetime to the
-	// intended local calendar day (WOOA7S-1656/1664), so start_date/end_date
-	// are passed through as-is instead of being trimmed to a bare date first.
+	// Stats v1.1 resolves an offset-bearing ISO datetime to the local calendar
+	// day (WOOA7S-1656/1664), so start_date/end_date pass through untrimmed.
 	const endDate = params.end_date ?? params.date ?? params.to;
 	const startDate = params.start_date ?? params.from;
 	const days =
@@ -186,9 +175,8 @@ export function reportParamsToStatsQueryParams(
 }
 
 export function statsQueryParamsToApiParams( params: StatsQueryParams = {} ): StatsProxyParams {
-	// window_start/window_end are sanitizer-only (see StatsQueryParamFields):
-	// stripped here so a caller that passes them in request params by mistake
-	// cannot leak them into request URLs and query keys.
+	// window_start/window_end are sanitizer-only (see StatsQueryParamFields);
+	// stripped here so a stray one can't leak into request URLs or query keys.
 	const { end_date: endDate, ...apiParams } = params;
 
 	delete apiParams.window_start;

--- a/projects/packages/premium-analytics/packages/data/src/utils/text.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/text.ts
@@ -9,11 +9,10 @@ function decodeHtmlEntities( value: string ): string {
 }
 
 /**
- * Decode the HTML entities WordPress and WPCOM return in user-authored titles
- * and names, while preserving non-string values.
+ * Decode the HTML entities WordPress and WPCOM return in user-authored titles.
  *
- * Decoding belongs in the data layer rather than in a row component because the
- * same value also reaches report tables, CSV exports, and `title` attributes.
+ * In the data layer rather than a row component because the same value reaches
+ * report tables, CSV exports, and `title` attributes.
  */
 export function decodeHtmlText< T >( value: T ): T | string;
 export function decodeHtmlText( value: unknown, fallback: string ): string;

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
@@ -56,9 +56,8 @@ describe( 'getComparisonRangeFromPreset', () => {
 		} );
 
 		it( 'mirrors the hour-snapped 24-hour preset window one day back', () => {
-			// The `last-24-hours` shape. Shifting by the exclusive span landed `to`
-			// on the reference's own `from`, pulling every hourly comparison bucket
-			// one hour late.
+			// The `last-24-hours` shape: shifting by the exclusive span landed `to` on
+			// the reference's own `from`, pulling hourly buckets one hour late.
 			const last24Hours = {
 				from: new Date( 2026, 7, 17, 15, 0, 0, 0 ),
 				to: new Date( 2026, 7, 18, 14, 59, 59, 999 ),

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/quick-surface-presets.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/quick-surface-presets.test.ts
@@ -6,8 +6,7 @@ import { DETAIL_SURFACE_PRESETS, PRESET_ALL_TIME, QUICK_SURFACE_PRESETS } from '
 import { dateToISOStringWithTZ } from '../tz';
 
 // A zone ahead of UTC, so a naive (UTC) day boundary would land on the wrong
-// day: 2026-07-08T10:29:35Z is already the 8th's evening in Taipei, and its
-// site-local day starts at 2026-07-08T00:00+08:00 = 2026-07-07T16:00Z.
+// day: 2026-07-08T10:29:35Z is already the 8th's evening in Taipei.
 const TIME_ZONE = 'Asia/Taipei';
 const PUBLISHED = new Date( '2026-07-08T10:29:35.000Z' );
 

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/step-date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/step-date-range.test.ts
@@ -84,13 +84,8 @@ describe( 'stepDateRange', () => {
 	} );
 
 	/*
-	 * The first acceptance criterion, asserted the way the control exercises it:
-	 * each call re-derives the span from whatever range it is handed, so a step
-	 * that changes what the window measures as has to survive that too.
-	 *
-	 * The clamping case is why this is a property rather than one example.
-	 * `addMonths` shortens a day the target month cannot hold, and the clamp does
-	 * not undo: August 31 two months back is June 30, forward again August 30.
+	 * A property rather than one example because of clamping: `addMonths` shortens
+	 * a day the target month cannot hold, and the clamp does not undo.
 	 */
 	describe( 'is reversible', () => {
 		const cases = [
@@ -125,10 +120,8 @@ describe( 'stepDateRange', () => {
 	} );
 
 	/*
-	 * The window keeps its length whichever unit the step had to fall back to.
-	 * Counted in calendar days, not elapsed milliseconds: a window that crosses a
-	 * daylight-saving change is an hour longer than one that does not, and the
-	 * step is meant to preserve the days a reader sees rather than the seconds.
+	 * Counted in calendar days, not elapsed milliseconds: a window crossing a DST
+	 * change is an hour longer, and the step preserves the days a reader sees.
 	 */
 	it( 'preserves the window length when a calendar step would clamp', () => {
 		const range = wholeDays( at( 2026, 8, 31 ), at( 2026, 10, 30 ) );
@@ -153,10 +146,8 @@ describe( 'canStepForward', () => {
 	const now = at( 2026, 7, 27, 12 );
 
 	/*
-	 * The shapes a live preset takes. `Last 24 hours` ends at the end of the
-	 * running hour, `today` at the end of the running day, `Last 7 days` at the
-	 * end of yesterday: the first two end in the future, the last never contains
-	 * the present, and all are the latest window available.
+	 * Live presets end in the future (`Last 24 hours`, `today`) or before the
+	 * present (`Last 7 days`), yet all are the latest window available.
 	 */
 	it( 'is false on a rolling window whose end has just gone stale', () => {
 		const to = at( 2026, 7, 27, 11, 59 );
@@ -164,9 +155,8 @@ describe( 'canStepForward', () => {
 		expect( canStepForward( { from: at( 2026, 7, 26, 11, 59 ), to }, now ) ).toBe( false );
 	} );
 
-	// The live window ends at the end of the running hour, in the future on
-	// purpose; counting that bucket is what keeps it reachable after a step
-	// back.
+	// The live window ends in the future on purpose; counting that bucket is what
+	// keeps it reachable after a step back.
 	it( 'is true on the window right behind a live hour-snapped one', () => {
 		const live = {
 			from: at( 2026, 7, 26, 13 ),

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
@@ -61,9 +61,8 @@ describe( 'toLocalTZ', () => {
 	} );
 
 	describe( 'daylight-saving wall times', () => {
-		// Where DST starts at midnight, a date-only value names a wall time that
-		// does not exist. It normalizes forward to 01:00, and the round-trip
-		// guard has to accept that rather than read it as an impossible date.
+		// Where DST starts at midnight a date-only value names a wall time that does
+		// not exist; it normalizes forward to 01:00 and the guard must accept that.
 		it.each( [
 			[ 'America/Santiago', '2026-09-06' ],
 			[ 'America/Havana', '2026-03-08' ],

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/year-presets.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/year-presets.test.ts
@@ -21,10 +21,8 @@ import { dateToISOStringWithTZ } from '../tz';
 const TIME_ZONE = 'America/New_York';
 
 /*
- * Pinned clock. The module derives the current year in `TIME_ZONE` while the
- * test runner reads it in its own zone, and around New Year the two disagree
- * for as long as the offset between them. Midday mid-year is far from both the
- * year boundary and any DST transition, so the two readings can't diverge.
+ * Pinned to midday mid-year: the module derives the current year in `TIME_ZONE`
+ * while the runner reads its own zone, and near New Year the two disagree.
  */
 const NOW = new Date( '2026-06-15T12:00:00.000Z' );
 const CURRENT_YEAR = NOW.getUTCFullYear();
@@ -204,9 +202,8 @@ describe( 'computePrimaryRange for the year surface', () => {
 	} );
 
 	it( 'holds the last-24-hours range steady as the clock moves within the hour', () => {
-		// The range lands in start_date/end_date, which are sent verbatim and key
-		// the request cache. Off a raw `now` these drift by milliseconds between
-		// callers, so identical requests never dedupe and never hit the cache.
+		// The range is sent verbatim and keys the request cache; off a raw `now` it
+		// drifts by milliseconds and identical requests never dedupe.
 		const before = rangeOf( 'last-24-hours', TIME_ZONE );
 
 		jest.setSystemTime( new Date( NOW.getTime() + 20 * 60 * 1000 ) );

--- a/projects/packages/premium-analytics/packages/datetime/src/date-range-span.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/date-range-span.ts
@@ -54,10 +54,6 @@ const MONTHS_PER_YEAR = 12;
  * Whether the range covers whole calendar days, from the first instant of
  * `from` to the last instant of `to`.
  *
- * Rolling sub-day windows (`last-24-hours`, `today` while it is still running)
- * end at the current time instead, which is what separates them from ranges
- * that should be counted in days.
- *
  * @param from - Range start.
  * @param to   - Range end.
  * @return Whether both ends sit on a day boundary.
@@ -67,12 +63,10 @@ function coversWholeDays( from: Date, to: Date ): boolean {
 }
 
 /**
- * Whole calendar months covered by the range, or null when it does not divide
- * evenly into months.
+ * Whole calendar months covered by the range.
  *
  * Counted against the day after `to`, since an inclusive range ends on the last
- * instant of its final day: July 1 through June 30 is twelve months, and the
- * boundary that proves it is July 1 a year later.
+ * instant of its final day.
  *
  * @param from - Range start.
  * @param to   - Range end.
@@ -80,8 +74,7 @@ function coversWholeDays( from: Date, to: Date ): boolean {
  */
 function getWholeMonths( from: Date, to: Date ): number | null {
 	// `addDays` keeps the input's `Date` subclass, so a site-timezone `TZDate`
-	// stays anchored to that zone. A plain `new Date()` would drop back to the
-	// browser's and shift the boundary.
+	// stays anchored to that zone rather than the browser's.
 	const dayAfterTo = startOfDay( addDays( to, 1 ) );
 	const months = differenceInCalendarMonths( dayAfterTo, from );
 
@@ -89,9 +82,8 @@ function getWholeMonths( from: Date, to: Date ): number | null {
 		return null;
 	}
 
-	// `addMonths` clamps a day that the target month is too short for (Jan 31
-	// plus one month is Feb 28), so compare the round trip rather than the
-	// day-of-month, which would call Jan 31 - Feb 27 a whole month.
+	// `addMonths` clamps a day the target month is too short for (Jan 31 plus one
+	// month is Feb 28), so compare the round trip rather than the day-of-month.
 	return isSameDay( addMonths( from, months ), dayAfterTo ) ? months : null;
 }
 
@@ -99,20 +91,10 @@ function getWholeMonths( from: Date, to: Date ): number | null {
  * Measure how long a date range is, in the unit that describes it best.
  *
  * Derived from the range itself rather than the preset that produced it, so a
- * window stepped back from "Last 7 days" still reads as 7 days once the preset
- * has become a custom range.
+ * window stepped back from "Last 7 days" still reads as 7 days.
  *
  * A unit is only reported where the range divides evenly into it, so an
- * open-ended range measures by the day it is read on: the same selection can
- * land in days, months or years depending on whether today closes a month or a
- * year. Callers describing a selection that grows day by day should say so from
- * the selection rather than measure it.
- *
- * @example
- * getDateRangeSpan( { from, to } ) // 7 days:     { unit: 'day', value: 7 }
- *                                  // 12 months:  { unit: 'month', value: 12 }
- *                                  // 24 hours:   { unit: 'hour', value: 24 }
- *                                  // 5 years:    { unit: 'year', value: 5 }
+ * open-ended range measures by the day it is read on.
  *
  * @param range - The range to measure.
  * @return The span, or null when the range is missing an end.
@@ -126,9 +108,8 @@ export function getDateRangeSpan( range?: DateRange ): DateRangeSpan | null {
 	}
 
 	if ( ! coversWholeDays( from, to ) ) {
-		// `round`, not the default truncation: an hour-snapped window runs to
-		// the last millisecond of its final hour, and truncation reads it one
-		// hour short.
+		// `round`, not the default truncation: an hour-snapped window runs to the
+		// last millisecond of its final hour, and truncation reads it an hour short.
 		const hours = differenceInHours( to, from, { roundingMethod: 'round' } );
 
 		if ( hours <= MAX_HOURS_SPAN ) {

--- a/projects/packages/premium-analytics/packages/datetime/src/date.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/date.ts
@@ -23,13 +23,10 @@ export function getDatePart( value: unknown ): string | undefined {
 }
 
 /**
- * Format a date part and time into the Premium Analytics response shape: a
- * timezone-naive stamp naming a site-local wall time.
+ * Format a date part and time into the Premium Analytics response shape.
  *
- * Deliberately offset-less. Stats bucket labels are site-local calendar dates,
- * and a fabricated offset would assert an instant the bucket never named —
- * `toLocalTZ` would then anchor it in the wrong zone, and every chart consumer
- * would have to strip it back off.
+ * Deliberately offset-less: Stats bucket labels are site-local calendar dates,
+ * and a fabricated offset would assert an instant the bucket never named.
  *
  * @param datePart - Date part, normally `YYYY-MM-DD`.
  * @param time     - Time part, normally `HH:mm:ss`.

--- a/projects/packages/premium-analytics/packages/datetime/src/drill-date-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/drill-date-range.ts
@@ -36,13 +36,6 @@ const BUCKET_BOUNDS: Partial<
 /**
  * The window behind one chart bucket: the range a click on it should open.
  *
- * The caller applies the result through the usual range machinery, which
- * re-resolves the interval — a bucket's own length never allows the interval
- * that drew it, so the reading always lands one level finer.
- *
- * The end is clamped at `now`, so opening the bucket in progress shows the part
- * of it that exists rather than a window running into the future.
- *
  * Boundaries are cut in `date`'s own timezone, so a `TZDate` carrying the site
  * zone closes its buckets on the site's clock rather than the browser's.
  *

--- a/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
@@ -55,20 +55,12 @@ function getInclusiveDayCount( from: Date, to: Date ): number {
 }
 
 /**
- * Returns a comparison DateRange (as Date objects) derived from a reference range
- * and a given preset.
+ * Returns a comparison DateRange derived from a reference range and a preset.
  *
- * - This function is pure and has no side effects.
- * - It does not apply any timezone adjustments; day boundaries are resolved in
- *   the frame of the incoming dates (pass TZDate instances for site-local math).
- * - Day-aligned references (midnight to end of day) produce day-aligned
- *   comparison ranges. Sub-day references (rolling windows like the last 24
- *   hours) mirror the exact window instead.
- * - Comparison ranges match the reference duration, except that whole-month
- *   `previous-month` and `previous-year` ranges preserve calendar boundaries.
- *   Whole months are detected from the range shape alone, so a rolling window
- *   that happens to land on one (April 1-30 from a "last 30 days" preset) also
- *   compares calendar-to-calendar, against all 31 days of March.
+ * - Day boundaries are resolved in the frame of the incoming dates; pass TZDate
+ *   instances for site-local math.
+ * - Whole months are detected from the range shape alone, so a rolling window
+ *   that happens to land on one also compares calendar-to-calendar.
  *
  * @param reference - The reference range to compare against (must include both `from` and `to`).
  * @param presetId  - One of the supported preset identifiers.
@@ -89,17 +81,15 @@ export function getComparisonRangeFromPreset(
 		refFrom.getTime() === startOfDay( refFrom ).getTime() &&
 		refTo.getTime() === endOfDay( refTo ).getTime();
 
-	// Sub-day windows shift only their end, then rebuild `from` from the
-	// original duration: calendar shifts clamp day-of-month (Mar 31 - 1 month
-	// = Feb 28) and would otherwise shrink or collapse the window.
+	// Sub-day windows shift only their end, then rebuild `from` from the original
+	// duration: a calendar shift clamps day-of-month and would collapse the window.
 	if ( ! isDayAligned ) {
 		const windowMs = differenceInMilliseconds( refTo, refFrom );
 		let to: Date;
 
 		if ( presetId === COMPARISON_PREVIOUS_PERIOD ) {
-			// Both ends are inclusive, so the window lasts `windowMs + 1`. Shifting
-			// by `windowMs` alone lands `to` on `refFrom` itself, inside the
-			// reference window, which reads one bucket late at hourly granularity.
+			// Both ends are inclusive, so the window lasts `windowMs + 1`; shifting
+			// by `windowMs` alone lands `to` inside the reference window.
 			to = subMilliseconds( refTo, windowMs + 1 );
 		} else if ( presetId === COMPARISON_PREVIOUS_MONTH ) {
 			to = subMonths( refTo, 1 );

--- a/projects/packages/premium-analytics/packages/datetime/src/presets/primary.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/presets/primary.ts
@@ -103,18 +103,12 @@ export const PRESET_DEFINITIONS: ReadonlyArray< PresetDefinition > = [
 		getShortLabel: () =>
 			/* translators: abbreviation for "Last 24 hours". Shown in a segmented control too narrow for the full label, so keep it as short as the language allows. */
 			_x( '24H', 'short date range preset', 'jetpack-premium-analytics-pkg' ),
-		// Snapped to the hour rather than taken from the raw instant. The range
-		// ends up in `start_date`/`end_date`, which are sent verbatim and form
-		// part of the request's React Query key: off a raw `now` every widget
-		// (and every remount) resolves a different millisecond, so identical
-		// requests never dedupe and never hit the cache. The hour is the natural
-		// granularity — this is the only preset that buckets hourly — and the
-		// open-ended `endOfHour` keeps the in-progress hour visible, matching how
-		// `today` runs to `endOfToday`.
+		// Snapped to the hour rather than the raw instant: the range is sent
+		// verbatim and forms part of the request's React Query key, so off a raw
+		// `now` identical requests never dedupe or hit the cache.
 		//
 		// `subHours` counts elapsed time, so the window spans 24 real hours even
-		// across a DST transition, where the local clock reads 23 or 25 hour
-		// labels over the same span.
+		// across a DST transition.
 		getRange: ( { now } ) => ( {
 			from: subHours( startOfHour( now ), 23 ),
 			to: endOfHour( now ),
@@ -468,15 +462,13 @@ export function getYearSurfacePresets(
 }
 
 /**
- * Compute the absolute date range (as Date objects) for a given
- * preset ID in the specified timezone.
+ * Compute the absolute date range for a preset ID in the given timezone.
  *
  * @param presetId - A valid computable preset identifier.
  * @param timeZone - IANA timezone string.
  * @param options  - All-time options; only read for the all-time preset,
  *                 whose start is a property of the surface, not of the ID.
- * @return The computed { from, to } Date range, or undefined
- *         if the preset is not recognized.
+ * @return The computed range, or undefined if the preset is not recognized.
  */
 export function computePrimaryRange(
 	presetId: ComputablePresetId,

--- a/projects/packages/premium-analytics/packages/datetime/src/site-datetime.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/site-datetime.ts
@@ -10,10 +10,9 @@ import { readSiteTimestamp } from './site-timestamp';
 /**
  * Parse a timestamp in the WordPress site timezone.
  *
- * `getDate` anchors offset-less Stats API values to the timezone configured in
- * WordPress while preserving the instant identified by offset-bearing values.
- * It shares `toLocalTZ`'s reading of which values are timestamps and which of
- * those are valid, so the two cannot disagree.
+ * `getDate` anchors offset-less Stats API values to the WordPress site timezone
+ * while preserving the instant of offset-bearing values. It shares `toLocalTZ`'s
+ * reading of validity, so the two cannot disagree.
  *
  * @param value - The raw timestamp, or a `Date`.
  * @return The instant, or `undefined` when the value is missing or malformed.

--- a/projects/packages/premium-analytics/packages/datetime/src/site-timestamp.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/site-timestamp.ts
@@ -1,10 +1,8 @@
 /**
- * Date-only, MySQL datetime, or ISO datetime values used by Stats and report
- * params.
+ * Date-only, MySQL datetime, or ISO datetime values used by Stats and report params.
  *
- * The fractional second is matched at any length, and truncated below. Capping
- * it here would drop a value like `.123456` through to `Date`, which reads an
- * offset-less string in the *browser's* zone — the shift this package avoids.
+ * The fractional second is matched at any length: capping it here would drop
+ * `.123456` through to `Date`, which reads it in the browser's zone.
  */
 const SITE_TIMESTAMP =
 	/^(\d{4})-(\d{2})-(\d{2})(?:[ T](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?(Z|[+-]\d{2}:?\d{2})?)?$/;

--- a/projects/packages/premium-analytics/packages/datetime/src/step-date-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/step-date-range.ts
@@ -52,12 +52,10 @@ function shift( from: Date, to: Date, unit: DateRangeSpanUnit, amount: number ):
 }
 
 /**
- * Shift a range backward or forward by its own length, measured from the range
- * rather than from the preset that produced it.
+ * Shift a range backward or forward by its own length.
  *
- * Falls back to the day count where a calendar step will not undo. `addMonths`
- * clamps a day the target month is too short for: August 31 two months back is
- * June 30, forward again August 30. Reversibility wins over calendar shape.
+ * Falls back to the day count where a calendar step will not undo — `addMonths`
+ * clamps a day the target month is too short for, and reversibility wins.
  *
  * @param range     - The window to move.
  * @param direction - Which way to move it.
@@ -98,11 +96,8 @@ const END_OF_BUCKET: Record< DateRangeSpanUnit, ( date: Date ) => Date > = {
 /**
  * Whether there is a later window to step into.
  *
- * The next window qualifies once it ends within the bucket `now` sits in, at
- * the window's own granularity. Live presets end at the end of the running
- * hour or day, so the window a reader stepped back from ends in the future;
- * counting the running bucket keeps it reachable, while a window reaching
- * into the next bucket stays out.
+ * The next window qualifies once it ends within the bucket `now` sits in, so a
+ * live preset ending in the running hour or day stays reachable.
  *
  * @param range - The window to test.
  * @param now   - The instant to compare against.

--- a/projects/packages/premium-analytics/packages/datetime/src/tz.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/tz.ts
@@ -12,26 +12,10 @@ type GrowTuple< T extends unknown[], Max extends number > = T[ 'length' ] extend
 	? T
 	: T | GrowTuple< [ ...T, number ], Max >;
 /**
- * Date parts tuple in the same order as the native `Date` constructor:
- * [ year, month, day, hours, minutes, seconds, milliseconds ]
+ * Date parts in the same order as the native `Date` constructor, from
+ * `[ year, month ]` up to milliseconds.
  *
- * Positions:
- * - year: full year, e.g. 2025
- * - month: month index 0–11 (0=January, 11=December)
- * - day: day of month 1–31 (default 1 if omitted)
- * - hours: 0–23 (default 0)
- * - minutes: 0–59 (default 0)
- * - seconds: 0–59 (default 0)
- * - milliseconds: 0–999 (default 0)
- *
- * Rules:
- * - Valid lengths: 2 to 7 elements (must always start with [year, month]).
- * - Do not skip intermediate positions: contiguous prefixes only (trimmed at the first `undefined`).
- * - Time zone is applied when creating the date (see `createTZDateFromParts`).
- *
- * Examples:
- * - [ 2025, 0 ] → 2025-01-01T00:00:00.000 (January is 0)
- * - [ 2025, 6, 15, 14, 30 ] → 2025-07-15T14:30:00.000
+ * Contiguous prefixes only — the tuple is trimmed at the first `undefined`.
  */
 type DateParts = GrowTuple< [ number, number ], 7 >;
 
@@ -42,11 +26,8 @@ const MINUTE_IN_MS = 60 * 1000;
  * Resolve wall-clock parts to the instant they name in a timezone.
  *
  * `TZDateMini`'s own parts constructor seeds its offset guess from the machine
- * timezone, so wall times a DST transition skips or repeats resolve to
- * different instants depending on the host — in production, the visitor's
- * browser. This resolves them deterministically instead: a wall time a
- * fall-back transition names twice takes its first occurrence, and one a
- * spring-forward gap skips normalizes forward by the gap's length.
+ * timezone, so DST-ambiguous wall times resolve differently per host. This
+ * resolves them deterministically instead.
  *
  * @param parts    - Wall-clock parts, `[ year, month, ...rest ]` as `Date.UTC` reads them.
  * @param timeZone - The timezone the wall time belongs to.
@@ -76,9 +57,8 @@ function wallPartsToTimestamp( parts: number[], timeZone: string ): number {
 		return Math.min( ...candidates );
 	}
 
-	// No survivor means a spring-forward gap skips the wall time. Anchoring
-	// with the pre-gap offset lands just past the transition, normalizing the
-	// wall time forward by the gap's length.
+	// No survivor means a spring-forward gap skips the wall time; the pre-gap
+	// offset normalizes it forward past the transition.
 	return wallAsUTC - before * MINUTE_IN_MS;
 }
 
@@ -120,9 +100,8 @@ export function createTZDateFromParts(
 function wallTimeToTZDate( parts: TimestampParts, timeZone: string ): TZDate {
 	const date = createTZDateFromParts( parts, timeZone );
 
-	// A zone that skips a whole day, as Pacific/Apia did on 2011-12-30, moves
-	// the wall time onto the next one. Compare only the date parts, so a wall
-	// time normalized by a DST jump stays valid.
+	// A zone that skips a whole day (Pacific/Apia, 2011-12-30) moves the wall time
+	// onto the next one; comparing date parts keeps a DST-normalized time valid.
 	const survivedRoundTrip =
 		date.getFullYear() === parts[ 0 ] &&
 		date.getMonth() === parts[ 1 ] &&
@@ -147,10 +126,8 @@ export function toLocalTZ( value?: number | string | Date, timeZone?: string ): 
 	if ( typeof value === 'string' ) {
 		const timestamp = readSiteTimestamp( value );
 
-		// A shape this package does not read reaches `Date` otherwise, which
-		// resolves an offset-less string in the *browser's* zone — the shift this
-		// module avoids — and leaves `parseSiteDateTime` rejecting a value this
-		// accepts.
+		// Otherwise an unrecognized shape reaches `Date`, which resolves an
+		// offset-less string in the browser's zone — the shift this module avoids.
 		if ( ! timestamp?.isValid ) {
 			return new TZDateMini( NaN, tzid );
 		}

--- a/projects/packages/premium-analytics/packages/externals/src/index.ts
+++ b/projects/packages/premium-analytics/packages/externals/src/index.ts
@@ -53,20 +53,18 @@ export { LineShape, RectShape } from '@automattic/charts/visx/legend';
 /**
  * Calendar
  *
- * `DateRangeCalendar` is the package's only `@automattic/ui` consumer, but it
- * reaches `react-day-picker` and `date-fns` behind it — ~55 KB of minified
- * vendor code that would otherwise be re-emitted on every edit to the module
- * that imports it.
+ * `DateRangeCalendar` is the package's only `@automattic/ui` consumer, but
+ * pulls in `react-day-picker` + `date-fns` behind it — ~55 KB that would
+ * otherwise re-emit on every edit to the importing module.
  */
 export { DateRangeCalendar } from '@automattic/ui';
 
 /**
  * WordPress design system
  *
- * `Field` is exported as `FormField`: `@wordpress/ui`'s form-field namespace and
- * `@wordpress/dataviews`' `Field` type collide under one barrel, and DataViews'
- * `Field` is the name consumers already import from here. The alias is still a
- * plain re-export — it renames, it does not wrap.
+ * `Field` is exported as `FormField`: `@wordpress/ui`'s form-field namespace
+ * collides with DataViews' `Field` type under one barrel, and DataViews' name
+ * is what consumers already import. Still a plain re-export, not a wrap.
  */
 export {
 	Button,

--- a/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/toggle-group-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/field-toggle-group/toggle-group-field.tsx
@@ -76,10 +76,8 @@ export default function ToggleGroupField< Item >( {
 	}
 
 	const iconOptions = hasIconOptions( elements );
-	// A value matching no option leaves every segment unpressed, while the
-	// consumer keeps drawing its own default. The first option stands in as the
-	// rendered selection, as it does in `SelectField`; nothing is written until
-	// the user picks one.
+	// No matching option leaves every segment visually unpressed while the
+	// consumer's default stands in — as in `SelectField`, nothing writes until picked.
 	const selectedValue = elements.some( element => element.value === value )
 		? value
 		: elements[ 0 ].value;
@@ -90,9 +88,8 @@ export default function ToggleGroupField< Item >( {
 			label={ label }
 			help={ description }
 			hideLabelFromVision={ hideLabelFromVision }
-			// Segments stretch only where the control owns a full form row and
-			// reads as text. Icon segments are square, and inline in a widget
-			// header the control sizes to its content.
+			// Full-row text segments stretch (isBlock); icon segments are square, and
+			// an inline widget-header control sizes to its content instead.
 			isBlock={ ! iconOptions && ! hideLabelFromVision }
 			value={ selectedValue }
 			onChange={ onValueChange }

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
@@ -161,11 +161,9 @@ describe( 'createReportParamsField', () => {
 	} );
 
 	/*
-	 * `DateRangeFilter` applies a quick preset by calling `onChange` and then
-	 * `onApply` back to back in one tick. A commit reading the staged state
-	 * writes the previous selection back over the new one, so the widget lands a
-	 * click behind — and on the first click, on the range it already had, which
-	 * is why picking "Last 24 hours" left the previous range's buckets on offer.
+	 * `DateRangeFilter` calls `onChange` then `onApply` in the same tick; a
+	 * commit reading staged state lands a click behind — the first click, on
+	 * the range it already had, left the previous range's buckets on offer.
 	 */
 	it( 'applies the clicked quick preset, not the one before it', async () => {
 		const user = userEvent.setup();
@@ -236,10 +234,9 @@ describe( 'createReportParamsField', () => {
 	} );
 
 	/*
-	 * Reading the options from the applied range while the checked value comes
-	 * from the draft lets the menu offer a bucket the drafted range cannot hold:
-	 * the click then resolves away, the tick springs back, and Apply drops the
-	 * choice. Both must read the same range.
+	 * Reading options from the applied range while checked value comes from the
+	 * draft could offer a bucket the draft can't hold — the click resolves away
+	 * and Apply silently drops it. Both must read the same range.
 	 */
 	it( 'reshapes the bucket menu with the range being drafted', async () => {
 		const user = userEvent.setup();
@@ -269,9 +266,8 @@ describe( 'createReportParamsField', () => {
 		expect( latest() ).toEqual( expect.objectContaining( { interval: 'hour' } ) );
 	} );
 
-	// The bucket rides along with an open range draft, so cancelling the draft has
-	// to take it with them — and leave the control clean enough that the next
-	// bucket click commits on its own again.
+	// The bucket rides along with an open range draft, so cancelling it drops
+	// the bucket too — and leaves the control clean for the next click to commit.
 	it( 'drops a bucket picked mid-draft when the range draft is cancelled', async () => {
 		const user = userEvent.setup();
 		const { saved } = renderField( true );

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
@@ -85,11 +85,9 @@ function ReportParamsControl( {
 	);
 
 	/*
-	 * `DateRangeFilter` applies a quick preset by calling `onChange` and then
-	 * `onApply` in the same tick, so the commit below cannot read the state that
-	 * `onChange` just queued — it would write the previous selection back over
-	 * the new one, leaving the widget a click behind. Mirror the staged params
-	 * into a ref that every stage updates synchronously.
+	 * `DateRangeFilter` calls `onChange` then `onApply` in the same tick, so a
+	 * commit reading component state would still see the previous selection.
+	 * Mirror staged params into a ref that every stage updates synchronously.
 	 */
 	const stagedRef = useRef< ReportParams >( stagedReportParams );
 
@@ -99,11 +97,10 @@ function ReportParamsControl( {
 	}, [] );
 
 	/*
-	 * Realign the draft when the params change from outside this control — an
-	 * undo, a dashboard reset, another surface saving the same widget. Without
-	 * it `commit` writes the stale draft back over that change. Key on the
-	 * value, not the object: a host that builds the attribute during render
-	 * would otherwise wipe the draft on every render.
+	 * Realign the draft when params change from outside (undo, a dashboard
+	 * reset, another surface saving the same widget) — otherwise `commit` writes
+	 * the stale draft back over that change. Key on the value, not the object:
+	 * a host that rebuilds the attribute every render would wipe the draft.
 	 */
 	const committed = attributes?.reportParams;
 	const committedKey = JSON.stringify( committed ?? null );
@@ -242,11 +239,10 @@ function ReportParamsControl( {
 	}, [ stage, attributes ] );
 
 	/*
-	 * Options and checked value both come from the staged params, so the checked
-	 * bucket is always a listed one — `normalizeReportParams` already resolved
-	 * `interval` against this very range. Reading the options from the committed
-	 * range instead would let the menu offer a bucket the drafted range cannot
-	 * hold, and the resolve below would then silently drop the click.
+	 * Options and checked value both read from the staged params, so the
+	 * checked bucket is always a listed one. Reading options from the
+	 * committed range instead would offer a bucket the draft can't hold,
+	 * silently dropping the click.
 	 */
 	const intervalOptions = useMemo(
 		() =>

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__fixtures__/wp-date-settings.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__fixtures__/wp-date-settings.ts
@@ -1,9 +1,7 @@
 /**
  * `@wordpress/date` settings fixtures.
  *
- * The formatter reads the site's `date_format` and WordPress's translated
- * month names, so tests drive it by installing real settings rather than by
- * mocking the formatter.
+ * Tests drive the formatter by installing real settings rather than mocking it.
  */
 
 /**
@@ -46,20 +44,15 @@ const ES_WEEKDAYS = [ 'domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'vie
  * Build a settings object for a locale.
  *
  * The timezone is fixed to UTC so assertions do not depend on the machine
- * running the suite. Tests that vary the zone spread the result and replace
- * the `timezone` block.
+ * running the suite.
  *
  * @param locale      - Moment locale name. Must be unique per fixture, since
  *                    `setSettings` skips redefining a locale it already knows.
  * @param dateFormat  - The site's `date_format` option, in PHP tokens.
- * @param months      - Translated month names, January first. Defaults to the
- *                    package's English names.
- * @param weekdays    - Translated weekday names, Sunday first. Defaults to the
- *                    package's English names.
+ * @param months      - Translated month names, January first.
+ * @param weekdays    - Translated weekday names, Sunday first.
  * @param monthsShort - Abbreviated month names. Defaults to the first three
- *                    letters of each, which is only right where the locale
- *                    abbreviates that way. Hungarian, for one, punctuates its
- *                    abbreviations, so it has to pass its own.
+ *                    letters, which only suits locales that abbreviate that way.
  * @return Settings ready for `setSettings`.
  */
 export const settingsFor = (
@@ -102,9 +95,8 @@ export const ES_ES_SETTINGS = settingsFor(
  * @param year   - Full year.
  * @param month  - 1-based month.
  * @param day    - Day of month.
- * @param [hour] - Hour of day. Defaults to midnight, which is where a
- *               day-aligned range starts; pass one to build a rolling window
- *               that does not sit on a day boundary.
+ * @param [hour] - Hour of day. Defaults to midnight, where a day-aligned range
+ *               starts.
  * @return The date.
  */
 export const utcDate = ( year: number, month: number, day: number, hour: number = 0 ): Date =>

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range-long.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range-long.test.ts
@@ -10,10 +10,8 @@ import { EN_US_SETTINGS } from '../__fixtures__/wp-date-settings';
 import { formatDateRangeLong } from '../format-date-range-long';
 
 /**
- * The zone both frames are pinned to: `date-fns` reads a `TZDate`'s own zone
- * for day boundaries, and `dateI18n` renders in the site's. Production keeps
- * the two in step because the range carries the site's zone; the fixtures pin
- * the site to UTC, so the dates are built there too.
+ * `date-fns` reads a `TZDate`'s own zone for day boundaries and `dateI18n`
+ * renders in the site's; the fixtures pin the site to UTC, so dates are built there.
  */
 const TEST_TIMEZONE = 'UTC';
 
@@ -85,9 +83,8 @@ describe( 'formatDateRangeLong', () => {
 	} );
 
 	it( 'names a rolling 24-hour window by the day it ends on', () => {
-		// The window straddles two calendar days; naming both ends would
-		// overstate its reach, and the day the reading is taken on is the one
-		// it is about.
+		// The window straddles two calendar days; the day the reading is taken on
+		// is the one it is about.
 		expect(
 			formatDateRangeLong(
 				{
@@ -176,9 +173,8 @@ describe( 'formatDateRangeLong', () => {
 	} );
 
 	it( 'keeps the calendar shape for a running year still inside its first week', () => {
-		// Measured, this is a 3-day window and would lead with weekdays and
-		// drop the year — a shape the selection loses again the moment it
-		// grows past a week.
+		// Measured, this is a 3-day window and would lead with weekdays and drop
+		// the year.
 		const range = { from: at( 2026, 1, 1 ), to: endOf( 2026, 1, 3 ) };
 
 		expect( formatDateRangeLong( range, { referenceYear: 2026, calendarScale: true } ) ).toBe(

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range.test.ts
@@ -176,8 +176,7 @@ describe( 'formatDateRange', () => {
 
 	describe( 'site whose date format carries no year', () => {
 		// `date_format` is a free-text field, so a format without a year is
-		// reachable. Collapsing on the rendered strings would fold a whole year
-		// apart into a single date.
+		// reachable; collapsing on rendered strings would fold a year into a day.
 		beforeEach( () => setSettings( settingsFor( 'en-no-year-test', 'F j' ) ) );
 
 		it( 'still spells out both ends of a range spanning years', () => {
@@ -197,9 +196,8 @@ describe( 'formatDateRange', () => {
 			resetLocaleData( {}, 'jetpack-premium-analytics-pkg' );
 		} );
 
-		// A custom `date_format` is the site telling us how it wants dates
-		// written. CLDR's rules describe a different format, so borrowing its
-		// elision would quietly overrule the setting.
+		// A custom `date_format` is the site telling us how it wants dates written,
+		// so borrowing CLDR's elision would quietly overrule the setting.
 		it( 'keeps a custom date format and spells both ends out', () => {
 			setSettings( settingsFor( 'en-custom-test', 'd/m/Y' ) );
 
@@ -226,8 +224,7 @@ describe( 'formatDateRange', () => {
 		} );
 
 		// `ja` renders a single date as 2025年6月21日 but switches its ranges to
-		// 2025/06/21～2025/06/25, so its elision cannot be mixed with the rest
-		// of the dashboard's dates.
+		// 2025/06/21～2025/06/25, so its elision cannot be mixed in.
 		it( 'spells both ends out where the locale restyles its ranges', () => {
 			setSettings( settingsFor( 'ja-JP', 'Y年n月j日', JA_MONTHS ) );
 
@@ -316,10 +313,8 @@ describe( 'formatDateRangeMinimal', () => {
 	describe( 'es_ES site', () => {
 		beforeEach( () => setSettings( ES_ES_SETTINGS ) );
 
-		// Dropping the year takes the "de" that introduced it along with it, so
-		// the shorter form is still written the way the locale writes dates.
-		// Spanish keeps both ends spelled out here for the same reason the
-		// compact form does: its abbreviated dates and CLDR's do not agree.
+		// Dropping the year takes the "de" that introduced it along with it. Both
+		// ends stay spelled out: Spanish abbreviated dates and CLDR's disagree.
 		it( 'drops the year the way the locale writes the rest of the date', () => {
 			expect(
 				formatDateRangeMinimal( { from: utcDate( 2026, 7, 13 ), to: utcDate( 2026, 7, 26 ) } )
@@ -327,10 +322,8 @@ describe( 'formatDateRangeMinimal', () => {
 		} );
 	} );
 
-	// A year-less range spanning two years leaves ICU nothing to tell them
-	// apart by, so it puts a year back. Probing the year-less form across the
-	// turn of a year measures that instead of the rendering the form produces,
-	// and locales whose ranges ICU re-years that way lose their elision.
+	// A year-less range spanning two years leaves ICU nothing to tell them apart
+	// by, so it puts a year back and such locales lose their elision.
 	describe( 'hu_HU site', () => {
 		beforeEach( () =>
 			setSettings( settingsFor( 'hu-HU-test', 'Y. F j.', HU_MONTHS, undefined, HU_MONTHS_SHORT ) )

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-hour-of-day.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-hour-of-day.test.ts
@@ -34,8 +34,7 @@ function withSite( timeFormat: string, offset: number, locale = 'en' ) {
  * The label with its spaces flattened.
  *
  * `Intl` separates the hour from its meridiem with a narrow no-break space, and
- * which space that is has moved between ICU versions. The tests are about the
- * hour, not the character between its parts.
+ * which space that is has moved between ICU versions.
  *
  * @param hour - Site-local hour, 0-23.
  * @return The label, with every space rendered as U+0020.

--- a/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
@@ -41,17 +41,12 @@ const SINGLE_PROBES = [
 const PROBE_FROM = SINGLE_PROBES[ 0 ];
 
 /**
- * The far end, per form: a date sharing no requested part with `PROBE_FROM`,
- * so nothing in the probe can be elided and both ends have to render whole.
+ * The far end, per form: a date sharing no requested part with `PROBE_FROM`, so
+ * nothing in the probe can be elided.
  *
- * Which year it falls in is what has to vary. A form carrying the year needs
- * the two ends in different ones, or the year elides and the probe measures an
- * elision rather than the full rendering it is checking for.
- *
- * The year-less form needs them in the same one. Asked to span two years with
- * no year to tell them apart, ICU puts one back to keep the range unambiguous.
- * That is right of ICU, but it is not a rendering this form ever produces, and
- * a probe that provokes it costs Hungarian and Czech their elision.
+ * A form carrying the year needs its ends in different years, or the year
+ * elides. The year-less form needs them in the same one — ICU puts a year back
+ * to disambiguate a two-year range, costing Hungarian and Czech their elision.
  */
 const PROBE_TO: Record< RangeFormatName, Date > = {
 	medium: new Date( Date.UTC( 2021, 1, 3, 12 ) ),
@@ -66,14 +61,9 @@ const normalizeSpaces = ( value: string ): string =>
 /**
  * The site's locale as a tag `Intl` accepts.
  *
- * WordPress sends its own locale name (`es_ES`, `de_DE_formal`), which first
- * needs underscores converted to BCP 47 separators. Some WordPress variants
- * remain invalid after that conversion, so subtags are dropped from the right
- * until a supported ancestor is found; for example, `pt_PT_ao90` resolves to
- * `pt-PT`.
- *
- * A structurally valid but unsupported tag is not usable: `Intl` would resolve
- * it to the visitor's locale, making range output depend on who views the site.
+ * WordPress sends its own locale name (`es_ES`, `pt_PT_ao90`), so subtags are
+ * dropped from the right until a supported ancestor is found. A structurally
+ * valid but unsupported tag would resolve to the visitor's locale instead.
  *
  * @return The supported tag, or `undefined` when no supported ancestor exists.
  */
@@ -100,21 +90,11 @@ export function intlLocale(): string | undefined {
 /**
  * Build a range formatter for the current settings, if one can be trusted.
  *
- * WordPress publishes whole date formats and no rules for eliding a month or
- * year shared by both ends of a range — but CLDR, which `Intl` is built on, has
- * them for every locale. They can only be borrowed where WordPress and `Intl`
- * agree on how dates look. Two checks establish that, so no allowlist of
- * trusted locales has to be kept in step with CLDR:
- *
- * 1. `Intl` renders representative dates exactly as `formatDate` does. A site
- *    with a custom `date_format` or different month translations fails here
- *    and keeps the format it asked for.
- * 2. `Intl` builds a range that cannot be elided out of that same rendering.
- *    Japanese and Chinese fail here: their range patterns use numeric dates
- *    and locale-specific separators instead of their single-date rendering.
- *
- * Both checks are run per form, since a locale can agree with WordPress on one
- * month width and not on the other.
+ * WordPress publishes no rules for eliding a month or year shared by both ends
+ * of a range; CLDR, which `Intl` is built on, has them. Two probes establish
+ * that the two agree — `Intl` renders like `formatDate`, and its range keeps
+ * that rendering — so no allowlist of trusted locales has to track CLDR. Run
+ * per form, since a locale can agree on one month width and not the other.
  *
  * @param name - The form to build the formatter for.
  * @return The formatter, or `undefined` when the two do not agree.
@@ -139,10 +119,8 @@ function buildRangeFormatter( name: RangeFormatName ): Intl.DateTimeFormat | und
 		return undefined;
 	}
 
-	// `formatRange` was added to ECMA-402 later than `Intl.DateTimeFormat`
-	// itself. Refusing the formatter here is what keeps a runtime that has the
-	// class but not the method on the spelled-out path, since every later call
-	// goes through a formatter this function returned.
+	// `formatRange` postdates `Intl.DateTimeFormat`; refusing here keeps a runtime
+	// that has the class but not the method on the spelled-out path.
 	if ( typeof formatter.formatRange !== 'function' ) {
 		return undefined;
 	}
@@ -168,9 +146,7 @@ const cache = new Map<
  * Format a range with the shared month or year elided, where the site's own
  * date format allows it.
  *
- * The probes in `buildRangeFormatter` run once per settings combination, so the
- * result is held against the locale, date format, and timezone it was derived
- * from.
+ * The probes in `buildRangeFormatter` run once per settings combination.
  *
  * @param from   - Start of the range.
  * @param to     - End of the range.

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date-range-long.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date-range-long.ts
@@ -21,14 +21,9 @@ type FormatDateRangeLongOptions = {
 	referenceYear?: number;
 
 	/**
-	 * Render the calendar shape (no weekday, always the year) whatever the
-	 * range measures.
-	 *
-	 * For selections whose scale is a property of the selection rather than of
-	 * the dates. A calendar year still running ends at the end of today, so its
-	 * measured length, and with it the shape, would otherwise change by the
-	 * day — and in its first week it would even measure short enough to lead
-	 * with a weekday.
+	 * Render the calendar shape (no weekday, always the year) whatever the range
+	 * measures — a calendar year still running would otherwise change shape by
+	 * the day.
 	 */
 	calendarScale?: boolean;
 };
@@ -104,30 +99,11 @@ function getSiteYear( date: Date | number ): number {
 }
 
 /**
- * Format a date range in the explicit, readable form the section header
- * subtitle uses.
+ * Format a date range in the explicit form the section header subtitle uses.
  *
- * The shape follows the range's own length, along two independent axes.
- *
- * A window of a week or less leads each end with its weekday, which is what
- * makes a rolling window legible at a glance and what a reader of one actually
- * asks of it. Past a week the weekday stops answering anything — nobody reads
- * a month by the day it opened on — and only costs two words in front of each
- * date, so it is dropped.
- *
- * The year is carried only where it disambiguates: a range that sits entirely
- * in the reference year drops it, so stepping back through past periods stays
- * unambiguous without repeating the current year on every render. Longer
- * ranges routinely straddle two years and pick it up on their own.
- *
- * A window of a day or less is named by a single date instead of a range.
- *
- * @example
- * formatDateRangeLong( { from, to } ) // 24 hours:    'Tuesday, July 28'
- *                                     // 7 days:      'Tuesday, July 21 – Monday, July 27'
- *                                     // past year:   'Tuesday, July 16, 2024 – Monday, July 22, 2024'
- *                                     // 30 days:     'July 21 – August 19'
- *                                     // 12 months:   'July 1, 2025 – June 30, 2026'
+ * The shape follows the range's own length: a week or less leads each end with
+ * its weekday, the year is carried only outside the reference year, and a day
+ * or less is named by a single date.
  *
  * @param range     - The range to format.
  * @param [options] - Formatting options.

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date-range.ts
@@ -61,23 +61,13 @@ const formatRange = (
  * Format a date range into a human-readable string.
  *
  * A shared month or year is elided where the site's locale has a rule for it —
- * see `elideRange`, which borrows those rules from CLDR rather than inventing
- * them. Eliding by hand is not an option: "Jun 21-25, 2025" is an English
- * typographic convention that, applied to a Spanish site, yields
- * "21 de junio-25 de junio de 2025". Where no rule can be trusted — a custom
- * `date_format`, or a locale whose ranges do not read like its single dates —
- * both ends are spelled out in full instead.
- *
- * Returns `''` when `range`, `from`, or `to` is missing.
+ * see `elideRange`. Eliding by hand is not an option: "Jun 21-25, 2025" is an
+ * English convention that on a Spanish site yields "21 de junio-25 de junio de
+ * 2025". Where no rule can be trusted, both ends are spelled out in full.
  *
  * @param range     - The range to format.
  * @param [options] - Formatting options.
- * @return The formatted range.
- *
- * @example
- * formatDateRange( { from, to } ) // same day:  'June 21, 2025'
- *                                 // elided:    'June 21 – 25, 2025'
- *                                 // spelt out: 'June 21, 2025 – June 25, 2025'
+ * @return The formatted range, or `''` when `range`, `from`, or `to` is missing.
  */
 export const formatDateRange = (
 	range?: DateRange,
@@ -87,22 +77,12 @@ export const formatDateRange = (
 /**
  * Format a date range with the month abbreviated.
  *
- * For controls sized by the row they sit in rather than by their content, where
- * a spelled-out month costs width the row does not have. Everything else
- * follows `formatDateRange`, including the elision, so the two stay one
- * typographic system.
- *
- * The abbreviation comes from WordPress's translation tables, so a locale that
- * does not shorten its month names is left with the full form and simply reads
- * the same as `formatDateRange`.
+ * For controls sized by their row rather than their content. The abbreviation
+ * comes from WordPress's translation tables, so a locale that does not shorten
+ * its month names reads the same as `formatDateRange`.
  *
  * @param range - The range to format.
  * @return The formatted range.
- *
- * @example
- * formatDateRangeCompact( { from, to } ) // same day:  'Jun 21, 2025'
- *                                        // elided:    'Jun 21 – 25, 2025'
- *                                        // spelt out: 'Jun 21, 2025 – Jun 25, 2025'
  */
 export const formatDateRangeCompact = ( range?: DateRange ): string =>
 	formatRange( 'compact', range );
@@ -110,21 +90,12 @@ export const formatDateRangeCompact = ( range?: DateRange ): string =>
 /**
  * Format a date range in the shortest form that still identifies it.
  *
- * For controls that carry a range as their own label, where every character is
- * width taken from something else on the row. It drops the year on top of what
- * `formatDateRangeCompact` already shortens, but only while the whole range
- * sits in the current year — a range anywhere else needs its year to say which
- * one it is, and reads as the compact form instead.
- *
- * "Current" is the site's own year, since the year each end falls in is read in
- * the site's timezone like every other date the dashboard renders.
+ * Drops the year on top of `formatDateRangeCompact`, but only while the whole
+ * range sits in the site's current year — a range anywhere else needs its year
+ * and reads as the compact form instead.
  *
  * @param range - The range to format.
  * @return The formatted range.
- *
- * @example
- * formatDateRangeMinimal( { from, to } ) // this year:  'Jul 24' / 'Jul 13 – 26'
- *                                        // any other: 'Jun 21, 2025'
  */
 export const formatDateRangeMinimal = ( range?: DateRange ): string => {
 	const { from, to } = range ?? {};

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
@@ -28,10 +28,8 @@ export type DateFormatName =
 /**
  * An instant to render, such as a `TZDate` or a timestamp.
  *
- * Narrower than what `dateI18n` accepts, to keep strings out: a date-only
- * string such as `'2026-01-01'` is read as browser-local midnight, so it
- * renders as the previous day for anyone ahead of the site. Parse site-local
- * strings with `parseSiteDateTime` first.
+ * Narrower than `dateI18n` accepts: a date-only string is read as browser-local
+ * midnight, so parse site-local strings with `parseSiteDateTime` first.
  */
 type DateInput = Date | number;
 
@@ -83,20 +81,12 @@ function formatFor( name: DateFormatName ): string {
 /**
  * Format a date in the site's locale and timezone.
  *
- * Month and weekday names come from WordPress's own translation tables, and
- * the ordering from the site's `date_format` option, so dates match the rest
- * of wp-admin rather than the browser's locale.
+ * Month and weekday names come from WordPress's translation tables and the
+ * ordering from `date_format`, so dates match wp-admin rather than the browser.
  *
  * @param date - The instant to render. See `DateInput`.
  * @param name - Named format. Defaults to `'medium'`.
  * @return The formatted date.
- *
- * @example
- * formatDate( date )                  // 'June 21, 2025'           — or '21 de junio de 2025'
- * formatDate( date, 'compact' )       // 'Jun 21, 2025'            — or '21 de jun de 2025'
- * formatDate( date, 'compactNoYear' ) // 'Jun 21'                  — or '21 de jun'
- * formatDate( date, 'short' )         // 'June 21'                 — or '21 de junio'
- * formatDate( date, 'full' )          // 'Saturday, June 21, 2025' — or 'sábado, 21 de junio de 2025'
  */
 export const formatDate = ( date: DateInput, name: DateFormatName = 'medium' ): string =>
 	dateI18n( formatFor( name ), date );
@@ -141,12 +131,9 @@ const LOWERCASE_MERIDIEM_TOKENS = new Set( [ 'a' ] );
 /**
  * Render an hour of the day the way the site's locale names one.
  *
- * `Intl` is asked for the hour rather than an hour-only pattern being derived
- * from `time_format`, which names minutes these buckets never carry. It also
- * supplies the unit a locale attaches to a bare hour (`19 Uhr`, `19時`), which
- * no subset of the site's format spells out. Only the clock's length and the
- * meridiem's case are still read from `time_format`: those are the site's
- * choice, not the locale's.
+ * `Intl` supplies the unit a locale attaches to a bare hour (`19 Uhr`, `19時`),
+ * which no subset of `time_format` spells out. Only the clock's length and the
+ * meridiem's case are read from `time_format` — those are the site's choice.
  *
  * @param hour - Site-local hour, 0–23.
  * @return The localized hour label, e.g. `7 pm`, `19`, or `19時`.

--- a/projects/packages/premium-analytics/packages/formatters/src/date/php-format.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/php-format.ts
@@ -36,9 +36,8 @@ type Segment = {
 /**
  * Split a PHP format string into tokens and literals.
  *
- * Backslash escapes have to be honoured rather than scanned past: `es_ES`
- * ships `j \d\e F \d\e Y`, where `\d` and `\e` spell the word "de" but are
- * also the letters for the day and timezone tokens.
+ * Backslash escapes have to be honoured rather than scanned past: `es_ES` ships
+ * `j \d\e F \d\e Y`, where `\d` and `\e` spell "de" but are also date tokens.
  *
  * @param phpFormat - PHP `date()` format string.
  * @return The segments, in order.
@@ -80,17 +79,10 @@ export function hasToken( phpFormat: string, tokens: Set< string > ): boolean {
 }
 
 /**
- * Remove the year from a PHP format string, along with the punctuation that
- * introduces it.
+ * Remove the year from a PHP format string, with its adjoining punctuation.
  *
- * WordPress only publishes whole date formats, so a month-and-day format has
- * to be derived from one. The separator run adjoining the year is taken with
- * it — the run on the side facing the rest of the format, which is the side
- * the punctuation belongs to (`F j, Y` → `F j`, but `Y-m-d` → `m-d`). Where
- * the year is the last token, any literal trailing it goes too, since it was
- * qualifying the year (`j F Y г.` → `j F`). A dot immediately before a
- * trailing year is retained because dot-separated locales use it to terminate
- * the preceding ordinal (`j.n.Y` → `j.n.`).
+ * WordPress only publishes whole date formats, so a month-and-day format has to
+ * be derived from one (`F j, Y` → `F j`, but `Y-m-d` → `m-d`).
  *
  * @param phpFormat - PHP `date()` format string.
  * @return The format without its year, or unchanged when it has none.
@@ -120,9 +112,8 @@ export function withoutYear( phpFormat: string ): string {
 
 	if ( precedingToken >= 0 ) {
 		start = precedingToken + 1;
-		// In dot-separated formats the dot also marks the preceding numeric
-		// day or month as ordinal (`j.n.Y` → `j.n.`). Keep it while dropping
-		// any whitespace before the year.
+		// In dot-separated formats the dot also marks the preceding day or month
+		// as ordinal (`j.n.Y` → `j.n.`), so keep it.
 		if ( segments[ start ]?.source === '.' ) {
 			start++;
 		}
@@ -145,9 +136,7 @@ export function withoutYear( phpFormat: string ): string {
  * Abbreviate the month in a PHP format string.
  *
  * The abbreviation itself still comes from WordPress's translation tables, so a
- * locale that does not shorten its month names keeps them whole. Formats that
- * number the month rather than name it are returned unchanged, having nothing
- * to abbreviate.
+ * locale that does not shorten its month names keeps them whole.
  *
  * @param phpFormat - PHP `date()` format string.
  * @return The format with a three-letter month, or unchanged when it names none.
@@ -164,9 +153,8 @@ export function withShortMonth( phpFormat: string ): string {
  * Put the weekday in front of a PHP format string.
  *
  * WordPress publishes no weekday-bearing format, so one has to be derived from
- * the site's. The weekday name still comes from WordPress's translation
- * tables; only the separator is ours, and only the leading position is assumed
- * — every locale core ships puts the weekday first when it names one at all.
+ * the site's. Only the separator is ours, and only the leading position is
+ * assumed — every locale core ships puts the weekday first when it names one.
  *
  * @param phpFormat - PHP `date()` format string.
  * @return The format led by its weekday, or unchanged when it already has one.

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/build-range-patch.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/build-range-patch.test.ts
@@ -1,10 +1,7 @@
 /**
- * Pin the site timezone to UTC so day-bound math is deterministic regardless
- * of the machine timezone running the tests. `siteTimeZone()` is the leaf
- * every timezone read resolves through, so stubbing it alone pins paths a
- * barrel stub cannot reach (the interval rules get `localTZDate` through a
- * relative import, not the `data` barrel) while keeping the real range and
- * interval implementations under test.
+ * Pin the site timezone to UTC for deterministic day-bound math. Stubs
+ * `siteTimeZone()` directly rather than the `datetime` barrel: the interval
+ * rules import `localTZDate` via a relative path a barrel stub can't reach.
  */
 jest.mock( '@jetpack-premium-analytics/datetime', () => ( {
 	...jest.requireActual( '@jetpack-premium-analytics/datetime' ),

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/build-range-patch.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/build-range-patch.ts
@@ -68,12 +68,9 @@ export function buildRangePatch( {
 
 	if ( nextRange?.from && nextRange.to ) {
 		/*
-		 * Preset and exact ranges are authoritative: rolling windows end at
-		 * the current time, not at a day boundary. Calendar and manual edits
-		 * stage midnight `to` dates, so only those are adjusted to the end of
-		 * the day — the site's day, not the visitor's: date-fns' bare
-		 * `endOfDay` would use the browser's boundary and stretch the range
-		 * for visitors west of the site timezone.
+		 * Preset/exact ranges are authoritative and skip end-of-day adjustment;
+		 * calendar edits stage midnight `to`, adjusted to the *site's* end of day —
+		 * date-fns' bare `endOfDay` would use the browser's and stretch the range.
 		 */
 		const rangeFrom = encodeDateToSearchParam( nextRange.from );
 		const rangeTo = encodeDateToSearchParam(
@@ -84,11 +81,8 @@ export function buildRangePatch( {
 		patch.from = rangeFrom;
 		patch.to = rangeTo;
 
-		/*
-		 * The interval carries across the change and the new range's rules
-		 * decide: a bucket it still allows survives, one it does not coerces to
-		 * the finest allowed.
-		 */
+		// The interval carries across the change; the new range's rules decide
+		// whether it survives or coerces to the finest allowed.
 		patch.interval = resolveIntervalForRange(
 			nextPresetId,
 			rangeFrom,

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
@@ -73,11 +73,9 @@ export type ReportDateFilters = {
 	onStep: ( direction: StepDirection ) => void;
 
 	/**
-	 * Open the chart bucket containing a date: narrow the applied window to that
-	 * bucket, which drops the reading to the next finer interval.
-	 *
-	 * `interval` is the bucket size the chart drew, for a chart that clamps the
-	 * applied interval into the sizes it offers. Defaults to the applied one.
+	 * Open the chart bucket containing a date, narrowing to the next finer
+	 * interval. `interval` is the bucket size the chart drew; defaults to the
+	 * applied interval.
 	 */
 	drillDown: ( date: Date, interval?: IntervalType ) => void;
 
@@ -87,14 +85,9 @@ export type ReportDateFilters = {
 	timeZone: string;
 
 	/**
-	 * Stage a primary range change and commit it in the same tick, replacing the
-	 * current history entry instead of pushing one.
-	 *
-	 * For range changes the page makes on the user's behalf rather than in
-	 * response to a date edit — reconciling the preset with what the current
-	 * screen can show, for instance. Those must not leave a Back step, or Back
-	 * would return to the state that triggered the reconciliation and be
-	 * corrected straight back out of.
+	 * Stage and commit a range change without pushing a history entry — for
+	 * programmatic reconciliation (not a direct date edit), so Back can't loop
+	 * into the state that triggered the reconciliation.
 	 */
 	replaceRange: ( range: DateRange, presetId: PrimaryPresetId ) => void;
 };
@@ -170,13 +163,9 @@ export function useReportDateFilters< TFrom extends string >( from?: TFrom ): Re
 	);
 
 	/*
-	 * The applied comparison, for surfaces that describe what the widgets are
-	 * actually showing rather than what the picker is drafting. A comparison
-	 * change normally commits on its own, but it rides along uncommitted when a
-	 * primary edit is already staged, so this cannot read `effective`.
-	 *
-	 * Gated on the same predicate the report params run through, so a surface
-	 * can never announce a comparison the widgets did not request.
+	 * Applied, not staged: a comparison commits on its own but can ride
+	 * uncommitted alongside a staged primary edit, so this can't read `effective`.
+	 * Gated like the report params, so it never shows an unrequested comparison.
 	 */
 	const { appliedComparisonPresetId, appliedComparisonRange } = useMemo( () => {
 		if ( ! hasComparisonEnabled( committed ) ) {
@@ -206,10 +195,9 @@ export function useReportDateFilters< TFrom extends string >( from?: TFrom ): Re
 		effective.preset !== committed.preset;
 
 	/*
-	 * The buckets the interval control lists, and the one it checks. Both read
-	 * the applied range: the control sits outside the picker, so a range being
-	 * drafted must not reshape the menu, and resolving the value through the
-	 * same range that produced the options keeps the checked item a listed one.
+	 * The buckets the control lists and the one it checks both read the applied
+	 * range, so a drafted-but-unapplied range can't reshape the menu or disagree
+	 * with the checked item.
 	 */
 	const intervalOptions = useMemo(
 		() => getAllowedIntervalsForPreset( appliedPresetId, committed.from ?? '', committed.to ?? '' ),
@@ -241,10 +229,9 @@ export function useReportDateFilters< TFrom extends string >( from?: TFrom ): Re
 	);
 
 	/**
-	 * Comparison changes commit immediately — but only when the primary date
-	 * isn't mid-edit. If a primary edit is staged but not yet applied, the
-	 * comparison change rides along and commits together on Apply, so tweaking
-	 * the comparison never commits an un-applied primary draft.
+	 * Comparison changes commit immediately, unless a primary edit is staged —
+	 * then it rides along and commits with it on Apply, so a comparison tweak
+	 * never commits an un-applied primary draft.
 	 */
 	const onComparisonChange = useCallback(
 		( nextComparisonRange: DateRange | undefined, nextComparisonPresetId?: ComparisonPresetId ) => {
@@ -278,11 +265,9 @@ export function useReportDateFilters< TFrom extends string >( from?: TFrom ): Re
 	);
 
 	/*
-	 * Commits on click and pushes a history entry, so Back undoes the step and
-	 * the stepped window survives a reload as real URL state.
-	 *
-	 * Steps the applied range, not the staged one: the arrows sit outside the
-	 * picker, so stepping is not the gesture that applies someone's open draft.
+	 * Commits and pushes a history entry so Back undoes the step. Steps the
+	 * applied range, not the staged one — the arrows sit outside the picker,
+	 * so stepping must not apply an open draft.
 	 */
 	const onStep = useCallback(
 		( direction: StepDirection ) => {
@@ -308,21 +293,16 @@ export function useReportDateFilters< TFrom extends string >( from?: TFrom ): Re
 	);
 
 	/*
-	 * Commits on click and pushes a history entry, like `onStep`, so Back is the
-	 * way out of a drill-down and the narrowed window survives a reload.
-	 *
-	 * Reads the applied range rather than the staged one: the chart draws what
-	 * is applied, so the bucket the user clicked belongs to that window, not to
-	 * a draft the picker is holding. The same goes for the interval, unless the
-	 * chart names the size it actually drew.
+	 * Commits and pushes a history entry, like `onStep`, so Back exits a
+	 * drill-down. Reads the applied range/interval, not the staged one: the
+	 * chart draws what's applied, so the click belongs to that window.
 	 */
 	const drillDown = useCallback(
 		( date: Date, bucketInterval: IntervalType = appliedInterval ) => {
 			/*
-			 * `drillDateRange` closes a bucket on the clock of the date handed to it,
-			 * so the click is re-anchored in the site's zone first. A caller may pass
-			 * a plain instant, which would otherwise cut the bucket on the browser's
-			 * clock and open the wrong day west or east of the site.
+			 * Re-anchored to the site zone first: `drillDateRange` closes a bucket
+			 * on the clock of the date passed in, and a plain instant would cut it
+			 * on the browser's clock instead.
 			 */
 			const drilled = drillDateRange( toLocalTZ( date, timeZone ), bucketInterval, new Date() );
 

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-search/use-staged-search.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-search/use-staged-search.tsx
@@ -111,7 +111,7 @@ export function useStagedSearch< TSearch extends AnyObject, TFrom extends string
 
 	const [ staged, setStaged ] = useState< TSearch >( committed );
 
-	const [ isSyncing, setIsSyncing ] = useState( false ); // not used yet
+	const [ isSyncing, setIsSyncing ] = useState( false );
 
 	// Buffer for not-yet-committed changes.
 	const bufferRef = useRef< Partial< TSearch > >( {} );
@@ -174,10 +174,9 @@ export function useStagedSearch< TSearch extends AnyObject, TFrom extends string
 	);
 
 	/**
-	 * Commit all staged changes in a single atomic navigate().
-	 * - No `to`: keep the current route (prevents heavy remounts).
-	 * - Default `replace` to false so history is preserved on explicit commits.
-	 * - Cancels any pending debounced commit.
+	 * Commit all staged changes in a single atomic navigate(). No `to`: keeps
+	 * the current route to avoid a heavy remount. Defaults `replace` to false so
+	 * explicit commits still push history.
 	 */
 	const commit = useCallback(
 		( commitOpts?: { replace?: boolean } ) => {

--- a/projects/packages/premium-analytics/packages/routing/src/search/comparison/__tests__/derive-comparison-range.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/comparison/__tests__/derive-comparison-range.test.ts
@@ -73,10 +73,8 @@ describe( 'deriveComparisonRange', () => {
 		} );
 	} );
 
-	// A hand-typed deep link carries no offset. Reading it as a UTC instant would
-	// put a site west of Greenwich on the previous calendar day and, because the
-	// range would no longer sit on day boundaries, derive a rolling window
-	// instead of the previous period the picker shows.
+	// A hand-typed deep link carries no offset; reading it as UTC would land a
+	// site west of Greenwich on the wrong calendar day and derive the wrong window.
 	it( 'anchors an offset-less range to the site zone', () => {
 		siteOn( 'America/New_York', -4 );
 
@@ -93,9 +91,8 @@ describe( 'deriveComparisonRange', () => {
 		} );
 	} );
 
-	// A link saved while the preset existed drops its comparison rather than
-	// deriving a range the picker can no longer show. Typed as a string
-	// because that is what the URL carries, whatever the current set is.
+	// A link saved under a preset since removed drops its comparison rather
+	// than deriving a range the picker can no longer show.
 	it( 'returns undefined for a preset outside the current set', () => {
 		const presetFromOldUrl: string = 'previous-week';
 

--- a/projects/packages/premium-analytics/packages/routing/src/search/comparison/derive-comparison-range.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/comparison/derive-comparison-range.ts
@@ -38,14 +38,9 @@ const toComparisonPresetId = ( value?: string ): ComparisonPresetId | undefined 
 };
 
 /**
- * Derive compare_from/compare_to from the main range + preset,
- * honoring the site's timezone via existing data utils.
- *
- * Rules:
- * - Only derive when comparison is enabled (comp === "1") AND a preset is present.
- * - The main range is interpreted in the site timezone; day-aligned ranges get
- *   day-aligned comparisons, sub-day rolling windows are mirrored exactly.
- * - Return ISO strings WITH site offset (same format you write to the URL).
+ * Derive compare_from/compare_to for the main range + preset, in the site
+ * timezone: day-aligned ranges get day-aligned comparisons, rolling windows
+ * mirror the exact window. Returns ISO strings with the site offset.
  */
 export function deriveComparisonRange( opts: ReportParams ):
 	| {
@@ -65,13 +60,9 @@ export function deriveComparisonRange( opts: ReportParams ):
 	}
 
 	/*
-	 * Parse the URL params through the same reader the picker uses, so an
-	 * offset-less `from`/`to` anchors to the site zone here too. Parsing them as
-	 * raw instants would put a date-only deep link on UTC midnight, which is a
-	 * different calendar day — and a different alignment — than the picker shows.
-	 * Day boundaries then resolve site-locally: day-aligned ranges keep
-	 * day-aligned comparisons; rolling windows (e.g. last-24-hours) mirror the
-	 * exact window.
+	 * Same reader the picker uses, so an offset-less `from`/`to` anchors to the
+	 * site zone here too — a raw instant would put a date-only deep link on UTC
+	 * midnight, a different calendar day than the picker shows.
 	 */
 	const timezone = siteTimeZone();
 	const reference = {
@@ -88,7 +79,6 @@ export function deriveComparisonRange( opts: ReportParams ):
 		return undefined;
 	}
 
-	// Serialize back to ISO with site offset (string-to-string stable)
 	return {
 		compare_from: dateToISOStringWithLocalTZ( cmp.from ),
 		compare_to: dateToISOStringWithLocalTZ( cmp.to ),

--- a/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.ts
@@ -23,9 +23,8 @@ export function decodeDateSearchParam( value?: string, timezone?: string ): Date
 }
 
 /**
- * Serializes a Date into an ISO string with the site's timezone
- * (or returns an empty string if no date is provided).
- * Useful for writing dates to the URL and for API requests.
+ * Serialize a Date into an ISO string with the site's timezone, for writing
+ * to the URL or API requests.
  */
 export function encodeDateToSearchParam( date?: Date, timezone?: string ): string | undefined {
 	return date ? dateToISOStringWithLocalTZ( localTZDate( date, timezone ) ) : undefined;
@@ -45,14 +44,9 @@ type WriteDateRangeToSearchProps = {
 };
 
 /**
- * Writes a DateRange to the URL using navigate().
- *
- * - Centralizes the conversion from Date -> ISO(+offset) according to
- *   the site's timezone.
- * - If you need to preserve/propagate `interval` or other params,
- *   pass them in `search`.
- * - Note: whether other existing params are preserved depends on the
- *   router's navigate implementation. This helper sets an explicit object.
+ * Write a DateRange to the URL, converting each end to ISO+offset in the
+ * site's timezone. Pass `interval` or other params via `search` to keep them
+ * alongside `from`/`to`.
  */
 export function writeDateRangeToSearch( {
 	navigate,

--- a/projects/packages/premium-analytics/packages/site-sync/src/hooks/use-sync-status.ts
+++ b/projects/packages/premium-analytics/packages/site-sync/src/hooks/use-sync-status.ts
@@ -25,15 +25,9 @@ function readMilestone(): number {
 }
 
 /**
- * Polls Jetpack's sync status and returns analytics-scoped progress.
- *
- * Polling auto-stops when the sync completes or stalls, or after
- * `MAX_POLL_FAILURES` consecutive fetch errors; a single transient error is
- * retried on the next tick and self-heals on the next success. If the
- * page-load milestone is already set, the status reports complete immediately
- * and no polling occurs. `triggerSync` POSTs the full-sync trigger and resumes
- * polling; it never rejects (failures surface via `error`), and a start that
- * failed keeps reporting until a poll proves the sync is under way.
+ * Polls Jetpack's sync status; analytics-scoped progress. Auto-stops on
+ * completion, stall, or `MAX_POLL_FAILURES` consecutive errors (a single
+ * failure self-heals). `triggerSync` never rejects — failures surface via `error`.
  *
  * @param options           - Hook options.
  * @param options.enabled   - Whether to watch the sync at all.
@@ -47,10 +41,9 @@ export function useSyncStatus( {
 	const milestoneRef = useRef< number >( readMilestone() );
 	const [ data, setData ] = useState< SyncStatus >();
 	const [ error, setError ] = useState< Error | null >( null );
-	// A start that failed leaves nothing running, so no amount of successful
-	// polling disproves it: only the analytics module appearing in the sync
-	// progress does. Held apart from the poll's own errors, which a single
-	// success clears, so the retry stays on screen until the sync is under way.
+	// A start that failed isn't disproven by mere polling success — only the
+	// analytics module appearing in progress clears it. Held apart from the
+	// poll's own errors so the retry banner survives until sync is under way.
 	const startErrorRef = useRef< Error | null >( null );
 
 	const intervalRef = useRef< ReturnType< typeof setInterval > | null >( null );
@@ -58,8 +51,7 @@ export function useSyncStatus( {
 	// (re)starts; polling only gives up once this reaches `MAX_POLL_FAILURES`.
 	const failureCountRef = useRef( 0 );
 	// Hold the latest `poll` in a ref so the interval always calls the current
-	// closure. Preserves the original package's pollRef pattern and keeps the
-	// interval stable if `poll`'s identity ever changes.
+	// closure, keeping the interval stable across `poll` identity changes.
 	const pollRef = useRef< () => void >();
 
 	const clearPolling = useCallback( () => {
@@ -72,9 +64,8 @@ export function useSyncStatus( {
 	const poll = useCallback( () => {
 		fetchSyncStatus()
 			.then( raw => {
-				// Refresh the milestone live: the backend exposes the persisted
-				// value on every /sync/status response, so it can flip mid-session
-				// even though the script-data seed was captured once at mount.
+				// Refresh the milestone live: the backend exposes it on every poll,
+				// so it can flip mid-session even though script-data was seeded once.
 				const live = raw.initial_full_sync_finished ?? 0;
 				if ( live > milestoneRef.current ) {
 					milestoneRef.current = live;

--- a/projects/packages/premium-analytics/packages/site-sync/src/status.test.ts
+++ b/projects/packages/premium-analytics/packages/site-sync/src/status.test.ts
@@ -104,10 +104,9 @@ describe( 'toSyncStatus', () => {
 	} );
 
 	it( 'is not started or stalled after the connection-time initial_sync (no analytics bucket)', () => {
-		// Jetpack runs a lightweight initial_sync on connection (options/functions/
-		// users only) that sets started/finished but never includes the analytics
-		// module. Treat this as "not started yet" so the analytics sync auto-starts,
-		// rather than classifying the finished initial_sync as a stalled analytics sync.
+		// Jetpack's lightweight connection-time initial_sync sets started/finished
+		// but never touches the analytics bucket — treat it as "not started yet"
+		// so the analytics sync still auto-starts, instead of reading it as stalled.
 		const status = toSyncStatus(
 			{
 				started: true,

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/dataviews-drilldown-native.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/dataviews-drilldown-native.tsx
@@ -37,12 +37,9 @@ type CollapseContextValue = {
 	forcedIds: ReadonlySet< string >;
 	onToggle: ( id: string ) => void;
 	/**
-	 * The consumer's own title field and id resolver, which the grafted cell
-	 * renders through. They travel by context rather than by closure so the
-	 * grafted `render` can stay one module-level component: a per-render
-	 * component identity would remount the cell and drop focus from the
-	 * toggle whenever the consumer's `fields` array is a fresh reference.
-	 * `Item` is erased here because one context serves every instantiation.
+	 * Travels by context, not closure, so the grafted `render` stays one
+	 * module-level component — a per-render identity would remount the cell
+	 * and drop toggle focus. `Item` is erased since one context serves all.
 	 */
 	titleField?: Field< unknown >;
 	getItemId: ( item: unknown ) => string;
@@ -51,10 +48,9 @@ type CollapseContextValue = {
 const CollapseContext = createContext< CollapseContextValue | null >( null );
 
 /**
- * `DataViews`' own `getItemId` prop is conditionally optional on `Item` having
- * an `id: string`, which TypeScript cannot discharge for an unresolved
- * generic. This table always requires `getItemId`, so erase the conditional
- * behind an alias that reflects that.
+ * `DataViews`' `getItemId` prop is conditionally optional based on `Item`
+ * having `id: string`, which TS can't discharge for an unresolved generic.
+ * This table always requires it, so erase the conditional via an alias.
  */
 const GenericDataViews = DataViews as unknown as < Item >( props: {
 	view: View;
@@ -72,11 +68,9 @@ const GenericDataViews = DataViews as unknown as < Item >( props: {
 } ) => ReturnType< typeof DataViews >;
 
 /**
- * The title field's cell with the fold control prepended.
- *
- * Module-level on purpose: this is the `render` the component grafts onto the
- * consumer's title field, and a `render` rebuilt per render would remount the
- * cell — taking the focused toggle with it.
+ * The title field's cell with the fold control prepended. Module-level on
+ * purpose: a `render` rebuilt per render would remount the cell and take the
+ * focused toggle with it.
  */
 function CollapsibleTitleCell< Item >( props: DataViewRenderFieldProps< Item > ) {
 	const collapse = useContext( CollapseContext );
@@ -144,11 +138,9 @@ export interface DataViewsDrilldownNativeProps< Item > {
 }
 
 /**
- * Render flat parent/child rows through DataViews' native hierarchy support
- * (`view.showLevels` + `getItemLevel`), keeping the hierarchy legible across
- * interactions: search and filter keep each match under its ancestors, sort
- * orders within each level (not a flat global sort), and rows are emitted in
- * depth-first order before pagination. Pass `collapsible` to fold branches.
+ * Render flat parent/child rows through DataViews' native hierarchy support,
+ * keeping search/filter/sort legible across the hierarchy (matches keep their
+ * ancestors, sort is per-level, rows emit depth-first). `collapsible` folds branches.
  */
 export function DataViewsDrilldownNative< Item >( {
 	data,
@@ -180,15 +172,13 @@ export function DataViewsDrilldownNative< Item >( {
 		} as View;
 	} );
 
-	// The rows the reader has toggled away from `defaultExpanded`, rather than
-	// the expanded ids themselves: rows that arrive later (an async load, a
-	// filter change) then follow the default instead of coming back folded.
+	// Rows toggled away from `defaultExpanded`, not the expanded ids: rows
+	// arriving later (async load, filter change) follow the default instead.
 	const [ toggledIds, setToggledIds ] = useState< ReadonlySet< string > >( () => new Set() );
 	const expandedByDefault = defaultExpanded !== 'none';
 
-	// Keep the hierarchy legible instead of the flat `filterSortAndPaginate`
-	// semantics: match, re-attach ancestors, re-emit in hierarchy order, then
-	// paginate. Runs over the in-memory rows, so the extra passes are cheap.
+	// Keeps the hierarchy legible instead of `filterSortAndPaginate`'s flat
+	// semantics — cheap since it runs over the in-memory rows.
 	const { pageData, levelById, paginationInfo, parentIds, forcedIds, isExpanded } = useMemo( () => {
 		// 1. Match: apply the view's search + filters only (no sort, one page).
 		const matches = filterSortAndPaginate(
@@ -198,9 +188,8 @@ export function DataViewsDrilldownNative< Item >( {
 		).data;
 		const matchedIds = new Set( matches.map( getItemId ) );
 
-		// 2. Re-attach each match's ancestors (so filtered children stay under
-		//    their parents instead of orphaned) and descendants (so a matched
-		//    parent keeps the group its aggregate describes).
+		// 2. Re-attach ancestors (so filtered children stay under their parents)
+		//    and descendants (so a matched parent keeps its aggregate group).
 		const subset = withHierarchyContext( data, matchedIds, getItemId, getItemParentId );
 
 		// 3. Sort within levels: sort the subset flat, then re-emit in hierarchy
@@ -216,9 +205,8 @@ export function DataViewsDrilldownNative< Item >( {
 			getItemParentId
 		);
 
-		// 4. Fold the collapsed branches away. A narrowed table must still answer
-		//    the search that narrowed it, so the matches' ancestors unfold for as
-		//    long as the search or filter is on.
+		// 4. Fold collapsed branches away. A narrowed table must still answer the
+		//    search that narrowed it, so matched ancestors stay unfolded meanwhile.
 		const isNarrowed = matches.length !== data.length;
 		const forcedRowIds =
 			collapsible && isNarrowed
@@ -234,10 +222,8 @@ export function DataViewsDrilldownNative< Item >( {
 			? findParentIds( orderedData, getItemId, getItemParentId )
 			: NO_IDS;
 
-		// 5. Paginate the rows that survived, so folded children stop consuming
-		//    pages. Folding cannot strand the reader past the last page: the rows
-		//    a fold removes all follow the folded row, which is on the page they
-		//    folded it from.
+		// 5. Paginate the survivors, so folded children stop consuming pages —
+		//    this can't strand the reader, since removed rows follow the folded one.
 		const perPage = view.perPage ?? 10;
 		const page = view.page ?? 1;
 		const start = ( page - 1 ) * perPage;
@@ -250,9 +236,8 @@ export function DataViewsDrilldownNative< Item >( {
 				totalPages: Math.max( 1, Math.ceil( visibleData.length / perPage ) ),
 			},
 			parentIds: parentRowIds,
-			// A forced-open row keeps its control but must not write a fold the
-			// reader cannot see take effect — it would only surface once the
-			// search clears.
+			// A forced-open row keeps its control but must not write a fold that
+			// takes effect invisibly — it would only surface once the search clears.
 			forcedIds: forcedRowIds,
 			isExpanded: isExpandedForRow,
 		};
@@ -296,8 +281,7 @@ export function DataViewsDrilldownNative< Item >( {
 	);
 
 	// The fold control belongs to the title cell — the only column DataViews
-	// renders levels on — so it is grafted onto the consumer's title field
-	// rather than asked for in every field config.
+	// renders levels on — so it's grafted on rather than asked for per field.
 	const displayFields = useMemo( () => {
 		if ( ! collapsible ) {
 			return fields;
@@ -315,11 +299,9 @@ export function DataViewsDrilldownNative< Item >( {
 		[ levelById, getItemId ]
 	);
 
-	// DataViews' appearance panel force-sets `showLevels: false` when you sort
-	// (native levels assume the default order). Our pipeline sorts within each
-	// level, so re-assert `showLevels: true` on every view change.
-	// TODO(upstream): DataViews shouldn't drop levels when the consumer's sort
-	// preserves the hierarchy; worth upstreaming so this workaround can go.
+	// DataViews clears `showLevels` on sort (assumes default order); we sort
+	// within each level, so re-assert it here.
+	// TODO(upstream): stop dropping levels when the sort preserves hierarchy.
 	const handleChangeView = useCallback(
 		( nextView: View ) => setView( { ...nextView, showLevels: true } ),
 		[]

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/process-hierarchy-levels.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/process-hierarchy-levels.ts
@@ -20,26 +20,17 @@ type ProcessedHierarchyLevels< Item > = {
 	/** The items re-emitted in depth-first hierarchy order. */
 	data: Item[];
 	/**
-	 * Depth per item id, for DataViews' `getItemLevel`. Keyed by id rather
-	 * than item identity because DataViews clones each record internally (for
-	 * position tracking), so the objects reaching `getItemLevel` are never the
-	 * ones this walk saw.
+	 * Depth per item id, for `getItemLevel`. Keyed by id, not item identity:
+	 * DataViews clones each record internally, so `getItemLevel` never sees
+	 * the objects this walk saw.
 	 */
 	levelById: ReadonlyMap< string, number >;
 };
 
 /**
- * Resolve flat parent/child rows into what DataViews' native hierarchy
- * support consumes: the rows re-emitted in depth-first hierarchy order, and a
- * depth per item for `getItemLevel`.
- *
- * This is the only preprocessing the native `view.showLevels` rendering
- * needs — DataViews displays the level marker per row but does not order the
- * rows itself, so consumers (like the Gutenberg Pages screen) supply both.
- * Rows whose parent is absent from the data (or self-referential) become
- * roots. Ids are expected to be stable, non-empty, and unique (DataViews
- * requires that too); colliding ids degrade the parent/child wiring, but no
- * row is ever dropped.
+ * Resolve flat parent/child rows into depth-first hierarchy order plus a
+ * depth per item for `getItemLevel`. Rows with a missing or self-referential
+ * parent become roots; no row is ever dropped, even on a cycle or id collision.
  *
  * @param data            - Flat rows: parents and children mixed.
  * @param getItemId       - Row id resolver.
@@ -103,26 +94,15 @@ export function processHierarchyLevels< Item >(
 }
 
 /**
- * Given the ids of the rows a search or filter matched, return those rows plus
- * the rows needed to read each match in its hierarchy, in the original `data`
- * order (ready for {@link processHierarchyLevels}):
- *
- * - **Ancestors** of a match, so a matching child stays under its parents
- *   instead of orphaned.
- * - **Descendants** of a match, so a matching parent keeps its group. Without
- *   this a matched parent renders alone while still showing the aggregate its
- *   children explain — reading as a group that has no children at all.
- *
- * Descendants are collected only for the matches themselves, never for the
- * ancestors pulled in above them, so a match never drags in its siblings. Both
- * walks stop on a missing, self-referential, or already-visited id, so cycles
- * cannot loop.
+ * Given matched row ids, return those rows plus their ancestors (so a
+ * matching child stays under its parents) and descendants (so a matching
+ * parent keeps its group) — never a match's siblings. Cycle-safe.
  *
  * @param data            - The full flat rows.
  * @param matchedIds      - Ids (from `getItemId`) of the rows that matched.
  * @param getItemId       - Row id resolver.
  * @param getItemParentId - Parent id resolver.
- * @return The matched rows plus their ancestors and descendants, in `data` order.
+ * @return The matched rows plus ancestors and descendants, in `data` order.
  */
 export function withHierarchyContext< Item >(
 	data: Item[],
@@ -139,9 +119,8 @@ export function withHierarchyContext< Item >(
 		while ( current ) {
 			const parentId = resolveParentId( getItemParentId( current ) );
 
-			// Stop at a root, a self-referential parent, or one already kept
-			// (the last also breaks cycles, since a kept id's ancestors are
-			// guaranteed collected).
+			// Stop at a root, self-referential parent, or one already kept — the
+			// last also breaks cycles, since a kept id's ancestors are already collected.
 			if ( ! parentId || parentId === getItemId( current ) || keep.has( parentId ) ) {
 				break;
 			}

--- a/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/date-comparison-dropdown.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/date-comparison-dropdown.tsx
@@ -84,15 +84,9 @@ export function DateComparisonDropdown( {
 	);
 
 	/*
-	 * Additive: `Compare +` until a preset is picked, then a trigger naming it.
-	 * Both open the same menu, so the way back to "No comparison" is the way in.
-	 *
-	 * The additive state spells itself out rather than offering a bare `+`: a
-	 * glyph alone left the one control on the row that adds something reading
-	 * as decoration, and its purpose behind a hover.
-	 *
-	 * It names the preset rather than the period it resolves to, which the
-	 * section header's subtitle already spells out.
+	 * Additive: `Compare +` until a preset is picked, then a trigger naming it —
+	 * spelled out rather than a bare `+`, since a glyph alone read as decoration.
+	 * Names the preset, not the period: the section header's subtitle covers that.
 	 */
 	return (
 		<DropdownMenu
@@ -110,9 +104,8 @@ export function DateComparisonDropdown( {
 				// A tooltip only where the trigger's text is an abbreviation.
 				// Over the additive state it would repeat the label beneath it.
 				showTooltip: isComparisonActive,
-				// The trigger shows an abbreviation, so carry the full preset
-				// name for anyone not reading the glyphs. Same treatment the
-				// preset pills give their short labels.
+				// The trigger shows an abbreviation, so carry the full preset name
+				// for anyone not reading the glyphs — same as the preset pills.
 				'aria-label': selectedPreset?.label,
 			} }
 		>

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
@@ -189,9 +189,8 @@ describe( 'DateFiltersPanel', () => {
 		);
 	} );
 
-	// The custom trigger used to keep labelling itself with the range it held
-	// before the preset took over, putting two different ranges on screen at
-	// once (WOOA7S-1936).
+	// The custom trigger used to keep showing the pre-preset range, putting two
+	// different ranges on screen at once (WOOA7S-1936).
 	it( 'drops the custom range from the trigger once a preset takes over', () => {
 		mockContainerResize();
 		const customRange = {

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
@@ -138,20 +138,15 @@ export type DateFiltersPanelProps = {
 
 	/**
 	 * Element to measure for the responsive layout instead of the panel's own
-	 * root. Required when the panel sits in a shrink-to-fit slot (e.g. sharing
-	 * a header row with a title): there the root's width follows the panel's
-	 * own content, so self-measurement could neither collapse when narrow nor
-	 * expand back when widened. Callers whose panel fills its container should
-	 * omit it.
+	 * root. Required in a shrink-to-fit slot (e.g. a shared header row), where
+	 * the root's width follows the panel's own content and can't self-measure.
 	 */
 	containerElement?: HTMLElement | null;
 
 	/**
-	 * Inline space in the measured container that is never available to the
-	 * panel — e.g. a title's minimum share on a shared header row. Subtracted
-	 * from the measured width before resolving the responsive layout, so the
-	 * panel steps down while its row-mates still have their minimum, instead
-	 * of only once the whole container is narrower than the panel itself.
+	 * Inline space in the measured container never available to the panel —
+	 * e.g. a title's minimum share on a shared header row. Subtracted before
+	 * resolving layout, so the panel steps down before the row-mates lose theirs.
 	 */
 	reservedInlineSize?: number;
 };
@@ -193,9 +188,8 @@ export function DateFiltersPanel( {
 	reservedInlineSize = 0,
 }: DateFiltersPanelProps ) {
 	/*
-	 * Read rather than taken as a prop: the same declaration keeps the params
-	 * away from the widgets, so a header can never offer a comparison nothing
-	 * below will read, or hide one the widgets are still fetching.
+	 * Read rather than a prop, so this and the widgets share one declaration —
+	 * a header can never offer a comparison the widgets below aren't fetching.
 	 */
 	const { offersComparison } = useReportScope();
 
@@ -223,11 +217,9 @@ export function DateFiltersPanel( {
 	const comparisonEnabled = !! validatedComparisonPresetId;
 
 	/*
-	 * Track whether the primary picker popover is open so the comparison label
-	 * mirrors it: while the picker is open it previews the draft range, but once
-	 * closed without Apply it reverts to the applied range (just like the
-	 * picker's own trigger). Without this, the comparison label would keep
-	 * showing the un-applied draft's derived range.
+	 * Tracks whether the picker popover is open so the comparison label mirrors
+	 * it: previews the draft range while open, reverts to applied when closed
+	 * (like the picker's own trigger) — otherwise it'd show a stale draft.
 	 */
 	const [ isPrimaryPickerOpen, setIsPrimaryPickerOpen ] = useState( false );
 	const comparisonSourceRange = isPrimaryPickerOpen ? range : appliedRange ?? range;
@@ -259,12 +251,9 @@ export function DateFiltersPanel( {
 	const handleResize = useCallback( ( entries: ResizeObserverEntry[] ) => {
 		const entry = entries[ 0 ];
 		if ( entry ) {
-			// Flushed synchronously: ResizeObserver fires between layout and
-			// paint, so committing here keeps a resized slot and its label form
-			// in the same frame. Ceiled, so a slot sized by the published width
-			// compares equal to it; on an external measure the ceil can
-			// overhang by under a pixel, absorbed by the row's shrinkable
-			// trigger.
+			// Flushed synchronously: ResizeObserver fires between layout and paint,
+			// so this keeps the resize and its label form in the same frame.
+			// Ceiled so a slot sized by the published width compares equal.
 			flushSync( () => {
 				setContainerWidth( Math.ceil( entry.contentRect.width ) );
 			} );
@@ -274,13 +263,9 @@ export function DateFiltersPanel( {
 	const setObserverRef = useResizeObserver< HTMLElement >( handleResize );
 
 	/*
-	 * Measure the caller's container when there is one, the panel's own root
-	 * otherwise (the body only until the ref lands). A flex slot follows the
-	 * panel's own content and needs `containerElement`; a slot sized from the
-	 * rig's intrinsic width measures honestly on its own.
-	 *
-	 * The setter doubles as the detach: `useResizeObserver` unobserves only
-	 * when called with `null`.
+	 * Measures the caller's container when given one, else the panel's own root
+	 * (body until the ref lands). The setter also detaches: `useResizeObserver`
+	 * unobserves only when called with `null`.
 	 */
 	useEffect( () => {
 		setObserverRef( containerElement ?? rootElement ?? document.body );
@@ -357,12 +342,9 @@ export function DateFiltersPanel( {
 	);
 
 	/*
-	 * Same arrangement as the other two: built once, rendered in the row and in
-	 * the probe.
-	 *
-	 * Read from the applied range, not the staged one. The arrows sit outside
-	 * the picker and commit on click, so a range being drafted must not decide
-	 * whether the forward one is there.
+	 * Built once, rendered in the row and the probe, like the other controls.
+	 * Reads the applied range, not staged: the arrows commit on click, so a
+	 * drafted range must not decide whether the forward step is available.
 	 */
 	const navigationControl = useMemo( () => {
 		if ( ! onStep ) {
@@ -398,11 +380,9 @@ export function DateFiltersPanel( {
 		setFullRowWidth( width );
 	}, [] );
 
-	// Measured, so the boundary follows the active locale rather than a
-	// breakpoint picked for English, and moves with the comparison control:
-	// adding one takes room the presets give back. The caller-reserved share
-	// (see `reservedInlineSize`) is subtracted first, so on a shared header
-	// row the panel steps down while its row-mates keep their minimum.
+	// Measured, so the boundary follows the active locale, not an English
+	// breakpoint, and shifts as the comparison control is added or removed.
+	// The reserved share is subtracted first, so row-mates keep their minimum.
 	const labelMode = useMemo(
 		() =>
 			resolvePresetLabelMode(

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/preset-row-probe.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/preset-row-probe.tsx
@@ -43,18 +43,9 @@ export type PresetRowProbeProps = {
 };
 
 /**
- * Measures what the date-controls row needs with its labels spelled out.
- *
- * Measured in the DOM because the width depends on the font resolved for the
- * locale's script, the button padding tokens, and the group's borders.
- *
- * The presets render in their full form unconditionally: measuring the live row
- * oscillates, since shortening the labels shrinks it and the full labels then
- * look like they fit. The comparison control can be measured live because its
- * width follows the active preset rather than the label mode.
- *
- * Exported memoized: the panel re-renders on every step of a resize, and this
- * output only moves when the labels do.
+ * Measures the date-controls row with labels spelled out, in the DOM. Always
+ * full-length — measuring the live (possibly-abbreviated) row would oscillate.
+ * Memoized: the panel re-renders every resize step, this only moves with labels.
  */
 function PresetRowProbeComponent( {
 	presets,

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/stories/date-filters-panel.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/stories/date-filters-panel.stories.tsx
@@ -268,33 +268,18 @@ export const AbbreviatedLabels: Story = {
 };
 
 /*
- * Translated stories.
+ * Translated stories, run through real WordPress.org language-pack strings
+ * (never invented) so the layout is reviewed against what users actually see.
+ * Locales were picked by measuring all 15 that translate the preset set.
  *
- * The panel is laid out for English, where every preset label is short. These
- * stories run it through real translations so the layout is reviewed against
- * the strings it will actually hold.
- *
- * Every translation below is taken from a shipped WordPress.org language pack,
- * never invented, so the widths are what users see rather than a guess:
- *
- * - Presets and `Custom` come from the Jetpack plugin's own pack.
- * - `Previous period` / `Previous year` come from WooCommerce, which already
- *   ships them. Jetpack does not.
- * - `All time` reuses the translation of Jetpack Stats' `All-time`. Note the
- *   hyphen: this package introduced a near-duplicate msgid, so at runtime it
- *   gets no translation at all and falls back to English.
- * - `Previous month` and `No comparison` are translated nowhere, so they stay
- *   English here too. That is today's real behavior, and it means these stories
- *   understate the comparison menu's eventual width.
- *
- * Locales were picked by measuring all 15 that translate the full preset set,
- * not by intuition. German is only 7th (1.24x English); Russian is the widest
- * by a wide margin, and CJK is narrower than English.
+ * `All time` reuses Jetpack Stats' `All-time` — note the hyphen: this package's
+ * near-duplicate msgid gets no translation at runtime and falls back to English,
+ * as do `Previous month` and `No comparison`, so these stories understate the
+ * comparison menu's eventual width.
  */
 
 /*
- * Everything from here down quotes translated strings, so a spell checker has
- * nothing useful to say about it.
+ * Everything below quotes translated strings a spell checker can't judge.
  *
  * cspell:disable
  */
@@ -347,10 +332,9 @@ const DUTCH: LocaleFixture = {
 };
 
 /*
- * The locale everyone expects to be worst, which measures 7th. Kept as the
- * control, and because it holds the widest single Latin pill
- * ("Die letzten 24 Stunden", 139px) plus the non-breaking space that German
- * and French packs use between a number and its unit.
+ * The locale everyone expects to be worst, but measures only 7th — kept as
+ * the control. Holds the widest single Latin pill ("Die letzten 24 Stunden",
+ * 139px) and the non-breaking space German/French use before a unit.
  */
 const GERMAN: LocaleFixture = {
 	name: 'German',
@@ -371,9 +355,8 @@ const GERMAN: LocaleFixture = {
 /**
  * Install a fixture's translations for the duration of one story.
  *
- * `setLocaleData` writes to the global i18n singleton, hence the cleanup: the
- * locale would otherwise leak into the next story opened. Same reason these are
- * off the autodocs page, which renders every sibling at once.
+ * `setLocaleData` writes the global i18n singleton, hence the cleanup and why
+ * these stories are off autodocs, which renders every sibling at once.
  */
 function withLocale( fixture: LocaleFixture ) {
 	return () => {
@@ -398,12 +381,9 @@ function withLocale( fixture: LocaleFixture ) {
 const LADDER_WIDTHS = [ 960, 782, 600, 360, 280 ];
 
 /**
- * One locale's bar at each reference width, so the point where it stops fitting
- * is visible rather than asserted.
- *
- * Rungs are annotated against the four preset pills alone. That is a floor: the
- * custom trigger, the comparison control, and the interval control share the
- * same line, as will the period navigation.
+ * One locale's bar at each reference width, so where it stops fitting is
+ * visible rather than asserted. Annotated against the four preset pills
+ * alone — a floor, since the trigger/comparison/interval/navigation share the line.
  */
 function WidthLadder( { fixture }: { fixture: LocaleFixture } ) {
 	return (
@@ -434,10 +414,9 @@ function WidthLadder( { fixture }: { fixture: LocaleFixture } ) {
 			) ) }
 
 			{ /*
-			 * Dragging across a boundary is the part the fixed rungs cannot show:
-			 * whether the mode settles in one state or flickers between two. Both
-			 * transitions are in reach here, full to abbreviated first and the
-			 * select further down, and where they land differs per locale.
+			 * Dragging across a boundary shows what the fixed rungs cannot: whether
+			 * the mode settles or flickers. Both transitions are reachable here —
+			 * full to abbreviated first, then the select — and differ per locale.
 			 */ }
 			<div
 				style={ {

--- a/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/date-interval-dropdown.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/date-interval-dropdown.tsx
@@ -49,15 +49,9 @@ function getIntervalLabel( interval: IntervalType ): string {
 }
 
 /**
- * The bucket size every chart on the page draws, as a glyph opening a menu of
- * the buckets the active range allows.
- *
- * The glyph is a chart rather than a clock: the control buckets what the charts
- * draw, it does not narrow the period the rest of the surface reports on.
- *
- * A range with one allowed bucket still opens a menu listing it, checked: the
- * trigger carries no text, so the menu is the only place the choice can be
- * inspected. The section header's subtitle names the active bucket.
+ * The bucket size every chart draws, as a glyph (not a clock — it buckets the
+ * charts, doesn't narrow the reported period) opening a menu of what the
+ * active range allows. Opens even with one option, since the trigger has no text.
  */
 export function DateIntervalDropdown( {
 	options,

--- a/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/stories/story-interval-options.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/date-interval-dropdown/stories/story-interval-options.ts
@@ -1,10 +1,9 @@
 import type { IntervalType, PrimaryPresetId } from '@jetpack-premium-analytics/datetime';
 
 /*
- * Story stand-in for `getAllowedIntervalsForPreset`, which lives in the data
- * package and is not a dependency of this one. Covers the presets the date
- * surfaces offer; anything else, custom ranges included, falls back to what a
- * range of a few weeks allows.
+ * Story stand-in for `getAllowedIntervalsForPreset` (in the data package, not
+ * a dependency here). Covers the presets the date surfaces offer; anything
+ * else, custom ranges included, falls back to a few-weeks range's options.
  */
 const STORY_INTERVAL_OPTIONS: Partial< Record< PrimaryPresetId, IntervalType[] > > = {
 	'last-24-hours': [ 'hour', 'day' ],

--- a/projects/packages/premium-analytics/packages/ui/src/date-period-navigation/date-period-navigation.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-period-navigation/date-period-navigation.tsx
@@ -24,9 +24,8 @@ type DatePeriodNavigationProps = {
 /**
  * Steps the active window backward and forward by its own length.
  *
- * The forward control is absent rather than disabled on the latest window: a
- * disabled arrow states a rule the reader has to work out, and on a live preset
- * that rule holds for as long as they stay on it.
+ * The forward control is absent rather than disabled on the latest window —
+ * a disabled arrow states a rule the reader has to work out for themselves.
  *
  * @param {DatePeriodNavigationProps} props - The props for the DatePeriodNavigation component.
  * @return The navigation element.

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-layout.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-layout.ts
@@ -1,12 +1,7 @@
 /**
- * How the date-range presets render for the width they have been given.
- *
- * Measured rather than compared against a breakpoint: the same row needs 470px
- * in English and 694px in Russian, so any hardcoded boundary is wrong for some
- * language. See WOOA7S-1817 for the measurements.
- *
- * Abbreviated is the last step. A row too narrow even for that keeps its pills
- * rather than hiding the whole choice behind a menu.
+ * How the date-range presets render for the given width. Measured, not a
+ * breakpoint: the same row needs 470px in English, 694px in Russian — see
+ * WOOA7S-1817. Abbreviated is the last step; a too-narrow row keeps its pills.
  */
 export type PresetLabelMode =
 	/** Full labels ("7 days"), while they fit. */
@@ -15,14 +10,9 @@ export type PresetLabelMode =
 	| 'abbreviated';
 
 /**
- * Longest label form that fits the width available.
- *
- * Falls back to `full` until the measurement is in; a wrong guess corrects on
- * the next frame. The boundary is inclusive.
- *
- * The row is every control, not just the presets: the custom-range trigger and
- * the comparison control share the width, and only the presets have a shorter
- * form to give back.
+ * Longest label form that fits the width available. Falls back to `full`
+ * until measured (a wrong guess corrects next frame; boundary inclusive).
+ * The row is every control, not just presets — only presets have a shorter form.
  */
 export function resolvePresetLabelMode(
 	availableWidth: number | null,

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.tsx
@@ -106,10 +106,9 @@ export function DateRangePopoverContent( {
 	};
 
 	/*
-	 * First click starts a new range, second click completes it. The computed
-	 * range from `onSelect` is ignored in favor of the clicked day, since
-	 * react-day-picker never restarts a complete range on click; it only moves
-	 * the nearest endpoint.
+	 * First click starts a new range, second completes it. Uses the clicked day,
+	 * not `onSelect`'s computed range: react-day-picker never restarts a
+	 * complete range on click, it only moves the nearest endpoint.
 	 */
 	const handleCalendarSelect = ( _nextRange: DateRange | undefined, triggerDate: Date ) => {
 		if ( draftRange?.from && ! draftRange.to ) {

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/index.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/index.ts
@@ -2,8 +2,7 @@ export { DateRangePopover, DateRangePopoverContent } from './date-range-filter';
 export type { DateRange } from './date-range-filter';
 /*
  * The custom trigger's label has a second reader: the panel's measuring probe
- * needs the exact string the trigger is showing, since "Custom" and a formatted
- * range differ by enough width to move the label-mode boundary. Exported so both
- * derive it from one implementation instead of two.
+ * needs the exact string shown, since "Custom" vs. a formatted range differ
+ * enough to move the label-mode boundary. Exported so both share one source.
  */
 export { getCustomTriggerLabel, getCustomTriggerState } from './get-custom-trigger-state';

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/__tests__/get-section-subtitle.test.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/__tests__/get-section-subtitle.test.ts
@@ -203,10 +203,9 @@ describe( 'getSectionSubtitle', () => {
 
 	describe( 'the year surface', () => {
 		/*
-		 * `all-time` and the running year both start on a calendar boundary and
-		 * end at the end of today, so the day they are read on decides the unit.
-		 * These are one selection each, read on three days: mid-month, on a month
-		 * boundary, and on a year boundary.
+		 * `all-time` and the running year start on a calendar boundary and end at
+		 * the end of today, so the day they're read on decides the unit — each is
+		 * one selection, read on three days: mid-month, month-end, year-end.
 		 */
 		const READ_ON = [
 			[ 'mid-month', endOf( 2026, 7, 30 ) ],

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/get-section-subtitle.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/get-section-subtitle.ts
@@ -103,24 +103,8 @@ function getIntervalCadenceLabel( interval: IntervalType ): string {
 
 /**
  * Describe the applied date configuration for a section header subtitle.
- *
- * Reads the applied range rather than the preset, so a window stepped back off
- * a preset still describes its own length.
- *
- * The year surface is the exception, and carries no length. `All time` and the
- * running year both start on a calendar boundary and end at the end of today,
- * so their length grows by a day at a time and measuring it reports the shape
- * of today's date rather than of the selection. Left to the measurement, one
- * site reads "2037 days" mid-month, "67 months" on the last day of one, and "6
- * years" on December 31, and the range itself reformats along with the unit.
- * Past years measure consistently, but their label already names the year, so
- * "(12 months)" adds nothing and the whole surface is treated alike.
- *
- * @example
- * getSectionSubtitle( { range, interval } )
- *   // 'Tuesday, July 21 – Monday, July 27 (7 days, daily)'
- *   // with comparison: '… (7 days, daily) vs. July 14 – 20, 2026'
- *   // year surface: 'January 1, 2021 – July 30, 2026 (monthly)'
+ * Reads the applied range, not the preset — except the year surface, whose
+ * length reflects today's date, not the selection, so it states none.
  *
  * @return The subtitle, or undefined when the range is incomplete.
  */

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.tsx
@@ -13,13 +13,9 @@ type SectionHeaderProps = {
 	subtitle?: string;
 
 	/**
-	 * Condenses the header into a compact bar once it pins: the subtitle fades
-	 * out and gives its row back, and the title drops a step on the type
-	 * scale. Only for surfaces that pin this header, and the surface must also
-	 * publish a `--section-header-pin` view timeline marking where it pins
-	 * (see the dashboard's pin marker in `routes/dashboard/stage.module.scss`).
-	 * Without that timeline, or without browser support for it, the header
-	 * keeps its resting layout.
+	 * Condenses into a compact bar once it pins: subtitle fades out, title
+	 * drops a type-scale step. Requires the surface to publish a
+	 * `--section-header-pin` view timeline; falls back to resting layout without it.
 	 */
 	condenseOnScroll?: boolean;
 
@@ -31,16 +27,9 @@ type SectionHeaderProps = {
 };
 
 /**
- * Section header for an analytics surface. The title and a slot for the date
- * controls share the first row, anchored to opposite edges: the controls keep
- * their natural width and a long title truncates with an ellipsis. The
- * subtitle takes a row of its own below them, so its length never costs the
- * controls width either.
- *
- * Once the header is too narrow to hold those two side by side everything
- * stacks, the subtitle returns to its place directly under the title, and the
- * title wraps rather than truncating. Measured by a container query rather
- * than against the viewport.
+ * Section header for an analytics surface: title and date controls share the
+ * first row (title truncates, controls keep natural width); the subtitle sits
+ * below. Below a container-query width everything stacks and the title wraps.
  *
  * @param {SectionHeaderProps} props - The props for the SectionHeader component.
  * @return The section header element.

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/stories/section-header.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/stories/section-header.stories.tsx
@@ -172,10 +172,9 @@ function RollingDateControls( {
 	}, [ committed ] );
 
 	/*
-	 * Mirrors `useReportDateFilters`: a comparison change commits on its own, so
-	 * it moves the subtitle right away. Not while a primary edit is staged,
-	 * though — then it rides along and both land on Apply, so tweaking the
-	 * comparison never commits an un-applied primary draft.
+	 * Mirrors `useReportDateFilters`: a comparison change commits on its own and
+	 * moves the subtitle right away, unless a primary edit is staged — then it
+	 * rides along and both land on Apply.
 	 */
 	const handleComparisonChange = useCallback(
 		( _range: PanelDateRange | undefined, nextPresetId?: ComparisonPresetId ) => {

--- a/projects/packages/premium-analytics/packages/ui/src/stale-data-notice/__tests__/stale-data-notice.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/stale-data-notice/__tests__/stale-data-notice.test.tsx
@@ -76,9 +76,8 @@ describe( 'StaleDataNotice', () => {
 			} );
 
 			expect( description( /Showing data from 7 minutes ago\./ ) ).toBeInTheDocument();
-			// Interrupting a screen reader once a minute, for as long as the notice
-			// stays up, is what the fixed `spokenMessage` exists to prevent: the
-			// announcement never mentions an age, so it never changes.
+			// Interrupting a screen reader every minute is what the fixed
+			// `spokenMessage` prevents — it never mentions an age, so it never changes.
 			expect( announcement() ).toBe( announced );
 			expect( announced ).not.toMatch( /minutes ago/ );
 		} finally {

--- a/projects/packages/premium-analytics/packages/ui/src/stale-data-notice/stale-data-notice.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/stale-data-notice/stale-data-notice.tsx
@@ -55,8 +55,7 @@ export function StaleDataNotice( {
 
 	return (
 		// A fixed announcement, not `message`: the ageing label would interrupt a
-		// screen reader every minute, and the default — the children — would
-		// trail the Retry button's label.
+		// screen reader every minute, and the default (children) would trail Retry's label.
 		<Notice.Root
 			intent="warning"
 			className={ className }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/__tests__/adaptive-calendar-heatmap.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/__tests__/adaptive-calendar-heatmap.test.tsx
@@ -14,13 +14,12 @@ import type { CalendarHeatmapPager } from '../calendar-heatmap-pager-overlay';
 const PERIOD = { startDate: '2025-01-01', endDate: '2025-12-31' };
 const ONE_MONTH = { startDate: '2025-06-01', endDate: '2025-06-30' };
 
-// The body height of a one-row dashboard tile, measured in the widget dashboard:
-// a 200px grid row less the widget's own chrome. The shipped size for both
-// calendar heatmaps, and the tightest one they have to fit.
+// A 200px dashboard grid row less the widget's own chrome — the shipped size for
+// both calendar heatmaps, and the tightest one they have to fit.
 const ONE_ROW_TILE_HEIGHT = 86;
 
-// A single populated day is enough: these tests are about geometry, and it also
-// shows whether the day survived the window the tile settled on.
+// One populated day is enough: these tests are about geometry, and it also shows
+// whether the day survived the window the tile settled on.
 const VALUE_BY_DAY = { '2025-06-02': 120 };
 
 // jsdom reports every element as 0x0, so the tile has to be faked. Returns a
@@ -35,9 +34,8 @@ function stubTileSize( width: number, height: number ) {
 	};
 }
 
-// Renders into a tile of the given size and returns the resolved chart props as
-// plain values. Snapshotting them here (rather than handing back a DOM node)
-// keeps each call independent, so a test can measure two tile sizes in a row.
+// Returns the resolved chart props as plain values rather than a DOM node, so a
+// test can measure two tile sizes in a row.
 function chartFor( {
 	width,
 	height,
@@ -117,10 +115,8 @@ describe( 'AdaptiveCalendarHeatmap', () => {
 	it( 'fits the grid inside a one-row tile rather than overflowing it', () => {
 		const chart = chartFor( { width: 1000, height: ONE_ROW_TILE_HEIGHT } );
 
-		// The regression this guards: the chart's own compact mode has a fixed 11px
-		// cell needing ~104px of body height, so at the shipped one-row size the grid
-		// overflowed and `overflow: hidden` sliced the month labels off the top and
-		// the last weekday row off the bottom.
+		// Guards the compact-mode regression: a fixed 11px cell needs ~104px of body
+		// height, so at the shipped one-row size the grid overflowed and was clipped.
 		expect( chart.height ).toBeGreaterThan( 0 );
 		expect( chart.height ).toBeLessThanOrEqual( ONE_ROW_TILE_HEIGHT );
 		expect( chart.columns ).toBeGreaterThan( 0 );
@@ -175,9 +171,8 @@ describe( 'AdaptiveCalendarHeatmap', () => {
 			period: ONE_MONTH,
 		} );
 
-		// The regression this guards (WOOA7S-1963): dates drawn only to fill the
-		// tile were interactive no-data cells, so the heatmap told a reader there
-		// was no traffic on days it had never asked about.
+		// Guards WOOA7S-1963: dates drawn only to fill the tile were interactive
+		// no-data cells, claiming no traffic on days never asked about.
 		expect( chart.placeholders ).toBeGreaterThan( 0 );
 		expect( chart.firstRealLabel ).toBe( 'Sun, Jun 1, 2025' );
 	} );
@@ -203,9 +198,8 @@ describe( 'AdaptiveCalendarHeatmap', () => {
 
 		expect( chart.columns ).toBeLessThan( 53 );
 
-		// The trim spends its columns on the end of the period, so December
-		// survives and January is what falls off. The regression this guards ran
-		// the grid on past the data instead, leaving the surviving columns empty.
+		// The trim spends its columns on the end of the period; the regression it
+		// guards ran the grid past the data, leaving the surviving columns empty.
 		expect( chart.values ).toBe( 'Mon, Dec 29, 2025:120' );
 		expect( chart.lastVisibleLabel ).toBe( 'Wed, Dec 31, 2025' );
 
@@ -331,9 +325,8 @@ describe( 'AdaptiveCalendarHeatmap paging', () => {
 		const { read, restore } = renderPaged( { width: 240, height: ONE_ROW_TILE_HEIGHT } );
 
 		try {
-			// The newest page shows first: nothing newer to step to, plenty older.
-			// The boundaries are pinned (not merely "changed"): this width draws 15
-			// week columns, so the newest page spans exactly these dates.
+			// The boundaries are pinned rather than merely "changed": this width draws
+			// 15 week columns, so the newest page spans exactly these dates.
 			expect( read() ).toMatchObject( {
 				firstVisibleLabel: 'Mon, Sep 22, 2025',
 				lastVisibleLabel: 'Wed, Dec 31, 2025',
@@ -378,9 +371,8 @@ describe( 'AdaptiveCalendarHeatmap paging', () => {
 			expect( oldest.columns ).toBe( newestColumns );
 			expect( isUnavailable( newer() ) ).toBe( false );
 
-			// The last click removed the arrow that held keyboard focus; the
-			// overlay hands focus to the surviving arrow so `:focus-within` (and
-			// paging back) survives.
+			// The last click removed the arrow holding focus; the overlay hands it to
+			// the survivor so `:focus-within` (and paging back) survives.
 			expect( newer() ).toHaveFocus();
 		} finally {
 			restore();

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/__tests__/calendar-heatmap-tooltip.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/__tests__/calendar-heatmap-tooltip.test.tsx
@@ -29,8 +29,7 @@ describe( 'CalendarHeatmapTooltip', () => {
 	it.each( [
 		[ 'null', null ],
 		// The package builds without `strictNullChecks`, so `undefined` type-checks
-		// here; without the `== null` check it would reach `formatValue` and render
-		// "undefined views".
+		// here; without the `== null` check it would render "undefined views".
 		[ 'undefined', undefined ],
 	] )( 'shows the empty label instead of a count for a %s cell', ( _label, value ) => {
 		render(

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/adaptive-calendar-heatmap.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/adaptive-calendar-heatmap.tsx
@@ -24,18 +24,12 @@ const CELL_ASPECT_RATIO = 61 / 40;
 // Labelled cells narrower than this have no room for a number.
 const VALUE_MIN_CELL_WIDTH = 30;
 
-/**
- * The props to spread onto `HeatmapChartUnresponsive`.
- *
- * The cells are sized to the exact rectangle they fill, so the grid never
- * overflows the tile. The dimensions are absent while the tile is unmeasured.
- */
+/** The props to spread onto `HeatmapChartUnresponsive`. Dimensions are absent while the tile is unmeasured. */
 type AdaptiveCalendarHeatmapChartBaseProps = {
 	/** The columns that fit, oldest first. */
 	data: HeatmapColumn[];
 	rowLabels: string[];
 	className: string;
-	/** Adaptive heatmaps always use measured cells, never fixed compact cells. */
 	compact?: never;
 };
 
@@ -54,9 +48,8 @@ export type AdaptiveCalendarHeatmapProps = {
 	 */
 	period: CalendarHeatmapWindow;
 	/**
-	 * Renders the chart. `pager` exists only while the period holds more week
-	 * columns than the tile draws; pass it to `CalendarHeatmapPagerOverlay` so
-	 * the extra weeks are reachable instead of silently dropped.
+	 * `pager` exists only while the period holds more week columns than the tile
+	 * draws; pass it to `CalendarHeatmapPagerOverlay` or those weeks are silently dropped.
 	 */
 	children: (
 		chartProps: AdaptiveCalendarHeatmapChartProps,
@@ -65,17 +58,8 @@ export type AdaptiveCalendarHeatmapProps = {
 };
 
 /**
- * Fits a calendar heatmap to the tile it is given.
- *
- * The tile's height picks the cell size and its width picks how many week columns
- * it shows. The grid always ends on the period's last day. A period with fewer
- * weeks than the width can draw is opened backwards with filler columns so the
- * tile still fills; one with more is paged — the newest page first, a window of
- * whole columns at a time — through the `pager` handed to the children. Both
- * widgets share this, so they stay consistent as the dashboard is resized.
- *
- * It renders the measured tile wrapper and hands the caller the chart props to
- * spread, leaving the widget to own its data, states, and tooltip.
+ * Fits a calendar heatmap to the tile it is given, leaving the widget to own its
+ * data, states, and tooltip.
  *
  * @param props            - Component props.
  * @param props.valueByDay - Value per `yyyy-MM-dd`.
@@ -97,10 +81,8 @@ export function AdaptiveCalendarHeatmap( {
 		[ valueByDay, period ]
 	);
 
-	// The tile's capacity, settled before the data is considered: the height picks
-	// the cell size and the width divides by it. `dataColumns` is deliberately
-	// omitted — this is how many columns the tile could draw, not how many the
-	// period has.
+	// `dataColumns` is deliberately omitted: this is how many columns the tile
+	// could draw, not how many the period has.
 	const fitColumns = useMemo(
 		() =>
 			computeCalendarHeatmapLayout( {
@@ -112,10 +94,8 @@ export function AdaptiveCalendarHeatmap( {
 		[ size.width, size.height ]
 	);
 
-	// A period with fewer weeks than the tile fits opens backwards into filler
-	// columns, so the grid fills its tile without the request reaching outside the
-	// period (WOOA7S-1963). `gridSpan` never narrows the grid, so a period longer
-	// than the tile passes through untouched and is trimmed below instead.
+	// A short period opens backwards into filler columns to fill the tile without
+	// reaching outside it (WOOA7S-1963); a long period passes through untouched.
 	const { data: heatmapData, rowLabels } = useMemo( () => {
 		const gridStart = resolveCalendarHeatmapGridStart( period.endDate, fitColumns );
 
@@ -125,15 +105,8 @@ export function AdaptiveCalendarHeatmap( {
 		);
 	}, [ daySeries, period.endDate, fitColumns ] );
 
-	// Height picks the cell size, width the column count, and the grid is sized to
-	// the rectangle it occupies — so it fills the tile without ever overflowing it.
-	//
-	// The chart's own `compact` mode is deliberately not used. Its cell size is
-	// fixed by the chart theme (11px square, 2px gap), which needs ~104px of body
-	// height once the month-label header is counted; a one-row dashboard tile only
-	// offers ~86px, so the grid overflowed and `overflow: hidden` sliced the month
-	// labels off the top and the last weekday row off the bottom. Sizing every tile
-	// lets the cells shrink to fit instead.
+	// `compact` mode isn't used: its theme-fixed cells need ~104px and a one-row
+	// tile offers ~86px, so `overflow: hidden` sliced off labels and the last row.
 	const { columns, sizingProps } = useMemo( () => {
 		const layout = computeCalendarHeatmapLayout( {
 			availWidth: size.width,
@@ -141,8 +114,7 @@ export function AdaptiveCalendarHeatmap( {
 			dataColumns: heatmapData.length,
 			aspectRatio: CELL_ASPECT_RATIO,
 			// Neither heatmap draws a legend; the default allowance would shrink every
-			// cell to reserve room for one. A caller adding a
-			// `HeatmapChartUnresponsive.Legend` child has to reserve it here.
+			// cell to reserve room for one. A `.Legend` child has to reserve it here.
 			legendHeight: 0,
 		} );
 
@@ -162,11 +134,8 @@ export function AdaptiveCalendarHeatmap( {
 		};
 	}, [ size.width, size.height, heatmapData.length ] );
 
-	// Pages step back whole windows from the range end; a new period or a
-	// resized page span restarts at the newest page, mirroring the post-detail
-	// pager's reset on its page span — otherwise a stale offset reopens an
-	// unpredictable page after a widen-and-narrow round trip. Adjusted during
-	// render, not in an effect, so no frame paints at the stale offset.
+	// A new period/span restarts at the newest page, or a stale offset reopens an
+	// unpredictable one; adjusted during render (not an effect) so no stale frame paints.
 	const [ pageOffset, setPageOffset ] = useState( 0 );
 	const [ pageContext, setPageContext ] = useState( { period, columns } );
 	if (
@@ -186,9 +155,8 @@ export function AdaptiveCalendarHeatmap( {
 	const offset = Math.min( pageOffset, maxOffset );
 
 	const chartProps = useMemo( () => {
-		// Trimming drops the oldest columns — the filler first, and only then the
-		// period's own earliest weeks. `slice( -0 )` returns the whole array, so an
-		// unmeasured or collapsed tile leaves the grid intact.
+		// `slice( -0 )` returns the whole array, so an unmeasured or collapsed tile
+		// leaves the grid intact rather than emptying it.
 		let data = heatmapData.slice( -columns );
 		if ( isPaged && offset > 0 ) {
 			const start = Math.max( 0, total - ( offset + 1 ) * columns );
@@ -203,9 +171,8 @@ export function AdaptiveCalendarHeatmap( {
 		};
 	}, [ heatmapData, rowLabels, columns, sizingProps, isPaged, offset, total ] );
 
-	// Step from the clamped `offset`, never the raw state: the two could only
-	// drift while `columns` changed, which resets the offset above, but stepping
-	// the displayed page keeps the arrows honest even if that coupling changes.
+	// Step from the clamped `offset`, never the raw state, so the arrows stay honest
+	// even if the reset above stops covering every drift.
 	const showOlder = useCallback(
 		() => setPageOffset( Math.min( offset + 1, maxOffset ) ),
 		[ offset, maxOffset ]

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/calendar-heatmap-pager-overlay.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/calendar-heatmap-pager-overlay.tsx
@@ -17,33 +17,23 @@ import type { ReactNode } from 'react';
  * its tile can draw. The newest page shows first; "older" steps back in time.
  */
 export type CalendarHeatmapPager = {
-	/** Whether an older page exists inside the range. */
 	canShowOlder: boolean;
-	/** Whether a newer page exists (the newest page shows first). */
 	canShowNewer: boolean;
 	showOlder: () => void;
 	showNewer: () => void;
 };
 
 export type CalendarHeatmapPagerOverlayProps = {
-	/** The paging state; omit it to render the children with no arrows. */
+	/** Omit to render the children with no arrows. */
 	pager?: CalendarHeatmapPager;
-	/** Optional class for widget-specific layout on the host element. */
 	className?: string;
 	children: ReactNode;
 };
 
 /**
- * Floats the calendar-heatmap pager arrows over the chart's inline edges.
- *
- * Per the design, the arrows appear on hover (or keyboard focus) instead of
- * taking a header row the widget chrome has no room for; viewports without
- * hover keep them visible. An arrow with nowhere to go is not rendered at all
- * rather than shown disabled, also per the design. The host wraps the chart so
- * the arrows center on it vertically, and it always renders — pager or not —
- * so paging in and out of a range never changes the chart's layout.
- *
- * @return The chart wrapped in the pager host.
+ * Floats the pager arrows over the chart's inline edges. Per design, they show
+ * only on hover/keyboard focus, and an arrow with nowhere to go is omitted
+ * (not disabled) so the chart layout never shifts.
  */
 export function CalendarHeatmapPagerOverlay( {
 	pager,
@@ -60,12 +50,8 @@ export function CalendarHeatmapPagerOverlay( {
 	const canShowOlder = pager?.canShowOlder ?? false;
 	const canShowNewer = pager?.canShowNewer ?? false;
 
-	// Reaching an end unmounts the arrow being pressed, and focus falls
-	// wherever the browser or the removed button drops it, collapsing
-	// `:focus-within` mid-interaction — so hand focus to the surviving arrow.
-	// An intentional move away instead fires the blur that clears
-	// `arrowHadFocus` first, and the animation-frame re-check covers fallback
-	// restores that land after this commit.
+	// Unmounting the pressed arrow fires no blur, so focus must be handed off manually;
+	// the rAF recheck catches a focus restore that lands after this commit.
 	useLayoutEffect( () => {
 		const doc = hostRef.current?.ownerDocument;
 		if ( ! doc ) {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/calendar-heatmap-tooltip.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/calendar-heatmap-tooltip.tsx
@@ -3,9 +3,8 @@
  */
 import type { HeatmapTooltipData } from '@jetpack-premium-analytics/externals';
 
-// The chart's own payload fields are picked, not restated: every caller forwards
-// them straight from a `HeatmapTooltipData`, and the package builds without
-// `strictNullChecks`, so a copy that drifted from upstream would not error here.
+// Picked, not restated: the package builds without `strictNullChecks`, so a copy
+// that drifted from the upstream payload would not error here.
 export type CalendarHeatmapTooltipProps = Pick< HeatmapTooltipData, 'value' | 'cellLabel' > & {
 	/** Shown in place of a count when there is no value. */
 	emptyLabel: string;
@@ -15,11 +14,8 @@ export type CalendarHeatmapTooltipProps = Pick< HeatmapTooltipData, 'value' | 'c
 
 /**
  * A calendar heatmap cell tooltip, leading with the count where the chart's own
- * tooltip would lead with the date.
- *
- * The copy stays with the caller because `__()` and `_n()` need literal arguments
- * to be extracted, so neither the empty label nor the plural forms can be built
- * here.
+ * tooltip would lead with the date. The copy stays with the caller because `__()`
+ * and `_n()` need literal arguments to be extracted.
  */
 export function CalendarHeatmapTooltip( {
 	value,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/stories/adaptive-calendar-heatmap.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/calendar-heatmap/stories/adaptive-calendar-heatmap.stories.tsx
@@ -14,11 +14,6 @@ const SHORT_PERIOD = { startDate: '2026-06-01', endDate: '2026-06-30' };
 /**
  * A deterministic weekday-weighted series. Real traffic dips at weekends, and a
  * flat ramp would hide the color scale.
- *
- * @param period           - The period to generate values for.
- * @param period.startDate - First day, inclusive.
- * @param period.endDate   - Last day, inclusive.
- * @return Views per `yyyy-MM-dd`.
  */
 function buildViewsByDay( period: { startDate: string; endDate: string } ) {
 	return Object.fromEntries(
@@ -52,8 +47,7 @@ interface AdaptiveCalendarHeatmapStoryControls {
 }
 
 // The current year is selected as January through today, so early in the year it is
-// the shortest period Insights can produce. Fixed dates: a story that moved with the
-// clock would render differently on every visual diff.
+// the shortest period Insights can produce.
 const CURRENT_YEAR_AS_OF = [
 	{ label: 'Jan 15 — 2 weeks of data', endDate: '2026-01-15' },
 	{ label: 'Apr 15 — 15 weeks of data', endDate: '2026-04-15' },
@@ -62,19 +56,9 @@ const CURRENT_YEAR_AS_OF = [
 ] as const;
 
 /**
- * Mock widget tile. The component measures its parent, so the story has to give it
- * a real box; `width` / `height` are the widget *body*, which is what it sees.
- *
- * Measured in the widget dashboard: a one-row tile is a 200px grid row, about 86px
- * of it body — two rows is about 300px. Keep `ShortTile` on the real figure. It was
- * 110px here for a while, which is roomy enough to hide a grid that overflowed the
- * real tile, so the story showed a clean heatmap the dashboard never rendered.
- *
- * @param props          - Component props.
- * @param props.width    - Body width, in px.
- * @param props.height   - Body height, in px.
- * @param props.children - The tile's contents.
- * @return The mock tile.
+ * Mock widget tile. The component measures its parent, so `width` / `height` must be
+ * the widget *body* box, not the tile — keep `ShortTile` on the real ~86px body
+ * height, since a roomier value hides overflow the real tile would show.
  */
 function TileCanvas( {
 	width,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/__tests__/bar-chart-skeleton.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/__tests__/bar-chart-skeleton.test.tsx
@@ -16,9 +16,8 @@ describe( 'BarChartSkeleton', () => {
 	} );
 
 	it( 'falls back to a handful of columns when the widget cannot count its bars', () => {
-		// Only `sales-by-device` builds its bars from the response; the rest
-		// pass a count they know, so the default just has to read as a small
-		// categorical chart rather than the prototype's dense time series.
+		// Only `sales-by-device` builds its bars from the response, so the default
+		// just has to read as a small categorical chart, not a dense time series.
 		render( <BarChartSkeleton /> );
 
 		expect( screen.getAllByTestId( 'skeleton-bar-column' ) ).toHaveLength( 4 );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart-skeleton.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart-skeleton.tsx
@@ -9,10 +9,8 @@ import { SkeletonRoot } from '../widget-skeleton';
 import styles from './bar-chart-skeleton.module.scss';
 
 /**
- * Columns for a widget that cannot know its own bar count. These charts are
- * categorical rather than time series, so a handful of bars is the shape to
- * expect — the prototype's denser twelve stands in for a chart this package
- * has no consumer for.
+ * Columns for a widget that cannot know its own bar count: these charts are
+ * categorical rather than time series, so a handful of bars is the shape to expect.
  */
 const DEFAULT_COLUMN_COUNT = 4;
 
@@ -23,10 +21,6 @@ export interface BarChartSkeletonProps {
 
 /**
  * Loading shape for `BarChart`: bottom-aligned columns of stepping heights.
- *
- * @param props         - Component props.
- * @param props.columns - Columns to draw.
- * @return The rendered skeleton.
  */
 export function BarChartSkeleton( { columns = DEFAULT_COLUMN_COUNT }: BarChartSkeletonProps ) {
 	const columnCount = columns > 0 ? columns : DEFAULT_COLUMN_COUNT;

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/__tests__/comparative-bar-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/__tests__/comparative-bar-chart.test.tsx
@@ -10,9 +10,8 @@ import { siteSettingsIn } from '../../../__fixtures__/wp-date-settings';
 import { ComparativeBarChart } from '../comparative-bar-chart';
 import type { ComparativeBarChartSeries } from '../types';
 
-// Record the options handed to the underlying chart. The real one renders SVG
-// through a provider jsdom cannot lay out, and what matters here is the option
-// object this wrapper composes.
+// Record the options handed to the underlying chart: the real one renders SVG
+// through a provider jsdom cannot lay out.
 const mockBarSpy = jest.fn();
 const mockLegendSpy = jest.fn();
 
@@ -50,9 +49,8 @@ jest.mock( '@jetpack-premium-analytics/externals', () => {
 	};
 } );
 
-// jsdom's ResizeObserver is a no-op stub, so the real hook's callback never
-// fires and the chart would measure as infinitely tall in every test — leaving
-// the whole `compactWhenShort` branch unreachable. Drive the height instead.
+// jsdom's ResizeObserver is a no-op stub, so the real hook's callback never fires
+// and the chart measures as infinitely tall, leaving `compactWhenShort` unreachable.
 let mockChartHeight = Infinity;
 
 jest.mock( '@wordpress/compose', () => ( {
@@ -73,9 +71,8 @@ const DATA_FORMAT = { type: 'number' as const, options: { decimals: 0 } };
 const JULY_1 = new Date( '2026-07-01T00:00:00Z' );
 const JULY_2 = new Date( '2026-07-02T00:00:00Z' );
 
-// A tooltip label reads its point as the instant it is, in the site's timezone,
-// so this one is an instant and every label assertion fixes the site's zone.
-// Callers whose points are wall clocks pass their own `formatTooltipDate`.
+// A tooltip label reads its point as the instant it is, in the site's timezone, so
+// every label assertion below fixes the site's zone.
 const JULY_2_2PM_TOKYO = new Date( '2026-07-02T05:00:00Z' );
 
 const SERIES: ComparativeBarChartSeries[] = [
@@ -139,11 +136,7 @@ type TooltipProps = {
 	getLabel: ( datum: { date?: Date; realDate?: Date }, index: number, key: string ) => string;
 };
 
-/**
- * Every prop the most recent chart render received.
- *
- * @return The recorded props.
- */
+/** Every prop the most recent chart render received. */
 function recordedProps(): {
 	options: {
 		axis: { x: Record< string, unknown >; y: Record< string, unknown > };
@@ -163,11 +156,7 @@ function recordedProps(): {
 	return mockBarSpy.mock.calls.at( -1 )[ 0 ];
 }
 
-/**
- * The options the most recent chart render received.
- *
- * @return The recorded chart options.
- */
+/** The options the most recent chart render received. */
 function recordedOptions() {
 	return recordedProps().options;
 }
@@ -175,9 +164,6 @@ function recordedOptions() {
 /**
  * Run the chart's `renderTooltip` for a hovered primary point and report the
  * tooltip rows it produced, as `label → value`.
- *
- * @param hoveredDate - The category the pointer (or keyboard focus) is on.
- * @return One entry per tooltip row.
  */
 function tooltipRowsFor( hoveredDate: Date ): Record< string, number > {
 	/* eslint-disable testing-library/render-result-naming-convention --
@@ -201,12 +187,7 @@ function tooltipRowsFor( hoveredDate: Date ): Record< string, number > {
 	);
 }
 
-/**
- * The label the tooltip puts on a hovered point.
- *
- * @param hoveredDate - The point's date.
- * @return The rendered row label.
- */
+/** The label the tooltip puts on a hovered point. */
 function tooltipLabelFor( hoveredDate: Date ): string {
 	/* eslint-disable testing-library/render-result-naming-convention --
 	   As above: this is the chart's `renderTooltip` prop, not testing-library's
@@ -307,9 +288,8 @@ describe( 'ComparativeBarChart', () => {
 	it( 'adds the previous-period value to the tooltip when comparing', () => {
 		render( <ComparativeBarChart series={ SERIES_WITH_COMPARISON } dataFormat={ DATA_FORMAT } /> );
 
-		// The chart hands a custom tooltip renderer only the primary series, so
-		// without re-pairing here the shadow bar's value would be unreadable —
-		// including to screen readers, which get the same tooltip content.
+		// The chart hands a custom tooltip renderer only the primary series, so without
+		// re-pairing here the shadow bar's value would be unreadable.
 		expect( tooltipRowsFor( JULY_1 ) ).toEqual( { July: 100, June: 80 } );
 		expect( tooltipRowsFor( JULY_2 ) ).toEqual( { July: 100, June: 120 } );
 	} );
@@ -335,9 +315,8 @@ describe( 'ComparativeBarChart', () => {
 			tooltipData: { nearestDatum: { datum: { date: JULY_1, value: 100 }, key: 'July' } },
 		} ).props;
 
-		// Every row on a paired chart covers the same hovered date, so a date alone
-		// would label two of them identically. A comparison row is named after the
-		// metric it shadows, not by its own internal label.
+		// Every row on a paired chart covers the same hovered date, so a date alone would
+		// label two of them identically.
 		expect( getLabel( { date: JULY_1 }, 0, 'July' ) ).toBe( 'July · July 1, 2026' );
 		expect( getLabel( { date: JULY_1 }, 2, 'Visitors' ) ).toBe( 'Visitors · July 1, 2026' );
 		expect(
@@ -358,9 +337,8 @@ describe( 'ComparativeBarChart', () => {
 			tooltipData: { nearestDatum: { datum: { date: JULY_1, value: 100 }, key: 'July' } },
 		} );
 
-		// The chart lists both current periods before either previous period, while
-		// the styles follow the series. Without the keys the tooltip pairs each row
-		// with whichever style happens to sit at its position.
+		// The chart lists both current periods before either previous period, while the
+		// styles follow the series, so without the keys each row takes the wrong style.
 		expect( tooltip.props.seriesKeys ).toEqual( [ 'July', 'June', 'Visitors', 'Visitors · June' ] );
 	} );
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/comparative-bar-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/comparative-bar-chart.tsx
@@ -35,10 +35,7 @@ import type { ComparativeDatePointDate } from '../chart-comparative-line/types';
 import type { TooltipStyle } from '../chart-tooltip';
 import type { ComponentProps } from 'react';
 
-/**
- * Default margin for charts.
- * Y-axis is on the left, so right margin is always 0.
- */
+/** The y-axis is on the left, so the right margin is always 0. */
 const DEFAULT_MARGIN = { right: 0 };
 
 /**
@@ -48,18 +45,12 @@ const DEFAULT_MARGIN = { right: 0 };
  */
 const COMPACT_CHART_HEIGHT = 140;
 
-/**
- * Inferred types from BarChart.
- */
 type BarChartProps = ComponentProps< typeof BarChart >;
 type RenderTooltipParams = Parameters< NonNullable< BarChartProps[ 'renderTooltip' ] > >[ 0 ];
 
 /**
- * Props for the ComparativeBarChart component.
- *
- * Deliberately mirrors `ComparativeLineChartProps` so a consumer can swap the
- * two on one flag without reshaping its data. The one difference is that there
- * is no `styles` prop — see the component docblock for why.
+ * Deliberately mirrors `ComparativeLineChartProps` so a consumer can swap the two
+ * on one flag without reshaping its data. There is no `styles` prop — see below.
  */
 export type ComparativeBarChartProps = {
 	/**
@@ -68,25 +59,18 @@ export type ComparativeBarChartProps = {
 	 */
 	series: ComparativeBarChartSeries[];
 
-	/**
-	 * CSS class for the chart container.
-	 */
 	className?: string;
 
-	/**
-	 * Format configuration for chart values (Y-axis ticks and tooltips).
-	 */
+	/** Format for chart values: y-axis ticks and tooltips. */
 	dataFormat: DataFormat;
 
 	/** Named date format for the X-axis ticks. Uses the chart default when omitted. */
 	tickFormat?: DateFormatName;
 
 	/**
-	 * The series' bucket size. Declaring it lets the automatic tick formatter pick
-	 * its regime from a known granularity instead of measuring the gaps between
-	 * points, which a single-bucket or DST-shortened series gives it no way to
-	 * read. An explicit `tickFormat` still wins over both. The tooltip reads it
-	 * too, to decide whether a date alone identifies a bucket.
+	 * The series' bucket size. Declaring it lets the tick formatter pick its regime
+	 * from a known granularity instead of measuring the gaps between points, which a
+	 * single-bucket or DST-shortened series gives it no way to read.
 	 */
 	tickResolution?: TickResolution;
 
@@ -103,9 +87,6 @@ export type ComparativeBarChartProps = {
 	 */
 	compactWhenShort?: boolean;
 
-	/**
-	 * Maximum chart width. Passed through to the underlying chart.
-	 */
 	maxWidth?: number;
 
 	/**
@@ -128,32 +109,20 @@ export type ComparativeBarChartProps = {
 	 */
 	legendInteractive?: boolean;
 
-	/**
-	 * Pointer-down on the plot, carrying the datum nearest the pointer.
-	 */
+	/** Pointer-down on the plot, carrying the datum nearest the pointer. */
 	onPointerDown?: BarChartProps[ 'onPointerDown' ];
 
-	/**
-	 * Pointer-up on the plot, carrying the datum nearest the pointer.
-	 */
+	/** Pointer-up on the plot, carrying the datum nearest the pointer. */
 	onPointerUp?: BarChartProps[ 'onPointerUp' ];
 
-	/**
-	 * Enter or Space on the keyboard-selected bar, carrying its datum.
-	 */
+	/** Enter or Space on the keyboard-selected bar, carrying its datum. */
 	onDatumActivate?: BarChartProps[ 'onDatumActivate' ];
 };
 
 /**
  * A date-keyed bar chart with previous-period comparison, built on
- * `@automattic/charts` `BarChart`.
- *
- * Bar styling is left to the charts theme rather than passed in: the comparison
- * shadow's geometry is driven by the theme's `barStyles.widthFactor`, so
- * overriding fills here would decouple the shadow from the bar it shadows.
- * Colours are read back through `getElementStyles` only to tint the tooltip
- * swatches, matching what the chart drew. Reading the theme means this must be
- * rendered inside a `GlobalChartsProvider`, unlike `ComparativeLineChart`.
+ * `@automattic/charts` `BarChart`. Styling is left to the theme, whose
+ * `barStyles.widthFactor` drives the shadow's geometry — must render inside a `GlobalChartsProvider`.
  *
  * @param {ComparativeBarChartProps} props - The component props.
  * @return The rendered chart.
@@ -190,20 +159,14 @@ export function ComparativeBarChart( {
 	} );
 	const isCompact = compactWhenShort && chartAreaHeight < COMPACT_CHART_HEIGHT;
 
-	/**
-	 * Align comparison series dates to the primary series so both land in the
-	 * same band slot. Original dates are preserved in `realDate` for tooltips.
-	 */
+	// Aligning moves comparison dates onto the primary series' band slots; the
+	// originals survive in `realDate` for tooltips.
 	const alignedSeries = useMemo( () => alignSeriesDates( series ), [ series ] );
 
 	const isEmptyData = useMemo( () => isEmptyChartData( alignedSeries ), [ alignedSeries ] );
 
-	/**
-	 * Tooltip swatches, resolved from the chart theme so they match the bars the
-	 * chart drew. The opacity matters: a comparison series shares its primary's
-	 * colour and is set apart only by the theme dimming it, so a swatch without
-	 * it renders the previous period as an identical twin of the current one.
-	 */
+	// The opacity matters: a comparison series shares its primary's colour, dimmed
+	// only by the theme — without it the swatch reads as an identical twin.
 	const seriesStyles = useMemo< TooltipStyle[] >(
 		() =>
 			alignedSeries.map( ( seriesData, index ) => {
@@ -213,10 +176,7 @@ export function ComparativeBarChart( {
 		[ alignedSeries, getElementStyles ]
 	);
 
-	/**
-	 * Y-axis formatter using dataFormat configuration, but with multipliers and
-	 * 0 decimals to keep tick strings short.
-	 */
+	// Multipliers and 0 decimals keep the tick strings short.
 	const yTickFormat = useMemo(
 		() => ( value: number ) =>
 			formatMetricValue( value, dataFormat.type, {
@@ -226,9 +186,8 @@ export function ComparativeBarChart( {
 		[ dataFormat ]
 	);
 
-	// With no declared format, `undefined` hands the axis to the chart's derived
-	// date formatter; `formatDate`'s `medium` default would otherwise put full
-	// site-format dates on every tick.
+	// `undefined` hands the axis to the chart's derived formatter; `formatDate`'s
+	// `medium` default would otherwise put full site-format dates on every tick.
 	const xTickFormat = useMemo(
 		() => ( xTickFormatType ? ( date: number ) => formatDate( date, xTickFormatType ) : undefined ),
 		[ xTickFormatType ]
@@ -238,21 +197,15 @@ export function ComparativeBarChart( {
 		() => resolveSeriesNames( series ),
 		[ series ]
 	);
-	// A legend item names a metric; the solid mark against its previous-period
-	// twin is what tells the periods apart. So a metric's two periods always
-	// collapse into one item, whether or not a counterpart shares the chart.
+	// A legend item names a metric; the solid mark against its previous-period twin
+	// is what tells the periods apart, so a metric's two periods always collapse.
 	const legendConfig = useMemo(
 		() => ( { collapseGroups: true, interactive: legendInteractive } ),
 		[ legendInteractive ]
 	);
 
-	/**
-	 * Label a tooltip row by its point's own date. Comparison points carry the
-	 * primary series' date for axis alignment, so read `realDate` when present
-	 * or the row would repeat the current period's date. A chart handed more than
-	 * one metric prefixes every row with its metric: dates alone would name two
-	 * rows the same as soon as the reader reveals the counterpart.
-	 */
+	// Comparison points carry the primary's date for axis alignment, so read
+	// `realDate`; a multi-metric chart also prefixes the metric to avoid duplicate names.
 	const getTooltipLabel = useCallback(
 		( datum: { date?: Date; realDate?: Date }, _index: number, key: string ): string => {
 			const displayDate = datum.realDate ?? datum.date;
@@ -269,15 +222,9 @@ export function ComparativeBarChart( {
 	);
 
 	/**
-	 * Re-attach the hovered category's previous-period value to the tooltip data.
-	 *
-	 * The bar chart draws comparison series as a separate shadow layer and hands
-	 * its tooltip only the primary series, so a datum for the previous period
-	 * never reaches a custom renderer. Its own default tooltip compensates by
-	 * looking the pair up, but supplying `renderTooltip` replaces that default
-	 * outright — without this the shadow bar would be visible while its value
-	 * stayed unreadable, including to screen readers. The line chart needs no
-	 * equivalent: it passes every series to its tooltip.
+	 * Re-attaches the hovered category's previous-period value to the tooltip
+	 * data: the bar chart's default tooltip only carries the primary series, so
+	 * without this the shadow bar would be visible but its value unreadable.
 	 *
 	 * @param tooltipData - The tooltip data from the chart.
 	 * @return The same data with a previous-period entry appended when one exists.
@@ -299,9 +246,8 @@ export function ComparativeBarChart( {
 					continue;
 				}
 
-				// A hidden metric contributes no bar, so its group's current period is
-				// absent here. Re-adding its shadow would put a series the reader chose
-				// not to see back in the tooltip.
+				// A hidden metric contributes no bar, so re-adding its shadow would put a
+				// series the reader chose not to see back in the tooltip.
 				const primaryLabel =
 					seriesData.group !== undefined ? primaryByGroup.get( seriesData.group ) : undefined;
 				if ( primaryLabel && ! datumByKey[ primaryLabel ] ) {
@@ -309,8 +255,7 @@ export function ComparativeBarChart( {
 				}
 
 				// Comparison dates were aligned onto the primary axis, so the hovered
-				// category matches on `date`; `realDate` still carries the true one and
-				// is what `getTooltipLabel` shows.
+				// category matches on `date`, not on `realDate`.
 				const paired = seriesData.data.find( point => point.date?.getTime() === hoveredTime );
 
 				if ( paired?.value != null ) {
@@ -389,8 +334,6 @@ export function ComparativeBarChart( {
 				data={ alignedSeries }
 				options={ chartOptions }
 				defaultHiddenSeries={ defaultHiddenSeries }
-				// Paired metrics collapse each current/comparison group into one item;
-				// single-metric charts retain their two period labels.
 				legend={ legendConfig }
 				margin={ margin }
 				maxWidth={ maxWidth }
@@ -407,8 +350,7 @@ export function ComparativeBarChart( {
 				onDatumActivate={ onDatumActivate }
 			>
 				{ /* Circle swatches, not the bar's own shape: the legend only needs to name
-				     the metrics — the solid bar against its translucent shadow is what
-				     tells the periods apart in the chart itself. */ }
+				     the metrics, since the chart itself tells the periods apart. */ }
 				{ ! isCompact && (
 					<BarChart.Legend
 						interactive={ legendInteractive }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/types.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-bar/types.ts
@@ -4,11 +4,8 @@
 import type { ComparativeLineChartSeries } from '../chart-comparative-line/types';
 
 /**
- * One bar series.
- *
- * An alias rather than its own shape: both comparative charts plot a date-keyed
- * time series and both run comparison points through `alignSeriesDates`, so a
- * separate declaration would only be a copy free to drift from the one the
- * shared helper actually accepts.
+ * One bar series. An alias rather than its own shape: both comparative charts plot a
+ * date-keyed time series and run comparison points through `alignSeriesDates`, so a
+ * separate declaration would only be free to drift from what that helper accepts.
  */
 export type ComparativeBarChartSeries = ComparativeLineChartSeries;

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/__tests__/comparative-line-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/__tests__/comparative-line-chart.test.tsx
@@ -10,9 +10,8 @@ import { siteSettingsIn } from '../../../__fixtures__/wp-date-settings';
 import { ComparativeLineChart } from '../comparative-line-chart';
 import type { ComparativeLineChartSeries } from '../types';
 
-// Record the props handed to the underlying chart. The real one renders SVG
-// through a provider jsdom cannot lay out, and what matters here is the tooltip
-// renderer and the visibility settings this wrapper composes.
+// The real chart renders SVG through a provider jsdom cannot lay out, so record
+// the props instead: the tooltip renderer and visibility settings are the subject.
 const mockLineSpy = jest.fn();
 const mockLegendSpy = jest.fn();
 
@@ -53,9 +52,8 @@ jest.mock( '../../../hooks', () => ( {
 
 const DATA_FORMAT = { type: 'number' as const, options: { decimals: 0 } };
 
-// A tooltip label reads its point as the instant it is, in the site's timezone,
-// so these are instants and every assertion below fixes the site's zone. Callers
-// whose points are wall clocks instead pass their own `formatTooltipDate`.
+// A tooltip label reads its point as the instant it is, in the site's timezone, so
+// these are instants and every assertion below fixes the site's zone.
 const JULY_1 = new Date( '2026-07-01T00:00:00Z' );
 // 2pm on July 2 in Tokyo.
 const JULY_2 = new Date( '2026-07-02T05:00:00Z' );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
@@ -28,14 +28,7 @@ import { alignSeriesDates } from './utils';
 import type { ComparativeLineChartSeries, SeriesStyle } from './types';
 import type { DataFormat } from '../../types';
 
-/**
- * Resolves series styles from either the explicit styles prop or series options.
- * Priority: styles prop > series[].options fallback
- *
- * @param stylesFromProp - Explicit styles passed as component prop
- * @param series         - Series data (may contain options with styles)
- * @return Array of resolved styles, one per series
- */
+/** Series styles, with the explicit `styles` prop taking priority over `series[].options`. */
 function resolveSeriesStyles(
 	stylesFromProp: SeriesStyle[] | undefined,
 	series: ComparativeLineChartSeries[]
@@ -58,10 +51,7 @@ function resolveSeriesStyles(
 	} );
 }
 
-/**
- * Default margin for charts.
- * Y-axis is on the left, so right margin is always 0.
- */
+/** The y-axis is on the left, so the right margin is always 0. */
 const DEFAULT_MARGIN = { right: 0 };
 
 /**
@@ -94,25 +84,14 @@ function applyStylesToSeries(
 	} );
 }
 
-/**
- * Inferred types
- */
 type LineChartProps = ComponentProps< typeof LineChart >;
 type RenderTooltipParams = Parameters< NonNullable< LineChartProps[ 'renderTooltip' ] > >[ 0 ];
 
 export type ComparativeLineChartProps = {
-	/**
-	 * Array of series data to display in the chart.
-	 * Series can include styling via options.stroke and options.seriesLineStyle
-	 * as a fallback when styles prop is not provided.
-	 */
+	/** A series may carry its own `options.stroke` / `options.seriesLineStyle` as a fallback. */
 	series: ComparativeLineChartSeries[];
 
-	/**
-	 * Explicit styles for each series. When provided, these take priority
-	 * over any styles defined in series[].options.
-	 * Array index corresponds to series index.
-	 */
+	/** Styles by series index; these win over anything in `series[].options`. */
 	styles?: SeriesStyle[];
 
 	className?: string;
@@ -123,10 +102,9 @@ export type ComparativeLineChartProps = {
 	tickFormat?: DateFormatName;
 
 	/**
-	 * The series' bucket size. Declaring it lets the automatic tick formatter pick
-	 * its regime from a known granularity instead of measuring the gaps between
-	 * points, which a single-bucket or DST-shortened series gives it no way to
-	 * read. An explicit `tickFormat` still wins over both.
+	 * The series' bucket size. Declaring it lets the automatic tick formatter read its
+	 * regime from a known granularity rather than the gaps between points, which a
+	 * single-bucket or DST-shortened series makes unreadable.
 	 */
 	tickResolution?: TickResolution;
 
@@ -138,8 +116,8 @@ export type ComparativeLineChartProps = {
 	formatTooltipDate?: ( date: Date, format: DateFormatName ) => string;
 
 	/**
-	 * Degrade to a sparkline (no y-axis, grid, or legend) when the chart area
-	 * is too short for readable axis labels. Defaults to false.
+	 * Degrade to a sparkline (no y-axis, grid, or legend) when the chart area is too
+	 * short for readable axis labels.
 	 */
 	compactWhenShort?: boolean;
 
@@ -198,18 +176,15 @@ export function ComparativeLineChart( {
 	);
 
 	const { seriesNames, isPaired } = useMemo( () => resolveSeriesNames( series ), [ series ] );
-	// A legend item names a metric; the solid mark against its previous-period
-	// twin is what tells the periods apart. So a metric's two periods always
-	// collapse into one item, whether or not a counterpart shares the chart.
+	// A legend item names a metric; the solid mark against its previous-period twin is
+	// what tells the periods apart, so a metric's two periods always collapse into one.
 	const legendConfig = useMemo(
 		() => ( { collapseGroups: true, interactive: legendInteractive } ),
 		[ legendInteractive ]
 	);
 
-	// Comparison points sit on the primary series' dates, so the tooltip reads
-	// the `realDate` preserved by `alignSeriesDates`. A chart handed more than
-	// one metric prefixes every row with its metric: dates alone would name two
-	// rows the same as soon as the reader reveals the counterpart.
+	// Comparison points share the primary series' dates, so the tooltip reads back
+	// `realDate`; multi-metric charts also prefix each row so two rows don't share a date.
 	const getTooltipLabel = useCallback(
 		( datum: { date: Date; realDate?: Date }, _index: number, key: string ): string => {
 			const name = seriesNames.get( key );
@@ -252,8 +227,6 @@ export function ComparativeLineChart( {
 		[ dataFormat ]
 	);
 
-	// Comparison dates are aligned onto the primary series for the X axis; the
-	// originals stay in `realDate` for tooltips.
 	const alignedSeries = useMemo( () => alignSeriesDates( series ), [ series ] );
 
 	const styledSeries = useMemo( () => {
@@ -282,9 +255,8 @@ export function ComparativeLineChart( {
 		const baseOptions = {
 			axis: {
 				x: {
-					// Must stay conditional: `formatDate` defaults to `medium`, so an
-					// unconditional `xTickFormat` would put full site-format dates on every
-					// tick. Without the prop, the chart library's own tick labels stay in use.
+					// Must stay conditional: `formatDate` defaults to `medium`, so passing
+					// `xTickFormat` unconditionally puts full dates on every tick.
 					tickFormat: xTickFormatType ? xTickFormat : undefined,
 					tickResolution,
 				},
@@ -313,8 +285,6 @@ export function ComparativeLineChart( {
 				data={ styledSeries }
 				options={ chartOptions }
 				defaultHiddenSeries={ defaultHiddenSeries }
-				// Paired metrics collapse each current/comparison group into one item;
-				// single-metric charts retain their two period labels.
 				legend={ legendConfig }
 				// With the y-axis hidden, reclaim its reserved left margin for the line.
 				margin={ isCompact ? { ...margin, left: 0 } : margin }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/utils/align-series-dates.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/utils/align-series-dates.test.ts
@@ -105,9 +105,7 @@ describe( 'alignSeriesDates', () => {
 		} );
 
 		it( 'handles weekly intervals with different start days', () => {
-			// This is the key scenario: weeks that don't start on the same day
-			// Primary: Sep 12 (Thu) - period starts mid-week
-			// Comparison: Jun 14 (Sat) - period starts on different day
+			// The key scenario: the two periods start on different weekdays.
 			const primary = createSeries( 'Current Period', [
 				new Date( '2024-09-12' ), // Week 1 starts Thu
 				new Date( '2024-09-16' ), // Week 2 starts Mon

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/utils/align-series-dates.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/utils/align-series-dates.ts
@@ -5,24 +5,9 @@ import { resolvePrimarySeriesByGroup } from '../../../helpers/resolve-series-nam
 import type { ComparativeLineChartSeries } from '../types';
 
 /**
- * Aligns comparison series dates to primary series dates by index.
- *
- * Each comparison point gets assigned the date of the corresponding primary point
- * (same index), ensuring both series align perfectly on the X-axis regardless of
- * their original date intervals. Original dates are preserved in realDate for tooltips.
- *
- * This approach handles:
- * - Different period lengths (e.g., weeks starting on different days)
- * - Partial intervals at period boundaries
- * - Any time granularity (daily, weekly, monthly)
- *
- * Only series marked `options.type: 'comparison'` are moved. A grouped
- * comparison aligns to its group's current period; an ungrouped one retains
- * the historical behavior of aligning to the first series. A second current
- * period is not moved.
- *
- * @param series - Array of series data to align by group and index
- * @return New array with aligned series (comparison dates match primary, originals in realDate)
+ * Aligns comparison points onto the primary series by index, keeping their real dates
+ * in `realDate` for tooltips. A grouped comparison aligns to its group's current
+ * period; an ungrouped one keeps the historical behavior of aligning to series[0].
  */
 export function alignSeriesDates(
 	series: ComparativeLineChartSeries[]

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart-skeleton.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart-skeleton.tsx
@@ -9,10 +9,8 @@ import { SkeletonRoot } from '../widget-skeleton';
 import styles from './donut-chart-skeleton.module.scss';
 
 /**
- * The design prototype draws four legend rows, and the count is deliberately
- * not derived from the widget: a donut's segment count only arrives with the
- * response, so a stand-in tracking it would land on the wrong count and read as
- * the layout jump it was meant to prevent.
+ * Deliberately not derived from the widget: a donut's segment count only arrives
+ * with the response, so a stand-in tracking it would read as a layout jump.
  */
 const LEGEND_ROW_COUNT = 4;
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.tsx
@@ -34,9 +34,6 @@ export type LegendLabels = {
 export type LeaderboardChartProps = {
 	className?: string;
 
-	/**
-	 * Leaderboard data (label, currentValue, previousValue, currentShare, previousShare, delta)
-	 */
 	data: LeaderboardChartData;
 
 	loading?: boolean;
@@ -62,21 +59,17 @@ export type LeaderboardChartProps = {
 	};
 
 	/**
-	 * Show only complete rows that fit the widget height instead of scrolling.
-	 *
-	 * Defaults to `true` here, unlike the underlying charts prop, because widgets
-	 * sit in fixed-height tiles. Pass `false` to keep the list scrollable.
+	 * Show only complete rows that fit the widget height instead of scrolling. Defaults
+	 * to `true` here, unlike the underlying charts prop, because widgets sit in
+	 * fixed-height tiles.
 	 * @default true
 	 */
 	fitRows?: boolean;
 };
 
 /**
- * "Top X by Y" ranking chart wrapping `LeaderboardChartUnresponsive` with the
- * package's formatting and styling.
- *
- * Must render inside a `GlobalChartsProvider`: colors, theme, and element
- * styles are read from that context.
+ * "Top X by Y" ranking chart wrapping `LeaderboardChartUnresponsive`. Must render
+ * inside a `GlobalChartsProvider`: colors, theme, and element styles come from it.
  */
 export function LeaderboardChart( {
 	className,
@@ -102,15 +95,8 @@ export function LeaderboardChart( {
 		[ dataFormat ]
 	);
 
-	/**
-	 * Bar color for overlay-label mode.
-	 *
-	 * The label sits on top of the bar, so the bar needs to read as a faint
-	 * tint of the primary color. We can't pass a translucent color through the
-	 * chart's `primaryColor` prop — it resolves the value via getElementStyles,
-	 * which strips the alpha channel. Instead we pre-blend the primary with
-	 * white to produce the opaque equivalent of an 8% alpha fill.
-	 */
+	// A translucent `primaryColor` would not survive `getElementStyles`, which strips
+	// the alpha channel, so pre-blend with white to the opaque equivalent of an 8% fill.
 	const barColor = useMemo( () => {
 		if ( ! withOverlayLabel ) {
 			return undefined;

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-row.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-row.tsx
@@ -79,9 +79,8 @@ export type LeaderboardRowChartProps =
 /**
  * Resolve raw row navigation facts into one mutually exclusive action.
  *
- * Child rows take precedence over an external URL because chart rows cannot
- * be buttons and contain interactive link content at the same time. A URL is
- * therefore used only for a childless row; otherwise the row stays static.
+ * Child rows take precedence over an external URL because a chart row cannot be a
+ * button and hold interactive link content at the same time.
  *
  * @return The single action that the leaderboard row should expose.
  */
@@ -102,9 +101,8 @@ export function resolveLeaderboardRowAction(
 /**
  * Render the shared leaderboard row chrome around a label.
  *
- * Drill-down actions stay non-interactive here because `LeaderboardChart` turns
- * the whole row into a button; `buildLeaderboardRow` passes that action to the
- * chart.
+ * Drill-down actions stay non-interactive here because `LeaderboardChart` turns the
+ * whole row into a button.
  *
  * @return A single label element accepted by `LeaderboardEntry.label`.
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-skeleton.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-skeleton.tsx
@@ -18,32 +18,21 @@ const DEFAULT_ROW_COUNT = 5;
 const ALL_ROWS_COUNT = 12;
 
 /**
- * Which of the design's two leaderboard shapes to draw.
- *
- * `list` matches a chart drawn `withOverlayLabel`, where the label sits on the
- * bar and the row loads as one line. `bars` matches the plain chart, whose
- * label sits above its bar.
+ * Which of the design's two leaderboard shapes to draw. `list` matches a chart drawn
+ * `withOverlayLabel`, whose label sits on the bar; `bars` matches the plain chart,
+ * whose label sits above it.
  */
 export type LeaderboardSkeletonVariant = 'list' | 'bars';
 
 export interface LeaderboardSkeletonProps {
 	/** Rows to draw; pass the widget's own row count so the shape matches the list that will load. */
 	rows?: number;
-	/** Which shape to draw. */
 	variant?: LeaderboardSkeletonVariant;
 }
 
 /**
- * Loading shape for `LeaderboardChart`: a centred stack of rows.
- *
- * Rows past the tile's height are clipped rather than overflowing, mirroring
- * the chart's `fitRows` — a ten-row widget in a tile with room for three shows
- * three either way.
- *
- * @param props         - Component props.
- * @param props.rows    - Rows to draw.
- * @param props.variant - Which shape to draw.
- * @return The rendered skeleton.
+ * Loading shape for `LeaderboardChart`: a centred stack of rows. Rows past the tile's
+ * height are clipped rather than overflowing, mirroring the chart's `fitRows`.
  */
 export function LeaderboardSkeleton( {
 	rows = DEFAULT_ROW_COUNT,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-tooltip/__tests__/chart-tooltip.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-tooltip/__tests__/chart-tooltip.test.tsx
@@ -7,9 +7,8 @@ import { render, screen } from '@testing-library/react';
  */
 import { ChartTooltip } from '../chart-tooltip';
 
-// The swatches come from the charts library's own shape components, which need
-// a provider jsdom cannot lay out. Stand them in for elements that expose the
-// style they were handed.
+// The library's shape components need a provider jsdom cannot lay out, so stand
+// them in for elements that expose the style they were handed.
 jest.mock( '@jetpack-premium-analytics/externals', () => ( {
 	LineShape: ( { fill }: { fill: string } ) => <span data-testid="swatch" data-fill={ fill } />,
 	RectShape: ( { fill }: { fill: string } ) => <span data-testid="swatch" data-fill={ fill } />,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-tooltip/chart-tooltip.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-tooltip/chart-tooltip.tsx
@@ -10,21 +10,14 @@ import { TooltipRow } from './tooltip-row';
 import { isChartDatumEntry } from './utils';
 import type { DataFormat } from '../../types';
 
-/**
- * Style configuration for tooltip indicators.
- * Matches SeriesStyle pattern from chart components.
- */
+/** Mirrors the `SeriesStyle` shape the chart components use. */
 export type TooltipStyle = {
-	/** Color for the indicator */
 	stroke: string;
 
-	/** Stroke width (for line indicator) */
 	strokeWidth?: string | number;
 
-	/** Stroke dash array (for line indicator) */
 	strokeDasharray?: string | number;
 
-	/** Stroke dash offset (for line indicator) */
 	strokeDashoffset?: string | number;
 
 	/** Indicator opacity, so a swatch can match a mark the chart drew translucent. */
@@ -45,35 +38,23 @@ function defaultGetValue( datum: unknown ): number {
 }
 
 export type ChartTooltipProps< TDatum = unknown > = {
-	/**
-	 * Tooltip data from visx chart
-	 */
+	/** Tooltip data from the visx chart. */
 	tooltipData?: {
 		datumByKey?: Record< string, unknown >;
 	};
 
 	dataFormat: DataFormat;
 
-	/**
-	 * Array of styles for each series (required).
-	 * Index corresponds to series index.
-	 */
+	/** One style per series, indexed by series position. */
 	seriesStyles: TooltipStyle[];
 
 	/**
-	 * Series keys in the same order as `seriesStyles`, used to pair a row with
-	 * its style by key instead of by position. Charts emit their tooltip rows in
-	 * their own order — a bar chart drawing two metrics lists both current
-	 * periods before either previous period — so a positional lookup hands rows
-	 * the wrong swatch as soon as the two orders diverge. Omit for charts whose
-	 * rows always arrive in series order.
+	 * Series keys in the same order as `seriesStyles`, pairing a row with its style by
+	 * key rather than position — charts emit rows in their own order, so a positional
+	 * lookup hands rows the wrong swatch. Omit when rows arrive in series order.
 	 */
 	seriesKeys?: string[];
 
-	/**
-	 * Indicator type: 'line' for line charts, 'rect' for bar charts
-	 * Uses chart library's LineShape and RectShape components.
-	 */
 	indicatorType: 'line' | 'rect';
 
 	getLabel?: ( datum: TDatum, index: number, key: string ) => string;
@@ -111,9 +92,8 @@ export function ChartTooltip< TDatum >( {
 					return null;
 				}
 
-				// No positional fallback once `seriesKeys` is given: that lookup is the
-				// bug the prop exists to fix, and reinstating it on a miss would paint
-				// the row a wrong-but-plausible swatch rather than an obviously odd one.
+				// No positional fallback once `seriesKeys` is given: that lookup is the bug
+				// the prop exists to fix, and on a miss it paints a plausible wrong swatch.
 				const style = seriesKeys
 					? seriesStyles[ seriesKeys.indexOf( entry.key ) ]
 					: seriesStyles[ index ];

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/download-csv/__tests__/csv-download-button.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/download-csv/__tests__/csv-download-button.test.tsx
@@ -12,11 +12,8 @@ const mockDispatch = jest.fn( () => ( {
 	createErrorNotice: mockCreateErrorNotice,
 } ) );
 
-// Override `useRegistry` only, falling through to the real module for everything else:
-// the component's import graph now reaches other consumers of `@wordpress/data`
-// (rich-text's store calls `combineReducers` at import time), which a `useRegistry`-only
-// mock breaks. The fall-through has to resolve lazily — calling `requireActual` in the
-// factory body re-enters `@wordpress/data` while it is still initialising.
+// Override `useRegistry` only — a bare mock breaks other `@wordpress/data`
+// consumers; the fall-through resolves lazily since `requireActual` re-enters mid-init.
 jest.mock(
 	'@wordpress/data',
 	() =>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
@@ -12,10 +12,8 @@ import { MetricTabsChart } from '../metric-tabs-chart';
 import type { ComparativeLineChartSeries } from '../../chart-comparative-line/types';
 import type { MetricTab } from '../metric-tabs-chart';
 
-// The charts themselves render SVG through a provider that jsdom cannot lay
-// out. Standing them in for prop recorders keeps this test on what this
-// component decides: which chart renders, and how the comparison series is
-// shaped for it.
+// The charts render SVG through a provider jsdom cannot lay out, so stand them in
+// for prop recorders.
 const mockLineSpy = jest.fn();
 const mockBarSpy = jest.fn();
 
@@ -87,12 +85,7 @@ const VISITORS: MetricTab = {
 	counterpartKey: 'views',
 };
 
-/**
- * The props the most recent chart render received.
- *
- * @param spy - The chart stand-in to read.
- * @return The recorded props.
- */
+/** The props the most recent chart render received. */
 function recordedProps( spy: jest.Mock ): ChartProps {
 	// Without this, a chart that never rendered yields `undefined` and the
 	// assertions below fail as a TypeError that names the wrong cause.
@@ -111,23 +104,12 @@ const WALL_CLOCK_METRIC: MetricTab = {
 	previous: undefined,
 };
 
-/**
- * The series the most recent chart render received.
- *
- * @param spy - The chart stand-in to read.
- * @return The recorded series.
- */
+/** The series the most recent chart render received. */
 function recordedSeries( spy: jest.Mock ): ComparativeLineChartSeries[] {
 	return recordedProps( spy ).series;
 }
 
-/**
- * Play a press and release over a datum, optionally moving between them.
- *
- * @param spy      - The chart stand-in to drive.
- * @param datum    - The datum the pointer resolves to.
- * @param distance - How far (px) the pointer travels before release.
- */
+/** Play a press and release over a datum, optionally moving between them. */
 function pressAndRelease( spy: jest.Mock, datum: unknown, distance = 0 ) {
 	const { onPointerDown, onPointerUp } = recordedProps( spy );
 
@@ -139,10 +121,6 @@ function pressAndRelease( spy: jest.Mock, datum: unknown, distance = 0 ) {
  * The props of the render that drew `label` as its active metric. During a tab
  * switch, the outgoing panel may render again before the incoming panel mounts,
  * so the most recent call is not necessarily the metric under test.
- *
- * @param spy   - The chart stand-in to read.
- * @param label - The active metric's label, which is also its first series'.
- * @return The recorded props.
  */
 function recordedPropsFor( spy: jest.Mock, label: string ): ChartProps {
 	const call = spy.mock.calls
@@ -152,12 +130,7 @@ function recordedPropsFor( spy: jest.Mock, label: string ): ChartProps {
 	return call[ 0 ];
 }
 
-/**
- * The tooltip date formatter the most recent chart render received.
- *
- * @param spy - The chart stand-in to read.
- * @return The recorded formatter.
- */
+/** The tooltip date formatter the most recent chart render received. */
 function recordedTooltipDateFormatter(
 	spy: jest.Mock
 ): ( date: Date, format: DateFormatName ) => string {
@@ -248,12 +221,8 @@ describe( 'MetricTabsChart', () => {
 		expect( screen.queryByText( '300' ) ).not.toBeInTheDocument();
 	} );
 
-	// Only the Stats widgets build wall clocks; the post and video charts hand
-	// over real instants (`parseSiteDateTime`), which re-anchoring would shift
-	// (see `chart-date.ts`) — so the reading has to stay opt-in. Asserted against
-	// the formatter rather than a literal, and over two site zones, so the check
-	// cannot come out vacuous on whichever timezone the machine running it
-	// happens to be in.
+	// Only Stats widgets build wall clocks; post/video instants would shift if
+	// re-anchored (see `chart-date.ts`). Two zones keep this check non-vacuous.
 	it.each( [ 'Asia/Tokyo', 'America/Los_Angeles' ] )(
 		'reads a point as the instant it is unless the producer says otherwise, on a site in %s',
 		siteZone => {
@@ -329,9 +298,8 @@ describe( 'MetricTabsChart', () => {
 
 		const { series } = recordedPropsFor( mockLineSpy, 'Views' );
 
-		// The current period carries the bare metric name, which is what the
-		// collapsed legend item shows. Comparison labels remain distinct and stable
-		// when the selected dashboard range changes.
+		// The current period carries the bare metric name, which is what the collapsed
+		// legend item shows.
 		expect( series[ 0 ].label ).toBe( 'Views' );
 		expect( series[ 2 ].label ).toBe( 'Visitors' );
 		expect( new Set( series.map( item => item.label ) ).size ).toBe( series.length );
@@ -420,9 +388,8 @@ describe( 'MetricTabsChart', () => {
 		expect( recordedProps( mockLineSpy ).legendInteractive ).toBe( false );
 	} );
 
-	// The Traffic summary pairs Views with Visitors, but the hourly grain serves
-	// Views alone. Drawing the pair there would offer the legend a series the
-	// request never asked for, which reveals as a flat zero line.
+	// The Traffic summary pairs Views with Visitors, but the hourly grain serves Views
+	// alone, so drawing the pair there offers the legend a flat zero line.
 	it( 'ignores a counterpart with nothing to report at this bucket size', () => {
 		const unavailableVisitors = { ...VISITORS, unavailable: "Hourly data isn't available." };
 
@@ -462,10 +429,8 @@ describe( 'MetricTabsChart', () => {
 	} );
 
 	it( 'keeps the same chart ID across a chart-type switch', () => {
-		// The line and bar charts are different components, so switching between
-		// them remounts. The provider only carries a reveal over that remount if
-		// both mounts name the same chart, so this is what keeps a revealed
-		// counterpart revealed when the reader flips the chart type.
+		// Switching chart type remounts a different component, and the provider only
+		// carries a revealed counterpart over that remount under the same chart ID.
 		const { rerender } = render(
 			<MetricTabsChart metrics={ [ VIEWS, VISITORS ] } dataFormat={ DATA_FORMAT } />
 		);
@@ -505,9 +470,8 @@ describe( 'MetricTabsChart', () => {
 		} );
 
 		/*
-		 * A wall-clock point names a bucket, not an instant, so the date handed on
-		 * must be re-anchored in the site's zone first — otherwise an hourly
-		 * bucket opens the browser's day rather than the site's.
+		 * A wall-clock point names a bucket, not an instant: re-anchor the date in
+		 * the site's zone first, or an hourly bucket opens the browser's day, not the site's.
 		 */
 		it.each( [
 			[ 'America/Los_Angeles', '2026-07-21T20:00:00.000Z' ],
@@ -553,9 +517,8 @@ describe( 'MetricTabsChart', () => {
 		} );
 
 		/*
-		 * A release the chart never saw a press for belongs to a gesture that
-		 * started off the plot, so it must not open a date the pointer only
-		 * happened to end over.
+		 * A release the chart never saw a press for started off the plot, so it
+		 * must not open a date the pointer only happened to end over.
 		 */
 		it( 'ignores a release with no press behind it', () => {
 			const onDatumClick = jest.fn();

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -34,31 +34,20 @@ const MIN_TAB_WIDTH = 120;
 
 /**
  * How far (px) the pointer may travel between down and up and still count as a
- * click. Above it the gesture is a drag — a zoom selection, or a slip on the
- * way up — and must not drill the dashboard to a date the reader was only
- * passing over.
+ * click. Above it the gesture is a drag and must not drill the dashboard.
  */
 const CLICK_DRAG_TOLERANCE_PX = 6;
 
-/**
- * The pointer-event payload both comparative charts report, carrying the datum
- * nearest the pointer.
- */
+/** The pointer-event payload both comparative charts report. */
 type ChartPointerParams = Parameters<
 	NonNullable< ComponentProps< typeof ComparativeLineChart >[ 'onPointerUp' ] >
 >[ 0 ];
 
-/**
- * The keyboard activation payload both comparative charts report, carrying the
- * datum keyboard navigation had selected.
- */
+/** The keyboard activation payload both comparative charts report. */
 type ChartActivateParams = Parameters<
 	NonNullable< ComponentProps< typeof ComparativeLineChart >[ 'onDatumActivate' ] >
 >[ 0 ];
 
-/**
- * A single time-series point for a metric.
- */
 export interface MetricTabDatum {
 	date: Date;
 	value: number;
@@ -85,11 +74,9 @@ export interface MetricTab {
 	/** Optional explanatory text, surfaced as the card's tooltip. */
 	description?: string;
 	/**
-	 * Key of the metric to draw beside this one, hidden until the reader reveals
-	 * it from the legend. Pairs are declared per metric rather than derived, so
-	 * a widget decides which of its metrics are worth comparing. A key naming no
-	 * metric in the list, the metric itself, or a metric that is `unavailable` at
-	 * the current bucket size, is ignored.
+	 * Key of the metric to draw beside this one, hidden until the reader reveals it
+	 * from the legend. A key naming no metric in the list, the metric itself, or an
+	 * `unavailable` metric, is ignored.
 	 */
 	counterpartKey?: string;
 	/**
@@ -127,10 +114,9 @@ export interface MetricTabsChartProps {
 	 */
 	tickResolution?: TickResolution;
 	/**
-	 * Whether each point's date is a Stats bucket's wall clock (as `toChartDate`
-	 * builds them) rather than a real instant. Wall clocks are re-anchored via
-	 * `fromChartDate` before a label reads them; instants must be read as they
-	 * are, hence the opt-in. Full rationale in `chart-date.ts`.
+	 * Whether each point's date is a Stats bucket's wall clock rather than a real
+	 * instant; wall clocks are re-anchored via `fromChartDate` before a label reads
+	 * them. Full rationale in `chart-date.ts`.
 	 */
 	pointsAreWallClocks?: boolean;
 	/**
@@ -149,16 +135,9 @@ type ReadPointDate = ( date: Date ) => Date;
 const asInstant: ReadPointDate = date => date;
 
 /**
- * Build the chart series for a metric: the current period plus, when present,
- * the previous period as a same-`group` (same colour) `comparison` series. The
- * current period is labelled by metric name, which is what the collapsed legend
- * item reads; the section header names the dates.
- *
- * The comparison series' options differ by chart type. A line needs its area
- * fill suppressed so only the current period is filled — but that same
- * transparent gradient would erase the bar chart's shadow bar, which is a fill
- * rather than a stroke. Bars therefore carry `type` alone and let the charts
- * theme resolve the shadow's colour and width factor.
+ * Build the chart series for a metric: current period plus, when present, the
+ * previous period as a same-`group` comparison series. A line needs its area
+ * fill suppressed — that gradient would erase the bar chart's shadow fill.
  *
  * @param metric    - The metric to draw.
  * @param chartType - How the metric is drawn.
@@ -197,13 +176,8 @@ function buildSeries(
 
 /**
  * The chart for a single metric — the current period with its previous-period
- * overlay, drawn as lines or bars. `compactWhenShort` lets the chart degrade to
- * a sparkline (dropping its axis, grid, and legend) on short tiles instead of
- * squashing its labels on top of each other.
- *
- * A `counterpart` is drawn alongside the metric but seeded hidden, so the
- * legend offers it as a one-click comparison. Its previous period is seeded
- * with it, which is why revealing the item brings the whole overlay back.
+ * overlay, drawn as lines or bars. A `counterpart` is drawn alongside it but
+ * seeded hidden, so the legend offers it as a one-click comparison.
  *
  * @return The chart for the metric.
  */
@@ -248,11 +222,8 @@ function MetricChart( {
 
 	const reportDatum = useCallback(
 		( datum: unknown ) => {
-			/*
-			 * `alignSeriesDates` rewrites a comparison point's date to the primary
-			 * point it is drawn under, so whichever series the gesture resolves to,
-			 * its datum carries the current-period date.
-			 */
+			// `alignSeriesDates` rewrites a comparison point's date to the primary point
+			// it is drawn under, so either series' datum carries the current-period date.
 			const date = ( datum as { date?: unknown } | undefined )?.date;
 
 			if ( date instanceof Date ) {
@@ -304,11 +275,8 @@ function MetricChart( {
 		  }
 		: {};
 
-	// Resolve each series' colour + line style from the chart theme so the chart
-	// lines and the tooltip glyphs share the same styling — including the dashed
-	// pattern on the previous-period series. Bars resolve their own styles inside
-	// `ComparativeBarChart`, since the shadow's geometry comes from the theme's
-	// bar styles rather than these line styles.
+	// Resolved from the chart theme so the lines and the tooltip glyphs match. Bars
+	// resolve their own inside `ComparativeBarChart`, off the theme's bar styles.
 	const seriesStyles = useSeriesStyles( series );
 	const resolvedDataFormat = metric.dataFormat ?? dataFormat;
 
@@ -349,10 +317,8 @@ function MetricChart( {
 }
 
 /**
- * A metric's card face: its label over the headline value and delta, or over a
- * placeholder when the metric has nothing to report at this bucket size. Shared
- * by the tab, single-metric, and dropdown-trigger layouts so the three cannot
- * drift apart.
+ * A metric's card face, shared by the tab, single-metric, and dropdown-trigger
+ * layouts so the three cannot drift apart.
  *
  * @return The card's content.
  */
@@ -367,19 +333,16 @@ function MetricTabContent( {
 	fontSize?: ComponentProps< typeof MetricWithComparison >[ 'fontSize' ];
 	withDescription?: boolean;
 } ) {
-	// The unavailable reason has no other channel here, so it is always exposed.
-	// The description is not: as a tab it already rides on `title`, and inside the
-	// dropdown trigger a hidden node would join the button's accessible name and
-	// be announced on every focus.
+	// The description is opt-in: a tab already carries it on `title`, and in the
+	// dropdown trigger a hidden node would join the button's accessible name.
 	const note = metric.unavailable ?? ( withDescription ? metric.description : undefined );
 
 	return (
 		<span className={ styles.tabContent }>
 			<Text className={ styles.tabLabel }>{ metric.label }</Text>
 			{ metric.unavailable ? (
-				// Sized off the same token as the value it stands in for — the tab and
-				// trigger layouts ask for different ones, so a fixed size reads a step
-				// too large in one of them. `MetricWithComparison`'s own default.
+				// Sized off the same token as the value it stands in for: the tab and
+				// trigger layouts ask for different ones, so a fixed size misreads in one.
 				<span
 					className={ styles.unavailableValue }
 					style={
@@ -410,21 +373,9 @@ function MetricTabContent( {
 }
 
 /**
- * A metric switcher over a comparative chart: a row of selectable cards
- * (each a headline value + period-over-period delta) built on `@wordpress/ui`
- * `Tabs`, and below them the selected metric's current period with its
- * previous-period overlay, drawn as lines or bars per `chartType`. Reused by
- * Stats time-series widgets (subscribers chart, traffic chart) — the consumer
- * supplies the per-metric data and headline values; this owns selection, series
- * building, and layout.
- *
- * A metric naming another through `counterpartKey` is drawn with that metric
- * beside it, seeded hidden so the legend offers it as a one-click comparison.
- * The legend names the metrics; the dates the chart covers are the section
- * header's job.
- *
- * Responsive: on narrow tiles the tabs collapse into a dropdown whose trigger
- * is the selected metric's card; on short tiles the chart degrades to a sparkline.
+ * A metric switcher over a comparative chart: a row of selectable cards and, below
+ * them, the selected metric's chart. The consumer supplies the per-metric data;
+ * this owns selection, series building, and layout.
  *
  * @param {MetricTabsChartProps} props - The component props.
  * @return The metric tabs + chart.
@@ -444,9 +395,8 @@ export function MetricTabsChart( {
 	const readPointDate = pointsAreWallClocks ? fromChartDate : asInstant;
 	const [ selectedKey, setSelectedKey ] = useState( defaultMetricKey ?? metrics[ 0 ]?.key );
 
-	// The chart seeds its hidden series once per chart ID, so the ID has to name
-	// the metric: switching metrics swaps which of a pair is hidden, and a stable
-	// ID would leave the chart showing the previous selection's hidden set.
+	// The chart seeds its hidden series once per chart ID, so a stable ID would leave
+	// the chart showing the previous selection's hidden set.
 	const chartIdBase = useId();
 	const chartIdFor = useCallback(
 		( metric: MetricTab ) => `${ chartIdBase }-${ metric.key }`,
@@ -460,23 +410,19 @@ export function MetricTabsChart( {
 
 			const counterpart = metrics.find( candidate => candidate.key === metric.counterpartKey );
 
-			// A counterpart with nothing to report at this bucket size would reach
-			// the legend as a series the request never asked for, and reveal as a
-			// flat zero line.
+			// A counterpart with nothing to report at this bucket size would reveal as
+			// a flat zero line for a series the request never asked for.
 			return counterpart?.unavailable ? undefined : counterpart;
 		},
 		[ metrics ]
 	);
 
-	// Controlled open state: the dashboard's focusable drag-sortable wrapper
-	// closes the popup (reason 'none') right after it opens, so we open on
-	// click, drop 'none' closes, and close explicitly on selection. Real closes
-	// (outside press, Escape) carry a specific reason and pass through.
+	// Controlled open state: the drag-sortable wrapper closes the popup (reason
+	// 'none') right after it opens, so those closes are dropped; selection closes it explicitly.
 	const [ isDropdownOpen, setIsDropdownOpen ] = useState( false );
 
-	// Tabs↔dropdown flips are debounced: each flip remounts the header + chart
-	// subtree, and during a drag-resize the width oscillates around grid snap
-	// boundaries fast enough to freeze the page and abort the gesture.
+	// Flips are debounced: each remounts the header + chart subtree, and a drag-resize
+	// oscillates the width around grid snap boundaries fast enough to freeze the page.
 	const [ width, setWidth ] = useState< number >();
 	const hasMeasuredRef = useRef( false );
 	const flipTimerRef = useRef< ReturnType< typeof setTimeout > >();
@@ -497,7 +443,6 @@ export function MetricTabsChart( {
 	useEffect( () => () => clearTimeout( flipTimerRef.current ), [] );
 	const useDropdown = width !== undefined && width < metrics.length * MIN_TAB_WIDTH;
 
-	// Fall back to the first metric if the selected one is no longer present.
 	const activeMetric = metrics.find( metric => metric.key === selectedKey ) ?? metrics[ 0 ];
 
 	const handleValueChange = useCallback(
@@ -555,18 +500,16 @@ export function MetricTabsChart( {
 		return (
 			<div ref={ measureRef } className={ styles.root }>
 				<div className={ styles.header }>
-					{ /* Stops pointer-down from starting a widget drag and opens the select
-					     on click (see `isDropdownOpen`). Mouse-only supplement — keyboard
-					     users open the select through the trigger button itself. */ }
+					{ /* Stops pointer-down from starting a widget drag. Mouse-only supplement —
+					     keyboard users open the select through the trigger button itself. */ }
 					{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */ }
 					<div
 						className={ styles.picker }
 						onPointerDown={ event => event.stopPropagation() }
 						onMouseDown={ event => event.stopPropagation() }
 						onClick={ event => {
-							// React bubbles portaled popup events through the component tree,
-							// so option clicks land here too; reopening on them would undo the
-							// close-on-select. Only treat clicks inside the wrapper as opens.
+							// React bubbles portaled popup events through the component tree, so
+							// option clicks land here too and would undo the close-on-select.
 							if ( event.currentTarget.contains( event.target as Node ) ) {
 								setIsDropdownOpen( true );
 							}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/stories/metric-tabs-chart.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/stories/metric-tabs-chart.stories.tsx
@@ -26,13 +26,7 @@ const PREVIOUS_DATES = [
 	new Date( '2026-05-31' ),
 ];
 
-/**
- * Pair a value series with a set of dates.
- *
- * @param dates  - One date per value.
- * @param values - The series values.
- * @return The metric points.
- */
+/** Pair a value series with a set of dates. */
 const points = ( dates: Date[], values: number[] ) =>
 	dates.map( ( date, index ) => ( { date, value: values[ index ] } ) );
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/__tests__/metric-tile-grid-skeleton.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/__tests__/metric-tile-grid-skeleton.test.tsx
@@ -15,9 +15,8 @@ describe( 'MetricTileGridSkeleton', () => {
 	} );
 
 	it( 'fills the grid when every metric is switched off', () => {
-		// Callers pass a count they know before the response, but it is 0 when
-		// the user has deselected every metric — drawing that literally would
-		// leave an empty loading state.
+		// The caller's known count is 0 when every metric is deselected; drawing
+		// that literally would leave an empty loading state.
 		render( <MetricTileGridSkeleton tiles={ 0 } /> );
 
 		expect( screen.getAllByTestId( 'skeleton-tile' ).length ).toBeGreaterThan( 1 );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.tsx
@@ -16,20 +16,14 @@ export interface MetricTileGridSkeletonProps {
 }
 
 /**
- * Loading shape for `MetricTileGrid`: a label and value placeholder per metric,
- * stacked as full-width rows and switching to a centred row of columns at the
- * same width the loaded grid does.
- *
- * @param props       - Component props.
- * @param props.tiles - Tiles to draw.
- * @return The rendered skeleton.
+ * Loading shape for `MetricTileGrid`: a label and value placeholder per metric, which
+ * switches from stacked rows to a centred row of columns where the loaded grid does.
  */
 export function MetricTileGridSkeleton( {
 	tiles = DEFAULT_TILE_COUNT,
 }: MetricTileGridSkeletonProps ) {
-	// Every caller passes a count it knows before the response, but that count
-	// is 0 when the user has switched every metric off; drawing it literally
-	// would leave an empty loading state.
+	// The caller's count is 0 when the user has switched every metric off, and drawing
+	// that literally would leave an empty loading state.
 	const tileCount = tiles > 0 ? tiles : DEFAULT_TILE_COUNT;
 
 	return (

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/peak-distribution/peak-distribution.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/peak-distribution/peak-distribution.tsx
@@ -33,9 +33,8 @@ export function PeakDistribution( {
 	valueUnit = 'views',
 }: PeakDistributionProps ) {
 	const plainViewsOptions = { ...PLAIN_VIEWS_OPTIONS, decimals: valueDecimals };
-	// A positive figure can still round to zero at the shown precision: one view
-	// a month is 0.03 a day. A named peak sitting over "0 views per day" reads as
-	// no data, so report the smallest figure the precision can carry instead.
+	// A positive figure can round to zero at the shown precision (one view a month is
+	// 0.03 a day), and a named peak over "0 views per day" reads as no data.
 	const isBelowPrecision = value > 0 && Number( value.toFixed( valueDecimals ) ) === 0;
 	const shownValue = isBelowPrecision ? 10 ** -valueDecimals : value;
 	const exactViews = formatMetricValue( shownValue, 'number', plainViewsOptions );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/__tests__/post-highlight-card.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/__tests__/post-highlight-card.test.tsx
@@ -48,9 +48,8 @@ jest.mock( '@wordpress/route', () => {
 const props: PostHighlightCardProps = {
 	title: 'Quarterly update',
 	url: 'https://example.com/quarterly-update/',
-	// Midnight on purpose: the publish line formats in the site timezone (UTC
-	// here), so the date must hold on hosts west of it. A host-zone regression
-	// would show Jun 4 under `test-tz`.
+	// Midnight on purpose: formats in the site zone (UTC here), so this must hold
+	// on hosts west of it — a regression would show Jun 4 under `test-tz`.
 	date: '2026-06-05T00:00:00+00:00',
 	metrics: [
 		{ key: 'views', label: 'Views', value: 42 },
@@ -123,9 +122,8 @@ describe( 'PostHighlightCard', () => {
 		expect( screen.queryByText( /^Post published on/ ) ).not.toBeInTheDocument();
 	} );
 
-	// A metric whose request failed must not be shown as a real count: on a
-	// private site the Stats endpoint 403s, and "Likes 0" would be a wrong number
-	// rather than a missing one.
+	// A failed metric must not render as a real zero — e.g. a 403'd Stats request
+	// showing "Likes 0" would be a wrong count, not a missing one.
 	it( 'renders an unavailable metric as a dash, not as zero', () => {
 		render(
 			<PostHighlightCard

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/post-highlight-card-skeleton.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/post-highlight-card-skeleton.tsx
@@ -12,15 +12,10 @@ import styles from './post-highlight-card-skeleton.module.scss';
 const STAT_COUNT = 3;
 
 /**
- * Loading shape for `PostHighlightCard`: the post's title lines above its row
- * of stat tiles.
- *
- * The design prototype leads with a thumbnail, but the card renders its
- * featured image only when the post has one, and hides it below a 520px cell
- * either way — so a thumbnail placeholder would resolve to nothing in most
- * cells, which is the layout jump the shape exists to prevent.
- *
- * @return The rendered skeleton.
+ * Loading shape for `PostHighlightCard`: the post's title lines above its row of stat
+ * tiles. No thumbnail placeholder, unlike the design prototype: the card hides its
+ * featured image below a 520px cell, so the placeholder would cause the very jump the
+ * shape exists to prevent.
  */
 export function PostHighlightCardSkeleton() {
 	return (

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/post-highlight-card.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/post-highlight-card.tsx
@@ -39,10 +39,9 @@ export type PostHighlightCardMetric = {
 	value: number | undefined;
 
 	/**
-	 * Caveat about how the value is aggregated, e.g. that it is an all-time total
-	 * while its neighbours are scoped to the dashboard's date range. Shown as a
-	 * hover tooltip on the tile and mirrored as visually hidden text for
-	 * assistive technology.
+	 * Caveat about how the value is aggregated (e.g. an all-time total among
+	 * date-scoped neighbours). Shown as a hover tooltip and mirrored as
+	 * visually hidden text for assistive technology.
 	 */
 	note?: string;
 };
@@ -157,14 +156,9 @@ function PostHighlightMetric( {
 }
 
 /**
- * Presentational card highlighting a single post: its title (linking to the
- * published post), its publish date, a row of metric tiles, and its featured
- * image when present.
- *
- * Shared by the "Latest post" and "Popular post" widgets. It renders only the
- * populated state — loading, error, and empty belong to the calling widget's
- * `<WidgetState>` — and adapts to the dashboard cell size through the container
- * queries in its stylesheet.
+ * Presentational card for a single post: title, publish date, metric tiles,
+ * and an optional featured image. Renders only the populated state — the
+ * calling widget owns loading/error/empty via `<WidgetState>`.
  *
  * @param {PostHighlightCardProps} props - The component props.
  * @return The rendered card.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-metric/__tests__/report-metric.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-metric/__tests__/report-metric.test.tsx
@@ -9,10 +9,8 @@ import { ReportMetricWidget } from '../report-metric';
 import type { ComparativeLineChartSeries } from '../../chart-comparative-line/types';
 import type { ReportMetricWidgetProps } from '../report-metric';
 
-// The chart underneath draws SVG through a provider jsdom cannot lay out.
-// Standing it in for a prop recorder keeps this test on what this component
-// decides: how the series are labelled and styled, and which value each period
-// contributes.
+// The chart underneath draws SVG through a provider jsdom cannot lay out, so stand
+// it in for a prop recorder.
 const mockMetricComparisonSpy = jest.fn();
 
 jest.mock( '../../../widgets/metric-comparison', () => ( {
@@ -50,14 +48,7 @@ type MetricComparisonProps = {
 const METRIC_KEY = 'visitors';
 const DATA_FORMAT = { type: 'number' as const, options: { decimals: 0 } };
 
-/**
- * Build one period's report payload.
- *
- * @param range - The period's inclusive bounds, as `YYYY-MM-DD`.
- * @param total - The period's summary value.
- * @param daily - One value per day in the period.
- * @return A report payload shaped like the one `useReport` returns.
- */
+/** Build one period's report payload, shaped like the one `useReport` returns. */
 function reportFor( range: [ string, string ], total: number, daily: number[] ) {
 	return {
 		summary: { date_start: range[ 0 ], date_end: range[ 1 ], [ METRIC_KEY ]: total },
@@ -73,12 +64,7 @@ function reportFor( range: [ string, string ], total: number, daily: number[] ) 
 const PRIMARY = reportFor( [ '2026-02-01', '2026-02-03' ], 60, [ 10, 20, 30 ] );
 const COMPARISON = reportFor( [ '2026-01-01', '2026-01-03' ], 30, [ 5, 10, 15 ] );
 
-/**
- * Assemble the `data` prop, defaulting every flag to a loaded, healthy report.
- *
- * @param overrides - The parts of the hook result this test cares about.
- * @return A complete `useReport` result.
- */
+/** Assemble the `data` prop, defaulting every flag to a loaded, healthy report. */
 function hookResult(
 	overrides: Partial< ReportMetricWidgetProps[ 'data' ] > = {}
 ): ReportMetricWidgetProps[ 'data' ] {
@@ -95,12 +81,7 @@ function hookResult(
 	};
 }
 
-/**
- * Render the widget and return the props the chart was called with.
- *
- * @param props - Overrides for the widget's props.
- * @return The recorded chart props.
- */
+/** Render the widget and return the props the chart was called with. */
 function renderWidget( props: Partial< ReportMetricWidgetProps > = {} ): MetricComparisonProps {
 	render(
 		<ReportMetricWidget

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-metric/report-metric.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-metric/report-metric.tsx
@@ -121,9 +121,8 @@ export function ReportMetricWidget( {
 		[ series, getElementStyles ]
 	);
 
-	// metricKey always refers to a numeric metric field (e.g., "visitors", "orders_no"),
-	// never to date fields (e.g., "date_start"). The summary type includes both for flexibility,
-	// but we know the actual value will be a number at runtime.
+	// metricKey always names a numeric field, never a date field; the summary
+	// type covers both for flexibility, so the cast to number is safe here.
 	const primaryValue = ( primaryData?.summary[ metricKey ] as number ) ?? 0;
 	const comparisonValue = comparisonData?.summary[ metricKey ] as number | undefined;
 
@@ -131,9 +130,8 @@ export function ReportMetricWidget( {
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep placeholders from the previous period across
+			// range changes, so only surface the error when nothing is left to show.
 			isError={ isError && ! hasData }
 			// Empty keys off the time-series row count, not summary values: no rows
 			// means nothing to chart, while rows with an all-zero summary stay ready.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/__tests__/report-page-layout.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/__tests__/report-page-layout.test.tsx
@@ -33,11 +33,7 @@ const STAGED_RANGE = {
 	to: new Date( Date.UTC( 2019, 0, 13, 23, 59, 59, 999 ) ),
 };
 
-/**
- * A controller mid-edit: a staged range and comparison over an applied window.
- *
- * @return The date filters.
- */
+/** A controller mid-edit: a staged range and comparison over an applied window. */
 function buildDateFilters(): ReportDateFilters {
 	return {
 		presetId: 'custom',
@@ -118,9 +114,8 @@ describe( 'ReportPageLayout', () => {
 		expect( subtitle ).not.toHaveTextContent( /vs\.|Previous period|Previous month/ );
 	} );
 
-	// Whether the panel draws the comparison control is the report route's
-	// declared scope, not this layout's business — it only has to leave the
-	// comparison state alone on its way through.
+	// Whether the panel draws the comparison control is the report route's scope; the
+	// layout only has to leave the comparison state alone on its way through.
 	it( 'passes the comparison state through without disturbing it', () => {
 		const dateFilters = buildDateFilters();
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-layout.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-layout.tsx
@@ -23,11 +23,9 @@ export interface ReportPageLayoutProps {
 }
 
 /**
- * The shared second-level report page scaffold: optional internal tabs, the
- * section header, and the stacked report sections.
- *
- * The header offers the range alone. Its interval and comparison controls are
- * hidden rather than cleared, so both survive on the URL for the dashboard.
+ * Second-level report page scaffold: tabs, section header, and stacked
+ * sections. The header shows only the range — interval/comparison controls
+ * are hidden, not cleared, so they survive on the URL.
  *
  * @param {ReportPageLayoutProps} props - The component props.
  * @return The report page scaffold.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-performance-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-performance-chart.tsx
@@ -72,20 +72,11 @@ export interface ReportPerformanceChartProps {
 }
 
 /**
- * The report page's multi-metric performance section: a card with the
- * Views/Visitors/Comments/Likes series drawn together, a metric show/hide
- * menu, the time-bucket selector, and a chart collapse toggle. The page owns
- * data fetching (`useStatsVisits`) and the interval, and passes the reports in.
+ * The report page's multi-metric performance section: the series drawn together with
+ * a metric show/hide menu, the time-bucket selector, and a collapse toggle.
  *
- * Chart theming comes from the `GlobalChartsProvider` mounted once by the
- * `/reports/$report` stage, so this component must render under that stage —
- * or under a provider of its own in isolated contexts like Storybook.
- *
- * With a single visible metric and comparison data present, the previous
- * period renders as a dashed overlay (see `buildReportMetricSeries`).
- *
- * @param {ReportPerformanceChartProps} props - The component props.
- * @return The performance chart section.
+ * Chart theming comes from the `GlobalChartsProvider` the `/reports/$report` stage
+ * mounts, so this must render under that stage — or its own provider in Storybook.
  */
 export function ReportPerformanceChart( {
 	title = __( 'Performance', 'jetpack-premium-analytics-pkg' ),

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/utils/build-report-metric-series.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/utils/build-report-metric-series.test.ts
@@ -91,9 +91,8 @@ describe( 'buildReportMetricSeries', () => {
 		expect( series[ 1 ].group ).toBe( 'views' );
 		expect( series[ 1 ].options?.type ).toBe( 'comparison' );
 		expect( series[ 1 ].data.map( point => point.value ) ).toEqual( [ 80, 90 ] );
-		// The current period keeps the bare metric name, which is what the
-		// collapsed legend item shows; the labels still differ so the charts
-		// provider can track their visibility apart.
+		// The current period keeps the bare metric name (what the collapsed legend
+		// shows); the labels still differ so the charts provider tracks visibility.
 		expect( series[ 0 ].label ).toBe( 'Views' );
 		expect( series[ 0 ].label ).not.toBe( series[ 1 ].label );
 	} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/utils/build-report-metric-series.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/utils/build-report-metric-series.ts
@@ -22,13 +22,9 @@ type ReportTimeSeriesResponse = {
 };
 
 /**
- * Map a time-series report's points to chart points for one metric. Each
- * `StatsTimeSeriesDataPoint` carries every requested `stat_fields` metric as a
- * raw field keyed by name (`views`, `visitors`, …).
- *
- * @param report - The time-series report.
- * @param key    - The metric field to read from each point.
- * @return The chart points, oldest first.
+ * Map a time-series report's points to chart points for one metric. A
+ * `StatsTimeSeriesDataPoint` carries every requested `stat_fields` metric as a raw
+ * field keyed by name (`views`, `visitors`, …).
  */
 function toChartPoints( report: StatsTimeSeriesReport, key: string ): ComparativeDatePointDate[] {
 	return ( report.data ?? [] ).map( point => ( {
@@ -38,12 +34,8 @@ function toChartPoints( report: StatsTimeSeriesReport, key: string ): Comparativ
 }
 
 /**
- * Project the report page's richer time-series point shape into the shared
- * line-chart helper's generic response shape for one metric.
- *
- * @param report - The time-series report.
- * @param key    - The metric field to read from each point.
- * @return The generic time-series response expected by `buildTimeSeriesChartData`.
+ * Project the report page's richer time-series point shape into the generic response
+ * shape `buildTimeSeriesChartData` expects, for one metric.
  */
 function toTimeSeriesResponse(
 	report: StatsTimeSeriesReport,
@@ -103,21 +95,12 @@ function buildSingleMetricSeries(
 }
 
 /**
- * Build the performance chart series from a visits time-series report: one
- * solid series per visible metric, labelled by metric name.
+ * Build the performance chart series from a visits time-series report: one solid
+ * series per visible metric.
  *
- * When exactly one metric is visible and a comparison report is provided, the
- * previous period is added as a same-`group` (same colour) dashed `comparison`
- * series with a transparent fill — mirroring `MetricTabsChart`, down to naming
- * both series after the metric so they collapse into one legend item. With
- * multiple visible metrics the comparison is omitted: overlaying a dashed twin
- * per metric would make the chart unreadable.
- *
- * @param options            - The build options.
- * @param options.primary    - The current-period time-series report.
- * @param options.comparison - The previous-period report, when comparison is enabled.
- * @param options.metrics    - The visible metrics, in render order.
- * @return The chart series.
+ * A single visible metric with a comparison report also gets the previous period as a
+ * same-`group` dashed series, so the two collapse into one legend item. With several
+ * metrics the comparison is dropped: a dashed twin each would be unreadable.
  */
 export function buildReportMetricSeries( {
 	primary,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/__tests__/subscriber-list-fit-rows.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/__tests__/subscriber-list-fit-rows.test.tsx
@@ -26,11 +26,9 @@ const makeItems = ( count: number ): SubscriberListItem[] =>
 	} ) );
 
 /**
- * Mocks the element geometry that JSDOM does not calculate.
- *
- * The roster root is the measured box and the footer takes room from the rows,
- * mirroring the stylesheet: the root is clamped to the tile, `.list` flexes,
- * and `.more` does not shrink.
+ * Mocks the element geometry JSDOM does not calculate: the roster root is the
+ * measured box, and the footer takes room from the rows, mirroring the
+ * stylesheet (root clamped to tile, `.list` flexes, `.more` does not shrink).
  *
  * @param tileHeight - Starting height of the roster root.
  * @return Handle for resizing the roster and restoring the globals.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list.tsx
@@ -40,19 +40,13 @@ export type SubscriberListItem = {
 
 export type SubscriberListProps = {
 	items?: SubscriberListItem[];
-	/**
-	 * Empty-state message shown when there are no rows.
-	 */
 	emptyStateText?: string;
-	/**
-	 * Number of additional rows not included in `items`.
-	 */
+	/** Rows beyond `items`, counted into the "N more" footer. */
 	moreCount?: number;
 	/**
-	 * Show only the whole rows that fit the available height instead of letting
-	 * the roster grow and the widget host scroll it. Hidden rows are added to
-	 * the "N more" footer, so the footer can appear with `moreCount` at zero.
-	 * Requires an ancestor with a definite height.
+	 * Show only the whole rows that fit the available height, rather than letting the
+	 * host scroll the roster. Hidden rows join the "N more" footer, so the footer can
+	 * appear with `moreCount` at zero. Requires an ancestor with a definite height.
 	 * @default true
 	 */
 	fitRows?: boolean;
@@ -65,12 +59,9 @@ const DEFAULT_AVATAR_URL =
 	'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50"><circle cx="25" cy="25" r="25" fill="%23e5e7eb"/></svg>';
 
 /**
- * A roster of people — avatar, name, and an optional relative-time secondary
- * line per row, with an optional "N more" footer. Used by list-style Stats
- * widgets (e.g. the Subscribers card) where rows are ordered by recency rather
- * than ranked by a metric, so a bar leaderboard would not fit.
- * @param {SubscriberListProps} props - The component props.
- * @return The rendered list, or the empty state.
+ * A roster of people — avatar, name, and an optional relative-time secondary line per
+ * row. For Stats widgets whose rows are ordered by recency rather than ranked by a
+ * metric, where a bar leaderboard would not fit.
  */
 export function SubscriberList( {
 	items = [],

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/use-fitted-roster-rows.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/use-fitted-roster-rows.ts
@@ -7,15 +7,9 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 export const SUBPIXEL_TOLERANCE = 0.5;
 
 /**
- * Counts how many leading roster rows fit inside the roster.
- *
- * Measures the DOM because row height depends on the rendered styles.
- *
- * Measurement is taken against the roster root, not the list box: the "N more"
- * footer only exists once a row is hidden, so measuring the list would let the
- * result shrink the box it was measured from. That box is then bistable — a
- * tile that shrank and grew back would keep the footer and settle one row short
- * of where it started.
+ * Counts how many leading roster rows fit, measured against the roster root
+ * rather than the list box — the footer shrinks the list once a row hides, so
+ * measuring the list would make the box bistable and settle one row short.
  *
  * @param enabled      - Whether to measure at all. When false every row fits.
  * @param rowCount     - Total number of rows rendered.
@@ -54,9 +48,8 @@ export function useFittedRosterRows( enabled: boolean, rowCount: number, hasExtr
 
 		const rootBottom = rootRect.bottom + SUBPIXEL_TOLERANCE;
 
-		// Every row fits with no footer to make room for, so the roster keeps the
-		// full height. Deciding this against the root — never the list — is what
-		// lets the footer disappear again when the tile grows back.
+		// No footer needed here, so keep full height — checked against the root,
+		// not the list, so the footer can disappear again once the tile grows back.
 		const fits =
 			! hasExtraRows && countFittingAbove( rootBottom ) === rows.length
 				? rows.length
@@ -65,10 +58,8 @@ export function useFittedRosterRows( enabled: boolean, rowCount: number, hasExtr
 		setFittedCount( current => ( current === fits ? current : fits ) );
 	}, [ rowCount, hasExtraRows ] );
 
-	// `fittedCount` is a dependency because mounting the footer changes the room
-	// left for rows without resizing the root, so the observer never sees it.
-	// This settles: the footer's height is the only geometry the fit feeds back
-	// into, and the no-footer branch above is measured independently of it.
+	// `fittedCount` is a dependency: mounting the footer changes room without
+	// resizing the root, and settles because that's the only geometry fed back.
 	useLayoutEffect( () => {
 		if ( ! enabled ) {
 			setFittedCount( rowCount );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/video-title-link/video-title-link.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/video-title-link/video-title-link.tsx
@@ -22,12 +22,8 @@ export type VideoTitleLinkProps = {
 };
 
 /**
- * Render a video title as an internal detail link, an external fallback link,
- * or plain text. `search` takes either an object or an updater that receives
- * the current search. Mirrors `PostTitleLink`'s structure so post and video
- * rows read identically across the dashboard.
- *
- * @return The linked or plain video title.
+ * Render a video title as an internal detail link, an external fallback link, or plain
+ * text. Mirrors `PostTitleLink`'s structure so post and video rows read identically.
  */
 export function VideoTitleLink( {
 	id,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/widget-root.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/widget-root.tsx
@@ -45,13 +45,8 @@ type WidgetRootProps = {
 function useResolveReportParams( attributes?: Partial< ReportParamsFieldAttributes > ) {
 	let search: Record< string, unknown > = {};
 
-	/*
-	 * Read the search params of the current route. `{ strict: false }` returns
-	 * whatever route is matched, so widgets pick up the date range (and the
-	 * single-resource scope like `post_id`) on any page — not only the dashboard
-	 * at `/`. `useSearch` throws when rendered outside a matched route (e.g.
-	 * Storybook), so the empty fallback stands in there.
-	 */
+	// `{ strict: false }` lets widgets read params on any matched route, not
+	// only `/`; `useSearch` throws outside one (e.g. Storybook), hence the catch.
 	try {
 		// eslint-disable-next-line react-hooks/rules-of-hooks -- useSearch may throw outside a matched route
 		search = useSearch( { strict: false } );
@@ -65,16 +60,7 @@ function useResolveReportParams( attributes?: Partial< ReportParamsFieldAttribut
 	return hasReportParams ? attributes.reportParams : search;
 }
 
-/**
- * WidgetRoot
- *
- * A wrapper component that encapsulates all the infrastructure a lazy-loaded
- * dashboard widget needs:
- * - AnalyticsQueryClientProvider for data fetching
- * - GlobalChartsProvider with chart theme
- * - Report params resolution (from attributes or URL fallback)
- * - Context provider for child widgets to access resolved params
- */
+/** Wraps a lazy-loaded widget with its query client, chart theme, and resolved report params. */
 export function WidgetRoot( { attributes, children, setError }: WidgetRootProps ) {
 	const chartTheme = useChartTheme();
 	const rawReportParams = useResolveReportParams( attributes );
@@ -82,13 +68,8 @@ export function WidgetRoot( { attributes, children, setError }: WidgetRootProps 
 	const { launchedDate } = getStoreInfo();
 	const defaultPreset = getDefaultPreset( launchedDate );
 
-	/*
-	 * Stripped after resolution rather than at either source, so a surface that
-	 * offers no comparison holds the invariant by construction: neither the URL
-	 * nor a widget's own attributes can put a comparison in front of a reader
-	 * who has no control to switch it off. The params stay in the URL, for the
-	 * surfaces that do offer one to pick back up.
-	 */
+	// Stripped after resolution, not at the source, so a no-comparison surface
+	// never shows one regardless of URL/attributes; params stay in the URL for others.
 	const { offersComparison } = useReportScope();
 	const navigationParams = useMemo(
 		() => normalizeReportParams( rawReportParams, defaultPreset ),

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/heatmap-skeleton.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/heatmap-skeleton.tsx
@@ -13,12 +13,9 @@ const COLUMNS = 28;
 const ROWS = 3;
 
 /**
- * Loading shape for the calendar-heatmap widgets: a fixed grid of square cells.
- *
- * The grid is deliberately not derived from the widget: the loaded heatmap's
- * column count comes from `computeCalendarHeatmapLayout` over the measured tile,
- * which is only known after the first paint, so a stand-in tracking it would land
- * on the wrong count and read as the jump it was meant to prevent.
+ * Loading shape for the calendar-heatmap widgets: a fixed grid of square cells,
+ * deliberately not derived from the widget — the real column count is only
+ * known after first paint, and tracking it would read as the jump this prevents.
  *
  * @return The rendered skeleton.
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/metric-sparkline-skeleton.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/metric-sparkline-skeleton.tsx
@@ -14,17 +14,9 @@ export interface MetricSparklineSkeletonProps {
 }
 
 /**
- * Loading shape for the widgets that put a headline metric over a sparkline:
- * the headline, and the sparkline band filling what it leaves.
- *
- * The prototype stacks a label under the value, but none of these widgets
- * render one — `popular-days` sits its count beside the weekday on the same
- * line, and the two totals widgets have no second line at all. So the count is
- * opt-in and inline, and drawing it is the caller's call.
- *
- * @param props                   - Component props.
- * @param props.withHeadlineCount - Whether the headline carries a trailing count.
- * @return The rendered skeleton.
+ * Loading shape for the widgets that put a headline metric over a sparkline. The
+ * prototype stacks a label under the value, but none of these widgets render one, so
+ * the trailing count is opt-in and inline instead.
  */
 export function MetricSparklineSkeleton( {
 	withHeadlineCount = false,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/skeleton-root.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-skeleton/skeleton-root.tsx
@@ -14,11 +14,9 @@ export interface SkeletonRootProps {
 }
 
 /**
- * Deliberately no `aria-busy`: on a live region it means "hold updates until I
- * say otherwise", and this node is unmounted the moment the data lands, so it
- * would never say otherwise — the announcement it exists to make could be held
- * forever. Marking the region that is actually being updated is `WidgetState`'s
- * job, on a wrapper that outlives the fetch.
+ * Deliberately no `aria-busy`: it means "hold updates" on a live region, but
+ * this node unmounts the moment data lands and would never say otherwise.
+ * `WidgetState`, which outlives the fetch, owns marking the region as busy.
  */
 export function SkeletonRoot( { children }: SkeletonRootProps ) {
 	return (

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/__tests__/widget-state.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/__tests__/widget-state.test.tsx
@@ -104,16 +104,14 @@ describe( 'WidgetState', () => {
 		);
 		expect( screen.queryByText( 'rows' ) ).not.toBeInTheDocument();
 		expect( screen.getByRole( 'status' ) ).toBeInTheDocument();
-		// And nothing above it is busy. `aria-busy` defers descendant changes, so
-		// a busy ancestor could hold this status back until the moment the node is
-		// unmounted — silencing the one announcement a first load owes.
+		// Nothing above it is busy either: a busy ancestor could hold this status back
+		// until unmount, silencing the one announcement a first load owes.
 		expect( screen.queryAllByRole( 'generic', { busy: true } ) ).toHaveLength( 0 );
 	} );
 
 	it( 'keeps a slow first load out of a busy region, though it reports as fetching too', () => {
-		// React Query raises `isFetching` alongside `isLoading` on the first load,
-		// so a load that outlasts the delay must not be mistaken for a refetch and
-		// wrapped in the busy region that would defer its own announcement.
+		// React Query raises `isFetching` alongside `isLoading` on first load; a slow
+		// first load must not be mistaken for a refetch and wrapped in the busy region.
 		render(
 			<WidgetState isLoading isFetching isError={ false } isEmpty={ false }>
 				{ CONTENT }
@@ -126,9 +124,8 @@ describe( 'WidgetState', () => {
 	} );
 
 	it( 'renders the loading state whenever isLoading, regardless of the caller-derived isEmpty', () => {
-		// `isEmpty` is derived by the caller and can be false during first load
-		// (e.g. `data?.rows.length === 0` while data is still undefined); loading
-		// must still block rendering children against absent data.
+		// `isEmpty` is caller-derived and can be false during first load (e.g.
+		// `data?.rows.length === 0` while data is undefined); loading must still block children.
 		render(
 			<WidgetState isLoading isError={ false } isEmpty={ false }>
 				{ CONTENT }
@@ -278,9 +275,8 @@ describe( 'WidgetState', () => {
 		);
 		expect( screen.queryByRole( 'status', { hidden: true } ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'rows' ) ).toBeInTheDocument();
-		// Not busy either. Nothing on screen changed, so telling assistive tech
-		// the region is updating would interrupt a reader over an update a
-		// sighted one never sees.
+		// Not busy either: nothing changed on screen, so announcing an update would
+		// interrupt a reader over a change a sighted one never sees.
 		expect( screen.queryAllByRole( 'generic', { busy: true } ) ).toHaveLength( 0 );
 	} );
 
@@ -362,10 +358,8 @@ describe( 'WidgetState', () => {
 		[ 'the empty state', { isLoading: false, isEmpty: true, isError: false } ],
 		[ 'an error', { isLoading: false, isEmpty: false, isError: true } ],
 	] )( 'catches the focus %s takes down with the children', ( _label, resolved ) => {
-		// Keyboard-activating a drill-down row changes the params by definition,
-		// so it lands on the skeleton and unmounts the row that was activated.
-		// Without this the browser drops focus to <body> and the next Tab
-		// restarts at the top of the page.
+		// A keyboard-activated drill-down row changes the params, landing on the
+		// skeleton; without the parking effect, focus would drop to <body>.
 		const { rerender } = render(
 			<WidgetState isLoading={ false } isError={ false } isEmpty={ false }>
 				<button type="button">Taiwan</button>
@@ -385,9 +379,8 @@ describe( 'WidgetState', () => {
 	} );
 
 	it( 'catches focus when new rows replace the focused one with no branch change', () => {
-		// A revalidation that comes back reordered unmounts the focused row
-		// without the state ever changing, so there is no branch to key on.
-		// Keyed, so React unmounts the old row rather than reusing the node.
+		// A reordered revalidation unmounts the focused row with no branch change to
+		// key on; keyed rows ensure React actually unmounts rather than reuses the node.
 		const props = { isLoading: false, isError: false, isEmpty: false };
 		const { rerender } = render(
 			<WidgetState { ...props }>
@@ -473,10 +466,8 @@ describe( 'WidgetState', () => {
 	} );
 
 	it( 'forgets a row it did not park focus for, so a later fall to <body> stays put', () => {
-		// Something else claiming focus in the same commit takes the widget out of
-		// the running. Left pointing at the detached row, it would answer the next
-		// unrelated fall to <body> — in tree order, ahead of the widget that
-		// actually lost its focused element.
+		// Something else claims focus in the same commit; left pointing at the
+		// detached row, this widget would wrongly answer a later, unrelated fall to <body>.
 		const props = { isError: false, isEmpty: false };
 		const elsewhereRef: RefObject< HTMLButtonElement | null > = { current: null };
 		const tree = ( { steal, isLoading }: { steal: boolean; isLoading: boolean } ) => (
@@ -505,9 +496,8 @@ describe( 'WidgetState', () => {
 	} );
 
 	it( 'error wins over loading and empty (retry in flight after a failed fetch)', () => {
-		// The production shape on a failed fetch: isError with isEmpty derived
-		// true, plus loading signals while a retry is in flight. The priority
-		// contract (error → loading → empty → ready) must hold.
+		// Production shape on a failed fetch: isError with isEmpty derived true, plus
+		// loading signals mid-retry. The priority order (error → loading → empty → ready) must hold.
 		render(
 			<WidgetState isLoading isFetching isError isEmpty error={ { description: 'Failed.' } }>
 				{ CONTENT }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/stories/widget-state.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/stories/widget-state.stories.tsx
@@ -70,8 +70,7 @@ const meta: Meta< typeof WidgetState > = {
 		},
 	},
 	// Every story renders inside the mock widget card; `withChartTheme` supplies
-	// the charts context so the mock `BarChart` renders, mirroring what
-	// `WidgetRoot` provides at the top of the widget tree in the app.
+	// the charts context, mirroring what `WidgetRoot` provides in the app.
 	decorators: [ withWidgetCard, withChartTheme ],
 };
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
@@ -83,14 +83,8 @@ export function WidgetState( {
 		}
 	};
 
-	// Every branch but the ready one unmounts the children, and a drill-down or a
-	// range change reaches the skeleton by definition — both take the row the
-	// reader activated with them, and the browser hands focus to <body>, where the
-	// next Tab restarts at the top of the page. Catch it on the root instead.
-	//
-	// Deliberately unconditional: a branch change is the common way to lose the
-	// focused element, but not the only one — new rows arriving under unchanged
-	// params unmount it just the same, without any branch change to key on.
+	// Deliberately unconditional — every non-ready branch unmounts the children and
+	// drops focus to <body>, including a same-branch row swap under unchanged params.
 	useLayoutEffect( () => {
 		const target = focusedInside.current;
 		const root = rootRef.current;
@@ -103,9 +97,8 @@ export function WidgetState( {
 		if ( target.isConnected ) {
 			return;
 		}
-		// Gone either way, so stop tracking it now. Held past the render that
-		// dropped it, it would let the next fall to <body> anywhere on the page
-		// pull focus in here.
+		// Held past the render that dropped it, it would let the next fall to <body>
+		// anywhere on the page pull focus in here.
 		focusedInside.current = null;
 		// Step in only for focus this widget just dropped: focus that went
 		// anywhere but <body> is not ours to move.
@@ -119,9 +112,8 @@ export function WidgetState( {
 	let body: ReactNode;
 
 	if ( isError ) {
-		// Vertical centering lives in the stylesheet (`safe center`), not the
-		// `justify` prop: the prop's inline style would beat the class rule and
-		// reintroduce the unreachable-top overflow on short tiles.
+		// Vertical centering lives in the stylesheet (`safe center`), not the `justify`
+		// prop, whose inline style would beat it and clip the top on short tiles.
 		body = (
 			<Stack className={ styles.state } direction="column" gap="lg" align="center" role="alert">
 				<Icon size={ 40 } className={ styles.stateIcon } icon={ errorStateIcon } />
@@ -155,11 +147,8 @@ export function WidgetState( {
 	} else if ( isEmpty ) {
 		body = (
 			<ChartEmptyState
-				// No default icon: the caller opts in via `empty.icon`. Keeping the
-				// component icon-agnostic avoids a domain-specific default (e.g. a
-				// chart glyph on a non-chart widget) and stays visually distinct from
-				// the error state, which always carries its own glyph. `null`
-				// suppresses `ChartEmptyState`'s own `cautionFilled` default.
+				// No default icon: `null` suppresses `ChartEmptyState`'s own
+				// `cautionFilled`, which would read as an error state here.
 				icon={ empty?.icon ?? null }
 				// `ChartEmptyState` supplies the "No data in this period." default when
 				// `description` is omitted — keep that copy in one place.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/build-metric-tab.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/build-metric-tab.test.ts
@@ -5,10 +5,8 @@ import { buildMetricTab } from '../build-metric-tab';
 
 describe( 'buildMetricTab', () => {
 	it( 'reads the headline from summary, not by re-summing the data points', () => {
-		// Deliberately disagree: a real sanitizer never produces this, but WordAds
-		// `cpm` is a period-weighted average, not a sum of point values — if this
-		// ever regressed to re-summing, every traffic-chart test (where summary and
-		// the row sum coincide) would stay green while CPM silently corrupted.
+		// Deliberately disagree: CPM is a period-weighted average, not a sum, so a
+		// regression to re-summing would stay green on every other traffic-chart test.
 		const tab = buildMetricTab( {
 			primary: { summary: { views: 999 }, data: [ { date_start: '2026-05-01', views: 1 } ] },
 			comparison: undefined,
@@ -83,9 +81,8 @@ describe( 'buildMetricTab', () => {
 		expect( tab.previous ).toBeUndefined();
 	} );
 
-	// The misleading-zero guard: comparison is on, but the comparison report has
-	// no rows (still loading, or a genuinely empty period). `previousValue` must
-	// read as absent, not as a previous total of 0.
+	// The misleading-zero guard: with no comparison rows (loading, or a genuinely
+	// empty period), `previousValue` must read as absent, not as a total of 0.
 	it( 'omits previous when comparison is on but the comparison report has no rows', () => {
 		const tab = buildMetricTab( {
 			primary: { summary: { views: 30 }, data: [ { date_start: '2026-05-01', views: 30 } ] },
@@ -98,13 +95,11 @@ describe( 'buildMetricTab', () => {
 		expect( tab.previousValue ).toBeUndefined();
 		expect( tab.previous ).toBeUndefined();
 	} );
-	// Bucket stamps carry a nominal offset that must be dropped, not honoured
-	// (the full rationale lives on `toChartDate`). These cases fail under the
-	// old `localTZDate` reading and are the only guard on that.
+	// Bucket stamps carry a nominal offset that must be dropped (rationale on
+	// `toChartDate`); these cases are the only guard against the old buggy reading.
 	describe( 'bucket stamps are read as the wall clock they name', () => {
-		// Pinned west of UTC on purpose: under a UTC runner the correct reading and
-		// the buggy one coincide, so these cases would pass either way. `TZ` is not
-		// on the typed env shape, hence the cast.
+		// Pinned west of UTC — under a UTC runner the correct and buggy readings
+		// coincide and this would pass either way. `TZ` isn't on the typed env shape, hence the cast.
 		const env = process.env as Record< string, string | undefined >;
 		const runnerTimeZone = env.TZ;
 		beforeAll( () => {
@@ -134,9 +129,8 @@ describe( 'buildMetricTab', () => {
 			[ '2026-06-15T00:00:00+00:00', 15, 0 ],
 			[ '2026-06-15T09:00:00+00:00', 15, 9 ],
 			[ '2026-06-15T00:00:00Z', 15, 0 ],
-			// The `row.date_start` passthrough in `getRowIntervalFields` forwards
-			// whatever the API sent, which need not carry a time at all. A bare date
-			// parses as UTC unless it is anchored, so this is the same bug's back door.
+			// `row.date_start` passes through whatever the API sent, which may carry no
+			// time; a bare date parses as UTC unless anchored — same bug, different door.
 			[ '2026-06-15', 15, 0 ],
 		] )( 'reads %s as day %i hour %i in the local frame', ( stamp, day, hour ) => {
 			const date = dateOf( stamp );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/chart-date.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/chart-date.test.ts
@@ -15,10 +15,8 @@ describe( 'toChartDate', () => {
 		expect( date.getHours() ).toBe( 9 );
 	} );
 
-	// `getRowIntervalFields` forwards `row.date_start` verbatim when the API
-	// supplies it, so the shapes that arrive here are not only the ones this
-	// package stamps itself. A bare date parsed as-is would land in UTC, and a
-	// space-separated stamp would not parse at all.
+	// `getRowIntervalFields` forwards `row.date_start` verbatim, so these shapes
+	// aren't only ones this package stamps; unanchored, a bare date lands in UTC.
 	it.each( [
 		[ 'a bare date', '2026-06-29', 0 ],
 		[ 'a space-separated stamp', '2026-06-29 09:00:00', 9 ],

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-metric-tab.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-metric-tab.ts
@@ -57,11 +57,9 @@ function toPoints( report: MetricReport | undefined, field: string ) {
 }
 
 /**
- * Build one metric tab from a primary/comparison report pair. The headline is
- * the period total; the previous-period total and overlay are included only when
- * comparison is on *and* the comparison request actually returned rows — while
- * that request is still loading or came back empty, its total would be `0`,
- * which would render a misleading previous-period value.
+ * Build one metric tab from a primary/comparison report pair. The previous-period
+ * total/overlay appear only when comparison is on and the comparison request
+ * actually returned rows — an empty or loading response would otherwise total to a misleading 0.
  *
  * @param options - The report pair, field, and presentation options.
  * @return The metric tab.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-time-series-chart-data.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-time-series-chart-data.ts
@@ -55,12 +55,8 @@ type BuildTimeSeriesChartOptions< T extends TimeSeriesData > = {
 
 /**
  * Build a chart's current- and previous-period series from a time-series
- * response, reading one metric out of each point.
- *
- * Both series share a `group`, so the legend collapses them into the single
- * item the current period's label carries. Pass `label` when that item should
- * name the metric — the section header already names the dates, so a range
- * there says nothing the reader cannot already see.
+ * response, reading one metric out of each point. Both series share a `group`
+ * and collapse into one legend item; pass `label` to name it after the metric.
  *
  * @param options                   - The build options.
  * @param options.primary           - The current-period response.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/calendar-heatmap-layout.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/calendar-heatmap-layout.ts
@@ -1,11 +1,7 @@
 /**
- * Pure geometry for the calendar heatmap widgets.
- *
- * Given the tile's available width and height, this decides the cell size, how
- * many week columns to render, and the exact pixel rectangle the heatmap should
- * occupy. It is intentionally dependency-free (no React, no charts imports) so it
- * can be lifted into `@automattic/charts` later; the adaptive component owns the
- * trimming policy around it.
+ * Pure geometry for the calendar heatmap widgets: given the tile's width/height,
+ * decides cell size, column count, and the exact heatmap rectangle. Deliberately
+ * dependency-free (no React/charts) so it can move into `@automattic/charts` later.
  */
 
 export type CalendarHeatmapLayoutInput = {
@@ -61,14 +57,9 @@ const isPositiveFinite = ( value: number ): boolean => Number.isFinite( value ) 
 const isNonNegativeFinite = ( value: number ): boolean => Number.isFinite( value ) && value >= 0;
 
 /**
- * Allowance for the chart's weekday-label column.
- *
- * The chart lays that column out as an `auto` grid track sized by its own label
- * text, so the real width is not knowable before layout. Measured at 27.34px —
- * the widest label ("Wed") at the track's 11px font plus its 4px inline-end
- * padding — rounded up here for the font differences across platforms. The
- * labels come from `format( date, 'EEE' )` with no locale, so they are always
- * English and do not vary by site language.
+ * Allowance for the chart's weekday-label column (an `auto` grid track sized by
+ * its own text). Measured at 27.34px — widest label "Wed" at 11px font + 4px
+ * padding — rounded up for font variance across platforms; labels are locale-invariant.
  */
 const ROW_LABEL_WIDTH = 32;
 const COMPACT_CELL_SIZE = 11;
@@ -87,21 +78,15 @@ export type FitWeekColumnsInput = {
 };
 
 /**
- * How many whole week columns a width can draw at a fixed cell size. The
- * arithmetic is shared; each caller keeps its own cell metrics.
- *
- * A column costs a cell plus a gap: the grid is `auto repeat(n, …)`, so n columns
- * carry n gaps, counting the one before the first column.
- * `computeCalendarHeatmapLayout` keeps its own arithmetic. It sizes the cell from
- * the height first, so it cannot start from a fixed cell, and it counts n-1 gaps
- * — a different model of the same grid, so the two are not interchangeable.
+ * How many whole week columns a width can draw at a fixed cell size (grid is
+ * `auto repeat(n, …)`, so n columns carry n gaps). Not interchangeable with
+ * `computeCalendarHeatmapLayout`, which sizes from height first and counts n-1 gaps.
  */
 export function fitWeekColumns( input: FitWeekColumnsInput ): number {
 	const { availWidth, cellWidth, cellGap, minColumns = 0 } = input;
 
-	// Normalized rather than trusted: `minColumns` is the one input that leaves
-	// through both branches, so a NaN or fractional value would reach the caller
-	// and size a data request with it.
+	// Normalized rather than trusted: `minColumns` leaves through both branches, so a
+	// NaN or fractional value would reach the caller and size a data request with it.
 	const floorColumns = isNonNegativeFinite( minColumns ) ? Math.floor( minColumns ) : 0;
 
 	// Guard every metric the arithmetic touches: an unchecked one divides by zero
@@ -121,11 +106,9 @@ export function fitWeekColumns( input: FitWeekColumnsInput ): number {
 }
 
 /**
- * How many compact cells a width can hold, ignoring how many the range has.
- *
- * Compact cell dimensions provide a stable proxy for the most week columns worth
- * planning for at this width. Adaptive cells can shrink further in very short
- * tiles, so this is a request-sizing heuristic rather than a layout invariant.
+ * How many compact cells a width can hold, ignoring how many the range has —
+ * a stable proxy for request sizing. Adaptive cells can shrink further in very
+ * short tiles, so this is a heuristic, not a layout invariant.
  */
 export function compactCalendarHeatmapCapacity( availWidth: number ): number {
 	return fitWeekColumns( {
@@ -135,22 +118,16 @@ export function compactCalendarHeatmapCapacity( availWidth: number ): number {
 	} );
 }
 
-// Exported for widgets that mirror the chart's non-compact grid geometry
-// (e.g. deriving a cell height from a measured tile) so the metrics are
-// stated once.
+// Exported for widgets that mirror the chart's non-compact grid geometry (e.g.
+// deriving a cell height from a measured tile), so the metrics are stated once.
 export const CELL_GAP = 4;
 export const HEADER_HEIGHT = 16;
 const DEFAULT_LEGEND_HEIGHT = 44;
 
 /**
- * Computes the calendar-heatmap layout for a tile.
- *
- * Height drives the cell size; width drives the column count. The grid fills the
- * tile in both directions: the cells take the height, and the width left over by
- * an integer column count goes back into the cells rather than showing as a gap.
- * `aspectRatio` therefore sets the cell's shape before that last adjustment, not
- * after. When even the minimum column count will not fit, the whole cell is scaled
- * down instead of scrolling.
+ * Computes the calendar-heatmap layout for a tile. Height drives cell size,
+ * width drives column count, and leftover width from an integer column count
+ * goes back into the cells rather than showing as a gap. Never scrolls — an unfit minimum shrinks the cell instead.
  */
 export function computeCalendarHeatmapLayout(
 	input: CalendarHeatmapLayoutInput
@@ -180,9 +157,8 @@ export function computeCalendarHeatmapLayout(
 
 	const safeMaxCellHeight = isPositiveFinite( maxCellHeight ) ? maxCellHeight : Infinity;
 
-	// The rows always take the height (minus overhead and inter-row gaps), whatever
-	// the width turns out to allow — a narrow tile must not leave the lower two
-	// thirds of a tall widget empty.
+	// The rows always take the height (minus overhead and gaps), whatever the width
+	// allows — a narrow tile must not leave the lower two-thirds of a tall widget empty.
 	const heightForRows = availHeight - HEADER_HEIGHT - legendHeight - ( rows - 1 ) * CELL_GAP;
 	const cellHeight = Math.max( 0, Math.min( heightForRows / rows, safeMaxCellHeight ) );
 
@@ -206,13 +182,9 @@ export function computeCalendarHeatmapLayout(
 		dataColumns === undefined ? fitColumns : Math.min( fitColumns, dataColumns )
 	);
 
-	// The width is what limited the column count whenever the grid draws at least as
-	// many columns as the target cell would fit — including the narrow tile forced up
-	// to `minColumns`. Then the columns share out the whole width: an integer count
-	// otherwise leaves up to a cell of it as a band at the edge, and a tile too narrow
-	// for the minimum needs the cells narrower than the ratio rather than shorter than
-	// the tile. A grid trimmed to its data keeps the ratio instead, or a few weeks
-	// would stretch across the whole tile.
+	// Width-limited (columns >= fitColumns, incl. minColumns forcing) shares leftover
+	// width across cells, which can widen past the ratio; data-limited (fewer weeks
+	// than fit) keeps the exact ratio so a short range doesn't stretch to fill the tile.
 	const cellWidth =
 		columns >= fitColumns
 			? Math.max( 0, ( availWidth - ROW_LABEL_WIDTH - ( columns - 1 ) * CELL_GAP ) / columns )

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/calendar-heatmap-window.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/calendar-heatmap-window.ts
@@ -19,12 +19,9 @@ export type CalendarHeatmapWindowBounds = {
 };
 
 /**
- * Caps a report range at an inclusive maximum day count.
- *
- * A floor is deliberately not offered: it would reach back past the selection,
- * and the card would attribute years the user did not choose to the year in its
- * heading (WOOA7S-1963). A range too short to fill the tile is filled with
- * filler weeks instead — see `resolveCalendarHeatmapGridStart`.
+ * Caps a report range at an inclusive maximum day count. No floor is offered:
+ * it would reach past the selection and misattribute years to the card's
+ * heading (WOOA7S-1963); a short range gets filler weeks instead.
  */
 export function resolveCalendarHeatmapWindow(
 	params: { from?: string; to?: string },
@@ -50,16 +47,9 @@ export function resolveCalendarHeatmapWindow(
 }
 
 /**
- * The date a heatmap grid has to open on to draw `columns` week columns ending
- * with `endDate`.
- *
- * A period shorter than the tile leaves the grid part-filled, so the grid is
- * opened back far enough to fill it. Those earlier weeks are drawn, not
- * requested: the chart paints them as filler that reports nothing, and the
- * fetch window stays inside the period the user selected (WOOA7S-1963).
- *
- * Opening backwards rather than running on past `endDate` also keeps trimming
- * honest — the grid drops its oldest columns first, which are the filler.
+ * Date a heatmap grid opens on to draw `columns` columns ending `endDate`. A
+ * short period is padded backwards with unrequested filler (WOOA7S-1963), so
+ * trimming later drops the oldest — filler — columns first.
  *
  * @param endDate - Last day the grid covers, `yyyy-MM-dd`.
  * @param columns - Week columns the tile can draw.
@@ -122,14 +112,9 @@ const WINDOW_YEAR_DAYS = 366;
 const MAX_WINDOW_YEARS = 6;
 
 /**
- * How many days of history a calendar heatmap is worth requesting at a given
- * viewport width.
- *
- * The grid only draws the week columns that fit, so history beyond what the widest
- * possible tile could show would be fetched and thrown away. Compact-cell capacity
- * is a stable proxy for that ceiling; adaptive cells can shrink further in unusually
- * short tiles. The result is quantized to whole years so resizing the window cannot
- * fire a fresh request per column gained.
+ * Days of history worth requesting for a calendar heatmap at a given viewport
+ * width. Compact-cell capacity stands in for the widest tile's column ceiling,
+ * quantized to whole years so resizing can't fire a request per column gained.
  *
  * @param viewportWidth - Viewport width in px.
  * @return Days of history to request.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-date.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-date.ts
@@ -9,36 +9,24 @@ const nominalOffset = /(?:Z|[+-]\d{2}:?\d{2})$/;
 /**
  * Read a bucket's `date_start` as the wall clock it names.
  *
- * Bucket stamps name site-local wall times (see `getStatsIntervalFields`), and
- * the chart library lays a point out and labels the axis through the browser's
- * timezone — so honouring an offset would shift every label by the viewer's own
- * offset, turning a midnight bucket into the previous day west of UTC. Parsing
- * the wall clock locally keeps a label on the bucket it names.
- *
- * The instant this produces is therefore only meaningful as a wall clock. Read
- * it back with `fromChartDate` before handing it to a date formatter, which
- * resolves the site's timezone rather than the browser's.
+ * Bucket stamps name site-local wall time; the chart library labels the axis
+ * through the browser's timezone, so honouring an offset would shift labels by
+ * the viewer's own offset. The resulting instant is a wall clock only — read it
+ * back with `fromChartDate` before formatting, which resolves the site's timezone.
  *
  * @param dateStart - The bucket's `date_start`.
  * @return The bucket's wall clock as a local instant.
  */
 export function toChartDate( dateStart: string ): Date {
-	// The normalizers emit naive stamps, but the `getRowIntervalFields`
-	// passthrough forwards whatever `date_start` the API sent, which can still
-	// carry a nominal offset — knowing that offset is a label is Stats API
-	// knowledge the generic parser must not have, so it is stripped here before
-	// the charts library's own wall-clock reading handles the naive remainder.
+	// The passthrough (`getRowIntervalFields`) can still carry a nominal offset that
+	// normalized stamps lack — stripped here, since that's Stats-only knowledge.
 	return parseAsLocalDate( dateStart.replace( nominalOffset, '' ).trim() );
 }
 
 /**
- * Re-anchor a chart point's wall clock in the site's timezone.
- *
- * The inverse of `toChartDate`: it hands back the instant the bucket named, so
- * the site's date formatters read out the clock the axis drew rather than one
- * shifted by the offset between the viewer's timezone and the site's. Every
- * label derived from a chart point — a tooltip's date, a legend's range — goes
- * through here first.
+ * Re-anchor a chart point's wall clock in the site's timezone — the inverse of
+ * `toChartDate`. Every label derived from a chart point (tooltip date, legend
+ * range) must go through here first, or it reads out shifted by the viewer's own timezone offset.
  *
  * @param date - A chart point's date.
  * @return The same wall clock, anchored in the site's timezone.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-display-attribute-fields.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-display-attribute-fields.ts
@@ -13,12 +13,9 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 import type { ReactElement } from 'react';
 
 /**
- * The chart types the display control offers, in segment order. One list keeps
- * every chart widget's control identical, and `satisfies` ties it to the
- * toolkit's own union so a value `MetricTabsChart` cannot draw fails to
- * compile here rather than shipping as a broken option. The label names the
- * type for assistive technology and for the segment's tooltip; the icon is
- * what the control shows.
+ * The chart types the display control offers, in segment order — one list keeps
+ * every widget's control identical. `satisfies` ties it to the toolkit's union
+ * so an unsupported type fails to compile here instead of shipping broken.
  */
 export const CHART_DISPLAY_CHART_TYPES = [
 	{ id: 'line', label: __( 'Line chart', 'jetpack-premium-analytics-pkg' ), icon: chartLine },

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/default-period-for-interval.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/default-period-for-interval.ts
@@ -16,16 +16,9 @@ const PERIOD_ORDER = [
 ] as const satisfies readonly StatsPeriod[];
 
 /**
- * Chart granularity for a dashboard interval: the bucket size a widget draws
- * for whatever the page's interval control has selected. The interval maps to a
- * bucket the same way a Stats request does, so a chart is bucketed as the data
- * behind it is.
- *
- * A widget rarely supports every granularity, so the mapped period is clamped
- * into the set it does support. `allowed` is ordered finest to coarsest, so a
- * period finer than everything offered resolves to the finest and one coarser
- * to the coarsest — an hourly page interval lands on `day` for a day/week/month
- * widget, and a yearly one lands on `month`.
+ * Chart granularity for a dashboard interval, clamped into what a widget supports.
+ * `allowed` is ordered finest to coarsest: a period finer than everything offered
+ * resolves to the finest, and one coarser resolves to the coarsest.
  *
  * @param interval - The dashboard-derived interval.
  * @param allowed  - The periods this widget offers, ordered finest to coarsest.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/describe-error.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/describe-error.ts
@@ -17,11 +17,9 @@ interface DescribeErrorOptions {
 }
 
 /**
- * Map an API error to a Stats widget error descriptor.
- *
- * The access check is `isAccessDenied`, shared with the dashboard's stale-data
- * notice so a widget and the banner above it cannot disagree about whether a
- * Retry is worth offering.
+ * Maps an API error to a Stats widget error descriptor, using `isAccessDenied`
+ * (shared with the dashboard's stale-data notice) so a widget and the banner
+ * above it cannot disagree about offering a Retry.
  *
  * @param error                    - The failed query error.
  * @param options                  - Error-state copy and retry options.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/fixed-y-axis.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/fixed-y-axis.ts
@@ -15,17 +15,10 @@ export type FixedYAxis = {
 };
 
 /**
- * Resolve the y-axis domain a comparative chart should pin, if any.
- *
- * Two cases want a fixed domain instead of the data's own range: a percentage
- * metric always reads 0%–100%, so a series sitting between 2% and 5% doesn't
- * fill the plot; and an all-zero period gets a real axis instead of a flat
- * baseline.
- *
- * A pinned domain has to carry its own left margin. `useChartMargin` sizes the
- * axis gutter by re-deriving ticks from the data's own min/max — it overwrites
- * `options.yScale.domain` while doing so — so the widest tick of a pinned domain
- * would otherwise be drawn outside the gutter reserved for it and clipped.
+ * Resolve the y-axis domain a comparative chart should pin, if any: a percentage
+ * metric always reads 0–100%, an all-zero period gets a real axis instead of a
+ * flat baseline, and the domain carries its own margin since `useChartMargin`'s
+ * data-derived ticks would otherwise clip a pinned domain's widest tick.
  *
  * @param metricType  - The data format type (currency, number, percentage).
  * @param isEmptyData - Whether every value in the chart is 0 or null.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/format-comparison-series-label.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/format-comparison-series-label.ts
@@ -4,13 +4,9 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
- * Label a metric's previous-period series.
- *
- * The charts provider stores visibility by label, so this has to stay stable
- * while the dashboard dates change: including the range would reveal a
- * seeded-hidden comparison whenever the reader picked a new period without
- * remounting the chart. The legend collapses it into its metric's item, so the
- * text itself surfaces only to assistive technology.
+ * Label a metric's previous-period series. Must stay stable across date
+ * changes — including the range would reveal a seeded-hidden comparison on
+ * every period change; the legend collapses it into the metric's own item.
  *
  * @param name - The metric name.
  * @return The comparison series' label.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/resolve-series-names.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/resolve-series-names.ts
@@ -40,16 +40,10 @@ export function resolvePrimarySeriesByGroup(
 }
 
 /**
- * Resolve the metric name each series' tooltip row should lead with.
- *
- * A metric's previous period is folded into its legend item, so a comparison
- * row is named after its group's current period rather than by its own internal
- * label ('Visitors', not 'Visitors · previous period').
- *
- * `isPaired` asks whether the chart was handed more than one metric, not
- * whether both are currently visible: a counterpart seeded hidden can be
- * revealed at any time, and a row label that changed shape as the reader
- * toggled it would be worse than one that always leads with its metric.
+ * Resolve the metric name each series' tooltip row should lead with. A
+ * comparison row is named after its group's current period, not its own label
+ * ('Visitors', not 'Visitors · previous period'). `isPaired` counts metrics
+ * handed to the chart, not those currently visible, so a row's label doesn't reshape as a hidden counterpart is revealed.
  *
  * @param series - The series the chart was handed.
  * @return The group's primary labels, the per-label metric names, and whether more than one metric is present.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/tick-resolution-date-format.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/tick-resolution-date-format.ts
@@ -5,12 +5,9 @@ import type { TickResolution } from '@jetpack-premium-analytics/externals';
 import type { DateFormatName } from '@jetpack-premium-analytics/formatters';
 
 /**
- * How precisely a label has to name a point for the bucket size it was drawn at.
- *
- * A bucket is identified by the finest field its size varies in: a date alone
- * names 24 hourly buckets and so identifies none of them, while it names a daily
- * one exactly. Anything coarser than a day is still named by its date, since the
- * range covered is what the axis and legend already spell out.
+ * How precisely a label must name a point for its bucket size. A date alone
+ * names 24 hourly buckets (so identifies none) but a daily one exactly;
+ * anything coarser stays date-named since the axis/legend already cover the range.
  */
 const DATE_FORMAT_FOR_RESOLUTION: Partial< Record< TickResolution, DateFormatName > > = {
 	hour: 'dateTime',

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-attributes-with-search-fallback.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-attributes-with-search-fallback.ts
@@ -25,11 +25,9 @@ export function useAttributesWithSearchFallback< T extends Partial< ReportParams
 	let search: Record< string, any >;
 
 	try {
-		// `strict: false` rather than `from: '/'`, matching `WidgetRoot`: widgets
-		// pick up the date range on any page, not only the dashboard at `/`. Pinned
-		// to `/`, this throws on every other matched route and falls back to `{}` —
-		// leaving a widget's header control reading a default range while its body
-		// reads the real one.
+		// `strict: false`, not `from: '/'` (matching `WidgetRoot`): widgets read the date
+		// range on any page, not just `/`. `from: '/'` would throw off-dashboard and fall
+		// back to `{}`, leaving the header control on a default range while the body reads the real one.
 		// eslint-disable-next-line react-hooks/rules-of-hooks
 		search = useSearch( { strict: false } );
 	} catch {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
@@ -26,12 +26,8 @@ export function useChartTheme(): WooChartTheme {
 			tickLength: 4,
 			gridColor: '',
 			gridColorDark: '',
-			// `fontSize` is load-bearing: it has to stay a plain number, since resolveFontSize()
-			// rejects var(); without it visx falls back to 11 and the chart margin and pie label
-			// measurements go with it. `fill` is not, any more — CHARTS-203 made the charts
-			// default a single-level pointer that resolves on its own, so this only restates it.
-			// Harmless, since the value publishes the theme layer and degrades rather than
-			// breaking, but it goes with the color props in CHARTS-227.
+			// `fontSize` is load-bearing: it must stay a plain number, since resolveFontSize()
+			// rejects var() — without it visx falls back to 11 and margin/pie-label sizing break.
 			svgLabelSmall: {
 				fill: 'var(--wpds-color-foreground-content-neutral)',
 				fontSize: 12,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -257,13 +257,9 @@ export {
 export type { MetricKey, OrderMetricKey, OrderMetrics, OrdersSummary, DataFormat } from './types';
 
 /**
- * Charts passthrough
- *
- * Widgets must import chart components from here, never from
- * `@automattic/charts` directly: the toolkit is a shared script module, so
- * charts is bundled once instead of once per widget. The toolkit itself takes
- * charts from `@jetpack-premium-analytics/externals`, which is where the
- * library is actually compiled in.
+ * Charts passthrough. Widgets must import chart components from here, never
+ * from `@automattic/charts` directly: the toolkit bundles charts once instead
+ * of once per widget, itself sourcing them from `@jetpack-premium-analytics/externals`.
  */
 export {
 	GeoChart,
@@ -282,10 +278,8 @@ export {
 } from '@jetpack-premium-analytics/externals';
 
 /**
- * UI passthrough
- *
- * Widgets must import these from here, never from
- * `@jetpack-premium-analytics/ui` directly: the toolkit is a shared script
- * module, so the ui package is bundled once instead of once per widget.
+ * UI passthrough. Widgets must import these from here, never from
+ * `@jetpack-premium-analytics/ui` directly: the toolkit bundles the ui package
+ * once instead of once per widget.
  */
 export { safeHttpUrl } from '@jetpack-premium-analytics/ui';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.test.ts
@@ -42,9 +42,8 @@ describe( 'buildEmailTimelineResponse', () => {
 	} );
 
 	it( 'anchors hourly buckets on the start day midnight whatever time of day date carries', () => {
-		// The production endpoint resolves `date` to its calendar day and
-		// buckets from midnight; a mid-day last-24-hours request must roll into
-		// the next day at hour 0, not start at the requested hour.
+		// The production endpoint resolves `date` to its calendar day and buckets
+		// from midnight; a mid-day request must roll into the next day at hour 0.
 		const response = buildEmailTimelineResponse(
 			'clicks',
 			'/stats/clicks/emails/1234?period=hour&quantity=26&date=2026-06-17T09%3A00%3A00.000-04%3A00&stats_fields=timeline'

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.ts
@@ -5,9 +5,8 @@ import { addDays, format, isValid, parse } from 'date-fns';
 
 /**
  * The timeline matrix `stats/<opens|clicks>/emails/<postId>?stats_fields=timeline`
- * nests under a `timeline` key. Daily rows are `[ date, <metric>_count ]`;
- * hourly rows are `[ date, hour, <metric>_count ]` (Calypso's
- * parseEmailChartData shapes).
+ * nests under a `timeline` key. Daily rows are `[date, count]`; hourly rows add
+ * an hour: `[date, hour, count]` (mirrors Calypso's parseEmailChartData).
  */
 type EmailTimelineRow = [ string, number ] | [ string, number, number ];
 
@@ -32,11 +31,8 @@ function emailTimelineCount( metric: 'opens' | 'clicks', index: number ): number
 
 /**
  * Builds a mock email timeline response for the "Email performance" widget. The
- * email timeline endpoint reads `date` as the window start, resolves it to its
- * calendar day, and returns `quantity` periods going forward — hourly buckets
- * anchored on that day's midnight. Mirroring that behaviour keeps a story's
- * chart aligned with its dashboard date range, including the out-of-window
- * buckets the data layer is expected to trim.
+ * real endpoint resolves `date` to its calendar day and returns `quantity`
+ * buckets forward from midnight — mirrored here to keep a story's chart aligned with its dashboard date range.
  *
  * @param metric      - Which timeline to return.
  * @param requestPath - The request path; `period`, `quantity`, and `date` are read off its query.
@@ -52,10 +48,8 @@ export function buildEmailTimelineResponse(
 	const quantity = Number.isInteger( parsedQuantity )
 		? Math.min( Math.max( parsedQuantity, 1 ), 24 * 90 )
 		: 30;
-	// Only the date part matters: the endpoint resolves `date` to its calendar
-	// day (hourly buckets anchor on that day's midnight whatever time of day it
-	// carries), and parsing the part in the runner's own zone keeps the emitted
-	// wall-clock labels aligned with the requested day in any browser timezone.
+	// Only the date part matters: the endpoint resolves `date` to its calendar day,
+	// and parsing that part in the runner's own zone keeps labels timezone-stable.
 	const dayPart = ( query.get( 'date' ) ?? '' ).match( /^\d{4}-\d{2}-\d{2}/ )?.[ 0 ] ?? '';
 	const parsedDay = parse( dayPart, 'yyyy-MM-dd', new Date() );
 	const startDay = isValid( parsedDay ) ? parsedDay : new Date();

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/insights.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/insights.ts
@@ -1,9 +1,7 @@
 /**
- * Raw `stats/insights` response (pre-sanitizer shape), populated so every widget
- * built on this endpoint renders fully in Storybook: a clear peak day and hour
- * for the Most popular time widget, and more than one year for the Year in
- * review widget (so its year dropdown has a second entry to switch to). The
- * endpoint reports across the whole site lifetime and has no comparison period.
+ * Raw `stats/insights` response (pre-sanitizer shape): a clear peak day/hour
+ * for the Most popular time widget, and 2+ years for the Year in review widget's
+ * dropdown. Reports the whole site lifetime, with no comparison period.
  */
 // Relative to today so the Year in review widget, which defaults to the
 // current year, keeps rendering data after New Year.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -1,17 +1,8 @@
 /**
- * Storybook report-data mocking via a `@wordpress/api-fetch` middleware.
- *
- * The shared Jetpack Storybook config cannot be modified, and there is no
- * analytics backend in Storybook, so report requests have nothing to resolve
- * against.
- *
- * To mock report data we register an `apiFetch` middleware that intercepts the
- * proxy report paths and returns generated mock data. The data package fetches
- * every report through `fetchReport()`, which builds the same base path, so a
- * single middleware covers all widget stories.
- *
- * The middleware is registered exactly once (guarded by a module-level flag) and
- * is triggered automatically when `with-widget-root.tsx` is imported.
+ * Storybook report-data mocking via a `@wordpress/api-fetch` middleware: since
+ * Storybook has no analytics backend, this middleware intercepts proxy report
+ * paths (matching `fetchReport()`'s base path) and returns generated mock data.
+ * Registered once, triggered when `with-widget-root.tsx` is imported.
  */
 /**
  * External dependencies
@@ -102,11 +93,8 @@ const POST_LIKES_PATH_PATTERN =
 const POST_COMMENTS_PATH_PATTERN =
 	/^\/jetpack-premium-analytics\/v1\/proxy\/v1\.1\/posts\/\d+\/replies(?:\?|$)/;
 const WP_SETTINGS_PATH = '/wp/v2/settings';
-// Core posts endpoint, addressed by ID. The single-post highlight widgets read a
-// reported post's content (title, permalink, publish date, featured image) from
-// core, because Stats report rows carry no featured image. Only the `include=`
-// form is handled here — the Latest post stories mock the unfiltered "newest
-// post" form themselves.
+// Core posts endpoint: single-post highlight widgets read post content (title,
+// permalink, image) from core since Stats rows lack it; only `include=` is handled here.
 const WP_POSTS_PATH = '/wp/v2/posts';
 
 const coreSettingsMock = {
@@ -166,11 +154,9 @@ const requestCounters: Record< string, number > = {};
 
 /**
  * Forced response state for a request path fragment, so stories can exercise a
- * widget's loading, error, and empty UI. `error` rejects the request with a
- * permission-gated 403; `error-retryable` rejects it with the proxy's
- * `no_connection` 403, which widgets on `describeError` render with a Retry
- * action; `loading` returns a promise that never settles; `empty` resolves with
- * a valid response that has no rows.
+ * widget's loading, error, and empty UI. `error` is a permission-gated 403;
+ * `error-retryable` is the proxy's `no_connection` 403 (which `describeError`
+ * renders with Retry); `loading` never settles; `empty` resolves with no rows.
  */
 export type ReportMockState = 'error' | 'error-retryable' | 'loading' | 'empty';
 
@@ -188,10 +174,8 @@ export function resetForcedStateQueries(): void {
 
 /**
  * Force every request whose path contains `pathFragment` into a loading or error
- * state, or clear the override with `null`. Intended for a story's `beforeEach`
- * (set on enter, clear on cleanup). Because the override is keyed by path, scope
- * stories that use it out of the shared autodocs page (`tags: [ '!autodocs' ]`)
- * so it cannot bleed into sibling stories rendered alongside it.
+ * state (or clear it with `null`), for a story's `beforeEach`. Keyed by path, so
+ * scope stories that use it out of autodocs (`tags: [ '!autodocs' ]`) to avoid bleeding into siblings.
  *
  * @param pathFragment - Substring matched against the request path (e.g. `stats/search-terms`).
  * @param state        - The forced state, or `null` to clear.
@@ -207,16 +191,9 @@ export function setReportMockState( pathFragment: string, state: ReportMockState
 
 /**
  * Story `beforeEach` that forces the shared `wordads/earnings` request into a
- * loading, error, or empty state and drops its cached query on both enter and
- * cleanup. Shared by every WordAds earnings widget story (highlights and the
- * three history tables) so the cache-reset cannot drift between them.
- *
- * The earnings endpoint takes no params, so its query key is static and every
- * WordAds story shares one cache entry (a distinct date preset can't separate
- * them). Resetting on both edges gives each forced-state story a fresh fetch and
- * clears a never-settling `loading` fetch before the next story reuses the key.
- * Because the override is keyed by path, keep such stories off the shared
- * autodocs page (`tags: [ '!autodocs' ]`).
+ * loading, error, or empty state, resetting its cache on both enter and cleanup.
+ * The endpoint takes no params, so every WordAds story shares one static query
+ * key — the reset avoids drift and clears a never-settling `loading` fetch before reuse.
  *
  * @param state - The forced mock state.
  * @return A Storybook `beforeEach` implementation returning its cleanup.
@@ -234,16 +211,9 @@ export function forceWordAdsEarningsState( state: ReportMockState ) {
 
 /**
  * Story `beforeEach` that forces the shared `stats/comments` request into a
- * loading, error, or empty state and drops its cached query on both enter and
- * cleanup. Shared by the Top commented authors and Top commented posts stories,
- * which read the same response, so the cache-reset cannot drift between them.
- *
- * The comments endpoint is all-time, so its query key does not vary by date and
- * every comment-widget story shares one cache entry (a distinct date preset
- * can't separate them). Resetting on both edges gives each forced-state story a
- * fresh fetch and clears a never-settling `loading` fetch before the next story
- * reuses the key. Because the override is keyed by path, keep such stories off
- * the shared autodocs page (`tags: [ '!autodocs' ]`).
+ * loading, error, or empty state, resetting its cache on both enter and cleanup.
+ * The endpoint is all-time, so every comment-widget story shares one static
+ * query key — the reset avoids drift and clears a never-settling `loading` fetch before reuse.
  *
  * @param state - The forced mock state.
  * @return A Storybook `beforeEach` implementation returning its cleanup.
@@ -263,12 +233,8 @@ const mockResponseOverrides = new Map< string, unknown >();
 
 /**
  * Force every request whose path contains `pathFragment` to resolve with a
- * specific payload, or clear the override with `null`. Unlike
- * `setReportMockState`, which forces a widget's loading/error/empty UI, this
- * swaps the successful response body — for exercising a data-driven variant (an
- * over-limit reading, a specific row shape) the default fixture doesn't cover.
- * Same scoping caveat: keyed by path, so scope such stories out of the shared
- * autodocs page (`tags: [ '!autodocs' ]`) and clear the override on cleanup.
+ * specific payload (or clear with `null`) — unlike `setReportMockState`, this
+ * swaps the response body for data-driven variants the default fixture doesn't cover. Same autodocs-scoping caveat applies.
  *
  * @param pathFragment - Substring matched against the request path.
  * @param response     - The response body to resolve with, or `null` to clear.
@@ -821,15 +787,10 @@ function buildFollowersResponse( max: number ) {
 }
 
 /**
- * Builds the stats/subscribers time-series response.
- *
- * Honours the `unit`, `quantity`, and `date` query params so the subscribers
- * chart's two requests (current window and the immediately preceding window)
- * return continuous data: values are anchored to each bucket's absolute date,
- * so the current window trends above the previous one and the headline shows a
- * positive period-over-period delta. The series is wavy (not flat) so the
- * dashed previous-period overlay reads clearly against the solid current line.
- * Paid subscribers are always present so both chart lines are exercised.
+ * Builds the stats/subscribers time-series response. Values are anchored to each
+ * bucket's absolute date so the current window trends above the previous one
+ * (continuous across both windows, wavy so the comparison overlay reads clearly);
+ * paid subscribers are always present so both chart lines are exercised.
  *
  * @param query - Parsed query params (`unit`, `quantity`, `date`).
  * @return Raw subscribers response in the WPCOM matrix shape.
@@ -868,9 +829,8 @@ function buildSubscribersResponse( query: URLSearchParams ) {
 		}
 
 		const absDay = Math.floor( bucket.getTime() / DAY_MS );
-		// Upward trend plus a wave whose period (~44 days) does not align with a
-		// 30-day window, so the index-aligned previous-period series stays out of
-		// phase and its dashed line diverges visibly from the current solid line.
+		// Upward trend plus a ~44-day wave that doesn't align with a 30-day window, so
+		// the previous-period series stays out of phase and its dashed line diverges visibly.
 		const trend = ( absDay - anchorDay ) * 9;
 		const wave = 420 * Math.sin( absDay / 7 ) + 180 * Math.cos( absDay / 11 );
 		const subscribers = Math.max( 0, Math.round( 900 + trend + wave ) );
@@ -930,12 +890,9 @@ function buildHourOfDayResponse( query: URLSearchParams ) {
 }
 
 /**
- * The hourly slice of `stats/visits`.
- *
- * Two things set it apart from the coarser units, and both are what the real
- * endpoint does: the bucket's date and hour are packed into a single `period`
- * string rather than split across columns, and only Views carries a number —
- * every other requested field comes back `null`.
+ * The hourly slice of `stats/visits`: mirrors the real endpoint by packing date
+ * and hour into a single `period` string (not split columns), with only Views
+ * carrying a number — every other requested field comes back `null`.
  *
  * @param query   - Parsed query params (`start_date`, `quantity`, `stat_fields`).
  * @param fields  - The requested stat fields, in order.
@@ -943,10 +900,8 @@ function buildHourOfDayResponse( query: URLSearchParams ) {
  * @return Raw hourly visits response in the WPCOM matrix shape.
  */
 function buildHourlyVisitsResponse( query: URLSearchParams, fields: string[], endDate: Date ) {
-	// Counted from the range, as the endpoint does, rather than from `quantity`:
-	// a range-bounded request carries no `quantity`, so reading one would peg
-	// every hourly story to 24 buckets whatever window it asked for. `quantity`
-	// stays as the fallback for the range-less shape.
+	// Counted from the range, as the endpoint does, not `quantity` — a range-bounded
+	// request carries none, so reading it would peg every story to 24 buckets. `quantity` is the range-less fallback.
 	const startDate = query.get( 'start_date' )
 		? parseDateParam( query.get( 'start_date' ), endDate )
 		: null;
@@ -983,15 +938,10 @@ function buildHourlyVisitsResponse( query: URLSearchParams, fields: string[], en
 }
 
 /**
- * Builds the stats/visits time-series response for the traffic chart.
- *
- * Honours the `unit`, `date`, `start_date`, and `stat_fields` query params, and
- * returns only the requested fields (the traffic chart fetches views/visitors
- * and likes/comments as two separate requests). Values are anchored to each
- * bucket's absolute date so the current window trends above the comparison
- * window and each metric shows a positive period-over-period delta; the series
- * is wavy so the dashed previous-period overlay reads clearly against the solid
- * current line.
+ * Builds the stats/visits time-series response for the traffic chart, honouring
+ * `unit`/`date`/`start_date`/`stat_fields` and returning only the requested
+ * fields (views/visitors and likes/comments are separate requests). Values are
+ * anchored to each bucket's absolute date so the window trends above the comparison and the wavy series reads clearly.
  *
  * @param query - Parsed query params (`unit`, `date`, `start_date`, `stat_fields`).
  * @return Raw visits response in the WPCOM matrix shape.
@@ -1061,12 +1011,9 @@ function buildVisitsResponse( query: URLSearchParams ) {
 }
 
 /**
- * Builds a mock Stats "email summary" response so the Emails widget renders
- * populated in Storybook. The shape matches what `sanitizeStatsEmailSummaryResponse`
- * expects (`{ posts: [ { title, opens_rate, clicks_rate, … } ] }`); rates are
- * 0–100 percentages and the rows are newest-first to mirror the live endpoint.
- * One subject line carries HTML entities, because the live endpoint returns them
- * encoded.
+ * Builds a mock Stats "email summary" response matching what
+ * `sanitizeStatsEmailSummaryResponse` expects (`{ posts: [...] }`); rates are
+ * 0–100 percentages, rows are newest-first, and one subject carries HTML entities to mirror the live endpoint's encoding.
  *
  * @return Raw email-summary response.
  */
@@ -1109,9 +1056,8 @@ function buildEmailSummaryResponse() {
 
 /**
  * Builds a mock email breakdown response for the "Email breakdown" widget. The
- * request path ends with the breakdown dimension
- * (`.../stats/opens|clicks/emails/{id}/{breakdown}`), so the trailing segment
- * selects the matching fieldless fixture. The endpoints have no comparison period.
+ * trailing path segment (`.../emails/{id}/{breakdown}`) selects the matching
+ * fixture; the endpoints have no comparison period.
  *
  * @param requestPath - The request path, used to read the breakdown dimension.
  * @return Raw email breakdown response.
@@ -1143,9 +1089,8 @@ function buildEmailBreakdownResponse( requestPath: string ): unknown {
  * @return The mock response body, or `null` if no specific handler matched.
  */
 function routeStatsReport( subPath: string, requestPath: string ): unknown {
-	// Single-post detail — `stats/post/{id}`. Any post ID resolves to the shared
-	// fixture, but the fixture must report the ID that was asked for: widgets
-	// attribute metrics to the current post and skeleton on a mismatch.
+	// Single-post detail — `stats/post/{id}`. Any ID resolves to the shared fixture,
+	// but must echo the requested ID: widgets skeleton on a mismatch.
 	const statsPost = subPath.match( /^\/post\/(\d+)/ );
 	if ( statsPost ) {
 		return {
@@ -1233,14 +1178,10 @@ function queryParamsOf( requestPath: string ): URLSearchParams {
 }
 
 /**
- * Builds a single-video response for the requested metric and window while
- * preserving the shared embed-page and post fixtures. Requests carrying an
- * explicit `start_date`/`date` window (the video detail widgets) get the
- * fixture days inside that window; requests without one (the embeds widget's
- * default `period=month` request) keep the endpoint's default trailing
- * 31-day window. `statType=all` responses mirror wpcom #229903: four-metric
- * tuples named by `fields` plus canonical range totals (retention
- * play-weighted, not averaged).
+ * Builds a single-video response for the requested metric and window. Requests
+ * with an explicit `start_date`/`date` window get fixture days inside it; others
+ * (the embeds widget's default `period=month`) keep the default trailing 31-day
+ * window. `statType=all` mirrors wpcom #229903: four-metric tuples plus range totals (retention play-weighted, not averaged).
  *
  * @param requestPath - The request path, used to read `statType` and the window.
  * @return Raw single-video response.
@@ -1303,10 +1244,9 @@ function buildSingleVideoResponse( requestPath: string ) {
 }
 
 /**
- * Scale factor for play counts based on how recent the requested window ends,
- * so the primary (recent) period reads higher than the comparison (earlier)
- * period and the widget shows period-over-period growth. Recent windows return
- * the full count; windows ~30+ days back taper to ~70%.
+ * Scale factor for play counts based on how recent the window ends, so the
+ * primary (recent) period reads higher than the comparison and the widget shows
+ * growth. Recent windows return the full count; ~30+ days back tapers to ~70%.
  *
  * @param endDate - The window's end date (YYYY-MM-DD), or undefined for "today".
  * @return A multiplier in the range [0.7, 1].
@@ -1322,20 +1262,17 @@ function playsFactorForWindow( endDate: string | undefined ): number {
 		return 1;
 	}
 
-	// `differenceInCalendarDays` counts whole calendar days between the two
-	// dates, so the scaling (and the mocked counts) stay stable regardless of
-	// the machine's timezone.
+	// `differenceInCalendarDays` counts whole calendar days, so the scaling (and
+	// mocked counts) stay stable regardless of the machine's timezone.
 	const daysAgo = Math.max( 0, differenceInCalendarDays( new Date(), end ) );
 
 	return 1 - Math.min( daysAgo / 30, 1 ) * 0.3;
 }
 
 /**
- * Builds a mock Stats "video-plays" response so the Videos widget renders a
- * populated leaderboard in Storybook. The shape matches what
- * `sanitizeStatsVideoPlaysResponse` reads (`days.<date>.plays[]`), and play
- * metrics scale by how recent the requested window is so the comparison period
- * reads lower than the primary one, including complete-stats highlight rows.
+ * Builds a mock Stats "video-plays" response matching what
+ * `sanitizeStatsVideoPlaysResponse` reads (`days.<date>.plays[]`); play metrics
+ * scale by window recency so the comparison period reads lower than the primary.
  *
  * @param requestPath - The request path, used to read the window's end date.
  * @return Raw video-plays response.
@@ -1382,14 +1319,10 @@ function buildVideoPlaysResponse( requestPath: string ) {
 }
 
 /**
- * Builds the wordads/stats time-series response for the WordAds chart tabs.
- *
- * Honours the `unit`, `date`, and `quantity` query params and returns the raw
- * WPCOM matrix shape (`fields: [ 'period', 'impressions', 'revenue', 'cpm' ]`).
- * Impressions are anchored to each bucket's absolute date so the current window
- * trends above the comparison window (a positive period-over-period delta), and
- * revenue is derived from impressions and a wavy CPM so all three metrics move
- * together and read clearly against the dashed previous-period overlay.
+ * Builds the wordads/stats time-series response for the WordAds chart tabs,
+ * honouring `unit`/`date`/`quantity` and returning the raw WPCOM matrix shape.
+ * Impressions anchor to each bucket's date so the window trends above the
+ * comparison; revenue derives from impressions and a wavy CPM so all three metrics move together.
  *
  * @param query - Parsed query params (`unit`, `date`, `quantity`).
  * @return Raw wordads/stats response in the WPCOM matrix shape.
@@ -1446,14 +1379,9 @@ function buildWordAdsStatsResponse( query: URLSearchParams ) {
 }
 
 /**
- * Builds the wordads/earnings response for the WordAds earnings widgets.
- *
- * The earnings module reports all-time totals (not period-scoped), so this
- * returns a fixed raw WPCOM payload: `total_earnings` and `total_amount_owed`
- * feed the widget's Earnings / Paid / Outstanding cards (paid = earnings −
- * owed). All three per-period breakdowns are populated so the three history
- * widgets render their primary table state by default. Together the rows cover
- * every known payment status for visual review.
+ * Builds the wordads/earnings response. All-time totals (not period-scoped):
+ * `total_earnings`/`total_amount_owed` feed the Earnings/Paid/Outstanding cards
+ * (paid = earnings − owed), and all three breakdowns are populated, covering every payment status, so the history tables render fully by default.
  *
  * @return Raw wordads/earnings response in the WPCOM shape.
  */
@@ -1517,19 +1445,16 @@ const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 			return { date: '2026-01-01', period: 'day', summary: {}, days: {}, data: [] };
 		}
 		if ( state === 'error-retryable' ) {
-			// The local proxy's `no_connection` shape. Still a 403, so the error UI
-			// shows at once, but `describeError` keeps it retryable: a broken Jetpack
-			// connection can heal, unlike a permission gate.
+			// The local proxy's `no_connection` shape: still a 403, so the error UI shows
+			// at once, but `describeError` keeps it retryable since a broken connection can heal.
 			return Promise.reject( {
 				code: 'no_connection',
 				message: 'Mocked connection failure for Storybook.',
 				data: { status: 403 },
 			} );
 		}
-		// The WPCOM pass-through error envelope, with the status attached the way
-		// the fetch layer attaches it. A 403 is not retried by `shouldRetryApiError`,
-		// so the error UI shows at once instead of after the query's retry backoff.
-		// Widgets on `describeError` read it as a permission gate and drop Retry.
+		// The WPCOM pass-through error envelope. A 403 isn't retried by
+		// `shouldRetryApiError`, so the error UI shows at once; `describeError` reads it as a permission gate and drops Retry.
 		return Promise.reject( {
 			error: 'unauthorized',
 			message: 'Mocked error response for Storybook.',
@@ -1613,8 +1538,7 @@ const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 		const subPath = requestPath.slice( STATS_API_BASE.length ).split( '?' )[ 0 ];
 
 		// Per-post email timelines — `/opens|clicks/emails/<postId>` with
-		// `stats_fields=timeline`. Matched here rather than in routeStatsReport()
-		// because the generated buckets read period/quantity/date off the query.
+		// `stats_fields=timeline`. Matched here, not in routeStatsReport(), since buckets read period/quantity/date off the query.
 		const emailTimeline = subPath.match( /^\/(opens|clicks)\/emails\/\d+$/ );
 		if ( emailTimeline && getQueryParam( requestPath, 'stats_fields' ) === 'timeline' ) {
 			return buildEmailTimelineResponse( emailTimeline[ 1 ] as 'opens' | 'clicks', requestPath );
@@ -1626,9 +1550,8 @@ const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 			return response;
 		}
 
-		// Stats endpoints this middleware doesn't route may be owned by the
-		// legacy stats mocks (register-stats-mocks.ts). Fall through so
-		// middleware registration order doesn't decide whether they load.
+		// Unrouted Stats endpoints may be owned by the legacy mocks (register-stats-mocks.ts);
+		// fall through so middleware registration order doesn't decide whether they load.
 		return next( options );
 	}
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
@@ -1,9 +1,7 @@
 /**
- * Stats API mock middleware for Storybook.
- *
- * Intercepts `@wordpress/api-fetch` requests to the PA Stats proxy and returns
- * fixture data so Stats-backed widgets render in Storybook without a live
- * WordPress + WPCOM connection.
+ * Stats API mock middleware for Storybook: intercepts `@wordpress/api-fetch`
+ * requests to the PA Stats proxy and returns fixture data so Stats-backed
+ * widgets render without a live WordPress + WPCOM connection.
  */
 /**
  * External dependencies
@@ -358,10 +356,8 @@ const MOCK_TOP_POSTS_COMPARISON = {
 	},
 };
 
-// `stats/archives` groups archive-page views by archive type; the widget's
-// Archives view renders one aggregate row per type.
-// With skip_archives=1 (sent to both reports, mirroring the Stats card) the
-// API returns no `home` entry here — it lives in the top-posts response.
+// `stats/archives` groups views by archive type (one row per type); with
+// skip_archives=1 the API omits `home` here — it's in the top-posts response.
 const MOCK_ARCHIVES = {
 	date: '2026-06-29',
 	period: 'day',
@@ -392,11 +388,8 @@ const MOCK_ARCHIVES_COMPARISON = {
 	},
 };
 
-// Exercises every referrer shape the widget renders: a multi-source group that
-// drills down twice (group → source → domain), a single-result group (which the
-// normalizer flattens into the result itself), and childless domains with URLs
-// that render as outbound links (label + favicon), while rows with children
-// drill down.
+// Exercises every referrer shape: multi-source drill-down (group → source →
+// domain), a single-result group (flattened), and childless outbound-link domains.
 const MOCK_REFERRERS = {
 	date: '2026-06-29',
 	period: 'day',
@@ -494,9 +487,8 @@ const MOCK_REFERRERS = {
 	},
 };
 
-// The Search Engines comparison total exceeds every current-period value so the
-// combined-scale contract is visible: the widest current bar stays below 100%
-// and its width agrees with the negative delta (see getCombinedPeriodMax).
+// The comparison total exceeds every current-period value so the combined-scale
+// contract is visible: the widest bar stays under 100%, matching the negative delta.
 const MOCK_REFERRERS_COMPARISON = {
 	date: '2026-05-30',
 	period: 'day',
@@ -1065,11 +1057,8 @@ const MOCK_DEVICES_PLATFORM_COMPARISON = {
 	},
 };
 
-// Heuristic: a request whose `date` param is more than 1 day ago is treated as the
-// comparison-period request. This works for the default `last-30-days` preset (primary
-// date ~= today, comparison date ~= 30 days ago). It would misclassify a `today` preset
-// (comparison date = yesterday, daysFromToday === 1), but the stories only use the default
-// preset so this is fine in practice.
+// Heuristic: a `date` more than 1 day old is the comparison request — works for
+// the default last-30-days preset but would misclassify a `today` preset (fine here).
 function isComparisonRequest( path: string ): boolean {
 	const queryString = path.split( '?' )[ 1 ];
 	const requestDate = queryString ? new URLSearchParams( queryString ).get( 'date' ) : null;
@@ -1229,12 +1218,8 @@ const statsMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOption
 		return prepareStatsMockResponse( mock, options.parse );
 	}
 
-	// Stats endpoints this middleware doesn't know may be owned by the shared
-	// report mocks (register-report-mocks.ts), including its forced-state
-	// overrides. Fall through instead of answering with an empty catch-all:
-	// story-module load order decides which mock middleware runs first, so
-	// swallowing unknown endpoints here starves the other middleware whenever
-	// this one registers later.
+	// Unknown endpoints may belong to the shared report mocks; fall through rather
+	// than swallowing them, since module load order decides which mock runs first.
 	return next( options );
 };
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/widget-card.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/widget-card.tsx
@@ -12,10 +12,9 @@ export interface WidgetCardProps {
 }
 
 /**
- * Widget card wrapper for skeleton stories, simulating a dashboard widget
+ * Widget card wrapper for skeleton stories: simulates a dashboard widget
  * container so a shape is shown within typical widget dimensions. The inset
- * matches the dashboard's `--wp-ui-card-padding` override, so a story's shape
- * clears the card border by the same distance it does in product.
+ * matches the dashboard's `--wp-ui-card-padding`, so a story's border-clearance matches product.
  *
  * @param props          - Component props.
  * @param props.height   - Card height.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/bookings-by-attendance/bookings-by-attendance-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/bookings-by-attendance/bookings-by-attendance-widget.tsx
@@ -16,12 +16,8 @@ import { useSegmentStyles } from '../common';
 import styles from '../common/donut-widget.module.scss';
 
 /**
- * Displays a donut chart showing bookings breakdown by status.
- * Shows the total bookings count in the center with a breakdown in the legend.
- *
- * Statuses include: Booked, Checked In, No Show, and Cancelled.
- *
- * Must be used within a WidgetRoot which provides reportParams via context.
+ * Donut chart of bookings by status (Booked, Checked In, No Show, Cancelled),
+ * with the total count in the center and a breakdown in the legend.
  */
 export function BookingsByAttendanceWidget() {
 	const { reportParams } = useWidgetRootContext();
@@ -40,9 +36,8 @@ export function BookingsByAttendanceWidget() {
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep placeholders from the previous period across
+			// range changes, so only surface the error when nothing is left to show.
 			isError={ isError && ! hasData }
 			isEmpty={ isEmptyPieChartData( chartData ) }
 			error={ {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/conversion-rate/conversion-rate-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/conversion-rate/conversion-rate-widget.tsx
@@ -63,9 +63,8 @@ export function ConversionRateWidget( {
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep the previous period's data as placeholders across
+			// range changes, so only surface the error when nothing else is showing.
 			isError={ isError && ! hasData }
 			isEmpty={ steps.length === 0 }
 			error={ {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/coupon-use/coupon-use-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/coupon-use/coupon-use-widget.tsx
@@ -38,9 +38,8 @@ export function CouponUseWidget() {
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep placeholders from the previous period across
+			// range changes, so only surface the error when nothing is left to show.
 			isError={ isError && ! hasData }
 			isEmpty={ isEmptyPieChartData( chartData ) }
 			error={ {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/new-vs-returning-customer/new-vs-returning-customer-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/new-vs-returning-customer/new-vs-returning-customer-widget.tsx
@@ -38,9 +38,8 @@ export function NewVsReturningCustomerWidget() {
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep the previous period's data as placeholders across
+			// range changes, so only surface the error when nothing else is showing.
 			isError={ isError && ! hasData }
 			isEmpty={ isEmptyPieChartData( chartData ) }
 			error={ {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/orders-fulfillment/orders-fulfillment-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/orders-fulfillment/orders-fulfillment-widget.tsx
@@ -21,13 +21,9 @@ import { useSegmentStyles } from '../common';
 import styles from '../common/donut-widget.module.scss';
 
 /**
- * Displays a donut chart showing the breakdown of fulfilled vs unfulfilled
- * order counts over the selected time period.
- *
- * Makes two separate API calls with different fulfillment status filters
- * since fulfillment data is not pre-aggregated in the orders summary.
- *
- * Must be used within a WidgetRoot which provides reportParams via context.
+ * Donut chart of fulfilled vs unfulfilled order counts. Makes two separate API
+ * calls with different fulfillment filters, since fulfillment isn't
+ * pre-aggregated in the orders summary.
  */
 export function OrdersFulfillmentWidget() {
 	const { reportParams } = useWidgetRootContext();
@@ -85,9 +81,8 @@ export function OrdersFulfillmentWidget() {
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep placeholders from the previous period across
+			// range changes, so only surface the error when nothing is left to show.
 			isError={ isError && ! hasData }
 			isEmpty={ isEmptyPieChartData( chartData ) }
 			error={ {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/product-leaderboard/top-performing-product-leaderboard-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/product-leaderboard/top-performing-product-leaderboard-widget.tsx
@@ -119,13 +119,9 @@ export function TopPerformingProductLeaderboardWidget( {
 			// Match by product_id instead of index.
 			const comparisonProduct = comparisonMap.get( product.product_id );
 
-			// A product ranked below the previous top-N cutoff is absent from
-			// the comparison list. That is an unknown previous value, not a
-			// real 0, so leave the comparison fields undefined and let the
-			// chart show a missing-data placeholder instead of implying the
-			// product earned nothing. A product present with 0 revenue keeps
-			// its known comparison value while its unavailable delta renders
-			// separately.
+			// A product below the previous top-N cutoff is absent from the comparison list —
+			// an unknown previous value, not a real 0 — so leave it undefined for the missing-data
+			// placeholder. A product present with 0 revenue keeps its known comparison value.
 			const previousValue = comparisonProduct?.product_net_revenue;
 			const hasComparisonValue = previousValue !== undefined;
 
@@ -141,9 +137,8 @@ export function TopPerformingProductLeaderboardWidget( {
 					action: { kind: 'static' },
 				} ),
 				currentValue,
-				// Net revenue can be negative once refunds outweigh sales; a
-				// negative share would render an invalid bar width, so clamp
-				// both periods' shares to zero-width bars.
+				// Net revenue can go negative once refunds outweigh sales; clamp both periods'
+				// shares to zero-width bars rather than render an invalid negative width.
 				currentShare: sharePercentage( Math.max( currentValue, 0 ), maxValue ),
 				previousValue,
 				previousShare: hasComparisonValue
@@ -154,9 +149,8 @@ export function TopPerformingProductLeaderboardWidget( {
 		} );
 	}, [ data?.data, comparisonData?.data, hasComparison, productImages ] );
 
-	// `hasComparison` only tracks the date range. When none of the visible
-	// products carry over from the comparison period, comparison mode would draw
-	// a column of placeholders, so suppress it rather than show an empty column.
+	// `hasComparison` only tracks the date range; when no visible product carries
+	// over from that period, suppress comparison mode rather than draw an empty column.
 	const hasVisibleComparison = useMemo(
 		() => chartData.some( row => row.previousValue !== undefined ),
 		[ chartData ]
@@ -166,14 +160,12 @@ export function TopPerformingProductLeaderboardWidget( {
 
 	return (
 		<WidgetState
-			// The images query only starts once the report supplies product IDs, so
-			// rows land first and the thumbnails fill in behind them. That gap is
-			// a refetch, not a missing answer, so it belongs in `isFetching`.
+			// Images only start fetching once the report supplies product IDs, so rows
+			// land first and thumbnails fill in behind — that gap belongs in `isFetching`, not loading.
 			isLoading={ isLoading }
 			isFetching={ isFetching || imagesLoading }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep the previous period's data as placeholders across
+			// range changes, so only surface the error when nothing else is showing.
 			isError={ isError && ! hasData }
 			isEmpty={ chartData.length === 0 }
 			error={ {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/revenue-by-customer-type/revenue-by-customer-type-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/revenue-by-customer-type/revenue-by-customer-type-widget.tsx
@@ -50,9 +50,8 @@ function CustomerTypeRevenueWidget( { filter }: CustomerTypeRevenueWidgetProps )
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep placeholders from the previous period across
+			// range changes, so only surface the error when nothing is left to show.
 			isError={ isError && ! hasData }
 			isEmpty={ isEmptyChartData( chartData ) }
 			error={ {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-coupon/sales-by-coupon-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-coupon/sales-by-coupon-widget.tsx
@@ -17,9 +17,8 @@ import { useBarStyles } from '../common';
 const TOP_COUPON_SEGMENTS = 3;
 
 /**
- * Displays a bar chart showing coupon discount distribution.
- * Shows top 3 coupons plus "Other" segment.
- * Displays data for all product types.
+ * Bar chart of coupon discount distribution: top 3 coupons plus an "Other"
+ * segment, across all product types.
  *
  * Must be used within a WidgetRoot which provides reportParams via context.
  */
@@ -41,9 +40,8 @@ export function SalesByCouponWidget() {
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep the previous period's data as placeholders across
+			// range changes, so only surface the error when nothing else is showing.
 			isError={ isError && ! hasData }
 			isEmpty={ isEmptyChartData( chartData ) }
 			error={ {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-device/sales-by-device-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-device/sales-by-device-widget.tsx
@@ -62,9 +62,8 @@ export function SalesByDeviceWidget( {
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep placeholders from the previous period across
+			// range changes, so only surface the error when nothing is left to show.
 			isError={ isError && ! hasData }
 			isEmpty={ isEmptyChartData( chartData ) }
 			error={ {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-utm/sales-by-utm-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-utm/sales-by-utm-widget.tsx
@@ -25,14 +25,8 @@ type SalesByUtmWidgetProps = {
 };
 
 /**
- * Displays order attribution data in a leaderboard chart, showing how sales are
- * distributed across different UTM parameters (source, channel, or campaign).
- *
- * Features:
- * - Multiple views: source, channel, campaign
- * - Displays data for all product types
- * - Comparison support (current vs previous period)
- * - Formatted legend labels with date ranges
+ * Order attribution data as a leaderboard chart, showing how sales split across
+ * UTM parameters (source, channel, or campaign) with comparison support.
  *
  * Must be used within a WidgetRoot which provides reportParams via context.
  *
@@ -74,9 +68,8 @@ export function SalesByUtmWidget( { view }: SalesByUtmWidgetProps ) {
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep the previous period's data as placeholders across
+			// range changes, so only surface the error when nothing else is showing.
 			isError={ isError && ! hasData }
 			isEmpty={ chartData.length === 0 }
 			error={ {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sessions-by-device/sessions-by-device-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sessions-by-device/sessions-by-device-widget.tsx
@@ -38,9 +38,8 @@ export function SessionsByDeviceWidget() {
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep placeholders from the previous period across
+			// range changes, so only surface the error when nothing is left to show.
 			isError={ isError && ! hasData }
 			isEmpty={ isEmptyPieChartData( chartData ) }
 			error={ {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/total-returns/total-returns-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/total-returns/total-returns-widget.tsx
@@ -36,9 +36,8 @@ export function TotalReturnsWidget() {
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The report queries keep the previous period's data as placeholders
-			// across range changes, so only surface the error when there is
-			// nothing to show.
+			// The report queries keep the previous period's data as placeholders across
+			// range changes, so only surface the error when nothing else is showing.
 			isError={ isError && ! hasData }
 			isEmpty={ isEmptyChartData( chartData ) }
 			error={ {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.tsx
@@ -108,9 +108,8 @@ export function VisitorsByLocationWidget() {
 				<WidgetState
 					isLoading={ isLoading }
 					isFetching={ isFetching }
-					// The report queries keep the previous period's data as placeholders
-					// across range changes, so only surface the error when there is
-					// nothing to show.
+					// The report queries keep placeholders from the previous period across
+					// range changes, so only surface the error when nothing is left to show.
 					isError={ isError && ! hasData }
 					isEmpty={ leaderboardData.length === 0 }
 					error={ {

--- a/projects/packages/premium-analytics/routes/dashboard/components/refresh-failure-notice/refresh-failure-notice.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/refresh-failure-notice/refresh-failure-notice.test.tsx
@@ -86,9 +86,8 @@ function description( text: RegExp ) {
 }
 
 describe( 'RefreshFailureNotice', () => {
-	// The provider hands out the module-level client, which outlives each test.
-	// The notice is still mounted at this point — RTL's own cleanup runs after —
-	// so emptying the cache re-renders it.
+	// The client is module-level and outlives tests; clear it before RTL's cleanup
+	// unmounts the notice, so this actually re-renders it.
 	afterEach( () => act( () => queryClient.clear() ) );
 
 	it( 'stays out of the way while the widgets have what they asked for', async () => {

--- a/projects/packages/premium-analytics/routes/dashboard/components/section-sync-notice/section-sync-notice.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/section-sync-notice/section-sync-notice.test.tsx
@@ -90,9 +90,8 @@ describe( 'SectionSyncNotice', () => {
 			<SectionSyncNotice percentage={ 40 } hasError={ false } onRetry={ noop } isRetrying />
 		);
 
-		// The button the user just pressed is still there and reports itself busy,
-		// through `aria-disabled` rather than `disabled`, so it keeps the focus the
-		// press gave it. Nothing announced a switch back to "still syncing" either.
+		// Reports busy via `aria-disabled`, not `disabled`, so it keeps the focus the
+		// press gave it; nothing announced a switch back to "still syncing" either.
 		const retry = screen.getByRole( 'button', { name: 'Try again' } );
 		expect( retry ).toHaveAttribute( 'aria-disabled', 'true' );
 		expect( container ).toHaveTextContent( 'Something went wrong' );

--- a/projects/packages/premium-analytics/routes/dashboard/components/section-sync-notice/section-sync-notice.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/section-sync-notice/section-sync-notice.tsx
@@ -9,7 +9,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import styles from './section-sync-notice.module.scss';
 
 type SectionSyncNoticeProps = {
-	/** Sync progress, 0–100. */
 	percentage: number;
 	hasError: boolean;
 	onRetry: () => void;
@@ -17,11 +16,10 @@ type SectionSyncNoticeProps = {
 };
 
 /**
- * Banner above a section whose data is still being synced to WordPress.com.
+ * Banner above a section whose data is still syncing to WordPress.com.
  *
- * The widgets below it render throughout, so the copy says the numbers are
- * incomplete rather than only that a sync is running: until it finishes they
- * read as zeros, which is a claim about the store rather than about the sync.
+ * The widgets below read as zeros until sync finishes, so the copy says the
+ * numbers are incomplete rather than that a sync is merely running.
  *
  * @param props            - Component props.
  * @param props.percentage - Sync progress, 0–100.
@@ -44,18 +42,16 @@ export function SectionSyncNotice( {
 		'Something went wrong while syncing your store data, so the numbers below are incomplete.',
 		'jetpack-premium-analytics-pkg'
 	);
-	// A retry clears the error before it settles, so reading `hasError` alone
-	// would drop the failure layout mid-click: the button the user just pressed
-	// unmounts, and the announcement flips to "still syncing" and back.
+	// A retry clears the error before it settles, so reading `hasError` alone would
+	// drop the failure layout mid-click and flip the announcement back and forth.
 	const showError = hasError || isRetrying;
 	let message: string = syncingMessage;
 
 	if ( showError ) {
 		message = errorMessage;
 	} else if ( percentage > 0 && percentage < 100 ) {
-		// 100 before the milestone lands means everything queued has been sent and
-		// WordPress.com has yet to confirm it — "still syncing (100%)" reads as a
-		// finished sync nagging the user, so the plain sentence covers that window.
+		// "still syncing (100%)" — everything sent, WordPress.com yet to confirm —
+		// reads as a finished sync nagging the user, so the plain sentence covers it.
 		message = sprintf(
 			/* translators: %d: sync progress percentage. */
 			__(
@@ -68,9 +64,8 @@ export function SectionSyncNotice( {
 
 	return (
 		/*
-		 * Announce only status changes. The visible percentage updates every poll,
-		 * but repeating the full sentence that often would overwhelm screen-reader
-		 * users; the action label is already exposed by its button.
+		 * Announce only status changes: the percentage updates every poll, and
+		 * repeating the full sentence that often would overwhelm screen readers.
 		 */
 		<Notice.Root
 			intent={ showError ? 'error' : 'info' }

--- a/projects/packages/premium-analytics/routes/dashboard/config/date-filter.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/date-filter.test.ts
@@ -39,9 +39,8 @@ describe( 'resolvePresetForSurface', () => {
 } );
 
 describe( 'Date-filter surface constants', () => {
-	// An unrecognized surface falls back to `range` silently, so a typo here
-	// would go unnoticed. A surface added on the PHP side only fails in
-	// `Dashboard_Section_Test::test_sections_schema_documents_the_date_filter`.
+	// An unrecognized surface silently falls back to `range`, so a typo here goes
+	// unnoticed; a PHP-side addition is only caught by `Dashboard_Section_Test`.
 	it( 'pins the surface literals the PHP constants use', () => {
 		expect( DATE_FILTER_RANGE ).toBe( 'range' );
 		expect( DATE_FILTER_YEAR ).toBe( 'year' );

--- a/projects/packages/premium-analytics/routes/dashboard/config/date-filter.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/date-filter.ts
@@ -44,8 +44,6 @@ export type DateFilterOptions = {
  * Not just chrome: false has `WidgetRoot` drop the comparison from the params
  * every widget in the section fetches and renders with.
  *
- * The year surface never supports it; otherwise the section decides.
- *
  * @param surface - The active section's date-filter surface.
  * @param options - The active section's date-filter options, if any.
  * @return Whether the section supports comparison.
@@ -62,19 +60,9 @@ export function offersDateComparison(
 }
 
 /**
- * The preset a surface should take over with when the URL carries one it cannot
- * represent, or `null` when the current preset is already coherent.
- *
- * `?preset=` is shared by every section, so switching sections can land a
- * rolling window on the year surface — where no pill matches it and the whole
- * control reads as unset — or a single year on the range surface, where the
- * picker would label it a custom range. Rather than leave either looking blank,
- * the surface the user is now looking at takes over with its own default: all
- * time for the year surface, the shared default preset for the range surface.
- *
- * Presets a surface can represent are left alone. That includes an absent
- * preset on the range surface, which is how a `?from=&to=` deep link expresses
- * a custom range.
+ * The preset a surface should switch to when the current URL preset is
+ * incompatible with it, or `null` when it already fits. A range surface with
+ * no preset is left alone — that's how a `?from=&to=` deep link works.
  *
  * @param surface  - The active section's date-filter surface.
  * @param presetId - The preset currently in the URL, if any.

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
@@ -93,9 +93,8 @@ describe( 'resolveSectionHeading', () => {
 	} );
 
 	it( 'falls back to the label when the heading is an empty string', () => {
-		// The registry normalises `''` to null before it ever reaches here; this
-		// pins the client's own guard, since an empty heading would render an
-		// `<h2>` with no accessible name.
+		// The registry normalises `''` to null before this; this pins the client's
+		// own guard against an accessible-name-less `<h2>`.
 		expect( resolveSectionHeading( { ...STORE, title: '' } ) ).toBe( 'Store' );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
@@ -31,10 +31,8 @@ export type DashboardSection = {
 	label: string;
 
 	/**
-	 * Translated section heading, deliberately not the tab label: the `Traffic`
-	 * tab heads its section `Site traffic`. Read it through
-	 * `resolveSectionHeading`. Optional for the same reason as `date_filter`
-	 * below.
+	 * Translated section heading, deliberately not the tab label. Read it through
+	 * `resolveSectionHeading`. Optional for the same reason as `date_filter` below.
 	 */
 	title?: string | null;
 
@@ -51,14 +49,9 @@ export type DashboardSection = {
 	order: number;
 
 	/**
-	 * Which date filter this section's header offers. Server-registered per
-	 * section, so a section reporting on whole history can ask for the year
-	 * surface while the rest keep the rolling date-range picker.
-	 *
-	 * Optional because the field can genuinely be absent: WPCOM's public-api
-	 * registers this route from its own checkout, so a Simple site can be served
-	 * a sections payload built before the field existed. A missing value means
-	 * the date-range surface.
+	 * Which date filter this section's header offers, registered per section on
+	 * the server. Optional because a Simple site's public-api route may serve a
+	 * payload built before this field existed; a missing value means the range surface.
 	 */
 	date_filter?: DateFilterSurface;
 

--- a/projects/packages/premium-analytics/routes/dashboard/route.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.test.ts
@@ -89,10 +89,8 @@ describe( 'dashboard route.beforeLoad', () => {
 	} );
 
 	it( 'registers dashboardSection even when a detail-page entry already registered widgetModule', async () => {
-		// Regression for the empty edit-mode dashboard: reloading on a detail
-		// page registered `widgetModule` alone, and the dashboard's old guard
-		// then skipped `dashboardSection` entirely, so the stage resolved zero
-		// sections and force-opened an empty edit-mode canvas.
+		// Regression: reloading on a detail page had registered `widgetModule` alone,
+		// so the old guard skipped `dashboardSection`, force-opening an empty canvas.
 		mockGetEntityConfig.mockImplementation( ( _kind: string, name: string ) =>
 			name === 'widgetModule' ? {} : undefined
 		);

--- a/projects/packages/premium-analytics/routes/dashboard/route.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.ts
@@ -16,39 +16,10 @@ import { isPremiumAnalyticsSiteConnected } from '../site-readiness';
 type DashboardSearch = Record< string, string | undefined >;
 
 /**
- * Route lifecycle for the dashboard.
- *
- * Guard:
- * - Not connected → /connect
- *
- * The initial analytics sync is not a guard: only the store section's data waits
- * on it, so that section shows sync progress while the rest of the dashboard
- * renders (see `stage.tsx`).
- *
- * Seed the default date range into the URL on first visit so the date picker
- * and the widgets share a populated search state. Defaults to the last 30 days
- * with a previous-period comparison, resolved from the shared analytics
- * defaults (`getDefaultQueryParams`). Also re-seeds when `interval` is missing
- * or not allowed for the active range. The seed itself needs nothing async —
- * the site timezone comes from the WordPress date settings that ship with the
- * page — but it still awaits `ensureCoreSettingsReady()` to warm the core
- * `site` record that `useSiteHomeUrl()` reads once the stage renders.
- *
- * Then register the widget-modules discovery entity before the stage renders,
- * so the stage's `getEntityRecords` read resolves and feeds the records to
- * `useWidgetTypes`. Premium Analytics serves the records from its own namespace
- * (see `src/widget-modules.php`), independent of core's `wp/v2` endpoint.
- * The route is registered under `wpcom/v2` so WPCOM can expose it through the
- * site-scoped public-api path for Simple sites.
- * Registration is idempotent per entity (see `ensureDashboardEntities`):
- * beforeLoad re-runs on every navigation and preload, and a detail route may
- * already have registered `widgetModule` alone before the user reaches the
- * dashboard.
- *
- * That registration is one-time bootstrap setup that could move to the page's
- * `init` module (`packages/init`) now that `@wordpress/build` supports it —
- * registering once at boot instead of on every beforeLoad run. Left here for
- * now (idempotency-guarded); tracked as a follow-up.
+ * Route lifecycle for the dashboard. The initial analytics sync is not a guard
+ * — only the store section waits on it and shows progress meanwhile (see
+ * `stage.tsx`). Widget-module registration is idempotent for repeat visits; it
+ * could move to `packages/init` and run once at boot — tracked as a follow-up.
  */
 export const route = {
 	beforeLoad: async ( { search }: { search?: DashboardSearch } = {} ) => {
@@ -59,11 +30,8 @@ export const route = {
 		const params = ( search ?? {} ) as DashboardSearch;
 		if ( needsReportDateParamsSeed( params ) ) {
 			/*
-			 * Warm the core `site` record before the stage renders, so
-			 * `useSiteHomeUrl()` has it. A rejection here (network/auth)
-			 * shouldn't error the whole page, so fall through to the seed —
-			 * matching upstream's loader behavior. The seed's own dates do not
-			 * depend on this; they resolve from the WordPress date settings.
+			 * Warm the core `site` record for `useSiteHomeUrl()`; a rejection should
+			 * not error the page since the seed's own dates don't depend on it.
 			 */
 			try {
 				await ensureCoreSettingsReady();
@@ -72,16 +40,8 @@ export const route = {
 			}
 
 			/*
-			 * Resolve the date params through `normalizeReportParams` — the same
-			 * resolver the widgets use — so the URL and the widgets agree on
-			 * dates, interval, preset, and comparison. A raw default spread would
-			 * force `comp: '1'` onto a custom `from`/`to` deep-link the user never
-			 * asked to compare; normalizeReportParams only applies the default
-			 * comparison on a genuinely fresh load (no `from`/`to`).
-			 *
-			 * Overlay the resolved report params onto the original search so
-			 * non-report params that may be deep-linked (e.g. `section`) survive
-			 * the seed redirect.
+			 * Overlay `normalizeReportParams` onto `params`, not replace it — a raw
+			 * default would force `comp=1` onto a custom deep-link and drop `section`.
 			 */
 			const seeded: Record< string, unknown > = {
 				...params,
@@ -92,10 +52,8 @@ export const route = {
 				to: '/',
 				replace: true,
 				/*
-				 * The router is built dynamically, so the '/' route has no
-				 * statically-typed search schema (tanstack widens it to
-				 * `never`). Cast the seeded params the same way the routing
-				 * package does when it writes the URL.
+				 * The router is built dynamically, so '/' has no typed search schema
+				 * (TanStack widens it to `never`); cast as the routing package does.
 				 */
 				search: seeded as unknown as never,
 			} );

--- a/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
@@ -13,12 +13,10 @@ import { stage as Dashboard } from './stage';
 import type { SyncStatus } from '@jetpack-premium-analytics/site-sync';
 import type { ReactNode } from 'react';
 
-// Read inside the mocked functions, never at factory time: the factories run
-// while `./stage` is still being imported, when these are in the temporal dead
-// zone.
+// Read inside the mocked functions, never at factory time — the factories run
+// while `./stage` is still importing, so these are in the temporal dead zone.
 // Base UI's `Tabs.Panel` defaults to `keepMounted={false}`, so only the active
-// section is ever in the DOM. The mock below models that: without it, anything
-// the stage renders per section would silently multiply here but not in product.
+// section is ever in the DOM; the mock below models that.
 let mockActiveSectionSlug = 'insights';
 let mockSyncState: { data?: SyncStatus; error: Error | null; isComplete: boolean };
 let mockIsSyncFinished: boolean;
@@ -292,9 +290,8 @@ describe( 'Dashboard refresh-failure notice', () => {
 		const notices = screen.getAllByTestId( 'refresh-failure-notice' );
 		expect( notices ).toHaveLength( 1 );
 
-		// In the pinned band right after the header, not down among the widgets,
-		// so it stays reachable however far the reader has scrolled. Sibling order
-		// is the assertion, and Testing Library has no query for it.
+		// Pinned right after the header, not among the widgets, so it stays reachable
+		// however far scrolled; sibling order is the assertion Testing Library lacks.
 		// eslint-disable-next-line testing-library/no-node-access -- position in the header band is what this test is for.
 		expect( notices[ 0 ].previousElementSibling ).toContainElement(
 			screen.getByText( 'header offers comparison' )

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -54,11 +54,8 @@ function Dashboard(): JSX.Element {
 	const [ gridSettings ] = useDashboardGridSettings();
 
 	/*
-	 * Only a section whose data reaches WordPress.com through the analytics full
-	 * sync has incomplete numbers; the rest read data it already holds. The
-	 * watcher runs at the dashboard level rather than inside the notice below, so
-	 * the sync starts as soon as the dashboard opens instead of only once that
-	 * section is visited.
+	 * The watcher runs at the dashboard level, not inside the notice below, so the
+	 * sync starts as soon as the dashboard opens rather than when the section is visited.
 	 */
 	const isSyncFinished = isPremiumAnalyticsInitialSyncFinished();
 	const sectionsAwaitSync = sections.some( section =>
@@ -99,38 +96,32 @@ function Dashboard(): JSX.Element {
 					) => WidgetModuleRecord[] | null;
 				}
 			 )
-				// `per_page: -1` returns every widget type. Without it, core-data's default
-				// query (`per_page: 10`) caps the mapped records at 10, silently hiding any
-				// widget past the tenth from the "Add widget" gallery.
+				// `per_page: -1` returns every widget type; core-data's default query
+				// (`per_page: 10`) would silently hide any widget past the tenth.
 				.getEntityRecords( 'root', 'widgetModule', { per_page: -1 } ),
 		[]
 	);
 
 	const [ editMode, setEditMode ] = useState( false );
 
-	// Only the widgets this section renders need their metadata resolved at
-	// boot; the complete registry is what the widget picker lists, so it can
-	// wait for edit mode. `null` until the sections resolve — the layout is
-	// empty until then, and this hook runs on those renders too, below the
-	// spinner returned further down. See `useWidgetTypesWithI18n`.
+	// Only the widgets this section renders need metadata at boot; the full registry
+	// waits for edit mode. `null` until sections resolve, since the layout is empty until then.
 	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypesWithI18n( widgetModules, {
 		visibleNames: hasResolvedSections ? layout.map( widget => widget.type ) : null,
 		includeAll: editMode,
 	} );
 
 	/*
-	 * Date-range state lives in the URL search params. The shared controller
-	 * stages edits locally and commits atomically on Apply (or immediately for
-	 * comparison changes), so widgets re-fetch only on commit.
+	 * Date-range state lives in the URL search params; the controller stages edits
+	 * locally and commits on Apply, so widgets re-fetch only on commit.
 	 */
 	const dateFilters = useReportDateFilters( '/' );
 
 	const activeSectionRecord = sections.find( section => section.slug === activeSection );
 
 	/*
-	 * Which date filter the active section's header shows. Also reconciles the
-	 * preset in the URL with that filter's surface, so a section switch never
-	 * leaves the visible control unable to represent the selection.
+	 * Also reconciles the preset in the URL with the resolved surface, so a section
+	 * switch never leaves the visible control unable to represent the selection.
 	 */
 	const dateFilterSurface = useSectionDateFilter( activeSectionRecord, dateFilters );
 
@@ -145,12 +136,8 @@ function Dashboard(): JSX.Element {
 		activeSectionRecord?.date_filter_options?.with_header_date_control ?? true;
 
 	/*
-	 * The subtitle states what the widgets are currently showing, so it follows
-	 * the applied range and comparison rather than the picker's staged draft:
-	 * it must not move while an edit is open, only once Apply commits it.
-	 *
-	 * A header without the comparison control must not announce one, and a
-	 * header that does not own the date control must not announce the range.
+	 * The subtitle follows the applied range, not the picker's staged draft, since it
+	 * states what the widgets show; a header missing a control must not announce it.
 	 */
 	const comparisonPresetId = showComparison ? dateFilters.appliedComparisonPresetId : undefined;
 	const comparisonRange = showComparison ? dateFilters.appliedComparisonRange : undefined;
@@ -165,8 +152,7 @@ function Dashboard(): JSX.Element {
 			comparisonPresetId,
 			comparisonRange,
 			// The interval control renders as a glyph, so the subtitle is where
-			// the active bucket is readable. Both surfaces that render a header
-			// control carry it.
+			// the active bucket is readable.
 			interval: dateFilters.appliedInterval,
 		} );
 	}, [
@@ -179,9 +165,8 @@ function Dashboard(): JSX.Element {
 	] );
 
 	/*
-	 * The year surface applies on click — it has no Apply step of its own — so
-	 * stage and commit together, the way the quick presets do inside
-	 * `DateRangeFilter`.
+	 * The year surface applies on click — no Apply step of its own — so stage and
+	 * commit together, the way the quick presets do inside `DateRangeFilter`.
 	 */
 	const { onChange: onDateChange, onApply: onDateApply } = dateFilters;
 	const selectYear = useCallback(
@@ -192,13 +177,10 @@ function Dashboard(): JSX.Element {
 		[ onDateChange, onDateApply ]
 	);
 
-	// Container element for the date filters panel responsive layout.
 	const [ containerElement, setContainerElement ] = useState< HTMLDivElement | null >( null );
 
-	// The sections carry each section's default layout, so until the entity
-	// resolves the layout above is transiently empty. WidgetDashboard treats an
-	// empty layout as "no widgets" and force-opens edit mode, so it must not
-	// mount before the sections exist.
+	// WidgetDashboard treats a transiently-empty layout as "no widgets" and
+	// force-opens edit mode, so it must not mount before the sections resolve.
 	if ( ! hasResolvedSections ) {
 		return (
 			<Stack justify="center" align="center" className={ styles.loading }>
@@ -208,10 +190,8 @@ function Dashboard(): JSX.Element {
 	}
 
 	/*
-	 * The date controls belong to the active section: the tab panels unmount
-	 * when they lose focus, so only the active section's header is ever rendered
-	 * and one set of controls is enough. A section that opts out of the header
-	 * control renders none at all — its widgets host their own.
+	 * Tab panels unmount when unfocused, so only the active section's header renders
+	 * and one set of controls suffices; an opted-out section renders none at all.
 	 */
 	let dateControls: JSX.Element | null = null;
 
@@ -219,18 +199,13 @@ function Dashboard(): JSX.Element {
 		dateControls =
 			dateFilterSurface === DATE_FILTER_YEAR ? (
 				/*
-				 * The year surface carries the interval control but no comparison.
-				 * Composed here rather than inside `DateYearFilter`, which stays the
-				 * preset surface alone.
+				 * The interval control is composed here rather than inside
+				 * `DateYearFilter`, which stays the preset surface alone.
 				 */
 				<Stack direction="row" align="center" gap="sm">
 					{ /*
-					 * `startYear` is left out on purpose: nothing in this package knows how
-					 * far back the site's data goes yet (`getStoreInfo()` is still a stub),
-					 * so the surface falls back to `DEFAULT_YEAR_SURFACE_COUNT` — six years,
-					 * which is the window the design shows. Pass the site's oldest year of
-					 * content here once a source for it exists, so a younger site stops
-					 * offering years it has nothing to show for.
+					 * `startYear` is omitted: `getStoreInfo()` is still a stub, so nothing here
+					 * knows how far back data goes; the surface falls back to `DEFAULT_YEAR_SURFACE_COUNT`.
 					 */ }
 					<DateYearFilter
 						value={ dateFilters.appliedPresetId }
@@ -247,9 +222,8 @@ function Dashboard(): JSX.Element {
 				</Stack>
 			) : (
 				/*
-				 * The dashboard's widgets are charts bucketed by the interval. The
-				 * report pages mount this same panel over records tables, which are
-				 * not, so the control is asked for rather than implied by the props.
+				 * Report pages mount this same panel over records tables, which have no
+				 * interval, so the control is asked for rather than implied.
 				 */
 				<DateFiltersPanel { ...dateFilters } withIntervalControl />
 			);
@@ -258,11 +232,8 @@ function Dashboard(): JSX.Element {
 	return (
 		<GlobalErrorProvider>
 			{ /*
-			 * The same answer the header uses to decide whether to render the
-			 * comparison control, declared once for the widgets below: hiding
-			 * the control does not strip the params, and a widget reading them
-			 * straight off the URL would show a comparison this section's
-			 * reader has no way to see or switch off.
+			 * Declared once for widgets below: hiding the control doesn't strip the params,
+			 * so a widget reading them off the URL could show a comparison the reader can't see.
 			 */ }
 			<ReportScopeProvider offersComparison={ showComparison }>
 				<WidgetDashboard

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.tsx
@@ -15,10 +15,8 @@ import type { PostSummary } from '../../hooks';
 type PostSummaryCardProps = {
 	summary: PostSummary;
 	/**
-	 * Which identity the header carries, per the design mocks. The email tabs
-	 * describe the post's newsletter send — an envelope tile instead of the
-	 * featured image, and "Email sent on …" instead of the publish wording —
-	 * while the default post identity shows the thumbnail and publish date.
+	 * Header identity: 'email' frames the header as the newsletter send
+	 * (envelope tile, "Email sent on…") instead of the post identity.
 	 */
 	variant?: 'post' | 'email';
 	/**
@@ -66,9 +64,8 @@ export function PostSummaryCard( {
 	const formattedDate = publishedDateObject
 		? format( toLocalTZ( publishedDateObject, siteTimeZone() ), DATE_FORMAT )
 		: undefined;
-	// The email wording reuses the publish date: WordPress.com sends the
-	// newsletter when the post publishes, and the email stats API exposes no
-	// separate send timestamp (`stats/emails/summary` returns the post date).
+	// Reuses the publish date: the newsletter sends when the post publishes,
+	// and `stats/emails/summary` exposes no separate send timestamp.
 	let publishedSentence;
 	if ( formattedDate ) {
 		publishedSentence =
@@ -98,11 +95,8 @@ export function PostSummaryCard( {
 			: undefined;
 	const subtitle = [ publishedSentence, performanceSentence ].filter( Boolean ).join( ' ' );
 
-	// The email identity always shows the envelope tile — even when the post
-	// has a featured image — so the email tabs read as the newsletter send
-	// rather than the post, per the design mocks. The post identity shows the
-	// thumbnail, or a type-glyph placeholder so the type still reads at a
-	// glance without its own badge row.
+	// Email variant always shows the envelope tile, even with a featured
+	// image, so email tabs read as the newsletter send, not the post.
 	let media;
 	if ( variant === 'email' ) {
 		media = (

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -3,18 +3,14 @@ import type { PostDetailTabId } from './tabs';
 import type { DashboardWidget } from '@wordpress/widget-dashboard';
 
 /**
- * Fixed widget composition for each post-detail tab.
- *
- * The post detail page is not user-customizable (WOOA7S-1622): each tab
- * renders a fixed arrangement so required widgets and their sizing cannot be
- * removed or reshaped. A tab stays hidden only while its composition is empty.
+ * Fixed widget composition for each post-detail tab (not user-customizable,
+ * WOOA7S-1622); a tab stays hidden only while its composition is empty.
  */
 export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[] > = {
 	'post-traffic': [
 		{
 			uuid: 'post-detail-highlights',
-			// Full-width row like the email highlights, per the updated design
-			// mocks; the widget spreads its three tiles across the span.
+			// Full-width row, matching the email highlights layout.
 			type: 'jpa/post-detail-highlights',
 			placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
 		},
@@ -43,9 +39,8 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			// The alias carries the mock's "UTM" card title; the registry's
 			// global "UTM Insights" title is owned by the copy spreadsheet work.
 			type: 'jpa/utm-insights--utm',
-			// Detail-page widgets carry no "View all" action per the design
-			// mocks — the post detail page is itself the terminal page, and the
-			// site-wide UTM report would silently drop this post's scope.
+			// No "View all" action: this page is the terminal page, and the
+			// site-wide UTM report would drop this post's scope.
 			attributes: { utmDimension: 'utm_source,utm_medium', showReportLink: false },
 			placement: { width: 1, height: 2, order: 6 },
 		},
@@ -109,9 +104,7 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 		},
 		{
 			uuid: 'email-clicks-countries',
-			// The updated design mocks draw the country map beside the
-			// leaderboard again (the earlier mocks dropped it in #50928); the
-			// widget still unmounts the map below its 720px container floor.
+			// Keep width: 2 — the map unmounts below a 720px container floor.
 			type: 'jpa/email-breakdown--location-clicks',
 			attributes: { view: 'countries', metric: 'clicks', showMap: true },
 			placement: { width: 2, height: 2, order: 5 },

--- a/projects/packages/premium-analytics/routes/post-detail/config/tabs.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tabs.ts
@@ -4,12 +4,9 @@
 import { __ } from '@wordpress/i18n';
 
 /**
- * Ordered list of the post-detail tab IDs.
- *
- * This is the single source of truth for which tabs exist and in what order.
- * Each tab is surfaced in the tab bar and renders its own customizable widget
- * grid, so the IDs are kept stable and URL-friendly (they are persisted in the
- * `?section=` search param, mirroring the dashboard).
+ * Ordered list of the post-detail tab IDs — the single source of truth for
+ * which tabs exist and their order. IDs are kept stable and URL-friendly:
+ * they persist in the `?section=` param, mirroring the dashboard.
  */
 export const POST_DETAIL_TAB_IDS = [ 'post-traffic', 'email-opens', 'email-clicks' ] as const;
 
@@ -37,10 +34,8 @@ export type PostDetailTab = {
 
 /**
  * Canonical tab definitions with lazy label getters, in display order.
- *
- * Labels are defined once here, as getters resolved at call time, so translations
- * are applied after the i18n locale data has loaded. Mirrors the dashboard's
- * section definitions.
+ * Labels resolve at call time so translations apply once i18n locale data
+ * has loaded, mirroring the dashboard's section definitions.
  */
 const TAB_DEFINITIONS: ReadonlyArray< {
 	id: PostDetailTabId;

--- a/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.test.tsx
@@ -95,12 +95,8 @@ describe( 'usePostDetailTabs', () => {
 		mockRouteSearch = {};
 	} );
 
-	/*
-	 * The page's no-comparison invariant is declared once by the stage, as a
-	 * report scope, and enforced in `WidgetRoot`. The layout this hook returns
-	 * is the fixed one, carrying no injected report params — see
-	 * `stage.test.tsx` for the scope the widgets actually read.
-	 */
+	// The stage declares the no-comparison invariant once; this layout carries no
+	// injected params (see stage.test.tsx for what widgets actually read).
 	it( 'returns the tab’s fixed layout untouched', () => {
 		mockSearch( 'post-traffic' );
 		mockRouteSearch = {
@@ -202,9 +198,8 @@ describe( 'usePostDetailTabs', () => {
 
 		const { result } = renderHook( () => usePostDetailTabs( POST_ID ) );
 
-		// The tabs stay hidden (fail closed), but the URL keeps the deep link:
-		// a failed request doesn't tell us whether the post has email stats,
-		// and a later successful refetch can still settle it.
+		// Fail closed: tabs stay hidden, but the URL keeps the deep link since
+		// a later successful refetch can still settle whether email stats exist.
 		expect( result.current.tabs.map( tab => tab.id ) ).toEqual( [ 'post-traffic' ] );
 		expect( result.current.activeTab ).toBe( 'post-traffic' );
 		expect( stage ).not.toHaveBeenCalled();

--- a/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.ts
@@ -20,22 +20,17 @@ import type { PostDetailTabId } from '../config';
 const EMAIL_TAB_IDS: readonly PostDetailTabId[] = [ 'email-opens', 'email-clicks' ];
 
 /**
- * Resolve the visible post-detail tabs and normalize hidden-tab deep links.
+ * Resolves visible post-detail tabs and normalizes hidden-tab deep links.
+ * Kept in full because the email-tab gating and URL-normalization order are
+ * not obvious from the code below.
  *
- * Tabs without a fixed composition remain hidden, and the email tabs only
- * show for posts that were actually sent to subscribers: `total_sends` from
- * the per-post opens rate summary is the send signal. (Calypso infers the
- * same availability from subscription settings and post metadata because it
- * decides before fetching; the summary is the direct source, and the Email
- * top row widget reads the same query, so React Query shares the result.)
- * The gate fails closed — while the summary is loading or errored the email
- * tabs stay hidden, so they appear rather than disappear.
+ * Tabs without a fixed composition stay hidden. Email tabs also require
+ * `total_sends` > 0 from the opens-rate summary, and fail closed: they stay
+ * hidden while that query is loading or has errored.
  *
- * If the URL points at a hidden tab, the first visible tab renders
- * immediately and replaces the hidden value in the URL without adding a
- * browser-history entry — but an email-tab URL is only normalized once the
- * gate query has succeeded, so a deep link survives the summary's first load
- * and any failed request.
+ * A hidden-tab URL is replaced with the first visible tab, without adding a
+ * history entry. An email-tab URL is normalized only once the gate query
+ * succeeds, so a deep link survives the summary's first load or a failure.
  *
  * @param postId - The scoped post ID (0/NaN disables the email-tab check).
  * @return Visible tabs, the active tab and layout, and the active-tab setter.
@@ -60,15 +55,8 @@ export function usePostDetailTabs( postId: number ) {
 	const [ storedTab, setActiveTab ] = useActiveTab();
 	const activeTab = tabs.find( tab => tab.id === storedTab )?.id ?? tabs[ 0 ]?.id ?? DEFAULT_TAB_ID;
 
-	// Normalize an email-tab URL only after the gate query has *succeeded*:
-	// while the send summary is loading — or after it fails, when we still
-	// don't know whether the post has email stats — the email tabs are hidden
-	// provisionally, and rewriting the URL then would destroy a legitimate
-	// deep link. The visible fallback still renders immediately; the URL write
-	// waits for a definitive answer (a later successful refetch settles it).
-	// Deep links to non-email tabs don't depend on the gate and normalize
-	// right away; without a valid post scope the query never runs, so email
-	// deep links normalize immediately there too.
+	// Non-email/no-scope deep links normalize immediately; a pending or
+	// failed email-tab gate holds off so a real deep link isn't destroyed.
 	const storedIsEmailTab = EMAIL_TAB_IDS.includes( storedTab as PostDetailTabId );
 	const canNormalize = ! storedIsEmailTab || postId <= 0 || opens.isSuccess;
 

--- a/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-summary.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-summary.ts
@@ -30,19 +30,14 @@ export type PostSummary = {
 };
 
 /**
- * Resolve the public URL a list surface carried into this route.
+ * Resolve the public URL a list surface carried into this route. Kept
+ * detailed: this is a security-relevant origin check, not a plain lookup.
  *
- * A public post type that sets `show_in_rest: false` has no core-data entity
- * config, so the permalink lookup below can never resolve it. The Stats report
- * does hold a URL for those rows, so the list surfaces pass it through the
- * route as a search param.
- *
- * That param comes from the address bar, so it is only honoured for an http(s)
- * URL on the site's own origin. Otherwise a crafted dashboard link could point
- * the header's link out at any host. The site URL needs `manage_options`, so
- * where it is unreadable the origin serving the dashboard stands in for it —
- * that is the site itself on a self-hosted install. A URL that passes neither
- * check resolves to `undefined`, and the header simply offers no link out.
+ * A `show_in_rest: false` post type has no core-data entity, so list surfaces
+ * pass the Stats-report URL through as a search param instead — honoured only
+ * for an http(s) URL matching the site's own origin (falling back to the
+ * dashboard's own origin when the site URL is unreadable), so a crafted link
+ * can't point the header out at another host.
  *
  * @return The carried URL when it is safe to use, otherwise `undefined`.
  */
@@ -67,12 +62,9 @@ function useCarriedPostUrl(): string | undefined {
 }
 
 /**
- * Resolve the header summary for a single post/page.
- *
- * Title, type, and published date come straight from the Stats `post` payload
- * (the raw post row). The featured image isn't part of that payload, so it's
- * read from the site's own post entity via `@wordpress/core-data`, degrading
- * gracefully to `undefined` when the record or the featured media is missing.
+ * Resolve the header summary for a single post/page. Title, type, and
+ * published date come from the Stats `post` payload; the featured image
+ * isn't in that payload, so it's read separately from core-data.
  *
  * @param postId - The post/page ID from the route.
  * @return The resolved post summary.
@@ -110,10 +102,8 @@ export function usePostSummary( postId: number ): PostSummary {
 		[ postId, type ]
 	);
 
-	// The public URL is not part of the Stats payload, so it comes from the same
-	// post entity the featured image is read from — already resolved, so this
-	// adds no request. Kept as its own selector so the mapped value stays a
-	// primitive and cannot re-render the header on every store change.
+	// Reads the same already-resolved post entity as the image (no extra
+	// request); its own selector avoids re-rendering on every store change.
 	const url = useSelect(
 		select => {
 			if ( ! type || ! Number.isInteger( postId ) || postId <= 0 ) {
@@ -138,9 +128,8 @@ export function usePostSummary( postId: number ): PostSummary {
 	return {
 		title: post?.post_title,
 		type,
-		// The site-local publish time, as the Stats API's own timestamps are read.
-		// Only the GMT column is ever the fallback, and it says so, so nothing
-		// downstream mistakes it for a wall time in the site timezone.
+		// GMT fallback gets an explicit `Z` suffix so downstream code doesn't
+		// mistake it for a site-timezone wall time.
 		publishedDate:
 			post?.post_date ?? ( post?.post_date_gmt ? `${ post.post_date_gmt }Z` : undefined ),
 		imageUrl,

--- a/projects/packages/premium-analytics/routes/post-detail/route.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/route.ts
@@ -31,12 +31,9 @@ function isValidPostId( value: string | undefined ): value is string {
 /**
  * Route lifecycle for the post/page detail page.
  *
- * Guards mirror the dashboard (not connected → /connect). On first visit it
- * seeds the URL search so the date picker and the
- * widgets share a populated state, and it seeds `post_id` from the route param
- * so every widget on the page is scoped to this single resource. The
- * widget-modules discovery entity is registered here too (idempotently) so a
- * direct deep link resolves widget types without first visiting the dashboard.
+ * `post_id` is seeded from the route param so every widget on the page is scoped
+ * to this single resource. The widget-modules entity is registered here too, so
+ * a direct deep link resolves widget types without visiting the dashboard first.
  */
 export const route = {
 	beforeLoad: async ( {
@@ -47,21 +44,16 @@ export const route = {
 			throw redirect( { to: '/connect' } );
 		}
 
-		// A malformed path param (e.g. `/post/foo`) has no single-post view to
-		// show, and letting it through would render site-wide stats under a
-		// single-post header. Send it back to the dashboard rather than present
-		// unscoped data as if it were scoped. This also closes the spoof where a
-		// `?post_id=` query on an invalid path could bind the page to a different
-		// post than the URL claims.
+		// A malformed path param would render site-wide stats under a
+		// single-post header; this also closes the `?post_id=` spoof.
 		const postId = params?.postId;
 		if ( ! isValidPostId( postId ) ) {
 			throw redirect( { to: '/' } );
 		}
 
 		const currentSearch = ( search ?? {} ) as PostDetailSearch;
-		// A `section` carried in from a link may not be a valid post-detail tab
-		// (e.g. a dashboard section forwarded by a widget link); resolve it so a
-		// shareable URL never persists a bogus tab.
+		// A `section` from an inbound link may not be a valid post-detail tab, so
+		// resolve it rather than persist a bogus tab in a shareable URL.
 		const resolvedSection = currentSearch.section
 			? resolveTabId( currentSearch.section )
 			: undefined;
@@ -71,10 +63,9 @@ export const route = {
 
 		if ( needsDateSeed || needsPostSeed || needsSectionSeed ) {
 			/*
-			 * Warm the core `site` record before the stage renders, so
-			 * `useSiteHomeUrl()` has it. A rejection here shouldn't error the
-			 * whole page, so fall through to the seed. The seed's own dates do
-			 * not depend on this; they resolve from the WordPress date settings.
+			 * Warm the core `site` record for `useSiteHomeUrl()`. A rejection
+			 * shouldn't error the whole page, and the seed's own dates don't
+			 * depend on it, so fall through.
 			 */
 			try {
 				await ensureCoreSettingsReady();
@@ -82,13 +73,8 @@ export const route = {
 				// Proceed with the default seed below.
 			}
 
-			// Allowlist the params this page owns rather than spreading
-			// `currentSearch` wholesale: `normalizeReportParams` yields only the
-			// known report-window params, and the path-derived `post_id` is the
-			// single source of scope. This contains any foreign params a link
-			// carried in (e.g. a dashboard `section`) instead of persisting them.
-			// The report origin is part of that allowlist, so the breadcrumb keeps
-			// its link back to the referring report across this seed.
+			// Allowlist this page's own params instead of spreading `currentSearch`
+			// wholesale; the report origin stays so the breadcrumb survives.
 			const seeded: Record< string, unknown > = {
 				...normalizeReportParams(
 					currentSearch as Parameters< typeof normalizeReportParams >[ 0 ]
@@ -100,10 +86,8 @@ export const route = {
 
 			/*
 			 * Comparison params ride along untouched: this page renders no
-			 * comparison (its widgets ignore them), but the breadcrumb's
-			 * dashboard link carries the URL state back out, so stripping them
-			 * here would silently lose the user's comparison settings on a
-			 * Dashboard → Post → Dashboard round trip.
+			 * comparison, but the breadcrumb's dashboard link carries the URL state
+			 * back out, so stripping them would lose the setting on a round trip.
 			 */
 
 			throw redirect( {
@@ -111,8 +95,7 @@ export const route = {
 				/*
 				 * The router is built dynamically, so `/post/$postId` has no
 				 * statically-typed params/search schema (tanstack widens them to
-				 * `never`). Cast the same way the routing package does when it
-				 * writes the URL.
+				 * `never`); cast as the routing package does when it writes the URL.
 				 */
 				params: { postId } as unknown as never,
 				replace: true,

--- a/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
@@ -41,12 +41,8 @@ jest.mock( '@jetpack-premium-analytics/ui', () => ( {
 
 jest.mock( '@wordpress/core-data', () => ( { store: {} } ) );
 
-// Falls through to the real module for everything but `useSelect`. Reaching the
-// externals passthrough pulls `@wordpress/components` -> `@wordpress/rich-text`
-// into the graph, whose store calls `combineReducers` at import time; a
-// `useSelect`-only mock leaves that undefined and the suite fails to load.
-// `requireActual` has to stay lazy — calling it in the factory body re-enters
-// the module while it is still initialising.
+// Proxies `@wordpress/data` lazily: `requireActual` at import time would
+// re-enter `@wordpress/rich-text`'s module init via `combineReducers`.
 jest.mock(
 	'@wordpress/data',
 	() =>
@@ -224,9 +220,8 @@ describe( 'post detail stage', () => {
 		expect( screen.queryByRole( 'link', { name: /^View (post|page)/ } ) ).not.toBeInTheDocument();
 	} );
 
-	// One declaration drives both halves: the panel reads it to drop the Compare
-	// control (covered in the ui package) and `WidgetRoot` reads it to strip the
-	// params. This asserts the declaration the page makes.
+	// One declaration drives both halves: the panel drops the Compare control and
+	// `WidgetRoot` strips the params. This asserts the page's declaration.
 	it( 'declares no comparison for the widgets it renders', () => {
 		mockSummary();
 

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -31,32 +31,24 @@ import styles from './stage.module.scss';
 
 const ROUTE_FROM = route.path;
 
-// The post-detail composition is fixed (WOOA7S-1622) and laid out against the
-// small (200px) row height used by the design. Keep its grid independent from
-// the customizable main-dashboard preference so a future settings control
-// cannot stretch these tiles out of proportion.
+// Fixed composition (WOOA7S-1622): grid stays independent from the
+// customizable main-dashboard preference so it can't be stretched.
 const POST_DETAIL_GRID = { ...DEFAULT_GRID, rowHeight: ROW_HEIGHT_PRESETS.small };
 
 // The layout is fixed, so the change callback never fires; the dashboard
 // still requires one because it owns a staging copy internally.
 const noopLayoutChange = () => {};
 
-// The share of the header row the date filter presets can never use: the
-// summary's 400px `min-inline-size` floor plus the row's 16px gap (see
-// `.summary` and `.header` in stage.module.scss — keep the three in sync),
-// plus a 24px buffer so the panel steps down before the wrap threshold —
-// layout wraps synchronously while the measured layout flip lags a frame, so
-// equal thresholds would flash a wrapped row at every boundary.
+// = summary's min-inline-size + row gap (keep in sync with stage.module.scss)
+// + a buffer, so the panel steps down before CSS wrap — wrap is synchronous
+// but the measured flip lags a frame, so equal thresholds would flash.
 const HEADER_RESERVED_INLINE_SIZE = 440;
 
 /**
  * Premium Analytics post/page detail page stage component.
  *
- * A fixed, non-customizable page (WOOA7S-1622): each tab renders the widget
- * composition from `POST_DETAIL_TAB_LAYOUTS`, scoped to a single post/page
- * and driven by a shared date range and comparison, with its own header
- * (breadcrumb + summary card) and tab set. There is no edit mode — required
- * widgets and their sizing cannot be removed or reshaped.
+ * A fixed, non-customizable page (WOOA7S-1622): there is no edit mode, so
+ * required widgets and their sizing cannot be removed or reshaped.
  *
  * @return {JSX.Element} The post detail page.
  */
@@ -81,20 +73,16 @@ function PostDetail(): JSX.Element {
 					) => WidgetModuleRecord[] | null;
 				}
 			 )
-				// `per_page: -1` returns every widget type. Without it, core-data's
-				// default query (`per_page: 10`) caps the records at 10 and could
-				// silently drop the widgets this page's fixed layout requires.
+				// `per_page: -1` returns every widget type; core-data's default query
+				// (`per_page: 10`) could silently drop ones this fixed layout requires.
 				.getEntityRecords( 'root', 'widgetModule', { per_page: -1 } ),
 		[]
 	);
 
 	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypesWithI18n( widgetModules );
 
-	// The fixed compositions reuse registered widget types under page-local
-	// aliases so each card carries its design title — the host titles a card
-	// by its widget *type*. Each alias clones the resolved base type (render
-	// module and all) under a variant name and title; see
-	// `config/widget-variants`.
+	// The host titles a card by its widget *type*; fixed compositions reuse
+	// registered types under page-local aliases to carry the design title.
 	const pageWidgetTypes = useMemo( () => {
 		const aliases = POST_DETAIL_WIDGET_TYPE_ALIASES.flatMap( ( { baseType, variants } ) => {
 			const base = widgetTypes.find( widgetType => widgetType.name === baseType );
@@ -112,17 +100,12 @@ function PostDetail(): JSX.Element {
 		return aliases.length ? [ ...widgetTypes, ...aliases ] : widgetTypes;
 	}, [ widgetTypes ] );
 
-	// The single resource, date range, and comparison all live in the URL search
-	// params, staged and committed by the shared date-filter controller.
+	// The resource, date range, and comparison all live in the URL search params.
 	const dateFilters = useReportDateFilters( ROUTE_FROM );
-	// The preset pills alone — all time, then the rolling windows — with no
-	// custom range, period arrows, or interval dropdown, per the detail-page
-	// design; all time runs from the day this resource was published.
 	const dateControls = useDetailDateControls( summary.publishedDate, dateFilters );
 
-	// The header row hosts the panel in a shrink-to-fit slot, so the panel
-	// measures the row itself to pick its responsive layout; see the
-	// `containerElement` prop.
+	// The header row hosts the panel in a shrink-to-fit slot, so the panel measures
+	// the row itself to pick its responsive layout; see the `containerElement` prop.
 	const [ headerElement, setHeaderElement ] = useState< HTMLElement | null >( null );
 
 	const breadcrumbs = useDetailBreadcrumbs( summary.title );
@@ -160,17 +143,12 @@ function PostDetail(): JSX.Element {
 					<PostDetailTabs tabs={ tabs } value={ activeTab } onChange={ setActiveTab }>
 						<div className={ styles.scrollArea }>
 							{ /*
-							 * The summary card and the date filter presets share the
-							 * header row — title on the left, presets on the right, per
-							 * the design mocks. Both are shared by every tab (same post,
-							 * same date range), so they render once above the per-tab
-							 * widget grid and scroll away with it.
+							 * The summary card and the date filter presets are shared by every
+							 * tab (same post, same date range), so they render once above the
+							 * per-tab widget grid and scroll away with it.
 							 */ }
 							<div ref={ setHeaderElement } className={ styles.header }>
 								<div className={ styles.summary }>
-									{ /* The email tabs give the shared header an email identity
-									     (envelope tile, "Email sent on …") while the title and
-									     performance window stay the post's. */ }
 									<PostSummaryCard
 										summary={ summary }
 										variant={ EMAIL_TAB_IDS.includes( activeTab ) ? 'email' : 'post' }
@@ -179,16 +157,9 @@ function PostDetail(): JSX.Element {
 								</div>
 								<div className={ styles.dateFilters }>
 									{ /*
-									 * The design has no period-over-period comparison on
-									 * this page. The panel reads that from the scope the
-									 * stage declares, which is the same declaration that keeps
-									 * the params away from the widgets; the params themselves
-									 * stay in the URL so the breadcrumb carries them back to the
-									 * dashboard.
-									 *
-									 * The Post views and Email performance charts bucket by the
-									 * interval the range resolves; the design offers no control
-									 * over it, nor the period arrows — see `useDetailDateControls`.
+									 * The design has no comparison on this page. The panel reads
+									 * that from the scope the stage declares; the params themselves
+									 * stay in the URL so the breadcrumb carries them back out.
 									 */ }
 									<DateFiltersPanel
 										{ ...dateFilters }
@@ -214,11 +185,9 @@ function PostDetail(): JSX.Element {
 }
 
 /**
- * Route stage wrapper.
- *
- * The header summary fetches through React Query at the page level (widgets get
- * their own client inside each WidgetRoot), so the page mounts its own
- * AnalyticsQueryClientProvider above the component that reads it.
+ * Route stage wrapper. Mounts its own AnalyticsQueryClientProvider above
+ * PostDetail because widgets fetch through their own client inside
+ * WidgetRoot, while the header summary fetches at the page level.
  *
  * @return {JSX.Element} The post detail page.
  */
@@ -226,9 +195,8 @@ export function stage(): JSX.Element {
 	return (
 		<AnalyticsQueryClientProvider>
 			{ /*
-			 * The page names no compared period and offers no control for one, so
-			 * nothing below may fetch or draw a comparison. The params stay on the
-			 * URL so the breadcrumb carries the dashboard's state back out.
+			 * The page names no compared period, so nothing below may fetch or draw
+			 * one. The params stay on the URL for the breadcrumb to carry back out.
 			 */ }
 			<ReportScopeProvider offersComparison={ false }>
 				<PostDetail />

--- a/projects/packages/premium-analytics/routes/reports/clicks/page.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/page.test.tsx
@@ -93,11 +93,8 @@ describe( 'ClicksReportPage', () => {
 	} );
 
 	it( 'keeps the rows on screen while a background refetch is in flight', () => {
-		// The queries carry `placeholderData`, so a refetch triggered by a date or
-		// comparison change still has the previous rows. Handing the table an empty
-		// set would drop the user's search, sorting, page position, and the expanded
-		// state of every click group mid-refetch, so the rows stay mounted and only
-		// the loading state reflects the refetch.
+		// `placeholderData` keeps the previous rows during a refetch, so search/sort/
+		// expanded state survive a date or comparison change instead of resetting.
 		mockRecords( { isFetching: true } );
 
 		render( <ClicksReportPage /> );

--- a/projects/packages/premium-analytics/routes/reports/comment-followers/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comment-followers/page.tsx
@@ -26,10 +26,7 @@ import { REPORTS } from '../registry';
 import { getCommentFollowersFields, useCommentFollowersReportRecords } from './config';
 import styles from './page.module.css';
 
-/**
- * Initial records-table view: subscribers sort descending, the post column
- * absorbs spare width, and the numeric column stays compact and right-aligned.
- */
+/** Default records-table view: sort by subscribers, other columns auto-sized. */
 const RECORDS_VIEW = {
 	sort: { field: 'subscribers', direction: 'desc' as const },
 	layout: {
@@ -54,11 +51,8 @@ function getCommentFollowerRowId( item: StatsCommentFollowersItem ): string {
 }
 
 /**
- * Premium Analytics Comments Subscribers report page component.
- *
- * This legacy report is an all-time paginated list without date buckets, so
- * it composes only the breadcrumb header and records table: no date filters,
- * tabs, or performance chart.
+ * Legacy all-time paginated list with no date buckets: only the breadcrumb header and
+ * records table render, no date filters, tabs, or performance chart.
  *
  * @return The Comments Subscribers report page.
  */
@@ -147,10 +141,8 @@ function CommentFollowersReport(): JSX.Element {
 }
 
 /**
- * Comments Subscribers report page (default export for the report registry).
- *
- * React Query and global error handling are provided by the shared report
- * stage, which lazily renders this page through the registry.
+ * Registry entry point; React Query and error handling come from the shared
+ * report stage that renders this lazily.
  *
  * @return The Comments Subscribers report page.
  */

--- a/projects/packages/premium-analytics/routes/reports/downloads/page.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/downloads/page.test.tsx
@@ -88,10 +88,8 @@ describe( 'DownloadsReportPage', () => {
 	} );
 
 	it( 'keeps the rows on screen while a background refetch is in flight', () => {
-		// The queries carry `placeholderData`, so a refetch triggered by a date or
-		// comparison change still has the previous rows. Handing the table an empty
-		// set would drop the user's search, sorting, and page position mid-refetch,
-		// so the rows stay mounted and only the loading state reflects the refetch.
+		// `placeholderData` keeps the previous rows during a refetch, so search/sort/
+		// page position survive a date or comparison change instead of resetting.
 		useRecordsMock.mockReturnValue( {
 			isError: false,
 			refetch: jest.fn(),

--- a/projects/packages/premium-analytics/routes/reports/emails/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/emails/page.tsx
@@ -53,13 +53,9 @@ function getEmailRowId( item: StatsEmailSummaryItem ): string {
 }
 
 /**
- * Premium Analytics Emails report page component.
- *
- * The summary endpoint reports across the whole lifetime of the site and
- * caps its row count at 30, so the page composes only the breadcrumb header
- * and records table: no date filters, tabs, or performance chart. Each row's
- * title links into the post detail page's Email opens tab — the per-email
- * detail surface.
+ * All-time summary capped at 30 rows, so only the breadcrumb header and records table
+ * render — no date filters, tabs, or performance chart. Row titles link to the post
+ * detail page's Email opens tab.
  *
  * @return The Emails report page.
  */

--- a/projects/packages/premium-analytics/routes/reports/locations/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/locations/page.tsx
@@ -126,9 +126,8 @@ export default function LocationsReportPage(): JSX.Element {
 		sort: sortLocationCsvRows,
 	} );
 
-	// A country picked on one tab does not carry to the next: the Countries tab
-	// cannot be scoped at all, and a country with regions may have no cities.
-	// The table remounts per tab, so its own filter clears alongside this.
+	// Country filter doesn't carry between tabs: Countries can't be scoped, and
+	// cities/regions vary per tab, so clear it on tab change.
 	const handleTabChange = useCallback(
 		( tab: ReportLocationsTabId ) => {
 			setCountryFilter( '' );

--- a/projects/packages/premium-analytics/routes/reports/posts/config/tabs.ts
+++ b/projects/packages/premium-analytics/routes/reports/posts/config/tabs.ts
@@ -18,12 +18,8 @@ export type ReportPostsTabId = 'posts-pages' | 'archives';
 const DEFAULT_TAB_ID: ReportPostsTabId = 'posts-pages';
 
 /**
- * Canonical tab machinery built from the ordered definitions.
- *
- * Labels are defined once here, as getters resolved at call time, so translations
- * are applied after the i18n locale data has loaded. The generic `defineReportTabs`
- * helper turns these into the `resolve`/`getTabs`/`getTabLabel` API. Mirrors the
- * post-detail tab definitions.
+ * Canonical tab machinery. Labels are getters resolved at call time so translations
+ * apply after i18n locale data loads; mirrors the post-detail tab definitions.
  */
 const reportPostsTabs = defineReportTabs< ReportPostsTabId >(
 	[

--- a/projects/packages/premium-analytics/routes/reports/posts/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/posts/page.tsx
@@ -35,9 +35,8 @@ import {
 	type ArchiveRow,
 } from './config';
 
-// Every report is served by the single dynamic route, so route-level hooks read
-// from the shared `/reports/$report` path and navigations target it with the
-// `posts` param.
+// Every report shares the single dynamic route, so route-level hooks and
+// navigations target this path with the `posts` param.
 const ROUTE_FROM = route.path;
 
 type ReportCsvRow = StatsTopPostsComparisonItem | ArchiveRow;
@@ -76,10 +75,8 @@ function getArchiveRowParentId( item: ArchiveRow ): string | undefined {
 }
 
 /**
- * Shared initial view for both tabs' records tables: sorted by views, with the
- * title absorbing all spare width so the metric columns shrink to their
- * content and read right-aligned — table-layout auto otherwise stretches an
- * arbitrary column to fill the table.
+ * Shared initial view for both tabs: sorted by views, title absorbs spare width so
+ * metric columns shrink to content instead of table-layout auto stretching them.
  */
 const RECORDS_VIEW = {
 	sort: { field: 'views', direction: 'desc' as const },
@@ -92,20 +89,14 @@ const RECORDS_VIEW = {
 };
 
 /**
- * Premium Analytics Posts & Pages report page component.
- *
- * The second-level "view all" report for the Posts & Pages traffic module,
- * composed on the shared report-page framework: breadcrumb header, internal
- * Posts & Pages / Archives tabs, the shared date-range + comparison picker,
- * and a Core DataViews table of the active tab's records by views for the
- * selected range. Post titles drill into the post/page detail route.
+ * Second-level "view all" report for the Posts & Pages traffic module. Post titles
+ * drill into the post/page detail route.
  *
  * @return {JSX.Element} The Posts & Pages report page.
  */
 function PostsReport(): JSX.Element {
-	// The route guard guarantees the report window params are seeded, so the
-	// URL search is the single source of truth for dates, interval, and
-	// comparison — resolve it with the same normalizer the widgets use.
+	// The route guard guarantees the window params are seeded, so URL search is the
+	// single source of truth — resolve it with the same normalizer the widgets use.
 	const reportParams = useReportParams();
 
 	const tabs = useMemo( () => getReportPostsTabs(), [] );
@@ -223,11 +214,8 @@ function PostsReport(): JSX.Element {
 }
 
 /**
- * Posts & Pages report page (default export for the report registry).
- *
- * React Query and global errors are provided by the `/reports/$report` stage,
- * which renders this lazily via the registry's `load` — the page mounts no
- * providers of its own.
+ * Registry entry point; React Query and error handling come from the
+ * `/reports/$report` stage that renders this lazily.
  *
  * @return {JSX.Element} The Posts & Pages report page.
  */

--- a/projects/packages/premium-analytics/routes/reports/registry.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.test.ts
@@ -49,10 +49,8 @@ describe( 'getReportDefinition', () => {
 	} );
 
 	it( 'hides the downloads report on non-Simple sites', () => {
-		// Calypso only shows file downloads on Simple sites ("not yet supported
-		// in Jetpack environment", which includes Atomic); the route guard
-		// redirects an unavailable report to the dashboard, same as an unknown
-		// one.
+		// Calypso shows file downloads only on Simple sites; an unavailable report
+		// gets the same route-guard redirect as an unknown one.
 		mockIsSimpleSite.mockReturnValue( false );
 
 		expect( getReportDefinition( 'downloads' ) ).toBeUndefined();

--- a/projects/packages/premium-analytics/routes/reports/registry.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.ts
@@ -7,12 +7,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { isVideoPressAvailable } from '../site-readiness';
-// Import the tab resolver from `config/tabs` directly rather than the report's
-// `config` barrel. `route.ts` imports this registry in `beforeLoad`, so the
-// registry must stay free of React/UI at module scope; the `config/index.ts`
-// barrel re-exports `fields.tsx` (JSX + `@wordpress/route` Link), which would
-// pull the UI into the route guard's import chain. `config/tabs.ts` only
-// depends on the routing helper and i18n, so it's safe to import here.
+// Import from `config/tabs` directly, not the `config` barrel — it re-exports JSX,
+// and `route.ts` imports this registry in `beforeLoad`, which must stay React-free.
 import { resolveTabId as resolveCommentsTabId } from './comments/config/tabs';
 import { resolveSection as resolveLocationsSection } from './locations/config/tabs';
 import { resolveTabId } from './posts/config/tabs';
@@ -22,16 +18,8 @@ import type { ComponentType } from 'react';
 /**
  * A single report's registration in the report registry.
  *
- * One dynamic route (`/reports/$report`) serves every report; a definition
- * describes one report and the stage renders its page component. Labels are
- * getters (resolved at call time) rather than plain strings so translations
- * apply after the i18n locale data has loaded — the same lazy-label convention
- * the section/tab definitions use (see `config/tabs.ts` on the tabbed routes).
- *
- * `load` is a dynamic import of the report's page component so the registry
- * itself stays free of React/UI at module scope: `route.ts` imports this module
- * in `beforeLoad` (which runs before the page bundle needs React), so pulling a
- * component in at the top level here would drag the UI into the route guard.
+ * Labels are getters rather than plain strings so translations apply after the
+ * i18n locale data has loaded.
  */
 export type ReportDefinition = {
 	/**
@@ -58,10 +46,9 @@ export type ReportDefinition = {
 	getDescription?: () => string;
 
 	/**
-	 * Resolve a raw `?section=` value to a section this report owns, falling
-	 * back to the report's default section — mirroring the per-page
-	 * `resolveTabId` used by the tabbed routes so a shareable URL never persists
-	 * a section the report can't render. Omit for reports that have no sections.
+	 * Resolve a raw `?section=` value to a section this report owns, falling back
+	 * to its default, so a shareable URL never persists a section the report can't
+	 * render. Omit for reports that have no sections.
 	 */
 	resolveSection?: ( value: string | undefined ) => string;
 
@@ -83,9 +70,8 @@ export type ReportDefinition = {
 /**
  * The report registry: one entry per report, keyed by its `id`.
  *
- * To add a report, drop a `<id>/` module folder under `routes/reports/` that
- * default-exports its page component and add one entry here; no new route is
- * needed (see this folder's README).
+ * To add a report, drop a `<id>/` folder under `routes/reports/` that
+ * default-exports its page component and add an entry here; no new route needed.
  */
 export const REPORTS: Record< string, ReportDefinition > = {
 	'annual-insights': {
@@ -130,10 +116,8 @@ export const REPORTS: Record< string, ReportDefinition > = {
 		id: 'downloads',
 		getLabel: () => __( 'File downloads', 'jetpack-premium-analytics-pkg' ),
 		getTitle: () => __( 'File downloads report', 'jetpack-premium-analytics-pkg' ),
-		// File download tracking happens on WPCOM infrastructure; Calypso only
-		// shows the module on Simple sites ("not yet supported in Jetpack
-		// environment") and we mirror that boundary. Mirrors the widget-level
-		// gate in `src/widget-type-support.php`.
+		// Download tracking is WPCOM-only, so Calypso shows the module on Simple
+		// sites only; mirrors the gate in `src/widget-type-support.php`.
 		isAvailable: isSimpleSite,
 		load: () => import( './downloads/page' ),
 	},
@@ -182,8 +166,7 @@ export const REPORTS: Record< string, ReportDefinition > = {
 		getLabel: () => __( 'Videos', 'jetpack-premium-analytics-pkg' ),
 		getTitle: () => __( 'Videos report', 'jetpack-premium-analytics-pkg' ),
 		getDescription: () => __( 'See how your videos perform.', 'jetpack-premium-analytics-pkg' ),
-		// Play counts only exist for VideoPress-hosted videos, and Calypso gates
-		// its Videos module on the same signal. Mirrors the widget-level gate in
+		// Play counts only exist for VideoPress-hosted videos; mirrors the gate in
 		// `src/widget-type-support.php`.
 		isAvailable: isVideoPressAvailable,
 		load: () => import( './videos/page' ),
@@ -206,9 +189,8 @@ export const REPORTS: Record< string, ReportDefinition > = {
 /**
  * Look up a report definition by its id.
  *
- * The id comes from the URL, so the lookup is an own-property check: a plain
- * index would resolve an inherited name such as `constructor` to a function and
- * hand back something that is not a report definition.
+ * The id comes from the URL, so this is an own-property check: a plain index
+ * would resolve an inherited name such as `constructor` to a function.
  *
  * @param id - The `$report` path segment (may be missing on a malformed URL).
  * @return The matching definition, or `undefined` when the id is missing or unknown.
@@ -226,9 +208,8 @@ export function getReportDefinition( id: string | undefined ): ReportDefinition 
 /**
  * Resolve the report origin behind a detail breadcrumb.
  *
- * A section is kept only when the referring report defines a section resolver
- * and the value round-trips through it, so a section belonging to a different
- * report — or one that report can no longer render — is never linked.
+ * A section is kept only when it round-trips through the referring report's own
+ * resolver, so a section from a different report is never linked.
  *
  * @param origin - The report origin read from the current search params.
  * @return The referring report definition and its validated section, when valid.

--- a/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
@@ -113,9 +113,8 @@ jest.mock( '@wordpress/route', () => ( {
 	useSearch: () => ( {} ),
 } ) );
 
-// The page imports `EmptyState`/`Text` from the externals passthrough, so the
-// stubs have to replace them there; the Proxy leaves the rest of the barrel
-// intact for any other consumer in the graph.
+// Pages import `EmptyState`/`Text` from the externals passthrough, so the stubs replace them
+// there; the Proxy leaves the rest of the barrel intact for other consumers.
 jest.mock(
 	'@jetpack-premium-analytics/externals',
 	() =>

--- a/projects/packages/premium-analytics/routes/reports/report-names.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/report-names.test.ts
@@ -1,9 +1,8 @@
 /**
  * Internal dependencies
  */
-// The tab sets come from `config/tabs` directly rather than each report's
-// `config` barrel, which re-exports `fields.tsx` and would pull JSX and the
-// router in. Same reason `registry.ts` imports them this way.
+// `config/tabs` is imported directly, not through each report's `config` barrel, which
+// re-exports `fields.tsx` and pulls in JSX/router. `registry.ts` imports them the same way.
 import { getCommentsReportTabs, getTabTitle as getCommentsTabTitle } from './comments/config/tabs';
 import {
 	getReportLocationsTabs,
@@ -44,9 +43,8 @@ const REPORT_NAMES = Object.entries( REPORTS ).map( ( [ key, report ] ) => [
 ] );
 
 /*
- * The crumb names the report and the heading names its records, one `report`
- * apart. That convention drifts a string at a time, so it is asserted rather
- * than written down.
+ * The crumb names the report and the heading names its records, one `report` word apart —
+ * asserted here instead of documented, since the convention drifts a string at a time.
  */
 describe( 'report names', () => {
 	it.each( REPORT_NAMES )( '%s heads its records with its own label', ( key, id, label, title ) => {

--- a/projects/packages/premium-analytics/routes/reports/route.ts
+++ b/projects/packages/premium-analytics/routes/reports/route.ts
@@ -19,23 +19,8 @@ type ReportRouteSearch = Record< string, string | undefined >;
 /**
  * Route lifecycle for the dynamic report page (`/reports/$report`).
  *
- * One route serves every report: the `$report` path segment selects a report
- * definition from the registry, and the stage renders that report's page
- * component. Guards mirror the dashboard and post-detail routes:
- *
- * - Not connected → /connect
- * - Unknown or missing `$report` → / (dashboard)
- *
- * The unknown-report guard uses the same reasoning as post-detail's invalid
- * `postId` guard: a `/reports/<unknown>` URL has no report to render, and
- * letting it through would mount an ambiguous page under a scoped URL. Send it
- * back to the dashboard rather than render unscoped chrome.
- *
- * On first visit it seeds the shared report-window params into the URL (so the
- * date picker and the report's widgets share a populated state) and resolves an
- * incoming `?section=` through the report's own `resolveSection` when the report
- * defines one, so a shareable URL never persists a section the report can't
- * render.
+ * The `$report` path segment selects a definition from the registry; guards
+ * mirror the dashboard and post-detail routes.
  */
 export const route = {
 	beforeLoad: async ( {
@@ -46,9 +31,8 @@ export const route = {
 			throw redirect( { to: '/connect' } );
 		}
 
-		// Validate the path param against the registry. An unknown or missing
-		// report has nothing to render under this scoped URL, so send it back to
-		// the dashboard (same rationale as post-detail's invalid-postId guard).
+		// An unknown or missing report has nothing to render under this scoped URL,
+		// so redirect rather than mount unscoped chrome under a scoped header.
 		const report = params?.report;
 		const definition = getReportDefinition( report );
 		if ( ! definition ) {
@@ -60,11 +44,8 @@ export const route = {
 		const reportId = report as string;
 
 		const currentSearch = ( search ?? {} ) as ReportRouteSearch;
-		// A `section` carried in from a link may not be one this report owns
-		// (e.g. a dashboard section forwarded by a widget link); resolve it
-		// through the report's own resolver so a shareable URL never persists a
-		// bogus section. Reports without sections omit `resolveSection`, in which
-		// case there is nothing to resolve or seed.
+		// A `section` from a link may not belong to this report (e.g. forwarded from a
+		// dashboard widget); resolve it so a shareable URL never persists a bogus section.
 		const resolvedSection =
 			currentSearch.section && definition.resolveSection
 				? definition.resolveSection( currentSearch.section )
@@ -77,10 +58,8 @@ export const route = {
 
 		if ( needsDateSeed || needsSectionSeed ) {
 			/*
-			 * Warm the core `site` record before the stage renders, so
-			 * `useSiteHomeUrl()` has it. A rejection here shouldn't error the
-			 * whole page, so fall through to the seed. The seed's own dates do
-			 * not depend on this; they resolve from the WordPress date settings.
+			 * Warm the core `site` record for `useSiteHomeUrl()`; a rejection shouldn't block
+			 * the page and the seed's own dates don't depend on it, so fall through.
 			 */
 			try {
 				await ensureCoreSettingsReady();
@@ -88,29 +67,23 @@ export const route = {
 				// Proceed with the default seed below.
 			}
 
-			// Allowlist the params this page owns rather than spreading
-			// `currentSearch` wholesale: `normalizeReportParams` yields only the
-			// known report-window params, and the resolved section is the only
-			// report-scoped param seeded here. This contains any foreign params a
-			// link carried in instead of persisting them.
+			// Allowlist the params this page owns rather than spreading `currentSearch`
+			// wholesale, so foreign params a link carried in aren't persisted.
 			const seeded: Record< string, unknown > = {
 				...normalizeReportParams(
 					currentSearch as Parameters< typeof normalizeReportParams >[ 0 ]
 				),
 				...( resolvedSection ? { section: resolvedSection } : {} ),
 			};
-			// `normalizeReportParams` preserves a valid `post_id` for the
-			// post-detail surface, but reports are site-wide — drop it so a link
-			// carrying one can't scope a report to a single post.
+			// Reports are site-wide: drop the `post_id` `normalizeReportParams` keeps
+			// for post-detail, so a link carrying one can't scope a report to a post.
 			delete seeded.post_id;
 
 			throw redirect( {
 				to: '/reports/$report',
 				/*
-				 * The router is built dynamically, so `/reports/$report` has no
-				 * statically-typed params/search schema (tanstack widens them to
-				 * `never`). Cast the same way the routing package does when it
-				 * writes the URL.
+				 * The router is built dynamically, so tanstack widens `/reports/$report`'s
+				 * params/search to `never`; cast as the routing package does when writing the URL.
 				 */
 				params: { report: reportId } as unknown as never,
 				replace: true,

--- a/projects/packages/premium-analytics/routes/reports/search-terms/page.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/page.test.tsx
@@ -94,10 +94,8 @@ describe( 'SearchTermsReportPage', () => {
 	} );
 
 	it( 'keeps the rows on screen while a background refetch is in flight', () => {
-		// The queries carry `placeholderData`, so a refetch triggered by a date or
-		// comparison change still has the previous rows. Handing the table an empty
-		// set would drop the user's search, sorting, and page position mid-refetch,
-		// so the rows stay mounted and only the loading state reflects the refetch.
+		// `placeholderData` keeps rows mounted through a date/comparison refetch — clearing them
+		// would drop the user's search, sort, and page position mid-refetch.
 		mockRecords( { isFetching: true } );
 
 		render( <SearchTermsReportPage /> );

--- a/projects/packages/premium-analytics/routes/reports/stage.tsx
+++ b/projects/packages/premium-analytics/routes/reports/stage.tsx
@@ -37,15 +37,8 @@ function ReportLoading(): JSX.Element {
 /**
  * Dispatcher for the `/reports/$report` route.
  *
- * Reads the `$report` path param, looks up the report definition in the
- * registry, and renders that report's page component lazily. It carries no
- * report-specific logic — page chrome (header, tabs, widget grid) belongs to
- * each report's own component.
- *
- * `route.ts`'s `beforeLoad` validates `$report` against the registry and
- * redirects unknown or missing reports to the dashboard, so a definition is
- * guaranteed to exist by the time this renders. The empty-definition branch
- * below only satisfies the type; it should never be reached at runtime.
+ * Page chrome (header, tabs, widget grid) belongs to each report's own
+ * component; this carries no report-specific logic.
  *
  * @return {JSX.Element} The report page.
  */
@@ -54,11 +47,8 @@ function ReportDispatcher(): JSX.Element {
 
 	const definition = getReportDefinition( report );
 
-	// Recreate the lazy component whenever the report id changes so each report
-	// loads its own page module. `React.lazy` memoizes the resolved component by
-	// its own identity, so a fresh `lazy()` per definition is what lets a switch
-	// mount a different report; keying the element by id below makes the remount
-	// explicit rather than relying on that identity change alone.
+	// `React.lazy` memoizes by component identity, so a fresh `lazy()` per definition is what
+	// lets switching reports mount a different page; `key` below makes the remount explicit.
 	const LazyReport = useMemo(
 		() => ( definition ? lazy( definition.load ) : null ),
 		[ definition ]
@@ -77,9 +67,8 @@ function ReportDispatcher(): JSX.Element {
 }
 
 /**
- * The report surface's provider stack, mounted once here so every report page
- * composes data hooks and chart components directly (`useSeriesStyles` +
- * `ComparativeLineChart`, same as widgets) without mounting its own providers.
+ * The report surface's provider stack, mounted once so no report page mounts its
+ * own.
  *
  * @param {object}    props          - The component props.
  * @param {ReactNode} props.children - The report page.
@@ -93,9 +82,8 @@ function ReportProviders( { children }: { children: ReactNode } ): JSX.Element {
 			<GlobalErrorProvider>
 				<GlobalChartsProvider theme={ chartTheme }>
 					{ /*
-					 * A report names no compared period and offers no control for
-					 * one, so nothing below may fetch or draw a comparison. The
-					 * params stay on the URL for the dashboard to pick back up.
+					 * A report names no compared period, so nothing below may fetch or
+					 * draw one. The params stay on the URL for the dashboard.
 					 */ }
 					<ReportScopeProvider offersComparison={ false }>{ children }</ReportScopeProvider>
 				</GlobalChartsProvider>

--- a/projects/packages/premium-analytics/routes/reports/tags/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/tags/page.tsx
@@ -40,10 +40,8 @@ const sortTagCsvRows = ( a: StatsTagsItem, b: StatsTagsItem ) => b.value - a.val
 /**
  * Premium Analytics Tags & categories report page component.
  *
- * The `stats/tags` endpoint reports one flat all-time list and ignores
- * date-window parameters (verified against WPCOM; Calypso never sends date
- * params here either), so the page composes only the breadcrumb header and
- * records table: no date filters, tabs, or performance chart.
+ * `stats/tags` returns one flat all-time list and ignores date-window params, so this page
+ * has no date filters, tabs, or performance chart — just the header and records table.
  *
  * @return The Tags & categories report page.
  */
@@ -88,10 +86,9 @@ function TagsReport(): JSX.Element {
 		>
 			<ReportPageLayout title={ getTitle() }>
 				{ /*
-				 * The error state replaces the table rather than sitting beside it:
-				 * `ReportRecordsTable`'s `empty` renders on row count, not fetch
-				 * status, so a failed refetch over cached rows would otherwise leave
-				 * stale data on screen with no notice and no way to retry.
+				 * The error state replaces the table: `ReportRecordsTable`'s `empty` renders on
+				 * row count, not fetch status, so a failed refetch over cached rows would
+				 * otherwise leave stale data on screen with no notice or retry.
 				 */ }
 				{ records.isError ? (
 					<ReportErrorState

--- a/projects/packages/premium-analytics/routes/reports/use-report-params.ts
+++ b/projects/packages/premium-analytics/routes/reports/use-report-params.ts
@@ -16,14 +16,9 @@ import { route } from './package.json';
 const ROUTE_FROM = route.path;
 
 /**
- * The window a report's records are fetched for, resolved from the URL with the
- * same normalizer the widgets use.
- *
- * Comparison follows the surface's declared scope, which the report route sets
- * to none: a report offers no control for one and its header names no compared
- * period, so a delta in the table would have no baseline the reader could see
- * or change. The params themselves stay on the URL, for the dashboard to pick
- * back up.
+ * The report's fetch window from the URL, normalized like the widgets use it. Comparison is
+ * stripped when the surface doesn't offer it — a report's header has no baseline to show a
+ * delta against — though the params themselves stay on the URL for the dashboard to reuse.
  *
  * @return The report params, carrying a comparison only where one is offered.
  */

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
@@ -3,9 +3,8 @@ import { getMockRouteLinkUrl, setMockRouteSearch } from '../../../../tests/js/ro
 import { getVideosFields } from './fields';
 import type { StatsVideoPlaysComparisonItem } from '@jetpack-premium-analytics/data';
 
-// The router is built dynamically at runtime, so a field-level test has no
-// router to mount. Render `Link` as the anchor it becomes, keeping `to`/
-// `params`/`search` assertable, matching the other report field tests.
+// The router is built dynamically, so a field-level test has no router to mount; render `Link`
+// as the anchor it becomes so `to`/`params`/`search` stay assertable, matching other field tests.
 jest.mock( '@wordpress/route', () => {
 	const { mockWordPressRoute } = jest.requireActual( '../../../../tests/js/route-test-utils' );
 

--- a/projects/packages/premium-analytics/routes/reports/videos/page.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/page.test.tsx
@@ -181,10 +181,8 @@ describe( 'VideosReportPage', () => {
 	} );
 
 	it( 'keeps the rows on screen while a changed range is fetching', () => {
-		// The queries carry `placeholderData`, so a refetch triggered by a date or
-		// comparison change still has the previous rows. Handing the table an empty
-		// set would drop the user's search, sorting, and page position mid-refetch,
-		// so the rows stay mounted and only the loading state reflects the refetch.
+		// `placeholderData` keeps rows mounted through a date/comparison refetch — clearing them
+		// would drop the user's search, sort, and page position mid-refetch.
 		const rows = [
 			{
 				id: 12,

--- a/projects/packages/premium-analytics/routes/site-readiness.ts
+++ b/projects/packages/premium-analytics/routes/site-readiness.ts
@@ -26,11 +26,9 @@ export function isPremiumAnalyticsInitialSyncFinished(): boolean {
 /**
  * Check whether the site's VideoPress-backed surfaces should be shown.
  *
- * Defaults to false, unlike the sibling `csv_exports_enabled` flag: showing the
- * video surfaces on a site that cannot produce play data is the empty report
- * this gate exists to remove. Safe to default that way because every path that
- * renders the dashboard runs `Analytics::load_dashboard_components()`, which
- * registers the filter that injects the flag (`src/videopress-availability.php`).
+ * Defaults to false, unlike the sibling `csv_exports_enabled` flag, because an
+ * empty video report is what this gate removes; every dashboard path registers
+ * the filter that injects the flag (`src/videopress-availability.php`).
  *
  * @return Whether VideoPress is available on this site.
  */

--- a/projects/packages/premium-analytics/routes/use-detail-breadcrumbs.test.ts
+++ b/projects/packages/premium-analytics/routes/use-detail-breadcrumbs.test.ts
@@ -108,10 +108,8 @@ describe( 'useDetailBreadcrumbs', () => {
 		expect( result.current ).toEqual( [ { label: 'Detail title' } ] );
 	} );
 
-	// `?origin=videos` outlives the feature: it survives in shared URLs, browser
-	// history, and bookmarks taken before a site turned VideoPress off. A known
-	// but unavailable report must be as unlinkable as an unknown one, or the crumb
-	// points at a page the route guard bounces straight back to the dashboard.
+	// `?origin=videos` can outlive VideoPress being turned off, so an unavailable
+	// report must be as unlinkable as an unknown one — else the crumb outruns the guard.
 	it( 'drops the videos crumb on a site without VideoPress', () => {
 		setVideoPress( false );
 		mockSearch( 'videos' );

--- a/projects/packages/premium-analytics/routes/use-detail-date-controls.ts
+++ b/projects/packages/premium-analytics/routes/use-detail-date-controls.ts
@@ -31,18 +31,12 @@ type DetailDateFilters = {
 };
 
 /**
- * The date controls a resource detail page (post, video) offers, per its
- * design: the preset pills alone — all time, then the rolling windows — with no
- * custom-range popover, no period-navigation arrows, and no chart-interval
- * dropdown. The charts bucket by the interval the range resolves on its own.
+ * The date controls a resource detail page (post, video) offers: preset pills
+ * alone, with all time anchored to the resource's publish date. The controls
+ * render before the summary loads, so an all-time range applied against an
+ * unknown or stale start is re-anchored in place once it resolves.
  *
- * All time starts on the day the resource was published — the earliest day its
- * report can hold data for. The controls render while the summary is still
- * loading, so an all-time range applied before that day is known (or deep-linked
- * with a stale start) is re-anchored in place once it resolves; a resource with
- * no readable date keeps the year surface's default span.
- *
- * Spread after the date-filter controller's props: `onStep` and the interval
+ * Spread after the date-filter controller's props — `onStep` and the interval
  * props it hands out are what this unsets.
  *
  * @param publishedDate               - The resource's publish date, as the summary carries it:

--- a/projects/packages/premium-analytics/routes/video-detail/components/video-summary-card/video-summary-card.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/components/video-summary-card/video-summary-card.tsx
@@ -26,12 +26,9 @@ type VideoSummaryCardProps = {
 const DATE_FORMAT = 'MMM d, yyyy';
 
 /**
- * The page-header summary of the video being viewed: poster-frame thumbnail
- * (or a video-glyph placeholder, matching the post detail header's
- * missing-image treatment), title, and one line stating the publish date and
- * the applied performance window. The poster can be tokenless (unusable) for
- * private videos, so a failing image swaps itself for the placeholder, the
- * same as when no poster is returned.
+ * Page-header summary for the video: poster (or placeholder), title, publish
+ * date, and performance window. Poster URLs can be tokenless and 404 for
+ * private videos, so a failed load swaps in the placeholder.
  *
  * @param props                  - Component props.
  * @param props.summary          - The resolved video summary.

--- a/projects/packages/premium-analytics/routes/video-detail/config/layout.test.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/config/layout.test.ts
@@ -14,9 +14,8 @@ describe( 'video detail layout', () => {
 		expect( new Set( uuids ).size ).toBe( uuids.length );
 	} );
 
-	// The page's composition is fixed (WOOA7S-1625): assert the exact
-	// arrangement, like the post-detail tab layouts test, so accidental
-	// reshuffles surface here rather than in the rendered dashboard.
+	// The composition is fixed (WOOA7S-1625): assert the exact arrangement so an
+	// accidental reshuffle surfaces here, not in the rendered dashboard.
 	it( 'composes the full-width performance chart above the three-column embeds list', () => {
 		expect( VIDEO_DETAIL_LAYOUT ).toEqual( [
 			{

--- a/projects/packages/premium-analytics/routes/video-detail/config/layout.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/config/layout.ts
@@ -2,13 +2,10 @@ import { WIDGET_DASHBOARD_COLUMN_COUNT } from '@wordpress/widget-dashboard';
 import type { DashboardWidget } from '@wordpress/widget-dashboard';
 
 /**
- * Fixed widget composition for the video detail page.
- *
- * The page is not user-customizable (WOOA7S-1625): the performance chart —
- * which carries the four highlight metrics as its tabs — spans the full
- * width, with the "Used on posts & pages" list below it. The list stops at
- * three columns because a full-width leaderboard hits its max content width
- * and leaves trailing empty space.
+ * Fixed widget composition for the video detail page (not user-customizable,
+ * WOOA7S-1625). The "Used on posts & pages" list stops at three columns
+ * because a full-width leaderboard hits its max content width and leaves
+ * trailing empty space.
  */
 export const VIDEO_DETAIL_LAYOUT: DashboardWidget[] = [
 	{

--- a/projects/packages/premium-analytics/routes/video-detail/route.test.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/route.test.ts
@@ -108,9 +108,8 @@ describe( 'video detail route.beforeLoad', () => {
 		} );
 	} );
 
-	// The page renders no comparison, but the dashboard link carries the URL
-	// state back out — stripping the params would lose the user's comparison
-	// settings on a Dashboard → Video → Dashboard round trip.
+	// The page renders no comparison, but the dashboard link carries the URL state
+	// back out — stripping the params would lose it on a round trip.
 	it( 'passes through comparison params without redirecting on a settled URL', async () => {
 		await expect(
 			beforeLoad( { videoId: '42' }, { ...settledSearch, comp: 'previous_period' } )

--- a/projects/packages/premium-analytics/routes/video-detail/route.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/route.ts
@@ -42,9 +42,8 @@ export const route = {
 			throw redirect( { to: '/connect' } );
 		}
 
-		// Kept apart from the id check below: a bookmarked URL on a site without
-		// VideoPress and a malformed one are different events, even though both
-		// currently land on the dashboard.
+		// Kept apart from the id check below: an unsupported site and a malformed id
+		// are different events, even though both currently land on the dashboard.
 		if ( ! isVideoPressAvailable() ) {
 			throw redirect( { to: '/' } );
 		}
@@ -60,10 +59,9 @@ export const route = {
 
 		if ( needsDateSeed || needsPostSeed ) {
 			/*
-			 * Warm the core `site` record before the stage renders, so
-			 * `useSiteHomeUrl()` has it. A rejection here shouldn't error the
-			 * whole page, so fall through to the seed. The seed's own dates do
-			 * not depend on this; they resolve from the WordPress date settings.
+			 * Warm the core `site` record for `useSiteHomeUrl()`. A rejection
+			 * shouldn't error the whole page, and the seed's own dates don't
+			 * depend on it, so fall through.
 			 */
 			try {
 				await ensureCoreSettingsReady();
@@ -83,11 +81,8 @@ export const route = {
 
 			/*
 			 * Comparison params ride along untouched: this page renders no
-			 * comparison (the stage strips them from the reportParams it injects
-			 * into its widgets), but the dashboard link and
-			 * "Back to Videos" carry the URL state back out, so stripping them
-			 * here would silently lose the user's comparison settings on a
-			 * Dashboard → Video → Dashboard round trip.
+			 * comparison, but the dashboard link and "Back to Videos" carry the URL
+			 * state back out, so stripping them would lose the setting on a round trip.
 			 */
 
 			throw redirect( {
@@ -95,8 +90,7 @@ export const route = {
 				/*
 				 * The router is built dynamically, so `/video/$videoId` has no
 				 * statically-typed params/search schema (tanstack widens them to
-				 * `never`). Cast the same way the routing package does when it
-				 * writes the URL.
+				 * `never`); cast as the routing package does when it writes the URL.
 				 */
 				params: { videoId } as unknown as never,
 				replace: true,

--- a/projects/packages/premium-analytics/routes/video-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.test.tsx
@@ -13,10 +13,8 @@ jest.mock( '@jetpack-premium-analytics/data', () => ( {
 } ) );
 
 jest.mock( '@jetpack-premium-analytics/routing', () => ( {
-	// Spread the real module so the report registry's tab configs, which call
-	// `defineReportTabs`, still resolve now that the registry is not mocked.
-	// `buildReportLink` and `pickReportDateParams` stay real too, so the link
-	// assertions below exercise the code that builds the href in product.
+	// Spreads the real module so the tab configs (which call `defineReportTabs`)
+	// resolve, and `buildReportLink`/`pickReportDateParams` build real hrefs below.
 	...jest.requireActual( '@jetpack-premium-analytics/routing' ),
 	useDashboardLink: () => '/?from=2026-06-01&to=2026-06-16',
 	useReportDateFilters: () => ( {
@@ -40,12 +38,9 @@ jest.mock( '@wordpress/core-data', () => ( {
 	store: {},
 } ) );
 
-// Falls through to the real module for everything but `useSelect`. Reaching the
-// externals passthrough pulls `@wordpress/components` -> `@wordpress/rich-text`
-// into the graph, whose store calls `combineReducers` at import time; a
-// `useSelect`-only mock leaves that undefined and the suite fails to load.
-// `requireActual` has to stay lazy — calling it in the factory body re-enters
-// the module while it is still initialising.
+// Falls through to the real module except `useSelect`: the externals path pulls
+// in `@wordpress/rich-text`, whose store calls `combineReducers` at import time,
+// so `requireActual` must stay lazy or it re-enters the module mid-init.
 jest.mock(
 	'@wordpress/data',
 	() =>
@@ -276,12 +271,9 @@ describe( 'video detail stage', () => {
 	} );
 
 	it( 'keeps a long unbroken title single-line-ready: full text in markup plus the hover attr', () => {
-		// Layout is out of jsdom's reach; the single-line clip is CSS
-		// (`white-space: nowrap` + ellipsis on `.title`, with the breadcrumb
-		// slot's shrink fix in stage.module.scss keeping the page from
-		// horizontal scrolling). This guards the DOM contract the clip relies
-		// on: the heading carries the full untruncated text and mirrors it in
-		// `title`, so the ellipsized line stays reachable on hover.
+		// Layout is out of jsdom's reach (the clip is CSS, `white-space: nowrap` +
+		// ellipsis, in stage.module.scss), so this guards the DOM contract it relies
+		// on: full text in the heading, mirrored in `title` for hover access.
 		const longTitle = `VID_20260731_${ 'a'.repeat( 120 ) }.mp4`;
 		mockSummary( { title: longTitle } );
 
@@ -332,9 +324,8 @@ describe( 'video detail stage', () => {
 		).toBeInTheDocument();
 	} );
 
-	// One declaration drives both halves: the panel reads it to drop the Compare
-	// control (covered in the ui package) and `WidgetRoot` reads it to strip the
-	// params. This asserts the declaration the page makes.
+	// One declaration drives both halves: the panel drops the Compare control and
+	// `WidgetRoot` strips the params. This asserts the page's declaration.
 	it( 'declares no comparison for the widgets it renders', () => {
 		mockSummary( { title: 'Launch recap' } );
 		mockSearch = {

--- a/projects/packages/premium-analytics/routes/video-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.tsx
@@ -31,22 +31,20 @@ import styles from './stage.module.scss';
 
 const ROUTE_FROM = route.path;
 
-// The video-detail composition is fixed (WOOA7S-1625) and laid out against the
-// small (200px) row height used by the design, matching post detail. Keep its
-// grid independent from the customizable main-dashboard preference so a future
-// settings control cannot stretch these tiles out of proportion.
+// The composition is fixed (WOOA7S-1625), so keep its grid independent from the
+// customizable main-dashboard preference — a future settings control must not
+// stretch these tiles out of proportion.
 const VIDEO_DETAIL_GRID = { ...DEFAULT_GRID, rowHeight: ROW_HEIGHT_PRESETS.small };
 
 // The layout is fixed, so the change callback never fires; the dashboard
 // still requires one because it owns a staging copy internally.
 const noopLayoutChange = () => {};
 
-// The share of the header row the date filter presets can never use: the
-// summary's 400px `min-inline-size` floor plus the row's 16px gap (see
-// `.summary` and `.header` in stage.module.scss — keep the three in sync),
-// plus a 24px buffer so the panel steps down before the wrap threshold —
-// layout wraps synchronously while the measured layout flip lags a frame, so
-// equal thresholds would flash a wrapped row at every boundary.
+// The share of the header row the presets can never use: the summary's
+// `min-inline-size` floor plus the row gap (see `.summary` and `.header` in
+// stage.module.scss — keep them in sync), plus a buffer so the panel steps down
+// before the wrap threshold — wrapping is synchronous while the measured flip
+// lags a frame, so equal thresholds would flash a wrapped row at every boundary.
 const HEADER_RESERVED_INLINE_SIZE = 440;
 
 /**
@@ -69,34 +67,25 @@ function VideoDetail(): JSX.Element {
 					) => WidgetModuleRecord[] | null;
 				}
 			 )
-				// `per_page: -1` returns every widget type. Without it, core-data's
-				// default query (`per_page: 10`) caps the records at 10 and could
-				// silently drop the widgets this page's fixed layout requires.
+				// `per_page: -1` returns every widget type; core-data's default query
+				// (`per_page: 10`) could silently drop ones this fixed layout requires.
 				.getEntityRecords( 'root', 'widgetModule', { per_page: -1 } ),
 		[]
 	);
 
 	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypesWithI18n( widgetModules );
 
-	// The applied report date range lives in the URL search params, staged and
-	// committed by the shared date-filter controller (WOOA7S-1816 — restored
-	// after the preset-measurement rework in #50906 landed).
+	// The applied report date range lives in the URL search params.
 	const dateFilters = useReportDateFilters( ROUTE_FROM );
-	// The preset pills alone — all time, then the rolling windows — with no
-	// custom range, period arrows, or interval dropdown, per the detail-page
-	// design; all time runs from the day this resource was published.
 	const dateControls = useDetailDateControls( summary.publishedDate, dateFilters );
 
-	// The header row hosts the panel in a shrink-to-fit slot, so the panel
-	// measures the row itself to pick its responsive layout; see the
-	// `containerElement` prop.
+	// The header row hosts the panel in a shrink-to-fit slot, so the panel measures
+	// the row itself to pick its responsive layout; see the `containerElement` prop.
 	const [ headerElement, setHeaderElement ] = useState< HTMLElement | null >( null );
 
 	const search = useSearch( { strict: false } ) as Record< string, unknown > | undefined;
 	const reportSearch = pickReportDateParams( search );
 
-	// The page's no-comparison invariant is the report scope the stage declares,
-	// so the layout is the fixed composition.
 	const layout = VIDEO_DETAIL_LAYOUT;
 
 	// Error and not-found responses have no trustworthy title, so only resolved
@@ -161,23 +150,16 @@ function VideoDetail(): JSX.Element {
 			>
 				<div className={ styles.scrollArea }>
 					{ /*
-					 * The summary and the date filter presets share the header row —
-					 * title on the left, presets on the right, per the design mocks.
-					 * The presets render in every summary state so the range stays
+					 * The presets render in every summary state, so the range stays
 					 * adjustable while the video loads or errors.
 					 */ }
 					<div ref={ setHeaderElement } className={ styles.header }>
 						{ summaryContent ? <div className={ styles.summary }>{ summaryContent }</div> : null }
 						<div className={ styles.dateFilters }>
 							{ /*
-							 * The design has no period-over-period comparison on this
-							 * page. The panel reads that from the scope the stage
-							 * declares, which is the same declaration that keeps the
-							 * params away from the widgets.
-							 *
-							 * The Video performance chart buckets by the interval the range
-							 * resolves; the design offers no control over it, nor the period
-							 * arrows — see `useDetailDateControls`.
+							 * The design has no comparison on this page. The panel reads that
+							 * from the scope the stage declares, which is the same declaration
+							 * that keeps the params away from the widgets.
 							 */ }
 							<DateFiltersPanel
 								{ ...dateFilters }
@@ -208,10 +190,8 @@ export function stage(): JSX.Element {
 		<AnalyticsQueryClientProvider>
 			<GlobalErrorProvider>
 				{ /*
-				 * The page names no compared period and offers no control for one,
-				 * so nothing below may fetch or draw a comparison. The params stay
-				 * on the URL so the breadcrumb carries the dashboard's state back
-				 * out.
+				 * The page names no compared period, so nothing below may fetch or draw
+				 * one. The params stay on the URL for the breadcrumb to carry back out.
 				 */ }
 				<ReportScopeProvider offersComparison={ false }>
 					<VideoDetail />

--- a/projects/packages/premium-analytics/src/Reports/Export/class-abstract-csv-report-controller.php
+++ b/projects/packages/premium-analytics/src/Reports/Export/class-abstract-csv-report-controller.php
@@ -19,22 +19,17 @@ use Exception;
 /**
  * Abstract base class for CSV report controllers.
  *
- * All report controllers extend this base, which centralizes comparison-period
- * handling, empty-row logic, requested-field selection, and value formatting.
- * The abstract methods below are the per-report contract; the concrete ones
- * carry defaults a controller may override.
- *
  * @since 0.1.0
  */
 abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_Interface {
 
 	/**
-	 * Default batch limit for time-based reports (1000 items).
+	 * Default batch limit for time-based reports.
 	 */
 	protected const DEFAULT_BATCH_LIMIT = 1000;
 
 	/**
-	 * Default date type for order-based reports (creation date).
+	 * Default date type for order-based reports.
 	 */
 	protected const DEFAULT_DATE_TYPE = 'created';
 
@@ -48,7 +43,7 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Cached result of should_include_empty_rows() to avoid repeated filter calls.
 	 *
-	 * @var bool|null Null if not yet determined, otherwise the cached boolean result.
+	 * @var bool|null
 	 */
 	private $cached_include_empty_rows = null;
 
@@ -72,9 +67,6 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 
 	/**
 	 * Format a row with automatic comparison field handling.
-	 *
-	 * This method wraps format_row_for_csv() and automatically adds
-	 * comparison fields if present in the data.
 	 *
 	 * @param array       $item     The raw data item.
 	 * @param string|null $interval Optional time interval for formatting.
@@ -123,8 +115,7 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Format a single data item for CSV export.
 	 *
-	 * This method should return the base row data without comparison fields.
-	 * Comparison fields are automatically added by format_row_with_comparison().
+	 * Return the base row only; format_row_with_comparison() adds the comparison fields.
 	 *
 	 * @param array       $item     The raw data item.
 	 * @param string|null $interval Optional time interval for formatting.
@@ -135,8 +126,7 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Get default values for missing data fields.
 	 *
-	 * This method should return an array of default values for all possible fields
-	 * in this report. Used when creating empty items for missing comparison data.
+	 * Used to build empty items when comparison data is missing.
 	 *
 	 * @return array Array of field_name => default_value pairs.
 	 */
@@ -144,8 +134,6 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 
 	/**
 	 * Get the batch limit (max items per request).
-	 *
-	 * Override this method in child classes if a different batch limit is needed.
 	 *
 	 * @return int
 	 */
@@ -156,9 +144,6 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Get additional request parameters for data fetching.
 	 *
-	 * Override this method in child classes to add controller-specific parameters
-	 * (e.g., filters) that should be included in every data fetch request.
-	 *
 	 * @return array Additional parameters to include in data requests.
 	 */
 	public function get_additional_params(): array {
@@ -168,9 +153,7 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Get the list of fields to request from the API.
 	 *
-	 * Override in subclasses to request only the fields needed for
-	 * this report, reducing API response payload size.
-	 * Return an empty array to request all fields (default behavior).
+	 * Override to request only the fields this report needs, shrinking the API response.
 	 *
 	 * @return array Field names to request, or empty array for all fields.
 	 */
@@ -193,9 +176,8 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Get the identifying fields that should be preserved in comparison data.
 	 *
-	 * Default: empty array (no fields preserved for time-series reports).
-	 * Override in ranked report controllers to specify identifying fields like
-	 * 'product_name' or 'coupon_code' that should be copied when comparison data is missing.
+	 * Default: empty array (no fields preserved for time-series reports). Ranked reports name
+	 * identifying fields here so they are copied over when comparison data is missing.
 	 *
 	 * @return array Array of field names to preserve.
 	 */
@@ -218,9 +200,6 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Whether to include empty rows by default.
 	 *
-	 * Default: true (include rows with empty identifying fields).
-	 * Override in child controllers to return false if empty rows should be excluded by default.
-	 *
 	 * @return bool True to include empty rows, false to exclude them.
 	 */
 	protected function should_include_empty_rows_by_default(): bool {
@@ -230,9 +209,8 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Whether to include rows with empty identifying fields in the export.
 	 *
-	 * The controller's default, overridable globally or per report through
-	 * 'jetpack_premium_analytics_csv_include_empty_rows'. Cached per instance, since it
-	 * is consulted once per row.
+	 * The controller's default, overridable via 'jetpack_premium_analytics_csv_include_empty_rows';
+	 * cached per instance since it's consulted once per row.
 	 *
 	 * @return bool True to include empty rows with custom label, false to skip them.
 	 */
@@ -261,7 +239,6 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	 * Get the label to use for rows with empty identifying fields.
 	 *
 	 * Only used when should_include_empty_rows() returns true.
-	 * Override in child controllers to customize the label for empty rows.
 	 *
 	 * @return string The label to use for empty rows.
 	 */
@@ -272,9 +249,8 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Get the field name(s) to check for emptiness when determining if a row should be skipped.
 	 *
-	 * Default: null (no empty row checking).
-	 * Override in ranked report controllers to specify the identifying field(s) to check.
-	 * Returns an array of field names (all must be empty to skip the row).
+	 * Default: null (no empty row checking). When an array is returned, every named field
+	 * must be empty before the row counts as empty.
 	 *
 	 * @return array|null Array of field name(s) to check, or null to skip empty checking.
 	 */
@@ -284,8 +260,6 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 
 	/**
 	 * Format a time interval for display in CSV.
-	 *
-	 * If 'hour', formats as 'Y-m-d H:00', otherwise 'Y-m-d'.
 	 *
 	 * @param array       $item     The data item containing date_start.
 	 * @param string|null $interval Optional time interval. If 'hour', formats as 'Y-m-d H:00', otherwise 'Y-m-d'.
@@ -372,10 +346,8 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Format a row with empty value handling.
 	 *
-	 * A row whose configured identifying field(s) are empty is either skipped or kept with
-	 * the custom empty-row label, per should_include_empty_rows(). A row whose values are
-	 * all empty strings keeps them, rather than picking up the controller's defaults —
-	 * "no data" and "zero" must not collapse into each other.
+	 * A row whose values are all empty strings keeps them, rather than picking up the
+	 * controller's defaults — "no data" and "zero" must not collapse into each other.
 	 *
 	 * @param array       $extracted_data The extracted data item and empty flag.
 	 * @param array       $item_to_format The item to use for formatting (may differ from extracted data).
@@ -386,7 +358,6 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 		$item      = $extracted_data['item'];
 		$all_empty = $extracted_data['all_empty'];
 
-		// Check if this row should be skipped due to empty identifying fields.
 		$check_fields = $this->get_empty_row_check_field();
 		$is_empty     = ( null !== $check_fields ) ? $this->is_row_empty( $item, $check_fields ) : false;
 
@@ -398,11 +369,7 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 			// Otherwise keep the row; the empty identifying field gets the custom label below.
 		}
 
-		// If all values are empty strings, return empty strings for all fields
-		// instead of using default values from format_row_for_csv().
 		if ( $all_empty && ! empty( $item ) ) {
-			// Get the expected field structure by formatting an empty item.
-			// This gives us the field names, but we'll set all values to empty strings.
 			$row_structure = $this->format_row_for_csv( array(), $interval );
 			$row           = array();
 			foreach ( array_keys( $row_structure ) as $key ) {
@@ -413,7 +380,6 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 
 		$row = $this->format_row_for_csv( $item_to_format, $interval );
 
-		// If we determined the row is empty but should be included, replace empty identifying field with custom label.
 		// $is_empty implies $check_fields is non-null (see above), but check explicitly for the type checker.
 		if ( $is_empty && null !== $check_fields && $this->should_include_empty_rows() ) {
 			$row = $this->apply_empty_row_label( $row, $check_fields );
@@ -444,14 +410,8 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Apply the custom empty row label to the formatted row.
 	 *
-	 * Replaces the value of the identifying field(s) with the custom label.
-	 * If the field name changed during formatting, child classes should override this method.
-	 *
-	 * Note: When multiple check fields are configured (e.g., ['campaign', 'label']),
-	 * only the first matching empty field receives the label. This is intentional
-	 * because the first field is typically the primary identifier (index/label column)
-	 * that should be displayed to users. Applying the label to multiple columns would
-	 * be redundant and could confuse users.
+	 * Only the first empty check field (the primary identifier column) gets the label; child
+	 * classes that rename the field while formatting must override this.
 	 *
 	 * @param array $row          The formatted row data.
 	 * @param array $check_fields The field names that were empty.
@@ -463,7 +423,7 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 		foreach ( $check_fields as $field_name ) {
 			if ( isset( $row[ $field_name ] ) && '' === $row[ $field_name ] ) {
 				$row[ $field_name ] = $custom_label;
-				return $row; // Only update the first matching empty field.
+				return $row;
 			}
 		}
 
@@ -473,15 +433,8 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 	/**
 	 * Automatically add comparison fields to a formatted row.
 	 *
-	 * This helper method dynamically adds comparison data by:
-	 * 1. Checking if comparison data exists (any comparison_ prefixed field)
-	 * 2. Creating a synthetic item with comparison_ prefixes stripped
-	 * 3. Calling format_row_for_csv() on the synthetic item (applying all field mapping)
-	 * 4. Adding comparison_ prefix back to the formatted keys
-	 * 5. Merging into the original row
-	 *
-	 * This ensures that field name mapping (e.g., orders_value_net → net_sales)
-	 * is applied consistently to both base and comparison data.
+	 * Comparison data round-trips through format_row_for_csv() with the prefix stripped and
+	 * re-added, so field name mapping (orders_value_net → net_sales) applies to it too.
 	 *
 	 * @param array       $row      The formatted row with original data.
 	 * @param array       $item     The raw item with both original and comparison data.
@@ -503,12 +456,9 @@ abstract class Abstract_Csv_Report_Controller implements Csv_Report_Controller_I
 			return $row;
 		}
 
-		// Extract comparison data with prefix stripped.
-		// Note: We format the extracted comparison item (with prefix stripped), not the full item.
 		$comparison_data = $this->extract_data_by_prefix( $item, $prefix, true, true );
 		$comparison_row  = $this->format_row_with_empty_handling( $comparison_data, $comparison_data['item'], $interval );
 
-		// Add comparison_ prefix back to the formatted keys and merge into main row.
 		foreach ( $comparison_row as $key => $value ) {
 			$row[ $prefix . $key ] = $value;
 		}

--- a/projects/packages/premium-analytics/src/Reports/Export/class-csv-export-controller.php
+++ b/projects/packages/premium-analytics/src/Reports/Export/class-csv-export-controller.php
@@ -136,9 +136,8 @@ class Csv_Export_Controller extends WC_REST_Controller implements Registrable_In
 	/**
 	 * Check if user has permission to export reports.
 	 *
-	 * Must match the capability the analytics proxy enforces (the `analytics` prefix
-	 * in Api_Proxy_Controller); otherwise the route would advertise access the async
-	 * data fetch cannot honor, scheduling a job that then fails.
+	 * Must match the capability the analytics proxy enforces (Api_Proxy_Controller's `analytics`
+	 * prefix) — otherwise the route advertises access the async data fetch can't honor.
 	 *
 	 * @return bool True if user has permission.
 	 */
@@ -274,7 +273,7 @@ class Csv_Export_Controller extends WC_REST_Controller implements Registrable_In
 
 		$to_timestamp = strtotime( $value );
 
-		// Check that the date is not beyond today (compare at day level, not time level).
+		// Compare at day level, not time level.
 		$to_date_only    = wp_date( 'Y-m-d', $to_timestamp );
 		$today_date_only = current_datetime()->format( 'Y-m-d' );
 
@@ -344,7 +343,7 @@ class Csv_Export_Controller extends WC_REST_Controller implements Registrable_In
 
 		$compare_to_timestamp = strtotime( $value );
 
-		// Check that the date is not beyond today (compare at day level, not time level).
+		// Compare at day level, not time level.
 		$compare_to_date_only = wp_date( 'Y-m-d', $compare_to_timestamp );
 		$today_date_only      = current_datetime()->format( 'Y-m-d' );
 		if ( $compare_to_date_only > $today_date_only ) {
@@ -370,10 +369,8 @@ class Csv_Export_Controller extends WC_REST_Controller implements Registrable_In
 	/**
 	 * Validate the comparison period date order.
 	 *
-	 * The comparison window does not need to match the original period length: the merge
-	 * strategies align by position (time-series) or matching field (ranked) and pad any
-	 * gap, so uneven windows are handled downstream without a strict length check (which
-	 * also mis-rejected DST-crossing ranges compared by raw seconds).
+	 * The comparison window need not match the original period's length: merge strategies align
+	 * by position/field and pad gaps, and a strict check also mis-rejected DST-crossing ranges.
 	 *
 	 * @param string $compare_from The compare_from date.
 	 * @param string $compare_to   The compare_to date.
@@ -404,15 +401,13 @@ class Csv_Export_Controller extends WC_REST_Controller implements Registrable_In
 		$report_type     = $request->get_param( 'report_type' );
 		$delivery_method = $request->get_param( 'delivery_method' );
 
-		// Validate the report type. Also enforced by validate_report_type() at the route
-		// layer; kept here as a guard for direct callers.
+		// Also enforced by validate_report_type() at the route layer; kept for direct callers.
 		$controller = $this->registry->get_controller( $report_type );
 		if ( is_wp_error( $controller ) ) {
 			return $controller;
 		}
 
-		// Extract request parameters. Controller-specific additional params (date_type,
-		// orderby, limit, etc.) are merged once in Report_Data_Fetcher::fetch().
+		// Controller-specific params (orderby, limit, …) are merged in Report_Data_Fetcher::fetch().
 		$params = array(
 			'from'         => $request->get_param( 'from' ),
 			'to'           => $request->get_param( 'to' ),
@@ -439,7 +434,6 @@ class Csv_Export_Controller extends WC_REST_Controller implements Registrable_In
 	 * @return WP_REST_Response|WP_Error Response or error.
 	 */
 	private function generate_download_export( string $report_type, array $params ) {
-		// Controller drives the data endpoint, requested fields, and merge strategy.
 		$controller = $this->registry->get_controller( $report_type );
 		if ( is_wp_error( $controller ) ) {
 			return $controller;
@@ -452,7 +446,6 @@ class Csv_Export_Controller extends WC_REST_Controller implements Registrable_In
 
 		$is_comparison = $this->is_comparison_request( $params );
 
-		// Interval drives time-series column labels and row formatting.
 		$interval = $params['interval'] ?? null;
 
 		$columns = $this->registry->get_columns( $report_type, $is_comparison, $interval );
@@ -486,9 +479,8 @@ class Csv_Export_Controller extends WC_REST_Controller implements Registrable_In
 
 		$this->csv_generator->delete_file( $file_path );
 
-		// The file body has already been written to the output buffer; terminate so the REST
-		// stack does not append a JSON response. (Streaming a file is inherently a non-REST
-		// response; there is no cleaner hook once headers + body are sent.)
+		// The file body is already in the output buffer; terminate so the REST stack does not
+		// append a JSON response.
 		exit;
 	}
 

--- a/projects/packages/premium-analytics/src/Reports/Export/class-report-csv-generator.php
+++ b/projects/packages/premium-analytics/src/Reports/Export/class-report-csv-generator.php
@@ -68,21 +68,20 @@ class Report_Csv_Generator {
 
 			// Use try/finally so the file handle is always closed, even if the formatter throws.
 			try {
-				// Write BOM for UTF-8 (helps Excel recognize encoding).
+				// Helps Excel recognize the UTF-8 encoding.
 				$this->write_bom( $handle );
 
-				// Write header row (labels are our own strings, but escape for consistency).
+				// Labels are our own strings, but escape them for consistency.
 				$this->write_csv_row( $handle, array_map( array( self::class, 'escape_csv_value' ), array_values( $columns ) ) );
 
 				foreach ( $rows as $row ) {
 					$formatted_row = call_user_func( $formatter, $row );
 
-					// Skip empty rows (when formatter returns empty array).
+					// An empty array is the formatter's skip signal.
 					if ( empty( $formatted_row ) ) {
 						continue;
 					}
 
-					// Extract values in the same order as columns, neutralizing CSV formula injection.
 					$csv_row = array();
 					foreach ( array_keys( $columns ) as $column_key ) {
 						$csv_row[] = self::escape_csv_value( $formatted_row[ $column_key ] ?? '' );
@@ -120,9 +119,8 @@ class Report_Csv_Generator {
 	/**
 	 * Neutralize CSV formula injection.
 	 *
-	 * Spreadsheet apps execute a cell whose value begins with =, +, -, @, tab, or CR.
-	 * Prefixing with a single quote renders it as literal text. Exported values (e.g.
-	 * product names) are store data and must not be trusted.
+	 * Spreadsheet apps execute a cell starting with =, +, -, @, tab, or CR; a leading single
+	 * quote renders it as literal text. Exported values (e.g. product names) are untrusted store data.
 	 *
 	 * @param mixed $value The cell value.
 	 * @return string The escaped value.
@@ -205,8 +203,8 @@ class Report_Csv_Generator {
 		// Drop directory-listing/access protection so exports are not enumerable or web-served.
 		$this->protect_export_dir( $export_dir );
 
-		// Sanitize filename, add an unguessable suffix, and add extension. Files are delivered as
-		// email attachments; the random suffix is defense-in-depth against URL guessing.
+		// Files are delivered as email attachments; the random suffix is defense-in-depth
+		// against URL guessing.
 		$safe_filename = sanitize_file_name( $filename ) . '-' . wp_generate_password( 12, false ) . '.csv';
 
 		return trailingslashit( $export_dir ) . $safe_filename;

--- a/projects/packages/premium-analytics/src/Sync/class-configuration.php
+++ b/projects/packages/premium-analytics/src/Sync/class-configuration.php
@@ -2,18 +2,9 @@
 /**
  * TEMPORARY: interim port for WOOA7S-1550 — remove when the shared sync-modules composer package lands.
  *
- * Plain replacement for woocommerce-analytics' src/Internal/Jetpack/Sync/Configuration.php.
- * The upstream class is wired through a PHP-DI container and RegistrableInterface; the
- * monorepo package has no DI container, so this is a plain class invoked from
- * {@see \Automattic\Jetpack\PremiumAnalytics\Analytics::init()}.
- *
- * It registers the same Jetpack Sync filters upstream's Configuration does and ensures the
- * Sync feature so the `woocommerce_analytics` full-sync module runs. Connection bootstrap and
- * the admin-script enqueue from the upstream class are intentionally omitted — they are handled
- * elsewhere in the monorepo and are out of scope for this sync port.
- *
- * WooCommerce is a runtime (not composer) dependency, so {@see register()} guards on WooCommerce
- * being active before hooking anything; the ported module is only ever instantiated in that case.
+ * Plain replacement for woocommerce-analytics' src/Internal/Jetpack/Sync/Configuration.php, invoked
+ * from {@see \Automattic\Jetpack\PremiumAnalytics\Analytics::init()} since this package has no PHP-DI
+ * container to wire it through like upstream. Omits upstream's connection bootstrap and admin-script enqueue.
  *
  * @package automattic/jetpack-premium-analytics
  */
@@ -39,7 +30,7 @@ class Configuration {
 
 	/**
 	 * List of post meta to add to Sync's post meta whitelist.
-	 * Any changes to these meta will by synced to WordPress.com.
+	 * Any changes to these meta will be synced to WordPress.com.
 	 *
 	 * @static
 	 * @var array
@@ -76,11 +67,8 @@ class Configuration {
 	public static function register(): void {
 		$instance = new self();
 
-		// Defer the WooCommerce-active guard and all hookups to plugins_loaded so they run after
-		// every plugin (including WooCommerce) has loaded, regardless of plugin load order.
-		// Analytics::init() runs during plugin include, before plugins_loaded fires; the priority-1
-		// timing also lets the Jetpack Config constructed below run its own on_plugins_loaded
-		// (priority 2) handler in the same cycle.
+		// Defer to plugins_loaded so the WooCommerce-active guard runs after every plugin loads; priority 1
+		// also lets the Jetpack Config constructed below run its on_plugins_loaded (priority 2) handler in the same cycle.
 		if ( did_action( 'plugins_loaded' ) ) {
 			$instance->configure_sync();
 		} else {
@@ -121,8 +109,6 @@ class Configuration {
 	/**
 	 * Add the WooCommerce Analytics module to the list of Jetpack Sync modules.
 	 *
-	 * Additive: appends to whatever module list is already configured rather than replacing it.
-	 *
 	 * @param array $modules The current list of sync module class names.
 	 * @return array
 	 */
@@ -143,7 +129,7 @@ class Configuration {
 		$jetpack_sync_modules = array_keys(
 			array_filter(
 				array(
-					WooCommerce_Analytics_Module::class => true, // WooCommerce Analytics module.
+					WooCommerce_Analytics_Module::class => true,
 					Meta_Module::class                  => true,
 					Posts_Module::class                 => true,
 					Terms_Module::class                 => true,
@@ -162,10 +148,8 @@ class Configuration {
 					'woocommerce_date_type', // Date used to determine the date range for analytics reports.
 				),
 				'jetpack_sync_constants_whitelist' => array(
-					// Syncing this triggers WPCom to provision the WC Analytics tables. Defined by the
-					// plugin at load (double underscore, per the JETPACK__VERSION convention). (WOOA7S-1643)
-					// WC_ANALYTICS_VERSION is intentionally omitted: it is defined and whitelisted by the
-					// standalone woocommerce-analytics plugin, and on a PA-only store would only sync null.
+					// Syncing this triggers WPCom to provision the WC Analytics tables (WOOA7S-1643).
+					// WC_ANALYTICS_VERSION is omitted: only woocommerce-analytics defines it, so a PA-only store would sync null.
 					'JETPACK_PREMIUM_ANALYTICS__VERSION',
 				),
 			)
@@ -252,7 +236,7 @@ class Configuration {
 
 	/**
 	 * Add WC Analytics post meta to Sync's post meta whitelist.
-	 * Any changes to these meta will by synced to WordPress.com.
+	 * Any changes to these meta will be synced to WordPress.com.
 	 *
 	 * @param array $whitelist Existing post meta whitelist.
 	 * @return array Updated post meta whitelist.

--- a/projects/packages/premium-analytics/src/Sync/class-sync-status-tracker.php
+++ b/projects/packages/premium-analytics/src/Sync/class-sync-status-tracker.php
@@ -10,16 +10,10 @@ namespace Automattic\Jetpack\PremiumAnalytics\Sync;
 use Automattic\Jetpack\Sync\Modules;
 
 /**
- * Listens for the end of the analytics full sync, persists a one-time milestone
- * option, and exposes that milestone to the frontend both at page load (via
- * `JetpackScriptData.premium_analytics`) and live on Jetpack's
- * `/jetpack/v4/sync/status` REST response.
+ * Listens for the end of the analytics full sync and persists a one-time milestone option.
  *
- * Why this exists: /jetpack/v4/sync/status reports current sync state, but not
- * whether the analytics full sync has completed at least once, which tells the
- * dashboard's store section whether its numbers are complete. The milestone
- * also lets consumer plugins (e.g. WooCommerce Analytics) fire one-time
- * side-effects like the full-sync-complete email, via the action hook below.
+ * /jetpack/v4/sync/status reports current sync state but not whether the analytics full sync
+ * has completed at least once — which is what tells the dashboard's store section its numbers are complete.
  */
 class Sync_Status_Tracker {
 
@@ -30,11 +24,8 @@ class Sync_Status_Tracker {
 	const INITIAL_ANALYTICS_SYNC_OPTION = 'jetpack_premium_analytics_initial_analytics_sync_finished';
 
 	/**
-	 * Default sync-module names whose end-of-sync event flips the milestone.
-	 * Currently provided by WooCommerce Analytics, which registers a custom
-	 * full-sync module under this key. Consumers can extend or override the set
-	 * via the `jetpack_premium_analytics_sync_modules` filter — see
-	 * {@see get_analytics_sync_modules()}.
+	 * Default sync-module names whose end-of-sync event flips the milestone. Provided by
+	 * WooCommerce Analytics, which registers a custom full-sync module under this key.
 	 *
 	 * @var string[]
 	 */
@@ -50,8 +41,7 @@ class Sync_Status_Tracker {
 	const MILESTONE_ACTION = 'jetpack_premium_analytics_initial_full_sync_finished';
 
 	/**
-	 * Jetpack core's sync-status REST route. We enrich this existing response with
-	 * the milestone rather than registering a dedicated endpoint.
+	 * Jetpack core's sync-status REST route, enriched with the milestone.
 	 */
 	const SYNC_STATUS_ROUTE = '/jetpack/v4/sync/status';
 
@@ -69,13 +59,10 @@ class Sync_Status_Tracker {
 	}
 
 	/**
-	 * Append the milestone to Jetpack core's GET /jetpack/v4/sync/status response
-	 * so the dashboard can read it on every poll, not just at page load.
+	 * Append the milestone to Jetpack core's GET /jetpack/v4/sync/status response.
 	 *
-	 * Page-load script-data ({@see inject_script_data()}) is a one-time snapshot;
-	 * reading the milestone here keeps it live for in-session completion without a
-	 * dedicated endpoint. Only the already-authorized, successful status payload is
-	 * touched — other routes and error responses pass through untouched.
+	 * Unlike the one-time script-data snapshot ({@see inject_script_data()}), this stays live for
+	 * in-session completion — but touches only the already-authorized, successful status payload.
 	 *
 	 * @param mixed $response Result to send to the client. Usually a WP_REST_Response.
 	 * @param mixed $server   The REST server instance (unused).
@@ -139,13 +126,10 @@ class Sync_Status_Tracker {
 	}
 
 	/**
-	 * Pure-logic counterpart to on_sync_processed_actions(): decide whether the
-	 * supplied full-sync status + actions list represents the analytics sync
-	 * ending, and flip the milestone if so.
+	 * Decide whether the supplied full-sync status and actions represent the analytics sync ending.
 	 *
-	 * Only a full sync whose config includes an analytics module counts, so a
-	 * generic sync can't mark the store data complete. Split out so unit
-	 * tests can exercise the decision without the Jetpack sync module registry.
+	 * Only a full sync whose config includes an analytics module counts — a generic sync can't mark
+	 * store data complete; split out so tests can exercise it without the sync module registry.
 	 *
 	 * @param array $full_status Result of Full_Sync_Immediately::get_status().
 	 * @param array $actions     Processed sync actions.
@@ -172,14 +156,12 @@ class Sync_Status_Tracker {
 			return;
 		}
 
-		// The last update_status() call in Full_Sync_Immediately::send() runs
-		// after jetpack_full_sync_end fires, so the action's own timestamp is
-		// the most reliable "finished at" value. Note: Year 2038 problem.
+		// The last update_status() call in Full_Sync_Immediately::send() runs after jetpack_full_sync_end
+		// fires, so the action's own timestamp is the most reliable "finished at" value (Year 2038 problem aside).
 		$finished_at = isset( $end_action[3] ) ? (int) $end_action[3] : 0;
 		if ( $finished_at <= 0 ) {
-			// Defensive: avoid persisting a zero timestamp, which would equal
-			// the "not yet set" sentinel and cause the listener to re-trigger
-			// on the next batch.
+			// Defensive: avoid persisting a zero timestamp, which would equal the "not yet set" sentinel
+			// and cause the listener to re-trigger on the next batch.
 			return;
 		}
 		$full_status['finished'] = $finished_at;

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -31,10 +31,8 @@ class Analytics {
 	private static $initialized = false;
 
 	/**
-	 * Menu title override for the admin page. Null falls back to the package's
-	 * own translated label, resolved on admin_menu — callers init far too early
-	 * to translate anything themselves. A closure is resolved there too, which is
-	 * how a caller supplies a label in its own textdomain.
+	 * Menu title override for the admin page. Null falls back to the package's own
+	 * translated label, resolved on admin_menu — init runs far too early to translate.
 	 *
 	 * @var string|\Closure|null
 	 */
@@ -52,9 +50,8 @@ class Analytics {
 	/**
 	 * Path to the wp-build entry point. Null uses the generated build.
 	 *
-	 * A test seam: `build/` is gitignored and `test-php` runs no build step, so a
-	 * test has nothing to observe unless it can redirect this. Private, so unlike
-	 * the widget manifest's path it needs no filter to stay out of reach.
+	 * A test seam: `build/` is gitignored and test-php runs no build step, so tests redirect this
+	 * instead. Private, so — unlike the widget manifest's path — it needs no filter to stay out of reach.
 	 *
 	 * @var string|null
 	 */
@@ -95,12 +92,8 @@ class Analytics {
 	/**
 	 * Load the dashboard render surface, on the requests that can render it.
 	 *
-	 * With the rollout flag on, init() runs on every request — on WordPress.com
-	 * Simple, every request across WPCOM's public-api process — so everything
-	 * below would otherwise be parsed for visitors who can never use it.
-	 *
-	 * REST serves the dashboard too but is deliberately excluded: it loads what
-	 * it needs itself. See load_build().
+	 * With the rollout flag on, init() runs on every request — including every WPCOM public-api
+	 * request on Simple — so this stays gated for visitors who never use it (REST excluded; see load_build()).
 	 *
 	 * @return void
 	 */
@@ -118,9 +111,8 @@ class Analytics {
 	/**
 	 * Whether this request can render an admin screen.
 	 *
-	 * Core also sets is_admin() on admin-ajax.php and admin-post.php, which render
-	 * no dashboard and for which this package registers no handlers, so neither
-	 * needs the build parsed.
+	 * Core also sets is_admin() on admin-ajax.php and admin-post.php, which render no dashboard
+	 * and get no handlers from this package, so neither needs the build parsed.
 	 *
 	 * @return bool
 	 */
@@ -136,9 +128,8 @@ class Analytics {
 	/**
 	 * Initialize the Analytics app on WordPress.com Simple.
 	 *
-	 * Simple reaches public-api.wordpress.com directly via WPCOM's apiFetch
-	 * bridge, so it registers no local REST surface: no proxy, notices, sync
-	 * bootstrap, or dashboard support routes. WPCOM registers those separately.
+	 * Simple reaches public-api.wordpress.com directly via WPCOM's apiFetch bridge, registering
+	 * no local REST surface (no proxy, notices, sync bootstrap, or dashboard routes) — WPCOM handles those.
 	 *
 	 * @param array $options Optional configuration options.
 	 *                       Supported keys:
@@ -198,9 +189,8 @@ class Analytics {
 	/**
 	 * URL of a dashboard route on this site.
 	 *
-	 * The SPA path travels in `p`; the router reads that param and ignores the
-	 * rest of the query. Encoded here because add_query_arg() leaves values
-	 * alone, and a `?` inside the path would read as an outer query param.
+	 * The SPA path travels in `p`, encoded here since add_query_arg() leaves values alone and a
+	 * raw `?` inside it would read as an outer query param.
 	 *
 	 * @since 0.4.0
 	 *
@@ -212,11 +202,8 @@ class Analytics {
 	}
 
 	/**
-	 * Announce to Jetpack's other surfaces that this dashboard is the site's
-	 * analytics UI, so they link here instead of the Stats page. Publishing it
-	 * from the package that owns the dashboard means the key exists exactly
-	 * where the dashboard does. Registered from both init paths, so Simple gets
-	 * it too.
+	 * Announce to Jetpack's other surfaces that this dashboard is the site's analytics UI,
+	 * so they link here instead of the Stats page.
 	 *
 	 * @return void
 	 */
@@ -243,10 +230,9 @@ class Analytics {
 	}
 
 	/**
-	 * Prefers `timezone_string` over `gmt_offset`, matching the dashboard's own
-	 * `siteTimeZone()`: analytics links point at past dates, so they cross
-	 * daylight-saving boundaries routinely, and a fixed offset applied to the far
-	 * side of a transition shifts the day.
+	 * Prefers `timezone_string` over `gmt_offset`, matching the dashboard's own `siteTimeZone()`:
+	 * analytics links point at past dates, so a fixed offset applied to the far side of a
+	 * daylight-saving transition shifts the day.
 	 *
 	 * @return string An IANA timezone name, or a `+HH:MM` UTC offset.
 	 */
@@ -381,21 +367,13 @@ class Analytics {
 	}
 
 	/**
-	 * Unhook wp-build's full-page render interceptor.
+	 * Unhook wp-build's full-page render interceptor — security-relevant: it renders
+	 * `?page=jetpack-premium-analytics` from admin_init with no capability check, and only
+	 * renders_admin_chrome() gates the admin-post.php/admin-ajax.php paths that reach admin_init
+	 * without Core's own slug check.
 	 *
-	 * It renders `?page=jetpack-premium-analytics` — a slug the menu never
-	 * registers — from admin_init, with no capability check of its own. On
-	 * wp-admin screens Core already refuses that slug first, in
-	 * wp-admin/includes/menu.php, which admin.php requires before admin_init;
-	 * admin-post.php and admin-ajax.php reach admin_init without that check, and
-	 * renders_admin_chrome() is what currently keeps the build off both. Unhooking
-	 * removes the reliance on that single guard.
-	 *
-	 * wp-build derives the callback name from the page slug, and remove_action() is
-	 * a no-op on a name or priority it doesn't find — so drift would put the second
-	 * entry point back silently. Nothing to remove is normal (the build may be
-	 * absent), but a live interceptor we failed to unhook is not, so say so the way
-	 * register_admin_menu() reports incomplete build output.
+	 * Because remove_action() no-ops on a callback name it can't find, a wp-build rename would
+	 * silently restore this entry point — hence the _doing_it_wrong() below when that happens.
 	 *
 	 * @return void
 	 */
@@ -416,9 +394,8 @@ class Analytics {
 	/**
 	 * Absolute path to the generated widget manifest.
 	 *
-	 * On the class rather than beside its readers in widget-modules.php: two copies
-	 * of this package can load in one request, and only classes go through the
-	 * autoloader's version dedupe. See load_dashboard_components().
+	 * On the class, not beside its readers in widget-modules.php: two copies of this package can
+	 * load in one request, and only classes get the autoloader's version dedupe (see load_dashboard_components()).
 	 *
 	 * @return string
 	 */
@@ -451,8 +428,6 @@ class Analytics {
 				)
 			);
 
-			// Enqueue the i18n loader so the init module can download its JS
-			// translation catalogs.
 			add_action( 'admin_enqueue_scripts', array( static::class, 'enqueue_i18n_loader' ) );
 		}
 
@@ -468,10 +443,8 @@ class Analytics {
 	/**
 	 * Whether the current request is rendering the Premium Analytics dashboard.
 	 *
-	 * Used to scope the wp-build polyfill registration (which force-replaces core
-	 * script handles) to this dashboard, so it never affects other admin pages.
-	 * Must be cheap and safe to call at plugin-load time, before current_screen
-	 * exists, so it reads the menu page slug directly.
+	 * Scopes the wp-build polyfill registration (which force-replaces core script handles) to
+	 * this dashboard; reads the menu slug directly, not current_screen, to stay safe at plugin-load time.
 	 *
 	 * @return bool True when serving the dashboard page in wp-admin.
 	 */
@@ -489,12 +462,8 @@ class Analytics {
 	/**
 	 * Register the admin menu page.
 	 *
-	 * Uses wp-build's `-wp-admin` variant so Core applies the menu capability check.
-	 * The generated build provides the render callback; a missing build shows a
-	 * notice instead of an empty page.
-	 *
-	 * Report missing page and widget build artifacts independently because the
-	 * build loader includes each one conditionally.
+	 * Uses wp-build's `-wp-admin` variant so Core applies the menu capability check. Reports the
+	 * page and widget artifacts independently since the build loader includes each conditionally.
 	 *
 	 * @return void
 	 */
@@ -560,13 +529,9 @@ class Analytics {
 	/**
 	 * The caller's menu label override, or the package's own translated label.
 	 *
-	 * Only call once translations can load — admin_menu or later. Memoized, so every
-	 * call site in a request shows the same label.
-	 *
-	 * Closures are resolved here rather than at init time, so a caller can hand us
-	 * `__()` in its own textdomain without translating too early. Deliberately not
-	 * is_callable(): PHP function names are case-insensitive, so a plain label like
-	 * "Analytics" would match a stray analytics() function and get called.
+	 * Call only once translations can load — admin_menu or later — and memoize so every call site
+	 * agrees. Deliberately not is_callable(): PHP function names are case-insensitive, so a plain
+	 * label like "Analytics" could match a stray analytics() function and get called.
 	 *
 	 * @return string
 	 */
@@ -579,9 +544,8 @@ class Analytics {
 			? ( self::$menu_title )()
 			: self::$menu_title;
 
-		// A positive check rather than a null coalesce: a closure is free to return an
-		// empty string, or something that isn't a string at all, and either would reach
-		// esc_html() as a broken label instead of falling back here.
+		// A positive check rather than a null coalesce: a closure may return an empty string, or
+		// something that isn't a string at all, and either would reach esc_html() as a broken label.
 		self::$resolved_menu_title = is_string( $title ) && '' !== $title
 			? $title
 			: __( 'Stats v2', 'jetpack-premium-analytics-pkg' );

--- a/projects/packages/premium-analytics/src/class-capabilities.php
+++ b/projects/packages/premium-analytics/src/class-capabilities.php
@@ -2,16 +2,9 @@
 /**
  * Who may see the Premium Analytics dashboard.
  *
- * Jetpack Stats lets a site grant non-administrators access through the
- * `view_stats` meta capability, and this dashboard replaces that UI, so it has
- * to honour the same grant. `add_menu_page()` takes a single capability string,
- * so the "manage_options OR view_stats" rule lives in a meta capability of our
- * own rather than being spelled out at each call site.
- *
- * A class rather than a function file so every consumer reaches it through the
- * autoloader: gating lives in files loaded on several different paths, and a
- * `require_once` in each of them is a dependency to keep in sync (and an
- * unmeasurable line of coverage) for no benefit.
+ * Jetpack Stats grants non-administrators access via the `view_stats` meta capability; this
+ * dashboard must honour that grant, and add_menu_page() takes one capability string — hence a
+ * meta capability of our own.
  *
  * @package automattic/jetpack-premium-analytics
  */
@@ -33,9 +26,8 @@ class Capabilities {
 	/**
 	 * Hooks the dashboard's meta capability mapping.
 	 *
-	 * Called from WordPress-aware entry points, never at load time: this class is
-	 * autoloaded in contexts where WordPress — and add_filter() — isn't there.
-	 * Idempotent, so overlapping callers are free to call it.
+	 * Called from WordPress-aware entry points, never at load time: this class is autoloaded where
+	 * WordPress — and add_filter() — isn't there. Idempotent, so overlapping callers may call it freely.
 	 *
 	 * @return void
 	 */
@@ -58,11 +50,8 @@ class Capabilities {
 	/**
 	 * Maps the dashboard capability to the primitives that grant it.
 	 *
-	 * `view_stats` alone would track Stats more closely, but it only means
-	 * anything once the Stats package has hooked its own `map_meta_cap` — which
-	 * `Analytics::init_wpcom_simple()` never does. Without the `manage_options`
-	 * arm, an unmapped `view_stats` would take the dashboard away from
-	 * administrators too, which is worse than the gap this closes.
+	 * `view_stats` alone would track Stats more closely, but it only works once Stats hooks its
+	 * own `map_meta_cap` — which Analytics::init_wpcom_simple() never does, locking out administrators too.
 	 *
 	 * @param string[] $caps    Primitive capabilities required of the user.
 	 * @param string   $cap     Capability being checked.
@@ -93,11 +82,8 @@ class Capabilities {
 	/**
 	 * Whether the current user may read the store reports.
 	 *
-	 * "Store reports" is everything the proxy serves from its `analytics` prefix —
-	 * WooCommerce's own reporting data. Mirrors the capability
-	 * {@see \Automattic\Jetpack\PremiumAnalytics\REST\Api_Proxy_Controller} enforces
-	 * there (Capabilities_Test pins the two together); surfaces backed by the prefix
-	 * are hidden from readers who fail it, since all they could collect is 403s.
+	 * "Store reports" is everything the proxy serves from its `analytics` prefix, mirroring what
+	 * {@see \Automattic\Jetpack\PremiumAnalytics\REST\Api_Proxy_Controller} enforces there (pinned by Capabilities_Test).
 	 *
 	 * @return bool
 	 */

--- a/projects/packages/premium-analytics/src/class-dashboard-section.php
+++ b/projects/packages/premium-analytics/src/class-dashboard-section.php
@@ -10,9 +10,7 @@ namespace Automattic\Jetpack\PremiumAnalytics;
 /**
  * Represents a dashboard section.
  *
- * A dashboard section is the server-owned model behind a top-level dashboard
- * tab. It carries display metadata plus availability and default-layout
- * callbacks that can be extended by consumers.
+ * The server-owned model behind a top-level dashboard tab.
  */
 final class Dashboard_Section {
 
@@ -109,12 +107,10 @@ final class Dashboard_Section {
 	/**
 	 * What the section's date filter supports, and where it renders.
 	 *
-	 * - `with_date_comparison`: whether the section supports comparison at all.
-	 *   Not just chrome — false drops the comparison from the params every
-	 *   widget in the section fetches with.
-	 * - `with_header_date_control`: whether the header renders the date control.
-	 *   False hands it to the section's widgets, which may save the range onto the
-	 *   widget instance rather than the URL.
+	 * - `with_date_comparison`: false drops the comparison param from every widget fetch in the
+	 *   section, not just the chrome.
+	 * - `with_header_date_control`: false hands the control to the section's widgets, which may
+	 *   save the range onto the widget instance rather than the URL.
 	 *
 	 * @since 0.3.0
 	 * @since $$next-version$$ Added `with_header_date_control`.

--- a/projects/packages/premium-analytics/src/class-post-list-link.php
+++ b/projects/packages/premium-analytics/src/class-post-list-link.php
@@ -30,15 +30,11 @@ class Post_List_Link {
 	/**
 	 * Point one row at its post detail page.
 	 *
-	 * Wins even where the row would otherwise point at Calypso: the dashboard is
-	 * this site's analytics UI, and it only exists in wp-admin, so the
-	 * admin-interface preference has no bearing on where analytics lives.
+	 * Wins even where the row would otherwise point at Calypso: this dashboard is the site's
+	 * analytics UI and exists only in wp-admin, so the admin-interface preference doesn't apply.
 	 *
-	 * The capability arm is defence in depth rather than a path a reader reaches:
-	 * `Admin_Post_List_Column::add_stats_post_table()` already drops the whole
-	 * column unless the user has `view_stats` or `manage_options`, the same
-	 * primitives `jetpack_view_analytics` maps to. It stays because the filter is
-	 * public and its next caller may not gate anything.
+	 * Defence in depth: Admin_Post_List_Column::add_stats_post_table() already drops the column
+	 * without `view_stats`/`manage_options`, but this filter is public and its next caller may not gate.
 	 *
 	 * @param string $url     Stats URL for the post.
 	 * @param int    $post_id The post the row belongs to.

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -2,12 +2,8 @@
 /**
  * Dashboard Layout: Premium Analytics server-side defaults.
  *
- * Premium Analytics owns its dashboard, so it ships its own default layout
- * rather than relying on the core dashboard endpoint (which is Gutenberg-only
- * and returns the core dashboard's widgets). The default is served on the
- * `dashboardSection` REST shape and a per-dashboard `default-layout` route; the
- * frontend reads it from the section entity, so there is no server-seeded
- * preference.
+ * Ships its own default layout rather than the core dashboard endpoint (Gutenberg-only, returns
+ * core's widgets); the frontend reads the default from the section entity, so nothing is server-seeded.
  *
  * @package automattic/jetpack-premium-analytics
  */
@@ -373,9 +369,8 @@ function get_dashboard_default_section_layouts() {
 				1,
 				1
 			),
-			// Row 6: daily views heatmap. Two rows tall, as in the prototype: the
-			// cells are sized from the tile's height, and only at this height do they
-			// grow wide enough to label each day with its view count.
+			// Row 6: daily views heatmap. Two rows tall, as in the prototype: cells are sized
+			// from the tile's height, and only here do they fit each day's view count.
 			get_dashboard_default_widget_instance(
 				'default-traffic-views-activity-widget-instance',
 				'jpa/traffic-views-activity',
@@ -576,9 +571,8 @@ function get_dashboard_default_section_id_for( $dashboard_name ) {
 /**
  * Seeds the bundled default layouts for the Premium Analytics dashboard tabs.
  *
- * Only contributes to the known Premium Analytics dashboard and tab aliases;
- * other dashboards are left untouched so the filter can be reused if more
- * dashboards are added later.
+ * Only contributes to known Premium Analytics dashboard/tab aliases, leaving other dashboards
+ * untouched so the filter stays reusable if more dashboards are added later.
  *
  * @param array  $dashboard_layout Default layout from earlier callbacks.
  * @param string $dashboard_name   Identifier of the dashboard receiving the

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -295,9 +295,7 @@ function get_available_dashboard_section_for_route( $dashboard_name, $section_id
 /**
  * REST schema for one dashboard section, as returned by the sections route.
  *
- * The dashboard's frontend mirrors this shape in
- * `routes/dashboard/config/sections.ts`, and WPCOM serves the same route for
- * Simple sites (see AGENTS.md), so both are consumers of this contract.
+ * Mirrored by the frontend's `sections.ts` and reused by WPCOM for Simple sites (see AGENTS.md).
  *
  * @since 0.2.0
  *
@@ -423,9 +421,7 @@ function register_dashboard_sections_rest_routes() {
 		'/dashboards/(?P<name>' . get_dashboard_name_pattern() . ')/sections',
 		array(
 			array(
-				// A route-level `schema` beside the numerically keyed endpoint list is
-				// register_rest_route()'s own signature, reading to Phan as a mixed array.
-				// @phan-suppress-next-line PhanPluginMixedKeyNoKey
+				// @phan-suppress-next-line PhanPluginMixedKeyNoKey -- register_rest_route()'s own signature mixes a numerically keyed endpoint list with a route-level `schema` key.
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => __NAMESPACE__ . '\\get_dashboard_sections_response',
 				'permission_callback' => __NAMESPACE__ . '\\check_dashboard_sections_permission',

--- a/projects/packages/premium-analytics/src/videopress-availability.php
+++ b/projects/packages/premium-analytics/src/videopress-availability.php
@@ -2,19 +2,14 @@
 /**
  * VideoPress availability, shared by the widget layer and the client routes.
  *
- * Calypso gates its Videos module on the `videopress` plan feature, which
- * `wpcom_site_has_feature()` answers on the WPCOM platform. That function does
- * not exist off-platform. `Current_Plan::supports()` grants `videopress` to
- * every plan because of the free tier, while
- * `Product::get_site_features_from_wpcom()` can make a synchronous WPCOM
- * request and answers entitlement rather than whether VideoPress is running.
- * The off-platform question is therefore answered from the module or plugin.
+ * Calypso gates its Videos module on the `videopress` plan feature, which `wpcom_site_has_feature()`
+ * answers on the WPCOM platform but which does not exist off-platform. `Current_Plan::supports()`
+ * grants `videopress` to every plan because of the free tier, and `Product::get_site_features_from_wpcom()`
+ * answers entitlement rather than whether VideoPress is running, over a synchronous WPCOM request.
  *
- * The canonical gates already exist: `VideoPress\Status::is_active()` for the
- * off-platform branch, the WPCOM arm of `Current_Plan::supports()` for the
- * platform one. Neither `jetpack-videopress` nor `jetpack-plans` is in this
- * package's dependency graph, so the detection below is local by necessity.
- * Widen the graph before writing another detector.
+ * The canonical gates (`VideoPress\Status::is_active()`, the WPCOM arm of `Current_Plan::supports()`)
+ * live in packages this one does not depend on, so the detection below is local by necessity. Widen
+ * the dependency graph before writing another detector.
  *
  * @package automattic/jetpack-premium-analytics
  */
@@ -35,22 +30,14 @@ const VIDEOPRESS_AVAILABLE_FILTER = 'jetpack_premium_analytics_videopress_availa
 /**
  * Whether the site can produce VideoPress play data.
  *
- * Atomic reads the plan feature alongside Simple, not the module: wpcomsh
- * provides `wpcom_site_has_feature()` there, and the VideoPress module has no
- * `Auto Activate` header, so a plan that includes VideoPress routinely comes
- * with the module off. wpcomsh grants `videopress` to every business-and-higher
- * plan and WoA only exists on those, so the platform branch effectively gates
- * Simple alone: an Atomic site with the module off keeps the video surfaces.
- * That is intended — hosting is service-level on WPCOM, so the module would be
- * a false negative there.
+ * Atomic reads the plan feature alongside Simple, not the module: wpcomsh provides
+ * `wpcom_site_has_feature()` there, and the VideoPress module has no `Auto Activate` header, so a
+ * plan that includes VideoPress routinely comes with the module off. An Atomic site with the module
+ * off therefore keeps the video surfaces, which is intended — hosting is service-level on WPCOM.
  *
- * Off-platform the question becomes "is VideoPress running here", not "is it
- * paid for" — without the module there is no new play data to report. That is
- * deliberately narrower than `Initial_State::has_videopress_access()`, which
- * never looks at the module and counts the paid storage tiers instead.
- *
- * `Current_Plan::supports( 'videopress' )` is avoided because off-platform it
- * returns true for every plan, thanks to the VideoPress free tier.
+ * Off-platform the question becomes "is VideoPress running here", not "is it paid for": without the
+ * module there is no new play data. Deliberately narrower than
+ * `Initial_State::has_videopress_access()`, which counts the paid storage tiers instead.
  *
  * @return bool Whether Premium Analytics treats VideoPress as available.
  */
@@ -87,9 +74,8 @@ function configure_videopress_availability() {
 /**
  * Injects the VideoPress availability flag into JetpackScriptData.
  *
- * The client cannot read `site.plan.features` for this: that key is only
- * populated when the Publicize package happens to be loaded, which the
- * standalone Premium Analytics plugin never loads.
+ * The client can't read `site.plan.features` here: that key is only populated when the
+ * Publicize package happens to load, which the standalone Premium Analytics plugin never does.
  *
  * @param array $data The script data passed by the assets package.
  * @return array

--- a/projects/packages/premium-analytics/src/widget-availability.php
+++ b/projects/packages/premium-analytics/src/widget-availability.php
@@ -1,14 +1,8 @@
 <?php
 /**
- * Widget availability policy (consumer layer).
- *
- * Premium Analytics' policy over the neutral filters in widget-types.php:
- * availability is the consumer's job, core only offers the hooks.
- *
- * Policies are hooked on the registry-time filter (a hard hide, which keeps
- * every registry consumer correct without a filtered accessor): developer-only
- * widget types are never registered in production, Simple-only types are only
- * registered on WPCOM Simple, and commerce categories require their plugins.
+ * Widget availability policy (consumer layer): hides developer-only, Simple-only, and
+ * plugin-gated widget types at registry time — a hard hide, so every consumer of the
+ * registry sees the same set, over the neutral hooks in widget-types.php.
  *
  * @package automattic/jetpack-premium-analytics
  */
@@ -32,13 +26,9 @@ const WOOCOMMERCE_WIDGET_CATEGORIES = array( 'store', 'orders', 'coupons' );
 const WOOCOMMERCE_BOOKINGS_WIDGET_CATEGORIES = array( 'bookings' );
 
 /**
- * Widget categories whose data counts as a store report.
- *
- * The membership rule is the data source, not the subject matter: every
- * category here reaches WPCOM through the proxy's `analytics` prefix, which
- * {@see \Automattic\Jetpack\PremiumAnalytics\REST\Api_Proxy_Controller} gates
- * on `view_woocommerce_reports`. That is why `visitors` is in the list: its
- * widgets read `sessions/…` from the same prefix.
+ * Widget categories whose data counts as a store report — by data source, not subject
+ * matter: each reaches WPCOM via the proxy's `analytics` prefix (gated on
+ * `view_woocommerce_reports`), including `visitors`, which reads `sessions/…` from it.
  */
 const STORE_REPORT_WIDGET_CATEGORIES = array( 'store', 'orders', 'coupons', 'bookings', 'visitors' );
 
@@ -144,14 +134,9 @@ function is_bookings_plugin_active() {
 }
 
 /**
- * Registry-time callback: hides commerce widget categories without their plugin.
- *
- * WooCommerce availability is read through the store section's signal
- * (dashboard-sections.php, including its availability filter) so section and
- * widgets can't disagree — a consumer overriding the section filter gets
- * matching widget types. Both dashboard entry points load
- * dashboard-sections.php before the widget registry can hydrate, so the
- * function is always defined by the time this callback runs.
+ * Registry-time callback: hides commerce categories without their plugin, reading
+ * WooCommerce availability through the store section's signal so section and widgets
+ * agree; both entry points load dashboard-sections.php before the registry hydrates.
  *
  * @param array $widget_candidates Manifest candidates.
  * @return array The candidates, minus commerce categories missing their plugin.
@@ -166,9 +151,8 @@ function filter_registrable_widget_types_by_plugin( $widget_candidates ) {
 
 add_filter( REGISTRABLE_WIDGET_TYPES_FILTER, __NAMESPACE__ . '\\filter_registrable_widget_types_by_plugin' );
 
-// Subscriber widgets remain available when their section is hidden because
-// their data does not depend on the local module. Unregistering them would also
-// break instances placed in other sections.
+// Subscriber widgets stay registered even when their section is hidden: their data
+// doesn't depend on the local module, and unregistering would break instances placed elsewhere.
 
 /**
  * Removes candidates the reader could not load data for anyway.
@@ -197,11 +181,9 @@ function remove_capability_gated_widget_types( $widget_candidates, $can_view_sto
 }
 
 /**
- * Registry-time callback: hides widgets whose data the reader cannot fetch.
- *
- * A `view_stats` reader reaching one of them would only collect 403s from the
- * proxy's `analytics` prefix, so the types are never registered for them. The
- * registry is request-scoped, so filtering on the current user is safe here.
+ * Registry-time callback: hides widgets whose data the reader cannot fetch — a
+ * `view_stats` reader would only collect 403s from the proxy's `analytics` prefix.
+ * The registry is request-scoped, so filtering on the current user is safe here.
  *
  * @since 0.1.0
  *

--- a/projects/packages/premium-analytics/src/widget-modules.php
+++ b/projects/packages/premium-analytics/src/widget-modules.php
@@ -2,10 +2,8 @@
 /**
  * Dashboard widget modules: REST exposure + import-map wiring.
  *
- * Reads get_available_widget_types() (the registry filtered by
- * widget-availability.php) and exposes it two ways: the
- * `/wpcom/v2/widget-modules` REST list, and the page import map, where each
- * widget's render and metadata modules are registered for dynamic `import()`.
+ * Reads get_available_widget_types() and exposes it two ways: the `/wpcom/v2/widget-modules`
+ * REST list, and the page import map, for dynamic `import()`.
  *
  * @package automattic/jetpack-premium-analytics
  */
@@ -34,12 +32,8 @@ function register_widget_modules_rest_route() {
 /**
  * Load and hydrate the widget type registry, once.
  *
- * Deferred to here (the registry's only two readers) instead of running
- * unconditionally at boot: this package boots on every request to a site
- * that has it active, and on WPCOM Simple this file's registration runs on
- * every public-api request across all of WPCOM, not just ones that touch
- * Premium Analytics. Most such requests never read the registry at all, so
- * parsing the widget manifest and hydrating it eagerly was wasted work.
+ * Deferred to the registry's only two readers rather than run at boot: on Simple this file's
+ * registration runs on every WPCOM public-api request, and most never read the registry.
  *
  * @return void
  */
@@ -53,9 +47,8 @@ function ensure_widget_registry_ready() {
 	require_once __DIR__ . '/widget-types.php';
 	require_once __DIR__ . '/widget-availability.php';
 
-	// REST does not load the admin build, so this require is the manifest's only route
-	// in (WOOA7S-1804). Drop it and every widget renders "Widget is no longer
-	// available" — the #49961 bug.
+	// REST does not load the admin build, so this require is the manifest's only route in
+	// (WOOA7S-1804). Drop it and every widget renders "Widget is no longer available" (#49961).
 	$widgets_manifest = Analytics::widget_manifest_path();
 	if ( file_exists( $widgets_manifest ) ) {
 		require_once $widgets_manifest;

--- a/projects/packages/premium-analytics/src/widget-type-support.php
+++ b/projects/packages/premium-analytics/src/widget-type-support.php
@@ -1,11 +1,8 @@
 <?php
 /**
- * Widget type support shared by the registry and default layouts.
- *
- * Persisted layouts are left unchanged so missing types remain as removable
- * ghost widgets. This is for hard availability — the host, or a feature the site
- * either has or does not. Request-dependent or soft state (shown locked, say)
- * belongs in the runtime types filter instead.
+ * Widget type support shared by the registry and default layouts — hard availability only
+ * (a feature the site has or doesn't); soft/request-dependent state belongs in the runtime
+ * types filter. Persisted layouts keep missing types as removable ghost widgets.
  *
  * @package automattic/jetpack-premium-analytics
  */
@@ -55,17 +52,13 @@ function get_unsupported_widget_types( $context ) {
 	if ( empty( $context['is_wpcom_simple'] ) ) {
 		$unsupported[] = 'jpa/file-downloads';
 
-		// Share counts are recorded when the share request is processed, which
-		// only happens on WPCOM Simple. Elsewhere the button click is handled by
-		// the site itself and never reaches the counter, so the site summary's
-		// `shares_<service>` fields stay at zero however much the content is
-		// shared. Calypso excludes the module on the same grounds.
+		// Share counts are recorded only when WPCOM processes the share click; elsewhere the
+		// click never reaches the counter, so `shares_<service>` stays zero. Calypso excludes it too.
 		$unsupported[] = 'jpa/shares';
 	}
 
-	// Play counts only exist for VideoPress-hosted videos, so without VideoPress
-	// these widgets have nothing to report. Calypso gates its Videos module the
-	// same way (see videopress-availability.php).
+	// Play counts only exist for VideoPress-hosted videos; Calypso gates its Videos module
+	// the same way (see videopress-availability.php).
 	if ( empty( $context['has_videopress'] ) ) {
 		$unsupported = array_merge( $unsupported, VIDEOPRESS_WIDGET_TYPES );
 	}

--- a/projects/packages/premium-analytics/tests/js/test-groups.test.ts
+++ b/projects/packages/premium-analytics/tests/js/test-groups.test.ts
@@ -188,10 +188,8 @@ describe( 'test groups', () => {
 		expect( groups.length ).toBeGreaterThan( 0 );
 	} );
 
-	// The Jest config keeps a member out of the ungrouped run by matching the
-	// same import lines this test reads. Anything either side cannot read is
-	// left running twice — standalone and inside its group — with nothing here
-	// checking it, so a group file carries imports and comments and nothing else.
+	// The Jest config excludes a member from the ungrouped run by matching these same import
+	// lines; anything unreadable runs twice, uncaught — so a group file must be only imports/comments.
 	it.each( groups )( '%s carries nothing but member imports', groupFile => {
 		expect( readGroup( groupFile ).unreadable ).toEqual( [] );
 	} );
@@ -226,10 +224,8 @@ describe( 'test groups', () => {
 		}
 	} );
 
-	// Jest reads the environment docblock of the file it collects, which for a
-	// grouped suite is the group file. A member pinning its own environment gets
-	// the group's instead, silently: `@jest-environment node` becomes jsdom, and
-	// the suite fails on whatever the node environment was there to provide.
+	// Jest reads the environment docblock of the file it collects — the group file for a grouped
+	// suite — so a member's own `@jest-environment` pin is silently ignored (e.g. node becomes jsdom).
 	it.each( groups )( '%s members do not pin a Jest environment', groupFile => {
 		const pinned = membersOf( groupFile )
 			.map( member => resolveSuite( member ) as string )

--- a/projects/packages/premium-analytics/tests/php/Analytics_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Analytics_Test.php
@@ -15,13 +15,9 @@ use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests for the Analytics class.
- *
- * Covers metadata names ensure_widget_registry_ready() alongside the class,
- * because test_rest_request_still_serves_the_widget_manifest exercises it on
- * purpose. Coverage is attributed to those declared units too — php-code-coverage
- * discards every executed line outside them — so leaving it off would report the
- * manifest require as dead code while a green test runs it.
+ * Tests for the Analytics class. Also covers ensure_widget_registry_ready(): only
+ * test_rest_request_still_serves_the_widget_manifest exercises it, and php-code-coverage
+ * discards lines outside declared @covers units — omitting it would mark the manifest require dead.
  *
  * @covers \Automattic\Jetpack\PremiumAnalytics\Analytics
  * @covers ::Automattic\Jetpack\PremiumAnalytics\ensure_widget_registry_ready
@@ -50,10 +46,8 @@ class Analytics_Test extends TestCase {
 	/**
 	 * Fail loudly if the fixture build leaked in from an earlier test.
 	 *
-	 * Because load_build() uses require_once and there is one fixture file, a
-	 * second load is a no-op. Without this check, dropping the process isolation would
-	 * turn every "does not load the build" assertion into a vacuous pass — the
-	 * unset() below clears the marker and nothing re-sets it, gate or no gate.
+	 * Because load_build() uses require_once, a second load is a no-op — without this check,
+	 * dropping process isolation would silently pass every "does not load the build" assertion.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -227,9 +221,8 @@ class Analytics_Test extends TestCase {
 	/**
 	 * Normal package bootstrap serves the dashboard support routes from the site.
 	 *
-	 * The route files themselves are loaded lazily, on rest_api_init, via
-	 * Dashboard_Support_Routes::boot_routes() - so this checks that hook is
-	 * wired, then dispatches it and confirms the routes actually land.
+	 * Routes load lazily on rest_api_init via Dashboard_Support_Routes::boot_routes(), so this
+	 * checks the hook is wired and that dispatching it actually registers the routes.
 	 */
 	public function test_init_registers_dashboard_support_routes_by_default() {
 		$this->reset_analytics_init_state();
@@ -372,17 +365,13 @@ class Analytics_Test extends TestCase {
 	/**
 	 * A REST request still gets the full widget manifest.
 	 *
-	 * Because is_admin() is false on REST, the gate skips the build there; the route
-	 * and the lazy hydration both come from boot_routes() on rest_api_init. The
-	 * fixture is staged through the manifest-path filter rather than by declaring
-	 * jpa_get_registered_widget_modules() up front, so the sentinel can only reach
-	 * the registry via the manifest require in ensure_widget_registry_ready() —
-	 * delete that require (the #49961 outage) and this test reddens.
+	 * Since is_admin() is false on REST, the build gate skips it there; the route and its lazy
+	 * hydration come from boot_routes(). The fixture is staged via the manifest-path filter so
+	 * the sentinel can only reach the registry through the require in
+	 * ensure_widget_registry_ready() — delete that require (the #49961 outage) and this reddens.
 	 *
-	 * Asserts a uniquely named sentinel rather than "the response is not empty":
-	 * the widget type registry is process-wide, so a non-empty response could be
-	 * another test's leftovers. Isolation keeps the registry and
-	 * ensure_widget_registry_ready()'s static memo clean.
+	 * Asserts a uniquely named sentinel, not "response is not empty": the widget type registry
+	 * is process-wide, so a non-empty response could be another test's leftovers.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -413,9 +402,8 @@ class Analytics_Test extends TestCase {
 
 			$response = $wp_rest_server->dispatch( new \WP_REST_Request( 'GET', '/wpcom/v2/widget-modules' ) );
 
-			// Asserted separately so a permissions regression reads as one, rather
-			// than as a missing sentinel: array_column() over an error envelope is
-			// an empty list either way.
+			// Asserted separately so a permissions regression reads as one, not a missing sentinel:
+			// array_column() over an error envelope is an empty list either way.
 			$this->assertSame( 200, $response->get_status(), 'The manifest route must authorize the test user.' );
 			$this->assertContains( 'test/rest-gate-sentinel', array_column( (array) $response->get_data(), 'name' ) );
 		} finally {
@@ -797,12 +785,10 @@ class Analytics_Test extends TestCase {
 	/**
 	 * With the build present, the menu wires the generated render callback.
 	 *
-	 * The other menu tests all run the missing-build half. This one covers the
-	 * normal path, whose failure is quiet: the render function's name is derived
-	 * from the page slug at build time, so a rename on either side swaps the
-	 * dashboard for the missing-build notice with nothing else to notice it.
-	 *
-	 * Use fixtures because the test suite does not generate build artifacts.
+	 * Unlike the missing-build tests, this covers the normal path, whose failure is quiet:
+	 * the render function name is derived from the page slug at build time, so a rename on
+	 * either side silently swaps the dashboard for the missing-build notice. Uses fixtures
+	 * since the test suite generates no build artifacts.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -877,9 +863,8 @@ class Analytics_Test extends TestCase {
 	/**
 	 * The unfiltered manifest path points at the generated build output.
 	 *
-	 * Every other test stages this path through the filter, so nothing else would
-	 * notice the default breaking - and on REST a wrong path empties the widget
-	 * registry with no error at all (the #49961 bug).
+	 * Every other test stages this path through the filter, so nothing else would notice the
+	 * default breaking — on REST, a wrong path silently empties the widget registry (#49961).
 	 */
 	public function test_widget_manifest_path_defaults_to_the_generated_manifest() {
 		// Collapse the ".." the default is built from rather than realpath()ing it:
@@ -897,11 +882,9 @@ class Analytics_Test extends TestCase {
 	}
 
 	/**
-	 * Register the admin menu from a clean menu global, with the generated render
-	 * function absent - the state _doing_it_wrong() deliberately reports, so the
-	 * call is captured rather than left to trip the suite's warning gate.
-	 * add_menu_page() only wires the render callback for a user who can reach the
-	 * page, hence the capability grant.
+	 * Register the admin menu from a clean menu global, with the generated render function absent
+	 * — the state _doing_it_wrong() deliberately reports, captured here to avoid tripping the
+	 * suite's warning gate. The capability grant lets add_menu_page() wire the render callback.
 	 *
 	 * @param string $manifest_filter Method on this class supplying the manifest path.
 	 * @return array|null The registered menu entry.
@@ -967,17 +950,14 @@ class Analytics_Test extends TestCase {
 	}
 
 	/**
-	 * A front-end request registers none of the admin render surface: no menu,
-	 * no widget import map, no CSV export script data.
+	 * A front-end request registers none of the admin render surface: no menu, no widget
+	 * import map, no CSV export script data.
 	 *
-	 * Isolated because the filters being asserted are registered at file scope
-	 * by widget-modules.php and csv-exports.php, and require_once means an
-	 * earlier test that loaded them would leave them registered for this one.
-	 *
-	 * Each assertion names its callback rather than just the hook.
-	 * Sync_Status_Tracker also filters jetpack_admin_js_script_data, and it
-	 * stays outside the gate, so a bare has_filter() on that hook is true on a
-	 * front-end request no matter what this gate does.
+	 * Isolated because widget-modules.php and csv-exports.php register these filters at file
+	 * scope via require_once, so an earlier test that loaded them would leave them registered
+	 * here. Each assertion names its callback, not just the hook: Sync_Status_Tracker also
+	 * filters jetpack_admin_js_script_data outside this gate, so a bare has_filter() there is
+	 * true regardless.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled

--- a/projects/packages/premium-analytics/tests/php/Capabilities_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Capabilities_Test.php
@@ -109,11 +109,9 @@ class Capabilities_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Pins the helper to the capability the proxy enforces for the `analytics`
-	 * prefix, so the two can't drift apart and leave widgets that answer 403.
-	 * Asserted through check_data_permission() rather than by reading
-	 * PREFIX_CONFIG, so what's compared is the decision each side actually
-	 * reaches for the same user.
+	 * Pins the helper to the capability the proxy enforces for `analytics`, so the two can't
+	 * drift apart and leave widgets that answer 403. Asserted through check_data_permission()
+	 * rather than PREFIX_CONFIG, so what's compared is the decision each side actually reaches.
 	 */
 	public function test_store_report_helper_matches_the_proxy_capability() {
 		$controller = new Api_Proxy_Controller();
@@ -137,9 +135,8 @@ class Capabilities_Test extends BaseTestCase {
 			'An administrator must be admitted by both.'
 		);
 
-		// WooCommerce's own capability, held by shop managers, who have no
-		// manage_options. WorDBless has no shop_manager role, so grant the
-		// capability the role would carry.
+		// WooCommerce's own capability, held by shop managers (no manage_options). WorDBless
+		// has no shop_manager role, so grant the capability the role would carry.
 		$shop_manager = $this->login_as( 'subscriber' );
 		$this->grant_capability_to( $shop_manager, 'view_woocommerce_reports' );
 

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -536,9 +536,8 @@ class Dashboard_Section_Test extends BaseTestCase {
 	/**
 	 * The sections schema documents the date-filter surfaces and their default.
 	 *
-	 * `routes/dashboard/config/date-filter.ts` re-declares these rather than
-	 * importing them, and falls back to `range` silently, so a new surface has to
-	 * widen `DateFilterSurface` there too or the dashboard will never render it.
+	 * `routes/dashboard/config/date-filter.ts` re-declares these and falls back to `range`
+	 * silently — widen `DateFilterSurface` there too, or new surfaces won't render.
 	 */
 	public function test_sections_schema_documents_the_date_filter() {
 		$schema = get_dashboard_section_schema();

--- a/projects/packages/premium-analytics/tests/php/Videopress_Availability_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Videopress_Availability_Test.php
@@ -79,9 +79,8 @@ class Videopress_Availability_Test extends BaseTestCase {
 	/**
 	 * The WPCOM platform reads the plan feature, never the module list.
 	 *
-	 * The module stays active throughout, so every assertion here also proves the
-	 * platform branch was the one taken: the self-hosted branch would answer true
-	 * in all three cases.
+	 * The module stays active throughout, so every assertion here also proves the platform branch
+	 * was taken — the self-hosted branch would answer true in all three cases otherwise.
 	 *
 	 * @dataProvider provide_wpcom_platform_sites
 	 *

--- a/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
@@ -45,9 +45,8 @@ class Widget_Availability_Test extends BaseTestCase {
 	/**
 	 * Reset constants and availability filters between tests.
 	 *
-	 * The support context now reaches Host::is_wpcom_platform(), which memoizes
-	 * `is_woa_site` into the process-global status cache; clearing constants alone
-	 * would leave a stale host verdict for the next test that sets Atomic ones.
+	 * The support context reaches Host::is_wpcom_platform(), which memoizes `is_woa_site` into
+	 * the process-global status cache — clearing constants alone would leave a stale host verdict.
 	 */
 	public function tear_down() {
 		Constants::clear_constants();
@@ -221,15 +220,12 @@ class Widget_Availability_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The gate and the manifests agree in both directions: a renamed widget can't
-	 * drop out of the gate, and a new video widget can't be added without joining
-	 * it.
+	 * The gate and the manifests agree in both directions: a renamed widget can't drop out of the
+	 * gate, and a new video widget can't be added without joining it.
 	 *
-	 * The second half rests on a naming heuristic, which bounds what it can catch:
-	 * a VideoPress-backed widget named without `video` would not be demanded here,
-	 * and an unrelated `video-*` widget would be demanded wrongly. Widget manifests
-	 * carry no "requires" field to key on instead; if one is ever added, this
-	 * should read that rather than the name.
+	 * The second half rests on a naming heuristic: a VideoPress widget not named with `video` would
+	 * be missed, and an unrelated `video-*` widget wrongly demanded. Widget manifests have no
+	 * "requires" field to key on instead — read that here if one is ever added.
 	 */
 	public function test_videopress_widget_types_match_the_manifest() {
 		$manifests = glob( __DIR__ . '/../../widgets/*/widget.json' );
@@ -237,9 +233,8 @@ class Widget_Availability_Test extends BaseTestCase {
 
 		$video_names = array();
 		foreach ( $manifests as $manifest ) {
-			// Assert rather than skip: a manifest silently dropped here is absent from
-			// both sides of the comparison below, so the guard would pass while the
-			// gate is missing a type — the one failure this test exists to catch.
+			// Assert rather than skip: a silently dropped manifest is absent from both sides of the
+			// comparison below, so the guard would pass while the gate is missing a type — the failure this test exists to catch.
 			$raw = file_get_contents( $manifest ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			$this->assertNotFalse( $raw, "Could not read $manifest" );
 

--- a/projects/packages/premium-analytics/tests/php/bootstrap.php
+++ b/projects/packages/premium-analytics/tests/php/bootstrap.php
@@ -7,22 +7,18 @@
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-// PHPUnit pipes process-isolated child scripts through stdin, so a child starts with an
-// empty SCRIPT_FILENAME. wp_guess_url() derives a needle from it and hands the empty result
-// to strpos(), which warns on PHP 7.x and errors every isolated test before it runs. Give it
-// what the parent process has: a real path outside ABSPATH.
+// PHPUnit's process-isolated children start with an empty SCRIPT_FILENAME (piped via stdin),
+// which wp_guess_url() feeds to strpos() and errors on PHP 7.x — give it a real path outside ABSPATH.
 if ( empty( $_SERVER['SCRIPT_FILENAME'] ) ) {
 	$_SERVER['SCRIPT_FILENAME'] = __FILE__;
 }
 
 \Automattic\Jetpack\Test_Environment::init();
 
-// Minimal WooCommerce stubs so the CSV export classes (which extend/depend on WC) can load
-// and be exercised. Loaded after Test_Environment::init() so WordPress base classes
-// (e.g. WP_REST_Controller) are already available for the stubs to extend.
+// Minimal WooCommerce stubs so the CSV export classes (which extend/depend on WC) can load and
+// be exercised; loaded after Test_Environment::init() so WP_REST_Controller etc. already exist to extend.
 require_once __DIR__ . '/mocks/woocommerce-mocks.php';
 
-// Controllable stand-in for the WPCOM platform's feature gate, so the Simple/Atomic
-// branch of is_videopress_available() can be driven in both directions. Inert until a
-// test populates $GLOBALS['jpa_test_wpcom_features'].
+// Controllable stand-in for the WPCOM platform's feature gate, so the Simple/Atomic branch of
+// is_videopress_available() can be driven either way; inert until a test populates $GLOBALS['jpa_test_wpcom_features'].
 require_once __DIR__ . '/mocks/wpcom-feature-mocks.php';

--- a/projects/packages/premium-analytics/tests/php/fixtures/build-entry/build.php
+++ b/projects/packages/premium-analytics/tests/php/fixtures/build-entry/build.php
@@ -2,12 +2,9 @@
 /**
  * Test fixture: stand-in for the generated wp-build entry point.
  *
- * Records that it was loaded so tests can assert whether Analytics::init()
- * reached the build on a given request type. The real build/ is gitignored and
- * CI runs no build step, so without this there is nothing to observe.
- *
- * Also provides the generated render callback and full-page interceptor. Their
- * names depend on the page slug, so both behaviors need test coverage.
+ * Records that it loaded so tests can tell whether Analytics::init() reached the build on a given
+ * request type — build/ is gitignored and CI runs no build step, so without this there's nothing
+ * to observe. Also provides the render callback and full-page interceptor, whose names depend on the page slug.
  *
  * @package automattic/jetpack-premium-analytics
  */

--- a/projects/packages/premium-analytics/tests/php/fixtures/build-entry/widgets.php
+++ b/projects/packages/premium-analytics/tests/php/fixtures/build-entry/widgets.php
@@ -2,10 +2,9 @@
 /**
  * Test fixture: stand-in for the generated widget manifest.
  *
- * Reached only through Analytics::widget_manifest_path(), so a test can prove
- * ensure_widget_registry_ready() still requires the manifest: drop that require
- * and this file never loads, the registry stays empty, and the REST test fails.
- * Delegates the declaration so there is one stub accessor, not two.
+ * Reached only through Analytics::widget_manifest_path(), proving ensure_widget_registry_ready()
+ * still requires the manifest: drop that require and this file never loads, so the REST test fails.
+ * Delegates the declaration so there's one stub accessor, not two.
  *
  * @package automattic/jetpack-premium-analytics
  */

--- a/projects/packages/premium-analytics/tests/php/mocks/wpcom-feature-mocks.php
+++ b/projects/packages/premium-analytics/tests/php/mocks/wpcom-feature-mocks.php
@@ -2,20 +2,16 @@
 /**
  * Mock for the WordPress.com feature-gating function.
  *
- * `wpcom_site_has_feature()` is provided by the WPCOM platform (wpcom itself on
- * Simple, wpcomsh on Atomic), not by any package, so without this the platform
- * branch of `is_videopress_available()` can only ever short-circuit on
- * `function_exists()` and answer false. That leaves the true path — the one
- * Simple and Atomic actually take — unexercised, so a wrong feature slug would
- * ship green.
+ * `wpcom_site_has_feature()` is provided by the platform (wpcom on Simple, wpcomsh on Atomic),
+ * not by any package; without this, the platform branch of `is_videopress_available()` can only
+ * short-circuit on `function_exists()` and read false, leaving the real path unexercised — so a
+ * wrong feature slug would ship green.
  *
- * State lives in a global rather than a class so this file stays self-contained:
- * `tests/php/mocks/` is excluded from Phan (see .phan/config.php), because the
- * real `wpcom_site_has_feature()` already arrives via the `wpcom` stub set, and
- * a class declared in here would read as undeclared everywhere it is used.
+ * State lives in a global, not a class: `tests/php/mocks/` is excluded from Phan (the real
+ * `wpcom_site_has_feature()` already arrives via the `wpcom` stub set), so a class declared here
+ * would read as undeclared everywhere it's used.
  *
- * The default is inert: with nothing entitled, every feature reads as false,
- * exactly as it did before this mock existed.
+ * Default is inert: with nothing entitled, every feature reads false, as before this mock existed.
  *
  * @package automattic/jetpack-premium-analytics
  */

--- a/projects/packages/premium-analytics/widgets/all-time-stats/render.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/render.tsx
@@ -26,16 +26,13 @@ import {
 } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
-// The host (and Storybook) may inject report params via `attributes`, but the
-// totals are all-time: the summary query takes no date params, so the picker's
-// range and comparison state do not change what this widget shows.
+// Report params arrive from the host but change nothing here: the all-time
+// summary query takes no date params.
 type AllTimeStatsRenderAttributes = AllTimeStatsAttributes & Partial< ReportParamsFieldAttributes >;
 type AllTimeStatsWidgetProps = WidgetRenderProps< AllTimeStatsRenderAttributes >;
 
 /**
- * The all-time summary carries dynamic WPCOM keys (`views`, `visitors`,
- * `posts`, `comments`, …); values arrive numeric or as numeric strings, so
- * each field is read defensively.
+ * Dynamic WPCOM keys, whose values arrive numeric or as numeric strings.
  */
 type StatsSummary = Record< string, unknown >;
 
@@ -45,9 +42,7 @@ const COUNT_FORMAT: DataFormat = {
 };
 
 /**
- * Render-only config per metric: the tile icon. Ids and labels are shared with
- * the settings checkboxes via `ALL_TIME_STATS_METRICS` in `widget.ts`; the id
- * doubles as the summary field the tile reads.
+ * Render-only icon per metric; the id doubles as the summary field the tile reads.
  */
 const TILE_CONFIG: Record< AllTimeStatsMetricId, { icon: typeof seen } > = {
 	views: { icon: seen },
@@ -63,20 +58,11 @@ type AllTimeStatsTile = {
 	value: number;
 };
 
-/**
- * Fetches the all-time site summary through the designated `useStatsSite` hook
- * and renders the lifetime totals as a grid of metric tiles. Which tiles
- * appear is controlled by the `metrics` attribute; fields absent from the
- * response are skipped. There is no comparison period for this module, so each
- * value renders as a bare number.
- */
 function AllTimeStatsReport( {
 	metrics = DEFAULT_ALL_TIME_STATS_METRICS,
 }: {
 	metrics?: AllTimeStatsMetricId[];
 } ) {
-	// The summary is all-time, so the query takes no date params — its key stays
-	// stable across dashboard date-range and comparison changes.
 	const { data, isLoading, isFetching, isError, refetch } = useStatsSite();
 
 	const summary = ( data as { stats?: StatsSummary } | undefined )?.stats;
@@ -106,9 +92,8 @@ function AllTimeStatsReport( {
 			<WidgetState
 				isLoading={ isLoading }
 				isFetching={ isFetching }
-				// The query keeps prior data via `placeholderData`, so a transient
-				// refetch failure keeps the totals visible; only surface the error
-				// when there is nothing to show.
+				// `placeholderData` keeps the last totals on screen, so a transient
+				// refetch failure should not replace them with an error.
 				isError={ tiles.length === 0 && isError }
 				isEmpty={ tiles.length === 0 }
 				error={ {
@@ -127,9 +112,8 @@ function AllTimeStatsReport( {
 							? __( 'Select at least one metric to display.', 'jetpack-premium-analytics-pkg' )
 							: __( 'No stats recorded yet.', 'jetpack-premium-analytics-pkg' ),
 				} }
-				// `tiles` is built from the summary, so it is empty until the
-				// response lands; the enabled metrics are the count the loaded
-				// grid will show.
+				// `tiles` is empty until the response lands, so the skeleton counts
+				// the enabled metrics instead.
 				renderLoading={ <MetricTileGridSkeleton tiles={ enabledMetrics.length } /> }
 			>
 				<MetricTileGrid tiles={ tiles } dataFormat={ COUNT_FORMAT } />
@@ -138,12 +122,6 @@ function AllTimeStatsReport( {
 	);
 }
 
-/**
- * WidgetRoot provides the analytics query client and chart theme the inner
- * report needs. This widget is all-time, so it does not read the dashboard date
- * range; report params still flow into WidgetRoot for parity with the other
- * Stats widgets.
- */
 export default function AllTimeStats( { attributes = {} }: AllTimeStatsWidgetProps ) {
 	return (
 		<WidgetRoot attributes={ attributes }>

--- a/projects/packages/premium-analytics/widgets/all-time-stats/widget.ts
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/widget.ts
@@ -11,16 +11,9 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 import { ArrayCheckboxField } from '@jetpack-premium-analytics/fields';
 
 /**
- * The lifetime totals the widget can show, in display order: the persisted id
- * and label of each metric. Single source for the settings checkboxes and the
- * rendered tiles so the two cannot drift apart; `render.tsx` maps the ids to
- * icons and summary fields.
- *
- * The Insights default layout hardcodes a subset of these ids server-side
- * (`src/dashboard-layout.php`, the `jpa/all-time-stats` instance), so renaming
- * an id means updating both. A rename here alone is silent: unknown ids are
- * filtered out in `render.tsx` and the default instance falls through to the
- * "select a metric" empty state.
+ * Lifetime totals the widget can show, in display order. Renaming an id
+ * breaks the Insights default layout silently: `dashboard-layout.php`
+ * hardcodes a subset, and `render.tsx` filters ids it doesn't know.
  */
 export const ALL_TIME_STATS_METRICS = [
 	{ id: 'views', label: __( 'Views', 'jetpack-premium-analytics-pkg' ) },
@@ -36,32 +29,20 @@ export const ALL_TIME_STATS_METRICS = [
 export type AllTimeStatsMetricId = ( typeof ALL_TIME_STATS_METRICS )[ number ][ 'id' ];
 
 /**
- * Configurable attributes for the All-time stats widget. The widget does not
- * read the dashboard date range: the site summary is all-time, so
- * `useStatsSite()` is queried without report params. Host-injected
- * `attributes.reportParams` still flow into WidgetRoot for parity with the
- * other Stats widgets.
+ * Configurable attributes for the All-time stats widget. The site summary is
+ * all-time, so `useStatsSite()` is queried without the dashboard date range.
  */
 export type AllTimeStatsAttributes = {
-	/**
-	 * Lifetime totals to show in the widget body.
-	 */
 	metrics?: AllTimeStatsMetricId[];
 };
 
-/**
- * Default selection for new widget instances: every metric enabled.
- */
 export const DEFAULT_ALL_TIME_STATS_METRICS: AllTimeStatsMetricId[] = ALL_TIME_STATS_METRICS.map(
 	metric => metric.id
 );
 
 /**
- * Widget type definition.
- *
- * Ported from the Jetpack Stats "All-time stats" card: a grid of metric tiles
- * for lifetime totals — views, visitors, posts, and comments. `example.attributes`
- * doubles as the defaults applied to new instances: every metric enabled.
+ * Ported from the Jetpack Stats "All-time stats" card. `example.attributes`
+ * doubles as the defaults applied to new instances.
  */
 export default {
 	icon: trendingUp,

--- a/projects/packages/premium-analytics/widgets/annual-highlights/__tests__/annual-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/__tests__/annual-highlights.test.tsx
@@ -36,12 +36,9 @@ jest.mock( '@wordpress/route', () => ( {
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 
-// An instance with no year of its own shows the current one, so the payload is
-// built relative to today — hardcoded years would silently move that default
-// off the data after New Year. Distinct totals per year, so the wrong year
-// cannot pass by matching the other one's numbers. The package test script pins
-// TZ=UTC, which is also what the widget's `siteTimeZone()` resolves to under
-// jsdom's default WP date settings — so this year and the widget's agree.
+// Built relative to today: hardcoded years would silently move the no-attribute
+// default off the data after New Year. The package test script pins TZ=UTC, which
+// is what the widget's `siteTimeZone()` also resolves to under jsdom.
 const CURRENT_YEAR = new Date().getFullYear();
 const PREVIOUS_YEAR = CURRENT_YEAR - 1;
 
@@ -101,9 +98,8 @@ describe( 'AnnualHighlightsWidget', () => {
 	} );
 
 	it( 'defaults to the current year when the instance carries no year', async () => {
-		// The server's default layout creates the instance without attributes,
-		// and the host's dropdown selects the current year on its own — the body
-		// has to agree with what that control shows.
+		// The default layout creates the instance without attributes, and the host's
+		// dropdown selects the current year — the body has to agree with it.
 		const { container } = renderWidget();
 
 		await expect( screen.findByText( 'Posts' ) ).resolves.toBeInTheDocument();

--- a/projects/packages/premium-analytics/widgets/annual-highlights/__tests__/years.test.ts
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/__tests__/years.test.ts
@@ -14,9 +14,7 @@ jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 
 // The list runs down from today, so the payload is built relative to it — a
-// hardcoded year would drift out of the surface after New Year. The package
-// test script pins TZ=UTC, which is also what `siteTimeZone()` resolves to
-// under jsdom's default WP date settings.
+// hardcoded year would drift out of the surface after New Year.
 const CURRENT_YEAR = new Date().getFullYear();
 
 const yearRow = ( year: number ) => ( {

--- a/projects/packages/premium-analytics/widgets/annual-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/render.tsx
@@ -28,9 +28,8 @@ import type { AnnualHighlightsAttributes } from './widget';
 import type { YearPresetId } from '@jetpack-premium-analytics/datetime';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
-// The insights endpoint is not period-scoped: one request returns every year,
-// and the widget's own `year` attribute picks which one is shown (see
-// `selectYearTotals`), so the host's report params play no part here.
+// The insights endpoint is not period-scoped: one request returns every year and
+// the widget's own `year` attribute picks one, so host report params play no part.
 type AnnualHighlightsRenderAttributes = AnnualHighlightsAttributes &
 	Partial< ReportParamsFieldAttributes >;
 type AnnualHighlightsWidgetProps = WidgetRenderProps< AnnualHighlightsRenderAttributes >;
@@ -41,9 +40,8 @@ const COUNT_FORMAT: DataFormat = {
 };
 
 /**
- * Resolves the totals for the selected year. A year the site did not publish
- * in has no row; leaving it undefined shows the empty state rather than a
- * screen of zeros.
+ * A year the site did not publish in has no row; leaving it undefined shows the
+ * empty state rather than a screen of zeros.
  */
 function selectYearTotals(
 	data: StatsInsightsResponse | undefined,
@@ -54,19 +52,10 @@ function selectYearTotals(
 	return data?.years?.find( year => Number( year.year ) === selectedYear );
 }
 
-/**
- * Fetches the insights report through the designated `useStatsInsights` Stats
- * hook and renders the totals for the selected year as a `MetricTileGrid` (see
- * `selectYearTotals`). The endpoint returns every year in one request, so
- * switching years is a client-side row pick — no new fetch. The insights
- * module has no comparison period, so each tile shows a bare formatted count.
- */
 function AnnualHighlightsReport( { year }: { year?: YearPresetId } ) {
 	const { data, isLoading, isFetching, isError, refetch } = useStatsInsights();
 	const totals = selectYearTotals( data, resolveSelectedYear( year ) );
 
-	// Guarded on `totals`: the tile values read the selected year, which is
-	// absent in the loading / error / empty states handled by <WidgetState>.
 	const tiles = totals
 		? [
 				{
@@ -101,9 +90,8 @@ function AnnualHighlightsReport( { year }: { year?: YearPresetId } ) {
 			<WidgetState
 				isLoading={ isLoading }
 				isFetching={ isFetching }
-				// The query keeps prior data via `placeholderData`, so a transient
-				// refetch failure keeps the highlights visible; only surface the
-				// error when there is nothing to show.
+				// `placeholderData` keeps the last highlights on screen, so a transient
+				// refetch failure should not replace them with an error.
 				isError={ ! totals && isError }
 				isEmpty={ ! totals }
 				error={ {
@@ -132,12 +120,6 @@ function AnnualHighlightsReport( { year }: { year?: YearPresetId } ) {
 	);
 }
 
-/**
- * WidgetRoot provides the analytics query client and chart theme consumed by the
- * inner report. Host attributes are forwarded per the widget contract, though
- * the report ignores report params: the year shown comes from the widget's own
- * `year` attribute, which the host renders as a dropdown in the frame header.
- */
 export default function AnnualHighlights( { attributes = {} }: AnnualHighlightsWidgetProps ) {
 	return (
 		<WidgetRoot attributes={ attributes }>

--- a/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
@@ -29,10 +29,8 @@ registerReportMocks();
 
 const ANNUAL_HIGHLIGHTS_RENDER_MODULE = 'storybook/annual-highlights';
 
-// Carry the widget's metadata, including the year attribute schema, so the
+// Carries the widget's metadata, including the year attribute schema, so the
 // dashboard story's frame header renders the real year dropdown.
-// `presentation` comes from widget.json ( 'framed' ), so the host frames the
-// widget and renders its identity (title + icon).
 const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 function renderAnnualHighlights() {
@@ -40,13 +38,9 @@ function renderAnnualHighlights() {
 }
 
 /**
- * Forces the insights request into a loading/error/empty state for a story.
- *
- * The insights endpoint is not period-scoped, so its query key carries no date
- * params and a distinct date preset alone would not give the story a fresh
- * cache entry. Evict the query from the shared client on enter and on cleanup
- * so each forced-state story hits the mock fresh (and no forced result leaks
- * into the sibling stories).
+ * Forces the insights request into a loading/error/empty state for a story. The
+ * insights query key carries no date params, so only evicting it from the shared
+ * client keeps a forced result from leaking into sibling stories.
  */
 function forceInsightsState( state: 'loading' | 'error' | 'empty' ) {
 	setReportMockState( 'stats/insights', state );
@@ -126,9 +120,8 @@ function AnnualHighlightsDashboardStory( dashboardArgs: WidgetDashboardWithWidge
 			renderModule={ ANNUAL_HIGHLIGHTS_RENDER_MODULE }
 			renderComponent={ AnnualHighlightsRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
-				// Comparison params by default, per the story template: the widget
-				// ignores report params, and this story covers that it keeps doing so
-				// when the host supplies them.
+				// The widget ignores report params; this story covers that it keeps
+				// doing so when the host supplies them.
 				reportParams: getDefaultQueryParams( true ),
 			} }
 		/>

--- a/projects/packages/premium-analytics/widgets/annual-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/widget.ts
@@ -13,28 +13,18 @@ import { getYearElements } from './years';
 import type { YearPresetId } from '@jetpack-premium-analytics/datetime';
 
 /**
- * Configurable attributes for the Annual highlights widget. The widget has no
- * date range — the insights endpoint is not period-scoped, and the year below
- * picks a row out of the single payload it returns.
+ * No date range: the insights endpoint is not period-scoped, and `year` picks a
+ * row out of the single payload it returns.
  */
 export type AnnualHighlightsAttributes = {
-	/**
-	 * Year the widget summarizes, as a year preset ID (e.g. `year-2026`).
-	 * Absent on an instance whose year was never picked.
-	 */
+	/** Year preset ID, e.g. `year-2026`. */
 	year?: YearPresetId;
 };
 
 /**
- * Widget type definition. The widget type keeps the `annual-highlights` name
- * (saved layouts reference it); its display title in widget.json is "Year in
- * review".
- *
- * `year` is the only attribute and carries `relevance: 'high'`, so the host
- * renders its dropdown in the frame header and the widget body holds nothing
- * but the tiles. No `example` year comes with it: the years on offer depend on
- * the site's own data, so a new instance starts on the one the dropdown lists
- * first — the current year.
+ * The type keeps the `annual-highlights` name because saved layouts reference it;
+ * widget.json titles it "Year in review". No `example` year: the years on offer
+ * depend on the site's own data, so a new instance starts on the current year.
  */
 export default {
 	icon: pin,

--- a/projects/packages/premium-analytics/widgets/annual-highlights/years.ts
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/years.ts
@@ -17,39 +17,28 @@ import {
 import type { Option } from '@jetpack-premium-analytics/externals';
 
 /**
- * Oldest year in the insights payload, which is where the dropdown's list
- * starts — the endpoint reports across the whole site lifetime. Rows dated
- * past the current year are intentionally out of reach: the year surface
- * enumerates down from today.
+ * Oldest year in the insights payload, where the dropdown's list starts.
  */
 function findStartYear( data: StatsInsightsResponse | undefined ): number | undefined {
 	const years = ( data?.years ?? [] )
 		.map( year => Number( year.year ) )
-		// A row with no year normalizes to '' and then to 0, and a bad start
-		// year would put centuries of entries in the dropdown — the clamp below
-		// caps the damage a single garbled row can do.
+		// A row with no year normalizes to 0, and a bad start year would put
+		// centuries of entries in the dropdown.
 		.filter( year => Number.isInteger( year ) && year > 1000 );
 
 	if ( years.length === 0 ) {
 		return undefined;
 	}
 
-	// The browser clock is fine for this floor: it guards against garbled
-	// rows, where an off-by-one at the New Year boundary is immaterial. Year
-	// math the reader can see goes through the site timezone instead.
+	// The browser clock is fine for this floor: an off-by-one at the New Year
+	// boundary is immaterial. Year math users see uses the site timezone.
 	return Math.max( Math.min( ...years ), new Date().getFullYear() - 50 );
 }
 
 /**
- * Years the widget's dropdown offers: the current year back to the site's
- * oldest year of data, publish gaps included — the year surface the section's
- * own filter used to provide.
- *
- * The host renders the control outside the widget, where no hook can reach the
- * report, so the payload is read straight from the shared query cache. It is
- * the entry `useStatsInsights` fills, so a widget that already loaded costs no
- * request. A payload that never arrives leaves the surface at its default
- * depth rather than at no years at all.
+ * Years the widget's dropdown offers, current year back to the site's oldest.
+ * The host renders the control outside the widget (no hook can reach the
+ * report), so this reads the shared query cache `useStatsInsights` fills directly.
  */
 export async function getYearElements(): Promise< Option[] > {
 	const data = await queryClient.fetchQuery( statsInsightsQuery() ).catch( () => undefined );
@@ -61,8 +50,7 @@ export async function getYearElements(): Promise< Option[] > {
 
 /**
  * Calendar year the widget summarizes. An instance whose year was never picked
- * carries none and reads as the current year — the entry the dropdown lists
- * first, and so selects on its own.
+ * reads as the current year, which the dropdown lists first.
  */
 export function resolveSelectedYear( year: YearPresetId | undefined ): number {
 	return getPresetYear( year ) ?? toLocalTZ( undefined, siteTimeZone() ).getFullYear();

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -38,53 +38,19 @@ type AuthorsRenderAttributes = AuthorsAttributes & Partial< ReportParamsFieldAtt
 type AuthorsWidgetProps = WidgetRenderProps< AuthorsRenderAttributes >;
 
 export type AuthorsLeaderboardProps = {
-	/**
-	 * Author rows to render, already built from the top-authors report. Each row
-	 * carries its avatar and posts so the leaderboard can show a name + picture
-	 * label and drill down into that author's posts on click.
-	 * When omitted, the empty state is shown (unless `isLoading` is set).
-	 */
 	rows?: AuthorLeaderboardRow[];
-	/**
-	 * When `true`, the first fetch is in flight and there is no data to show yet.
-	 */
 	isLoading?: boolean;
-	/**
-	 * When `true`, a background refetch is in flight while data is shown.
-	 */
 	isFetching?: boolean;
-	/**
-	 * When `true`, the error state is rendered instead of the chart.
-	 */
 	isError?: boolean;
-	/**
-	 * Re-runs the failed query from the error state's Retry action.
-	 */
 	refetch?: () => void;
-	/**
-	 * When `true`, render each row's previous-period delta next to its value.
-	 */
 	withComparison?: boolean;
-	/**
-	 * Custom legend labels for the current/comparison periods.
-	 */
 	legendLabels?: LegendLabels;
 };
 
 /**
- * Presentational leaderboard for the Authors widget. Renders the site's top
- * authors by views — each row labelled with the author's name and avatar — and
- * lets a click drill down into that author's posts, with a back link to return.
- *
- * Both the interactive row affordance (chevron, hover, keyboard access) and the
- * name + picture label come from the shared `@automattic/charts` leaderboard
- * primitives via the toolkit's `LeaderboardChart` / `LeaderboardRow`; only the
- * drill-down navigation state lives here.
- *
- * Takes already-built rows via props (and is exported) so Storybook can
- * exercise these states — including the drill-down — with fixture data; there
- * is no Stats backend in Storybook, so the data-connected entry point would
- * only ever show chrome.
+ * Takes already-built rows via props, and is exported, so Storybook can exercise
+ * every state including the drill-down: there is no Stats backend there, so the
+ * data-connected entry point would only ever show chrome.
  */
 export function AuthorsLeaderboard( {
 	rows = [],
@@ -95,9 +61,8 @@ export function AuthorsLeaderboard( {
 	withComparison = false,
 	legendLabels,
 }: AuthorsLeaderboardProps ) {
-	// Store only the author id and resolve the row fresh from the current rows,
-	// so a background refetch that drops the author cleanly falls back to the
-	// top view instead of pinning a stale snapshot.
+	// Store only the id and resolve the row fresh, so a refetch that drops the
+	// author falls back to the top view instead of pinning a stale snapshot.
 	const {
 		drillDownItem: selectedAuthorId,
 		drillDown: selectAuthor,
@@ -119,9 +84,8 @@ export function AuthorsLeaderboard( {
 	}, [ selectedAuthorId, selectedAuthor, isLoading, isFetching, clearSelectedAuthor ] );
 
 	const chartData: LeaderboardChartData = useMemo( () => {
-		// Drilled-in: show the selected author's posts. Rows are not interactive;
-		// the data layer already aligned current/comparison values, including
-		// posts that only existed in the comparison period.
+		// The data layer already aligned current/comparison values, including posts
+		// that only existed in the comparison period.
 		if ( selectedAuthor ) {
 			return selectedAuthor.posts.map( post => ( {
 				id: post.id,
@@ -134,8 +98,6 @@ export function AuthorsLeaderboard( {
 			} ) );
 		}
 
-		// Top authors: name + avatar label, and a click drills into the author's
-		// posts. Authors without posts stay inert (no onClick).
 		return rows.map( row => ( {
 			id: row.id,
 			...buildLeaderboardRow( {
@@ -213,11 +175,6 @@ export function AuthorsLeaderboard( {
 	);
 }
 
-/**
- * Fetches the top-authors report through the Jetpack Stats hook, builds the
- * leaderboard rows from the data layer's merged comparison rows, and hands
- * them to the presentational `AuthorsLeaderboard`.
- */
 function AuthorsReport() {
 	const { reportParams } = useWidgetRootContext();
 	const statsParams = useMemo(
@@ -245,10 +202,8 @@ function AuthorsReport() {
 				rows={ rows }
 				isLoading={ isInitialLoading }
 				isFetching={ isFetching }
-				// The Stats queries carry `placeholderData: previousData => previousData`, so a
-				// failed range change keeps the prior period's rows while `isError` flips true.
-				// Only surface the error when there's nothing to show, so a transient refetch
-				// failure doesn't replace populated rows with the error state.
+				// `placeholderData` keeps the prior period's rows on screen while `isError`
+				// flips true, so a transient refetch failure should not replace them.
 				isError={ rows.length === 0 && isError }
 				refetch={ refetch }
 				withComparison={ hasComparison }
@@ -261,12 +216,6 @@ function AuthorsReport() {
 	);
 }
 
-/**
- * Passes host `attributes` into `WidgetRoot`, which resolves the report params:
- * the dashboard leaves `reportParams` out of `attributes`, so it falls back to
- * the date-range URL search params the picker writes to; Storybook injects
- * `attributes.reportParams` directly.
- */
 export default function Authors( { attributes = {} }: AuthorsWidgetProps ) {
 	return (
 		<WidgetRoot attributes={ attributes }>

--- a/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
@@ -57,9 +57,8 @@ const meta = {
 			},
 		},
 	},
-	// The story args are the widget-specific controls, but `component` is the
-	// render component (host `WidgetRenderProps`). Intersect the two so
-	// `component` type-checks against the meta while the controls drive argTypes.
+	// Intersected so `component` type-checks against the meta while the
+	// widget-specific controls still drive argTypes.
 } satisfies Meta< ComponentProps< typeof AuthorsRender > & AuthorsStoryControls >;
 
 export default meta;

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/render.tsx
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/render.tsx
@@ -23,12 +23,6 @@ type AverageItemsPerOrderWidgetProps = WidgetRenderProps< AverageItemsPerOrderRe
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
-/**
- * Thin composition over the widgets-toolkit: WidgetRoot provides the query
- * client, chart theme, and resolved report params; OrderMetricWidget fetches
- * the orders report and renders the avg_items metric with a comparison delta
- * and sparkline.
- */
 export default function AverageItemsPerOrderRender( {
 	attributes = {},
 	setError,

--- a/projects/packages/premium-analytics/widgets/average-order-value/render.tsx
+++ b/projects/packages/premium-analytics/widgets/average-order-value/render.tsx
@@ -20,12 +20,6 @@ type AverageOrderValueWidgetProps = WidgetRenderProps< AverageOrderValueRenderAt
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
-/**
- * Thin composition over the widgets-toolkit: WidgetRoot provides the query
- * client, chart theme, and resolved report params; OrderMetricWidget fetches
- * the orders report and renders the average_order_value metric with a
- * comparison delta and sparkline.
- */
 export default function AverageOrderValueRender( {
 	attributes = {},
 	setError,

--- a/projects/packages/premium-analytics/widgets/clicks/render.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/render.tsx
@@ -248,12 +248,9 @@ function ClicksInner() {
 	const activeRows = isDrillDown ? selectedClick.children ?? [] : rows;
 	const withComparison = isDrillDown ? !! selectedClick?.childrenHaveComparison : hasComparison;
 
-	// The view already falls back to the top list when the selected link is
-	// missing or no longer drillable (no children); clear the stored selection
-	// too once data has settled without a drillable match, so stale state
-	// can't resurface on a later refetch (WOOA7S-1666). In-flight fetches keep
-	// placeholder rows and errors aren't settled data, so a valid selection
-	// survives refetches and transient failures.
+	// Clear the stored selection only once data has settled without a drillable
+	// match, so it can't resurface on a later refetch (WOOA7S-1666) and a valid
+	// selection survives in-flight fetches and transient failures.
 	useEffect( () => {
 		if ( selectedClickLabel && ! isDrillDown && ! isLoading && ! isFetching && ! isError ) {
 			clearSelectedClick();
@@ -281,10 +278,8 @@ function ClicksInner() {
 			<WidgetState
 				isLoading={ isLoading }
 				isFetching={ isFetching }
-				// The Stats queries carry `placeholderData: previousData => previousData`, so a
-				// failed range change keeps the prior period's rows while `isError` flips true.
-				// Only surface the error when there's nothing to show, so a transient refetch
-				// failure doesn't replace populated rows with the error state.
+				// `placeholderData` keeps the prior period's rows on screen while `isError`
+				// flips true, so a transient refetch failure should not replace them.
 				isError={ rows.length === 0 && isError }
 				isEmpty={ activeRows.length === 0 }
 				error={ {

--- a/projects/packages/premium-analytics/widgets/clicks/stories/clicks-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/stories/clicks-widget.stories.tsx
@@ -101,8 +101,8 @@ export const WithComparison: Story = {
  * First load: the fetch is in flight, so the widget shows its loading state. The
  * mock is forced to never resolve for the duration of this story.
  *
- * Forced through `forceStatsMockState`: `stats/clicks` is answered by the legacy
- * stats mocks before the shared `setReportMockState` override can intercept it.
+ * Uses `forceStatsMockState`: the legacy stats mocks answer `stats/clicks`
+ * before `setReportMockState` can intercept it.
  */
 export const Loading: Story = {
 	render: () => renderClicksOnPreset( 'last-90-days' ),

--- a/projects/packages/premium-analytics/widgets/devices/widget.ts
+++ b/projects/packages/premium-analytics/widgets/devices/widget.ts
@@ -8,11 +8,7 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 export type DevicesAttributes = Record< never, never >;
 
 /**
- * Devices widget type definition.
- *
- * Shows screen size breakdown (Desktop / Mobile / Tablet) via the PA proxy
- * at `stats/devices/screensize`. Date range comes from WidgetRoot's
- * reportParams (the shared dashboard date picker).
+ * Screen size breakdown, from the PA proxy at `stats/devices/screensize`.
  */
 export default {
 	icon: mobile,

--- a/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
@@ -41,9 +41,8 @@ jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mo
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 
-// Raw WPCOM fieldless all-time shapes the email breakdown sanitizer reads. Each
-// per-breakdown endpoint returns only its own payload key, mirroring Calypso
-// fetching `link` and `user-content-link` separately and merging.
+// Raw WPCOM fieldless all-time shapes the sanitizer reads. Each endpoint
+// returns only its own payload key, as in Calypso.
 const COUNTRY_RESPONSE = {
 	countries: {
 		data: [
@@ -57,9 +56,8 @@ const COUNTRY_RESPONSE = {
 	},
 };
 
-// `some-other-internal` aggregates into the catch-all row and outranks every other
-// row by value, so the fixture proves that row is pinned last across the merge
-// rather than just landing there.
+// `some-other-internal` aggregates into the catch-all row and outranks every
+// other row, so the fixture proves that row is pinned last, not merely sorted last.
 const INTERNAL_LINKS_RESPONSE = {
 	links: {
 		data: [
@@ -214,9 +212,8 @@ describe( 'EmailBreakdownWidget', () => {
 		const otherRow = screen.getByText( 'Other' );
 		expect( otherRow ).toBeInTheDocument();
 
-		// The catch-all row stays pinned last after the two breakdowns are merged
-		// and re-sorted, even though it holds the highest value. The two nodes sit in
-		// separate rows, so the position mask is exactly PRECEDING or FOLLOWING.
+		// The catch-all row stays pinned last despite holding the highest value.
+		// Separate rows, so the position mask is exactly PRECEDING or FOLLOWING.
 		expect( otherRow.compareDocumentPosition( link ) ).toBe( Node.DOCUMENT_POSITION_PRECEDING );
 
 		// The links view fetches both clicks breakdowns, matching Calypso.
@@ -230,10 +227,8 @@ describe( 'EmailBreakdownWidget', () => {
 	} );
 
 	it( 'shows the error state when one of the two links-view queries fails on first load', async () => {
-		// The `link` breakdown fails (non-retryable 403 so React Query surfaces the
-		// error immediately) while `user-content-link` succeeds. Half a merged list
-		// with no error would silently hide the internal link types, so the widget
-		// must surface the error (with Retry) instead of the incomplete rows.
+		// 403 is non-retryable, so React Query surfaces the error immediately. Half
+		// a merged list with no error would silently hide the internal link types.
 		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
 			path.includes( '/user-content-link' )
 				? Promise.resolve( USER_CONTENT_LINKS_RESPONSE )

--- a/projects/packages/premium-analytics/widgets/email-breakdown/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/render.tsx
@@ -40,15 +40,11 @@ type EmailBreakdownWidgetProps = WidgetRenderProps< EmailBreakdownRenderAttribut
 
 const DATA_FORMAT = { type: 'number' as const, options: { useMultipliers: true, decimals: 0 } };
 
-// Mirrors the 720px container query in `style.module.css`: below it the map
-// is `display: none`, so mounting `GeoChart` there would pay the Google
-// Charts load for a chart that can never be seen. CSS still owns the visual
-// fallback; this width only gates the mount.
+// Mirrors the 720px container query in `style.module.css`, where the map is
+// `display: none`: mounting `GeoChart` below it would pay the Google Charts load
+// for a chart that can never be seen. This gates only the mount, not the visuals.
 const MAP_MIN_WIDTH = 720;
 
-/**
- * Builds the complete country dataset consumed by `GeoChart`.
- */
 function buildEmailGeoData( rows: EmailBreakdownRow[], metric: EmailBreakdownMetric ): GeoData {
 	return [
 		[
@@ -64,13 +60,9 @@ function buildEmailGeoData( rows: EmailBreakdownRow[], metric: EmailBreakdownMet
 }
 
 /**
- * Maps normalized breakdown rows onto the shape `LeaderboardChart` expects.
  * Shares are relative to the highest value in the set so the top row always
  * fills. The breakdown endpoints return no comparison period, so the comparison
  * fields are zeroed and the chart renders without deltas.
- *
- * The `countries` view renders a flag next to each label; the `links` view
- * renders each row as an external link; other views render a plain label.
  */
 function buildLeaderboardData(
 	rows: EmailBreakdownRow[],
@@ -107,10 +99,6 @@ function buildLeaderboardData(
 	} );
 }
 
-/**
- * The per-view empty-state copy shown when the selected email has no data for
- * the active breakdown.
- */
 function emptyStateText( view: EmailBreakdownView ): string {
 	switch ( view ) {
 		case 'devices':
@@ -126,53 +114,24 @@ function emptyStateText( view: EmailBreakdownView ): string {
 }
 
 type EmailBreakdownLeaderboardProps = {
-	/**
-	 * Normalized breakdown rows to render. When omitted, the empty state is shown
-	 * (unless `isLoading` is set).
-	 */
 	rows?: EmailBreakdownRow[];
-	/**
-	 * Complete row set used by the country map. This can contain more entries
-	 * than the capped leaderboard `rows`.
-	 */
+	/** Uncapped row set for the map; can hold more entries than `rows`. */
 	mapRows?: EmailBreakdownRow[];
-	/**
-	 * The active breakdown view; drives the label rendering and empty-state copy.
-	 */
 	view?: EmailBreakdownView;
-	/** Whether to render a map beside the countries leaderboard. */
 	showMap?: boolean;
-	/** Metric label to use for the map values. */
 	metric?: EmailBreakdownMetric;
-	/**
-	 * When `true` and there are no rows yet, the loading state is shown.
-	 */
 	isLoading?: boolean;
 	isFetching?: boolean;
-	/**
-	 * When `true`, the error state is rendered in place of the chart.
-	 */
 	isError?: boolean;
-	/**
-	 * Whether an email is selected; drives the empty-state copy when there are no
-	 * rows (`false` prompts to select an email instead of "no data yet").
-	 */
+	/** `false` prompts to select an email instead of "no data yet". */
 	hasEmail?: boolean;
-	/**
-	 * Invoked by the error state's Retry action to re-run the queries.
-	 */
 	onRetry?: () => void;
 };
 
 /**
- * Presentational leaderboard for the "Email breakdown" widget. Lists a single
- * email's opens (or clicks) broken down by the active view.
- *
- * Takes already-fetched rows and the active view via props and renders the
- * loading, error, empty, and populated states through `WidgetState`. Exported so
- * Storybook can exercise those states with fixture rows (there is no analytics
- * backend in Storybook, so the data-connected entry point would only ever show
- * chrome).
+ * Takes already-fetched rows via props, and is exported, so Storybook can
+ * exercise every state with fixture rows: there is no analytics backend there,
+ * so the data-connected entry point would only ever show chrome.
  */
 export const EmailBreakdownLeaderboard = ( {
 	rows = [],
@@ -253,9 +212,7 @@ type EmailBreakdownReportProps = {
 };
 
 /**
- * Fetches the email breakdown rows for the selected email, view, and metric,
- * then hands them to the presentational `EmailBreakdownLeaderboard`. The email
- * is scoped by the host through `reportParams.post_id` — the shared
+ * The email is scoped by the host through `reportParams.post_id` — the shared
  * single-resource "detail page" param — so the widget needs no id attribute.
  */
 function EmailBreakdownReport( { view, metric, showMap }: EmailBreakdownReportProps ) {
@@ -286,13 +243,8 @@ function EmailBreakdownReport( { view, metric, showMap }: EmailBreakdownReportPr
 }
 
 /**
- * The breakdown is scoped to a single email by the host through
- * `reportParams.post_id` (the shared single-resource "detail page" param); the
- * `view` attribute (`relevance: 'high'`) is exposed as a control by the widget
- * host and the `metric` attribute picks opens or clicks for the dimension views.
  * The endpoints report across the whole lifetime of the email, so the date range
- * and comparison period are ignored — `reportParams` is passed into `WidgetRoot`,
- * which exposes it to the inner report, but only `post_id` is read from it.
+ * and comparison period are ignored: only `post_id` is read from `reportParams`.
  */
 export default function EmailBreakdown( { attributes = {} }: EmailBreakdownWidgetProps ) {
 	const view = attributes.view ?? 'countries';

--- a/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
@@ -11,11 +11,9 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 import { SelectField } from '@jetpack-premium-analytics/fields';
 
 /**
- * Which breakdown dimension the widget lists for the selected email.
- *
- * `countries`, `devices`, and `clients` read the opens or clicks breakdown per
- * the `metric` attribute; `links` always reads the *clicks* breakdown (only
- * clicked links exist). See `use-email-breakdown-rows.ts`.
+ * Which breakdown dimension the widget lists for the selected email. `links`
+ * ignores the `metric` attribute and always reads the clicks breakdown, since
+ * only clicked links exist.
  */
 export type EmailBreakdownView = 'countries' | 'devices' | 'clients' | 'links';
 
@@ -26,40 +24,19 @@ export type EmailBreakdownView = 'countries' | 'devices' | 'clients' | 'links';
 export type EmailBreakdownMetric = 'opens' | 'clicks';
 
 /**
- * Configurable attributes for the Email breakdown widget. Mirrors the
- * `attributes` declared on the widget definition below; the host passes the
- * selected values through to `render.tsx`.
+ * Configurable attributes for the Email breakdown widget.
  */
 export type EmailBreakdownAttributes = {
-	/**
-	 * Which breakdown dimension to display. Defaults to `countries`.
-	 */
 	view?: EmailBreakdownView;
-	/**
-	 * Whether the dimension views show opens or clicks. Defaults to `opens`.
-	 */
 	metric?: EmailBreakdownMetric;
-	/**
-	 * Whether the countries view also renders a world map. Used by the wide
-	 * Location clicks card in the fixed post-detail composition.
-	 */
+	/** Set by the wide Location clicks card in the fixed post-detail composition. */
 	showMap?: boolean;
 };
 
 /**
- * Widget type definition.
- *
- * Ported from the Jetpack Stats email detail "breakdown" modules
- * (`stats-email-module`). That family is one module rendered four times — by
- * country, device, email client, and clicked link — so this ships as a single
- * widget with a `view` selector instead of four near-identical widgets. The
- * attributes stay at the default (low) relevance: the post detail page pins
- * each view as its own fixed, page-titled card, so a header control would
- * fight the composition. The breakdown is
- * scoped to a single email by the host through `reportParams.post_id` (the
- * shared single-resource "detail page" param), not by an attribute; the
- * endpoints report over the whole lifetime of the email, so there is no date
- * range or comparison period.
+ * Ported from the Jetpack Stats "breakdown" modules (`stats-email-module`), one
+ * module rendered four times via the `view` selector; relevance stays low since
+ * the post detail page titles each view, and endpoints are all-time (no date range).
  */
 export default {
 	icon: envelope,

--- a/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
@@ -48,9 +48,8 @@ jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mo
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 
-// An explicit window covering the fixture buckets below: the data layer trims
-// buckets to the requested window, so a default (today-relative) preset would
-// trim these fixed July dates away.
+// The data layer trims buckets to the requested window, so a default
+// (today-relative) preset would trim these fixed July dates away.
 const JULY_WEEK_PARAMS = {
 	...getDefaultQueryParams( false ),
 	preset: undefined,
@@ -58,10 +57,9 @@ const JULY_WEEK_PARAMS = {
 	to: '2026-07-07T23:59:59.999+08:00',
 };
 
-// Raw WPCOM email timeline shape (`stats_fields=timeline`): a matrix nested
-// under `timeline`, one daily row per bucket. 2026-07-04/05 fall in one ISO
-// week (Mon 2026-06-29) and 2026-07-06 opens the next, so weekly grouping
-// collapses the three rows into two buckets (15 and 7).
+// Raw WPCOM `stats_fields=timeline` shape. 2026-07-04/05 fall in one ISO week
+// and 2026-07-06 opens the next, so weekly grouping collapses the three rows
+// into two buckets (15 and 7).
 const OPENS_TIMELINE_RESPONSE = {
 	timeline: {
 		unit: 'day',
@@ -97,8 +95,6 @@ describe( 'EmailTimeSeriesWidget', () => {
 		const chart = await screen.findByTestId( 'metric-tabs-chart' );
 		expect( chart ).toHaveAttribute( 'data-metric-label', 'Total opens' );
 		expect( chart ).toHaveAttribute( 'data-values', '10,5,7' );
-		// The metric headline is the window total, and the chart type
-		// defaults to line.
 		expect( chart ).toHaveAttribute( 'data-metric-total', '22' );
 		expect( chart ).toHaveAttribute( 'data-chart-type', 'line' );
 
@@ -168,10 +164,9 @@ describe( 'EmailTimeSeriesWidget', () => {
 	} );
 
 	it( 'draws exactly the selected hourly window from a midnight-anchored payload', async () => {
-		// The endpoint anchors hourly buckets on the start day's midnight and
-		// returns `quantity` buckets forward, so a last-24-hours window (09:00
-		// → 08:59 next day) is served as 33 buckets from hour 0. The widget
-		// must chart and sum only the 24 in-window hours.
+		// The endpoint anchors hourly buckets on the start day's midnight and returns
+		// `quantity` buckets forward, so a last-24-hours window arrives as 33 buckets
+		// from hour 0 and the widget must chart only the 24 in-window ones.
 		mockApiFetch.mockResolvedValue( {
 			timeline: {
 				unit: 'hour',
@@ -226,10 +221,9 @@ describe( 'EmailTimeSeriesWidget', () => {
 						preset: undefined,
 						from: '2026-07-01T00:00:00.000+08:00',
 						to: '2026-07-07T23:59:59.999+08:00',
-						// Comparison params pass through the post detail URL untouched
-						// (dashboard state survives the round trip), so a widget
-						// receiving them must neither fetch a second window nor draw
-						// an overlay — the page renders no comparison.
+						// The post detail URL carries comparison params through untouched,
+						// but the page renders no comparison, so the widget must neither
+						// fetch a second window nor draw an overlay.
 						comp: '1',
 						compare_from: '2026-06-24T00:00:00.000+08:00',
 						compare_to: '2026-06-30T23:59:59.999+08:00',
@@ -244,7 +238,6 @@ describe( 'EmailTimeSeriesWidget', () => {
 		expect( chart ).toHaveAttribute( 'data-metric-count', '1' );
 		expect( chart ).toHaveAttribute( 'data-values', '10,5,7' );
 
-		// One request, scoped to the primary window only.
 		const requestedDates = mockApiFetch.mock.calls.map( call =>
 			new URLSearchParams( String( call[ 0 ].path ).split( '?' )[ 1 ] ).get( 'date' )
 		);

--- a/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
@@ -62,14 +62,9 @@ type EmailTimeSeriesReportProps = {
 };
 
 /**
- * Fetches the selected email's opens or clicks timeline over the dashboard
- * date range and draws it with the window total as the metric headline. The
- * endpoint reports hourly or daily buckets; weekly/monthly intervals
- * aggregate the daily ones client-side. Only the active metric's query runs.
- * The post detail design
- * has no period-over-period comparison, so comparison report params are
- * ignored — they ride along in the URL untouched so dashboard state survives
- * the round trip, and every widget on this page disregards them.
+ * Draws the selected email's opens or clicks timeline. Comparison report
+ * params are ignored (no period-over-period here) but left in the URL so
+ * dashboard state survives the round trip.
  */
 function EmailTimeSeriesReport( { metric, chartType }: EmailTimeSeriesReportProps ) {
 	const { reportParams } = useWidgetRootContext();
@@ -111,10 +106,8 @@ function EmailTimeSeriesReport( { metric, chartType }: EmailTimeSeriesReportProp
 		} );
 	}, [ report, period, field ] );
 
-	// One metric: the headline is the window total (the timeline is summed per
-	// bucket, so the sum of buckets is the range's opens/clicks). Point dates are
-	// wall clocks, read back via `pointsAreWallClocks` (rationale in
-	// `chart-date.ts`).
+	// The headline is the window total: buckets are per-period sums, so their sum
+	// is the range's opens/clicks. Point dates are wall clocks — see `chart-date.ts`.
 	const metricTabs = useMemo< MetricTab[] >( () => {
 		const points = ( chartReport?.data ?? [] ).map( point => ( {
 			date: toChartDate( point.date_start ),

--- a/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
@@ -1,15 +1,7 @@
 /**
- * The stories mount the data-connected "Email performance" widget; a mocked
- * `stats/opens|clicks/emails/{id}?stats_fields=timeline` response from
- * `registerReportMocks` supplies daily buckets spanning the requested window.
- * `WidgetDashboardWithWidget` mounts the real dashboard so it renders exactly
- * as it does in product.
- *
- * The timeline is scoped to a single email via a mocked `reportParams.post_id`.
- * The post detail design has no period-over-period comparison, so the widget
- * maps no comparison rows; the dashboard story still passes comparison params
- * so the widget stays covered against crashing or inventing an overlay when a
- * host supplies them.
+ * The post detail design has no period-over-period comparison, so the widget maps
+ * no comparison rows; the dashboard story still passes comparison params so the
+ * widget stays covered against inventing an overlay when a host supplies them.
  */
 /**
  * External dependencies
@@ -55,10 +47,6 @@ const MOCK_EMAIL_ID = 1234;
 const METRIC_OPTIONS: EmailTimeSeriesMetric[] = [ 'opens', 'clicks' ];
 const INTERVAL_OPTIONS: StatsChartBucketPeriod[] = [ 'day', 'week', 'month' ];
 
-/**
- * Widget-specific controls: the opens/clicks metric and the page's chart
- * interval, which the widget buckets its daily timeline into.
- */
 interface EmailTimeSeriesStoryControls {
 	metric: EmailTimeSeriesMetric;
 	interval: StatsChartBucketPeriod;
@@ -66,8 +54,8 @@ interface EmailTimeSeriesStoryControls {
 }
 
 /**
- * Builds the widget attributes. Comparison stays a parameter so the dashboard
- * story can pass host comparison params without duplicating the scoping rule.
+ * Comparison stays a parameter so the dashboard story can pass host comparison
+ * params without duplicating the scoping rule.
  */
 function getEmailTimeSeriesAttributes(
 	{ metric, interval, chartType }: EmailTimeSeriesStoryControls,

--- a/projects/packages/premium-analytics/widgets/email-time-series/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-time-series/widget.ts
@@ -28,26 +28,17 @@ export type EmailTimeSeriesChartType = ChartDisplayChartType;
  */
 export type EmailTimeSeriesAttributes = {
 	/**
-	 * Which timeline to draw: opens (default) or clicks. The post detail page
-	 * pins one per email tab through the tab layout, so this is not a
-	 * user-facing control — exposing it would let a pinned tab contradict its
-	 * own title.
+	 * Not a user-facing control: the post detail page pins one per email tab, and
+	 * exposing it would let a pinned tab contradict its own title.
 	 */
 	metric?: EmailTimeSeriesMetric;
-	/**
-	 * How to draw the timeline (`relevance: 'high'`). Defaults to `line`.
-	 */
 	chartType?: EmailTimeSeriesChartType;
 };
 
 /**
- * Widget type definition.
- *
- * The opens/clicks-over-time chart from the legacy email detail page
- * (`stats-email-chart-tabs`), with the window total as the metric headline.
- * The email is scoped by the host through `reportParams.post_id` (the shared
- * single-resource "detail page" param); the timeline spans the dashboard
- * date range and is bucketed at the page's chart interval.
+ * Ported from the legacy email detail page's opens/clicks-over-time chart
+ * (`stats-email-chart-tabs`). The host scopes the email through
+ * `reportParams.post_id`.
  */
 export default {
 	icon: envelope,

--- a/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
@@ -28,9 +28,8 @@ import { type EmailMetric, type EmailTopRowAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
-// Report params are dashboard-driven, but this widget reads the all-time per-post
-// rate breakdown and ignores the date range. The host (and Storybook) may still
-// inject them via `attributes`, so accept them here.
+// The all-time per-post rate breakdown ignores the date range, but the host may
+// still inject report params via `attributes`, so accept them here.
 type EmailTopRowRenderAttributes = EmailTopRowAttributes & Partial< ReportParamsFieldAttributes >;
 type EmailTopRowWidgetProps = WidgetRenderProps< EmailTopRowRenderAttributes >;
 
@@ -50,46 +49,29 @@ const RATE_FORMAT: DataFormat = {
 };
 
 /**
- * One row of the metric table below: everything that describes a top-row tile —
- * its summary key, icon, label, whether it is a count or a rate, and which
- * view(s) it belongs to. The tiles and the "does this summary carry email
- * metrics" check both derive from the same table, so they cannot drift.
+ * The tiles and the "does this summary carry email metrics" check both derive
+ * from this shape, so they cannot drift.
  */
 type EmailMetricSpec = {
-	/**
-	 * The scalar key on the rate summary, also used as the tile's stable key.
-	 */
+	/** Scalar key on the rate summary, also the tile's stable key. */
 	key: string;
-	/**
-	 * Icon shown alongside the label.
-	 */
 	icon: TileIcon;
-	/**
-	 * Builds the translated label (deferred so it runs at render time).
-	 */
+	/** Deferred so the translation runs at render time. */
 	label: () => string;
 	/**
 	 * Counts are read with a zero default; rates pass through 0–1 fractions and
 	 * collapse missing/zero to `null` for the placeholder.
 	 */
 	kind: 'count' | 'rate';
-	/**
-	 * Which view(s) show this tile, in table order.
-	 */
 	views: readonly EmailMetric[];
-	/**
-	 * Skip the tile when its count is zero (upstream hides Unique opens then).
-	 */
+	/** Upstream hides Unique opens when its count is zero. */
 	hideWhenZero?: boolean;
 };
 
 /**
- * The single source of truth for the top-row tiles, in display order. Mirrors
- * the post-detail design: the Opens view shows emails sent, unique opens,
- * total opens, and open rate; the Clicks view shows total opens, total
- * clicks, and click rate. Total opens comes from the opens rate summary, so
- * the Clicks composition merges the opens and clicks rate summaries before it
- * reaches this table.
+ * The top-row tiles, in display order. Total opens comes from the opens rate
+ * summary, so the Clicks composition merges the opens and clicks rate summaries
+ * before they reach this table.
  */
 const EMAIL_METRICS: readonly EmailMetricSpec[] = [
 	{
@@ -137,37 +119,18 @@ const EMAIL_METRICS: readonly EmailMetricSpec[] = [
 	},
 ];
 
-/**
- * A single top-row tile: an icon, a label, and the formatted metric value.
- */
 export type EmailTopRowMetric = {
-	/**
-	 * Stable key for the tile.
-	 */
 	key: string;
-	/**
-	 * Icon shown alongside the label.
-	 */
 	icon: TileIcon;
-	/**
-	 * Label shown next to the icon (e.g. "Total opens").
-	 */
 	label: string;
 	/**
-	 * The value to render. Counts are integers; rates are fractions (0–1). `null`
-	 * marks a rate the email doesn't have yet, rendered as a placeholder.
+	 * Counts are integers; rates are fractions (0–1). `null` marks a rate the
+	 * email doesn't have yet, rendered as a placeholder.
 	 */
 	value: number | null;
-	/**
-	 * How to format the value.
-	 */
 	dataFormat: DataFormat;
 };
 
-/**
- * Reads a count field off a rate summary, defaulting a missing or non-numeric
- * value to 0.
- */
 function readCount( summary: EmailRateSummary, key: string ): number {
 	const value = Number( summary[ key ] );
 
@@ -175,13 +138,9 @@ function readCount( summary: EmailRateSummary, key: string ): number {
 }
 
 /**
- * Reads a rate field off a rate summary. The endpoint returns rates as 0–1
- * fractions — wp-calypso's `stats-email-top-row/index.jsx` renders
- * `Math.round( counts.opens_rate * 100 )}%` — which is exactly what the
- * percentage formatter takes, so the value passes through. Returns `null` for
- * a missing or zero rate so the tile renders the grid's placeholder ("—")
- * instead of "0%", mirroring the Jetpack Stats top row (a truthy check there
- * turns 0 into "-").
+ * The endpoint returns rates as 0–1 fractions, which the percentage formatter
+ * takes as-is. A missing or zero rate returns `null` so the tile renders the
+ * grid's placeholder instead of "0%", mirroring the Jetpack Stats top row.
  */
 function readRate( summary: EmailRateSummary, key: string ): number | null {
 	const value = Number( summary[ key ] );
@@ -190,9 +149,8 @@ function readRate( summary: EmailRateSummary, key: string ): number | null {
 }
 
 /**
- * Whether a rate summary carries any of the email metric fields. Distinguishes a
- * real (possibly all-zero) email from an empty response for a post that has no
- * stats, so the widget can show its empty state rather than a row of zeros.
+ * Distinguishes a real (possibly all-zero) email from an empty response, so the
+ * widget shows its empty state rather than a row of zeros.
  */
 export function hasEmailMetrics( summary: EmailRateSummary | undefined ): boolean {
 	return (
@@ -205,10 +163,6 @@ export function hasEmailMetrics( summary: EmailRateSummary | undefined ): boolea
 	);
 }
 
-/**
- * Maps a per-post rate summary onto the ordered top-row tiles for the active
- * view, straight from the `EMAIL_METRICS` table.
- */
 export function toEmailTopRowMetrics(
 	summary: EmailRateSummary,
 	metric: EmailMetric
@@ -240,48 +194,28 @@ export function toEmailTopRowMetrics(
 }
 
 /**
- * How many tiles a view shows, read from the same table. The view is known
- * before the rate summaries are, so this is the count the loading shape can
- * draw; `hideWhenZero` may still drop one once the data lands.
+ * The view is known before the summaries are, so this is the count the loading
+ * shape can draw; `hideWhenZero` may still drop one once the data lands.
  */
 function countEmailTopRowTiles( metric: EmailMetric ): number {
 	return EMAIL_METRICS.filter( spec => spec.views.includes( metric ) ).length;
 }
 
 type EmailTopRowTilesProps = {
-	/**
-	 * The ordered metric tiles to render. When omitted, the empty state is shown
-	 * (unless the widget is loading or in error).
-	 */
 	metrics?: EmailTopRowMetric[];
-	/**
-	 * Tiles the active view will show, so the loading shape draws the row that is
-	 * coming. The view lives in the report above, not here, and `metrics` is
-	 * `undefined` until the request resolves.
-	 */
+	/** Tiles the active view will show, so the loading shape draws the row coming. */
 	tileCount?: number;
-	/**
-	 * Whether an email is selected. Drives the empty-state message: a prompt to
-	 * select an email when `false`, or a "no stats yet" message when `true`.
-	 */
+	/** `false` prompts to select an email instead of "no stats yet". */
 	hasSelection?: boolean;
 	isLoading?: boolean;
 	isFetching?: boolean;
-	/**
-	 * Whether the request failed — shows the error state.
-	 */
 	isError?: boolean;
-	/**
-	 * Re-runs the request from the error state's Retry action.
-	 */
 	onRetry?: () => void;
 };
 
 /**
- * Presentational top row for the "Email top row" widget. Renders the selected
- * email's headline totals as bordered metric tiles and delegates the loading,
- * error, and empty states to `<WidgetState>`. The rate breakdowns have no
- * comparison period, so each tile shows a bare formatted value with no delta.
+ * The rate breakdowns have no comparison period, so each tile shows a bare
+ * formatted value with no delta.
  */
 const EmailTopRowTiles = ( {
 	metrics,
@@ -325,21 +259,13 @@ const EmailTopRowTiles = ( {
 };
 
 type EmailTopRowReportProps = {
-	/**
-	 * Which view's metrics to fetch and show.
-	 */
 	metric: EmailMetric;
 };
 
 /**
- * Fetches the selected email's all-time rate breakdowns for the active view and
- * hands their metrics to `EmailTopRowTiles`. The email is scoped by the host
- * through `reportParams.post_id` — the shared single-resource "detail page"
- * param — so the widget needs no id attribute of its own. The Opens and Clicks
- * view always reads the opens rate endpoint. The Clicks view reads both rate
- * endpoints: total opens comes from the opens response, while total clicks and
- * click rate come from the clicks response. React Query shares the opens
- * result with the Opens tab, so visiting both tabs does not duplicate it.
+ * The email is scoped by the host through `reportParams.post_id` — the shared
+ * single-resource "detail page" param. Both views read the opens rate endpoint,
+ * and React Query shares that result, so visiting both tabs fetches it once.
  */
 function EmailTopRowReport( { metric }: EmailTopRowReportProps ) {
 	const { reportParams } = useWidgetRootContext();
@@ -385,23 +311,14 @@ function EmailTopRowReport( { metric }: EmailTopRowReportProps ) {
 			hasSelection={ hasSelection }
 			isLoading={ activeQueries.some( query => query.isLoading ) }
 			isFetching={ activeQueries.some( query => query.isFetching ) }
-			// Queries keep prior data via `placeholderData`, so a transient refetch
-			// failure keeps complete tiles visible. A first-load failure in either
-			// required response must not silently render a partial Clicks row.
+			// `placeholderData` keeps complete tiles visible through a transient refetch
+			// failure; a first-load failure must not render a partial Clicks row.
 			isError={ activeQueries.some( query => query.isError && query.data === undefined ) }
 			onRetry={ retryActiveQueries }
 		/>
 	);
 }
 
-/**
- * The email is selected by the host through `reportParams.post_id` (the shared
- * single-resource "detail page" scope) and the view by the `metric` attribute
- * (defaulting to Opens). Host attributes (including `reportParams`) are passed
- * through to `<WidgetRoot>`, which exposes `reportParams` to the inner report;
- * the all-time rate breakdown ignores the date range but reads the single-email
- * scope from `post_id`.
- */
 export default function EmailTopRow( { attributes = {} }: EmailTopRowWidgetProps ) {
 	const metric: EmailMetric = attributes.metric === 'clicks' ? 'clicks' : 'opens';
 

--- a/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
@@ -1,15 +1,7 @@
 /**
- * The close-up stories render the data-connected widget against a mocked per-post
- * `stats/<opens|clicks>/emails/<postId>/rate` response so the tiles populate without a
- * backend. `WidgetDashboardWithWidget` mounts the real dashboard with the same
- * widget.
- *
- * The widget is scoped to a single email by the host through
- * `reportParams.post_id` and to one view by the `metric` attribute (Opens or Clicks).
- *
- * The Loading / Error / Empty stories force the mock into that state with
- * `setReportMockState`; each uses a distinct `post_id` so its request has its own
- * query key and hits the override fresh rather than reading a sibling's cache.
+ * The Loading / Error / Empty stories force the mock state with
+ * `setReportMockState`; each uses a distinct `post_id` so its request has its
+ * own query key and hits the override fresh rather than a sibling's cache.
  */
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/widgets/emails/render.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/render.tsx
@@ -123,9 +123,8 @@ function EmailsReport( { attributes }: EmailsReportProps ) {
 				<WidgetState
 					isLoading={ isLoading }
 					isFetching={ isFetching }
-					// The query keeps the prior response via `placeholderData`, so a failed
-					// refetch leaves rows on screen; only surface the error when there is
-					// nothing to show.
+					// `placeholderData` keeps the prior rows on screen, so a transient
+					// refetch failure should not replace them with an error.
 					isError={ rows.length === 0 && isError }
 					isEmpty={ rows.length === 0 }
 					error={ {

--- a/projects/packages/premium-analytics/widgets/emails/widget.ts
+++ b/projects/packages/premium-analytics/widgets/emails/widget.ts
@@ -22,20 +22,13 @@ export type EmailMetric = 'opens' | 'clicks';
  * through to `render.tsx`.
  */
 export type EmailsAttributes = {
-	/**
-	 * Which rate to display. Defaults to `opens`.
-	 */
 	metric?: EmailMetric;
 };
 
 /**
- * Widget type definition.
- *
- * Ported from the Jetpack Stats "Emails" module. Lists the most recently sent
- * emails with their open and click rates. The displayed rate is the `metric`
- * attribute (`relevance: 'high'`), so the widget host renders its control.
- * The summary endpoint reports across the whole lifetime of the site, so
- * there is no date range or comparison period.
+ * Ported from the Jetpack Stats "Emails" module. The summary endpoint reports
+ * across the whole lifetime of the site, so there is no date range or
+ * comparison period.
  */
 export default {
 	icon: envelope,

--- a/projects/packages/premium-analytics/widgets/file-downloads/render.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/render.tsx
@@ -109,23 +109,13 @@ function toFileDownloadRows( items: StatsFileDownloadsComparisonItem[] ): FileDo
 }
 
 export type FileDownloadsLeaderboardProps = {
-	/**
-	 * Normalized download rows to render.
-	 */
 	rows?: FileDownloadRow[];
-	/**
-	 * When true, render previous-period deltas.
-	 */
 	withComparison?: boolean;
 };
 
 /**
- * Presentational leaderboard for the "File downloads" widget.
- *
- * Accepts already-fetched rows and renders only the populated (ready) state —
- * loading, error, and empty are handled by `<WidgetState>` in the
- * data-connected inner component. Exported so Storybook can render fixture
- * rows without needing a live WordPress backend.
+ * Renders only the populated state — the data-connected inner component owns the
+ * rest. Exported so Storybook can render fixture rows without a live backend.
  */
 export function FileDownloadsLeaderboard( {
 	rows = [],
@@ -159,9 +149,8 @@ function FileDownloadsInner() {
 				<WidgetState
 					isLoading={ isLoading }
 					isFetching={ isFetching }
-					// The Stats queries carry `placeholderData`, so a failed range change
-					// keeps the prior period's rows visible; only surface the error when
-					// there is nothing to show.
+					// `placeholderData` keeps the prior period's rows on screen, so a
+					// transient refetch failure should not replace them with an error.
 					isError={ rows.length === 0 && isError }
 					isEmpty={ rows.length === 0 }
 					error={ {

--- a/projects/packages/premium-analytics/widgets/file-downloads/widget.ts
+++ b/projects/packages/premium-analytics/widgets/file-downloads/widget.ts
@@ -8,11 +8,7 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 export type FileDownloadsAttributes = Record< never, never >;
 
 /**
- * File downloads widget type definition.
- *
- * Shows the most-downloaded files for the period via the PA proxy at
- * `stats/file-downloads`. Date range comes from WidgetRoot's reportParams
- * (the shared dashboard date picker).
+ * Reads the PA proxy at `stats/file-downloads`.
  */
 export default {
 	icon: download,

--- a/projects/packages/premium-analytics/widgets/latest-post/render.tsx
+++ b/projects/packages/premium-analytics/widgets/latest-post/render.tsx
@@ -27,10 +27,6 @@ type LatestPostRenderAttributes = LatestPostAttributes & Partial< ReportParamsFi
 type LatestPostWidgetProps = WidgetRenderProps< LatestPostRenderAttributes >;
 
 /**
- * Fetches the site's latest post (with its metrics) through `useLatestPost` and
- * hands it to the shared `PostHighlightCard`, with loading, error, and empty
- * states handled by `<WidgetState>`.
- *
  * Every tile is a lifetime total, so no tile carries an aggregation note.
  */
 function LatestPostReport() {

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -60,11 +60,8 @@ type GoogleChartsWindow = Window & {
 };
 
 const MISSING_MAP_ERROR_MESSAGE = 'Requested map does not exist';
-// Google GeoChart has no `provinces` map file for some countries (e.g. TW, SG).
-// There is no upstream list of them; each is learned at runtime when its
-// provinces draw fails, via the GeoChart `onError` callback. This module-level
-// cache carries what was learned across widget remounts, so within one page
-// load each country pays the failed draw (a brief error flash) at most once.
+// Google GeoChart has no `provinces` map for some countries (e.g. TW, SG) and no
+// upstream list exists, so each is learned on a failed draw and cached across remounts.
 const runtimeUnsupportedProvinceMapCountries = new Set< string >();
 
 type GeoGranularity = NonNullable< LocationsAttributes[ 'geoGranularity' ] >;
@@ -137,9 +134,8 @@ function LocationsInner( { geoGranularity }: LocationsInnerProps ) {
 		resetDrillDown: clearSelectedCountry,
 	} = useWidgetDrillDown< DrillDownCountry >();
 
-	// The "View by" control lives in the widget host header (the
-	// `relevance: 'high'` attribute). Only Countries mode drills down, so leaving
-	// the other modes would strand a selected country the user can't clear.
+	// Only Countries mode drills down, so leaving it would strand a selected
+	// country the user can no longer clear.
 	useEffect( () => {
 		if ( geoGranularity !== 'country' ) {
 			clearSelectedCountry();
@@ -165,9 +161,8 @@ function LocationsInner( { geoGranularity }: LocationsInnerProps ) {
 	const useCountryFallbackMap =
 		geoMode === 'region' && !! activeSelectedCountry && ! useProvinceMap;
 	const fallbackCountry = useCountryFallbackMap ? activeSelectedCountry : undefined;
-	// Cities, and Regions outside a country drill-down, span the whole world.
-	// Google GeoChart can't place either row type on the world map, so both are
-	// summed back up to their country.
+	// Google GeoChart can't place city or region rows on the world map, so both
+	// are summed back up to their country.
 	const useCountrySummaryMap =
 		geoMode === 'city' || ( geoMode === 'region' && ! activeSelectedCountry );
 	const countrySummaryRows = useMemo( () => {
@@ -192,13 +187,9 @@ function LocationsInner( { geoGranularity }: LocationsInnerProps ) {
 	const handleGeoChartError = useCallback(
 		( error: GeoChartError ) => {
 			const message = `${ error.message ?? '' } ${ error.detailedMessage ?? '' }`;
-			// Any error during a provinces draw means this country's map is unusable —
-			// fall back regardless of the message text, which Google may localize.
-			// Stragglers from that failed draw keep arriving after the widget already
-			// switched to the fallback map (resize and drill-down layout shifts each
-			// redraw), so a selected country already learned as unsupported also
-			// qualifies without depending on the message. The English message match
-			// stays only as a last resort for errors arriving outside those states.
+			// Fall back on any error during a provinces draw — the message text may be
+			// localized, and late stragglers after a switch still hit an already-known
+			// country, so the English match alone only catches the first-time case.
 			const isProvinceDrawError = !! selectedCountryCode && useProvinceMap;
 			const isKnownUnsupportedProvinceDraw =
 				!! selectedCountryCode && runtimeUnsupportedProvinceMapCountries.has( selectedCountryCode );
@@ -211,9 +202,8 @@ function LocationsInner( { geoGranularity }: LocationsInnerProps ) {
 				return;
 			}
 
-			// Clear the error element Google injected into the chart container; the
-			// fallback redraw replaces the failed map, but the error element would
-			// otherwise linger above it.
+			// The fallback redraw replaces the failed map, but the error element
+			// Google injected would otherwise linger above it.
 			if ( error.id && typeof window !== 'undefined' ) {
 				( window as GoogleChartsWindow ).google?.visualization?.errors?.removeError?.( error.id );
 			}
@@ -427,9 +417,8 @@ function LocationsInner( { geoGranularity }: LocationsInnerProps ) {
  * Jetpack Stats Locations module.
  */
 export default function Locations( { attributes = {} }: LocationsWidgetProps ) {
-	// Attributes are persisted, so a stale layout can carry a granularity this
-	// widget no longer knows. Normalize once, before it becomes both the endpoint
-	// path segment and the report tab.
+	// A persisted layout can carry a granularity this widget no longer knows, and
+	// it becomes both an endpoint path segment and a report tab.
 	const storedGranularity = attributes?.geoGranularity ?? DEFAULT_GEO_GRANULARITY;
 	// `in` would also accept inherited keys such as `toString`, which would then
 	// reach the endpoint as a path segment.

--- a/projects/packages/premium-analytics/widgets/locations/use-location-views.ts
+++ b/projects/packages/premium-analytics/widgets/locations/use-location-views.ts
@@ -102,10 +102,8 @@ export default function useLocationViews( {
 		isLoading,
 		isFetching,
 		hasData,
-		// The Stats queries carry `placeholderData: previousData => previousData`, so a
-		// failed range change keeps the prior period's rows in `data` while `isError`
-		// flips true. Only surface the error when there's nothing to show, so a transient
-		// refetch failure doesn't replace populated rows with the error state.
+		// `placeholderData` keeps the prior period's rows in `data` while `isError`
+		// flips true, so a transient refetch failure should not replace them.
 		isError: items.length === 0 && isError,
 		refetch,
 	};

--- a/projects/packages/premium-analytics/widgets/locations/widget.ts
+++ b/projects/packages/premium-analytics/widgets/locations/widget.ts
@@ -15,20 +15,9 @@ export type LocationsAttributes = {
 };
 
 /**
- * Widget type definition.
- *
- * Ported from the Jetpack Stats "Locations" module. Countries, Regions, and
- * Cities modes all read the `location-views/{geoMode}` endpoint; Countries mode
- * additionally drills down into one country's regions. Region and city rows are
- * listed in the leaderboard and summarized on the map by country.
- *
- * Data: fetched via the PA proxy at `stats/location-views/{country|region|city}`.
- * Date range comes from WidgetRoot's reportParams (the shared dashboard date
- * picker).
- *
- * Known limitation: Google GeoChart `provinces` resolution is unavailable for
- * some countries/territories; unsupported region maps fall back at runtime to
- * highlighting the country on the world map.
+ * Ported from the Jetpack Stats "Locations" module (`stats/location-views/
+ * {country|region|city}` via the PA proxy). GeoChart `provinces` resolution is
+ * unavailable for some countries, so those fall back to the country-level world map.
  */
 export default {
 	icon: mapMarker,

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/render.tsx
@@ -34,9 +34,8 @@ type MostCommentedAuthorsWidgetProps = WidgetRenderProps< MostCommentedAuthorsRe
 const DATA_FORMAT = { type: 'number' as const, options: { useMultipliers: true, decimals: 0 } };
 
 /**
- * Top commented authors inner component. The comment counts come from the
- * all-time `stats/comments` report, so there is no date range or comparison
- * period to read from context.
+ * Counts come from the all-time `stats/comments` report, so there is no date
+ * range or comparison period to read from context.
  */
 function MostCommentedAuthorsInner() {
 	const { rows, isLoading, isFetching, isError, error, refetch } = useStatsCommentsRows( {
@@ -106,10 +105,6 @@ function MostCommentedAuthorsInner() {
 }
 
 /**
- * Top commented authors widget: the people who comment the most on the site,
- * ranked by comment count. Each row links to the comment management screen
- * filtered to that author when the report reports an email for them.
- *
  * One half of the Jetpack Stats "Comments" module; `jpa/most-commented-posts`
  * covers the other. Both read the same `stats/comments` response through
  * `useStatsCommentsRows`, so showing both costs a single request.

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/widget.ts
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/widget.ts
@@ -8,14 +8,8 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 export type MostCommentedAuthorsAttributes = Record< never, never >;
 
 /**
- * Widget type definition for the Top commented authors widget.
- *
- * One half of the Jetpack Stats "Comments" module: the site's most active
- * commenters, ranked by comment count. The other half ships as
- * `jpa/most-commented-posts`.
- *
- * Data: fetched via the PA proxy at `stats/comments` through
- * `useStatsCommentsRows`. The endpoint is all-time and has no comparison
+ * One half of the Jetpack Stats "Comments" module; the other ships as
+ * `jpa/most-commented-posts`. `stats/comments` is all-time with no comparison
  * period, so the widget ignores the dashboard date range.
  */
 export default {

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/render.tsx
@@ -34,9 +34,8 @@ type MostCommentedPostsWidgetProps = WidgetRenderProps< MostCommentedPostsRender
 const DATA_FORMAT = { type: 'number' as const, options: { useMultipliers: true, decimals: 0 } };
 
 /**
- * Top commented posts inner component. The comment counts come from the
- * all-time `stats/comments` report, so there is no date range or comparison
- * period to read from context.
+ * Counts come from the all-time `stats/comments` report, so there is no date
+ * range or comparison period to read from context.
  */
 function MostCommentedPostsInner() {
 	const { rows, isLoading, isFetching, isError, error, refetch } = useStatsCommentsRows( {
@@ -99,10 +98,6 @@ function MostCommentedPostsInner() {
 }
 
 /**
- * Top commented posts widget: the posts and pages that receive the most
- * comments, ranked by comment count. Each row opens the post detail page, and
- * falls back to the published post when the report carries no post ID.
- *
  * One half of the Jetpack Stats "Comments" module; `jpa/most-commented-authors`
  * covers the other. Both read the same `stats/comments` response through
  * `useStatsCommentsRows`, so showing both costs a single request.

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/widget.ts
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/widget.ts
@@ -8,14 +8,8 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 export type MostCommentedPostsAttributes = Record< never, never >;
 
 /**
- * Widget type definition for the Top commented posts widget.
- *
- * One half of the Jetpack Stats "Comments" module: the posts and pages that
- * receive the most comments. The other half ships as
- * `jpa/most-commented-authors`.
- *
- * Data: fetched via the PA proxy at `stats/comments` through
- * `useStatsCommentsRows`. The endpoint is all-time and has no comparison
+ * One half of the Jetpack Stats "Comments" module; the other ships as
+ * `jpa/most-commented-authors`. `stats/comments` is all-time with no comparison
  * period, so the widget ignores the dashboard date range.
  */
 export default {

--- a/projects/packages/premium-analytics/widgets/most-popular-day/__tests__/most-popular-day.test.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/__tests__/most-popular-day.test.tsx
@@ -71,9 +71,8 @@ describe( 'MostPopularDayWidget', () => {
 	} );
 
 	it( 'ignores the report params the host injects', async () => {
-		// The pitfall this guards is the opposite of the usual one: the card is
-		// all-time, so host report params must reach WidgetRoot (the contract) and
-		// still leave both the request and the figures untouched.
+		// The card is all-time, so host report params must reach WidgetRoot (the
+		// contract) and still leave both the request and the figures untouched.
 		render(
 			<MostPopularDayWidget attributes={ { reportParams: getDefaultQueryParams( true ) } } />
 		);
@@ -146,10 +145,9 @@ describe( 'MostPopularDayWidget', () => {
 
 		await expect( screen.findByText( 'October 17' ) ).resolves.toBeInTheDocument();
 
-		// `placeholderData` keeps the prior response, so a transient failure must
-		// not replace figures that are still on screen with an error. Awaited on
-		// the refetch itself: "October 17" is already mounted, so asserting it
-		// without waiting would pass before the rejection could land.
+		// `placeholderData` keeps the prior response, so a transient failure must not
+		// replace figures still on screen. Awaited on the refetch itself: "October 17"
+		// is already mounted, so asserting it would pass before the rejection lands.
 		mockApiFetch.mockRejectedValue( { status: 403, code: 'no_connection' } );
 		await queryClient.refetchQueries( { queryKey: [ 'stats', 'site' ] } );
 		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalledTimes( 2 ) );

--- a/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
@@ -22,26 +22,17 @@ import type { MostPopularDayAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ReactNode } from 'react';
 
-// Report params are dashboard-driven — WidgetRoot resolves them from the date
-// picker — but this highlight is site-wide and ignores them. The host (and
-// Storybook) may still inject them via `attributes`, so accept them here.
+// The highlight is site-wide and ignores report params, but the host may still
+// inject them via `attributes`, so the shape has to accept them.
 type MostPopularDayRenderAttributes = MostPopularDayAttributes &
 	Partial< ReportParamsFieldAttributes >;
 type MostPopularDayWidgetProps = WidgetRenderProps< MostPopularDayRenderAttributes >;
 
 type MostPopularDayHighlightProps = {
-	/**
-	 * The all-time best day for views.
-	 */
+	/** The all-time best day for views. */
 	date: Date;
-	/**
-	 * The number of views recorded on `date`.
-	 */
 	views: number;
-	/**
-	 * The share of all-time views that fall on `date`, as a fraction (0–1), or
-	 * `undefined` when the summary carries no all-time total to divide by.
-	 */
+	/** Fraction (0–1) of all-time views, or `undefined` with no all-time total. */
 	share?: number;
 };
 
@@ -59,9 +50,8 @@ type MostPopularDayFieldProps = {
  */
 const MostPopularDayField = ( { label, value, valueTitle, caption }: MostPopularDayFieldProps ) => (
 	<Stack direction="column" gap="xs">
-		{ /* Heading, matching the Most popular time card this one sits beside: the
-		     labels carry the card's structure, so they should read as structure to
-		     a screen reader too. */ }
+		{ /* A heading, like the Most popular time card beside it: the labels carry
+		     the card's structure, so screen readers should hear it as structure. */ }
 		<Text variant="heading-md" render={ <h4 /> }>
 			{ label }
 		</Text>
@@ -77,16 +67,13 @@ const MostPopularDayField = ( { label, value, valueTitle, caption }: MostPopular
 );
 
 // `decimals: 0` would round 102,631 to "103K"; the design's headline keeps the
-// digit ("102.6K"). Below the first multiplier that digit is only ever ".0", so
-// the count renders whole there — the same split Total views makes.
+// digit ("102.6K"). Below the first multiplier it is always ".0", so use plain there.
 const ABBREVIATED_COUNT_OPTIONS = { useMultipliers: true, decimals: 1 };
 const PLAIN_COUNT_OPTIONS = { decimals: 0 };
 
 /**
- * Presentational body for the "Most popular day" widget: the all-time best day
- * for views and how many views it drew. Loading / error / empty are handled by
- * `<WidgetState>` in the report component, so this only renders the populated
- * highlight.
+ * Presentational body for the "Most popular day" widget. Loading / error / empty
+ * are handled by `<WidgetState>` in the report component.
  */
 export const MostPopularDayHighlight = ( { date, views, share }: MostPopularDayHighlightProps ) => {
 	const fullViews = formatMetricValue( views, 'number', PLAIN_COUNT_OPTIONS );

--- a/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
@@ -1,8 +1,6 @@
 /**
- * The stories render the data-connected widget fed by the shared
- * report-mock harness. `registerReportMocks` routes the `stats/` site summary
- * (`/proxy/v1.1/stats`) — including the `views_best_day*` fields this widget
- * reads — through `routeStatsReport()`, so no story-scoped middleware is needed.
+ * `registerReportMocks` already routes the `/proxy/v1.1/stats` site summary this
+ * widget reads, so no story-scoped middleware is needed.
  */
 /**
  * External dependencies
@@ -41,14 +39,9 @@ const MOST_POPULAR_DAY_RENDER_MODULE = 'storybook/most-popular-day';
 const SITE_SUMMARY_PATH_FRAGMENT = 'proxy/v1.1/stats';
 
 /**
- * Forces the site-summary request into the given state for a story's lifetime.
- *
- * `useStatsSite()` has a constant query key — the all-time summary ignores the
- * dashboard date range — so distinct date presets cannot give the forced-state
- * stories their own cache entries. Instead, drop the cached summary from the
- * shared query client so the widget re-fetches and hits the forced mock, and
- * drop it again on cleanup so a forced empty/error result doesn't leak into the
- * other stories' shared cache entry.
+ * `useStatsSite()` has a constant query key, so distinct date presets cannot give
+ * the forced-state stories their own cache entries. Evict the cached summary
+ * instead — on entry so the forced mock is hit, on cleanup so it does not leak.
  */
 function forceSiteSummaryState( state: ReportMockState ) {
 	queryClient.removeQueries( { queryKey: [ 'stats', 'site' ] } );

--- a/projects/packages/premium-analytics/widgets/popular-days/__tests__/bucket-views-by-weekday.test.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/__tests__/bucket-views-by-weekday.test.ts
@@ -51,9 +51,8 @@ describe( 'bucketViewsByWeekday', () => {
 	} );
 
 	it( 'reads the calendar date, not a UTC instant', () => {
-		// `date_start` carries a nominal +00:00 that is a bucket label, not a real
-		// instant. Parsing it as UTC would shift the day west of Greenwich and move
-		// this row onto Sunday.
+		// `date_start`'s +00:00 is a bucket label, not a real instant: parsing it as
+		// UTC would shift the day west of Greenwich and move this row onto Sunday.
 		const buckets = bucketViewsByWeekday( [ dailyRow( '2026-07-06', 10 ) ] );
 
 		expect( buckets[ 0 ].occurrences ).toBe( 1 );
@@ -98,9 +97,8 @@ describe( 'bucketViewsByWeekday', () => {
 
 describe( 'pickPeakWeekday', () => {
 	it( 'picks the highest average, not the highest total', () => {
-		// This is the whole point of averaging: a range that is not a whole number
-		// of weeks samples some weekdays more often than others, and the extra
-		// sample alone must not decide the winner.
+		// A range that is not a whole number of weeks samples some weekdays more
+		// often, and the extra sample alone must not decide the winner.
 		const buckets = bucketViewsByWeekday( [
 			dailyRow( '2026-07-06', 10 ),
 			dailyRow( '2026-07-13', 10 ),

--- a/projects/packages/premium-analytics/widgets/popular-days/bucket-views-by-weekday.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/bucket-views-by-weekday.ts
@@ -46,8 +46,6 @@ function readRowViews( row: Record< string, unknown > ) {
 }
 
 /**
- * Fold a daily `stats/visits` series into one bucket per day of the week.
- *
  * Always seven buckets, so the chart keeps a stable shape; weekdays the range
  * never covered carry `occurrences: 0`.
  */
@@ -80,12 +78,8 @@ export function bucketViewsByWeekday( rows: Record< string, unknown >[] ): Popul
 }
 
 /**
- * The busiest weekday by mean views per occurrence.
- *
- * Mean, not total: a selected range rarely spans a whole number of weeks — over
- * 30 days two weekdays occur five times and five occur four — so a total would
- * let that extra occurrence alone decide the winner.
- * Returns no peak when the entire range received no views.
+ * Mean, not total: a selected range rarely spans a whole number of weeks, so a
+ * total would let one extra occurrence of a weekday decide the winner.
  */
 export function pickPeakWeekday( buckets: PopularDayBucket[] ): PopularDayBucket | undefined {
 	return buckets

--- a/projects/packages/premium-analytics/widgets/popular-days/render.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-days/render.tsx
@@ -37,8 +37,7 @@ function PopularDaysReport() {
 	const points = useMemo( () => buckets.map( bucket => bucket.average ), [ buckets ] );
 
 	// `placeholderData` keeps the prior response on a transient refetch failure,
-	// so the error only surfaces when there is nothing left to show. `error` is
-	// gated on the same predicate so the two cannot disagree.
+	// so the error only surfaces when there is nothing left to show.
 	const showError = isError && ! peak;
 
 	return (

--- a/projects/packages/premium-analytics/widgets/popular-days/stories/popular-days-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-days/stories/popular-days-widget.stories.tsx
@@ -138,12 +138,8 @@ export const Empty: Story = {
 };
 
 /**
- * Renders the data-connected widget through the shared dashboard harness, so it
- * appears exactly as it does in product (framed card, sizing, edit mode).
- *
  * Comparison params are passed even though the widget strips them, so the story
- * covers the widget against crashing or inventing deltas when the host supplies
- * comparison dates.
+ * covers it against inventing deltas when the host supplies comparison dates.
  *
  * @param {WidgetDashboardWithWidgetControls} dashboardArgs - The dashboard story controls.
  * @return The widget mounted inside the real `WidgetDashboard`.

--- a/projects/packages/premium-analytics/widgets/popular-hours/use-popular-hours.ts
+++ b/projects/packages/premium-analytics/widgets/popular-hours/use-popular-hours.ts
@@ -18,11 +18,8 @@ export type PopularHourPeak = PopularHourBucket & {
 };
 
 /**
- * Pick the busiest hour by total views.
- *
- * Every hour occurs once per reported day, so ranking by total and average is
- * equivalent. Totals avoid allowing division or display rounding to affect the
- * selected bucket.
+ * Picks the busiest hour by total views: every hour occurs once per reported
+ * day, so totals rank the same as averages without risking rounding drift.
  */
 function pickPeakHour( buckets: PopularHourBucket[] ) {
 	const peak = buckets.reduce< PopularHourBucket | undefined >(

--- a/projects/packages/premium-analytics/widgets/popular-post/render.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-post/render.tsx
@@ -28,10 +28,8 @@ type PopularPostRenderAttributes = PopularPostAttributes & Partial< ReportParams
 type PopularPostWidgetProps = WidgetRenderProps< PopularPostRenderAttributes >;
 
 /**
- * The dashboard's date range picks which post is shown; all three tiles are
- * all-time totals from the Stats post endpoint, so they share one window and
- * need no per-tile aggregation note — the same treatment as `Latest post`,
- * which shares this card.
+ * The dashboard's date range picks which post is shown, but all three tiles are
+ * all-time totals, so none carries a per-tile aggregation note.
  */
 function PopularPostReport() {
 	const { reportParams } = useWidgetRootContext();

--- a/projects/packages/premium-analytics/widgets/popular-post/stories/popular-post-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-post/stories/popular-post-widget.stories.tsx
@@ -1,8 +1,6 @@
 /**
- * The widget ranks posts with the proxied `stats/top-posts` endpoint (covered by
- * the legacy stats mocks), then reads the winning post's content from the local
- * `/wp/v2/posts` endpoint and all three of its all-time metrics from `stats/post/{id}`
- * (both covered by the shared report mocks).
+ * `stats/top-posts` is served by the legacy stats mocks; `/wp/v2/posts` and
+ * `stats/post/{id}` by the shared report mocks.
  */
 /**
  * External dependencies
@@ -135,14 +133,9 @@ export const Empty: Story = {
 };
 
 /**
- * Mounts the real `WidgetDashboard` with this single widget so it renders exactly
- * as it does in product (framed card, sizing, edit mode). Drop `widgetWidth` to 1
- * to walk the card's size ladder: below 520px wide the featured image drops out and
- * the metric row wraps. Shortening the cell below 300px also switches the card to
- * its compact type scale.
- *
- * Comparison report params are passed unconditionally, so the widget stays covered
- * against crashing or inventing deltas when the host supplies comparison dates.
+ * Mounts the real `WidgetDashboard` with this single widget. Comparison report
+ * params are passed unconditionally, so the widget stays covered against
+ * crashing or inventing deltas when the host supplies comparison dates.
  */
 function PopularPostDashboardStory( dashboardArgs: WidgetDashboardWithWidgetControls ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/post-comments/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-comments/render.tsx
@@ -62,9 +62,8 @@ function PostCommentsInner() {
 			<WidgetState
 				isLoading={ isLoading }
 				isFetching={ isFetching }
-				// The query keeps prior data via `placeholderData`, so a transient
-				// refetch failure keeps the comments visible; only surface the error
-				// when there is nothing to show.
+				// `placeholderData` keeps the prior comments on screen, so a transient
+				// refetch failure should not replace them with an error.
 				isError={ ! data && isError }
 				isEmpty={ isEmpty }
 				renderLoading={ <SubscriberListSkeleton rows={ COMMENTS_SHOWN } /> }

--- a/projects/packages/premium-analytics/widgets/post-detail-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-detail-highlights/render.tsx
@@ -36,13 +36,9 @@ const ALL_TIME_NOTE = () =>
 	__( 'All-time total — this metric has no per-post history.', 'jetpack-premium-analytics-pkg' );
 
 /**
- * Without a post scope (e.g. the widget added outside a post detail page) the
- * query never enables and the empty state shows.
- *
- * Views is period-scoped with a period-over-period delta when comparison is
- * on. Comments and likes are lifetime totals: when comparison is on their
- * `previousValue` is `null` — the tile keeps the comparison layout but shows
- * no fabricated delta.
+ * Without a post scope the query never enables and the empty state shows.
+ * Comments and likes are lifetime totals, so under comparison their
+ * `previousValue` is `null` — the tile keeps the layout but fabricates no delta.
  */
 function PostDetailHighlightsInner() {
 	const { reportParams } = useWidgetRootContext();
@@ -96,9 +92,8 @@ function PostDetailHighlightsInner() {
 			<WidgetState
 				isLoading={ isLoading }
 				isFetching={ isFetching }
-				// As with `isLoading` above: the highlights stay on screen through a
-				// transient refetch failure, so only surface the error when there is
-				// nothing to show.
+				// The highlights stay on screen through a transient refetch failure, so
+				// only surface the error when there is nothing to show.
 				isError={ ! hasData && isError }
 				isEmpty={ postId <= 0 }
 				error={ {

--- a/projects/packages/premium-analytics/widgets/post-likes/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-likes/render.tsx
@@ -66,9 +66,8 @@ function PostLikesInner() {
 			<WidgetState
 				isLoading={ isLoading }
 				isFetching={ isFetching }
-				// The query keeps prior data via `placeholderData`, so a transient
-				// refetch failure keeps the likes visible; only surface the error
-				// when there is nothing to show.
+				// `placeholderData` keeps the prior likes on screen, so a transient
+				// refetch failure should not replace them with an error.
 				isError={ ! data && isError }
 				isEmpty={ isEmpty }
 				renderLoading={ <SubscriberListSkeleton rows={ LIKES_SHOWN } /> }

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/render.test.tsx
@@ -23,21 +23,16 @@ let mockAttachRef: ( ( element: HTMLElement | null ) => void ) | undefined;
 type ResizeHandler = ( entries: { contentRect: { width: number } }[] ) => void;
 let mockResizeHandlers: ResizeHandler[] = [];
 
-// jsdom's ResizeObserver never fires, so the real hook leaves the card unmeasured
-// and the width-driven page span is unreachable from a test. Drive it directly.
-// The widget consumes the hook twice — its own card-width observer plus the one
-// inside `useElementSize` — so a resize is broadcast to every handler: the width
-// handler reads the entry, while `useElementSize` falls back to measuring its
-// own element, and both dedupe repeats.
+// jsdom's ResizeObserver never fires, so tests drive width via the mock; the
+// widget consumes the hook twice, so a resize broadcasts to every handler.
 jest.mock( '@wordpress/compose', () => ( {
 	...jest.requireActual( '@wordpress/compose' ),
 	useResizeObserver: ( onResize: ResizeHandler ) => {
 		mockResizeHandlers.push( onResize );
 		mockFireResize = width =>
 			mockResizeHandlers.forEach( handler => handler( [ { contentRect: { width } } ] ) );
-		// One stable ref callback for the whole file. A fresh arrow per render would
-		// make React detach and re-attach on every commit, replaying the mount width
-		// and undoing whatever a test fired.
+		// A fresh arrow per render would make React re-attach on every commit,
+		// replaying the mount width and undoing whatever a test fired.
 		mockAttachRef ??= element => {
 			if ( element && mockCardWidth !== undefined ) {
 				mockFireResize?.( mockCardWidth );
@@ -50,9 +45,8 @@ jest.mock( '@wordpress/compose', () => ( {
 
 type TooltipData = { value: number | null; cellLabel?: string; row: number; column: number };
 
-// Keep visx out of jsdom while exercising the widget's tooltip renderer with
-// one cell of each kind: a pre-range filler blank, an in-range blank, and
-// singular/plural counted cells.
+// Keeps visx out of jsdom while still exercising the widget's tooltip renderer
+// with one cell of each kind.
 jest.mock( '@jetpack-premium-analytics/externals', () => {
 	const actual = jest.requireActual( '@jetpack-premium-analytics/externals' );
 
@@ -157,9 +151,8 @@ describe( 'PostTrafficActivity tooltip', () => {
 	} );
 } );
 
-// The cell-height cap follows the measured chart area so the grid — month-label
-// header row included — never outgrows the tile and clips. jsdom reports a zero
-// rect by default, which doubles as the unmeasured initial render.
+// The cell-height cap follows the measured chart area so the grid never clips.
+// jsdom's default zero rect doubles as the unmeasured initial render.
 describe( 'PostTrafficActivity cell sizing', () => {
 	beforeEach( () => {
 		mockUsePostTrafficActivity.mockReset();

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -52,10 +52,9 @@ describe( 'usePostTrafficActivity', () => {
 
 		const { days } = result.current;
 
-		// The 4-day range pads backward with the page snapped to week
-		// boundaries (Monday 2026-01-19), but stops at the range end: the
-		// week-completion days past it (2026-07-05) emit no points, so the
-		// chart's ragged-edge option hides their cells.
+		// The 4-day range pads backward to a week boundary (Monday 2026-01-19) but
+		// stops at the range end: the week-completion days past it emit no points,
+		// so the chart's ragged-edge option hides their cells.
 		expect( days ).toHaveLength( 167 );
 		expect( days[ 0 ].dateString ).toBe( '2026-01-19' );
 
@@ -71,7 +70,6 @@ describe( 'usePostTrafficActivity', () => {
 		// Filler days stay blank even where the history has views (2026-06-30).
 		expect( days.slice( 0, -4 ).every( day => day.value === null ) ).toBe( true );
 
-		// One page covers the range, so no pager.
 		expect( result.current.isPaged ).toBe( false );
 	} );
 

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -37,11 +37,8 @@ type PostTrafficActivityRenderAttributes = PostTrafficActivityAttributes &
 type PostTrafficActivityWidgetProps = WidgetRenderProps< PostTrafficActivityRenderAttributes >;
 
 /**
- * Sizing the page to the card: one page shows as many whole week columns as
- * fit at the design's cell width. The cell is the design's 64px; the gap and
- * the month-label header height come from the shared layout helper, so the
- * grid metrics are stated once. The weekday-label gutter is the chart's own,
- * so `fitWeekColumns` owns it.
+ * One page shows as many whole week columns as fit at the design's cell width.
+ * Gap and header height come from the shared layout helper, not restated here.
  */
 const CELL_WIDTH = 64;
 const MIN_PAGE_WEEKS = 4;
@@ -70,10 +67,9 @@ const MIN_CELL_HEIGHT = 8;
 const GRID_VERTICAL_OVERHEAD = CALENDAR_HEATMAP_HEADER_HEIGHT + 7 * CALENDAR_HEATMAP_CELL_GAP;
 
 /**
- * Cell height that keeps the whole grid — month-label header row included —
- * inside the measured chart area, capped at the design's 42px. A fixed cap
- * alone overflows short tiles, and the content's centering then pushes the
- * month labels above the scroll origin where they clip.
+ * Cell height that keeps the whole grid inside the measured chart area. A fixed
+ * cap alone overflows short tiles, and centering then pushes the month labels
+ * above the scroll origin where they clip.
  */
 function cellHeightForArea( height: number ): number {
 	if ( ! height ) {
@@ -87,11 +83,8 @@ function cellHeightForArea( height: number ): number {
 }
 
 /**
- * Renders one page of the post's daily views as a calendar heatmap. Ranges
- * longer than one page grow floating pager arrows over the chart's edges,
- * stepping through the range; without a post scope (e.g. the widget added
- * outside a post detail page) the query never enables and the empty state
- * shows.
+ * Renders one page of the post's daily views as a calendar heatmap. Without a
+ * post scope the query never enables and the empty state shows.
  */
 function PostTrafficActivityInner() {
 	const { reportParams } = useWidgetRootContext();
@@ -122,9 +115,8 @@ function PostTrafficActivityInner() {
 		refetch,
 	} = usePostTrafficActivity( postId, reportParams, weeksForWidth( width ) * 7 );
 
-	// The height the tile offers the grid. Only the cell height reads it — the
-	// page span stays width-derived, so paging cannot feed back into the
-	// measurement and oscillate.
+	// Only the cell height reads this; the page span stays width-derived, so
+	// paging cannot feed back into the measurement and oscillate.
 	const [ chartAreaRef, chartAreaSize ] = useElementSize< HTMLDivElement >();
 	const maxCellHeight = cellHeightForArea( chartAreaSize.height );
 
@@ -136,11 +128,8 @@ function PostTrafficActivityInner() {
 	const from = toDay( reportParams.from );
 	const to = toDay( reportParams.to );
 
-	// Blank cells split by what the blank means: a day inside the range really had
-	// no views, while the filler days padding the grid before the range start were
-	// masked rather than measured, so "No views" there could be false. Cells map
-	// back to `days` by grid position — the page start is week-aligned, so
-	// `column * 7 + row` indexes the flat series.
+	// Filler days before the range start are masked, not measured — "No views"
+	// would be false there; the week-aligned start makes `column * 7 + row` the flat index.
 	const renderCellTooltip = useCallback(
 		( { value, cellLabel, row, column }: HeatmapTooltipData ) => {
 			const day = days[ column * 7 + row ];
@@ -191,14 +180,11 @@ function PostTrafficActivityInner() {
 					renderLoading={ <HeatmapSkeleton /> }
 				>
 					<div className={ styles.content }>
-						{ /* The unresponsive chart export: the capped grid is
-						     content-sized and the page span is derived from the widget's
-						     own measurement, so the responsive wrapper's full-height
-						     measuring container would only break the centered grid. */ }
+						{ /* The unresponsive export: the grid is content-sized already, so
+						     the responsive wrapper would only break the centered grid. */ }
 						<div ref={ chartAreaRef } className={ styles.chartArea }>
-							{ /* The arrows float over the grid's edges on hover; they only
-							     exist when the range exceeds one page (and only in the ready
-							     state, where the grid they step is visible). */ }
+							{ /* Arrows only exist when the range exceeds one page, and only in
+							     the ready state where the grid they step is visible. */ }
 							<CalendarHeatmapPagerOverlay
 								pager={ isPaged ? { canShowOlder, canShowNewer, showOlder, showNewer } : undefined }
 								className={ styles.chartHost }
@@ -208,11 +194,8 @@ function PostTrafficActivityInner() {
 									rowLabels={ rowLabels }
 									primaryColor="var(--wp-admin-theme-color, #3858e9)"
 									withTooltips
-									// Cap cells at the design's 64px width; the page span is
-									// already sized to the card, so tracks never need to
-									// shrink below it. The height cap follows the measured
-									// area so short tiles get flatter cells, not a clipped
-									// month-label row.
+									// The page span is already sized to the card, so width tracks
+									// never need to shrink below the design's 64px.
 									maxCellWidth={ 64 }
 									maxCellHeight={ maxCellHeight }
 									renderTooltip={ renderCellTooltip }

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -15,9 +15,8 @@ import {
 import { toDay, type DataPointDate } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
- * Normalized activity state: one point per calendar day of the visible page
- * plus paging controls and the request's load/error flags. `hasData`
- * distinguishes the first load from refetches.
+ * One point per calendar day of the visible page. `hasData` distinguishes the
+ * first load from refetches.
  */
 export interface PostTrafficActivityState {
 	days: DataPointDate[];
@@ -37,19 +36,9 @@ export interface PostTrafficActivityState {
 }
 
 /**
- * Fetch the scoped post's daily view activity for the dashboard's report
- * params and expose one page of it. The caller derives `pageSpanDays` from
- * the card width (whole week columns that fit), so one page always fills the
- * card exactly: a range at or under one page pads backward to
- * `range end − (pageSpanDays − 1)` with blank filler weeks, and a longer
- * range is paged — the newest page shows first and the header arrows step
- * through the range one page at a time, the oldest page padding backward the
- * same way. Every calendar day of the page through the range end gets a
- * point: days without traffic — and leading filler days before the range —
- * carry `null` (blank cells per the design, not zero labels), while the days
- * completing the newest week past the range end emit no point at all, so the
- * chart's ragged-edge option hides their cells and the current week only
- * draws through today. A `postId` of 0 disables the request.
+ * The caller derives `pageSpanDays` from the card width (whole week columns that
+ * fit), so one page always fills the card exactly; a range longer than a page is
+ * paged, newest first. A `postId` of 0 disables the request.
  */
 export default function usePostTrafficActivity(
 	postId: number,
@@ -79,12 +68,9 @@ export default function usePostTrafficActivity(
 		const history = data?.data ?? [];
 		const viewsByDay = new Map( history.map( day => [ day.date, day.views ] ) );
 
-		// Pages snap to week boundaries: the chart grids Monday-start week
-		// columns from the window's first week, so an unaligned window would
-		// span one more column than the width measurement sized the card for.
-		// With both bounds aligned, a page is exactly `pageSpanDays / 7`
-		// columns; the days past the range edges inside those weeks stay
-		// blank filler.
+		// Pages snap to week boundaries: the chart grids Monday-start week columns
+		// from the window's first week, so an unaligned window would span one more
+		// column than the width measurement sized the card for.
 		const firstWeekStart = startOfWeek( parseISO( from ), { weekStartsOn: 1 } );
 		const newestPageEnd = endOfWeek( parseISO( to ), { weekStartsOn: 1 } );
 		const paged = firstWeekStart < subDays( newestPageEnd, pageSpanDays - 1 );
@@ -92,20 +78,18 @@ export default function usePostTrafficActivity(
 		let pageEnd = subDays( newestPageEnd, pageOffset * pageSpanDays );
 		let pageStart = subDays( pageEnd, pageSpanDays - 1 );
 
-		// The oldest page of a paged range clamps to the range's first week
-		// and fills forward (overlapping the previous page), instead of
-		// padding months of out-of-range blanks before it. Short ranges keep
-		// padding backward from the range end so the grid still fills the card.
+		// The oldest page clamps to the range's first week and fills forward,
+		// overlapping the previous page, instead of padding months of
+		// out-of-range blanks before it.
 		if ( paged && pageStart < firstWeekStart ) {
 			pageStart = firstWeekStart;
 			const clampedEnd = addDays( firstWeekStart, pageSpanDays - 1 );
 			pageEnd = clampedEnd < newestPageEnd ? clampedEnd : newestPageEnd;
 		}
 
-		// No points past the range end: the chart's ragged-edge option then
-		// hides the trailing cells of the newest week (future days, on a
-		// rolling preset), per the design. `pageEnd` itself stays week-aligned
-		// so the column count still matches the width measurement.
+		// No points past the range end, so the chart's ragged-edge option hides the
+		// newest week's future cells. `pageEnd` itself stays week-aligned so the
+		// column count still matches the width measurement.
 		const rangeEnd = parseISO( to );
 		const pointsEnd = rangeEnd < pageEnd ? rangeEnd : pageEnd;
 

--- a/projects/packages/premium-analytics/widgets/post-views/__tests__/post-views.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/__tests__/post-views.test.tsx
@@ -92,9 +92,8 @@ const WINDOW_PARAMS = {
 	post_id: 779,
 };
 
-// A 28-day window, the shortest that allows a weekly interval: `WidgetRoot`
-// normalizes report params through `resolveIntervalForRange`, so an interval
-// the range disallows is coerced away before the widget ever sees it.
+// 28 days, the shortest window allowing a weekly interval: `WidgetRoot` coerces
+// an interval the range disallows away before the widget ever sees it.
 const WEEKLY_WINDOW_PARAMS = {
 	...DEFAULT_PARAMS,
 	from: '2026-06-22T00:00:00.000+08:00',
@@ -133,9 +132,8 @@ describe( 'PostViewsWidget', () => {
 	} );
 
 	it( 'anchors bucket days at site-local midnight so negative-offset sites keep the calendar day', async () => {
-		// A UTC-12 site: a date-only bucket key parsed as UTC midnight would
-		// render as the previous day once formatted in the site timezone. The
-		// point instant must be the key's site-local midnight instead.
+		// On a UTC-12 site, a date-only bucket key parsed as UTC midnight would
+		// render as the previous day once formatted in the site timezone.
 		const defaultSettings = getSettings();
 		setSettings( {
 			...defaultSettings,
@@ -183,10 +181,8 @@ describe( 'PostViewsWidget', () => {
 				attributes={ {
 					reportParams: {
 						...WINDOW_PARAMS,
-						// Comparison params pass through the post detail URL untouched
-						// (dashboard state survives the round trip), so a widget
-						// receiving them must neither draw an overlay nor change the
-						// primary series — the page renders no comparison.
+						// Comparison params pass through the post detail URL untouched, so
+						// a widget receiving them must still render no comparison.
 						comp: '1',
 						compare_from: '2026-06-24T00:00:00.000+08:00',
 						compare_to: '2026-06-30T23:59:59.999+08:00',

--- a/projects/packages/premium-analytics/widgets/post-views/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/render.tsx
@@ -52,9 +52,8 @@ function PostViewsInner( { chartType }: PostViewsInnerProps ) {
 		period
 	);
 
-	// One "Views" metric: the headline is the window total (views are summed
-	// per bucket, so the sum of buckets is the range's views). The post detail
-	// page has no comparison control, so there is no previous series.
+	// The post detail page has no comparison control, so there is no previous
+	// series, and the headline is just the sum of the window's buckets.
 	const metricTabs = useMemo< MetricTab[] >(
 		() => [
 			{

--- a/projects/packages/premium-analytics/widgets/post-views/stories/post-views-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/stories/post-views-widget.stories.tsx
@@ -1,17 +1,6 @@
 /**
- * The Post views widget is the post detail Traffic view's view-trend card:
- * the scoped post's views over the dashboard date range as a line chart. The
- * post scope arrives through `reportParams.post_id` (seeded from the detail
- * page URL in product); the `hasPostScope` control toggles it to exercise the
- * scopeless empty state.
- *
- * Data comes from the proxied `stats/post/{id}` endpoint, covered by the
- * shared report mocks' `stats-post` fixture (a deterministic daily series
- * ending today, so relative date presets always intersect it). The post
- * detail design has no period-over-period comparison, so the widget maps no
- * comparison rows; the dashboard story still passes comparison params so the
- * widget stays covered against crashing or inventing an overlay when a host
- * supplies them.
+ * Served by the shared report mocks' `stats-post` fixture: a deterministic daily
+ * series ending today, so relative date presets always intersect it.
  */
 /**
  * External dependencies
@@ -53,11 +42,8 @@ interface PostViewsStoryControls {
 }
 
 /**
- * Builds the widget attributes: report params carrying the page's chart
- * interval (which the widget buckets by) plus the post scope the detail page
- * seeds from its URL when `hasPostScope` is on. Comparison stays a parameter
- * so the dashboard story can pass host comparison params without duplicating
- * the scoping rule.
+ * Builds the widget attributes. Comparison stays a parameter so the dashboard
+ * story can pass host comparison params without duplicating the scoping rule.
  */
 function getPostViewsAttributes(
 	{ hasPostScope, interval, chartType }: PostViewsStoryControls,
@@ -138,11 +124,9 @@ interface PostViewsDashboardStoryProps
 		PostViewsStoryControls {}
 
 /**
- * Mounts the real `WidgetDashboard` with this single widget so it renders
- * exactly as it does in product (framed card, host toolbar controls, sizing,
- * edit mode). It passes comparison params unconditionally,
- * so the widget stays covered against crashing or inventing an overlay when
- * a host supplies comparison dates.
+ * Mounts the real `WidgetDashboard` with this single widget. Comparison params
+ * are passed unconditionally, so the widget stays covered against crashing or
+ * inventing an overlay when a host supplies comparison dates.
  */
 function PostViewsDashboardStory( {
 	hasPostScope,

--- a/projects/packages/premium-analytics/widgets/post-views/use-post-views.ts
+++ b/projects/packages/premium-analytics/widgets/post-views/use-post-views.ts
@@ -58,10 +58,8 @@ type BucketWindow = {
 };
 
 /**
- * Extract a validated `YYYY-MM-DD` day from an ISO report param. The report
- * params originate from URL search params, so the shape and calendar validity
- * are both checked — `bucketDays()` feeds these to `parseISO()`/
- * `each*OfInterval()`, which throw on invalid dates.
+ * Extract a validated `YYYY-MM-DD` day — validated because `bucketDays()` feeds
+ * it to `parseISO()`/`each*OfInterval()`, which throw on invalid dates.
  */
 function toValidDay( value?: string ): string | undefined {
 	const day = value?.slice( 0, 10 );
@@ -126,11 +124,9 @@ function calendarBucketWindows(
 }
 
 /**
- * Sum the post's daily view history into zero-filled buckets. The endpoint
- * may omit zero-view days and the history only starts at publication, but
- * those missing values are genuine zeroes. The full history is bucketed
- * client-side because the endpoint's `weeks` field only covers a fixed recent
- * window.
+ * Sum the post's daily view history into zero-filled buckets — missing days are
+ * genuine zeroes, not gaps. Bucketed client-side since the endpoint's `weeks`
+ * field only covers a fixed recent window.
  */
 function bucketDays( days: StatsPostDay[], buckets: BucketWindow[] ): PostViewsPoint[] {
 	const totals = new Map< string, number >( buckets.map( bucket => [ bucket.date, 0 ] ) );
@@ -144,12 +140,8 @@ function bucketDays( days: StatsPostDay[], buckets: BucketWindow[] ): PostViewsP
 		}
 	}
 
-	// The endpoint's day keys are plain site-local calendar dates, so each
-	// point's instant must be that day's site-local midnight. `parseSiteDateTime`
-	// anchors the offset-less key in the site timezone; the chart's `formatDate`
-	// labels render in the same zone, so the calendar day round-trips.
-	// `bucket.date` comes from `format( start, 'yyyy-MM-dd' )`, so the parse
-	// cannot fail in practice; drop the point rather than guess if it ever does.
+	// `parseSiteDateTime` keeps the site-local day key round-tripping through the
+	// chart's same-zone labels; a null parse can't happen with `format()`-built keys.
 	return buckets.flatMap( bucket => {
 		const date = parseSiteDateTime( bucket.date );
 		return date ? [ { date, value: totals.get( bucket.date ) ?? 0 } ] : [];
@@ -157,13 +149,9 @@ function bucketDays( days: StatsPostDay[], buckets: BucketWindow[] ): PostViewsP
 }
 
 /**
- * Fetch the scoped post's view trend for the dashboard's report params. One
- * `stats/post` request carries the full daily view history; the selected
- * window is sliced from it client-side. A `postId` of 0 disables the request.
- * The post detail design has no period-over-period comparison, so comparison
- * report params are ignored — they ride along in the URL untouched so
- * dashboard state survives the round trip, and every widget on this page
- * disregards them.
+ * Fetch the scoped post's view trend and slice it to the report params' window
+ * client-side. A `postId` of 0 disables the request; comparison params are
+ * ignored since the post detail design has no period-over-period comparison.
  */
 export default function usePostViews(
 	postId: number,

--- a/projects/packages/premium-analytics/widgets/post-views/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-views/widget.ts
@@ -19,23 +19,17 @@ import {
 export type PostViewsChartType = ChartDisplayChartType;
 
 /**
- * Configurable attributes for the Post views widget. The post scope and
- * report params reach it through WidgetRoot: the detail page seeds
- * `post_id` into the URL, and the dashboard date picker owns the range.
- *
- * @property chartType - How to draw the views series. Defaults to `line`.
+ * Configurable attributes for the Post views widget. The post scope reaches it
+ * through WidgetRoot: the detail page seeds `post_id` into the URL.
  */
 export type PostViewsAttributes = {
 	chartType?: PostViewsChartType;
 };
 
 /**
- * The post detail Traffic view's view-trend card, the legacy Calypso post
- * summary chart (`stats-post-summary`): the scoped post's views over the
- * dashboard date range, with the window total as the metric headline. The
- * series comes from the `stats/post/{id}` daily history, bucketed client-side
- * at the page's chart interval; the `chartType` attribute
- * (`relevance: 'high'`) is rendered by the widget host.
+ * Ported from the legacy Calypso post summary chart (`stats-post-summary`). The
+ * series comes from the `stats/post/{id}` daily history, bucketed client-side at
+ * the page's chart interval.
  */
 export default {
 	icon: seen,

--- a/projects/packages/premium-analytics/widgets/posting-activity/__tests__/posting-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/__tests__/posting-activity.test.tsx
@@ -227,8 +227,7 @@ describe( 'PostingActivityWidget', () => {
 				restoreTileSize();
 			}
 
-			// The regression this guards (WOOA7S-1963): the grid ran on to a December
-			// that had not happened, so a tile too small for all 53 columns kept the
+			// Regression guard (WOOA7S-1963): a tile too small for all 53 columns kept
 			// empty future weeks and trimmed the year's own posts away.
 			expect( chartDayValues() ).toContain( 'Mon, Aug 10, 2026:4' );
 		} );

--- a/projects/packages/premium-analytics/widgets/posting-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/render.tsx
@@ -59,22 +59,15 @@ function renderCellTooltip( { value, cellLabel }: HeatmapTooltipData ) {
 }
 
 /**
- * The `stats/streak` endpoint returns a `{ 'yyyy-MM-dd': count }` map of posts
- * per day, with no comparison period.
- *
- * The date range comes from the dashboard picker via `reportParams`. The fetch
- * window is that range, capped at the history the widest possible tile could draw
- * so a long selection cannot request years the grid would throw away.
- *
- * `AdaptiveCalendarHeatmap` fits the grid to the tile: the height picks the cell
- * size, the width picks how many week columns are drawn.
+ * `stats/streak` returns a `{ 'yyyy-MM-dd': count }` map with no comparison
+ * period. The fetch window is capped at the widest tile's history, so a long
+ * selection can't request years the grid would discard.
  */
 function PostingActivityInner() {
 	const { reportParams } = useWidgetRootContext();
 
-	// Same window rule as the other calendar heatmap: a ceiling at the history the
-	// viewport could draw, and no floor. A floor would reach back past the selection,
-	// putting years outside the card's heading inside it (WOOA7S-1963).
+	// A ceiling but no floor: a floor would reach back past the selection, putting
+	// years outside the card's heading inside it (WOOA7S-1963).
 	const viewportWidth = useViewportWidth();
 	const windowDays = resolveCalendarHeatmapWindowDays( viewportWidth );
 
@@ -89,9 +82,8 @@ function PostingActivityInner() {
 		[ reportParams, windowDays, today ]
 	);
 
-	// The period as selected, before the ceiling. All time on a long-lived site
-	// reaches back past the window, and the empty state has to know the response
-	// says nothing about the years left out.
+	// The period as selected, before the ceiling: the empty state has to know the
+	// response says nothing about the years the ceiling left out.
 	const periodWindow = useMemo(
 		() => resolveCalendarHeatmapWindow( reportParams, {}, today ),
 		[ reportParams, today ]
@@ -104,10 +96,8 @@ function PostingActivityInner() {
 
 	const { data, isLoading, isFetching, isError, error, refetch } = useStatsStreak( streakParams );
 
-	// The endpoint returns only days with posts, so an empty response means the
-	// window has none — the component densifies the rest into empty cells. Days
-	// outside the range are still ruled out, so a stale response for a wider
-	// selection cannot suppress the empty state while the new one loads.
+	// The endpoint returns only days with posts. Days outside the range are ruled
+	// out so a stale response for a wider selection cannot suppress the empty state.
 	const postsByDay = data ?? NO_POSTS_BY_DAY;
 	const hasData = useMemo(
 		() =>

--- a/projects/packages/premium-analytics/widgets/referrers/render.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/render.tsx
@@ -169,9 +169,8 @@ function ReferrersInner() {
 		max: WIDGET_ROW_LIMIT,
 	} as StatsReportParams;
 
-	// Row matching (per level, so same-named rows at different drill levels
-	// cannot cross-match), the visible-row cap, and the comparison-overlap
-	// gate all live in the data layer's merge helper (see AGENTS.md).
+	// Row matching (per level, so same-named rows at different drill levels can't
+	// cross-match), the row cap, and the comparison-overlap gate live in the merge helper.
 	const { comparisonRows, hasComparison, isLoading, isFetching, isError, refetch } =
 		useStatsReferrers( statsParams, { maxRows: WIDGET_ROW_LIMIT } );
 
@@ -181,8 +180,7 @@ function ReferrersInner() {
 	);
 
 	// Referrer groups nest twice (group → source → domain), so the drill-down
-	// selection is a path of row labels rather than a single row. The shared
-	// hook stores the whole path; append/pop happens here.
+	// selection is a path of row labels; the shared hook stores it, append/pop happens here.
 	const {
 		drillDownItem: drillPath,
 		drillDown: setDrillPath,
@@ -209,13 +207,8 @@ function ReferrersInner() {
 		return matched;
 	}, [ rows, drillPath ] );
 
-	// When settled data no longer resolves the whole stored path (e.g. the
-	// date range changed and the drilled group disappeared), trim it to the
-	// deepest level that still exists so stored state matches the view and
-	// stale levels can't resurface on a later refetch (WOOA7S-1666). A path
-	// that still resolves survives range changes; in-flight fetches keep
-	// placeholder rows and errors aren't settled data, so a valid selection
-	// survives refetches and transient failures.
+	// Trim the stored path to the deepest level that still resolves once data
+	// settles, so stale levels can't resurface later (WOOA7S-1666).
 	useEffect( () => {
 		if (
 			! drillPath?.length ||
@@ -259,9 +252,8 @@ function ReferrersInner() {
 		}
 	}, [ trail, setDrillPath, resetDrillDown ] );
 
-	// The back link is labelled after the list it returns to: the parent row
-	// one level up, or the full top-level list. The visible label stays short
-	// while the accessible name spells out the action.
+	// Labelled after the list it returns to (parent row or full top list); the
+	// visible label stays short while the accessible name spells out the action.
 	const parentLabel = trail.length > 1 ? trail[ trail.length - 2 ].label : null;
 	const backLabel = parentLabel ?? __( 'All referrers', 'jetpack-premium-analytics-pkg' );
 	const backAriaLabel = parentLabel
@@ -280,10 +272,8 @@ function ReferrersInner() {
 			<WidgetState
 				isLoading={ isLoading }
 				isFetching={ isFetching }
-				// The Stats queries carry `placeholderData: previousData => previousData`, so a
-				// failed range change keeps the prior period's rows while `isError` flips true.
-				// Only surface the error when there's nothing to show, so a transient refetch
-				// failure doesn't replace populated rows with the error state.
+				// `placeholderData` keeps the prior period's rows on screen while `isError`
+				// flips true, so a transient refetch failure should not replace them.
 				isError={ rows.length === 0 && isError }
 				isEmpty={ rows.length === 0 }
 				error={ {

--- a/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
@@ -108,9 +108,8 @@ export const WithComparison: Story = {
  * First load: the fetch is in flight, so the widget shows its loading state. The
  * mock is forced to never resolve for the duration of this story.
  *
- * Forced through `forceStatsMockState`: `stats/referrers` is answered by the
- * legacy stats mocks before the shared `setReportMockState` override can
- * intercept it.
+ * Uses `forceStatsMockState`: the legacy stats mocks answer `stats/referrers`
+ * before `setReportMockState` can intercept it.
  */
 export const Loading: Story = {
 	render: () => renderReferrersOnPreset( 'last-90-days' ),

--- a/projects/packages/premium-analytics/widgets/search-terms/widget.ts
+++ b/projects/packages/premium-analytics/widgets/search-terms/widget.ts
@@ -8,13 +8,8 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 export type SearchTermsAttributes = Record< never, never >;
 
 /**
- * Widget type definition for the Search Terms widget.
- *
- * Ported from the Jetpack Stats "Search Terms" module. Displays the top search
- * queries visitors used to reach the site, ranked by view count.
- *
- * Data: fetched via the PA proxy at `stats/search-terms`.
- * Date range comes from WidgetRoot's reportParams (the shared dashboard date picker).
+ * Ported from the Jetpack Stats "Search Terms" module; data via the PA proxy at
+ * `stats/search-terms`.
  */
 export default {
 	icon: search,

--- a/projects/packages/premium-analytics/widgets/shares/stories/shares-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/stories/shares-widget.stories.tsx
@@ -1,8 +1,6 @@
 /**
- * The Shares widget lists each social network the site's content was shared to,
- * ranked by share count. Data comes from the all-time site summary via
- * `useStatsSite`; the summary has no date range or comparison period, so the
- * widget shows the same counts regardless of the dashboard's comparison state.
+ * The all-time site summary behind this widget has no date range or comparison
+ * period, so every story shows the same counts.
  */
 /**
  * External dependencies
@@ -37,10 +35,8 @@ const SITE_SUMMARY_PATH_FRAGMENT = 'proxy/v1.1/stats';
 
 /**
  * Forces the all-time site summary into a state for a story's lifetime.
- *
- * `useStatsSite()` has a constant query key because its summary ignores the
- * dashboard date range. Remove that shared entry before and after each forced
- * story so it reaches the mock and cannot leak its result into another story.
+ * `useStatsSite()` has a constant query key, so the shared entry has to be
+ * evicted or the forced result leaks into another story.
  */
 function forceSiteSummaryState( state: 'loading' | 'error' | 'empty' ) {
 	queryClient.removeQueries( { queryKey: [ 'stats', 'site' ] } );

--- a/projects/packages/premium-analytics/widgets/shares/widget.ts
+++ b/projects/packages/premium-analytics/widgets/shares/widget.ts
@@ -8,14 +8,8 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 export type SharesAttributes = Record< never, never >;
 
 /**
- * Widget type definition for the Shares widget.
- *
- * Ported from the Jetpack Stats "Shares" module. Lists each social network your
- * content was shared to, ranked by the number of shares.
- *
- * Data: read from the site summary (`stats` endpoint) via `useStatsSite`; the
- * `shares_<service>` fields hold the per-network counts. The summary is all-time
- * and has no comparison period, so the widget ignores the dashboard date range.
+ * Ported from the Jetpack Stats "Shares" module. Reads `shares_<service>` fields
+ * from the all-time site summary, so it ignores the dashboard date range.
  */
 export default {
 	icon: share,

--- a/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
@@ -209,9 +209,8 @@ describe( 'SiteOverviewWidget', () => {
 		expect( requestedPaths.some( path => path.includes( 'date=2026-03-10' ) ) ).toBe( true );
 		expect( requestedPaths.some( path => path.includes( 'date=2026-02-10' ) ) ).toBe( true );
 
-		// Each tile derives its delta from the same metric in the comparison
-		// response, so distinct metrics show distinct period-over-period changes
-		// rather than one shared value: views 420 vs 300 rises, likes 48 vs 60 falls.
+		// Distinct metrics must show distinct deltas, not one shared value: views
+		// 420 vs 300 rises, likes 48 vs 60 falls.
 		await expect( screen.findByText( '+40%' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( '-20%' ) ).toBeInTheDocument();
 	} );

--- a/projects/packages/premium-analytics/widgets/site-overview/render.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/render.tsx
@@ -39,14 +39,9 @@ const COUNT_FORMAT: DataFormat = {
 };
 
 /**
- * Render-only config per metric: the tile icon, the summary-response field the
- * tile displays, and an optional aggregation caveat. Ids and labels are shared
- * with the settings checkboxes via `SITE_OVERVIEW_METRICS` in `widget.ts`.
- *
- * Each metric reads a numeric field of the `summary` response, which totals
- * views/visitors/likes/comments over the period; `followers` is excluded
- * because it is an all-time running total, not a period metric, so it has no
- * meaningful period-over-period comparison.
+ * Render-only per-metric config; ids/labels are shared with the settings
+ * checkboxes via `SITE_OVERVIEW_METRICS` in `widget.ts`. `followers` is excluded
+ * — it's an all-time running total, not a period metric with a meaningful delta.
  */
 const TILE_CONFIG: Record<
 	SiteOverviewMetricId,
@@ -76,10 +71,8 @@ const TILE_CONFIG: Record<
 };
 
 /**
- * When a comparison period is requested and returns data, each tile shows its
- * period-over-period change; the comparison total is looked up per metric so a
- * primary metric is never paired with a fabricated previous value. Which tiles
- * appear is controlled by the `metrics` attribute — missing means every metric.
+ * Looks up the comparison total per metric so a primary metric is never paired
+ * with a fabricated previous value. Missing `metrics` attribute means every tile.
  */
 function SiteOverviewReport( {
 	metricIds = DEFAULT_SITE_OVERVIEW_METRICS,
@@ -128,11 +121,8 @@ function SiteOverviewReport( {
 			icon,
 			label,
 			value,
-			// Only pair a comparison value when the comparison period actually
-			// returned a summary; a `null` (never `undefined`) keeps every tile in
-			// the fixed-size comparison layout — no fabricated delta, and one value
-			// size instead of MetricTileGrid's responsive `.value` clamp — so tiles
-			// stay consistently sized with or without comparison data.
+			// `null` (never `undefined`) keeps every tile in the fixed-size comparison
+			// layout instead of MetricTileGrid's responsive single-value sizing.
 			previousValue: hasComparison && comparisonSummary ? metricValue( comparisonSummary ) : null,
 			note,
 			// The tile shows a shortened count (e.g. 18K); the hover title carries

--- a/projects/packages/premium-analytics/widgets/site-overview/widget.ts
+++ b/projects/packages/premium-analytics/widgets/site-overview/widget.ts
@@ -22,16 +22,12 @@ export type SiteOverviewMetricId = 'views' | 'visitors' | 'likes' | 'comments';
  * from attributes.
  */
 export type SiteOverviewAttributes = {
-	/**
-	 * Metric tiles to show in the widget body.
-	 */
 	metrics?: SiteOverviewMetricId[];
 };
 
 /**
- * The metric tiles the widget can show, in display order. Single source for
- * the settings checkboxes and the rendered tiles so the two cannot drift
- * apart; `render.tsx` maps the ids to icons and summary-response fields.
+ * The metric tiles the widget can show, in display order. `render.tsx` maps the
+ * ids to icons and summary-response fields.
  */
 export const SITE_OVERVIEW_METRICS: { id: SiteOverviewMetricId; label: string }[] = [
 	{ id: 'views', label: __( 'Views', 'jetpack-premium-analytics-pkg' ) },
@@ -40,19 +36,13 @@ export const SITE_OVERVIEW_METRICS: { id: SiteOverviewMetricId; label: string }[
 	{ id: 'likes', label: __( 'Likes', 'jetpack-premium-analytics-pkg' ) },
 ];
 
-/**
- * Default selection for new widget instances: every metric enabled.
- */
 export const DEFAULT_SITE_OVERVIEW_METRICS: SiteOverviewMetricId[] = SITE_OVERVIEW_METRICS.map(
 	metric => metric.id
 );
 
 /**
- * Ported from the Jetpack Stats "Site overview" card: the period's headline
- * traffic and engagement totals with period-over-period comparison.
- * The `metrics` attribute (`relevance: 'high'`) selects which metric tiles
- * render; `example.attributes` doubles as the defaults applied to new
- * instances: every metric enabled.
+ * Ported from the Jetpack Stats "Site overview" card. `example.attributes`
+ * doubles as the defaults applied to new instances.
  */
 export default {
 	icon: globe,

--- a/projects/packages/premium-analytics/widgets/store-performance/render.tsx
+++ b/projects/packages/premium-analytics/widgets/store-performance/render.tsx
@@ -203,10 +203,8 @@ function StorePerformanceContent() {
 		() => [ generalReport, bookingsReport, visitorsReport, conversionReport, customersReport ],
 		[ generalReport, bookingsReport, visitorsReport, conversionReport, customersReport ]
 	);
-	// Gate the error per report — each metric tab has its own report, so a failed
-	// one must surface an error rather than render as an empty chart beside the
-	// others. Placeholder data keeps a report's rows on a transient refetch failure,
-	// so a report with data is not errored.
+	// Gate the error per report so a failed one surfaces beside the others' charts
+	// instead of rendering empty; placeholder data spares a report that still has rows.
 	const isError = reports.some( report => report.isError && ! report.hasData );
 	// Retry re-runs every metric report, not only the failed one.
 	const refetch = useCallback(

--- a/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
@@ -103,9 +103,8 @@ function renderStorePerformanceOnPreset( preset: SelectablePresetId ) {
 	);
 }
 
-// Every report endpoint behind the widget's metrics (net sales/orders, bookings,
-// visitors, conversion rate, customers). State stories force all of them so no
-// metric report resolves with data.
+// Every report endpoint behind the widget's metrics. State stories force all of
+// them so no metric report resolves with data.
 const STORE_PERFORMANCE_ENDPOINTS = [
 	'orders/by-date',
 	'orders-by-product-type/by-date',

--- a/projects/packages/premium-analytics/widgets/store-performance/widget.ts
+++ b/projects/packages/premium-analytics/widgets/store-performance/widget.ts
@@ -4,18 +4,13 @@
 import { store } from '@wordpress/icons';
 
 /**
- * The widget has no user-configurable attributes. Report params still reach it
- * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
- * when a host injects them (e.g. Storybook and dashboard previews).
+ * No user-configurable attributes; report params still reach it through
+ * WidgetRoot from the dashboard date range or an injected `attributes.reportParams`.
  */
 export type StorePerformanceAttributes = Record< never, never >;
 
 /**
- * Widget type definition.
- *
- * Ported from `woocommerce-analytics/at-a-glance` in
- * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
- *
+ * Ported from `woocommerce-analytics/at-a-glance` in woocommerce/woocommerce-analytics.
  * Which metric is plotted is the chart's own tab selection, not an attribute.
  */
 export default {

--- a/projects/packages/premium-analytics/widgets/stories/force-stats-mock-state.ts
+++ b/projects/packages/premium-analytics/widgets/stories/force-stats-mock-state.ts
@@ -29,19 +29,16 @@ const forcedStateMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 			return { date: '2026-01-01', period: 'day', summary: {}, days: {}, data: [] };
 		}
 		if ( state === 'error-retryable' ) {
-			// The local proxy's `no_connection` shape. Still a 403, so the error UI
-			// shows at once, but `describeError` keeps it retryable: a broken Jetpack
-			// connection can heal, unlike a permission gate.
+			// The local proxy's `no_connection` shape: still a 403, but `describeError`
+			// keeps it retryable because a broken connection can heal.
 			return Promise.reject( {
 				code: 'no_connection',
 				message: 'Mocked connection failure for Storybook.',
 				data: { status: 403 },
 			} );
 		}
-		// The WPCOM pass-through envelope, with the status attached the way the fetch
-		// layer attaches it. A 403 is not retried by `shouldRetryApiError`, so the
-		// error UI shows at once instead of after the query's retry backoff. Widgets
-		// on `describeError` read this as a permission gate and drop their Retry action.
+		// The WPCOM pass-through envelope. `shouldRetryApiError` does not retry a 403,
+		// so the error UI shows at once and `describeError` drops the Retry action.
 		return Promise.reject( {
 			error: 'unauthorized',
 			message: 'Mocked error response for Storybook.',
@@ -53,13 +50,9 @@ const forcedStateMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 };
 
 /**
- * Force a state for requests handled by story-local or legacy mocks.
- *
- * Re-register the middleware when setting a state because the most recently
- * registered `apiFetch` middleware runs first and stories load lazily.
- *
- * Use in `beforeEach`, clear on cleanup, and exclude the story from autodocs
- * because overrides are keyed by path. Cache isolation is automatic.
+ * Forces a state for requests handled by story-local or legacy mocks. Setting
+ * a state re-registers the middleware, since the most recently registered one
+ * runs first and stories load lazily. Keyed by path, so exclude the story from autodocs.
  *
  * @param pathFragment - Substring matched against the request path (e.g. `stats/clicks`).
  * @param state        - The forced state, or `null` to clear.

--- a/projects/packages/premium-analytics/widgets/stories/preset-for-story-interval.ts
+++ b/projects/packages/premium-analytics/widgets/stories/preset-for-story-interval.ts
@@ -5,17 +5,9 @@ import { PRESET_LAST_30_DAYS, PRESET_LAST_90_DAYS } from '@jetpack-premium-analy
 import type { StatsChartBucketPeriod, PresetType } from '@jetpack-premium-analytics/data';
 
 /**
- * The date preset a story needs to actually draw its chosen chart bucket.
- *
- * `WidgetRoot` normalizes injected report params through
- * `resolveIntervalForRange`, which coerces a bucket the range does not allow
- * back to the finest one it does. A story pinned to the default 30-day preset
- * therefore redraws a `month` pick as `day`, leaving the control inert. Moving
- * the range with the bucket keeps every option live, and mirrors the product,
- * where the interval control only offers what the range can fill.
- *
- * @param interval - The bucket the story control selected.
- * @return A preset whose range allows that bucket.
+ * `WidgetRoot` normalizes an injected report param through `resolveIntervalForRange`,
+ * which redraws a bucket the range can't fill down to the finest one it can — so
+ * the preset must move with the bucket to keep every story control option live.
  */
 export function presetForStoryInterval( interval: StatsChartBucketPeriod ): PresetType {
 	// 30 days allows `day` and `week`; 90 days is the shortest preset allowing `month`.

--- a/projects/packages/premium-analytics/widgets/stories/with-story-router.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/with-story-router.tsx
@@ -13,13 +13,10 @@ import type { Decorator } from '@storybook/react';
 import type { ReactNode } from 'react';
 
 /*
- * The story's own tree, rendered by the root route. A widget that reads the
- * report window off the URL needs an active match to read it from, and a match
- * exists only for a route the router actually renders — so the story is
- * rendered *by* the router rather than beside it. The root, not the dashboard
- * route, does the rendering: the dashboard and detail routes below carry no
- * component, so a link click that moves the memory history onto one of them
- * would otherwise unmount the story.
+ * The story is rendered *by* the router, since a widget reading the report
+ * window off the URL needs an active match. The root route does it, not the
+ * dashboard route: the routes below carry no component, so a link click moving
+ * the memory history onto one would otherwise unmount the story.
  */
 const storyChildren = createContext< ReactNode >( null );
 

--- a/projects/packages/premium-analytics/widgets/stories/with-widget-canvas.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/with-widget-canvas.tsx
@@ -2,16 +2,9 @@ import { useLayoutEffect, useRef } from 'react';
 import type { Decorator } from '@storybook/react';
 import type { ReactNode } from 'react';
 
-// Frame the widget root like the dashboard host cell for state stories:
-// - `justify-content: safe center` vertically centers a state shorter than the
-//   frame (the `height: 100%` error/empty boxes otherwise cling to the top);
-//   `safe` falls back to top alignment when content is taller, so a full
-//   leaderboard is never clipped at the top.
-//
-// The styles are applied to the widget's own root (the element WidgetRoot marks
-// with `container-name: widget`) rather than via a CSS descendant selector,
-// because Storybook inserts a `display: contents` wrapper of varying depth
-// between the card and the widget that makes positional selectors unreliable.
+// Frames the widget root like the dashboard host cell: `safe center` vertically
+// centers short states without clipping a taller one. Applied to the widget's own
+// root, not a CSS descendant selector, since Storybook's wrapper depth varies.
 function frameWidgetRoot( host: HTMLElement | null ) {
 	if ( ! host ) {
 		return;
@@ -28,9 +21,8 @@ function frameWidgetRoot( host: HTMLElement | null ) {
 	widgetRoot.style.justifyContent = 'safe center';
 }
 
-// A white, widget-sized card that frames a story the way the dashboard host frames a
-// widget in product, so each state (ready / loading / error / empty) reads as a real
-// dashboard widget rather than a bare fragment on the Storybook canvas.
+// A white, widget-sized card that frames a story like the dashboard host frames a
+// widget in product, so every state reads as a real widget, not a bare fragment.
 export function WidgetCanvas( { children }: { children: ReactNode } ) {
 	const hostRef = useRef< HTMLDivElement >( null );
 	useLayoutEffect( () => {

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/__tests__/subscriber-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/__tests__/subscriber-highlights.test.tsx
@@ -48,10 +48,8 @@ describe( 'SubscriberHighlightsWidget', () => {
 	} );
 
 	it( 'maps each subscriber count to its matching tile', async () => {
-		// Distinct sub-1000 values so the `useMultipliers` formatter leaves them
-		// unabbreviated, and `social_followers` is omitted so the `?? 0` fallback
-		// renders. The `Free` tile reads `email_subscribers`, so a mis-wired field
-		// (or a dropped fallback) changes this sequence and fails the test.
+		// Distinct sub-1000 values so `useMultipliers` leaves them unabbreviated,
+		// and `social_followers` is omitted so the `?? 0` fallback renders.
 		mockApiFetch.mockResolvedValue( {
 			counts: {
 				total_subscribers: 428,

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/render.tsx
@@ -29,10 +29,8 @@ import {
 } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
-// The subscribers/counts endpoint reports current totals and is not
-// period-scoped, so the widget ignores the dashboard date range. Report params
-// are still accepted at the WidgetRoot boundary (and Storybook may inject them)
-// so the host contract holds.
+// The subscribers/counts endpoint is not period-scoped, so the widget ignores
+// the dashboard date range; report params still flow to WidgetRoot for the host contract.
 type SubscriberHighlightsRenderAttributes = SubscriberHighlightsAttributes &
 	Partial< ReportParamsFieldAttributes >;
 type SubscriberHighlightsWidgetProps = WidgetRenderProps< SubscriberHighlightsRenderAttributes >;
@@ -58,11 +56,9 @@ const TILE_CONFIG: Record<
 };
 
 /**
- * Fetches the subscriber counts through the designated `useStatsSubscribersCounts`
- * Stats hook and renders the totals as a `MetricTileGrid`, with the loading /
- * error / empty states rendered through `<WidgetState>`. The counts module has
- * no comparison period, so each tile shows a bare formatted count. Which tiles
- * appear is controlled by the `metrics` attribute.
+ * Renders subscriber counts as tiles via `<WidgetState>`. The counts module has
+ * no comparison period, so each tile shows a bare count; `metrics` controls which
+ * tiles appear.
  */
 function SubscriberHighlightsReport( {
 	metrics = DEFAULT_SUBSCRIBER_METRICS,
@@ -90,9 +86,8 @@ function SubscriberHighlightsReport( {
 			<WidgetState
 				isLoading={ isLoading }
 				isFetching={ isFetching }
-				// The query keeps the prior response via `placeholderData`, so a failed
-				// refetch leaves the tiles on screen; only surface the error when there
-				// is nothing to show.
+				// `placeholderData` keeps the prior tiles on screen, so a transient
+				// refetch failure should not replace them with an error.
 				isError={ isError && ! hasCounts }
 				isEmpty={ ! hasCounts }
 				error={ {

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/__tests__/subscribers-chart.test.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/__tests__/subscribers-chart.test.tsx
@@ -57,8 +57,7 @@ describe( 'SubscribersChartWidget', () => {
 	} );
 
 	// Pinned west of UTC on purpose: under a UTC runner the wall-clock reading
-	// and the old instant reading coincide, so this would pass either way. `TZ`
-	// is not on the typed env shape, hence the cast.
+	// and the old instant reading coincide, so this would pass either way.
 	it( 'builds chart points as the wall clocks the buckets name, declared to the chart', async () => {
 		const env = process.env as Record< string, string | undefined >;
 		const runnerTimeZone = env.TZ;

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
@@ -46,9 +46,8 @@ const DATA_FORMAT = {
 	options: { useMultipliers: true, decimals: 0 },
 };
 
-// Ordered finest to coarsest, as `defaultPeriodForInterval` requires. Mirrors
-// `getStatsPeriodFromInterval` + `toSubscribersUnit` in the data layer, narrowed
-// to the dropdown's options.
+// Ordered finest to coarsest, as `defaultPeriodForInterval` requires; mirrors
+// `getStatsPeriodFromInterval` + `toSubscribersUnit`, narrowed to dropdown options.
 const SUBSCRIBERS_PERIODS = [
 	'day',
 	'week',
@@ -79,10 +78,9 @@ const METRIC_ACCESSORS: Record<
 };
 
 /**
- * Build the metric tabs from the fetched state, in canonical order, with Paid
- * subscribers only when the site has any. Each tab carries its headline total +
- * the previous-window total for the delta, and the per-period points for the
- * chart.
+ * Builds the metric tabs in canonical order, with Paid subscribers only when the
+ * site has any. Each tab carries its headline total, previous-window total, and
+ * per-period points.
  */
 function buildMetrics( state: SubscribersChartState ): MetricTab[] {
 	return SUBSCRIBERS_CHART_METRICS.filter( ( { id } ) => id !== 'paid' || state.hasPaid ).map(
@@ -110,10 +108,8 @@ type SubscribersChartInnerProps = {
 };
 
 /**
- * The bucket size follows the dashboard's chart interval control, clamped to
- * what this chart supports. The "Chart type" control is the `chartType`
- * attribute (`relevance: 'high'`), rendered by the widget host. Which metric is
- * plotted is the chart's own tab selection.
+ * The bucket size follows the dashboard's chart interval control, clamped to what
+ * this chart supports; which metric is plotted is the chart's own tab selection.
  */
 function SubscribersChartInner( { chartType }: SubscribersChartInnerProps ) {
 	const { reportParams } = useWidgetRootContext();
@@ -131,9 +127,8 @@ function SubscribersChartInner( { chartType }: SubscribersChartInnerProps ) {
 			<WidgetState
 				isLoading={ state.isLoading }
 				isFetching={ state.isFetching }
-				// The query keeps prior data via `placeholderData`, so a transient
-				// refetch failure keeps the chart visible; only surface the error
-				// when there is nothing to show.
+				// `placeholderData` keeps the prior chart on screen, so a transient
+				// refetch failure should not replace it with an error.
 				isError={ state.current.length === 0 && state.isError }
 				isEmpty={ state.current.length === 0 }
 				error={ {

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/use-subscribers-chart.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/use-subscribers-chart.ts
@@ -51,13 +51,8 @@ function toPoints( report: StatsSubscribersResponse | undefined ): SubscribersCh
 }
 
 /**
- * Fetch the subscribers time series for the dashboard's date range at the
- * given bucket size, together with the dashboard comparison window.
- *
- * The dashboard drives all three: the range, the previous-period overlay via
- * its comparison state, and `period` via its chart interval control. Both
- * windows are fetched by `useStatsSubscribersReport`, which layers the
- * comparison range on top of `reportParams`.
+ * Fetches the subscribers time series for the dashboard's date range and
+ * bucket size, including the comparison window when the dashboard requests it.
  */
 export default function useSubscribersChart(
 	reportParams: ReportParams,
@@ -75,11 +70,8 @@ export default function useSubscribersChart(
 		hasPaid: current.some( point => point.paid > 0 ),
 		isLoading: report.isLoading,
 		isFetching: report.isFetching,
-		// The Stats queries carry `placeholderData: previousData => previousData`, so a
-		// failed range change keeps the prior period's points in `current` while
-		// `isError` flips true. Only surface the error when there's nothing to show,
-		// so a transient refetch failure doesn't replace a populated chart with the
-		// error state.
+		// `placeholderData` keeps stale points in `current` after a failed refetch; only
+		// surface the error once there is nothing on screen to show.
 		isError: current.length === 0 && report.isError,
 		refetch: report.refetch,
 	};

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
@@ -35,11 +35,6 @@ export const SUBSCRIBERS_CHART_METRICS = [
 export type SubscribersChartMetricId = ( typeof SUBSCRIBERS_CHART_METRICS )[ number ][ 'id' ];
 
 /**
- * Configurable attributes for the Subscribers chart widget. Report params
- * still reach it through WidgetRoot: the dashboard date range, or
- * `attributes.reportParams` when a host injects them (e.g. Storybook and
- * dashboard previews).
- *
  * @property chartType - How to draw the selected metric. Defaults to `line`.
  */
 export type SubscribersChartAttributes = {
@@ -47,14 +42,9 @@ export type SubscribersChartAttributes = {
 };
 
 /**
- * Widget type definition.
- *
- * Ported from the Jetpack Stats `stats-subscribers-chart-section` card in
- * wp-calypso. The date range, previous-period comparison, and bucket size all
- * follow the dashboard controls — the legacy interval segmented control is the
- * dashboard's chart interval control now. Which metric is plotted is the
- * chart's own tab selection, not an attribute; `example.attributes` doubles as
- * the defaults applied to new instances.
+ * Ported from the Jetpack Stats `stats-subscribers-chart-section` card; the
+ * legacy interval control is now the dashboard's chart interval control.
+ * `example.attributes` doubles as the defaults applied to new instances.
  */
 export default {
 	icon: people,

--- a/projects/packages/premium-analytics/widgets/subscribers-list/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/render.tsx
@@ -70,9 +70,6 @@ function toSubscriberItems(
 }
 
 type SubscribersRosterProps = {
-	/**
-	 * Subscriber rows to render.
-	 */
 	items?: SubscriberListItem[];
 	/**
 	 * Number of subscribers beyond those in `items`. Rows the roster hides to
@@ -82,26 +79,14 @@ type SubscribersRosterProps = {
 };
 
 /**
- * Presentational subscriber roster. The card title ("Latest Subscribers") is
- * rendered by the dashboard host from the widget's `title`, so this body
- * renders the list only; loading, error, and empty are handled by
- * `<WidgetState>` in the data-connected `SubscribersReport`. Takes
- * already-fetched rows via props so Storybook can exercise the populated state
- * without an analytics backend.
- *
- * Renders `<SubscriberList>` directly: an intermediate wrapper has auto height,
- * which stops the roster's percentage height resolving against the tile and
- * disables row fitting.
+ * Presentational subscriber roster; title comes from the widget host, not here.
+ * Renders `<SubscriberList>` directly — an intermediate wrapper breaks row fitting.
  */
 export const SubscribersRoster = ( { items = [], moreCount = 0 }: SubscribersRosterProps ) => (
 	<SubscriberList items={ items } moreCount={ moreCount } />
 );
 
-/**
- * Fetches the latest subscribers through the designated `useStatsFollowers`
- * Stats hook and hands the normalized rows to the presentational roster, with
- * the loading / error / empty states rendered through `<WidgetState>`.
- */
+/** Fetches subscribers via `useStatsFollowers` and renders the roster through `<WidgetState>`. */
 function SubscribersReport() {
 	const { data, isLoading, isFetching, isError, refetch } = useStatsFollowers( {
 		type: 'all',
@@ -120,9 +105,8 @@ function SubscribersReport() {
 		<WidgetState
 			isLoading={ isLoading }
 			isFetching={ isFetching }
-			// The query keeps the prior response via `placeholderData`, so a failed
-			// refetch leaves rows on screen; only surface the error when there is
-			// nothing to show.
+			// `placeholderData` keeps stale rows after a failed refetch; only surface
+			// the error when nothing is on screen.
 			isError={ items.length === 0 && isError }
 			isEmpty={ items.length === 0 }
 			renderLoading={ <SubscriberListSkeleton rows={ WIDGET_ROW_LIMIT } /> }

--- a/projects/packages/premium-analytics/widgets/tags/render.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/render.tsx
@@ -77,9 +77,8 @@ function TagsInner() {
 		max: WIDGET_ROW_LIMIT,
 	} );
 
-	// Key the selection on the group's stable label and resolve the row fresh from
-	// the current data, so a background refetch that reorders rows keeps the user
-	// in the drilled-in view, and one that drops the group falls back to the top.
+	// Key the selection on the group's stable label and resolve it fresh from the
+	// data, so a reorder keeps the drilled-in view and a dropped group falls back to top.
 	const {
 		drillDownItem: selectedLabel,
 		drillDown: selectGroup,
@@ -188,10 +187,8 @@ function TagsInner() {
 }
 
 /**
- * Tags & categories widget: the site's most visited tags and categories for the
- * selected period, ranked by views. Ported from the Jetpack Stats "Tags &
- * categories" module. Grouped rows (several tags/categories sharing a post) drill
- * down to their individual members.
+ * Ported from the Jetpack Stats "Tags & categories" module. Grouped rows
+ * (several tags/categories sharing a post) drill down to their individual members.
  */
 export default function Tags( { attributes = {} }: TagsWidgetProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/tags/widget.ts
+++ b/projects/packages/premium-analytics/widgets/tags/widget.ts
@@ -8,14 +8,9 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 export type TagsAttributes = Record< never, never >;
 
 /**
- * Widget type definition for the Tags & categories widget.
- *
- * Ported from the Jetpack Stats "Tags & categories" module. Lists the site's
- * most visited tags and categories for the selected period, ranked by views.
- *
- * Data: read from the `stats/tags` endpoint via `useStatsTags`. A row can group
- * several tags/categories that share a post; those grouped rows have no single
- * archive URL and drill down to their individual members instead.
+ * Ported from the Jetpack Stats "Tags & categories" module: most-visited tags
+ * and categories, ranked by views. Grouped rows (multiple tags on one post)
+ * have no single archive URL and drill down to their members instead.
  */
 export default {
 	icon: category,

--- a/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
@@ -22,9 +22,8 @@ registerStatsMocks();
 
 const TOP_PLATFORMS_RENDER_MODULE = 'storybook/top-platforms';
 
-// attributes/example flow through from the module so the dashboard host renders
-// the real "View by" toolbar control for the `relevance: 'high'` attribute, as
-// in Locations. `presentation` comes from widget.json ( 'framed' ).
+// attributes/example flow through so the dashboard host renders the real "View by"
+// toolbar control (`relevance: 'high'`); `presentation` comes from widget.json.
 const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface TopPlatformsStoryControls {

--- a/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
@@ -18,11 +18,9 @@ export type TopPlatformsAttributes = {
 };
 
 /**
- * Top Platforms widget type definition.
- *
  * Shows Browser and OS breakdown as a ranked leaderboard. The active
- * dimension is the `platformDimension` attribute (`relevance: 'high'`),
- * so the widget host renders its control.
+ * dimension is `platformDimension` (`relevance: 'high'`), so the widget host
+ * renders its control.
  */
 export default {
 	icon: desktop,

--- a/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
@@ -41,9 +41,8 @@ function DashboardWidgetChromeFixture( { children }: { children: ReactNode } ) {
 	);
 }
 
-// The widget requests a multi-day window, so the stats query layer summarizes
-// the views into the top-level `summary` bucket rather than per-day `days`
-// buckets.
+// A multi-day window makes the stats query layer summarize into the top-level
+// `summary` bucket rather than per-day `days` buckets.
 const TOP_POSTS_RESPONSE = {
 	date: '2026-06-10',
 	days: {},
@@ -90,9 +89,8 @@ describe( 'TopPostsWidget', () => {
 		expect( titleLink ).not.toHaveAttribute( 'target' );
 		expect( titleLink ).toHaveAttribute( 'title', 'Hello World Post' );
 
-		// A row with a detail page carries no link out to the live post: the
-		// external-link icon marks destinations outside the app, and the detail
-		// page holds that link.
+		// A row with a detail page carries no outbound link: the external-link
+		// icon marks destinations outside the app; the detail page holds that link.
 		expect(
 			screen.queryByRole( 'link', { name: /open hello world post in a new tab/i } )
 		).not.toBeInTheDocument();

--- a/projects/packages/premium-analytics/widgets/top-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/render.tsx
@@ -201,11 +201,8 @@ export const TopPostsLeaderboard = ( {
 };
 
 /**
- * Map the data layer's merged top-posts rows onto the shape the leaderboard
- * renders. Rows without a link are kept but render unlinked — with
- * `skip_archives=1` the API still returns the "Homepage (Latest posts)"
- * entry, which has no URL or post ID. Missing comparison matches stay
- * `undefined`.
+ * Maps merged top-posts rows to leaderboard shape. With `skip_archives=1` the
+ * API still returns a link-less "Homepage (Latest posts)" entry, kept unlinked.
  */
 function toTopPostRows( items: StatsTopPostsComparisonItem[] ): TopPostRow[] {
 	return items.map( item => {
@@ -226,15 +223,8 @@ function toTopPostRows( items: StatsTopPostsComparisonItem[] ): TopPostRow[] {
 }
 
 /**
- * Fetches the top-posts report through the designated `useStatsTopPosts` Stats
- * traffic hook and hands the normalized rows to the presentational
- * `TopPostsLeaderboard`. The date range and comparison period come from the
- * dashboard picker via `reportParams`.
- *
- * With `skip_archives=1` the API keeps the homepage-as-latest-posts entry in
- * `postviews` (titled "Homepage (Latest posts)", no URL), so it surfaces here
- * in the Posts & pages list — same distribution as the Stats "Most viewed"
- * card, where the Archives list excludes it.
+ * Fetches top-posts via `useStatsTopPosts` and feeds `TopPostsLeaderboard`.
+ * Same `skip_archives=1` homepage-entry caveat as `toTopPostRows`.
  */
 function TopPostsReport() {
 	const { reportParams } = useWidgetRootContext();
@@ -244,9 +234,8 @@ function TopPostsReport() {
 		[ reportParams ]
 	);
 
-	// Row matching, ranked capping (the API caps `postviews` at `max` but
-	// appends the homepage entry on top of it), and comparison-overlap gating
-	// all live in the data layer's merge helper (see AGENTS.md).
+	// Row matching, capping, and comparison-overlap gating live in the data
+	// layer's merge helper (see AGENTS.md), which appends the homepage entry on top of `max`.
 	const { comparisonRows, hasComparison, isLoading, isFetching, isError, refetch } =
 		useStatsTopPosts( statsParams, { maxRows: WIDGET_ROW_LIMIT } );
 
@@ -272,9 +261,8 @@ function TopPostsReport() {
 		return base;
 	}, [ withComparison ] );
 
-	// Stats queries keep the previous period's rows as placeholder data while a
-	// refetch is in flight. The shared hook keeps the export hidden until those
-	// rows belong to the active date range.
+	// Stats queries keep placeholder rows during a refetch; the shared hook hides
+	// export until rows belong to the active date range.
 	const {
 		canExport,
 		rows: csvRows,
@@ -292,9 +280,8 @@ function TopPostsReport() {
 				<WidgetState
 					isLoading={ isLoading }
 					isFetching={ isFetching }
-					// The Stats queries carry `placeholderData`, so a failed range change
-					// keeps the prior period's rows visible; only surface the error when
-					// there is nothing to show.
+					// `placeholderData` keeps stale rows visible after a failed range change;
+					// only surface the error when nothing is on screen.
 					isError={ rows.length === 0 && isError }
 					isEmpty={ rows.length === 0 }
 					error={ {
@@ -334,10 +321,8 @@ function TopPostsReport() {
  * report groups by. Types the API may add later fall back to the raw key.
  */
 function archiveTypeLabel( archiveType: string ): string {
-	// Same labels as the Calypso Stats "Most viewed" card's Archives tab
-	// (`getArchiveKeyLabel` in calypso/state/stats/lists/utils.js), so both
-	// surfaces name archive categories identically. `post_type` is a PA
-	// addition — Calypso falls through to capitalization for it.
+	// Mirrors Calypso's `getArchiveKeyLabel` (state/stats/lists/utils.js); `post_type`
+	// is PA-only — Calypso capitalizes it instead.
 	switch ( archiveType ) {
 		case 'author':
 			return __( 'Authors', 'jetpack-premium-analytics-pkg' );
@@ -346,10 +331,8 @@ function archiveTypeLabel( archiveType: string ): string {
 		case 'err':
 			return __( 'Error', 'jetpack-premium-analytics-pkg' );
 		case 'home':
-			// Defensive only: with `skip_archives=1` the API surfaces the homepage
-			// entry inside the Posts & pages list (server-titled) and drops it
-			// from this report, and the Archives view filters any residual `home`
-			// entry out. This label matches the server title if one slips through.
+			// Defensive: `skip_archives=1` normally keeps `home` out of this report (it's
+			// filtered in the Archives view); matches the server title if one slips through.
 			return __( 'Homepage (Latest posts)', 'jetpack-premium-analytics-pkg' );
 		case 'search':
 			return __( 'Searches', 'jetpack-premium-analytics-pkg' );
@@ -381,12 +364,9 @@ function humanizeArchiveGroupLabel( label: string ): string {
 }
 
 /**
- * Recursively map the data layer's merged archive rows onto leaderboard rows.
- * Top-level items get the shared archive-category labels; nested group items
- * (taxonomy keys) are humanized; leaf items keep their own label (term name,
- * search phrase, …) and carry their archive-page URL. Children are preserved
- * so grouped rows can drill down, and missing comparison matches stay
- * `undefined`.
+ * Recursively maps merged archive rows to leaderboard rows: top-level items
+ * get shared category labels, nested groups get humanized labels, leaves keep
+ * their own label and URL, and children are preserved for drill-down.
  */
 function toArchiveRows( items: StatsArchivesComparisonItem[], isTopLevel = true ): TopPostRow[] {
 	return items.map( item => {
@@ -413,22 +393,16 @@ function toArchiveRows( items: StatsArchivesComparisonItem[], isTopLevel = true 
 }
 
 /**
- * The Archives view: views of archive pages (taxonomy, post-type, search, and
- * date archives) as one aggregate row per archive type, through the designated
- * `useStatsArchives` Stats traffic hook. Grouped rows drill into their
- * individual archive pages (taxonomies drill twice: taxonomy → terms), with a
- * back link to the parent list — the same convention as the Locations and
- * Clicks widgets. Mirrors `TopPostsReport` otherwise: the date range and
- * comparison period come from the dashboard picker via `reportParams`, and
- * comparison UI is gated on real row overlap between the two periods.
+ * Archives view via `useStatsArchives`: one aggregate row per archive type,
+ * drilling into pages (taxonomies drill twice). Back-link convention matches
+ * Locations and Clicks. Comparison UI is gated on real row overlap.
  */
 function ArchivesReport() {
 	const { reportParams } = useWidgetRootContext();
 	const { drillDownItem: drillPath, drillDown, resetDrillDown } = useWidgetDrillDown< string[] >();
 
-	// Row matching (per level, so same-named terms under different parents
-	// cannot cross-match), the visible-row cap, and the comparison-overlap
-	// gate all live in the data layer's merge helper (see AGENTS.md).
+	// Row matching (per level, so same-named terms under different parents can't
+	// cross-match), capping, and comparison gating live in the merge helper (see AGENTS.md).
 	const { comparisonRows, hasComparison, isLoading, isFetching, isError, refetch } =
 		useStatsArchives( reportParams, { maxRows: WIDGET_ROW_LIMIT } );
 
@@ -443,9 +417,8 @@ function ArchivesReport() {
 	);
 	const withComparison = hasComparison;
 
-	// Resolve the drill path against the current rows. The back link names the
-	// list it returns to: the root list on the first drill level, otherwise the
-	// parent row's label.
+	// Resolve the drill path against current rows; the back link names the list
+	// it returns to (root on the first level, else the parent row's label).
 	const { activeRows, backLabel, isPathResolved } = useMemo( () => {
 		let list = rows;
 		let label: string | null = null;
@@ -466,10 +439,8 @@ function ArchivesReport() {
 		return { activeRows: list, backLabel: label, isPathResolved: resolved };
 	}, [ rows, drillPath ] );
 
-	// When the data no longer contains the drilled path (e.g. the date range
-	// changed and the archive type disappeared), drop the stale selection so
-	// the root list is fully interactive again. Skip while a fetch is in
-	// flight: placeholder/refreshing data must not wipe a valid selection.
+	// Drop a drilled path the current data no longer contains (e.g. after a date
+	// range change) once loading settles — refetches must not wipe a valid selection.
 	useEffect( () => {
 		if ( drillPath && ! isPathResolved && ! isLoading && ! isFetching ) {
 			resetDrillDown();
@@ -535,10 +506,8 @@ function ArchivesReport() {
 }
 
 /**
- * The `contentView` attribute (`relevance: 'high'`, so the widget host renders
- * its control in the frame header) switches between the Posts & pages and
- * Archives views. Attribute defaults are applied here, in exactly one place,
- * before the inner components receive them.
+ * `contentView` (`relevance: 'high'`) switches Posts & pages vs. Archives.
+ * Defaults are applied here, in exactly one place, before inner components see them.
  */
 export default function TopPosts( { attributes = {} }: TopPostsWidgetProps ) {
 	const contentView = attributes.contentView ?? 'posts';

--- a/projects/packages/premium-analytics/widgets/top-posts/stories/top-posts.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/stories/top-posts.stories.tsx
@@ -29,9 +29,8 @@ registerStatsMocks();
 
 const TOP_POSTS_RENDER_MODULE = 'storybook/top-posts';
 
-// Attribute metadata flows through from the module to drive the host-rendered
-// chrome: the high-relevance `contentView` control in the framed header and the
-// settings fields. `presentation` comes from widget.json ( 'framed' ).
+// Attribute metadata flows through to drive host chrome: the high-relevance
+// `contentView` control and settings fields. `presentation` comes from widget.json.
 const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface TopPostsStoryControls {

--- a/projects/packages/premium-analytics/widgets/top-posts/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-posts/widget.ts
@@ -11,10 +11,8 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 import { SelectField } from '@jetpack-premium-analytics/fields';
 
 /**
- * Configurable attributes for the Most viewed widget. Mirrors the
- * `attributes` declared on the widget definition below; the host passes the
- * selected values through to `render.tsx`. The date range is owned by the
- * dashboard picker and read from report params, not from attributes.
+ * Mirrors the widget definition's `attributes` below. The date range is
+ * owned by the dashboard picker, not by these attributes.
  */
 export type TopPostsAttributes = {
 	/**
@@ -26,14 +24,9 @@ export type TopPostsAttributes = {
 };
 
 /**
- * Widget type definition.
- *
- * Ported from the Jetpack Stats "Most viewed" card: a leaderboard of the
- * most-viewed posts & pages, switchable to archive pages. The active view is
- * the `contentView` attribute (`relevance: 'high'`), so the widget host
- * renders its control in the frame header.
- *
- * New instances default to the Posts & pages view.
+ * Ported from the Jetpack Stats "Most viewed" card. The active view is the
+ * `contentView` attribute (`relevance: 'high'`), so the widget host renders
+ * its control in the frame header.
  */
 export default {
 	icon: page,

--- a/projects/packages/premium-analytics/widgets/total-views/render.tsx
+++ b/projects/packages/premium-analytics/widgets/total-views/render.tsx
@@ -33,12 +33,10 @@ type TotalViewsWidgetProps = WidgetRenderProps< TotalViewsRenderAttributes > & {
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
-// Fixed, never derived from the dashboard interval. `stats/visits` reports
-// visitors as unique-within-bucket and the headline is the sum of the buckets,
-// so a coarser bucket silently changes what the number means: a daily visitor
-// counts 30 times across 30 daily buckets but 13 across 13 weekly ones, which
-// lets a longer range report a smaller total. Views are additive and unaffected,
-// but both cards use the same unit so they stay comparable and share a request.
+// Fixed, never derived from the dashboard interval: `stats/visits` counts a
+// visitor once per bucket, so a coarser bucket undercounts a repeat visitor and a
+// longer range could report a smaller total. Views are additive and unaffected,
+// but both cards share one unit and one request.
 const PERIOD = 'day';
 
 // `decimals: 0` would round 291,900 to "292K"; the prototype's headline keeps

--- a/projects/packages/premium-analytics/widgets/total-visitors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/total-visitors/render.tsx
@@ -34,12 +34,10 @@ type TotalVisitorsWidgetProps = WidgetRenderProps< TotalVisitorsRenderAttributes
 	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
 };
 
-// Fixed, never derived from the dashboard interval. `stats/visits` reports
-// visitors as unique-within-bucket and the headline is the sum of the buckets,
-// so a coarser bucket silently changes what the number means: a daily visitor
-// counts 30 times across 30 daily buckets but 13 across 13 weekly ones, which
-// lets a longer range report a smaller total. Views are additive and unaffected,
-// but both cards use the same unit so they stay comparable and share a request.
+// Fixed, never derived from the dashboard interval: `stats/visits` counts
+// visitors unique-within-bucket, so a coarser bucket silently shrinks the
+// summed headline (a daily visitor counts 30 times across 30 daily buckets but
+// only 13 across 13 weekly ones). Views are additive and unaffected.
 const PERIOD = 'day';
 
 // `decimals: 0` would round 291,900 to "292K"; the prototype's headline keeps

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/render.test.tsx
@@ -21,9 +21,8 @@ jest.mock( '@jetpack-premium-analytics/routing', () => ( {
 	} ),
 } ) );
 
-// The chart itself is not this file's subject: the bucket the widget resolves is,
-// and `useTrafficChart` is where it lands. The stand-in records its props so the
-// click handler the widget hands it can be driven.
+// The chart itself is not this file's subject: `useTrafficChart` resolves the
+// bucket. The stand-in records props so the click handler can be driven.
 const mockMetricTabsChart = jest.fn();
 jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 	...jest.requireActual( '@jetpack-premium-analytics/widgets-toolkit' ),

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/use-traffic-chart.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/use-traffic-chart.test.tsx
@@ -87,10 +87,9 @@ function routeRequests( comparison?: ComparisonFixtures ) {
 }
 
 /**
- * The `stats/visits` requests the hook issued. `apiFetch` is mocked wholesale, so
- * it also records core-data's own `/wp/v2/settings` traffic (the site timezone
- * resolves through it) — counting raw calls would make these assertions depend on
- * when that happens to be warmed.
+ * The `stats/visits` requests the hook issued. `apiFetch` is mocked wholesale
+ * and also records core-data's `/wp/v2/settings` traffic, so raw call counts
+ * would depend on when that warms.
  *
  * @return One path per visits request, in call order.
  */
@@ -125,10 +124,8 @@ describe( 'useTrafficChart', () => {
 			'comments',
 			'likes',
 		] );
-		// This only proves `value` is each metric's correct total (not a
-		// hardcoded or swapped field) — sanitizeStatsTimeSeriesResponse derives
-		// the summary by summing these same rows, so it can't tell a
-		// summary-read apart from a re-sum of the points.
+		// Proves `value` is each metric's correct total, not that it's read from the
+		// summary field — sanitizeStatsTimeSeriesResponse sums these same rows either way.
 		expect( metrics[ 0 ].value ).toBe( 2000 );
 		expect( metrics[ 1 ].value ).toBe( 1500 );
 		expect( metrics[ 2 ].value ).toBe( 20 );
@@ -183,9 +180,8 @@ describe( 'useTrafficChart', () => {
 		expect( byKey.views.previous ).toHaveLength( 1 );
 	} );
 
-	// The misleading-zero guard: an empty comparison response must read as "no
-	// previous period", not as a previous total of 0 (which would render a
-	// -100% delta against a real current value).
+	// Misleading-zero guard: an empty comparison response must read as "no
+	// previous period", not a previous total of 0 (would render a false -100% delta).
 	it( 'omits the previous period when the comparison request returns no rows', async () => {
 		// Shared between the views/visitors and likes/comments requests below, so
 		// `fields` names neither pair specifically; `data: []` means it's never read.

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -45,10 +45,8 @@ type TrafficChartInnerProps = {
 };
 
 /**
- * The bucket size follows the dashboard's chart interval control, clamped to
- * what this chart supports. The "Chart type" control is the `chartType`
- * attribute (`relevance: 'high'`), rendered by the widget host. Which metric is
- * plotted is the chart's own tab selection.
+ * The bucket size follows the dashboard's chart interval control, clamped to what
+ * this chart supports; which metric is plotted is the chart's own tab selection.
  */
 function TrafficChartInner( { chartType }: TrafficChartInnerProps ) {
 	const { reportParams } = useWidgetRootContext();
@@ -76,8 +74,7 @@ function TrafficChartInner( { chartType }: TrafficChartInnerProps ) {
 	} = useTrafficChart( reportParams, period );
 	const groupLabel = __( 'Traffic metric', 'jetpack-premium-analytics-pkg' );
 	// A metric the endpoint can't serve at this bucket size carries its own
-	// explanation, so it must not count towards emptiness and let the empty state
-	// hide that explanation.
+	// explanation, so it must not count toward emptiness and hide that message.
 	const servedMetrics = metricTabs.filter( metric => ! metric.unavailable );
 
 	return (
@@ -88,9 +85,8 @@ function TrafficChartInner( { chartType }: TrafficChartInnerProps ) {
 				// `useTrafficChart` already gates `isError` per query on that query
 				// having no rows, so a transient refetch failure keeps the chart.
 				isError={ isError }
-				// `[].every()` is true, so the length test is what keeps a chart whose
-				// every metric is unavailable out of the empty state, which would
-				// replace those explanations with "no data".
+				// `[].every()` is true, so the length check keeps an all-unavailable chart
+				// out of the empty state, which would replace those explanations with "no data".
 				isEmpty={
 					servedMetrics.length > 0 && servedMetrics.every( metric => metric.current.length === 0 )
 				}

--- a/projects/packages/premium-analytics/widgets/traffic-chart/use-traffic-chart.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/use-traffic-chart.ts
@@ -57,13 +57,9 @@ function toVisitsParams(
 }
 
 /**
- * Fetch the traffic time series for the dashboard's report params. Views and
- * visitors ride one request, likes and comments a second — split (rather than a
- * single four-field request) because the visits endpoint's latency grows with
- * the number of requested fields, so two smaller requests resolve faster in
- * parallel. Mirrors how Calypso's chart tabs fetch each pair. The likes and
- * comments request is skipped entirely at the hourly grain, which cannot fill
- * either field.
+ * Views/visitors and likes/comments ride separate requests — the visits
+ * endpoint's latency grows with requested fields, so two smaller requests
+ * resolve faster in parallel, mirroring Calypso's chart tabs.
  */
 export default function useTrafficChart(
 	reportParams: ReportParams,
@@ -123,9 +119,8 @@ export default function useTrafficChart(
 		[ isServed, vvPrimary, vvComparison, vvHasComparison, lcPrimary, lcComparison, lcHasComparison ]
 	);
 
-	// Depend on the underlying refetch callbacks (each a stable `useReport`
-	// `useCallback`), not the fresh result objects, so this stays stable across
-	// renders.
+	// Depend on the underlying refetch callbacks (stable `useReport` `useCallback`s),
+	// not the fresh result objects, so this stays stable across renders.
 	const { refetch: refetchViewsVisitors } = viewsVisitors;
 	const { refetch: refetchLikesComments } = likesComments;
 	const refetch = useCallback( () => {
@@ -133,10 +128,8 @@ export default function useTrafficChart(
 		refetchLikesComments();
 	}, [ refetchViewsVisitors, refetchLikesComments ] );
 
-	// Gate the error per query — the two independent queries back separate tabs, so
-	// one failing on first load must surface an error rather than render as empty
-	// tabs beside the other's populated chart. `placeholderData` keeps a query's
-	// prior rows on a transient refetch failure, so a query with rows is not errored.
+	// Gate the error per query so a failed one surfaces beside the other's populated
+	// tabs instead of rendering empty; placeholder data spares a query that still has rows.
 	const isError =
 		( viewsVisitors.isError && ! vvPrimary?.data?.length ) ||
 		( likesComments.isError && ! lcPrimary?.data?.length );

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
@@ -38,18 +38,9 @@ export type TrafficChartType = ChartDisplayChartType;
 export type TrafficChartMetricId = 'views' | 'visitors' | 'comments' | 'likes';
 
 /**
- * The metric tabs the chart shows, in display order: the id and label of each
- * metric. The id doubles as the visits `stat_fields` field the tab reads.
- *
- * Views and Visitors name each other as `counterpartId`, so whichever of the
- * two is selected draws the other alongside it, hidden until the reader reveals
- * it from the legend — except at the hourly bucket, where Visitors is
- * unavailable and Views stands alone. Comments and Likes answer different
- * questions from each other and stand alone.
- *
- * `counterpartId` is constrained to the ids above rather than to `string`: a
- * key naming no metric is ignored in silence, so a typo would simply drop the
- * pairing with nothing to notice.
+ * Metric tabs in display order; id doubles as the `stat_fields` value. Views
+ * and Visitors pair via `counterpartId` (unavailable at the hourly bucket);
+ * `counterpartId` is typed to the id set so a typo can't silently drop the pairing.
  */
 export const TRAFFIC_CHART_METRICS = [
 	{ id: 'views', label: __( 'Views', 'jetpack-premium-analytics-pkg' ), counterpartId: 'visitors' },
@@ -67,10 +58,8 @@ export const TRAFFIC_CHART_METRICS = [
 }[];
 
 /**
- * Configurable attributes for the Traffic chart widget. Report params still
- * reach it through WidgetRoot: the dashboard date range, or
- * `attributes.reportParams` when a host injects them (e.g. Storybook and
- * dashboard previews).
+ * Configurable attributes for the Traffic chart widget; report params still
+ * reach it through WidgetRoot or `attributes.reportParams` from a host.
  *
  * @property chartType - How to draw the selected metric. Defaults to `line`.
  */
@@ -79,15 +68,9 @@ export type TrafficChartAttributes = {
 };
 
 /**
- * Widget type definition.
- *
- * Ported from the Jetpack Stats `stats-chart-tabs` card in wp-calypso (the chart
- * above the Traffic page). Renders the selected period's Views, Visitors,
- * Comments, and Likes as selectable metric tabs over a comparative chart. The
- * date range, comparison state, and bucket size come from the dashboard via
- * `reportParams`; `chartType` switches between lines and bars. Which metric is
- * plotted is the chart's own tab selection, not an attribute.
- * `example.attributes` doubles as the defaults applied to new instances.
+ * Ported from the Jetpack Stats `stats-chart-tabs` card in wp-calypso. Date
+ * range, comparison, and bucket size come from `reportParams`; the plotted
+ * metric is the chart's own tab selection, not an attribute.
  */
 export default {
 	icon: trendingUp,

--- a/projects/packages/premium-analytics/widgets/traffic-views-activity/__tests__/traffic-views-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-views-activity/__tests__/traffic-views-activity.test.tsx
@@ -323,9 +323,8 @@ describe( 'TrafficViewsActivityWidget', () => {
 			expect( screen.getByTestId( 'heatmap' ) ).toHaveAttribute( 'data-columns', '53' );
 		} );
 
-		// jsdom measures every element as 0x0, which resolves to zero columns and
-		// hands the chart the whole series — so a `data-columns` assertion alone
-		// never exercises trimming. These stub a real tile so it does.
+		// jsdom measures every element as 0x0, which hands the chart the whole series
+		// — a `data-columns` assertion alone never exercises trimming. These stub a real tile.
 		describe( 'in a measured tile', () => {
 			const currentYear = {
 				...REPORT_PARAMS,
@@ -357,10 +356,8 @@ describe( 'TrafficViewsActivityWidget', () => {
 					restoreTileSize();
 				}
 
-				// The regression this guards (WOOA7S-1963): the grid ran on to a
-				// December that had not happened, so the columns a smaller tile kept
-				// were the empty future weeks and the year's own traffic was trimmed
-				// away — at 1000x300 the heatmap came out entirely blank.
+				// Regression guard (WOOA7S-1963): a smaller tile kept empty future-week
+				// columns and trimmed the year's own traffic away — 1000x300 came out blank.
 				expect( chartDayValues() ).toContain( 'Mon, Aug 10, 2026:44' );
 			} );
 
@@ -468,9 +465,8 @@ describe( 'TrafficViewsActivityWidget', () => {
 
 	describe( 'cell presentation', () => {
 		it( 'fits the grid inside the shipped one-row tile', () => {
-			// A 200px grid row less the widget's own chrome — the size this widget
-			// ships at, and the tightest it has to fit. The grid is sized to the tile
-			// so it cannot overflow and have its month labels clipped away.
+			// The widget's shipped tile size, and the tightest it has to fit; sized so
+			// the grid cannot overflow and clip its month labels.
 			const restoreTileSize = stubTileSize( 1000, 86 );
 
 			try {

--- a/projects/packages/premium-analytics/widgets/traffic-views-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-views-activity/render.tsx
@@ -60,18 +60,15 @@ function TrafficViewsActivityInner() {
 	// them against different days.
 	const today = format( new Date(), 'yyyy-MM-dd' );
 
-	// A ceiling only. A floor would reach back past the selection, putting years
-	// outside the card's heading inside it (WOOA7S-1963). It is equally the range
-	// the heatmap draws and pages through — with no floor the two coincide, so
-	// paging can never leave the selection.
+	// A ceiling only — a floor would leak years outside the selection into the
+	// card's heading (WOOA7S-1963); it also bounds paging, so paging can't escape the selection.
 	const fetchWindow = useMemo(
 		() => resolveCalendarHeatmapWindow( reportParams, { maxDays: windowDays }, today ),
 		[ reportParams, windowDays, today ]
 	);
 
-	// The period as selected, before the ceiling. All time on a long-lived site
-	// reaches back past the window, and the empty state has to know the response
-	// says nothing about the years left out.
+	// The period as selected, before the ceiling — the empty state needs it to know
+	// the response says nothing about years the ceiling left out.
 	const periodWindow = useMemo(
 		() => resolveCalendarHeatmapWindow( reportParams, {}, today ),
 		[ reportParams, today ]
@@ -106,10 +103,8 @@ function TrafficViewsActivityInner() {
 		[ report ]
 	);
 
-	// Key the empty state to the response rather than the densified calendar, whose
-	// missing dates are represented by null-valued cells. Days outside the window
-	// are still ruled out, so a stale response for a wider selection cannot
-	// suppress the empty state while the new one loads.
+	// Key the empty state to the response, not the densified calendar (whose gaps
+	// are null cells) — a stale wider-selection response can't hide the empty state.
 	const hasViews = ( report?.data ?? [] ).some( row => {
 		const day = String( row.time_interval );
 
@@ -118,10 +113,8 @@ function TrafficViewsActivityInner() {
 		);
 	} );
 
-	// And where the period outran the window, the message names the days the request
-	// covers instead of the period: the site may well have views outside them. Both
-	// ends are named — the clipped end is the start, but the period can also end
-	// before today, and "since" would speak for the days after it.
+	// When the period outran the window, name the days the request covers (both
+	// ends) — the period can end before today, so "since" would misname the tail.
 	const windowStart = parseSiteDateTime( fetchWindow.startDate );
 	const windowEnd = parseSiteDateTime( fetchWindow.endDate );
 	const emptyDescription =

--- a/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
@@ -109,12 +109,9 @@ function UtmInsightsInner( { utmDimension, showReportLink }: UtmInsightsInnerPro
 	);
 	const withComparison = isDrillDown ? !! selectedUtm?.childrenHaveComparison : hasComparison;
 
-	// The view already falls back to the top list when the selected row is
-	// missing or no longer drillable (no children); clear the stored selection
-	// too once data has settled without a drillable match, so stale state
-	// can't resurface on a later refetch (WOOA7S-1666). In-flight fetches keep
-	// placeholder rows and errors aren't settled data, so a valid selection
-	// survives refetches and transient failures.
+	// Clear the stored selection only once data has settled without a drillable
+	// match, so it can't resurface on a later refetch (WOOA7S-1666) and a valid
+	// selection survives in-flight fetches and transient failures.
 	useEffect( () => {
 		if ( selectedUtmLabel && ! isDrillDown && ! isLoading && ! isFetching && ! isError ) {
 			clearSelectedUtm();

--- a/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
@@ -25,13 +25,9 @@ export type UtmInsightsAttributes = {
 };
 
 /**
- * UTM Insights widget type definition.
- *
- * Shows traffic breakdown by UTM parameter via the PA proxy at
- * `stats/utm/{utmParam}`. The active dimension is the `utmDimension`
- * attribute (`relevance: 'high'`), so the widget host renders its
- * control. Date range comes from WidgetRoot's reportParams (the
- * shared dashboard date picker).
+ * Shows traffic breakdown by UTM parameter via `stats/utm/{utmParam}`. The
+ * active dimension is `utmDimension` (`relevance: 'high'`), so the widget
+ * host renders its control.
  */
 export default {
 	icon: megaphone,

--- a/projects/packages/premium-analytics/widgets/video-detail-views-performance/__tests__/video-detail-views-performance.test.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-views-performance/__tests__/video-detail-views-performance.test.tsx
@@ -73,11 +73,9 @@ function chartedMetrics( chart: HTMLElement ): ChartedMetric[] {
 }
 
 /**
- * Builds a raw `statType=all` response (wpcom #229903): per-day tuples named
- * by `fields`, with impressions/watch-time columns derived from the plays the
- * test cares about and an explicit per-day retention rate, plus canonical
- * totals over the window. The retention total is play-weighted server-side, so
- * the fixture computes the same weighting.
+ * Raw `statType=all` response shape (wpcom #229903): per-day tuples, with
+ * impressions/watch-time derived from plays. The retention total is
+ * play-weighted server-side, so the fixture computes the same weighting.
  */
 function buildSingleVideoResponse( data: Array< [ string, number, number? ] > ) {
 	const totalPlays = data.reduce( ( sum, [ , plays ] ) => sum + plays, 0 );
@@ -136,8 +134,7 @@ const PRIMARY_WINDOW_RESPONSE = buildSingleVideoResponse( [
 ] );
 
 // A 28-day window, the shortest that allows a weekly interval: `WidgetRoot`
-// normalizes report params through `resolveIntervalForRange`, so an interval
-// the range disallows is coerced away before the widget ever sees it.
+// normalizes report params, coercing away an interval the range disallows.
 const WEEKLY_WINDOW_PARAMS = {
 	...DEFAULT_PARAMS,
 	from: '2026-06-22T00:00:00.000+08:00',
@@ -186,9 +183,8 @@ describe( 'VideoDetailViewsPerformanceWidget', () => {
 		expect( watchTime.values ).toEqual( [ 0, 1.25, 0, 1.75, 0, 0, 0 ] );
 		expect( watchTime.value ).toBe( 3 );
 
-		// Retention charts as a fraction for the percentage format: each day's
-		// rate is its own weight group, and zero-play days have no measured
-		// retention. The headline comes from the server total, play-weighted.
+		// Retention charts as a fraction for the percentage format; zero-play days
+		// have no measured retention, and the headline is the server's play-weighted total.
 		expect( retention.format ).toBe( 'percentage' );
 		expect( retention.values ).toEqual( [ 0, 0.4, 0, 0.6, 0, 0, 0 ] );
 		expect( retention.value ).toBeCloseTo( ( 5 * 40 + 7 * 60 ) / 12 / 100, 10 );
@@ -201,17 +197,15 @@ describe( 'VideoDetailViewsPerformanceWidget', () => {
 		expect( requestedPaths ).toHaveLength( 1 );
 		expect( requestedPaths[ 0 ] ).toContain( 'statType=all' );
 		expect( requestedPaths[ 0 ] ).toContain( 'period=day' );
-		// The unmodified report params: the request shape is shared with the rest
-		// of the page (see use-video-metrics), so this pins the exact shape rather
-		// than just the calendar day.
+		// The unmodified report params: the request shape is shared with the rest of
+		// the page (see use-video-metrics), so this pins the exact shape, not just the day.
 		const requestedParams = new URLSearchParams( requestedPaths[ 0 ].split( '?' )[ 1 ] );
 		expect( requestedParams.get( 'start_date' ) ).toBe( WINDOW_PARAMS.from );
 		expect( requestedParams.get( 'date' ) ).toBe( WINDOW_PARAMS.to );
 	} );
 
-	// Pinned west of UTC on purpose: under a UTC runner the wall-clock reading
-	// and an instant reading coincide, so this would pass either way. `TZ` is
-	// not on the typed env shape, hence the cast.
+	// Pinned west of UTC: under a UTC runner the wall-clock and instant readings
+	// coincide, so this would pass either way. `TZ` isn't on the typed env shape.
 	it( 'builds bucket points as the wall clocks the buckets name, declared to the chart', async () => {
 		const env = process.env as Record< string, string | undefined >;
 		const runnerTimeZone = env.TZ;
@@ -228,8 +222,7 @@ describe( 'VideoDetailViewsPerformanceWidget', () => {
 
 			const chart = await screen.findByTestId( 'metric-tabs-chart' );
 			// A site-midnight instant for this UTC+8 window would read back as the
-			// previous day in Los Angeles; the wall-clock reading keeps every
-			// label on the bucket it names.
+			// previous day in Los Angeles; the wall-clock reading avoids that.
 			expect( chartedMetrics( chart )[ 0 ].days ).toEqual( [ 1, 2, 3, 4, 5, 6, 7 ] );
 			expect( chart ).toHaveAttribute( 'data-wall-clocks', 'true' );
 		} finally {
@@ -280,10 +273,8 @@ describe( 'VideoDetailViewsPerformanceWidget', () => {
 				attributes={ {
 					reportParams: {
 						...WINDOW_PARAMS,
-						// Comparison params pass through the video detail URL untouched
-						// (dashboard state survives the round trip), so a widget
-						// receiving them must neither fetch a second window nor draw
-						// an overlay — the page renders no comparison.
+						// The video detail URL carries comparison params through untouched,
+						// but the page renders no comparison, so the widget must ignore them.
 						comp: '1',
 						compare_from: '2026-06-24T00:00:00.000+08:00',
 						compare_to: '2026-06-30T23:59:59.999+08:00',
@@ -343,9 +334,8 @@ describe( 'VideoDetailViewsPerformanceWidget', () => {
 	} );
 
 	it( 'shows the error state with a Retry action when the fetch fails', async () => {
-		// A 403 skips React Query's retry backoff so the error surfaces
-		// immediately; the `no_connection` code keeps `describeError` on the
-		// retryable branch (a broken Jetpack connection can heal).
+		// A 403 skips React Query's retry backoff so the error surfaces immediately;
+		// `no_connection` keeps `describeError` on the retryable branch.
 		mockApiFetch.mockRejectedValue( { status: 403, code: 'no_connection', message: 'Forbidden' } );
 
 		render( <VideoDetailViewsPerformanceWidget attributes={ { reportParams: WINDOW_PARAMS } } /> );

--- a/projects/packages/premium-analytics/widgets/video-detail-views-performance/render.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-views-performance/render.tsx
@@ -89,11 +89,9 @@ function VideoDetailViewsPerformanceInner( { chartType }: VideoDetailViewsPerfor
 }
 
 /**
- * Video performance widget: the scoped video's views, impressions, hours
- * watched, and retention rate over the dashboard date range as selectable
- * metric tabs, each headlined by the window's canonical total. The series come
- * from one `stats/video/{id}` `statType=all` range report, zero-filled and
- * bucketed client-side at the page's chart interval.
+ * Video performance widget: views, impressions, hours watched, and retention
+ * rate as metric tabs. Comes from one `stats/video/{id}` `statType=all`
+ * report, zero-filled and bucketed client-side.
  */
 export default function VideoDetailViewsPerformance( {
 	attributes = {},

--- a/projects/packages/premium-analytics/widgets/video-detail-views-performance/stories/video-detail-views-performance-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-views-performance/stories/video-detail-views-performance-widget.stories.tsx
@@ -1,18 +1,7 @@
 /**
- * The Video performance widget is the video detail page's performance card:
- * the scoped video's views, impressions, hours watched, and retention rate
- * over the dashboard date range as selectable metric tabs over a chart. The
- * video scope arrives through `reportParams.post_id` (seeded from the detail
- * page URL in product); the `hasVideoScope` control toggles it to exercise
- * the scopeless empty state.
- *
- * Data comes from one proxied `stats/video/{id}` `statType=all` range
- * request, covered by the shared single-video report mock (a deterministic
- * daily series ending today, so relative date presets always intersect it).
- * The video detail design has no period-over-period comparison, so the
- * widget maps no comparison rows; the dashboard story still passes
- * comparison params so the widget stays covered against crashing or
- * inventing an overlay when a host supplies them.
+ * The video detail design has no period-over-period comparison, so the widget
+ * maps no comparison rows; the dashboard story still passes comparison params so
+ * it stays covered against inventing an overlay when a host supplies them.
  */
 /**
  * External dependencies
@@ -54,11 +43,8 @@ interface VideoDetailViewsPerformanceStoryControls {
 }
 
 /**
- * Builds the widget attributes: report params carrying the page's chart
- * interval (which the widget buckets by) plus the video scope the detail page
- * seeds from its URL when `hasVideoScope` is on. Comparison stays a parameter
- * so the dashboard story can pass host comparison params without duplicating
- * the scoping rule.
+ * Comparison stays a parameter so the dashboard story can pass host comparison
+ * params without duplicating the scoping rule.
  */
 function getVideoDetailViewsPerformanceAttributes(
 	{ hasVideoScope, interval, chartType }: VideoDetailViewsPerformanceStoryControls,
@@ -146,11 +132,9 @@ interface VideoDetailViewsPerformanceDashboardStoryProps
 		VideoDetailViewsPerformanceStoryControls {}
 
 /**
- * Mounts the real `WidgetDashboard` with this single widget so it renders
- * exactly as it does in product (framed card, host toolbar controls, sizing,
- * edit mode). It passes comparison params unconditionally,
- * so the widget stays covered against crashing or inventing an overlay when
- * a host supplies comparison dates.
+ * Mounts the real `WidgetDashboard` so the widget renders exactly as it does in
+ * product. Passes comparison params unconditionally so it stays covered against
+ * inventing an overlay when a host supplies comparison dates.
  */
 function VideoDetailViewsPerformanceDashboardStory( {
 	hasVideoScope,

--- a/projects/packages/premium-analytics/widgets/video-detail-views-performance/use-video-metrics.ts
+++ b/projects/packages/premium-analytics/widgets/video-detail-views-performance/use-video-metrics.ts
@@ -88,11 +88,9 @@ type BucketWindow = {
 };
 
 /**
- * Extract a `YYYY-MM-DD` window from ISO report params, or undefined when
- * either bound is missing/malformed (`toDay` also rejects calendar-invalid
- * days before they reach `parseISO()`/`each*OfInterval()`, which throw on
- * them). The endpoint's day keys are date-only, so comparing date prefixes
- * keeps the slice timezone-stable.
+ * Extracts a `YYYY-MM-DD` window from ISO report params, or undefined when a
+ * bound is missing/malformed — `toDay` rejects invalid days before they'd
+ * reach `parseISO()`/`each*OfInterval()`, which throw on them.
  */
 function toDayWindow( from?: string, to?: string ): DayWindow | undefined {
 	const fromDay = toDay( from );
@@ -142,10 +140,9 @@ function calendarBucketWindows(
 }
 
 /**
- * Sum a daily series into zero-filled bucket totals keyed by bucket date. The
- * endpoint returns a contiguous daily `{ period, value }` array for the
- * requested window, so bucketing only sums the returned days and zero-fills
- * whatever the response is missing.
+ * Sums a daily series into zero-filled bucket totals. The endpoint returns a
+ * contiguous daily array for the window, so this only sums returned days and
+ * zero-fills what's missing.
  */
 function bucketTotals(
 	points: StatsSingleVideoDataPoint[],
@@ -165,14 +162,9 @@ function bucketTotals(
 }
 
 /**
- * Turn bucket totals into chart points.
- *
- * The bucket keys are plain site-local calendar dates, and the chart lays
- * points out and labels the axis through the browser's timezone — so the keys
- * are read as wall clocks with `toChartDate`, and the widget declares
- * `pointsAreWallClocks` to the chart (rationale in `chart-date.ts`). A real
- * site-midnight instant here would shift the label a day for any viewer west
- * of the site.
+ * Turns bucket totals into chart points. Keys are wall clocks, not instants —
+ * read via `toChartDate` with `pointsAreWallClocks` declared to the chart
+ * (rationale in `chart-date.ts`); a real instant would shift labels by timezone.
  */
 function toBucketPoints(
 	buckets: BucketWindow[],
@@ -185,11 +177,9 @@ function toBucketPoints(
 }
 
 /**
- * Weight each day's retention rate by that day's plays, so a bucket's value is
- * the retention of its combined plays rather than a raw average of days. The
- * daily rates arrive as percentages; the returned fractions match the tab's
- * percentage format. A bucket with no plays has no measured retention — it
- * stays at 0.
+ * Weights each day's retention by that day's plays, so a bucket reflects the
+ * retention of its combined plays, not a raw average of days. Rates arrive as
+ * percentages; returned fractions match the tab's format. No plays → 0.
  */
 function playWeightedRetention(
 	rates: StatsSingleVideoDataPoint[],
@@ -217,17 +207,9 @@ function playWeightedRetention(
 }
 
 /**
- * Fetch the scoped video's metric tabs for the dashboard's report params. The
- * `stats/video/{id}` endpoint takes its window from `period`/`start_date`/
- * `date` (wpcom #229903); the request uses `statType=all` with the raw report
- * params so it stays one request for the whole page, and each returned metric
- * series becomes a chart tab. Headlines come from the response's canonical
- * whole-range `total`s — including the play-weighted retention rate the daily
- * series alone cannot reproduce — falling back to the bucketed sums when a
- * total is missing. The video detail design has no period-over-period
- * comparison, so comparison report params are ignored — they ride along in the
- * URL untouched so dashboard state survives the round trip, and every widget
- * on this page disregards them.
+ * Fetches metric tabs via one `stats/video/{id}` `statType=all` report,
+ * headlined by the response's canonical totals (falling back to bucketed
+ * sums). Comparison params are ignored but left in the URL for round-trip state.
  */
 export default function useVideoMetrics(
 	videoId: number,

--- a/projects/packages/premium-analytics/widgets/video-detail-views-performance/widget.ts
+++ b/projects/packages/premium-analytics/widgets/video-detail-views-performance/widget.ts
@@ -19,9 +19,7 @@ import {
 export type VideoDetailViewsPerformanceChartType = ChartDisplayChartType;
 
 /**
- * Configurable attributes for the Video performance widget. The video scope
- * and report params reach it through WidgetRoot: the detail page seeds
- * `post_id` into the URL, and the dashboard date picker owns the range.
+ * `post_id` (video scope) and report params reach the widget via WidgetRoot.
  *
  * @property chartType - How to draw the selected metric. Defaults to `line`.
  */
@@ -30,14 +28,8 @@ export type VideoDetailViewsPerformanceAttributes = {
 };
 
 /**
- * Widget type definition.
- *
- * The video detail page's performance card: the scoped video's views,
- * impressions, hours watched, and retention rate over the dashboard date
- * range as selectable metric tabs, each headlined by the window's canonical
- * total. The series come from the `stats/video/{id}` `statType=all` daily
- * history, bucketed client-side at the page's chart interval; the `chartType`
- * attribute (`relevance: 'high'`) is rendered by the widget host.
+ * Series come from the `stats/video/{id}` `statType=all` daily history,
+ * bucketed client-side at the page's chart interval.
  */
 export default {
 	icon: seen,

--- a/projects/packages/premium-analytics/widgets/videopress/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/render.tsx
@@ -43,10 +43,9 @@ type VideoPressWidgetProps = WidgetRenderProps< VideoPressRenderAttributes > & {
 };
 
 /**
- * Maps normalized video rows onto the shape `LeaderboardChart` expects. Shares
- * are computed against the largest value of either period so the overlay bars
- * stay proportional. Rows without a matching comparison-period value keep
- * comparison fields undefined so the chart suppresses fabricated deltas.
+ * Maps normalized video rows to `LeaderboardChart` shape. Shares are computed
+ * against the largest value of either period; rows without a comparison match
+ * keep fields undefined so the chart doesn't fabricate deltas.
  */
 function buildLeaderboardData(
 	rows: VideoPlaysRow[],
@@ -86,9 +85,8 @@ function VideoPressReport() {
 		[ reportParams ]
 	);
 
-	// The hook merges comparison rows in the data layer and gates
-	// `hasComparison` on at least one visible row (`maxRows`) having a matching
-	// comparison row, so the chart never fabricates vs-zero deltas.
+	// The hook merges comparison rows and gates `hasComparison` on at least one
+	// visible row having a match, so the chart never fabricates vs-zero deltas.
 	const { primary, comparisonRows, hasComparison, isLoading, isFetching, isError, refetch } =
 		useStatsVideoPlays( statsParams, { maxRows: WIDGET_ROW_LIMIT } );
 
@@ -106,9 +104,8 @@ function VideoPressReport() {
 		<WidgetState
 			isLoading={ isInitialLoading }
 			isFetching={ isFetching }
-			// The Stats queries carry `placeholderData`, so a failed range change keeps
-			// the prior period's rows visible; only surface the error when there is
-			// nothing to show.
+			// `placeholderData` keeps prior rows visible after a failed range change; only
+			// surface the error when nothing is on screen.
 			isError={ rows.length === 0 && isError }
 			isEmpty={ rows.length === 0 }
 			error={ {

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/__tests__/wordads-chart-tabs.test.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/__tests__/wordads-chart-tabs.test.tsx
@@ -63,9 +63,8 @@ jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mo
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 
-// Raw WPCOM `wordads/stats` matrix shape: two monthly buckets, so the summary
-// totals impressions (2000) and revenue (9.75), and CPM is the weighted average
-// revenue / impressions * 1000 = 4.875.
+// Raw WPCOM `wordads/stats` matrix: two monthly buckets, summing to impressions
+// 2000 / revenue 9.75, with CPM the weighted average 4.875.
 const PRIMARY_RESPONSE = {
 	unit: 'month',
 	fields: [ 'period', 'impressions', 'revenue', 'cpm' ],
@@ -241,10 +240,8 @@ describe( 'WordAdsChartTabsWidget', () => {
 	} );
 
 	/*
-	 * The Ads default layout saves this widget with no attributes, and
-	 * `WidgetRoot` falls back to the URL for a missing `reportParams` — the
-	 * section date state this widget no longer follows. The fallback in
-	 * `render.tsx` must win over the URL.
+	 * The Ads default layout saves this widget with no attributes; `render.tsx`'s
+	 * own fallback must win over WidgetRoot's URL fallback for a missing `reportParams`.
 	 */
 	it( 'ignores the URL range for an instance saved without report params', async () => {
 		setMockRouteSearch( { from: '2020-01-01', to: '2020-01-31', interval: 'month' } );
@@ -256,9 +253,8 @@ describe( 'WordAdsChartTabsWidget', () => {
 		expect( requestedPath ).not.toContain( 'date=2020-01-31' );
 	} );
 
-	// The widget scopes itself with `offersComparison={ false }`, so `WidgetRoot`
-	// strips the comparison params before the chart fetches — stripped params
-	// must mean no second request, not a request with the dates removed.
+	// `offersComparison={ false }` makes `WidgetRoot` strip comparison params before
+	// the fetch — that must mean no second request, not one with the dates removed.
 	it( 'issues one request even when its attributes carry a comparison', async () => {
 		render(
 			<WordAdsChartTabsWidget

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/render.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/render.tsx
@@ -82,9 +82,8 @@ export default function WordAdsChartTabs( { attributes = {} }: WordAdsChartTabsW
 	const reportParams = attributes.reportParams ?? DEFAULT_REPORT_PARAMS;
 
 	return (
-		// Scope the widget body before WidgetRoot strips the unsupported
-		// comparison parameters. The header control is host chrome outside this
-		// tree; it takes its scope from the section provider.
+		// Scope the widget body before WidgetRoot strips unsupported comparison params;
+		// the header control is host chrome and takes its scope from the section provider.
 		<ReportScopeProvider offersComparison={ false }>
 			<WidgetRoot attributes={ { ...attributes, reportParams } }>
 				<WordAdsChartTabsInner />

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/use-wordads-chart.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/use-wordads-chart.ts
@@ -48,9 +48,8 @@ export default function useWordAdsChart( reportParams: ReportParams, period: Wor
 		metrics,
 		isLoading,
 		isFetching,
-		// The query keeps prior data via `placeholderData`, so a failed range change
-		// keeps the previous period's chart while `isError` flips true. Gate the
-		// error on having nothing to show, as `useTrafficChart` does.
+		// `placeholderData` keeps the previous chart while `isError` flips true; gate
+		// the error on having nothing to show, as `useTrafficChart` does.
 		isError: isError && ! primaryData?.data?.length,
 		isEmpty: primaryData !== undefined && ! primaryData.data?.length,
 		refetch,

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/__tests__/wordads-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/__tests__/wordads-highlights.test.tsx
@@ -17,9 +17,8 @@ jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mo
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 
-// total_earnings − total_amount_owed = paid, so Earnings/$1,200.00,
-// Paid/$900.00, Outstanding/$300.00 pin both the field wiring and the
-// subtraction.
+// total_earnings − total_amount_owed = paid; these fixture values pin both
+// the field wiring and the subtraction (Earnings $1,200, Paid $900, Outstanding $300).
 const EARNINGS_RESPONSE = {
 	earnings: {
 		total_earnings: 1200,
@@ -52,9 +51,8 @@ describe( 'WordAdsHighlightsWidget', () => {
 
 		await expect( screen.findByText( 'Earnings' ) ).resolves.toBeInTheDocument();
 
-		// Tiles render in a fixed order: Earnings, Paid, Outstanding. Reading the
-		// currency values in document order pins the field-to-tile wiring and the
-		// paid subtraction (1200 − 300 = 900).
+		// Tiles render in a fixed order (Earnings, Paid, Outstanding); reading values
+		// in document order pins the field-to-tile wiring and the subtraction.
 		const values = screen.getAllByText( /^\$[\d,]+\.\d{2}$/ ).map( el => el.textContent );
 		expect( values ).toEqual( [ '$1,200.00', '$900.00', '$300.00' ] );
 	} );
@@ -89,9 +87,8 @@ describe( 'WordAdsHighlightsWidget', () => {
 	} );
 
 	it( 'renders a zero balance as $0.00 rather than an empty state', async () => {
-		// A site that just enabled WordAds: the endpoint reports no totals, which
-		// the sanitizer resolves to real zeros. That is data — a zero balance is a
-		// valid amount, not an absence of earnings.
+		// A newly enabled site: the endpoint reports no totals, which the sanitizer
+		// resolves to real zeros — a valid amount, not an absence of earnings.
 		mockApiFetch.mockResolvedValue( { earnings: {} } );
 
 		render( <WordAdsHighlightsWidget attributes={ {} } /> );

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/render.tsx
@@ -28,10 +28,8 @@ import {
 } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
-// The wordads/earnings endpoint reports all-time totals and is not
-// period-scoped, so the widget ignores the dashboard date range. Report params
-// are still accepted at the WidgetRoot boundary (and Storybook may inject them)
-// so the host contract holds.
+// The wordads/earnings endpoint is all-time and not period-scoped, so the widget
+// ignores the dashboard date range; report params still flow to WidgetRoot for the host contract.
 type WordAdsHighlightsRenderAttributes = WordAdsHighlightsAttributes &
 	Partial< ReportParamsFieldAttributes >;
 type WordAdsHighlightsWidgetProps = WidgetRenderProps< WordAdsHighlightsRenderAttributes >;
@@ -41,11 +39,9 @@ type WordAdsHighlightsWidgetProps = WidgetRenderProps< WordAdsHighlightsRenderAt
 const CURRENCY_FORMAT: DataFormat = { type: 'currency', options: { decimals: 2 } };
 
 /**
- * Render-only config per card: the tile icon and the earnings value it shows.
- * Ids and labels are shared with the settings checkboxes via
- * `WORDADS_EARNINGS_METRICS` in `widget.ts`. "Paid" is derived — the payload
- * carries total earnings and the outstanding balance, and paid is their
- * difference — matching the Calypso WordAds Totals section.
+ * Render-only per-card config; ids/labels shared with the settings checkboxes via
+ * `WORDADS_EARNINGS_METRICS`. "Paid" is derived (earnings − outstanding balance),
+ * matching the Calypso WordAds Totals section.
  */
 const TILE_CONFIG: Record<
 	WordAdsEarningsMetricId,
@@ -60,10 +56,9 @@ const TILE_CONFIG: Record<
 };
 
 /**
- * Fetches WordAds earnings through the designated `useStatsWordAdsEarnings` hook
- * and renders the totals as a currency `MetricTileGrid`. The earnings module has
- * no comparison period, so each tile shows a bare formatted amount. Which cards
- * appear is controlled by the `metrics` attribute.
+ * Renders WordAds earnings as currency tiles. The earnings module has no
+ * comparison period, so each tile shows a bare amount; `metrics` controls which
+ * cards appear.
  */
 function WordAdsHighlightsReport( {
 	metrics = DEFAULT_WORDADS_EARNINGS_METRICS,

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/widget.ts
@@ -7,10 +7,8 @@ import { megaphone } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
- * The earnings cards the widget can show, in display order: the persisted id and
- * label of each metric. Single source for the settings checkboxes and the
- * rendered tiles so the two cannot drift apart; `render.tsx` maps the ids to
- * icons and earnings fields.
+ * Earnings cards the widget can show, in display order. Single source for the
+ * settings checkboxes and rendered tiles so the two cannot drift apart.
  */
 export const WORDADS_EARNINGS_METRICS = [
 	{ id: 'earnings', label: __( 'Earnings', 'jetpack-premium-analytics-pkg' ) },
@@ -42,12 +40,8 @@ export const DEFAULT_WORDADS_EARNINGS_METRICS: WordAdsEarningsMetricId[] =
 	WORDADS_EARNINGS_METRICS.map( metric => metric.id );
 
 /**
- * Widget type definition.
- *
- * `help` surfaces as an info popover in the widget header; its copy mirrors the
- * Calypso WordAds payout notice explaining the payout threshold and timing.
- * `example.attributes` doubles as the defaults applied to new instances: every
- * card enabled.
+ * `help` mirrors the Calypso WordAds payout notice (threshold and timing).
+ * `example.attributes` doubles as the defaults for new instances.
  */
 export default {
 	icon: megaphone,


### PR DESCRIPTION
## Proposed changes

- Trim over-budget code comments across the package, covering everything touched since the last audit (#51091).
- Cut restated signatures, narrated types, and rejected-alternative recaps; keep the why, the gotchas, and the provenance.
- Fix three comments that contradicted the code: a `// not used yet` on a value that is read and returned, and two `date-range.ts` docblocks describing a return value and a param-preservation rule the code does not have.
- Keep the load-bearing rationale `AGENTS.md` names — `max = 0` semantics, `undefined`-not-`0` comparison rules, `safeHttpUrl` guards, import boundaries, WPCOM Simple route guards.
- Keep what lint and the build need: `// translators:`, `eslint-disable` justifications, Storybook autodocs, and the WordPress Coding Standards docblock tags on the PHP side.

Comments only. No executable line changed anywhere in the diff.

## Related product discussion/links

- Follows the same pass as #51091.
- The rule these trims follow, and the public standards behind it: #51702.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Nothing to click through. To check the diff is what it claims:

- `git diff trunk...` and confirm every added or removed line is a comment line.
- `pnpm exec eslint` over the changed `.ts`/`.tsx` files — 0 errors, 0 warnings, including `jsdoc/check-param-names`.
- `vendor/bin/phpcs` over the changed `.php` files — clean.
- Reviewer's real job: the judgment calls. Where a comment was cut hard rather than deleted, check that the surviving line still carries the claim that made it worth keeping.

