### PR TITLE
At a Glance: wait for plugin data before asking for a speed score

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -27,6 +27,7 @@ import {
 import { hasActiveBoostPurchase as getActiveBoostPurchase } from 'state/site';
 import {
 	isFetchingPluginsData,
+	hasFetchedPluginsData as getHasFetchedPluginsData,
 	isPluginInstalled,
 	isPluginActive,
 	fetchPluginsData as dispatchFetchPluginsData,
@@ -48,6 +49,7 @@ const DashBoost = ( {
 	apiNonce,
 	fetchPluginsData,
 	fetchingPluginsData,
+	hasFetchedPluginsData,
 	isBoostInstalled,
 	isBoostActive,
 	hasActiveBoostPurchase,
@@ -117,6 +119,13 @@ const DashBoost = ( {
 	};
 
 	useEffect( () => {
+		// getSpeedScores() skips sites that already have Boost, but isBoostInstalled and
+		// isBoostActive both read false until the plugin data arrives. Deciding before then
+		// starts a speed score run on every Boost site, which nobody ever sees.
+		if ( ! hasFetchedPluginsData ) {
+			return;
+		}
+
 		// Use cache scores if they are less than 21 days old.
 		if ( latestSpeedScores && calculateDaysSince( latestSpeedScores.timestamp * 1000 ) < 21 ) {
 			setScoresFromCache();
@@ -125,7 +134,7 @@ const DashBoost = ( {
 		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ hasFetchedPluginsData ] );
 
 	const getSpeedScoreText = () => {
 		switch ( speedLetterGrade ) {
@@ -366,6 +375,7 @@ DashBoost.propTypes = {
 	apiRoot: PropTypes.string.isRequired,
 	apiNonce: PropTypes.string.isRequired,
 	fetchingPluginsData: PropTypes.bool.isRequired,
+	hasFetchedPluginsData: PropTypes.bool.isRequired,
 	isBoostInstalled: PropTypes.bool.isRequired,
 	isBoostActive: PropTypes.bool.isRequired,
 	hasActiveBoostPurchase: PropTypes.bool.isRequired,
@@ -386,6 +396,7 @@ export default connect(
 		apiRoot: getApiRootUrl( state ),
 		apiNonce: getApiNonce( state ),
 		fetchingPluginsData: isFetchingPluginsData( state ),
+		hasFetchedPluginsData: getHasFetchedPluginsData( state ),
 		isBoostInstalled: BOOST_PLUGIN_FILES.some( pluginFile =>
 			isPluginInstalled( state, pluginFile )
 		),

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -123,11 +123,6 @@ const DashBoost = ( {
 	const hasDecided = useRef( false );
 
 	useEffect( () => {
-		// getSpeedScores() skips sites that already have Boost, but isBoostInstalled and
-		// isBoostActive both read false until the plugin data arrives. Deciding before then
-		// starts a speed score run on every Boost site, which nobody ever sees.
-		// A flag left true by an earlier settled fetch must not decide from stale items,
-		// so wait out any in-flight refetch; the ref keeps the decision one-shot.
 		if ( hasDecided.current || ! hasFetchedPluginsData || fetchingPluginsData ) {
 			return;
 		}

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -10,7 +10,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import InfoPopover from 'components/info-popover';
 import PluginInstallSection from 'components/plugin-install-section';
@@ -57,7 +57,7 @@ const DashBoost = ( {
 } ) => {
 	const isSiteOffline = siteConnectionStatus === 'offline';
 
-	const [ isLoading, setIsLoading ] = useState( false );
+	const [ isLoading, setIsLoading ] = useState( true );
 	const [ isInstalling, setIsInstalling ] = useState( false );
 	const [ isActivating, setIsActivating ] = useState( false );
 	const [ speedLetterGrade, setSpeedLetterGrade ] = useState( 'C' );
@@ -81,11 +81,13 @@ const DashBoost = ( {
 			getScoreLetter( latestSpeedScores.scores.mobile, latestSpeedScores.scores.desktop )
 		);
 		setDaysSinceTested( calculateDaysSince( latestSpeedScores.timestamp * 1000 ) );
+		setIsLoading( false );
 	};
 
 	const getSpeedScores = async () => {
 		// Don't get speed scores if site is offline or the user already has boost
 		if ( isSiteOffline || hasBoost ) {
+			setIsLoading( false );
 			return;
 		}
 
@@ -118,13 +120,18 @@ const DashBoost = ( {
 		}
 	};
 
+	const hasDecided = useRef( false );
+
 	useEffect( () => {
 		// getSpeedScores() skips sites that already have Boost, but isBoostInstalled and
 		// isBoostActive both read false until the plugin data arrives. Deciding before then
 		// starts a speed score run on every Boost site, which nobody ever sees.
-		if ( ! hasFetchedPluginsData ) {
+		// A flag left true by an earlier settled fetch must not decide from stale items,
+		// so wait out any in-flight refetch; the ref keeps the decision one-shot.
+		if ( hasDecided.current || ! hasFetchedPluginsData || fetchingPluginsData ) {
 			return;
 		}
+		hasDecided.current = true;
 
 		// Use cache scores if they are less than 21 days old.
 		if ( latestSpeedScores && calculateDaysSince( latestSpeedScores.timestamp * 1000 ) < 21 ) {
@@ -134,7 +141,7 @@ const DashBoost = ( {
 		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ hasFetchedPluginsData ] );
+	}, [ hasFetchedPluginsData, fetchingPluginsData ] );
 
 	const getSpeedScoreText = () => {
 		switch ( speedLetterGrade ) {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/index.jsx
@@ -120,13 +120,13 @@ const DashBoost = ( {
 		}
 	};
 
-	const hasDecided = useRef( false );
+	const hasChosenScoreSource = useRef( false );
 
 	useEffect( () => {
-		if ( hasDecided.current || ! hasFetchedPluginsData || fetchingPluginsData ) {
+		if ( hasChosenScoreSource.current || ! hasFetchedPluginsData || fetchingPluginsData ) {
 			return;
 		}
-		hasDecided.current = true;
+		hasChosenScoreSource.current = true;
 
 		// Use cache scores if they are less than 21 days old.
 		if ( latestSpeedScores && calculateDaysSince( latestSpeedScores.timestamp * 1000 ) < 21 ) {

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/test/component.jsx
@@ -1,8 +1,3 @@
-/**
- * The At a Glance Boost card must not ask for a speed score until the site's
- * plugin data has settled, and never for a site that already runs Boost.
- * Renders the real connected card over the real root reducer.
- */
 import { jest } from '@jest/globals';
 import { render as rtlRender, act } from '@testing-library/react';
 import { Provider } from 'react-redux';
@@ -54,9 +49,9 @@ jest.mock( 'lib/analytics', () => ( {
 const BOOST_PLUGINS_DATA = { 'jetpack-boost/jetpack-boost.php': { active: true } };
 
 /**
- * State for an online, connected site; plugins data is left to the real reducer.
+ * Builds initial state.
  *
- * @return {object} Initial redux state.
+ * @return {object} Initial state.
  */
 function buildInitialState() {
 	return {
@@ -79,7 +74,7 @@ function buildInitialState() {
 }
 
 /**
- * Build a store over the real root reducer and render the connected card.
+ * Renders the connected card.
  *
  * @param {object} store - Redux store.
  * @return {import('@testing-library/react').RenderResult} Render result.
@@ -144,7 +139,6 @@ describe( 'DashBoost speed-score gating', () => {
 
 	test( 'a flag latched by an earlier failed fetch does not decide while a refetch is in flight', () => {
 		const store = createStore( rootReducer, buildInitialState(), applyMiddleware( thunk ) );
-		// An earlier route's fetch failed (flag latched true, items empty), and a refetch is in flight.
 		store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH } );
 		store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH_FAIL } );
 		store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH } );
@@ -180,7 +174,6 @@ describe( 'DashBoost speed-score gating', () => {
 			store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH_RECEIVE, pluginsData: {} } );
 		} );
 
-		// Bars are visible and the request is in flight: every committed frame must be a loading frame.
 		expect( mockScoreBarRenders.length ).toBeGreaterThan( 0 );
 		expect( mockScoreBarRenders.filter( r => ! r.isLoading ) ).toHaveLength( 0 );
 

--- a/projects/plugins/jetpack/_inc/client/at-a-glance/boost/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/boost/test/component.jsx
@@ -1,0 +1,192 @@
+/**
+ * The At a Glance Boost card must not ask for a speed score until the site's
+ * plugin data has settled, and never for a site that already runs Boost.
+ * Renders the real connected card over the real root reducer.
+ */
+import { jest } from '@jest/globals';
+import { render as rtlRender, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createStore, applyMiddleware } from 'redux';
+import { thunk } from 'redux-thunk';
+import {
+	JETPACK_PLUGINS_DATA_FETCH,
+	JETPACK_PLUGINS_DATA_FETCH_RECEIVE,
+	JETPACK_PLUGINS_DATA_FETCH_FAIL,
+} from 'state/action-types';
+import rootReducer from 'state/reducer';
+import DashBoost from '../index';
+
+const mockRequestSpeedScores = jest.fn();
+const mockScoreBarRenders = [];
+
+jest.mock( '@automattic/jetpack-boost-score-api', () => ( {
+	__esModule: true,
+	requestSpeedScores: ( ...args ) => mockRequestSpeedScores( ...args ),
+	getScoreLetter: () => 'B',
+	// Any value past the 21-day cache window, so the card always asks for a fresh score.
+	calculateDaysSince: () => 30,
+} ) );
+
+jest.mock( '@automattic/jetpack-components', () => {
+	const actual = jest.requireActual( '@automattic/jetpack-components' );
+	// Object-spreading the actual module throws on a re-export getter, so proxy it.
+	return new Proxy( actual, {
+		get: ( target, prop ) =>
+			prop === 'BoostScoreBar'
+				? props => {
+						mockScoreBarRenders.push( { isLoading: props.isLoading, score: props.score } );
+						return null;
+				  }
+				: target[ prop ],
+	} );
+} );
+
+jest.mock( '@automattic/jetpack-api', () => ( {
+	__esModule: true,
+	default: new Proxy( {}, { get: () => () => Promise.resolve( {} ) } ),
+} ) );
+
+jest.mock( 'lib/analytics', () => ( {
+	__esModule: true,
+	default: { tracks: { recordEvent: () => {}, recordJetpackClick: () => {} } },
+} ) );
+
+const BOOST_PLUGINS_DATA = { 'jetpack-boost/jetpack-boost.php': { active: true } };
+
+/**
+ * State for an online, connected site; plugins data is left to the real reducer.
+ *
+ * @return {object} Initial redux state.
+ */
+function buildInitialState() {
+	return {
+		jetpack: {
+			connection: {
+				status: { siteConnected: { isActive: true, offlineMode: { isActive: false } } },
+				user: { currentUser: { isConnected: true } },
+				requests: {},
+			},
+			initialState: {
+				rawUrl: 'example.com',
+				WP_API_root: 'https://example.com/wp-json/',
+				WP_API_nonce: 'nonce',
+				siteData: {},
+				userData: { currentUser: { permissions: { manage_modules: true } } },
+			},
+			siteData: { data: {} },
+		},
+	};
+}
+
+/**
+ * Build a store over the real root reducer and render the connected card.
+ *
+ * @param {object} store - Redux store.
+ * @return {import('@testing-library/react').RenderResult} Render result.
+ */
+function renderCard( store ) {
+	return rtlRender(
+		<Provider store={ store }>
+			<DashBoost siteAdminUrl="https://example.com/wp-admin/" />
+		</Provider>
+	);
+}
+
+describe( 'DashBoost speed-score gating', () => {
+	beforeEach( () => {
+		mockRequestSpeedScores
+			.mockReset()
+			.mockResolvedValue( { current: { mobile: 80, desktop: 90 } } );
+		mockScoreBarRenders.length = 0;
+	} );
+
+	test( 'does not request a speed score before plugin data has settled', () => {
+		const store = createStore( rootReducer, buildInitialState(), applyMiddleware( thunk ) );
+		renderCard( store );
+
+		act( () => {
+			store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH } );
+		} );
+
+		expect( mockRequestSpeedScores ).not.toHaveBeenCalled();
+	} );
+
+	test( 'never requests a speed score when plugin data reveals Boost', () => {
+		const store = createStore( rootReducer, buildInitialState(), applyMiddleware( thunk ) );
+		renderCard( store );
+
+		act( () => {
+			store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH } );
+		} );
+		act( () => {
+			store.dispatch( {
+				type: JETPACK_PLUGINS_DATA_FETCH_RECEIVE,
+				pluginsData: BOOST_PLUGINS_DATA,
+			} );
+		} );
+
+		expect( mockRequestSpeedScores ).not.toHaveBeenCalled();
+	} );
+
+	test( 'requests exactly one speed score once plugin data shows no Boost', async () => {
+		const store = createStore( rootReducer, buildInitialState(), applyMiddleware( thunk ) );
+		renderCard( store );
+
+		act( () => {
+			store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH } );
+		} );
+		await act( async () => {
+			store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH_RECEIVE, pluginsData: {} } );
+		} );
+
+		expect( mockRequestSpeedScores ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'a flag latched by an earlier failed fetch does not decide while a refetch is in flight', () => {
+		const store = createStore( rootReducer, buildInitialState(), applyMiddleware( thunk ) );
+		// An earlier route's fetch failed (flag latched true, items empty), and a refetch is in flight.
+		store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH } );
+		store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH_FAIL } );
+		store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH } );
+
+		renderCard( store );
+		expect( mockRequestSpeedScores ).not.toHaveBeenCalled();
+
+		act( () => {
+			store.dispatch( {
+				type: JETPACK_PLUGINS_DATA_FETCH_RECEIVE,
+				pluginsData: BOOST_PLUGINS_DATA,
+			} );
+		} );
+
+		expect( mockRequestSpeedScores ).not.toHaveBeenCalled();
+	} );
+
+	test( 'never paints the score bars with resting data before the scores arrive', async () => {
+		let resolveScores;
+		mockRequestSpeedScores.mockImplementation(
+			() =>
+				new Promise( resolve => {
+					resolveScores = resolve;
+				} )
+		);
+		const store = createStore( rootReducer, buildInitialState(), applyMiddleware( thunk ) );
+		renderCard( store );
+
+		act( () => {
+			store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH } );
+		} );
+		await act( async () => {
+			store.dispatch( { type: JETPACK_PLUGINS_DATA_FETCH_RECEIVE, pluginsData: {} } );
+		} );
+
+		// Bars are visible and the request is in flight: every committed frame must be a loading frame.
+		expect( mockScoreBarRenders.length ).toBeGreaterThan( 0 );
+		expect( mockScoreBarRenders.filter( r => ! r.isLoading ) ).toHaveLength( 0 );
+
+		await act( async () => {
+			resolveScores( { current: { mobile: 80, desktop: 90 } } );
+		} );
+		expect( mockScoreBarRenders.some( r => ! r.isLoading && r.score === 80 ) ).toBe( true );
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js
@@ -16,6 +16,7 @@ const items = ( state = {}, action ) => {
 
 const initialRequestsState = {
 	isFetchingPluginsData: false,
+	hasFetchedPluginsData: false,
 };
 
 const requests = ( state = initialRequestsState, action ) => {
@@ -28,6 +29,7 @@ const requests = ( state = initialRequestsState, action ) => {
 		case JETPACK_PLUGINS_DATA_FETCH_RECEIVE:
 			return Object.assign( {}, state, {
 				isFetchingPluginsData: false,
+				hasFetchedPluginsData: true,
 			} );
 
 		default:
@@ -49,6 +51,19 @@ export const reducer = combineReducers( {
  */
 export function isFetchingPluginsData( state ) {
 	return !! state.jetpack.pluginsData.requests.isFetchingPluginsData;
+}
+
+/**
+ * Returns true once a plugin data request has come back, whether it succeeded
+ * or failed. Until then `items` is empty, so isPluginInstalled() and
+ * isPluginActive() answer false for every plugin and cannot be told apart from
+ * a site that genuinely has none.
+ *
+ * @param {object} state - Global state tree
+ * @return {boolean} - Whether plugin data has been fetched
+ */
+export function hasFetchedPluginsData( state ) {
+	return !! state.jetpack.pluginsData.requests.hasFetchedPluginsData;
 }
 
 /**

--- a/projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js
@@ -22,7 +22,7 @@ const initialRequestsState = {
 const requests = ( state = initialRequestsState, action ) => {
 	switch ( action.type ) {
 		case JETPACK_PLUGINS_DATA_FETCH:
-			// hasFetchedPluginsData deliberately stays set here: consumers treat it as a one-shot latch.
+			// Preserve this flag during refetches; it is a one-shot latch.
 			return Object.assign( {}, state, {
 				isFetchingPluginsData: true,
 			} );
@@ -55,10 +55,7 @@ export function isFetchingPluginsData( state ) {
 }
 
 /**
- * Returns true once a plugin data request has come back, whether it succeeded
- * or failed. Until then `items` is empty, so isPluginInstalled() and
- * isPluginActive() answer false for every plugin and cannot be told apart from
- * a site that genuinely has none.
+ * Returns true after a plugin data request finishes.
  *
  * @param {object} state - Global state tree
  * @return {boolean} - Whether plugin data has been fetched

--- a/projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/plugins/reducer.js
@@ -22,6 +22,7 @@ const initialRequestsState = {
 const requests = ( state = initialRequestsState, action ) => {
 	switch ( action.type ) {
 		case JETPACK_PLUGINS_DATA_FETCH:
+			// hasFetchedPluginsData deliberately stays set here: consumers treat it as a one-shot latch.
 			return Object.assign( {}, state, {
 				isFetchingPluginsData: true,
 			} );

--- a/projects/plugins/jetpack/_inc/client/state/site/plugins/test/reducer.js
+++ b/projects/plugins/jetpack/_inc/client/state/site/plugins/test/reducer.js
@@ -1,0 +1,41 @@
+import {
+	JETPACK_PLUGINS_DATA_FETCH,
+	JETPACK_PLUGINS_DATA_FETCH_RECEIVE,
+	JETPACK_PLUGINS_DATA_FETCH_FAIL,
+} from 'state/action-types';
+import { reducer, hasFetchedPluginsData, isFetchingPluginsData } from '../reducer';
+
+const stateFrom = pluginsData => ( { jetpack: { pluginsData } } );
+
+describe( 'plugins reducer', () => {
+	describe( '#hasFetchedPluginsData', () => {
+		test( 'is false before anything has been requested', () => {
+			const pluginsData = reducer( undefined, { type: '@@INIT' } );
+
+			expect( hasFetchedPluginsData( stateFrom( pluginsData ) ) ).toBe( false );
+		} );
+
+		test( 'stays false while the request is in flight', () => {
+			const pluginsData = reducer( undefined, { type: JETPACK_PLUGINS_DATA_FETCH } );
+
+			expect( isFetchingPluginsData( stateFrom( pluginsData ) ) ).toBe( true );
+			expect( hasFetchedPluginsData( stateFrom( pluginsData ) ) ).toBe( false );
+		} );
+
+		test( 'becomes true once the data arrives', () => {
+			const pluginsData = reducer( undefined, {
+				type: JETPACK_PLUGINS_DATA_FETCH_RECEIVE,
+				pluginsData: {},
+			} );
+
+			expect( hasFetchedPluginsData( stateFrom( pluginsData ) ) ).toBe( true );
+		} );
+
+		test( 'becomes true when the request fails, so callers stop waiting', () => {
+			const pluginsData = reducer( undefined, { type: JETPACK_PLUGINS_DATA_FETCH_FAIL } );
+
+			expect( isFetchingPluginsData( stateFrom( pluginsData ) ) ).toBe( false );
+			expect( hasFetchedPluginsData( stateFrom( pluginsData ) ) ).toBe( true );
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/boost-642-at-a-glance-boost-mount-guard
+++ b/projects/plugins/jetpack/changelog/boost-642-at-a-glance-boost-mount-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+At a Glance: stop requesting a new speed score on sites that already have Boost.

--- a/projects/plugins/jetpack/tests/jest.config.gui.js
+++ b/projects/plugins/jetpack/tests/jest.config.gui.js
@@ -17,6 +17,7 @@ module.exports = {
 		'<rootDir>/_inc/client/ai/scheduled-tasks/test/use-scheduled-tasks.js',
 		'<rootDir>/_inc/client/ai/test/main.jsx',
 		'<rootDir>/_inc/client/ai/test/tracks.js',
+		'<rootDir>/_inc/client/at-a-glance/boost/test/component.jsx',
 		'<rootDir>/_inc/client/sharing/test/component.jsx',
 		'<rootDir>/_inc/client/traffic/test/component.jsx',
 		'<rootDir>/_inc/client/at-a-glance/stats/test/chart-bar-range.js',


### PR DESCRIPTION
Part of [BOOST-642](https://linear.app/a8c/issue/BOOST-642/my-jetpack-boost-card-re-measures-the-speed-score-on-every-load).

## Proposed changes

* Hold the At a Glance Boost card's mount decision until the site's plugin data has been fetched.
* Add a `hasFetchedPluginsData` flag to the plugins state, set on receive and on fail.
* Start the card in its loading state so it never paints the default C-grade/empty bars.
* Guard the decision with a one-shot ref plus the in-flight fetch flag, so a flag left true by an earlier fetch cannot start a measurement from stale plugin data.

The card decides whether to measure in a mount effect, before `QuerySitePlugins` has fetched anything, so `hasBoost` reads false and `getSpeedScores()` starts a real Lighthouse run on every dashboard load of a Boost site. The store cannot tell "not fetched yet" from "fetched, no plugins" (`items` starts `{}`, `isFetchingPluginsData` starts `false`), hence the new flag; setting it on fail keeps the card from waiting forever.

Raised by @kangzj while reviewing #51605.

## Related product discussion/links

* [BOOST-642](https://linear.app/a8c/issue/BOOST-642/my-jetpack-boost-card-re-measures-the-speed-score-on-every-load)

## Does this pull request change what data or activity we track or use?

No. It reduces how often the speed score endpoint is called; the `jetpack_boost_speed_score_error` event is unchanged.

## Testing instructions

On a connected site with Boost installed and active: open At a Glance with the network tab open. Trunk fires a `POST` to `jetpack-boost/v1/speed-scores/refresh` on every load; with this change it does not.

On a site without Boost: score bars behave as on trunk, with two visible differences — the request starts once the plugin list has loaded, and the card shows its loading state instead of briefly painting the defaults.

`pnpm jetpack test js plugins/jetpack` covers the reducer cases (`_inc/client/state/site/plugins/test/reducer.js`) and the card's gating end to end (`_inc/client/at-a-glance/boost/test/component.jsx`).