### PR TITLE
CODEOWNERS: disown the Stats plugin lock files, re-own the package changelogs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,11 +59,8 @@
 
 # Packages
 /projects/packages/premium-analytics @Automattic/jetpack-stats 
-/projects/packages/premium-analytics/changelog # No owner - too noisy on cross-project PRs
 /projects/packages/stats @Automattic/jetpack-stats
-/projects/packages/stats/changelog # No owner - too noisy on cross-project PRs
 /projects/packages/stats-admin @Automattic/jetpack-stats
-/projects/packages/stats-admin/changelog # No owner - too noisy on cross-project PRs
 /projects/packages/search/src/wpes @Automattic/prometheus
 /projects/packages/connection/src @Automattic/jetpack-connection
 /projects/packages/connection/legacy @Automattic/jetpack-connection
@@ -76,9 +73,11 @@
 # Plugins
 
 /projects/plugins/premium-analytics @Automattic/jetpack-stats 
-/projects/plugins/premium-analytics/changelog # No owner - too noisy on cross-project PRs
+/projects/plugins/premium-analytics/composer.lock # No owner - too noisy
+/projects/plugins/premium-analytics/changelog # No owner - to go with the above
 /projects/plugins/stats @Automattic/jetpack-stats
-/projects/plugins/stats/changelog # No owner - too noisy on cross-project PRs
+/projects/plugins/stats/composer.lock # No owner - too noisy
+/projects/plugins/stats/changelog # No owner - to go with the above
 /projects/plugins/boost @Automattic/jetpack-boost
 
 # Functionality that is important to our partners


### PR DESCRIPTION
Fixes N/A

## Proposed changes
* Follow-up to #51651, from the review comments there. The package `changelog/` lines it added have nothing to match: package dependencies are pinned as `@dev`, so a change in another package never touches a Stats package tree. Since January, `packages/stats` has zero changelog-only commits out of 42, `packages/stats-admin` two out of 47 (both `force-a-release` entries from release backports), and `packages/premium-analytics` two out of 528. This drops those three lines, so the packages are owned in full again.
* Plugins are where the noise is. A plugin's `composer.lock` pins the git reference of every bundled package, so each merged package change rewrites the lock and adds an "Update package dependencies." entry: 6 of 20 commits to `plugins/stats` and 43 of 116 to `plugins/premium-analytics` since January touched only `composer.lock` plus the changelog (backports, package releases, lock file maintenance). This disowns `composer.lock` for both plugins, next to the existing `changelog/` lines, in the same form the `beta` and `starter-plugin` entries use.
* Real Stats work still touches Stats source, so `@Automattic/jetpack-stats` is still requested on anything that needs their eyes.

## Related product discussion/links
* #51651

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

There is nothing to run locally. CODEOWNERS only takes effect once it is on `trunk`.

* Read the diff and confirm each `composer.lock` and `changelog` line sits *after* the line that grants ownership of the plugin. CODEOWNERS uses last-match-wins, so the order matters.
* After merge, the next backport or package release that only rewrites `projects/plugins/stats/composer.lock` and drops a changelog entry should no longer list `Jetpack Stats` under reviewers. A PR that changes Stats source should still request them.
