### PR TITLE
Move the code comment rules to the root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,14 @@ The `$$next-version$$` placeholder is automatically replaced with the correct ve
 - Use BEM-like naming conventions
 - Use CSS logical properties instead of physical direction/dimension mappings to make styles RTL-aware by default (reference: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties)
 
+### Comments
+
+One sentence, at most two lines — the summary rule the WordPress documentation standards
+already impose on our PHP, applied to JavaScript too. Anything past it must carry a why, a
+gotcha, or provenance. Omit what the signature already says, and prefer a clearer name over a
+comment explaining a bad one. If reading the comment costs as much as reading the code, delete
+it. Never invent rationale: a comment that contradicts the code is worse than no comment.
+
 ## Testing
 
 ```bash

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -211,15 +211,6 @@ See Automattic/jetpack#50266 for the PR that established this contract.
 
 ## Comments and documentation
 
-Code explains what; comments explain why. Keep them minimal.
-
-- Document non-obvious rules, constraints, invariants, risks, and workarounds — not names,
-  types, or signatures. Prefer a clearer name over an explanatory comment.
-- Private functions do not need a docstring by default. One sentence is usually enough.
-- Never invent rationale. Treat a stale comment as a bug: one that contradicts the code is
-  worse than no comment at all.
-- All source code comments must be in English.
-
 Load-bearing here and easy to delete by mistake: the `max = 0` semantics, the
 `undefined`-not-`0` comparison rules, `safeHttpUrl` guards (including the ones explaining why a
 URL needs _no_ guard), import-boundary notes (WOOA7S-1836), and the WPCOM Simple route guards.

--- a/projects/packages/premium-analytics/changelog/comment-guidelines
+++ b/projects/packages/premium-analytics/changelog/comment-guidelines
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Point the comment guidance at the root AGENTS.md; no code change.
+
+


### PR DESCRIPTION

## Proposed changes

- Add repository-wide guidance for writing useful, concise code comments to the root `AGENTS.md`.
- Remove the duplicated general guidance from Premium Analytics' `AGENTS.md`, while preserving its package-specific list of load-bearing comments and lint requirements.

Centralizing the shared guidance makes it available to every agent session in the repository and keeps package instructions focused on exceptions that need local context. In particular, Claude Code can skip nested package-level `AGENTS.md` files, so keeping general comment guidance only in Premium Analytics does not reliably reach it. This supports the Premium Analytics comment audit in #51699.

No production code or runtime behavior changes.

## Related product discussion/links

- #51699

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Documentation-only change; no automated tests are required.

- Review the new `Comments` section in the root `AGENTS.md` and confirm it provides clear repository-wide guidance.
- Confirm Premium Analytics' `AGENTS.md` still contains its package-specific, load-bearing comment guidance and lint exceptions.
