### PR TITLE
Premium Analytics: widen the Email breakdown map story so the map renders

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-pa-email-breakdown-map-story
+++ b/projects/packages/premium-analytics/changelog/update-pa-email-breakdown-map-story
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Storybook only: widen the Email breakdown map story so the country map actually renders.
+
+

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -1117,15 +1117,19 @@ function buildEmailSummaryResponse() {
  * @return Raw email breakdown response.
  */
 function buildEmailBreakdownResponse( requestPath: string ): unknown {
-	const breakdown = requestPath.split( '?' )[ 0 ].split( '/' ).pop() ?? '';
+	const path = requestPath.split( '?' )[ 0 ];
+	const breakdown = path.split( '/' ).pop() ?? '';
+	const isClicks = /\/clicks\/emails\//.test( path );
 
 	switch ( breakdown ) {
 		case 'country':
-			return mockEmailCountryBreakdown;
+			return isClicks
+				? scaleEmailBreakdown( mockEmailCountryBreakdown )
+				: mockEmailCountryBreakdown;
 		case 'device':
-			return mockEmailDeviceBreakdown;
+			return isClicks ? scaleEmailBreakdown( mockEmailDeviceBreakdown ) : mockEmailDeviceBreakdown;
 		case 'client':
-			return mockEmailClientBreakdown;
+			return isClicks ? scaleEmailBreakdown( mockEmailClientBreakdown ) : mockEmailClientBreakdown;
 		case 'link':
 			return mockEmailInternalLinkBreakdown;
 		case 'user-content-link':
@@ -1133,6 +1137,36 @@ function buildEmailBreakdownResponse( requestPath: string ): unknown {
 		default:
 			return {};
 	}
+}
+
+// Only a fraction of the recipients who open an email click through, so the
+// clicks breakdowns reuse the opens fixtures scaled down. That keeps one
+// fixture per dimension while letting the opens/clicks switch visibly change
+// the numbers in the stories.
+const EMAIL_CLICKS_RATIO = 0.3;
+
+function scaleEmailBreakdown< Fixture extends Record< string, unknown > >(
+	fixture: Fixture
+): Fixture {
+	return Object.fromEntries(
+		Object.entries( fixture ).map( ( [ key, section ] ) => {
+			const data = ( section as { data?: unknown } )?.data;
+			if ( ! Array.isArray( data ) ) {
+				return [ key, section ];
+			}
+			return [
+				key,
+				{
+					...( section as object ),
+					data: data.map( row =>
+						Array.isArray( row ) && typeof row[ 1 ] === 'number'
+							? [ row[ 0 ], Math.round( row[ 1 ] * EMAIL_CLICKS_RATIO ) ]
+							: row
+					),
+				},
+			];
+		} )
+	) as Fixture;
 }
 
 /**

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -27,7 +27,7 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { createStoryWidgetType } from '../../stories/create-story-widget-type';
-import { withWideWidgetCanvas, withWidgetCanvas } from '../../stories/with-widget-canvas';
+import { withMapAwareWidgetCanvas, withWidgetCanvas } from '../../stories/with-widget-canvas';
 import EmailBreakdownRender from '../render';
 import widgetDefinition from '../widget';
 import widgetManifest from '../widget.json';
@@ -130,19 +130,19 @@ type Story = StoryObj< EmailBreakdownStoryControls >;
 export const Default: Story = {
 	render: renderEmailBreakdown,
 	args: { view: 'countries', metric: 'opens', showMap: false },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withMapAwareWidgetCanvas ],
 };
 
 /**
  * The country map beside the countries leaderboard, as the two-column
  * "Location clicks" card on the post detail Email clicks tab renders it. The
- * widget only mounts the map at container widths of 720px and up, so this story
- * uses the wide canvas; on the default one-column card `showMap` has no effect.
+ * widget only mounts the map at container widths of 720px and up, so the canvas
+ * widens to a two-column card while `showMap` is on.
  */
 export const LocationClicksWithMap: Story = {
 	render: renderEmailBreakdown,
 	args: { view: 'countries', metric: 'clicks', showMap: true },
-	decorators: [ withWideWidgetCanvas ],
+	decorators: [ withMapAwareWidgetCanvas ],
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -27,7 +27,7 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { createStoryWidgetType } from '../../stories/create-story-widget-type';
-import { withWidgetCanvas } from '../../stories/with-widget-canvas';
+import { withWideWidgetCanvas, withWidgetCanvas } from '../../stories/with-widget-canvas';
 import EmailBreakdownRender from '../render';
 import widgetDefinition from '../widget';
 import widgetManifest from '../widget.json';
@@ -134,14 +134,15 @@ export const Default: Story = {
 };
 
 /**
- * The optional map beside the countries leaderboard. No fixed composition
- * enables it anymore (the Email clicks Locations card is a plain leaderboard
- * per the design mocks); the story keeps the capability covered.
+ * The country map beside the countries leaderboard, as the two-column
+ * "Location clicks" card on the post detail Email clicks tab renders it. The
+ * widget only mounts the map at container widths of 720px and up, so this story
+ * uses the wide canvas; on the default one-column card `showMap` has no effect.
  */
 export const LocationClicksWithMap: Story = {
 	render: renderEmailBreakdown,
 	args: { view: 'countries', metric: 'clicks', showMap: true },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWideWidgetCanvas ],
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -137,7 +137,7 @@ export const Default: Story = {
  * The country map beside the countries leaderboard, as the two-column
  * "Location clicks" card on the post detail Email clicks tab renders it. The
  * widget only mounts the map at container widths of 720px and up, so the canvas
- * widens to a two-column card while `showMap` is on.
+ * widens to a two-column card while `showMap` is on for the countries view.
  */
 export const LocationClicksWithMap: Story = {
 	render: renderEmailBreakdown,

--- a/projects/packages/premium-analytics/widgets/stories/with-widget-canvas.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/with-widget-canvas.tsx
@@ -31,7 +31,14 @@ function frameWidgetRoot( host: HTMLElement | null ) {
 // A white, widget-sized card that frames a story the way the dashboard host frames a
 // widget in product, so each state (ready / loading / error / empty) reads as a real
 // dashboard widget rather than a bare fragment on the Storybook canvas.
-export function WidgetCanvas( { children }: { children: ReactNode } ) {
+export function WidgetCanvas( {
+	children,
+	width = '380px',
+}: {
+	children: ReactNode;
+	/** Card width. Defaults to a one-column dashboard cell. */
+	width?: string;
+} ) {
 	const hostRef = useRef< HTMLDivElement >( null );
 	useLayoutEffect( () => {
 		frameWidgetRoot( hostRef.current );
@@ -40,7 +47,7 @@ export function WidgetCanvas( { children }: { children: ReactNode } ) {
 		<div
 			ref={ hostRef }
 			style={ {
-				width: '380px',
+				width,
 				height: '440px',
 				margin: '0 auto',
 				padding: '16px',
@@ -59,6 +66,14 @@ export function WidgetCanvas( { children }: { children: ReactNode } ) {
 // Decorator form of WidgetCanvas for the close-up widget stories.
 export const withWidgetCanvas: Decorator = Story => (
 	<WidgetCanvas>
+		<Story />
+	</WidgetCanvas>
+);
+
+// A two-column-wide card, for widgets whose layout only appears above the
+// 720px container query (the email breakdown's country map, for example).
+export const withWideWidgetCanvas: Decorator = Story => (
+	<WidgetCanvas width="800px">
 		<Story />
 	</WidgetCanvas>
 );

--- a/projects/packages/premium-analytics/widgets/stories/with-widget-canvas.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/with-widget-canvas.tsx
@@ -61,4 +61,3 @@ export const withWidgetCanvas: Decorator = Story => (
 		<Story />
 	</WidgetCanvas>
 );
-

--- a/projects/packages/premium-analytics/widgets/stories/with-widget-canvas.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/with-widget-canvas.tsx
@@ -70,10 +70,12 @@ export const withWidgetCanvas: Decorator = Story => (
 	</WidgetCanvas>
 );
 
-// A two-column-wide card, for widgets whose layout only appears above the
-// 720px container query (the email breakdown's country map, for example).
-export const withWideWidgetCanvas: Decorator = Story => (
-	<WidgetCanvas width="800px">
+// Canvas that widens to a two-column card while the story's `showMap` arg is
+// on, for widgets whose map only mounts above the 720px container query (the
+// email breakdown, for example). Toggling the control then actually shows the
+// map instead of silently doing nothing in the one-column card.
+export const withMapAwareWidgetCanvas: Decorator = ( Story, { args } ) => (
+	<WidgetCanvas width={ args.showMap ? '800px' : undefined }>
 		<Story />
 	</WidgetCanvas>
 );

--- a/projects/packages/premium-analytics/widgets/stories/with-widget-canvas.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/with-widget-canvas.tsx
@@ -71,11 +71,12 @@ export const withWidgetCanvas: Decorator = Story => (
 );
 
 // Canvas that widens to a two-column card while the story's `showMap` arg is
-// on, for widgets whose map only mounts above the 720px container query (the
-// email breakdown, for example). Toggling the control then actually shows the
-// map instead of silently doing nothing in the one-column card.
+// on and the `view` is `countries` — the same condition under which the email
+// breakdown mounts its map, which also needs the 720px container floor. Toggling
+// the control then actually shows the map instead of silently doing nothing in
+// the one-column card, and the card stays one column for the other views.
 export const withMapAwareWidgetCanvas: Decorator = ( Story, { args } ) => (
-	<WidgetCanvas width={ args.showMap ? '800px' : undefined }>
+	<WidgetCanvas width={ args.showMap && args.view === 'countries' ? '800px' : undefined }>
 		<Story />
 	</WidgetCanvas>
 );


### PR DESCRIPTION
Storybook-only fix in `packages/premium-analytics`; no product change.

## Proposed changes:

* The `EmailBreakdown → LocationClicksWithMap` story exists to cover the country map beside the countries leaderboard, but it was mounted in the shared 380px one-column `WidgetCanvas`. The widget only mounts the map at container widths of 720px and up (`MAP_MIN_WIDTH`, mirroring the container query in `style.module.css`), so the story rendered a plain leaderboard and `showMap` had no visible effect.
* Add an optional `width` to `WidgetCanvas` (default unchanged at 380px) plus a `withMapAwareWidgetCanvas` decorator that widens the card to 800px while the story's `showMap` arg is on and `view` is `countries` (the widget's own map condition). Both `Default` and `LocationClicksWithMap` use it, so toggling `showMap` in the Controls panel actually shows the map instead of doing nothing.
* Update the story comment, which still said no fixed composition enabled the map — the post detail Email clicks "Location clicks" card sets `showMap: true` (`routes/post-detail/config/tab-layouts.ts`).

* The mocked `stats/opens/emails/…` and `stats/clicks/emails/…` breakdowns returned the same fixture, so the `metric` control in the same stories changed nothing visible either. The clicks breakdowns now return the opens fixtures scaled to 30%, keeping one fixture per dimension.

Spotted while addressing #51659.

## Screenshots
|Before|After|
|-|-|
|<img width="1458" height="829" alt="截圖 2026-08-28 下午2 49 34" src="https://github.com/user-attachments/assets/e3835eae-7594-4a08-98e0-4a1d20e623bc" />|<img width="1302" height="869" alt="截圖 2026-08-28 下午2 42 56" src="https://github.com/user-attachments/assets/c398c102-3f03-4385-814c-3749c3893c80" />|

## Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable (if so, you'll see a generated comment below)?

## Jetpack product discussion

N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

1. Check out this branch, `cd projects/packages/premium-analytics`, `pnpm run storybook`.
2. Open **Packages / Premium Analytics / Widgets / EmailBreakdown → Location Clicks With Map**: the card is wide and shows the world map to the right of the countries leaderboard. On `trunk` the same story is a 380px card with no map.
3. Open **EmailBreakdown → Default**: still the 380px card, unchanged.
4. Toggle `showMap` in the Controls panel on the Default story: the card widens and the map appears; untick, or switch `view` away from `countries`, and it returns to the 380px card. On `trunk` the toggle does nothing.
5. On the Default story switch `metric` between `opens` and `clicks`: the leaderboard numbers change (clicks are ~30% of opens). On `trunk` they stay the same.
