### PR TITLE
Jetpack AI: link the Writing Assistant row to the docs instead of the editor

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -22,7 +22,8 @@ const { seoSettingsUrl } = window?.jetpackAiSettings ?? {};
 
 // Per the design, a row's action link depends on the toggle state: enabled
 // features invite you to try them (AI SEO opens its settings), disabled ones
-// link to documentation via registered Jetpack Redirects handlers.
+// link to documentation via registered Jetpack Redirects handlers. A row with
+// a single `action` shows that link in both states.
 const SECTIONS = [
 	{
 		key: 'content',
@@ -35,13 +36,10 @@ const SECTIONS = [
 					'Draft, rewrite, translate, and adjust tone for your content right in the block editor.',
 					'jetpack'
 				),
-				enabledAction: {
-					label: __( 'Try it out in the editor', 'jetpack' ),
-					// The arg asks the ai-assistant-plugin sidebar to open itself
-					// once the editor loads (same convention as openSidebar=global-styles).
-					href: 'post-new.php?openSidebar=jetpack-ai-assistant',
-				},
-				disabledAction: {
+				// Docs in both states for now. The editor link
+				// (post-new.php?openSidebar=jetpack-ai-assistant) returns with the
+				// sidebar agent; its editor-side handler is still in place.
+				action: {
 					label: __( 'Learn more', 'jetpack' ),
 					href: getRedirectUrl( 'jetpack-ai-settings-writing-assistant-learn-more' ),
 					external: true,
@@ -173,7 +171,7 @@ function FeatureRow( {
 		[ feature.key, onChange ]
 	);
 
-	const action = checked ? feature.enabledAction : feature.disabledAction;
+	const action = ( checked ? feature.enabledAction : feature.disabledAction ) ?? feature.action;
 	// The toggle keeps showing the SAVED value but can't be used while the
 	// connection gate fails (no feature can load without it), while the master
 	// switch is off (the saved choice returns when master does), or while the

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -32,7 +32,11 @@ describe( 'AiFeatures rendering', () => {
 		const toggle = screen.getByRole( 'checkbox', { name: /Writing Assistant/ } );
 		expect( toggle ).toBeChecked();
 		expect( toggle ).toBeEnabled();
-		expect( screen.getByText( 'Try it out in the editor' ) ).toBeInTheDocument();
+		const content = screen.getByRole( 'region', { name: 'Content' } );
+		expect( within( content ).getByRole( 'link', { name: /Learn more/ } ) ).toHaveAttribute(
+			'target',
+			'_blank'
+		);
 	} );
 
 	test( 'renders one Agent capabilities card with title and subtitle', () => {
@@ -128,7 +132,8 @@ describe( 'AiFeatures rendering', () => {
 		const toggle = screen.getByRole( 'checkbox', { name: /AI Search/ } );
 		expect( toggle ).toBeDisabled();
 		expect( toggle ).not.toBeChecked();
-		expect( screen.getByText( 'Learn more' ) ).toBeInTheDocument();
+		const searchGroup = screen.getByRole( 'region', { name: 'Search' } );
+		expect( within( searchGroup ).getByText( 'Learn more' ) ).toBeInTheDocument();
 	} );
 
 	test( 'no Search entitlement: the badge popover names the upgrade remedy', async () => {
@@ -201,7 +206,6 @@ describe( 'AiFeatures rendering', () => {
 		expect( toggle ).toBeChecked();
 		expect( toggle ).toBeDisabled();
 
-		expect( screen.queryByText( 'Try it out in the editor' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Learn more' ) ).not.toBeInTheDocument();
 	} );
 
@@ -222,7 +226,7 @@ describe( 'AiFeatures rendering', () => {
 		// The connection ask comes before any upgrade messaging: without a
 		// connection the plan is unknown, so no upgrade badge may show.
 		expect( screen.queryByText( 'Requires upgrade' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Try it out in the editor' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Learn more' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'not connected takes precedence over the master-off notice', () => {
@@ -250,7 +254,8 @@ describe( 'AiFeatures rendering', () => {
 		const toggle = screen.getByRole( 'checkbox', { name: /Writing Assistant/ } );
 		expect( toggle ).toBeChecked();
 		expect( toggle ).toBeEnabled();
-		expect( screen.getByText( 'Try it out in the editor' ) ).toBeInTheDocument();
+		const content = screen.getByRole( 'region', { name: 'Content' } );
+		expect( within( content ).getByRole( 'link', { name: /Learn more/ } ) ).toBeInTheDocument();
 	} );
 
 	test( 'free plan: toggling a feature still saves', async () => {
@@ -404,7 +409,7 @@ describe( 'AiFeatures rendering', () => {
 			/>
 		);
 
-		// Writing Assistant is off → its action is the external "Learn more" docs link.
+		// Writing Assistant links to the docs in either state, in a new tab.
 		const learnMore = screen.getByRole( 'link', { name: /Learn more/ } );
 		expect( learnMore ).toHaveAttribute( 'target', '_blank' );
 
@@ -413,7 +418,7 @@ describe( 'AiFeatures rendering', () => {
 		expect( tryIt ).not.toHaveAttribute( 'target' );
 	} );
 
-	test( 'Try it out links target each feature surface', () => {
+	test( 'action links target each feature surface', () => {
 		render(
 			<AiFeatures
 				settings={ {
@@ -430,12 +435,13 @@ describe( 'AiFeatures rendering', () => {
 			/>
 		);
 
-		// Writing Assistant asks the editor to pre-open the AI Assistant panel
-		// (handled by the ai-assistant-plugin sidebar on the other end).
-		expect( screen.getByRole( 'link', { name: 'Try it out in the editor' } ) ).toHaveAttribute(
+		// Writing Assistant links to the docs even when on, in a new tab.
+		const writingLink = screen.getByRole( 'link', { name: /Learn more/ } );
+		expect( writingLink ).toHaveAttribute(
 			'href',
-			'post-new.php?openSidebar=jetpack-ai-assistant'
+			expect.stringContaining( 'jetpack-ai-settings-writing-assistant-learn-more' )
 		);
+		expect( writingLink ).toHaveAttribute( 'target', '_blank' );
 
 		// The Image Studio bundle opens Generate mode when the Media Library
 		// URL carries ai-assistant (handled bundle-side, param then stripped).

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -128,7 +128,6 @@ describe( 'AI admin page (main.jsx)', () => {
 		// AiFeatures never mounts: no feature toggle, no upgrade badge, no action link.
 		expect( screen.queryByRole( 'checkbox' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Requires upgrade' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Try it out in the editor' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Learn more' ) ).not.toBeInTheDocument();
 	} );
 

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-writing-assistant-learn-more
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-writing-assistant-learn-more
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI: Show the Learn more link for the Writing Assistant instead of the editor link.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -249,7 +249,7 @@ export default function AiAssistantPluginSidebar() {
 
 	const planType = usePlanType( currentTier );
 
-	// The AI settings "Try it out" link asks for the sidebar to start open.
+	// A post-new.php?openSidebar=jetpack-ai-assistant URL asks for the sidebar to start open.
 	const sidebarOpenRequested = useSidebarOpenFromUrl();
 
 	// If the post type is not viewable, do not render my plugin.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/open-sidebar-from-url.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/open-sidebar-from-url.ts
@@ -5,10 +5,10 @@ import { dispatch } from '@wordpress/data';
 import { getQueryArg } from '@wordpress/url';
 import { useEffect, useMemo } from 'react';
 
-// The AI settings "Try it out" link lands on post-new.php with this arg so the
-// editor greets the user with the AI panel already open. The arg name follows
-// the existing openSidebar=global-styles convention; the value names us as the
-// target, since other features share the arg.
+// post-new.php with this arg opens the editor with the AI panel already open.
+// The arg name follows the openSidebar=global-styles convention; the value names
+// us as the target. The AI settings page does not link here for now (its
+// Writing Assistant row points at the docs), but the handler stays for when it does.
 const OPEN_SIDEBAR_QUERY_VALUE = 'jetpack-ai-assistant';
 
 // The AI panel lives in the shared Jetpack sidebar (a JetpackPluginSidebar


### PR DESCRIPTION
Fixes #JETPACK 2384

## Proposed changes
* Replace the Writing Assistant "Try it out in the editor" link with "Learn more" on the WordPress Agent tab.

## Related product discussion/links
* #JETPACK 2384

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
You need a site connected to Jetpack, with the Jetpack AI module on, logged in through the Automattic proxy so the WordPress Agent tab shows.

1. Go to `/wp-admin/admin.php?page=jetpack-ai#/features`.
2. Under Content, with Writing Assistant turned on, you see a "Learn more" link that opens the Jetpack AI documentation in a new tab. There is no "Try it out in the editor" link.
3. Turn Writing Assistant off. The link still reads "Learn more" and opens the same page.
4. Under Media, Image Editor still shows "Try it out" when on.

This description was written by Claude and reviewed by me.
