### PR TITLE
Omnibar: fix site name and wpcom account menu item height

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-admin-bar-node-css
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-admin-bar-node-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: Fix site name and wpcom account menu item height.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -130,11 +130,6 @@
 	margin-top: -12px;
 }
 
-// Pad the wrapper top instead, pushing Visit Site down to match Calypso.
-#wpadminbar #wp-admin-bar-site-name .ab-sub-wrapper {
-	padding-top: 6px;
-}
-
 #wp-admin-bar-site-plan,
 #wp-admin-bar-site-status {
 	display: flex;
@@ -243,6 +238,8 @@
 
 				span.wpcom-button {
 					display: inline-block;
+					min-height: 32px;
+					line-height: 30px;
 					color: #fff;
 					background-color: #3858e9;
 					border-color: #3858e9;

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-wpcom-admin-bar-node-css
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-wpcom-admin-bar-node-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: Fix site name and wpcom account menu item height.

--- a/projects/plugins/wpcomsh/changelog/fix-wpcom-admin-bar-node-css
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcom-admin-bar-node-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: Fix site name and wpcom account menu item height.


### PR DESCRIPTION
## Proposed changes

Fixes broken UI layout in the omnibar. Now it matches Calypso's

|Before|After|
|-|-|
|<img width="260" height="183" alt="image" src="https://github.com/user-attachments/assets/a6de2ff3-a29f-454a-8854-760ffbcc5a46" />|<img width="260" height="178" alt="image" src="https://github.com/user-attachments/assets/3b720a91-6ef6-48e0-9ef2-74a37b55c8dd" />
|<img width="266" height="218" alt="image" src="https://github.com/user-attachments/assets/0b3b58fd-11d8-4056-8ab3-104b4def9b29" />|<img width="264" height="211" alt="image" src="https://github.com/user-attachments/assets/a1f96925-d42d-40a1-bab0-c2310530a3a9" />


## Related product discussion/links

-

## Does this pull request change what data or activity we track or use?

No
